### PR TITLE
fix(server): provision dashboard trigger via ON CONFLICT DO NOTHING

### DIFF
--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -185,21 +185,7 @@ func (s *ServiceCore) DisableManagedAssistant(ctx context.Context, projectID uui
 // when absent. Idempotent so the enable fast path can heal a managed assistant
 // that predates dashboard ingress without depending on a fresh create.
 func (s *ServiceCore) ensureDashboardTrigger(ctx context.Context, db triggerrepo.DBTX, organizationID string, projectID, assistantID uuid.UUID, name string) error {
-	queries := triggerrepo.New(db)
-	existing, err := queries.ListActiveTriggerInstancesByTarget(ctx, triggerrepo.ListActiveTriggerInstancesByTargetParams{
-		ProjectID:      projectID,
-		DefinitionSlug: sourceKindDashboard,
-		TargetKind:     bgtriggers.TargetKindAssistant,
-		TargetRef:      assistantID.String(),
-	})
-	if err != nil {
-		return fmt.Errorf("list dashboard trigger instances: %w", err)
-	}
-	if len(existing) > 0 {
-		return nil
-	}
-
-	if _, err := queries.CreateTriggerInstance(ctx, triggerrepo.CreateTriggerInstanceParams{
+	_, err := triggerrepo.New(db).CreateDashboardTriggerInstance(ctx, triggerrepo.CreateDashboardTriggerInstanceParams{
 		OrganizationID: organizationID,
 		ProjectID:      projectID,
 		DefinitionSlug: sourceKindDashboard,
@@ -210,7 +196,10 @@ func (s *ServiceCore) ensureDashboardTrigger(ctx context.Context, db triggerrepo
 		TargetDisplay:  name,
 		ConfigJson:     []byte("{}"),
 		Status:         StatusActive,
-	}); err != nil {
+	})
+	// ON CONFLICT DO NOTHING returns no rows when an active trigger already
+	// exists for this project and target — the idempotent success path.
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("create dashboard trigger instance: %w", err)
 	}
 	return nil

--- a/server/internal/assistants/provisioning_test.go
+++ b/server/internal/assistants/provisioning_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
 )
 
 func newProvisioningCore(t *testing.T, conn *pgxpool.Pool) *ServiceCore {
@@ -61,6 +63,15 @@ func TestEnableManagedAssistantIsIdempotent(t *testing.T) {
 	got, err := core.GetManagedAssistant(ctx, projectID)
 	require.NoError(t, err)
 	require.Equal(t, first.ID, got.ID)
+
+	triggers, err := triggerrepo.New(conn).ListActiveTriggerInstancesByTarget(ctx, triggerrepo.ListActiveTriggerInstancesByTargetParams{
+		ProjectID:      projectID,
+		DefinitionSlug: sourceKindDashboard,
+		TargetKind:     bgtriggers.TargetKindAssistant,
+		TargetRef:      first.ID.String(),
+	})
+	require.NoError(t, err)
+	require.Len(t, triggers, 1, "re-enable must not duplicate the dashboard trigger")
 }
 
 func TestEnableManagedAssistantAttachesMCPReachableToolsets(t *testing.T) {

--- a/server/internal/triggers/repo/queries.sql
+++ b/server/internal/triggers/repo/queries.sql
@@ -23,6 +23,35 @@ INSERT INTO trigger_instances (
     @status
 ) RETURNING *;
 
+-- name: CreateDashboardTriggerInstance :one
+INSERT INTO trigger_instances (
+    organization_id,
+    project_id,
+    definition_slug,
+    name,
+    environment_id,
+    target_kind,
+    target_ref,
+    target_display,
+    config_json,
+    status
+) VALUES (
+    @organization_id,
+    @project_id,
+    @definition_slug,
+    @name,
+    @environment_id,
+    @target_kind,
+    @target_ref,
+    @target_display,
+    @config_json,
+    @status
+)
+ON CONFLICT (project_id, target_ref)
+  WHERE definition_slug = 'dashboard' AND status = 'active' AND deleted IS FALSE
+DO NOTHING
+RETURNING *;
+
 -- name: ListTriggerInstances :many
 SELECT *
 FROM trigger_instances ti

--- a/server/internal/triggers/repo/queries.sql.go
+++ b/server/internal/triggers/repo/queries.sql.go
@@ -12,6 +12,83 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const createDashboardTriggerInstance = `-- name: CreateDashboardTriggerInstance :one
+INSERT INTO trigger_instances (
+    organization_id,
+    project_id,
+    definition_slug,
+    name,
+    environment_id,
+    target_kind,
+    target_ref,
+    target_display,
+    config_json,
+    status
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10
+)
+ON CONFLICT (project_id, target_ref)
+  WHERE definition_slug = 'dashboard' AND status = 'active' AND deleted IS FALSE
+DO NOTHING
+RETURNING id, organization_id, project_id, definition_slug, name, environment_id, target_kind, target_ref, target_display, config_json, status, created_at, updated_at, deleted_at, deleted
+`
+
+type CreateDashboardTriggerInstanceParams struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	DefinitionSlug string
+	Name           string
+	EnvironmentID  uuid.NullUUID
+	TargetKind     string
+	TargetRef      string
+	TargetDisplay  string
+	ConfigJson     []byte
+	Status         string
+}
+
+func (q *Queries) CreateDashboardTriggerInstance(ctx context.Context, arg CreateDashboardTriggerInstanceParams) (TriggerInstance, error) {
+	row := q.db.QueryRow(ctx, createDashboardTriggerInstance,
+		arg.OrganizationID,
+		arg.ProjectID,
+		arg.DefinitionSlug,
+		arg.Name,
+		arg.EnvironmentID,
+		arg.TargetKind,
+		arg.TargetRef,
+		arg.TargetDisplay,
+		arg.ConfigJson,
+		arg.Status,
+	)
+	var i TriggerInstance
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.ProjectID,
+		&i.DefinitionSlug,
+		&i.Name,
+		&i.EnvironmentID,
+		&i.TargetKind,
+		&i.TargetRef,
+		&i.TargetDisplay,
+		&i.ConfigJson,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const createTriggerInstance = `-- name: CreateTriggerInstance :one
 INSERT INTO trigger_instances (
     organization_id,


### PR DESCRIPTION
Stacked on #3151 (the unique-index migration).

Replaces the race-prone list-then-create in `ensureDashboardTrigger` with a single `INSERT … ON CONFLICT DO NOTHING`, backed by the partial unique index that #3151 adds. Concurrent managed-assistant enables (the repair fast-path runs outside a transaction) can no longer create duplicate dashboard triggers — the DB now enforces the invariant instead of an application-level check.

- New `CreateDashboardTriggerInstance` sqlc query with `ON CONFLICT (project_id, target_ref) WHERE definition_slug = 'dashboard' AND status = 'active' AND deleted IS FALSE DO NOTHING`; the no-rows return is the idempotent success path.
- Drops the `ListActiveTriggerInstancesByTarget` + length-check + create dance.
- Strengthens `TestEnableManagedAssistantIsIdempotent` to assert a re-enable leaves exactly one active dashboard trigger.

Merge after #3151 so the index exists before this code runs.

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate dashboard triggers by inserting with ON CONFLICT DO NOTHING, backed by the partial unique index from #3151. Enabling a managed assistant is now idempotent under concurrency.

- **Bug Fixes**
  - Added `CreateDashboardTriggerInstance` in `server/internal/triggers/repo` using `ON CONFLICT (project_id, target_ref) WHERE definition_slug = 'dashboard' AND status = 'active' AND deleted IS FALSE DO NOTHING`; the sqlc method returns `pgx.ErrNoRows` on conflict and we treat it as success.
  - Updated `ensureDashboardTrigger` to call the new query and expanded `TestEnableManagedAssistantIsIdempotent` to assert exactly one active dashboard trigger after re-enable.

<sup>Written for commit d8f39b8523376d22abdbeedd0244f52ca83631dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

