### PR TITLE
fix(plugins): use toolset custom domain when generating MCP URLs

### DIFF
--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -14,6 +14,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGeneratePluginWithCustomDomainURL(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "custom-server", MCPURL: "https://mcp.acme.com/mcp/my-slug"},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Acme",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	var mcpConfig claudeMCPConfig
+	err = json.Unmarshal(files["test/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+
+	server := mcpConfig.MCPServers["custom-server"]
+	require.Equal(t, "https://mcp.acme.com/mcp/my-slug", server.URL, "custom domain URL must be preserved verbatim in generated config")
+}
+
 func TestGeneratePluginPackagesProducesExpectedFiles(t *testing.T) {
 	t.Parallel()
 	plugins := []PluginInfo{

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1346,10 +1346,14 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 		}
 
 		if mcpSlug := conv.FromPGText[string](r.ToolsetMcpSlug); mcpSlug != nil {
+			mcpBase := s.serverURL
+			if cd := conv.FromPGText[string](r.ToolsetCustomDomain); cd != nil {
+				mcpBase = fmt.Sprintf("https://%s", *cd)
+			}
 			serverInfo := PluginServerInfo{
 				DisplayName: r.ServerDisplayName,
 				Policy:      r.ServerPolicy,
-				MCPURL:      fmt.Sprintf("%s/mcp/%s", s.serverURL, *mcpSlug),
+				MCPURL:      fmt.Sprintf("%s/mcp/%s", mcpBase, *mcpSlug),
 				IsPublic:    r.ToolsetIsPublic,
 				IsOAuth:     r.ToolsetIsOauth,
 				EnvConfigs:  nil,

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -127,7 +127,7 @@ SELECT
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
-LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.activated IS TRUE AND cd.verified IS TRUE
+LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.activated IS TRUE AND cd.verified IS TRUE AND cd.deleted IS FALSE
 WHERE p.project_id = @project_id
   AND p.deleted IS FALSE
 ORDER BY p.slug, ps.sort_order ASC;

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -122,10 +122,12 @@ SELECT
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
   t.mcp_is_public AS toolset_is_public,
-  (t.user_session_issuer_id IS NOT NULL)::bool AS toolset_is_oauth
+  (t.user_session_issuer_id IS NOT NULL)::bool AS toolset_is_oauth,
+  cd.domain AS toolset_custom_domain
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
+LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.activated IS TRUE AND cd.verified IS TRUE
 WHERE p.project_id = @project_id
   AND p.deleted IS FALSE
 ORDER BY p.slug, ps.sort_order ASC;

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -388,28 +388,31 @@ SELECT
   ps.toolset_id,
   t.mcp_slug AS toolset_mcp_slug,
   t.mcp_is_public AS toolset_is_public,
-  (t.user_session_issuer_id IS NOT NULL)::bool AS toolset_is_oauth
+  (t.user_session_issuer_id IS NOT NULL)::bool AS toolset_is_oauth,
+  cd.domain AS toolset_custom_domain
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
+LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.activated IS TRUE AND cd.verified IS TRUE
 WHERE p.project_id = $1
   AND p.deleted IS FALSE
 ORDER BY p.slug, ps.sort_order ASC
 `
 
 type ListPluginsWithServersForProjectRow struct {
-	PluginID          uuid.UUID
-	PluginName        string
-	PluginSlug        string
-	PluginDescription pgtype.Text
-	ServerID          uuid.UUID
-	ServerDisplayName string
-	ServerPolicy      string
-	ServerSortOrder   int32
-	ToolsetID         uuid.UUID
-	ToolsetMcpSlug    pgtype.Text
-	ToolsetIsPublic   bool
-	ToolsetIsOauth    bool
+	PluginID            uuid.UUID
+	PluginName          string
+	PluginSlug          string
+	PluginDescription   pgtype.Text
+	ServerID            uuid.UUID
+	ServerDisplayName   string
+	ServerPolicy        string
+	ServerSortOrder     int32
+	ToolsetID           uuid.UUID
+	ToolsetMcpSlug      pgtype.Text
+	ToolsetIsPublic     bool
+	ToolsetIsOauth      bool
+	ToolsetCustomDomain pgtype.Text
 }
 
 // Used during plugin generation: returns all active plugin servers joined with
@@ -436,6 +439,7 @@ func (q *Queries) ListPluginsWithServersForProject(ctx context.Context, projectI
 			&i.ToolsetMcpSlug,
 			&i.ToolsetIsPublic,
 			&i.ToolsetIsOauth,
+			&i.ToolsetCustomDomain,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -393,7 +393,7 @@ SELECT
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
 JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
-LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.activated IS TRUE AND cd.verified IS TRUE
+LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.activated IS TRUE AND cd.verified IS TRUE AND cd.deleted IS FALSE
 WHERE p.project_id = $1
   AND p.deleted IS FALSE
 ORDER BY p.slug, ps.sort_order ASC


### PR DESCRIPTION
## Summary

- `ListPluginsWithServersForProject` now LEFT JOINs `custom_domains` (filtered to `activated = TRUE AND verified = TRUE`) and surfaces `cd.domain AS toolset_custom_domain`
- `resolvePluginInfos` uses the custom domain as the MCP base URL when present, falling back to `s.serverURL` — no behaviour change for toolsets without a custom domain
- `repo/queries.sql.go` updated manually (no local DB for `gen:sqlc-server`)

## Test plan

- [ ] `TestGeneratePluginWithCustomDomainURL` — new test verifying a custom-domain MCP URL is preserved verbatim in generated configs
- [ ] All other `plugins` package tests pass (`88 tests, 0 new failures`)
- [ ] Manually verify plugin generation for a toolset with a verified custom domain uses `https://{custom_domain}/mcp/{slug}` in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves AGE-2646


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP URL generation to use a toolset’s verified custom domain when available and to ignore soft-deleted domains (AGE-2646). No change for toolsets without a custom domain.

- **Bug Fixes**
  - `ListPluginsWithServersForProject` LEFT JOINs `custom_domains` (activated, verified, not deleted) and surfaces `toolset_custom_domain`.
  - `resolvePluginInfos` uses the custom domain as the MCP base URL; falls back to `serverURL`.
  - Added `TestGeneratePluginWithCustomDomainURL` to ensure the custom-domain URL is preserved verbatim.

<sup>Written for commit 45c2440eace107e623b78e891f5a1f654bb95328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



