### PR TITLE
fix(dashboard): surface proxy MCPs in role picker, drop misleading No Tools badge

### DIFF
--- a/.changeset/proxy-mcp-rbac-visibility.md
+++ b/.changeset/proxy-mcp-rbac-visibility.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+External MCP proxy servers (whose tools cannot be enumerated until a user authenticates) now appear in the "Specific MCP Servers" picker when creating an access role, and no longer display a misleading "No Tools" badge on the MCP list and table views.

--- a/client/dashboard/src/components/mcp/MCPCard.tsx
+++ b/client/dashboard/src/components/mcp/MCPCard.tsx
@@ -58,6 +58,16 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
     ? `Installed from ${toolset.origin.registrySpecifier}`
     : undefined;
 
+  // External MCP "proxy" servers can't enumerate their tools until a user
+  // authenticates against them, so hide the misleading "No Tools" badge and
+  // surface the visible (non-proxy) tools only.
+  const visibleToolNames = toolset.tools
+    .filter((t) => !(t.type === "externalmcp" && t.name.endsWith(":proxy")))
+    .map((t) => t.name);
+  const isExternalMcpProxy = toolset.tools.some(
+    (t) => t.type === "externalmcp" && t.name.endsWith(":proxy"),
+  );
+
   return (
     <DotCard
       className="cursor-pointer"
@@ -117,7 +127,10 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
               <Package className="text-muted-foreground group-hover:text-foreground h-4 w-4" />
             </Button>
           )}
-          <ToolCollectionBadge toolNames={toolset.tools.map((t) => t.name)} />
+          <ToolCollectionBadge
+            toolNames={visibleToolNames}
+            emptyLabel={isExternalMcpProxy ? null : undefined}
+          />
         </div>
       </div>
 

--- a/client/dashboard/src/components/mcp/MCPTableRow.tsx
+++ b/client/dashboard/src/components/mcp/MCPTableRow.tsx
@@ -53,6 +53,16 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
     ? `Installed from ${toolset.origin.registrySpecifier}`
     : undefined;
 
+  // External MCP "proxy" servers can't enumerate their tools until a user
+  // authenticates against them, so hide the misleading "No Tools" badge and
+  // surface the visible (non-proxy) tools only.
+  const visibleToolNames = toolset.tools
+    .filter((t) => !(t.type === "externalmcp" && t.name.endsWith(":proxy")))
+    .map((t) => t.name);
+  const isExternalMcpProxy = toolset.tools.some(
+    (t) => t.type === "externalmcp" && t.name.endsWith(":proxy"),
+  );
+
   return (
     <DotRow
       onClick={handleClick}
@@ -134,7 +144,10 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
 
       {/* Tools */}
       <td className="px-3 py-3">
-        <ToolCollectionBadge toolNames={toolset.tools.map((t) => t.name)} />
+        <ToolCollectionBadge
+          toolNames={visibleToolNames}
+          emptyLabel={isExternalMcpProxy ? null : undefined}
+        />
       </td>
     </DotRow>
   );

--- a/client/dashboard/src/components/tool-collection-badge.tsx
+++ b/client/dashboard/src/components/tool-collection-badge.tsx
@@ -94,11 +94,19 @@ export const ToolCollectionBadge = ({
   variant = "neutral",
   className,
   warnOnTooManyTools = false,
+  emptyLabel,
 }: {
   toolNames: string[] | undefined;
   variant?: React.ComponentProps<typeof Badge>["variant"];
   className?: string;
   warnOnTooManyTools?: boolean;
+  /**
+   * What to render when there are no tools.
+   * - undefined (default): the "No Tools" badge.
+   * - null: render nothing.
+   * - ReactNode: render this instead.
+   */
+  emptyLabel?: React.ReactNode | null;
 }) => {
   let tooltipContent: React.ReactNode = (
     <div className="max-h-[300px] overflow-y-auto">
@@ -123,6 +131,8 @@ export const ToolCollectionBadge = ({
   }
 
   if (!toolNames || toolNames.length === 0) {
+    if (emptyLabel === null) return null;
+    if (emptyLabel !== undefined) return <>{emptyLabel}</>;
     return (
       <Badge variant={variant} className={className}>
         No Tools

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -100,22 +100,30 @@ function useMCPServers(enabled: boolean) {
         ? `${baseUrl}/mcp/${t.mcpSlug}`
         : `${baseUrl}/mcp/${project?.slug ?? ""}/${t.slug}/${t.defaultEnvironmentSlug ?? ""}`;
       const mcpUrl = fullUrl.replace(/^https?:\/\//, "");
-      // Skip toolsets containing proxy external MCP tools — proxy tools are not
-      // RBAC-compatible yet. Backend encodes proxy entries with a ":proxy" name
-      // suffix while direct entries get the real ":<tool-name>".
-      const hasProxyExternalMcp = t.tools.some(
+      // External MCP "proxy" entries (name suffix ":proxy") represent servers
+      // whose tools/list requires user auth, so we can't enumerate them at
+      // deploy time. They still resolve at call-time via mcp:connect, so the
+      // grant model supports them; we just don't surface the proxy entry as a
+      // selectable tool in the picker.
+      const tools = t.tools
+        .filter(
+          (tool) =>
+            !(tool.type === "externalmcp" && tool.name.endsWith(":proxy")),
+        )
+        .map((tool) => ({
+          id: tool.id,
+          name: tool.name,
+          type: tool.type,
+          httpMethod: tool.httpMethod,
+          annotations: tool.annotations,
+        }));
+      const isExternalMcpProxy = t.tools.some(
         (tool) => tool.type === "externalmcp" && tool.name.endsWith(":proxy"),
       );
-      if (hasProxyExternalMcp) continue;
-      const tools = t.tools.map((tool) => ({
-        id: tool.id,
-        name: tool.name,
-        type: tool.type,
-        httpMethod: tool.httpMethod,
-        annotations: tool.annotations,
-      }));
-      // Skip servers with no tools
-      if (tools.length === 0) continue;
+      // Skip servers with nothing grantable: zero visible tools and not a
+      // proxy server (proxy servers stay listed so users can grant at the
+      // server level).
+      if (tools.length === 0 && !isExternalMcpProxy) continue;
       group.servers.push({
         id: t.id,
         name: t.name,

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -292,6 +292,21 @@ export function GrantRuleDrawerContent({
       .filter((g) => g.servers.length > 0);
   }, [scopedMcpServers, resourceSearch]);
 
+  // The "Specific tools" picker only makes sense for servers with enumerable
+  // tools. Proxy servers (no tools/list at deploy time) appear in the
+  // "Specific servers" picker for server-level grants but must not render
+  // a zero-tools row here.
+  const toolPanelMcpServers = useMemo(
+    () =>
+      scopedMcpServers
+        .map((g) => ({
+          ...g,
+          servers: g.servers.filter((s) => s.tools.length > 0),
+        }))
+        .filter((g) => g.servers.length > 0),
+    [scopedMcpServers],
+  );
+
   // Fixed-scope permissions have no resource picker — their granularity is
   // baked into the scope definition. Org scopes are always org-wide;
   // environment scopes apply to every environment in the project.
@@ -540,7 +555,7 @@ export function GrantRuleDrawerContent({
 
   const customTabs = (toolScrollClass?: string) => (
     <ToolSelectionPanel
-      mcpServers={scopedMcpServers}
+      mcpServers={toolPanelMcpServers}
       selectors={selectors ?? []}
       annotations={annotations}
       onChangeAnnotations={onChangeAnnotations}

--- a/client/dashboard/src/pages/catalog/ServerCard.tsx
+++ b/client/dashboard/src/pages/catalog/ServerCard.tsx
@@ -55,6 +55,12 @@ export function ServerCard({
     return tools.map((t) => t.name || "Unknown tool");
   }, [server.tools]);
 
+  // Remote-only servers (auth-gated proxies like GitHub, Make) can't enumerate
+  // tools until a user authenticates, so the "No Tools" badge would be
+  // misleading. Hide it for them.
+  const isRemoteOnly =
+    (server.remotes?.length ?? 0) > 0 && toolNames.length === 0;
+
   const handleCardClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation(); // Prevent click-outside-to-deselect from firing
     onToggleSelect?.();
@@ -119,7 +125,10 @@ export function ServerCard({
           </div>
           <div className="flex items-baseline gap-1">
             {isSpeakeasyServer && <PoweredBySpeakeasyBadge />}
-            <ToolCollectionBadge toolNames={toolNames} />
+            <ToolCollectionBadge
+              toolNames={toolNames}
+              emptyLabel={isRemoteOnly ? null : undefined}
+            />
           </div>
         </div>
 

--- a/client/dashboard/src/pages/catalog/ServerTableRow.tsx
+++ b/client/dashboard/src/pages/catalog/ServerTableRow.tsx
@@ -40,6 +40,12 @@ export function ServerTableRow({
     return tools.map((t) => t.name || "Unknown tool");
   }, [server.tools]);
 
+  // Remote-only servers (auth-gated proxies like GitHub, Make) can't enumerate
+  // tools until a user authenticates, so the "No Tools" badge would be
+  // misleading. Hide it for them.
+  const isRemoteOnly =
+    (server.remotes?.length ?? 0) > 0 && toolNames.length === 0;
+
   const handleRowClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
     e.stopPropagation();
     onToggleSelect?.();
@@ -113,7 +119,10 @@ export function ServerTableRow({
 
       {/* Tools */}
       <td className="px-3 py-3">
-        <ToolCollectionBadge toolNames={toolNames} />
+        <ToolCollectionBadge
+          toolNames={toolNames}
+          emptyLabel={isRemoteOnly ? null : undefined}
+        />
       </td>
 
       {/* View */}


### PR DESCRIPTION
## Demo

https://github.com/speakeasy-api/gram/releases/download/_gh-attach-assets/recording-8k5cci.mp4

## Why

External MCP "proxy" servers (e.g. Incident.io, Notion installed via the registry) can't enumerate their tools until a user authenticates against them. Two dashboard surfaces treated those servers as empty:

1. The MCP list and table views rendered a misleading "No Tools" badge.
2. The "Specific MCP Servers" picker in the role-grant drawer skipped them entirely, so admins couldn't grant access to any proxy-based MCP via RBAC.

The backend already supports server-level grants for these via the call-time `mcp:connect` check; only the UI was hiding them.

## What changed

- `ToolCollectionBadge` gains an `emptyLabel` prop. Pass `null` to render nothing when the tool list is empty (default behavior is unchanged).
- `MCPCard`, `MCPTableRow`, and the catalog views (`ServerCard`, `ServerTableRow`) detect external MCP proxy entries (tool `type === "externalmcp"` with a `:proxy` name suffix), strip them from the visible tool count, and suppress the badge when the toolset is a proxy server.
- `GrantRuleDrawerContent`'s `useMCPServers` no longer drops servers that contain a proxy entry. The proxy entry itself is filtered from the per-server tool list (it isn't a grantable tool URN), but the server stays in the picker so admins can grant at the server level.

### Before

- MCP list and table: proxy-only servers show a "No Tools" badge.
- Role drawer "Specific MCP Servers" picker: proxy servers (Incident.io, Notion, etc.) are missing entirely.

### After

- MCP list and table: proxy-only servers show no tools badge; servers that combine proxy + non-proxy entries show the count of the non-proxy tools.
- Role drawer "Specific MCP Servers" picker: proxy servers are listed and selectable for server-level grants.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface external MCP proxy servers in the role picker and suppress misleading "No Tools" badges across MCP and catalog views. Enables server-level grants for providers like Incident.io and Notion and keeps tool counts accurate.

- **Bug Fixes**
  - Role drawer: list proxy servers in "Specific MCP Servers"; filter the proxy entry out of tools; hide proxy-only servers from "Specific tools"; allow server-level grants when tools aren't enumerable.
  - MCP list/table and catalog cards/rows: hide the "No Tools" badge for proxy-only or remote-only servers; show counts only for non-proxy tools.
  - `ToolCollectionBadge`: add `emptyLabel` to customize or hide the empty state.

<sup>Written for commit 5aa87c0a8af0bb496c3e882d1cd09c44948d4d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


