### PR TITLE
fix(mcpmetadata): suppress GRAM key prompt on issuer-gated install pages

### DIFF
--- a/.changeset/issuer-gated-install-no-gram-key.md
+++ b/.changeset/issuer-gated-install-no-gram-key.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+MCP install pages no longer ask for a GRAM API key on private servers whose identity is delegated to a `user_session_issuer` (the newer OAuth scheme). Previously `resolveSecurityMode` only recognized the legacy `oauth_proxy_server_id` / `external_oauth_server_id` fields, so an issuer-gated private server fell through to the Gram-key prompt even though OAuth handles authentication. The check now also honors the `user_session_issuer` on the toolset and on the bridging `mcp_server`, matching the public serve path.

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -173,8 +173,10 @@ type Service struct {
 	installPageScriptData []byte
 }
 
-var _ gen.Service = (*Service)(nil)
-var _ gen.Auther = (*Service)(nil)
+var (
+	_ gen.Service = (*Service)(nil)
+	_ gen.Auther  = (*Service)(nil)
+)
 
 func NewService(
 	logger *slog.Logger,
@@ -570,7 +572,7 @@ func (s *Service) ExportMcpMetadata(ctx context.Context, payload *gen.ExportMcpM
 	}
 
 	// Collect security inputs
-	securityMode := s.resolveSecurityMode(&toolset)
+	securityMode := s.resolveSecurityMode(&toolset, nil)
 	securityInputs := s.collectEnvironmentVariables(securityMode, toolsetDetails, headerDisplayNames, variableProvidedBy)
 
 	// Build tools list
@@ -1124,7 +1126,7 @@ func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseW
 		}
 	}
 
-	securityMode := s.resolveSecurityMode(toolset)
+	securityMode := s.resolveSecurityMode(toolset, ic.mcpServer)
 	securityInputs := s.collectEnvironmentVariables(securityMode, toolsetDetails, headerDisplayNames, variableProvidedBy)
 
 	tools := []toolInfo{}
@@ -1527,12 +1529,21 @@ func (s *Service) loadToolsetFromContextAndSlug(ctx context.Context, mcpSlug str
 	return &toolset, nil
 }
 
-// resolveSecurityMode determines the security mode based on toolset configuration.
-// OAuth wins regardless of public/private: when an OAuth proxy or external OAuth
-// server is attached, identity auth is delegated to the OAuth flow and the
-// install instructions must not ask the user for an Authorization/GRAM_KEY header.
-func (s *Service) resolveSecurityMode(toolset *toolsets_repo.Toolset) securityMode {
-	if toolset.OauthProxyServerID.Valid || toolset.ExternalOauthServerID.Valid {
+// resolveSecurityMode determines the security mode based on toolset and
+// mcp_server configuration. OAuth wins regardless of public/private: when an
+// OAuth proxy, external OAuth server, or user_session_issuer is attached,
+// identity auth is delegated to the OAuth flow and the install instructions
+// must not ask the user for an Authorization/GRAM_KEY header. The
+// user_session_issuer can sit on the toolset (legacy toolset routing) or on
+// the bridging mcp_server (Remote-MCP path), mirroring the public serve path
+// which gates OAuth on UserSessionIssuerID.Valid from both sources. server is
+// nil when the install is not mcp_server-backed.
+func (s *Service) resolveSecurityMode(toolset *toolsets_repo.Toolset, server *mcpservers_repo.McpServer) securityMode {
+	oauthRequired := toolset.OauthProxyServerID.Valid ||
+		toolset.ExternalOauthServerID.Valid ||
+		toolset.UserSessionIssuerID.Valid ||
+		(server != nil && server.UserSessionIssuerID.Valid)
+	if oauthRequired {
 		return securityModeOAuth
 	}
 

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -1009,6 +1009,105 @@ func TestServeInstallPage_PrivateWithGramOAuth_NoAuthorizationHeader(t *testing.
 	assert.NotContains(t, body, "GRAM_KEY", "OAuth-protected install command must not reference the GRAM_KEY env var")
 }
 
+// TestServeInstallPage_PrivateWithUserSessionIssuer_NoGramKey covers the new
+// OAuth scheme: a private toolset gated by a user_session_issuer (rather than
+// the legacy oauth_proxy/external_oauth fields) delegates identity to OAuth, so
+// the install page must not ask for a GRAM key.
+func TestServeInstallPage_PrivateWithUserSessionIssuer_NoGramKey(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mcpSlug := "private-usi-mcp-" + uuid.NewString()[:8]
+	toolset, err := ti.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Private USI Toolset",
+		Slug:                   "private-usi-ts-" + uuid.NewString()[:8],
+		Description:            conv.ToPGText("Private toolset gated by a user_session_issuer"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText(mcpSlug),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	usi := createUserSessionIssuer(t, ctx, ti, *authCtx.ProjectID)
+
+	_, err = ti.toolsetRepo.UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+		UserSessionIssuerID: uuid.NullUUID{UUID: usi.ID, Valid: true},
+		Slug:                toolset.Slug,
+		ProjectID:           toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, ti.service.ServeInstallPage(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.NotContains(t, body, "gram-key", "issuer-gated install command must not reference the gram-key input")
+	assert.NotContains(t, body, "gram-environment", "issuer-gated install command must not reference the gram-environment input")
+	assert.NotContains(t, body, "GRAM_KEY", "issuer-gated install command must not reference the GRAM_KEY env var")
+}
+
+// TestServeInstallPage_McpServer_UserSessionIssuer_NoGramKey covers the bridge
+// case: the user_session_issuer is attached to the mcp_server, not the
+// toolset. The toolset is private with no OAuth of its own, so without
+// consulting the mcp_server's issuer the page would wrongly render the GRAM
+// key input.
+func TestServeInstallPage_McpServer_UserSessionIssuer_NoGramKey(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset, err := ti.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Bridged USI Toolset",
+		Slug:                   "bridged-usi-ts-" + uuid.NewString()[:8],
+		Description:            conv.ToPGText("Private toolset bridged by an issuer-gated mcp_server"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText("bridged-usi-mcp-" + uuid.NewString()[:8]),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	usi := createUserSessionIssuer(t, ctx, ti, *authCtx.ProjectID)
+
+	endpointSlug := "bridged-usi-endpoint-" + uuid.NewString()[:8]
+	createMcpServerWithEndpoint(t, ctx, ti, mcpServerFixtureOptions{
+		name:                "Issuer-Gated Bridged Server",
+		visibility:          mcpservers.VisibilityPrivate,
+		endpointSlug:        endpointSlug,
+		toolsetID:           uuid.NullUUID{UUID: toolset.ID, Valid: true},
+		userSessionIssuerID: uuid.NullUUID{UUID: usi.ID, Valid: true},
+	})
+
+	req := httptest.NewRequest("GET", "/mcp/"+endpointSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", endpointSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, ti.service.ServeInstallPage(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.NotContains(t, body, "gram-key", "issuer-gated mcp_server install command must not reference the gram-key input")
+	assert.NotContains(t, body, "GRAM_KEY", "issuer-gated mcp_server install command must not reference the GRAM_KEY env var")
+}
+
 // TestServeInstallPage_NoDomain_AuthedUserWithOrgDomain verifies that a toolset
 // WITHOUT a custom domain can still be loaded via the platform domain when the
 // logged-in user's organization happens to have a custom domain configured. This

--- a/server/internal/mcpmetadata/setup_test.go
+++ b/server/internal/mcpmetadata/setup_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -28,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
 var (
@@ -112,12 +114,13 @@ func newTestMCPMetadataService(t *testing.T) (context.Context, *testInstance) {
 // mcp_servers (the dual-source bridge path); RemoteMcpServerID is non-Nil for
 // Remote-MCP-backed installs.
 type mcpServerFixtureOptions struct {
-	name              string
-	visibility        string
-	endpointSlug      string
-	toolsetID         uuid.NullUUID
-	remoteMcpServerID uuid.NullUUID
-	customDomainID    uuid.NullUUID
+	name                string
+	visibility          string
+	endpointSlug        string
+	toolsetID           uuid.NullUUID
+	remoteMcpServerID   uuid.NullUUID
+	customDomainID      uuid.NullUUID
+	userSessionIssuerID uuid.NullUUID
 }
 
 func createMcpServerWithEndpoint(
@@ -169,7 +172,7 @@ func createMcpServerWithEndpoint(
 		Name:                conv.ToPGText(opts.name),
 		Slug:                conv.ToPGText("mcp-server-" + uuid.NewString()[:8]),
 		EnvironmentID:       uuid.NullUUID{},
-		UserSessionIssuerID: uuid.NullUUID{},
+		UserSessionIssuerID: opts.userSessionIssuerID,
 		RemoteMcpServerID:   opts.remoteMcpServerID,
 		ToolsetID:           opts.toolsetID,
 		Visibility:          opts.visibility,
@@ -185,4 +188,27 @@ func createMcpServerWithEndpoint(
 	require.NoError(t, err)
 
 	return server, endpoint
+}
+
+// createUserSessionIssuer inserts a bare user_session_issuer row in the
+// project. The install-page security mode only reads UserSessionIssuerID.Valid
+// off the toolset/mcp_server, so no remote_session_issuer/client wiring is
+// needed here.
+func createUserSessionIssuer(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID) usersessions_repo.UserSessionIssuer {
+	t.Helper()
+
+	usi, err := usersessions_repo.New(ti.conn).CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
+		ProjectID:          projectID,
+		Slug:               "usi-" + uuid.NewString()[:8],
+		AuthnChallengeMode: "interactive",
+		SessionDuration: pgtype.Interval{
+			Microseconds: int64(time.Hour / time.Microsecond),
+			Days:         0,
+			Months:       0,
+			Valid:        true,
+		},
+	})
+	require.NoError(t, err)
+
+	return usi
 }


### PR DESCRIPTION
## Summary

`resolveSecurityMode` (`server/internal/mcpmetadata/impl.go`) decides whether the MCP install page tells the user to supply a GRAM API key. It treated a server as OAuth-protected only when `oauth_proxy_server_id` or `external_oauth_server_id` was set on the toolset, ignoring `user_session_issuer_id` — the newer OAuth scheme.

Result: a **private** server gated only by a `user_session_issuer` fell into `securityModeGram`, so the install page asked for a GRAM API key even though OAuth handles identity.

## Change

- Include `toolset.UserSessionIssuerID.Valid` and the bridging `mcp_server`'s issuer in the OAuth check, mirroring the public serve path (`server/internal/mcp`) which gates OAuth on `UserSessionIssuerID.Valid` from both sources.
- Behavior now: private + requires OAuth (oauth proxy, external oauth, **or** user_session_issuer) → no API key; private + no OAuth → API key.

## Tests

- `TestServeInstallPage_PrivateWithUserSessionIssuer_NoGramKey` — toolset-attached issuer.
- `TestServeInstallPage_McpServer_UserSessionIssuer_NoGramKey` — bridge case, issuer on the `mcp_server`.

Resolves AGE-2652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP install page asking for a GRAM key on issuer-gated private servers by treating `user_session_issuer` as OAuth in `mcpmetadata`. Aligns `resolveSecurityMode` with the public serve path so OAuth-gated installs never ask for `GRAM_KEY`. Addresses AGE-2652.

- **Bug Fixes**
  - Include `UserSessionIssuerID` on toolsets and bridged `mcp_server` in the OAuth check; updated `resolveSecurityMode(toolset, server)`.
  - Install page now suppresses `GRAM_KEY` for issuer-gated private servers; only prompts when private and no OAuth is configured.
  - Added tests for toolset-attached and `mcp_server`-attached issuer cases.

<sup>Written for commit aac79e6421202f78c56c79edb43ebe55de5e6f1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

