### PR TITLE
chore: prevent go.sum drift from goa codegen scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ report.md
 /posting.env
 /client/sdk/docs
 /server/goa*
+/dev-idp/goa*
 /server/gram
 /server/risk_accuracy_metrics.json
 # Goa generates OpenAPI specs with non-deterministic examples. Nothing consumes them.

--- a/.mise-tasks/gen/devidp.sh
+++ b/.mise-tasks/gen/devidp.sh
@@ -5,4 +5,24 @@
 
 set -e
 
-exec goa gen github.com/speakeasy-api/gram/dev-idp/design -o .
+# `goa gen` writes a throwaway `goa<random>/main.go` generator into its working
+# directory. goa removes it on both success and failure, but on a hard interrupt
+# (Ctrl-C) or --debug it can linger. That main imports goa's codegen deps
+# (kin-openapi, mohae/deepcopy, ...), so a later `go mod tidy` walks the orphaned
+# package and writes spurious go.sum entries that CI then flags as dirty
+# (AGE-2621); dev-idp shares the root go.mod, so it has the same exposure. The
+# pre-run sweep clears any stale scratch from a crashed prior run; the trap removes
+# it on exit while preserving goa's exit code.
+#
+# Invoke goa via `go tool` so codegen always uses the version pinned by the
+# `tool` directive in go.mod rather than whichever `goa` happens to be on PATH;
+# version drift would otherwise show up as unexpected generated-output diffs.
+cleanup() {
+  rc=$?
+  rm -rf goa*
+  exit "$rc"
+}
+trap cleanup EXIT
+
+rm -rf goa*
+go tool goa gen github.com/speakeasy-api/gram/dev-idp/design -o .

--- a/.mise-tasks/gen/goa-server.sh
+++ b/.mise-tasks/gen/goa-server.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
+
 #MISE dir="{{ config_root }}/server"
 #MISE description="Generate from Goa design files"
 
 set -e
-exec goa gen github.com/speakeasy-api/gram/server/design
+
+# `goa gen` writes a throwaway `goa<random>/main.go` generator into its working
+# directory. goa removes it on both success and failure, but on a hard interrupt
+# (Ctrl-C) or --debug it can linger. That main imports goa's codegen deps
+# (kin-openapi, mohae/deepcopy, ...), so a later `go mod tidy` walks the orphaned
+# package and writes spurious go.sum entries that CI then flags as dirty
+# (AGE-2621). The pre-run sweep clears any stale scratch from a crashed prior run;
+# the trap removes it on exit while preserving goa's exit code.
+#
+# Invoke goa via `go tool` so codegen always uses the version pinned by the
+# `tool` directive in go.mod rather than whichever `goa` happens to be on PATH;
+# version drift would otherwise show up as unexpected generated-output diffs.
+cleanup() {
+  rc=$?
+  rm -rf goa*
+  exit "$rc"
+}
+trap cleanup EXIT
+
+rm -rf goa*
+go tool goa gen github.com/speakeasy-api/gram/server/design


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2621/prevent-unexpected-gosum-differences-after-gengoa-server-task

`goa gen` writes a throwaway `goa<random>/main.go` generator into its working directory. It normally removes it, but on a hard interrupt (Ctrl-C) or `--debug` it can linger; because that main imports goa's codegen deps (kin-openapi, mohae/deepcopy, ...), a later `go mod tidy` walks the orphaned package and writes spurious go.sum entries that CI flags as dirty on a fresh checkout.

The `gen:goa-server` and `gen:devidp` tasks now sweep any stale scratch before running and remove it on exit via a trap (preserving goa's exit code). `/dev-idp/goa*` is added to `.gitignore` to match the existing `/server/goa*` entry, since dev-idp shares the root go.mod and had the same exposure.

Both tasks also now invoke goa via `go tool` so codegen uses the version pinned by the go.mod `tool` directive rather than whichever `goa` is on PATH, removing version drift as another source of unexpected diffs.