### PR TITLE
mig: add published_fingerprint to plugin_github_connections

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2646,6 +2646,13 @@ CREATE TABLE IF NOT EXISTS plugin_github_connections (
   -- existing connections (and any future connection without the marketplace
   -- surface enabled) are unconstrained.
   marketplace_token TEXT,
+  -- Stable content hash of the plugin packages last published to this repo,
+  -- independent of per-publish values (manifest version, injected API keys).
+  -- The automated generator rollout compares the current fingerprint against
+  -- this value and skips republishing when nothing has changed. Nullable so
+  -- connections published before fingerprinting existed re-publish once to
+  -- backfill it.
+  published_fingerprint TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -995,14 +995,15 @@ type PluginAssignment struct {
 }
 
 type PluginGithubConnection struct {
-	ID               uuid.UUID
-	ProjectID        uuid.UUID
-	InstallationID   int64
-	RepoOwner        string
-	RepoName         string
-	MarketplaceToken pgtype.Text
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
+	ID                   uuid.UUID
+	ProjectID            uuid.UUID
+	InstallationID       int64
+	RepoOwner            string
+	RepoName             string
+	MarketplaceToken     pgtype.Text
+	PublishedFingerprint pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }
 
 type PluginServer struct {

--- a/server/internal/plugins/repo/models.go
+++ b/server/internal/plugins/repo/models.go
@@ -32,14 +32,15 @@ type PluginAssignment struct {
 }
 
 type PluginGithubConnection struct {
-	ID               uuid.UUID
-	ProjectID        uuid.UUID
-	InstallationID   int64
-	RepoOwner        string
-	RepoName         string
-	MarketplaceToken pgtype.Text
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
+	ID                   uuid.UUID
+	ProjectID            uuid.UUID
+	InstallationID       int64
+	RepoOwner            string
+	RepoName             string
+	MarketplaceToken     pgtype.Text
+	PublishedFingerprint pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }
 
 type PluginServer struct {

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -147,7 +147,7 @@ func (q *Queries) DeletePlugin(ctx context.Context, arg DeletePluginParams) erro
 }
 
 const getGitHubConnection = `-- name: GetGitHubConnection :one
-SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, created_at, updated_at
+SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, created_at, updated_at
 FROM plugin_github_connections
 WHERE project_id = $1
 `
@@ -162,6 +162,7 @@ func (q *Queries) GetGitHubConnection(ctx context.Context, projectID uuid.UUID) 
 		&i.RepoOwner,
 		&i.RepoName,
 		&i.MarketplaceToken,
+		&i.PublishedFingerprint,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -169,7 +170,7 @@ func (q *Queries) GetGitHubConnection(ctx context.Context, projectID uuid.UUID) 
 }
 
 const getGitHubConnectionByMarketplaceToken = `-- name: GetGitHubConnectionByMarketplaceToken :one
-SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, created_at, updated_at
+SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, created_at, updated_at
 FROM plugin_github_connections
 WHERE marketplace_token = $1
 `
@@ -186,6 +187,7 @@ func (q *Queries) GetGitHubConnectionByMarketplaceToken(ctx context.Context, mar
 		&i.RepoOwner,
 		&i.RepoName,
 		&i.MarketplaceToken,
+		&i.PublishedFingerprint,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -588,7 +590,7 @@ ON CONFLICT (project_id) DO UPDATE
       repo_name = EXCLUDED.repo_name,
       marketplace_token = COALESCE(plugin_github_connections.marketplace_token, EXCLUDED.marketplace_token),
       updated_at = clock_timestamp()
-RETURNING id, project_id, installation_id, repo_owner, repo_name, marketplace_token, created_at, updated_at
+RETURNING id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, created_at, updated_at
 `
 
 type UpsertGitHubConnectionParams struct {
@@ -620,6 +622,7 @@ func (q *Queries) UpsertGitHubConnection(ctx context.Context, arg UpsertGitHubCo
 		&i.RepoOwner,
 		&i.RepoName,
 		&i.MarketplaceToken,
+		&i.PublishedFingerprint,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/migrations/20260601212536_plugin-github-connections-add-published-fingerprint.sql
+++ b/server/migrations/20260601212536_plugin-github-connections-add-published-fingerprint.sql
@@ -1,0 +1,2 @@
+-- Modify "plugin_github_connections" table
+ALTER TABLE "plugin_github_connections" ADD COLUMN "published_fingerprint" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:TnApjhUhoqkH7+8fkFKNyimd8ZRyGey9Zik7MQ8TRcA=
+h1:TGR/ou3s3ZD6Ukb1mYxd1gAbfZB8MuylyNcpiBUoouA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -199,3 +199,4 @@ h1:TnApjhUhoqkH7+8fkFKNyimd8ZRyGey9Zik7MQ8TRcA=
 20260529114006_add-ip-allowlist-to-custom-domains.sql h1:9li8X25rRb2c1wPhfA/k4FuS65biWbmttXGP0uuOpBQ=
 20260529185739_plugin-assignments-org-principal-index.sql h1:zxjbc2mIBYmXegrSPPDfoMFQn7fagQs8Sd8Ld2JH4+o=
 20260601092138_risk-policies-add-audience-type.sql h1:M1gvNAwdWQAX6bIyEhF7VnLvIltOPdob+093qPfiM+A=
+20260601212536_plugin-github-connections-add-published-fingerprint.sql h1:eYANo4SQbbKipX/n3geIZ4qZ2yT8RV3lw/PAn0YoPA8=


### PR DESCRIPTION
Nullable content-hash column the automated plugin generator rollout uses to skip republishing projects whose generated output has not changed. Migration only, per expand-contract rules; the app code that reads/writes it lands separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a nullable `published_fingerprint` column to `plugin_github_connections` to store a stable hash of the last published plugin packages so the generator can skip republishing when nothing changed. Migration + `sqlc` regen only; app read/write lands separately and existing connections backfill on next publish.

<sup>Written for commit 0edfea285c2c547e6a63c2b61364e14f6c26789f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

