### PR TITLE
fix: resolve /mcp well-known OAuth metadata via mcp_endpoints with toolset fallback

### DIFF
--- a/.changeset/age-2624-mcp-well-known-endpoints.md
+++ b/.changeset/age-2624-mcp-well-known-endpoints.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+resolve /mcp well-known OAuth metadata via mcp_endpoints with toolset fallback

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
@@ -17,10 +18,15 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
+	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
 )
 
@@ -61,23 +67,33 @@ type oauthAuthorizationServerMetadata struct {
 // HandleGetProtectedResource serves RFC 9728 protected-resource metadata at
 // the canonical RFC path `/.well-known/oauth-protected-resource/mcp/{mcpSlug}`
 // — the only path a spec-compliant client constructs from a resource URL of
-// `<base>/mcp/{slug}`. Dispatches internally:
+// `<base>/mcp/{slug}`.
 //
-//   - If toolset.user_session_issuer_id is set: emit the issuer-gated metadata
-//     shape (resource + authorization_servers point at the same /mcp/{slug}
-//     URL the AS metadata is keyed under).
-//   - Else: delegate to wellknown.ResolveOAuthProtectedResourceFromToolset for
-//     legacy toolsets (oauth_proxy_server_id / external_oauth_server_id).
-//   - Else still: 404.
-//
-// Replaces the prior HandleWellKnownOAuthProtectedResourceMetadata in
-// mcp/impl.go (deleted in this commit; route is now registered to this
-// dispatcher).
+// Resolution mirrors ServePublic: try mcp_endpoints → mcp_servers first and,
+// on 404, fall back to the legacy toolsets.mcp_slug lookup. The resolved
+// path delegates to the shared per-backend dispatch
+// (ServeWellKnownProtectedResourceForServer); the fallback handles
+// toolset-backed servers that have no mcp_servers row yet (pre the
+// toolsets→mcp_servers migration) and preserves loadToolset's
+// custom-domain/platform-URL asymmetry.
 func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+	}
+
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+
+	mcpEndpoint, mcpServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, mcpSlug)
+	var shareErr *oops.ShareableError
+	switch {
+	case err == nil:
+		return s.ServeWellKnownProtectedResourceForServer(w, r, logger, mcpEndpoint, mcpServer, "mcp")
+	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
+		// Fall through to the legacy toolset-by-slug lookup below.
+	default:
+		return err
 	}
 
 	var customDomainID uuid.NullUUID
@@ -91,8 +107,6 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
 	}
-
-	baseURL := s.BaseURLForRequest(r)
 
 	if toolset.UserSessionIssuerID.Valid {
 		endpoint := newResolvedMcpEndpointFromToolset(toolset, "mcp")
@@ -102,34 +116,36 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 		return s.ServeGetProtectedResource(w, r, endpoint)
 	}
 
-	// Legacy fallback: delegate to the existing wellknown resolver. A nil
-	// result means the toolset has no OAuth configuration at all — 404.
-	resourceURL, err := url.JoinPath(baseURL, "mcp", mcpSlug)
+	resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), "mcp", mcpSlug)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build legacy resource URL").Log(ctx, s.logger)
 	}
-	legacy, err := wellknown.ResolveOAuthProtectedResourceFromToolset(
-		ctx, s.logger, s.db, &s.toolsetCache, toolset, resourceURL,
-	)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").Log(ctx, s.logger)
-	}
-	if legacy == nil {
-		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
-	}
-	return writeOAuthProtectedResourceMetadataResponse(ctx, s.logger, w, legacy)
+	return s.serveLegacyToolsetProtectedResource(ctx, w, logger, toolset, resourceURL)
 }
 
 // HandleGetAuthorizationServer serves RFC 8414 authorization-server metadata
 // at the canonical RFC path
 // `/.well-known/oauth-authorization-server/mcp/{mcpSlug}` — the only path a
 // spec-compliant client constructs from an issuer URL of `<base>/mcp/{slug}`.
-// Same dispatch model as HandleGetProtectedResource.
+// Same resolve-first-then-fallback model as HandleGetProtectedResource.
 func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+	}
+
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+
+	mcpEndpoint, mcpServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, mcpSlug)
+	var shareErr *oops.ShareableError
+	switch {
+	case err == nil:
+		return s.ServeWellKnownAuthorizationServerForServer(w, r, logger, mcpEndpoint, mcpServer, "mcp")
+	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
+		// Fall through to the legacy toolset-by-slug lookup below.
+	default:
+		return err
 	}
 
 	var customDomainID uuid.NullUUID
@@ -144,8 +160,6 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
 	}
 
-	baseURL := s.BaseURLForRequest(r)
-
 	if toolset.UserSessionIssuerID.Valid {
 		endpoint := newResolvedMcpEndpointFromToolset(toolset, "mcp")
 		if err := s.RequireUserSessionIssuer(ctx, endpoint); err != nil {
@@ -154,22 +168,153 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 		return s.ServeGetAuthorizationServer(w, r, endpoint)
 	}
 
-	// Legacy fallback: delegate to the existing wellknown resolver. A nil
-	// result means the toolset has no OAuth configuration at all — 404.
-	legacy, err := wellknown.ResolveOAuthServerMetadataFromToolset(
-		ctx, s.logger, s.db, s.oauthRepo, &s.toolsetCache, toolset, baseURL, mcpSlug,
-	)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").Log(ctx, s.logger)
+	// The legacy /mcp OAuth machinery is keyed on the toolset's mcp_slug,
+	// which equals the requested slug on this fallback path.
+	return s.serveLegacyToolsetAuthorizationServer(ctx, w, r, logger, toolset, mcpSlug)
+}
+
+// ServeWellKnownProtectedResourceForServer serves RFC 9728 protected-resource
+// metadata for an already-resolved (mcp_endpoint, mcp_server) pair. It is the
+// single per-backend dispatch shared by the /mcp (routeBase "mcp") and /x/mcp
+// (routeBase "x/mcp") well-known surfaces:
+//
+//   - Issuer-gated (any backend): emit the Gram-hosted metadata shape rooted
+//     at the resolved endpoint's URL on routeBase's surface.
+//   - Remote-backed, not issuer-gated: 404 — the upstream remote MCP server
+//     publishes its own .well-known and Gram is not its authorization server.
+//   - Toolset-backed, not issuer-gated: reuse the legacy wellknown resolver
+//     (oauth_proxy_server_id / external_oauth_server_id).
+func (s *Service) ServeWellKnownProtectedResourceForServer(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	mcpEndpoint *mcpendpoints_repo.McpEndpoint,
+	mcpServer *mcpservers_repo.McpServer,
+	routeBase string,
+) error {
+	ctx := r.Context()
+
+	if mcpServer.UserSessionIssuerID.Valid {
+		endpoint, err := s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, routeBase)
+		if err != nil {
+			return fmt.Errorf("build resolved mcp endpoint: %w", err)
+		}
+		return s.ServeGetProtectedResource(w, r, endpoint)
 	}
-	if legacy == nil {
+
+	switch {
+	case mcpServer.RemoteMcpServerID.Valid:
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+	case mcpServer.ToolsetID.Valid:
+		toolset, err := s.loadToolsetForServer(ctx, logger, mcpServer.ToolsetID.UUID, mcpEndpoint.ProjectID)
+		if err != nil {
+			return err
+		}
+		resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), routeBase, mcpEndpoint.Slug)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "build resource URL").Log(ctx, logger)
+		}
+		return s.serveLegacyToolsetProtectedResource(ctx, w, logger, toolset, resourceURL)
+	default:
+		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
+	}
+}
+
+// ServeWellKnownAuthorizationServerForServer serves RFC 8414
+// authorization-server metadata for an already-resolved (mcp_endpoint,
+// mcp_server) pair. Shared per-backend dispatch with the same backend
+// semantics as [Service.ServeWellKnownProtectedResourceForServer].
+func (s *Service) ServeWellKnownAuthorizationServerForServer(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	mcpEndpoint *mcpendpoints_repo.McpEndpoint,
+	mcpServer *mcpservers_repo.McpServer,
+	routeBase string,
+) error {
+	ctx := r.Context()
+
+	if mcpServer.UserSessionIssuerID.Valid {
+		endpoint, err := s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, routeBase)
+		if err != nil {
+			return fmt.Errorf("build resolved mcp endpoint: %w", err)
+		}
+		return s.ServeGetAuthorizationServer(w, r, endpoint)
+	}
+
+	switch {
+	case mcpServer.RemoteMcpServerID.Valid:
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+	case mcpServer.ToolsetID.Valid:
+		toolset, err := s.loadToolsetForServer(ctx, logger, mcpServer.ToolsetID.UUID, mcpEndpoint.ProjectID)
+		if err != nil {
+			return err
+		}
+		// Today's OAuth machinery is keyed on the toolset's mcp_slug; the
+		// production model assumes mcp_endpoints.slug == toolsets.mcp_slug
+		// for toolset-backed servers until the upcoming OAuth migration.
+		oauthSlug := toolset.McpSlug.String
+		if oauthSlug == "" {
+			return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+		}
+		return s.serveLegacyToolsetAuthorizationServer(ctx, w, r, logger, toolset, oauthSlug)
+	default:
+		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
+	}
+}
+
+// loadToolsetForServer loads the toolset a toolset-backed mcp_server points
+// at, mapping a missing row to 404. Shared by the toolset-backed branch of
+// both well-known dispatchers.
+func (s *Service) loadToolsetForServer(ctx context.Context, logger *slog.Logger, toolsetID, projectID uuid.UUID) (*toolsets_repo.Toolset, error) {
+	toolset, err := toolsets_repo.New(s.db).GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+		ID:        toolsetID,
+		ProjectID: projectID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found")
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
+	}
+	return &toolset, nil
+}
+
+// serveLegacyToolsetProtectedResource resolves and writes RFC 9728
+// protected-resource metadata for a toolset via the legacy wellknown
+// resolver. A nil result means the toolset carries no OAuth configuration —
+// 404. resourceURL is the runtime URL the caller addressed; it is emitted
+// verbatim as both `resource` and `authorization_servers`.
+func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, toolset *toolsets_repo.Toolset, resourceURL string) error {
+	metadata, err := wellknown.ResolveOAuthProtectedResourceFromToolset(ctx, logger, s.db, &s.toolsetCache, toolset, resourceURL)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").Log(ctx, logger)
+	}
+	if metadata == nil {
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+	}
+	return writeOAuthProtectedResourceMetadataResponse(ctx, logger, w, metadata)
+}
+
+// serveLegacyToolsetAuthorizationServer resolves and writes RFC 8414
+// authorization-server metadata for a toolset via the legacy wellknown
+// resolver, dispatching the proxy variant through a reverse proxy. A nil
+// result means the toolset carries no OAuth configuration — 404. oauthSlug
+// keys the emitted issuer / endpoint URLs onto the legacy /oauth/{slug}
+// surface.
+func (s *Service) serveLegacyToolsetAuthorizationServer(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, toolset *toolsets_repo.Toolset, oauthSlug string) error {
+	result, err := wellknown.ResolveOAuthServerMetadataFromToolset(ctx, logger, s.db, s.oauthRepo, &s.toolsetCache, toolset, s.BaseURLForRequest(r), oauthSlug)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").Log(ctx, logger)
+	}
+	if result == nil {
 		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
 	}
 
-	if legacy.Kind == wellknown.OAuthServerMetadataResultKindProxy {
-		target, parseErr := url.Parse(legacy.ProxyURL)
+	if result.Kind == wellknown.OAuthServerMetadataResultKindProxy {
+		target, parseErr := url.Parse(result.ProxyURL)
 		if parseErr != nil {
-			return oops.E(oops.CodeUnexpected, parseErr, "failed to parse well-known URL").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, parseErr, "failed to parse well-known URL").Log(ctx, logger)
 		}
 		proxy := &httputil.ReverseProxy{
 			Director: nil,
@@ -187,7 +332,7 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 		return nil
 	}
 
-	return writeOAuthServerMetadataResponse(ctx, s.logger, w, legacy)
+	return writeOAuthServerMetadataResponse(ctx, logger, w, result)
 }
 
 // ServeGetProtectedResource is the post-resolution entry point for the

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -36,7 +36,9 @@ import (
 // createToolsetMcpEndpoint writes the mcp_servers row pointing at a
 // toolset and the mcp_endpoints row exposing it under slug. visibility
 // must be "public", "private", or "disabled". customDomainID may be
-// invalid (Valid=false) for a platform-scoped endpoint.
+// invalid (Valid=false) for a platform-scoped endpoint. issuerID, when
+// non-Nil, sets the mcp_servers.user_session_issuer_id FK to gate the
+// endpoint.
 func createToolsetMcpEndpoint(
 	t *testing.T,
 	ctx context.Context,
@@ -45,19 +47,27 @@ func createToolsetMcpEndpoint(
 	toolsetID uuid.UUID,
 	slug, visibility string,
 	customDomainID uuid.NullUUID,
+	issuerID uuid.UUID,
 ) mcpserversrepo.McpServer {
 	t.Helper()
 	id, err := uuid.NewV7()
 	require.NoError(t, err)
+
+	var issuer uuid.NullUUID
+	if issuerID != uuid.Nil {
+		issuer = uuid.NullUUID{UUID: issuerID, Valid: true}
+	}
+
 	mcpServer, err := mcpserversrepo.New(conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
-		ID:                id,
-		ProjectID:         projectID,
-		Name:              conv.ToPGText("test mcp server"),
-		Slug:              conv.ToPGText("test-mcp-server-" + uuid.NewString()[:8]),
-		EnvironmentID:     uuid.NullUUID{},
-		RemoteMcpServerID: uuid.NullUUID{},
-		ToolsetID:         uuid.NullUUID{UUID: toolsetID, Valid: true},
-		Visibility:        visibility,
+		ID:                  id,
+		ProjectID:           projectID,
+		Name:                conv.ToPGText("test mcp server"),
+		Slug:                conv.ToPGText("test-mcp-server-" + uuid.NewString()[:8]),
+		EnvironmentID:       uuid.NullUUID{},
+		UserSessionIssuerID: issuer,
+		RemoteMcpServerID:   uuid.NullUUID{},
+		ToolsetID:           uuid.NullUUID{UUID: toolsetID, Valid: true},
+		Visibility:          visibility,
 	})
 	require.NoError(t, err)
 
@@ -161,7 +171,7 @@ func TestServePublic_McpEndpoint_ToolsetBacked_ResolvesViaEndpoints(t *testing.T
 	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "toolset-slug-"+uuid.NewString()[:8])
 
 	endpointSlug := "endpoint-" + uuid.NewString()
-	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{})
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, uuid.Nil)
 
 	w, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeInitializeBody(), "", nil)
 	require.NoError(t, err)
@@ -316,7 +326,7 @@ func TestServePublic_McpEndpoint_DisabledMcpServer_FallsBackToLegacyToolset(t *t
 	disabledToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "disabled-"+uuid.NewString()[:8])
 	createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, sharedSlug)
 
-	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, disabledToolset.ID, sharedSlug, "disabled", uuid.NullUUID{})
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, disabledToolset.ID, sharedSlug, "disabled", uuid.NullUUID{}, uuid.Nil)
 
 	w, err := servePublicHTTP(t, ctx, ti, sharedSlug, makeInitializeBody(), "", nil)
 	require.NoError(t, err, "disabled mcp_server must fall through to the legacy toolset lookup")
@@ -359,7 +369,7 @@ func TestServePublic_PlatformDomain_DoesNotResolveCustomDomainEndpoint(t *testin
 
 	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "custom-only-"+uuid.NewString()[:8])
 	endpointSlug := "endpoint-" + uuid.NewString()
-	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{UUID: customDomain.ID, Valid: true})
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{UUID: customDomain.ID, Valid: true}, uuid.Nil)
 
 	// Request arrives on the platform domain (no customdomains.Context).
 	// The custom-domain mcp_endpoint must not resolve, and the legacy

--- a/server/internal/mcp/wellknown_test.go
+++ b/server/internal/mcp/wellknown_test.go
@@ -1,0 +1,534 @@
+// wellknown_test.go covers the /.well-known/.../mcp/{slug} OAuth metadata
+// handlers (HandleGetAuthorizationServer, HandleGetProtectedResource)
+// end-to-end. Resolution tries mcp_endpoints → mcp_servers first and falls
+// back to the legacy toolsets.mcp_slug lookup, so these tests exercise the
+// full per-backend dispatch matrix on the resolved path (remote / toolset /
+// issuer-gated) plus the legacy slug fallback — mirroring the /x/mcp
+// coverage in xmcp/wellknown_test.go, but with metadata URLs rooted at
+// /mcp/{slug}.
+//
+// The low-level response writers these handlers share
+// (writeOAuth{Server,ProtectedResource}MetadataResponse) are unit-tested
+// separately in wellknown_oauth_test.go, which is white-box (package mcp)
+// because those helpers are unexported.
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	usersessionsrepo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// runMCPWellKnown invokes a /mcp well-known handler with the chi `mcpSlug`
+// URL param set to slug. Passing slug="" exercises the missing-slug branch
+// (chi.URLParam returns "" for both missing and empty params, matching
+// production routing).
+func runMCPWellKnown(
+	t *testing.T,
+	ctx context.Context,
+	handler func(http.ResponseWriter, *http.Request) error,
+	slug string,
+) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/.well-known/oauth/mcp/"+slug, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", slug)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	err := handler(w, req)
+	return w, err
+}
+
+// ---------------------------------------------------------------------------
+// HandleGetAuthorizationServer
+// ---------------------------------------------------------------------------
+
+func TestHandleGetAuthorizationServer_MissingSlug(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mcp slug must be provided")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetAuthorizationServer_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, "definitely-missing-"+uuid.NewString()[:8])
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mcp server not found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetAuthorizationServer_DisabledServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "disabled-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", slug, "disabled", uuid.Nil)
+
+	// Disabled mcp_server resolves as not-found; with no legacy toolset for
+	// the slug the fallback also misses → 404.
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.Error(t, err)
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetAuthorizationServer_RemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	// Remote-backed mcp_servers without issuer gating have no Gram-hosted
+	// authorization server — the upstream publishes its own .well-known.
+	slug := "remote-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", slug, "public", uuid.Nil)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no OAuth configuration found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetAuthorizationServer_ToolsetBackendWithoutOAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "ts-noauth-"+uuid.NewString()[:8])
+	slug := "ep-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, slug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no OAuth configuration found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetAuthorizationServer_ToolsetBackendWithProxy(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	proxy := oauthtest.CreateProxyToolset(t, ctx, ti.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "mcp-srv-proxy",
+		IsPublic:     true,
+		ProviderType: "",
+	})
+	slug := proxy.Toolset.McpSlug.String
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, proxy.Toolset.ID, slug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	// Legacy proxy metadata is keyed on the toolset's mcp_slug under
+	// /oauth/{slug}, not the /mcp/{slug} surface.
+	expectedIssuer := "http://0.0.0.0/oauth/" + slug
+	require.Equal(t, expectedIssuer, metadata["issuer"])
+	require.Equal(t, expectedIssuer+"/authorize", metadata["authorization_endpoint"])
+	require.Equal(t, expectedIssuer+"/token", metadata["token_endpoint"])
+	require.Equal(t, expectedIssuer+"/register", metadata["registration_endpoint"])
+
+	scopes, ok := metadata["scopes_supported"].([]any)
+	require.True(t, ok)
+	require.Contains(t, scopes, "offline_access")
+}
+
+func TestHandleGetAuthorizationServer_ToolsetBackendWithExternalOAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
+		Slug:     "mcp-srv-external",
+		IsPublic: true,
+		Metadata: nil,
+	})
+	slug := external.Toolset.McpSlug.String
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, external.Toolset.ID, slug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	// External OAuth toolsets surface the upstream provider's metadata verbatim.
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+	require.Equal(t, "https://test-oauth-server.example.com", metadata["issuer"])
+}
+
+// TestHandleGetAuthorizationServer_IssuerGatedRemoteBackend is the primary
+// regression for AGE-2624: an issuer-gated remote-backed mcp_server
+// addressed at /mcp/{slug} now serves Gram-hosted RFC 8414 metadata
+// (previously 404). The advertised issuer + endpoint URLs are rooted at
+// /mcp/{slug}, matching the resource_metadata URL ServePublic advertises.
+func TestHandleGetAuthorizationServer_IssuerGatedRemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	slug := "issuer-remote-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", slug, "public", issuerID)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedIssuer := "http://0.0.0.0/mcp/" + slug
+	require.Equal(t, expectedIssuer, metadata["issuer"])
+	require.Equal(t, expectedIssuer+"/authorize", metadata["authorization_endpoint"])
+	require.Equal(t, expectedIssuer+"/token", metadata["token_endpoint"])
+	require.Equal(t, expectedIssuer+"/register", metadata["registration_endpoint"])
+	require.Equal(t, expectedIssuer+"/revoke", metadata["revocation_endpoint"])
+}
+
+// TestHandleGetAuthorizationServer_IssuerGatedToolsetBackend is the
+// toolset companion of the remote-backed test. The dispatch branches on
+// backend after the issuer check, so both backends need coverage.
+func TestHandleGetAuthorizationServer_IssuerGatedToolsetBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "ts-issuer-"+uuid.NewString()[:8])
+	slug := "issuer-toolset-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, slug, "public", uuid.NullUUID{}, issuerID)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedIssuer := "http://0.0.0.0/mcp/" + slug
+	require.Equal(t, expectedIssuer, metadata["issuer"])
+	require.Equal(t, expectedIssuer+"/authorize", metadata["authorization_endpoint"])
+}
+
+// TestHandleGetAuthorizationServer_IssuerGatedRemoteBackend_DanglingIssuerFK
+// covers the race where the user_session_issuer FK target is deleted
+// between mcp_server resolution and metadata emission.
+func TestHandleGetAuthorizationServer_IssuerGatedRemoteBackend_DanglingIssuerFK(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	slug := "dangling-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", slug, "public", issuerID)
+
+	// Sanity check: resolves cleanly before deletion.
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	_, err = usersessionsrepo.New(ti.conn).DeleteUserSessionIssuer(ctx, usersessionsrepo.DeleteUserSessionIssuerParams{
+		ID:        issuerID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	w, err = runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.Error(t, err, "dangling issuer FK must surface as a request-level error")
+	require.Contains(t, err.Error(), "user_session_issuer not found")
+	require.Empty(t, w.Body.String())
+}
+
+// TestHandleGetAuthorizationServer_LegacySlugFallbackProxy confirms a
+// toolset with no mcp_endpoint row (pre the toolsets→mcp_servers
+// migration) still resolves via the legacy toolsets.mcp_slug fallback.
+func TestHandleGetAuthorizationServer_LegacySlugFallbackProxy(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	// No mcp_endpoint is created — the slug is only addressable via the
+	// legacy toolsets.mcp_slug path.
+	proxy := oauthtest.CreateProxyToolset(t, ctx, ti.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "mcp-legacy-proxy",
+		IsPublic:     true,
+		ProviderType: "",
+	})
+	slug := proxy.Toolset.McpSlug.String
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+	require.Equal(t, "http://0.0.0.0/oauth/"+slug, metadata["issuer"])
+}
+
+// ---------------------------------------------------------------------------
+// HandleGetProtectedResource
+// ---------------------------------------------------------------------------
+
+func TestHandleGetProtectedResource_MissingSlug(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mcp slug must be provided")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetProtectedResource_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, "definitely-missing-"+uuid.NewString()[:8])
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mcp server not found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetProtectedResource_RemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "remote-pr-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", slug, "public", uuid.Nil)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, slug)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no OAuth configuration found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetProtectedResource_ToolsetBackendWithoutOAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "ts-prnoauth-"+uuid.NewString()[:8])
+	slug := "ep-pr-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, slug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, slug)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no OAuth configuration found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleGetProtectedResource_ToolsetBackendWithProxy(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	proxy := oauthtest.CreateProxyToolset(t, ctx, ti.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "mcp-pr-proxy",
+		IsPublic:     true,
+		ProviderType: "",
+	})
+	slug := proxy.Toolset.McpSlug.String
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, proxy.Toolset.ID, slug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedResource := "http://0.0.0.0/mcp/" + slug
+	require.Equal(t, expectedResource, metadata["resource"])
+	authServers, ok := metadata["authorization_servers"].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{expectedResource}, authServers)
+}
+
+// TestHandleGetProtectedResource_IssuerGatedRemoteBackend is the
+// protected-resource companion of the AGE-2624 regression: an issuer-gated
+// remote-backed mcp_server at /mcp/{slug} serves RFC 9728 metadata whose
+// resource + authorization_servers point back at /mcp/{slug}.
+func TestHandleGetProtectedResource_IssuerGatedRemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	slug := "issuer-remote-pr-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", slug, "public", issuerID)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedResource := "http://0.0.0.0/mcp/" + slug
+	require.Equal(t, expectedResource, metadata["resource"])
+	authServers, ok := metadata["authorization_servers"].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{expectedResource}, authServers)
+}
+
+func TestHandleGetProtectedResource_IssuerGatedToolsetBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "ts-issuer-pr-"+uuid.NewString()[:8])
+	slug := "issuer-toolset-pr-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, slug, "public", uuid.NullUUID{}, issuerID)
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+	require.Equal(t, "http://0.0.0.0/mcp/"+slug, metadata["resource"])
+}
+
+// TestHandleGetProtectedResource_IssuerGatedToolsetBackend_OnCustomDomain
+// asserts an issuer-gated endpoint registered against a custom domain
+// emits https://<domain>/mcp/<slug> as both resource and
+// authorization_servers — clients reject discovery responses whose host
+// doesn't match the resource they were directed to.
+func TestHandleGetProtectedResource_IssuerGatedToolsetBackend_OnCustomDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	domainName := "mcp-issuer-cd-" + uuid.NewString()[:8] + ".example.com"
+	toolset, domain := createPublicMCPToolsetWithCustomDomain(t, ctx, ti, authCtx, "ts-cd-"+uuid.NewString()[:8], domainName)
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	slug := "issuer-cd-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, slug, "public", uuid.NullUUID{UUID: domain.ID, Valid: true}, issuerID)
+
+	domainCtx := customdomains.WithContext(ctx, &customdomains.Context{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         domain.Domain,
+		DomainID:       domain.ID,
+	})
+
+	w, err := runMCPWellKnown(t, domainCtx, ti.service.HandleGetProtectedResource, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedResource := "https://" + domain.Domain + "/mcp/" + slug
+	require.Equal(t, expectedResource, metadata["resource"])
+	authServers, ok := metadata["authorization_servers"].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{expectedResource}, authServers)
+}
+
+// TestHandleGetProtectedResource_LegacySlugFallbackProxy is the
+// protected-resource companion of the legacy fallback test.
+func TestHandleGetProtectedResource_LegacySlugFallbackProxy(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	proxy := oauthtest.CreateProxyToolset(t, ctx, ti.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "mcp-legacy-pr-proxy",
+		IsPublic:     true,
+		ProviderType: "",
+	})
+	slug := proxy.Toolset.McpSlug.String
+
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+	require.Equal(t, "http://0.0.0.0/mcp/"+slug, metadata["resource"])
+}

--- a/server/internal/xmcp/wellknown.go
+++ b/server/internal/xmcp/wellknown.go
@@ -1,44 +1,25 @@
 package xmcp
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/oauth/repo"
-	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
-	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
 // HandleWellKnownOAuthServerMetadata serves
 // /.well-known/oauth-authorization-server/x/mcp/{mcpSlug}.
 //
-// Resolution mirrors the runtime path: slug → mcp_endpoint → mcp_server.
-// Dispatch is per-backend so each backend can source OAuth state from the
-// model that fits it best:
-//
-//   - Toolset-backed: load the linked toolset by ID and reuse the existing
-//     toolset-keyed wellknown resolver. The OAuth flow itself is still
-//     keyed by toolsets.mcp_slug today; the production model assumes
-//     mcp_endpoints.slug == toolsets.mcp_slug for these servers, and a
-//     separate upcoming OAuth migration (tracked independently of
-//     AGE-1902) will re-key the OAuth machinery onto mcp_servers.id, at
-//     which point the dependency on toolsets.mcp_slug drops entirely.
-//   - Remote-backed: returns 404 today. Remote MCP servers publish their
-//     own .well-known and Gram does not yet act as an authorization server
-//     for them. Once that upcoming OAuth migration generalises the
-//     machinery off toolset_id, this branch will source from mcp_servers /
-//     oauth_proxy_servers.
+// Resolution walks slug → mcp_endpoint → mcp_server, then delegates to the
+// shared per-backend dispatch on mcp.Service with the "x/mcp" route base.
+// Unlike /mcp, /x/mcp has no legacy toolsets.mcp_slug fallback — it is a
+// fresh surface keyed entirely on mcp_endpoints. See
+// [mcp.Service.ServeWellKnownAuthorizationServerForServer] for the
+// per-backend semantics (issuer-gated → Gram-hosted metadata; remote-backed
+// → 404; toolset-backed → legacy wellknown resolver).
 func (s *Service) HandleWellKnownOAuthServerMetadata(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	slug := chi.URLParam(r, "mcpSlug")
@@ -53,80 +34,16 @@ func (s *Service) HandleWellKnownOAuthServerMetadata(w http.ResponseWriter, r *h
 		return fmt.Errorf("resolve mcp endpoint: %w", err)
 	}
 
-	// Issuer-gated mcp_servers (regardless of backend) get the Gram-hosted
-	// authorization-server metadata pointing at the /x/mcp/{slug}/...
-	// OAuth handler family. The toolset-backed branch below remains as a
-	// fallback for legacy oauth_proxy / external-oauth configurations
-	// surfaced through the toolsets row.
-	if mcpServer.UserSessionIssuerID.Valid {
-		resolvedEndpoint, err := s.mcpService.BuildResolvedMcpEndpointForServer(ctx, logger, endpoint, mcpServer, "x/mcp")
-		if err != nil {
-			return fmt.Errorf("build resolved mcp endpoint: %w", err)
-		}
-		if err := s.mcpService.ServeGetAuthorizationServer(w, r, resolvedEndpoint); err != nil {
-			return fmt.Errorf("serve oauth authorization server metadata: %w", err)
-		}
-		return nil
+	if err := s.mcpService.ServeWellKnownAuthorizationServerForServer(w, r, logger, endpoint, mcpServer, "x/mcp"); err != nil {
+		return fmt.Errorf("serve oauth authorization server metadata: %w", err)
 	}
-
-	switch {
-	case mcpServer.RemoteMcpServerID.Valid:
-		// Remote-backed mcp_servers without issuer gating have no
-		// Gram-hosted authorization server — the upstream remote MCP
-		// server publishes its own .well-known.
-		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
-	case mcpServer.ToolsetID.Valid:
-		toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{
-			ID:        mcpServer.ToolsetID.UUID,
-			ProjectID: endpoint.ProjectID,
-		})
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-			return oops.E(oops.CodeNotFound, err, "toolset not found")
-		case err != nil:
-			return oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
-		}
-
-		// Today's OAuth machinery (issuance, callback, token exchange) is
-		// still keyed by toolsets.mcp_slug, so the issuer family points at
-		// /oauth/{toolset.mcp_slug}/... — see the function comment for
-		// the upcoming OAuth migration that will re-key onto mcp_servers.
-		oauthSlug := toolset.McpSlug.String
-		if oauthSlug == "" {
-			return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
-		}
-
-		baseURL := s.mcpService.BaseURLForRequest(r)
-		result, err := wellknown.ResolveOAuthServerMetadataFromToolset(
-			ctx,
-			logger,
-			s.db,
-			repo.New(s.db),
-			nil,
-			&toolset,
-			baseURL,
-			oauthSlug,
-		)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").Log(ctx, logger)
-		}
-
-		if result == nil {
-			return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
-		}
-
-		return writeOAuthServerMetadata(ctx, w, r, logger, result)
-	default:
-		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
-	}
+	return nil
 }
 
 // HandleWellKnownOAuthProtectedResourceMetadata serves
-// /.well-known/oauth-protected-resource/x/mcp/{mcpSlug}.
-//
-// The resource URL embedded in the response is the runtime URL the caller
-// is actually addressing — `<baseURL>/x/mcp/<mcp_endpoint.slug>`. See
-// [Service.HandleWellKnownOAuthServerMetadata] for the dispatch rationale.
+// /.well-known/oauth-protected-resource/x/mcp/{mcpSlug}. Same resolution
+// model as [Service.HandleWellKnownOAuthServerMetadata]; the emitted resource
+// URL is the runtime URL the caller addressed (`<baseURL>/x/mcp/<slug>`).
 func (s *Service) HandleWellKnownOAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	slug := chi.URLParam(r, "mcpSlug")
@@ -141,125 +58,8 @@ func (s *Service) HandleWellKnownOAuthProtectedResourceMetadata(w http.ResponseW
 		return fmt.Errorf("resolve mcp endpoint: %w", err)
 	}
 
-	// Issuer-gated mcp_servers (regardless of backend) get the Gram-hosted
-	// protected-resource metadata pointing at the matching Gram AS. The
-	// toolset-backed branch below remains as a fallback for legacy
-	// oauth_proxy / external-oauth configurations.
-	if mcpServer.UserSessionIssuerID.Valid {
-		resolvedEndpoint, err := s.mcpService.BuildResolvedMcpEndpointForServer(ctx, logger, endpoint, mcpServer, "x/mcp")
-		if err != nil {
-			return fmt.Errorf("build resolved mcp endpoint: %w", err)
-		}
-		if err := s.mcpService.ServeGetProtectedResource(w, r, resolvedEndpoint); err != nil {
-			return fmt.Errorf("serve oauth protected resource metadata: %w", err)
-		}
-		return nil
-	}
-
-	switch {
-	case mcpServer.RemoteMcpServerID.Valid:
-		// Remote-backed mcp_servers without issuer gating have no
-		// Gram-hosted protected-resource metadata.
-		return oops.E(oops.CodeNotFound, nil, "not found")
-	case mcpServer.ToolsetID.Valid:
-		toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{
-			ID:        mcpServer.ToolsetID.UUID,
-			ProjectID: endpoint.ProjectID,
-		})
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-			return oops.E(oops.CodeNotFound, err, "toolset not found")
-		case err != nil:
-			return oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
-		}
-
-		resourceURL := s.mcpService.BaseURLForRequest(r) + "/x/mcp/" + endpoint.Slug
-		metadata, err := wellknown.ResolveOAuthProtectedResourceFromToolset(
-			ctx,
-			logger,
-			s.db,
-			nil,
-			&toolset,
-			resourceURL,
-		)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").Log(ctx, logger)
-		}
-
-		if metadata == nil {
-			return oops.E(oops.CodeNotFound, nil, "not found")
-		}
-
-		// Marshal before committing the 200 — see writeOAuthServerMetadata.
-		body, err := json.Marshal(metadata)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth protected resource metadata").Log(ctx, logger)
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(body); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
-		}
-		return nil
-	default:
-		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
-	}
-}
-
-// writeOAuthServerMetadata serialises a resolver result onto the response,
-// dispatching the proxy variant via httputil.ReverseProxy.
-func writeOAuthServerMetadata(
-	ctx context.Context,
-	w http.ResponseWriter,
-	r *http.Request,
-	logger *slog.Logger,
-	result *wellknown.OAuthServerMetadataResult,
-) error {
-	if result.Kind == wellknown.OAuthServerMetadataResultKindProxy {
-		target, err := url.Parse(result.ProxyURL)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to parse well-known URL").Log(ctx, logger)
-		}
-
-		proxy := &httputil.ReverseProxy{
-			Director: nil,
-			Rewrite: func(pr *httputil.ProxyRequest) {
-				pr.SetURL(target)
-			},
-			Transport:      nil,
-			FlushInterval:  0,
-			ErrorLog:       nil,
-			BufferPool:     nil,
-			ModifyResponse: nil,
-			ErrorHandler:   nil,
-		}
-		proxy.ServeHTTP(w, r)
-		return nil
-	}
-
-	// Resolve the response body before committing the 200 status. Once
-	// WriteHeader is called we lose the ability to surface a downstream
-	// failure (marshalling, unexpected kind) as a proper error response,
-	// so any work that can fail must happen first.
-	var body []byte
-	switch result.Kind {
-	case wellknown.OAuthServerMetadataResultKindRaw:
-		body = result.Raw
-	case wellknown.OAuthServerMetadataResultKindStatic:
-		marshalled, err := json.Marshal(result.Static)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth server metadata").Log(ctx, logger)
-		}
-		body = marshalled
-	default:
-		return oops.E(oops.CodeUnexpected, nil, "unexpected OAuth server metadata result kind").Log(ctx, logger)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+	if err := s.mcpService.ServeWellKnownProtectedResourceForServer(w, r, logger, endpoint, mcpServer, "x/mcp"); err != nil {
+		return fmt.Errorf("serve oauth protected resource metadata: %w", err)
 	}
 	return nil
 }

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -401,7 +401,7 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_RemoteBackend(t *testing.
 
 	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not found")
+	require.Contains(t, err.Error(), "no OAuth configuration found")
 	require.Empty(t, w.Body.String())
 }
 
@@ -418,7 +418,7 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendWithoutOAut
 
 	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not found")
+	require.Contains(t, err.Error(), "no OAuth configuration found")
 	require.Empty(t, w.Body.String())
 }
 


### PR DESCRIPTION
The `/mcp` well-known handlers (`HandleGetProtectedResource`, `HandleGetAuthorizationServer`) only resolved toolsets by `mcp_slug`, so they 404'd for remote-backed `mcp_servers` — breaking OAuth/DCR discovery for Remote MCP Servers addressed at `https://app.getgram.ai/mcp/<slug>`. `ServePublic` already resolved these via `mcp_endpoints` → `mcp_servers` (#3068); the well-known handlers on the same surface did not.

Both handlers now resolve `mcp_endpoints` → `mcp_servers` first (mirroring `ServePublic`) and fall back to the legacy `toolsets.mcp_slug` lookup on a not-found, with emitted resource/issuer URLs pinned to the `mcp` route base. The per-backend dispatch — issuer-gated → Gram-hosted metadata; non-issuer-gated remote → 404; toolset-backed → legacy `wellknown` resolver — is centralized in two shared `mcp.Service` methods (`ServeWellKnownProtectedResourceForServer`, `ServeWellKnownAuthorizationServerForServer`) now used by both `/mcp` and `/x/mcp`, removing the duplicated dispatch that had drifted between the two surfaces.

Adds handler-level well-known coverage for `/mcp` matching the `/x/mcp` matrix (remote, toolset proxy/external, issuer-gated remote + toolset, custom domain, dangling issuer FK, legacy slug fallback).

Resolves [AGE-2624](https://linear.app/speakeasy/issue/AGE-2624/well-knownoauth-protected-resourceauthorization-servermcpslug-404s-for).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth discovery under /mcp by resolving via mcp_endpoints → mcp_servers with a legacy toolset fallback, restoring well-known metadata for remote-backed and issuer-gated servers. Centralizes backend dispatch and reuses it for /x/mcp to prevent drift and adds full test coverage. Resolves AGE-2624.

- **Bug Fixes**
  - `/mcp` well-known handlers now resolve `mcp_endpoints` → `mcp_servers`, with fallback to `toolsets.mcp_slug`.
  - Remote-backed without issuer gating return 404; issuer-gated servers emit Gram-hosted metadata rooted at `/mcp/{slug}`.
  - Toolset-backed servers continue using the legacy resolver; resource/issuer URLs are pinned to `/mcp`.
  - Correct handling on custom domains; fixes the 404s described in AGE-2624.

- **Refactors**
  - Added shared `mcp` methods: `ServeWellKnownProtectedResourceForServer` and `ServeWellKnownAuthorizationServerForServer`.
  - `xmcp` well-known handlers now call the shared methods; duplicate logic removed.
  - Added end-to-end tests for `/mcp` well-known; updated `/x/mcp` tests and helpers.

<sup>Written for commit 9dd6dfcb51e22b206b242f27d4fd0df5c1583584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

