### PR TITLE
feat(mcp): wire MCP server tool filtering into /mcp handler

### DIFF
--- a/.changeset/age-2358-mcp-tag-filtering.md
+++ b/.changeset/age-2358-mcp-tag-filtering.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+The public `/mcp` handler now supports filtering exposed tools by variation tag via the `?tags=` URL query parameter (comma-separated, OR/union). Tool variation overrides are resolved from the MCP server's or toolset's configured tool variation group, falling back to the project default.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -167,8 +167,12 @@ const (
 	IngressNameKey                 = attribute.Key("gram.ingress.name")
 	CustomDomainProvisionerKindKey = attribute.Key("gram.custom_domain.provisioner.kind")
 	McpMethodKey                   = attribute.Key("gram.mcp.method")
+	McpRequestedTagsKey            = attribute.Key("gram.mcp.requested_tags")
+	McpToolsReturnedKey            = attribute.Key("gram.mcp.tools_returned")
+	McpToolsFilteredKey            = attribute.Key("gram.mcp.tools_filtered")
 	McpServerIDKey                 = attribute.Key("gram.mcp_server.id")
 	McpURLKey                      = attribute.Key("gram.mcp.url")
+	ToolVariationsGroupIDKey       = attribute.Key("gram.tool_variations_group.id")
 	MetricNameKey                  = attribute.Key("gram.metric.name")
 	MimeTypeKey                    = attribute.Key("mime.type")
 	OAuthAuthorizationEndpointKey  = attribute.Key("gram.oauth.authorization_endpoint")
@@ -1251,6 +1255,22 @@ func SlogMcpURL(v string) slog.Attr      { return slog.String(string(McpURLKey),
 
 func McpMethod(v string) attribute.KeyValue { return McpMethodKey.String(v) }
 func SlogMcpMethod(v string) slog.Attr      { return slog.String(string(McpMethodKey), v) }
+
+func MCPRequestedTags(v []string) attribute.KeyValue { return McpRequestedTagsKey.StringSlice(v) }
+func SlogMCPRequestedTags(v []string) slog.Attr {
+	return slog.Any(string(McpRequestedTagsKey), v)
+}
+
+func MCPToolsReturned(v int) attribute.KeyValue { return McpToolsReturnedKey.Int(v) }
+func SlogMCPToolsReturned(v int) slog.Attr      { return slog.Int(string(McpToolsReturnedKey), v) }
+
+func MCPToolsFiltered(v int) attribute.KeyValue { return McpToolsFilteredKey.Int(v) }
+func SlogMCPToolsFiltered(v int) slog.Attr      { return slog.Int(string(McpToolsFilteredKey), v) }
+
+func ToolVariationsGroupID(v string) attribute.KeyValue { return ToolVariationsGroupIDKey.String(v) }
+func SlogToolVariationsGroupID(v string) slog.Attr {
+	return slog.String(string(ToolVariationsGroupIDKey), v)
+}
 
 func MimeType(v string) attribute.KeyValue { return MimeTypeKey.String(v) }
 func SlogMimeType(v string) slog.Attr      { return slog.String(string(MimeTypeKey), v) }

--- a/server/internal/background/activities/generate_toolset_embeddings.go
+++ b/server/internal/background/activities/generate_toolset_embeddings.go
@@ -56,6 +56,7 @@ func (a *GenerateToolsetEmbeddings) Do(
 		mv.ProjectID(input.ProjectID),
 		mv.ToolsetSlug(conv.ToLower(input.ToolsetSlug)),
 		nil,
+		nil,
 	)
 
 	if getToolsetErr != nil {

--- a/server/internal/chat/agent_client.go
+++ b/server/internal/chat/agent_client.go
@@ -259,7 +259,7 @@ func (c *Client) LoadToolsetTools(
 	toolsetSlug string,
 ) ([]AgentTool, error) {
 	// Get default environment for the toolset
-	toolset, err := mv.DescribeToolset(ctx, c.logger, c.db, mv.ProjectID(projectID), mv.ToolsetSlug(toolsetSlug), &c.toolsetCache)
+	toolset, err := mv.DescribeToolset(ctx, c.logger, c.db, mv.ProjectID(projectID), mv.ToolsetSlug(toolsetSlug), &c.toolsetCache, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -146,7 +146,7 @@ func (s *Service) GetInstance(ctx context.Context, payload *gen.GetInstanceForm)
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	toolset, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(conv.ToLower(payload.ToolsetSlug)), &s.toolsetCache)
+	toolset, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(conv.ToLower(payload.ToolsetSlug)), &s.toolsetCache, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +304,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 	var toolsetUUID uuid.UUID
 	if chatID != "" && toolsetSlug != "" {
 		var toolsetErr error
-		toolset, toolsetErr = mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(toolsetSlug), &s.toolsetCache)
+		toolset, toolsetErr = mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(toolsetSlug), &s.toolsetCache, nil)
 		if toolsetErr != nil {
 			logger.ErrorContext(ctx, "failed to load toolset", attr.SlogError(err))
 		} else if toolset != nil {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -153,6 +153,13 @@ type mcpInputs struct {
 	userID           string
 	externalUserID   string
 	apiKeyID         string
+	// toolVariationsGroupID is the effective variation group resolved per
+	// request (mcp_servers, then toolsets, then nil for the project default).
+	toolVariationsGroupID *uuid.UUID
+	// tags is the parsed ?tags= filter. When non-empty, tools/list and
+	// tools/call expose only tools whose variation row carries one of these
+	// tags. Empty means no filtering.
+	tags []string
 }
 
 func NewService(
@@ -434,7 +441,10 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, "")
+	// Legacy toolset-by-slug path has no mcp_server, so there is no
+	// server-level variation group override; ServeToolsetResolved falls back to
+	// the toolset's own column.
+	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, "", nil)
 }
 
 // ServeToolsetResolved serves an MCP runtime request after the slug has
@@ -458,10 +468,29 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 // the downstream tool dispatch doesn't 401 when the in-toolset gate is
 // skipped. /mcp callers pass "".
 //
+// mcpServerVariationsGroupID is the variation group resolved from the
+// mcp_servers row, when this request arrived via an mcp_endpoint that maps to
+// one. It takes precedence over the toolset's own tool_variations_group_id;
+// when nil, the toolset's column is used, and when that is also unset the
+// project-default group applies. /mcp's legacy toolset-by-slug path has no
+// mcp_server and passes nil.
+//
 // The caller is responsible for closing r.Body.
-func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamToken string) error {
+func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamToken string, mcpServerVariationsGroupID *uuid.UUID) error {
 	ctx := r.Context()
 	var err error
+
+	// Resolve the effective variation group: mcp_servers value first, then the
+	// toolset's own column, else nil (project default).
+	toolVariationsGroupID := mcpServerVariationsGroupID
+	if toolVariationsGroupID == nil && toolset.ToolVariationsGroupID.Valid {
+		id := toolset.ToolVariationsGroupID.UUID
+		toolVariationsGroupID = &id
+	}
+
+	// Parse the ?tags= filter (comma-separated, OR/union). Absent or empty
+	// means no filtering.
+	tags := parseTagsFilter(r.URL.Query().Get("tags"))
 
 	baseURL := s.serverURL.String()
 	if customDomainCtx := customdomains.FromContext(ctx); customDomainCtx != nil {
@@ -713,18 +742,31 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	}
 
 	mcpInputs := &mcpInputs{
-		projectID:        toolset.ProjectID,
-		toolset:          toolset.Slug,
-		environment:      selectedEnvironment,
-		mcpEnvVariables:  parseMcpEnvVariables(r, headerDisplayNames),
-		authenticated:    authenticated,
-		oauthTokenInputs: tokenInputs,
-		sessionID:        sessionID,
-		chatID:           r.Header.Get("Gram-Chat-ID"),
-		mode:             resolveToolMode(r, *toolset),
-		userID:           userID,
-		externalUserID:   externalUserID,
-		apiKeyID:         apiKeyID,
+		projectID:             toolset.ProjectID,
+		toolset:               toolset.Slug,
+		environment:           selectedEnvironment,
+		mcpEnvVariables:       parseMcpEnvVariables(r, headerDisplayNames),
+		authenticated:         authenticated,
+		oauthTokenInputs:      tokenInputs,
+		sessionID:             sessionID,
+		chatID:                r.Header.Get("Gram-Chat-ID"),
+		mode:                  resolveToolMode(r, *toolset),
+		userID:                userID,
+		externalUserID:        externalUserID,
+		apiKeyID:              apiKeyID,
+		toolVariationsGroupID: toolVariationsGroupID,
+		tags:                  tags,
+	}
+
+	// Record the resolved variation group and requested tag filter for
+	// debugging which tools a client sees.
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		if toolVariationsGroupID != nil {
+			span.SetAttributes(attr.ToolVariationsGroupID(toolVariationsGroupID.String()))
+		}
+		if len(tags) > 0 {
+			span.SetAttributes(attr.MCPRequestedTags(tags))
+		}
 	}
 
 	// Check security schemes before dispatching any RPC — including initialize.
@@ -779,7 +821,11 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 // (or if the toolset has no security requirements).
 func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_repo.Toolset, payload *mcpInputs) (bool, error) {
 	projectID := mv.ProjectID(payload.projectID)
-	described, err := mv.DescribeToolset(ctx, s.logger, s.db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), &s.toolsetCache, s.platformExtras...)
+	// Security-scheme detection must see the full, unfiltered toolset, so this
+	// always uses the project-default variation group (nil) regardless of any
+	// ?groups= filter on the request. Variations never change a tool's security
+	// requirements, so this does not weaken the auth gate.
+	described, err := mv.DescribeToolset(ctx, s.logger, s.db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), &s.toolsetCache, nil, s.platformExtras...)
 	if err != nil {
 		return false, oops.E(oops.CodeUnexpected, err, "failed to describe toolset for security check").Log(ctx, s.logger)
 	}
@@ -1012,6 +1058,36 @@ func parseMcpSessionID(headers http.Header) string {
 		session = uuid.New().String()
 	}
 	return session
+}
+
+// parseTagsFilter parses the ?tags= query value into a deduplicated set of tag
+// names. The value is comma-separated; surrounding whitespace and empty
+// segments are dropped. An absent or empty value yields nil, meaning no
+// filtering is applied.
+func parseTagsFilter(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	tags := make([]string, 0)
+	for part := range strings.SplitSeq(raw, ",") {
+		tag := strings.TrimSpace(part)
+		if tag == "" {
+			continue
+		}
+		if _, ok := seen[tag]; ok {
+			continue
+		}
+		seen[tag] = struct{}{}
+		tags = append(tags, tag)
+	}
+
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return tags
 }
 
 // RequirePrivateIdentityAuth runs identity authentication for a non-public

--- a/server/internal/mcp/rpc_prompts_list.go
+++ b/server/internal/mcp/rpc_prompts_list.go
@@ -70,7 +70,7 @@ func parsePromptArgumentsFromJSONSchema(schemaStr string, logger *slog.Logger, c
 func handlePromptsList(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, payload *mcpInputs, req *rawRequest, toolsetCache *cache.TypedCacheObject[mv.ToolsetBaseContents], platformExtras []platformtools.ExternalTool) (json.RawMessage, error) {
 	projectID := mv.ProjectID(payload.projectID)
 
-	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), toolsetCache, platformExtras...)
+	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), toolsetCache, nil, platformExtras...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/mcp/rpc_resources_list.go
+++ b/server/internal/mcp/rpc_resources_list.go
@@ -29,7 +29,7 @@ type resourceListEntry struct {
 func handleResourcesList(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, payload *mcpInputs, req *rawRequest, toolsetCache *cache.TypedCacheObject[mv.ToolsetBaseContents], platformExtras []platformtools.ExternalTool) (json.RawMessage, error) {
 	projectID := mv.ProjectID(payload.projectID)
 
-	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), toolsetCache, platformExtras...)
+	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), toolsetCache, nil, platformExtras...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -76,7 +76,7 @@ func handleResourcesRead(
 	projectID := mv.ProjectID(payload.projectID)
 
 	toolsetHelpers := toolsets.NewToolsets(db, platformExtras...)
-	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), nil, platformExtras...)
+	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), nil, nil, platformExtras...)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset").Log(ctx, logger)
 	}

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -88,9 +88,18 @@ func handleToolsCall(
 
 	projectID := mv.ProjectID(payload.projectID)
 
-	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), toolsetCache, platformExtras...)
+	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), toolsetCache, payload.toolVariationsGroupID, platformExtras...)
 	if err != nil {
 		return nil, err
+	}
+
+	// Apply the ?tags= filter before any tool resolution — dynamic dispatch,
+	// proxy matching, and the static name lookup all read this slice, so a
+	// filtered-out tool surfaces as method-not-found.
+	if len(payload.tags) > 0 {
+		before := len(toolset.Tools)
+		toolset.Tools = filterToolsByTags(toolset.Tools, payload.tags)
+		recordToolFilterSpan(ctx, len(toolset.Tools), before-len(toolset.Tools))
 	}
 
 	if payload.mode != ToolModeStatic {

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -61,9 +61,19 @@ func handleToolsList(
 ) (json.RawMessage, error) {
 	projectID := mv.ProjectID(payload.projectID)
 
-	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), toolsetCache, platformExtras...)
+	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), toolsetCache, payload.toolVariationsGroupID, platformExtras...)
 	if err != nil {
 		return nil, err
+	}
+
+	// Apply the ?tags= filter before building any tool list (static or
+	// dynamic). Filtering toolset.Tools here also restricts dynamic-mode
+	// search_tools/describe_tools, which resolve results back through this same
+	// slice.
+	if len(payload.tags) > 0 {
+		before := len(toolset.Tools)
+		toolset.Tools = filterToolsByTags(toolset.Tools, payload.tags)
+		recordToolFilterSpan(ctx, len(toolset.Tools), before-len(toolset.Tools))
 	}
 
 	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {

--- a/server/internal/mcp/rpc_tools_list_test.go
+++ b/server/internal/mcp/rpc_tools_list_test.go
@@ -64,8 +64,10 @@ func toolNames(resp toolsListResponse) []string {
 }
 
 // addHTTPTools creates a deployment + HTTP tool definitions + a single
-// toolset_version linking all named tools to the toolset.
-func addHTTPTools(t *testing.T, ctx context.Context, ti *testInstance, toolsetID uuid.UUID, projectID uuid.UUID, orgID string, toolNames ...string) {
+// toolset_version linking all named tools to the toolset. It returns the
+// created tool URNs keyed by name so callers can attach variations to specific
+// tools; callers that don't need the URNs may ignore the return.
+func addHTTPTools(t *testing.T, ctx context.Context, ti *testInstance, toolsetID uuid.UUID, projectID uuid.UUID, orgID string, toolNames ...string) map[string]urn.Tool {
 	t.Helper()
 
 	deploymentID, err := deployments_repo.New(ti.conn).InsertDeployment(ctx, deployments_repo.InsertDeploymentParams{
@@ -82,10 +84,12 @@ func addHTTPTools(t *testing.T, ctx context.Context, ti *testInstance, toolsetID
 	})
 	require.NoError(t, err)
 
+	urnsByName := make(map[string]urn.Tool, len(toolNames))
 	toolURNs := make([]urn.Tool, len(toolNames))
 	for i, toolName := range toolNames {
 		toolURN := urn.NewTool(urn.ToolKindHTTP, toolName, uuid.New().String()[:8])
 		toolURNs[i] = toolURN
+		urnsByName[toolName] = toolURN
 		err = tools_repo.New(ti.conn).CreateHTTPToolDefinition(ctx, tools_repo.CreateHTTPToolDefinitionParams{
 			ProjectID:       projectID,
 			DeploymentID:    deploymentID,
@@ -120,6 +124,74 @@ func addHTTPTools(t *testing.T, ctx context.Context, ti *testInstance, toolsetID
 		PredecessorID: uuid.NullUUID{},
 	})
 	require.NoError(t, err)
+
+	return urnsByName
+}
+
+// addHTTPToolsWithSourceTags creates HTTP tools carrying source-defined tags
+// (unlike addHTTPTools, which leaves source tags empty) and registers them as a
+// single toolset version. It is used to exercise ?tags= filtering driven by
+// source tags rather than tool variations. The map key is the tool name and the
+// value is its source tags; the returned map associates each name with its URN.
+func addHTTPToolsWithSourceTags(t *testing.T, ctx context.Context, ti *testInstance, toolsetID uuid.UUID, projectID uuid.UUID, orgID string, toolTags map[string][]string) map[string]urn.Tool {
+	t.Helper()
+
+	deploymentID, err := deployments_repo.New(ti.conn).InsertDeployment(ctx, deployments_repo.InsertDeploymentParams{
+		ProjectID:      projectID,
+		OrganizationID: orgID,
+		UserID:         "test-user",
+		IdempotencyKey: uuid.New().String(),
+	})
+	require.NoError(t, err)
+
+	err = deployments_repo.New(ti.conn).CreateDeploymentStatus(ctx, deployments_repo.CreateDeploymentStatusParams{
+		DeploymentID: deploymentID,
+		Status:       "completed",
+	})
+	require.NoError(t, err)
+
+	urnsByName := make(map[string]urn.Tool, len(toolTags))
+	toolURNs := make([]urn.Tool, 0, len(toolTags))
+	for toolName, tags := range toolTags {
+		toolURN := urn.NewTool(urn.ToolKindHTTP, toolName, uuid.New().String()[:8])
+		toolURNs = append(toolURNs, toolURN)
+		urnsByName[toolName] = toolURN
+		err = tools_repo.New(ti.conn).CreateHTTPToolDefinition(ctx, tools_repo.CreateHTTPToolDefinitionParams{
+			ProjectID:       projectID,
+			DeploymentID:    deploymentID,
+			ToolUrn:         toolURN,
+			Name:            toolName,
+			UntruncatedName: pgtype.Text{},
+			Summary:         toolName + " summary",
+			Description:     toolName + " description",
+			Tags:            tags,
+			HttpMethod:      "GET",
+			Path:            "/test",
+			SchemaVersion:   "3.0.0",
+			Schema:          []byte(`{}`),
+			ServerEnvVar:    "TEST_SERVER_URL",
+			Security:        []byte(`[]`),
+			HeaderSettings:  []byte(`{}`),
+			QuerySettings:   []byte(`{}`),
+			PathSettings:    []byte(`{}`),
+			ReadOnlyHint:    pgtype.Bool{},
+			DestructiveHint: pgtype.Bool{},
+			IdempotentHint:  pgtype.Bool{},
+			OpenWorldHint:   pgtype.Bool{},
+		})
+		require.NoError(t, err)
+	}
+
+	_, err = toolsets_repo.New(ti.conn).CreateToolsetVersion(ctx, toolsets_repo.CreateToolsetVersionParams{
+		ToolsetID:     toolsetID,
+		Version:       1,
+		ToolUrns:      toolURNs,
+		ResourceUrns:  []urn.Resource{},
+		PredecessorID: uuid.NullUUID{},
+	})
+	require.NoError(t, err)
+
+	return urnsByName
 }
 
 // ---------------------------------------------------------------------------
@@ -418,4 +490,83 @@ func TestServePublic_RBAC_ToolsList_DispositionGrant_ServerLevelAllowsAll(t *tes
 		Disposition: "destructive",
 	}))
 	require.NoError(t, err)
+}
+
+func TestServePublic_ToolsList_NoTagsFilter_ReturnsAllWithVariationNames(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupTagFilterToolset(t, ctx, ti)
+
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	// Variation-renamed names are exposed on the wire; the untagged tool keeps
+	// its original name.
+	require.ElementsMatch(t, []string{"alpha_renamed", "beta_renamed", "tool_gamma"}, names)
+}
+
+func TestServePublic_ToolsList_TagsFilter_SingleTag(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupTagFilterToolset(t, ctx, ti)
+
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=alpha", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	// Only the alpha-tagged tool; beta and the variation-less gamma are excluded.
+	require.Equal(t, []string{"alpha_renamed"}, names)
+}
+
+func TestServePublic_ToolsList_TagsFilter_Union(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupTagFilterToolset(t, ctx, ti)
+
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=alpha,beta", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.ElementsMatch(t, []string{"alpha_renamed", "beta_renamed"}, names)
+}
+
+func TestServePublic_ToolsList_TagsFilter_SharedTagMatchesBoth(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupTagFilterToolset(t, ctx, ti)
+
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=shared", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.ElementsMatch(t, []string{"alpha_renamed", "beta_renamed"}, names)
+}
+
+func TestServePublic_ToolsList_TagsFilter_NonexistentReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupTagFilterToolset(t, ctx, ti)
+
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=does-not-exist", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	// An all-nonexistent filter must be a successful empty list, not a
+	// JSON-RPC error (which would also be HTTP 200 with no tools).
+	var rpcResp struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rpcResp))
+	require.Nil(t, rpcResp.Error, "expected empty tools list, got JSON-RPC error: %s", w.Body.String())
+
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.Empty(t, names)
 }

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -156,7 +156,16 @@ func (s *Service) serveResolvedMCPEndpoint(
 			return oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
 		}
 
-		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamToken); err != nil {
+		// The mcp_servers row's variation group, when set, overrides the
+		// toolset's own column. Pass it through so ServeToolsetResolved resolves
+		// the effective group (mcp_server, then toolset, then project default).
+		var mcpServerVariationsGroupID *uuid.UUID
+		if mcpServer.ToolVariationsGroupID.Valid {
+			id := mcpServer.ToolVariationsGroupID.UUID
+			mcpServerVariationsGroupID = &id
+		}
+
+		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamToken, mcpServerVariationsGroupID); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oauth"
 	oauth_repo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	variations_repo "github.com/speakeasy-api/gram/server/internal/variations/repo"
 )
 
 // ---------------------------------------------------------------------------
@@ -427,4 +428,246 @@ func TestServePublic_BatchRequestRejected(t *testing.T) {
 	_, err = servePublicHTTP(t, unauthCtx, ti, toolset.McpSlug.String, bodyBytes, "", nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "batch requests are not supported")
+}
+
+// servePublicToolsRequest issues a POST to /mcp/{slug} with an optional raw
+// query string (e.g. "tags=alpha,beta") and returns the recorder. Unlike
+// servePublicHTTP it threads a query string onto the URL so ?tags= filtering
+// can be exercised through the full serve path.
+func servePublicToolsRequest(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug, rawQuery string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	target := "/mcp/" + mcpSlug
+	if rawQuery != "" {
+		target += "?" + rawQuery
+	}
+
+	req := httptest.NewRequest(http.MethodPost, target, bytes.NewReader(body))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.ServePublic(w, req))
+	return w
+}
+
+func makeToolsCallBody(toolName string) []byte {
+	bs, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      toolName,
+			"arguments": map[string]any{},
+		},
+	})
+	return bs
+}
+
+// setupTagFilterToolset builds a public MCP toolset with three HTTP tools and a
+// project-default variation group. tool_alpha and tool_beta carry tagged,
+// renamed variations; tool_gamma has no variation at all. It returns the MCP
+// slug. The toolset has no tool_variations_group_id, so the project-default
+// group applies — exercising the "?tags= filters against the project default"
+// behavior.
+func setupTagFilterToolset(t *testing.T, ctx context.Context, ti *testInstance) string {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "tag-filter-"+uuid.New().String()[:8])
+
+	urns := addHTTPTools(t, ctx, ti, toolset.ID, *authCtx.ProjectID, authCtx.ActiveOrganizationID,
+		"tool_alpha", "tool_beta", "tool_gamma")
+
+	variationsRepo := variations_repo.New(ti.conn)
+	group, err := variationsRepo.InitGlobalToolVariationsGroup(ctx, variations_repo.InitGlobalToolVariationsGroupParams{
+		ProjectID:   *authCtx.ProjectID,
+		Name:        "default-group",
+		Description: conv.ToPGText("default group"),
+	})
+	require.NoError(t, err)
+
+	_, err = variationsRepo.UpsertToolVariation(ctx, variations_repo.UpsertToolVariationParams{
+		GroupID:     group,
+		SrcToolUrn:  urns["tool_alpha"],
+		SrcToolName: "tool_alpha",
+		Name:        conv.ToPGText("alpha_renamed"),
+		Tags:        []string{"alpha", "shared"},
+	})
+	require.NoError(t, err)
+
+	_, err = variationsRepo.UpsertToolVariation(ctx, variations_repo.UpsertToolVariationParams{
+		GroupID:     group,
+		SrcToolUrn:  urns["tool_beta"],
+		SrcToolName: "tool_beta",
+		Name:        conv.ToPGText("beta_renamed"),
+		Tags:        []string{"beta", "shared"},
+	})
+	require.NoError(t, err)
+
+	return toolset.McpSlug.String
+}
+
+// setupSourceTagFilterToolset builds a public MCP toolset whose tools carry
+// source-defined tags, exercising the rule that a variation is not required for
+// ?tags= filtering. Three tools cover the three tag states:
+//
+//   - source_only: source tags ["billing"], no variation — filterable by its
+//     source tag with no variation row at all.
+//   - reporting_renamed: source tags ["reporting"], a variation that renames it
+//     but does not modify tags (nil) — source tags stay authoritative.
+//   - removed: source tags ["billing"], a variation with an explicit empty tag
+//     set — removed from every tag filter even though its source tag matches.
+//
+// It returns the MCP slug and the renamed/removed source names for assertions.
+func setupSourceTagFilterToolset(t *testing.T, ctx context.Context, ti *testInstance) string {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "src-tag-filter-"+uuid.New().String()[:8])
+
+	urns := addHTTPToolsWithSourceTags(t, ctx, ti, toolset.ID, *authCtx.ProjectID, authCtx.ActiveOrganizationID,
+		map[string][]string{
+			"source_only": {"billing"},
+			"reporting":   {"reporting"},
+			"removed":     {"billing"},
+		})
+
+	variationsRepo := variations_repo.New(ti.conn)
+	group, err := variationsRepo.InitGlobalToolVariationsGroup(ctx, variations_repo.InitGlobalToolVariationsGroupParams{
+		ProjectID:   *authCtx.ProjectID,
+		Name:        "default-group",
+		Description: conv.ToPGText("default group"),
+	})
+	require.NoError(t, err)
+
+	// A variation that renames but leaves tags unset (nil) — source tags remain
+	// authoritative for filtering.
+	_, err = variationsRepo.UpsertToolVariation(ctx, variations_repo.UpsertToolVariationParams{
+		GroupID:     group,
+		SrcToolUrn:  urns["reporting"],
+		SrcToolName: "reporting",
+		Name:        conv.ToPGText("reporting_renamed"),
+		Tags:        nil,
+	})
+	require.NoError(t, err)
+
+	// A variation with an explicit empty tag set — removes the tool from every
+	// tag filter despite its source "billing" tag.
+	_, err = variationsRepo.UpsertToolVariation(ctx, variations_repo.UpsertToolVariationParams{
+		GroupID:     group,
+		SrcToolUrn:  urns["removed"],
+		SrcToolName: "removed",
+		Tags:        []string{},
+	})
+	require.NoError(t, err)
+
+	return toolset.McpSlug.String
+}
+
+func TestServePublic_ToolsList_SourceTags_NoVariationRequired(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupSourceTagFilterToolset(t, ctx, ti)
+
+	// source_only has no variation at all, yet its source tag drives filtering.
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=billing", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	// removed also has source tag "billing" but its empty variation tag set takes
+	// it out of every filter, so only source_only remains.
+	require.Equal(t, []string{"source_only"}, names)
+}
+
+func TestServePublic_ToolsList_SourceTags_NilVariationFallsBackToSource(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupSourceTagFilterToolset(t, ctx, ti)
+
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=reporting", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	// The renaming variation leaves tags unset, so the source "reporting" tag
+	// still matches; the wire name reflects the variation rename.
+	require.Equal(t, []string{"reporting_renamed"}, names)
+}
+
+func TestServePublic_ToolsList_EmptyVariationTags_RemovesFromAllFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupSourceTagFilterToolset(t, ctx, ti)
+
+	// With no ?tags= filter, every tool is returned — removed is present.
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	all := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.ElementsMatch(t, []string{"source_only", "reporting_renamed", "removed"}, all)
+
+	// Under a filter matching its source tag, the empty variation tag set keeps
+	// removed out of the results entirely.
+	w = servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=billing", makeToolsListBody())
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	filtered := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.NotContains(t, filtered, "removed")
+}
+
+func TestServePublic_ToolsCall_EmptyVariationTags_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupSourceTagFilterToolset(t, ctx, ti)
+
+	// removed is excluded by its empty variation tag set, so calling it under a
+	// filter matching its source tag must resolve to method-not-found.
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=billing", makeToolsCallBody("removed"))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "body: %s", w.Body.String())
+	require.NotNil(t, resp.Error, "expected a JSON-RPC error, body: %s", w.Body.String())
+	require.Contains(t, resp.Error.Message, "not found")
+}
+
+func TestServePublic_ToolsCall_FilteredOutTool_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	mcpSlug := setupTagFilterToolset(t, ctx, ti)
+
+	// alpha_renamed exists but is excluded by the beta-only filter, so the call
+	// must resolve to method-not-found rather than executing.
+	w := servePublicToolsRequest(t, ctx, ti, mcpSlug, "tags=beta", makeToolsCallBody("alpha_renamed"))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "body: %s", w.Body.String())
+	require.NotNil(t, resp.Error, "expected a JSON-RPC error, body: %s", w.Body.String())
+	require.Contains(t, resp.Error.Message, "not found")
 }

--- a/server/internal/mcp/tool_filter.go
+++ b/server/internal/mcp/tool_filter.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+// filterToolsByTags returns the subset of tools whose effective tag set carries
+// at least one of the requested tags (OR/union). See effectiveToolTags for how a
+// tool's effective tags are derived from its variation and source tags. Callers
+// should only invoke this when tags is non-empty; an empty tags slice yields an
+// empty result.
+//
+// Matching is exact and case-sensitive.
+func filterToolsByTags(tools []*types.Tool, tags []string) []*types.Tool {
+	want := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		want[tag] = struct{}{}
+	}
+
+	filtered := make([]*types.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if tool == nil {
+			continue
+		}
+
+		for _, tag := range effectiveToolTags(tool) {
+			if _, ok := want[tag]; ok {
+				filtered = append(filtered, tool)
+				break
+			}
+		}
+	}
+
+	return filtered
+}
+
+// effectiveToolTags returns the tags used for ?tags= filtering. A variation that
+// defines tags replaces the source tags — including an explicit empty set
+// (non-nil, length 0), which removes the tool from every tag filter. A nil
+// variation tag set means "no tag modification", so the source tool's own tags
+// remain authoritative. This lets source-defined tags drive filtering without
+// forcing a variation row to exist for every tool.
+//
+// Tools that carry neither variation tags nor source tags — proxy/external MCP
+// tools, prompts, platform tools — yield an empty set and are excluded whenever a
+// filter is active.
+func effectiveToolTags(tool *types.Tool) []string {
+	if base, err := conv.ToBaseTool(tool); err == nil && base.Variation != nil && base.Variation.Tags != nil {
+		return base.Variation.Tags
+	}
+
+	switch {
+	case tool.HTTPToolDefinition != nil:
+		return tool.HTTPToolDefinition.Tags
+	case tool.FunctionToolDefinition != nil:
+		return tool.FunctionToolDefinition.Tags
+	default:
+		return nil
+	}
+}
+
+// recordToolFilterSpan annotates the active span with how many tools survived
+// the ?tags= filter and how many were dropped, to aid debugging of missing
+// tools.
+func recordToolFilterSpan(ctx context.Context, returned, filtered int) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	span.SetAttributes(attr.MCPToolsReturned(returned), attr.MCPToolsFiltered(filtered))
+}

--- a/server/internal/mcp/tool_filter_test.go
+++ b/server/internal/mcp/tool_filter_test.go
@@ -1,0 +1,181 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+func httpToolWithTags(name string, tags []string) *types.Tool {
+	return &types.Tool{
+		HTTPToolDefinition: &types.HTTPToolDefinition{
+			Name:      name,
+			Variation: &types.ToolVariation{Tags: tags},
+		},
+	}
+}
+
+func httpToolWithoutVariation(name string) *types.Tool {
+	return &types.Tool{
+		HTTPToolDefinition: &types.HTTPToolDefinition{Name: name},
+	}
+}
+
+func httpToolWithSourceTags(name string, tags []string) *types.Tool {
+	return &types.Tool{
+		HTTPToolDefinition: &types.HTTPToolDefinition{Name: name, Tags: tags},
+	}
+}
+
+func toolNames(t *testing.T, tools []*types.Tool) []string {
+	t.Helper()
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		require.NotNil(t, tool.HTTPToolDefinition)
+		names = append(names, tool.HTTPToolDefinition.Name)
+	}
+	return names
+}
+
+func TestParseTagsFilter_AbsentReturnsNil(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, parseTagsFilter(""))
+}
+
+func TestParseTagsFilter_OnlyDelimitersReturnsNil(t *testing.T) {
+	t.Parallel()
+	// A value made up entirely of empty segments must not become a one-element
+	// [""] slice, which would otherwise filter every tool out.
+	require.Nil(t, parseTagsFilter(" , , "))
+}
+
+func TestParseTagsFilter_TrimsAndDropsEmptySegments(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{"a", "b"}, parseTagsFilter("a,,  b "))
+}
+
+func TestParseTagsFilter_Deduplicates(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{"a", "b"}, parseTagsFilter("a,b,a,b"))
+}
+
+func TestParseTagsFilter_Single(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{"billing"}, parseTagsFilter("billing"))
+}
+
+func TestFilterToolsByTags_UnionMatch(t *testing.T) {
+	t.Parallel()
+
+	tools := []*types.Tool{
+		httpToolWithTags("a", []string{"billing"}),
+		httpToolWithTags("b", []string{"admin"}),
+		httpToolWithTags("c", []string{"reporting"}),
+	}
+
+	got := filterToolsByTags(tools, []string{"billing", "admin"})
+	require.Equal(t, []string{"a", "b"}, toolNames(t, got))
+}
+
+func TestFilterToolsByTags_SourceTagsMatchWithoutVariation(t *testing.T) {
+	t.Parallel()
+
+	// A variation is not required: source-defined tags drive filtering on their
+	// own.
+	tools := []*types.Tool{
+		httpToolWithSourceTags("a", []string{"billing"}),
+		httpToolWithSourceTags("b", []string{"admin"}),
+	}
+
+	got := filterToolsByTags(tools, []string{"billing"})
+	require.Equal(t, []string{"a"}, toolNames(t, got))
+}
+
+func TestFilterToolsByTags_VariationTagsReplaceSourceTags(t *testing.T) {
+	t.Parallel()
+
+	// A variation that defines tags replaces the source tags entirely.
+	tool := &types.Tool{HTTPToolDefinition: &types.HTTPToolDefinition{
+		Name:      "a",
+		Tags:      []string{"source-only"},
+		Variation: &types.ToolVariation{Tags: []string{"variation-only"}},
+	}}
+
+	require.Empty(t, filterToolsByTags([]*types.Tool{tool}, []string{"source-only"}))
+	require.Len(t, filterToolsByTags([]*types.Tool{tool}, []string{"variation-only"}), 1)
+}
+
+func TestFilterToolsByTags_NilVariationTagsFallBackToSourceTags(t *testing.T) {
+	t.Parallel()
+
+	// A variation present but not modifying tags (nil) leaves the source tags
+	// authoritative.
+	tool := &types.Tool{HTTPToolDefinition: &types.HTTPToolDefinition{
+		Name:      "a",
+		Tags:      []string{"billing"},
+		Variation: &types.ToolVariation{Tags: nil},
+	}}
+
+	require.Len(t, filterToolsByTags([]*types.Tool{tool}, []string{"billing"}), 1)
+}
+
+func TestFilterToolsByTags_EmptyVariationTagsRemoveFromAllFilters(t *testing.T) {
+	t.Parallel()
+
+	// An explicit empty set (non-nil, length 0) removes the tool from every tag
+	// filter, even though the source defines a matching tag.
+	tool := &types.Tool{HTTPToolDefinition: &types.HTTPToolDefinition{
+		Name:      "a",
+		Tags:      []string{"billing"},
+		Variation: &types.ToolVariation{Tags: []string{}},
+	}}
+
+	require.Empty(t, filterToolsByTags([]*types.Tool{tool}, []string{"billing"}))
+}
+
+func TestFilterToolsByTags_ExcludesToolsWithoutAnyTags(t *testing.T) {
+	t.Parallel()
+
+	tools := []*types.Tool{
+		httpToolWithSourceTags("a", []string{"billing"}),
+		// No variation and no source tags.
+		httpToolWithoutVariation("b"),
+		// External MCP (proxy) tools never carry tags, so they are excluded
+		// whenever a filter is active.
+		{ExternalMcpToolDefinition: &types.ExternalMCPToolDefinition{Name: "proxy"}},
+	}
+
+	got := filterToolsByTags(tools, []string{"billing"})
+	require.Equal(t, []string{"a"}, toolNames(t, got))
+}
+
+func TestFilterToolsByTags_NonexistentTagReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tools := []*types.Tool{
+		httpToolWithTags("a", []string{"billing"}),
+		httpToolWithTags("b", []string{"admin"}),
+	}
+
+	got := filterToolsByTags(tools, []string{"does-not-exist"})
+	require.Empty(t, got)
+}
+
+func TestFilterToolsByTags_CaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	tools := []*types.Tool{httpToolWithTags("a", []string{"Billing"})}
+
+	require.Empty(t, filterToolsByTags(tools, []string{"billing"}))
+	require.Len(t, filterToolsByTags(tools, []string{"Billing"}), 1)
+}
+
+func TestFilterToolsByTags_ToolWithMultipleTagsMatchesAny(t *testing.T) {
+	t.Parallel()
+
+	tools := []*types.Tool{httpToolWithTags("a", []string{"x", "y", "z"})}
+
+	require.Len(t, filterToolsByTags(tools, []string{"y"}), 1)
+}

--- a/server/internal/mcp/types.go
+++ b/server/internal/mcp/types.go
@@ -94,5 +94,9 @@ func (m *McpInputs) toInternal() *mcpInputs {
 		userID:           m.UserID,
 		externalUserID:   m.ExternalUserID,
 		apiKeyID:         m.APIKeyID,
+		// Internal clients (agent workflows) always use the project-default
+		// variation group and never filter by tag.
+		toolVariationsGroupID: nil,
+		tags:                  nil,
 	}
 }

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -521,7 +521,7 @@ func (s *Service) ExportMcpMetadata(ctx context.Context, payload *gen.ExportMcpM
 		// Ignore errors - custom domain is optional
 	}
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(toolset.Slug), &s.toolsetCache)
+	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(toolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe toolset").Log(ctx, s.logger)
 	}
@@ -1080,7 +1080,7 @@ func (s *Service) loadInstallPageMetadata(ctx context.Context, ic *installContex
 func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseWriter, ic *installContext, mcpSlug string, metadataRecord *repo.McpMetadatum) error {
 	toolset := ic.toolset
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(toolset.ProjectID), mv.ToolsetSlug(toolset.Slug), &s.toolsetCache)
+	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(toolset.ProjectID), mv.ToolsetSlug(toolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "describe toolset").Log(ctx, s.logger)
 	}

--- a/server/internal/mv/templates.go
+++ b/server/internal/mv/templates.go
@@ -53,7 +53,7 @@ func DescribePromptTemplate(
 	}
 
 	pt := fromPromptTemplateRow(row)
-	err = ApplyVariations(ctx, logger, tx, pid, []*types.Tool{{PromptTemplate: pt}})
+	err = ApplyVariations(ctx, logger, tx, pid, nil, []*types.Tool{{PromptTemplate: pt}})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to prompt template").Log(ctx, logger)
 	}
@@ -85,7 +85,7 @@ func DescribePromptTemplates(
 	templates := make([]*types.PromptTemplate, 0, len(rows))
 	for _, row := range rows {
 		pt := fromPromptTemplateRow(row)
-		err = ApplyVariations(ctx, logger, tx, pid, []*types.Tool{{PromptTemplate: pt}})
+		err = ApplyVariations(ctx, logger, tx, pid, nil, []*types.Tool{{PromptTemplate: pt}})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to prompt template").Log(ctx, logger)
 		}

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -333,6 +333,12 @@ func DescribeToolsetEntry(
 	}, nil
 }
 
+// DescribeToolset builds the full view of a toolset including its tools with
+// variation overrides applied. toolVariationsGroupID selects which variation
+// group supplies those overrides: a non-nil value resolves overrides from that
+// explicit group, while nil resolves from the project's default group. It does
+// not filter tools — callers that need tag-based filtering apply it on the
+// returned Tools slice.
 func DescribeToolset(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -340,6 +346,7 @@ func DescribeToolset(
 	projectID ProjectID,
 	toolsetSlug ToolsetSlug,
 	toolsetCache *cache.TypedCacheObject[ToolsetBaseContents],
+	toolVariationsGroupID *uuid.UUID,
 	platformExtras ...platformtools.ExternalTool,
 ) (*types.Toolset, error) {
 	toolsetRepo := tsr.New(tx)
@@ -403,7 +410,7 @@ func DescribeToolset(
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset tools").Log(ctx, logger)
 	}
 
-	err = ApplyVariations(ctx, logger, tx, pid, toolsetTools.Tools)
+	err = ApplyVariations(ctx, logger, tx, pid, toolVariationsGroupID, toolsetTools.Tools)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to toolset").Log(ctx, logger)
 	}
@@ -1260,7 +1267,11 @@ func getToolsetOrigin(
 	}, nil
 }
 
-func ApplyVariations(ctx context.Context, logger *slog.Logger, tx DBTX, projectID uuid.UUID, tools []*types.Tool) error {
+// ApplyVariations merges tool variation overrides onto the provided tools in
+// place. When toolVariationsGroupID is non-nil the overrides are resolved from
+// that explicit variation group; when nil they are resolved from the project's
+// default variation group (preserving the historical behavior).
+func ApplyVariations(ctx context.Context, logger *slog.Logger, tx DBTX, projectID uuid.UUID, toolVariationsGroupID *uuid.UUID, tools []*types.Tool) error {
 	variationsRepo := vr.New(tx)
 
 	toolUrns := make([]string, 0, len(tools))
@@ -1273,12 +1284,22 @@ func ApplyVariations(ctx context.Context, logger *slog.Logger, tx DBTX, projectI
 		toolUrns = append(toolUrns, toolURN.String())
 	}
 
-	allVariations, err := variationsRepo.FindGlobalVariationsByToolURNs(ctx, vr.FindGlobalVariationsByToolURNsParams{
-		ProjectID: projectID,
-		ToolUrns:  toolUrns,
-	})
+	var allVariations []vr.ToolVariation
+	var err error
+	if toolVariationsGroupID != nil {
+		allVariations, err = variationsRepo.ListByGroupIDAndToolURNs(ctx, vr.ListByGroupIDAndToolURNsParams{
+			GroupID:   *toolVariationsGroupID,
+			ProjectID: projectID,
+			ToolUrns:  toolUrns,
+		})
+	} else {
+		allVariations, err = variationsRepo.FindGlobalVariationsByToolURNs(ctx, vr.FindGlobalVariationsByToolURNsParams{
+			ProjectID: projectID,
+			ToolUrns:  toolUrns,
+		})
+	}
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to list global tool variations").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to list tool variations").Log(ctx, logger)
 	}
 
 	urnToVariation := make(map[string]types.ToolVariation, len(allVariations))

--- a/server/internal/shadowmcp/validator.go
+++ b/server/internal/shadowmcp/validator.go
@@ -119,6 +119,7 @@ func (c *Client) resolveToolsetCall(
 		mv.ProjectID(toolsetRow.ProjectID),
 		mv.ToolsetSlug(toolsetRow.Slug),
 		&c.toolsetCache,
+		nil,
 	)
 	if err != nil {
 		detail, failed := fail(fmt.Sprintf("failed to load toolset %s", toolsetID))

--- a/server/internal/tools/impl.go
+++ b/server/internal/tools/impl.go
@@ -207,7 +207,7 @@ func (s *Service) ListTools(ctx context.Context, payload *gen.ListToolsPayload) 
 		result.Tools = append(result.Tools, tools...)
 	}
 
-	err := mv.ApplyVariations(ctx, s.logger, s.db, *authCtx.ProjectID, result.Tools)
+	err := mv.ApplyVariations(ctx, s.logger, s.db, *authCtx.ProjectID, nil, result.Tools)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to tools").Log(ctx, s.logger)
 	}

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -226,7 +226,7 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving toolset").Log(ctx, logger)
 	}
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(createdToolset.Slug), &s.toolsetCache)
+	toolsetDetails, err := mv.DescribeToolset(ctx, logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(createdToolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, existingToolset.ID.String(), authCtx.ProjectID.String())); err != nil {
 		return nil, err
 	}
-	existingView, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(existingToolset.Slug), new(s.toolsetCache.SkipCache()))
+	existingView, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(existingToolset.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe existing toolset").Log(ctx, logger)
 	}
@@ -455,7 +455,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		}
 	}
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(updatedToolset.Slug), new(s.toolsetCache.SkipCache()))
+	toolsetDetails, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(updatedToolset.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -595,7 +595,7 @@ func (s *Service) GetToolset(ctx context.Context, payload *gen.GetToolsetPayload
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	toolset, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), &s.toolsetCache)
+	toolset, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), &s.toolsetCache, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +763,7 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 		}
 	}
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(clonedToolset.Slug), &s.toolsetCache)
+	toolsetDetails, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(clonedToolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to describe cloned toolset", attr.SlogError(err))
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe cloned toolset").Log(ctx, logger)
@@ -808,7 +808,7 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 
 	tr := s.repo.WithTx(dbtx)
 
-	existingToolset, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	existingToolset, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -858,7 +858,7 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to associate external OAuth server with toolset").Log(ctx, s.logger)
 	}
 
-	updatedToolset, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	updatedToolset, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -969,7 +969,7 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to remove OAuth server from toolset").Log(ctx, logger)
 	}
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	toolsetDetails, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1029,7 +1029,7 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1171,7 +1171,7 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to associate OAuth proxy server with toolset").Log(ctx, s.logger)
 	}
 
-	toolsetDetails, err = mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	toolsetDetails, err = mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/toolsets/set_tool_variations_group.go
+++ b/server/internal/toolsets/set_tool_variations_group.go
@@ -31,7 +31,7 @@ func (s *Service) SetToolVariationsGroup(ctx context.Context, payload *gen.SetTo
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	beforeView, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	beforeView, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (s *Service) SetToolVariationsGroup(ctx context.Context, payload *gen.SetTo
 		return nil, oops.E(oops.CodeUnexpected, err, "update toolset tool_variations_group").Log(ctx, s.logger)
 	}
 
-	afterView, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	afterView, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/toolsets/set_user_session_issuer.go
+++ b/server/internal/toolsets/set_user_session_issuer.go
@@ -31,7 +31,7 @@ func (s *Service) SetUserSessionIssuer(ctx context.Context, payload *gen.SetUser
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	beforeView, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	beforeView, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (s *Service) SetUserSessionIssuer(ctx context.Context, payload *gen.SetUser
 		return nil, oops.E(oops.CodeUnexpected, err, "update toolset user_session_issuer").Log(ctx, s.logger)
 	}
 
-	afterView, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	afterView, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/toolsets/updateoauthproxyserver.go
+++ b/server/internal/toolsets/updateoauthproxyserver.go
@@ -31,7 +31,7 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 
 	form := payload.OauthProxyServer
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	// Load the toolset inside the transaction so the returned view reflects a consistent snapshot.
-	toolsetDetails, err = mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	toolsetDetails, err = mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	}
 
 	// Re-fetch the toolset so the returned value reflects all updates.
-	toolsetDetails, err = mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	toolsetDetails, err = mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/variations/listbygroup_test.go
+++ b/server/internal/variations/listbygroup_test.go
@@ -1,0 +1,189 @@
+package variations_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	repo "github.com/speakeasy-api/gram/server/internal/variations/repo"
+)
+
+// TestListByGroupIDAndToolURNs verifies the explicit-group variation lookup
+// used by mv.ApplyVariations when an mcp_server or toolset pins a variation
+// group: it returns only the requested group's matching rows.
+func TestListByGroupIDAndToolURNs(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	projectID := *authCtx.ProjectID
+
+	r := repo.New(ti.conn)
+
+	group, err := r.InitGlobalToolVariationsGroup(ctx, repo.InitGlobalToolVariationsGroupParams{
+		ProjectID:   projectID,
+		Name:        "group",
+		Description: conv.ToPGText("group"),
+	})
+	require.NoError(t, err)
+
+	toolURN, err := urn.ParseTool("tools:http:test:shared-tool")
+	require.NoError(t, err)
+
+	_, err = r.UpsertToolVariation(ctx, repo.UpsertToolVariationParams{
+		GroupID:     group,
+		SrcToolUrn:  toolURN,
+		SrcToolName: "shared-tool",
+		Name:        conv.ToPGText("variation"),
+		Tags:        []string{"alpha", "beta"},
+	})
+	require.NoError(t, err)
+
+	urns := []string{toolURN.String()}
+
+	// Correct group resolves the variation with its tags intact.
+	rows, err := r.ListByGroupIDAndToolURNs(ctx, repo.ListByGroupIDAndToolURNsParams{
+		GroupID:   group,
+		ProjectID: projectID,
+		ToolUrns:  urns,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, group, rows[0].GroupID)
+	require.Equal(t, []string{"alpha", "beta"}, rows[0].Tags)
+
+	// A different group id (same project) matches nothing.
+	rows, err = r.ListByGroupIDAndToolURNs(ctx, repo.ListByGroupIDAndToolURNsParams{
+		GroupID:   uuid.New(),
+		ProjectID: projectID,
+		ToolUrns:  urns,
+	})
+	require.NoError(t, err)
+	require.Empty(t, rows)
+
+	// A tool URN with no variation in the group matches nothing.
+	rows, err = r.ListByGroupIDAndToolURNs(ctx, repo.ListByGroupIDAndToolURNsParams{
+		GroupID:   group,
+		ProjectID: projectID,
+		ToolUrns:  []string{"tools:http:test:other-tool"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}
+
+// TestUpsertToolVariation_TagsNilEmptySetRoundTrip locks down the three-state
+// semantics the ?tags= MCP filter relies on: a variation's tags must survive a
+// write/read round-trip distinguishing nil (no tag modification — source tags
+// stay authoritative), a non-nil empty set (tool removed from every tag filter),
+// and a populated set (replaces the source tags). The tool_variations.tags
+// column is nullable with no default, and pgx maps SQL NULL <-> nil []string and
+// '{}' <-> a non-nil empty []string; if that ever regressed, "unset" would
+// silently collapse into "removed from all filters".
+func TestUpsertToolVariation_TagsNilEmptySetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	projectID := *authCtx.ProjectID
+
+	r := repo.New(ti.conn)
+
+	group, err := r.InitGlobalToolVariationsGroup(ctx, repo.InitGlobalToolVariationsGroupParams{
+		ProjectID:   projectID,
+		Name:        "group",
+		Description: conv.ToPGText("group"),
+	})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name      string
+		write     []string
+		wantNil   bool
+		wantValue []string
+	}{
+		{name: "nil-stays-nil", write: nil, wantNil: true},
+		{name: "empty-stays-non-nil-empty", write: []string{}, wantNil: false, wantValue: []string{}},
+		{name: "populated-round-trips", write: []string{"alpha", "beta"}, wantNil: false, wantValue: []string{"alpha", "beta"}},
+	}
+
+	for i, tc := range cases {
+		toolURN, err := urn.ParseTool("tools:http:test:tags-roundtrip-" + uuid.New().String()[:8])
+		require.NoError(t, err)
+
+		written, err := r.UpsertToolVariation(ctx, repo.UpsertToolVariationParams{
+			GroupID:     group,
+			SrcToolUrn:  toolURN,
+			SrcToolName: "tags-roundtrip",
+			Tags:        tc.write,
+		})
+		require.NoError(t, err, "case %d (%s) write", i, tc.name)
+
+		// Assert on the value read back through a SELECT, not just the RETURNING
+		// row, so we exercise the read decode path the filter actually uses.
+		rows, err := r.ListByGroupIDAndToolURNs(ctx, repo.ListByGroupIDAndToolURNsParams{
+			GroupID:   group,
+			ProjectID: projectID,
+			ToolUrns:  []string{toolURN.String()},
+		})
+		require.NoError(t, err, "case %d (%s) read", i, tc.name)
+		require.Len(t, rows, 1, "case %d (%s)", i, tc.name)
+
+		for _, got := range [][]string{written.Tags, rows[0].Tags} {
+			if tc.wantNil {
+				require.Nil(t, got, "case %d (%s): nil tags must stay nil", i, tc.name)
+			} else {
+				require.NotNil(t, got, "case %d (%s): empty tags must stay non-nil", i, tc.name)
+				require.Equal(t, tc.wantValue, got, "case %d (%s)", i, tc.name)
+			}
+		}
+	}
+}
+
+// TestListByGroupIDAndToolURNs_ProjectScoped confirms a group id is not
+// honored under a project that does not own it, preventing cross-project
+// variation leakage.
+func TestListByGroupIDAndToolURNs_ProjectScoped(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	projectID := *authCtx.ProjectID
+
+	r := repo.New(ti.conn)
+
+	group, err := r.InitGlobalToolVariationsGroup(ctx, repo.InitGlobalToolVariationsGroupParams{
+		ProjectID:   projectID,
+		Name:        "group",
+		Description: conv.ToPGText("group"),
+	})
+	require.NoError(t, err)
+
+	toolURN, err := urn.ParseTool("tools:http:test:scoped-tool")
+	require.NoError(t, err)
+
+	_, err = r.UpsertToolVariation(ctx, repo.UpsertToolVariationParams{
+		GroupID:     group,
+		SrcToolUrn:  toolURN,
+		SrcToolName: "scoped-tool",
+		Tags:        []string{"alpha"},
+	})
+	require.NoError(t, err)
+
+	rows, err := r.ListByGroupIDAndToolURNs(ctx, repo.ListByGroupIDAndToolURNsParams{
+		GroupID:   group,
+		ProjectID: uuid.New(), // unrelated project
+		ToolUrns:  []string{toolURN.String()},
+	})
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}

--- a/server/internal/variations/queries.sql
+++ b/server/internal/variations/queries.sql
@@ -113,6 +113,20 @@ WHERE
   AND src_tool_urn = ANY(@tool_urns::text[])
   AND deleted IS FALSE;
 
+-- name: ListByGroupIDAndToolURNs :many
+-- Resolves variation overrides from an explicit variation group, scoped to the
+-- owning project. Unlike FindGlobalVariationsByToolURNs (which resolves the
+-- project-default group), the caller supplies the group id directly.
+SELECT tool_variations.*
+FROM tool_variations
+INNER JOIN tool_variations_groups
+  ON tool_variations.group_id = tool_variations_groups.id
+WHERE
+  tool_variations.group_id = @group_id
+  AND tool_variations_groups.project_id = @project_id
+  AND tool_variations.src_tool_urn = ANY(@tool_urns::text[])
+  AND tool_variations.deleted IS FALSE;
+
 -- name: FindGlobalVariationsForProjects :many
 -- Batch-resolves variation name overrides across multiple projects.
 WITH global_groups AS (

--- a/server/internal/variations/repo/queries.sql.go
+++ b/server/internal/variations/repo/queries.sql.go
@@ -207,6 +207,68 @@ func (q *Queries) InitGlobalToolVariationsGroup(ctx context.Context, arg InitGlo
 	return id, err
 }
 
+const listByGroupIDAndToolURNs = `-- name: ListByGroupIDAndToolURNs :many
+SELECT tool_variations.id, tool_variations.group_id, tool_variations.src_tool_urn, tool_variations.src_tool_name, tool_variations.confirm, tool_variations.confirm_prompt, tool_variations.name, tool_variations.summary, tool_variations.description, tool_variations.tags, tool_variations.summarizer, tool_variations.title, tool_variations.read_only_hint, tool_variations.destructive_hint, tool_variations.idempotent_hint, tool_variations.open_world_hint, tool_variations.created_at, tool_variations.updated_at, tool_variations.deleted_at, tool_variations.deleted
+FROM tool_variations
+INNER JOIN tool_variations_groups
+  ON tool_variations.group_id = tool_variations_groups.id
+WHERE
+  tool_variations.group_id = $1
+  AND tool_variations_groups.project_id = $2
+  AND tool_variations.src_tool_urn = ANY($3::text[])
+  AND tool_variations.deleted IS FALSE
+`
+
+type ListByGroupIDAndToolURNsParams struct {
+	GroupID   uuid.UUID
+	ProjectID uuid.UUID
+	ToolUrns  []string
+}
+
+// Resolves variation overrides from an explicit variation group, scoped to the
+// owning project. Unlike FindGlobalVariationsByToolURNs (which resolves the
+// project-default group), the caller supplies the group id directly.
+func (q *Queries) ListByGroupIDAndToolURNs(ctx context.Context, arg ListByGroupIDAndToolURNsParams) ([]ToolVariation, error) {
+	rows, err := q.db.Query(ctx, listByGroupIDAndToolURNs, arg.GroupID, arg.ProjectID, arg.ToolUrns)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ToolVariation
+	for rows.Next() {
+		var i ToolVariation
+		if err := rows.Scan(
+			&i.ID,
+			&i.GroupID,
+			&i.SrcToolUrn,
+			&i.SrcToolName,
+			&i.Confirm,
+			&i.ConfirmPrompt,
+			&i.Name,
+			&i.Summary,
+			&i.Description,
+			&i.Tags,
+			&i.Summarizer,
+			&i.Title,
+			&i.ReadOnlyHint,
+			&i.DestructiveHint,
+			&i.IdempotentHint,
+			&i.OpenWorldHint,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listGlobalToolVariations = `-- name: ListGlobalToolVariations :many
 SELECT tool_variations.id, tool_variations.group_id, tool_variations.src_tool_urn, tool_variations.src_tool_name, tool_variations.confirm, tool_variations.confirm_prompt, tool_variations.name, tool_variations.summary, tool_variations.description, tool_variations.tags, tool_variations.summarizer, tool_variations.title, tool_variations.read_only_hint, tool_variations.destructive_hint, tool_variations.idempotent_hint, tool_variations.open_world_hint, tool_variations.created_at, tool_variations.updated_at, tool_variations.deleted_at, tool_variations.deleted
 FROM tool_variations


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2358/wire-mcp-server-filtering-into-mcp-handler

Resolve an effective tool variation group per request (`mcp_servers`, then `toolsets`, else the project default) and apply a `?tags=` filter to the runtime MCP surface.

- Add `ListByGroupIDAndToolURNs` SQLc query resolving overrides from an explicit, project-scoped variation group; `ApplyVariations` and `DescribeToolset` take a `toolVariationsGroupID` (nil = project default).
- Resolve the effective group in the serve layer and parse `?tags=` (comma-separated, OR/union; absent/empty = no filter) onto the request.
- Filter `tools/list` and `tools/call` by variation tag before tool resolution, so static, dynamic, and proxy paths share one filtered set and excluded tools surface as method-not-found. The security-check describe stays unfiltered.
- Record the resolved group, requested tags, and returned/filtered counts on the request span.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tag-based tool filtering to the public `/mcp` handler and resolves an effective tool-variation group per request so MCP servers and toolsets control which tools are exposed. Implements AGE-2358.

- **New Features**
  - `?tags=` (comma-separated, OR; absent/empty = no filter) filters `tools/list` and `tools/call` before resolution so all paths share one filtered set; tools with no tags (variation or source) like proxies are excluded when filtering; nil variation tags fall back to source tags, while an explicit empty tag list removes the tool from all filters; excluded tools return method-not-found.
  - Effective variation group resolution: `mcp_servers` → `toolsets` → project default; `mv.ApplyVariations` and `mv.DescribeToolset` accept an optional group; new `ListByGroupIDAndToolURNs` enables explicit, project-scoped lookups.
  - Observability: request spans record `gram.tool_variations_group.id`, `gram.mcp.requested_tags`, `gram.mcp.tools_returned`, and `gram.mcp.tools_filtered`. The security-check describe remains unfiltered.

<sup>Written for commit 252664a37789d3e8476551b8e32d38ab60d1ef0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

