### PR TITLE
feat(dashboard): pinned Project Insights card + Project Assistant rename

### DIFF
--- a/.changeset/project-assistant-ui.md
+++ b/.changeset/project-assistant-ui.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Surface the project's built-in assistant in the dashboard: add a pinned "Project Assistant" card on the Assistants page (always shown, opens the assistant sidebar, can't be deleted) and rename the "AI Insights" navbar trigger and sidebar to "Project Assistant" with updated window copy. Part of AGE-2631.

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -136,8 +136,8 @@ const GlobalInsightsWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
     <InsightsProvider
       mcpConfig={mcpConfig}
-      title="Ask AI"
-      subtitle="Your assistant for exploring the platform — logs, traces, MCP servers, and more."
+      title="Ask the Project Assistant"
+      subtitle="Your project's built-in assistant for exploring logs, traces, MCP servers, and more."
       suggestions={[
         {
           title: "Summarize errors",

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -22,7 +22,7 @@ export const INSIGHTS_AI_RAINBOW_CLASS = "insights-ai-rainbow";
 /**
  * Reveals a full-spectrum Speakeasy brand gradient border on hover — same
  * 9-stop palette as the login page's BrandGradientBar. Used for the nav-bar
- * AI Insights trigger where the button shape can host a real border.
+ * Project Assistant trigger where the button shape can host a real border.
  * Requires <InsightsRainbowStyles /> in the tree. Works best on elements
  * with a 1px border and a border-radius.
  */
@@ -102,7 +102,7 @@ function isMacPlatform(): boolean {
 }
 
 /**
- * Header-bar trigger for opening the AI Insights sidebar. Renders only
+ * Header-bar trigger for opening the Project Assistant sidebar. Renders only
  * when inside an InsightsProvider so it can be slotted globally (e.g. into
  * PageHeaderBreadcrumbs) without appearing on pages that opt out via
  * hideTrigger.
@@ -166,10 +166,12 @@ export function InsightsTrigger({ className }: { className?: string }) {
         startSpin();
         setIsExpanded(!isExpanded);
       }}
-      aria-label={isExpanded ? "Close AI Insights" : "Open AI Insights"}
+      aria-label={
+        isExpanded ? "Close Project Assistant" : "Open Project Assistant"
+      }
       aria-keyshortcuts={shortcutAria}
       aria-pressed={isExpanded}
-      title={`AI Insights (${shortcutKeys.join("+")})`}
+      title={`Project Assistant (${shortcutKeys.join("+")})`}
       className={cn(
         "group border-border hover:bg-accent hover:text-accent-foreground inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors",
         isExpanded && "bg-accent text-accent-foreground",
@@ -180,7 +182,7 @@ export function InsightsTrigger({ className }: { className?: string }) {
       <Wand2
         className={cn("size-3.5", spinning && "insights-trigger-spinning")}
       />
-      <span className="font-medium">AI Insights</span>
+      <span className="font-medium">Project Assistant</span>
       {/* Hover-revealed shortcut hint. The outer wrapper animates between
           0fr and 1fr grid columns so the contents transition cleanly from
           width 0 to their natural width without us hardcoding a pixel value.
@@ -458,12 +460,12 @@ When the user asks about "current period", "selected period", "this timeframe", 
           <div className="border-border bg-muted/30 flex items-center justify-between border-b px-4 py-3">
             <div className="flex items-center gap-2">
               <Sparkles className="text-primary size-5" />
-              <span className="font-semibold">AI Insights</span>
+              <span className="font-semibold">Project Assistant</span>
             </div>
             <button
               onClick={() => setIsExpanded(false)}
               className="hover:bg-muted rounded p-1.5 transition-colors"
-              aria-label="Close AI Insights"
+              aria-label="Close Project Assistant"
             >
               <ChevronRight className="size-5" />
             </button>

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -1,6 +1,8 @@
 import { TopUpCTA, UsageProgress } from "@/components/billing/usage-controls";
+import { useInsightsState } from "@/components/insights-context";
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
+import { Badge } from "@/components/ui/badge";
 import { Card, Cards } from "@/components/ui/card";
 import { MoreActions } from "@/components/ui/more-actions";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -24,7 +26,7 @@ import {
 } from "@gram/client/react-query/index.js";
 import { Button, Icon, Stack } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { Info, Plus } from "lucide-react";
+import { Info, Plus, Sparkles } from "lucide-react";
 import { MouseEvent } from "react";
 import { Outlet } from "react-router";
 import { toast } from "sonner";
@@ -81,32 +83,40 @@ function StatusToggle({ assistant }: { assistant: Assistant }) {
   );
 }
 
-function AssistantsEmptyState({ onCreate }: { onCreate: () => void }) {
+// BuiltInAssistantCard is the pinned, out-of-the-box "Project Assistant".
+// Unlike user-created assistants it isn't a row the user manages — it's the
+// project's built-in assistant, so the card opens the assistant sidebar instead
+// of navigating to a detail/edit page, and it can't be deleted.
+function BuiltInAssistantCard() {
+  const { setIsExpanded } = useInsightsState();
+
   return (
-    <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
-      <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
-        <Icon name="bot" className="text-muted-foreground h-6 w-6" />
-      </div>
-      <Type variant="subheading" className="mb-1">
-        No assistants yet
-      </Type>
-      <Type small muted className="mb-4 max-w-md text-center">
-        Create an assistant to wire a model up to your MCP servers.
-      </Type>
-      <RequireScope
-        scope={["project:write", "mcp:write"]}
-        all
-        level="component"
-        reason="You don't have permission to create assistants."
-      >
-        <Button onClick={onCreate}>
-          <Button.LeftIcon>
-            <Plus className="h-4 w-4" />
-          </Button.LeftIcon>
-          <Button.Text>Create Assistant</Button.Text>
-        </Button>
-      </RequireScope>
-    </div>
+    <button
+      type="button"
+      onClick={() => setIsExpanded(true)}
+      className="w-full text-left hover:no-underline"
+    >
+      <Card>
+        <Card.Header>
+          <Stack direction="horizontal" gap={2} align="center">
+            <Sparkles className="text-primary size-4" />
+            <Card.Title className="normal-case">Project Assistant</Card.Title>
+          </Stack>
+          <Badge variant="secondary">Built-in</Badge>
+        </Card.Header>
+        <Card.Content>
+          <Card.Description>
+            Your project's built-in assistant for exploring logs, traces, MCP
+            servers, and security findings — always on, right from the sidebar.
+          </Card.Description>
+        </Card.Content>
+        <Card.Footer>
+          <Type muted small>
+            Opens in the sidebar
+          </Type>
+        </Card.Footer>
+      </Card>
+    </button>
   );
 }
 
@@ -119,52 +129,51 @@ export default function AssistantsIndex() {
 
   const assistants = data?.assistants ?? [];
 
-  const content =
-    !isLoading && assistants.length === 0 ? (
-      <AssistantsEmptyState
-        onCreate={() => routes.assistants.newAssistant.goTo()}
-      />
-    ) : (
-      <Page.Section>
-        <Page.Section.Title stage="preview">Assistants</Page.Section.Title>
-        <Page.Section.Description>
-          Claude Code-inspired secure Assistants. Every assistant connects
-          through the MCPs and Skills your org already uses, with identity,
-          guardrails, and audit built in. Deployed to Slack.
-        </Page.Section.Description>
-        <Page.Section.CTA>
-          <RequireScope
-            scope={["project:write", "mcp:write"]}
-            all
-            level="component"
-            reason="You don't have permission to create assistants."
-          >
-            <Button onClick={() => routes.assistants.newAssistant.goTo()}>
-              <Button.LeftIcon>
-                <Plus className="h-4 w-4" />
-              </Button.LeftIcon>
-              <Button.Text>New Assistant</Button.Text>
-            </Button>
-          </RequireScope>
-        </Page.Section.CTA>
-        <Page.Section.Body>
-          {isLoading ? (
-            <Stack align="center" justify="center" className="py-16">
-              <Icon
-                name="loader-circle"
-                className="text-muted-foreground h-6 w-6 animate-spin"
-              />
-            </Stack>
-          ) : (
-            <Cards>
-              {assistants.map((assistant) => (
-                <AssistantCard key={assistant.id} assistant={assistant} />
-              ))}
-            </Cards>
-          )}
-        </Page.Section.Body>
-      </Page.Section>
-    );
+  // The built-in Project Assistant is always pinned first — it ships out of the
+  // box, so the page is never truly empty even before a user creates their own
+  // assistant.
+  const content = (
+    <Page.Section>
+      <Page.Section.Title stage="preview">Assistants</Page.Section.Title>
+      <Page.Section.Description>
+        Claude Code-inspired secure Assistants. Every assistant connects through
+        the MCPs and Skills your org already uses, with identity, guardrails,
+        and audit built in. Deployed to Slack.
+      </Page.Section.Description>
+      <Page.Section.CTA>
+        <RequireScope
+          scope={["project:write", "mcp:write"]}
+          all
+          level="component"
+          reason="You don't have permission to create assistants."
+        >
+          <Button onClick={() => routes.assistants.newAssistant.goTo()}>
+            <Button.LeftIcon>
+              <Plus className="h-4 w-4" />
+            </Button.LeftIcon>
+            <Button.Text>New Assistant</Button.Text>
+          </Button>
+        </RequireScope>
+      </Page.Section.CTA>
+      <Page.Section.Body>
+        {isLoading ? (
+          <Stack align="center" justify="center" className="py-16">
+            <Icon
+              name="loader-circle"
+              className="text-muted-foreground h-6 w-6 animate-spin"
+            />
+          </Stack>
+        ) : (
+          <Cards>
+            <BuiltInAssistantCard />
+            {assistants.map((assistant) => (
+              <AssistantCard key={assistant.id} assistant={assistant} />
+            ))}
+          </Cards>
+        )}
+      </Page.Section.Body>
+    </Page.Section>
+  );
 
   return (
     <Page>


### PR DESCRIPTION
## Summary

Frontend slice of AGE-2631 (the backend round-trip — ingress, sendMessage, egress, listMessages — is now fully merged to main).

**1. Pinned built-in "Project Assistant" card** on the Assistants page:
- Always rendered first in the grid — it ships out of the box, so the page is never empty even before a user creates their own assistant.
- Represents the project's built-in assistant, so it **opens the assistant sidebar** (not a detail/edit page) and **can't be deleted**. Tagged with a `Built-in` badge.
- The page no longer swaps to a separate full-page empty state (the pinned card + the New Assistant CTA cover that).

**2. Rename "AI Insights" → "Project Assistant"**:
- Navbar trigger label, sidebar header title, aria-labels, and tooltip.
- Updated the window welcome copy (`title` / `subtitle`).

Naming is consistent: card, button, and sidebar all read **"Project Assistant"**. (The backend managed-assistant entity name is reconciled in the follow-up PR.)

## Next (follow-up PR, now unblocked)
With the backend merged, the next slice is the **transport cutover** — rewire the sidebar from the client-side AI SDK to the persistent server-side assistant (`sendMessage` / `listMessages`) — plus the **welcome-back-from-conversation-memory** greeting. Kept separate so this card+rename slice ships independently.

## Verification
- `client-build-lint` ✅ (CI), `lint:eslint` + `lint:format` clean on the changed files. Rebased onto current main; no conflicts.

Ref: AGE-2631