### PR TITLE
chore: skip pnpm modules-purge confirm in no-TTY envs

### DIFF
--- a/.mise-tasks/install/pnpm.sh
+++ b/.mise-tasks/install/pnpm.sh
@@ -12,4 +12,4 @@ if [[ "${usage_offline:-}" == "true" ]]; then
   args+=(--offline)
 fi
 
-exec pnpm i "${args[@]}"
+exec pnpm i --config.confirmModulesPurge=false "${args[@]}"


### PR DESCRIPTION
## Summary

- Pass `--config.confirmModulesPurge=false` to `pnpm i` in `.mise-tasks/install/pnpm.sh` so the install step never blocks on an interactive prompt.
- pnpm 9+ asks for confirmation before purging `node_modules` when relevant config changes; in no-TTY environments (CI, mise-spawned hooks, agent shells) the prompt hangs the task forever.

## Test plan

- [ ] `mise run install:pnpm` completes without prompting in a fresh checkout / changed package-manager scenario.
- [ ] Existing dev-machine runs still install normally (flag is a no-op when no purge is needed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `pnpm i` from hanging in CI and other no-TTY environments by disabling the modules purge confirmation. Adds `--config.confirmModulesPurge=false` to the install command in .mise-tasks/install/pnpm.sh; behavior is unchanged when no purge is needed.

<sup>Written for commit a0a06ecf79df58b97b2e3c2b97fe7df47b221f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3100?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

