### PR TITLE
mig: ip allowlist CRUD

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -612,6 +612,8 @@ CREATE TABLE IF NOT EXISTS custom_domains (
   cert_secret_name TEXT,
   -- Discriminates which K8s API provisioned this domain. Gateway rows write NULL cert_secret_name.
   provisioner_kind TEXT NOT NULL DEFAULT 'ingress',
+  -- IP addresses or CIDR ranges allowed to access this domain. Empty array = unrestricted.
+  ip_allowlist TEXT[] NOT NULL DEFAULT '{}',
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   deleted_at timestamptz,

--- a/server/internal/customdomains/repo/models.go
+++ b/server/internal/customdomains/repo/models.go
@@ -18,6 +18,7 @@ type CustomDomain struct {
 	IngressName     pgtype.Text
 	CertSecretName  pgtype.Text
 	ProvisionerKind string
+	IpAllowlist     []string
 	CreatedAt       pgtype.Timestamptz
 	UpdatedAt       pgtype.Timestamptz
 	DeletedAt       pgtype.Timestamptz

--- a/server/internal/customdomains/repo/queries.sql.go
+++ b/server/internal/customdomains/repo/queries.sql.go
@@ -26,7 +26,7 @@ INSERT INTO custom_domains (
     $4,
     $5
 )
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateCustomDomainParams struct {
@@ -55,6 +55,7 @@ func (q *Queries) CreateCustomDomain(ctx context.Context, arg CreateCustomDomain
 		&i.IngressName,
 		&i.CertSecretName,
 		&i.ProvisionerKind,
+		&i.IpAllowlist,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -76,7 +77,7 @@ func (q *Queries) DeleteCustomDomain(ctx context.Context, organizationID string)
 }
 
 const getCustomDomainByDomain = `-- name: GetCustomDomainByDomain :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE domain = $1
   AND deleted IS FALSE
@@ -94,6 +95,7 @@ func (q *Queries) GetCustomDomainByDomain(ctx context.Context, domain string) (C
 		&i.IngressName,
 		&i.CertSecretName,
 		&i.ProvisionerKind,
+		&i.IpAllowlist,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -103,7 +105,7 @@ func (q *Queries) GetCustomDomainByDomain(ctx context.Context, domain string) (C
 }
 
 const getCustomDomainByID = `-- name: GetCustomDomainByID :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND deleted IS FALSE
@@ -121,6 +123,7 @@ func (q *Queries) GetCustomDomainByID(ctx context.Context, id uuid.UUID) (Custom
 		&i.IngressName,
 		&i.CertSecretName,
 		&i.ProvisionerKind,
+		&i.IpAllowlist,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -130,7 +133,7 @@ func (q *Queries) GetCustomDomainByID(ctx context.Context, id uuid.UUID) (Custom
 }
 
 const getCustomDomainByIDAndOrganization = `-- name: GetCustomDomainByIDAndOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND organization_id = $2
@@ -158,6 +161,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganization(ctx context.Context, arg Ge
 		&i.IngressName,
 		&i.CertSecretName,
 		&i.ProvisionerKind,
+		&i.IpAllowlist,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -167,7 +171,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganization(ctx context.Context, arg Ge
 }
 
 const getCustomDomainByOrganization = `-- name: GetCustomDomainByOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE organization_id = $1
   AND deleted IS FALSE
@@ -186,6 +190,7 @@ func (q *Queries) GetCustomDomainByOrganization(ctx context.Context, organizatio
 		&i.IngressName,
 		&i.CertSecretName,
 		&i.ProvisionerKind,
+		&i.IpAllowlist,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -205,7 +210,7 @@ SET
     updated_at = clock_timestamp()
 WHERE id = $6
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainParams struct {
@@ -236,6 +241,7 @@ func (q *Queries) UpdateCustomDomain(ctx context.Context, arg UpdateCustomDomain
 		&i.IngressName,
 		&i.CertSecretName,
 		&i.ProvisionerKind,
+		&i.IpAllowlist,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -306,6 +306,7 @@ type CustomDomain struct {
 	IngressName     pgtype.Text
 	CertSecretName  pgtype.Text
 	ProvisionerKind string
+	IpAllowlist     []string
 	CreatedAt       pgtype.Timestamptz
 	UpdatedAt       pgtype.Timestamptz
 	DeletedAt       pgtype.Timestamptz

--- a/server/migrations/20260528160651_add-ip-allowlist-to-custom-domains.sql
+++ b/server/migrations/20260528160651_add-ip-allowlist-to-custom-domains.sql
@@ -1,0 +1,2 @@
+-- Modify "custom_domains" table
+ALTER TABLE "custom_domains" ADD COLUMN "ip_allowlist" text[] NOT NULL DEFAULT '{}';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WpO3t/j2s1Y3t8G1YwdMrkRRLkeeFMujFCzteCK/A3c=
+h1:Dy9XcegwBCTlZeicP0/HAlMlaJsZin30UsA/9yrH5EE=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -195,4 +195,5 @@ h1:WpO3t/j2s1Y3t8G1YwdMrkRRLkeeFMujFCzteCK/A3c=
 20260528094046_chat-messages-add-risk-analyzed-at.sql h1:p0/C4C1jFr/WH5l/W4fSLi+yqBP0EQYYWD5j6WB3Stk=
 20260528120324_add-custom-detection-rules.sql h1:nvGeihJOJMbo8CUamKuoMlHi6D8r9jJtMK80c+X60NU=
 20260528145659_add-mcp-server-id-to-mcp-metadata.sql h1:fnNq7bTqxCG1Ipb70XLaZh9oZcypAonT/OvqOlQH8oI=
-20260528192406_age-2484-remote-session-issuers-organization-id.sql h1:ptd3XyEBDWDB1mrd4Xsg3u2dj/W79WcRch4X8myUYbw=
+20260528160651_add-ip-allowlist-to-custom-domains.sql h1:EjdYjlXcbId4zUx77nbl3/n9O4fyxbGkaIDyDqKfu+E=
+20260528192406_age-2484-remote-session-issuers-organization-id.sql h1:D5XNnqNsDqW5UxQlDbg9vdq1mk8qRtGtEF6w1sGXiaI=


### PR DESCRIPTION
Schema and migrations split off `worktree-feat+ip_allowlist_crud` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IP allowlist support to custom domains by adding an `ip_allowlist` text[] column and wiring it through repo models and generated queries. Preps the system for future CRUD and enforcement; no behavior change today.

- **Migration**
  - Adds `ip_allowlist` text[] NOT NULL DEFAULT '{}'.
  - Empty array = unrestricted access.
  - Run migrations; no backfill or downtime required.

<sup>Written for commit ef762be7a0d35edb4d61fd7b039dc922945aeae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

