### PR TITLE
fix(dashboard): correct Project Overview metrics + MCP-hosting fallback

### DIFF
--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -317,8 +317,11 @@ export function ProjectDashboard() {
       .map((t) => ({
         key: t.key,
         label: t.label,
-        value: Math.round(t.rate),
-        valueLabel: `${Math.round(t.rate)}%`,
+        // Keep the raw rate for the bar width: every tool here has ≥1 failure,
+        // so rounding (e.g. 0.4% → 0) would zero out the bar and the label.
+        value: t.rate,
+        // Never render "0%" in a failures-only list; show "<1%" below 1%.
+        valueLabel: t.rate < 1 ? "<1%" : `${Math.round(t.rate)}%`,
       }));
   }, [externalUsersData]);
 

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -162,9 +162,9 @@ export function ProjectDashboard() {
   // Total agent sessions = sum of per-user distinct hook sessions (totalChats).
   // Each session id (gen_ai.conversation.id) belongs to a single user, so summing
   // per-user counts gives the project-wide distinct-session total.
-  const totalSessions = useMemo(
-    () => (topUsersSearchData ?? []).reduce((sum, u) => sum + u.totalChats, 0),
-    [topUsersSearchData],
+  const totalSessions = (topUsersSearchData ?? []).reduce(
+    (sum, u) => sum + u.totalChats,
+    0,
   );
 
   // Most Used Agents: aggregate per-user hook-source breakdowns (hookSources)
@@ -218,9 +218,9 @@ export function ProjectDashboard() {
     placeholderData: keepPreviousData,
   });
 
-  const totalSpend = useMemo(
-    () => (allUsersSpendData ?? []).reduce((sum, u) => sum + u.totalCost, 0),
-    [allUsersSpendData],
+  const totalSpend = (allUsersSpendData ?? []).reduce(
+    (sum, u) => sum + u.totalCost,
+    0,
   );
 
   // MCP-hosting fallback: external end-users (customer-supplied IDs) and their

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -113,6 +113,13 @@ export function ProjectDashboard() {
     placeholderData: keepPreviousData,
   });
 
+  // Mode detection: a project that only hosts MCP servers produces no hook
+  // telemetry, so the hook-filtered fetch above is empty. Once it has loaded we
+  // know which view to render — prefer the hook/agent view whenever any hook
+  // data exists, else fall back to the MCP-hosting view.
+  const hookDataLoaded = topUsersSearchData !== undefined;
+  const hasHookData = (topUsersSearchData?.length ?? 0) > 0;
+
   const topUsersByTokens = useMemo(() => {
     if (!topUsersSearchData) return [];
     return [...topUsersSearchData]
@@ -206,7 +213,8 @@ export function ProjectDashboard() {
       } while (cursor);
       return users;
     },
-    enabled: logsEnabled,
+    // Spend is only shown in the hook/agent view.
+    enabled: logsEnabled && hasHookData,
     placeholderData: keepPreviousData,
   });
 
@@ -215,10 +223,84 @@ export function ProjectDashboard() {
     [allUsersSpendData],
   );
 
+  // MCP-hosting fallback: external end-users (customer-supplied IDs) and their
+  // tool-call activity. Fetched only when the project has no hook data. No
+  // eventSource filter — these projects' activity is MCP tool calls, not hooks.
+  const { data: externalUsersData } = useQuery({
+    queryKey: [
+      "project",
+      "externalUsers",
+      from.toISOString(),
+      to.toISOString(),
+    ],
+    queryFn: async () => {
+      const users = [];
+      let cursor: string | undefined;
+      do {
+        const result = await unwrapAsync(
+          telemetrySearchUsers(client, {
+            searchUsersPayload: {
+              cursor,
+              filter: { from, to },
+              limit: 1000,
+              sort: "desc",
+              userType: "external",
+            },
+          }),
+        );
+        users.push(...result.users);
+        cursor = result.nextCursor;
+      } while (cursor);
+      return users;
+    },
+    enabled: logsEnabled && hookDataLoaded && !hasHookData,
+    placeholderData: keepPreviousData,
+  });
+
+  // Top end-users by MCP tool-call volume. External IDs are customer-supplied,
+  // not Gram members, so they render raw (no member resolution).
+  const topEndUsers = useMemo(
+    () =>
+      [...(externalUsersData ?? [])]
+        .sort((a, b) => b.totalToolCalls - a.totalToolCalls)
+        .slice(0, 5)
+        .map((u) => ({
+          key: u.userId,
+          label: u.userId,
+          value: u.totalToolCalls,
+        })),
+    [externalUsersData],
+  );
+
+  // Most-used tools = aggregate per-user tool breakdowns by URN across all
+  // external users (replaces Most Used Agents, which has no MCP equivalent).
+  const mostUsedTools = useMemo(() => {
+    const byTool = new Map<string, number>();
+    for (const u of externalUsersData ?? []) {
+      for (const t of u.tools) {
+        byTool.set(t.urn, (byTool.get(t.urn) ?? 0) + t.count);
+      }
+    }
+    return [...byTool.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([urn, count]) => ({
+        key: urn,
+        label: toolLabelFromUrn(urn),
+        value: count,
+      }));
+  }, [externalUsersData]);
+
+  const endUsersCount = externalUsersData?.length ?? 0;
+
   const isTopUsersLoading =
     logsEnabled && (isTopUsersPending || isMembersPending);
 
-  const isSpendLoading = logsEnabled && isSpendPending;
+  // Mode is unknown until the hook fetch + members settle.
+  const modePending = isTopUsersLoading;
+  // Spend (hook view) / external users (MCP view) still loading after mode known.
+  const isSpendLoading = hasHookData && (isSpendPending || !allUsersSpendData);
+  const mcpUsersPending = !hasHookData && externalUsersData === undefined;
 
   const featuresSettled = !isFeaturesPending || isFeaturesError;
   const isOverviewLoading =
@@ -338,9 +420,10 @@ export function ProjectDashboard() {
                     tooltip="Total tool invocations recorded across all servers and sources in the selected period."
                   />
                 )}
-                {isSpendLoading ? (
+                {modePending ||
+                (hasHookData ? isSpendLoading : mcpUsersPending) ? (
                   <Skeleton className="h-[100px] rounded-lg" />
-                ) : (
+                ) : hasHookData ? (
                   <MetricCard
                     title="Total Spend"
                     value={totalSpend}
@@ -348,15 +431,29 @@ export function ProjectDashboard() {
                     icon="dollar-sign"
                     tooltip="Total LLM spend by project members in the selected period, summed from per-user cost. Matches the figure on the Employees page."
                   />
-                )}
-                {isTopUsersLoading ? (
-                  <Skeleton className="h-[100px] rounded-lg" />
                 ) : (
+                  <MetricCard
+                    title="End Users"
+                    value={endUsersCount}
+                    icon="users"
+                    tooltip="Distinct external end users that made MCP tool calls in the selected period."
+                  />
+                )}
+                {modePending || isOverviewPending ? (
+                  <Skeleton className="h-[100px] rounded-lg" />
+                ) : hasHookData ? (
                   <MetricCard
                     title="Sessions"
                     value={totalSessions}
                     icon="message-circle"
                     tooltip="Distinct agent sessions across project members in the selected period."
+                  />
+                ) : (
+                  <MetricCard
+                    title="Failed Tool Calls"
+                    value={overview?.summary.failedToolCalls ?? 0}
+                    icon="circle-alert"
+                    tooltip="MCP tool calls that returned an error (HTTP 4xx/5xx) in the selected period."
                   />
                 )}
               </div>
@@ -364,8 +461,12 @@ export function ProjectDashboard() {
               {/* Row 1: Top Activity */}
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                 <DashboardCard
-                  title="Top Users"
-                  tooltip="Employees ranked by total token consumption (input + output tokens) in the selected period."
+                  title={hasHookData ? "Top Users" : "Top End Users"}
+                  tooltip={
+                    hasHookData
+                      ? "Employees ranked by total token consumption (input + output tokens) in the selected period."
+                      : "External end users ranked by MCP tool calls in the selected period."
+                  }
                   action={
                     <CardActions>
                       <ExploreWithAIButton
@@ -389,12 +490,15 @@ export function ProjectDashboard() {
                     </CardActions>
                   }
                 >
-                  {isTopUsersLoading ? (
+                  {modePending || (!hasHookData && mcpUsersPending) ? (
                     <SkeletonList />
-                  ) : topUsersByTokens.length === 0 ? (
+                  ) : (hasHookData ? topUsersByTokens : topEndUsers).length ===
+                    0 ? (
                     <EmptyState message="No user activity recorded" />
                   ) : (
-                    <RankedBarList items={topUsersByTokens} />
+                    <RankedBarList
+                      items={hasHookData ? topUsersByTokens : topEndUsers}
+                    />
                   )}
                 </DashboardCard>
 
@@ -442,115 +546,138 @@ export function ProjectDashboard() {
                 </DashboardCard>
               </div>
 
-              {/* Row 2: Sessions */}
+              {/* Row 2: Sessions (hook view) / Tools (MCP view) */}
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                <DashboardCard
-                  title="Most Agent Sessions by User"
-                  tooltip="Employees ranked by the number of distinct agent sessions in the selected period."
-                  action={
-                    <CardActions>
-                      <ExploreWithAIButton
-                        onClick={() =>
-                          exploreWithAI({
-                            title: "Analyze agent sessions",
-                            subtitle:
-                              "Understand how your power users interact with agents.",
-                            contextInfo: `${timeWindowContext} The user clicked "Explore with AI" on the Most Agent Sessions by User chart.`,
-                            suggestions: [
-                              {
-                                title: "Power users & agent behavior",
-                                label: rangeLabel,
-                                prompt: `For the users with the most agent sessions in the ${rangeLabel}, what are the common prompts they send and which tools get invoked most often?`,
-                              },
-                            ],
-                          })
-                        }
-                      />
-                      <ViewAllLink
-                        to={
-                          // no hooks data and no chat sessions
-                          isProjectEmpty && overview?.summary.totalChats === 0
-                            ? routes.insights.href()
-                            : // has hooks data but no chat sessions
-                              !isProjectEmpty &&
-                                overview?.summary.totalChats === 0
-                              ? routes.insights.href()
-                              : routes.logs.agents.href()
-                        }
-                      />
-                    </CardActions>
-                  }
-                >
-                  {isTopUsersLoading ? (
-                    <SkeletonList />
-                  ) : topUsersBySessions.length === 0 ? (
-                    <EmptyState message="No session activity recorded" />
-                  ) : (
-                    <ul className="divide-border divide-y">
-                      {topUsersBySessions.map((user, i) => (
-                        <li
-                          key={user.userId}
-                          className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
-                        >
-                          <Avatar className="size-8 shrink-0">
-                            <AvatarFallback
-                              className={cn(
-                                "text-xs font-medium",
-                                avatarColor(i),
-                              )}
+                {hasHookData ? (
+                  <>
+                    <DashboardCard
+                      title="Most Agent Sessions by User"
+                      tooltip="Employees ranked by the number of distinct agent sessions in the selected period."
+                      action={
+                        <CardActions>
+                          <ExploreWithAIButton
+                            onClick={() =>
+                              exploreWithAI({
+                                title: "Analyze agent sessions",
+                                subtitle:
+                                  "Understand how your power users interact with agents.",
+                                contextInfo: `${timeWindowContext} The user clicked "Explore with AI" on the Most Agent Sessions by User chart.`,
+                                suggestions: [
+                                  {
+                                    title: "Power users & agent behavior",
+                                    label: rangeLabel,
+                                    prompt: `For the users with the most agent sessions in the ${rangeLabel}, what are the common prompts they send and which tools get invoked most often?`,
+                                  },
+                                ],
+                              })
+                            }
+                          />
+                          <ViewAllLink
+                            to={
+                              // no hooks data and no chat sessions
+                              isProjectEmpty &&
+                              overview?.summary.totalChats === 0
+                                ? routes.insights.href()
+                                : // has hooks data but no chat sessions
+                                  !isProjectEmpty &&
+                                    overview?.summary.totalChats === 0
+                                  ? routes.insights.href()
+                                  : routes.logs.agents.href()
+                            }
+                          />
+                        </CardActions>
+                      }
+                    >
+                      {isTopUsersLoading ? (
+                        <SkeletonList />
+                      ) : topUsersBySessions.length === 0 ? (
+                        <EmptyState message="No session activity recorded" />
+                      ) : (
+                        <ul className="divide-border divide-y">
+                          {topUsersBySessions.map((user, i) => (
+                            <li
+                              key={user.userId}
+                              className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
                             >
-                              {emailInitials(user.initialsSource)}
-                            </AvatarFallback>
-                          </Avatar>
-                          <div className="min-w-0 flex-1">
-                            <p className="truncate text-sm font-medium">
-                              {user.name}
-                            </p>
-                            <p className="text-muted-foreground text-xs">
-                              {user.sessions.toLocaleString()}{" "}
-                              {user.sessions === 1 ? "session" : "sessions"}
-                            </p>
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </DashboardCard>
+                              <Avatar className="size-8 shrink-0">
+                                <AvatarFallback
+                                  className={cn(
+                                    "text-xs font-medium",
+                                    avatarColor(i),
+                                  )}
+                                >
+                                  {emailInitials(user.initialsSource)}
+                                </AvatarFallback>
+                              </Avatar>
+                              <div className="min-w-0 flex-1">
+                                <p className="truncate text-sm font-medium">
+                                  {user.name}
+                                </p>
+                                <p className="text-muted-foreground text-xs">
+                                  {user.sessions.toLocaleString()}{" "}
+                                  {user.sessions === 1 ? "session" : "sessions"}
+                                </p>
+                              </div>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </DashboardCard>
 
-                <DashboardCard
-                  title="Most Used Agents"
-                  tooltip="Agents (e.g. Claude, Cursor, Codex) ranked by activity volume in the selected period, identified from client metadata sent with each call."
-                  action={
-                    <CardActions>
-                      <ExploreWithAIButton
-                        onClick={() =>
-                          exploreWithAI({
-                            title: "Analyze LLM client usage",
-                            subtitle:
-                              "Compare how different LLM clients exercise your tools.",
-                            contextInfo: `${timeWindowContext} The user clicked "Explore with AI" on the Most Used LLM Clients chart.`,
-                            suggestions: [
-                              {
-                                title: "LLM clients & reliability",
-                                label: rangeLabel,
-                                prompt: `Break down tool-call activity by LLM client in the ${rangeLabel} and highlight any clients with unusually high error rates or latency.`,
-                              },
-                            ],
-                          })
-                        }
-                      />
-                      <ViewAllLink to={routes.insights.tools.href()} />
-                    </CardActions>
-                  }
-                >
-                  {isTopUsersLoading ? (
-                    <SkeletonList />
-                  ) : mostUsedAgents.length === 0 ? (
-                    <EmptyState message="No agent activity recorded" />
-                  ) : (
-                    <RankedBarList items={mostUsedAgents} />
-                  )}
-                </DashboardCard>
+                    <DashboardCard
+                      title="Most Used Agents"
+                      tooltip="Agents (e.g. Claude, Cursor, Codex) ranked by activity volume in the selected period, identified from client metadata sent with each call."
+                      action={
+                        <CardActions>
+                          <ExploreWithAIButton
+                            onClick={() =>
+                              exploreWithAI({
+                                title: "Analyze LLM client usage",
+                                subtitle:
+                                  "Compare how different LLM clients exercise your tools.",
+                                contextInfo: `${timeWindowContext} The user clicked "Explore with AI" on the Most Used LLM Clients chart.`,
+                                suggestions: [
+                                  {
+                                    title: "LLM clients & reliability",
+                                    label: rangeLabel,
+                                    prompt: `Break down tool-call activity by LLM client in the ${rangeLabel} and highlight any clients with unusually high error rates or latency.`,
+                                  },
+                                ],
+                              })
+                            }
+                          />
+                          <ViewAllLink to={routes.insights.tools.href()} />
+                        </CardActions>
+                      }
+                    >
+                      {isTopUsersLoading ? (
+                        <SkeletonList />
+                      ) : mostUsedAgents.length === 0 ? (
+                        <EmptyState message="No agent activity recorded" />
+                      ) : (
+                        <RankedBarList items={mostUsedAgents} />
+                      )}
+                    </DashboardCard>
+                  </>
+                ) : (
+                  <DashboardCard
+                    title="Most Used Tools"
+                    tooltip="Tools ranked by the number of MCP calls they served in the selected period."
+                    action={
+                      <CardActions>
+                        <ViewAllLink to={routes.insights.tools.href()} />
+                      </CardActions>
+                    }
+                  >
+                    {modePending || mcpUsersPending ? (
+                      <SkeletonList />
+                    ) : mostUsedTools.length === 0 ? (
+                      <EmptyState message="No tool activity recorded" />
+                    ) : (
+                      <RankedBarList items={mostUsedTools} />
+                    )}
+                  </DashboardCard>
+                )}
               </div>
             </>
           )}
@@ -678,6 +805,13 @@ const AVATAR_COLORS = [
 
 function avatarColor(index: number): string {
   return AVATAR_COLORS[index % AVATAR_COLORS.length]!;
+}
+
+// Tool URNs look like `tools:externalmcp:<server>:<tool>`; show the trailing
+// tool segment, falling back to the full URN.
+function toolLabelFromUrn(urn: string): string {
+  const parts = urn.split(":");
+  return parts[parts.length - 1] || urn;
 }
 
 function emailInitials(email: string): string {

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -152,8 +152,73 @@ export function ProjectDashboard() {
       });
   }, [topUsersSearchData, memberById]);
 
+  // Total agent sessions = sum of per-user distinct hook sessions (totalChats).
+  // Each session id (gen_ai.conversation.id) belongs to a single user, so summing
+  // per-user counts gives the project-wide distinct-session total.
+  const totalSessions = useMemo(
+    () => (topUsersSearchData ?? []).reduce((sum, u) => sum + u.totalChats, 0),
+    [topUsersSearchData],
+  );
+
+  // Most Used Agents: aggregate per-user hook-source breakdowns (hookSources)
+  // across all users, ranking agents (claude-code, cursor, ...) by total events.
+  // Replaces overview.summary.llmClientBreakdown, whose tool-call-only count
+  // reads 0 for hook events (they carry no `tools:` URN).
+  const mostUsedAgents = useMemo(() => {
+    const bySource = new Map<string, number>();
+    for (const u of topUsersSearchData ?? []) {
+      for (const h of u.hookSources) {
+        bySource.set(h.source, (bySource.get(h.source) ?? 0) + h.eventCount);
+      }
+    }
+    return [...bySource.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([source, eventCount]) => ({
+        key: source,
+        label: source,
+        value: eventCount,
+      }));
+  }, [topUsersSearchData]);
+
+  // Total Spend mirrors the Employees ("cost") page exactly: internal users,
+  // all event sources (no eventSource filter), summing per-user totalCost — so
+  // this card shows the same figure as that page.
+  const { data: allUsersSpendData, isPending: isSpendPending } = useQuery({
+    queryKey: ["project", "totalSpend", from.toISOString(), to.toISOString()],
+    queryFn: async () => {
+      const users = [];
+      let cursor: string | undefined;
+      do {
+        const result = await unwrapAsync(
+          telemetrySearchUsers(client, {
+            searchUsersPayload: {
+              cursor,
+              filter: { from, to },
+              limit: 1000,
+              sort: "desc",
+              userType: "internal",
+            },
+          }),
+        );
+        users.push(...result.users);
+        cursor = result.nextCursor;
+      } while (cursor);
+      return users;
+    },
+    enabled: logsEnabled,
+    placeholderData: keepPreviousData,
+  });
+
+  const totalSpend = useMemo(
+    () => (allUsersSpendData ?? []).reduce((sum, u) => sum + u.totalCost, 0),
+    [allUsersSpendData],
+  );
+
   const isTopUsersLoading =
     logsEnabled && (isTopUsersPending || isMembersPending);
+
+  const isSpendLoading = logsEnabled && isSpendPending;
 
   const featuresSettled = !isFeaturesPending || isFeaturesError;
   const isOverviewLoading =
@@ -273,24 +338,25 @@ export function ProjectDashboard() {
                     tooltip="Total tool invocations recorded across all servers and sources in the selected period."
                   />
                 )}
-                {isOverviewPending ? (
+                {isSpendLoading ? (
                   <Skeleton className="h-[100px] rounded-lg" />
                 ) : (
                   <MetricCard
-                    title="End Users"
-                    value={overview?.summary.activeUsersCount ?? 0}
-                    icon="users"
-                    tooltip="Unique end users identified during the selected period. If agent sessions are captured they are counted from chat messages; otherwise they are counted from tool-call events."
+                    title="Total Spend"
+                    value={totalSpend}
+                    format="currency"
+                    icon="dollar-sign"
+                    tooltip="Total LLM spend by project members in the selected period, summed from per-user cost. Matches the figure on the Employees page."
                   />
                 )}
-                {isOverviewPending ? (
+                {isTopUsersLoading ? (
                   <Skeleton className="h-[100px] rounded-lg" />
                 ) : (
                   <MetricCard
                     title="Sessions"
-                    value={overview?.summary.totalChats ?? 0}
+                    value={totalSessions}
                     icon="message-circle"
-                    tooltip="Agent sessions started in the selected period."
+                    tooltip="Distinct agent sessions across project members in the selected period."
                   />
                 )}
               </div>
@@ -477,21 +543,12 @@ export function ProjectDashboard() {
                     </CardActions>
                   }
                 >
-                  {isOverviewPending ? (
+                  {isTopUsersLoading ? (
                     <SkeletonList />
-                  ) : (overview?.summary.llmClientBreakdown.length ?? 0) ===
-                    0 ? (
-                    <EmptyState message="No LLM activity recorded" />
+                  ) : mostUsedAgents.length === 0 ? (
+                    <EmptyState message="No agent activity recorded" />
                   ) : (
-                    <RankedBarList
-                      items={(overview?.summary.llmClientBreakdown ?? [])
-                        .slice(0, 5)
-                        .map((m) => ({
-                          key: m.clientName,
-                          label: m.clientName,
-                          value: m.activityCount,
-                        }))}
-                    />
+                    <RankedBarList items={mostUsedAgents} />
                   )}
                 </DashboardCard>
               </div>

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -291,6 +291,37 @@ export function ProjectDashboard() {
       }));
   }, [externalUsersData]);
 
+  // Top tools by failure rate (MCP view): aggregate per-tool call + failure
+  // counts across external users; rank by failure rate, tie-broken by absolute
+  // failures so a high-volume failing tool outranks a one-off 100% failure.
+  const topToolsByFailureRate = useMemo(() => {
+    const agg = new Map<string, { calls: number; failures: number }>();
+    for (const u of externalUsersData ?? []) {
+      for (const t of u.tools) {
+        const cur = agg.get(t.urn) ?? { calls: 0, failures: 0 };
+        cur.calls += t.count;
+        cur.failures += t.failureCount;
+        agg.set(t.urn, cur);
+      }
+    }
+    return [...agg.entries()]
+      .filter(([, v]) => v.failures > 0)
+      .map(([urn, v]) => ({
+        key: urn,
+        label: toolLabelFromUrn(urn),
+        rate: v.calls > 0 ? (v.failures / v.calls) * 100 : 0,
+        failures: v.failures,
+      }))
+      .sort((a, b) => b.rate - a.rate || b.failures - a.failures)
+      .slice(0, 5)
+      .map((t) => ({
+        key: t.key,
+        label: t.label,
+        value: Math.round(t.rate),
+        valueLabel: `${Math.round(t.rate)}%`,
+      }));
+  }, [externalUsersData]);
+
   const endUsersCount = externalUsersData?.length ?? 0;
 
   const isTopUsersLoading =
@@ -660,23 +691,43 @@ export function ProjectDashboard() {
                     </DashboardCard>
                   </>
                 ) : (
-                  <DashboardCard
-                    title="Most Used Tools"
-                    tooltip="Tools ranked by the number of MCP calls they served in the selected period."
-                    action={
-                      <CardActions>
-                        <ViewAllLink to={routes.insights.tools.href()} />
-                      </CardActions>
-                    }
-                  >
-                    {modePending || mcpUsersPending ? (
-                      <SkeletonList />
-                    ) : mostUsedTools.length === 0 ? (
-                      <EmptyState message="No tool activity recorded" />
-                    ) : (
-                      <RankedBarList items={mostUsedTools} />
-                    )}
-                  </DashboardCard>
+                  <>
+                    <DashboardCard
+                      title="Most Used Tools"
+                      tooltip="Tools ranked by the number of MCP calls they served in the selected period."
+                      action={
+                        <CardActions>
+                          <ViewAllLink to={routes.insights.tools.href()} />
+                        </CardActions>
+                      }
+                    >
+                      {modePending || mcpUsersPending ? (
+                        <SkeletonList />
+                      ) : mostUsedTools.length === 0 ? (
+                        <EmptyState message="No tool activity recorded" />
+                      ) : (
+                        <RankedBarList items={mostUsedTools} />
+                      )}
+                    </DashboardCard>
+
+                    <DashboardCard
+                      title="Top Tools by Failure Rate"
+                      tooltip="Tools with the highest share of failed MCP calls (HTTP 4xx/5xx) in the selected period. Only tools with at least one failure are shown."
+                      action={
+                        <CardActions>
+                          <ViewAllLink to={routes.insights.tools.href()} />
+                        </CardActions>
+                      }
+                    >
+                      {modePending || mcpUsersPending ? (
+                        <SkeletonList />
+                      ) : topToolsByFailureRate.length === 0 ? (
+                        <EmptyState message="No tool failures recorded" />
+                      ) : (
+                        <RankedBarList items={topToolsByFailureRate} />
+                      )}
+                    </DashboardCard>
+                  </>
                 )}
               </div>
             </>
@@ -750,7 +801,13 @@ function LoggingDisabledBanner({ settingsHref }: { settingsHref: string }) {
   );
 }
 
-type RankedBarListItem = { key: string; label: string; value: number };
+type RankedBarListItem = {
+  key: string;
+  label: string;
+  value: number;
+  // Optional display override for the value (e.g. "42%"); bar width still uses `value`.
+  valueLabel?: string;
+};
 
 function RankedBarList({ items }: { items: RankedBarListItem[] }) {
   const max = items[0]?.value || 1;
@@ -765,7 +822,7 @@ function RankedBarList({ items }: { items: RankedBarListItem[] }) {
             <div className="mb-1 flex items-center justify-between">
               <span className="truncate text-sm">{item.label}</span>
               <span className="text-muted-foreground ml-2 shrink-0 text-xs">
-                {item.value.toLocaleString()}
+                {item.valueLabel ?? item.value.toLocaleString()}
               </span>
             </div>
             <div className="bg-muted h-1 w-full rounded-full">

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -15,6 +15,10 @@ import {
 } from "@gram/client/react-query";
 import { telemetryGetProjectOverview } from "@gram/client/funcs/telemetryGetProjectOverview";
 import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
+import type {
+  SearchUsersFilter,
+  UserSummary,
+} from "@gram/client/models/components";
 import { unwrapAsync } from "@gram/client/types/fp";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
@@ -89,26 +93,8 @@ export function ProjectDashboard() {
 
   const { data: topUsersSearchData, isPending: isTopUsersPending } = useQuery({
     queryKey: ["project", "topUsers", from.toISOString(), to.toISOString()],
-    queryFn: async () => {
-      const users = [];
-      let cursor: string | undefined;
-      do {
-        const result = await unwrapAsync(
-          telemetrySearchUsers(client, {
-            searchUsersPayload: {
-              cursor,
-              filter: { from, to, eventSource: "hook" },
-              limit: 1000,
-              sort: "desc",
-              userType: "internal",
-            },
-          }),
-        );
-        users.push(...result.users);
-        cursor = result.nextCursor;
-      } while (cursor);
-      return users;
-    },
+    queryFn: () =>
+      fetchAllUsers(client, { from, to, eventSource: "hook" }, "internal"),
     enabled: logsEnabled,
     placeholderData: keepPreviousData,
   });
@@ -193,26 +179,7 @@ export function ProjectDashboard() {
   // this card shows the same figure as that page.
   const { data: allUsersSpendData, isPending: isSpendPending } = useQuery({
     queryKey: ["project", "totalSpend", from.toISOString(), to.toISOString()],
-    queryFn: async () => {
-      const users = [];
-      let cursor: string | undefined;
-      do {
-        const result = await unwrapAsync(
-          telemetrySearchUsers(client, {
-            searchUsersPayload: {
-              cursor,
-              filter: { from, to },
-              limit: 1000,
-              sort: "desc",
-              userType: "internal",
-            },
-          }),
-        );
-        users.push(...result.users);
-        cursor = result.nextCursor;
-      } while (cursor);
-      return users;
-    },
+    queryFn: () => fetchAllUsers(client, { from, to }, "internal"),
     // Spend is only shown in the hook/agent view.
     enabled: logsEnabled && hasHookData,
     placeholderData: keepPreviousData,
@@ -233,26 +200,7 @@ export function ProjectDashboard() {
       from.toISOString(),
       to.toISOString(),
     ],
-    queryFn: async () => {
-      const users = [];
-      let cursor: string | undefined;
-      do {
-        const result = await unwrapAsync(
-          telemetrySearchUsers(client, {
-            searchUsersPayload: {
-              cursor,
-              filter: { from, to },
-              limit: 1000,
-              sort: "desc",
-              userType: "external",
-            },
-          }),
-        );
-        users.push(...result.users);
-        cursor = result.nextCursor;
-      } while (cursor);
-      return users;
-    },
+    queryFn: () => fetchAllUsers(client, { from, to }, "external"),
     enabled: logsEnabled && hookDataLoaded && !hasHookData,
     placeholderData: keepPreviousData,
   });
@@ -865,6 +813,34 @@ const AVATAR_COLORS = [
 
 function avatarColor(index: number): string {
   return AVATAR_COLORS[index % AVATAR_COLORS.length]!;
+}
+
+// Fetch every page of telemetrySearchUsers for the given filter, following the
+// pagination cursor. Shared by the overview's hook / spend / external queries.
+async function fetchAllUsers(
+  client: Parameters<typeof telemetrySearchUsers>[0],
+  filter: SearchUsersFilter,
+  userType: "internal" | "external",
+): Promise<UserSummary[]> {
+  const users: UserSummary[] = [];
+  let cursor: string | undefined;
+  for (;;) {
+    const result = await unwrapAsync(
+      telemetrySearchUsers(client, {
+        searchUsersPayload: {
+          cursor,
+          filter,
+          limit: 1000,
+          sort: "desc",
+          userType,
+        },
+      }),
+    );
+    users.push(...result.users);
+    if (!result.nextCursor) break;
+    cursor = result.nextCursor;
+  }
+  return users;
 }
 
 // Tool URNs look like `tools:externalmcp:<server>:<tool>`; show the trailing


### PR DESCRIPTION
## What

Two related changes to the **Project Overview** so it's correct for both audiences — customers using the AI-coding hooks *and* customers who only host MCP servers.

### 1. Correct the metrics (hook/agent view)
Three data points were wrong; all now derive from the trusted `telemetrySearchUsers` source (consistent with #3097):

| Card | Before | After |
|---|---|---|
| **End Users** | `activeUsersCount` — no longer relevant | **Total Spend** — `$` from per-user `totalCost` (matches the Employees/cost page: internal, all event sources) |
| **Sessions** | `totalChats` = PG `chats` (playground/elements sessions) | Distinct **agent/hook sessions** (sum of per-user `totalChats`) |
| **Most Used Agents** | `llmClientBreakdown` counted `tools:`-URN events → always 0 for hook events | Aggregated per-user `hookSources` |

### 2. MCP-hosting fallback
The hook-derived cards go blank for projects that **only host MCP servers** (no Claude Code/Cursor/Codex) — that telemetry has no hook source, no session id, and no LLM cost. Added a **whole-page mode switch**:

- **Detection:** `hasHookData` = the internal/hook `searchUsers` fetch is non-empty. Prefer the hook view whenever any hook data exists.
- **MCP-only card set** (from a `searchUsers(userType: external)` fetch):
  - Metrics: Active Servers · Tool Calls · **End Users** (distinct external end-users) · **Failed Tool Calls**
  - Lists: **Top End Users** (by tool calls) · **Top Servers** · **Most Used Tools** · **Top Tools by Failure Rate**
  - External IDs are customer-supplied (not Gram members) → shown raw.

#### Note on "Most Used Agents" for MCP
The LLM client connecting to a hosted MCP server is only captured as an OAuth registration (`user_session_clients.client_name`), **not** on per-tool-call telemetry — so a usage-ranked clients card isn't possible frontend-only. The 4th MCP slot instead surfaces tool **reliability** (failure rate), which the tool breakdown already carries.

## How
Frontend-only (`ProjectDashboard.tsx`), no backend/Goa changes. Mode-specific `searchUsers` fetches are gated so only the active view's data is fetched.

## Testing
- `cd client/dashboard && npx tsc --noEmit` → no errors.

## Notes
- Builds on #3097 (already merged to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Fixes [AGE-2598](https://linear.app/speakeasy/issue/AGE-2598/fix-dashboard-data-inconsistencies-in-project-homepage).
