### PR TITLE
wip: isolated presidio lab experiment

### DIFF
--- a/services/presidio-lab/Dockerfile
+++ b/services/presidio-lab/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/presidio-analyzer:2.2.362
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN pip install --no-cache-dir \
+    fastapi==0.115.6 \
+    uvicorn[standard]==0.32.1
+
+WORKDIR /app
+COPY app.py /app/app.py
+
+EXPOSE 3000
+
+CMD ["python", "-m", "uvicorn", "app:app", "--host", "0.0.0.0", "--port", "3000", "--workers", "1"]

--- a/services/presidio-lab/app.py
+++ b/services/presidio-lab/app.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+BASE_SUPPORTED_ENTITIES = {
+    "CREDIT_CARD",
+    "CRYPTO",
+    "DATE_TIME",
+    "DOMAIN_NAME",
+    "EMAIL_ADDRESS",
+    "IBAN_CODE",
+    "IP_ADDRESS",
+    "LOCATION",
+    "MAC_ADDRESS",
+    "MEDICAL_LICENSE",
+    "NRP",
+    "PERSON",
+    "PHONE_NUMBER",
+    "SG_NRIC_FIN",
+    "UK_NHS",
+    "URL",
+    "US_BANK_NUMBER",
+    "US_DRIVER_LICENSE",
+    "US_ITIN",
+    "US_PASSPORT",
+    "US_SSN",
+}
+
+HEALTHCARE_EXPERIMENTAL_ENTITIES = {
+    "US_MBI",
+    "US_NPI",
+    "MEDICAL_DISEASE_DISORDER",
+    "MEDICAL_MEDICATION",
+    "MEDICAL_THERAPEUTIC_PROCEDURE",
+    "MEDICAL_CLINICAL_EVENT",
+    "MEDICAL_BIOLOGICAL_ATTRIBUTE",
+    "MEDICAL_FAMILY_HISTORY",
+}
+
+SUPPORTED_ENTITIES = sorted(BASE_SUPPORTED_ENTITIES | HEALTHCARE_EXPERIMENTAL_ENTITIES)
+
+PROCEDURE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"\bcolonoscopy\b",
+        r"\bbiopsy\b",
+        r"\bmri\b",
+        r"\bct scan\b",
+        r"\bchemotherapy\b",
+        r"\bradiation therapy\b",
+        r"\bappendectomy\b",
+        r"\bdialysis\b",
+        r"\bphysical therapy\b",
+        r"\bsurgery\b",
+    ]
+]
+
+DISEASE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"\bcrohn'?s disease\b",
+        r"\bdiabetes\b",
+        r"\bhypertension\b",
+        r"\basthma\b",
+        r"\bmigraine\b",
+        r"\bcancer\b",
+        r"\bpsoriasis\b",
+        r"\bdepression\b",
+    ]
+]
+
+MEDICATION_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"\bamoxicillin\b",
+        r"\bmetformin\b",
+        r"\binsulin\b",
+        r"\blisinopril\b",
+        r"\bibuprofen\b",
+        r"\balbuterol\b",
+        r"\bsertraline\b",
+        r"\bprednisone\b",
+    ]
+]
+
+CLINICAL_EVENT_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"\bhospitalized\b",
+        r"\badmitted\b",
+        r"\bdischarged\b",
+        r"\bseizure(?: episode)?\b",
+        r"\bstroke\b",
+        r"\brelapse\b",
+        r"\bflare(?:-up)?\b",
+        r"\bpost-?op complication\b",
+        r"\ber visit\b",
+    ]
+]
+
+BIOLOGICAL_ATTRIBUTE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"\bblood pressure\b(?:\s+was|\s+of|\s*:)?\s*\d{2,3}/\d{2,3}\b",
+        r"\bheart rate\b(?:\s+was|\s+of|\s*:)?\s*\d{2,3}\b",
+        r"\ba1c\b(?:\s+was|\s+of|\s*:)?\s*\d+(?:\.\d+)?%",
+        r"\bbmi\b(?:\s+was|\s+of|\s*:)?\s*\d+(?:\.\d+)?\b",
+        r"\boxygen saturation\b(?:\s+was|\s+of|\s*:)?\s*\d+(?:\.\d+)?%",
+        r"\bhemoglobin\b(?:\s+was|\s+of|\s*:)?\s*\d+(?:\.\d+)?\b",
+    ]
+]
+
+FAMILY_HISTORY_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"\bfamily history of [^.]+",
+        r"\bmother had [^.]+",
+        r"\bfather had [^.]+",
+        r"\bsister had [^.]+",
+        r"\bbrother had [^.]+",
+        r"\bruns in the family\b",
+    ]
+]
+
+MEDICAL_LICENSE_PATTERN = re.compile(r"\bMD\d{6}\b")
+US_NPI_PATTERN = re.compile(r"\b\d{10}\b")
+US_MBI_PATTERN = re.compile(r"\b[1-9][A-Z]{2}\d[A-Z]{2}\d[A-Z]{2}\d{2}\b")
+
+
+@dataclass(frozen=True)
+class Detection:
+    entity_type: str
+    start: int
+    end: int
+    score: float
+
+    def to_dict(self) -> dict[str, int | float | str]:
+        return {
+            "entity_type": self.entity_type,
+            "start": self.start,
+            "end": self.end,
+            "score": self.score,
+        }
+
+
+class AnalyzeRequest(BaseModel):
+    text: list[str] = Field(default_factory=list)
+    language: str = "en"
+    score_threshold: float = 0.0
+    entities: list[str] | None = None
+
+
+app = FastAPI(title="Gram Presidio Lab")
+
+
+@app.get("/health")
+def health() -> str:
+    return "Presidio Analyzer service is up"
+
+
+@app.get("/supportedentities")
+def supported_entities() -> list[str]:
+    return SUPPORTED_ENTITIES
+
+
+@app.post("/analyze")
+def analyze(request: AnalyzeRequest) -> list[list[dict[str, int | float | str]]]:
+    if not request.text:
+        raise HTTPException(status_code=500, detail="No text provided")
+
+    allowed = requested_entities(request.entities)
+    response: list[list[dict[str, int | float | str]]] = []
+    for text in request.text:
+        detections = detect_text(text, allowed)
+        detections = [d for d in detections if d.score >= request.score_threshold]
+        detections.sort(key=lambda item: (item.start, item.end, item.entity_type))
+        response.append([d.to_dict() for d in dedupe(detections)])
+    return response
+
+
+def requested_entities(entities: list[str] | None) -> set[str]:
+    if not entities:
+        return set(SUPPORTED_ENTITIES)
+    return {entity for entity in entities if entity in SUPPORTED_ENTITIES}
+
+
+def detect_text(text: str, allowed: set[str]) -> list[Detection]:
+    detections: list[Detection] = []
+
+    if "MEDICAL_LICENSE" in allowed:
+        detections.extend(match_pattern(text, MEDICAL_LICENSE_PATTERN, "MEDICAL_LICENSE", 0.9))
+    if "US_NPI" in allowed:
+        detections.extend(detect_npi(text))
+    if "US_MBI" in allowed:
+        detections.extend(match_pattern(text, US_MBI_PATTERN, "US_MBI", 0.92))
+    if "MEDICAL_DISEASE_DISORDER" in allowed:
+        detections.extend(match_patterns(text, DISEASE_PATTERNS, "MEDICAL_DISEASE_DISORDER", 0.85))
+    if "MEDICAL_MEDICATION" in allowed:
+        detections.extend(match_patterns(text, MEDICATION_PATTERNS, "MEDICAL_MEDICATION", 0.84))
+    if "MEDICAL_THERAPEUTIC_PROCEDURE" in allowed:
+        detections.extend(match_patterns(text, PROCEDURE_PATTERNS, "MEDICAL_THERAPEUTIC_PROCEDURE", 0.87))
+    if "MEDICAL_CLINICAL_EVENT" in allowed:
+        detections.extend(match_patterns(text, CLINICAL_EVENT_PATTERNS, "MEDICAL_CLINICAL_EVENT", 0.83))
+    if "MEDICAL_BIOLOGICAL_ATTRIBUTE" in allowed:
+        detections.extend(match_patterns(text, BIOLOGICAL_ATTRIBUTE_PATTERNS, "MEDICAL_BIOLOGICAL_ATTRIBUTE", 0.9))
+    if "MEDICAL_FAMILY_HISTORY" in allowed:
+        detections.extend(match_patterns(text, FAMILY_HISTORY_PATTERNS, "MEDICAL_FAMILY_HISTORY", 0.88))
+
+    return detections
+
+
+def match_pattern(text: str, pattern: re.Pattern[str], entity_type: str, score: float) -> list[Detection]:
+    return [
+        Detection(entity_type=entity_type, start=match.start(), end=match.end(), score=score)
+        for match in pattern.finditer(text)
+    ]
+
+
+def match_patterns(
+    text: str,
+    patterns: Iterable[re.Pattern[str]],
+    entity_type: str,
+    score: float,
+) -> list[Detection]:
+    detections: list[Detection] = []
+    for pattern in patterns:
+        detections.extend(match_pattern(text, pattern, entity_type, score))
+    return detections
+
+
+def detect_npi(text: str) -> list[Detection]:
+    detections: list[Detection] = []
+    for match in US_NPI_PATTERN.finditer(text):
+        candidate = match.group(0)
+        if not has_npi_context(text, match.start(), match.end()):
+            continue
+        if not is_valid_npi(candidate):
+            continue
+        detections.append(
+            Detection(
+                entity_type="US_NPI",
+                start=match.start(),
+                end=match.end(),
+                score=0.94,
+            )
+        )
+    return detections
+
+
+def has_npi_context(text: str, start: int, end: int) -> bool:
+    left = text[max(0, start - 24) : start].lower()
+    right = text[end : min(len(text), end + 24)].lower()
+    context = f"{left} {right}"
+    return "npi" in context or "provider" in context
+
+
+def is_valid_npi(value: str) -> bool:
+    if len(value) != 10 or not value.isdigit():
+        return False
+    digits = [int(char) for char in ("80840" + value[:9])]
+    total = 0
+    for index, digit in enumerate(reversed(digits), start=1):
+        if index % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit = digit // 10 + digit % 10
+        total += digit
+    check_digit = (10 - (total % 10)) % 10
+    return check_digit == int(value[-1])
+
+
+def dedupe(detections: Iterable[Detection]) -> list[Detection]:
+    best: dict[tuple[str, int, int], Detection] = {}
+    for detection in detections:
+        key = (detection.entity_type, detection.start, detection.end)
+        existing = best.get(key)
+        if existing is None or detection.score > existing.score:
+            best[key] = detection
+    return list(best.values())

--- a/services/presidio-lab/cases.json
+++ b/services/presidio-lab/cases.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "medical-license-control",
+    "entity": "MEDICAL_LICENSE",
+    "text": "Physician license MD123456 was renewed before onboarding."
+  },
+  {
+    "id": "us-mbi",
+    "entity": "US_MBI",
+    "text": "The patient confirmed Medicare ID 1EG4TE5MK73 during intake."
+  },
+  {
+    "id": "us-npi",
+    "entity": "US_NPI",
+    "text": "Referring provider NPI 1234567893 is listed on the claim."
+  },
+  {
+    "id": "disease-disorder",
+    "entity": "MEDICAL_DISEASE_DISORDER",
+    "text": "She was diagnosed with Crohn's disease after the GI workup."
+  },
+  {
+    "id": "medication",
+    "entity": "MEDICAL_MEDICATION",
+    "text": "He started amoxicillin 500 mg twice daily after the visit."
+  },
+  {
+    "id": "therapeutic-procedure",
+    "entity": "MEDICAL_THERAPEUTIC_PROCEDURE",
+    "text": "He underwent a colonoscopy after the positive screening result."
+  },
+  {
+    "id": "clinical-event",
+    "entity": "MEDICAL_CLINICAL_EVENT",
+    "text": "She was hospitalized after a seizure episode last weekend."
+  },
+  {
+    "id": "biological-attribute",
+    "entity": "MEDICAL_BIOLOGICAL_ATTRIBUTE",
+    "text": "Her blood pressure was 168/96 and A1C was 8.4% at triage."
+  },
+  {
+    "id": "family-history",
+    "entity": "MEDICAL_FAMILY_HISTORY",
+    "text": "Family history of breast cancer was noted on the maternal side."
+  }
+]

--- a/services/presidio-lab/evaluate.py
+++ b/services/presidio-lab/evaluate.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+CUSTOM_IMAGE = "gram-presidio-lab:local"
+DEFAULT_BASELINE_URL = "http://127.0.0.1:5050"
+
+
+@dataclass
+class ServiceResult:
+    name: str
+    supported_entities: list[str] | None
+    cases: list[dict[str, object]]
+
+    @property
+    def hits(self) -> int:
+        return sum(1 for case in self.cases if case["matched"])
+
+    @property
+    def total(self) -> int:
+        return len(self.cases)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline-url", default=DEFAULT_BASELINE_URL)
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+
+    cases = json.loads((ROOT / "cases.json").read_text())
+
+    if not args.skip_build:
+        run(["docker", "build", "-t", CUSTOM_IMAGE, str(ROOT)])
+
+    custom = Container(CUSTOM_IMAGE, 13002, "presidio-custom")
+
+    try:
+        custom.start()
+
+        baseline_result = evaluate_service("baseline", args.baseline_url, cases)
+        custom_result = evaluate_service("custom", custom.base_url, cases)
+        emit_report(baseline_result, custom_result)
+    finally:
+        custom.stop()
+
+    return 0
+
+
+class Container:
+    def __init__(self, image: str, port: int, name_prefix: str) -> None:
+        self.image = image
+        self.port = port
+        self.name = f"{name_prefix}-{int(time.time())}"
+        self.base_url = f"http://127.0.0.1:{port}"
+
+    def start(self) -> None:
+        run(["docker", "rm", "-f", self.name], check=False)
+        run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-d",
+                "--name",
+                self.name,
+                "-p",
+                f"{self.port}:3000",
+                self.image,
+            ]
+        )
+        wait_for_health(self.base_url)
+
+    def stop(self) -> None:
+        run(["docker", "rm", "-f", self.name], check=False)
+
+
+def evaluate_service(name: str, base_url: str, cases: list[dict[str, str]]) -> ServiceResult:
+    supported_entities = fetch_supported_entities(base_url)
+    results: list[dict[str, object]] = []
+    for case in cases:
+        payload = {
+            "text": [case["text"]],
+            "language": "en",
+            "score_threshold": 0.0,
+            "entities": [case["entity"]],
+        }
+        status_code, body = post_json(f"{base_url}/analyze", payload)
+        parsed = None
+        matched = False
+        if status_code == 200:
+            parsed = json.loads(body)
+            findings = parsed[0] if parsed else []
+            matched = any(finding.get("entity_type") == case["entity"] for finding in findings)
+        results.append(
+            {
+                "id": case["id"],
+                "entity": case["entity"],
+                "status_code": status_code,
+                "matched": matched,
+                "body": parsed if parsed is not None else body,
+            }
+        )
+    return ServiceResult(name=name, supported_entities=supported_entities, cases=results)
+
+
+def emit_report(baseline: ServiceResult, custom: ServiceResult) -> None:
+    print()
+    print(f"baseline supported entities: {len(baseline.supported_entities or [])}")
+    print(f"custom supported entities:   {len(custom.supported_entities or [])}")
+    print()
+    print("case                           entity                              baseline  custom")
+    print("------------------------------------------------------------------------------------")
+    custom_by_id = {case["id"]: case for case in custom.cases}
+    for baseline_case in baseline.cases:
+        custom_case = custom_by_id[baseline_case["id"]]
+        print(
+            f"{baseline_case['id']:<30} "
+            f"{baseline_case['entity']:<35} "
+            f"{format_case(baseline_case):<9} "
+            f"{format_case(custom_case):<9}"
+        )
+    print("------------------------------------------------------------------------------------")
+    print(f"coverage hits                    {baseline.hits}/{baseline.total}    {custom.hits}/{custom.total}")
+
+
+def format_case(case: dict[str, object]) -> str:
+    if case["matched"]:
+        return "hit"
+    return f"http{case['status_code']}"
+
+
+def fetch_supported_entities(base_url: str) -> list[str] | None:
+    try:
+        with urllib.request.urlopen(f"{base_url}/supportedentities", timeout=5) as response:
+            if response.status != 200:
+                return None
+            parsed = json.loads(response.read().decode("utf-8"))
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed]
+    except Exception:
+        return None
+    return None
+
+
+def post_json(url: str, payload: dict[str, object]) -> tuple[int, str]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def wait_for_health(base_url: str) -> None:
+    deadline = time.time() + 180
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/health", timeout=5) as response:
+                if response.status == 200:
+                    return
+        except Exception:
+            pass
+        time.sleep(2)
+    raise RuntimeError(f"timed out waiting for {base_url}/health")
+
+
+def run(command: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, text=True, capture_output=True, check=False)
+    if check and result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise SystemExit(result.returncode)
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an isolated `services/presidio-lab` experiment with a Presidio-compatible API
- cover the currently broken healthcare entity surface with synthetic recognizers and deterministic cases
- add a baseline-vs-custom comparison harness for quick local coverage checks

## Validation
- rtk python services/presidio-lab/evaluate.py

## Notes
- this is intentionally not production wiring
- the current experiment is heuristic-driven and demonstrates synthetic coverage movement, not production precision/recall


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an isolated Presidio Lab service to prototype healthcare entity coverage and a local harness to compare it against the baseline. Helps validate coverage improvements without touching production.

- **New Features**
  - New `services/presidio-lab` service with a Presidio-compatible API (`/health`, `/supportedentities`, `/analyze`).
  - Experimental healthcare recognizers: `US_NPI` (Luhn + context), `US_MBI`, and `MEDICAL_*` categories via simple patterns.
  - Deterministic cases in `cases.json` and a baseline-vs-custom comparison script (`evaluate.py`) that builds/runs the Docker image and prints a coverage report.

- **Migration**
  - Run the local comparison: rtk python services/presidio-lab/evaluate.py [--baseline-url http://127.0.0.1:5050]

<sup>Written for commit f06cc537882db88afbb28debbba0c57e87716291. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3101?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

