### PR TITLE
mig: agent.getPlugins endpoint for device agent

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2628,6 +2628,11 @@ CREATE TABLE IF NOT EXISTS plugin_assignments (
 CREATE UNIQUE INDEX IF NOT EXISTS plugin_assignments_plugin_id_principal_urn_key
   ON plugin_assignments (plugin_id, principal_urn);
 
+-- Read-side index for the device-agent endpoint, which resolves an
+-- organization to its assignments by principal URN on every poll.
+CREATE INDEX IF NOT EXISTS plugin_assignments_organization_id_principal_urn_idx
+  ON plugin_assignments (organization_id, principal_urn);
+
 -- Tracks the GitHub repository where plugin packages are published for a project.
 CREATE TABLE IF NOT EXISTS plugin_github_connections (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/migrations/20260529185739_plugin-assignments-org-principal-index.sql
+++ b/server/migrations/20260529185739_plugin-assignments-org-principal-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "plugin_assignments_organization_id_principal_urn_idx" to table: "plugin_assignments"
+CREATE INDEX CONCURRENTLY "plugin_assignments_organization_id_principal_urn_idx" ON "plugin_assignments" ("organization_id", "principal_urn");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:31iU3gNNcREhL18MmLai2Th4RMziAQAM4Iika3IfIcM=
+h1:n8EdPqd7f6swOdnXNterrqtPc4G8CJKVKr4umhjDVfU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -197,3 +197,4 @@ h1:31iU3gNNcREhL18MmLai2Th4RMziAQAM4Iika3IfIcM=
 20260528145659_add-mcp-server-id-to-mcp-metadata.sql h1:fnNq7bTqxCG1Ipb70XLaZh9oZcypAonT/OvqOlQH8oI=
 20260528192406_age-2484-remote-session-issuers-organization-id.sql h1:ptd3XyEBDWDB1mrd4Xsg3u2dj/W79WcRch4X8myUYbw=
 20260529114006_add-ip-allowlist-to-custom-domains.sql h1:9li8X25rRb2c1wPhfA/k4FuS65biWbmttXGP0uuOpBQ=
+20260529185739_plugin-assignments-org-principal-index.sql h1:zxjbc2mIBYmXegrSPPDfoMFQn7fagQs8Sd8Ld2JH4+o=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/3088 so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-side index on plugin_assignments (organization_id, principal_urn) to speed up device agent agent.getPlugins polls. Uses a concurrent migration to avoid locks during creation.

- **Migration**
  - Creates plugin_assignments_organization_id_principal_urn_idx via CREATE INDEX CONCURRENTLY; run DB migrations.

<sup>Written for commit cb0dcc75429725efc04dddee6fc5a3c79bd672e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

