### PR TITLE
feat: gate manual access rule creation

### DIFF
--- a/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   useRoles: vi.fn(),
   useApprovalRequests: vi.fn(),
   useAccessRules: vi.fn(),
+  useRiskListPolicies: vi.fn(),
   useSdkClient: vi.fn(),
   mutation: vi.fn(),
   invalidate: vi.fn(),
@@ -65,6 +67,10 @@ vi.mock("@gram/client/react-query/shadowMCPAccessRules.js", () => ({
   useShadowMCPAccessRules: mocks.useAccessRules,
 }));
 
+vi.mock("@gram/client/react-query/riskListPolicies.js", () => ({
+  useRiskListPolicies: mocks.useRiskListPolicies,
+}));
+
 vi.mock("@gram/client/react-query/approveShadowMCPApprovalRequest.js", () => ({
   useApproveShadowMCPApprovalRequestMutation: mocks.mutation,
 }));
@@ -110,8 +116,22 @@ vi.mock("@speakeasy-api/moonshine", () => ({
       LeftIcon: ({ children }: { children: ReactNode }) => (
         <span>{children}</span>
       ),
+      RightIcon: ({ children }: { children: ReactNode }) => (
+        <span>{children}</span>
+      ),
       Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
     },
+  ),
+  Icon: ({ name }: { name: string }) => <span aria-hidden>{name}</span>,
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipPortal: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
   ),
   DropdownMenu: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
@@ -281,9 +301,20 @@ function renderContent(projectId = "project-1") {
   const queryClient = new QueryClient();
 
   return render(
-    <QueryClientProvider client={queryClient}>
-      <ApprovalRequestsContent projectId={projectId} />
-    </QueryClientProvider>,
+    <MemoryRouter
+      initialEntries={["/speakeasy/projects/project-1/approval-requests"]}
+    >
+      <Routes>
+        <Route
+          path="/:orgSlug/projects/:projectSlug/approval-requests"
+          element={
+            <QueryClientProvider client={queryClient}>
+              <ApprovalRequestsContent projectId={projectId} />
+            </QueryClientProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
   );
 }
 
@@ -307,6 +338,20 @@ beforeEach(() => {
   });
   mocks.useAccessRules.mockReturnValue({
     data: { rules: [] },
+    isLoading: false,
+    error: null,
+  });
+  mocks.useRiskListPolicies.mockReturnValue({
+    data: {
+      policies: [
+        {
+          id: "policy-1",
+          enabled: true,
+          action: "block",
+          sources: ["shadow_mcp"],
+        },
+      ],
+    },
     isLoading: false,
     error: null,
   });
@@ -350,6 +395,108 @@ describe("ApprovalRequestsContent", () => {
     expect(screen.queryByText("Approved")).toBeNull();
     expect(screen.queryByText("All")).toBeNull();
     expect(screen.queryByText("Approval History")).toBeNull();
+  });
+
+  it("shows a manage policies empty state when no blocking Shadow MCP policy is enabled", async () => {
+    mocks.useRBAC.mockReturnValue({
+      hasScope: (scope: string) => scope === "org:admin",
+      hasAnyScope: (scopes: string[]) => scopes.includes("org:admin"),
+      hasAllScopes: () => true,
+      isLoading: false,
+    });
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: {
+        policies: [
+          {
+            id: "policy-1",
+            enabled: true,
+            action: "flag",
+            sources: ["shadow_mcp"],
+          },
+          {
+            id: "policy-2",
+            enabled: false,
+            action: "block",
+            sources: ["shadow_mcp"],
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(screen.getByText("No access rules")).toBeTruthy();
+    });
+    expect(
+      screen.getByText(
+        "Create a blocking risk policy for Shadow MCP servers before adding access rules.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add Rule" })).toBeNull();
+    const managePoliciesLink = screen.getByRole("link", {
+      name: "Manage Policies",
+    });
+    expect(managePoliciesLink.getAttribute("href")).toBe(
+      "/speakeasy/projects/project-1/risk-policies",
+    );
+  });
+
+  it("shows the add rule empty state when a blocking Shadow MCP policy is enabled", async () => {
+    mocks.useRBAC.mockReturnValue({
+      hasScope: (scope: string) => scope === "org:admin",
+      hasAnyScope: (scopes: string[]) => scopes.includes("org:admin"),
+      hasAllScopes: () => true,
+      isLoading: false,
+    });
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(screen.getByText("No access rules")).toBeTruthy();
+    });
+    expect(
+      screen.getByText(
+        "Create a rule manually or approve a request to allow or deny matching resources.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add Rule" })).toHaveProperty(
+      "disabled",
+      false,
+    );
+    expect(screen.queryByRole("link", { name: "Manage Policies" })).toBeNull();
+  });
+
+  it("shows the add rule empty state when policies fail to load", async () => {
+    mocks.useRBAC.mockReturnValue({
+      hasScope: (scope: string) => scope === "org:admin",
+      hasAnyScope: (scopes: string[]) => scopes.includes("org:admin"),
+      hasAllScopes: () => true,
+      isLoading: false,
+    });
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Policy load failed"),
+    });
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(screen.getByText("No access rules")).toBeTruthy();
+    });
+    expect(
+      screen.getByText(
+        "Create a rule manually or approve a request to allow or deny matching resources.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add Rule" })).toHaveProperty(
+      "disabled",
+      false,
+    );
+    expect(screen.queryByRole("link", { name: "Manage Policies" })).toBeNull();
   });
 
   it("does not load or render approval requests for non-admin org readers", () => {

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
@@ -25,6 +25,7 @@ import { useOrganization } from "@/contexts/Auth";
 import { useRBAC } from "@/hooks/useRBAC";
 import { cn } from "@/lib/utils";
 import { useSdkClient } from "@/contexts/Sdk";
+import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
 import type { ShadowMCPAccessRule } from "@gram/client/models/components/shadowmcpaccessrule.js";
 import type { ShadowMCPApprovalRequest } from "@gram/client/models/components/shadowmcpapprovalrequest.js";
 import { useApproveShadowMCPApprovalRequestMutation } from "@gram/client/react-query/approveShadowMCPApprovalRequest.js";
@@ -33,6 +34,7 @@ import { useDeleteShadowMCPAccessRuleMutation } from "@gram/client/react-query/d
 import { useDenyShadowMCPApprovalRequestMutation } from "@gram/client/react-query/denyShadowMCPApprovalRequest.js";
 import { invalidateAllShadowMCPAccessRules } from "@gram/client/react-query/shadowMCPAccessRules.js";
 import { invalidateAllShadowMCPApprovalRequests } from "@gram/client/react-query/shadowMCPApprovalRequests.js";
+import { useRiskListPolicies } from "@gram/client/react-query/riskListPolicies.js";
 import { useUpdateShadowMCPAccessRuleMutation } from "@gram/client/react-query/updateShadowMCPAccessRule.js";
 import {
   Badge,
@@ -42,12 +44,18 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Icon,
   Table,
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipTrigger,
 } from "@speakeasy-api/moonshine";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { Ellipsis, Inbox, Plus, ShieldCheck } from "lucide-react";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router";
 import { toast } from "sonner";
 import {
   formatShortDate,
@@ -75,6 +83,21 @@ type ReviewAction = "approve" | "deny";
 const APPROVAL_REQUESTS_PAGE_SIZE = 100;
 const APPROVAL_REQUESTS_QUERY_KEY = ["approval-requests", "requests"];
 const APPROVAL_REQUEST_RULES_QUERY_KEY = ["approval-requests", "access-rules"];
+const ACCESS_RULE_BLOCKING_POLICY_REQUIREMENTS = [
+  {
+    source: "shadow_mcp",
+    label: "Shadow MCP",
+  },
+] as const;
+const CREATE_BLOCKING_POLICY_MESSAGE =
+  "Create a blocking Shadow MCP policy before adding access rules.";
+const DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION =
+  "Create a rule manually or approve a request to allow or deny matching resources.";
+
+type AccessRuleCreateAvailability =
+  | { status: "available" }
+  | { status: "checking"; reason: string }
+  | { status: "missing_blocking_policy"; reason: string };
 
 const MATCH_BREADTH_OPTIONS: {
   value: ShadowMCPMatchBreadth;
@@ -83,6 +106,40 @@ const MATCH_BREADTH_OPTIONS: {
   { value: "full_url", label: "Full URL" },
   { value: "url_host", label: "URL host" },
 ];
+
+function getAccessRuleCreateAvailability({
+  canCreateAccessRules,
+  isLoadingPolicies,
+}: {
+  canCreateAccessRules: boolean;
+  isLoadingPolicies: boolean;
+}): AccessRuleCreateAvailability {
+  if (isLoadingPolicies) {
+    return {
+      status: "checking",
+      reason: "Checking Shadow MCP policies...",
+    };
+  }
+
+  if (!canCreateAccessRules) {
+    return {
+      status: "missing_blocking_policy",
+      reason: CREATE_BLOCKING_POLICY_MESSAGE,
+    };
+  }
+
+  return { status: "available" };
+}
+
+function policyEnablesAccessRules(policy: RiskPolicy) {
+  return (
+    policy.enabled &&
+    policy.action === "block" &&
+    ACCESS_RULE_BLOCKING_POLICY_REQUIREMENTS.some((requirement) =>
+      policy.sources.includes(requirement.source),
+    )
+  );
+}
 
 function TableEmptyState({
   title,
@@ -111,7 +168,7 @@ function ApprovalSectionEmptyState({
 }: {
   icon: React.ComponentType<{ className?: string }>;
   title: string;
-  description: string;
+  description: React.ReactNode;
   action?: React.ReactNode;
 }) {
   return (
@@ -128,6 +185,24 @@ function ApprovalSectionEmptyState({
       {action}
     </div>
   );
+}
+
+function getAccessRulesEmptyDescription(
+  availability: AccessRuleCreateAvailability,
+) {
+  if (availability.status === "missing_blocking_policy") {
+    const policyLabel = ACCESS_RULE_BLOCKING_POLICY_REQUIREMENTS.map(
+      (requirement) => requirement.label,
+    ).join(", ");
+
+    return `Create a blocking risk policy for ${policyLabel} servers before adding access rules.`;
+  }
+
+  if (availability.status === "checking") {
+    return availability.reason;
+  }
+
+  return DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION;
 }
 
 function ServerCell({
@@ -714,13 +789,49 @@ function RuleActionsMenu({
   );
 }
 
-function AddRuleButton({ onClick }: { onClick: () => void }) {
-  return (
-    <Button onClick={onClick}>
+function AddRuleButton({
+  disabled,
+  disabledReason,
+  onClick,
+}: {
+  disabled?: boolean;
+  disabledReason?: string;
+  onClick: () => void;
+}) {
+  const button = (
+    <Button disabled={disabled} onClick={disabled ? undefined : onClick}>
       <Button.LeftIcon>
         <Plus className="h-4 w-4" />
       </Button.LeftIcon>
       <Button.Text>Add Rule</Button.Text>
+    </Button>
+  );
+
+  if (!disabled) {
+    return button;
+  }
+
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild>
+        <div className="inline-flex cursor-not-allowed">{button}</div>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent>{disabledReason}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}
+
+function ManagePoliciesButton() {
+  return (
+    <Button variant="primary" asChild>
+      <Link to="../risk-policies" relative="path">
+        <Button.Text>Manage Policies</Button.Text>
+        <Button.RightIcon>
+          <Icon name="arrow-right" />
+        </Button.RightIcon>
+      </Link>
     </Button>
   );
 }
@@ -771,6 +882,9 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     enabled: projectId.length > 0,
   });
+  const policiesQuery = useRiskListPolicies(undefined, undefined, {
+    enabled: canAdmin && projectId.length > 0,
+  });
 
   const requests = useMemo(
     () => requestsQuery.data?.pages.flatMap((page) => page.requests) ?? [],
@@ -780,6 +894,27 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
     () => rulesQuery.data?.pages.flatMap((page) => page.rules) ?? [],
     [rulesQuery.data?.pages],
   );
+  const canCreateAccessRules = useMemo(
+    () =>
+      policiesQuery.error
+        ? true
+        : (policiesQuery.data?.policies.some(policyEnablesAccessRules) ??
+          false),
+    [policiesQuery.data?.policies, policiesQuery.error],
+  );
+  const accessRuleCreateAvailability = getAccessRuleCreateAvailability({
+    canCreateAccessRules,
+    isLoadingPolicies: policiesQuery.isLoading,
+  });
+  const addRuleDisabledReason =
+    accessRuleCreateAvailability.status === "available"
+      ? undefined
+      : accessRuleCreateAvailability.reason;
+  const accessRulesEmptyDescription = getAccessRulesEmptyDescription(
+    accessRuleCreateAvailability,
+  );
+  const showManagePoliciesEmptyAction =
+    accessRuleCreateAvailability.status === "missing_blocking_policy";
   const requestsLoading = requestsQuery.isLoading;
   const requestsError = requestsQuery.error;
   const rulesLoading = rulesQuery.isLoading;
@@ -1221,7 +1356,11 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
                 </SelectContent>
               </Select>
               <RequireScope scope="org:admin" level="component">
-                <AddRuleButton onClick={openCreateRuleSheet} />
+                <AddRuleButton
+                  disabled={!!addRuleDisabledReason}
+                  disabledReason={addRuleDisabledReason}
+                  onClick={openCreateRuleSheet}
+                />
               </RequireScope>
             </div>
           )}
@@ -1238,11 +1377,19 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
           <ApprovalSectionEmptyState
             icon={ShieldCheck}
             title="No access rules"
-            description="Create a rule manually or approve a request to allow or deny matching resources."
+            description={accessRulesEmptyDescription}
             action={
-              <RequireScope scope="org:admin" level="component">
-                <AddRuleButton onClick={openCreateRuleSheet} />
-              </RequireScope>
+              showManagePoliciesEmptyAction ? (
+                <ManagePoliciesButton />
+              ) : (
+                <RequireScope scope="org:admin" level="component">
+                  <AddRuleButton
+                    disabled={!!addRuleDisabledReason}
+                    disabledReason={addRuleDisabledReason}
+                    onClick={openCreateRuleSheet}
+                  />
+                </RequireScope>
+              )
             }
           />
         ) : (


### PR DESCRIPTION
## Summary
-Disable manual Add Rule actions while a blocking Shadow MCP policy state is loading, not created, or not enabled
- Show a Manage Policies empty state when no blocking Shadow MCP policy enables access rules
- Add tests for missing, present, and failed policy loads

These are UX improvements based on some feedback

## Test Plan
- [x] pnpm -F dashboard test ApprovalRequestsContent.test.tsx
- [x] pnpm -F dashboard type-check
- [x] pnpm -F dashboard lint

Linear: https://linear.app/speakeasy/issue/AGE-2655/feat-hide-the-ability-to-add-access-rule-when-no-policy-is-blocking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate manual “Add Rule” behind a blocking Shadow MCP risk policy. Show a “Manage Policies” empty state when no blocking policy is enabled, and disable the button with a tooltip while policies load. Aligns with Linear AGE-2655.

- **New Features**
  - Query policies via `@gram/client/react-query/riskListPolicies` and detect enabled `block` policy for `shadow_mcp`.
  - Disable “Add Rule” with a tooltip during policy load; show “Manage Policies” action when a blocking policy is missing.
  - Keep normal empty state and enable “Add Rule” when a blocking policy exists or policy fetching fails.
  - Added tests for present/missing/failed policy loads and updated tests to use `MemoryRouter` for the new “Manage Policies” link.

<sup>Written for commit c0421173dd76886742c293407fbed3169707ed84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

