### PR TITLE
mig: add assistant_dashboard_messages table

### DIFF
--- a/.changeset/assistant-dashboard-messages-table.md
+++ b/.changeset/assistant-dashboard-messages-table.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add the `assistant_dashboard_messages` table — the user-visible conversation log for the AI Insights sidebar (user messages + the assistant's delivered replies), kept separate from the raw `chat_messages` transcript. Keyed by chat with a monotonic `seq` for incremental polling. Foundation for AGE-2631.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1182,6 +1182,33 @@ CREATE TABLE IF NOT EXISTS project_managed_assistants (
 
 CREATE INDEX IF NOT EXISTS project_managed_assistants_assistant_id_idx ON project_managed_assistants (assistant_id);
 
+-- assistant_dashboard_messages is the user-visible conversation log for a
+-- dashboard assistant chat: the user's messages and the assistant's delivered
+-- replies (written by the platform_dashboard_send_message egress tool). Kept
+-- separate from chat_messages, which holds the raw model/tool transcript — the
+-- dashboard renders only this clean log. Keyed by chat_id (the deterministic
+-- assistant thread chat) with a monotonic seq for incremental polling. user_id
+-- is the dashboard user the conversation belongs to, stamped on both the user's
+-- messages and the assistant's replies so reads scope to their owner.
+CREATE TABLE IF NOT EXISTS assistant_dashboard_messages (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  chat_id uuid NOT NULL,
+  user_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  seq BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT assistant_dashboard_messages_pkey PRIMARY KEY (id),
+  CONSTRAINT assistant_dashboard_messages_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT assistant_dashboard_messages_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE
+);
+
+-- (chat_id, seq) is the stable cursor for incremental polling.
+CREATE INDEX IF NOT EXISTS assistant_dashboard_messages_chat_id_seq_idx ON assistant_dashboard_messages (chat_id, seq);
+
 CREATE TABLE IF NOT EXISTS assistant_toolsets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   assistant_id uuid NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -99,6 +99,17 @@ type Assistant struct {
 	Deleted         bool
 }
 
+type AssistantDashboardMessage struct {
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+	ChatID    uuid.UUID
+	UserID    string
+	Role      string
+	Content   string
+	Seq       int64
+	CreatedAt pgtype.Timestamptz
+}
+
 type AssistantMemory struct {
 	ID             uuid.UUID
 	AssistantID    uuid.NullUUID

--- a/server/migrations/20260603143315_age-2631-assistant-dashboard-messages.sql
+++ b/server/migrations/20260603143315_age-2631-assistant-dashboard-messages.sql
@@ -1,0 +1,16 @@
+-- Create "assistant_dashboard_messages" table
+CREATE TABLE "assistant_dashboard_messages" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "chat_id" uuid NOT NULL,
+  "user_id" text NOT NULL,
+  "role" text NOT NULL,
+  "content" text NOT NULL,
+  "seq" bigint NOT NULL GENERATED ALWAYS AS IDENTITY,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "assistant_dashboard_messages_chat_id_fkey" FOREIGN KEY ("chat_id") REFERENCES "chats" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "assistant_dashboard_messages_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "assistant_dashboard_messages_chat_id_seq_idx" to table: "assistant_dashboard_messages"
+CREATE INDEX "assistant_dashboard_messages_chat_id_seq_idx" ON "assistant_dashboard_messages" ("chat_id", "seq");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:g8zhdLs7OZUa4etGDWOaYefVDNLx0aV4/Zkon9JcDSw=
+h1:DiRNUj4Tk+kLLTqSyn1tCpLOdFDOXUaUt266H6NrSgI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -205,3 +205,4 @@ h1:g8zhdLs7OZUa4etGDWOaYefVDNLx0aV4/Zkon9JcDSw=
 20260602183035_dashboard_trigger_unique_index.sql h1:tgKPbzPEDQjjPhjpjb/yMK3dDJDY4xjFlvtOMZwy5LY=
 20260602202253_mcp_collection_attachment_mcp_server_id.sql h1:Oy4CAg/xcVVrq+mMho5fmvWckLQdhCecrpRadQ1JiL0=
 20260603130426_risk-policies-add-message-types.sql h1:U9s5GPUuoojFLFjPnQyxftN10IUxFw+iTHuDgJ5voB4=
+20260603143315_age-2631-assistant-dashboard-messages.sql h1:cY9snSVnbLTFV+vKZ4pw5mH11TkZ2cBfb4IscJlQtkY=


### PR DESCRIPTION
## Summary

**Migration only**, now rebased to stand alone on `main` (the AGE-2631 stack's lower PRs merged).

Adds `assistant_dashboard_messages`, the user-visible AI Insights sidebar conversation log (user messages + the assistant's delivered replies), kept separate from `chat_messages` (the raw transcript). Keyed by `chat_id` with a monotonic `seq` for incremental polling; cascade FKs to `projects` and `chats`.

Migration re-diffed with a fresh timestamp (`20260602150948`) on top of the current main after #3124's managed-assistants migration was re-stamped on merge.

### Validation
- `mise lint:migrations`: ordering ✅, txmode ✅
- `atlas migrate lint` (clean pgvector dev DB): no findings ✅

Ref: AGE-2631