### PR TITLE
feat(hooks): add hostname to plugin request headers

### DIFF
--- a/hooks/plugin-claude/hooks/send_hook.sh
+++ b/hooks/plugin-claude/hooks/send_hook.sh
@@ -22,7 +22,7 @@ fi
 
 response=$(curl -s -w "\n%{http_code}" -X POST \
   -H "Content-Type: application/json" \
-  "${hook_hostname_header[@]}" \
+  ${hook_hostname_header[@]+"${hook_hostname_header[@]}"} \
   -d @- \
   --max-time 10 \
   "${server_url}/rpc/hooks.claude")

--- a/hooks/plugin-claude/hooks/send_hook.sh
+++ b/hooks/plugin-claude/hooks/send_hook.sh
@@ -14,8 +14,15 @@ set -u
 
 server_url="${GRAM_HOOKS_SERVER_URL:-https://app.getgram.ai}"
 
+hook_hostname=$(hostname 2>/dev/null || true)
+hook_hostname_header=()
+if [ -n "$hook_hostname" ]; then
+  hook_hostname_header=(-H "X-Gram-Hook-Hostname: ${hook_hostname}")
+fi
+
 response=$(curl -s -w "\n%{http_code}" -X POST \
   -H "Content-Type: application/json" \
+  "${hook_hostname_header[@]}" \
   -d @- \
   --max-time 10 \
   "${server_url}/rpc/hooks.claude")

--- a/hooks/plugin-claude/hooks/send_session_start.sh
+++ b/hooks/plugin-claude/hooks/send_session_start.sh
@@ -14,6 +14,11 @@
 set -u
 
 server_url="${GRAM_HOOKS_SERVER_URL:-https://app.getgram.ai}"
+hook_hostname=$(hostname 2>/dev/null || true)
+hook_hostname_header=()
+if [ -n "$hook_hostname" ]; then
+  hook_hostname_header=(-H "X-Gram-Hook-Hostname: ${hook_hostname}")
+fi
 
 payload=$(cat)
 
@@ -109,6 +114,7 @@ print(json.dumps(p))
 
 curl -s -o /dev/null -X POST \
   -H "Content-Type: application/json" \
+  "${hook_hostname_header[@]}" \
   -d "$enriched" \
   --max-time 30 \
   "${server_url}/rpc/hooks.claude" >/dev/null 2>&1 || true

--- a/hooks/plugin-claude/hooks/send_session_start.sh
+++ b/hooks/plugin-claude/hooks/send_session_start.sh
@@ -114,7 +114,7 @@ print(json.dumps(p))
 
 curl -s -o /dev/null -X POST \
   -H "Content-Type: application/json" \
-  "${hook_hostname_header[@]}" \
+  ${hook_hostname_header[@]+"${hook_hostname_header[@]}"} \
   -d "$enriched" \
   --max-time 30 \
   "${server_url}/rpc/hooks.claude" >/dev/null 2>&1 || true

--- a/hooks/plugin-cursor/hooks/send_hook.sh
+++ b/hooks/plugin-cursor/hooks/send_hook.sh
@@ -21,7 +21,7 @@ curl -s -X POST \
   -H "Content-Type: application/json" \
   -H "Gram-Key: ${api_key}" \
   -H "Gram-Project: ${project_slug}" \
-  "${hook_hostname_header[@]}" \
+  ${hook_hostname_header[@]+"${hook_hostname_header[@]}"} \
   -d @- \
   --max-time 10 \
   "${server_url}/rpc/hooks.cursor" 2>/dev/null || echo '{}'

--- a/hooks/plugin-cursor/hooks/send_hook.sh
+++ b/hooks/plugin-cursor/hooks/send_hook.sh
@@ -11,10 +11,17 @@ if [ -z "$api_key" ] || [ -z "$project_slug" ]; then
   exit 0
 fi
 
+hook_hostname=$(hostname 2>/dev/null || true)
+hook_hostname_header=()
+if [ -n "$hook_hostname" ]; then
+  hook_hostname_header=(-H "X-Gram-Hook-Hostname: ${hook_hostname}")
+fi
+
 curl -s -X POST \
   -H "Content-Type: application/json" \
   -H "Gram-Key: ${api_key}" \
   -H "Gram-Project: ${project_slug}" \
+  "${hook_hostname_header[@]}" \
   -d @- \
   --max-time 10 \
   "${server_url}/rpc/hooks.cursor" 2>/dev/null || echo '{}'

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -725,8 +725,15 @@ set -u
 
 server_url="${GRAM_HOOKS_SERVER_URL:-%s}"
 
+hook_hostname=$(hostname 2>/dev/null || true)
+hook_hostname_header=()
+if [ -n "$hook_hostname" ]; then
+  hook_hostname_header=(-H "X-Gram-Hook-Hostname: ${hook_hostname}")
+fi
+
 response=$(curl -s -w "\n%%{http_code}" -X POST \
 %s  -H "Content-Type: application/json" \
+  "${hook_hostname_header[@]}" \
   -d @- \
   --max-time 10 \
   "${server_url}/rpc/hooks.codex")
@@ -770,8 +777,15 @@ set -u
 
 server_url="${GRAM_HOOKS_SERVER_URL:-%s}"
 
+hook_hostname=$(hostname 2>/dev/null || true)
+hook_hostname_header=()
+if [ -n "$hook_hostname" ]; then
+  hook_hostname_header=(-H "X-Gram-Hook-Hostname: ${hook_hostname}")
+fi
+
 response=$(curl -s -w "\n%%{http_code}" -X POST \
 %s  -H "Content-Type: application/json" \
+  "${hook_hostname_header[@]}" \
   -d @- \
   --max-time 10 \
   "${server_url}/rpc/hooks.%s")
@@ -849,6 +863,12 @@ func renderClaudeSessionStartScript(cfg GenerateConfig) []byte {
 set -u
 
 server_url="${GRAM_HOOKS_SERVER_URL:-%s}"
+
+hook_hostname=$(hostname 2>/dev/null || true)
+hook_hostname_header=()
+if [ -n "$hook_hostname" ]; then
+  hook_hostname_header=(-H "X-Gram-Hook-Hostname: ${hook_hostname}")
+fi
 
 payload=$(cat)
 
@@ -944,6 +964,7 @@ print(json.dumps(p))
 
 curl -s -o /dev/null -X POST \
 %s  -H "Content-Type: application/json" \
+  "${hook_hostname_header[@]}" \
   -d "$enriched" \
   --max-time 30 \
   "${server_url}/rpc/hooks.claude" >/dev/null 2>&1 || true

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -733,7 +733,7 @@ fi
 
 response=$(curl -s -w "\n%%{http_code}" -X POST \
 %s  -H "Content-Type: application/json" \
-  "${hook_hostname_header[@]}" \
+  ${hook_hostname_header[@]+"${hook_hostname_header[@]}"} \
   -d @- \
   --max-time 10 \
   "${server_url}/rpc/hooks.codex")
@@ -785,7 +785,7 @@ fi
 
 response=$(curl -s -w "\n%%{http_code}" -X POST \
 %s  -H "Content-Type: application/json" \
-  "${hook_hostname_header[@]}" \
+  ${hook_hostname_header[@]+"${hook_hostname_header[@]}"} \
   -d @- \
   --max-time 10 \
   "${server_url}/rpc/hooks.%s")
@@ -964,7 +964,7 @@ print(json.dumps(p))
 
 curl -s -o /dev/null -X POST \
 %s  -H "Content-Type: application/json" \
-  "${hook_hostname_header[@]}" \
+  ${hook_hostname_header[@]+"${hook_hostname_header[@]}"} \
   -d "$enriched" \
   --max-time 30 \
   "${server_url}/rpc/hooks.claude" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- Adds `X-Gram-Hook-Hostname` request header to all plugin hook scripts (Claude and Cursor) so the server receives the endpoint hostname on every hook call.
- Header is only sent when `hostname` returns a non-empty value — no header is emitted on machines where the call fails or returns nothing.

## Test plan

- [ ] Trigger a hook from a Claude Code session and confirm `X-Gram-Hook-Hostname` appears in the server's incoming request headers.
- [ ] Trigger a hook from a Cursor session and confirm the same.
- [ ] Confirm no header is sent in an environment where `hostname` is unavailable (e.g. by temporarily masking it).