### PR TITLE
mig: add tool_variations_group_id to toolsets and mcp_servers

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -951,6 +951,22 @@ CREATE UNIQUE INDEX IF NOT EXISTS remote_sessions_subject_client_issuer_key
 ON remote_sessions (subject_urn, remote_session_client_id, user_session_issuer_id)
 WHERE deleted IS FALSE;
 
+CREATE TABLE IF NOT EXISTS tool_variations_groups (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 40),
+  description TEXT CHECK (description <> '' AND CHAR_LENGTH(description) <= 100),
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT tool_variations_groups_pkey PRIMARY KEY (id),
+  CONSTRAINT tool_variations_groups_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS toolsets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
 
@@ -976,6 +992,11 @@ CREATE TABLE IF NOT EXISTS toolsets (
   -- behaviour is gated only when this is set, so legacy paths stay unchanged.
   user_session_issuer_id uuid,
 
+  -- Optionally enables a variations group for runtime filtering and
+  -- modifications. Otherwise defaults to project global (source-level)
+  -- variations for runtime modifications.
+  tool_variations_group_id uuid,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   deleted_at timestamptz,
@@ -987,6 +1008,7 @@ CREATE TABLE IF NOT EXISTS toolsets (
   CONSTRAINT toolsets_external_oauth_server_id_fkey FOREIGN KEY (external_oauth_server_id) REFERENCES external_oauth_server_metadata (id) ON DELETE SET NULL,
   CONSTRAINT toolsets_oauth_proxy_server_id_fkey FOREIGN KEY (oauth_proxy_server_id) REFERENCES oauth_proxy_servers (id) ON DELETE SET NULL,
   CONSTRAINT toolsets_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE SET NULL,
+  CONSTRAINT toolsets_tool_variations_group_id_fkey FOREIGN KEY (tool_variations_group_id) REFERENCES tool_variations_groups (id) ON DELETE SET NULL,
   CONSTRAINT toolsets_oauth_exclusivity CHECK ((external_oauth_server_id IS NULL) != (oauth_proxy_server_id IS NULL) OR (external_oauth_server_id IS NULL AND oauth_proxy_server_id IS NULL))
 );
 
@@ -1456,22 +1478,6 @@ CREATE TABLE IF NOT EXISTS slack_registrations (
 
   CONSTRAINT slack_registrations_slack_app_id_fkey FOREIGN KEY (slack_app_id) REFERENCES slack_apps (id) ON DELETE CASCADE,
   CONSTRAINT slack_registrations_slack_app_id_slack_account_id_key UNIQUE (slack_app_id, slack_account_id)
-);
-
-CREATE TABLE IF NOT EXISTS tool_variations_groups (
-  id uuid NOT NULL DEFAULT generate_uuidv7(),
-  project_id uuid NOT NULL,
-
-  name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 40),
-  description TEXT CHECK (description <> '' AND CHAR_LENGTH(description) <= 100),
-
-  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  deleted_at timestamptz,
-  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
-
-  CONSTRAINT tool_variations_groups_pkey PRIMARY KEY (id),
-  CONSTRAINT tool_variations_groups_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS project_tool_variations (
@@ -2447,6 +2453,10 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   user_session_issuer_id uuid,
   remote_mcp_server_id uuid,
   toolset_id uuid,
+  -- Optionally enables a variations group for runtime filtering and
+  -- modifications. Otherwise defaults to project global (source-level)
+  -- variations for runtime modifications.
+  tool_variations_group_id uuid,
   visibility TEXT NOT NULL CHECK (visibility <> ''),
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -2460,6 +2470,7 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
+  CONSTRAINT mcp_servers_tool_variations_group_id_fkey FOREIGN KEY (tool_variations_group_id) REFERENCES tool_variations_groups (id) ON DELETE SET NULL,
   -- Exactly one backend must be set: either a remote MCP server or a toolset.
   CONSTRAINT mcp_servers_backend_exclusivity_check CHECK ((remote_mcp_server_id IS NULL) != (toolset_id IS NULL))
 );

--- a/server/internal/collections/repo/models.go
+++ b/server/internal/collections/repo/models.go
@@ -47,6 +47,7 @@ type Toolset struct {
 	ExternalOauthServerID  uuid.NullUUID
 	OauthProxyServerID     uuid.NullUUID
 	UserSessionIssuerID    uuid.NullUUID
+	ToolVariationsGroupID  uuid.NullUUID
 	CreatedAt              pgtype.Timestamptz
 	UpdatedAt              pgtype.Timestamptz
 	DeletedAt              pgtype.Timestamptz

--- a/server/internal/collections/repo/queries.sql.go
+++ b/server/internal/collections/repo/queries.sql.go
@@ -466,7 +466,7 @@ func (q *Queries) IsServerAttachedToOrganizationMcpCollection(ctx context.Contex
 }
 
 const listOrganizationMcpCollectionServerAttachments = `-- name: ListOrganizationMcpCollectionServerAttachments :many
-SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.created_at, t.updated_at, t.deleted_at, t.deleted FROM toolsets t
+SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.tool_variations_group_id, t.created_at, t.updated_at, t.deleted_at, t.deleted FROM toolsets t
 JOIN organization_mcp_collection_server_attachments rt ON t.id = rt.toolset_id
 JOIN organization_mcp_collections c ON c.id = rt.collection_id
 WHERE
@@ -509,6 +509,7 @@ func (q *Queries) ListOrganizationMcpCollectionServerAttachments(ctx context.Con
 			&i.ExternalOauthServerID,
 			&i.OauthProxyServerID,
 			&i.UserSessionIssuerID,
+			&i.ToolVariationsGroupID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -701,19 +701,20 @@ type McpRegistry struct {
 }
 
 type McpServer struct {
-	ID                  uuid.UUID
-	ProjectID           uuid.UUID
-	Name                pgtype.Text
-	Slug                pgtype.Text
-	EnvironmentID       uuid.NullUUID
-	UserSessionIssuerID uuid.NullUUID
-	RemoteMcpServerID   uuid.NullUUID
-	ToolsetID           uuid.NullUUID
-	Visibility          string
-	CreatedAt           pgtype.Timestamptz
-	UpdatedAt           pgtype.Timestamptz
-	DeletedAt           pgtype.Timestamptz
-	Deleted             bool
+	ID                    uuid.UUID
+	ProjectID             uuid.UUID
+	Name                  pgtype.Text
+	Slug                  pgtype.Text
+	EnvironmentID         uuid.NullUUID
+	UserSessionIssuerID   uuid.NullUUID
+	RemoteMcpServerID     uuid.NullUUID
+	ToolsetID             uuid.NullUUID
+	ToolVariationsGroupID uuid.NullUUID
+	Visibility            string
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	DeletedAt             pgtype.Timestamptz
+	Deleted               bool
 }
 
 type OauthProxyClientInfo struct {
@@ -1349,6 +1350,7 @@ type Toolset struct {
 	ExternalOauthServerID  uuid.NullUUID
 	OauthProxyServerID     uuid.NullUUID
 	UserSessionIssuerID    uuid.NullUUID
+	ToolVariationsGroupID  uuid.NullUUID
 	CreatedAt              pgtype.Timestamptz
 	UpdatedAt              pgtype.Timestamptz
 	DeletedAt              pgtype.Timestamptz

--- a/server/internal/mcpservers/repo/models.go
+++ b/server/internal/mcpservers/repo/models.go
@@ -10,17 +10,18 @@ import (
 )
 
 type McpServer struct {
-	ID                  uuid.UUID
-	ProjectID           uuid.UUID
-	Name                pgtype.Text
-	Slug                pgtype.Text
-	EnvironmentID       uuid.NullUUID
-	UserSessionIssuerID uuid.NullUUID
-	RemoteMcpServerID   uuid.NullUUID
-	ToolsetID           uuid.NullUUID
-	Visibility          string
-	CreatedAt           pgtype.Timestamptz
-	UpdatedAt           pgtype.Timestamptz
-	DeletedAt           pgtype.Timestamptz
-	Deleted             bool
+	ID                    uuid.UUID
+	ProjectID             uuid.UUID
+	Name                  pgtype.Text
+	Slug                  pgtype.Text
+	EnvironmentID         uuid.NullUUID
+	UserSessionIssuerID   uuid.NullUUID
+	RemoteMcpServerID     uuid.NullUUID
+	ToolsetID             uuid.NullUUID
+	ToolVariationsGroupID uuid.NullUUID
+	Visibility            string
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	DeletedAt             pgtype.Timestamptz
+	Deleted               bool
 }

--- a/server/internal/mcpservers/repo/queries.sql.go
+++ b/server/internal/mcpservers/repo/queries.sql.go
@@ -35,7 +35,7 @@ VALUES (
     $8,
     $9
 )
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateMCPServerParams struct {
@@ -72,6 +72,7 @@ func (q *Queries) CreateMCPServer(ctx context.Context, arg CreateMCPServerParams
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
+		&i.ToolVariationsGroupID,
 		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -85,7 +86,7 @@ const deleteMCPServer = `-- name: DeleteMCPServer :one
 UPDATE mcp_servers
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteMCPServerParams struct {
@@ -105,6 +106,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
+		&i.ToolVariationsGroupID,
 		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -115,7 +117,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 }
 
 const getMCPServerByID = `-- name: GetMCPServerByID :one
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -137,6 +139,7 @@ func (q *Queries) GetMCPServerByID(ctx context.Context, arg GetMCPServerByIDPara
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
+		&i.ToolVariationsGroupID,
 		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -147,7 +150,7 @@ func (q *Queries) GetMCPServerByID(ctx context.Context, arg GetMCPServerByIDPara
 }
 
 const getMCPServerBySlug = `-- name: GetMCPServerBySlug :one
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE slug = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -169,6 +172,7 @@ func (q *Queries) GetMCPServerBySlug(ctx context.Context, arg GetMCPServerBySlug
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
+		&i.ToolVariationsGroupID,
 		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -179,7 +183,7 @@ func (q *Queries) GetMCPServerBySlug(ctx context.Context, arg GetMCPServerBySlug
 }
 
 const listMCPServersByProjectID = `-- name: ListMCPServersByProjectID :many
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -212,6 +216,7 @@ func (q *Queries) ListMCPServersByProjectID(ctx context.Context, arg ListMCPServ
 			&i.UserSessionIssuerID,
 			&i.RemoteMcpServerID,
 			&i.ToolsetID,
+			&i.ToolVariationsGroupID,
 			&i.Visibility,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -240,7 +245,7 @@ SET
     visibility = $7,
     updated_at = clock_timestamp()
 WHERE id = $8 AND project_id = $9 AND deleted IS FALSE
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateMCPServerParams struct {
@@ -277,6 +282,7 @@ func (q *Queries) UpdateMCPServer(ctx context.Context, arg UpdateMCPServerParams
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
+		&i.ToolVariationsGroupID,
 		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/internal/toolsets/repo/models.go
+++ b/server/internal/toolsets/repo/models.go
@@ -46,6 +46,7 @@ type Toolset struct {
 	ExternalOauthServerID  uuid.NullUUID
 	OauthProxyServerID     uuid.NullUUID
 	UserSessionIssuerID    uuid.NullUUID
+	ToolVariationsGroupID  uuid.NullUUID
 	CreatedAt              pgtype.Timestamptz
 	UpdatedAt              pgtype.Timestamptz
 	DeletedAt              pgtype.Timestamptz

--- a/server/internal/toolsets/repo/queries.sql.go
+++ b/server/internal/toolsets/repo/queries.sql.go
@@ -44,7 +44,7 @@ SET
   , oauth_proxy_server_id = NULL
   , updated_at = clock_timestamp()
 WHERE slug = $1 AND project_id = $2
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type ClearToolsetOAuthServersParams struct {
@@ -71,6 +71,7 @@ func (q *Queries) ClearToolsetOAuthServers(ctx context.Context, arg ClearToolset
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -115,7 +116,7 @@ INSERT INTO toolsets (
   , $7
   , $8
 )
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateToolsetParams struct {
@@ -157,6 +158,7 @@ func (q *Queries) CreateToolset(ctx context.Context, arg CreateToolsetParams) (T
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -530,7 +532,7 @@ func (q *Queries) GetPromptTemplatesForToolset(ctx context.Context, arg GetPromp
 }
 
 const getToolset = `-- name: GetToolset :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE slug = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -559,6 +561,7 @@ func (q *Queries) GetToolset(ctx context.Context, arg GetToolsetParams) (Toolset
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -568,7 +571,7 @@ func (q *Queries) GetToolset(ctx context.Context, arg GetToolsetParams) (Toolset
 }
 
 const getToolsetByIDAndOrganization = `-- name: GetToolsetByIDAndOrganization :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE id = $1 AND organization_id = $2 AND deleted IS FALSE
 `
@@ -597,6 +600,7 @@ func (q *Queries) GetToolsetByIDAndOrganization(ctx context.Context, arg GetTool
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -606,7 +610,7 @@ func (q *Queries) GetToolsetByIDAndOrganization(ctx context.Context, arg GetTool
 }
 
 const getToolsetByIDAndProject = `-- name: GetToolsetByIDAndProject :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -635,6 +639,7 @@ func (q *Queries) GetToolsetByIDAndProject(ctx context.Context, arg GetToolsetBy
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -644,7 +649,7 @@ func (q *Queries) GetToolsetByIDAndProject(ctx context.Context, arg GetToolsetBy
 }
 
 const getToolsetByMCPSlug = `-- name: GetToolsetByMCPSlug :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE mcp_slug = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -674,6 +679,7 @@ func (q *Queries) GetToolsetByMCPSlug(ctx context.Context, arg GetToolsetByMCPSl
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -683,7 +689,7 @@ func (q *Queries) GetToolsetByMCPSlug(ctx context.Context, arg GetToolsetByMCPSl
 }
 
 const getToolsetByMcpSlug = `-- name: GetToolsetByMcpSlug :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE mcp_slug = $1
   AND deleted IS FALSE
@@ -710,6 +716,7 @@ func (q *Queries) GetToolsetByMcpSlug(ctx context.Context, mcpSlug pgtype.Text) 
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -719,7 +726,7 @@ func (q *Queries) GetToolsetByMcpSlug(ctx context.Context, mcpSlug pgtype.Text) 
 }
 
 const getToolsetByMcpSlugAndCustomDomain = `-- name: GetToolsetByMcpSlugAndCustomDomain :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE mcp_slug = $1
   AND custom_domain_id = $2
@@ -750,6 +757,7 @@ func (q *Queries) GetToolsetByMcpSlugAndCustomDomain(ctx context.Context, arg Ge
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -759,7 +767,7 @@ func (q *Queries) GetToolsetByMcpSlugAndCustomDomain(ctx context.Context, arg Ge
 }
 
 const getToolsetByMcpSlugAndProject = `-- name: GetToolsetByMcpSlugAndProject :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE mcp_slug = $1
   AND project_id = $2
@@ -790,6 +798,7 @@ func (q *Queries) GetToolsetByMcpSlugAndProject(ctx context.Context, arg GetTool
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -799,7 +808,7 @@ func (q *Queries) GetToolsetByMcpSlugAndProject(ctx context.Context, arg GetTool
 }
 
 const getToolsetByPlatformMcpSlug = `-- name: GetToolsetByPlatformMcpSlug :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE mcp_slug = $1
   AND custom_domain_id IS NULL
@@ -825,6 +834,7 @@ func (q *Queries) GetToolsetByPlatformMcpSlug(ctx context.Context, mcpSlug pgtyp
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -907,7 +917,7 @@ func (q *Queries) GetToolsetPromptTemplateNames(ctx context.Context, arg GetTool
 
 const getToolsetsByToolURN = `-- name: GetToolsetsByToolURN :many
 SELECT
-    t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.created_at, t.updated_at, t.deleted_at, t.deleted,
+    t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.tool_variations_group_id, t.created_at, t.updated_at, t.deleted_at, t.deleted,
     tv.version as latest_version
 FROM toolsets t
 JOIN toolset_versions tv ON t.id = tv.toolset_id
@@ -944,6 +954,7 @@ type GetToolsetsByToolURNRow struct {
 	ExternalOauthServerID  uuid.NullUUID
 	OauthProxyServerID     uuid.NullUUID
 	UserSessionIssuerID    uuid.NullUUID
+	ToolVariationsGroupID  uuid.NullUUID
 	CreatedAt              pgtype.Timestamptz
 	UpdatedAt              pgtype.Timestamptz
 	DeletedAt              pgtype.Timestamptz
@@ -976,6 +987,7 @@ func (q *Queries) GetToolsetsByToolURN(ctx context.Context, arg GetToolsetsByToo
 			&i.ExternalOauthServerID,
 			&i.OauthProxyServerID,
 			&i.UserSessionIssuerID,
+			&i.ToolVariationsGroupID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -993,7 +1005,7 @@ func (q *Queries) GetToolsetsByToolURN(ctx context.Context, arg GetToolsetsByToo
 }
 
 const listToolsetsByOrganization = `-- name: ListToolsetsByOrganization :many
-SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.created_at, t.updated_at, t.deleted_at, t.deleted
+SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.tool_variations_group_id, t.created_at, t.updated_at, t.deleted_at, t.deleted
 FROM toolsets t
 JOIN projects p ON t.project_id = p.id
 WHERE p.organization_id = $1
@@ -1027,6 +1039,7 @@ func (q *Queries) ListToolsetsByOrganization(ctx context.Context, organizationID
 			&i.ExternalOauthServerID,
 			&i.OauthProxyServerID,
 			&i.UserSessionIssuerID,
+			&i.ToolVariationsGroupID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -1043,7 +1056,7 @@ func (q *Queries) ListToolsetsByOrganization(ctx context.Context, organizationID
 }
 
 const listToolsetsByProject = `-- name: ListToolsetsByProject :many
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -1075,6 +1088,7 @@ func (q *Queries) ListToolsetsByProject(ctx context.Context, projectID uuid.UUID
 			&i.ExternalOauthServerID,
 			&i.OauthProxyServerID,
 			&i.UserSessionIssuerID,
+			&i.ToolVariationsGroupID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -1239,7 +1253,7 @@ SET
   , tool_selection_mode = COALESCE($8, tool_selection_mode)
   , updated_at = clock_timestamp()
 WHERE slug = $9 AND project_id = $10
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetParams struct {
@@ -1285,6 +1299,7 @@ func (q *Queries) UpdateToolset(ctx context.Context, arg UpdateToolsetParams) (T
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -1299,7 +1314,7 @@ SET
     external_oauth_server_id = $1
   , updated_at = clock_timestamp()
 WHERE slug = $2 AND project_id = $3
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetExternalOAuthServerParams struct {
@@ -1327,6 +1342,7 @@ func (q *Queries) UpdateToolsetExternalOAuthServer(ctx context.Context, arg Upda
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -1341,7 +1357,7 @@ SET
     oauth_proxy_server_id = $1
   , updated_at = clock_timestamp()
 WHERE slug = $2 AND project_id = $3
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetOAuthProxyServerParams struct {
@@ -1369,6 +1385,7 @@ func (q *Queries) UpdateToolsetOAuthProxyServer(ctx context.Context, arg UpdateT
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -1383,7 +1400,7 @@ SET
     user_session_issuer_id = $1
   , updated_at = clock_timestamp()
 WHERE slug = $2 AND project_id = $3
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetUserSessionIssuerParams struct {
@@ -1411,6 +1428,7 @@ func (q *Queries) UpdateToolsetUserSessionIssuer(ctx context.Context, arg Update
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
+		&i.ToolVariationsGroupID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql
+++ b/server/migrations/20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql
@@ -1,4 +1,10 @@
+-- atlas:txmode none
+
 -- Modify "mcp_servers" table
-ALTER TABLE "mcp_servers" ADD COLUMN "tool_variations_group_id" uuid NULL, ADD CONSTRAINT "mcp_servers_tool_variations_group_id_fkey" FOREIGN KEY ("tool_variations_group_id") REFERENCES "tool_variations_groups" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+ALTER TABLE "mcp_servers" ADD COLUMN "tool_variations_group_id" uuid NULL;
+ALTER TABLE "mcp_servers" ADD CONSTRAINT "mcp_servers_tool_variations_group_id_fkey" FOREIGN KEY ("tool_variations_group_id") REFERENCES "tool_variations_groups" ("id") ON UPDATE NO ACTION ON DELETE SET NULL NOT VALID;
+ALTER TABLE "mcp_servers" VALIDATE CONSTRAINT "mcp_servers_tool_variations_group_id_fkey";
 -- Modify "toolsets" table
-ALTER TABLE "toolsets" ADD COLUMN "tool_variations_group_id" uuid NULL, ADD CONSTRAINT "toolsets_tool_variations_group_id_fkey" FOREIGN KEY ("tool_variations_group_id") REFERENCES "tool_variations_groups" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+ALTER TABLE "toolsets" ADD COLUMN "tool_variations_group_id" uuid NULL;
+ALTER TABLE "toolsets" ADD CONSTRAINT "toolsets_tool_variations_group_id_fkey" FOREIGN KEY ("tool_variations_group_id") REFERENCES "tool_variations_groups" ("id") ON UPDATE NO ACTION ON DELETE SET NULL NOT VALID;
+ALTER TABLE "toolsets" VALIDATE CONSTRAINT "toolsets_tool_variations_group_id_fkey";

--- a/server/migrations/20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql
+++ b/server/migrations/20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql
@@ -1,0 +1,4 @@
+-- Modify "mcp_servers" table
+ALTER TABLE "mcp_servers" ADD COLUMN "tool_variations_group_id" uuid NULL, ADD CONSTRAINT "mcp_servers_tool_variations_group_id_fkey" FOREIGN KEY ("tool_variations_group_id") REFERENCES "tool_variations_groups" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+-- Modify "toolsets" table
+ALTER TABLE "toolsets" ADD COLUMN "tool_variations_group_id" uuid NULL, ADD CONSTRAINT "toolsets_tool_variations_group_id_fkey" FOREIGN KEY ("tool_variations_group_id") REFERENCES "tool_variations_groups" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Yt8QrOWtqTNjPBVIah921ZzpxojZ8TXCJYTfloaDRHc=
+h1:X3ZE0b8GIpWVdJtPul3uv3rClSaHEfux4KHszgufECI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -201,3 +201,4 @@ h1:Yt8QrOWtqTNjPBVIah921ZzpxojZ8TXCJYTfloaDRHc=
 20260601092138_risk-policies-add-audience-type.sql h1:M1gvNAwdWQAX6bIyEhF7VnLvIltOPdob+093qPfiM+A=
 20260601212536_plugin-github-connections-add-published-fingerprint.sql h1:eYANo4SQbbKipX/n3geIZ4qZ2yT8RV3lw/PAn0YoPA8=
 20260602103955_age-2631-project-managed-assistants.sql h1:WTzRGPg815dtWcPpBbkJlWNyu2PRdArmtjbX0UDKySI=
+20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql h1:1pJ/WNykvGMc3fuGSS+ZbzNDefXJmEiL2L6KZk2iAeQ=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:X3ZE0b8GIpWVdJtPul3uv3rClSaHEfux4KHszgufECI=
+h1:Y5mZCoDhBzu57Z1rGoALSvDirgQsSkzrnW3JUgUcxNA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -201,4 +201,4 @@ h1:X3ZE0b8GIpWVdJtPul3uv3rClSaHEfux4KHszgufECI=
 20260601092138_risk-policies-add-audience-type.sql h1:M1gvNAwdWQAX6bIyEhF7VnLvIltOPdob+093qPfiM+A=
 20260601212536_plugin-github-connections-add-published-fingerprint.sql h1:eYANo4SQbbKipX/n3geIZ4qZ2yT8RV3lw/PAn0YoPA8=
 20260602103955_age-2631-project-managed-assistants.sql h1:WTzRGPg815dtWcPpBbkJlWNyu2PRdArmtjbX0UDKySI=
-20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql h1:1pJ/WNykvGMc3fuGSS+ZbzNDefXJmEiL2L6KZk2iAeQ=
+20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql h1:evD/ljifFim1YzJ59/guBM+buZD8hMlxSKNmtLkMXg8=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2357/database-migration-for-mcp-server-filtering-configuration

Migration-only change adding the schema columns and foreign keys required to enable per-toolset and per-mcp-server variations group selection. Adds a nullable `tool_variations_group_id uuid` column to both `toolsets` and `mcp_servers`, each with an `ON DELETE SET NULL` foreign key to `tool_variations_groups`. Existing rows default to `NULL`, so there is no behavior change on its own. No application code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add database support for selecting a tool variations group on `toolsets` and `mcp_servers` to enable filtering configuration (Linear AGE-2357). No behavior changes.

- **Migration**
  - Add nullable `tool_variations_group_id uuid` to `toolsets` and `mcp_servers` with FKs to `tool_variations_groups` (ON DELETE SET NULL).
  - Apply FKs as NOT VALID and validate separately under `-- atlas:txmode none` to avoid blocking locks; `atlas.sum` updated.
  - Existing rows stay `NULL`; no backfill.

- **Refactors**
  - Update generated models and queries for `toolsets` and `mcp_servers` to include `tool_variations_group_id`.

<sup>Written for commit 1cdbc06574a9251f8a59f39f35c59f9581869dce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

