### PR TITLE
chore: add policy audience authz foundation

### DIFF
--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -310,33 +310,12 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 		attr.AccessMemberID(ac.UserID),
 	)
 
-	connectedUser, err := connectedUser(ctx, s.db, ac.ActiveOrganizationID, ac.UserID)
+	principals, err := authz.ResolveUserPrincipals(ctx, s.db, ac.ActiveOrganizationID, ac.UserID)
 	switch {
-	case errors.Is(err, errConnectedUserNotFound):
+	case errors.Is(err, authz.ErrPrincipalNotFound):
 		return nil, oops.E(oops.CodeNotFound, nil, "current user has not joined this organization").Log(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "load connected user").Log(ctx, logger)
-	}
-
-	principals := []urn.Principal{urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID)}
-	rolePrincipals, err := s.roleMgr.MemberRolePrincipals(ctx, ac.ActiveOrganizationID, connectedUser.WorkosID.String)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list member roles").Log(ctx, logger)
-	}
-	roleSlugs := make([]string, 0, len(rolePrincipals))
-	for _, role := range rolePrincipals {
-		// Effective-grant responses must include grants stored under either the
-		// canonical role URN or the legacy role slug during the migration.
-		rolePrincipalURNs, err := authz.RolePrincipals(role.RoleSlug, role.PrincipalUrn)
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "build role principals").Log(ctx, logger)
-		}
-		principals = append(principals, rolePrincipalURNs...)
-		roleSlugs = append(roleSlugs, role.RoleSlug)
-	}
-	if len(roleSlugs) == 1 {
-		logger = logger.With(attr.SlogAccessRoleSlug(roleSlugs[0]))
-		trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSlug(roleSlugs[0]))
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve user principals").Log(ctx, logger)
 	}
 
 	grants, err := authz.LoadGrants(ctx, s.db, ac.ActiveOrganizationID, principals)

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -17,6 +17,18 @@ FROM principal_grants
 WHERE organization_id = @organization_id
   AND principal_urn = ANY(@principal_urns::text[]);
 
+-- name: ListPrincipalGrantsByResource :many
+-- Returns grant rows for a single resource selector.
+SELECT principal_urn, scope, effect, selectors
+FROM principal_grants
+WHERE organization_id = @organization_id
+  AND scope = @scope
+  AND selectors @> jsonb_build_object(
+    'resource_kind', sqlc.arg(resource_kind)::text,
+    'resource_id', sqlc.arg(resource_id)::text
+  )
+ORDER BY principal_urn;
+
 -- name: UpsertPrincipalGrant :one
 -- Creates or updates a single grant row. On conflict (same org/principal/scope/effect/selectors),
 -- the updated_at is refreshed. Uses COALESCE to match the functional unique index.
@@ -32,12 +44,35 @@ DELETE FROM principal_grants
 WHERE id = @id
   AND organization_id = @organization_id;
 
+-- name: DeletePrincipalGrantsByResource :execrows
+-- Removes grant rows for a single resource selector.
+DELETE FROM principal_grants
+WHERE organization_id = @organization_id
+  AND scope = @scope
+  AND selectors @> jsonb_build_object(
+    'resource_kind', sqlc.arg(resource_kind)::text,
+    'resource_id', sqlc.arg(resource_id)::text
+  );
+
 -- name: DeletePrincipalGrantsByPrincipal :execrows
 -- Removes all grants for a specific principal within an org.
 -- Useful when removing a user from an organization.
 DELETE FROM principal_grants
 WHERE organization_id = @organization_id
   AND principal_urn = @principal_urn;
+
+-- name: HasActiveOrganizationUser :one
+-- Returns whether a Gram user is an active member of the organization.
+SELECT EXISTS(
+  SELECT 1
+  FROM users
+  JOIN organization_user_relationships
+    ON organization_user_relationships.user_id = users.id
+  WHERE users.id = @user_id
+    AND users.deleted_at IS NULL
+    AND organization_user_relationships.organization_id = @organization_id
+    AND organization_user_relationships.deleted_at IS NULL
+) AS exists;
 
 -- Queries for authz challenge resolutions.
 -- authz_challenge_resolutions is org-scoped (no project_id).
@@ -431,6 +466,26 @@ LEFT JOIN global_roles
   AND global_roles.workos_deleted IS FALSE
 WHERE ora.organization_id = @organization_id
   AND ora.workos_user_id = @workos_user_id
+  AND COALESCE(organization_roles.workos_slug, global_roles.workos_slug) IS NOT NULL
+  AND ora.deleted_at IS NULL
+ORDER BY role_slug;
+
+-- name: ListMemberRolePrincipalsByUser :many
+SELECT
+  COALESCE(organization_roles.workos_slug, global_roles.workos_slug)::text AS role_slug,
+  ora.role_urn::text AS principal_urn
+FROM organization_role_assignments AS ora
+LEFT JOIN organization_roles
+  ON ora.role_urn = 'role:organization:' || organization_roles.id::text
+  AND organization_roles.organization_id = ora.organization_id
+  AND organization_roles.deleted IS FALSE
+  AND organization_roles.workos_deleted IS FALSE
+LEFT JOIN global_roles
+  ON ora.role_urn = 'role:global:' || global_roles.id::text
+  AND global_roles.deleted IS FALSE
+  AND global_roles.workos_deleted IS FALSE
+WHERE ora.organization_id = @organization_id
+  AND ora.user_id = sqlc.arg(user_id)::text
   AND COALESCE(organization_roles.workos_slug, global_roles.workos_slug) IS NOT NULL
   AND ora.deleted_at IS NULL
 ORDER BY role_slug;

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -61,19 +61,6 @@ DELETE FROM principal_grants
 WHERE organization_id = @organization_id
   AND principal_urn = @principal_urn;
 
--- name: HasActiveOrganizationUser :one
--- Returns whether a Gram user is an active member of the organization.
-SELECT EXISTS(
-  SELECT 1
-  FROM users
-  JOIN organization_user_relationships
-    ON organization_user_relationships.user_id = users.id
-  WHERE users.id = @user_id
-    AND users.deleted_at IS NULL
-    AND organization_user_relationships.organization_id = @organization_id
-    AND organization_user_relationships.deleted_at IS NULL
-) AS exists;
-
 -- Queries for authz challenge resolutions.
 -- authz_challenge_resolutions is org-scoped (no project_id).
 

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -392,32 +392,6 @@ func (q *Queries) GetPrincipalGrants(ctx context.Context, arg GetPrincipalGrants
 	return items, nil
 }
 
-const hasActiveOrganizationUser = `-- name: HasActiveOrganizationUser :one
-SELECT EXISTS(
-  SELECT 1
-  FROM users
-  JOIN organization_user_relationships
-    ON organization_user_relationships.user_id = users.id
-  WHERE users.id = $1
-    AND users.deleted_at IS NULL
-    AND organization_user_relationships.organization_id = $2
-    AND organization_user_relationships.deleted_at IS NULL
-) AS exists
-`
-
-type HasActiveOrganizationUserParams struct {
-	UserID         string
-	OrganizationID string
-}
-
-// Returns whether a Gram user is an active member of the organization.
-func (q *Queries) HasActiveOrganizationUser(ctx context.Context, arg HasActiveOrganizationUserParams) (bool, error) {
-	row := q.db.QueryRow(ctx, hasActiveOrganizationUser, arg.UserID, arg.OrganizationID)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
-}
-
 const insertChallengeResolutions = `-- name: InsertChallengeResolutions :many
 INSERT INTO authz_challenge_resolutions (
   organization_id, challenge_id, principal_urn, scope,

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -54,6 +54,37 @@ func (q *Queries) DeletePrincipalGrantsByPrincipal(ctx context.Context, arg Dele
 	return result.RowsAffected(), nil
 }
 
+const deletePrincipalGrantsByResource = `-- name: DeletePrincipalGrantsByResource :execrows
+DELETE FROM principal_grants
+WHERE organization_id = $1
+  AND scope = $2
+  AND selectors @> jsonb_build_object(
+    'resource_kind', $3::text,
+    'resource_id', $4::text
+  )
+`
+
+type DeletePrincipalGrantsByResourceParams struct {
+	OrganizationID string
+	Scope          string
+	ResourceKind   string
+	ResourceID     string
+}
+
+// Removes grant rows for a single resource selector.
+func (q *Queries) DeletePrincipalGrantsByResource(ctx context.Context, arg DeletePrincipalGrantsByResourceParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deletePrincipalGrantsByResource,
+		arg.OrganizationID,
+		arg.Scope,
+		arg.ResourceKind,
+		arg.ResourceID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getActiveOrganizationRoleBySlug = `-- name: GetActiveOrganizationRoleBySlug :one
 WITH active_roles AS (
   SELECT id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at, 'global'::text AS role_kind
@@ -359,6 +390,32 @@ func (q *Queries) GetPrincipalGrants(ctx context.Context, arg GetPrincipalGrants
 		return nil, err
 	}
 	return items, nil
+}
+
+const hasActiveOrganizationUser = `-- name: HasActiveOrganizationUser :one
+SELECT EXISTS(
+  SELECT 1
+  FROM users
+  JOIN organization_user_relationships
+    ON organization_user_relationships.user_id = users.id
+  WHERE users.id = $1
+    AND users.deleted_at IS NULL
+    AND organization_user_relationships.organization_id = $2
+    AND organization_user_relationships.deleted_at IS NULL
+) AS exists
+`
+
+type HasActiveOrganizationUserParams struct {
+	UserID         string
+	OrganizationID string
+}
+
+// Returns whether a Gram user is an active member of the organization.
+func (q *Queries) HasActiveOrganizationUser(ctx context.Context, arg HasActiveOrganizationUserParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasActiveOrganizationUser, arg.UserID, arg.OrganizationID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
 }
 
 const insertChallengeResolutions = `-- name: InsertChallengeResolutions :many
@@ -689,6 +746,57 @@ func (q *Queries) ListGlobalRoles(ctx context.Context) ([]GlobalRole, error) {
 			&i.DeletedAt,
 			&i.Deleted,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listMemberRolePrincipalsByUser = `-- name: ListMemberRolePrincipalsByUser :many
+SELECT
+  COALESCE(organization_roles.workos_slug, global_roles.workos_slug)::text AS role_slug,
+  ora.role_urn::text AS principal_urn
+FROM organization_role_assignments AS ora
+LEFT JOIN organization_roles
+  ON ora.role_urn = 'role:organization:' || organization_roles.id::text
+  AND organization_roles.organization_id = ora.organization_id
+  AND organization_roles.deleted IS FALSE
+  AND organization_roles.workos_deleted IS FALSE
+LEFT JOIN global_roles
+  ON ora.role_urn = 'role:global:' || global_roles.id::text
+  AND global_roles.deleted IS FALSE
+  AND global_roles.workos_deleted IS FALSE
+WHERE ora.organization_id = $1
+  AND ora.user_id = $2::text
+  AND COALESCE(organization_roles.workos_slug, global_roles.workos_slug) IS NOT NULL
+  AND ora.deleted_at IS NULL
+ORDER BY role_slug
+`
+
+type ListMemberRolePrincipalsByUserParams struct {
+	OrganizationID string
+	UserID         string
+}
+
+type ListMemberRolePrincipalsByUserRow struct {
+	RoleSlug     string
+	PrincipalUrn string
+}
+
+func (q *Queries) ListMemberRolePrincipalsByUser(ctx context.Context, arg ListMemberRolePrincipalsByUserParams) ([]ListMemberRolePrincipalsByUserRow, error) {
+	rows, err := q.db.Query(ctx, listMemberRolePrincipalsByUser, arg.OrganizationID, arg.UserID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListMemberRolePrincipalsByUserRow
+	for rows.Next() {
+		var i ListMemberRolePrincipalsByUserRow
+		if err := rows.Scan(&i.RoleSlug, &i.PrincipalUrn); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -1034,6 +1142,63 @@ func (q *Queries) ListPrincipalGrantsByOrg(ctx context.Context, arg ListPrincipa
 			&i.Selectors,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPrincipalGrantsByResource = `-- name: ListPrincipalGrantsByResource :many
+SELECT principal_urn, scope, effect, selectors
+FROM principal_grants
+WHERE organization_id = $1
+  AND scope = $2
+  AND selectors @> jsonb_build_object(
+    'resource_kind', $3::text,
+    'resource_id', $4::text
+  )
+ORDER BY principal_urn
+`
+
+type ListPrincipalGrantsByResourceParams struct {
+	OrganizationID string
+	Scope          string
+	ResourceKind   string
+	ResourceID     string
+}
+
+type ListPrincipalGrantsByResourceRow struct {
+	PrincipalUrn urn.Principal
+	Scope        string
+	Effect       pgtype.Text
+	Selectors    []byte
+}
+
+// Returns grant rows for a single resource selector.
+func (q *Queries) ListPrincipalGrantsByResource(ctx context.Context, arg ListPrincipalGrantsByResourceParams) ([]ListPrincipalGrantsByResourceRow, error) {
+	rows, err := q.db.Query(ctx, listPrincipalGrantsByResource,
+		arg.OrganizationID,
+		arg.Scope,
+		arg.ResourceKind,
+		arg.ResourceID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPrincipalGrantsByResourceRow
+	for rows.Next() {
+		var i ListPrincipalGrantsByResourceRow
+		if err := rows.Scan(
+			&i.PrincipalUrn,
+			&i.Scope,
+			&i.Effect,
+			&i.Selectors,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -8,14 +8,11 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	authzrepo "github.com/speakeasy-api/gram/server/internal/authz/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
-	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
 type IsRBACEnabled func(ctx context.Context, organizationID string) (bool, error)
@@ -130,27 +127,19 @@ func (e *Engine) PrepareContext(ctx context.Context) (context.Context, error) {
 		}
 	}
 
-	principals := []urn.Principal{urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID)}
-
-	rolePrincipals, err := e.resolveRolePrincipals(ctx, authCtx.UserID, authCtx.ActiveOrganizationID)
+	principals, err := ResolveUserPrincipals(ctx, e.db, authCtx.ActiveOrganizationID, authCtx.UserID)
 	if err != nil {
+		if errors.Is(err, ErrPrincipalNotFound) {
+			return GrantsToContext(ctx, nil), nil
+		}
 		e.logger.ErrorContext(
 			ctx,
-			"failed to resolve roles for authz grants",
+			"failed to resolve principals for authz grants",
 			attr.SlogOrganizationID(authCtx.ActiveOrganizationID),
 			attr.SlogUserID(authCtx.UserID),
 			attr.SlogError(err),
 		)
-		return ctx, fmt.Errorf("resolve role slugs: %w", err)
-	}
-	for _, role := range rolePrincipals {
-		// Load grants for both canonical role:<kind>:<uuid> principals and
-		// legacy role:<slug> principals while existing grant rows are backfilled.
-		rolePrincipalURNs, err := RolePrincipals(role.RoleSlug, role.PrincipalUrn)
-		if err != nil {
-			return ctx, fmt.Errorf("build role principals: %w", err)
-		}
-		principals = append(principals, rolePrincipalURNs...)
+		return ctx, fmt.Errorf("resolve principals: %w", err)
 	}
 
 	grants, err := LoadGrants(ctx, e.db, authCtx.ActiveOrganizationID, principals)
@@ -166,29 +155,6 @@ func (e *Engine) PrepareContext(ctx context.Context) (context.Context, error) {
 	}
 
 	return GrantsToContext(ctx, grants), nil
-}
-
-func (e *Engine) resolveRolePrincipals(ctx context.Context, userID, orgID string) ([]accessrepo.ListMemberRolePrincipalsByWorkosUserRow, error) {
-	user, err := usersrepo.New(e.db).GetUser(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("get user: %w", err)
-	}
-	if !user.WorkosID.Valid || user.WorkosID.String == "" {
-		return nil, nil
-	}
-
-	// Role assignments are local source-of-truth records. They are written by
-	// the access write path and by WorkOS sync, so invitation/admin-console
-	// changes can lag until the sync job catches up.
-	rolePrincipals, err := accessrepo.New(e.db).ListMemberRolePrincipalsByWorkosUser(ctx, accessrepo.ListMemberRolePrincipalsByWorkosUserParams{
-		OrganizationID: orgID,
-		WorkosUserID:   user.WorkosID.String,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list member role slugs: %w", err)
-	}
-
-	return rolePrincipals, nil
 }
 
 func (e *Engine) Require(ctx context.Context, checks ...Check) error {

--- a/server/internal/authz/principal_resolution.go
+++ b/server/internal/authz/principal_resolution.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/speakeasy-api/gram/server/internal/access/repo"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -24,8 +25,7 @@ func ResolveUserPrincipals(ctx context.Context, db repo.DBTX, organizationID str
 		return nil, ErrPrincipalNotFound
 	}
 
-	q := repo.New(db)
-	isMember, err := q.HasActiveOrganizationUser(ctx, repo.HasActiveOrganizationUserParams{
+	isMember, err := orgrepo.New(db).HasActiveOrganizationUser(ctx, orgrepo.HasActiveOrganizationUserParams{
 		UserID:         userID,
 		OrganizationID: organizationID,
 	})
@@ -39,6 +39,7 @@ func ResolveUserPrincipals(ctx context.Context, db repo.DBTX, organizationID str
 	principals := []urn.Principal{urn.NewPrincipal(urn.PrincipalTypeUser, userID)}
 	seen := map[string]struct{}{principals[0].String(): {}}
 
+	q := repo.New(db)
 	roleRows, err := q.ListMemberRolePrincipalsByUser(ctx, repo.ListMemberRolePrincipalsByUserParams{
 		OrganizationID: organizationID,
 		UserID:         userID,

--- a/server/internal/authz/principal_resolution.go
+++ b/server/internal/authz/principal_resolution.go
@@ -1,0 +1,66 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// ErrPrincipalNotFound reports that a Gram user could not be resolved to an
+// active in-organization principal.
+var ErrPrincipalNotFound = errors.New("principal not found")
+
+// ResolveUserPrincipals resolves user:<id> plus assigned role principals
+// only when the Gram user is an active member of the organization. Missing or
+// cross-org users return ErrPrincipalNotFound.
+func ResolveUserPrincipals(ctx context.Context, db repo.DBTX, organizationID string, userID string) ([]urn.Principal, error) {
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization id is required")
+	}
+	if userID == "" {
+		return nil, ErrPrincipalNotFound
+	}
+
+	q := repo.New(db)
+	isMember, err := q.HasActiveOrganizationUser(ctx, repo.HasActiveOrganizationUserParams{
+		UserID:         userID,
+		OrganizationID: organizationID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolve organization user principal: %w", err)
+	}
+	if !isMember {
+		return nil, ErrPrincipalNotFound
+	}
+
+	principals := []urn.Principal{urn.NewPrincipal(urn.PrincipalTypeUser, userID)}
+	seen := map[string]struct{}{principals[0].String(): {}}
+
+	roleRows, err := q.ListMemberRolePrincipalsByUser(ctx, repo.ListMemberRolePrincipalsByUserParams{
+		OrganizationID: organizationID,
+		UserID:         userID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolve role principals: %w", err)
+	}
+
+	for _, role := range roleRows {
+		rolePrincipals, err := RolePrincipals(role.RoleSlug, role.PrincipalUrn)
+		if err != nil {
+			return nil, err
+		}
+		for _, principal := range rolePrincipals {
+			key := principal.String()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			principals = append(principals, principal)
+		}
+	}
+
+	return principals, nil
+}

--- a/server/internal/authz/principal_resolution_test.go
+++ b/server/internal/authz/principal_resolution_test.go
@@ -1,0 +1,100 @@
+package authz
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+func TestResolveKnownUserPrincipals_resolvesUserAndRolesForOrgMember(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn := newTestDB(t)
+	organizationID := "org_resolve_principals"
+	userID := "user_123"
+
+	seedOrganization(t, ctx, conn, organizationID)
+	seedActiveOrganizationUser(t, ctx, conn, organizationID, userID)
+	require.NoError(t, SeedSystemRoleGrants(ctx, testenv.NewLogger(t), conn, organizationID))
+	seedRoleAssignmentForUser(t, ctx, conn, organizationID, userID, SystemRoleMember)
+
+	principals, err := ResolveUserPrincipals(ctx, conn, organizationID, userID)
+	require.NoError(t, err)
+
+	principalURNs := make([]string, 0, len(principals))
+	for _, principal := range principals {
+		principalURNs = append(principalURNs, principal.String())
+	}
+	require.Contains(t, principalURNs, urn.NewPrincipal(urn.PrincipalTypeUser, userID).String())
+	require.Contains(t, principalURNs, "role:member")
+	require.True(t, slices.ContainsFunc(principalURNs, func(principalURN string) bool {
+		return strings.HasPrefix(principalURN, "role:global:")
+	}))
+}
+
+func TestResolveKnownUserPrincipals_unidentifiedWhenUserMissingOrNotInOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn := newTestDB(t)
+	organizationID := "org_resolve_principals_missing"
+	otherOrganizationID := "org_resolve_principals_other"
+	otherOrgUserID := "user_other_org"
+
+	seedOrganization(t, ctx, conn, organizationID)
+	seedOrganization(t, ctx, conn, otherOrganizationID)
+	seedActiveOrganizationUser(t, ctx, conn, otherOrganizationID, otherOrgUserID)
+
+	for _, userID := range []string{"", "user_missing", otherOrgUserID} {
+		principals, err := ResolveUserPrincipals(ctx, conn, organizationID, userID)
+		require.ErrorIs(t, err, ErrPrincipalNotFound)
+		require.Empty(t, principals)
+	}
+}
+
+func seedActiveOrganizationUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, userID string) {
+	t.Helper()
+
+	_, err := usersrepo.New(conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       userID + "@example.com",
+		DisplayName: userID,
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+}
+
+func seedRoleAssignmentForUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, userID string, roleSlug string) {
+	t.Helper()
+
+	_, err := accessrepo.New(conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       userID,
+		UserID:             conv.ToPGText(userID),
+		WorkosMembershipID: conv.ToPGText("membership_" + userID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     roleSlug,
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/authz/resource_grants.go
+++ b/server/internal/authz/resource_grants.go
@@ -13,13 +13,18 @@ import (
 
 // ReplaceGrantsForResource replaces allow grants for one resource-scoped permission.
 func ReplaceGrantsForResource(ctx context.Context, db *pgxpool.Pool, organizationID string, scope Scope, resourceID string, principals []urn.Principal) error {
+	replacement, err := newResourceGrantReplacement(organizationID, scope, resourceID, principals)
+	if err != nil {
+		return err
+	}
+
 	tx, err := db.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin resource grant transaction: %w", err)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
-	if err := ReplaceGrantsForResourceTx(ctx, tx, organizationID, scope, resourceID, principals); err != nil {
+	if err := replaceGrantsForResourceTx(ctx, tx, replacement); err != nil {
 		return err
 	}
 
@@ -32,21 +37,39 @@ func ReplaceGrantsForResource(ctx context.Context, db *pgxpool.Pool, organizatio
 
 // ReplaceGrantsForResourceTx replaces allow grants using the caller's transaction.
 func ReplaceGrantsForResourceTx(ctx context.Context, db repo.DBTX, organizationID string, scope Scope, resourceID string, principals []urn.Principal) error {
+	replacement, err := newResourceGrantReplacement(organizationID, scope, resourceID, principals)
+	if err != nil {
+		return err
+	}
+
+	return replaceGrantsForResourceTx(ctx, db, replacement)
+}
+
+type resourceGrantReplacement struct {
+	OrganizationID   string
+	Scope            Scope
+	ResourceID       string
+	ResourceKind     string
+	SelectorBytes    []byte
+	UniquePrincipals []urn.Principal
+}
+
+func newResourceGrantReplacement(organizationID string, scope Scope, resourceID string, principals []urn.Principal) (resourceGrantReplacement, error) {
 	if organizationID == "" {
-		return fmt.Errorf("organization id is required")
+		return resourceGrantReplacement{}, fmt.Errorf("organization id is required")
 	}
 	if scope == "" {
-		return fmt.Errorf("scope is required")
+		return resourceGrantReplacement{}, fmt.Errorf("scope is required")
 	}
 	if resourceID == "" {
-		return fmt.Errorf("resource id is required")
+		return resourceGrantReplacement{}, fmt.Errorf("resource id is required")
 	}
 
 	uniquePrincipals := make([]urn.Principal, 0, len(principals))
 	seen := make(map[string]struct{}, len(principals))
 	for _, principal := range principals {
 		if _, err := principal.Value(); err != nil {
-			return fmt.Errorf("invalid grant principal: %w", err)
+			return resourceGrantReplacement{}, fmt.Errorf("invalid grant principal: %w", err)
 		}
 		if _, ok := seen[principal.String()]; ok {
 			continue
@@ -57,35 +80,46 @@ func ReplaceGrantsForResourceTx(ctx context.Context, db repo.DBTX, organizationI
 
 	resourceKind := ResourceKindForScope(scope)
 	if resourceKind == WildcardResource {
-		return fmt.Errorf("scope %q does not map to a resource kind", scope)
+		return resourceGrantReplacement{}, fmt.Errorf("scope %q does not map to a resource kind", scope)
 	}
 
 	selector := NewSelector(scope, resourceID)
 	if err := ValidateSelector(scope, selector); err != nil {
-		return err
+		return resourceGrantReplacement{}, err
 	}
 	selectorBytes, err := selector.MarshalJSON()
 	if err != nil {
-		return fmt.Errorf("marshal grant selector: %w", err)
+		return resourceGrantReplacement{}, fmt.Errorf("marshal grant selector: %w", err)
 	}
 
+	return resourceGrantReplacement{
+		OrganizationID:   organizationID,
+		Scope:            scope,
+		ResourceID:       resourceID,
+		ResourceKind:     resourceKind,
+		SelectorBytes:    selectorBytes,
+		UniquePrincipals: uniquePrincipals,
+	}, nil
+}
+
+func replaceGrantsForResourceTx(ctx context.Context, db repo.DBTX, replacement resourceGrantReplacement) error {
 	q := repo.New(db)
 	if _, err := q.DeletePrincipalGrantsByResource(ctx, repo.DeletePrincipalGrantsByResourceParams{
-		OrganizationID: organizationID,
-		Scope:          string(scope),
-		ResourceKind:   resourceKind,
-		ResourceID:     resourceID,
+		OrganizationID: replacement.OrganizationID,
+		Scope:          string(replacement.Scope),
+		ResourceKind:   replacement.ResourceKind,
+		ResourceID:     replacement.ResourceID,
 	}); err != nil {
 		return fmt.Errorf("delete resource grants: %w", err)
 	}
 
-	for _, principal := range uniquePrincipals {
+	for _, principal := range replacement.UniquePrincipals {
 		if _, err := q.UpsertPrincipalGrant(ctx, repo.UpsertPrincipalGrantParams{
-			OrganizationID: organizationID,
+			OrganizationID: replacement.OrganizationID,
 			PrincipalUrn:   principal,
-			Scope:          string(scope),
+			Scope:          string(replacement.Scope),
 			Effect:         effectToPgtype(PolicyEffectAllow),
-			Selectors:      selectorBytes,
+			Selectors:      replacement.SelectorBytes,
 		}); err != nil {
 			return fmt.Errorf("upsert resource grant: %w", err)
 		}

--- a/server/internal/authz/resource_grants.go
+++ b/server/internal/authz/resource_grants.go
@@ -4,12 +4,34 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 // ReplaceGrantsForResource replaces allow grants for one resource-scoped permission.
-func ReplaceGrantsForResource(ctx context.Context, db repo.DBTX, organizationID string, scope Scope, resourceID string, principals []urn.Principal) error {
+func ReplaceGrantsForResource(ctx context.Context, db *pgxpool.Pool, organizationID string, scope Scope, resourceID string, principals []urn.Principal) error {
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin resource grant transaction: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	if err := ReplaceGrantsForResourceTx(ctx, tx, organizationID, scope, resourceID, principals); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit resource grant transaction: %w", err)
+	}
+
+	return nil
+}
+
+// ReplaceGrantsForResourceTx replaces allow grants using the caller's transaction.
+func ReplaceGrantsForResourceTx(ctx context.Context, db repo.DBTX, organizationID string, scope Scope, resourceID string, principals []urn.Principal) error {
 	if organizationID == "" {
 		return fmt.Errorf("organization id is required")
 	}

--- a/server/internal/authz/resource_grants.go
+++ b/server/internal/authz/resource_grants.go
@@ -1,0 +1,117 @@
+package authz
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// ReplaceGrantsForResource replaces allow grants for one resource-scoped permission.
+func ReplaceGrantsForResource(ctx context.Context, db repo.DBTX, organizationID string, scope Scope, resourceID string, principals []urn.Principal) error {
+	if organizationID == "" {
+		return fmt.Errorf("organization id is required")
+	}
+	if scope == "" {
+		return fmt.Errorf("scope is required")
+	}
+	if resourceID == "" {
+		return fmt.Errorf("resource id is required")
+	}
+
+	uniquePrincipals := make([]urn.Principal, 0, len(principals))
+	seen := make(map[string]struct{}, len(principals))
+	for _, principal := range principals {
+		if _, err := principal.Value(); err != nil {
+			return fmt.Errorf("invalid grant principal: %w", err)
+		}
+		if _, ok := seen[principal.String()]; ok {
+			continue
+		}
+		seen[principal.String()] = struct{}{}
+		uniquePrincipals = append(uniquePrincipals, principal)
+	}
+
+	resourceKind := ResourceKindForScope(scope)
+	if resourceKind == WildcardResource {
+		return fmt.Errorf("scope %q does not map to a resource kind", scope)
+	}
+
+	selector := NewSelector(scope, resourceID)
+	if err := ValidateSelector(scope, selector); err != nil {
+		return err
+	}
+	selectorBytes, err := selector.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("marshal grant selector: %w", err)
+	}
+
+	q := repo.New(db)
+	if _, err := q.DeletePrincipalGrantsByResource(ctx, repo.DeletePrincipalGrantsByResourceParams{
+		OrganizationID: organizationID,
+		Scope:          string(scope),
+		ResourceKind:   resourceKind,
+		ResourceID:     resourceID,
+	}); err != nil {
+		return fmt.Errorf("delete resource grants: %w", err)
+	}
+
+	for _, principal := range uniquePrincipals {
+		if _, err := q.UpsertPrincipalGrant(ctx, repo.UpsertPrincipalGrantParams{
+			OrganizationID: organizationID,
+			PrincipalUrn:   principal,
+			Scope:          string(scope),
+			Effect:         effectToPgtype(PolicyEffectAllow),
+			Selectors:      selectorBytes,
+		}); err != nil {
+			return fmt.Errorf("upsert resource grant: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ListGrantsForResource loads grants for one resource-scoped permission.
+func ListGrantsForResource(ctx context.Context, db repo.DBTX, organizationID string, scope Scope, resourceID string) ([]Grant, error) {
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization id is required")
+	}
+	if scope == "" {
+		return nil, fmt.Errorf("scope is required")
+	}
+	if resourceID == "" {
+		return nil, fmt.Errorf("resource id is required")
+	}
+
+	resourceKind := ResourceKindForScope(scope)
+	if resourceKind == WildcardResource {
+		return nil, fmt.Errorf("scope %q does not map to a resource kind", scope)
+	}
+
+	rows, err := repo.New(db).ListPrincipalGrantsByResource(ctx, repo.ListPrincipalGrantsByResourceParams{
+		OrganizationID: organizationID,
+		Scope:          string(scope),
+		ResourceKind:   resourceKind,
+		ResourceID:     resourceID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list resource grants: %w", err)
+	}
+
+	grants := make([]Grant, 0, len(rows))
+	for _, row := range rows {
+		selector, err := SelectorFromRow(row.Selectors)
+		if err != nil {
+			return nil, err
+		}
+		grants = append(grants, Grant{
+			PrincipalUrn: row.PrincipalUrn.String(),
+			Scope:        Scope(row.Scope),
+			Effect:       effectFromNullable(row.Effect),
+			Selector:     selector,
+		})
+	}
+
+	return grants, nil
+}

--- a/server/internal/authz/resource_grants_test.go
+++ b/server/internal/authz/resource_grants_test.go
@@ -68,6 +68,74 @@ func TestReplaceGrantsForResource_emptyPrincipalsClearsResourceGrants(t *testing
 	require.Empty(t, grants)
 }
 
+func TestReplaceGrantsForResource_invalidInputDoesNotBeginTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	testCases := []struct {
+		name           string
+		organizationID string
+		scope          Scope
+		resourceID     string
+		principals     []urn.Principal
+		wantErr        string
+	}{
+		{
+			name:           "missing organization id",
+			organizationID: "",
+			scope:          ScopeRiskPolicyEvaluate,
+			resourceID:     "policy_123",
+			principals:     nil,
+			wantErr:        "organization id is required",
+		},
+		{
+			name:           "missing scope",
+			organizationID: "org_policy_evaluate_invalid_input",
+			scope:          "",
+			resourceID:     "policy_123",
+			principals:     nil,
+			wantErr:        "scope is required",
+		},
+		{
+			name:           "missing resource id",
+			organizationID: "org_policy_evaluate_invalid_input",
+			scope:          ScopeRiskPolicyEvaluate,
+			resourceID:     "",
+			principals:     nil,
+			wantErr:        "resource id is required",
+		},
+		{
+			name:           "invalid principal",
+			organizationID: "org_policy_evaluate_invalid_input",
+			scope:          ScopeRiskPolicyEvaluate,
+			resourceID:     "policy_123",
+			principals:     []urn.Principal{{}},
+			wantErr:        "invalid grant principal",
+		},
+		{
+			name:           "scope without resource kind",
+			organizationID: "org_policy_evaluate_invalid_input",
+			scope:          ScopeRoot,
+			resourceID:     "policy_123",
+			principals:     nil,
+			wantErr:        `scope "root" does not map to a resource kind`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var err error
+			require.NotPanics(t, func() {
+				err = ReplaceGrantsForResource(ctx, nil, tc.organizationID, tc.scope, tc.resourceID, tc.principals)
+			})
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
 func TestReplaceGrantsForResource_invalidPrincipalDoesNotClearExistingGrants(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/authz/resource_grants_test.go
+++ b/server/internal/authz/resource_grants_test.go
@@ -1,0 +1,90 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestReplaceGrantsForResource_replacesGrantsForResource(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn := newTestDB(t)
+	organizationID := "org_policy_evaluate"
+	policyID := "policy_123"
+	otherPolicyID := "policy_456"
+	userPrincipal := urn.NewPrincipal(urn.PrincipalTypeUser, "user_123")
+	rolePrincipal := urn.NewPrincipal(urn.PrincipalTypeRole, "role_support")
+	otherPrincipal := urn.NewPrincipal(urn.PrincipalTypeUser, "user_other")
+
+	seedOrganization(t, ctx, conn, organizationID)
+	require.NoError(t, ReplaceGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, otherPolicyID, []urn.Principal{otherPrincipal}))
+
+	require.NoError(t, ReplaceGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID, []urn.Principal{userPrincipal, rolePrincipal, rolePrincipal}))
+
+	grants, err := ListGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID)
+	require.NoError(t, err)
+	require.Len(t, grants, 2)
+	require.ElementsMatch(t, []string{userPrincipal.String(), rolePrincipal.String()}, []string{grants[0].PrincipalUrn, grants[1].PrincipalUrn})
+	for _, grant := range grants {
+		require.Equal(t, ScopeRiskPolicyEvaluate, grant.Scope)
+		require.Equal(t, PolicyEffectAllow, grant.Effect)
+		require.Equal(t, Selector{"resource_kind": ResourceKindRiskPolicy, "resource_id": policyID}, grant.Selector)
+	}
+
+	require.NoError(t, ReplaceGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID, []urn.Principal{rolePrincipal}))
+
+	grants, err = ListGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID)
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	require.Equal(t, rolePrincipal.String(), grants[0].PrincipalUrn)
+
+	otherGrants, err := ListGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, otherPolicyID)
+	require.NoError(t, err)
+	require.Len(t, otherGrants, 1)
+	require.Equal(t, otherPrincipal.String(), otherGrants[0].PrincipalUrn)
+}
+
+func TestReplaceGrantsForResource_emptyPrincipalsClearsResourceGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn := newTestDB(t)
+	organizationID := "org_policy_evaluate_clear"
+	policyID := "policy_123"
+
+	seedOrganization(t, ctx, conn, organizationID)
+	require.NoError(t, ReplaceGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID, []urn.Principal{
+		urn.NewPrincipal(urn.PrincipalTypeUser, "user_123"),
+	}))
+
+	require.NoError(t, ReplaceGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID, nil))
+
+	grants, err := ListGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID)
+	require.NoError(t, err)
+	require.Empty(t, grants)
+}
+
+func TestReplaceGrantsForResource_invalidPrincipalDoesNotClearExistingGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn := newTestDB(t)
+	organizationID := "org_policy_evaluate_invalid"
+	policyID := "policy_123"
+	userPrincipal := urn.NewPrincipal(urn.PrincipalTypeUser, "user_123")
+
+	seedOrganization(t, ctx, conn, organizationID)
+	require.NoError(t, ReplaceGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID, []urn.Principal{userPrincipal}))
+
+	err := ReplaceGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID, []urn.Principal{{}})
+	require.Error(t, err)
+
+	grants, err := ListGrantsForResource(ctx, conn, organizationID, ScopeRiskPolicyEvaluate, policyID)
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	require.Equal(t, userPrincipal.String(), grants[0].PrincipalUrn)
+}

--- a/server/internal/authz/resource_kinds.go
+++ b/server/internal/authz/resource_kinds.go
@@ -1,0 +1,10 @@
+package authz
+
+const (
+	ResourceKindWildcard    = WildcardResource
+	ResourceKindProject     = "project"
+	ResourceKindMCP         = "mcp"
+	ResourceKindOrg         = "org"
+	ResourceKindEnvironment = "environment"
+	ResourceKindRiskPolicy  = "risk_policy"
+)

--- a/server/internal/authz/scopes.go
+++ b/server/internal/authz/scopes.go
@@ -3,23 +3,39 @@ package authz
 import (
 	"cmp"
 	"slices"
+	"strings"
 )
 
 // Scope identifies an authorization capability granted on a resource.
 type Scope string
 
+type ScopeParts struct {
+	Resource string
+	Action   string
+}
+
 const (
-	ScopeRoot             Scope = "root"
-	ScopeOrgRead          Scope = "org:read"
-	ScopeOrgAdmin         Scope = "org:admin"
-	ScopeProjectRead      Scope = "project:read"
-	ScopeProjectWrite     Scope = "project:write"
-	ScopeMCPRead          Scope = "mcp:read"
-	ScopeMCPWrite         Scope = "mcp:write"
-	ScopeMCPConnect       Scope = "mcp:connect"
-	ScopeEnvironmentRead  Scope = "environment:read"
-	ScopeEnvironmentWrite Scope = "environment:write"
+	ScopeRoot               Scope = "root"
+	ScopeOrgRead            Scope = "org:read"
+	ScopeOrgAdmin           Scope = "org:admin"
+	ScopeProjectRead        Scope = "project:read"
+	ScopeProjectWrite       Scope = "project:write"
+	ScopeMCPRead            Scope = "mcp:read"
+	ScopeMCPWrite           Scope = "mcp:write"
+	ScopeMCPConnect         Scope = "mcp:connect"
+	ScopeEnvironmentRead    Scope = "environment:read"
+	ScopeEnvironmentWrite   Scope = "environment:write"
+	ScopeRiskPolicyEvaluate Scope = "risk_policy:evaluate"
 )
+
+func (s Scope) Parts() ScopeParts {
+	resource, action, ok := strings.Cut(string(s), ":")
+	if !ok {
+		return ScopeParts{Resource: string(s), Action: ""}
+	}
+
+	return ScopeParts{Resource: resource, Action: action}
+}
 
 // scopeExpansions maps a required scope to the higher-privilege scopes that also satisfy it.
 // Scopes with no higher-privilege implication (admin tiers) map to nil. Expansion is
@@ -37,16 +53,31 @@ const (
 // (a generic project-viewer must not gain access to environment values, which include
 // secrets).
 var scopeExpansions = map[Scope][]Scope{
-	ScopeRoot:             nil,
-	ScopeOrgRead:          {ScopeOrgAdmin},
-	ScopeOrgAdmin:         nil,
-	ScopeProjectRead:      {ScopeProjectWrite},
-	ScopeProjectWrite:     nil,
-	ScopeMCPRead:          {ScopeMCPWrite},
-	ScopeMCPWrite:         nil,
-	ScopeMCPConnect:       {ScopeMCPRead, ScopeMCPWrite},
-	ScopeEnvironmentRead:  {ScopeEnvironmentWrite},
-	ScopeEnvironmentWrite: nil,
+	ScopeRoot:               nil,
+	ScopeOrgRead:            {ScopeOrgAdmin},
+	ScopeOrgAdmin:           nil,
+	ScopeProjectRead:        {ScopeProjectWrite},
+	ScopeProjectWrite:       nil,
+	ScopeMCPRead:            {ScopeMCPWrite},
+	ScopeMCPWrite:           nil,
+	ScopeMCPConnect:         {ScopeMCPRead, ScopeMCPWrite},
+	ScopeEnvironmentRead:    {ScopeEnvironmentWrite},
+	ScopeEnvironmentWrite:   nil,
+	ScopeRiskPolicyEvaluate: nil,
+}
+
+var internalScopes = map[Scope]bool{
+	ScopeRoot:               false,
+	ScopeOrgRead:            false,
+	ScopeOrgAdmin:           false,
+	ScopeProjectRead:        false,
+	ScopeProjectWrite:       false,
+	ScopeMCPRead:            false,
+	ScopeMCPWrite:           false,
+	ScopeMCPConnect:         false,
+	ScopeEnvironmentRead:    false,
+	ScopeEnvironmentWrite:   false,
+	ScopeRiskPolicyEvaluate: true,
 }
 
 // scopeSubScopes is the inverse of scopeExpansions: for each higher-privilege
@@ -74,4 +105,10 @@ func CalculateSubScopes(scope Scope) []string {
 		out[i] = string(s)
 	}
 	return out
+}
+
+// IsInternalScope reports whether a scope is used as an internal relation
+// rather than a user-facing RBAC capability.
+func IsInternalScope(scope Scope) bool {
+	return internalScopes[scope]
 }

--- a/server/internal/authz/scopes_test.go
+++ b/server/internal/authz/scopes_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestScopeParts(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, ScopeParts{Resource: "project", Action: "read"}, ScopeProjectRead.Parts())
+	require.Equal(t, ScopeParts{Resource: "risk_policy", Action: "evaluate"}, ScopeRiskPolicyEvaluate.Parts())
+	require.Equal(t, ScopeParts{Resource: "root", Action: ""}, ScopeRoot.Parts())
+}
+
 func TestCheckExpand_orgRead(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/authz/selector.go
+++ b/server/internal/authz/selector.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 )
 
 // Selector is a set of key-value constraints attached to a grant or check.
@@ -53,24 +52,27 @@ func (s Selector) StrictMatches(check Selector) bool {
 	return true
 }
 
-// ResourceKindForScope derives the resource kind from a scope's family prefix.
+// ResourceKindForScope derives the selector resource kind from a scope.
 func ResourceKindForScope(scope Scope) string {
-	s := string(scope)
-	switch {
-	case strings.HasPrefix(s, "project:"):
+	switch scope.Parts().Resource {
+	case "project":
 		return "project"
-	case strings.HasPrefix(s, "remote-mcp:"):
+	case "remote-mcp":
 		return "mcp"
-	case strings.HasPrefix(s, "mcp:"):
+	case "mcp":
 		return "mcp"
-	case strings.HasPrefix(s, "org:"):
+	case "org":
 		return "org"
-	case strings.HasPrefix(s, "environment:"):
+	case "environment":
 		return "environment"
+	case "risk_policy":
+		return ResourceKindRiskPolicy
 	default:
 		return "*"
 	}
 }
+
+const ResourceKindRiskPolicy = "risk_policy"
 
 // Disposition values matching MCP tool annotation hint names (snake_case, no _hint suffix).
 const (

--- a/server/internal/authz/selector.go
+++ b/server/internal/authz/selector.go
@@ -56,23 +56,21 @@ func (s Selector) StrictMatches(check Selector) bool {
 func ResourceKindForScope(scope Scope) string {
 	switch scope.Parts().Resource {
 	case "project":
-		return "project"
+		return ResourceKindProject
 	case "remote-mcp":
-		return "mcp"
+		return ResourceKindMCP
 	case "mcp":
-		return "mcp"
+		return ResourceKindMCP
 	case "org":
-		return "org"
+		return ResourceKindOrg
 	case "environment":
-		return "environment"
+		return ResourceKindEnvironment
 	case "risk_policy":
 		return ResourceKindRiskPolicy
 	default:
-		return "*"
+		return ResourceKindWildcard
 	}
 }
-
-const ResourceKindRiskPolicy = "risk_policy"
 
 // Disposition values matching MCP tool annotation hint names (snake_case, no _hint suffix).
 const (
@@ -94,8 +92,8 @@ var validDispositions = map[string]bool{
 // resource_id) are valid for each scope family. Scope families not listed here
 // allow no extra keys.
 var allowedSelectorKeys = map[string]map[string]bool{
-	"mcp": {"tool": true, "disposition": true, "project_id": true},
-	"environment": {
+	ResourceKindMCP: {"tool": true, "disposition": true, "project_id": true},
+	ResourceKindEnvironment: {
 		"project_id": true,
 	},
 }
@@ -115,8 +113,8 @@ func ValidateSelector(scope Scope, sel Selector) error {
 
 	expectedKind := ResourceKindForScope(scope)
 	if scope == ScopeRoot {
-		if kind != "*" {
-			return fmt.Errorf("root scope requires resource_kind=*, got %q", kind)
+		if kind != ResourceKindWildcard {
+			return fmt.Errorf("root scope requires resource_kind=%s, got %q", ResourceKindWildcard, kind)
 		}
 		// root allows no extra keys
 		for k := range sel {

--- a/server/internal/authz/selector_test.go
+++ b/server/internal/authz/selector_test.go
@@ -143,6 +143,12 @@ func TestResourceKindForScope_rootScope(t *testing.T) {
 	require.Equal(t, "*", ResourceKindForScope(ScopeRoot))
 }
 
+func TestResourceKindForScope_riskPolicyScope(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, ResourceKindRiskPolicy, ResourceKindForScope(ScopeRiskPolicyEvaluate))
+}
+
 func TestNewSelector_includesResourceKind(t *testing.T) {
 	t.Parallel()
 
@@ -234,6 +240,23 @@ func TestValidateSelector_mcpProjectIDAllowed(t *testing.T) {
 	require.NoError(t, ValidateSelector(ScopeMCPConnect, sel))
 	require.NoError(t, ValidateSelector(ScopeMCPRead, sel))
 	require.NoError(t, ValidateSelector(ScopeMCPWrite, sel))
+}
+
+func TestValidateSelector_riskPolicyAllowsOnlyResourceKeys(t *testing.T) {
+	t.Parallel()
+
+	valid := Selector{"resource_kind": ResourceKindRiskPolicy, "resource_id": "policy_123"}
+	require.NoError(t, ValidateSelector(ScopeRiskPolicyEvaluate, valid))
+
+	withExtraKey := Selector{"resource_kind": ResourceKindRiskPolicy, "resource_id": "policy_123", "tool": "search"}
+	require.ErrorContains(t, ValidateSelector(ScopeRiskPolicyEvaluate, withExtraKey), "not allowed")
+}
+
+func TestIsInternalScope(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, IsInternalScope(ScopeRiskPolicyEvaluate))
+	require.False(t, IsInternalScope(ScopeProjectRead))
 }
 
 func TestMCPCheck_injectsProjectID(t *testing.T) {

--- a/server/internal/authz/setup_test.go
+++ b/server/internal/authz/setup_test.go
@@ -84,7 +84,7 @@ func seedOrganization(t *testing.T, ctx context.Context, conn *pgxpool.Pool, org
 	_, err := orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
 		ID:       organizationID,
 		Name:     "Test Org",
-		Slug:     "test-org",
+		Slug:     organizationID,
 		WorkosID: conv.PtrToPGText(conv.PtrEmpty("workos-org-" + organizationID)),
 	})
 	require.NoError(t, err)

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -69,6 +69,19 @@ SELECT EXISTS(
     AND deleted_at IS NULL
 ) AS exists;
 
+-- name: HasActiveOrganizationUser :one
+-- Returns whether a Gram user is an active member of the organization.
+SELECT EXISTS(
+  SELECT 1
+  FROM users
+  JOIN organization_user_relationships
+    ON organization_user_relationships.user_id = users.id
+  WHERE users.id = @user_id
+    AND users.deleted_at IS NULL
+    AND organization_user_relationships.organization_id = @organization_id
+    AND organization_user_relationships.deleted_at IS NULL
+) AS exists;
+
 -- name: GetOrganizationUserRelationship :one
 SELECT *
 FROM organization_user_relationships

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -599,6 +599,32 @@ func (q *Queries) GetSvixAppID(ctx context.Context, id string) (pgtype.Text, err
 	return svix_app_id, err
 }
 
+const hasActiveOrganizationUser = `-- name: HasActiveOrganizationUser :one
+SELECT EXISTS(
+  SELECT 1
+  FROM users
+  JOIN organization_user_relationships
+    ON organization_user_relationships.user_id = users.id
+  WHERE users.id = $1
+    AND users.deleted_at IS NULL
+    AND organization_user_relationships.organization_id = $2
+    AND organization_user_relationships.deleted_at IS NULL
+) AS exists
+`
+
+type HasActiveOrganizationUserParams struct {
+	UserID         string
+	OrganizationID string
+}
+
+// Returns whether a Gram user is an active member of the organization.
+func (q *Queries) HasActiveOrganizationUser(ctx context.Context, arg HasActiveOrganizationUserParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasActiveOrganizationUser, arg.UserID, arg.OrganizationID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const hasOrganizationUserRelationship = `-- name: HasOrganizationUserRelationship :one
 SELECT EXISTS(
   SELECT 1


### PR DESCRIPTION
## Why

Policy audiences need an RBAC-backed way to express "this policy applies to these principals" without making policy-specific concepts part of the generic access model. This adds the authz foundation for that relation while keeping WorkOS IDs out of the risk policy path.

## How it works

- Adds an internal `risk_policy:evaluate` scope and `risk_policy` resource kind.
- Adds generic resource-scoped grant helpers for replacing and listing grants tied to any scope/resource pair.
- Adds generic `principal_grants` SQLC queries for inverse lookups by resource selector.
- Resolves effective principals from a Gram user ID plus assigned role principals, and reuses that in both request grant loading and `access.listUserGrants`.
- Uses JSONB containment for selector lookups so the existing selector GIN index can help.

