### PR TITLE
fix(workos): remove phantom dsync.deactivated event

### DIFF
--- a/server/internal/background/activities/process_workos_org_events.go
+++ b/server/internal/background/activities/process_workos_org_events.go
@@ -100,7 +100,6 @@ func (p *ProcessWorkOSOrganizationEvents) Do(ctx context.Context, params Process
 			string(workos.EventKindConnectionDeleted),
 
 			string(workos.EventKindDirectorySyncActivated),
-			string(workos.EventKindDirectorySyncDeactivated),
 			string(workos.EventKindDirectorySyncDeleted),
 		},
 		Limit:          workosOrgEventsPageSize,
@@ -224,7 +223,7 @@ func handleOrganizationEvent(ctx context.Context, logger *slog.Logger, dbtx data
 		return nil, handleSSOConnectionChange(ctx, logger, dbtx, event, false)
 	case string(workos.EventKindDirectorySyncActivated):
 		return nil, handleDSyncChange(ctx, logger, dbtx, event, true)
-	case string(workos.EventKindDirectorySyncDeactivated), string(workos.EventKindDirectorySyncDeleted):
+	case string(workos.EventKindDirectorySyncDeleted):
 		return nil, handleDSyncChange(ctx, logger, dbtx, event, false)
 	}
 
@@ -645,7 +644,7 @@ type workosDSyncEventPayload struct {
 }
 
 // handleDSyncChange sets scim_enabled on the organization when a WorkOS
-// dsync.activated, dsync.deactivated, or dsync.deleted event is received.
+// dsync.activated or dsync.deleted event is received.
 func handleDSyncChange(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event, enabled bool) error {
 	var payload workosDSyncEventPayload
 	if err := json.Unmarshal(event.Data, &payload); err != nil {

--- a/server/internal/background/activities/process_workos_org_events_test.go
+++ b/server/internal/background/activities/process_workos_org_events_test.go
@@ -1077,7 +1077,6 @@ func TestProcessWorkOSOrganizationEvents_MembershipFilterIncludesMembershipTypes
 		"connection.deactivated",
 		"connection.deleted",
 		"dsync.activated",
-		"dsync.deactivated",
 		"dsync.deleted",
 	}, stub.EventCalls()[0].Events)
 }
@@ -1587,36 +1586,6 @@ func TestProcessWorkOSOrganizationEvents_DSyncActivatedSetsSCIMEnabled(t *testin
 	require.True(t, row.ScimEnabled.Bool)
 }
 
-func TestProcessWorkOSOrganizationEvents_DSyncDeactivatedClearsSCIMEnabled(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	conn := newOrgEventsTestConn(t, "workos_org_events_dsync_deactivated")
-	logger := testenv.NewLogger(t)
-
-	const organizationID = "gram_org_scim_deactivated"
-	const workosOrgID = "org_01HZSCIMDEACT"
-
-	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
-
-	stub := newWorkOSClientWithEvents([][]events.Event{
-		{
-			newWorkOSDSyncEvent(t, "dsync.activated", "event_01HZSCIM1", workosOrgID),
-			newWorkOSDSyncEvent(t, "dsync.deactivated", "event_01HZSCIM2", workosOrgID),
-		},
-	})
-	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
-
-	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
-	require.NoError(t, err)
-	require.Equal(t, "event_01HZSCIM2", res.LastEventID)
-
-	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
-	require.NoError(t, err)
-	require.True(t, row.ScimEnabled.Valid)
-	require.False(t, row.ScimEnabled.Bool)
-}
-
 func TestProcessWorkOSOrganizationEvents_DSyncDeletedClearsSCIMEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -1791,12 +1760,12 @@ func TestProcessWorkOSOrganizationEvents_StaleDSyncEventSkipped(t *testing.T) {
 
 	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 
-	// Deliver activation with a high event ID, then a stale deactivation
+	// Deliver activation with a high event ID, then a stale deletion
 	// with a lower event ID (simulating out-of-order delivery).
 	stub := newWorkOSClientWithEvents([][]events.Event{
 		{
 			newWorkOSDSyncEvent(t, "dsync.activated", "event_01HZSCIMSTALE2", workosOrgID),
-			newWorkOSDSyncEvent(t, "dsync.deactivated", "event_01HZSCIMSTALE1", workosOrgID),
+			newWorkOSDSyncEvent(t, "dsync.deleted", "event_01HZSCIMSTALE1", workosOrgID),
 		},
 	})
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
@@ -1808,7 +1777,7 @@ func TestProcessWorkOSOrganizationEvents_StaleDSyncEventSkipped(t *testing.T) {
 	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
 	require.NoError(t, err)
 	require.True(t, row.ScimEnabled.Valid)
-	require.True(t, row.ScimEnabled.Bool, "SCIM should remain enabled — stale deactivation must be skipped")
+	require.True(t, row.ScimEnabled.Bool, "SCIM should remain enabled — stale deletion must be skipped")
 	require.Equal(t, "event_01HZSCIMSTALE2", row.WorkosLastEventID.String)
 }
 

--- a/server/internal/external/impl.go
+++ b/server/internal/external/impl.go
@@ -134,7 +134,6 @@ func (h *WebhookHandler) dispatch(ctx context.Context, logger *slog.Logger, even
 		string(workos.EventKindConnectionDeactivated),
 		string(workos.EventKindConnectionDeleted),
 		string(workos.EventKindDirectorySyncActivated),
-		string(workos.EventKindDirectorySyncDeactivated),
 		string(workos.EventKindDirectorySyncDeleted):
 
 		orgID := parseOrganizationID(event)

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -645,7 +645,7 @@ WHERE workos_id = @workos_id;
 
 -- name: SetSCIMEnabled :exec
 -- Update the SCIM/directory sync enabled flag on an organization. Called when
--- a WorkOS dsync.activated or dsync.deactivated event is processed.
+-- a WorkOS dsync.activated or dsync.deleted event is processed.
 UPDATE organization_metadata
 SET scim_enabled = @enabled,
     workos_last_event_id = @workos_last_event_id,

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -1178,7 +1178,7 @@ type SetSCIMEnabledParams struct {
 }
 
 // Update the SCIM/directory sync enabled flag on an organization. Called when
-// a WorkOS dsync.activated or dsync.deactivated event is processed.
+// a WorkOS dsync.activated or dsync.deleted event is processed.
 func (q *Queries) SetSCIMEnabled(ctx context.Context, arg SetSCIMEnabledParams) error {
 	_, err := q.db.Exec(ctx, setSCIMEnabled, arg.Enabled, arg.WorkosLastEventID, arg.WorkosID)
 	return err

--- a/server/internal/thirdparty/workos/events.go
+++ b/server/internal/thirdparty/workos/events.go
@@ -15,7 +15,6 @@ const (
 	EventKindConnectionDeleted     EventKind = "connection.deleted"
 
 	EventKindDirectorySyncActivated        EventKind = "dsync.activated"
-	EventKindDirectorySyncDeactivated      EventKind = "dsync.deactivated"
 	EventKindDirectorySyncDeleted          EventKind = "dsync.deleted"
 	EventKindDirectorySyncGroupCreated     EventKind = "dsync.group.created"
 	EventKindDirectorySyncGroupDeleted     EventKind = "dsync.group.deleted"


### PR DESCRIPTION
## Summary

- Remove `EventKindDirectorySyncDeactivated` constant (`"dsync.deactivated"`) — this event does not exist in the WorkOS API
- WorkOS directory sync only emits `dsync.activated` and `dsync.deleted` (unlike `connection.*` which has `deactivated`)
- The `dsync.deleted` handler already covers the SCIM-disable path, so no behavior change
- Remove duplicate test that was testing the phantom event

## Test plan

- [ ] Existing `DSyncDeletedClearsSCIMEnabled` test covers the disable-SCIM-on-delete path
- [ ] `StaleDSyncEventSkipped` test updated to use `dsync.deleted` 
- [ ] `go build ./server/...` passes locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the nonexistent WorkOS Directory Sync event `dsync.deactivated` and all references to align with the WorkOS API. Use only `dsync.activated` and `dsync.deleted`; deletion already clears SCIM, so behavior is unchanged, and tests/comments were updated accordingly.

<sup>Written for commit 7724a8d769781ca72432bff2b9ae33fdb0cd3371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3099?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

