### PR TITLE
chore: add cubic config in repo

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+
+# cubic.yaml
+# This file configures AI review behavior, ignore patterns, PR descriptions, and custom rules.
+# Place this file in your repository root to version-control your AI review settings.
+# Settings defined here take precedence over UI-configured settings.
+# See https://docs.cubic.dev/configure/cubic-yaml for documentation.
+
+version: 1
+reviews:
+  enabled: true
+  sensitivity: high
+  incremental_commits: true
+  check_drafts: false
+  architecture_diagrams: false
+  external_contributors_require_manual_review: true
+  resolve_threads_when_addressed: true
+  merge_confidence_summary: false
+  auto_approve_behavior: disabled
+  auto_approve: disabled
+  ignore:
+    files:
+      - client/sdk/**/*
+      - server/gen/**/*
+      - "**/repo/*.go"
+      - .changesets/*
+      - .speakeasy/**/*
+      - "**/*.svg"
+      - "**/*_gen.go"
+      - "**/*_gen.yaml"
+      - "**/*_gen.yml"
+    head_branches:
+      - changeset-release/main
+      - dependabot/*
+    pr_titles:
+      - "chore: version packages"
+  custom_rules:
+    - name: Flag Security Vulnerabilities
+      description: |-
+        Scan for security flaws: hardcoded secrets, SQL injection, XSS, weak auth, exposed data, poor crypto, unsafe deserialization, insecure HTTP calls in production, and more. Ensure all network requests use HTTPS/TLS. Identify attack vectors and security violations to maintain robust defenses.
+        Insecure Direct Object Reference (IDOR) vulnerabilities are mitigated by explicitly scoping all queries to organization or project ids. Ensure this is the case whenever SQLc queries are added or updated.
+pr_descriptions:
+  generate: true
+  cubic_review_link: true
+issues:
+  fix_with_cubic_buttons: true
+  pr_comment_fixes: true
+  fix_commits_to_pr: true


### PR DESCRIPTION
This change adds the cubic ai reviewer config as code managed in this repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cubic.yaml` to version-control automated review behavior, ignore patterns, and PR description generation. High-sensitivity reviews are enabled with incremental commit checks, a security rule flags vulnerabilities (including IDOR via org/project scoping), and issue quick-fix actions are turned on.

<sup>Written for commit 0aee30fcbd68814173114b5a7d94570f46529cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

