### PR TITLE
mig: add mcp_server_id to organization_mcp_collection_server_attachments

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2016,27 +2016,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS organization_mcp_collection_registries_collect
   ON organization_mcp_collection_registries (collection_id)
   WHERE deleted IS FALSE;
 
--- Join table linking servers to collections (for catalog publishing)
-CREATE TABLE IF NOT EXISTS organization_mcp_collection_server_attachments (
-  published_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  deleted_at timestamptz,
-  published_by TEXT,
-  id uuid NOT NULL DEFAULT generate_uuidv7(),
-  collection_id uuid NOT NULL,
-  toolset_id uuid NOT NULL,
-  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
-
-  CONSTRAINT organization_mcp_collection_server_attachments_pkey PRIMARY KEY (id),
-  CONSTRAINT organization_mcp_collection_server_attachments_collection_id_fkey FOREIGN KEY (collection_id) REFERENCES organization_mcp_collections (id) ON DELETE CASCADE,
-  CONSTRAINT organization_mcp_collection_server_attachments_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE CASCADE
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS organization_mcp_collection_server_attachments_collection_toolset_key
-  ON organization_mcp_collection_server_attachments (collection_id, toolset_id)
-  WHERE deleted IS FALSE;
-
 CREATE TABLE IF NOT EXISTS external_mcp_attachments (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   deployment_id uuid NOT NULL,
@@ -2494,6 +2473,35 @@ WHERE remote_mcp_server_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS mcp_servers_toolset_id_idx
 ON mcp_servers (toolset_id)
 WHERE toolset_id IS NOT NULL;
+
+-- Join table linking servers to collections (for catalog publishing)
+CREATE TABLE IF NOT EXISTS organization_mcp_collection_server_attachments (
+  published_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  published_by TEXT,
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  collection_id uuid NOT NULL,
+  toolset_id uuid,
+  mcp_server_id uuid,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT organization_mcp_collection_server_attachments_pkey PRIMARY KEY (id),
+  CONSTRAINT organization_mcp_collection_server_attachments_collection_id_fkey FOREIGN KEY (collection_id) REFERENCES organization_mcp_collections (id) ON DELETE CASCADE,
+  CONSTRAINT organization_mcp_collection_server_attachments_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE CASCADE,
+  CONSTRAINT organization_mcp_collection_server_attachments_mcp_server_id_fkey FOREIGN KEY (mcp_server_id) REFERENCES mcp_servers (id) ON DELETE CASCADE,
+  -- Exactly one backend must be set: either a toolset or an mcp_server.
+  CONSTRAINT organization_mcp_collection_server_attachments_backend_exclusivity_check CHECK ((toolset_id IS NULL) != (mcp_server_id IS NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS organization_mcp_collection_server_attachments_collection_toolset_key
+  ON organization_mcp_collection_server_attachments (collection_id, toolset_id)
+  WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS organization_mcp_collection_server_attachments_collection_mcp_server_key
+  ON organization_mcp_collection_server_attachments (collection_id, mcp_server_id)
+  WHERE deleted IS FALSE;
 
 CREATE TABLE IF NOT EXISTS mcp_metadata (
   id UUID NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -482,7 +482,7 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 	attached, err := tx.IsServerAttachedToOrganizationMcpCollection(ctx, repo.IsServerAttachedToOrganizationMcpCollectionParams{
 		CollectionID:   collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
-		ToolsetID:      toolsetID,
+		ToolsetID:      uuid.NullUUID{UUID: toolsetID, Valid: true},
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "error checking collection server attachment").Log(ctx, s.logger)
@@ -494,7 +494,7 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 	if err := tx.DetachServerFromOrganizationMcpCollection(ctx, repo.DetachServerFromOrganizationMcpCollectionParams{
 		CollectionID:   collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
-		ToolsetID:      toolsetID,
+		ToolsetID:      uuid.NullUUID{UUID: toolsetID, Valid: true},
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to detach server from collection").Log(ctx, s.logger)
 	}
@@ -678,7 +678,7 @@ func (s *Service) attachServerToCollection(ctx context.Context, queries *repo.Qu
 	_, err = queries.AttachServerToOrganizationMcpCollection(ctx, repo.AttachServerToOrganizationMcpCollectionParams{
 		CollectionID:   collectionID,
 		OrganizationID: organizationID,
-		ToolsetID:      toolsetID,
+		ToolsetID:      uuid.NullUUID{UUID: toolsetID, Valid: true},
 		PublishedBy:    conv.PtrToPGTextEmpty(&userID),
 	})
 	if err != nil {

--- a/server/internal/collections/repo/models.go
+++ b/server/internal/collections/repo/models.go
@@ -27,7 +27,8 @@ type OrganizationMcpCollectionServerAttachment struct {
 	PublishedBy  pgtype.Text
 	ID           uuid.UUID
 	CollectionID uuid.UUID
-	ToolsetID    uuid.UUID
+	ToolsetID    uuid.NullUUID
+	McpServerID  uuid.NullUUID
 	Deleted      bool
 }
 

--- a/server/internal/collections/repo/queries.sql.go
+++ b/server/internal/collections/repo/queries.sql.go
@@ -22,11 +22,11 @@ SELECT id, $1, $2
 FROM org_collection
 ON CONFLICT (collection_id, toolset_id) WHERE deleted IS FALSE DO UPDATE
 SET published_by = EXCLUDED.published_by, published_at = clock_timestamp(), deleted_at = NULL, updated_at = clock_timestamp()
-RETURNING published_at, created_at, updated_at, deleted_at, published_by, id, collection_id, toolset_id, deleted
+RETURNING published_at, created_at, updated_at, deleted_at, published_by, id, collection_id, toolset_id, mcp_server_id, deleted
 `
 
 type AttachServerToOrganizationMcpCollectionParams struct {
-	ToolsetID      uuid.UUID
+	ToolsetID      uuid.NullUUID
 	PublishedBy    pgtype.Text
 	CollectionID   uuid.UUID
 	OrganizationID string
@@ -49,6 +49,7 @@ func (q *Queries) AttachServerToOrganizationMcpCollection(ctx context.Context, a
 		&i.ID,
 		&i.CollectionID,
 		&i.ToolsetID,
+		&i.McpServerID,
 		&i.Deleted,
 	)
 	return i, err
@@ -203,7 +204,7 @@ WHERE
 `
 
 type DetachServerFromOrganizationMcpCollectionParams struct {
-	ToolsetID      uuid.UUID
+	ToolsetID      uuid.NullUUID
 	CollectionID   uuid.UUID
 	OrganizationID string
 }
@@ -455,7 +456,7 @@ SELECT EXISTS (
 type IsServerAttachedToOrganizationMcpCollectionParams struct {
 	CollectionID   uuid.UUID
 	OrganizationID string
-	ToolsetID      uuid.UUID
+	ToolsetID      uuid.NullUUID
 }
 
 func (q *Queries) IsServerAttachedToOrganizationMcpCollection(ctx context.Context, arg IsServerAttachedToOrganizationMcpCollectionParams) (bool, error) {

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -834,7 +834,8 @@ type OrganizationMcpCollectionServerAttachment struct {
 	PublishedBy  pgtype.Text
 	ID           uuid.UUID
 	CollectionID uuid.UUID
-	ToolsetID    uuid.UUID
+	ToolsetID    uuid.NullUUID
+	McpServerID  uuid.NullUUID
 	Deleted      bool
 }
 

--- a/server/migrations/20260602202253_mcp_collection_attachment_mcp_server_id.sql
+++ b/server/migrations/20260602202253_mcp_collection_attachment_mcp_server_id.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "organization_mcp_collection_server_attachments" table
+ALTER TABLE "organization_mcp_collection_server_attachments" ADD CONSTRAINT "organization_mcp_collection_server_attachments_backend_exclusiv" CHECK ((toolset_id IS NULL) <> (mcp_server_id IS NULL)), ALTER COLUMN "toolset_id" DROP NOT NULL, ADD COLUMN "mcp_server_id" uuid NULL, ADD CONSTRAINT "organization_mcp_collection_server_attachments_mcp_server_id_fk" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- Create index "organization_mcp_collection_server_attachments_collection_mcp_s" to table: "organization_mcp_collection_server_attachments"
+CREATE UNIQUE INDEX CONCURRENTLY "organization_mcp_collection_server_attachments_collection_mcp_s" ON "organization_mcp_collection_server_attachments" ("collection_id", "mcp_server_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:rmYpCQM5gNr513inj0COe2ut+e0Lm1/qQLkrFKmMnNI=
+h1:qVJKdG9Whw6FOS2FvbG13dP7kpAmdIOA/QBYQgucWXM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -203,3 +203,4 @@ h1:rmYpCQM5gNr513inj0COe2ut+e0Lm1/qQLkrFKmMnNI=
 20260602103955_age-2631-project-managed-assistants.sql h1:WTzRGPg815dtWcPpBbkJlWNyu2PRdArmtjbX0UDKySI=
 20260602133246_add-tool-variations-group-id-to-toolsets-and-mcp-servers.sql h1:evD/ljifFim1YzJ59/guBM+buZD8hMlxSKNmtLkMXg8=
 20260602183035_dashboard_trigger_unique_index.sql h1:tgKPbzPEDQjjPhjpjb/yMK3dDJDY4xjFlvtOMZwy5LY=
+20260602202253_mcp_collection_attachment_mcp_server_id.sql h1:Oy4CAg/xcVVrq+mMho5fmvWckLQdhCecrpRadQ1JiL0=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2238/migration-add-mcp-server-id-to-organization-mcp-collection-server

Expand step of expand-contract: relax `toolset_id` to nullable and add a nullable `mcp_server_id` column with a `CASCADE` FK to `mcp_servers`, gated by an XOR check so a collection attachment references exactly one backend. Add a unique index on `(collection_id, mcp_server_id)`. Regenerate sqlc code (`toolset_id` becomes nullable) and wrap the existing `collections` call sites to keep the build green. No new feature queries; those are tracked in AGE-2651.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `mcp_server_id` to `organization_mcp_collection_server_attachments` and make `toolset_id` nullable to support attaching collections to either a toolset or an MCP server. Expand step for AGE-2238; no behavior change, just schema + generated code updates.

- **Migration**
  - Add nullable `mcp_server_id` with CASCADE FK to `mcp_servers`; relax `toolset_id` to nullable.
  - Enforce XOR check (exactly one of `toolset_id` or `mcp_server_id` must be set).
  - Add unique index on `(collection_id, mcp_server_id)`; keep existing `(collection_id, toolset_id)`.
  - Include forward-only migration and schema updates.

- **Refactors**
  - Regenerate `sqlc` models (`ToolsetID` -> `uuid.NullUUID`; add `McpServerID`) and update `collections` call sites to pass nullable IDs.
  - No new feature queries; follow-up tracked in AGE-2651.

<sup>Written for commit 129e4870b9f8b2c98b67cf5462718243736ab8d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

