### PR TITLE
fix: copy raw agent session chat id

### DIFF
--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.test.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ChatOverview } from "@gram/client/models/components";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatLogsTable } from "./ChatLogsTable";
+
+vi.mock("@speakeasy-api/moonshine", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+  Icon: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+function makeChat(id: string): ChatOverview {
+  const createdAt = new Date("2026-01-01T12:00:00Z");
+
+  return {
+    createdAt,
+    id,
+    lastMessageTimestamp: new Date("2026-01-01T12:03:00Z"),
+    numMessages: 4,
+    title: "Investigate session",
+    updatedAt: new Date("2026-01-01T12:03:00Z"),
+  };
+}
+
+describe("ChatLogsTable", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("copies the raw chat id without a label prefix", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const chatId = "chat_01HXQ1P84WV3S9J7Z52DKVE7NE";
+
+    render(
+      <ChatLogsTable
+        chats={[makeChat(chatId)]}
+        onDeleteChat={vi.fn()}
+        onSelectChat={vi.fn()}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Copy Chat ID"));
+
+    expect(writeText).toHaveBeenCalledWith(chatId);
+  });
+});

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
@@ -193,7 +193,7 @@ export function ChatLogsTable({
                 "group w-full px-5 py-4 text-left transition-all duration-150",
                 "hover:bg-muted/50",
                 "focus-visible:bg-muted/50 focus:outline-none",
-                isSelected && "bg-primary/[0.03] hover:bg-primary/[0.05]",
+                isSelected && "bg-primary/3 hover:bg-primary/5",
               )}
             >
               <div className="flex items-center gap-5">

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
@@ -79,12 +79,11 @@ function CopyButton({
   const handleCopy = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation(); // Don't trigger row selection
-      // Copy with the label prefix
-      navigator.clipboard.writeText(`${label}: ${value}`);
+      navigator.clipboard.writeText(value);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     },
-    [value, label],
+    [value],
   );
 
   return (


### PR DESCRIPTION
## Summary
- Copy only the raw Agent Sessions chat ID from the session row copy button.
- Add a regression test covering the clipboard payload.

## Root Cause
The local copy button in `ChatLogsTable` wrote `${label}: ${value}` to the clipboard. For Chat IDs this produced `Chat ID: <id>`, which does not work when pasted into chat ID search. Customers complained that search returns no results
