### PR TITLE
feat(risk): drop US_DRIVER_LICENSE from Presidio scans (POC-52)

### DIFF
--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -828,7 +828,13 @@ function PolicySheetBody({
             const meta = RULE_CATEGORY_META[cat];
             const isAvailable = AVAILABLE_CATEGORIES.has(cat);
             const isExpanded = expandedCategory === cat;
-            const rules = DETECTION_RULES[cat];
+            // Hidden rules stay in the catalog so legacy risk_results keep
+            // resolving their title via risk-utils, but they are scrubbed
+            // from the form's display, counts, and bulk toggles. The
+            // underlying disabledRules/selectedCategories state is left
+            // untouched so existing policies that pin a hidden rule round-
+            // trip cleanly through edit.
+            const rules = DETECTION_RULES[cat].filter((r) => !r.hidden);
             const isExpandable = isAvailable && rules.length > 0;
             const categorySelected = selectedCategories.has(cat);
             const enabledRuleCount = categorySelected

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -153,6 +153,7 @@ function policyToCategories(
 function categoriesToPayload(
   cats: Set<RuleCategory>,
   disabledRules: Set<string>,
+  pinnedHidden: Set<string> = new Set(),
 ) {
   const sources: string[] = [];
   const presidioEntities: string[] = [];
@@ -167,6 +168,11 @@ function categoriesToPayload(
     if (cats.has(cat)) {
       for (const rule of DETECTION_RULES[cat]) {
         if (disabledRules.has(rule.id)) continue;
+        // Hidden rules (deprecated / unreliable upstream) are never newly
+        // serialized into the Presidio query just because their category is
+        // selected. We only keep one if the policy being edited already
+        // pinned it, so an edit round-trips without silently dropping it.
+        if (rule.hidden && !pinnedHidden.has(rule.id)) continue;
         presidioEntities.push(ruleIdToPresidioEntity(rule.id));
       }
     }
@@ -188,6 +194,25 @@ function categoriesToPayload(
     promptInjectionRules,
     disabledRules: persistedDisabled,
   };
+}
+
+/** Canonical ids of hidden rules an existing policy already pins via its
+ *  presidioEntities. Lets an edit preserve a deprecated entity the policy
+ *  carried before it was hidden, without ever newly adding one. */
+function pinnedHiddenRuleIds(presidioEntities?: string[]): Set<string> {
+  const pinned = new Set<string>();
+  if (!presidioEntities) return pinned;
+  for (const cat of PRESIDIO_CATEGORIES) {
+    for (const rule of DETECTION_RULES[cat]) {
+      if (
+        rule.hidden &&
+        presidioEntities.includes(ruleIdToPresidioEntity(rule.id))
+      ) {
+        pinned.add(rule.id);
+      }
+    }
+  }
+  return pinned;
 }
 
 /** Map sources to display categories for the table row badges. */
@@ -340,7 +365,11 @@ function PolicyCenterContent() {
       presidioEntities,
       promptInjectionRules,
       disabledRules: payloadDisabled,
-    } = categoriesToPayload(selectedCategories, disabledRules);
+    } = categoriesToPayload(
+      selectedCategories,
+      disabledRules,
+      pinnedHiddenRuleIds(editingPolicy?.presidioEntities),
+    );
     const messageTypes = policyMessageTypesForPayload(selectedMessageTypes);
     const action =
       sources.includes("destructive_tool") && formAction === "block"

--- a/client/dashboard/src/pages/security/detection-rules-data.ts
+++ b/client/dashboard/src/pages/security/detection-rules-data.ts
@@ -133,7 +133,11 @@ export const BUILTIN_RULES_BY_CATEGORY: Record<RuleCategory, BuiltinRule[]> = (
   Object.keys(DETECTION_RULES) as RuleCategory[]
 ).reduce(
   (acc, category) => {
-    const catalog = DETECTION_RULES[category];
+    // Hidden rules (deprecated / unreliable upstream scanner) stay in
+    // DETECTION_RULES so legacy risk_results keep resolving their title via
+    // risk-utils, but they are dropped from the visible Detection Rules
+    // catalog so users never see them as a selectable/listed rule.
+    const catalog = DETECTION_RULES[category].filter((r) => !r.hidden);
     const description = CATEGORY_RULE_DESCRIPTION[category];
     const severity = CATEGORY_DEFAULT_SEVERITY[category];
     if (catalog.length > 0) {
@@ -165,12 +169,15 @@ export const BUILTIN_RULES_BY_CATEGORY: Record<RuleCategory, BuiltinRule[]> = (
   {} as Record<RuleCategory, BuiltinRule[]>,
 );
 
-/** All builtin rule ids, used for custom rule id collision checks. */
-export const BUILTIN_RULE_IDS = new Set<string>(
-  Object.values(BUILTIN_RULES_BY_CATEGORY).flatMap((rules) =>
+/** All builtin rule ids, used for custom rule id collision checks. Includes
+ *  hidden/deprecated rule ids (which BUILTIN_RULES_BY_CATEGORY omits) so a
+ *  custom rule can never reuse an id that legacy findings still resolve. */
+export const BUILTIN_RULE_IDS = new Set<string>([
+  ...Object.values(BUILTIN_RULES_BY_CATEGORY).flatMap((rules) =>
     rules.map((r) => r.id),
   ),
-);
+  ...Object.values(DETECTION_RULES).flatMap((rules) => rules.map((r) => r.id)),
+]);
 
 export type CustomDetectionRule = {
   id: string;

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -23,6 +23,12 @@ export type DetectionRule = {
   id: string;
   title: string;
   source: "gitleaks" | "presidio" | "prompt_injection";
+  // When true the rule is kept in the catalog so legacy risk_results still
+  // resolve their human-readable title via risk-utils.ts, but it is hidden
+  // from the policy create/edit form so users cannot select it on new
+  // policies. Use for rules that are accepted-but-deprecated or whose
+  // upstream scanner is unreliable.
+  hidden?: boolean;
 };
 
 export type McpServerScope = {
@@ -1275,6 +1281,16 @@ export const DETECTION_RULES: Record<RuleCategory, DetectionRule[]> = {
       id: "pii.us_passport",
       title: "US passport number (9 digits)",
       source: "presidio",
+    },
+    {
+      // Kept for legacy risk_results display; hidden from the policy form.
+      // Upstream Presidio regex is unusably broad — see microsoft/presidio#1063
+      // and PR #3172. Server-side blacklist also drops it before any
+      // Presidio request.
+      id: "pii.us_driver_license",
+      title: "US state-issued driver license",
+      source: "presidio",
+      hidden: true,
     },
     {
       id: "pii.us_itin",

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -1277,11 +1277,6 @@ export const DETECTION_RULES: Record<RuleCategory, DetectionRule[]> = {
       source: "presidio",
     },
     {
-      id: "pii.us_driver_license",
-      title: "US state-issued driver license",
-      source: "presidio",
-    },
-    {
       id: "pii.us_itin",
       title: "US Individual Taxpayer ID Number",
       source: "presidio",
@@ -1449,7 +1444,6 @@ export const MOCK_POLICIES: DlpPolicy[] = [
       "pii.phone_number",
       "pii.us_ssn",
       "pii.us_passport",
-      "pii.us_driver_license",
     ],
     action: "flag",
     types: ["user_message", "assistant_message", "tool_response"],

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -182,8 +182,14 @@ type presidioResult struct {
 //     identifiers, etc.) and would deny legitimate tool calls / pollute
 //     batch findings. Re-enable once we have a confidence threshold or a
 //     scoped allow-list.
+//   - US_DRIVER_LICENSE: Presidio's pattern is so broad it flags arbitrary
+//     1-letter + N-digit substrings inside base64 hashes, URL paths, UUIDs,
+//     and any text containing "lic" via substring context boosting (e.g.
+//     "public", "duplicate"). See microsoft/presidio#1063 — open since 2023.
+//     Re-enable once the upstream regex is tightened.
 var presidioEntityBlacklist = map[string]struct{}{
-	"PERSON": {},
+	"PERSON":            {},
+	"US_DRIVER_LICENSE": {},
 }
 
 // filterEntities removes blacklisted entity types from the caller's list.

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -431,6 +431,28 @@ func TestTruncateAtRuneBoundaryHandlesMultibyte(t *testing.T) {
 	assert.Empty(t, truncateAtRuneBoundary(in, 0))
 }
 
+// TestFilterEntitiesDropsBlacklistedTypes asserts that PERSON and
+// US_DRIVER_LICENSE are stripped from any caller-supplied entity list
+// before reaching Presidio. PERSON is dropped because NER trips on
+// capitalized words inside tool calls; US_DRIVER_LICENSE because the
+// upstream regex is unusably broad (microsoft/presidio#1063).
+func TestFilterEntitiesDropsBlacklistedTypes(t *testing.T) {
+	t.Parallel()
+
+	// nil passes through untouched so Presidio's default entity set still applies.
+	assert.Nil(t, filterEntities(nil))
+
+	// Blacklisted entries are removed; the rest survive in order.
+	got := filterEntities([]string{"EMAIL_ADDRESS", "PERSON", "US_DRIVER_LICENSE", "CREDIT_CARD"})
+	assert.Equal(t, []string{"EMAIL_ADDRESS", "CREDIT_CARD"}, got)
+
+	// All-blacklisted input returns an empty (non-nil) slice so AnalyzeBatch
+	// can short-circuit instead of falling back to the unbounded default scan.
+	got = filterEntities([]string{"PERSON", "US_DRIVER_LICENSE"})
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
 func TestIsCancelErrClassifiesContextErrors(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/risk/categories/categories.go
+++ b/server/internal/risk/categories/categories.go
@@ -120,7 +120,6 @@ var Definitions = []Definition{
 		RuleIDs: []string{
 			"pii.us_ssn",
 			"pii.us_passport",
-			"pii.us_driver_license",
 			"pii.us_itin",
 			"pii.uk_nhs",
 			"pii.uk_nino",


### PR DESCRIPTION
Closes [POC-52](https://linear.app/speakeasy/issue/POC-52/feedback-review-pii-us-driver-license-matching-pattern).

## Why

Presidio's `US_DRIVER_LICENSE` recognizer is unusably broad. Its "weak" alternative `[A-Z][0-9]{1,12}` matches arbitrary one-letter-plus-digits substrings inside base64 hashes, URL paths, UUID fragments, and version strings. Context boosting then upgrades the score to 0.65 whenever the substring `lic` appears nearby — which it does in any text containing **"public"**, **"duplicate"**, **"policy"**, **"explicit"**, etc., because the default context matcher does *substring*, not whole-word, matching.

Reference: **[microsoft/presidio#1063](https://github.com/microsoft/presidio/issues/1063)** — open since April 2023, no upstream fix on the regex.

Reproduced locally on production data: an `m2` substring inside `sha512-0UPjpq0G+v2RyzxDbeM8ConLICmLjRgcwuy4...` scored 0.65 as a US driver license because the surrounding token contained `LIC`. Same shape across `public_production` chat logs.

## What changed

Before / After:

| | Before | After |
|---|---|---|
| `presidioEntityBlacklist` | filters `PERSON` only | also filters `US_DRIVER_LICENSE` |
| Dashboard catalog | offers US driver license as a selectable rule | entry removed |
| `Government Identifiers` category preset | includes `pii.us_driver_license` | removed |
| Existing policies that still pin `US_DRIVER_LICENSE` | sent to Presidio | scrubbed at the `AnalyzeBatch` boundary, no DB migration needed |

Description map (`presidio.go`) and SQL category CASE statements (`server/internal/risk/queries.sql`) intentionally untouched so legacy `pii.us_driver_license` findings still resolve cleanly in the UI.

## Test plan

- [x] `go test ./server/internal/background/activities/risk_analysis/...` passes
- [x] `go test ./server/internal/risk/categories/...` passes
- [x] `TestFilterEntitiesDropsBlacklistedTypes` asserts `US_DRIVER_LICENSE` is stripped alongside `PERSON`, from mixed inputs and from all-blacklisted inputs (covers the short-circuit branch)
- [ ] Smoke against staging — verify no new `pii.us_driver_license` risk events land after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove US driver license detection from Presidio scans to stop noisy false positives (addresses Linear POC-52: https://linear.app/speakeasy/issue/POC-52). The rule is hidden and not serialized on new policies; legacy `pii.us_driver_license` findings still display.

- **Bug Fixes**
  - Blacklist US_DRIVER_LICENSE in the server Presidio entity filter; short-circuit when only blacklisted types are provided.
  - Dashboard: add a `hidden` flag; hide the rule from the form, counts, bulk toggles, and the visible Detection Rules catalog; keep its id reserved in `BUILTIN_RULE_IDS`; do not serialize hidden rules into `presidioEntities` unless the edited policy already pins them; remove it from the Government Identifiers preset.
  - Add tests confirming PERSON and US_DRIVER_LICENSE are stripped and that nil/empty cases behave correctly; existing policies are scrubbed server-side, no DB migration needed.

<sup>Written for commit 21fa5d313b0f5e202e418be09232859d5636a9c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

