### PR TITLE
fix(hooks): allow Claude MCP calls with Gram provenance

### DIFF
--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -721,12 +721,68 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 		return result, nil
 	}
 
+	evidence := shadowmcp.AccessEvidence{
+		FullURL:        "",
+		URLHost:        "",
+		ServerIdentity: mcpServerIdentityFromToolName(rawToolName),
+	}
+	provenancePresent, provenanceDetail, provenanceDenied := s.validateGramToolsetProvenance(ctx, payload.ToolInput, mcpToolName, metadata.GramOrgID)
+	provenanceValid := provenancePresent && !provenanceDenied
+	provenanceInvalid := provenancePresent && provenanceDenied
+
 	// Look up the cached `claude mcp list` snapshot captured at SessionStart.
 	// If it's missing we can't enforce the policy — deny with a retry-or-
 	// restart message so the user knows the guard is fail-closed rather
 	// than silently allowing.
 	entries, cacheErr := s.getCachedMCPList(ctx, sessionID)
 	if cacheErr != nil {
+		if provenanceValid {
+			s.logger.InfoContext(ctx, "claude tool call allowed via gram toolset provenance",
+				attr.SlogEvent("claude_hook_toolset_provenance_allow"),
+				attr.SlogHookSource("claude"),
+				attr.SlogHookEvent(payload.HookEventName),
+				attr.SlogOrganizationID(metadata.GramOrgID),
+				attr.SlogProjectID(metadata.ProjectID),
+				attr.SlogGenAIConversationID(sessionID),
+				attr.SlogToolName(rawToolName),
+				attr.SlogRiskPolicyID(policy.ID),
+			)
+			if output != nil {
+				output.PermissionDecision = &allow
+			}
+			return result, nil
+		}
+		if provenanceInvalid {
+			auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, provenanceDetail)
+			userReason := s.renderShadowMCPUserBlockReason(ctx, shadowMCPRequestLinkParams{
+				OrganizationID:  metadata.GramOrgID,
+				ProjectID:       metadata.ProjectID,
+				RequesterUserID: metadata.UserID,
+				UserMessage:     policy.UserMessage,
+				AuditReason:     auditReason,
+				Evidence:        evidence,
+				ToolName:        mcpToolName,
+				ToolInput:       payload.ToolInput,
+				RiskPolicyID:    policy.ID,
+			})
+			s.logger.With(
+				attr.SlogHookSource("claude"),
+				attr.SlogHookEvent(payload.HookEventName),
+				attr.SlogOrganizationID(metadata.GramOrgID),
+				attr.SlogProjectID(metadata.ProjectID),
+				attr.SlogGenAIConversationID(sessionID),
+				attr.SlogToolName(rawToolName),
+			).InfoContext(ctx, "denying claude tool call: invalid gram toolset provenance",
+				attr.SlogEvent("claude_hook_denied_invalid_toolset_provenance"),
+				attr.SlogHookBlockReason(provenanceDetail),
+				attr.SlogRiskPolicyID(policy.ID),
+				attr.SlogRiskPolicyName(policy.Name),
+				attr.SlogError(cacheErr),
+			)
+			s.writeClaudeBlockToClickHouse(ctx, payload, &metadata, auditReason)
+			s.recordShadowMCPBlockFinding(ctx, payload, &metadata, policy, nil, serverPrefix, provenanceDetail)
+			return constructBlockResponse(payload.HookEventName, userReason), nil
+		}
 		auditReason := "missing MCP list snapshot for session"
 		userReason := "Speakeasy blocked this tool call: MCP server configuration is not available yet. Please retry in a moment, or restart Claude Code if the issue persists."
 		s.logger.With(
@@ -749,7 +805,25 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 	matched := matchCachedMCPEntry(entries, serverPrefix)
 	var detail string
 	switch {
+	case provenanceInvalid:
+		detail = provenanceDetail
 	case matched == nil:
+		if provenanceValid {
+			s.logger.InfoContext(ctx, "claude tool call allowed via gram toolset provenance",
+				attr.SlogEvent("claude_hook_toolset_provenance_allow"),
+				attr.SlogHookSource("claude"),
+				attr.SlogHookEvent(payload.HookEventName),
+				attr.SlogOrganizationID(metadata.GramOrgID),
+				attr.SlogProjectID(metadata.ProjectID),
+				attr.SlogGenAIConversationID(sessionID),
+				attr.SlogToolName(rawToolName),
+				attr.SlogRiskPolicyID(policy.ID),
+			)
+			if output != nil {
+				output.PermissionDecision = &allow
+			}
+			return result, nil
+		}
 		detail = fmt.Sprintf("MCP server %q is not in the active configuration", serverPrefix)
 	case matched.URL != "" && !s.isGramHostedMCPURLForOrg(ctx, matched.URL, metadata.GramOrgID):
 		detail = fmt.Sprintf("MCP server %q is not Gram-hosted (URL: %s)", serverPrefix, matched.URL)
@@ -764,11 +838,6 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 		// fail closed with a clear reason than silently allow.
 		detail = fmt.Sprintf("MCP server %q has no recognizable target", serverPrefix)
 	}
-	evidence := shadowmcp.AccessEvidence{
-		FullURL:        "",
-		URLHost:        "",
-		ServerIdentity: mcpServerIdentityFromToolName(rawToolName),
-	}
 	if matched != nil {
 		evidence.FullURL = matched.URL
 		evidence.ServerIdentity = serverPrefix
@@ -778,7 +847,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 	}
 	// Access Rules can explicitly allow a shadow MCP server by URL, command,
 	// or server identity. Deny rules win inside EvaluateAccessRules.
-	if detail != "" && matched != nil {
+	if detail != "" && matched != nil && !provenanceInvalid {
 		if s.shadowMCPClient == nil {
 			detail = "Shadow MCP validation is unavailable"
 		} else {
@@ -795,11 +864,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 				}),
 			)
 			if decision.Allows() {
-				matchedURL, matchedCommand := "", ""
-				if matched != nil {
-					matchedURL = matched.URL
-					matchedCommand = matched.Command
-				}
+				matchedURL, matchedCommand := matched.URL, matched.Command
 				s.logger.InfoContext(ctx, "shadow-mcp call allowed via approval",
 					attr.SlogEvent("claude_hook_allowlist_allow"),
 					attr.SlogToolName(rawToolName),

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/accesscontrol"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/risk"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 )
 
 // stubBlockingShadowMCPScanner is a RiskScanner that always reports a
@@ -108,6 +109,69 @@ func TestClaude_PreToolUse_DeniesWhenMCPListNotCached(t *testing.T) {
 		"deny reason should tell the user to retry or restart so they aren't stuck guessing")
 }
 
+func TestClaude_PreToolUse_AllowsValidGramToolsetProvenanceWithoutMCPList(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolsetID := createHookToolsetWithHTTPTool(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "do_thing")
+	sessionID := uuid.NewString()
+	toolName := "mcp__gram__do_thing"
+	toolUseID := "toolu_valid_toolset_provenance"
+
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		ToolInput: map[string]any{
+			shadowmcp.XGramToolsetIDField: toolsetID.String(),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
+	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
+	require.NotNil(t, output.PermissionDecision)
+	assert.Equal(t, "allow", *output.PermissionDecision)
+}
+
+func TestClaude_PreToolUse_DeniesInvalidGramToolsetProvenanceWithoutMCPList(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	sessionID := uuid.NewString()
+	toolName := "mcp__gram__do_thing"
+	toolUseID := "toolu_invalid_toolset_provenance"
+
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		ToolInput: map[string]any{
+			shadowmcp.XGramToolsetIDField: "not-a-uuid",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
+	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
+	require.NotNil(t, output.PermissionDecision)
+	assert.Equal(t, "deny", *output.PermissionDecision)
+	require.NotNil(t, output.PermissionDecisionReason)
+	assert.Contains(t, *output.PermissionDecisionReason, "not a UUID")
+}
+
 // Gram-hosted MCP servers (URL host == app.getgram.ai) are the only ones
 // the shadow-MCP guard permits — even a server present in the cache is
 // rejected when its URL points elsewhere.
@@ -134,6 +198,44 @@ func TestClaude_PreToolUse_DeniesWhenMatchedServerNotGramHosted(t *testing.T) {
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
 		ToolInput:     map[string]any{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
+	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
+	require.NotNil(t, output.PermissionDecision)
+	assert.Equal(t, "deny", *output.PermissionDecision)
+}
+
+func TestClaude_PreToolUse_DeniesMatchedNonGramServerWithValidProvenance(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolsetID := createHookToolsetWithHTTPTool(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "send_message")
+	sessionID := uuid.NewString()
+	toolName := "mcp__plugin_slack_slack__send_message"
+	toolUseID := "toolu_non_gram_with_valid_provenance"
+
+	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID),
+		[]MCPServerEntry{{Source: "plugin", PluginName: "slack", Name: "slack", URL: "https://mcp.slack.com/mcp"}},
+		sessionMCPListTTL,
+	))
+
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		ToolInput: map[string]any{
+			shadowmcp.XGramToolsetIDField: toolsetID.String(),
+		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -48,6 +48,22 @@ func (s *Service) enforceShadowMCPToolAccess(
 	return detail, true
 }
 
+func (s *Service) validateGramToolsetProvenance(ctx context.Context, toolInput any, toolName string, organizationID string) (present bool, detail string, denied bool) {
+	inputMap, ok := toolInput.(map[string]any)
+	if !ok {
+		return false, "", false
+	}
+	if _, ok := inputMap[shadowmcp.XGramToolsetIDField]; !ok {
+		return false, "", false
+	}
+	if s.shadowMCPClient == nil {
+		return true, "Shadow MCP validation is unavailable", true
+	}
+
+	detail, denied = s.shadowMCPClient.ValidateToolsetCall(ctx, toolInput, toolName, organizationID)
+	return true, detail, denied
+}
+
 func codexShadowMCPEvidence(payload *gen.CodexPayload) shadowmcp.AccessEvidence {
 	return shadowmcp.AccessEvidence{
 		FullURL:        "",


### PR DESCRIPTION
## Summary
- Validate Claude MCP tool calls with `x-gram-toolset-id` before failing closed on missing or unmatched MCP inventory.
- Allow verified Gram toolset calls while preserving blocks for invalid provenance, local stdio servers, and cached non-Gram MCP servers.
- Add regression coverage for valid/invalid provenance and cached non-Gram evidence precedence.

## Test Plan
- `cd gram && go test ./server/internal/hooks`

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use `x-gram-toolset-id` to validate MCP server provenance in Claude hooks, preventing Shadow MCP from blocking legitimate Gram toolset calls. Valid provenance now allows tool calls even when the session MCP list is missing; invalid provenance is denied with clear reasons.

- **Bug Fixes**
  - Validate provenance via `shadowmcp` when `x-gram-toolset-id` is present; deny only if validation fails or is unavailable.
  - Allow calls with valid provenance even without a cached MCP list; still block non‑Gram and stdio servers.
  - Improve logging/audit with provenance details and evidence.
  - Add tests for valid/invalid provenance without MCP list, and for matched non‑Gram servers with valid provenance.

<sup>Written for commit 3409826b71b35d5a713555d1fe25cda89393b3ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

