### PR TITLE
feat: applies allow list to k8s ingress/gateway resources

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -133,6 +133,12 @@ func newStartCommand() *cli.Command {
 			Required: true,
 			EnvVars:  []string{"GRAM_ENVIRONMENT"},
 		},
+		&cli.BoolFlag{
+			Name:    "enable-gateway-ip-allowlist",
+			Usage:   "Enable Envoy Gateway SecurityPolicy reconcile for custom domain IP allow listing. Requires the SecurityPolicy CRD to be installed.",
+			EnvVars: []string{"GRAM_ENABLE_GATEWAY_IP_ALLOWLIST"},
+			Value:   false,
+		},
 		&cli.StringFlag{
 			Name:     "ssl-key-file",
 			Usage:    "The SSL key file path to use for the server",
@@ -592,7 +598,7 @@ func newStartCommand() *cli.Command {
 			mcpMetadataRepo := mcpmetadata_repo.New(db)
 			env := environments.NewEnvironmentEntries(logger, db, encryptionClient, mcpMetadataRepo)
 
-			k8sClient, err := k8s.InitializeK8sClient(ctx, logger, c.String("environment"))
+			k8sClient, err := k8s.InitializeK8sClient(ctx, logger, c.String("environment"), c.Bool("enable-gateway-ip-allowlist"))
 			if err != nil {
 				return fmt.Errorf("failed to create kubernetes client: %w", err)
 			}

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -76,6 +76,12 @@ func newWorkerCommand() *cli.Command {
 			Required: true,
 			EnvVars:  []string{"GRAM_ENVIRONMENT"},
 		},
+		&cli.BoolFlag{
+			Name:    "enable-gateway-ip-allowlist",
+			Usage:   "Enable Envoy Gateway SecurityPolicy reconcile for custom domain IP allow listing. Requires the SecurityPolicy CRD to be installed.",
+			EnvVars: []string{"GRAM_ENABLE_GATEWAY_IP_ALLOWLIST"},
+			Value:   false,
+		},
 		&cli.StringFlag{
 			Name:    "temporal-address",
 			Usage:   "The address of the temporal server",
@@ -417,7 +423,7 @@ func newWorkerCommand() *cli.Command {
 			mcpMetadataRepo := mcpmetadata_repo.New(db)
 			env := environments.NewEnvironmentEntries(logger, db, encryptionClient, mcpMetadataRepo)
 
-			k8sClient, err := k8s.InitializeK8sClient(ctx, logger, c.String("environment"))
+			k8sClient, err := k8s.InitializeK8sClient(ctx, logger, c.String("environment"), c.Bool("enable-gateway-ip-allowlist"))
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %w", err)
 			}

--- a/server/internal/background/activities/custom_domain_ingress.go
+++ b/server/internal/background/activities/custom_domain_ingress.go
@@ -19,6 +19,11 @@ type CustomDomainIngressAction string
 const (
 	CustomDomainIngressActionSetup  CustomDomainIngressAction = "setup"
 	CustomDomainIngressActionDelete CustomDomainIngressAction = "delete"
+	// CustomDomainIngressActionReapply re-applies the current IP allowlist to an
+	// already-provisioned resource. Used by the edit flow. It skips the
+	// convergence wait and the verified/activated DB flip since the resource and
+	// its cert already exist.
+	CustomDomainIngressActionReapply CustomDomainIngressAction = "reapply"
 )
 
 type CustomDomainIngress struct {
@@ -103,13 +108,29 @@ func (c *CustomDomainIngress) Do(ctx context.Context, args CustomDomainIngressAr
 		return oops.E(oops.CodeUnauthorized, errors.New("custom domain does not belong to organization"), "custom domain does not belong to organization").Log(ctx, c.logger)
 	}
 
+	if args.Action == CustomDomainIngressActionReapply {
+		c.logger.InfoContext(ctx, "re-applying custom domain ip allowlist",
+			attr.SlogCustomDomainProvisionerKind(string(kind)),
+			attr.SlogURLDomain(customDomain.Domain),
+		)
+
+		// Setup is idempotent (create-or-update) and applies the current allowlist.
+		// The resource and its cert already exist, so there is no convergence wait
+		// and no verified/activated flip.
+		if _, err := provisioner.Setup(ctx, customDomain.Domain, customDomain.IpAllowlist); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to re-apply custom domain ip allowlist").Log(ctx, c.logger)
+		}
+
+		return nil
+	}
+
 	if args.Action == CustomDomainIngressActionSetup {
 		c.logger.InfoContext(ctx, "provisioning custom domain resource",
 			attr.SlogCustomDomainProvisionerKind(string(kind)),
 			attr.SlogURLDomain(customDomain.Domain),
 		)
 
-		result, err := provisioner.Setup(ctx, customDomain.Domain)
+		result, err := provisioner.Setup(ctx, customDomain.Domain, customDomain.IpAllowlist)
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "failed to provision custom domain resource").Log(ctx, c.logger)
 		}

--- a/server/internal/background/activities/custom_domain_ingress.go
+++ b/server/internal/background/activities/custom_domain_ingress.go
@@ -67,6 +67,10 @@ type CustomDomainIngressArgs struct {
 	ResourceName    string // Generic resource name (Ingress or HTTPRoute). Preferred over IngressName.
 	CertSecretName  string
 	ProvisionerKind k8s.ProvisionerKind // Empty = use activity default.
+	// IPAllowlist is the allowlist to apply on the Reapply action. It is passed
+	// explicitly (not read from the DB) so the caller can reconcile k8s before
+	// persisting. Unused by Setup (which reads the persisted value) and Delete.
+	IPAllowlist []string
 }
 
 func (c *CustomDomainIngress) resolveKind(args CustomDomainIngressArgs) k8s.ProvisionerKind {
@@ -114,10 +118,11 @@ func (c *CustomDomainIngress) Do(ctx context.Context, args CustomDomainIngressAr
 			attr.SlogURLDomain(customDomain.Domain),
 		)
 
-		// Setup is idempotent (create-or-update) and applies the current allowlist.
-		// The resource and its cert already exist, so there is no convergence wait
-		// and no verified/activated flip.
-		if _, err := provisioner.Setup(ctx, customDomain.Domain, customDomain.IpAllowlist); err != nil {
+		// Setup is idempotent (create-or-update) and applies the allowlist passed
+		// in args (the caller persists it only after this succeeds). The resource
+		// and its cert already exist, so there is no convergence wait and no
+		// verified/activated flip.
+		if _, err := provisioner.Setup(ctx, customDomain.Domain, args.IPAllowlist); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "failed to re-apply custom domain ip allowlist").Log(ctx, c.logger)
 		}
 

--- a/server/internal/background/activities/custom_domain_ingress_test.go
+++ b/server/internal/background/activities/custom_domain_ingress_test.go
@@ -192,6 +192,54 @@ func TestCustomDomainIngress_Setup_Gateway_WritesNullCertSecret(t *testing.T) {
 	require.False(t, row.CertSecretName.Valid, "CertSecretName must be NULL for gateway kind")
 }
 
+func TestCustomDomainIngress_Reapply_AppliesAllowlist(t *testing.T) {
+	t.Parallel()
+
+	const orgID = "org-reapply"
+	const domain = "reapply.example.com"
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+
+	conn, err := infra.CloneTestDatabase(t, "reapply_test")
+	require.NoError(t, err)
+
+	_, err = orgRepo.New(conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        orgID,
+		Slug:        orgID,
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	_, err = customdomainsRepo.New(conn).CreateCustomDomain(ctx, customdomainsRepo.CreateCustomDomainParams{
+		OrganizationID:  orgID,
+		Domain:          domain,
+		ProvisionerKind: "ingress",
+		IpAllowlist:     []string{"1.2.3.4", "10.0.0.0/8"},
+	})
+	require.NoError(t, err)
+
+	stub := k8s.NewStubProvisioner(k8s.ProvisionerKindIngress, logger)
+	act := activities.NewCustomDomainIngress(logger, conn, &stubProvisionerFactory{provisioner: stub}, k8s.ProvisionerKindIngress, activities.WithSetupSleep(0))
+
+	err = act.Do(ctx, activities.CustomDomainIngressArgs{
+		OrgID:           orgID,
+		Domain:          domain,
+		Action:          activities.CustomDomainIngressActionReapply,
+		ProvisionerKind: k8s.ProvisionerKindIngress,
+	})
+	require.NoError(t, err)
+
+	// Reapply runs a single idempotent Setup with the persisted allowlist —
+	// no convergence Get, no DB write.
+	calls := stub.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, "Setup", calls[0].Method)
+	require.Equal(t, domain, calls[0].Domain)
+	require.Equal(t, []string{"1.2.3.4", "10.0.0.0/8"}, calls[0].IPAllowlist)
+}
+
 func TestCustomDomainIngress_Setup_KindResolution_DefaultsToIngress(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/activities/custom_domain_ingress_test.go
+++ b/server/internal/background/activities/custom_domain_ingress_test.go
@@ -216,7 +216,7 @@ func TestCustomDomainIngress_Reapply_AppliesAllowlist(t *testing.T) {
 		OrganizationID:  orgID,
 		Domain:          domain,
 		ProvisionerKind: "ingress",
-		IpAllowlist:     []string{"1.2.3.4", "10.0.0.0/8"},
+		IpAllowlist:     []string{},
 	})
 	require.NoError(t, err)
 
@@ -228,11 +228,12 @@ func TestCustomDomainIngress_Reapply_AppliesAllowlist(t *testing.T) {
 		Domain:          domain,
 		Action:          activities.CustomDomainIngressActionReapply,
 		ProvisionerKind: k8s.ProvisionerKindIngress,
+		IPAllowlist:     []string{"1.2.3.4", "10.0.0.0/8"},
 	})
 	require.NoError(t, err)
 
-	// Reapply runs a single idempotent Setup with the persisted allowlist —
-	// no convergence Get, no DB write.
+	// Reapply runs a single idempotent Setup with the allowlist from args
+	// (not the DB) — no convergence Get, no DB write.
 	calls := stub.Calls()
 	require.Len(t, calls, 1)
 	require.Equal(t, "Setup", calls[0].Method)

--- a/server/internal/background/custom_domain_registration.go
+++ b/server/internal/background/custom_domain_registration.go
@@ -33,6 +33,12 @@ type CustomDomainDeletionParams struct {
 	ProvisionerKind k8s.ProvisionerKind
 }
 
+type CustomDomainUpdateParams struct {
+	OrgID           string
+	Domain          string
+	ProvisionerKind k8s.ProvisionerKind
+}
+
 type CustomDomainRegistrationClient struct {
 	TemporalEnv *tenv.Environment
 }
@@ -53,6 +59,26 @@ func (c *CustomDomainRegistrationClient) GetID(orgID string, domain string) stri
 
 func (c *CustomDomainRegistrationClient) GetDeletionID(orgID string, domain string) string {
 	return fmt.Sprintf("v1:custom-domain-deletion:%s:%s", orgID, domain)
+}
+
+func (c *CustomDomainRegistrationClient) GetUpdateID(orgID string, domain string) string {
+	return fmt.Sprintf("v1:custom-domain-update:%s:%s", orgID, domain)
+}
+
+// ExecuteCustomDomainUpdate re-applies the persisted IP allowlist to an
+// already-provisioned custom domain. Used by the edit flow.
+func (c *CustomDomainRegistrationClient) ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, provisionerKind k8s.ProvisionerKind) (client.WorkflowRun, error) {
+	id := c.GetUpdateID(orgID, domain)
+	return c.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    id,
+		TaskQueue:             string(c.TemporalEnv.Queue()),
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowRunTimeout:    5 * time.Minute,
+	}, CustomDomainUpdateWorkflow, CustomDomainUpdateParams{
+		OrgID:           orgID,
+		Domain:          domain,
+		ProvisionerKind: provisionerKind,
+	})
 }
 
 func (c *CustomDomainRegistrationClient) ExecuteCustomDomainDeletion(ctx context.Context, orgID, domain, ingressName, certSecretName string, provisionerKind k8s.ProvisionerKind) (client.WorkflowRun, error) {
@@ -138,6 +164,37 @@ func CustomDomainRegistrationWorkflow(ctx workflow.Context, params CustomDomainR
 	if err != nil {
 		logger.Error("failed to create custom domain ingress", "error", err.Error(), "org_id", params.OrgID, "domain", params.Domain)
 		return fmt.Errorf("failed to create custom domain ingress: %w", err)
+	}
+
+	return nil
+}
+
+func CustomDomainUpdateWorkflow(ctx workflow.Context, params CustomDomainUpdateParams) error {
+	logger := workflow.GetLogger(ctx)
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 60 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 3,
+		},
+	})
+
+	var a *Activities
+	err := workflow.ExecuteActivity(
+		ctx,
+		a.CustomDomainIngress,
+		activities.CustomDomainIngressArgs{
+			OrgID:           params.OrgID,
+			Domain:          params.Domain,
+			Action:          activities.CustomDomainIngressActionReapply,
+			IngressName:     "",
+			ResourceName:    "",
+			CertSecretName:  "",
+			ProvisionerKind: params.ProvisionerKind,
+		},
+	).Get(ctx, nil)
+	if err != nil {
+		logger.Error("failed to re-apply custom domain ip allowlist", "error", err.Error(), "org_id", params.OrgID, "domain", params.Domain)
+		return fmt.Errorf("failed to re-apply custom domain ip allowlist: %w", err)
 	}
 
 	return nil

--- a/server/internal/background/custom_domain_registration.go
+++ b/server/internal/background/custom_domain_registration.go
@@ -37,6 +37,7 @@ type CustomDomainUpdateParams struct {
 	OrgID           string
 	Domain          string
 	ProvisionerKind k8s.ProvisionerKind
+	IPAllowlist     []string
 }
 
 type CustomDomainRegistrationClient struct {
@@ -67,7 +68,7 @@ func (c *CustomDomainRegistrationClient) GetUpdateID(orgID string, domain string
 
 // ExecuteCustomDomainUpdate re-applies the persisted IP allowlist to an
 // already-provisioned custom domain. Used by the edit flow.
-func (c *CustomDomainRegistrationClient) ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, provisionerKind k8s.ProvisionerKind) (client.WorkflowRun, error) {
+func (c *CustomDomainRegistrationClient) ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, provisionerKind k8s.ProvisionerKind, ipAllowlist []string) (client.WorkflowRun, error) {
 	id := c.GetUpdateID(orgID, domain)
 	return c.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		ID:                    id,
@@ -78,6 +79,7 @@ func (c *CustomDomainRegistrationClient) ExecuteCustomDomainUpdate(ctx context.C
 		OrgID:           orgID,
 		Domain:          domain,
 		ProvisionerKind: provisionerKind,
+		IPAllowlist:     ipAllowlist,
 	})
 }
 
@@ -159,6 +161,7 @@ func CustomDomainRegistrationWorkflow(ctx workflow.Context, params CustomDomainR
 			ResourceName:    "",
 			CertSecretName:  "",
 			ProvisionerKind: params.ProvisionerKind,
+			IPAllowlist:     nil, // Setup reads the persisted allowlist from the DB.
 		},
 	).Get(ingressCreateCtx, nil)
 	if err != nil {
@@ -190,6 +193,7 @@ func CustomDomainUpdateWorkflow(ctx workflow.Context, params CustomDomainUpdateP
 			ResourceName:    "",
 			CertSecretName:  "",
 			ProvisionerKind: params.ProvisionerKind,
+			IPAllowlist:     params.IPAllowlist,
 		},
 	).Get(ctx, nil)
 	if err != nil {
@@ -221,6 +225,7 @@ func CustomDomainDeletionWorkflow(ctx workflow.Context, params CustomDomainDelet
 			ResourceName:    "",
 			CertSecretName:  params.CertSecretName,
 			ProvisionerKind: params.ProvisionerKind,
+			IPAllowlist:     nil, // Unused by Delete.
 		},
 	).Get(ctx, nil)
 	if err != nil {

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -335,6 +335,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(OpenrouterKeyRefreshWorkflow)
 	temporalWorker.RegisterWorkflow(CustomDomainRegistrationWorkflow)
 	temporalWorker.RegisterWorkflow(CustomDomainDeletionWorkflow)
+	temporalWorker.RegisterWorkflow(CustomDomainUpdateWorkflow)
 	temporalWorker.RegisterWorkflow(CollectOpenRouterCreditsMetricsWorkflow)
 	temporalWorker.RegisterWorkflow(CollectPlatformUsageMetricsWorkflow)
 	temporalWorker.RegisterWorkflow(AIUsagePollerCoordinatorWorkflow)

--- a/server/internal/customdomains/impl.go
+++ b/server/internal/customdomains/impl.go
@@ -44,6 +44,7 @@ type TemporalClient interface {
 	GetWorkflowInfo(ctx context.Context, orgID string, domain string) (*workflowservice.DescribeWorkflowExecutionResponse, error)
 	ExecuteCustomDomainRegistration(ctx context.Context, orgID string, domain string, createdBy urn.Principal, createdByName *string, provisionerKind k8s.ProvisionerKind, ipAllowlist []string) (client.WorkflowRun, error)
 	ExecuteCustomDomainDeletion(ctx context.Context, orgID, domain, ingressName, certSecretName string, provisionerKind k8s.ProvisionerKind) (client.WorkflowRun, error)
+	ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, provisionerKind k8s.ProvisionerKind) (client.WorkflowRun, error)
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -168,6 +169,15 @@ func (s *Service) UpdateDomain(ctx context.Context, payload *gen.UpdateDomainPay
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeNotFound, err, "no custom domain found for organization").Log(ctx, s.logger)
+	}
+
+	// Push the new allowlist to the live k8s resource. Only meaningful once the
+	// domain is provisioned; otherwise the registration workflow picks up the
+	// persisted allowlist when it runs Setup.
+	if domain.Activated && domain.IngressName.Valid {
+		if _, err := s.temporalClient.ExecuteCustomDomainUpdate(ctx, authCtx.ActiveOrganizationID, domain.Domain, k8s.ProvisionerKind(domain.ProvisionerKind)); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to start custom domain update workflow").Log(ctx, s.logger)
+		}
 	}
 
 	isUpdating := false

--- a/server/internal/customdomains/impl.go
+++ b/server/internal/customdomains/impl.go
@@ -44,7 +44,7 @@ type TemporalClient interface {
 	GetWorkflowInfo(ctx context.Context, orgID string, domain string) (*workflowservice.DescribeWorkflowExecutionResponse, error)
 	ExecuteCustomDomainRegistration(ctx context.Context, orgID string, domain string, createdBy urn.Principal, createdByName *string, provisionerKind k8s.ProvisionerKind, ipAllowlist []string) (client.WorkflowRun, error)
 	ExecuteCustomDomainDeletion(ctx context.Context, orgID, domain, ingressName, certSecretName string, provisionerKind k8s.ProvisionerKind) (client.WorkflowRun, error)
-	ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, provisionerKind k8s.ProvisionerKind) (client.WorkflowRun, error)
+	ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, provisionerKind k8s.ProvisionerKind, ipAllowlist []string) (client.WorkflowRun, error)
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -163,21 +163,35 @@ func (s *Service) UpdateDomain(ctx context.Context, payload *gen.UpdateDomainPay
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid ip_allowlist entry").Log(ctx, s.logger)
 	}
 
-	domain, err := repo.New(s.db).UpdateCustomDomainIPAllowlist(ctx, repo.UpdateCustomDomainIPAllowlistParams{
-		IpAllowlist:    ipAllowlist,
-		OrganizationID: authCtx.ActiveOrganizationID,
-	})
+	repository := repo.New(s.db)
+
+	domain, err := repository.GetCustomDomainByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, oops.E(oops.CodeNotFound, err, "no custom domain found for organization").Log(ctx, s.logger)
 	}
 
-	// Push the new allowlist to the live k8s resource. Only meaningful once the
-	// domain is provisioned; otherwise the registration workflow picks up the
-	// persisted allowlist when it runs Setup.
+	// Reconcile the live k8s resource BEFORE persisting so a reconcile failure
+	// leaves no partial state: the request errors and the stored allowlist is
+	// unchanged, so a retry is safe. The allowlist is threaded through the
+	// workflow rather than read from the DB, which is why it can run first.
+	// Only meaningful once provisioned; otherwise the registration workflow
+	// picks up the persisted allowlist when it runs Setup.
 	if domain.Activated && domain.IngressName.Valid {
-		if _, err := s.temporalClient.ExecuteCustomDomainUpdate(ctx, authCtx.ActiveOrganizationID, domain.Domain, k8s.ProvisionerKind(domain.ProvisionerKind)); err != nil {
+		run, err := s.temporalClient.ExecuteCustomDomainUpdate(ctx, authCtx.ActiveOrganizationID, domain.Domain, k8s.ProvisionerKind(domain.ProvisionerKind), ipAllowlist)
+		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to start custom domain update workflow").Log(ctx, s.logger)
 		}
+		if err := run.Get(ctx, nil); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "custom domain update workflow failed").Log(ctx, s.logger)
+		}
+	}
+
+	domain, err = repository.UpdateCustomDomainIPAllowlist(ctx, repo.UpdateCustomDomainIPAllowlistParams{
+		IpAllowlist:    ipAllowlist,
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to update custom domain ip allowlist").Log(ctx, s.logger)
 	}
 
 	isUpdating := false

--- a/server/internal/customdomains/setup_test.go
+++ b/server/internal/customdomains/setup_test.go
@@ -35,6 +35,7 @@ func (stubTemporalRun) GetRunID() string { return "run" }
 type stubTemporalClient struct {
 	registrationCalls int
 	deletionCalls     int
+	updateCalls       int
 	lastDomain        string
 }
 
@@ -50,6 +51,12 @@ func (s *stubTemporalClient) ExecuteCustomDomainRegistration(ctx context.Context
 
 func (s *stubTemporalClient) ExecuteCustomDomainDeletion(ctx context.Context, orgID, domain, ingressName, certSecretName string, _ k8s.ProvisionerKind) (client.WorkflowRun, error) {
 	s.deletionCalls++
+	s.lastDomain = domain
+	return stubTemporalRun{}, nil
+}
+
+func (s *stubTemporalClient) ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, _ k8s.ProvisionerKind) (client.WorkflowRun, error) {
+	s.updateCalls++
 	s.lastDomain = domain
 	return stubTemporalRun{}, nil
 }

--- a/server/internal/customdomains/setup_test.go
+++ b/server/internal/customdomains/setup_test.go
@@ -55,7 +55,7 @@ func (s *stubTemporalClient) ExecuteCustomDomainDeletion(ctx context.Context, or
 	return stubTemporalRun{}, nil
 }
 
-func (s *stubTemporalClient) ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, _ k8s.ProvisionerKind) (client.WorkflowRun, error) {
+func (s *stubTemporalClient) ExecuteCustomDomainUpdate(ctx context.Context, orgID, domain string, _ k8s.ProvisionerKind, _ []string) (client.WorkflowRun, error) {
 	s.updateCalls++
 	s.lastDomain = domain
 	return stubTemporalRun{}, nil

--- a/server/internal/customdomains/updatedomain_test.go
+++ b/server/internal/customdomains/updatedomain_test.go
@@ -1,0 +1,92 @@
+package customdomains_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/domains"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	cdrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+)
+
+func TestUpdateDomain_Activated_TriggersUpdateWorkflow(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCustomDomainsService(t)
+	authCtx := testAuthContext(t, ctx)
+
+	created, err := ti.repo.CreateCustomDomain(ctx, cdrepo.CreateCustomDomainParams{
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		Domain:          "update-active.example.com",
+		IngressName:     pgTextValid("ingress-active"),
+		CertSecretName:  pgTextValid("cert-active"),
+		ProvisionerKind: "ingress",
+		IpAllowlist:     []string{},
+	})
+	require.NoError(t, err)
+
+	// Mark the domain activated so the edit flow re-applies to k8s.
+	_, err = ti.repo.UpdateCustomDomain(ctx, cdrepo.UpdateCustomDomainParams{
+		Verified:        true,
+		Activated:       true,
+		IngressName:     pgTextValid("ingress-active"),
+		CertSecretName:  pgTextValid("cert-active"),
+		ProvisionerKind: "ingress",
+		ID:              created.ID,
+	})
+	require.NoError(t, err)
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgAdmin,
+		Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID),
+	})
+
+	res, err := ti.service.UpdateDomain(ctx, &gen.UpdateDomainPayload{
+		SessionToken: nil,
+		IPAllowlist:  []string{"1.2.3.4", "10.0.0.0/8"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"1.2.3.4", "10.0.0.0/8"}, res.IPAllowlist)
+
+	require.Equal(t, 1, ti.temporal.updateCalls, "activated domain must re-apply allowlist to k8s")
+
+	row, err := ti.repo.GetCustomDomainByOrganization(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"1.2.3.4", "10.0.0.0/8"}, row.IpAllowlist)
+}
+
+func TestUpdateDomain_NotActivated_NoWorkflow(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCustomDomainsService(t)
+	authCtx := testAuthContext(t, ctx)
+
+	_, err := ti.repo.CreateCustomDomain(ctx, cdrepo.CreateCustomDomainParams{
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		Domain:          "update-pending.example.com",
+		IngressName:     pgtype.Text{},
+		CertSecretName:  pgtype.Text{},
+		ProvisionerKind: "ingress",
+		IpAllowlist:     []string{},
+	})
+	require.NoError(t, err)
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgAdmin,
+		Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID),
+	})
+
+	res, err := ti.service.UpdateDomain(ctx, &gen.UpdateDomainPayload{
+		SessionToken: nil,
+		IPAllowlist:  []string{"1.2.3.4"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"1.2.3.4"}, res.IPAllowlist)
+
+	// Not yet provisioned — the persisted allowlist is picked up by the
+	// registration workflow's Setup, so no separate update workflow runs.
+	require.Equal(t, 0, ti.temporal.updateCalls)
+}

--- a/server/internal/k8s/client.go
+++ b/server/internal/k8s/client.go
@@ -14,12 +14,13 @@ import (
 )
 
 type KubernetesClients struct {
-	Clientset     *kubernetes.Clientset
-	DynamicClient dynamic.Interface
-	gatewayClient gatewayclient.Interface
-	logger        *slog.Logger
-	namespace     string
-	enabled       bool
+	Clientset             *kubernetes.Clientset
+	DynamicClient         dynamic.Interface
+	gatewayClient         gatewayclient.Interface
+	logger                *slog.Logger
+	namespace             string
+	enabled               bool
+	securityPolicyEnabled bool
 }
 
 var (
@@ -28,16 +29,22 @@ var (
 )
 
 // InitializeK8sClient initializes and returns KubernetesClients singleton.
-func InitializeK8sClient(ctx context.Context, logger *slog.Logger, env string) (*KubernetesClients, error) {
+//
+// gatewayIPAllowlistEnabled gates the Envoy Gateway SecurityPolicy reconcile
+// used for gateway-kind custom domain IP allow listing. Keep it off until the
+// Envoy Gateway SecurityPolicy CRD is installed in the target namespaces; the
+// ingress path is unaffected.
+func InitializeK8sClient(ctx context.Context, logger *slog.Logger, env string, gatewayIPAllowlistEnabled bool) (*KubernetesClients, error) {
 	// not supporting k8s client in local dev mode currently
 	if env == "local" {
 		return &KubernetesClients{
-			Clientset:     nil,
-			DynamicClient: nil,
-			gatewayClient: nil,
-			logger:        logger.With(attr.SlogComponent("k8s_client")),
-			enabled:       false,
-			namespace:     "",
+			Clientset:             nil,
+			DynamicClient:         nil,
+			gatewayClient:         nil,
+			logger:                logger.With(attr.SlogComponent("k8s_client")),
+			enabled:               false,
+			securityPolicyEnabled: false,
+			namespace:             "",
 		}, nil
 	}
 
@@ -67,12 +74,13 @@ func InitializeK8sClient(ctx context.Context, logger *slog.Logger, env string) (
 		}
 
 		k8sClients = &KubernetesClients{
-			Clientset:     clientset,
-			DynamicClient: dynamicClient,
-			gatewayClient: gatewayClient,
-			logger:        logger,
-			enabled:       true,
-			namespace:     fmt.Sprintf("gram-%s", env),
+			Clientset:             clientset,
+			DynamicClient:         dynamicClient,
+			gatewayClient:         gatewayClient,
+			logger:                logger,
+			enabled:               true,
+			securityPolicyEnabled: gatewayIPAllowlistEnabled,
+			namespace:             fmt.Sprintf("gram-%s", env),
 		}
 
 		logger.InfoContext(ctx, "Kubernetes clients initialized successfully.")
@@ -88,7 +96,7 @@ func (k *KubernetesClients) Provisioner(kind ProvisionerKind) CustomDomainProvis
 		return &StubProvisioner{kind: kind, logger: k.logger, calls: nil}
 	}
 	if kind == ProvisionerKindGateway {
-		return &GatewayProvisioner{client: k.gatewayClient, namespace: k.namespace, logger: k.logger}
+		return &GatewayProvisioner{client: k.gatewayClient, dynamic: k.DynamicClient, securityPolicyEnabled: k.securityPolicyEnabled, namespace: k.namespace, logger: k.logger}
 	}
 	return &IngressProvisioner{clientset: k.Clientset, namespace: k.namespace, logger: k.logger}
 }

--- a/server/internal/k8s/gateway_provisioner.go
+++ b/server/internal/k8s/gateway_provisioner.go
@@ -8,19 +8,26 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
 
 type GatewayProvisioner struct {
-	client    gatewayclient.Interface
-	namespace string
-	logger    *slog.Logger
+	client  gatewayclient.Interface
+	dynamic dynamic.Interface
+	// securityPolicyEnabled gates the Envoy Gateway SecurityPolicy reconcile. It
+	// must stay off until Envoy Gateway and its SecurityPolicy CRD are installed
+	// in the target namespaces; otherwise create/delete calls hit a missing CRD
+	// and break provisioning. See InitializeK8sClient.
+	securityPolicyEnabled bool
+	namespace             string
+	logger                *slog.Logger
 }
 
 func (p *GatewayProvisioner) Kind() ProvisionerKind { return ProvisionerKindGateway }
 
-func (p *GatewayProvisioner) Setup(ctx context.Context, domain string) (SetupResult, error) {
+func (p *GatewayProvisioner) Setup(ctx context.Context, domain string, ipAllowlist []string) (SetupResult, error) {
 	name, err := SanitizeDomainForK8sName(domain)
 	if err != nil {
 		return SetupResult{}, fmt.Errorf("sanitize domain: %w", err)
@@ -38,13 +45,20 @@ func (p *GatewayProvisioner) Setup(ctx context.Context, domain string) (SetupRes
 		if _, createErr := routeInterface.Create(ctx, route, metav1.CreateOptions{}); createErr != nil {
 			return SetupResult{}, fmt.Errorf("create httproute %s: %w", name, createErr)
 		}
-		return SetupResult{ResourceName: name, SecretName: ""}, nil
+	} else {
+		p.logger.InfoContext(ctx, "httproute found, updating", attr.SlogResourceName(name))
+		route.ResourceVersion = existing.ResourceVersion
+		if _, updateErr := routeInterface.Update(ctx, route, metav1.UpdateOptions{}); updateErr != nil {
+			return SetupResult{}, fmt.Errorf("update httproute %s: %w", name, updateErr)
+		}
 	}
 
-	p.logger.InfoContext(ctx, "httproute found, updating", attr.SlogResourceName(name))
-	route.ResourceVersion = existing.ResourceVersion
-	if _, updateErr := routeInterface.Update(ctx, route, metav1.UpdateOptions{}); updateErr != nil {
-		return SetupResult{}, fmt.Errorf("update httproute %s: %w", name, updateErr)
+	// Gateway API has no native CIDR filtering; IP allow listing is delegated to
+	// an Envoy Gateway SecurityPolicy targeting the HTTPRoute. Isolated in
+	// gateway_security_policy.go so the mechanism can be swapped if the gateway
+	// implementation changes.
+	if err := p.reconcileSecurityPolicy(ctx, name, ipAllowlist); err != nil {
+		return SetupResult{}, fmt.Errorf("reconcile security policy %s: %w", name, err)
 	}
 
 	return SetupResult{ResourceName: name, SecretName: ""}, nil
@@ -58,8 +72,13 @@ func (p *GatewayProvisioner) Get(ctx context.Context, resourceName string) error
 	return nil
 }
 
-// Delete removes the HTTPRoute only. The parent Gateway's TLS Secret is shared and must not be touched.
+// Delete removes the HTTPRoute and any SecurityPolicy it owns. The parent
+// Gateway's TLS Secret is shared and must not be touched.
 func (p *GatewayProvisioner) Delete(ctx context.Context, resourceName, _ string) error {
+	if err := p.deleteSecurityPolicy(ctx, resourceName); err != nil {
+		return fmt.Errorf("delete security policy %s: %w", resourceName, err)
+	}
+
 	if err := p.client.GatewayV1().HTTPRoutes(p.namespace).Delete(ctx, resourceName, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("delete httproute %s: %w", resourceName, err)
 	}

--- a/server/internal/k8s/gateway_provisioner.go
+++ b/server/internal/k8s/gateway_provisioner.go
@@ -74,15 +74,21 @@ func (p *GatewayProvisioner) Get(ctx context.Context, resourceName string) error
 
 // Delete removes the HTTPRoute and any SecurityPolicy it owns. The parent
 // Gateway's TLS Secret is shared and must not be touched.
+//
+// The HTTPRoute is removed first. If that fails the SecurityPolicy stays in
+// place, so the still-live route remains IP-restricted rather than briefly
+// open. Once the route is gone the SecurityPolicy guards nothing, so deleting
+// it second is safe.
 func (p *GatewayProvisioner) Delete(ctx context.Context, resourceName, _ string) error {
-	if err := p.deleteSecurityPolicy(ctx, resourceName); err != nil {
-		return fmt.Errorf("delete security policy %s: %w", resourceName, err)
-	}
-
 	if err := p.client.GatewayV1().HTTPRoutes(p.namespace).Delete(ctx, resourceName, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("delete httproute %s: %w", resourceName, err)
 	}
 	p.logger.InfoContext(ctx, "httproute deleted", attr.SlogResourceName(resourceName))
+
+	if err := p.deleteSecurityPolicy(ctx, resourceName); err != nil {
+		return fmt.Errorf("delete security policy %s: %w", resourceName, err)
+	}
+
 	return nil
 }
 

--- a/server/internal/k8s/gateway_provisioner_test.go
+++ b/server/internal/k8s/gateway_provisioner_test.go
@@ -7,34 +7,44 @@ import (
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
 const gatewayTestNamespace = "gram-test"
 
-func newGatewayProvisioner(t *testing.T) (*GatewayProvisioner, *gatewayfake.Clientset) {
+func newGatewayProvisioner(t *testing.T) (*GatewayProvisioner, *gatewayfake.Clientset, *dynamicfake.FakeDynamicClient) {
 	t.Helper()
 	cs := gatewayfake.NewSimpleClientset()
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{securityPolicyGVR: "SecurityPolicyList"},
+	)
 	return &GatewayProvisioner{
-		client:    cs,
-		namespace: gatewayTestNamespace,
-		logger:    testenv.NewLogger(t),
-	}, cs
+		client:                cs,
+		dynamic:               dc,
+		securityPolicyEnabled: true,
+		namespace:             gatewayTestNamespace,
+		logger:                testenv.NewLogger(t),
+	}, cs, dc
 }
 
 func TestGatewayProvisioner_Kind(t *testing.T) {
 	t.Parallel()
-	p, _ := newGatewayProvisioner(t)
+	p, _, _ := newGatewayProvisioner(t)
 	require.Equal(t, ProvisionerKindGateway, p.Kind())
 }
 
 func TestGatewayProvisioner_Setup_CreateNew(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	p, cs := newGatewayProvisioner(t)
+	p, cs, _ := newGatewayProvisioner(t)
 	domain := "test.example.com"
 
-	result, err := p.Setup(ctx, domain)
+	result, err := p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
 	expectedName, err := SanitizeDomainForK8sName(domain)
@@ -54,13 +64,13 @@ func TestGatewayProvisioner_Setup_CreateNew(t *testing.T) {
 func TestGatewayProvisioner_Setup_UpdateExisting(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	p, cs := newGatewayProvisioner(t)
+	p, cs, _ := newGatewayProvisioner(t)
 	domain := "update.example.com"
 
-	_, err := p.Setup(ctx, domain)
+	_, err := p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
-	_, err = p.Setup(ctx, domain)
+	_, err = p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
 	expectedName, err := SanitizeDomainForK8sName(domain)
@@ -72,13 +82,84 @@ func TestGatewayProvisioner_Setup_UpdateExisting(t *testing.T) {
 	require.Equal(t, expectedName, routes.Items[0].Name)
 }
 
+func TestGatewayProvisioner_Setup_WithAllowlist_CreatesSecurityPolicy(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	p, _, dc := newGatewayProvisioner(t)
+	domain := "secure.example.com"
+
+	result, err := p.Setup(ctx, domain, []string{"1.2.3.4", "10.0.0.0/8"})
+	require.NoError(t, err)
+
+	policy, err := dc.Resource(securityPolicyGVR).Namespace(gatewayTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	defaultAction, _, err := unstructured.NestedString(policy.Object, "spec", "authorization", "defaultAction")
+	require.NoError(t, err)
+	require.Equal(t, "Deny", defaultAction)
+
+	rules, found, err := unstructured.NestedSlice(policy.Object, "spec", "authorization", "rules")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, rules, 1)
+	rule, ok := rules[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "Allow", rule["action"])
+	principal, ok := rule["principal"].(map[string]any)
+	require.True(t, ok)
+	rawCIDRs, ok := principal["clientCIDRs"].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{"1.2.3.4/32", "10.0.0.0/8"}, rawCIDRs)
+}
+
+func TestGatewayProvisioner_Setup_EmptyAllowlist_DeletesSecurityPolicy(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	p, _, dc := newGatewayProvisioner(t)
+	domain := "open.example.com"
+
+	// Restrict, then re-apply with an empty allowlist to lift the restriction.
+	result, err := p.Setup(ctx, domain, []string{"1.2.3.4"})
+	require.NoError(t, err)
+
+	_, err = dc.Resource(securityPolicyGVR).Namespace(gatewayTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	_, err = p.Setup(ctx, domain, nil)
+	require.NoError(t, err)
+
+	_, err = dc.Resource(securityPolicyGVR).Namespace(gatewayTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
+	require.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestGatewayProvisioner_Setup_GatedOff_SkipsSecurityPolicy(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	p, cs, dc := newGatewayProvisioner(t)
+	p.securityPolicyEnabled = false
+	domain := "gated.example.com"
+
+	result, err := p.Setup(ctx, domain, []string{"1.2.3.4"})
+	require.NoError(t, err)
+
+	// HTTPRoute is still provisioned; SecurityPolicy is not touched.
+	_, err = cs.GatewayV1().HTTPRoutes(gatewayTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	_, err = dc.Resource(securityPolicyGVR).Namespace(gatewayTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
+	require.True(t, k8serrors.IsNotFound(err))
+
+	// Delete must also skip the policy and not error.
+	require.NoError(t, p.Delete(ctx, result.ResourceName, ""))
+}
+
 func TestGatewayProvisioner_Get_Found(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	p, _ := newGatewayProvisioner(t)
+	p, _, _ := newGatewayProvisioner(t)
 	domain := "get.example.com"
 
-	result, err := p.Setup(ctx, domain)
+	result, err := p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, p.Get(ctx, result.ResourceName))
@@ -87,7 +168,7 @@ func TestGatewayProvisioner_Get_Found(t *testing.T) {
 func TestGatewayProvisioner_Get_NotFound(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	p, _ := newGatewayProvisioner(t)
+	p, _, _ := newGatewayProvisioner(t)
 
 	err := p.Get(ctx, "nonexistent-httproute")
 	require.Error(t, err)
@@ -96,24 +177,28 @@ func TestGatewayProvisioner_Get_NotFound(t *testing.T) {
 func TestGatewayProvisioner_Delete_DoesNotTouchSecret(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	p, cs := newGatewayProvisioner(t)
+	p, cs, dc := newGatewayProvisioner(t)
 	domain := "delete.example.com"
 
-	result, err := p.Setup(ctx, domain)
+	result, err := p.Setup(ctx, domain, []string{"1.2.3.4"})
 	require.NoError(t, err)
 
 	require.NoError(t, p.Delete(ctx, result.ResourceName, ""))
 
 	_, err = cs.GatewayV1().HTTPRoutes(gatewayTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
 	require.True(t, k8serrors.IsNotFound(err))
+
+	// The SecurityPolicy is owned by the route and must be removed alongside it.
+	_, err = dc.Resource(securityPolicyGVR).Namespace(gatewayTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
+	require.True(t, k8serrors.IsNotFound(err))
 }
 
 func TestGatewayProvisioner_Setup_SecretNameEmpty(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	p, _ := newGatewayProvisioner(t)
+	p, _, _ := newGatewayProvisioner(t)
 
-	result, err := p.Setup(ctx, "secret.example.com")
+	result, err := p.Setup(ctx, "secret.example.com", nil)
 	require.NoError(t, err)
 	require.Empty(t, result.SecretName)
 }

--- a/server/internal/k8s/gateway_security_policy.go
+++ b/server/internal/k8s/gateway_security_policy.go
@@ -1,0 +1,132 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// securityPolicyGVR is the Envoy Gateway SecurityPolicy custom resource. IP
+// allow listing on the Gateway API path is implemented through this CRD because
+// core Gateway API has no native CIDR filtering. The whole mechanism lives in
+// this file so it can be replaced wholesale if the gateway implementation
+// changes (e.g. Istio AuthorizationPolicy).
+var securityPolicyGVR = schema.GroupVersionResource{
+	Group:    "gateway.envoyproxy.io",
+	Version:  "v1alpha1",
+	Resource: "securitypolicies",
+}
+
+// reconcileSecurityPolicy creates/updates the SecurityPolicy that restricts the
+// HTTPRoute to the given IPv4 sources. An empty allowlist deletes any existing
+// policy so the route becomes open to all.
+func (p *GatewayProvisioner) reconcileSecurityPolicy(ctx context.Context, routeName string, ipAllowlist []string) error {
+	if !p.securityPolicyEnabled {
+		if len(ipAllowlist) > 0 {
+			p.logger.WarnContext(ctx, "gateway ip allowlist requested but SecurityPolicy reconcile is gated off; skipping", attr.SlogResourceName(routeName))
+		}
+		return nil
+	}
+
+	if len(ipAllowlist) == 0 {
+		return p.deleteSecurityPolicy(ctx, routeName)
+	}
+
+	desired := buildSecurityPolicy(p.namespace, routeName, ipAllowlist)
+	policies := p.dynamic.Resource(securityPolicyGVR).Namespace(p.namespace)
+
+	existing, err := policies.Get(ctx, routeName, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("get securitypolicy %s: %w", routeName, err)
+		}
+		p.logger.InfoContext(ctx, "securitypolicy not found, creating", attr.SlogResourceName(routeName))
+		if _, createErr := policies.Create(ctx, desired, metav1.CreateOptions{}); createErr != nil {
+			return fmt.Errorf("create securitypolicy %s: %w", routeName, createErr)
+		}
+		return nil
+	}
+
+	p.logger.InfoContext(ctx, "securitypolicy found, updating", attr.SlogResourceName(routeName))
+	desired.SetResourceVersion(existing.GetResourceVersion())
+	if _, updateErr := policies.Update(ctx, desired, metav1.UpdateOptions{}); updateErr != nil {
+		return fmt.Errorf("update securitypolicy %s: %w", routeName, updateErr)
+	}
+	return nil
+}
+
+// deleteSecurityPolicy removes the SecurityPolicy for the route. Missing policy
+// is not an error — Delete and the open-allowlist path both rely on this.
+func (p *GatewayProvisioner) deleteSecurityPolicy(ctx context.Context, routeName string) error {
+	if !p.securityPolicyEnabled {
+		return nil
+	}
+
+	err := p.dynamic.Resource(securityPolicyGVR).Namespace(p.namespace).Delete(ctx, routeName, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("delete securitypolicy %s: %w", routeName, err)
+	}
+	if err == nil {
+		p.logger.InfoContext(ctx, "securitypolicy deleted", attr.SlogResourceName(routeName))
+	}
+	return nil
+}
+
+// buildSecurityPolicy builds an Envoy Gateway SecurityPolicy that denies by
+// default and allows only the supplied client CIDRs, targeting the HTTPRoute of
+// the same name.
+func buildSecurityPolicy(namespace, routeName string, ipAllowlist []string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": securityPolicyGVR.Group + "/" + securityPolicyGVR.Version,
+			"kind":       "SecurityPolicy",
+			"metadata": map[string]any{
+				"name":      routeName,
+				"namespace": namespace,
+				"labels": map[string]any{
+					"app.kubernetes.io/managed-by": "custom-domain-chart",
+				},
+			},
+			"spec": map[string]any{
+				"targetRefs": []any{
+					map[string]any{
+						"group": "gateway.networking.k8s.io",
+						"kind":  "HTTPRoute",
+						"name":  routeName,
+					},
+				},
+				"authorization": map[string]any{
+					"defaultAction": "Deny",
+					"rules": []any{
+						map[string]any{
+							"action": "Allow",
+							"principal": map[string]any{
+								"clientCIDRs": toClientCIDRs(ipAllowlist),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// toClientCIDRs normalizes allowlist entries into CIDR notation as required by
+// the SecurityPolicy clientCIDRs field. Bare IPv4 addresses become /32.
+func toClientCIDRs(entries []string) []any {
+	cidrs := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		if strings.Contains(entry, "/") {
+			cidrs = append(cidrs, entry)
+			continue
+		}
+		cidrs = append(cidrs, entry+"/32")
+	}
+	return cidrs
+}

--- a/server/internal/k8s/ingress_provisioner.go
+++ b/server/internal/k8s/ingress_provisioner.go
@@ -21,8 +21,8 @@ type IngressProvisioner struct {
 
 func (p *IngressProvisioner) Kind() ProvisionerKind { return ProvisionerKindIngress }
 
-func (p *IngressProvisioner) Setup(ctx context.Context, domain string) (SetupResult, error) {
-	k8sName, secretName, ingress, err := p.buildIngress(domain)
+func (p *IngressProvisioner) Setup(ctx context.Context, domain string, ipAllowlist []string) (SetupResult, error) {
+	k8sName, secretName, ingress, err := p.buildIngress(domain, ipAllowlist)
 	if err != nil {
 		return SetupResult{}, fmt.Errorf("build ingress: %w", err)
 	}
@@ -70,7 +70,7 @@ func (p *IngressProvisioner) Delete(ctx context.Context, resourceName, secretNam
 	return nil
 }
 
-func (p *IngressProvisioner) buildIngress(domain string) (string, string, *networkingv1.Ingress, error) {
+func (p *IngressProvisioner) buildIngress(domain string, ipAllowlist []string) (string, string, *networkingv1.Ingress, error) {
 	nginxIngressClassName := "nginx"
 	pathTypePrefix := networkingv1.PathTypePrefix
 	pathTypeImplementationSpecific := networkingv1.PathTypeImplementationSpecific
@@ -80,15 +80,23 @@ func (p *IngressProvisioner) buildIngress(domain string) (string, string, *netwo
 	}
 	secretName := strings.ReplaceAll(domain, ".", "-") + "-tls"
 
+	annotations := map[string]string{
+		"cert-manager.io/cluster-issuer":              "gram-letsencrypt",
+		"nginx.ingress.kubernetes.io/proxy-body-size": "15m",
+		"nginx.ingress.kubernetes.io/use-regex":       "true",
+	}
+	// A non-empty allowlist restricts inbound traffic to the given IPv4 sources.
+	// An empty list omits the annotation entirely, which removes any prior
+	// restriction since Update replaces the whole object.
+	if len(ipAllowlist) > 0 {
+		annotations["nginx.ingress.kubernetes.io/whitelist-source-range"] = strings.Join(ipAllowlist, ",")
+	}
+
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      k8sName,
-			Namespace: p.namespace,
-			Annotations: map[string]string{
-				"cert-manager.io/cluster-issuer":              "gram-letsencrypt",
-				"nginx.ingress.kubernetes.io/proxy-body-size": "15m",
-				"nginx.ingress.kubernetes.io/use-regex":       "true",
-			},
+			Name:        k8sName,
+			Namespace:   p.namespace,
+			Annotations: annotations,
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by": "custom-domain-chart",
 				"custom-domain":                domain,

--- a/server/internal/k8s/ingress_provisioner_test.go
+++ b/server/internal/k8s/ingress_provisioner_test.go
@@ -36,7 +36,7 @@ func TestIngressProvisioner_Setup_CreateNew(t *testing.T) {
 	p, cs := newIngressProvisioner(t)
 	domain := "test.example.com"
 
-	result, err := p.Setup(ctx, domain)
+	result, err := p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
 	expectedName, err := SanitizeDomainForK8sName(domain)
@@ -55,16 +55,49 @@ func TestIngressProvisioner_Setup_CreateNew(t *testing.T) {
 	require.Equal(t, expectedSecret, ingress.Spec.TLS[0].SecretName)
 }
 
+func TestIngressProvisioner_Setup_WithAllowlist_SetsAnnotation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	p, cs := newIngressProvisioner(t)
+	domain := "allow.example.com"
+
+	result, err := p.Setup(ctx, domain, []string{"1.2.3.4", "10.0.0.0/8"})
+	require.NoError(t, err)
+
+	ingress, err := cs.NetworkingV1().Ingresses(ingressTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3.4,10.0.0.0/8", ingress.Annotations["nginx.ingress.kubernetes.io/whitelist-source-range"])
+}
+
+func TestIngressProvisioner_Setup_EmptyAllowlist_RemovesAnnotation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	p, cs := newIngressProvisioner(t)
+	domain := "clear.example.com"
+
+	// Provision with a restriction, then re-apply with an empty allowlist.
+	_, err := p.Setup(ctx, domain, []string{"1.2.3.4"})
+	require.NoError(t, err)
+
+	result, err := p.Setup(ctx, domain, nil)
+	require.NoError(t, err)
+
+	ingress, err := cs.NetworkingV1().Ingresses(ingressTestNamespace).Get(ctx, result.ResourceName, metav1.GetOptions{})
+	require.NoError(t, err)
+	_, ok := ingress.Annotations["nginx.ingress.kubernetes.io/whitelist-source-range"]
+	require.False(t, ok, "whitelist annotation must be removed when allowlist is empty")
+}
+
 func TestIngressProvisioner_Setup_UpdateExisting(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	p, cs := newIngressProvisioner(t)
 	domain := "update.example.com"
 
-	_, err := p.Setup(ctx, domain)
+	_, err := p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
-	_, err = p.Setup(ctx, domain)
+	_, err = p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
 	expectedName, err := SanitizeDomainForK8sName(domain)
@@ -82,7 +115,7 @@ func TestIngressProvisioner_Get_Found(t *testing.T) {
 	p, _ := newIngressProvisioner(t)
 	domain := "get.example.com"
 
-	result, err := p.Setup(ctx, domain)
+	result, err := p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, p.Get(ctx, result.ResourceName))
@@ -103,7 +136,7 @@ func TestIngressProvisioner_Delete(t *testing.T) {
 	p, cs := newIngressProvisioner(t)
 	domain := "delete.example.com"
 
-	result, err := p.Setup(ctx, domain)
+	result, err := p.Setup(ctx, domain, nil)
 	require.NoError(t, err)
 
 	_, err = cs.CoreV1().Secrets(ingressTestNamespace).Create(ctx, &corev1.Secret{

--- a/server/internal/k8s/provisioner.go
+++ b/server/internal/k8s/provisioner.go
@@ -24,9 +24,14 @@ type SetupResult struct {
 // CustomDomainProvisioner abstracts Kubernetes Ingress and Gateway API provisioning.
 // Get probes resource existence only; readiness polling is a follow-up.
 // Delete is idempotent; Gateway impl must not touch any Secret it did not create.
+//
+// Setup accepts an ipAllowlist of IPv4 addresses and/or CIDR ranges. A non-empty
+// list restricts inbound traffic to those sources; an empty/nil list removes any
+// previously applied restriction (open to all). Setup is idempotent and is also
+// the re-apply path when only the allowlist changes.
 type CustomDomainProvisioner interface {
 	Kind() ProvisionerKind
-	Setup(ctx context.Context, domain string) (SetupResult, error)
+	Setup(ctx context.Context, domain string, ipAllowlist []string) (SetupResult, error)
 	Get(ctx context.Context, resourceName string) error
 	Delete(ctx context.Context, resourceName, secretName string) error
 }

--- a/server/internal/k8s/stub_provisioner.go
+++ b/server/internal/k8s/stub_provisioner.go
@@ -26,25 +26,26 @@ type StubCall struct {
 	Domain       string
 	ResourceName string
 	SecretName   string
+	IPAllowlist  []string
 }
 
 func (p *StubProvisioner) Kind() ProvisionerKind { return p.kind }
 
-func (p *StubProvisioner) Setup(ctx context.Context, domain string) (SetupResult, error) {
-	p.calls = append(p.calls, StubCall{Method: "Setup", Domain: domain, ResourceName: "", SecretName: ""})
+func (p *StubProvisioner) Setup(ctx context.Context, domain string, ipAllowlist []string) (SetupResult, error) {
+	p.calls = append(p.calls, StubCall{Method: "Setup", Domain: domain, ResourceName: "", SecretName: "", IPAllowlist: ipAllowlist})
 	p.logger.InfoContext(ctx, "stub provisioner: setup (no-op)", attr.SlogURLDomain(domain))
 	name, _ := SanitizeDomainForK8sName(domain)
 	return SetupResult{ResourceName: name, SecretName: ""}, nil
 }
 
 func (p *StubProvisioner) Get(ctx context.Context, resourceName string) error {
-	p.calls = append(p.calls, StubCall{Method: "Get", Domain: "", ResourceName: resourceName, SecretName: ""})
+	p.calls = append(p.calls, StubCall{Method: "Get", Domain: "", ResourceName: resourceName, SecretName: "", IPAllowlist: nil})
 	p.logger.InfoContext(ctx, "stub provisioner: get (no-op)", attr.SlogResourceName(resourceName))
 	return nil
 }
 
 func (p *StubProvisioner) Delete(ctx context.Context, resourceName, secretName string) error {
-	p.calls = append(p.calls, StubCall{Method: "Delete", Domain: "", ResourceName: resourceName, SecretName: secretName})
+	p.calls = append(p.calls, StubCall{Method: "Delete", Domain: "", ResourceName: resourceName, SecretName: secretName, IPAllowlist: nil})
 	p.logger.InfoContext(ctx, "stub provisioner: delete (no-op)", attr.SlogResourceName(resourceName))
 	return nil
 }

--- a/server/internal/k8s/stub_provisioner_test.go
+++ b/server/internal/k8s/stub_provisioner_test.go
@@ -13,7 +13,7 @@ func TestStubProvisioner_KindMatchesRequest(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
-	clients, err := k8s.InitializeK8sClient(ctx, testenv.NewLogger(t), "local")
+	clients, err := k8s.InitializeK8sClient(ctx, testenv.NewLogger(t), "local", false)
 	require.NoError(t, err)
 
 	require.Equal(t, k8s.ProvisionerKindIngress, clients.Provisioner(k8s.ProvisionerKindIngress).Kind())
@@ -26,7 +26,7 @@ func TestStubProvisioner_IsNoOp(t *testing.T) {
 
 	p := k8s.NewStubProvisioner(k8s.ProvisionerKindIngress, testenv.NewLogger(t))
 
-	result, err := p.Setup(ctx, "test.example.com")
+	result, err := p.Setup(ctx, "test.example.com", nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, result.ResourceName)
 	require.Empty(t, result.SecretName, "stub never sets SecretName")
@@ -41,7 +41,7 @@ func TestStubProvisioner_RecordsCalls(t *testing.T) {
 
 	p := k8s.NewStubProvisioner(k8s.ProvisionerKindIngress, testenv.NewLogger(t))
 
-	result, err := p.Setup(ctx, "my.example.com")
+	result, err := p.Setup(ctx, "my.example.com", []string{"1.2.3.4"})
 	require.NoError(t, err)
 	require.NoError(t, p.Get(ctx, result.ResourceName))
 	require.NoError(t, p.Delete(ctx, result.ResourceName, "cert-secret"))
@@ -51,6 +51,7 @@ func TestStubProvisioner_RecordsCalls(t *testing.T) {
 
 	require.Equal(t, "Setup", calls[0].Method)
 	require.Equal(t, "my.example.com", calls[0].Domain)
+	require.Equal(t, []string{"1.2.3.4"}, calls[0].IPAllowlist)
 
 	require.Equal(t, "Get", calls[1].Method)
 	require.Equal(t, result.ResourceName, calls[1].ResourceName)
@@ -66,7 +67,7 @@ func TestStubProvisioner_ResourceNameHasNoDots(t *testing.T) {
 
 	p := k8s.NewStubProvisioner(k8s.ProvisionerKindIngress, testenv.NewLogger(t))
 
-	result, err := p.Setup(ctx, "my-domain.example.com")
+	result, err := p.Setup(ctx, "my-domain.example.com", nil)
 	require.NoError(t, err)
 	require.NotContains(t, result.ResourceName, ".", "k8s resource name must not contain dots")
 }


### PR DESCRIPTION
Wires the custom domain IP allowlist through to Kubernetes on both create and edit (previously persisted to DB but never applied). Covers ingress (whitelist-source-range annotation) and gateway (Envoy SecurityPolicy).

Gateway path is gated behind `GRAM_ENABLE_GATEWAY_IP_ALLOWLIST` (default off) until the Envoy SecurityPolicy CRD is installed; ingress is unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the custom domain IP allowlist to Kubernetes on create and edit. Ingress uses NGINX `whitelist-source-range`; Gateway uses Envoy `SecurityPolicy` behind a feature flag, and edits re-apply without reprovisioning.

- New Features
  - Ingress: apply IP allowlist via `nginx.ingress.kubernetes.io/whitelist-source-range`; empty list removes the annotation.
  - Gateway: reconcile Envoy `SecurityPolicy` targeting the `HTTPRoute`; bare IPs normalized to `/32`; empty list deletes the policy.
  - Edit flow: new Temporal `CustomDomainUpdateWorkflow` and activity action `reapply` call `Setup(domain, ipAllowlist)` to update in place; service `UpdateDomain` now reconciles k8s first for activated domains, then persists; pending domains persist only.
  - Feature flag: `--enable-gateway-ip-allowlist` (`GRAM_ENABLE_GATEWAY_IP_ALLOWLIST`) gates Gateway `SecurityPolicy` reconcile; off by default.
  - API changes: `InitializeK8sClient(ctx, logger, env, gatewayIPAllowlistEnabled)` and provisioner `Setup(ctx, domain, ipAllowlist)`; Gateway delete also removes its `SecurityPolicy`.
  - Tests: coverage for ingress, gateway (create/update/delete, gating), and service update flow.

- Migration
  - To enable Gateway allowlisting: install Envoy Gateway and the `SecurityPolicy` CRD in target namespaces, then set `GRAM_ENABLE_GATEWAY_IP_ALLOWLIST=true` (or pass the CLI flag). Ingress path requires no changes.

<sup>Written for commit 3a202f46e1334274156c964291f9b069cd4e8237. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

