### PR TITLE
chore(hooks): normalize hook events at ingress

### DIFF
--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -220,28 +220,23 @@ func (s *Service) persistCursorHook(ctx context.Context, payload *gen.CursorPayl
 		}
 	} else {
 		// Tool call events: ClickHouse + PG
-		if err := s.persistCursorToolCallEvent(ctx, payload, metadata, blockReason); err != nil {
+		if err := s.persistCursorToolCallEvent(ctx, payload, metadata, blockReason, hookEvent); err != nil {
 			s.logger.ErrorContext(ctx, "Failed to persist Cursor tool call event", attr.SlogError(err))
 		}
 	}
 }
 
 // persistCursorToolCallEvent writes tool call events to both ClickHouse and PostgreSQL
-func (s *Service) persistCursorToolCallEvent(ctx context.Context, payload *gen.CursorPayload, metadata *SessionMetadata, blockReason string) error {
+func (s *Service) persistCursorToolCallEvent(ctx context.Context, payload *gen.CursorPayload, metadata *SessionMetadata, blockReason string, hookEvent HookEvent) error {
 	// Write to ClickHouse for telemetry
 	s.writeCursorHookToClickHouse(ctx, payload, metadata.GramOrgID, metadata.ProjectID, metadata.UserID, blockReason)
 
 	// Write to PostgreSQL for chat history
-	hookEvent, ok := parseCursorHookEvent(payload.HookEventName)
-	if !ok {
-		return nil
-	}
-
 	switch hookEvent {
 	case HookEventPreToolUse, HookEventBeforeMCPExecution:
 		return s.writeCursorToolCallRequestToPG(ctx, payload, metadata)
 	case HookEventPostToolUse, HookEventPostToolUseFailure, HookEventAfterMCPExecution:
-		return s.writeCursorToolCallResultToPG(ctx, payload, metadata)
+		return s.writeCursorToolCallResultToPG(ctx, payload, metadata, hookEvent)
 	default:
 		return nil
 	}
@@ -622,7 +617,7 @@ func (s *Service) writeCursorToolCallRequestToPG(ctx context.Context, payload *g
 }
 
 // writeCursorToolCallResultToPG writes a Cursor tool call result (postToolUse/postToolUseFailure) to PostgreSQL.
-func (s *Service) writeCursorToolCallResultToPG(ctx context.Context, payload *gen.CursorPayload, metadata *SessionMetadata) error {
+func (s *Service) writeCursorToolCallResultToPG(ctx context.Context, payload *gen.CursorPayload, metadata *SessionMetadata, hookEvent HookEvent) error {
 	if payload.ConversationID == nil || *payload.ConversationID == "" {
 		return nil
 	}
@@ -635,11 +630,6 @@ func (s *Service) writeCursorToolCallResultToPG(ctx context.Context, payload *ge
 	chatID := sessionIDToUUID(*payload.ConversationID)
 
 	var content string
-	hookEvent, ok := parseCursorHookEvent(payload.HookEventName)
-	if !ok {
-		return nil
-	}
-
 	switch hookEvent {
 	case HookEventPostToolUse:
 		if payload.ToolResponse == nil {

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -23,9 +23,15 @@ import (
 
 // Cursor is the endpoint for Cursor hook events
 func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.CursorHookResult, error) {
+	hookEvent, ok := parseCursorHookEvent(payload.HookEventName)
+	logHookEventName := payload.HookEventName
+	if ok {
+		logHookEventName = string(hookEvent)
+	}
+
 	logger := s.logger.With(
 		attr.SlogHookSource("cursor"),
-		attr.SlogHookEvent(payload.HookEventName),
+		attr.SlogHookEvent(logHookEventName),
 		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
 		attr.SlogGenAIConversationID(conv.PtrValOr(payload.ConversationID, "")),
 		attr.SlogAuthUserEmail(conv.PtrValOr(payload.UserEmail, "")),
@@ -67,8 +73,8 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 	// the trace renders as "blocked" in dashboards.
 	var blockReason string
 
-	switch payload.HookEventName {
-	case "beforeMCPExecution":
+	switch hookEvent {
+	case HookEventBeforeMCPExecution:
 		// beforeMCPExecution fires for MCP-routed (non-local) tool calls. Run
 		// the risk scanner first (block-only today), then fall through to the
 		// shadow-MCP guard so unapproved toolsets are still blocked.
@@ -117,7 +123,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 		} else {
 			result.Permission = new("allow")
 		}
-	case "preToolUse":
+	case HookEventPreToolUse:
 		// preToolUse fires for ALL Cursor tool calls including MCP ones, while
 		// beforeMCPExecution also fires for MCP-routed calls and already runs
 		// the scan there. Skip the scan here for MCP tools to avoid scanning
@@ -138,7 +144,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 		} else {
 			result.Permission = new("allow")
 		}
-	case "beforeSubmitPrompt":
+	case HookEventBeforeSubmitPrompt:
 		if scanResult := s.scanCursorForEnforcement(ctx, payload, orgID, projectID); scanResult != nil {
 			auditReason := fmt.Sprintf("Speakeasy blocked this prompt: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
 			userReason := renderUserBlockReason(scanResult.UserMessage, auditReason)
@@ -191,13 +197,18 @@ func (s *Service) recordCursorHook(ctx context.Context, payload *gen.CursorPaylo
 }
 
 func (s *Service) persistCursorHook(ctx context.Context, payload *gen.CursorPayload, metadata *SessionMetadata, blockReason string) {
-	if isCursorConversationEvent(payload.HookEventName) {
+	hookEvent, ok := parseCursorHookEvent(payload.HookEventName)
+	if !ok {
+		return
+	}
+
+	if isCursorConversationEvent(hookEvent) {
 		// Conversation events: PG only (user prompts and agent responses)
 		var err error
-		switch payload.HookEventName {
-		case "beforeSubmitPrompt":
+		switch hookEvent {
+		case HookEventBeforeSubmitPrompt:
 			err = s.persistCursorUserPrompt(ctx, payload, metadata)
-		case "afterAgentResponse":
+		case HookEventAfterAgentResponse:
 			err = s.persistCursorAgentResponse(ctx, payload, metadata)
 			// afterAgentResponse also carries token usage — record a metrics entry in ClickHouse
 			s.writeCursorMetricsToClickHouse(ctx, payload, metadata.GramOrgID, metadata.ProjectID, metadata.UserID)
@@ -219,19 +230,24 @@ func (s *Service) persistCursorToolCallEvent(ctx context.Context, payload *gen.C
 	s.writeCursorHookToClickHouse(ctx, payload, metadata.GramOrgID, metadata.ProjectID, metadata.UserID, blockReason)
 
 	// Write to PostgreSQL for chat history
-	switch payload.HookEventName {
-	case "preToolUse", "beforeMCPExecution":
+	hookEvent, ok := parseCursorHookEvent(payload.HookEventName)
+	if !ok {
+		return nil
+	}
+
+	switch hookEvent {
+	case HookEventPreToolUse, HookEventBeforeMCPExecution:
 		return s.writeCursorToolCallRequestToPG(ctx, payload, metadata)
-	case "postToolUse", "postToolUseFailure", "afterMCPExecution":
+	case HookEventPostToolUse, HookEventPostToolUseFailure, HookEventAfterMCPExecution:
 		return s.writeCursorToolCallResultToPG(ctx, payload, metadata)
 	}
 	return nil
 }
 
 // isCursorConversationEvent returns true if the event is a conversation capture event (not a tool call).
-func isCursorConversationEvent(eventName string) bool {
-	switch eventName {
-	case "beforeSubmitPrompt", "afterAgentResponse":
+func isCursorConversationEvent(hookEvent HookEvent) bool {
+	switch hookEvent {
+	case HookEventBeforeSubmitPrompt, HookEventAfterAgentResponse:
 		return true
 	default:
 		return false
@@ -375,34 +391,19 @@ func (s *Service) buildCursorTelemetryAttributes(ctx context.Context, payload *g
 		userEmail = *payload.UserEmail
 	}
 
-	// Normalize to PascalCase to match Claude convention for consistent ClickHouse queries
-	hookEvent := payload.HookEventName
-	switch hookEvent {
-	case "preToolUse":
-		hookEvent = "PreToolUse"
-	case "postToolUse":
-		hookEvent = "PostToolUse"
-	case "postToolUseFailure":
-		hookEvent = "PostToolUseFailure"
-	case "beforeSubmitPrompt":
-		hookEvent = "BeforeSubmitPrompt"
-	case "afterAgentResponse":
-		hookEvent = "AfterAgentResponse"
-	case "beforeMCPExecution":
-		hookEvent = "BeforeMCPExecution"
-	case "afterMCPExecution":
-		hookEvent = "AfterMCPExecution"
-	case "stop":
-		hookEvent = "Stop"
+	hookEvent, ok := parseCursorHookEvent(payload.HookEventName)
+	hookEventName := payload.HookEventName
+	if ok {
+		hookEventName = string(hookEvent)
 	}
 
 	attrs := map[attr.Key]any{
 		attr.EventSourceKey:    string(telemetry.EventSourceHook),
 		attr.ToolNameKey:       toolName,
-		attr.HookEventKey:      hookEvent,
+		attr.HookEventKey:      hookEventName,
 		attr.SpanIDKey:         generateSpanID(),
 		attr.TraceIDKey:        generateTraceID(),
-		attr.LogBodyKey:        fmt.Sprintf("Hook: %s", hookEvent),
+		attr.LogBodyKey:        fmt.Sprintf("Hook: %s", hookEventName),
 		attr.UserEmailKey:      userEmail,
 		attr.ProjectIDKey:      projectID,
 		attr.OrganizationIDKey: orgID,
@@ -432,7 +433,7 @@ func (s *Service) buildCursorTelemetryAttributes(ctx context.Context, payload *g
 	// beforeMCPExecution / afterMCPExecution: derive tool_source from the MCP
 	// server URL (or command for stdio servers), which the generic
 	// preToolUse/postToolUse events do not expose.
-	if payload.HookEventName == "beforeMCPExecution" || payload.HookEventName == "afterMCPExecution" {
+	if hookEvent == HookEventBeforeMCPExecution || hookEvent == HookEventAfterMCPExecution {
 		if source := cursorMCPToolSource(payload); source != "" {
 			attrs[attr.ToolCallSourceKey] = source
 		}
@@ -458,7 +459,7 @@ func (s *Service) buildCursorTelemetryAttributes(ctx context.Context, payload *g
 	}
 
 	// Store prompt text as log body for beforeSubmitPrompt events only
-	if payload.HookEventName == "beforeSubmitPrompt" && payload.Prompt != nil && *payload.Prompt != "" {
+	if hookEvent == HookEventBeforeSubmitPrompt && payload.Prompt != nil && *payload.Prompt != "" {
 		attrs[attr.LogBodyKey] = *payload.Prompt
 	}
 
@@ -631,12 +632,23 @@ func (s *Service) writeCursorToolCallResultToPG(ctx context.Context, payload *ge
 	chatID := sessionIDToUUID(*payload.ConversationID)
 
 	var content string
-	switch {
-	case payload.HookEventName == "postToolUse" && payload.ToolResponse != nil:
+	hookEvent, ok := parseCursorHookEvent(payload.HookEventName)
+	if !ok {
+		return nil
+	}
+
+	switch hookEvent {
+	case HookEventPostToolUse:
+		if payload.ToolResponse == nil {
+			return nil
+		}
 		content = marshalToJSON(payload.ToolResponse)
-	case payload.HookEventName == "postToolUseFailure" && payload.Error != nil:
+	case HookEventPostToolUseFailure:
+		if payload.Error == nil {
+			return nil
+		}
 		content = marshalToJSON(payload.Error)
-	case payload.HookEventName == "afterMCPExecution":
+	case HookEventAfterMCPExecution:
 		// afterMCPExecution delivers the response as an already-stringified JSON
 		// payload; fall back to ToolResponse if a client sends the structured form.
 		if payload.ResultJSON != nil && *payload.ResultJSON != "" {

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -212,6 +212,8 @@ func (s *Service) persistCursorHook(ctx context.Context, payload *gen.CursorPayl
 			err = s.persistCursorAgentResponse(ctx, payload, metadata)
 			// afterAgentResponse also carries token usage — record a metrics entry in ClickHouse
 			s.writeCursorMetricsToClickHouse(ctx, payload, metadata.GramOrgID, metadata.ProjectID, metadata.UserID)
+		default:
+			return
 		}
 		if err != nil {
 			s.logger.ErrorContext(ctx, "Failed to persist Cursor conversation event", attr.SlogError(err))
@@ -240,8 +242,9 @@ func (s *Service) persistCursorToolCallEvent(ctx context.Context, payload *gen.C
 		return s.writeCursorToolCallRequestToPG(ctx, payload, metadata)
 	case HookEventPostToolUse, HookEventPostToolUseFailure, HookEventAfterMCPExecution:
 		return s.writeCursorToolCallResultToPG(ctx, payload, metadata)
+	default:
+		return nil
 	}
-	return nil
 }
 
 // isCursorConversationEvent returns true if the event is a conversation capture event (not a tool call).

--- a/server/internal/hooks/events.go
+++ b/server/internal/hooks/events.go
@@ -1,0 +1,88 @@
+package hooks
+
+type HookEvent string
+
+const (
+	HookEventUnknown            HookEvent = ""
+	HookEventSessionStart       HookEvent = "SessionStart"
+	HookEventPreToolUse         HookEvent = "PreToolUse"
+	HookEventPostToolUse        HookEvent = "PostToolUse"
+	HookEventPostToolUseFailure HookEvent = "PostToolUseFailure"
+	HookEventUserPromptSubmit   HookEvent = "UserPromptSubmit"
+	HookEventStop               HookEvent = "Stop"
+	HookEventSessionEnd         HookEvent = "SessionEnd"
+	HookEventNotification       HookEvent = "Notification"
+	HookEventPermissionRequest  HookEvent = "PermissionRequest"
+	HookEventBeforeSubmitPrompt HookEvent = "BeforeSubmitPrompt"
+	HookEventAfterAgentResponse HookEvent = "AfterAgentResponse"
+	HookEventAfterAgentThought  HookEvent = "AfterAgentThought"
+	HookEventBeforeMCPExecution HookEvent = "BeforeMCPExecution"
+	HookEventAfterMCPExecution  HookEvent = "AfterMCPExecution"
+)
+
+func parseClaudeHookEvent(raw string) (HookEvent, bool) {
+	switch raw {
+	case string(HookEventSessionStart):
+		return HookEventSessionStart, true
+	case string(HookEventPreToolUse):
+		return HookEventPreToolUse, true
+	case string(HookEventPostToolUse):
+		return HookEventPostToolUse, true
+	case string(HookEventPostToolUseFailure):
+		return HookEventPostToolUseFailure, true
+	case string(HookEventUserPromptSubmit):
+		return HookEventUserPromptSubmit, true
+	case string(HookEventStop):
+		return HookEventStop, true
+	case string(HookEventSessionEnd):
+		return HookEventSessionEnd, true
+	case string(HookEventNotification):
+		return HookEventNotification, true
+	default:
+		return HookEventUnknown, false
+	}
+}
+
+func parseCodexHookEvent(raw string) (HookEvent, bool) {
+	switch raw {
+	case string(HookEventSessionStart):
+		return HookEventSessionStart, true
+	case string(HookEventPreToolUse):
+		return HookEventPreToolUse, true
+	case string(HookEventPermissionRequest):
+		return HookEventPermissionRequest, true
+	case string(HookEventPostToolUse):
+		return HookEventPostToolUse, true
+	case string(HookEventUserPromptSubmit):
+		return HookEventUserPromptSubmit, true
+	case string(HookEventStop):
+		return HookEventStop, true
+	default:
+		return HookEventUnknown, false
+	}
+}
+
+func parseCursorHookEvent(raw string) (HookEvent, bool) {
+	switch raw {
+	case "beforeSubmitPrompt":
+		return HookEventBeforeSubmitPrompt, true
+	case "stop":
+		return HookEventStop, true
+	case "afterAgentResponse":
+		return HookEventAfterAgentResponse, true
+	case "afterAgentThought":
+		return HookEventAfterAgentThought, true
+	case "preToolUse":
+		return HookEventPreToolUse, true
+	case "postToolUse":
+		return HookEventPostToolUse, true
+	case "postToolUseFailure":
+		return HookEventPostToolUseFailure, true
+	case "beforeMCPExecution":
+		return HookEventBeforeMCPExecution, true
+	case "afterMCPExecution":
+		return HookEventAfterMCPExecution, true
+	default:
+		return HookEventUnknown, false
+	}
+}

--- a/server/internal/hooks/events_test.go
+++ b/server/internal/hooks/events_test.go
@@ -1,0 +1,79 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseClaudeHookEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		raw      string
+		expected HookEvent
+		ok       bool
+	}{
+		{raw: "PreToolUse", expected: HookEventPreToolUse, ok: true},
+		{raw: "UserPromptSubmit", expected: HookEventUserPromptSubmit, ok: true},
+		{raw: "unknown", expected: HookEventUnknown, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+
+			event, ok := parseClaudeHookEvent(tt.raw)
+			assert.Equal(t, tt.expected, event)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+func TestParseCodexHookEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		raw      string
+		expected HookEvent
+		ok       bool
+	}{
+		{raw: "PermissionRequest", expected: HookEventPermissionRequest, ok: true},
+		{raw: "Stop", expected: HookEventStop, ok: true},
+		{raw: "unknown", expected: HookEventUnknown, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+
+			event, ok := parseCodexHookEvent(tt.raw)
+			assert.Equal(t, tt.expected, event)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+func TestParseCursorHookEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		raw      string
+		expected HookEvent
+		ok       bool
+	}{
+		{raw: "beforeSubmitPrompt", expected: HookEventBeforeSubmitPrompt, ok: true},
+		{raw: "afterMCPExecution", expected: HookEventAfterMCPExecution, ok: true},
+		{raw: "unknown", expected: HookEventUnknown, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+
+			event, ok := parseCursorHookEvent(tt.raw)
+			assert.Equal(t, tt.expected, event)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}

--- a/server/internal/hooks/risk_scan.go
+++ b/server/internal/hooks/risk_scan.go
@@ -29,7 +29,12 @@ func (s *Service) scanClaudeForEnforcement(ctx context.Context, payload *gen.Cla
 		return nil
 	}
 
-	text := extractClaudeText(payload)
+	hookEvent, ok := parseClaudeHookEvent(payload.HookEventName)
+	if !ok {
+		return nil
+	}
+
+	text := extractClaudeText(payload, hookEvent)
 	if text == "" {
 		return nil
 	}
@@ -78,7 +83,12 @@ func (s *Service) scanCursorForEnforcement(ctx context.Context, payload *gen.Cur
 		return nil
 	}
 
-	text := extractCursorText(payload)
+	hookEvent, ok := parseCursorHookEvent(payload.HookEventName)
+	if !ok {
+		return nil
+	}
+
+	text := extractCursorText(payload, hookEvent)
 	if text == "" {
 		return nil
 	}
@@ -107,7 +117,12 @@ func (s *Service) scanCodexForEnforcement(ctx context.Context, payload *gen.Code
 		return nil
 	}
 
-	text := extractCodexText(payload)
+	hookEvent, ok := parseCodexHookEvent(payload.HookEventName)
+	if !ok {
+		return nil
+	}
+
+	text := extractCodexText(payload, hookEvent)
 	if text == "" {
 		return nil
 	}
@@ -143,13 +158,13 @@ func renderUserBlockReason(userMessage *string, auditReason string) string {
 }
 
 // extractClaudeText returns the scannable text content from a Claude hook payload.
-func extractClaudeText(payload *gen.ClaudePayload) string {
-	switch payload.HookEventName {
-	case "UserPromptSubmit":
+func extractClaudeText(payload *gen.ClaudePayload, hookEvent HookEvent) string {
+	switch hookEvent {
+	case HookEventUserPromptSubmit:
 		if payload.Prompt != nil {
 			return *payload.Prompt
 		}
-	case "PreToolUse":
+	case HookEventPreToolUse:
 		if payload.ToolInput != nil {
 			b, err := json.Marshal(payload.ToolInput)
 			if err != nil {
@@ -157,7 +172,7 @@ func extractClaudeText(payload *gen.ClaudePayload) string {
 			}
 			return string(b)
 		}
-	case "PostToolUse":
+	case HookEventPostToolUse:
 		if payload.ToolResponse != nil {
 			b, err := json.Marshal(payload.ToolResponse)
 			if err != nil {
@@ -170,13 +185,13 @@ func extractClaudeText(payload *gen.ClaudePayload) string {
 }
 
 // extractCursorText returns the scannable text content from a Cursor hook payload.
-func extractCursorText(payload *gen.CursorPayload) string {
-	switch payload.HookEventName {
-	case "beforeSubmitPrompt":
+func extractCursorText(payload *gen.CursorPayload, hookEvent HookEvent) string {
+	switch hookEvent {
+	case HookEventBeforeSubmitPrompt:
 		if payload.Prompt != nil {
 			return *payload.Prompt
 		}
-	case "preToolUse", "beforeMCPExecution":
+	case HookEventPreToolUse, HookEventBeforeMCPExecution:
 		if payload.ToolInput != nil {
 			b, err := json.Marshal(payload.ToolInput)
 			if err != nil {
@@ -189,13 +204,13 @@ func extractCursorText(payload *gen.CursorPayload) string {
 }
 
 // extractCodexText returns the scannable text content from a Codex hook payload.
-func extractCodexText(payload *gen.CodexPayload) string {
-	switch payload.HookEventName {
-	case "UserPromptSubmit":
+func extractCodexText(payload *gen.CodexPayload, hookEvent HookEvent) string {
+	switch hookEvent {
+	case HookEventUserPromptSubmit:
 		if payload.Prompt != nil {
 			return *payload.Prompt
 		}
-	case "PreToolUse", "PermissionRequest":
+	case HookEventPreToolUse, HookEventPermissionRequest:
 		if payload.ToolInput != nil {
 			b, err := json.Marshal(payload.ToolInput)
 			if err != nil {

--- a/server/internal/hooks/risk_scan.go
+++ b/server/internal/hooks/risk_scan.go
@@ -180,6 +180,8 @@ func extractClaudeText(payload *gen.ClaudePayload, hookEvent HookEvent) string {
 			}
 			return string(b)
 		}
+	default:
+		return ""
 	}
 	return ""
 }
@@ -199,6 +201,8 @@ func extractCursorText(payload *gen.CursorPayload, hookEvent HookEvent) string {
 			}
 			return string(b)
 		}
+	default:
+		return ""
 	}
 	return ""
 }
@@ -218,6 +222,8 @@ func extractCodexText(payload *gen.CodexPayload, hookEvent HookEvent) string {
 			}
 			return string(b)
 		}
+	default:
+		return ""
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- add a typed internal HookEvent enum plus parser helpers for Claude, Cursor, and Codex hook payloads
- normalize Cursor hook handling and telemetry/persistence to use HookEvent instead of raw provider-specific strings
- use the same typed event mapping in shared risk-scan text extraction without pulling in the input-scope work

## Testing
mise run test:server ./internal/hooks/... ./internal/risk/...
