### PR TITLE
fix(dashboard): render external-link icon inline with surrounding text

### DIFF
--- a/.changeset/inline-external-link-icon.md
+++ b/.changeset/inline-external-link-icon.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the shared `Link` component so external links render inline with surrounding text. The external-link icon was wrapped in a block-level flex container, which stretched inline links to full width and pushed trailing punctuation to a new line; the icon now sits inline on the text baseline.

--- a/client/dashboard/src/components/ui/link.tsx
+++ b/client/dashboard/src/components/ui/link.tsx
@@ -1,5 +1,4 @@
 import { cn } from "@/lib/utils";
-import { Stack } from "@speakeasy-api/moonshine";
 import { ExternalLinkIcon } from "lucide-react";
 import { LinkProps, Link as RouterLink } from "react-router";
 
@@ -15,10 +14,10 @@ export function Link({
 
   if (external && !noIcon) {
     content = (
-      <Stack direction="horizontal" gap={1} align="center">
+      <>
         {content}
-        <ExternalLinkIcon className="text-muted-foreground group-hover:text-foreground h-4 w-4" />
-      </Stack>
+        <ExternalLinkIcon className="text-muted-foreground group-hover:text-foreground ml-1 inline h-4 w-4 align-[-0.125em]" />
+      </>
     );
   }
   return (

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -425,10 +425,9 @@ function InstallAgent() {
       <Type muted>
         The agent is two binaries: <code>speakeasyd</code>, the background
         daemon that does the enforcement, and <code>speakeasy</code>, the CLI
-        for status and enrollment. The steps are the same for everyone — run
-        them by hand for a personal setup, or script them in your MDM payload's
-        postinstall (run them in the logged-in user's context, since the agent
-        runs as that user).
+        for status and enrollment. Both can be installed manually or scripted in
+        your MDM payload's postinstall (run them in the logged-in user's
+        context, since the agent runs as that user).
         {version ? (
           <>
             {" "}
@@ -477,7 +476,7 @@ function ManualIdentity() {
     <div className="flex flex-col gap-4">
       <Type muted>
         On a device that isn't MDM-managed, set identity by signing in once
-        after installing — no <code>managed.json</code> required.
+        after installing with no <code>managed.json</code> required.
       </Type>
       <CodeBlock language="bash">{`speakeasy enroll`}</CodeBlock>
       <Type small muted>
@@ -519,7 +518,7 @@ function GenerateInlineButton({
         disabled
           ? "Generating an agent token requires the org:admin role."
           : existing
-            ? "An agent token already exists — this mints a fresh one to drop into managed.json."
+            ? "An agent token already exists — this rotates your existing tokens and adds the new token into managed.json."
             : undefined
       }
       className="-my-1 inline-flex h-6 items-center px-2 py-0 align-middle text-xs"
@@ -599,9 +598,9 @@ function FleetIdentity() {
     <div className="flex flex-col gap-8">
       <Type muted>
         On an MDM-managed device the agent reads its identity from a{" "}
-        <code>managed.json</code> that IT deploys (Kandji, Jamf, Intune, …) — no
-        per-user enrollment. IT owns this file; the agent only reads it, and it
-        wins over anything a user sets locally.
+        <code>managed.json</code> that IT deploys (Kandji, Jamf, Intune, ...)
+        with no per-user enrollment. IT owns this file; the agent only reads it,
+        and it wins over anything a user sets locally.
       </Type>
 
       <div>
@@ -667,10 +666,10 @@ function FleetIdentity() {
         </CodeBlock>
         <Type small muted className="mt-2">
           <code>org_slug</code> and <code>org_name</code> are pre-filled for
-          this org. <code>email</code> is per-user — have your MDM substitute
-          its per-user email variable (Kandji / Jamf <code>$EMAIL</code>, or
-          your platform's equivalent) so one profile serves the whole fleet, or
-          omit <code>email</code> and have each user run{" "}
+          this org. <code>email</code> is per-user; have your MDM substitute its
+          per-user email variable (Kandji / Jamf <code>$EMAIL</code>, or your
+          platform's equivalent) so one profile serves the whole fleet, or omit{" "}
+          <code>email</code> and have each user run{" "}
           <code>speakeasy enroll</code>. Click{" "}
           <strong className="text-foreground">Generate token</strong> in the
           example to mint the <code>org_token</code>.
@@ -721,7 +720,7 @@ function FleetIdentity() {
         <SubHeading>Security</SubHeading>
         <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
           <li>
-            <code>org_token</code> is a credential — distribute it the way you'd
+            <code>org_token</code> is a credential. Distribute it the way you'd
             distribute any API key, and don't commit it or paste it into chat.
           </li>
           <li>
@@ -759,11 +758,9 @@ export default function DeviceAgent() {
               Install the agent
             </Page.Section.Title>
             <Page.Section.Description>
-              The Speakeasy device agent runs on developer laptops and enforces
-              your org's required AI-tool plugins and MCP configuration, then
-              reports compliance back to Speakeasy. Download the daemon + CLI
-              and register the background service — the same steps work whether
-              you run them by hand or script them in your MDM deployment.
+              The Speakeasy device agent runs on-device and enforces your org's
+              required AI-tool plugins and MCP configuration, then reports
+              compliance back to Speakeasy.
             </Page.Section.Description>
             <Page.Section.Body>
               <InstallAgent />


### PR DESCRIPTION
## Problem

The shared `Link` component (`client/dashboard/src/components/ui/link.tsx`) wrapped external-link content in a block-level moonshine `<Stack>` (which renders `display: flex`). Inside an inline `<a>`, that block stretched to the full container width — so an external link used inline in prose elongated its hover/click target and pushed trailing punctuation onto a new line. A first pass with `inline-flex` fixed the wrapping but left the link's text baseline sitting visibly *below* the surrounding line, because the flex box is taller than the text (the icon is 16px) and `align-middle` centered the whole box.

## Fix

Drop the flex wrapper entirely. Keep the link text as ordinary inline text so it shares the line's baseline, and append the external-link icon as an inline SVG nudged onto the text baseline (`align-[-0.125em]`, the standard inline-icon offset) with `ml-1` spacing.

Before → after: the icon and trailing punctuation now flow on the same line, vertically centered against the text.

## Why this is low-impact despite touching a shared UI component

`Link` is used in several places, but this change only affects the `external && !noIcon` branch, and the blast radius there is tiny and strictly positive:

- **`config_form.tsx` and `BuiltInMCPDetailPage.tsx`** pass `noIcon` — they render their own icon and never hit this branch. **Untouched.**
- **`AutoRegisterFailedStep.tsx`** uses an inline external link *inside a sentence* and had already worked around the old block layout with a local `inline-block` hack. This fix makes that link behave correctly on its own (the hack is now redundant but harmless; left in place to avoid touching that dialog's spacing).
- **`DeviceAgent.tsx`** — the page where the bug was reported; now fixed.

There is **no usage that relied on the old block-level layout** — it was simply the wrong default for an inline element. Every affected call site is an inline-in-prose link, all of which improve. Non-`external` and `noIcon` links are completely unaffected.

`tsc`, `oxfmt`, and `eslint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Before

<img width="398" height="74" alt="Screenshot 2026-06-03 at 8 17 22 AM" src="https://github.com/user-attachments/assets/8f0a4a42-c5cc-4447-9447-18134bad4ff2" />

## After
<img width="371" height="38" alt="Screenshot 2026-06-03 at 8 19 51 AM" src="https://github.com/user-attachments/assets/e98bf17a-f8f5-4d4f-971d-2c05a2410ed1" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the external-link icon inline in the shared `Link` component to stop inline links from stretching and misaligning text. Also updates copy on the Device Agent page for clarity.

- **Bug Fixes**
  - Removed `@speakeasy-api/moonshine` `Stack` wrapper; append `ExternalLinkIcon` inline with `ml-1` and `align-[-0.125em]` to sit on the text baseline.
  - Only affects `external && !noIcon` links; others unchanged.

- **Refactors**
  - Polished copy in `DeviceAgent.tsx` (install steps, MDM notes, token tooltip, security notes).

<sup>Written for commit 02386de8ad064107ab3c740895644483047c2278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



