### PR TITLE
feat(dashboard): re-target AI Insights sidebar at project toolsets with RBAC

### DIFF
--- a/.changeset/dynamic-insights-mcp.md
+++ b/.changeset/dynamic-insights-mcp.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Re-target AI Insights sidebar at project toolsets instead of hardcoded Speakeasy MCP. The sidebar now connects to all toolsets configured in the current project.

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -1,4 +1,4 @@
-import { devObservabilityMcpMissing } from "@/hooks/useObservabilityMcpConfig";
+import { useNoToolsetsConfigured } from "@/hooks/useObservabilityMcpConfig";
 import { cn } from "@/lib/utils";
 import { useAssistantRuntime } from "@assistant-ui/react";
 import type { ElementsConfig } from "@gram-ai/elements";
@@ -273,6 +273,7 @@ export function InsightsProvider({
   // found for lookup: __LOCALID_…` during render.
   const [sessionKey, setSessionKey] = useState(0);
   const { theme } = useMoonshineConfig();
+  const noToolsetsConfigured = useNoToolsetsConfigured();
 
   // Resolve effective values: per-page override wins, fall back to defaults.
   const mcpConfig = override?.mcpConfig ?? defaultMcpConfig;
@@ -468,16 +469,13 @@ When the user asks about "current period", "selected period", "this timeframe", 
             </button>
           </div>
 
-          {/* Dev notice when MCP is not configured */}
-          {devObservabilityMcpMissing && !("mcp" in mcpConfig) && (
+          {/* Notice when no toolsets are configured */}
+          {noToolsetsConfigured && (
             <div className="border-border bg-muted/50 text-muted-foreground mx-4 mt-3 flex items-start gap-2 rounded-md border px-3 py-2 text-xs">
               <Terminal className="mt-0.5 size-3.5 shrink-0" />
               <span>
-                AI tools are unavailable. Run{" "}
-                <code className="bg-muted text-foreground rounded px-1 py-0.5 font-mono">
-                  mise seed
-                </code>{" "}
-                to enable the observability MCP server.
+                AI tools are unavailable. Create an MCP server to enable AI
+                Insights.
               </span>
             </div>
           )}

--- a/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
+++ b/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
@@ -1,5 +1,5 @@
-import { useSession } from "@/contexts/Auth";
-import { useProject, useSlugs } from "@/contexts/Sdk";
+import { useProject, useSession } from "@/contexts/Auth";
+import { useSlugs } from "@/contexts/Sdk";
 import { internalMcpUrl } from "@/hooks/useToolsetUrl";
 import { getServerURL } from "@/lib/utils";
 import type {

--- a/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
+++ b/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
@@ -101,10 +101,3 @@ export function useNoToolsetsConfigured(): boolean {
   if (isLoading) return false;
   return !toolsetsData?.toolsets?.length;
 }
-
-/**
- * @deprecated Use useNoToolsetsConfigured() instead to check if toolsets are missing.
- * This was previously checking for the hardcoded observability MCP URL, but AI Insights
- * now dynamically connects to all project toolsets.
- */
-export const devObservabilityMcpMissing = false;

--- a/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
+++ b/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
@@ -1,9 +1,15 @@
 import { useSession } from "@/contexts/Auth";
-import { useSlugs } from "@/contexts/Sdk";
+import { useProject, useSlugs } from "@/contexts/Sdk";
+import { internalMcpUrl } from "@/hooks/useToolsetUrl";
 import { getServerURL } from "@/lib/utils";
-import type { ElementsConfig, ToolsFilter } from "@gram-ai/elements";
+import type {
+  ElementsConfig,
+  MCPServerEntry,
+  ToolsFilter,
+} from "@gram-ai/elements";
 import { chatSessionsCreate } from "@gram/client/funcs/chatSessionsCreate";
 import { useGramContext } from "@gram/client/react-query";
+import { useListToolsets } from "@gram/client/react-query/index.js";
 import { useCallback, useMemo } from "react";
 
 interface ObservabilityMcpConfigOptions {
@@ -11,8 +17,9 @@ interface ObservabilityMcpConfigOptions {
 }
 
 /**
- * Hook to generate MCP configuration for observability copilot features.
- * Filters tools based on the provided filter function.
+ * Hook to generate MCP configuration for AI Insights copilot features.
+ * Connects to all toolsets in the current project and filters tools
+ * based on the provided filter function.
  */
 export function useObservabilityMcpConfig({
   toolsToInclude,
@@ -21,8 +28,11 @@ export function useObservabilityMcpConfig({
   "variant" | "welcome" | "theme"
 > {
   const { projectSlug } = useSlugs();
+  const project = useProject();
   const client = useGramContext();
   const { session } = useSession();
+  const { data: toolsetsData, isLoading: isLoadingToolsets } =
+    useListToolsets();
 
   const getSession = useCallback(async (): Promise<string> => {
     const res = await chatSessionsCreate(
@@ -42,18 +52,25 @@ export function useObservabilityMcpConfig({
     return res.value?.clientToken ?? "";
   }, [client, projectSlug]);
 
+  // Build MCP server entries for all project toolsets
+  const mcps = useMemo<MCPServerEntry[] | undefined>(() => {
+    if (isLoadingToolsets || !toolsetsData?.toolsets?.length) {
+      return undefined;
+    }
+
+    return toolsetsData.toolsets.map((toolset) => ({
+      url: internalMcpUrl({ slug: project.slug }, toolset),
+      name: toolset.slug,
+      environment: toolset.defaultEnvironmentSlug,
+    }));
+  }, [toolsetsData?.toolsets, project.slug, isLoadingToolsets]);
+
   return useMemo(() => {
     if (!projectSlug) {
       throw new Error("No project slug found.");
     }
 
     const serverURL = getServerURL();
-
-    const mcpUrl = serverURL.includes("app.getgram.ai")
-      ? "https://app.getgram.ai/mcp/speakeasy-team-gram"
-      : serverURL.includes("dev.getgram.ai")
-        ? "https://dev.getgram.ai/mcp/speakeasy-team-gram"
-        : import.meta.env.VITE_GRAM_OBSERVABILITY_MCP_URL || undefined;
 
     return {
       projectSlug,
@@ -70,15 +87,24 @@ export function useObservabilityMcpConfig({
         GRAM_APIKEY_HEADER_GRAM_KEY: "",
         GRAM_PROJECT_SLUG_HEADER_GRAM_PROJECT: projectSlug,
       },
-      ...(mcpUrl && { mcp: mcpUrl }),
+      ...(mcps && mcps.length > 0 && { mcps }),
     };
-  }, [toolsToInclude, getSession, session, projectSlug]);
+  }, [toolsToInclude, getSession, session, projectSlug, mcps]);
 }
 
 /**
- * Whether the observability MCP URL is missing in local dev.
- * True when running in dev mode and `mise seed` hasn't been run
- * (VITE_GRAM_OBSERVABILITY_MCP_URL is not set).
+ * Whether the project has no toolsets configured yet.
+ * Used to show a setup prompt in the AI Insights sidebar.
  */
-export const devObservabilityMcpMissing =
-  import.meta.env.DEV && !import.meta.env.VITE_GRAM_OBSERVABILITY_MCP_URL;
+export function useNoToolsetsConfigured(): boolean {
+  const { data: toolsetsData, isLoading } = useListToolsets();
+  if (isLoading) return false;
+  return !toolsetsData?.toolsets?.length;
+}
+
+/**
+ * @deprecated Use useNoToolsetsConfigured() instead to check if toolsets are missing.
+ * This was previously checking for the hardcoded observability MCP URL, but AI Insights
+ * now dynamically connects to all project toolsets.
+ */
+export const devObservabilityMcpMissing = false;

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -1,4 +1,5 @@
 import { useQueryState } from "nuqs";
+import type { MCPServerEntry } from "@gram-ai/elements";
 import { recommended } from "@gram-ai/elements/plugins";
 import { RequireScope } from "@/components/require-scope";
 import {
@@ -21,12 +22,14 @@ import { Switch } from "@/components/ui/switch";
 import { useOrganization, useSession } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
 import { useRBAC } from "@/hooks/useRBAC";
+import { internalMcpUrl } from "@/hooks/useToolsetUrl";
 import type { AuditLog } from "@gram/client/models/components";
 import { chatSessionsCreate } from "@gram/client/funcs/chatSessionsCreate";
 import {
   useAuditLogsInfinite,
   useAuditLogFacets,
   useGramContext,
+  useListToolsets,
 } from "@gram/client/react-query";
 import { Icon, Input } from "@speakeasy-api/moonshine";
 import React, {
@@ -476,6 +479,12 @@ function AuditLogsInsightsWrapper({ children }: { children: React.ReactNode }) {
   const client = useGramContext();
 
   const projectSlug = organization.projects[0]?.slug ?? "";
+  const { data: toolsetsData, isLoading: isLoadingToolsets } = useListToolsets(
+    undefined,
+    {
+      headers: { "Gram-Project": projectSlug },
+    },
+  );
 
   const getSession = useCallback(async () => {
     const res = await chatSessionsCreate(
@@ -497,12 +506,18 @@ function AuditLogsInsightsWrapper({ children }: { children: React.ReactNode }) {
 
   const serverURL = getServerURL();
 
-  // Derive observability MCP URL the same way useObservabilityMcpConfig does.
-  const mcpUrl = serverURL.includes("app.getgram.ai")
-    ? "https://app.getgram.ai/mcp/speakeasy-team-gram"
-    : serverURL.includes("dev.getgram.ai")
-      ? "https://dev.getgram.ai/mcp/speakeasy-team-gram"
-      : import.meta.env.VITE_GRAM_OBSERVABILITY_MCP_URL || undefined;
+  // Build MCP server entries for all project toolsets
+  const mcps = useMemo<MCPServerEntry[] | undefined>(() => {
+    if (isLoadingToolsets || !toolsetsData?.toolsets?.length) {
+      return undefined;
+    }
+
+    return toolsetsData.toolsets.map((toolset) => ({
+      url: internalMcpUrl({ slug: projectSlug }, toolset),
+      name: toolset.slug,
+      environment: toolset.defaultEnvironmentSlug,
+    }));
+  }, [toolsetsData?.toolsets, projectSlug, isLoadingToolsets]);
 
   const auditToolsFilter = useCallback(
     ({ toolName }: { toolName: string }) =>
@@ -532,9 +547,9 @@ function AuditLogsInsightsWrapper({ children }: { children: React.ReactNode }) {
         GRAM_APIKEY_HEADER_GRAM_KEY: "",
         GRAM_PROJECT_SLUG_HEADER_GRAM_PROJECT: projectSlug,
       },
-      ...(mcpUrl && { mcp: mcpUrl }),
+      ...(mcps && mcps.length > 0 && { mcps }),
     }),
-    [projectSlug, auditToolsFilter, serverURL, getSession, session, mcpUrl],
+    [projectSlug, auditToolsFilter, serverURL, getSession, session, mcps],
   );
 
   return (

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -479,12 +479,9 @@ function AuditLogsInsightsWrapper({ children }: { children: React.ReactNode }) {
   const client = useGramContext();
 
   const projectSlug = organization.projects[0]?.slug ?? "";
-  const { data: toolsetsData, isLoading: isLoadingToolsets } = useListToolsets(
-    undefined,
-    {
-      headers: { "Gram-Project": projectSlug },
-    },
-  );
+  const { data: toolsetsData, isLoading: isLoadingToolsets } = useListToolsets({
+    gramProject: projectSlug,
+  });
 
   const getSession = useCallback(async () => {
     const res = await chatSessionsCreate(

--- a/server/internal/auth/chatsessions/jwt.go
+++ b/server/internal/auth/chatsessions/jwt.go
@@ -17,6 +17,16 @@ type ChatSessionClaims struct {
 	ProjectSlug      string  `json:"project_slug"`
 	ExternalUserID   *string `json:"external_user_id,omitempty"`
 	APIKeyID         string  `json:"api_key_id"`
+	// UserID is the authenticated dashboard user's ID. When present, allows
+	// RBAC enforcement at the MCP gateway. Empty for API-key-only sessions.
+	UserID string `json:"user_id,omitempty"`
+	// SessionID is the dashboard session ID. When present (non-nil), the authz
+	// engine will load and enforce RBAC grants for the user.
+	SessionID *string `json:"session_id,omitempty"`
+	// AccountType is the organization's billing tier (e.g. "enterprise").
+	// Required for RBAC enforcement — the authz engine only loads grants
+	// for enterprise accounts.
+	AccountType string `json:"account_type,omitempty"`
 	jwt.RegisteredClaims
 }
 

--- a/server/internal/auth/chatsessions/manager.go
+++ b/server/internal/auth/chatsessions/manager.go
@@ -110,12 +110,12 @@ func (m *Manager) Authorize(ctx context.Context, token string) (context.Context,
 		ProjectID:             &projectID,
 		OrganizationSlug:      claims.OrganizationSlug,
 		ProjectSlug:           &claims.ProjectSlug,
-		UserID:                "",
+		UserID:                claims.UserID,
 		ExternalUserID:        externalUserID,
 		APIKeyID:              claims.APIKeyID,
-		SessionID:             nil, // DO NOT SET THIS for chat sessions. The existence of this field implies that this is a dashboard-authenticated request.
+		SessionID:             claims.SessionID, // When set, the authz engine loads and enforces RBAC grants for the user
 		Email:                 nil,
-		AccountType:           "",
+		AccountType:           claims.AccountType, // Required for RBAC enforcement (only "enterprise" accounts)
 		HasActiveSubscription: false,
 		Whitelisted:           false,
 		APIKeyScopes:          nil,

--- a/server/internal/chatsessions/impl.go
+++ b/server/internal/chatsessions/impl.go
@@ -74,6 +74,15 @@ func (s *Service) Create(ctx context.Context, p *gen.CreatePayload) (*gen.Create
 		return nil, oops.C(oops.CodeUnauthorized).Log(ctx, s.logger)
 	}
 
+	// Extract user identity from the caller's auth context. When the dashboard
+	// user creates a chat session, their UserID and SessionID are carried into
+	// the JWT so the MCP gateway can enforce RBAC on tool calls.
+	var sessionID *string
+	if authCtx.SessionID != nil {
+		sid := *authCtx.SessionID
+		sessionID = &sid
+	}
+
 	claims := chatsessions.ChatSessionClaims{
 		OrgID:            authCtx.ActiveOrganizationID,
 		ProjectID:        authCtx.ProjectID.String(),
@@ -81,6 +90,9 @@ func (s *Service) Create(ctx context.Context, p *gen.CreatePayload) (*gen.Create
 		ProjectSlug:      *authCtx.ProjectSlug,
 		ExternalUserID:   p.UserIdentifier,
 		APIKeyID:         authCtx.APIKeyID,
+		UserID:           authCtx.UserID,
+		SessionID:        sessionID,
+		AccountType:      authCtx.AccountType,
 		RegisteredClaims: jwt.RegisteredClaims{}, //nolint:exhaustruct // to be populated by chatSessionsManager
 	}
 


### PR DESCRIPTION
## Summary

Re-targets the AI Insights sidebar away from the single hardcoded `speakeasy-team-gram` MCP endpoint and onto **every toolset in the current project**, then mints user-scoped chat session tokens so the MCP gateway can enforce per-tool RBAC.

- **Dynamic MCP targeting**: builds an `mcps[]` array (one entry per project toolset) instead of the hardcoded `app.getgram.ai`/`dev.getgram.ai` observability URL.
- **RBAC enforcement**: chat session JWTs now carry the dashboard user's identity (`UserID`, `SessionID`, `AccountType`), so the gateway's authz engine loads and enforces grants for enterprise accounts. No frontend scope filtering needed — `mcp:read` already implies `mcp:connect`.

### Why / roadmap

We're replacing the current AI Insights sidebar — a client-side chat (Vercel AI SDK) wired to a single hardcoded observability MCP, with ephemeral conversations and per-page `<InsightsConfig>` overrides — with a **persistent assistant-per-org** (AGE-2631): each organisation gets its own assistant entity with its own system prompt, server-side memory, and globally-available MCP toolsets, served via the assistant runtime API.

This PR is two stepping stones toward that, **without** yet swapping out the local AI SDK chat:

1. **AGE-2126** — decouple the sidebar from the hardcoded `speakeasy-team-gram` observability MCP and point it at the project's own toolsets.
2. **AGE-2631 work-item #3 (auth bridge)** — give the sidebar a user-scoped token so the MCP gateway can enforce per-org/per-tool access, the core auth-scoping problem the assistant migration depends on.

The assistant-runtime swap, per-org provisioning, and removal of the `<InsightsConfig>` override pattern land in follow-up PRs on AGE-2631.

### Frontend

- `useObservabilityMcpConfig` fetches project toolsets via `useListToolsets` and maps each to an `MCPServerEntry` (`url` from `internalMcpUrl`, `name`, `environment`).
- New `useNoToolsetsConfigured()` hook replaces the old `devObservabilityMcpMissing` dev-only flag (kept as `false` + `@deprecated` for back-compat). The sidebar empty-state copy changed from a "run `mise seed`" dev hint to a generic "Create an MCP server to enable AI Insights."
- `OrgAuditLogs` builds the same per-toolset `mcps[]` array (uses `organization.projects[0]`, passing `gramProject` explicitly to `useListToolsets`).

### Backend (RBAC)

- `ChatSessionClaims` (`jwt.go`): added `UserID`, `SessionID`, `AccountType`.
- `chatsessions.Create` (`impl.go`): copies the caller's `UserID`/`SessionID`/`AccountType` from the auth context into the minted JWT.
- `chatsessions.Manager.Authorize` (`manager.go`): populates `AuthContext` from those claims so the authz engine can resolve grants (gate: `SessionID != nil` AND `AccountType == "enterprise"`).

## Test plan

- [ ] AI Insights on a project **with** toolsets — connects to the project's MCP servers.
- [ ] AI Insights on a project **with no** toolsets — "Create an MCP server" notice appears.
- [ ] Org Audit Logs page — AI Insights works against the first project's toolsets.
- [ ] Tool calls work end-to-end in the sidebar chat.
- [ ] **RBAC (enterprise)**: a user lacking `mcp:connect` on a toolset cannot invoke its tools via the sidebar.
- [ ] **Non-enterprise**: sidebar still works (RBAC skipped, as before).

Ref: AGE-2126, AGE-2631
Slack: https://speakeasyapi.slack.com/archives/C0AP8M5PJLD/p1780099911336759?thread_ts=1780097706.511839&cid=C0AP8M5PJLD

https://claude.ai/code/session_01Y7nL9ddHmM3zFMDGpCmVMv
