### PR TITLE
feat(hooks): capture Codex token usage from OTEL logs

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -341,10 +341,16 @@ const (
 	GenAIConversationDuration             = attribute.Key("gen_ai.conversation.duration")
 	GenAIUsageCacheReadInputTokensKey     = attribute.Key("gen_ai.usage.cache_read.input_tokens")
 	GenAIUsageCacheCreationInputTokensKey = attribute.Key("gen_ai.usage.cache_creation.input_tokens")
+	GenAIUsageReasoningTokensKey          = attribute.Key("gen_ai.usage.reasoning_tokens")
 	GenAIUsageCostKey                     = attribute.Key("gen_ai.usage.cost")
 
 	CursorUsageEventHashKey = attribute.Key("cursor.event_hash")
 	CursorChargedCentsKey   = attribute.Key("cursor.charged_cents")
+
+	// CodexUsageToolTokensKey stores Codex's tool_token_count verbatim for
+	// fidelity. It equals input + output, so it is intentionally not summed
+	// into any total downstream.
+	CodexUsageToolTokensKey = attribute.Key("codex.usage.tool_tokens")
 
 	// GenAI evaluation keys (OTel semconv experimental - gen_ai.evaluation.*)
 	GenAIEvaluationNameKey        = attribute.Key("gen_ai.evaluation.name")        // Evaluation metric name (e.g., "chat_resolution")

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -204,6 +204,14 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		attr.SlogProjectID(projectID),
 	)
 
+	// Codex reports token usage on its OTEL logs stream (codex.sse_event /
+	// response.completed) rather than as metrics like Claude Code. Route those
+	// payloads to the usage writer; they carry no Claude session to seed.
+	if isCodexLogsPayload(payload) {
+		s.writeCodexUsageToClickHouse(ctx, payload, orgID, projectID)
+		return nil
+	}
+
 	if claudeMetadata.SessionID == "" {
 		logger.WarnContext(ctx, "claude OTEL logs payload contained no session ID",
 			attr.SlogEvent("claude_logs_no_session"),

--- a/server/internal/hooks/codex_usage.go
+++ b/server/internal/hooks/codex_usage.go
@@ -2,7 +2,6 @@ package hooks
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -138,10 +137,6 @@ func codexUsageFromRecord(rec *gen.OTELLogRecord) (codexUsageDataPoint, bool) {
 // gram.hook.source ("codex") and gram.resource.urn ("codex:usage:metrics"),
 // so existing per-user and time-series queries pick them up unchanged.
 func (s *Service) writeCodexUsageToClickHouse(ctx context.Context, payload *gen.LogsPayload, orgID, projectID string) {
-	if s.telemetryLogger == nil {
-		return
-	}
-
 	points := extractCodexUsage(payload)
 	if len(points) == 0 {
 		return
@@ -229,10 +224,6 @@ func (s *Service) writeCodexUsageToClickHouse(ctx context.Context, payload *gen.
 			Attributes: attrs,
 		})
 	}
-
-	s.logger.DebugContext(ctx, fmt.Sprintf("Wrote %d Codex usage metrics to ClickHouse", len(points)),
-		attr.SlogEvent("codex_usage_written"),
-	)
 }
 
 // indexLogAttributes builds a key->value lookup over a log record's attributes.

--- a/server/internal/hooks/codex_usage.go
+++ b/server/internal/hooks/codex_usage.go
@@ -1,0 +1,306 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+)
+
+const (
+	// codexServiceName is the OTEL resource service.name the Codex CLI reports.
+	codexServiceName = "codex_cli_rs"
+	// codexUsageMetricsURN types a Codex usage row, mirroring the
+	// "claude-code:usage:metrics" / "cursor:usage:metrics" convention.
+	codexUsageMetricsURN = "codex:usage:metrics"
+	// Codex emits token usage on the SSE event that closes a turn.
+	codexSSEEventName          = "codex.sse_event"
+	codexResponseCompletedKind = "response.completed"
+)
+
+// codexUsageDataPoint is one token-bearing Codex response.completed event.
+//
+// Each token-bearing event becomes its own ClickHouse row, keyed to a
+// conversation via ConversationID. Downstream queries sum across rows, so we do
+// not aggregate per conversation here.
+type codexUsageDataPoint struct {
+	ConversationID  string
+	Model           string
+	UserEmail       string
+	InputTokens     int64
+	OutputTokens    int64
+	CachedTokens    int64
+	ReasoningTokens int64
+	// ToolTokens is Codex's tool_token_count, stored verbatim for fidelity. It
+	// equals InputTokens + OutputTokens, so it never feeds a total downstream.
+	ToolTokens    int64
+	TimestampNano int64
+}
+
+// isCodexLogsPayload reports whether an OTLP logs payload originated from the
+// Codex CLI, identified by its resource service.name. Claude Code reports a
+// different service name and is handled by the session-seeding path instead.
+func isCodexLogsPayload(payload *gen.LogsPayload) bool {
+	if payload == nil {
+		return false
+	}
+	for _, rl := range payload.ResourceLogs {
+		if rl == nil {
+			continue
+		}
+		if extractResourceAttribute(rl.Resource, "service.name") == codexServiceName {
+			return true
+		}
+	}
+	return false
+}
+
+// extractCodexUsage pulls token usage out of every token-bearing
+// codex.sse_event/response.completed log record in the payload.
+func extractCodexUsage(payload *gen.LogsPayload) []codexUsageDataPoint {
+	if payload == nil {
+		return nil
+	}
+
+	var points []codexUsageDataPoint
+	for _, rl := range payload.ResourceLogs {
+		if rl == nil {
+			continue
+		}
+		for _, sl := range rl.ScopeLogs {
+			if sl == nil {
+				continue
+			}
+			for _, rec := range sl.LogRecords {
+				if rec == nil {
+					continue
+				}
+				if dp, ok := codexUsageFromRecord(rec); ok {
+					points = append(points, dp)
+				}
+			}
+		}
+	}
+
+	return points
+}
+
+// codexUsageFromRecord returns a usage data point if the log record is a
+// token-bearing response.completed event. Records that are not SSE completions,
+// or that carry no token counts, are skipped (ok=false).
+func codexUsageFromRecord(rec *gen.OTELLogRecord) (codexUsageDataPoint, bool) {
+	var none codexUsageDataPoint
+
+	attrs := indexLogAttributes(rec.Attributes)
+
+	if logAttrString(attrs, "event.name") != codexSSEEventName {
+		return none, false
+	}
+	if logAttrString(attrs, "event.kind") != codexResponseCompletedKind {
+		return none, false
+	}
+
+	// Only some response.completed events carry usage. Treat the presence of an
+	// input or output count as the signal that this event reports tokens.
+	input, hasInput := logAttrInt64(attrs, "input_token_count")
+	output, hasOutput := logAttrInt64(attrs, "output_token_count")
+	if !hasInput && !hasOutput {
+		return none, false
+	}
+
+	cached, _ := logAttrInt64(attrs, "cached_token_count")
+	reasoning, _ := logAttrInt64(attrs, "reasoning_token_count")
+	toolTokens, _ := logAttrInt64(attrs, "tool_token_count")
+
+	return codexUsageDataPoint{
+		ConversationID:  logAttrString(attrs, "conversation.id"),
+		Model:           logAttrString(attrs, "model"),
+		UserEmail:       strings.TrimSpace(logAttrString(attrs, "user.email")),
+		InputTokens:     input,
+		OutputTokens:    output,
+		CachedTokens:    cached,
+		ReasoningTokens: reasoning,
+		ToolTokens:      toolTokens,
+		TimestampNano:   codexRecordTimestamp(rec, attrs),
+	}, true
+}
+
+// writeCodexUsageToClickHouse normalizes Codex usage into the canonical
+// gen_ai.usage.* shape and writes one telemetry row per token-bearing event.
+// The rows are indistinguishable from Claude/Cursor usage rows except for the
+// gram.hook.source ("codex") and gram.resource.urn ("codex:usage:metrics"),
+// so existing per-user and time-series queries pick them up unchanged.
+func (s *Service) writeCodexUsageToClickHouse(ctx context.Context, payload *gen.LogsPayload, orgID, projectID string) {
+	if s.telemetryLogger == nil {
+		return
+	}
+
+	points := extractCodexUsage(payload)
+	if len(points) == 0 {
+		return
+	}
+
+	parsedProjectID, err := uuid.Parse(projectID)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "invalid project ID for Codex usage", attr.SlogError(err))
+		return
+	}
+
+	// Resolve each unique email to a user ID once so multiple events sharing an
+	// email don't each trigger a DB round-trip.
+	emailToUserID := make(map[string]string)
+	for _, p := range points {
+		email := strings.ToLower(strings.TrimSpace(p.UserEmail))
+		if email == "" {
+			continue
+		}
+		if _, seen := emailToUserID[email]; seen {
+			continue
+		}
+		emailToUserID[email] = s.resolveUserByEmail(ctx, email, orgID)
+	}
+
+	for _, p := range points {
+		attrs := map[attr.Key]any{
+			attr.EventSourceKey:    string(telemetry.EventSourceHook),
+			attr.LogBodyKey:        "Codex usage metrics",
+			attr.ProjectIDKey:      projectID,
+			attr.OrganizationIDKey: orgID,
+			attr.ResourceURNKey:    codexUsageMetricsURN,
+			attr.HookSourceKey:     "codex",
+		}
+
+		// Only include non-zero values, matching the Claude usage writer.
+		if p.InputTokens > 0 {
+			attrs[attr.GenAIUsageInputTokensKey] = p.InputTokens
+		}
+		if p.OutputTokens > 0 {
+			attrs[attr.GenAIUsageOutputTokensKey] = p.OutputTokens
+		}
+		if p.CachedTokens > 0 {
+			attrs[attr.GenAIUsageCacheReadInputTokensKey] = p.CachedTokens
+		}
+		if p.ReasoningTokens > 0 {
+			// Saved for completeness; not surfaced on the dashboard yet.
+			attrs[attr.GenAIUsageReasoningTokensKey] = p.ReasoningTokens
+		}
+		if p.ToolTokens > 0 {
+			// Stored raw for fidelity; intentionally not used downstream.
+			attrs[attr.CodexUsageToolTokensKey] = p.ToolTokens
+		}
+		if p.Model != "" {
+			attrs[attr.GenAIResponseModelKey] = p.Model
+		}
+		if p.UserEmail != "" {
+			attrs[attr.UserEmailKey] = p.UserEmail
+			if userID := emailToUserID[strings.ToLower(strings.TrimSpace(p.UserEmail))]; userID != "" {
+				attrs[attr.UserIDKey] = userID
+			}
+		}
+		if p.ConversationID != "" {
+			attrs[attr.GenAIConversationIDKey] = p.ConversationID
+		}
+
+		toolInfo := telemetry.ToolInfo{
+			Name:           "codex",
+			OrganizationID: orgID,
+			ProjectID:      parsedProjectID.String(),
+			ID:             "",
+			URN:            codexUsageMetricsURN,
+			DeploymentID:   "",
+			FunctionID:     nil,
+		}
+
+		ts := time.Now()
+		if p.TimestampNano > 0 {
+			ts = time.Unix(0, p.TimestampNano)
+		}
+
+		s.telemetryLogger.Log(ctx, telemetry.LogParams{
+			Timestamp:  ts,
+			ToolInfo:   toolInfo,
+			Attributes: attrs,
+		})
+	}
+
+	s.logger.DebugContext(ctx, fmt.Sprintf("Wrote %d Codex usage metrics to ClickHouse", len(points)),
+		attr.SlogEvent("codex_usage_written"),
+	)
+}
+
+// indexLogAttributes builds a key->value lookup over a log record's attributes.
+func indexLogAttributes(attrs []*gen.OTELAttribute) map[string]*gen.OTELAttributeValue {
+	m := make(map[string]*gen.OTELAttributeValue, len(attrs))
+	for _, a := range attrs {
+		if a == nil || a.Value == nil {
+			continue
+		}
+		m[a.Key] = a.Value
+	}
+	return m
+}
+
+// logAttrString returns the string value of an attribute, or "" if absent.
+func logAttrString(attrs map[string]*gen.OTELAttributeValue, key string) string {
+	v := attrs[key]
+	if v == nil || v.StringValue == nil {
+		return ""
+	}
+	return *v.StringValue
+}
+
+// logAttrInt64 reads an integer attribute. Codex encodes token counts as OTLP
+// stringValues ("92728"), but we also accept int and double encodings
+// defensively. Returns ok=false when the attribute is absent or unparseable.
+func logAttrInt64(attrs map[string]*gen.OTELAttributeValue, key string) (int64, bool) {
+	v := attrs[key]
+	if v == nil {
+		return 0, false
+	}
+	if v.StringValue != nil {
+		n, err := strconv.ParseInt(strings.TrimSpace(*v.StringValue), 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	}
+	if v.IntValue != nil {
+		return parseLooseInt64(v.IntValue)
+	}
+	if v.DoubleValue != nil {
+		f := *v.DoubleValue
+		if f != float64(int64(f)) {
+			return 0, false
+		}
+		return int64(f), true
+	}
+	return 0, false
+}
+
+// codexRecordTimestamp resolves the event time, preferring the record's own
+// nanosecond fields and falling back to the RFC3339 event.timestamp attribute.
+func codexRecordTimestamp(rec *gen.OTELLogRecord, attrs map[string]*gen.OTELAttributeValue) int64 {
+	if rec.TimeUnixNano != nil {
+		if n, err := strconv.ParseInt(*rec.TimeUnixNano, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	if rec.ObservedTimeUnixNano != nil {
+		if n, err := strconv.ParseInt(*rec.ObservedTimeUnixNano, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	if ts := logAttrString(attrs, "event.timestamp"); ts != "" {
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			return t.UnixNano()
+		}
+	}
+	return 0
+}

--- a/server/internal/hooks/codex_usage_test.go
+++ b/server/internal/hooks/codex_usage_test.go
@@ -9,9 +9,6 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 )
 
-//go:fix inline
-func sp(s string) *string { return new(s) }
-
 // strAttr builds an OTLP string-valued log attribute, the shape Codex emits.
 func strAttr(key, val string) *gen.OTELAttribute {
 	return &gen.OTELAttribute{Key: key, Value: &gen.OTELAttributeValue{StringValue: new(val)}}

--- a/server/internal/hooks/codex_usage_test.go
+++ b/server/internal/hooks/codex_usage_test.go
@@ -1,0 +1,158 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+)
+
+func sp(s string) *string { return &s }
+
+// strAttr builds an OTLP string-valued log attribute, the shape Codex emits.
+func strAttr(key, val string) *gen.OTELAttribute {
+	return &gen.OTELAttribute{Key: key, Value: &gen.OTELAttributeValue{StringValue: sp(val)}}
+}
+
+// codexLogsPayload wraps records under the Codex resource (service.name).
+func codexLogsPayload(records ...*gen.OTELLogRecord) *gen.LogsPayload {
+	return &gen.LogsPayload{
+		ResourceLogs: []*gen.OTELResourceLog{{
+			Resource: &gen.OTELResource{
+				Attributes: []*gen.OTELResourceAttribute{{
+					Key:   "service.name",
+					Value: &gen.OTELAttributeValue{StringValue: sp(codexServiceName)},
+				}},
+			},
+			ScopeLogs: []*gen.OTELScopeLog{{LogRecords: records}},
+		}},
+	}
+}
+
+// tokenBearingRecord mirrors a real response.completed SSE event with usage.
+func tokenBearingRecord() *gen.OTELLogRecord {
+	return &gen.OTELLogRecord{
+		ObservedTimeUnixNano: sp("1780468942284000000"),
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", codexSSEEventName),
+			strAttr("event.kind", codexResponseCompletedKind),
+			strAttr("input_token_count", "92728"),
+			strAttr("output_token_count", "1441"),
+			strAttr("cached_token_count", "68992"),
+			strAttr("reasoning_token_count", "1170"),
+			strAttr("tool_token_count", "94169"),
+			strAttr("conversation.id", "019e8c0e-740b-7113-b261-71fc14a82fb0"),
+			strAttr("model", "gpt-5.4-mini"),
+			strAttr("user.email", "dev@example.com"),
+		},
+	}
+}
+
+func TestIsCodexLogsPayload(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isCodexLogsPayload(codexLogsPayload(tokenBearingRecord())))
+	assert.False(t, isCodexLogsPayload(nil))
+
+	claude := &gen.LogsPayload{
+		ResourceLogs: []*gen.OTELResourceLog{{
+			Resource: &gen.OTELResource{
+				Attributes: []*gen.OTELResourceAttribute{{
+					Key:   "service.name",
+					Value: &gen.OTELAttributeValue{StringValue: sp("claude-code")},
+				}},
+			},
+		}},
+	}
+	assert.False(t, isCodexLogsPayload(claude))
+}
+
+func TestExtractCodexUsage_TokenBearingEvent(t *testing.T) {
+	t.Parallel()
+
+	points := extractCodexUsage(codexLogsPayload(tokenBearingRecord()))
+	require.Len(t, points, 1)
+
+	p := points[0]
+	assert.Equal(t, "019e8c0e-740b-7113-b261-71fc14a82fb0", p.ConversationID)
+	assert.Equal(t, "gpt-5.4-mini", p.Model)
+	assert.Equal(t, "dev@example.com", p.UserEmail)
+	assert.Equal(t, int64(92728), p.InputTokens)
+	assert.Equal(t, int64(1441), p.OutputTokens)
+	assert.Equal(t, int64(68992), p.CachedTokens)
+	assert.Equal(t, int64(1170), p.ReasoningTokens)
+	// tool_token_count is captured verbatim and happens to equal input+output.
+	assert.Equal(t, int64(94169), p.ToolTokens)
+	assert.Equal(t, p.InputTokens+p.OutputTokens, p.ToolTokens)
+	assert.Equal(t, int64(1780468942284000000), p.TimestampNano)
+}
+
+func TestExtractCodexUsage_SkipsRecordsWithoutUsage(t *testing.T) {
+	t.Parallel()
+
+	// A response.completed with no token counts — Codex emits these too.
+	noUsage := &gen.OTELLogRecord{
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", codexSSEEventName),
+			strAttr("event.kind", codexResponseCompletedKind),
+			strAttr("conversation.id", "conv-1"),
+		},
+	}
+	// A non-completion SSE event with stray counts — must not be mistaken for usage.
+	otherEvent := &gen.OTELLogRecord{
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", codexSSEEventName),
+			strAttr("event.kind", "response.output_item.done"),
+			strAttr("input_token_count", "10"),
+		},
+	}
+	// A websocket event — different event.name entirely.
+	wsEvent := &gen.OTELLogRecord{
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", "codex.websocket_event"),
+			strAttr("input_token_count", "20"),
+		},
+	}
+
+	points := extractCodexUsage(codexLogsPayload(noUsage, otherEvent, wsEvent))
+	assert.Empty(t, points)
+}
+
+func TestExtractCodexUsage_OutputOnlyEventCounts(t *testing.T) {
+	t.Parallel()
+
+	// Presence of output alone is enough to treat the event as token-bearing.
+	rec := &gen.OTELLogRecord{
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", codexSSEEventName),
+			strAttr("event.kind", codexResponseCompletedKind),
+			strAttr("output_token_count", "572"),
+			strAttr("conversation.id", "conv-2"),
+		},
+	}
+	points := extractCodexUsage(codexLogsPayload(rec))
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(0), points[0].InputTokens)
+	assert.Equal(t, int64(572), points[0].OutputTokens)
+}
+
+func TestExtractCodexUsage_MultipleTurnsSameConversation(t *testing.T) {
+	t.Parallel()
+
+	turn2 := &gen.OTELLogRecord{
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", codexSSEEventName),
+			strAttr("event.kind", codexResponseCompletedKind),
+			strAttr("input_token_count", "86277"),
+			strAttr("output_token_count", "572"),
+			strAttr("conversation.id", "019e8c0e-740b-7113-b261-71fc14a82fb0"),
+		},
+	}
+
+	points := extractCodexUsage(codexLogsPayload(tokenBearingRecord(), turn2))
+	require.Len(t, points, 2)
+	// Both turns roll up to the same conversation for correlation.
+	assert.Equal(t, points[0].ConversationID, points[1].ConversationID)
+}

--- a/server/internal/hooks/codex_usage_test.go
+++ b/server/internal/hooks/codex_usage_test.go
@@ -9,11 +9,12 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 )
 
-func sp(s string) *string { return &s }
+//go:fix inline
+func sp(s string) *string { return new(s) }
 
 // strAttr builds an OTLP string-valued log attribute, the shape Codex emits.
 func strAttr(key, val string) *gen.OTELAttribute {
-	return &gen.OTELAttribute{Key: key, Value: &gen.OTELAttributeValue{StringValue: sp(val)}}
+	return &gen.OTELAttribute{Key: key, Value: &gen.OTELAttributeValue{StringValue: new(val)}}
 }
 
 // codexLogsPayload wraps records under the Codex resource (service.name).
@@ -23,7 +24,7 @@ func codexLogsPayload(records ...*gen.OTELLogRecord) *gen.LogsPayload {
 			Resource: &gen.OTELResource{
 				Attributes: []*gen.OTELResourceAttribute{{
 					Key:   "service.name",
-					Value: &gen.OTELAttributeValue{StringValue: sp(codexServiceName)},
+					Value: &gen.OTELAttributeValue{StringValue: new(codexServiceName)},
 				}},
 			},
 			ScopeLogs: []*gen.OTELScopeLog{{LogRecords: records}},
@@ -34,7 +35,7 @@ func codexLogsPayload(records ...*gen.OTELLogRecord) *gen.LogsPayload {
 // tokenBearingRecord mirrors a real response.completed SSE event with usage.
 func tokenBearingRecord() *gen.OTELLogRecord {
 	return &gen.OTELLogRecord{
-		ObservedTimeUnixNano: sp("1780468942284000000"),
+		ObservedTimeUnixNano: new("1780468942284000000"),
 		Attributes: []*gen.OTELAttribute{
 			strAttr("event.name", codexSSEEventName),
 			strAttr("event.kind", codexResponseCompletedKind),
@@ -61,7 +62,7 @@ func TestIsCodexLogsPayload(t *testing.T) {
 			Resource: &gen.OTELResource{
 				Attributes: []*gen.OTELResourceAttribute{{
 					Key:   "service.name",
-					Value: &gen.OTELAttributeValue{StringValue: sp("claude-code")},
+					Value: &gen.OTELAttributeValue{StringValue: new("claude-code")},
 				}},
 			},
 		}},


### PR DESCRIPTION
## Summary

Codex reports token usage on its OTEL logs stream (`codex.sse_event` / `response.completed`) rather than as metrics like Claude Code. The existing logs handler ignored these records, so Codex appeared in telemetry with tool activity but zero tokens. This change parses that usage and writes it to ClickHouse in the canonical shape.

## Changes

- Detect Codex OTLP logs (`service.name=codex_cli_rs`) in the `Logs` handler and route them to a new usage writer. The Claude session-seeding path is unchanged.
- Extract token usage from each `codex.sse_event` record whose `event.kind=response.completed` carries token counts. Records without counts are skipped.
- Normalize Codex fields onto the canonical schema:
  - `input_token_count` → `gen_ai.usage.input_tokens`
  - `output_token_count` → `gen_ai.usage.output_tokens`
  - `cached_token_count` → `gen_ai.usage.cache_read.input_tokens`
  - `reasoning_token_count` → `gen_ai.usage.reasoning_tokens` (stored, not surfaced on the dashboard)
  - `tool_token_count` → `codex.usage.tool_tokens` (stored raw; equals input+output, not used downstream)
- Tag rows `gram.hook.source=codex` and `gram.resource.urn=codex:usage:metrics`, keyed by `gen_ai.conversation.id`. One row is written per token-bearing event.

Rows match the existing Claude/Cursor usage shape, so per-user and time-series telemetry queries pick up Codex usage with no further changes. No schema migration is required — the new token fields ride as JSON attributes.

## New attribute keys

- `gen_ai.usage.reasoning_tokens`
- `codex.usage.tool_tokens`

## Files

- `server/internal/hooks/codex_usage.go` (new) — detection, extraction, and ClickHouse write
- `server/internal/hooks/codex_usage_test.go` (new) — extraction tests
- `server/internal/hooks/claude_hooks.go` — dispatch Codex logs in `Logs`
- `server/internal/attr/conventions.go` — new attribute keys

## Testing

- `mise build:server`
- `mise lint:server`
- `go test ./server/internal/hooks ./server/internal/attr` — 177 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture Codex token usage from OTEL logs and write normalized rows to ClickHouse so telemetry shows correct tokens for Codex. No schema changes; existing queries pick this up.

- New Features
  - Detect Codex OTLP logs (`service.name=codex_cli_rs`) and route them to a usage writer.
  - Parse `codex.sse_event` with `event.kind=response.completed`; skip events without token counts.
  - Map fields: `input_token_count` → `gen_ai.usage.input_tokens`, `output_token_count` → `gen_ai.usage.output_tokens`, `cached_token_count` → `gen_ai.usage.cache_read.input_tokens`, `reasoning_token_count` → `gen_ai.usage.reasoning_tokens`, `tool_token_count` → `codex.usage.tool_tokens`.
  - Write one ClickHouse row per token-bearing event, tagged `gram.hook.source=codex` and `gram.resource.urn=codex:usage:metrics`, keyed by `gen_ai.conversation.id`; include `model`, `user.email`, and resolved user ID.

- Bug Fixes
  - Suppress the "no session ID" warning for Codex logs.

<sup>Written for commit 9d2f1abcd4181a29d6af42243d44ff3cb5ceddea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

