### PR TITLE
feat: add risk-only trace filter

### DIFF
--- a/.changeset/cruel-owls-count.md
+++ b/.changeset/cruel-owls-count.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Added a risk-only toggle to trace panels and deep-linked Risk Events to open with risk filtering enabled

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -48,9 +48,9 @@ import {
   type ToolCall,
   type TraceEntryType,
   getEntryTypeCounts,
+  getRiskEntryCount,
   getTraceEntryType,
-  getVisibleMessageCount,
-  isMessageVisible,
+  getVisibleMessages,
   parseToolCalls,
 } from "./traceEntries";
 
@@ -60,6 +60,7 @@ interface ChatDetailPanelProps {
   onDelete: (chatId: string) => void;
   /** When true, messages without risk findings are collapsed to a single line. */
   collapseNonRisk?: boolean;
+  initialRiskOnly?: boolean;
 }
 
 interface ChatDetailSheetProps extends Omit<ChatDetailPanelProps, "chatId"> {
@@ -77,6 +78,7 @@ export function ChatDetailSheet({
   onClose,
   onDelete,
   collapseNonRisk,
+  initialRiskOnly,
 }: ChatDetailSheetProps) {
   return (
     <Sheet
@@ -95,6 +97,7 @@ export function ChatDetailSheet({
             onClose={onClose}
             onDelete={onDelete}
             collapseNonRisk={collapseNonRisk}
+            initialRiskOnly={initialRiskOnly}
           />
         )}
       </SheetContent>
@@ -185,18 +188,23 @@ function ChatMessagesList({
   riskResultsByMessage,
   collapseNonRisk,
   enabledEntryTypes,
+  riskOnly,
 }: {
   messages: ChatMessage[];
   riskResultsByMessage: Map<string, RiskResult[]>;
   collapseNonRisk?: boolean;
   enabledEntryTypes: FilterableTraceEntryType[];
+  riskOnly: boolean;
 }) {
   const visibleMessages = useMemo(
     () =>
-      messages.filter((message) =>
-        isMessageVisible(message, enabledEntryTypes),
-      ),
-    [enabledEntryTypes, messages],
+      getVisibleMessages({
+        messages,
+        enabledEntryTypes,
+        riskOnly,
+        riskResultsByMessage,
+      }),
+    [enabledEntryTypes, messages, riskOnly, riskResultsByMessage],
   );
 
   const groups = useMemo(() => {
@@ -983,6 +991,7 @@ export function ChatDetailPanel({
   onClose,
   onDelete,
   collapseNonRisk,
+  initialRiskOnly = false,
 }: ChatDetailPanelProps) {
   const isSuperAdmin = useIsAdmin();
   const { hasScope } = useRBAC();
@@ -995,6 +1004,7 @@ export function ChatDetailPanel({
   const [enabledEntryTypes, setEnabledEntryTypes] = useState<
     FilterableTraceEntryType[]
   >([...DEFAULT_ENABLED_ENTRY_TYPES]);
+  const [riskOnly, setRiskOnly] = useState(initialRiskOnly);
   const {
     chat,
     messages: chatMessages,
@@ -1024,6 +1034,10 @@ export function ChatDetailPanel({
       },
     });
   }, [chatId, searchLogs]);
+
+  useEffect(() => {
+    setRiskOnly(initialRiskOnly);
+  }, [chatId, initialRiskOnly]);
 
   const logs = useMemo(() => logsData?.logs || [], [logsData?.logs]);
   const toolLogs = useMemo(() => filterToolLogs(logs), [logs]);
@@ -1073,10 +1087,13 @@ export function ChatDetailPanel({
     (new Date(endTime).getTime() - new Date(chat.createdAt).getTime()) / 1000,
   );
   const entryTypeCounts = getEntryTypeCounts(chatMessages);
-  const visibleEntryCount = getVisibleMessageCount(
-    chatMessages,
+  const visibleEntryCount = getVisibleMessages({
+    messages: chatMessages,
     enabledEntryTypes,
-  );
+    riskOnly,
+    riskResultsByMessage,
+  }).length;
+  const riskEntryCount = getRiskEntryCount(chatMessages, riskResultsByMessage);
 
   return (
     <div className="bg-background flex h-full flex-col">
@@ -1301,6 +1318,9 @@ export function ChatDetailPanel({
             totalCount={chatMessages.length}
             visibleCount={visibleEntryCount}
             onChange={setEnabledEntryTypes}
+            riskOnly={riskOnly}
+            riskCount={riskEntryCount}
+            onRiskOnlyChange={setRiskOnly}
           />
 
           {/* Chat Messages */}
@@ -1309,6 +1329,7 @@ export function ChatDetailPanel({
             riskResultsByMessage={riskResultsByMessage}
             collapseNonRisk={collapseNonRisk}
             enabledEntryTypes={enabledEntryTypes}
+            riskOnly={riskOnly}
           />
         </TabsContent>
 

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -35,7 +35,7 @@ export function EntryTypeFilterBar({
   onRiskOnlyChange?: (value: boolean) => void;
   title?: string;
 }) {
-  const riskOnlyDisabled = riskCount === 0;
+  const riskOnlyDisabled = !riskOnly && riskCount === 0;
 
   return (
     <div>

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -40,33 +40,32 @@ export function EntryTypeFilterBar({
   return (
     <div>
       <div className="flex items-center justify-between gap-3 px-6 py-3">
-        <div className="text-sm font-medium">{title}</div>
-        <div className="flex shrink-0 items-center gap-2">
-          {onRiskOnlyChange && (
-            <div
-              className={cn(
-                "border-border bg-background inline-flex h-8 items-center gap-2 rounded-md border px-2 text-xs",
-                riskOnly && "bg-muted/80 border-muted-foreground",
-                riskOnlyDisabled && "opacity-50",
-              )}
-            >
-              <span>Risk only</span>
-              <span className="font-mono text-[10px] leading-none">
-                {riskCount.toLocaleString()}
-              </span>
-              <Switch
-                checked={riskOnly}
-                disabled={riskOnlyDisabled}
-                onCheckedChange={onRiskOnlyChange}
-                aria-label="Show risk entries only"
-              />
-            </div>
-          )}
+        <div className="flex shrink-0 items-baseline gap-4">
+          <div className="text-sm font-medium">{title}</div>
           <div className="text-muted-foreground text-xs">
             Showing {visibleCount.toLocaleString()} of{" "}
             {totalCount.toLocaleString()} entries
           </div>
         </div>
+        {onRiskOnlyChange && (
+          <div
+            className={cn(
+              "inline-flex h-8 items-center gap-2 text-xs",
+              riskOnlyDisabled && "opacity-50",
+            )}
+          >
+            <span>Risk only</span>
+            <span className="font-mono text-[10px] leading-none">
+              {riskCount.toLocaleString()}
+            </span>
+            <Switch
+              checked={riskOnly}
+              disabled={riskOnlyDisabled}
+              onCheckedChange={onRiskOnlyChange}
+              aria-label="Show risk entries only"
+            />
+          </div>
+        )}
       </div>
       <ToggleGroup
         type="multiple"

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
 import {
@@ -19,6 +20,9 @@ export function EntryTypeFilterBar({
   totalCount,
   visibleCount,
   onChange,
+  riskOnly = false,
+  riskCount = 0,
+  onRiskOnlyChange,
   title = "Entries Filter",
 }: {
   value: FilterableTraceEntryType[];
@@ -26,15 +30,38 @@ export function EntryTypeFilterBar({
   totalCount: number;
   visibleCount: number;
   onChange: (value: FilterableTraceEntryType[]) => void;
+  riskOnly?: boolean;
+  riskCount?: number;
+  onRiskOnlyChange?: (value: boolean) => void;
   title?: string;
 }) {
+  const riskOnlyDisabled = riskCount === 0;
+
   return (
     <div>
       <div className="flex items-center justify-between gap-3 px-6 py-3">
         <div className="text-sm font-medium">{title}</div>
-        <div className="text-muted-foreground shrink-0 text-xs">
-          Showing {visibleCount.toLocaleString()} of{" "}
-          {totalCount.toLocaleString()} entries
+        <div className="flex shrink-0 items-center gap-2">
+          {onRiskOnlyChange && (
+            <Button
+              type="button"
+              variant={riskOnly ? "secondary" : "outline"}
+              size="sm"
+              aria-pressed={riskOnly}
+              disabled={riskOnlyDisabled}
+              onClick={() => onRiskOnlyChange(!riskOnly)}
+              className="h-7 gap-1.5 px-2 text-xs"
+            >
+              <span>Risk only</span>
+              <span className="font-mono text-[10px] leading-none">
+                {riskCount.toLocaleString()}
+              </span>
+            </Button>
+          )}
+          <div className="text-muted-foreground text-xs">
+            Showing {visibleCount.toLocaleString()} of{" "}
+            {totalCount.toLocaleString()} entries
+          </div>
         </div>
       </div>
       <ToggleGroup

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
+import { Switch } from "@speakeasy-api/moonshine";
 import {
   ENTRY_TYPE_META,
   FILTERABLE_ENTRY_TYPES,
@@ -43,20 +43,24 @@ export function EntryTypeFilterBar({
         <div className="text-sm font-medium">{title}</div>
         <div className="flex shrink-0 items-center gap-2">
           {onRiskOnlyChange && (
-            <Button
-              type="button"
-              variant={riskOnly ? "secondary" : "outline"}
-              size="sm"
-              aria-pressed={riskOnly}
-              disabled={riskOnlyDisabled}
-              onClick={() => onRiskOnlyChange(!riskOnly)}
-              className="h-7 gap-1.5 px-2 text-xs"
+            <div
+              className={cn(
+                "border-border bg-background inline-flex h-8 items-center gap-2 rounded-md border px-2 text-xs",
+                riskOnly && "bg-muted/80 border-muted-foreground",
+                riskOnlyDisabled && "opacity-50",
+              )}
             >
               <span>Risk only</span>
               <span className="font-mono text-[10px] leading-none">
                 {riskCount.toLocaleString()}
               </span>
-            </Button>
+              <Switch
+                checked={riskOnly}
+                disabled={riskOnlyDisabled}
+                onCheckedChange={onRiskOnlyChange}
+                aria-label="Show risk entries only"
+              />
+            </div>
           )}
           <div className="text-muted-foreground text-xs">
             Showing {visibleCount.toLocaleString()} of{" "}

--- a/client/dashboard/src/pages/chatLogs/traceEntries.test.ts
+++ b/client/dashboard/src/pages/chatLogs/traceEntries.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "@gram/client/models/components";
+import {
+  getRiskEntryCount,
+  getVisibleMessages,
+  type FilterableTraceEntryType,
+} from "./traceEntries";
+
+function makeMessage({
+  id,
+  role,
+  toolCalls,
+}: {
+  id: string;
+  role: ChatMessage["role"];
+  toolCalls?: string;
+}): ChatMessage {
+  return {
+    id,
+    role,
+    toolCalls,
+    generation: 0,
+  } as ChatMessage;
+}
+
+const allTypes: FilterableTraceEntryType[] = [
+  "user",
+  "assistant",
+  "tool_call",
+  "tool_result",
+];
+
+describe("getVisibleMessages", () => {
+  it("preserves existing entry type behavior when risk only is disabled", () => {
+    const user = makeMessage({ id: "user-1", role: "user" });
+    const assistant = makeMessage({ id: "assistant-1", role: "assistant" });
+    const riskResultsByMessage = new Map<string, readonly unknown[]>([
+      ["assistant-1", [{ action: "flag" }]],
+    ]);
+
+    const visible = getVisibleMessages({
+      messages: [user, assistant],
+      enabledEntryTypes: ["user"],
+      riskOnly: false,
+      riskResultsByMessage,
+    });
+
+    expect(visible.map((message) => message.id)).toEqual(["user-1"]);
+  });
+
+  it("includes flagged and blocked risk entries when risk only is enabled", () => {
+    const flagged = makeMessage({ id: "flagged", role: "user" });
+    const blocked = makeMessage({ id: "blocked", role: "assistant" });
+    const normal = makeMessage({ id: "normal", role: "assistant" });
+    const riskResultsByMessage = new Map<string, readonly unknown[]>([
+      ["flagged", [{ action: "flag" }]],
+      ["blocked", [{ action: "block" }]],
+    ]);
+
+    const visible = getVisibleMessages({
+      messages: [flagged, blocked, normal],
+      enabledEntryTypes: allTypes,
+      riskOnly: true,
+      riskResultsByMessage,
+    });
+
+    expect(visible.map((message) => message.id)).toEqual([
+      "flagged",
+      "blocked",
+    ]);
+  });
+
+  it("composes risk only with entry type filters", () => {
+    const riskyUser = makeMessage({ id: "risky-user", role: "user" });
+    const riskyToolCall = makeMessage({
+      id: "risky-tool-call",
+      role: "assistant",
+      toolCalls: JSON.stringify([{ function: { name: "search" } }]),
+    });
+    const riskResultsByMessage = new Map<string, readonly unknown[]>([
+      ["risky-user", [{ action: "flag" }]],
+      ["risky-tool-call", [{ action: "flag" }]],
+    ]);
+
+    const visible = getVisibleMessages({
+      messages: [riskyUser, riskyToolCall],
+      enabledEntryTypes: ["tool_call"],
+      riskOnly: true,
+      riskResultsByMessage,
+    });
+
+    expect(visible.map((message) => message.id)).toEqual(["risky-tool-call"]);
+  });
+});
+
+describe("getRiskEntryCount", () => {
+  it("counts messages that have one or more risk results", () => {
+    const messages = [
+      makeMessage({ id: "one", role: "user" }),
+      makeMessage({ id: "two", role: "assistant" }),
+      makeMessage({ id: "three", role: "assistant" }),
+    ];
+    const riskResultsByMessage = new Map<string, readonly unknown[]>([
+      ["one", [{ action: "flag" }, { action: "flag" }]],
+      ["three", [{ action: "block" }]],
+    ]);
+
+    expect(getRiskEntryCount(messages, riskResultsByMessage)).toBe(2);
+  });
+});

--- a/client/dashboard/src/pages/chatLogs/traceEntries.ts
+++ b/client/dashboard/src/pages/chatLogs/traceEntries.ts
@@ -124,6 +124,59 @@ export function isMessageVisible(
   return entryType === "system" || enabledEntryTypes.includes(entryType);
 }
 
+export function messageHasRiskResults(
+  message: ChatMessage,
+  riskResultsByMessage: ReadonlyMap<string, readonly unknown[]>,
+) {
+  return (riskResultsByMessage.get(message.id)?.length ?? 0) > 0;
+}
+
+export function isMessageVisibleWithRisk({
+  message,
+  enabledEntryTypes,
+  riskOnly,
+  riskResultsByMessage,
+}: {
+  message: ChatMessage;
+  enabledEntryTypes: FilterableTraceEntryType[];
+  riskOnly: boolean;
+  riskResultsByMessage: ReadonlyMap<string, readonly unknown[]>;
+}) {
+  if (!isMessageVisible(message, enabledEntryTypes)) return false;
+  if (!riskOnly) return true;
+  return messageHasRiskResults(message, riskResultsByMessage);
+}
+
+export function getVisibleMessages({
+  messages,
+  enabledEntryTypes,
+  riskOnly,
+  riskResultsByMessage,
+}: {
+  messages: ChatMessage[];
+  enabledEntryTypes: FilterableTraceEntryType[];
+  riskOnly: boolean;
+  riskResultsByMessage: ReadonlyMap<string, readonly unknown[]>;
+}) {
+  return messages.filter((message) =>
+    isMessageVisibleWithRisk({
+      message,
+      enabledEntryTypes,
+      riskOnly,
+      riskResultsByMessage,
+    }),
+  );
+}
+
+export function getRiskEntryCount(
+  messages: ChatMessage[],
+  riskResultsByMessage: ReadonlyMap<string, readonly unknown[]>,
+) {
+  return messages.filter((message) =>
+    messageHasRiskResults(message, riskResultsByMessage),
+  ).length;
+}
+
 export function getVisibleMessageCount(
   messages: ChatMessage[],
   enabledEntryTypes: FilterableTraceEntryType[],

--- a/client/dashboard/src/pages/security/RiskEvents.tsx
+++ b/client/dashboard/src/pages/security/RiskEvents.tsx
@@ -314,6 +314,7 @@ export default function RiskEvents() {
             onClose={() => setSelectedChatId(null)}
             onDelete={() => setSelectedChatId(null)}
             collapseNonRisk
+            initialRiskOnly
           />
         }
         scrollRef={containerRef}


### PR DESCRIPTION
## Summary
- Add risk-aware trace entry filtering to the chat detail panel.
- Add toggle switch for “Risk only” that composes with the existing entry type filters.
- Open trace panels from Risk Events with the risk-only filter enabled by default.

<img width="1411" height="807" alt="image" src="https://github.com/user-attachments/assets/35017f0d-ef81-4b53-834f-5f68de1c856a" />


## Test Plan
- pnpm --dir client/dashboard exec vitest run src/pages/chatLogs/traceEntries.test.ts
- pnpm --dir client/dashboard type-check
- pnpm --dir client/dashboard lint

Linear: https://linear.app/speakeasy/issue/AGE-2539/feat-add-risk-filter-to-traces-panel


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Risk only” filter to the chat trace panel to show only entries with risk findings and compose with existing entry-type filters. Opening from Risk Events enables the filter by default to speed up reviews (Linear: AGE-2539).

- **New Features**
  - Added “Risk only” toggle in the filter bar using `@speakeasy-api/moonshine` Switch; shows a risk count and disables when there are no risk entries (remains togglable if already on).
  - Composes with User/Assistant/Tool Call/Tool Result filters; visible count now reflects both risk and type filters.
  - `RiskEvents` opens the panel with Risk only enabled; state resets per chat via `initialRiskOnly`.
  - Added helpers and tests for risk-aware visibility and counts.

<sup>Written for commit 1e660a92148a2fdeee53d8b2af423e94b8515ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



