### PR TITLE
chore: fix billing usage refresh workflow

### DIFF
--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -14,10 +14,15 @@ import (
 
 // safely wait for polar rate limits
 const (
-	refreshBillingUsageBatchSize     = 5
-	maxBillingUsageBatchesPerRun     = 7
-	billingUsagePauseEveryBatches    = 2
-	refreshBillingUsagesWaitInterval = 10 * time.Second
+	refreshBillingUsageBatchSize                   = 5
+	billingUsagePauseEveryBatches                  = 2
+	refreshBillingUsageActivityStartToCloseTimeout = 60 * time.Second
+	refreshBillingUsageActivityMaximumAttempts     = 3
+	// Reserve more than the worst-case retry path for one batch:
+	// 3 activity attempts plus 10s/15s retry backoffs and Temporal jitter.
+	refreshBillingUsageActivityWorstCaseRetryWindow = 5 * time.Minute
+	refreshBillingUsageWorkflowRunTimeout           = 30 * time.Minute
+	refreshBillingUsagesWaitInterval                = 10 * time.Second
 )
 
 type RefreshBillingUsageInput struct {
@@ -34,8 +39,9 @@ type RefreshBillingUsageClient struct {
 func (c *RefreshBillingUsageClient) StartRefreshBillingUsage(ctx context.Context) (client.WorkflowRun, error) {
 	id := "v1:refresh-billing-usage"
 	return c.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:        id,
-		TaskQueue: string(c.TemporalEnv.Queue()),
+		ID:                 id,
+		TaskQueue:          string(c.TemporalEnv.Queue()),
+		WorkflowRunTimeout: refreshBillingUsageWorkflowRunTimeout,
 		// Allow restarting if needed
 		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
 	}, RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
@@ -52,9 +58,9 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 
 	// Configure activity options with retry policy
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 60 * time.Second,
+		StartToCloseTimeout: refreshBillingUsageActivityStartToCloseTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
-			MaximumAttempts:    3,
+			MaximumAttempts:    refreshBillingUsageActivityMaximumAttempts,
 			InitialInterval:    refreshBillingUsagesWaitInterval,
 			BackoffCoefficient: 1.5,
 			// Temporal automatically adds some jitter to retries here
@@ -86,6 +92,22 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 	failedBatchCount := input.FailedBatchCount
 	failedOrgCount := input.FailedOrgCount
 	batchesProcessed := 0
+	continueAsNew := func(nextStartIndex int) error {
+		nextInput := RefreshBillingUsageInput{
+			OrgIDs:           orgIDs,
+			StartIndex:       nextStartIndex,
+			FailedBatchCount: failedBatchCount,
+			FailedOrgCount:   failedOrgCount,
+		}
+		logger.Info(
+			"Continuing billing usage refresh as new",
+			"next_start_index", nextStartIndex,
+			"total_count", len(orgIDs),
+			"failed_batch_count", failedBatchCount,
+			"failed_org_count", failedOrgCount,
+		)
+		return workflow.NewContinueAsNewError(ctx, RefreshBillingUsageWorkflow, nextInput)
+	}
 
 	for i := startIndex; i < len(orgIDs); i += refreshBillingUsageBatchSize {
 		end := min(i+refreshBillingUsageBatchSize, len(orgIDs))
@@ -98,30 +120,18 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 		}
 
 		batchesProcessed++
-		if batchesProcessed >= maxBillingUsageBatchesPerRun && end < len(orgIDs) {
-			nextInput := RefreshBillingUsageInput{
-				OrgIDs:           orgIDs,
-				StartIndex:       end,
-				FailedBatchCount: failedBatchCount,
-				FailedOrgCount:   failedOrgCount,
+		if end < len(orgIDs) {
+			// Polar's usage endpoints are rate-limited, so keep a deterministic
+			// pause after small groups of batches instead of after every batch.
+			if batchesProcessed%billingUsagePauseEveryBatches == 0 {
+				if err := workflow.Sleep(ctx, refreshBillingUsagesWaitInterval); err != nil {
+					logger.Error("Failed to sleep to pause between billing usage batches", "error", err)
+					return fmt.Errorf("sleep between billing usage batches: %w", err)
+				}
 			}
-			logger.Info(
-				"Continuing billing usage refresh as new",
-				"next_start_index", end,
-				"total_count", len(orgIDs),
-				"failed_batch_count", failedBatchCount,
-				"failed_org_count", failedOrgCount,
-			)
-			return workflow.NewContinueAsNewError(ctx, RefreshBillingUsageWorkflow, nextInput)
-		}
 
-		// Polar's usage endpoints are rate-limited, so keep a deterministic
-		// pause after small groups of batches instead of after every batch. The
-		// per-run batch cap keeps worst-case activity retries inside the run timeout.
-		if end < len(orgIDs) && batchesProcessed%billingUsagePauseEveryBatches == 0 {
-			if err := workflow.Sleep(ctx, refreshBillingUsagesWaitInterval); err != nil {
-				logger.Error("Failed to sleep to pause between billing usage batches", "error", err)
-				return fmt.Errorf("sleep between billing usage batches: %w", err)
+			if shouldContinueRefreshBillingUsageAsNew(ctx) {
+				return continueAsNew(end)
 			}
 		}
 	}
@@ -138,6 +148,24 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 
 	logger.Info("Billing usage refreshing completed successfully", "total_count", len(orgIDs))
 	return nil
+}
+
+func shouldContinueRefreshBillingUsageAsNew(ctx workflow.Context) bool {
+	info := workflow.GetInfo(ctx)
+	if info.GetContinueAsNewSuggested() {
+		return true
+	}
+
+	runTimeout := info.WorkflowRunTimeout
+	if runTimeout == 0 {
+		runTimeout = refreshBillingUsageWorkflowRunTimeout
+	}
+	if runTimeout == 0 || info.WorkflowStartTime.IsZero() {
+		return false
+	}
+
+	elapsed := workflow.Now(ctx).Sub(info.WorkflowStartTime)
+	return elapsed+refreshBillingUsageActivityWorstCaseRetryWindow >= runTimeout
 }
 
 func AddRefreshBillingUsageSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
@@ -158,7 +186,7 @@ func AddRefreshBillingUsageSchedule(ctx context.Context, temporalEnv *tenv.Envir
 			Workflow:           RefreshBillingUsageWorkflow,
 			Args:               []any{RefreshBillingUsageInput{OrgIDs: nil, StartIndex: 0, FailedBatchCount: 0, FailedOrgCount: 0}},
 			TaskQueue:          string(temporalEnv.Queue()),
-			WorkflowRunTimeout: 30 * time.Minute,
+			WorkflowRunTimeout: refreshBillingUsageWorkflowRunTimeout,
 		},
 	})
 	if err != nil {

--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -15,8 +15,17 @@ import (
 // safely wait for polar rate limits
 const (
 	refreshBillingUsageBatchSize     = 5
+	maxBillingUsageBatchesPerRun     = 7
+	billingUsagePauseEveryBatches    = 2
 	refreshBillingUsagesWaitInterval = 10 * time.Second
 )
+
+type RefreshBillingUsageInput struct {
+	OrgIDs           []string
+	StartIndex       int
+	FailedBatchCount int
+	FailedOrgCount   int
+}
 
 type RefreshBillingUsageClient struct {
 	TemporalEnv *tenv.Environment
@@ -29,10 +38,15 @@ func (c *RefreshBillingUsageClient) StartRefreshBillingUsage(ctx context.Context
 		TaskQueue: string(c.TemporalEnv.Queue()),
 		// Allow restarting if needed
 		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
-	}, RefreshBillingUsageWorkflow)
+	}, RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
+		OrgIDs:           nil,
+		StartIndex:       0,
+		FailedBatchCount: 0,
+		FailedOrgCount:   0,
+	})
 }
 
-func RefreshBillingUsageWorkflow(ctx workflow.Context) error {
+func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsageInput) error {
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting billing usage refreshing")
 
@@ -47,34 +61,82 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context) error {
 		},
 	})
 
-	// Get all organizations
 	var a *Activities
-	var orgIDs []string
-	err := workflow.ExecuteActivity(ctx, a.GetAllOrganizations).Get(ctx, &orgIDs)
-	if err != nil {
-		logger.Error("Failed to get all organizations", "error", err)
-		return fmt.Errorf("failed to get all organizations: %w", err)
+	orgIDs := input.OrgIDs
+	// Initial call to workflow - no orgs yet, need to fetch them
+	if len(orgIDs) == 0 {
+		err := workflow.ExecuteActivity(ctx, a.GetAllOrganizations).Get(ctx, &orgIDs)
+		if err != nil {
+			logger.Error("Failed to get all organizations", "error", err)
+			return fmt.Errorf("failed to get all organizations: %w", err)
+		}
+
+		input = RefreshBillingUsageInput{
+			OrgIDs:           orgIDs,
+			StartIndex:       0,
+			FailedBatchCount: 0,
+			FailedOrgCount:   0,
+		}
 	}
 
 	logger.Info("Retrieved organizations for billing usage refreshing", "count", len(orgIDs))
 
-	// Process organizations in batches
-	for i := 0; i < len(orgIDs); i += refreshBillingUsageBatchSize {
+	startIndex := min(max(input.StartIndex, 0), len(orgIDs))
+
+	failedBatchCount := input.FailedBatchCount
+	failedOrgCount := input.FailedOrgCount
+	batchesProcessed := 0
+
+	for i := startIndex; i < len(orgIDs); i += refreshBillingUsageBatchSize {
 		end := min(i+refreshBillingUsageBatchSize, len(orgIDs))
 		batch := orgIDs[i:end]
 
-		err := workflow.ExecuteActivity(ctx, a.RefreshBillingUsage, batch).Get(ctx, nil)
-		if err != nil {
+		if err := workflow.ExecuteActivity(ctx, a.RefreshBillingUsage, batch).Get(ctx, nil); err != nil {
 			logger.Error("Failed to refresh billing usage batch", "error", err, "batch_start", i)
-			return fmt.Errorf("failed to refresh billing usage batch starting at %d: %w", i, err)
+			failedBatchCount++
+			failedOrgCount += len(batch)
 		}
 
-		if err = workflow.Sleep(ctx, refreshBillingUsagesWaitInterval); err != nil {
-			logger.Error("Failed to sleep to pause between batches", "error", err)
+		batchesProcessed++
+		if batchesProcessed >= maxBillingUsageBatchesPerRun && end < len(orgIDs) {
+			nextInput := RefreshBillingUsageInput{
+				OrgIDs:           orgIDs,
+				StartIndex:       end,
+				FailedBatchCount: failedBatchCount,
+				FailedOrgCount:   failedOrgCount,
+			}
+			logger.Info(
+				"Continuing billing usage refresh as new",
+				"next_start_index", end,
+				"total_count", len(orgIDs),
+				"failed_batch_count", failedBatchCount,
+				"failed_org_count", failedOrgCount,
+			)
+			return workflow.NewContinueAsNewError(ctx, RefreshBillingUsageWorkflow, nextInput)
+		}
+
+		// Polar's usage endpoints are rate-limited, so keep a deterministic
+		// pause after small groups of batches instead of after every batch. The
+		// per-run batch cap keeps worst-case activity retries inside the run timeout.
+		if end < len(orgIDs) && batchesProcessed%billingUsagePauseEveryBatches == 0 {
+			if err := workflow.Sleep(ctx, refreshBillingUsagesWaitInterval); err != nil {
+				logger.Error("Failed to sleep to pause between billing usage batches", "error", err)
+				return fmt.Errorf("sleep between billing usage batches: %w", err)
+			}
 		}
 	}
 
-	logger.Info("Billing usage refreshing completed successfully")
+	if failedBatchCount > 0 {
+		logger.Warn(
+			"Billing usage refreshing completed with failed batches",
+			"failed_batch_count", failedBatchCount,
+			"failed_org_count", failedOrgCount,
+			"total_count", len(orgIDs),
+		)
+		return nil
+	}
+
+	logger.Info("Billing usage refreshing completed successfully", "total_count", len(orgIDs))
 	return nil
 }
 
@@ -94,8 +156,9 @@ func AddRefreshBillingUsageSchedule(ctx context.Context, temporalEnv *tenv.Envir
 		Action: &client.ScheduleWorkflowAction{
 			ID:                 workflowID,
 			Workflow:           RefreshBillingUsageWorkflow,
+			Args:               []any{RefreshBillingUsageInput{OrgIDs: nil, StartIndex: 0, FailedBatchCount: 0, FailedOrgCount: 0}},
 			TaskQueue:          string(temporalEnv.Queue()),
-			WorkflowRunTimeout: 15 * time.Minute,
+			WorkflowRunTimeout: 30 * time.Minute,
 		},
 	})
 	if err != nil {

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -1,0 +1,158 @@
+package background
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+func TestRefreshBillingUsageWorkflow_ContinuesAsNewAfterMaxBatches(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	orgIDs := make([]string, (maxBillingUsageBatchesPerRun+1)*refreshBillingUsageBatchSize)
+	for i := range orgIDs {
+		orgIDs[i] = "org_" + strconv.Itoa(i)
+	}
+
+	getAllCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context) ([]string, error) {
+			getAllCallCount++
+			return orgIDs, nil
+		},
+		activity.RegisterOptions{Name: "GetAllOrganizations"},
+	)
+
+	refreshCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, batch []string) error {
+			refreshCallCount++
+			require.NotEmpty(t, batch)
+			require.LessOrEqual(t, len(batch), refreshBillingUsageBatchSize)
+			return nil
+		},
+		activity.RegisterOptions{Name: "RefreshBillingUsage"},
+	)
+
+	env.ExecuteWorkflow(RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
+		OrgIDs:           nil,
+		StartIndex:       0,
+		FailedBatchCount: 0,
+		FailedOrgCount:   0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	var continueAsNewErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &continueAsNewErr)
+	require.Equal(t, "RefreshBillingUsageWorkflow", continueAsNewErr.WorkflowType.Name)
+	require.Equal(t, 1, getAllCallCount)
+	require.Equal(t, maxBillingUsageBatchesPerRun, refreshCallCount)
+
+	var nextInput RefreshBillingUsageInput
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(continueAsNewErr.Input, &nextInput))
+	require.Equal(t, orgIDs, nextInput.OrgIDs)
+	require.Equal(t, maxBillingUsageBatchesPerRun*refreshBillingUsageBatchSize, nextInput.StartIndex)
+	require.Zero(t, nextInput.FailedBatchCount)
+	require.Zero(t, nextInput.FailedOrgCount)
+}
+
+func TestRefreshBillingUsageWorkflow_FailingBatchDoesNotAbortRun(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	orgIDs := []string{
+		"org_1",
+		"org_2",
+		"org_3",
+		"org_4",
+		"org_5",
+		"org_6",
+	}
+
+	refreshCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, batch []string) error {
+			refreshCallCount++
+			switch refreshCallCount {
+			case 1:
+				require.Equal(t, orgIDs[:refreshBillingUsageBatchSize], batch)
+				return temporal.NewNonRetryableApplicationError("polar failed", "", nil)
+			case 2:
+				require.Equal(t, orgIDs[refreshBillingUsageBatchSize:], batch)
+				return nil
+			default:
+				t.Fatalf("unexpected refresh call %d", refreshCallCount)
+				return nil
+			}
+		},
+		activity.RegisterOptions{Name: "RefreshBillingUsage"},
+	)
+
+	env.ExecuteWorkflow(RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
+		OrgIDs:           orgIDs,
+		StartIndex:       0,
+		FailedBatchCount: 0,
+		FailedOrgCount:   0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 2, refreshCallCount)
+}
+
+func TestRefreshBillingUsageWorkflow_SleepCancellationFailsRun(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	orgIDs := []string{
+		"org_1",
+		"org_2",
+		"org_3",
+		"org_4",
+		"org_5",
+		"org_6",
+		"org_7",
+		"org_8",
+		"org_9",
+		"org_10",
+		"org_11",
+	}
+
+	refreshCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, batch []string) error {
+			refreshCallCount++
+			require.NotEmpty(t, batch)
+			return nil
+		},
+		activity.RegisterOptions{Name: "RefreshBillingUsage"},
+	)
+	env.RegisterDelayedCallback(func() {
+		env.CancelWorkflow()
+	}, refreshBillingUsagesWaitInterval/2)
+
+	env.ExecuteWorkflow(RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
+		OrgIDs:           orgIDs,
+		StartIndex:       0,
+		FailedBatchCount: 0,
+		FailedOrgCount:   0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError())
+	require.Equal(t, billingUsagePauseEveryBatches, refreshCallCount)
+}

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -13,13 +13,14 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-func TestRefreshBillingUsageWorkflow_ContinuesAsNewAfterMaxBatches(t *testing.T) {
+func TestRefreshBillingUsageWorkflow_ContinuesAsNewNearRunTimeout(t *testing.T) {
 	t.Parallel()
 
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkflowRunTimeout(refreshBillingUsageActivityWorstCaseRetryWindow + refreshBillingUsagesWaitInterval)
 
-	orgIDs := make([]string, (maxBillingUsageBatchesPerRun+1)*refreshBillingUsageBatchSize)
+	orgIDs := make([]string, (billingUsagePauseEveryBatches+1)*refreshBillingUsageBatchSize)
 	for i := range orgIDs {
 		orgIDs[i] = "org_" + strconv.Itoa(i)
 	}
@@ -56,12 +57,12 @@ func TestRefreshBillingUsageWorkflow_ContinuesAsNewAfterMaxBatches(t *testing.T)
 	require.ErrorAs(t, env.GetWorkflowError(), &continueAsNewErr)
 	require.Equal(t, "RefreshBillingUsageWorkflow", continueAsNewErr.WorkflowType.Name)
 	require.Equal(t, 1, getAllCallCount)
-	require.Equal(t, maxBillingUsageBatchesPerRun, refreshCallCount)
+	require.Equal(t, billingUsagePauseEveryBatches, refreshCallCount)
 
 	var nextInput RefreshBillingUsageInput
 	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(continueAsNewErr.Input, &nextInput))
 	require.Equal(t, orgIDs, nextInput.OrgIDs)
-	require.Equal(t, maxBillingUsageBatchesPerRun*refreshBillingUsageBatchSize, nextInput.StartIndex)
+	require.Equal(t, billingUsagePauseEveryBatches*refreshBillingUsageBatchSize, nextInput.StartIndex)
 	require.Zero(t, nextInput.FailedBatchCount)
 	require.Zero(t, nextInput.FailedOrgCount)
 }


### PR DESCRIPTION
## Summary

- Change `RefreshBillingUsageWorkflow` to carry explicit input state and continue-as-new after a bounded number of batches.
- Fetch the org list once per full pass, then resume from `StartIndex` across continued runs instead of restarting the scan.
- Log and count failed batches so one Polar hiccup or bad org does not abort the entire pass.
- Keep Polar rate-limit safety while reducing serial wait time by pausing every two batches instead of after every batch.
- Raise the scheduled run timeout to 30 minutes as a guard.

## Why this way

The timeout is caused by the workflow shape, not by a Polar latency regression. The old run had to process every org in one serial workflow run while paying a 10 second sleep after every batch, so production’s stale 10 minute run timeout cancelled in-flight activities and generated Temporal activity failures.

Continue-as-new bounds each run independently of the schedule timeout and keeps workflow history small. Carrying the org ID slice plus a start index is intentionally simple here: the org list is small, the expensive work is the Polar calls, and fetching the list once per full pass avoids re-querying it on every continued run. If org volume grows far beyond current scale, this can move to a DB cursor/page token model.

The deployed schedule/worker must pick up the new workflow args and the 30 minute run timeout; current production behavior appears stale at 10 minutes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the billing usage refresh workflow by continuing-as-new near the run timeout and resuming from a saved index. This avoids timeouts and history bloat, improves resilience to Polar hiccups, and trims idle time; the schedule run timeout is now 30m.

- **Bug Fixes**
  - `RefreshBillingUsageWorkflow` now takes `RefreshBillingUsageInput` and continues-as-new when close to the run timeout (or when Temporal suggests), resuming from `StartIndex` across runs.
  - Do not abort on a failed batch; track `FailedBatchCount` and `FailedOrgCount` and log them.
  - Pause after every 2 batches (10s) to respect rate limits with less idle time.
  - Added tests for near-timeout continuation, non-aborting failures, and cancellation during the pause.

- **Migration**
  - Update the schedule to pass the new input args and set `WorkflowRunTimeout` to 30m.

<sup>Written for commit 597201d8dea2dfbfec4e4e704e5e8dfd4e8ae157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

