### PR TITLE
feat(dashboard): embed book-demo form + Cal.com booking in the in-app gate (AGE-2649)

### DIFF
--- a/client/dashboard/package.json
+++ b/client/dashboard/package.json
@@ -21,6 +21,7 @@
     "@ai-sdk/ui-utils": "catalog:",
     "@assistant-ui/react": "^0.11.53",
     "@assistant-ui/react-markdown": "^0.11.9",
+    "@calcom/embed-react": "^1.5.3",
     "@datadog/browser-rum": "^6.24.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -3,13 +3,8 @@ import { useSdkClient } from "@/contexts/Sdk";
 import { useCaptureEnterpriseGateViewed } from "@/contexts/Telemetry";
 import { AuthLayout } from "@/pages/login/components/login-section";
 import { JourneyDemo } from "@/pages/login/components/journey-demo";
-import { Button } from "@speakeasy-api/moonshine";
-import {
-  CalendarIcon,
-  CheckCircle2Icon,
-  LogOutIcon,
-  MailIcon,
-} from "lucide-react";
+import { DemoBookingFlow } from "@/pages/demo/components/DemoBookingFlow";
+import { LogOutIcon } from "lucide-react";
 
 export default function BookDemo() {
   const client = useSdkClient();
@@ -27,13 +22,12 @@ export default function BookDemo() {
     window.location.href = "/login";
   };
 
-  const orgName = session?.organization?.name;
-
   return (
     <main className="flex min-h-screen flex-col md:flex-row">
       <JourneyDemo />
 
       <AuthLayout
+        contentClassName="max-w-2xl"
         topRight={
           <button
             onClick={handleLogout}
@@ -44,63 +38,7 @@ export default function BookDemo() {
           </button>
         }
       >
-        {/* Success message */}
-        <div className="flex flex-col items-center gap-3 text-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-50">
-            <CheckCircle2Icon className="h-6 w-6 text-emerald-600" />
-          </div>
-          <h1 className="text-2xl font-bold tracking-tight text-gray-900">
-            {orgName ? `${orgName} is set up` : "You're all set up"}
-          </h1>
-          <p className="text-sm leading-relaxed text-[#8B8684]">
-            Book a demo with our team to activate your account and get started
-            with the Speakeasy AI Control Plane.
-          </p>
-        </div>
-
-        {/* What you'll get */}
-        <div className="w-full rounded-lg border border-gray-200 bg-white p-5">
-          <p className="mb-3 text-xs font-medium tracking-wide text-[#8B8684] uppercase">
-            In your demo
-          </p>
-          <ul className="space-y-2.5 text-sm text-gray-700">
-            <li className="flex items-start gap-2.5">
-              <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
-              Platform walkthrough tailored to your use case
-            </li>
-            <li className="flex items-start gap-2.5">
-              <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
-              Help configuring MCP servers and integrations
-            </li>
-            <li className="flex items-start gap-2.5">
-              <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
-              Security and governance best practices
-            </li>
-          </ul>
-        </div>
-
-        {/* CTA */}
-        <div className="flex w-full flex-col gap-3">
-          <Button variant="brand" asChild className="w-full">
-            <a
-              href="https://www.speakeasy.com/book-demo"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center justify-center gap-2"
-            >
-              <CalendarIcon className="h-4 w-4" />
-              Book a Demo
-            </a>
-          </Button>
-
-          <a
-            href="mailto:sales@speakeasy.com"
-            className="inline-flex items-center justify-center gap-1.5 text-xs text-[#8B8684] transition-colors hover:text-slate-600"
-          >
-            <MailIcon className="h-3.5 w-3.5" />
-            Or contact sales@speakeasy.com
-          </a>
-        </div>
+        <DemoBookingFlow />
       </AuthLayout>
     </main>
   );

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
@@ -1,7 +1,15 @@
 import { cleanup, render, screen, fireEvent } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 
-const { captureMock } = vi.hoisted(() => ({ captureMock: vi.fn() }));
+type MockSession = { user: { email: string; displayName?: string } } | null;
+const { captureMock, sessionHolder } = vi.hoisted(() => ({
+  captureMock: vi.fn(),
+  sessionHolder: {
+    current: {
+      user: { email: "jane@acme.com", displayName: "Jane Smith" },
+    } as MockSession,
+  },
+}));
 
 // moonshine's bundle can't resolve lucide dynamic icons in tests — render Button
 // as a plain <button>.
@@ -31,9 +39,7 @@ vi.mock("@calcom/embed-react", () => ({
 }));
 
 vi.mock("@/contexts/Auth", () => ({
-  useSessionData: () => ({
-    session: { user: { email: "jane@acme.com", displayName: "Jane Smith" } },
-  }),
+  useSessionData: () => ({ session: sessionHolder.current }),
 }));
 
 vi.mock("@/contexts/Telemetry", () => ({
@@ -44,6 +50,9 @@ import { DemoBookingFlow } from "./DemoBookingFlow";
 
 beforeEach(() => {
   captureMock.mockClear();
+  sessionHolder.current = {
+    user: { email: "jane@acme.com", displayName: "Jane Smith" },
+  };
 });
 
 afterEach(cleanup);
@@ -130,5 +139,53 @@ describe("DemoBookingFlow", () => {
     fireEvent.click(screen.getByRole("button", { name: /Back/i }));
     expect(screen.getByText("Talk to our experts")).toBeTruthy();
     expect(screen.queryByTestId("cal-embed")).toBeNull();
+  });
+
+  it("backfills empty fields when the session arrives after mount", () => {
+    sessionHolder.current = null; // session still loading at mount
+    const { rerender } = render(<DemoBookingFlow />);
+    expect(
+      (screen.getByLabelText(/Work email/i) as HTMLInputElement).value,
+    ).toBe("");
+    expect(
+      (screen.getByLabelText(/First name/i) as HTMLInputElement).value,
+    ).toBe("");
+
+    sessionHolder.current = {
+      user: { email: "jane@acme.com", displayName: "Jane Smith" },
+    };
+    rerender(<DemoBookingFlow />);
+
+    expect(
+      (screen.getByLabelText(/Work email/i) as HTMLInputElement).value,
+    ).toBe("jane@acme.com");
+    expect(
+      (screen.getByLabelText(/First name/i) as HTMLInputElement).value,
+    ).toBe("Jane");
+    expect(
+      (screen.getByLabelText(/Last name/i) as HTMLInputElement).value,
+    ).toBe("Smith");
+  });
+
+  it("does not overwrite fields the user already edited when the session arrives", () => {
+    sessionHolder.current = null;
+    const { rerender } = render(<DemoBookingFlow />);
+    fireEvent.change(screen.getByLabelText(/First name/i), {
+      target: { value: "Custom" },
+    });
+
+    sessionHolder.current = {
+      user: { email: "jane@acme.com", displayName: "Jane Smith" },
+    };
+    rerender(<DemoBookingFlow />);
+
+    // user's edit is preserved...
+    expect(
+      (screen.getByLabelText(/First name/i) as HTMLInputElement).value,
+    ).toBe("Custom");
+    // ...while still-empty fields are backfilled
+    expect(
+      (screen.getByLabelText(/Work email/i) as HTMLInputElement).value,
+    ).toBe("jane@acme.com");
   });
 });

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
@@ -1,0 +1,134 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+
+const { captureMock } = vi.hoisted(() => ({ captureMock: vi.fn() }));
+
+// moonshine's bundle can't resolve lucide dynamic icons in tests — render Button
+// as a plain <button>.
+vi.mock("@speakeasy-api/moonshine", () => ({
+  Button: ({
+    children,
+    type,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    type?: "button" | "submit";
+    onClick?: () => void;
+    variant?: string;
+    className?: string;
+  }) => (
+    <button type={type} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+// Replace the Cal embed with a probe that exposes the calLink it received.
+vi.mock("@calcom/embed-react", () => ({
+  default: ({ calLink }: { calLink: string }) => (
+    <div data-testid="cal-embed" data-cal-link={calLink} />
+  ),
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useSessionData: () => ({
+    session: { user: { email: "jane@acme.com", displayName: "Jane Smith" } },
+  }),
+}));
+
+vi.mock("@/contexts/Telemetry", () => ({
+  useTelemetry: () => ({ capture: captureMock }),
+}));
+
+import { DemoBookingFlow } from "./DemoBookingFlow";
+
+beforeEach(() => {
+  captureMock.mockClear();
+});
+
+afterEach(cleanup);
+
+describe("DemoBookingFlow", () => {
+  it("prefills name and email from the session", () => {
+    render(<DemoBookingFlow />);
+    expect(
+      (screen.getByLabelText(/First name/i) as HTMLInputElement).value,
+    ).toBe("Jane");
+    expect(
+      (screen.getByLabelText(/Last name/i) as HTMLInputElement).value,
+    ).toBe("Smith");
+    expect(
+      (screen.getByLabelText(/Work email/i) as HTMLInputElement).value,
+    ).toBe("jane@acme.com");
+  });
+
+  it("blocks submission and shows an error when a required field is empty", () => {
+    render(<DemoBookingFlow />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue to booking/i }),
+    );
+    expect(screen.getByText("This field is required")).toBeTruthy();
+    expect(captureMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("cal-embed")).toBeNull();
+  });
+
+  it("advances to the Cal embed with an encoded link and fires demo_form_submitted", () => {
+    render(<DemoBookingFlow />);
+    fireEvent.change(screen.getByLabelText(/How did you hear about us/i), {
+      target: { value: "Google" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue to booking/i }),
+    );
+
+    expect(captureMock).toHaveBeenCalledWith("demo_form_submitted", {
+      product: "AI Control Plane",
+    });
+    const embed = screen.getByTestId("cal-embed");
+    const link = embed.getAttribute("data-cal-link") ?? "";
+    expect(link).toContain("first-name=Jane");
+    expect(link).toContain("heard-about-us=Google");
+    expect(link).toContain("interested-products=AI%20Control%20Plane");
+  });
+
+  it("fires booked_demo on a Cal bookingSuccessful message", () => {
+    render(<DemoBookingFlow />);
+    fireEvent.change(screen.getByLabelText(/How did you hear about us/i), {
+      target: { value: "Google" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue to booking/i }),
+    );
+    captureMock.mockClear();
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          originator: "CAL",
+          fullType: "CAL:bookingSuccessful",
+        }),
+      }),
+    );
+
+    expect(captureMock).toHaveBeenCalledWith(
+      "booked_demo",
+      expect.objectContaining({
+        email: "jane@acme.com",
+        product: "AI Control Plane",
+      }),
+    );
+  });
+
+  it("returns to the form when Back is clicked", () => {
+    render(<DemoBookingFlow />);
+    fireEvent.change(screen.getByLabelText(/How did you hear about us/i), {
+      target: { value: "Google" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue to booking/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Back/i }));
+    expect(screen.getByText("Talk to our experts")).toBeTruthy();
+    expect(screen.queryByTestId("cal-embed")).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -46,6 +46,24 @@ export function DemoBookingFlow() {
   });
   const [errors, setErrors] = useState<DemoFormErrors>({});
 
+  // The useState initializer above captures the session synchronously when it's
+  // already loaded (the gate that renders this only mounts after auth resolves).
+  // When this component is reused somewhere the session is still loading at
+  // mount, backfill any still-empty fields once it arrives — without clobbering
+  // anything the user has already typed (prev value wins).
+  const sessionEmail = session?.user.email;
+  const sessionDisplayName = session?.user.displayName;
+  useEffect(() => {
+    if (!sessionEmail && !sessionDisplayName) return;
+    const { firstName, lastName } = splitDisplayName(sessionDisplayName);
+    setFormData((prev) => ({
+      ...prev,
+      firstName: prev.firstName || firstName,
+      lastName: prev.lastName || lastName,
+      email: prev.email || sessionEmail || "",
+    }));
+  }, [sessionEmail, sessionDisplayName]);
+
   useEffect(() => {
     if (step !== "booking") return;
     const handler = (e: MessageEvent) => {

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useState } from "react";
+import _Cal from "@calcom/embed-react";
+import { Button } from "@speakeasy-api/moonshine";
+import { useSessionData } from "@/contexts/Auth";
+import { useTelemetry } from "@/contexts/Telemetry";
+import { cn } from "@/lib/utils";
+import {
+  buildCalLink,
+  DemoFormData,
+  DemoFormErrors,
+  PRODUCT_OPTIONS,
+  splitDisplayName,
+  validateDemoForm,
+} from "./demo-booking";
+
+// Cal's .d.ts returns the legacy global `JSX.Element`, incompatible with
+// react-jsx/TS5. Widen only the return type; keep prop types intact so a
+// mistyped prop (e.g. calLink) is still caught.
+type CalProps = Parameters<typeof _Cal>[0];
+const Cal = _Cal as unknown as (props: CalProps) => React.ReactElement | null;
+
+type Step = "form" | "booking";
+
+const inputStyles = cn(
+  "w-full rounded-md border px-3 py-2.5 text-sm text-gray-900 transition-colors outline-none",
+  "border-gray-300 bg-white placeholder:text-gray-400 focus:border-gray-500",
+);
+
+const labelStyles = "mb-0.5 text-sm text-gray-700";
+const errorStyles = "mt-0.5 text-xs text-red-500";
+
+export function DemoBookingFlow() {
+  const { session } = useSessionData();
+  const telemetry = useTelemetry();
+  const [step, setStep] = useState<Step>("form");
+
+  const [formData, setFormData] = useState<DemoFormData>(() => {
+    const { firstName, lastName } = splitDisplayName(session?.user.displayName);
+    return {
+      firstName,
+      lastName,
+      email: session?.user.email ?? "",
+      referralSource: "",
+      product: "AI Control Plane",
+    };
+  });
+  const [errors, setErrors] = useState<DemoFormErrors>({});
+
+  useEffect(() => {
+    if (step !== "booking") return;
+    const handler = (e: MessageEvent) => {
+      try {
+        const data =
+          typeof e.data === "string"
+            ? (JSON.parse(e.data) as Record<string, unknown>)
+            : (e.data as Record<string, unknown>);
+        if (
+          data?.originator === "CAL" &&
+          (data?.fullType as string)?.endsWith("bookingSuccessful")
+        ) {
+          telemetry.capture("booked_demo", {
+            first_name: formData.firstName.trim(),
+            last_name: formData.lastName.trim(),
+            email: formData.email.trim(),
+            referral_source: formData.referralSource.trim(),
+            product: formData.product,
+          });
+        }
+      } catch {
+        // ignore non-JSON postMessages from other senders
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [step, formData, telemetry]);
+
+  const handleChange =
+    (field: keyof DemoFormData) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setFormData((prev) => ({ ...prev, [field]: value }));
+      setErrors((prev) => {
+        if (!prev[field]) return prev;
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
+    };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const nextErrors = validateDemoForm(formData);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+    telemetry.capture("demo_form_submitted", { product: formData.product });
+    setStep("booking");
+  };
+
+  if (step === "booking") {
+    return (
+      <div className="flex w-full flex-col gap-3">
+        <button
+          type="button"
+          onClick={() => setStep("form")}
+          className="self-start text-sm text-[#8B8684] transition-colors hover:text-slate-600"
+        >
+          &larr; Back
+        </button>
+        <div className="h-[70vh] min-h-[520px] w-full overflow-auto">
+          <Cal
+            calLink={buildCalLink(formData)}
+            config={{
+              layout: "month_view",
+              theme: "light",
+              hideEventTypeDetails: "true",
+              cssVarsPerTheme: JSON.stringify({
+                light: { "cal-bg": "transparent" },
+                dark: { "cal-bg": "transparent" },
+              }),
+            }}
+            style={{ width: "100%", height: "100%", overflow: "auto" }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <h2 className="text-lg font-semibold text-gray-900">
+        Talk to our experts
+      </h2>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+        <div className="flex flex-col gap-2.5 md:flex-row">
+          <div className="flex w-full flex-col">
+            <label htmlFor="demo-firstName" className={labelStyles}>
+              First name <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="demo-firstName"
+              type="text"
+              autoComplete="given-name"
+              value={formData.firstName}
+              onChange={handleChange("firstName")}
+              placeholder="Jane"
+              className={cn(inputStyles, errors.firstName && "border-red-300")}
+            />
+            {errors.firstName && (
+              <span className={errorStyles}>{errors.firstName}</span>
+            )}
+          </div>
+          <div className="flex w-full flex-col">
+            <label htmlFor="demo-lastName" className={labelStyles}>
+              Last name <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="demo-lastName"
+              type="text"
+              autoComplete="family-name"
+              value={formData.lastName}
+              onChange={handleChange("lastName")}
+              placeholder="Smith"
+              className={cn(inputStyles, errors.lastName && "border-red-300")}
+            />
+            {errors.lastName && (
+              <span className={errorStyles}>{errors.lastName}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2.5 md:flex-row">
+          <div className="flex w-full flex-col">
+            <label htmlFor="demo-email" className={labelStyles}>
+              Work email <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="demo-email"
+              type="email"
+              autoComplete="email"
+              value={formData.email}
+              onChange={handleChange("email")}
+              placeholder="jane@example.com"
+              className={cn(inputStyles, errors.email && "border-red-300")}
+            />
+            {errors.email && (
+              <span className={errorStyles}>{errors.email}</span>
+            )}
+          </div>
+          <div className="flex w-full flex-col">
+            <label htmlFor="demo-referralSource" className={labelStyles}>
+              How did you hear about us? <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="demo-referralSource"
+              type="text"
+              value={formData.referralSource}
+              onChange={handleChange("referralSource")}
+              placeholder="e.g. Google, Twitter, a friend"
+              className={cn(
+                inputStyles,
+                errors.referralSource && "border-red-300",
+              )}
+            />
+            {errors.referralSource && (
+              <span className={errorStyles}>{errors.referralSource}</span>
+            )}
+          </div>
+        </div>
+
+        <fieldset className="flex flex-col gap-1.5">
+          <legend className={labelStyles}>
+            What are you interested in? <span className="text-red-500">*</span>
+          </legend>
+          <div className="grid grid-cols-2 gap-1.5">
+            {PRODUCT_OPTIONS.map((option) => (
+              <label
+                key={option}
+                className="flex cursor-pointer items-center gap-2"
+              >
+                <input
+                  type="radio"
+                  name="product"
+                  value={option}
+                  checked={formData.product === option}
+                  onChange={handleChange("product")}
+                  className="h-4 w-4 accent-gray-900"
+                />
+                <span className="text-sm text-gray-700">{option}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <Button type="submit" variant="brand" className="mt-2 w-fit">
+          Continue to booking
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/demo/components/demo-booking.test.ts
+++ b/client/dashboard/src/pages/demo/components/demo-booking.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCalLink,
+  CAL_ROUTING_FORM_ID,
+  DemoFormData,
+  splitDisplayName,
+  validateDemoForm,
+} from "./demo-booking";
+
+describe("splitDisplayName", () => {
+  it("splits a two-part name", () => {
+    expect(splitDisplayName("Jane Smith")).toEqual({
+      firstName: "Jane",
+      lastName: "Smith",
+    });
+  });
+  it("keeps everything after the first space as the last name", () => {
+    expect(splitDisplayName("Jane Van Der Berg")).toEqual({
+      firstName: "Jane",
+      lastName: "Van Der Berg",
+    });
+  });
+  it("treats a single token as the first name", () => {
+    expect(splitDisplayName("Cher")).toEqual({
+      firstName: "Cher",
+      lastName: "",
+    });
+  });
+  it("returns empty strings for missing/blank input", () => {
+    expect(splitDisplayName(undefined)).toEqual({
+      firstName: "",
+      lastName: "",
+    });
+    expect(splitDisplayName("   ")).toEqual({ firstName: "", lastName: "" });
+  });
+  it("trims surrounding whitespace", () => {
+    expect(splitDisplayName("  Jane Smith  ")).toEqual({
+      firstName: "Jane",
+      lastName: "Smith",
+    });
+  });
+});
+
+const validData: DemoFormData = {
+  firstName: "Jane",
+  lastName: "Smith",
+  email: "jane@acme.com",
+  referralSource: "Google",
+  product: "AI Control Plane",
+};
+
+describe("validateDemoForm", () => {
+  it("returns no errors for valid data", () => {
+    expect(validateDemoForm(validData)).toEqual({});
+  });
+  it("flags every required field when empty", () => {
+    const errors = validateDemoForm({
+      firstName: "",
+      lastName: "",
+      email: "",
+      referralSource: "",
+      product: "AI Control Plane",
+    });
+    expect(errors.firstName).toBeTruthy();
+    expect(errors.lastName).toBeTruthy();
+    expect(errors.email).toBeTruthy();
+    expect(errors.referralSource).toBeTruthy();
+  });
+  it("rejects a malformed email", () => {
+    expect(
+      validateDemoForm({ ...validData, email: "not-an-email" }).email,
+    ).toBeTruthy();
+  });
+});
+
+describe("buildCalLink", () => {
+  it("targets the routing form and URL-encodes fields", () => {
+    const link = buildCalLink(validData);
+    expect(link.startsWith(`router?form=${CAL_ROUTING_FORM_ID}`)).toBe(true);
+    expect(link).toContain("interested-products=AI%20Control%20Plane");
+    expect(link).toContain("email=jane%40acme.com");
+    expect(link).toContain("first-name=Jane");
+    expect(link).toContain("last-name=Smith");
+    expect(link).toContain("heard-about-us=Google");
+  });
+});

--- a/client/dashboard/src/pages/demo/components/demo-booking.test.ts
+++ b/client/dashboard/src/pages/demo/components/demo-booking.test.ts
@@ -71,6 +71,11 @@ describe("validateDemoForm", () => {
       validateDemoForm({ ...validData, email: "not-an-email" }).email,
     ).toBeTruthy();
   });
+  it("accepts an email with surrounding whitespace (validated trimmed, like buildCalLink)", () => {
+    expect(
+      validateDemoForm({ ...validData, email: "  jane@acme.com  " }).email,
+    ).toBeUndefined();
+  });
 });
 
 describe("buildCalLink", () => {

--- a/client/dashboard/src/pages/demo/components/demo-booking.ts
+++ b/client/dashboard/src/pages/demo/components/demo-booking.ts
@@ -1,0 +1,66 @@
+// Cal.com routing-form UUID — same form the marketing site's /book-demo uses,
+// so in-app bookings route identically. Rotate here if the Cal form changes.
+export const CAL_ROUTING_FORM_ID = "80acef04-31fd-4b18-bcae-6ee91d352bb8";
+
+export const PRODUCT_OPTIONS = [
+  "AI Control Plane",
+  "SDK Generation",
+  "CLI Generation",
+  "Terraform Generation",
+] as const;
+
+export type ProductInterest = (typeof PRODUCT_OPTIONS)[number];
+
+export interface DemoFormData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  referralSource: string;
+  product: ProductInterest;
+}
+
+export type DemoFormErrors = Partial<Record<keyof DemoFormData, string>>;
+
+export function splitDisplayName(displayName?: string): {
+  firstName: string;
+  lastName: string;
+} {
+  const trimmed = (displayName ?? "").trim();
+  if (!trimmed) return { firstName: "", lastName: "" };
+  const spaceIndex = trimmed.indexOf(" ");
+  if (spaceIndex === -1) return { firstName: trimmed, lastName: "" };
+  return {
+    firstName: trimmed.slice(0, spaceIndex),
+    lastName: trimmed.slice(spaceIndex + 1).trim(),
+  };
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validateDemoForm(data: DemoFormData): DemoFormErrors {
+  const errors: DemoFormErrors = {};
+  if (!data.firstName.trim()) errors.firstName = "First name is required";
+  if (!data.lastName.trim()) errors.lastName = "Last name is required";
+  if (!data.email.trim()) {
+    errors.email = "Work email is required";
+  } else if (!EMAIL_RE.test(data.email)) {
+    errors.email = "Enter a valid email address";
+  }
+  if (!data.referralSource.trim())
+    errors.referralSource = "This field is required";
+  return errors;
+}
+
+// Mirrors the marketing site's encoding exactly (encodeURIComponent -> %20 for
+// spaces) so in-app bookings route through the same Cal routing form.
+export function buildCalLink(data: DemoFormData): string {
+  const query = [
+    `form=${CAL_ROUTING_FORM_ID}`,
+    `first-name=${encodeURIComponent(data.firstName.trim())}`,
+    `last-name=${encodeURIComponent(data.lastName.trim())}`,
+    `email=${encodeURIComponent(data.email.trim())}`,
+    `heard-about-us=${encodeURIComponent(data.referralSource.trim())}`,
+    `interested-products=${encodeURIComponent(data.product)}`,
+  ].join("&");
+  return `router?${query}`;
+}

--- a/client/dashboard/src/pages/demo/components/demo-booking.ts
+++ b/client/dashboard/src/pages/demo/components/demo-booking.ts
@@ -43,7 +43,7 @@ export function validateDemoForm(data: DemoFormData): DemoFormErrors {
   if (!data.lastName.trim()) errors.lastName = "Last name is required";
   if (!data.email.trim()) {
     errors.email = "Work email is required";
-  } else if (!EMAIL_RE.test(data.email)) {
+  } else if (!EMAIL_RE.test(data.email.trim())) {
     errors.email = "Enter a valid email address";
   }
   if (!data.referralSource.trim())

--- a/client/dashboard/src/pages/login/components/login-section.tsx
+++ b/client/dashboard/src/pages/login/components/login-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@speakeasy-api/moonshine";
-import { buildLoginRedirectURL } from "@/lib/utils";
+import { buildLoginRedirectURL, cn } from "@/lib/utils";
 import { useSearchParams } from "react-router";
 import { useState } from "react";
 import {
@@ -86,9 +86,11 @@ function DotBackground() {
 export function AuthLayout({
   children,
   topRight,
+  contentClassName = "max-w-sm",
 }: {
   children: React.ReactNode;
   topRight?: React.ReactNode;
+  contentClassName?: string;
 }) {
   return (
     <div className="login-right-pane relative flex min-h-screen w-full flex-col items-center justify-center overflow-hidden bg-[#FAFAFA] p-8 md:w-1/2 md:p-16">
@@ -99,7 +101,12 @@ export function AuthLayout({
         <div className="absolute top-6 right-6 z-10">{topRight}</div>
       )}
 
-      <div className="relative z-10 flex w-full max-w-sm flex-col items-center gap-8">
+      <div
+        className={cn(
+          "relative z-10 flex w-full flex-col items-center gap-8",
+          contentClassName,
+        )}
+      >
         <div className="flex flex-col items-center gap-4">
           <a
             href="https://www.speakeasy.com/product/mcp-platform"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@assistant-ui/react-markdown':
         specifier: ^0.11.9
         version: 0.11.9(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@calcom/embed-react':
+        specifier: ^1.5.3
+        version: 1.5.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@datadog/browser-rum':
         specifier: ^6.24.1
         version: 6.24.1
@@ -271,7 +274,7 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nuqs:
         specifier: ^2.8.9
-        version: 2.8.9(@tanstack/react-router@1.168.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router-dom@7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.8.9(@tanstack/react-router@1.168.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router-dom@7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       posthog-js:
         specifier: ^1.298.0
         version: 1.298.0
@@ -1080,7 +1083,7 @@ importers:
         version: 12.23.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: ^15.4.0
-        version: 15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.0
         version: 19.2.3
@@ -1728,6 +1731,18 @@ packages:
 
   '@braintree/sanitize-url@7.1.1':
     resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
+
+  '@calcom/embed-core@1.5.3':
+    resolution: {integrity: sha512-GeId9gaByJ5EWiPmuvelZOvFWPOTWkcWZr5vGTCbIUTX125oE5yn0n8lDF1MJk5Xj1WO+/dk9jKIE08Ad9ytiQ==}
+
+  '@calcom/embed-react@1.5.3':
+    resolution: {integrity: sha512-JCgge04pc8fhdvUmPNVLhW8/lCWK+AAziKecKWWPfv1nn2s+qKP2BwsEAnxhxK9yPOBgE1EIEgmYkrrNB1iajA==}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+      react-dom: ^18.2.0 || ^19.0.0
+
+  '@calcom/embed-snippet@1.3.3':
+    resolution: {integrity: sha512-pqqKaeLB8R6BvyegcpI9gAyY6Xyx1bKYfWvIGOvIbTpguWyM1BBBVcT9DCeGe8Zw7Ujp5K56ci7isRUrT2Uadg==}
 
   '@changesets/apply-release-plan@7.0.13':
     resolution: {integrity: sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==}
@@ -10601,6 +10616,19 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.1': {}
 
+  '@calcom/embed-core@1.5.3': {}
+
+  '@calcom/embed-react@1.5.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@calcom/embed-core': 1.5.3
+      '@calcom/embed-snippet': 1.3.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@calcom/embed-snippet@1.3.3':
+    dependencies:
+      '@calcom/embed-core': 1.5.3
+
   '@changesets/apply-release-plan@7.0.13':
     dependencies:
       '@changesets/config': 3.1.1
@@ -17724,7 +17752,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
@@ -17732,7 +17760,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.12
       '@next/swc-darwin-x64': 15.5.12
@@ -17779,13 +17807,13 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.8.9(@tanstack/react-router@1.168.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router-dom@7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  nuqs@2.8.9(@tanstack/react-router@1.168.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router-dom@7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.3
     optionalDependencies:
       '@tanstack/react-router': 1.168.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      next: 15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-router-dom: 7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
@@ -19195,10 +19223,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.28.5
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
## Summary

Replaces the in-app book-demo gate's external link (which bounced users out to `speakeasy.com/book-demo`) with the marketing site's booking experience embedded **inline**: a "Talk to our experts" form → Cal.com booking embed. Closes [AGE-2649](https://linear.app/speakeasy/issue/AGE-2649/feedback-in-app-demo-gate-redirects-to-marketing-site).

The gate (`pages/demo/BookDemo.tsx`, shown to non-whitelisted orgs) keeps its existing `JourneyDemo` + `AuthLayout` framing; only the right-side success/CTA block is swapped for the new flow.

## What changed

- **`@calcom/embed-react`** added as a dashboard dependency.
- **`demo-booking.ts`** — pure, unit-tested helpers: `splitDisplayName`, `validateDemoForm`, `buildCalLink` (+ types/constants). `buildCalLink` targets the **same Cal routing form** the marketing site uses, so in-app bookings route identically.
- **`DemoBookingFlow.tsx`** — two-step `form → booking` component. Pre-fills name + email from the authenticated session (all fields editable). On submit → Cal embed with the collected fields passed through; a `bookingSuccessful` postMessage fires conversion analytics.
- **`AuthLayout`** — gains an optional `contentClassName` prop (defaults to `max-w-sm`) so the booking step can widen for the calendar. Existing login/register callers are unchanged.
- **Analytics** via the app's telemetry context: `demo_form_submitted` and `booked_demo` (consistent with existing `enterprise_gate_viewed` / `authorize_gram_user` events). The existing `useCaptureEnterpriseGateViewed` mount event is preserved.

Scope is the full-page gate only; the inline `EnterpriseGate` component is intentionally left as a follow-up (the flow is a self-contained component, so adopting it there later is cheap).

## Test plan

- [x] Unit tests: 14/14 pass (`demo-booking` 9, `DemoBookingFlow` 5 — prefill, validation gate, step transition, encoded Cal link, both analytics events, Back).
- [x] `tsc` clean for all changed files; `eslint` clean.
- [x] Production `vite build` succeeds.
- [ ] Reviewer visual QA: render the gate (non-whitelisted org), confirm prefill, form validation, the Cal calendar loads/pre-fills, and Back preserves values. Calendar sits in a half-pane at `max-w-2xl` (~672px) — usable but worth an eyeball at ~1280px.

## Notes

- No DB migrations.
- Marketing source: `marketing-site-new` `src/app/(marketing)/book-demo/demo-flow.tsx`.
- Follow-up (non-blocking): `booked_demo` has no de-dup latch, so a repeated Cal `bookingSuccessful` would re-fire it (matches the marketing source's behavior).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed the demo booking flow directly in the in-app gate, replacing the external redirect with a two-step form → Cal.com calendar. Addresses AGE-2649 and keeps bookings routed like the marketing site.

- **New Features**
  - Added `DemoBookingFlow` with Cal.com embed via `@calcom/embed-react`: form prefilled from session → Cal; Back preserves inputs.
  - Gate now renders `DemoBookingFlow` and widens the pane via `AuthLayout` `contentClassName`.
  - Telemetry: `demo_form_submitted` on submit, `booked_demo` on Cal `bookingSuccessful`.
  - New helpers in `demo-booking.ts`: `splitDisplayName`, `validateDemoForm`, `buildCalLink`.

- **Bug Fixes**
  - Email is trimmed before validation to accept whitespace-padded addresses, matching Cal link encoding.
  - Session-based prefill backfills fields when the session arrives after mount, without overwriting user edits.

<sup>Written for commit 69a5420d5d09aa7c77679c36ec48a3834d7dc0be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

