### PR TITLE
fix: preserve configured Authorization in external MCP passthrough

### DIFF
--- a/.changeset/ais-83-external-mcp-auth.md
+++ b/.changeset/ais-83-external-mcp-auth.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Preserve a configured Authorization header for external MCP passthrough tools instead of overwriting it with the gating OAuth token.

--- a/server/internal/externalmcp/config.go
+++ b/server/internal/externalmcp/config.go
@@ -9,12 +9,13 @@ import (
 // BuildHeaders constructs HTTP headers from system environment variables and user configuration.
 //
 // Logic:
-// 1. ALL system env values become headers using the appropriate header names.
-// 2. For keys with header definitions, use the definition's HeaderName.
-// 3. For keys without definitions, derive the header name using ToHTTPHeader.
-// 4. User config can override values (only for keys with header definitions).
-// 5. Empty values are skipped.
-// 6. If oauthToken is provided, sets Authorization: Bearer <token>.
+//  1. ALL system env values become headers using the appropriate header names.
+//  2. For keys with header definitions, use the definition's HeaderName.
+//  3. For keys without definitions, derive the header name using ToHTTPHeader.
+//  4. User config can override values (only for keys with header definitions).
+//  5. Empty values are skipped.
+//  6. If oauthToken is provided and no Authorization header was already set from
+//     config, sets Authorization: Bearer <token>.
 func BuildHeaders(
 	systemEnv *toolconfig.CaseInsensitiveEnv,
 	userConfig *toolconfig.CaseInsensitiveEnv,
@@ -66,9 +67,13 @@ func BuildHeaders(
 		}
 	}
 
-	// Set Authorization header from OAuth token if provided
+	// Forward the gating OAuth token only when config did not already provide an
+	// explicit Authorization. A configured static credential (e.g. "Basic ...")
+	// for the upstream must win over the forwarded gating token.
 	if oauthToken != "" {
-		headers["Authorization"] = "Bearer " + oauthToken
+		if _, ok := headers["Authorization"]; !ok {
+			headers["Authorization"] = "Bearer " + oauthToken
+		}
 	}
 
 	return headers

--- a/server/internal/externalmcp/config_test.go
+++ b/server/internal/externalmcp/config_test.go
@@ -395,7 +395,7 @@ func TestBuildHeadersWithOAuthToken(t *testing.T) {
 			},
 		},
 		{
-			name:       "config Authorization wins over oauth token",
+			name:       "system config Authorization wins over oauth token",
 			systemEnv:  map[string]string{"gong_authorization": "Basic dXNlcjpwYXNz"},
 			userConfig: map[string]string{},
 			headerDefs: []HeaderDefinition{

--- a/server/internal/externalmcp/config_test.go
+++ b/server/internal/externalmcp/config_test.go
@@ -394,6 +394,30 @@ func TestBuildHeadersWithOAuthToken(t *testing.T) {
 				"Authorization": "Bearer oauth-token",
 			},
 		},
+		{
+			name:       "config Authorization wins over oauth token",
+			systemEnv:  map[string]string{"gong_authorization": "Basic dXNlcjpwYXNz"},
+			userConfig: map[string]string{},
+			headerDefs: []HeaderDefinition{
+				{Name: "gong_authorization", HeaderName: "Authorization"},
+			},
+			oauthToken: "gating-oauth-token",
+			expected: map[string]string{
+				"Authorization": "Basic dXNlcjpwYXNz",
+			},
+		},
+		{
+			name:       "user config Authorization wins over oauth token",
+			systemEnv:  map[string]string{},
+			userConfig: map[string]string{"gong_authorization": "Basic dXNlcjpwYXNz"},
+			headerDefs: []HeaderDefinition{
+				{Name: "gong_authorization", HeaderName: "Authorization"},
+			},
+			oauthToken: "gating-oauth-token",
+			expected: map[string]string{
+				"Authorization": "Basic dXNlcjpwYXNz",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

External MCP tools with `requires_oauth=true` forwarded the gating OAuth token (the token presented to the local Gram MCP server) upstream as `Authorization: Bearer <token>`, overwriting any `Authorization` header the user configured via env/user config in `BuildHeaders` (`server/internal/externalmcp/config.go`).

This broke setups where the local server is OAuth-guarded but the upstream MCP expects a static credential (e.g. `Basic ...`): the upstream rejected the forwarded gating token with `401`.

## Fix

Forward the gating OAuth token only when no explicit `Authorization` was already set from config. Config-provided `Authorization` now wins; the gating token remains the fallback when none is configured.

## Tests

Added two `TestBuildHeadersWithOAuthToken` cases: config-provided and user-config-provided `Authorization` each take precedence over the OAuth token.

Resolves AIS-83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the configured Authorization header in external MCP passthrough; only forwards the gating OAuth token if no Authorization is set. Prevents upstream 401s for MCPs that require static credentials (addresses AIS-83).

- **Bug Fixes**
  - Updated `BuildHeaders` in `server/internal/externalmcp/config.go` to apply `Bearer <oauthToken>` only when Authorization isn’t set by system or user config.
  - Added tests ensuring both system- and user-configured Authorization take precedence over the OAuth token; added changeset patch entry for `server`.

<sup>Written for commit 87df9ec1ddb4fdd83ca0dc0f8c4f17a17abcc078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

