### PR TITLE
fix: retry empty OpenRouter completions and surface upstream response

### DIFF
--- a/.changeset/retry-empty-completions.md
+++ b/.changeset/retry-empty-completions.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Retry chat completions when the upstream model returns an empty response, and report the upstream details when it still fails, reducing transient playground and chat errors.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -200,6 +200,7 @@ const (
 	OpenAPIVersionKey               = attribute.Key("gram.openapi.version")
 	OpenRouterKeyLimitKey           = attribute.Key("gram.openrouter.key.limit")
 	OpenRouterKeyPreviousLimitKey   = attribute.Key("gram.openrouter.key.previous_limit")
+	OpenRouterResponseBodyKey       = attribute.Key("gram.openrouter.response.body")
 	OrganizationAccountTypeKey      = attribute.Key("gram.org.account_type")
 	OrganizationInviteIDKey         = attribute.Key("gram.org.invite.id")
 	OrganizationInviteEmailKey      = attribute.Key("gram.org.invite.email")
@@ -922,6 +923,11 @@ func OpenRouterKeyPreviousLimit(v int) attribute.KeyValue {
 }
 func SlogOpenRouterKeyPreviousLimit(v int) slog.Attr {
 	return slog.Int(string(OpenRouterKeyPreviousLimitKey), v)
+}
+
+func OpenRouterResponseBody(v string) attribute.KeyValue { return OpenRouterResponseBodyKey.String(v) }
+func SlogOpenRouterResponseBody(v string) slog.Attr {
+	return slog.String(string(OpenRouterResponseBodyKey), v)
 }
 
 func AccessMemberID(v string) attribute.KeyValue { return AccessMemberIDKey.String(v) }

--- a/server/internal/thirdparty/openrouter/errors_test.go
+++ b/server/internal/thirdparty/openrouter/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
@@ -125,6 +126,84 @@ func TestChatClient_GetCompletion_WrapsHistoryCorruptionForBadRequest(t *testing
 			require.Equal(t, tc.wantCorruption, IsHistoryCorruptionCandidate(err))
 		})
 	}
+}
+
+func TestChatClient_GetCompletion_EmptyChoices_EmbedsResponseBody(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"id":"gen-abc123","model":"anthropic/claude","choices":[],"error":{"code":429,"message":"provider rate limited"}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClientForServer(t, server)
+	_, err := client.GetCompletion(t.Context(), CompletionRequest{
+		OrgID:       "test-org",
+		ProjectID:   uuid.New().String(),
+		Messages:    []or.ChatMessages{CreateMessageUser("hi")},
+		ChatID:      uuid.New(),
+		UsageSource: billing.ModelUsageSourcePlayground,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gen-abc123")            // generation id surfaced for OpenRouter lookup
+	require.Contains(t, err.Error(), "provider rate limited") // embedded upstream error surfaced verbatim
+}
+
+func TestChatClient_GetCompletion_RetriesEmptyChoicesThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if calls.Add(1) == 1 {
+			_, _ = w.Write([]byte(`{"id":"gen-empty","choices":[]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"gen-ok","model":"m","choices":[{"message":{"role":"assistant","content":"recovered"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClientForServer(t, server)
+	resp, err := client.GetCompletion(t.Context(), CompletionRequest{
+		OrgID:       "test-org",
+		ProjectID:   uuid.New().String(),
+		Messages:    []or.ChatMessages{CreateMessageUser("hi")},
+		ChatID:      uuid.New(),
+		UsageSource: billing.ModelUsageSourcePlayground,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), calls.Load()) // retried once after the empty response
+	require.Equal(t, "recovered", resp.Content)
+}
+
+func TestChatClient_GetCompletion_RetriesExhaustedReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"gen-empty","choices":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClientForServer(t, server)
+	_, err := client.GetCompletion(t.Context(), CompletionRequest{
+		OrgID:       "test-org",
+		ProjectID:   uuid.New().String(),
+		Messages:    []or.ChatMessages{CreateMessageUser("hi")},
+		ChatID:      uuid.New(),
+		UsageSource: billing.ModelUsageSourcePlayground,
+	})
+	require.Error(t, err)
+	require.Equal(t, int32(2), calls.Load()) // both attempts exhausted
+	require.Contains(t, err.Error(), "after 2 attempts")
+	require.Contains(t, err.Error(), "gen-empty")
 }
 
 func newTestClientForServer(t *testing.T, server *httptest.Server) *ChatClient {

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -277,6 +277,33 @@ func (c *ChatClient) onMessageComplete(ctx context.Context, session CaptureSessi
 	)
 }
 
+// requestCompletion issues a single non-streaming completion request and
+// returns the parsed response alongside the raw body (kept for diagnostics).
+// The response body lifetime is fully contained here so callers can retry.
+func (c *ChatClient) requestCompletion(ctx context.Context, apiKey string, reqBody OpenAIChatRequest) (OpenAIChatResponse, []byte, error) {
+	httpResp, err := c.makeHTTPRequest(ctx, apiKey, reqBody)
+	if err != nil {
+		return OpenAIChatResponse{}, nil, err
+	}
+	defer o11y.NoLogDefer(func() error { return httpResp.Body.Close() })
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return OpenAIChatResponse{}, nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		return OpenAIChatResponse{}, body, classifyHTTPError(httpResp.StatusCode, body)
+	}
+
+	var chatResp OpenAIChatResponse
+	if err := json.Unmarshal(body, &chatResp); err != nil {
+		return OpenAIChatResponse{}, body, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	return chatResp, body, nil
+}
+
 // GetCompletion makes a non-streaming completion request to OpenRouter and applies capture/tracking strategies.
 func (c *ChatClient) GetCompletion(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
 	start := time.Now()
@@ -289,33 +316,47 @@ func (c *ChatClient) GetCompletion(ctx context.Context, req CompletionRequest) (
 	reqBody := initResult.requestBody
 	reqBody.Stream = false
 
-	// Make HTTP request
-	httpResp, err := c.makeHTTPRequest(ctx, initResult.apiKey, reqBody)
-	if err != nil {
-		return nil, err
-	}
-	defer o11y.NoLogDefer(func() error { return httpResp.Body.Close() })
+	// OpenRouter intermittently returns 200 OK with an empty choices array when
+	// the upstream provider produces nothing. A fresh request usually re-routes
+	// to a healthy provider, so retry a bounded number of times before failing.
+	const maxAttempts = 2
 
-	// Read response body
-	body, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response body: %w", err)
+	var (
+		chatResp OpenAIChatResponse
+		body     []byte
+	)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var err error
+		chatResp, body, err = c.requestCompletion(ctx, initResult.apiKey, reqBody)
+		if err != nil {
+			return nil, err
+		}
+		if len(chatResp.Choices) > 0 {
+			break
+		}
+		if attempt < maxAttempts {
+			c.logger.WarnContext(ctx, "openrouter completion returned no choices; retrying",
+				attr.SlogGenAIResponseID(chatResp.ID),
+				attr.SlogRetryAttempt(attempt),
+			)
+		}
 	}
 
-	// Handle non-200 responses
-	if httpResp.StatusCode != http.StatusOK {
-		return nil, classifyHTTPError(httpResp.StatusCode, body)
-	}
-
-	// Parse response
-	var chatResp OpenAIChatResponse
-	if err := json.Unmarshal(body, &chatResp); err != nil {
-		return nil, fmt.Errorf("unmarshal response: %w", err)
-	}
-
-	// Check for choices
+	// A well-formed completion's bulk is choices[0]; with it absent the body is
+	// small and carries no generated content, so embed it whole — it holds the
+	// generation id and any error envelope OpenRouter returned in lieu of
+	// choices, which is otherwise discarded here.
 	if len(chatResp.Choices) == 0 {
-		return nil, fmt.Errorf("no choices in response")
+		const maxLoggedBody = 2048
+		snippet := strings.TrimSpace(string(body))
+		if len(snippet) > maxLoggedBody {
+			snippet = snippet[:maxLoggedBody]
+		}
+		trace.SpanFromContext(ctx).SetAttributes(
+			attr.OpenRouterResponseBody(snippet),
+			attr.GenAIResponseIDKey.String(chatResp.ID),
+		)
+		return nil, fmt.Errorf("no choices in response after %d attempts: generation_id=%q body=%s", maxAttempts, chatResp.ID, snippet)
 	}
 
 	// Extract response data


### PR DESCRIPTION
## Summary

- OpenRouter intermittently returns `200 OK` with an empty `choices` array when the upstream provider produces nothing. We collapsed that to an opaque `no choices in response` 502 and discarded everything OpenRouter *did* return.
- **Retry**: non-streaming completions now retry once on empty choices before failing — a fresh request usually re-routes to a healthy provider, turning many transient failures into successes.
- **Diagnosability**: when it still fails, the raw response body (small and content-free on this path — it carries the generation id and any embedded `error` envelope) is embedded in the returned error and recorded on the trace span (`gram.openrouter.response.body`, `gen_ai.response.id`), so the cause is legible instead of opaque.
- Retries are logged (`retry.attempt` + `gen_ai.response.id`) so we can measure how often they fire and recover.

Scope note: this targets the **non-streaming** path, which is where the production 502s originate (confirmed via ingress logs + traces — `upstream_status_code:502`, fast ~0.4s, 131-byte error body). The streaming path already passes upstream error frames through to the client in-band.

Closes [AGE-2635](https://linear.app/speakeasy/issue/AGE-2635/bug-remap-invalid-upstream-completions-responses-to-errors)

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries non-streaming `OpenRouter` chat completions when upstream returns 200 OK with empty `choices`, and surfaces the upstream response details in errors and traces so failures are diagnosable. Reduces transient 502s in playground/chat. Closes AGE-2635.

- **Bug Fixes**
  - Retry once on empty `choices`; many requests recover on the second attempt.
  - On failure, return an error containing the generation id and raw response body; record `gram.openrouter.response.body` and `gen_ai.response.id` on the trace.
  - Log retries with `retry.attempt` and response id for visibility.
  - Added tests for retry success and exhausted retries; changeset included.

<sup>Written for commit 69800930b955ab7b5e14cd194e2a40d57a18da09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

