### PR TITLE
feat(server): provision per-project managed assistant

### DIFF
--- a/.changeset/managed-assistant-provisioning.md
+++ b/.changeset/managed-assistant-provisioning.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add managed-assistant provisioning: `EnableManagedAssistant` / `DisableManagedAssistant` / `GetManagedAssistant` toggle a project's platform-managed assistant (AI Insights sidebar). Enabling creates the assistant with the ported Insights prompt and all MCP-reachable project toolsets attached and records the `project_managed_assistants` mapping; disabling tears both down. Idempotent and race-safe. Foundation for AGE-2631.

--- a/server/internal/assistants/managed_assistant_instructions.txt
+++ b/server/internal/assistants/managed_assistant_instructions.txt
@@ -1,0 +1,18 @@
+You are a helpful assistant for analyzing logs and security findings in Gram, an AI observability platform. Focus on log search, tool-call analysis, and risk/policy findings.
+
+Important: Treat all 4xx HTTP status codes (400, 401, 403, 404, etc.) as errors. From the user's perspective these indicate real problems — authentication failures, misconfigured requests, missing resources, etc.
+
+Custom attributes: SDK users can attach arbitrary key-value attributes to their logs. These appear with an @ prefix (e.g. @user, @tenant.id, @session). Standard system attributes have no prefix.
+
+When a user asks about logs for a specific user, tenant, customer, or entity:
+1. Always call listAttributeKeys first for the relevant time window to discover which @-prefixed attributes exist.
+2. Identify the most relevant attribute and filter on it (e.g. { path: "@user", operator: "eq", values: ["someone@example.com"] }).
+3. If no relevant @-prefixed attributes exist, tell the user and fall back to text search instead.
+
+MCP server vs. client breakdowns: `gram.hook.source` and `gram.tool_call.source` are complementary dimensions, not aliases. `gram.hook.source` identifies the agent/client that invoked Gram (e.g. "claude-code", "cursor") — use this for adoption / "who's using us" questions. `gram.tool_call.source` identifies the downstream MCP server that handled the call (e.g. "datadog-mcp", "linear") — use this for "top servers" / per-MCP usage questions. When asked about MCP server-level breakdowns, query BOTH dimensions: a server can appear in one and not the other depending on whether you're slicing by caller or callee.
+
+Risk and policy findings:
+- A risk policy scans chat messages for issues. Each `source` is a detector family: `gitleaks` (regex-based secret scanners — API keys, tokens), `presidio` (PII entities — emails, SSNs, credit cards), `prompt_injection` (heuristic + ML classifier for injection attempts), `destructive_tool` (tool calls matching destructive intent), `shadow_mcp` (calls to MCP servers not on an approved list).
+- Use `listRiskResultsForAgent` for finding-level data — it returns the same shape as the dashboard's findings list but with the raw `match` field replaced by `match_redacted`: an opaque token of the form `<redacted len=N sha=XXXXXXXX>` for secret-bearing sources, or the literal server identifier for `shadow_mcp`. The `sha` prefix is deterministic, so two findings of the same secret share a fingerprint — that's how you dedupe leak counts across chats without seeing the secret.
+- Use `listRiskResultsByChat` for chat-level rollups (findings_count, latest_detected), `listRiskPolicies` for the policy catalog, and `getRiskPolicyStatus` for analysis progress (pending vs analyzed counts, workflow state).
+- HARD RULE — never quote or repeat a `match_redacted` value, never attempt to reconstruct a redacted secret, and never echo any string that looks like an API key, token, password, or PII. Refer to findings by their `rule_id` (e.g. "aws-access-key-id"), `source` family, and `chat_id`. `shadow_mcp` matches (server URLs / stdio commands) are safe to name verbatim.

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -1,0 +1,248 @@
+package assistants
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	assistantrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+// managedAssistantInstructions is the system prompt for the platform-managed
+// assistant that powers the AI Insights sidebar. Ported from the inline prompt
+// that previously lived in the dashboard (insights-sidebar.tsx); the dynamic
+// "current date" line was dropped because the runtime composes time context
+// separately.
+//
+//go:embed managed_assistant_instructions.txt
+var managedAssistantInstructions string
+
+const (
+	// managedAssistantModel mirrors the model the sidebar used client-side.
+	managedAssistantModel = "anthropic/claude-sonnet-4.6"
+
+	// Schema defaults for the assistants table, applied explicitly so the
+	// managed assistant's intent is visible at the call site.
+	managedAssistantWarmTTLSeconds int64 = 60
+	managedAssistantMaxConcurrency int64 = 10
+)
+
+// ErrManagedAssistantNameTaken is returned by EnableManagedAssistant when a
+// non-managed assistant already occupies the managed assistant's name in the
+// project. The caller should ask the user to rename or remove it.
+var ErrManagedAssistantNameTaken = errors.New("an assistant with the managed assistant's name already exists in this project")
+
+// managedAssistantName composes a project's managed-assistant display name. The
+// project name is embedded so the per-project assistants stay distinguishable
+// across an organization. project.name is capped at 40 chars and assistants.name
+// at 120, so the composed name always fits.
+func managedAssistantName(projectName string) string {
+	return fmt.Sprintf("Speakeasy Assistant for %s", projectName)
+}
+
+// EnableManagedAssistant turns on the managed assistant for a project: it
+// creates the assistant (attaching every MCP-reachable project toolset) and
+// records it in project_managed_assistants. The managed assistant exists only
+// while this mapping row does — disabling or removing the project tears it down.
+//
+// Idempotent and safe under concurrency: the fast path returns the existing
+// managed assistant, and an enable that loses a race is recovered by re-reading
+// the winner. A unique violation has two causes — a concurrent enable (the
+// mapping now exists, so the re-read returns it) or a non-managed assistant
+// already holding the name (no mapping, so we surface ErrManagedAssistantNameTaken).
+//
+// createdByUserID may be empty for system-initiated enablement; it is recorded
+// as NULL in that case.
+func (s *ServiceCore) EnableManagedAssistant(
+	ctx context.Context,
+	organizationID string,
+	projectID uuid.UUID,
+	createdByUserID string,
+) (assistantRecord, error) {
+	existing, err := s.GetManagedAssistant(ctx, projectID)
+	switch {
+	case err == nil:
+		return existing, nil
+	case errors.Is(err, pgx.ErrNoRows):
+		// fall through to create
+	default:
+		return assistantRecord{}, err
+	}
+
+	projectName, err := assistantrepo.New(s.db).GetProjectName(ctx, projectID)
+	if err != nil {
+		return assistantRecord{}, fmt.Errorf("load project for managed assistant: %w", err)
+	}
+	name := managedAssistantName(projectName)
+
+	record, err := s.createManagedAssistant(ctx, organizationID, projectID, name, createdByUserID)
+	if err == nil {
+		return record, nil
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+		recovered, reErr := s.GetManagedAssistant(ctx, projectID)
+		if reErr == nil {
+			return recovered, nil
+		}
+		if errors.Is(reErr, pgx.ErrNoRows) {
+			return assistantRecord{}, fmt.Errorf("%w: %q — rename or remove it to enable the managed assistant for this project", ErrManagedAssistantNameTaken, name)
+		}
+		return assistantRecord{}, reErr
+	}
+	return assistantRecord{}, err
+}
+
+// GetManagedAssistant resolves a project's managed assistant and hydrates its
+// toolsets. Returns pgx.ErrNoRows when the feature isn't enabled for the project.
+func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UUID) (assistantRecord, error) {
+	row, err := assistantrepo.New(s.db).GetManagedAssistantByProject(ctx, projectID)
+	if err != nil {
+		return assistantRecord{}, fmt.Errorf("get managed assistant: %w", err)
+	}
+	record := assistantRecordFromManagedRow(row)
+	refs, err := s.loadAssistantToolsets(ctx, projectID, []uuid.UUID{record.ID})
+	if err != nil {
+		return assistantRecord{}, err
+	}
+	record.Toolsets = refs[record.ID]
+	return record, nil
+}
+
+// DisableManagedAssistant turns the managed assistant off for a project: it
+// removes the mapping and soft-deletes the assistant. No-op when the project
+// has no managed assistant.
+func (s *ServiceCore) DisableManagedAssistant(ctx context.Context, projectID uuid.UUID) error {
+	row, err := assistantrepo.New(s.db).GetManagedAssistantByProject(ctx, projectID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("get managed assistant: %w", err)
+	}
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin disable managed assistant tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	queries := assistantrepo.New(tx)
+	if err := queries.DeleteProjectManagedAssistant(ctx, projectID); err != nil {
+		return fmt.Errorf("delete managed assistant mapping: %w", err)
+	}
+	if err := queries.DeleteAssistant(ctx, assistantrepo.DeleteAssistantParams{
+		AssistantID: row.ID,
+		ProjectID:   projectID,
+	}); err != nil {
+		return fmt.Errorf("soft-delete managed assistant: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit disable managed assistant tx: %w", err)
+	}
+	return nil
+}
+
+// createManagedAssistant inserts the assistant, records the managed mapping, and
+// attaches all of the project's MCP-reachable toolsets in a single transaction.
+func (s *ServiceCore) createManagedAssistant(
+	ctx context.Context,
+	organizationID string,
+	projectID uuid.UUID,
+	name string,
+	createdByUserID string,
+) (assistantRecord, error) {
+	slugs, err := assistantrepo.New(s.db).ListProjectMCPToolsetSlugs(ctx, projectID)
+	if err != nil {
+		return assistantRecord{}, fmt.Errorf("list project toolsets for managed assistant: %w", err)
+	}
+	refs := make([]*types.AssistantToolsetRef, 0, len(slugs))
+	for _, slug := range slugs {
+		refs = append(refs, &types.AssistantToolsetRef{ToolsetSlug: slug, EnvironmentSlug: nil})
+	}
+
+	resolved, err := s.resolveToolsetRefsForWrite(ctx, projectID, refs)
+	if err != nil {
+		return assistantRecord{}, err
+	}
+
+	var createdBy pgtype.Text
+	if createdByUserID != "" {
+		createdBy = conv.ToPGText(createdByUserID)
+	}
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return assistantRecord{}, fmt.Errorf("begin managed assistant tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	queries := assistantrepo.New(tx)
+	created, err := queries.CreateAssistant(ctx, assistantrepo.CreateAssistantParams{
+		ProjectID:       projectID,
+		OrganizationID:  organizationID,
+		CreatedByUserID: createdBy,
+		Name:            name,
+		Model:           managedAssistantModel,
+		Instructions:    managedAssistantInstructions,
+		WarmTtlSeconds:  managedAssistantWarmTTLSeconds,
+		MaxConcurrency:  managedAssistantMaxConcurrency,
+		Status:          StatusActive,
+	})
+	if err != nil {
+		return assistantRecord{}, fmt.Errorf("insert managed assistant: %w", err)
+	}
+	record := assistantRecordFromCreateRow(created)
+
+	if err := queries.CreateProjectManagedAssistant(ctx, assistantrepo.CreateProjectManagedAssistantParams{
+		ProjectID:   projectID,
+		AssistantID: record.ID,
+	}); err != nil {
+		return assistantRecord{}, fmt.Errorf("insert managed assistant mapping: %w", err)
+	}
+
+	if err := writeAssistantToolsets(ctx, tx, record.ID, projectID, resolved); err != nil {
+		return assistantRecord{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return assistantRecord{}, fmt.Errorf("commit managed assistant tx: %w", err)
+	}
+
+	refs2, err := s.loadAssistantToolsets(ctx, projectID, []uuid.UUID{record.ID})
+	if err != nil {
+		return assistantRecord{}, err
+	}
+	record.Toolsets = refs2[record.ID]
+	return record, nil
+}
+
+func assistantRecordFromManagedRow(row assistantrepo.GetManagedAssistantByProjectRow) assistantRecord {
+	return assistantRecord{
+		ID:              row.ID,
+		ProjectID:       row.ProjectID,
+		OrganizationID:  row.OrganizationID,
+		CreatedByUserID: conv.FromPGTextOrEmpty[string](row.CreatedByUserID),
+		Name:            row.Name,
+		Model:           row.Model,
+		Instructions:    row.Instructions,
+		Toolsets:        nil,
+		WarmTTLSeconds:  conv.SafeInt(row.WarmTtlSeconds),
+		MaxConcurrency:  conv.SafeInt(row.MaxConcurrency),
+		Status:          row.Status,
+		CreatedAt:       row.CreatedAt.Time,
+		UpdatedAt:       row.UpdatedAt.Time,
+		DeletedAt:       row.DeletedAt,
+	}
+}

--- a/server/internal/assistants/provisioning_test.go
+++ b/server/internal/assistants/provisioning_test.go
@@ -1,0 +1,192 @@
+package assistants
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+func newProvisioningCore(t *testing.T, conn *pgxpool.Pool) *ServiceCore {
+	t.Helper()
+	logger := testenv.NewLogger(t)
+	return NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil)
+}
+
+func newProvisioningProject(t *testing.T, conn *pgxpool.Pool, slug string) uuid.UUID {
+	t.Helper()
+	proj, err := projectsrepo.New(conn).CreateProject(t.Context(), projectsrepo.CreateProjectParams{
+		Name:           slug,
+		Slug:           slug,
+		OrganizationID: "org-test",
+	})
+	require.NoError(t, err)
+	return proj.ID
+}
+
+func TestEnableManagedAssistantIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_idempotent")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "managed-idempotent")
+
+	first, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+	require.Equal(t, managedAssistantName("managed-idempotent"), first.Name)
+	require.Equal(t, managedAssistantModel, first.Model)
+	require.Equal(t, managedAssistantInstructions, first.Instructions)
+	require.NotEmpty(t, first.Instructions, "managed instructions must be embedded, not empty")
+
+	// A second enable (even by a different user) returns the same assistant.
+	second, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-2")
+	require.NoError(t, err)
+	require.Equal(t, first.ID, second.ID, "enable must be idempotent")
+
+	all, err := core.ListAssistants(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, all, 1, "only one managed assistant may exist per project")
+
+	got, err := core.GetManagedAssistant(ctx, projectID)
+	require.NoError(t, err)
+	require.Equal(t, first.ID, got.ID)
+}
+
+func TestEnableManagedAssistantAttachesMCPReachableToolsets(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_toolsets")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "managed-toolsets")
+
+	toolsetsQ := toolsetsrepo.New(conn)
+	// MCP-reachable toolset — should be attached.
+	reachable, err := toolsetsQ.CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID:         "org-test",
+		ProjectID:              projectID,
+		Name:                   "Billing",
+		Slug:                   "billing",
+		Description:            pgtype.Text{},
+		DefaultEnvironmentSlug: pgtype.Text{},
+		McpSlug:                pgtype.Text{String: "org-test-billing-xyz", Valid: true},
+		McpEnabled:             false,
+	})
+	require.NoError(t, err)
+	// Toolset without an mcp_slug — the runtime can't address it, so it must
+	// be excluded from the managed assistant.
+	_, err = toolsetsQ.CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID:         "org-test",
+		ProjectID:              projectID,
+		Name:                   "Internal",
+		Slug:                   "internal",
+		Description:            pgtype.Text{},
+		DefaultEnvironmentSlug: pgtype.Text{},
+		McpSlug:                pgtype.Text{Valid: false},
+		McpEnabled:             false,
+	})
+	require.NoError(t, err)
+
+	record, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+
+	require.Len(t, record.Toolsets, 1, "only the MCP-reachable toolset attaches")
+	require.Equal(t, reachable.Slug, record.Toolsets[0].ToolsetSlug)
+
+	reloaded, err := toolsetsQ.GetToolset(ctx, toolsetsrepo.GetToolsetParams{
+		Slug:      reachable.Slug,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+	require.True(t, reloaded.McpEnabled, "attaching toolset to assistant must enable MCP")
+}
+
+func TestDisableManagedAssistantTearsDown(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_disable")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "managed-disable")
+
+	enabled, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+
+	require.NoError(t, core.DisableManagedAssistant(ctx, projectID))
+
+	// Mapping is gone — resolver reports no managed assistant.
+	_, err = core.GetManagedAssistant(ctx, projectID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	// Underlying assistant is soft-deleted (not listed).
+	all, err := core.ListAssistants(ctx, projectID)
+	require.NoError(t, err)
+	require.Empty(t, all)
+
+	// Disabling again is a no-op.
+	require.NoError(t, core.DisableManagedAssistant(ctx, projectID))
+
+	// Re-enabling provisions a fresh managed assistant.
+	reenabled, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+	require.NotEqual(t, enabled.ID, reenabled.ID, "re-enable creates a new assistant")
+}
+
+// TestGetManagedAssistantNoRows guards the fast-path sentinel: a project with
+// the feature off must surface pgx.ErrNoRows so EnableManagedAssistant knows to
+// create rather than error out.
+func TestGetManagedAssistantNoRows(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_norows")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "managed-norows")
+
+	_, err = core.GetManagedAssistant(ctx, projectID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+// TestEnableManagedAssistantFailsWhenNameTaken: a user assistant already
+// holding the managed name blocks enablement with an actionable error instead
+// of silently masking it as "no managed assistant".
+func TestEnableManagedAssistantFailsWhenNameTaken(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_name_taken")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "managed-taken")
+
+	// A user creates an assistant that happens to occupy the managed name.
+	_, err = core.CreateAssistant(ctx, "org-test", projectID, "user-1",
+		managedAssistantName("managed-taken"), managedAssistantModel, "hi", nil,
+		int(managedAssistantWarmTTLSeconds), int(managedAssistantMaxConcurrency), StatusActive)
+	require.NoError(t, err)
+
+	_, err = core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.ErrorIs(t, err, ErrManagedAssistantNameTaken)
+
+	// The feature stays off — no mapping was created.
+	_, err = core.GetManagedAssistant(ctx, projectID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -185,6 +185,49 @@ FROM assistants
 WHERE id = @assistant_id
   AND deleted IS FALSE;
 
+-- name: GetManagedAssistantByProject :one
+-- Resolves a project's platform-managed assistant (powers the AI Insights
+-- sidebar) through the project_managed_assistants mapping. Returns no rows
+-- when the feature isn't toggled on for the project.
+SELECT a.id, a.project_id, a.organization_id, a.created_by_user_id, a.name, a.model, a.instructions, a.warm_ttl_seconds, a.max_concurrency, a.status, a.created_at, a.updated_at, a.deleted_at
+FROM project_managed_assistants pma
+JOIN assistants a ON a.id = pma.assistant_id
+WHERE pma.project_id = @project_id
+  AND a.deleted IS FALSE;
+
+-- name: GetProjectName :one
+-- Display name of a project, used to compose the managed assistant's name so
+-- it's distinguishable from other projects' managed assistants in the same org.
+SELECT name
+FROM projects
+WHERE id = @project_id
+  AND deleted IS FALSE;
+
+-- name: CreateProjectManagedAssistant :exec
+-- Marks an assistant as the project's managed assistant. PRIMARY KEY(project_id)
+-- enforces 0-or-1, so a concurrent enable raises a unique violation the caller
+-- recovers from by re-reading.
+INSERT INTO project_managed_assistants (project_id, assistant_id)
+VALUES (@project_id, @assistant_id);
+
+-- name: DeleteProjectManagedAssistant :exec
+-- Toggles the managed assistant off for a project (the assistant row itself is
+-- soft-deleted separately). Returns silently if no mapping exists.
+DELETE FROM project_managed_assistants
+WHERE project_id = @project_id;
+
+-- name: ListProjectMCPToolsetSlugs :many
+-- Slugs of every MCP-reachable toolset in a project, used to attach all of a
+-- project's toolsets to its managed assistant at provisioning time. Toolsets
+-- without an mcp_slug can't be addressed by the runtime, so they're excluded
+-- (mirrors the guard in EnableMCPForToolsets).
+SELECT slug
+FROM toolsets
+WHERE project_id = @project_id
+  AND mcp_slug IS NOT NULL
+  AND deleted IS FALSE
+ORDER BY created_at;
+
 -- name: UpdateAssistant :one
 UPDATE assistants
 SET

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -462,6 +462,24 @@ func (q *Queries) CreateAssistantRuntime(ctx context.Context, arg CreateAssistan
 	return err
 }
 
+const createProjectManagedAssistant = `-- name: CreateProjectManagedAssistant :exec
+INSERT INTO project_managed_assistants (project_id, assistant_id)
+VALUES ($1, $2)
+`
+
+type CreateProjectManagedAssistantParams struct {
+	ProjectID   uuid.UUID
+	AssistantID uuid.UUID
+}
+
+// Marks an assistant as the project's managed assistant. PRIMARY KEY(project_id)
+// enforces 0-or-1, so a concurrent enable raises a unique violation the caller
+// recovers from by re-reading.
+func (q *Queries) CreateProjectManagedAssistant(ctx context.Context, arg CreateProjectManagedAssistantParams) error {
+	_, err := q.db.Exec(ctx, createProjectManagedAssistant, arg.ProjectID, arg.AssistantID)
+	return err
+}
+
 const deleteAssistant = `-- name: DeleteAssistant :exec
 UPDATE assistants
 SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
@@ -477,6 +495,18 @@ type DeleteAssistantParams struct {
 
 func (q *Queries) DeleteAssistant(ctx context.Context, arg DeleteAssistantParams) error {
 	_, err := q.db.Exec(ctx, deleteAssistant, arg.AssistantID, arg.ProjectID)
+	return err
+}
+
+const deleteProjectManagedAssistant = `-- name: DeleteProjectManagedAssistant :exec
+DELETE FROM project_managed_assistants
+WHERE project_id = $1
+`
+
+// Toggles the managed assistant off for a project (the assistant row itself is
+// soft-deleted separately). Returns silently if no mapping exists.
+func (q *Queries) DeleteProjectManagedAssistant(ctx context.Context, projectID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteProjectManagedAssistant, projectID)
 	return err
 }
 
@@ -827,6 +857,70 @@ func (q *Queries) GetLatestAssistantThreadEventByThreadID(ctx context.Context, a
 		&i.Deleted,
 	)
 	return i, err
+}
+
+const getManagedAssistantByProject = `-- name: GetManagedAssistantByProject :one
+SELECT a.id, a.project_id, a.organization_id, a.created_by_user_id, a.name, a.model, a.instructions, a.warm_ttl_seconds, a.max_concurrency, a.status, a.created_at, a.updated_at, a.deleted_at
+FROM project_managed_assistants pma
+JOIN assistants a ON a.id = pma.assistant_id
+WHERE pma.project_id = $1
+  AND a.deleted IS FALSE
+`
+
+type GetManagedAssistantByProjectRow struct {
+	ID              uuid.UUID
+	ProjectID       uuid.UUID
+	OrganizationID  string
+	CreatedByUserID pgtype.Text
+	Name            string
+	Model           string
+	Instructions    string
+	WarmTtlSeconds  int64
+	MaxConcurrency  int64
+	Status          string
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+	DeletedAt       pgtype.Timestamptz
+}
+
+// Resolves a project's platform-managed assistant (powers the AI Insights
+// sidebar) through the project_managed_assistants mapping. Returns no rows
+// when the feature isn't toggled on for the project.
+func (q *Queries) GetManagedAssistantByProject(ctx context.Context, projectID uuid.UUID) (GetManagedAssistantByProjectRow, error) {
+	row := q.db.QueryRow(ctx, getManagedAssistantByProject, projectID)
+	var i GetManagedAssistantByProjectRow
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.OrganizationID,
+		&i.CreatedByUserID,
+		&i.Name,
+		&i.Model,
+		&i.Instructions,
+		&i.WarmTtlSeconds,
+		&i.MaxConcurrency,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
+const getProjectName = `-- name: GetProjectName :one
+SELECT name
+FROM projects
+WHERE id = $1
+  AND deleted IS FALSE
+`
+
+// Display name of a project, used to compose the managed assistant's name so
+// it's distinguishable from other projects' managed assistants in the same org.
+func (q *Queries) GetProjectName(ctx context.Context, projectID uuid.UUID) (string, error) {
+	row := q.db.QueryRow(ctx, getProjectName, projectID)
+	var name string
+	err := row.Scan(&name)
+	return name, err
 }
 
 const insertAssistantThreadEvent = `-- name: InsertAssistantThreadEvent :one
@@ -1212,6 +1306,39 @@ func (q *Queries) ListInactiveAssistantRuntimesForReap(ctx context.Context, arg 
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listProjectMCPToolsetSlugs = `-- name: ListProjectMCPToolsetSlugs :many
+SELECT slug
+FROM toolsets
+WHERE project_id = $1
+  AND mcp_slug IS NOT NULL
+  AND deleted IS FALSE
+ORDER BY created_at
+`
+
+// Slugs of every MCP-reachable toolset in a project, used to attach all of a
+// project's toolsets to its managed assistant at provisioning time. Toolsets
+// without an mcp_slug can't be addressed by the runtime, so they're excluded
+// (mirrors the guard in EnableMCPForToolsets).
+func (q *Queries) ListProjectMCPToolsetSlugs(ctx context.Context, projectID uuid.UUID) ([]string, error) {
+	rows, err := q.db.Query(ctx, listProjectMCPToolsetSlugs, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var slug string
+		if err := rows.Scan(&slug); err != nil {
+			return nil, err
+		}
+		items = append(items, slug)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Stacked on #3124 (→ #3123). **PR1 of the AGE-2631 stack** — provisioning for the project's platform-managed assistant.

Exposes three `ServiceCore` methods that toggle the managed assistant for a project:
- **`EnableManagedAssistant(org, project, user)`** — creates the assistant (ported AI Insights prompt, model `anthropic/claude-sonnet-4.6`, every MCP-reachable project toolset attached + MCP auto-enabled) and records the `project_managed_assistants` mapping. Idempotent + race-safe: fast-path read returns the existing one; an enable that loses a race recovers by re-reading (`UNIQUE(project_id)` from #3124 picks the winner).
- **`DisableManagedAssistant(project)`** — removes the mapping and soft-deletes the assistant. No-op if not enabled.
- **`GetManagedAssistant(project)`** — resolves via the mapping; `pgx.ErrNoRows` when the feature is off.

### Changed from the first cut (per Daniel's review on #3124)
Dropped the `is_default`-on-`assistants` + lazy-auto-provision approach. The managed assistant is now an ordinary `assistants` row pointed at by the `project_managed_assistants` mapping, stood up/torn down by an **explicit toggle** rather than minted implicitly on first sidebar open. "default" → "managed" throughout. (This resolves the Linear Q3: provisioning is toggle-gated, neither lazy nor eager.)

### What's intentionally *not* here
- **No public endpoint / UI toggle wiring yet** — tests are the caller, keeping this dead-code-free and independently reviewable. The endpoint that calls Enable/Get lands in the ingress PR.

## SQLc
- `GetManagedAssistantByProject :one` — mapping → assistant join.
- `CreateProjectManagedAssistant :exec` / `DeleteProjectManagedAssistant :exec` — toggle the mapping.
- `ListProjectMCPToolsetSlugs :many` — MCP-reachable toolsets to attach.

## Tests
- `TestEnableManagedAssistantIsIdempotent` — second enable returns same assistant; one row; defaults applied.
- `TestEnableManagedAssistantAttachesMCPReachableToolsets` — only `mcp_slug` toolsets attach; MCP auto-enabled.
- `TestDisableManagedAssistantTearsDown` — mapping gone, assistant soft-deleted, re-enable mints a fresh one; double-disable is a no-op.
- `TestGetManagedAssistantNoRows` — sentinel survives the `%w` wrap.

Verified: `mise build:server`, `go vet`, full `assistants` package tests, `mise lint:server` — all green.

## Stack
1. #3123 — AI Insights → project toolsets + RBAC tokens
2. #3124 — `project_managed_assistants` migration
3. **this PR** — managed-assistant provisioning toggle
4. _next_ — `dashboard` ingress source kind + send endpoint (pending Daniel Q2)
5. _next_ — egress platform tool + browser read path (pending Daniel Q1/Q4)
6. _next_ — sidebar cutover

Ref: AGE-2631