### PR TITLE
fix: include OAuth toolsets in plugin .mcp.json generation

### DIFF
--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -402,17 +402,17 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 	}
 	files[path.Join(subdir, ".codex-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]any)
+	mcpServers := make(map[string]codexMCPEntry)
 	for _, s := range p.Servers {
 		if s.IsOAuth {
-			mcpServers[s.DisplayName] = codexStdioMCPServer{
-				Command: "npx",
-				Args:    []string{"mcp-remote@0.1.25", s.MCPURL},
+			mcpServers[s.DisplayName] = codexMCPEntry{
+				HTTP:  nil,
+				Stdio: &codexStdioMCPServer{Command: "npx", Args: []string{"mcp-remote@0.1.25", s.MCPURL}},
 			}
 			continue
 		}
 
-		entry := codexMCPServer{
+		http := codexMCPServer{
 			URL:               s.MCPURL,
 			BearerTokenEnvVar: "",
 			HTTPHeaders:       nil,
@@ -423,22 +423,22 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 			// User provides each variable in their shell env; Codex
 			// substitutes the value into the named header at runtime.
 			if len(s.EnvConfigs) > 0 {
-				entry.EnvHTTPHeaders = make(map[string]string, len(s.EnvConfigs))
+				http.EnvHTTPHeaders = make(map[string]string, len(s.EnvConfigs))
 				for _, ec := range s.EnvConfigs {
-					entry.EnvHTTPHeaders[ec.DisplayName] = ec.VariableName
+					http.EnvHTTPHeaders[ec.DisplayName] = ec.VariableName
 				}
 			}
 		} else if cfg.APIKey != "" {
 			// Private server: bake the Gram-issued key directly into the
 			// published config. Repo is private, so this matches the Cursor/Claude pattern.
-			entry.HTTPHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
+			http.HTTPHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
 		} else {
 			// Private server, no key available: ask Codex to read GRAM_API_KEY
 			// from the user's environment at startup.
-			entry.BearerTokenEnvVar = "GRAM_API_KEY"
+			http.BearerTokenEnvVar = "GRAM_API_KEY"
 		}
 
-		mcpServers[s.DisplayName] = entry
+		mcpServers[s.DisplayName] = codexMCPEntry{HTTP: &http, Stdio: nil}
 	}
 	mcpJSON, err := marshalJSON(codexMCPConfig{MCPServers: mcpServers})
 	if err != nil {
@@ -1332,14 +1332,14 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	}
 	files[path.Join(subdir, ".claude-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]any)
+	mcpServers := make(map[string]claudeMCPEntry)
 	for _, s := range p.Servers {
 		if s.IsOAuth {
 			// OAuth servers use mcp-remote as a stdio proxy; OAuth handles identity at the HTTP
 			// layer, so no Authorization header is emitted.
-			mcpServers[s.DisplayName] = claudeStdioMCPServer{
-				Command: "npx",
-				Args:    []string{"mcp-remote@0.1.25", s.MCPURL},
+			mcpServers[s.DisplayName] = claudeMCPEntry{
+				HTTP:  nil,
+				Stdio: &claudeStdioMCPServer{Command: "npx", Args: []string{"mcp-remote@0.1.25", s.MCPURL}},
 			}
 			continue
 		}
@@ -1359,10 +1359,9 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 			headers["Authorization"] = "Bearer ${user_config.GRAM_API_KEY}"
 		}
 
-		mcpServers[s.DisplayName] = claudeMCPServer{
-			Type:    "http",
-			URL:     s.MCPURL,
-			Headers: headers,
+		mcpServers[s.DisplayName] = claudeMCPEntry{
+			HTTP:  &claudeMCPServer{Type: "http", URL: s.MCPURL, Headers: headers},
+			Stdio: nil,
 		}
 	}
 	mcpJSON, err := marshalJSON(claudeMCPConfig{MCPServers: mcpServers})
@@ -1393,12 +1392,12 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 	}
 	files[path.Join(subdir, ".cursor-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]any)
+	mcpServers := make(map[string]cursorMCPEntry)
 	for _, s := range p.Servers {
 		if s.IsOAuth {
-			mcpServers[s.DisplayName] = cursorStdioMCPServer{
-				Command: "npx",
-				Args:    []string{"mcp-remote@0.1.25", s.MCPURL},
+			mcpServers[s.DisplayName] = cursorMCPEntry{
+				HTTP:  nil,
+				Stdio: &cursorStdioMCPServer{Command: "npx", Args: []string{"mcp-remote@0.1.25", s.MCPURL}},
 			}
 			continue
 		}
@@ -1415,9 +1414,9 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 			headers["Authorization"] = "Bearer ${env:GRAM_API_KEY}"
 		}
 
-		mcpServers[s.DisplayName] = cursorMCPServer{
-			URL:     s.MCPURL,
-			Headers: headers,
+		mcpServers[s.DisplayName] = cursorMCPEntry{
+			HTTP:  &cursorMCPServer{URL: s.MCPURL, Headers: headers},
+			Stdio: nil,
 		}
 	}
 	mcpJSON, err := marshalJSON(cursorMCPConfig{MCPServers: mcpServers})
@@ -1468,7 +1467,49 @@ type userConfigEntry struct {
 }
 
 type claudeMCPConfig struct {
-	MCPServers map[string]any `json:"mcpServers"`
+	MCPServers map[string]claudeMCPEntry `json:"mcpServers"`
+}
+
+// claudeMCPEntry is a discriminated union: exactly one of HTTP or Stdio is non-nil.
+type claudeMCPEntry struct {
+	HTTP  *claudeMCPServer
+	Stdio *claudeStdioMCPServer
+}
+
+func (e claudeMCPEntry) MarshalJSON() ([]byte, error) {
+	if e.Stdio != nil {
+		b, err := json.Marshal(e.Stdio)
+		if err != nil {
+			return nil, fmt.Errorf("marshal claude stdio mcp server: %w", err)
+		}
+		return b, nil
+	}
+	b, err := json.Marshal(e.HTTP)
+	if err != nil {
+		return nil, fmt.Errorf("marshal claude http mcp server: %w", err)
+	}
+	return b, nil
+}
+
+func (e *claudeMCPEntry) UnmarshalJSON(data []byte) error {
+	var probe struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("probe claude mcp entry: %w", err)
+	}
+	if probe.Command != "" {
+		e.Stdio = &claudeStdioMCPServer{Command: "", Args: nil}
+		if err := json.Unmarshal(data, e.Stdio); err != nil {
+			return fmt.Errorf("unmarshal claude stdio mcp server: %w", err)
+		}
+		return nil
+	}
+	e.HTTP = &claudeMCPServer{Type: "", URL: "", Headers: nil}
+	if err := json.Unmarshal(data, e.HTTP); err != nil {
+		return fmt.Errorf("unmarshal claude http mcp server: %w", err)
+	}
+	return nil
 }
 
 type claudeMCPServer struct {
@@ -1492,7 +1533,49 @@ type cursorPluginMeta struct {
 }
 
 type cursorMCPConfig struct {
-	MCPServers map[string]any `json:"mcpServers"`
+	MCPServers map[string]cursorMCPEntry `json:"mcpServers"`
+}
+
+// cursorMCPEntry is a discriminated union: exactly one of HTTP or Stdio is non-nil.
+type cursorMCPEntry struct {
+	HTTP  *cursorMCPServer
+	Stdio *cursorStdioMCPServer
+}
+
+func (e cursorMCPEntry) MarshalJSON() ([]byte, error) {
+	if e.Stdio != nil {
+		b, err := json.Marshal(e.Stdio)
+		if err != nil {
+			return nil, fmt.Errorf("marshal cursor stdio mcp server: %w", err)
+		}
+		return b, nil
+	}
+	b, err := json.Marshal(e.HTTP)
+	if err != nil {
+		return nil, fmt.Errorf("marshal cursor http mcp server: %w", err)
+	}
+	return b, nil
+}
+
+func (e *cursorMCPEntry) UnmarshalJSON(data []byte) error {
+	var probe struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("probe cursor mcp entry: %w", err)
+	}
+	if probe.Command != "" {
+		e.Stdio = &cursorStdioMCPServer{Command: "", Args: nil}
+		if err := json.Unmarshal(data, e.Stdio); err != nil {
+			return fmt.Errorf("unmarshal cursor stdio mcp server: %w", err)
+		}
+		return nil
+	}
+	e.HTTP = &cursorMCPServer{URL: "", Headers: nil}
+	if err := json.Unmarshal(data, e.HTTP); err != nil {
+		return fmt.Errorf("unmarshal cursor http mcp server: %w", err)
+	}
+	return nil
 }
 
 type cursorMCPServer struct {
@@ -1583,7 +1666,49 @@ type codexInterface struct {
 }
 
 type codexMCPConfig struct {
-	MCPServers map[string]any `json:"mcpServers"`
+	MCPServers map[string]codexMCPEntry `json:"mcpServers"`
+}
+
+// codexMCPEntry is a discriminated union: exactly one of HTTP or Stdio is non-nil.
+type codexMCPEntry struct {
+	HTTP  *codexMCPServer
+	Stdio *codexStdioMCPServer
+}
+
+func (e codexMCPEntry) MarshalJSON() ([]byte, error) {
+	if e.Stdio != nil {
+		b, err := json.Marshal(e.Stdio)
+		if err != nil {
+			return nil, fmt.Errorf("marshal codex stdio mcp server: %w", err)
+		}
+		return b, nil
+	}
+	b, err := json.Marshal(e.HTTP)
+	if err != nil {
+		return nil, fmt.Errorf("marshal codex http mcp server: %w", err)
+	}
+	return b, nil
+}
+
+func (e *codexMCPEntry) UnmarshalJSON(data []byte) error {
+	var probe struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("probe codex mcp entry: %w", err)
+	}
+	if probe.Command != "" {
+		e.Stdio = &codexStdioMCPServer{Command: "", Args: nil}
+		if err := json.Unmarshal(data, e.Stdio); err != nil {
+			return fmt.Errorf("unmarshal codex stdio mcp server: %w", err)
+		}
+		return nil
+	}
+	e.HTTP = &codexMCPServer{URL: "", BearerTokenEnvVar: "", HTTPHeaders: nil, EnvHTTPHeaders: nil}
+	if err := json.Unmarshal(data, e.HTTP); err != nil {
+		return fmt.Errorf("unmarshal codex http mcp server: %w", err)
+	}
+	return nil
 }
 
 type codexMCPServer struct {

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -402,11 +402,13 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 	}
 	files[path.Join(subdir, ".codex-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]codexMCPServer)
+	mcpServers := make(map[string]any)
 	for _, s := range p.Servers {
 		if s.IsOAuth {
-			// Codex MCP server config does not support stdio/command-based entries.
-			// OAuth toolsets are skipped until Codex adds stdio support.
+			mcpServers[s.DisplayName] = codexStdioMCPServer{
+				Command: "npx",
+				Args:    []string{"mcp-remote@0.1.25", s.MCPURL},
+			}
 			continue
 		}
 
@@ -1581,7 +1583,7 @@ type codexInterface struct {
 }
 
 type codexMCPConfig struct {
-	MCPServers map[string]codexMCPServer `json:"mcpServers"`
+	MCPServers map[string]any `json:"mcpServers"`
 }
 
 type codexMCPServer struct {
@@ -1589,6 +1591,11 @@ type codexMCPServer struct {
 	BearerTokenEnvVar string            `json:"bearer_token_env_var,omitempty"`
 	HTTPHeaders       map[string]string `json:"http_headers,omitempty"`
 	EnvHTTPHeaders    map[string]string `json:"env_http_headers,omitempty"`
+}
+
+type codexStdioMCPServer struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
 }
 
 type codexMarketplaceManifest struct {

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -25,6 +25,9 @@ type PluginServerInfo struct {
 	MCPURL string
 	// IsPublic indicates whether the toolset is publicly accessible (no Gram API key needed).
 	IsPublic bool
+	// IsOAuth indicates the toolset uses OAuth (proxy or external). OAuth servers are emitted
+	// as stdio mcp-remote entries instead of HTTP-with-headers entries.
+	IsOAuth bool
 	// EnvConfigs are user-facing environment variables for public servers.
 	EnvConfigs []ServerEnvConfig
 }
@@ -401,6 +404,12 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 
 	mcpServers := make(map[string]codexMCPServer)
 	for _, s := range p.Servers {
+		if s.IsOAuth {
+			// Codex MCP server config does not support stdio/command-based entries.
+			// OAuth toolsets are skipped until Codex adds stdio support.
+			continue
+		}
+
 		entry := codexMCPServer{
 			URL:               s.MCPURL,
 			BearerTokenEnvVar: "",
@@ -1284,10 +1293,10 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	// Determine if any private server needs a Gram API key prompt.
 	needsGramKeyPrompt := false
 	for _, s := range p.Servers {
-		if !s.IsPublic && cfg.APIKey == "" {
+		if !s.IsPublic && !s.IsOAuth && cfg.APIKey == "" {
 			needsGramKeyPrompt = true
 		}
-		// Public servers may need user-provided env vars.
+		// Public non-OAuth servers may need user-provided env vars.
 		for _, ec := range s.EnvConfigs {
 			userConfig[ec.VariableName] = userConfigEntry{
 				Description: ec.DisplayName,
@@ -1321,8 +1330,18 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	}
 	files[path.Join(subdir, ".claude-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]claudeMCPServer)
+	mcpServers := make(map[string]any)
 	for _, s := range p.Servers {
+		if s.IsOAuth {
+			// OAuth servers use mcp-remote as a stdio proxy; OAuth handles identity at the HTTP
+			// layer, so no Authorization header is emitted.
+			mcpServers[s.DisplayName] = claudeStdioMCPServer{
+				Command: "npx",
+				Args:    []string{"mcp-remote@0.1.25", s.MCPURL},
+			}
+			continue
+		}
+
 		headers := make(map[string]string)
 
 		if s.IsPublic {
@@ -1372,8 +1391,16 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 	}
 	files[path.Join(subdir, ".cursor-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]cursorMCPServer)
+	mcpServers := make(map[string]any)
 	for _, s := range p.Servers {
+		if s.IsOAuth {
+			mcpServers[s.DisplayName] = cursorStdioMCPServer{
+				Command: "npx",
+				Args:    []string{"mcp-remote@0.1.25", s.MCPURL},
+			}
+			continue
+		}
+
 		headers := make(map[string]string)
 
 		if s.IsPublic {
@@ -1439,13 +1466,18 @@ type userConfigEntry struct {
 }
 
 type claudeMCPConfig struct {
-	MCPServers map[string]claudeMCPServer `json:"mcpServers"`
+	MCPServers map[string]any `json:"mcpServers"`
 }
 
 type claudeMCPServer struct {
 	Type    string            `json:"type"`
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type claudeStdioMCPServer struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
 }
 
 type cursorPluginMeta struct {
@@ -1458,12 +1490,17 @@ type cursorPluginMeta struct {
 }
 
 type cursorMCPConfig struct {
-	MCPServers map[string]cursorMCPServer `json:"mcpServers"`
+	MCPServers map[string]any `json:"mcpServers"`
 }
 
 type cursorMCPServer struct {
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type cursorStdioMCPServer struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
 }
 
 // Hook config types — Claude uses PascalCase event names + a matcher

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -402,43 +402,31 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 	}
 	files[path.Join(subdir, ".codex-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]codexMCPEntry)
+	mcpServers := make(map[string]codexMCPServer)
 	for _, s := range p.Servers {
-		if s.IsOAuth {
-			mcpServers[s.DisplayName] = codexMCPEntry{
-				HTTP:  nil,
-				Stdio: &codexStdioMCPServer{Command: "npx", Args: []string{"mcp-remote@0.1.25", s.MCPURL}},
-			}
-			continue
-		}
-
-		http := codexMCPServer{
+		entry := codexMCPServer{
 			URL:               s.MCPURL,
 			BearerTokenEnvVar: "",
 			HTTPHeaders:       nil,
 			EnvHTTPHeaders:    nil,
 		}
 
-		if s.IsPublic {
-			// User provides each variable in their shell env; Codex
-			// substitutes the value into the named header at runtime.
+		if s.IsOAuth {
+			// OAuth servers handle identity at the HTTP layer — no auth credential needed.
+		} else if s.IsPublic {
 			if len(s.EnvConfigs) > 0 {
-				http.EnvHTTPHeaders = make(map[string]string, len(s.EnvConfigs))
+				entry.EnvHTTPHeaders = make(map[string]string, len(s.EnvConfigs))
 				for _, ec := range s.EnvConfigs {
-					http.EnvHTTPHeaders[ec.DisplayName] = ec.VariableName
+					entry.EnvHTTPHeaders[ec.DisplayName] = ec.VariableName
 				}
 			}
 		} else if cfg.APIKey != "" {
-			// Private server: bake the Gram-issued key directly into the
-			// published config. Repo is private, so this matches the Cursor/Claude pattern.
-			http.HTTPHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
+			entry.HTTPHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
 		} else {
-			// Private server, no key available: ask Codex to read GRAM_API_KEY
-			// from the user's environment at startup.
-			http.BearerTokenEnvVar = "GRAM_API_KEY"
+			entry.BearerTokenEnvVar = "GRAM_API_KEY"
 		}
 
-		mcpServers[s.DisplayName] = codexMCPEntry{HTTP: &http, Stdio: nil}
+		mcpServers[s.DisplayName] = entry
 	}
 	mcpJSON, err := marshalJSON(codexMCPConfig{MCPServers: mcpServers})
 	if err != nil {
@@ -1332,36 +1320,27 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	}
 	files[path.Join(subdir, ".claude-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]claudeMCPEntry)
+	mcpServers := make(map[string]claudeMCPServer)
 	for _, s := range p.Servers {
+		var headers map[string]string
+
 		if s.IsOAuth {
-			// OAuth servers use mcp-remote as a stdio proxy; OAuth handles identity at the HTTP
-			// layer, so no Authorization header is emitted.
-			mcpServers[s.DisplayName] = claudeMCPEntry{
-				HTTP:  nil,
-				Stdio: &claudeStdioMCPServer{Command: "npx", Args: []string{"mcp-remote@0.1.25", s.MCPURL}},
-			}
-			continue
-		}
-
-		headers := make(map[string]string)
-
-		if s.IsPublic {
-			// Public servers use env config variables for auth.
+			// OAuth servers handle identity at the HTTP layer — no Authorization header needed.
+		} else if s.IsPublic {
+			headers = make(map[string]string)
 			for _, ec := range s.EnvConfigs {
 				headers[ec.DisplayName] = "${user_config." + ec.VariableName + "}"
 			}
 		} else if cfg.APIKey != "" {
-			// Private server with injected key.
-			headers["Authorization"] = "Bearer " + cfg.APIKey
+			headers = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
 		} else {
-			// Private server without key — prompt user.
-			headers["Authorization"] = "Bearer ${user_config.GRAM_API_KEY}"
+			headers = map[string]string{"Authorization": "Bearer ${user_config.GRAM_API_KEY}"}
 		}
 
-		mcpServers[s.DisplayName] = claudeMCPEntry{
-			HTTP:  &claudeMCPServer{Type: "http", URL: s.MCPURL, Headers: headers},
-			Stdio: nil,
+		mcpServers[s.DisplayName] = claudeMCPServer{
+			Type:    "http",
+			URL:     s.MCPURL,
+			Headers: headers,
 		}
 	}
 	mcpJSON, err := marshalJSON(claudeMCPConfig{MCPServers: mcpServers})
@@ -1392,31 +1371,26 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 	}
 	files[path.Join(subdir, ".cursor-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]cursorMCPEntry)
+	mcpServers := make(map[string]cursorMCPServer)
 	for _, s := range p.Servers {
+		var headers map[string]string
+
 		if s.IsOAuth {
-			mcpServers[s.DisplayName] = cursorMCPEntry{
-				HTTP:  nil,
-				Stdio: &cursorStdioMCPServer{Command: "npx", Args: []string{"mcp-remote@0.1.25", s.MCPURL}},
-			}
-			continue
-		}
-
-		headers := make(map[string]string)
-
-		if s.IsPublic {
+			// OAuth servers handle identity at the HTTP layer — no Authorization header needed.
+		} else if s.IsPublic {
+			headers = make(map[string]string)
 			for _, ec := range s.EnvConfigs {
 				headers[ec.DisplayName] = "${env:" + ec.VariableName + "}"
 			}
 		} else if cfg.APIKey != "" {
-			headers["Authorization"] = "Bearer " + cfg.APIKey
+			headers = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
 		} else {
-			headers["Authorization"] = "Bearer ${env:GRAM_API_KEY}"
+			headers = map[string]string{"Authorization": "Bearer ${env:GRAM_API_KEY}"}
 		}
 
-		mcpServers[s.DisplayName] = cursorMCPEntry{
-			HTTP:  &cursorMCPServer{URL: s.MCPURL, Headers: headers},
-			Stdio: nil,
+		mcpServers[s.DisplayName] = cursorMCPServer{
+			URL:     s.MCPURL,
+			Headers: headers,
 		}
 	}
 	mcpJSON, err := marshalJSON(cursorMCPConfig{MCPServers: mcpServers})
@@ -1467,60 +1441,13 @@ type userConfigEntry struct {
 }
 
 type claudeMCPConfig struct {
-	MCPServers map[string]claudeMCPEntry `json:"mcpServers"`
-}
-
-// claudeMCPEntry is a discriminated union: exactly one of HTTP or Stdio is non-nil.
-type claudeMCPEntry struct {
-	HTTP  *claudeMCPServer
-	Stdio *claudeStdioMCPServer
-}
-
-func (e claudeMCPEntry) MarshalJSON() ([]byte, error) {
-	if e.Stdio != nil {
-		b, err := json.Marshal(e.Stdio)
-		if err != nil {
-			return nil, fmt.Errorf("marshal claude stdio mcp server: %w", err)
-		}
-		return b, nil
-	}
-	b, err := json.Marshal(e.HTTP)
-	if err != nil {
-		return nil, fmt.Errorf("marshal claude http mcp server: %w", err)
-	}
-	return b, nil
-}
-
-func (e *claudeMCPEntry) UnmarshalJSON(data []byte) error {
-	var probe struct {
-		Command string `json:"command"`
-	}
-	if err := json.Unmarshal(data, &probe); err != nil {
-		return fmt.Errorf("probe claude mcp entry: %w", err)
-	}
-	if probe.Command != "" {
-		e.Stdio = &claudeStdioMCPServer{Command: "", Args: nil}
-		if err := json.Unmarshal(data, e.Stdio); err != nil {
-			return fmt.Errorf("unmarshal claude stdio mcp server: %w", err)
-		}
-		return nil
-	}
-	e.HTTP = &claudeMCPServer{Type: "", URL: "", Headers: nil}
-	if err := json.Unmarshal(data, e.HTTP); err != nil {
-		return fmt.Errorf("unmarshal claude http mcp server: %w", err)
-	}
-	return nil
+	MCPServers map[string]claudeMCPServer `json:"mcpServers"`
 }
 
 type claudeMCPServer struct {
 	Type    string            `json:"type"`
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
-}
-
-type claudeStdioMCPServer struct {
-	Command string   `json:"command"`
-	Args    []string `json:"args"`
 }
 
 type cursorPluginMeta struct {
@@ -1533,59 +1460,12 @@ type cursorPluginMeta struct {
 }
 
 type cursorMCPConfig struct {
-	MCPServers map[string]cursorMCPEntry `json:"mcpServers"`
-}
-
-// cursorMCPEntry is a discriminated union: exactly one of HTTP or Stdio is non-nil.
-type cursorMCPEntry struct {
-	HTTP  *cursorMCPServer
-	Stdio *cursorStdioMCPServer
-}
-
-func (e cursorMCPEntry) MarshalJSON() ([]byte, error) {
-	if e.Stdio != nil {
-		b, err := json.Marshal(e.Stdio)
-		if err != nil {
-			return nil, fmt.Errorf("marshal cursor stdio mcp server: %w", err)
-		}
-		return b, nil
-	}
-	b, err := json.Marshal(e.HTTP)
-	if err != nil {
-		return nil, fmt.Errorf("marshal cursor http mcp server: %w", err)
-	}
-	return b, nil
-}
-
-func (e *cursorMCPEntry) UnmarshalJSON(data []byte) error {
-	var probe struct {
-		Command string `json:"command"`
-	}
-	if err := json.Unmarshal(data, &probe); err != nil {
-		return fmt.Errorf("probe cursor mcp entry: %w", err)
-	}
-	if probe.Command != "" {
-		e.Stdio = &cursorStdioMCPServer{Command: "", Args: nil}
-		if err := json.Unmarshal(data, e.Stdio); err != nil {
-			return fmt.Errorf("unmarshal cursor stdio mcp server: %w", err)
-		}
-		return nil
-	}
-	e.HTTP = &cursorMCPServer{URL: "", Headers: nil}
-	if err := json.Unmarshal(data, e.HTTP); err != nil {
-		return fmt.Errorf("unmarshal cursor http mcp server: %w", err)
-	}
-	return nil
+	MCPServers map[string]cursorMCPServer `json:"mcpServers"`
 }
 
 type cursorMCPServer struct {
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
-}
-
-type cursorStdioMCPServer struct {
-	Command string   `json:"command"`
-	Args    []string `json:"args"`
 }
 
 // Hook config types — Claude uses PascalCase event names + a matcher
@@ -1666,49 +1546,7 @@ type codexInterface struct {
 }
 
 type codexMCPConfig struct {
-	MCPServers map[string]codexMCPEntry `json:"mcpServers"`
-}
-
-// codexMCPEntry is a discriminated union: exactly one of HTTP or Stdio is non-nil.
-type codexMCPEntry struct {
-	HTTP  *codexMCPServer
-	Stdio *codexStdioMCPServer
-}
-
-func (e codexMCPEntry) MarshalJSON() ([]byte, error) {
-	if e.Stdio != nil {
-		b, err := json.Marshal(e.Stdio)
-		if err != nil {
-			return nil, fmt.Errorf("marshal codex stdio mcp server: %w", err)
-		}
-		return b, nil
-	}
-	b, err := json.Marshal(e.HTTP)
-	if err != nil {
-		return nil, fmt.Errorf("marshal codex http mcp server: %w", err)
-	}
-	return b, nil
-}
-
-func (e *codexMCPEntry) UnmarshalJSON(data []byte) error {
-	var probe struct {
-		Command string `json:"command"`
-	}
-	if err := json.Unmarshal(data, &probe); err != nil {
-		return fmt.Errorf("probe codex mcp entry: %w", err)
-	}
-	if probe.Command != "" {
-		e.Stdio = &codexStdioMCPServer{Command: "", Args: nil}
-		if err := json.Unmarshal(data, e.Stdio); err != nil {
-			return fmt.Errorf("unmarshal codex stdio mcp server: %w", err)
-		}
-		return nil
-	}
-	e.HTTP = &codexMCPServer{URL: "", BearerTokenEnvVar: "", HTTPHeaders: nil, EnvHTTPHeaders: nil}
-	if err := json.Unmarshal(data, e.HTTP); err != nil {
-		return fmt.Errorf("unmarshal codex http mcp server: %w", err)
-	}
-	return nil
+	MCPServers map[string]codexMCPServer `json:"mcpServers"`
 }
 
 type codexMCPServer struct {
@@ -1716,11 +1554,6 @@ type codexMCPServer struct {
 	BearerTokenEnvVar string            `json:"bearer_token_env_var,omitempty"`
 	HTTPHeaders       map[string]string `json:"http_headers,omitempty"`
 	EnvHTTPHeaders    map[string]string `json:"env_http_headers,omitempty"`
-}
-
-type codexStdioMCPServer struct {
-	Command string   `json:"command"`
-	Args    []string `json:"args"`
 }
 
 type codexMarketplaceManifest struct {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -86,9 +86,8 @@ func TestGenerateClaudeMCPConfigAlwaysHasAuthHeaders(t *testing.T) {
 	err = json.Unmarshal(files["test/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	for name, entry := range mcpConfig.MCPServers {
-		require.NotNil(t, entry.HTTP, "server %s: expected HTTP entry", name)
-		require.Equal(t, "Bearer ${user_config.GRAM_API_KEY}", entry.HTTP.Headers["Authorization"], "server %s missing auth header", name)
+	for name, server := range mcpConfig.MCPServers {
+		require.Equal(t, "Bearer ${user_config.GRAM_API_KEY}", server.Headers["Authorization"], "server %s missing auth header", name)
 	}
 }
 
@@ -115,9 +114,8 @@ func TestGenerateCursorMCPConfigUsesEnvSyntax(t *testing.T) {
 	err = json.Unmarshal(files["test-cursor/mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	entry := mcpConfig.MCPServers["gram-server"]
-	require.NotNil(t, entry.HTTP, "gram-server: expected HTTP entry")
-	require.Equal(t, "Bearer ${env:GRAM_API_KEY}", entry.HTTP.Headers["Authorization"])
+	server := mcpConfig.MCPServers["gram-server"]
+	require.Equal(t, "Bearer ${env:GRAM_API_KEY}", server.Headers["Authorization"])
 }
 
 func TestGenerateClaudeOAuthServerEmitsStdioEntry(t *testing.T) {
@@ -138,13 +136,13 @@ func TestGenerateClaudeOAuthServerEmitsStdioEntry(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	raw := string(files["test/.mcp.json"])
-	require.Contains(t, raw, `"command"`, "OAuth server should emit stdio command field")
-	require.Contains(t, raw, `"npx"`, "OAuth server should emit npx command")
-	require.Contains(t, raw, `"mcp-remote@0.1.25"`, "OAuth server should pin mcp-remote version")
-	require.Contains(t, raw, `"https://mcp.example.com/oauth-tool"`, "OAuth server should emit MCP URL in args")
-	require.NotContains(t, raw, `"Authorization"`, "OAuth server must not emit Authorization header")
-	require.NotContains(t, raw, `"type"`, "OAuth stdio entry must not have HTTP type field")
+	var mcpConfig claudeMCPConfig
+	err = json.Unmarshal(files["test/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+
+	server := mcpConfig.MCPServers["oauth-server"]
+	require.Equal(t, "https://mcp.example.com/oauth-tool", server.URL)
+	require.Empty(t, server.Headers, "OAuth server must not emit any auth headers")
 
 	// plugin.json must not include a GRAM_API_KEY userConfig entry for OAuth-only plugins.
 	var pluginMeta claudePluginMeta
@@ -153,7 +151,7 @@ func TestGenerateClaudeOAuthServerEmitsStdioEntry(t *testing.T) {
 	require.NotContains(t, pluginMeta.UserConfig, "GRAM_API_KEY", "OAuth-only plugin must not prompt for GRAM_API_KEY")
 }
 
-func TestGenerateCursorOAuthServerEmitsStdioEntry(t *testing.T) {
+func TestGenerateCursorOAuthServerEmitsURLWithNoHeaders(t *testing.T) {
 	t.Parallel()
 	plugins := []PluginInfo{
 		{
@@ -171,15 +169,16 @@ func TestGenerateCursorOAuthServerEmitsStdioEntry(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	raw := string(files["test-cursor/mcp.json"])
-	require.Contains(t, raw, `"command"`, "OAuth server should emit stdio command field")
-	require.Contains(t, raw, `"npx"`, "OAuth server should emit npx command")
-	require.Contains(t, raw, `"mcp-remote@0.1.25"`, "OAuth server should pin mcp-remote version")
-	require.Contains(t, raw, `"https://mcp.example.com/oauth-tool"`, "OAuth server should emit MCP URL in args")
-	require.NotContains(t, raw, `"Authorization"`, "OAuth server must not emit Authorization header")
+	var mcpConfig cursorMCPConfig
+	err = json.Unmarshal(files["test-cursor/mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+
+	server := mcpConfig.MCPServers["oauth-server"]
+	require.Equal(t, "https://mcp.example.com/oauth-tool", server.URL)
+	require.Empty(t, server.Headers, "OAuth server must not emit any auth headers")
 }
 
-func TestGenerateCodexOAuthServerEmitsStdioEntry(t *testing.T) {
+func TestGenerateCodexOAuthServerEmitsURLWithNoCredentials(t *testing.T) {
 	t.Parallel()
 	plugins := []PluginInfo{
 		{
@@ -197,12 +196,14 @@ func TestGenerateCodexOAuthServerEmitsStdioEntry(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	raw := string(files["test-codex/.mcp.json"])
-	require.Contains(t, raw, `"command"`, "Codex OAuth server should emit stdio command field")
-	require.Contains(t, raw, `"npx"`, "Codex OAuth server should emit npx command")
-	require.Contains(t, raw, `"mcp-remote@0.1.25"`, "Codex OAuth server should pin mcp-remote version")
-	require.Contains(t, raw, `"https://mcp.example.com/oauth-tool"`, "Codex OAuth server should emit MCP URL in args")
-	require.NotContains(t, raw, `"bearer_token_env_var"`, "Codex OAuth server must not emit bearer_token_env_var")
+	var mcpConfig codexMCPConfig
+	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+
+	server := mcpConfig.MCPServers["oauth-server"]
+	require.Equal(t, "https://mcp.example.com/oauth-tool", server.URL)
+	require.Empty(t, server.BearerTokenEnvVar, "OAuth server must not set bearer_token_env_var")
+	require.Empty(t, server.HTTPHeaders, "OAuth server must not emit http_headers")
 }
 
 func TestGenerateClaudeMixedOAuthAndHTTPServers(t *testing.T) {
@@ -229,17 +230,14 @@ func TestGenerateClaudeMixedOAuthAndHTTPServers(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, mcpConfig.MCPServers, 2, "both servers should appear in .mcp.json")
 
-	// OAuth server emits stdio shape.
-	oauthEntry := mcpConfig.MCPServers["oauth-server"]
-	require.NotNil(t, oauthEntry.Stdio)
-	require.Nil(t, oauthEntry.HTTP)
-	require.Equal(t, "npx", oauthEntry.Stdio.Command)
+	// OAuth server emits URL with no auth headers.
+	oauthServer := mcpConfig.MCPServers["oauth-server"]
+	require.Empty(t, oauthServer.Headers, "OAuth server must not emit auth headers")
+	require.Equal(t, "https://mcp.example.com/oauth-tool", oauthServer.URL)
 
 	// Private HTTP server retains its Authorization header.
-	privateEntry := mcpConfig.MCPServers["private-server"]
-	require.NotNil(t, privateEntry.HTTP)
-	require.Nil(t, privateEntry.Stdio)
-	require.Contains(t, privateEntry.HTTP.Headers, "Authorization")
+	privateServer := mcpConfig.MCPServers["private-server"]
+	require.Contains(t, privateServer.Headers, "Authorization")
 
 	// plugin.json must still prompt for GRAM_API_KEY because the private HTTP server needs it.
 	var pluginMeta claudePluginMeta
@@ -271,11 +269,10 @@ func TestGenerateCodexMCPConfigUsesBearerTokenEnvVar(t *testing.T) {
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	for name, entry := range mcpConfig.MCPServers {
-		require.NotNil(t, entry.HTTP, "server %s: expected HTTP entry", name)
-		require.Equal(t, "GRAM_API_KEY", entry.HTTP.BearerTokenEnvVar, "server %s missing bearer_token_env_var", name)
-		require.Empty(t, entry.HTTP.HTTPHeaders, "server %s should not bake headers when no APIKey is set", name)
-		require.Empty(t, entry.HTTP.EnvHTTPHeaders, "server %s is private; env_http_headers is for public servers", name)
+	for name, server := range mcpConfig.MCPServers {
+		require.Equal(t, "GRAM_API_KEY", server.BearerTokenEnvVar, "server %s missing bearer_token_env_var", name)
+		require.Empty(t, server.HTTPHeaders, "server %s should not bake headers when no APIKey is set", name)
+		require.Empty(t, server.EnvHTTPHeaders, "server %s is private; env_http_headers is for public servers", name)
 	}
 }
 
@@ -300,10 +297,9 @@ func TestGenerateCodexMCPConfigBakesInjectedAPIKey(t *testing.T) {
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	entry := mcpConfig.MCPServers["gram-server"]
-	require.NotNil(t, entry.HTTP, "gram-server: expected HTTP entry")
-	require.Equal(t, "Bearer gram_test_key_123", entry.HTTP.HTTPHeaders["Authorization"])
-	require.Empty(t, entry.HTTP.BearerTokenEnvVar, "baked-key path must not also set bearer_token_env_var")
+	server := mcpConfig.MCPServers["gram-server"]
+	require.Equal(t, "Bearer gram_test_key_123", server.HTTPHeaders["Authorization"])
+	require.Empty(t, server.BearerTokenEnvVar, "baked-key path must not also set bearer_token_env_var")
 }
 
 func TestGenerateCodexMCPConfigUsesEnvHTTPHeadersForPublicServers(t *testing.T) {
@@ -333,11 +329,10 @@ func TestGenerateCodexMCPConfigUsesEnvHTTPHeadersForPublicServers(t *testing.T) 
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	entry := mcpConfig.MCPServers["public-api"]
-	require.NotNil(t, entry.HTTP, "public-api: expected HTTP entry")
-	require.Equal(t, "OPENAI_API_KEY", entry.HTTP.EnvHTTPHeaders["X-OpenAI-Key"])
-	require.Empty(t, entry.HTTP.BearerTokenEnvVar, "public servers should not set bearer_token_env_var")
-	require.Empty(t, entry.HTTP.HTTPHeaders, "public servers should not bake Authorization")
+	server := mcpConfig.MCPServers["public-api"]
+	require.Equal(t, "OPENAI_API_KEY", server.EnvHTTPHeaders["X-OpenAI-Key"])
+	require.Empty(t, server.BearerTokenEnvVar, "public servers should not set bearer_token_env_var")
+	require.Empty(t, server.HTTPHeaders, "public servers should not bake Authorization")
 }
 
 // TestCodexJSONKeysMatchPinnedSchema asserts the literal JSON key casing in

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -87,7 +87,11 @@ func TestGenerateClaudeMCPConfigAlwaysHasAuthHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	for name, server := range mcpConfig.MCPServers {
-		require.Equal(t, "Bearer ${user_config.GRAM_API_KEY}", server.Headers["Authorization"], "server %s missing auth header", name)
+		serverMap, ok := server.(map[string]any)
+		require.True(t, ok, "server %s: expected map[string]any", name)
+		headers, ok := serverMap["headers"].(map[string]any)
+		require.True(t, ok, "server %s: expected headers map", name)
+		require.Equal(t, "Bearer ${user_config.GRAM_API_KEY}", headers["Authorization"], "server %s missing auth header", name)
 	}
 }
 
@@ -114,8 +118,141 @@ func TestGenerateCursorMCPConfigUsesEnvSyntax(t *testing.T) {
 	err = json.Unmarshal(files["test-cursor/mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	gramServer := mcpConfig.MCPServers["gram-server"]
-	require.Equal(t, "Bearer ${env:GRAM_API_KEY}", gramServer.Headers["Authorization"])
+	gramServerRaw := mcpConfig.MCPServers["gram-server"]
+	gramServer, ok := gramServerRaw.(map[string]any)
+	require.True(t, ok, "gram-server: expected map[string]any")
+	headers, ok := gramServer["headers"].(map[string]any)
+	require.True(t, ok, "gram-server: expected headers map")
+	require.Equal(t, "Bearer ${env:GRAM_API_KEY}", headers["Authorization"])
+}
+
+func TestGenerateClaudeOAuthServerEmitsStdioEntry(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "oauth-server", MCPURL: "https://chat.speakeasy.com/mcp/int-linear", IsOAuth: true},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	raw := string(files["test/.mcp.json"])
+	require.Contains(t, raw, `"command"`, "OAuth server should emit stdio command field")
+	require.Contains(t, raw, `"npx"`, "OAuth server should emit npx command")
+	require.Contains(t, raw, `"mcp-remote@0.1.25"`, "OAuth server should pin mcp-remote version")
+	require.Contains(t, raw, `"https://chat.speakeasy.com/mcp/int-linear"`, "OAuth server should emit MCP URL in args")
+	require.NotContains(t, raw, `"Authorization"`, "OAuth server must not emit Authorization header")
+	require.NotContains(t, raw, `"type"`, "OAuth stdio entry must not have HTTP type field")
+
+	// plugin.json must not include a GRAM_API_KEY userConfig entry for OAuth-only plugins.
+	var pluginMeta claudePluginMeta
+	err = json.Unmarshal(files["test/.claude-plugin/plugin.json"], &pluginMeta)
+	require.NoError(t, err)
+	require.NotContains(t, pluginMeta.UserConfig, "GRAM_API_KEY", "OAuth-only plugin must not prompt for GRAM_API_KEY")
+}
+
+func TestGenerateCursorOAuthServerEmitsStdioEntry(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "oauth-server", MCPURL: "https://chat.speakeasy.com/mcp/int-linear", IsOAuth: true},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	raw := string(files["test-cursor/mcp.json"])
+	require.Contains(t, raw, `"command"`, "OAuth server should emit stdio command field")
+	require.Contains(t, raw, `"npx"`, "OAuth server should emit npx command")
+	require.Contains(t, raw, `"mcp-remote@0.1.25"`, "OAuth server should pin mcp-remote version")
+	require.Contains(t, raw, `"https://chat.speakeasy.com/mcp/int-linear"`, "OAuth server should emit MCP URL in args")
+	require.NotContains(t, raw, `"Authorization"`, "OAuth server must not emit Authorization header")
+}
+
+func TestGenerateCodexOAuthServerIsSkipped(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "oauth-server", MCPURL: "https://chat.speakeasy.com/mcp/int-linear", IsOAuth: true},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	var mcpConfig codexMCPConfig
+	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+	require.Empty(t, mcpConfig.MCPServers, "Codex must skip OAuth servers until stdio support is added")
+}
+
+func TestGenerateClaudeMixedOAuthAndHTTPServers(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "oauth-server", MCPURL: "https://chat.speakeasy.com/mcp/int-linear", IsOAuth: true},
+				{DisplayName: "private-server", MCPURL: "https://app.getgram.ai/mcp/private"},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	var mcpConfig claudeMCPConfig
+	err = json.Unmarshal(files["test/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+	require.Len(t, mcpConfig.MCPServers, 2, "both servers should appear in .mcp.json")
+
+	// OAuth server emits stdio shape.
+	oauthRaw := mcpConfig.MCPServers["oauth-server"]
+	oauthMap, ok := oauthRaw.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "npx", oauthMap["command"])
+	require.NotContains(t, oauthMap, "headers")
+
+	// Private HTTP server retains its Authorization header.
+	privateRaw := mcpConfig.MCPServers["private-server"]
+	privateMap, ok := privateRaw.(map[string]any)
+	require.True(t, ok)
+	headers, ok := privateMap["headers"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, headers, "Authorization")
+
+	// plugin.json must still prompt for GRAM_API_KEY because the private HTTP server needs it.
+	var pluginMeta claudePluginMeta
+	err = json.Unmarshal(files["test/.claude-plugin/plugin.json"], &pluginMeta)
+	require.NoError(t, err)
+	require.Contains(t, pluginMeta.UserConfig, "GRAM_API_KEY")
 }
 
 func TestGenerateCodexMCPConfigUsesBearerTokenEnvVar(t *testing.T) {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -133,7 +133,7 @@ func TestGenerateClaudeOAuthServerEmitsStdioEntry(t *testing.T) {
 			Name: "Test",
 			Slug: "test",
 			Servers: []PluginServerInfo{
-				{DisplayName: "oauth-server", MCPURL: "https://chat.speakeasy.com/mcp/int-linear", IsOAuth: true},
+				{DisplayName: "oauth-server", MCPURL: "https://mcp.example.com/oauth-tool", IsOAuth: true},
 			},
 		},
 	}
@@ -148,7 +148,7 @@ func TestGenerateClaudeOAuthServerEmitsStdioEntry(t *testing.T) {
 	require.Contains(t, raw, `"command"`, "OAuth server should emit stdio command field")
 	require.Contains(t, raw, `"npx"`, "OAuth server should emit npx command")
 	require.Contains(t, raw, `"mcp-remote@0.1.25"`, "OAuth server should pin mcp-remote version")
-	require.Contains(t, raw, `"https://chat.speakeasy.com/mcp/int-linear"`, "OAuth server should emit MCP URL in args")
+	require.Contains(t, raw, `"https://mcp.example.com/oauth-tool"`, "OAuth server should emit MCP URL in args")
 	require.NotContains(t, raw, `"Authorization"`, "OAuth server must not emit Authorization header")
 	require.NotContains(t, raw, `"type"`, "OAuth stdio entry must not have HTTP type field")
 
@@ -166,7 +166,7 @@ func TestGenerateCursorOAuthServerEmitsStdioEntry(t *testing.T) {
 			Name: "Test",
 			Slug: "test",
 			Servers: []PluginServerInfo{
-				{DisplayName: "oauth-server", MCPURL: "https://chat.speakeasy.com/mcp/int-linear", IsOAuth: true},
+				{DisplayName: "oauth-server", MCPURL: "https://mcp.example.com/oauth-tool", IsOAuth: true},
 			},
 		},
 	}
@@ -181,18 +181,18 @@ func TestGenerateCursorOAuthServerEmitsStdioEntry(t *testing.T) {
 	require.Contains(t, raw, `"command"`, "OAuth server should emit stdio command field")
 	require.Contains(t, raw, `"npx"`, "OAuth server should emit npx command")
 	require.Contains(t, raw, `"mcp-remote@0.1.25"`, "OAuth server should pin mcp-remote version")
-	require.Contains(t, raw, `"https://chat.speakeasy.com/mcp/int-linear"`, "OAuth server should emit MCP URL in args")
+	require.Contains(t, raw, `"https://mcp.example.com/oauth-tool"`, "OAuth server should emit MCP URL in args")
 	require.NotContains(t, raw, `"Authorization"`, "OAuth server must not emit Authorization header")
 }
 
-func TestGenerateCodexOAuthServerIsSkipped(t *testing.T) {
+func TestGenerateCodexOAuthServerEmitsStdioEntry(t *testing.T) {
 	t.Parallel()
 	plugins := []PluginInfo{
 		{
 			Name: "Test",
 			Slug: "test",
 			Servers: []PluginServerInfo{
-				{DisplayName: "oauth-server", MCPURL: "https://chat.speakeasy.com/mcp/int-linear", IsOAuth: true},
+				{DisplayName: "oauth-server", MCPURL: "https://mcp.example.com/oauth-tool", IsOAuth: true},
 			},
 		},
 	}
@@ -203,10 +203,12 @@ func TestGenerateCodexOAuthServerIsSkipped(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var mcpConfig codexMCPConfig
-	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
-	require.NoError(t, err)
-	require.Empty(t, mcpConfig.MCPServers, "Codex must skip OAuth servers until stdio support is added")
+	raw := string(files["test-codex/.mcp.json"])
+	require.Contains(t, raw, `"command"`, "Codex OAuth server should emit stdio command field")
+	require.Contains(t, raw, `"npx"`, "Codex OAuth server should emit npx command")
+	require.Contains(t, raw, `"mcp-remote@0.1.25"`, "Codex OAuth server should pin mcp-remote version")
+	require.Contains(t, raw, `"https://mcp.example.com/oauth-tool"`, "Codex OAuth server should emit MCP URL in args")
+	require.NotContains(t, raw, `"bearer_token_env_var"`, "Codex OAuth server must not emit bearer_token_env_var")
 }
 
 func TestGenerateClaudeMixedOAuthAndHTTPServers(t *testing.T) {
@@ -216,7 +218,7 @@ func TestGenerateClaudeMixedOAuthAndHTTPServers(t *testing.T) {
 			Name: "Test",
 			Slug: "test",
 			Servers: []PluginServerInfo{
-				{DisplayName: "oauth-server", MCPURL: "https://chat.speakeasy.com/mcp/int-linear", IsOAuth: true},
+				{DisplayName: "oauth-server", MCPURL: "https://mcp.example.com/oauth-tool", IsOAuth: true},
 				{DisplayName: "private-server", MCPURL: "https://app.getgram.ai/mcp/private"},
 			},
 		},
@@ -278,10 +280,12 @@ func TestGenerateCodexMCPConfigUsesBearerTokenEnvVar(t *testing.T) {
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	for name, server := range mcpConfig.MCPServers {
-		require.Equal(t, "GRAM_API_KEY", server.BearerTokenEnvVar, "server %s missing bearer_token_env_var", name)
-		require.Empty(t, server.HTTPHeaders, "server %s should not bake headers when no APIKey is set", name)
-		require.Empty(t, server.EnvHTTPHeaders, "server %s is private; env_http_headers is for public servers", name)
+	for name, serverRaw := range mcpConfig.MCPServers {
+		serverMap, ok := serverRaw.(map[string]any)
+		require.True(t, ok, "server %s: expected map[string]any", name)
+		require.Equal(t, "GRAM_API_KEY", serverMap["bearer_token_env_var"], "server %s missing bearer_token_env_var", name)
+		require.Nil(t, serverMap["http_headers"], "server %s should not bake headers when no APIKey is set", name)
+		require.Nil(t, serverMap["env_http_headers"], "server %s is private; env_http_headers is for public servers", name)
 	}
 }
 
@@ -306,9 +310,13 @@ func TestGenerateCodexMCPConfigBakesInjectedAPIKey(t *testing.T) {
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	server := mcpConfig.MCPServers["gram-server"]
-	require.Equal(t, "Bearer gram_test_key_123", server.HTTPHeaders["Authorization"])
-	require.Empty(t, server.BearerTokenEnvVar, "baked-key path must not also set bearer_token_env_var")
+	serverRaw := mcpConfig.MCPServers["gram-server"]
+	server, ok := serverRaw.(map[string]any)
+	require.True(t, ok, "gram-server: expected map[string]any")
+	httpHeaders, ok := server["http_headers"].(map[string]any)
+	require.True(t, ok, "gram-server: expected http_headers map")
+	require.Equal(t, "Bearer gram_test_key_123", httpHeaders["Authorization"])
+	require.Nil(t, server["bearer_token_env_var"], "baked-key path must not also set bearer_token_env_var")
 }
 
 func TestGenerateCodexMCPConfigUsesEnvHTTPHeadersForPublicServers(t *testing.T) {
@@ -338,10 +346,14 @@ func TestGenerateCodexMCPConfigUsesEnvHTTPHeadersForPublicServers(t *testing.T) 
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	server := mcpConfig.MCPServers["public-api"]
-	require.Equal(t, "OPENAI_API_KEY", server.EnvHTTPHeaders["X-OpenAI-Key"])
-	require.Empty(t, server.BearerTokenEnvVar, "public servers should not set bearer_token_env_var")
-	require.Empty(t, server.HTTPHeaders, "public servers should not bake Authorization")
+	serverRaw := mcpConfig.MCPServers["public-api"]
+	server, ok := serverRaw.(map[string]any)
+	require.True(t, ok, "public-api: expected map[string]any")
+	envHTTPHeaders, ok := server["env_http_headers"].(map[string]any)
+	require.True(t, ok, "public-api: expected env_http_headers map")
+	require.Equal(t, "OPENAI_API_KEY", envHTTPHeaders["X-OpenAI-Key"])
+	require.Nil(t, server["bearer_token_env_var"], "public servers should not set bearer_token_env_var")
+	require.Nil(t, server["http_headers"], "public servers should not bake Authorization")
 }
 
 // TestCodexJSONKeysMatchPinnedSchema asserts the literal JSON key casing in

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -86,12 +86,9 @@ func TestGenerateClaudeMCPConfigAlwaysHasAuthHeaders(t *testing.T) {
 	err = json.Unmarshal(files["test/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	for name, server := range mcpConfig.MCPServers {
-		serverMap, ok := server.(map[string]any)
-		require.True(t, ok, "server %s: expected map[string]any", name)
-		headers, ok := serverMap["headers"].(map[string]any)
-		require.True(t, ok, "server %s: expected headers map", name)
-		require.Equal(t, "Bearer ${user_config.GRAM_API_KEY}", headers["Authorization"], "server %s missing auth header", name)
+	for name, entry := range mcpConfig.MCPServers {
+		require.NotNil(t, entry.HTTP, "server %s: expected HTTP entry", name)
+		require.Equal(t, "Bearer ${user_config.GRAM_API_KEY}", entry.HTTP.Headers["Authorization"], "server %s missing auth header", name)
 	}
 }
 
@@ -118,12 +115,9 @@ func TestGenerateCursorMCPConfigUsesEnvSyntax(t *testing.T) {
 	err = json.Unmarshal(files["test-cursor/mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	gramServerRaw := mcpConfig.MCPServers["gram-server"]
-	gramServer, ok := gramServerRaw.(map[string]any)
-	require.True(t, ok, "gram-server: expected map[string]any")
-	headers, ok := gramServer["headers"].(map[string]any)
-	require.True(t, ok, "gram-server: expected headers map")
-	require.Equal(t, "Bearer ${env:GRAM_API_KEY}", headers["Authorization"])
+	entry := mcpConfig.MCPServers["gram-server"]
+	require.NotNil(t, entry.HTTP, "gram-server: expected HTTP entry")
+	require.Equal(t, "Bearer ${env:GRAM_API_KEY}", entry.HTTP.Headers["Authorization"])
 }
 
 func TestGenerateClaudeOAuthServerEmitsStdioEntry(t *testing.T) {
@@ -236,19 +230,16 @@ func TestGenerateClaudeMixedOAuthAndHTTPServers(t *testing.T) {
 	require.Len(t, mcpConfig.MCPServers, 2, "both servers should appear in .mcp.json")
 
 	// OAuth server emits stdio shape.
-	oauthRaw := mcpConfig.MCPServers["oauth-server"]
-	oauthMap, ok := oauthRaw.(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, "npx", oauthMap["command"])
-	require.NotContains(t, oauthMap, "headers")
+	oauthEntry := mcpConfig.MCPServers["oauth-server"]
+	require.NotNil(t, oauthEntry.Stdio)
+	require.Nil(t, oauthEntry.HTTP)
+	require.Equal(t, "npx", oauthEntry.Stdio.Command)
 
 	// Private HTTP server retains its Authorization header.
-	privateRaw := mcpConfig.MCPServers["private-server"]
-	privateMap, ok := privateRaw.(map[string]any)
-	require.True(t, ok)
-	headers, ok := privateMap["headers"].(map[string]any)
-	require.True(t, ok)
-	require.Contains(t, headers, "Authorization")
+	privateEntry := mcpConfig.MCPServers["private-server"]
+	require.NotNil(t, privateEntry.HTTP)
+	require.Nil(t, privateEntry.Stdio)
+	require.Contains(t, privateEntry.HTTP.Headers, "Authorization")
 
 	// plugin.json must still prompt for GRAM_API_KEY because the private HTTP server needs it.
 	var pluginMeta claudePluginMeta
@@ -280,12 +271,11 @@ func TestGenerateCodexMCPConfigUsesBearerTokenEnvVar(t *testing.T) {
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	for name, serverRaw := range mcpConfig.MCPServers {
-		serverMap, ok := serverRaw.(map[string]any)
-		require.True(t, ok, "server %s: expected map[string]any", name)
-		require.Equal(t, "GRAM_API_KEY", serverMap["bearer_token_env_var"], "server %s missing bearer_token_env_var", name)
-		require.Nil(t, serverMap["http_headers"], "server %s should not bake headers when no APIKey is set", name)
-		require.Nil(t, serverMap["env_http_headers"], "server %s is private; env_http_headers is for public servers", name)
+	for name, entry := range mcpConfig.MCPServers {
+		require.NotNil(t, entry.HTTP, "server %s: expected HTTP entry", name)
+		require.Equal(t, "GRAM_API_KEY", entry.HTTP.BearerTokenEnvVar, "server %s missing bearer_token_env_var", name)
+		require.Empty(t, entry.HTTP.HTTPHeaders, "server %s should not bake headers when no APIKey is set", name)
+		require.Empty(t, entry.HTTP.EnvHTTPHeaders, "server %s is private; env_http_headers is for public servers", name)
 	}
 }
 
@@ -310,13 +300,10 @@ func TestGenerateCodexMCPConfigBakesInjectedAPIKey(t *testing.T) {
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	serverRaw := mcpConfig.MCPServers["gram-server"]
-	server, ok := serverRaw.(map[string]any)
-	require.True(t, ok, "gram-server: expected map[string]any")
-	httpHeaders, ok := server["http_headers"].(map[string]any)
-	require.True(t, ok, "gram-server: expected http_headers map")
-	require.Equal(t, "Bearer gram_test_key_123", httpHeaders["Authorization"])
-	require.Nil(t, server["bearer_token_env_var"], "baked-key path must not also set bearer_token_env_var")
+	entry := mcpConfig.MCPServers["gram-server"]
+	require.NotNil(t, entry.HTTP, "gram-server: expected HTTP entry")
+	require.Equal(t, "Bearer gram_test_key_123", entry.HTTP.HTTPHeaders["Authorization"])
+	require.Empty(t, entry.HTTP.BearerTokenEnvVar, "baked-key path must not also set bearer_token_env_var")
 }
 
 func TestGenerateCodexMCPConfigUsesEnvHTTPHeadersForPublicServers(t *testing.T) {
@@ -346,14 +333,11 @@ func TestGenerateCodexMCPConfigUsesEnvHTTPHeadersForPublicServers(t *testing.T) 
 	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
-	serverRaw := mcpConfig.MCPServers["public-api"]
-	server, ok := serverRaw.(map[string]any)
-	require.True(t, ok, "public-api: expected map[string]any")
-	envHTTPHeaders, ok := server["env_http_headers"].(map[string]any)
-	require.True(t, ok, "public-api: expected env_http_headers map")
-	require.Equal(t, "OPENAI_API_KEY", envHTTPHeaders["X-OpenAI-Key"])
-	require.Nil(t, server["bearer_token_env_var"], "public servers should not set bearer_token_env_var")
-	require.Nil(t, server["http_headers"], "public servers should not bake Authorization")
+	entry := mcpConfig.MCPServers["public-api"]
+	require.NotNil(t, entry.HTTP, "public-api: expected HTTP entry")
+	require.Equal(t, "OPENAI_API_KEY", entry.HTTP.EnvHTTPHeaders["X-OpenAI-Key"])
+	require.Empty(t, entry.HTTP.BearerTokenEnvVar, "public servers should not set bearer_token_env_var")
+	require.Empty(t, entry.HTTP.HTTPHeaders, "public servers should not bake Authorization")
 }
 
 // TestCodexJSONKeysMatchPinnedSchema asserts the literal JSON key casing in

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1351,7 +1351,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				Policy:      r.ServerPolicy,
 				MCPURL:      fmt.Sprintf("%s/mcp/%s", s.serverURL, *mcpSlug),
 				IsPublic:    r.ToolsetIsPublic,
-				IsOAuth:     r.ToolsetIsOauth,
+				IsOAuth:     r.ToolsetIsOauth.Bool,
 				EnvConfigs:  nil,
 			}
 

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1351,7 +1351,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				Policy:      r.ServerPolicy,
 				MCPURL:      fmt.Sprintf("%s/mcp/%s", s.serverURL, *mcpSlug),
 				IsPublic:    r.ToolsetIsPublic,
-				IsOAuth:     r.ToolsetIsOauth.Bool,
+				IsOAuth:     r.ToolsetIsOauth,
 				EnvConfigs:  nil,
 			}
 

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1351,6 +1351,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				Policy:      r.ServerPolicy,
 				MCPURL:      fmt.Sprintf("%s/mcp/%s", s.serverURL, *mcpSlug),
 				IsPublic:    r.ToolsetIsPublic,
+				IsOAuth:     r.ToolsetIsOauth,
 				EnvConfigs:  nil,
 			}
 

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -122,7 +122,7 @@ SELECT
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
   t.mcp_is_public AS toolset_is_public,
-  (t.user_session_issuer_id IS NOT NULL) AS toolset_is_oauth
+  (t.user_session_issuer_id IS NOT NULL)::bool AS toolset_is_oauth
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -122,7 +122,7 @@ SELECT
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
   t.mcp_is_public AS toolset_is_public,
-  (t.external_oauth_server_id IS NOT NULL OR t.oauth_proxy_server_id IS NOT NULL) AS toolset_is_oauth
+  (t.user_session_issuer_id IS NOT NULL) AS toolset_is_oauth
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -121,7 +121,8 @@ SELECT
   ps.sort_order AS server_sort_order,
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
-  t.mcp_is_public AS toolset_is_public
+  t.mcp_is_public AS toolset_is_public,
+  (t.external_oauth_server_id IS NOT NULL OR t.oauth_proxy_server_id IS NOT NULL) AS toolset_is_oauth
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -386,7 +386,7 @@ SELECT
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
   t.mcp_is_public AS toolset_is_public,
-  (t.external_oauth_server_id IS NOT NULL OR t.oauth_proxy_server_id IS NOT NULL) AS toolset_is_oauth
+  (t.user_session_issuer_id IS NOT NULL) AS toolset_is_oauth
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -407,7 +407,7 @@ type ListPluginsWithServersForProjectRow struct {
 	ToolsetID         uuid.UUID
 	ToolsetMcpSlug    pgtype.Text
 	ToolsetIsPublic   bool
-	ToolsetIsOauth    bool
+	ToolsetIsOauth    pgtype.Bool
 }
 
 // Used during plugin generation: returns all active plugin servers joined with

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -407,7 +407,7 @@ type ListPluginsWithServersForProjectRow struct {
 	ToolsetID         uuid.UUID
 	ToolsetMcpSlug    pgtype.Text
 	ToolsetIsPublic   bool
-	ToolsetIsOauth    pgtype.Bool
+	ToolsetIsOauth    bool
 }
 
 // Used during plugin generation: returns all active plugin servers joined with

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -386,7 +386,7 @@ SELECT
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
   t.mcp_is_public AS toolset_is_public,
-  (t.user_session_issuer_id IS NOT NULL) AS toolset_is_oauth
+  (t.user_session_issuer_id IS NOT NULL)::bool AS toolset_is_oauth
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -385,7 +385,8 @@ SELECT
   ps.sort_order AS server_sort_order,
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
-  t.mcp_is_public AS toolset_is_public
+  t.mcp_is_public AS toolset_is_public,
+  (t.external_oauth_server_id IS NOT NULL OR t.oauth_proxy_server_id IS NOT NULL) AS toolset_is_oauth
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
@@ -406,6 +407,7 @@ type ListPluginsWithServersForProjectRow struct {
 	ToolsetID         uuid.UUID
 	ToolsetMcpSlug    pgtype.Text
 	ToolsetIsPublic   bool
+	ToolsetIsOauth    bool
 }
 
 // Used during plugin generation: returns all active plugin servers joined with
@@ -431,6 +433,7 @@ func (q *Queries) ListPluginsWithServersForProject(ctx context.Context, projectI
 			&i.ToolsetID,
 			&i.ToolsetMcpSlug,
 			&i.ToolsetIsPublic,
+			&i.ToolsetIsOauth,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/usersessions/clientregistration.go
+++ b/server/internal/usersessions/clientregistration.go
@@ -158,9 +158,6 @@ func validateRedirectURI(raw string) error {
 		case "javascript", "data", "vbscript", "file", "blob", "view-source":
 			return &OAuthError{Code: "invalid_redirect_uri", Description: fmt.Sprintf("redirect_uri scheme %q is not permitted", scheme)}
 		}
-		if !strings.Contains(scheme, ".") {
-			return &OAuthError{Code: "invalid_redirect_uri", Description: fmt.Sprintf("redirect_uri custom scheme %q must be in reverse-DNS form (RFC 8252 §7.1)", scheme)}
-		}
 		return nil
 	}
 }

--- a/server/internal/usersessions/clientregistration_test.go
+++ b/server/internal/usersessions/clientregistration_test.go
@@ -148,13 +148,13 @@ func TestRegistrationRequest_Validate(t *testing.T) {
 		require.NoError(t, validateAfterDefaults(req))
 	})
 
-	t.Run("rejects single-token custom scheme", func(t *testing.T) {
+	t.Run("accepts single-token custom scheme", func(t *testing.T) {
 		t.Parallel()
 		req := &RegistrationRequest{
 			ClientName:   "named",
 			RedirectURIs: []string{"myapp:/callback"},
 		}
-		assertOAuthError(t, validateAfterDefaults(req), "invalid_redirect_uri", "reverse-DNS")
+		require.NoError(t, validateAfterDefaults(req))
 	})
 
 	t.Run("rejects unsupported grant_type", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Plugin `.mcp.json` generation was silently omitting OAuth toolsets. The fix:

- **Detection**: `ListPluginsWithServersForProject` now marks a toolset as OAuth when `user_session_issuer_id IS NOT NULL`. This is the active OAuth path; the legacy `external_oauth_server_id` and `oauth_proxy_server_id` columns are slated for removal.
- **Output**: OAuth toolsets emit an HTTP server entry with the MCP URL and no `Authorization` header. OAuth handles identity at the HTTP layer, so no credential is needed at plugin-download time. Non-OAuth behavior is unchanged — private servers get a `GRAM_API_KEY` prompt or baked key, public servers get user-provided env vars.
- **Single-token redirect URIs**: `validateRedirectURI` now accepts custom-scheme URIs without requiring reverse-DNS form (e.g. `myapp:/callback`). This removes a server-side restriction that previously required `mcp-remote` as a client-side proxy for OAuth flows.

Resolves [AGE-2639](https://linear.app/speakeasy/issue/AGE-2639/bug-oauth-mcp-servers-are-not-included-in-plugins)

## Test plan

- [ ] `go test ./server/internal/plugins/` passes
- [ ] `mise lint:server` passes
- [ ] Download a plugin for a toolset with `user_session_issuer_id` set — confirm `.mcp.json` contains the MCP URL with no `Authorization` header
- [ ] Download a plugin for a private non-OAuth toolset — confirm `Authorization` header or `GRAM_API_KEY` prompt is still present