### PR TITLE
mig: add project_managed_assistants mapping table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1135,6 +1135,27 @@ CREATE UNIQUE INDEX IF NOT EXISTS assistants_project_id_name_key
 ON assistants (project_id, name)
 WHERE deleted IS FALSE;
 
+-- project_managed_assistants maps a project to its single platform-managed
+-- assistant (the one powering the AI Insights sidebar). Kept in its own table
+-- rather than a flag on assistants/projects so the relation has an explicit
+-- lifecycle: the row exists only while the feature is toggled on for the
+-- project, and cascades away when either the project or the assistant is
+-- removed. project_id is the primary key, enforcing 0-or-1 managed assistant
+-- per project.
+CREATE TABLE IF NOT EXISTS project_managed_assistants (
+  project_id uuid NOT NULL,
+  assistant_id uuid NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT project_managed_assistants_pkey PRIMARY KEY (project_id),
+  CONSTRAINT project_managed_assistants_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT project_managed_assistants_assistant_id_fkey FOREIGN KEY (assistant_id) REFERENCES assistants (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS project_managed_assistants_assistant_id_idx ON project_managed_assistants (assistant_id);
+
 CREATE TABLE IF NOT EXISTS assistant_toolsets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   assistant_id uuid NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1064,6 +1064,13 @@ type ProjectAllowedOrigin struct {
 	Deleted   bool
 }
 
+type ProjectManagedAssistant struct {
+	ProjectID   uuid.UUID
+	AssistantID uuid.UUID
+	CreatedAt   pgtype.Timestamptz
+	UpdatedAt   pgtype.Timestamptz
+}
+
 type ProjectMarketplaceSetting struct {
 	ProjectID       uuid.UUID
 	MarketplaceName pgtype.Text

--- a/server/migrations/20260602103955_age-2631-project-managed-assistants.sql
+++ b/server/migrations/20260602103955_age-2631-project-managed-assistants.sql
@@ -1,0 +1,12 @@
+-- Create "project_managed_assistants" table
+CREATE TABLE "project_managed_assistants" (
+  "project_id" uuid NOT NULL,
+  "assistant_id" uuid NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("project_id"),
+  CONSTRAINT "project_managed_assistants_assistant_id_fkey" FOREIGN KEY ("assistant_id") REFERENCES "assistants" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "project_managed_assistants_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "project_managed_assistants_assistant_id_idx" to table: "project_managed_assistants"
+CREATE INDEX "project_managed_assistants_assistant_id_idx" ON "project_managed_assistants" ("assistant_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:TGR/ou3s3ZD6Ukb1mYxd1gAbfZB8MuylyNcpiBUoouA=
+h1:Yt8QrOWtqTNjPBVIah921ZzpxojZ8TXCJYTfloaDRHc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -200,3 +200,4 @@ h1:TGR/ou3s3ZD6Ukb1mYxd1gAbfZB8MuylyNcpiBUoouA=
 20260529185739_plugin-assignments-org-principal-index.sql h1:zxjbc2mIBYmXegrSPPDfoMFQn7fagQs8Sd8Ld2JH4+o=
 20260601092138_risk-policies-add-audience-type.sql h1:M1gvNAwdWQAX6bIyEhF7VnLvIltOPdob+093qPfiM+A=
 20260601212536_plugin-github-connections-add-published-fingerprint.sql h1:eYANo4SQbbKipX/n3geIZ4qZ2yT8RV3lw/PAn0YoPA8=
+20260602103955_age-2631-project-managed-assistants.sql h1:WTzRGPg815dtWcPpBbkJlWNyu2PRdArmtjbX0UDKySI=


### PR DESCRIPTION
## Summary

Stacked on #3123. **Migration only** — first PR in the AGE-2631 stack.

Adds `project_managed_assistants`, a table mapping a project to its single platform-managed assistant (the one powering the AI Insights sidebar).

```sql
CREATE TABLE project_managed_assistants (
  id uuid PRIMARY KEY DEFAULT generate_uuidv7(),
  project_id uuid NOT NULL,
  organization_id text NOT NULL,
  assistant_id uuid NOT NULL,
  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
  CONSTRAINT project_managed_assistants_project_id_key UNIQUE (project_id),
  CONSTRAINT project_managed_assistants_project_id_fkey   FOREIGN KEY (project_id)   REFERENCES projects (id)   ON DELETE CASCADE,
  CONSTRAINT project_managed_assistants_assistant_id_fkey FOREIGN KEY (assistant_id) REFERENCES assistants (id) ON DELETE CASCADE
);
CREATE INDEX project_managed_assistants_assistant_id_idx ON project_managed_assistants (assistant_id);
```

### Why a mapping table (not a flag)
Per review feedback on the original approach: an `is_default` boolean on `assistants` would (a) implicitly mint an always-on managed assistant for every project a sidebar is opened in, and (b) leak the "managed" relation into the assistant row. Instead this models the relation explicitly:
- **`UNIQUE(project_id)`** — 0 or 1 managed assistant per project.
- **Row existence = the feature is toggled on** for that project (enable creates assistant + mapping; disable removes them).
- **Cascade FKs** — the mapping tears down automatically when the project or assistant is removed.

### Safety
- New empty table; plain (non-concurrent) `CREATE INDEX` is fine — nothing to lock.
- Additive only.

### Validation
- `mise lint:migrations`: ordering ✅
- `atlas migrate lint` (clean pgvector dev DB): no findings ✅

## Stack
1. **#3123** — AI Insights → project toolsets + RBAC tokens (base)
2. **this PR** — `project_managed_assistants` migration
3. _next_ — managed-assistant provisioning (enable/disable/get toggle)
4. _next_ — `dashboard` ingress source kind + send endpoint
5. _next_ — egress platform tool + browser read path
6. _next_ — sidebar cutover

Ref: AGE-2631