### PR TITLE
mig: add unique index for dashboard trigger instances

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -573,6 +573,10 @@ CREATE INDEX IF NOT EXISTS trigger_instances_environment_id_idx
 ON trigger_instances (environment_id)
 WHERE deleted IS FALSE;
 
+CREATE UNIQUE INDEX IF NOT EXISTS trigger_instances_dashboard_target_uniq
+ON trigger_instances (project_id, target_ref)
+WHERE definition_slug = 'dashboard' AND status = 'active' AND deleted IS FALSE;
+
 CREATE TABLE IF NOT EXISTS environment_entries (
   name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 60),
   value TEXT NOT NULL CHECK (value <> '' AND CHAR_LENGTH(value) <= 4000),

--- a/server/migrations/20260602183035_dashboard_trigger_unique_index.sql
+++ b/server/migrations/20260602183035_dashboard_trigger_unique_index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "trigger_instances_dashboard_target_uniq" to table: "trigger_instances"
+CREATE UNIQUE INDEX CONCURRENTLY "trigger_instances_dashboard_target_uniq" ON "trigger_instances" ("project_id", "target_ref") WHERE ((definition_slug = 'dashboard'::text) AND (status = 'active'::text) AND (deleted IS FALSE));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Y5mZCoDhBzu57Z1rGoALSvDirgQsSkzrnW3JUgUcxNA=
+h1:rmYpCQM5gNr513inj0COe2ut+e0Lm1/qQLkrFKmMnNI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -202,3 +202,4 @@ h1:Y5mZCoDhBzu57Z1rGoALSvDirgQsSkzrnW3JUgUcxNA=
 20260601212536_plugin-github-connections-add-published-fingerprint.sql h1:eYANo4SQbbKipX/n3geIZ4qZ2yT8RV3lw/PAn0YoPA8=
 20260602103955_age-2631-project-managed-assistants.sql h1:WTzRGPg815dtWcPpBbkJlWNyu2PRdArmtjbX0UDKySI=
 20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql h1:evD/ljifFim1YzJ59/guBM+buZD8hMlxSKNmtLkMXg8=
+20260602183035_dashboard_trigger_unique_index.sql h1:tgKPbzPEDQjjPhjpjb/yMK3dDJDY4xjFlvtOMZwy5LY=


### PR DESCRIPTION
Adds a partial unique index enforcing **at most one active dashboard trigger per (project, target)**.

Concurrent managed-assistant enables run `ensureDashboardTrigger` as a non-atomic list-then-create with no DB guard, so two simultaneous calls can both see an empty list and create duplicate dashboard triggers — every sidebar message would then dispatch twice. This index makes the invariant DB-enforced for all insert paths.

Scope notes:
- **Partial + slug-scoped** (`WHERE definition_slug = 'dashboard' AND status = 'active' AND deleted IS FALSE`) so other trigger kinds (slack, schedule) that legitimately allow multiple instances per target are unaffected. The predicate mirrors `ListActiveTriggerInstancesByTarget` exactly, so pausing (`status` change) or re-enabling after a soft-delete stays unblocked — only concurrent *active* dashboard triggers collide.
- Atlas emitted `CREATE UNIQUE INDEX CONCURRENTLY` with `txmode none` — no table lock.
- Safe to apply: the dashboard ingress feature isn't deployed yet, so there are zero `dashboard` trigger rows for the concurrent build to validate against.

Follow-up (separate app PR, after this lands): switch `ensureDashboardTrigger` to a single `INSERT … ON CONFLICT DO NOTHING` and drop the list-then-create.

✻ Clauded...