### PR TITLE
fix: plugins support for oauth servers

### DIFF
--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -25,6 +25,10 @@ type PluginServerInfo struct {
 	MCPURL string
 	// IsPublic indicates whether the toolset is publicly accessible (no Gram API key needed).
 	IsPublic bool
+	// OAuthEnabled indicates the toolset authenticates via OAuth at the MCP
+	// endpoint. Such servers need no auth headers baked into the published
+	// config — the client negotiates auth through the OAuth flow.
+	OAuthEnabled bool
 	// EnvConfigs are user-facing environment variables for public servers.
 	EnvConfigs []ServerEnvConfig
 }
@@ -408,7 +412,10 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 			EnvHTTPHeaders:    nil,
 		}
 
-		if s.IsPublic {
+		switch {
+		case s.OAuthEnabled:
+			// OAuth servers negotiate auth through the OAuth flow — no headers.
+		case s.IsPublic:
 			// User provides each variable in their shell env; Codex
 			// substitutes the value into the named header at runtime.
 			if len(s.EnvConfigs) > 0 {
@@ -417,11 +424,11 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 					entry.EnvHTTPHeaders[ec.DisplayName] = ec.VariableName
 				}
 			}
-		} else if cfg.APIKey != "" {
+		case cfg.APIKey != "":
 			// Private server: bake the Gram-issued key directly into the
 			// published config. Repo is private, so this matches the Cursor/Claude pattern.
 			entry.HTTPHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
-		} else {
+		default:
 			// Private server, no key available: ask Codex to read GRAM_API_KEY
 			// from the user's environment at startup.
 			entry.BearerTokenEnvVar = "GRAM_API_KEY"
@@ -1284,7 +1291,7 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	// Determine if any private server needs a Gram API key prompt.
 	needsGramKeyPrompt := false
 	for _, s := range p.Servers {
-		if !s.IsPublic && cfg.APIKey == "" {
+		if !s.OAuthEnabled && !s.IsPublic && cfg.APIKey == "" {
 			needsGramKeyPrompt = true
 		}
 		// Public servers may need user-provided env vars.
@@ -1325,15 +1332,18 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	for _, s := range p.Servers {
 		headers := make(map[string]string)
 
-		if s.IsPublic {
+		switch {
+		case s.OAuthEnabled:
+			// OAuth servers negotiate auth through the OAuth flow — no headers.
+		case s.IsPublic:
 			// Public servers use env config variables for auth.
 			for _, ec := range s.EnvConfigs {
 				headers[ec.DisplayName] = "${user_config." + ec.VariableName + "}"
 			}
-		} else if cfg.APIKey != "" {
+		case cfg.APIKey != "":
 			// Private server with injected key.
 			headers["Authorization"] = "Bearer " + cfg.APIKey
-		} else {
+		default:
 			// Private server without key — prompt user.
 			headers["Authorization"] = "Bearer ${user_config.GRAM_API_KEY}"
 		}
@@ -1376,13 +1386,16 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 	for _, s := range p.Servers {
 		headers := make(map[string]string)
 
-		if s.IsPublic {
+		switch {
+		case s.OAuthEnabled:
+			// OAuth servers negotiate auth through the OAuth flow — no headers.
+		case s.IsPublic:
 			for _, ec := range s.EnvConfigs {
 				headers[ec.DisplayName] = "${env:" + ec.VariableName + "}"
 			}
-		} else if cfg.APIKey != "" {
+		case cfg.APIKey != "":
 			headers["Authorization"] = "Bearer " + cfg.APIKey
-		} else {
+		default:
 			headers["Authorization"] = "Bearer ${env:GRAM_API_KEY}"
 		}
 

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -259,6 +259,51 @@ func TestCodexJSONKeysMatchPinnedSchema(t *testing.T) {
 	}
 }
 
+// TestGenerateConfigsOmitHeadersForOAuthServers asserts that OAuth-enabled
+// servers carry no auth headers in any generated config — the client
+// negotiates auth through the OAuth flow at the MCP endpoint. This holds even
+// when a Gram API key is injected.
+func TestGenerateConfigsOmitHeadersForOAuthServers(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "oauth-server", MCPURL: "https://app.getgram.ai/mcp/test", OAuthEnabled: true},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+		APIKey:    "gram_test_key_123",
+	})
+	require.NoError(t, err)
+
+	var claudeConfig claudeMCPConfig
+	require.NoError(t, json.Unmarshal(files["test/.mcp.json"], &claudeConfig))
+	require.Empty(t, claudeConfig.MCPServers["oauth-server"].Headers, "claude oauth server must have no headers")
+
+	var cursorConfig cursorMCPConfig
+	require.NoError(t, json.Unmarshal(files["test-cursor/mcp.json"], &cursorConfig))
+	require.Empty(t, cursorConfig.MCPServers["oauth-server"].Headers, "cursor oauth server must have no headers")
+
+	var codexConfig codexMCPConfig
+	require.NoError(t, json.Unmarshal(files["test-codex/.mcp.json"], &codexConfig))
+	codexServer := codexConfig.MCPServers["oauth-server"]
+	require.Empty(t, codexServer.HTTPHeaders, "codex oauth server must not bake Authorization")
+	require.Empty(t, codexServer.EnvHTTPHeaders, "codex oauth server must not set env_http_headers")
+	require.Empty(t, codexServer.BearerTokenEnvVar, "codex oauth server must not set bearer_token_env_var")
+
+	// The Claude manifest must not prompt for a Gram API key on behalf of an
+	// OAuth-only plugin.
+	var claudeMeta claudePluginMeta
+	require.NoError(t, json.Unmarshal(files["test/.claude-plugin/plugin.json"], &claudeMeta))
+	require.NotContains(t, claudeMeta.UserConfig, "GRAM_API_KEY", "oauth-only plugin must not prompt for GRAM_API_KEY")
+}
+
 func codexPrivateServer() PluginServerInfo {
 	return PluginServerInfo{DisplayName: "priv", MCPURL: "https://x"}
 }

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1347,11 +1347,12 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 
 		if mcpSlug := conv.FromPGText[string](r.ToolsetMcpSlug); mcpSlug != nil {
 			serverInfo := PluginServerInfo{
-				DisplayName: r.ServerDisplayName,
-				Policy:      r.ServerPolicy,
-				MCPURL:      fmt.Sprintf("%s/mcp/%s", s.serverURL, *mcpSlug),
-				IsPublic:    r.ToolsetIsPublic,
-				EnvConfigs:  nil,
+				DisplayName:  r.ServerDisplayName,
+				Policy:       r.ServerPolicy,
+				MCPURL:       fmt.Sprintf("%s/mcp/%s", s.serverURL, *mcpSlug),
+				IsPublic:     r.ToolsetIsPublic,
+				OAuthEnabled: r.ToolsetOauthEnabled.Bool,
+				EnvConfigs:   nil,
 			}
 
 			// For public servers, load user-facing environment configs. A public

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -121,7 +121,8 @@ SELECT
   ps.sort_order AS server_sort_order,
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
-  t.mcp_is_public AS toolset_is_public
+  t.mcp_is_public AS toolset_is_public,
+  (t.external_oauth_server_id IS NOT NULL OR t.oauth_proxy_server_id IS NOT NULL) AS toolset_oauth_enabled
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -387,7 +387,8 @@ SELECT
   ps.sort_order AS server_sort_order,
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
-  t.mcp_is_public AS toolset_is_public
+  t.mcp_is_public AS toolset_is_public,
+  (t.external_oauth_server_id IS NOT NULL OR t.oauth_proxy_server_id IS NOT NULL) AS toolset_oauth_enabled
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
@@ -397,17 +398,18 @@ ORDER BY p.slug, ps.sort_order ASC
 `
 
 type ListPluginsWithServersForProjectRow struct {
-	PluginID          uuid.UUID
-	PluginName        string
-	PluginSlug        string
-	PluginDescription pgtype.Text
-	ServerID          uuid.UUID
-	ServerDisplayName string
-	ServerPolicy      string
-	ServerSortOrder   int32
-	ToolsetID         uuid.UUID
-	ToolsetMcpSlug    pgtype.Text
-	ToolsetIsPublic   bool
+	PluginID            uuid.UUID
+	PluginName          string
+	PluginSlug          string
+	PluginDescription   pgtype.Text
+	ServerID            uuid.UUID
+	ServerDisplayName   string
+	ServerPolicy        string
+	ServerSortOrder     int32
+	ToolsetID           uuid.UUID
+	ToolsetMcpSlug      pgtype.Text
+	ToolsetIsPublic     bool
+	ToolsetOauthEnabled pgtype.Bool
 }
 
 // Used during plugin generation: returns all active plugin servers joined with
@@ -433,6 +435,7 @@ func (q *Queries) ListPluginsWithServersForProject(ctx context.Context, projectI
 			&i.ToolsetID,
 			&i.ToolsetMcpSlug,
 			&i.ToolsetIsPublic,
+			&i.ToolsetOauthEnabled,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes an issue where private mcp servers with oauth didn't work in plugins

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin config generation for OAuth-enabled MCP servers. OAuth servers no longer bake auth headers or prompt for `GRAM_API_KEY`, so clients complete the OAuth flow correctly across Claude, Cursor, and Codex.

- **Bug Fixes**
  - Added `OAuthEnabled` to server info, populated from DB when a toolset has an external OAuth or proxy server.
  - Updated generators to omit auth headers and key prompts for OAuth servers; behavior for public and non-OAuth private servers is unchanged.
  - Added tests to verify no headers are set for OAuth servers in Claude, Cursor, and Codex configs.

<sup>Written for commit 05fbaa2ce17df39fc526933ed385ac36de76f369. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

