### PR TITLE
chore(remotesessions): fix cloning onto organization-level issuers and add runtime test coverage

### DIFF
--- a/server/internal/remotesessions/challenge_scope_e2e_test.go
+++ b/server/internal/remotesessions/challenge_scope_e2e_test.go
@@ -128,3 +128,59 @@ func TestBuildAuthorizationUrl_ScopeResolution(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildAuthorizationUrl_OrgLevelIssuer drives the same ListClients →
+// BuildAuthorizationUrl path against a client bound to an organization-level
+// (cross-project, project_id IS NULL) issuer inherited from the project's org.
+// This is the consent + challenge data source (ListRemoteSessionClientsForUserSessionIssuer),
+// which joins to the issuer purely by id, so the org-level issuer's endpoints
+// flow through unchanged.
+func TestBuildAuthorizationUrl_OrgLevelIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "org-listclients")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "org-listclients")
+	createRemoteClient(t, ctx, ti, issuerID.String(), userIssuerID.String(), "org-list-cid")
+
+	enc := testenv.NewEncryptionClient(t)
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	mgr := remotesessions.NewChallengeManager(
+		logger,
+		ti.conn,
+		enc,
+		policy,
+		cache.NoopCache,
+		mustURL(t, "http://localhost"),
+	)
+
+	clients, err := mgr.ListClients(ctx, *authCtx.ProjectID, userIssuerID)
+	require.NoError(t, err)
+	require.Len(t, clients, 1)
+	require.Equal(t, "org-list-cid", clients[0].ExternalClientID)
+
+	subject := urn.NewUserSubject("org-list-subject")
+	authURL, err := mgr.BuildAuthorizationUrl(ctx, remotesessions.ParentChallenge{
+		ID:                  uuid.NewString(),
+		ProjectID:           *authCtx.ProjectID,
+		UserSessionIssuerID: userIssuerID,
+		Subject:             &subject,
+		McpSlug:             "",
+		FinalRedirectURI:    "",
+	}, clients[0])
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(authURL)
+	require.NoError(t, err)
+	require.Equal(t, "https", parsed.Scheme)
+	require.Equal(t, "idp.example.com", parsed.Host)
+	require.Equal(t, "/authorize", parsed.Path)
+	require.Equal(t, "org-list-cid", parsed.Query().Get("client_id"))
+}

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -226,15 +226,16 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 		return nil, oops.E(oops.CodeBadRequest, err, "oauth proxy provider client credentials unavailable for clone").Log(ctx, logger)
 	}
 
-	// Confirm the issuer the caller named lives in the same project so a clone
-	// cannot graft a client onto an unrelated tenant's issuer. A NULL
-	// organization_id keeps this lookup strictly project-scoped — cloning a
-	// client onto an organization-level issuer is part of the deferred runtime
-	// work, not this management path.
+	// Confirm the issuer the caller named is reachable from the caller's
+	// project — either an issuer the project owns or an organization-level
+	// issuer inherited from the project's org — so a clone cannot graft a
+	// client onto an unrelated tenant's issuer. The cloned client row is still
+	// owned by the caller's project regardless of the issuer's scope; this
+	// mirrors the reachability gate in CreateRemoteSessionClient.
 	if _, err := txRepo.GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
-		OrganizationID: conv.ToPGTextEmpty(""),
+		OrganizationID: conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").Log(ctx, logger)

--- a/server/internal/remotesessions/clienthandlers_test.go
+++ b/server/internal/remotesessions/clienthandlers_test.go
@@ -199,6 +199,64 @@ func TestCreateRemoteSessionClient_RejectsCrossProjectRemoteIssuer(t *testing.T)
 	requireOopsCode(t, err, oops.CodeNotFound)
 }
 
+// TestCreateRemoteSessionClient_OrgLevelIssuer binds a project-scoped client to
+// an organization-level (cross-project, project_id IS NULL) issuer inherited
+// from the project's org. AGE-2485 added inheritance for these issuers but
+// deferred runtime consumption; the client stays project-owned while the issuer
+// it references is shared across the org.
+func TestCreateRemoteSessionClient_OrgLevelIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	issuerID := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "org-create-client")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "org-create-client")
+
+	created, err := ti.service.CreateRemoteSessionClient(ctx, &clientsgen.CreateRemoteSessionClientPayload{
+		RemoteSessionIssuerID: issuerID.String(),
+		UserSessionIssuerID:   userIssuerID.String(),
+		ClientID:              "org-create-cid",
+		ClientSecret:          nil,
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, issuerID.String(), created.RemoteSessionIssuerID)
+
+	clientUUID, err := uuid.Parse(created.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, countRemoteSessionClientUserSessionIssuerBindings(t, ctx, ti.conn, clientUUID, userIssuerID))
+}
+
+// TestCreateRemoteSessionClient_CrossOrgIssuerRejected confirms a caller cannot
+// bind a client to an org-level issuer owned by a different organization: the
+// reachability gate matches inherited issuers only when organization_id equals
+// the caller's active org.
+func TestCreateRemoteSessionClient_CrossOrgIssuerRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	otherOrg := createOrganization(t, ctx, ti.conn, "other-org-create")
+	issuerID := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, otherOrg, "create-cross-org")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "create-cross-org").String()
+
+	_, err := ti.service.CreateRemoteSessionClient(ctx, &clientsgen.CreateRemoteSessionClientPayload{
+		RemoteSessionIssuerID: issuerID.String(),
+		UserSessionIssuerID:   userIssuerID,
+		ClientID:              "cross-org-cid",
+		ClientSecret:          nil,
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
 func TestUpdateRemoteSessionClient_RejectsCrossProjectUserIssuer(t *testing.T) {
 	t.Parallel()
 
@@ -279,6 +337,31 @@ func TestGetRemoteSessionClient(t *testing.T) {
 	})
 	require.Error(t, err)
 	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// TestGetRemoteSessionClientWithIssuerByID_OrgLevelIssuer guards the runtime
+// token resolver (used by the refresh path): the joined client+issuer view must
+// resolve an org-level issuer's token endpoint even though the issuer carries no
+// project_id. The join keys purely on remote_session_issuer_id, so no project
+// predicate filters the issuer side.
+func TestGetRemoteSessionClientWithIssuerByID_OrgLevelIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	issuerID := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "org-tokenresolve")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "org-tokenresolve")
+	clientID := createRemoteClient(t, ctx, ti, issuerID.String(), userIssuerID.String(), "org-resolve-cid")
+
+	clientUUID, err := uuid.Parse(clientID)
+	require.NoError(t, err)
+
+	row, err := repo.New(ti.conn).GetRemoteSessionClientWithIssuerByID(ctx, clientUUID)
+	require.NoError(t, err)
+	require.Equal(t, issuerID, row.RemoteSessionIssuerID)
+	require.Equal(t, "https://idp.example.com/token", row.TokenEndpoint.String, "token resolver joins to the org-level issuer's token endpoint")
 }
 
 func TestListRemoteSessionClients(t *testing.T) {
@@ -919,6 +1002,65 @@ func TestCloneClientFromOAuthProxyProvider_ProviderNotFound(t *testing.T) {
 	_, err := ti.service.CloneClientFromOAuthProxyProvider(ctx, &clientsgen.CloneClientFromOAuthProxyProviderPayload{
 		OauthProxyProviderID:  uuid.NewString(),
 		RemoteSessionIssuerID: issuerID,
+		UserSessionIssuerID:   userIssuerID,
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// TestCloneClientFromOAuthProxyProvider_OrgLevelIssuer is the regression test
+// for AGE-2593: the clone path used to force a project-only issuer lookup, so
+// cloning onto an inherited org-level issuer returned a spurious 404. The
+// dashboard "clone" wizard lets operators pick inherited issuers, so this is a
+// reachable path.
+func TestCloneClientFromOAuthProxyProvider_OrgLevelIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	ctx = withAdmin(t, ctx)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	secrets := []byte(`{"client_id":"upstream-cid","client_secret":"upstream-shhh"}`)
+	proxyProviderID := insertProxyProvider(t, ctx, ti.conn, "clone-org", "custom", secrets)
+	issuerID := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "clone-org")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "clone-org").String()
+
+	result, err := ti.service.CloneClientFromOAuthProxyProvider(ctx, &clientsgen.CloneClientFromOAuthProxyProviderPayload{
+		OauthProxyProviderID:  proxyProviderID.String(),
+		RemoteSessionIssuerID: issuerID.String(),
+		UserSessionIssuerID:   userIssuerID,
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "upstream-cid", result.ClientID)
+	require.Equal(t, issuerID.String(), result.RemoteSessionIssuerID)
+}
+
+// TestCloneClientFromOAuthProxyProvider_CrossOrgIssuerRejected confirms the
+// widened clone lookup still refuses an org-level issuer owned by a different
+// organization.
+func TestCloneClientFromOAuthProxyProvider_CrossOrgIssuerRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	ctx = withAdmin(t, ctx)
+
+	otherOrg := createOrganization(t, ctx, ti.conn, "other-org-clone")
+	issuerID := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, otherOrg, "clone-cross-org")
+
+	secrets := []byte(`{"client_id":"upstream-cid","client_secret":"upstream-shhh"}`)
+	proxyProviderID := insertProxyProvider(t, ctx, ti.conn, "clone-cross-org", "custom", secrets)
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "clone-cross-org").String()
+
+	_, err := ti.service.CloneClientFromOAuthProxyProvider(ctx, &clientsgen.CloneClientFromOAuthProxyProviderPayload{
+		OauthProxyProviderID:  proxyProviderID.String(),
+		RemoteSessionIssuerID: issuerID.String(),
 		UserSessionIssuerID:   userIssuerID,
 		SessionToken:          nil,
 		ApikeyToken:           nil,

--- a/server/internal/remotesessions/setup_test.go
+++ b/server/internal/remotesessions/setup_test.go
@@ -29,6 +29,7 @@ import (
 	mcpmetadatarepo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	oauthrepo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
@@ -258,6 +259,44 @@ func createRemoteIssuerInProject(t *testing.T, ctx context.Context, conn *pgxpoo
 	})
 	require.NoError(t, err)
 	return issuer.ID
+}
+
+// seedOrgLevelRemoteIssuer creates an organization-level (cross-project,
+// project_id IS NULL) remote session issuer owned by the supplied organization.
+// Org-level issuers are addressed only by id; pass the caller's active org to
+// mint an inherited issuer or a different org to exercise cross-org isolation.
+func seedOrgLevelRemoteIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, slug string) uuid.UUID {
+	t.Helper()
+	issuer, err := repo.New(conn).CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         uuid.NullUUID{},
+		OrganizationID:                    conv.ToPGText(organizationID),
+		Slug:                              slug,
+		Issuer:                            "https://idp.example.com",
+		AuthorizationEndpoint:             conv.ToPGText("https://idp.example.com/authorize"),
+		TokenEndpoint:                     conv.ToPGText("https://idp.example.com/token"),
+		ScopesSupported:                   []string{"openid"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+	})
+	require.NoError(t, err)
+	return issuer.ID
+}
+
+// createOrganization seeds a second organization_metadata row so tests can
+// exercise cross-organization isolation. Returns the new organization id.
+func createOrganization(t *testing.T, ctx context.Context, conn *pgxpool.Pool, slug string) string {
+	t.Helper()
+	orgID := uuid.NewString()
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        slug,
+		Slug:        slug,
+		WorkosID:    pgtype.Text{String: orgID, Valid: true},
+		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+	})
+	require.NoError(t, err)
+	return orgID
 }
 
 func createRemoteIssuer(t *testing.T, ctx context.Context, svc *testInstance, slug, regEndpoint string) string {


### PR DESCRIPTION
Follow-up to #3108, which added org-level (cross-project, `project_id IS NULL`) `remote_session_issuers` but deferred runtime consumption. The clone path (`CloneClientFromOAuthProxyProvider`) was the only runtime gap: it forced a project-only issuer lookup, so cloning a client onto an inherited org-level issuer returned a spurious 404. It now passes the caller's active organization id, matching `CreateRemoteSessionClient`.

The remaining runtime paths already resolved org-level issuers because clients stay project-scoped and the join queries key on `remote_session_issuer_id` without a project predicate on the issuer; this adds test coverage proving it across client create/clone (including cross-org rejection), the consent/challenge `ListClients` to `BuildAuthorizationUrl` path, and the token-refresh resolver.

Org-level issuers remain id-addressable only (no slug uniqueness), so no migration is included.

https://linear.app/speakeasy/issue/AGE-2593/wire-organization-level-remote-session-issuers-into-runtime


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow cloning remote session clients onto organization-level issuers and add runtime tests to validate issuer resolution and org isolation. Addresses AGE-2593.

- **Bug Fixes**
  - `CloneClientFromOAuthProxyProvider` now validates issuer reachability using the caller’s `ActiveOrganizationID`, allowing clones onto inherited org-level issuers and preventing false 404s. Mirrors the gate in `CreateRemoteSessionClient`; cross-org issuers are still rejected.
  - Added runtime coverage for org-level issuers across: client create/clone, consent/challenge `ListClients` → `BuildAuthorizationUrl`, and token refresh via `GetRemoteSessionClientWithIssuerByID`.

- **Migration**
  - No action needed. Org-level issuers remain id-addressable only; no migration required.

<sup>Written for commit 87b2aa8c0fd16cb3d2a17f34c641dfc4354ddad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

