### PR TITLE
fix: resolve /mcp/<slug> OAuth flow handlers via mcp_endpoints with toolset fallback

### DIFF
--- a/.changeset/age-2640-mcp-oauth-flow-endpoints.md
+++ b/.changeset/age-2640-mcp-oauth-flow-endpoints.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+resolve /mcp/<slug> OAuth flow handlers via mcp_endpoints with toolset fallback

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -45,7 +45,8 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	if mcpSlug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
 	}
-	endpoint, err := s.loadResolvedMcpEndpointByToolsetSlug(ctx, mcpSlug)
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
 	if err != nil {
 		return err
 	}

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -92,7 +93,8 @@ func (s *Service) HandleConsent(w http.ResponseWriter, r *http.Request) error {
 	if mcpSlug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
 	}
-	endpoint, err := s.loadResolvedMcpEndpointByToolsetSlug(ctx, mcpSlug)
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
 	if err != nil {
 		return err
 	}

--- a/server/internal/mcp/authnchallenge_register.go
+++ b/server/internal/mcp/authnchallenge_register.go
@@ -61,7 +61,8 @@ func (s *Service) HandleRegister(w http.ResponseWriter, r *http.Request) error {
 	if mcpSlug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
 	}
-	endpoint, err := s.loadResolvedMcpEndpointByToolsetSlug(ctx, mcpSlug)
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
 	if err != nil {
 		return err
 	}

--- a/server/internal/mcp/authnchallenge_revoke.go
+++ b/server/internal/mcp/authnchallenge_revoke.go
@@ -30,7 +30,8 @@ func (s *Service) HandleRevoke(w http.ResponseWriter, r *http.Request) error {
 	if mcpSlug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
 	}
-	endpoint, err := s.loadResolvedMcpEndpointByToolsetSlug(ctx, mcpSlug)
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
 	if err != nil {
 		return err
 	}

--- a/server/internal/mcp/authnchallenge_test.go
+++ b/server/internal/mcp/authnchallenge_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
@@ -802,4 +803,115 @@ func TestHandleIDPCallback_ExchangeFailure_ReturnsUnauthorized(t *testing.T) {
 	err = ti.service.HandleIDPCallback(w, req)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to exchange IDP code")
+}
+
+// dcrPublicClientBody is a minimal RFC 7591 registration request for a
+// public (PKCE-only) client — enough to pass RegistrationRequest.Validate
+// so the test reaches the resolution path under test.
+const dcrPublicClientBody = `{"client_name":"age-2640 test","redirect_uris":["http://localhost:3000/callback"],"token_endpoint_auth_method":"none"}`
+
+// newRegisterRequest builds a POST /mcp/{slug}/register request carrying a
+// JSON DCR body and the chi mcpSlug route param. The handler call is left to
+// each test so resolution errors surface in the test function itself.
+func newRegisterRequest(t *testing.T, slug, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+slug+"/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", slug)
+	return req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+}
+
+// TestHandleRegister_RemoteBackedIssuerGated_ResolvesViaEndpoints is the
+// direct AGE-2640 repro: a remote-backed, issuer-gated mcp_server has no
+// toolsets row, so the legacy toolset-only resolver 404'd at DCR. It must
+// now resolve via mcp_endpoints → mcp_servers and complete registration.
+//
+// HandleRegister is the representative OAuth flow handler here: register,
+// authorize, consent, token, and revoke all share the same
+// LoadResolvedMcpEndpointBySlug resolution path.
+func TestHandleRegister_RemoteBackedIssuerGated_ResolvesViaEndpoints(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	slug := "remote-register-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", slug, "public", issuerID)
+
+	w := httptest.NewRecorder()
+	err := ti.service.HandleRegister(w, newRegisterRequest(t, slug, dcrPublicClientBody))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp["client_id"])
+}
+
+// TestHandleRegister_RemoteBackedNotIssuerGated_ReturnsNotFound confirms a
+// remote-backed mcp_server that is NOT issuer-gated stays a 404 on the OAuth
+// flow surface: it is authoritative for the slug and never falls back to the
+// toolset lookup (parity with the well-known behaviour from AGE-2624).
+func TestHandleRegister_RemoteBackedNotIssuerGated_ReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "remote-noissuer-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", slug, "public", uuid.Nil)
+
+	w := httptest.NewRecorder()
+	err := ti.service.HandleRegister(w, newRegisterRequest(t, slug, dcrPublicClientBody))
+	require.Error(t, err)
+	require.Empty(t, w.Body.String())
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+}
+
+// TestHandleRegister_LegacyToolsetSlug_ResolvesViaFallback is the regression
+// guard for issuer-gated toolset-backed servers that predate the toolsets →
+// mcp_servers migration: they have no mcp_endpoint row, so the addressing
+// lookup misses and resolution must fall back to toolsets.mcp_slug.
+func TestHandleRegister_LegacyToolsetSlug_ResolvesViaFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, _, _ := seedPrivateToolsetWithIssuer(t, ctx, ti)
+
+	w := httptest.NewRecorder()
+	err := ti.service.HandleRegister(w, newRegisterRequest(t, toolset.McpSlug.String, dcrPublicClientBody))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp["client_id"])
+}
+
+// TestHandleRegister_UnknownSlug_ReturnsNotFound confirms a slug matching
+// neither an mcp_endpoint nor a toolset still 404s after the addressing miss
+// falls through the toolset fallback.
+func TestHandleRegister_UnknownSlug_ReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestMCPService(t)
+	slug := "definitely-missing-" + uuid.NewString()[:8]
+
+	w := httptest.NewRecorder()
+	err := ti.service.HandleRegister(w, newRegisterRequest(t, slug, dcrPublicClientBody))
+	require.Error(t, err)
+	require.Empty(t, w.Body.String())
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 }

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -55,7 +55,8 @@ func (s *Service) HandleToken(w http.ResponseWriter, r *http.Request) error {
 	if mcpSlug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
 	}
-	endpoint, err := s.loadResolvedMcpEndpointByToolsetSlug(ctx, mcpSlug)
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
 	if err != nil {
 		return err
 	}

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -355,14 +355,15 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 }
 
 // loadResolvedMcpEndpointByToolsetSlug resolves an mcp_slug to a
-// ResolvedMcpEndpoint via the toolsets path and verifies its issuer FK
-// is still live. Returns CodeNotFound when either no toolset matches
-// the slug or the toolset is not issuer-gated. Used by the six
-// /mcp/{slug} OAuth handlers (Register, Authorize, Consent, Token,
-// Revoke); the well-known handlers keep their own toolset load so they
-// can fall through to the legacy non-issuer-gated metadata response
-// when user_session_issuer_id is unset.
-func (s *Service) loadResolvedMcpEndpointByToolsetSlug(ctx context.Context, mcpSlug string) (*ResolvedMcpEndpoint, error) {
+// ResolvedMcpEndpoint via the legacy toolsets path and verifies its
+// issuer FK is still live. Returns CodeNotFound when either no toolset
+// matches the slug or the toolset is not issuer-gated. routeBase ("mcp"
+// or "x/mcp") is the surface the request arrived under and propagates
+// into the resolved endpoint's URL building. Used as the fallback leaf
+// of LoadResolvedMcpEndpointBySlug for slugs with no mcp_endpoint →
+// mcp_server row yet (issuer-gated toolset-backed servers predating the
+// toolsets → mcp_servers migration).
+func (s *Service) loadResolvedMcpEndpointByToolsetSlug(ctx context.Context, mcpSlug, routeBase string) (*ResolvedMcpEndpoint, error) {
 	var customDomainID uuid.NullUUID
 	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
 		customDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
@@ -377,7 +378,7 @@ func (s *Service) loadResolvedMcpEndpointByToolsetSlug(ctx context.Context, mcpS
 	if !toolset.UserSessionIssuerID.Valid {
 		return nil, oops.E(oops.CodeNotFound, nil, "not found")
 	}
-	endpoint := newResolvedMcpEndpointFromToolset(toolset, "mcp")
+	endpoint := newResolvedMcpEndpointFromToolset(toolset, routeBase)
 	if err := s.RequireUserSessionIssuer(ctx, endpoint); err != nil {
 		return nil, err
 	}

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -165,23 +165,37 @@ func (s *Service) ResolveMCPEndpointAndServer(ctx context.Context, logger *slog.
 	return &endpoint, &mcpServer, nil
 }
 
-// LoadResolvedMcpEndpointBySlug resolves a slug all the way to a
-// *ResolvedMcpEndpoint via the mcp_endpoints → mcp_servers path,
-// verifying its issuer FK is still live. Used by the OAuth route adapters
-// in /x/mcp (and eventually /mcp) that need to dispatch to Serve*
-// post-resolution handlers. Returns CodeNotFound when either the
-// addressing resolves to no row or the resolved mcp_server is not
-// issuer-gated. mcpRouteBase ("mcp" or "x/mcp") propagates into the
-// resolved endpoint's URL building.
+// LoadResolvedMcpEndpointBySlug resolves a slug to a *ResolvedMcpEndpoint
+// for the issuer-gated OAuth handlers, shared by both the /mcp and /x/mcp
+// surfaces. It mirrors the well-known handlers' resolution model:
+//
+//   - Addressing hit, issuer-gated: build the endpoint from the
+//     (mcp_endpoint, mcp_server) pair.
+//   - Addressing hit, not issuer-gated: CodeNotFound. The mcp_server is
+//     authoritative for the slug and is not an OAuth endpoint, so we do
+//     NOT fall back — this keeps non-issuer-gated remote-backed servers
+//     returning not-found, matching the well-known surface.
+//   - Addressing miss (CodeNotFound): fall back to the legacy
+//     toolsets.mcp_slug lookup so issuer-gated toolset-backed servers
+//     without an mcp_endpoint row (predating the toolsets → mcp_servers
+//     migration) still resolve.
+//
+// mcpRouteBase ("mcp" or "x/mcp") propagates into the resolved endpoint's
+// URL building on both the primary and fallback paths.
 func (s *Service) LoadResolvedMcpEndpointBySlug(ctx context.Context, logger *slog.Logger, slug, mcpRouteBase string) (*ResolvedMcpEndpoint, error) {
 	mcpEndpoint, mcpServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, slug)
-	if err != nil {
+	var shareErr *oops.ShareableError
+	switch {
+	case err == nil:
+		if !mcpServer.UserSessionIssuerID.Valid {
+			return nil, oops.E(oops.CodeNotFound, nil, "not found")
+		}
+		return s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, mcpRouteBase)
+	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
+		return s.loadResolvedMcpEndpointByToolsetSlug(ctx, slug, mcpRouteBase)
+	default:
 		return nil, err
 	}
-	if !mcpServer.UserSessionIssuerID.Valid {
-		return nil, oops.E(oops.CodeNotFound, nil, "not found")
-	}
-	return s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, mcpRouteBase)
 }
 
 // BuildResolvedMcpEndpointForServer materialises a ResolvedMcpEndpoint


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2640/mcpslugregisterauthorizeconsenttokenrevoke-404-for-remote-backed-mcp

The five issuer-gated OAuth flow handlers under `/mcp/<slug>` (`register`, `authorize`, `consent`, `token`, `revoke`) resolved only via `toolsets.mcp_slug`, so remote-backed MCP servers — which have no `toolsets` row — 404'd at the first call after a successful well-known fetch, breaking DCR.

Consolidate resolution into `LoadResolvedMcpEndpointBySlug`, which now resolves `mcp_endpoints` → `mcp_servers` first and falls back to the legacy `toolsets.mcp_slug` lookup on an addressing miss, mirroring the well-known handlers from #3118. An addressing hit that is not issuer-gated returns not-found without falling back, preserving parity for non-issuer-gated remote servers. Both `/mcp` and `/x/mcp` now share this path, so `/x/mcp` also gains the toolset fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404s in issuer-gated OAuth flows under /mcp/<slug> for remote-backed MCP servers by resolving via `mcp_endpoints` → `mcp_servers` with a toolset fallback, restoring DCR. `/mcp` and `/x/mcp` now share the same resolver. Addresses AGE-2640.

- **Bug Fixes**
  - `register`, `authorize`, `consent`, `token`, and `revoke` now use `LoadResolvedMcpEndpointBySlug` to resolve via `mcp_endpoints` → `mcp_servers`, falling back to `toolsets.mcp_slug` on an addressing miss.
  - If the addressing hit is not issuer-gated, return not found without fallback (matches well-known behavior). Unknown slugs still 404.
  - Route base (`mcp` or `x/mcp`) is propagated for correct URL building; `/x/mcp` also gains the toolset fallback.
  - Added tests for remote-backed issuer-gated success, non-issuer-gated 404, legacy toolset fallback, and unknown slug.

<sup>Written for commit 977baeac4f49742734a37b923c0c04a24109cf77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

