### PR TITLE
fix(risk): reformat JSON as YAML before sending to Presidio

### DIFF
--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/netip"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -22,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/semaphore"
+	"gopkg.in/yaml.v3"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -394,6 +396,16 @@ func (p *PresidioClient) analyzeOne(ctx context.Context, idx int, text string, e
 		onProgress()
 	}
 
+	// Reformat JSON payloads as YAML with literal block scalars for
+	// strings containing newlines. Presidio's recognizers (notably
+	// US_DRIVER_LICENSE, IBAN) trip on JSON-escaped multiline content
+	// where `\n`, `\uXXXX`, etc. produce digit-and-letter runs that look
+	// like license numbers or codes. The YAML literal form keeps the
+	// underlying characters but emits real newlines, so the surrounding
+	// markup no longer fabricates matches. Non-JSON payloads pass
+	// through unchanged.
+	text = reformatJSONAsYAML(text)
+
 	if originalSize := len(text); originalSize > presidioMaxMessageBytes {
 		text = truncateAtRuneBoundary(text, presidioMaxMessageBytes)
 		p.logger.WarnContext(ctx, "presidio: truncating oversized message",
@@ -662,6 +674,86 @@ func computeRetryBackoff(base time.Duration, attempt int) time.Duration {
 		}
 	}
 	return time.Duration(rand.Int64N(int64(backoff))) // #nosec G404 -- jitter, not security-sensitive
+}
+
+// reformatJSONAsYAML tries to parse text as a JSON value and re-emit it as
+// YAML where any string containing a newline is written as a literal block
+// scalar (`|`). The resulting text carries the same semantic content but
+// drops the JSON `\n` / `\uXXXX` escapes that lead Presidio's regex- and
+// pattern-based recognizers (US_DRIVER_LICENSE in particular) to fabricate
+// matches inside multiline string bodies.
+//
+// Returns text unchanged whenever it does not parse as a single JSON value
+// or whenever YAML encoding fails, so non-JSON payloads continue to flow
+// through to Presidio as-is.
+func reformatJSONAsYAML(text string) string {
+	if text == "" {
+		return text
+	}
+	dec := json.NewDecoder(strings.NewReader(text))
+	dec.UseNumber()
+	var data any
+	if err := dec.Decode(&data); err != nil {
+		return text
+	}
+
+	node := jsonValueToYAMLNode(data)
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(node); err != nil {
+		return text
+	}
+	if err := enc.Close(); err != nil {
+		return text
+	}
+	return buf.String()
+}
+
+func jsonValueToYAMLNode(v any) *yaml.Node {
+	switch x := v.(type) {
+	case nil:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}
+	case bool:
+		val := "false"
+		if x {
+			val = "true"
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: val}
+	case json.Number:
+		return &yaml.Node{Kind: yaml.ScalarNode, Value: x.String()}
+	case string:
+		return jsonStringToYAMLNode(x)
+	case []any:
+		seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, item := range x {
+			seq.Content = append(seq.Content, jsonValueToYAMLNode(item))
+		}
+		return seq
+	case map[string]any:
+		m := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			m.Content = append(m.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: k},
+				jsonValueToYAMLNode(x[k]),
+			)
+		}
+		return m
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: fmt.Sprint(v)}
+}
+
+func jsonStringToYAMLNode(s string) *yaml.Node {
+	n := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s}
+	if strings.Contains(s, "\n") {
+		n.Style = yaml.LiteralStyle
+	}
+	return n
 }
 
 // truncateAtRuneBoundary returns the longest prefix of s whose byte length is

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -683,9 +683,11 @@ func computeRetryBackoff(base time.Duration, attempt int) time.Duration {
 // pattern-based recognizers (US_DRIVER_LICENSE in particular) to fabricate
 // matches inside multiline string bodies.
 //
-// Returns text unchanged whenever it does not parse as a single JSON value
-// or whenever YAML encoding fails, so non-JSON payloads continue to flow
-// through to Presidio as-is.
+// Returns text unchanged whenever it does not parse as a JSON value or
+// whenever YAML encoding fails, so non-JSON payloads continue to flow
+// through to Presidio as-is. Any bytes after the first JSON value (mixed
+// prefix-JSON-then-prose inputs) are appended verbatim so Presidio still
+// scans them.
 func reformatJSONAsYAML(text string) string {
 	if text == "" {
 		return text
@@ -707,7 +709,7 @@ func reformatJSONAsYAML(text string) string {
 	if err := enc.Close(); err != nil {
 		return text
 	}
-	return buf.String()
+	return buf.String() + text[dec.InputOffset():]
 }
 
 func jsonValueToYAMLNode(v any) *yaml.Node {

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/semaphore"
+	"gopkg.in/yaml.v3"
 )
 
 // TestConvertPresidioFindings_FiltersIPv6Unspecified verifies that the
@@ -440,6 +441,109 @@ func TestIsCancelErrClassifiesContextErrors(t *testing.T) {
 	assert.True(t, isCancelErr(fmt.Errorf("wrapped: %w", context.DeadlineExceeded)))
 	assert.False(t, isCancelErr(nil))
 	assert.False(t, isCancelErr(errors.New("presidio returned status 500")))
+}
+
+// TestReformatJSONAsYAML_LeavesNonJSONUntouched documents the safety
+// fallback: anything we cannot decode as a JSON value flows through to
+// Presidio verbatim so plain prose and pre-formatted snippets are still
+// scanned.
+func TestReformatJSONAsYAML_LeavesNonJSONUntouched(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"",
+		"hello world",
+		"not { json",
+		"  leading whitespace and trailing garbage }",
+	}
+	for _, in := range cases {
+		assert.Equal(t, in, reformatJSONAsYAML(in))
+	}
+}
+
+// TestReformatJSONAsYAML_EscapedNewlinesBecomeLiteralBlock is the
+// regression test for POC-58: JSON-encoded multiline strings produce
+// `\n` and similar escapes that Presidio's pattern-based recognizers
+// (US_DRIVER_LICENSE in particular) misread as license numbers. The
+// YAML literal-block form replaces those escapes with real newlines.
+func TestReformatJSONAsYAML_EscapedNewlinesBecomeLiteralBlock(t *testing.T) {
+	t.Parallel()
+
+	in := `{"message":"first line\nsecond line\nthird line"}`
+	out := reformatJSONAsYAML(in)
+
+	assert.Contains(t, out, "|", "multiline strings should be emitted as a YAML literal block scalar")
+	assert.NotContains(t, out, `\n`, "JSON newline escapes must not survive into the Presidio payload")
+	for _, line := range []string{"first line", "second line", "third line"} {
+		assert.Contains(t, out, line)
+	}
+	assert.GreaterOrEqual(t, strings.Count(out, "\n"), 3, "literal block should preserve real newlines between lines")
+}
+
+// TestReformatJSONAsYAML_PreservesStructureAndValues confirms that
+// non-string JSON values (numbers, booleans, null, nested arrays and
+// objects) round-trip through the converter into a YAML document that
+// decodes back to the same data.
+func TestReformatJSONAsYAML_PreservesStructureAndValues(t *testing.T) {
+	t.Parallel()
+
+	in := `{"a":1,"b":1.5,"c":true,"d":null,"e":["x","y"],"f":{"nested":"value"}}`
+	out := reformatJSONAsYAML(in)
+
+	var roundTrip map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(out), &roundTrip))
+	assert.Equal(t, 1, roundTrip["a"])
+	assert.InEpsilon(t, 1.5, roundTrip["b"], 1e-9)
+	assert.Equal(t, true, roundTrip["c"])
+	assert.Nil(t, roundTrip["d"])
+	assert.Equal(t, []any{"x", "y"}, roundTrip["e"])
+	assert.Equal(t, map[string]any{"nested": "value"}, roundTrip["f"])
+}
+
+// TestReformatJSONAsYAML_SortsMapKeys makes the output deterministic so
+// repeated scans of the same payload produce stable Presidio offsets.
+func TestReformatJSONAsYAML_SortsMapKeys(t *testing.T) {
+	t.Parallel()
+
+	in := `{"zebra":"z","apple":"a","mango":"m"}`
+	out := reformatJSONAsYAML(in)
+
+	appleIdx := strings.Index(out, "apple:")
+	mangoIdx := strings.Index(out, "mango:")
+	zebraIdx := strings.Index(out, "zebra:")
+	require.GreaterOrEqual(t, appleIdx, 0)
+	require.GreaterOrEqual(t, mangoIdx, 0)
+	require.GreaterOrEqual(t, zebraIdx, 0)
+	assert.Less(t, appleIdx, mangoIdx)
+	assert.Less(t, mangoIdx, zebraIdx)
+}
+
+// TestAnalyzeOncePayloadIsYAMLForJSONInput is the end-to-end assertion
+// that the client converts JSON bodies before handing them to Presidio.
+// We send a JSON object with a multiline string and confirm the wire
+// payload no longer contains the raw `\n` escape sequence.
+func TestAnalyzeOncePayloadIsYAMLForJSONInput(t *testing.T) {
+	t.Parallel()
+
+	var got presidioRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode([][]presidioResult{{}}))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := newTestPresidioClient(t, srv.URL)
+	in := `{"body":"line one\nline two"}`
+	_, err := client.AnalyzeBatch(t.Context(), []string{in}, nil, nil)
+	require.NoError(t, err)
+
+	require.Len(t, got.Text, 1)
+	wire := got.Text[0]
+	assert.NotContains(t, wire, `\n`, "JSON newline escapes must not reach Presidio")
+	assert.Contains(t, wire, "body: |", "object key should be followed by a literal-block scalar marker")
+	assert.Contains(t, wire, "line one")
+	assert.Contains(t, wire, "line two")
 }
 
 // --- helpers ---

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -500,6 +500,20 @@ func TestReformatJSONAsYAML_PreservesStructureAndValues(t *testing.T) {
 	assert.Equal(t, map[string]any{"nested": "value"}, roundTrip["f"])
 }
 
+// TestReformatJSONAsYAML_PreservesTrailingBytes guards against
+// json.Decoder.Decode silently discarding bytes after the first JSON value:
+// for mixed prefix-JSON-then-prose inputs we must still hand the trailing
+// portion to Presidio so PII outside the JSON envelope is not dropped.
+func TestReformatJSONAsYAML_PreservesTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	in := `{"a":1} contact sarah@example.com for details`
+	out := reformatJSONAsYAML(in)
+
+	assert.Contains(t, out, "a: 1", "JSON prefix should still be reformatted as YAML")
+	assert.Contains(t, out, "sarah@example.com", "trailing bytes must survive into the Presidio payload")
+}
+
 // TestReformatJSONAsYAML_SortsMapKeys makes the output deterministic so
 // repeated scans of the same payload produce stable Presidio offsets.
 func TestReformatJSONAsYAML_SortsMapKeys(t *testing.T) {


### PR DESCRIPTION
## Why

[POC-58](https://linear.app/speakeasy/issue/POC-58/feat-improve-detection-accuracy-by-capturing-message-context)

Risk scans currently send the raw JSON-encoded message content to Presidio. When a string field contains newlines or other escapes (e.g. a multiline tool argument), the body reaches the analyzer as ``"...first line\nsecond line\n..."`` and Presidio's pattern-based recognizers (notably ``US_DRIVER_LICENSE`` and the unicode-codepoint scanners) match the escape sequences themselves. Production has surfaced fake findings like ``u00261`` and ``u2014``.

## What changed

### Before

``analyzeOne`` truncated oversized text, then handed it to ``/analyze`` as JSON:

```json
{"message":"first line\nsecond line\nthird line"}
```

Presidio sees the literal ``\n`` runs and reports false-positive PII.

### After

``analyzeOne`` first attempts to parse the text as a JSON value. On success it re-emits the payload as YAML with literal block scalars (`` | ``) for any string containing newlines, then proceeds with the normal truncation / throttle / retry path:

```yaml
message: |-
  first line
  second line
  third line
```

Real newlines stay, the JSON escape sequences are gone, and the surrounding content no longer fabricates regex matches. Map keys are sorted for deterministic offsets across re-scans. Non-JSON payloads (plain prose, malformed JSON) pass through unchanged so we never degrade the existing scan path.

### Tests

Added unit tests in ``presidio_internal_test.go`` covering:
- pass-through for non-JSON inputs
- regression: JSON multiline strings emit a literal block and no ``\n`` escapes
- structural round-trip (numbers, booleans, null, nested objects, arrays)
- deterministic key ordering
- end-to-end: the byte-level Presidio wire payload is YAML, not JSON

## Test plan

- [x] ``go test ./server/internal/background/activities/risk_analysis/...``
- [x] ``mise lint:server``

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformats JSON-encoded message text as YAML before sending to Presidio to remove escape sequences that caused false positives, and preserves trailing non-JSON bytes so mixed inputs are fully scanned. Supports POC-58 by improving detection accuracy for multiline content and stabilizing findings.

- **Bug Fixes**
  - Parse input as JSON and emit YAML with literal block scalars for multiline strings; non-JSON inputs pass through unchanged.
  - Sort object keys for deterministic offsets; keeps existing truncate/throttle/retry behavior intact.
  - Append any bytes after the first JSON value to the YAML output so trailing prose is still analyzed.

<sup>Written for commit 35f7c1979d5bf4992787cc8a3d5de1dd0824ad2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

