### PR TITLE
feat(server): add dashboard assistant ingress source

### DIFF
--- a/server/internal/assistants/dashboard_ingress_test.go
+++ b/server/internal/assistants/dashboard_ingress_test.go
@@ -66,6 +66,53 @@ func TestManagedAssistantDashboardTriggerLifecycle(t *testing.T) {
 	require.Empty(t, instances, "disable tears the dashboard trigger instance down")
 }
 
+// Managed assistants provisioned before dashboard ingress existed have no
+// dashboard trigger. The enable fast path is idempotent, so re-enabling heals a
+// missing trigger rather than returning early without one.
+func TestEnableManagedAssistantHealsMissingDashboardTrigger(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_dashboard_trigger_heal")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "dash-heal")
+
+	managed, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+
+	target := triggerrepo.ListActiveTriggerInstancesByTargetParams{
+		ProjectID:      projectID,
+		DefinitionSlug: sourceKindDashboard,
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      managed.ID.String(),
+	}
+
+	instances, err := triggerrepo.New(conn).ListActiveTriggerInstancesByTarget(ctx, target)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	// Simulate the pre-ingress state by tearing the trigger down out of band.
+	_, err = triggerrepo.New(conn).DeleteTriggerInstance(ctx, triggerrepo.DeleteTriggerInstanceParams{
+		ID:        instances[0].ID,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+
+	instances, err = triggerrepo.New(conn).ListActiveTriggerInstancesByTarget(ctx, target)
+	require.NoError(t, err)
+	require.Empty(t, instances)
+
+	healed, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+	require.Equal(t, managed.ID, healed.ID, "re-enable returns the existing managed assistant")
+
+	instances, err = triggerrepo.New(conn).ListActiveTriggerInstancesByTarget(ctx, target)
+	require.NoError(t, err)
+	require.Len(t, instances, 1, "re-enable re-provisions the dashboard trigger")
+}
+
 func mustDefinitionKind(t *testing.T, slug string) bgtriggers.Kind {
 	t.Helper()
 	def, ok := bgtriggers.GetDefinition(slug)

--- a/server/internal/assistants/dashboard_ingress_test.go
+++ b/server/internal/assistants/dashboard_ingress_test.go
@@ -1,0 +1,93 @@
+package assistants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
+)
+
+func TestDashboardAdapterThreadContext(t *testing.T) {
+	t.Parallel()
+
+	got, err := dashboardAdapter{}.ThreadContext([]byte(`{"user_id":"user-1"}`))
+	require.NoError(t, err)
+	require.Contains(t, got, "AI Insights sidebar")
+	require.Contains(t, got, "user-1")
+}
+
+func TestDashboardAdapterDecodeTurn(t *testing.T) {
+	t.Parallel()
+
+	got, err := dashboardAdapter{}.DecodeTurn(assistantThreadEventRecord{
+		EventID:               "evt-1",
+		NormalizedPayloadJSON: []byte(`{"text":"what are my top errors?","user_id":"user-1"}`),
+	})
+	require.NoError(t, err)
+	require.Contains(t, got, "evt-1")
+	require.Contains(t, got, "user-1")
+	require.Contains(t, got, "what are my top errors?")
+}
+
+// Dashboard messages reach the assistant through the trigger dispatch path, so
+// enabling the managed assistant must stand up a direct-ingress trigger instance
+// pointing at it, and disabling must tear it down.
+func TestManagedAssistantDashboardTriggerLifecycle(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_dashboard_trigger")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "dash-trigger")
+
+	managed, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+
+	target := triggerrepo.ListActiveTriggerInstancesByTargetParams{
+		ProjectID:      projectID,
+		DefinitionSlug: sourceKindDashboard,
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      managed.ID.String(),
+	}
+
+	instances, err := triggerrepo.New(conn).ListActiveTriggerInstancesByTarget(ctx, target)
+	require.NoError(t, err)
+	require.Len(t, instances, 1, "enable provisions one dashboard trigger instance")
+	require.Equal(t, bgtriggers.KindDirect, mustDefinitionKind(t, instances[0].DefinitionSlug))
+
+	require.NoError(t, core.DisableManagedAssistant(ctx, projectID))
+
+	instances, err = triggerrepo.New(conn).ListActiveTriggerInstancesByTarget(ctx, target)
+	require.NoError(t, err)
+	require.Empty(t, instances, "disable tears the dashboard trigger instance down")
+}
+
+func mustDefinitionKind(t *testing.T, slug string) bgtriggers.Kind {
+	t.Helper()
+	def, ok := bgtriggers.GetDefinition(slug)
+	require.True(t, ok, "definition %q registered", slug)
+	return def.Kind
+}
+
+// buildAssistantEventPayload maps a dispatched dashboard Task to the assistant
+// thread event shape: dashboard source kind, a source ref carrying the user id,
+// and the message as the normalized payload.
+func TestBuildAssistantEventPayloadDashboard(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"text":"what are my top errors?","user_id":"user-1"}`)
+	kind, sourceRef, normalized, source, err := buildAssistantEventPayload(bgtriggers.Task{
+		DefinitionSlug: sourceKindDashboard,
+		EventJSON:      payload,
+		RawPayload:     payload,
+	})
+	require.NoError(t, err)
+	require.Equal(t, sourceKindDashboard, kind)
+	require.JSONEq(t, `{"user_id":"user-1"}`, string(sourceRef))
+	require.Equal(t, payload, normalized)
+	require.JSONEq(t, string(payload), string(source))
+}

--- a/server/internal/assistants/impl.go
+++ b/server/internal/assistants/impl.go
@@ -225,7 +225,7 @@ func (s *Service) Dispatch(ctx context.Context, task bgtriggers.Task) error {
 	if err != nil {
 		return fmt.Errorf("enqueue assistant trigger task: %w", err)
 	}
-	if !result.EventCreated || result.AssistantID == uuid.Nil {
+	if !result.ShouldSignal || result.AssistantID == uuid.Nil {
 		return nil
 	}
 	if err := s.signaler.SignalCoordinator(ctx, result.AssistantID); err != nil {

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/speakeasy-api/gram/server/gen/types"
 	assistantrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
 )
 
 // managedAssistantInstructions is the system prompt for the platform-managed
@@ -148,6 +150,25 @@ func (s *ServiceCore) DisableManagedAssistant(ctx context.Context, projectID uui
 		return fmt.Errorf("soft-delete managed assistant: %w", err)
 	}
 
+	triggerQueries := triggerrepo.New(tx)
+	instances, err := triggerQueries.ListActiveTriggerInstancesByTarget(ctx, triggerrepo.ListActiveTriggerInstancesByTargetParams{
+		ProjectID:      projectID,
+		DefinitionSlug: sourceKindDashboard,
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      row.ID.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("list dashboard trigger instances: %w", err)
+	}
+	for _, inst := range instances {
+		if _, err := triggerQueries.DeleteTriggerInstance(ctx, triggerrepo.DeleteTriggerInstanceParams{
+			ID:        inst.ID,
+			ProjectID: projectID,
+		}); err != nil {
+			return fmt.Errorf("delete dashboard trigger instance: %w", err)
+		}
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit disable managed assistant tx: %w", err)
 	}
@@ -210,6 +231,24 @@ func (s *ServiceCore) createManagedAssistant(
 		AssistantID: record.ID,
 	}); err != nil {
 		return assistantRecord{}, fmt.Errorf("insert managed assistant mapping: %w", err)
+	}
+
+	// Dashboard sidebar messages reach the assistant through the trigger
+	// dispatch path, so the managed assistant gets a direct-ingress trigger
+	// instance. It's hidden from the user's trigger list (KindDirect).
+	if _, err := triggerrepo.New(tx).CreateTriggerInstance(ctx, triggerrepo.CreateTriggerInstanceParams{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+		DefinitionSlug: sourceKindDashboard,
+		Name:           name,
+		EnvironmentID:  uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      record.ID.String(),
+		TargetDisplay:  name,
+		ConfigJson:     []byte("{}"),
+		Status:         StatusActive,
+	}); err != nil {
+		return assistantRecord{}, fmt.Errorf("create dashboard trigger instance: %w", err)
 	}
 
 	if err := writeAssistantToolsets(ctx, tx, record.ID, projectID, resolved); err != nil {

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -73,6 +73,11 @@ func (s *ServiceCore) EnableManagedAssistant(
 	existing, err := s.GetManagedAssistant(ctx, projectID)
 	switch {
 	case err == nil:
+		// Repair managed assistants provisioned before dashboard ingress existed:
+		// the trigger is provisioned lazily here so re-running enable is enough.
+		if err := s.ensureDashboardTrigger(ctx, s.db, organizationID, projectID, existing.ID, existing.Name); err != nil {
+			return assistantRecord{}, err
+		}
 		return existing, nil
 	case errors.Is(err, pgx.ErrNoRows):
 		// fall through to create
@@ -175,6 +180,42 @@ func (s *ServiceCore) DisableManagedAssistant(ctx context.Context, projectID uui
 	return nil
 }
 
+// ensureDashboardTrigger provisions the direct-ingress trigger instance that
+// routes dashboard sidebar messages to the managed assistant, creating one only
+// when absent. Idempotent so the enable fast path can heal a managed assistant
+// that predates dashboard ingress without depending on a fresh create.
+func (s *ServiceCore) ensureDashboardTrigger(ctx context.Context, db triggerrepo.DBTX, organizationID string, projectID, assistantID uuid.UUID, name string) error {
+	queries := triggerrepo.New(db)
+	existing, err := queries.ListActiveTriggerInstancesByTarget(ctx, triggerrepo.ListActiveTriggerInstancesByTargetParams{
+		ProjectID:      projectID,
+		DefinitionSlug: sourceKindDashboard,
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      assistantID.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("list dashboard trigger instances: %w", err)
+	}
+	if len(existing) > 0 {
+		return nil
+	}
+
+	if _, err := queries.CreateTriggerInstance(ctx, triggerrepo.CreateTriggerInstanceParams{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+		DefinitionSlug: sourceKindDashboard,
+		Name:           name,
+		EnvironmentID:  uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      assistantID.String(),
+		TargetDisplay:  name,
+		ConfigJson:     []byte("{}"),
+		Status:         StatusActive,
+	}); err != nil {
+		return fmt.Errorf("create dashboard trigger instance: %w", err)
+	}
+	return nil
+}
+
 // createManagedAssistant inserts the assistant, records the managed mapping, and
 // attaches all of the project's MCP-reachable toolsets in a single transaction.
 func (s *ServiceCore) createManagedAssistant(
@@ -233,22 +274,8 @@ func (s *ServiceCore) createManagedAssistant(
 		return assistantRecord{}, fmt.Errorf("insert managed assistant mapping: %w", err)
 	}
 
-	// Dashboard sidebar messages reach the assistant through the trigger
-	// dispatch path, so the managed assistant gets a direct-ingress trigger
-	// instance. It's hidden from the user's trigger list (KindDirect).
-	if _, err := triggerrepo.New(tx).CreateTriggerInstance(ctx, triggerrepo.CreateTriggerInstanceParams{
-		OrganizationID: organizationID,
-		ProjectID:      projectID,
-		DefinitionSlug: sourceKindDashboard,
-		Name:           name,
-		EnvironmentID:  uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-		TargetKind:     bgtriggers.TargetKindAssistant,
-		TargetRef:      record.ID.String(),
-		TargetDisplay:  name,
-		ConfigJson:     []byte("{}"),
-		Status:         StatusActive,
-	}); err != nil {
-		return assistantRecord{}, fmt.Errorf("create dashboard trigger instance: %w", err)
+	if err := s.ensureDashboardTrigger(ctx, tx, organizationID, projectID, record.ID, name); err != nil {
+		return assistantRecord{}, err
 	}
 
 	if err := writeAssistantToolsets(ctx, tx, record.ID, projectID, resolved); err != nil {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -44,6 +44,7 @@ const (
 	sourceKindSlack      = "slack"
 	sourceKindCron       = "cron"
 	sourceKindWake       = "wake"
+	sourceKindDashboard  = "dashboard"
 	runtimeStateStarting = "starting"
 	runtimeStateActive   = "active"
 	runtimeStateExpiring = "expiring"
@@ -1257,6 +1258,23 @@ func buildAssistantEventPayload(task bgtriggers.Task) (string, []byte, []byte, [
 			}
 		}
 		return sourceKindWake, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
+	case sourceKindDashboard:
+		var event dashboardEventPayload
+		if err := json.Unmarshal(task.EventJSON, &event); err != nil {
+			return "", nil, nil, nil, fmt.Errorf("decode dashboard trigger event: %w", err)
+		}
+		sourceRefJSON, err := json.Marshal(dashboardSourceRef{UserID: event.UserID})
+		if err != nil {
+			return "", nil, nil, nil, fmt.Errorf("marshal dashboard source ref: %w", err)
+		}
+		sourcePayloadJSON := task.RawPayload
+		if !json.Valid(sourcePayloadJSON) {
+			sourcePayloadJSON, err = json.Marshal(map[string]string{"raw": string(task.RawPayload)})
+			if err != nil {
+				return "", nil, nil, nil, fmt.Errorf("marshal fallback source payload: %w", err)
+			}
+		}
+		return sourceKindDashboard, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
 	default:
 		return "", nil, nil, nil, fmt.Errorf("assistant source %q is not supported", task.DefinitionSlug)
 	}

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -253,7 +253,7 @@ func assistantRecordFromUpdateRow(row assistantrepo.UpdateAssistantRow) assistan
 type EnqueueResult struct {
 	AssistantID  uuid.UUID
 	ThreadID     uuid.UUID
-	EventCreated bool
+	ShouldSignal bool
 }
 
 type ProcessThreadEventsResult struct {
@@ -1107,7 +1107,7 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 			attr.SlogAssistantID(assistantID.String()),
 			attr.SlogTriggerInstanceID(task.TriggerInstanceID),
 		)
-		return EnqueueResult{AssistantID: uuid.Nil, ThreadID: uuid.Nil, EventCreated: false}, nil
+		return EnqueueResult{AssistantID: uuid.Nil, ThreadID: uuid.Nil, ShouldSignal: false}, nil
 	case err != nil:
 		return EnqueueResult{}, err
 	}
@@ -1115,7 +1115,7 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 		return EnqueueResult{
 			AssistantID:  assistant.ID,
 			ThreadID:     uuid.Nil,
-			EventCreated: false,
+			ShouldSignal: false,
 		}, nil
 	}
 
@@ -1159,7 +1159,6 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 		return EnqueueResult{}, fmt.Errorf("upsert assistant thread: %w", err)
 	}
 
-	var eventCreated bool
 	_, err = queries.InsertAssistantThreadEvent(ctx, assistantrepo.InsertAssistantThreadEventParams{
 		AssistantThreadID:     threadID,
 		AssistantID:           assistant.ID,
@@ -1171,13 +1170,11 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 		NormalizedPayloadJson: normalizedPayloadJSON,
 		SourcePayloadJson:     sourcePayloadJSON,
 	})
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		eventCreated = false
-	case err != nil:
+	// pgx.ErrNoRows means the event was already enqueued by an earlier attempt
+	// (idempotent retry). We still signal: a turn whose earlier coordinator
+	// signal failed must be picked up when the client retries.
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return EnqueueResult{}, fmt.Errorf("insert assistant thread event: %w", err)
-	default:
-		eventCreated = true
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -1187,7 +1184,7 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 	return EnqueueResult{
 		AssistantID:  assistant.ID,
 		ThreadID:     threadID,
-		EventCreated: eventCreated,
+		ShouldSignal: true,
 	}, nil
 }
 

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1386,6 +1386,6 @@ func TestServiceCoreEnqueueTriggerTaskSkipsMissingAssistant(t *testing.T) {
 		EventJSON:         []byte(`{}`),
 	})
 	require.NoError(t, err)
-	require.False(t, result.EventCreated)
+	require.False(t, result.ShouldSignal)
 	require.Equal(t, uuid.Nil, result.AssistantID)
 }

--- a/server/internal/assistants/source_adapter.go
+++ b/server/internal/assistants/source_adapter.go
@@ -13,9 +13,10 @@ type sourceAdapter interface {
 }
 
 var sourceAdapters = map[string]sourceAdapter{
-	sourceKindSlack: slackAdapter{},
-	sourceKindCron:  cronAdapter{},
-	sourceKindWake:  wakeAdapter{},
+	sourceKindSlack:     slackAdapter{},
+	sourceKindCron:      cronAdapter{},
+	sourceKindWake:      wakeAdapter{},
+	sourceKindDashboard: dashboardAdapter{},
 }
 
 func getSourceAdapter(kind string) (sourceAdapter, error) {
@@ -250,5 +251,55 @@ func (wakeAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error) 
 	if payload.Note != "" {
 		fmt.Fprintf(&b, " Self-note: %s", payload.Note)
 	}
+	return b.String(), nil
+}
+
+type dashboardSourceRef struct {
+	// UserID is the Gram dashboard user driving the conversation. It doubles as
+	// the thread correlation id (one continuing conversation per user per
+	// managed assistant), so sidebar history persists across opens.
+	UserID string `json:"user_id"`
+}
+
+type dashboardEventPayload struct {
+	Text   string `json:"text"`
+	UserID string `json:"user_id,omitempty"`
+}
+
+type dashboardAdapter struct{}
+
+func (dashboardAdapter) ThreadContext(sourceRefJSON []byte) (string, error) {
+	var ref dashboardSourceRef
+	if err := json.Unmarshal(sourceRefJSON, &ref); err != nil {
+		return "", fmt.Errorf("decode dashboard source ref: %w", err)
+	}
+	var b bytes.Buffer
+	b.WriteString("## Conversation context\n\n")
+	b.WriteString("Conversation originated on: Gram dashboard (AI Insights sidebar)\n")
+	if ref.UserID != "" {
+		fmt.Fprintf(&b, "UserID: %s\n", ref.UserID)
+	}
+	return b.String(), nil
+}
+
+func (dashboardAdapter) OutputChannelGuidance() string {
+	return `## Dashboard output preferences
+
+You are answering a Gram user in the AI Insights sidebar of the web dashboard. Reply conversationally and concisely in Markdown — the user reads your response directly in the sidebar. Prefer compact tables and short summaries over long prose; this is an analyst's side panel, not a chat app.`
+}
+
+func (dashboardAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error) {
+	var payload dashboardEventPayload
+	if err := json.Unmarshal(event.NormalizedPayloadJSON, &payload); err != nil {
+		return "", fmt.Errorf("decode dashboard event payload: %w", err)
+	}
+	var b bytes.Buffer
+	b.WriteString("<message-context>\n")
+	fmt.Fprintf(&b, "EventID: %s\n", event.EventID)
+	if payload.UserID != "" {
+		fmt.Fprintf(&b, "UserID: %s\n", payload.UserID)
+	}
+	b.WriteString("</message-context>\n\n")
+	b.WriteString(payload.Text)
 	return b.String(), nil
 }

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -832,6 +832,50 @@ func (a *App) ProcessEvent(ctx context.Context, instance triggerrepo.TriggerInst
 	return task, nil
 }
 
+// IngestDirect handles a synchronous, app-invoked trigger event (e.g. a message
+// from the dashboard assistant sidebar) through the same path as webhook and
+// schedule ingress: it builds the event from the instance's direct-ingress
+// definition, runs ProcessEvent (status/filter/target checks + delivery log),
+// and dispatches the resulting task inline. Returns the dispatched task, or nil
+// when the instance is paused or the event was filtered out.
+func (a *App) IngestDirect(ctx context.Context, instanceID uuid.UUID, payload []byte, receivedAt time.Time) (*Task, error) {
+	instance, err := a.repo.GetTriggerInstanceByIDPublic(ctx, instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("get trigger instance: %w", err)
+	}
+
+	rawConfig, err := configJSONToMap(instance.ConfigJson)
+	if err != nil {
+		return nil, fmt.Errorf("decode trigger config: %w", err)
+	}
+
+	definition, config, err := a.validateInstance(ctx, instance.ProjectID, nullUUIDToUUID(instance.EnvironmentID), instance.DefinitionSlug, rawConfig)
+	if err != nil {
+		return nil, fmt.Errorf("validate trigger instance: %w", err)
+	}
+	if definition.BuildDirectEvent == nil {
+		return nil, fmt.Errorf("trigger definition %q does not implement direct ingress", instance.DefinitionSlug)
+	}
+
+	envelope, err := definition.BuildDirectEvent(instance, config, payload, receivedAt)
+	if err != nil {
+		return nil, fmt.Errorf("build direct event: %w", err)
+	}
+
+	task, err := a.ProcessEvent(ctx, instance, *envelope)
+	if err != nil {
+		return nil, fmt.Errorf("process event: %w", err)
+	}
+	if task == nil {
+		return nil, nil
+	}
+
+	if err := a.Dispatch(ctx, *task); err != nil {
+		return nil, err
+	}
+	return task, nil
+}
+
 func (a *App) RegisterDispatcher(dispatcher Dispatcher) {
 	a.dispatchers[dispatcher.Kind()] = dispatcher
 }

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -236,6 +236,9 @@ func (a *App) Create(ctx context.Context, params CreateParams, hooks ...Instance
 	if err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("%w: validate trigger instance: %w", ErrBadRequest, err)
 	}
+	if definition.Kind == KindDirect {
+		return triggerrepo.TriggerInstance{}, fmt.Errorf("%w: %q triggers are system-managed and cannot be created directly", ErrBadRequest, params.DefinitionSlug)
+	}
 
 	configJSON, err := marshalConfigJSON(params.Config)
 	if err != nil {
@@ -307,6 +310,9 @@ func (a *App) Update(ctx context.Context, params UpdateParams, hooks ...Instance
 	definition, config, err := a.validateInstance(ctx, params.ProjectID, nullUUIDToUUID(params.EnvironmentID), params.DefinitionSlug, params.Config)
 	if err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("%w: validate trigger instance: %w", ErrBadRequest, err)
+	}
+	if definition.Kind == KindDirect {
+		return triggerrepo.TriggerInstance{}, fmt.Errorf("%w: %q triggers are system-managed and cannot be updated directly", ErrBadRequest, params.DefinitionSlug)
 	}
 
 	configJSON, err := marshalConfigJSON(params.Config)

--- a/server/internal/background/triggers/app_test.go
+++ b/server/internal/background/triggers/app_test.go
@@ -62,3 +62,21 @@ func TestAppDispatchRejectsUnconfiguredDispatcher(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, `trigger dispatcher for target kind "assistant" is not configured`)
 }
+
+func TestAppCreateRejectsDirectIngressDefinition(t *testing.T) {
+	t.Parallel()
+
+	// Direct-ingress definitions (e.g. dashboard) are system-managed; the public
+	// create path must refuse them. The guard fires before any DB access.
+	app := &App{}
+
+	_, err := app.Create(t.Context(), CreateParams{
+		DefinitionSlug: "dashboard",
+		Name:           "x",
+		TargetKind:     TargetKindAssistant,
+		TargetRef:      "assistant-ref",
+	})
+
+	require.ErrorIs(t, err, ErrBadRequest)
+	require.ErrorContains(t, err, "system-managed")
+}

--- a/server/internal/background/triggers/dashboard_definition_test.go
+++ b/server/internal/background/triggers/dashboard_definition_test.go
@@ -1,0 +1,38 @@
+package triggers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
+)
+
+func TestDashboardDefinitionBuildDirectEvent(t *testing.T) {
+	t.Parallel()
+
+	def := newDashboardDefinition()
+	require.Equal(t, KindDirect, def.Kind)
+	require.Nil(t, def.HandleWebhook)
+	require.Nil(t, def.BuildScheduledEvent)
+	require.NotNil(t, def.BuildDirectEvent)
+
+	instance := triggerrepo.TriggerInstance{ID: uuid.New(), DefinitionSlug: "dashboard"}
+	receivedAt := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	envelope, err := def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"top errors?","user_id":"user-1"}`), receivedAt)
+	require.NoError(t, err)
+	require.Equal(t, "user-1", envelope.CorrelationID, "user id doubles as the thread correlation id")
+	require.Equal(t, instance.ID.String(), envelope.TriggerInstanceID)
+	require.Equal(t, "dashboard", envelope.DefinitionSlug)
+	require.NotEmpty(t, envelope.EventID)
+	require.Equal(t, receivedAt, envelope.ReceivedAt)
+
+	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"user_id":"user-1"}`), receivedAt)
+	require.Error(t, err, "empty text rejected")
+
+	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"hi"}`), receivedAt)
+	require.Error(t, err, "empty user id rejected")
+}

--- a/server/internal/background/triggers/dashboard_definition_test.go
+++ b/server/internal/background/triggers/dashboard_definition_test.go
@@ -22,7 +22,7 @@ func TestDashboardDefinitionBuildDirectEvent(t *testing.T) {
 	instance := triggerrepo.TriggerInstance{ID: uuid.New(), DefinitionSlug: "dashboard"}
 	receivedAt := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
 
-	envelope, err := def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"top errors?","user_id":"user-1"}`), receivedAt)
+	envelope, err := def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"top errors?","user_id":"user-1","idempotency_key":"key-1"}`), receivedAt)
 	require.NoError(t, err)
 	require.Equal(t, "user-1", envelope.CorrelationID, "user id doubles as the thread correlation id")
 	require.Equal(t, instance.ID.String(), envelope.TriggerInstanceID)
@@ -30,9 +30,21 @@ func TestDashboardDefinitionBuildDirectEvent(t *testing.T) {
 	require.NotEmpty(t, envelope.EventID)
 	require.Equal(t, receivedAt, envelope.ReceivedAt)
 
-	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"user_id":"user-1"}`), receivedAt)
+	// Event id is derived from instance + idempotency key so retries dedupe.
+	retry, err := def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"top errors?","user_id":"user-1","idempotency_key":"key-1"}`), receivedAt.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, envelope.EventID, retry.EventID, "same idempotency key yields same event id")
+
+	other, err := def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"top errors?","user_id":"user-1","idempotency_key":"key-2"}`), receivedAt)
+	require.NoError(t, err)
+	require.NotEqual(t, envelope.EventID, other.EventID, "different idempotency key yields different event id")
+
+	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"user_id":"user-1","idempotency_key":"key-1"}`), receivedAt)
 	require.Error(t, err, "empty text rejected")
 
-	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"hi"}`), receivedAt)
+	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"hi","idempotency_key":"key-1"}`), receivedAt)
 	require.Error(t, err, "empty user id rejected")
+
+	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"hi","user_id":"user-1"}`), receivedAt)
+	require.Error(t, err, "empty idempotency key rejected")
 }

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -192,8 +192,9 @@ type dashboardTriggerConfig struct{}
 func (dashboardTriggerConfig) Filter(_ any) (bool, error) { return true, nil }
 
 type dashboardTriggerEvent struct {
-	Text   string `json:"text" cel:"text"`
-	UserID string `json:"user_id,omitempty" cel:"user_id"`
+	Text           string `json:"text" cel:"text"`
+	UserID         string `json:"user_id,omitempty" cel:"user_id"`
+	IdempotencyKey string `json:"idempotency_key,omitempty" cel:"idempotency_key"`
 }
 
 type slackEventRequest struct {
@@ -1008,8 +1009,11 @@ func newDashboardDefinition() Definition {
 			if event.UserID == "" {
 				return nil, fmt.Errorf("dashboard message user id is required")
 			}
+			if event.IdempotencyKey == "" {
+				return nil, fmt.Errorf("dashboard message idempotency key is required")
+			}
 			return &EventEnvelope{
-				EventID:           uuid.NewString(),
+				EventID:           uuid.NewSHA1(uuid.NameSpaceURL, []byte(instance.ID.String()+":"+event.IdempotencyKey)).String(),
 				CorrelationID:     event.UserID,
 				TriggerInstanceID: instance.ID.String(),
 				DefinitionSlug:    instance.DefinitionSlug,

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -37,6 +37,7 @@ type Kind string
 const (
 	KindWebhook  Kind = "webhook"
 	KindSchedule Kind = "schedule"
+	KindDirect   Kind = "direct"
 )
 
 type EnvRequirement struct {
@@ -58,6 +59,7 @@ type Definition struct {
 	AuthenticateWebhook  func(body []byte, headers http.Header, env map[string]string, config Config) error
 	HandleWebhook        func(body []byte, headers http.Header, config Config) (*WebhookIngressResult, error)
 	BuildScheduledEvent  func(instance triggerrepo.TriggerInstance, config Config, firedAt time.Time) (*EventEnvelope, error)
+	BuildDirectEvent     func(instance triggerrepo.TriggerInstance, config Config, payload []byte, receivedAt time.Time) (*EventEnvelope, error)
 	ExtractSchedule      func(config Config) (string, error)
 }
 
@@ -184,6 +186,15 @@ type wakeTriggerConfig struct {
 }
 
 func (c wakeTriggerConfig) Filter(_ any) (bool, error) { return true, nil }
+
+type dashboardTriggerConfig struct{}
+
+func (dashboardTriggerConfig) Filter(_ any) (bool, error) { return true, nil }
+
+type dashboardTriggerEvent struct {
+	Text   string `json:"text" cel:"text"`
+	UserID string `json:"user_id,omitempty" cel:"user_id"`
+}
 
 type slackEventRequest struct {
 	Type      string          `json:"type"`
@@ -629,14 +640,20 @@ var supportedSlackEventTypes = []string{
 }
 
 var registry = map[string]Definition{
-	"slack": newSlackDefinition(),
-	"cron":  newCronDefinition(),
-	"wake":  newWakeDefinition(),
+	"slack":     newSlackDefinition(),
+	"cron":      newCronDefinition(),
+	"wake":      newWakeDefinition(),
+	"dashboard": newDashboardDefinition(),
 }
 
 func List() []Definition {
 	definitions := make([]Definition, 0, len(registry))
 	for _, definition := range registry {
+		// Direct-ingress definitions (e.g. dashboard) are system-managed, not
+		// user-creatable trigger types — keep them out of the public catalog.
+		if definition.Kind == KindDirect {
+			continue
+		}
 		definitions = append(definitions, definition)
 	}
 	slices.SortFunc(definitions, func(a, b Definition) int {
@@ -772,9 +789,7 @@ func newSlackDefinition() Definition {
 			// originating message and CEL filters / correlation work.
 			channelID := event.Channel
 			timestamp := event.Ts
-			var (
-				itemType, itemChannel, itemTs string
-			)
+			var itemType, itemChannel, itemTs string
 			if event.Item != nil {
 				itemType = event.Item.Type
 				itemChannel = event.Item.Channel
@@ -828,6 +843,7 @@ func newSlackDefinition() Definition {
 			}, nil
 		},
 		BuildScheduledEvent: nil,
+		BuildDirectEvent:    nil,
 		ExtractSchedule:     nil,
 	}
 }
@@ -885,6 +901,7 @@ func newCronDefinition() Definition {
 				ReceivedAt:        firedAt.UTC(),
 			}, nil
 		},
+		BuildDirectEvent: nil,
 		ExtractSchedule: func(config Config) (string, error) {
 			cfg, ok := config.(cronTriggerConfig)
 			if !ok {
@@ -951,6 +968,7 @@ func newWakeDefinition() Definition {
 				ReceivedAt:        firedAt.UTC(),
 			}, nil
 		},
+		BuildDirectEvent: nil,
 		ExtractSchedule: func(config Config) (string, error) {
 			cfg, ok := config.(wakeTriggerConfig)
 			if !ok {
@@ -958,6 +976,49 @@ func newWakeDefinition() Definition {
 			}
 			return cfg.FireAt.UTC().Format(time.RFC3339Nano), nil
 		},
+	}
+}
+
+func newDashboardDefinition() Definition {
+	schema := buildInputSchema[dashboardTriggerConfig]()
+	compiled := mustCompileSchema(schema)
+	return Definition{
+		Slug:                 "dashboard",
+		Title:                "Dashboard",
+		Description:          "Direct messages from the Gram dashboard assistant sidebar.",
+		Kind:                 KindDirect,
+		ConfigSchema:         schema,
+		CompiledConfigSchema: compiled,
+		EnvRequirements:      []EnvRequirement{},
+		EventType:            reflect.TypeFor[dashboardTriggerEvent](),
+		DecodeConfig: func(raw map[string]any) (Config, error) {
+			return decodeConfig[dashboardTriggerConfig](raw, compiled)
+		},
+		AuthenticateWebhook: nil,
+		HandleWebhook:       nil,
+		BuildScheduledEvent: nil,
+		BuildDirectEvent: func(instance triggerrepo.TriggerInstance, _ Config, payload []byte, receivedAt time.Time) (*EventEnvelope, error) {
+			var event dashboardTriggerEvent
+			if err := json.Unmarshal(payload, &event); err != nil {
+				return nil, fmt.Errorf("decode dashboard message: %w", err)
+			}
+			if event.Text == "" {
+				return nil, fmt.Errorf("dashboard message text is required")
+			}
+			if event.UserID == "" {
+				return nil, fmt.Errorf("dashboard message user id is required")
+			}
+			return &EventEnvelope{
+				EventID:           uuid.NewString(),
+				CorrelationID:     event.UserID,
+				TriggerInstanceID: instance.ID.String(),
+				DefinitionSlug:    instance.DefinitionSlug,
+				Event:             event,
+				RawPayload:        payload,
+				ReceivedAt:        receivedAt.UTC(),
+			}, nil
+		},
+		ExtractSchedule: nil,
 	}
 }
 

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -106,6 +106,11 @@ func (s *Service) ListTriggerInstances(ctx context.Context, _ *gen.ListTriggerIn
 
 	result := make([]*types.TriggerInstance, 0, len(items))
 	for _, item := range items {
+		// Direct-ingress triggers (e.g. the dashboard assistant sidebar) are
+		// system-managed plumbing, not user-configured triggers — hide them.
+		if def, ok := bgtriggers.GetDefinition(item.DefinitionSlug); ok && def.Kind == bgtriggers.KindDirect {
+			continue
+		}
 		view, err := buildTriggerView(item, s.app.WebhookURL(item))
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").Log(ctx, s.logger)


### PR DESCRIPTION
## Summary

Stacked on #3125 (→ #3124 → #3123). **PR2 of the AGE-2631 stack** — teaches the assistant runtime to accept a message from the dashboard AI Insights sidebar, mirroring the existing Slack/cron/wake ingress.

- **`dashboard` source kind + `dashboardAdapter`** — `ThreadContext` / `OutputChannelGuidance` / `DecodeTurn`, registered in `sourceAdapters`. Same shape as the other adapters.
- **`EnqueueDashboardMessage(projectID, userID, text)`** — resolves the project's managed assistant (#3125), then enqueues the message as a pending thread event. Returns the standard `EnqueueResult`; the caller signals the coordinator on `EventCreated` (exactly as `Dispatch` does for triggers).
- **Refactor**: the chat→thread→event write is factored out of `EnqueueTriggerTask` into a shared `persistAssistantTurn` helper, so trigger and dashboard ingress share one atomic path instead of duplicating it.

### Design decisions (made without blocking on review — flagged on the Linear thread)
- **Thread identity (open Q2): stable.** `correlation_id = user_id`, so a user has one continuing dashboard conversation per managed assistant; sidebar history persists across opens. Easy to switch to per-window threads later.
- Each sidebar message is a **fresh event** (`event_id = uuid`), so there's no trigger-style dedup — every send is processed.

### What's intentionally *not* here
- **No public endpoint yet** — tests are the caller (same pattern as #3125). The `/rpc/assistants.sendMessage` endpoint + coordinator signal wiring, the **egress platform tool** (open Q1), and the **browser read path** (open Q4) come in the next PRs.

## Tests
- `TestDashboardAdapterThreadContext` / `TestDashboardAdapterDecodeTurn` — context + turn rendering.
- `TestEnqueueDashboardMessage` — enqueues onto the managed assistant; same user → one continuing thread; thread persisted under `source_kind = dashboard`, `correlation_id = user`.
- `TestEnqueueDashboardMessageRequiresManagedAssistant` — `pgx.ErrNoRows` when the feature is off.
- `TestEnqueueDashboardMessageValidatesInput` — empty user/text rejected.

Verified: `mise build:server`, `go vet`, full `assistants` package tests (trigger path unaffected by the refactor), `mise lint:server` — all green.

## Stack
1. #3123 — AI Insights → project toolsets + RBAC tokens
2. #3124 — `project_managed_assistants` migration
3. #3125 — managed-assistant provisioning toggle
4. **this PR** — `dashboard` ingress source kind + enqueue
5. _next_ — `/rpc/assistants.sendMessage` endpoint + egress platform tool + browser read path
6. _next_ — sidebar cutover

Ref: AGE-2631

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `dashboard` assistant ingress with a system‑managed direct trigger so the AI Insights sidebar can message a project's managed assistant, now idempotent and retry‑safe. One continuing thread per user; direct triggers auto‑heal on re‑enable and remain hidden; no public endpoint yet (AGE-2631).

- **New Features**
  - Added `dashboard` source kind with `dashboardAdapter` (thread context, output guidance, turn decode); `buildAssistantEventPayload` supports `dashboard`.
  - Added `IngestDirect` in `background/triggers` and a `dashboard` definition (`KindDirect`) with `BuildDirectEvent` (event id from client idempotency key; correlation id = user id).
  - Added `EnqueueDashboardMessage(projectID, userID, text)` with validation; returns `EnqueueResult` and signals the coordinator when accepted.

- **Bug Fixes**
  - Made dashboard ingress idempotent: retries dedupe via idempotency key and still re‑signal the coordinator; `EnqueueTriggerTask` now returns `ShouldSignal` and `Dispatch` checks it.
  - Block public Create/Update for `KindDirect` triggers (`dashboard`) and hide direct triggers from listing.

<sup>Written for commit 6f209a265fa165f9f69ea8b1f77fe4c9bcf4bc37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

