### PR TITLE
chore(dashboard): hide detection rule severity from UI

### DIFF
--- a/client/dashboard/src/pages/security/DetectionRules.tsx
+++ b/client/dashboard/src/pages/security/DetectionRules.tsx
@@ -5,13 +5,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -222,7 +215,6 @@ function CustomRulesSection({
                 key={rule.id}
                 title={rule.title || rule.id}
                 subtitle={rule.id}
-                severity={rule.severity}
                 onClick={() => onSelect(rule)}
               />
             ))}
@@ -273,7 +265,6 @@ function BuiltinRulesSection({
                       key={rule.id}
                       title={rule.title}
                       subtitle={rule.id}
-                      severity={rule.defaultSeverity}
                       onClick={() => onSelect(rule)}
                     />
                   ))}
@@ -335,12 +326,10 @@ function CategoryHeader({
 function RuleRow({
   title,
   subtitle,
-  severity,
   onClick,
 }: {
   title: string;
   subtitle: string;
-  severity: SeverityLevel;
   onClick: () => void;
 }) {
   return (
@@ -355,7 +344,6 @@ function RuleRow({
           {subtitle}
         </div>
       </div>
-      <SeverityBadge severity={severity} />
       <ChevronRight className="text-muted-foreground size-4 shrink-0" />
     </button>
   );
@@ -1387,25 +1375,6 @@ function CreateCustomRuleSheet({
                     full scanned payload.
                   </p>
                 )}
-              </div>
-
-              <div className="space-y-2">
-                <Label className="text-sm font-medium">Default severity</Label>
-                <Select
-                  value={severity}
-                  onValueChange={(v) => setSeverity(v as SeverityLevel)}
-                >
-                  <SelectTrigger className="w-[160px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {SEVERITY_LEVELS.map((level) => (
-                      <SelectItem key={level} value={level}>
-                        {SEVERITY_META[level].label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
               </div>
             </div>
             <SheetFooter className="border-border flex-row items-center justify-between border-t px-6 py-4">


### PR DESCRIPTION




https://github.com/user-attachments/assets/cb813749-dc02-42ab-ba4b-5c3abdb72b89



## Summary

- Removes the severity badge from detection rule rows in both custom and built-in rule lists
- Removes the "Default severity" dropdown from the create custom rule form
- Cleans up the now-unused `Select*` component imports

Severity state is still tracked internally and sent to the API (defaulting to `"medium"`, populated from AI suggestions) — it's just no longer displayed or user-configurable in the UI.

## Test plan

- [ ] Open the Security > Detection Rules page and confirm no severity badges appear in the rule list
- [ ] Open the "Create custom rule" sheet and confirm the "Default severity" dropdown is gone
- [ ] Confirm existing custom rules and built-in rules still load and open their detail sheet correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide detection rule severity in the dashboard UI. Removes severity badges from rule lists and the "Default severity" field in the create rule sheet; severity is still sent to the API (default "medium"), and unused `Select` imports are removed.

<sup>Written for commit 9b10c20e28d1277088cafa94aa6d62cab13ffa43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3103?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



