### PR TITLE
feat(dashboard): auto-create default endpoint for remote MCP sources

### DIFF
--- a/.changeset/age-2679-default-endpoint-remote-mcp-source.md
+++ b/.changeset/age-2679-default-endpoint-remote-mcp-source.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Auto-create a default MCP endpoint when importing a remote MCP server as a source. Previously the import created the server but required the user to add an endpoint by hand before it could serve traffic. The import flow and the detail-page re-link flow now pre-stage a default platform endpoint with slug `{orgSlug}-{random}`. Endpoint creation is best-effort: a failure leaves the source intact and surfaces a warning toast, and the server stays disabled so the endpoint begins serving once the user enables it.

--- a/client/dashboard/src/lib/externalMcpUserSessions.ts
+++ b/client/dashboard/src/lib/externalMcpUserSessions.ts
@@ -10,6 +10,7 @@ import {
   type AuthedFetch,
   proxyRegisterUpstreamClient,
 } from "@/lib/proxyRegisterUpstreamClient";
+import { randomSlugSuffix } from "@/lib/slug";
 import { getServerURL } from "@/lib/utils";
 
 function narrowTokenEndpointAuthMethod(
@@ -349,10 +350,4 @@ function slugify(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-}
-
-function randomSlugSuffix(): string {
-  const bytes = new Uint8Array(4);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }

--- a/client/dashboard/src/lib/slug.ts
+++ b/client/dashboard/src/lib/slug.ts
@@ -1,0 +1,8 @@
+// Returns a short random hex token (8 chars, 4 crypto-random bytes) suitable
+// for appending to slugs to make them unique. ~4.3 billion values, so
+// collisions within a single namespace are negligible.
+export function randomSlugSuffix(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/client/dashboard/src/pages/sources/remote-mcp/hooks.ts
+++ b/client/dashboard/src/pages/sources/remote-mcp/hooks.ts
@@ -1,5 +1,6 @@
-import { useSdkClient } from "@/contexts/Sdk";
+import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { formatRemoteMcpDisplay } from "@/lib/sources";
+import { randomSlugSuffix } from "@/lib/slug";
 import type {
   McpServer,
   RemoteMcpServer,
@@ -14,6 +15,42 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+type SdkClient = ReturnType<typeof useSdkClient>;
+
+const DEFAULT_ENDPOINT_FAILED_MESSAGE =
+  "MCP server created, but the default endpoint failed. Add one from the server page.";
+
+// Auto-provisions a default platform MCP endpoint for a freshly created
+// mcp_server backed by a remote source, so the user doesn't have to create one
+// by hand afterwards. Platform endpoint slugs (no custom domain) must be
+// prefixed with the org slug; a short random suffix keeps them unique.
+//
+// Best-effort: a failure here leaves the source intact and only surfaces a
+// warning. The endpoint is a convenience and can always be added later from
+// the server detail page, so it should never roll back the source.
+async function createDefaultMcpEndpoint(
+  client: SdkClient,
+  mcpServer: McpServer,
+  orgSlug: string | undefined,
+): Promise<void> {
+  if (!orgSlug) {
+    toast.warning(DEFAULT_ENDPOINT_FAILED_MESSAGE);
+    return;
+  }
+
+  try {
+    await client.mcpEndpoints.create({
+      createMcpEndpointForm: {
+        mcpServerId: mcpServer.id,
+        slug: `${orgSlug}-${randomSlugSuffix()}`,
+      },
+    });
+  } catch {
+    toast.warning(DEFAULT_ENDPOINT_FAILED_MESSAGE);
+  }
+}
 
 export type CreateRemoteMcpSourceVariables = {
   name?: string | undefined;
@@ -32,6 +69,7 @@ export function useCreateRemoteMcpSource(): UseMutationResult<
 > {
   const client = useSdkClient();
   const queryClient = useQueryClient();
+  const { orgSlug } = useSlugs();
 
   return useMutation({
     mutationFn: async ({ name, url }) => {
@@ -75,6 +113,10 @@ export function useCreateRemoteMcpSource(): UseMutationResult<
           : new Error(String(linkError));
       }
 
+      // Pre-stage a default endpoint so the user doesn't have to create one
+      // before the server can serve. Best-effort: never rolls back the source.
+      await createDefaultMcpEndpoint(client, mcpServer, orgSlug);
+
       return { remoteMcpServer, mcpServer };
     },
     onSuccess: async () => {
@@ -84,6 +126,7 @@ export function useCreateRemoteMcpSource(): UseMutationResult<
       await Promise.all([
         invalidateAllRemoteMcpServers(queryClient, { refetchType: "all" }),
         invalidateAllMcpServers(queryClient, { refetchType: "all" }),
+        invalidateAllMcpEndpoints(queryClient, { refetchType: "all" }),
       ]);
     },
   });
@@ -105,19 +148,26 @@ export function useLinkMcpServerToRemote(): UseMutationResult<
 > {
   const client = useSdkClient();
   const queryClient = useQueryClient();
+  const { orgSlug } = useSlugs();
 
   return useMutation({
     mutationFn: async ({ remoteMcpServer }) => {
-      await client.mcpServers.create({
+      const mcpServer = await client.mcpServers.create({
         createMcpServerForm: {
           name: formatRemoteMcpDisplay(remoteMcpServer),
           remoteMcpServerId: remoteMcpServer.id,
           visibility: "disabled",
         },
       });
+
+      // Mirror the create flow: pre-stage a default endpoint. Best-effort.
+      await createDefaultMcpEndpoint(client, mcpServer, orgSlug);
     },
     onSuccess: async () => {
-      await invalidateAllMcpServers(queryClient, { refetchType: "all" });
+      await Promise.all([
+        invalidateAllMcpServers(queryClient, { refetchType: "all" }),
+        invalidateAllMcpEndpoints(queryClient, { refetchType: "all" }),
+      ]);
     },
   });
 }


### PR DESCRIPTION
## Summary

When a user adds a remote MCP server as a source, Gram creates an `mcp_servers` row linked to the new remote server, but the user then has to create an MCP endpoint by hand before the server can serve traffic. This change pre-stages a default endpoint as part of the import flow so that manual step is no longer required.

- After the `mcp_servers` row is created, the dashboard now creates a default platform endpoint. This applies to both the initial import flow (`useCreateRemoteMcpSource`) and the detail-page re-link flow (`useLinkMcpServerToRemote`), via a shared `createDefaultMcpEndpoint` helper.
- The endpoint slug is `{orgSlug}-{random}` (platform endpoint, no custom domain). The org-slug prefix is required for platform endpoints; the random suffix guarantees uniqueness.
- Best-effort: if endpoint creation fails, the source is left intact and a warning toast is shown. The user can still add an endpoint manually from the server detail page.
- Server visibility stays `disabled`. The endpoint is pre-staged and begins serving once the user enables the server.
- `randomSlugSuffix` is extracted into `client/dashboard/src/lib/slug.ts` for reuse (previously private in `externalMcpUserSessions.ts`).

No backend or schema changes. Backfilling existing endpoint-less remote servers is out of scope.

## Test plan

- [ ] Add a remote MCP source: confirm a default endpoint is created and listed on the server detail page.
- [ ] Delete the auto-linked server, then re-link from the detail page: confirm a default endpoint is created.
- [ ] Simulate an endpoint-create failure: confirm the source is kept and a warning toast appears.
- [ ] Enable the server: confirm the pre-staged endpoint serves.

Resolves AGE-2679

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-create a default platform MCP endpoint when importing or re-linking a remote MCP server, so users don’t have to create one manually. Implements Linear AGE-2679.

- **New Features**
  - After the `mcp_servers` row is created, create a default endpoint in both flows via a shared `createDefaultMcpEndpoint`.
  - Endpoint slug: `{orgSlug}-{random}` (platform endpoint, no custom domain) using `randomSlugSuffix` for uniqueness.
  - Best-effort: on failure (including missing org slug), keep the source and show a warning toast; users can add an endpoint later.
  - Server visibility remains `disabled`; the pre-staged endpoint serves once the server is enabled.
  - Refresh MCP endpoints on success so the new endpoint appears immediately.

- **Refactors**
  - Extracted `randomSlugSuffix` to `client/dashboard/src/lib/slug.ts` and updated references in `client/dashboard/src/lib/externalMcpUserSessions.ts`.
  - Added a changeset to publish a dashboard patch.
  - Dashboard-only; no backend or schema changes.

<sup>Written for commit 0dd8f2f28adbddcd725e9cecc64ac2714c10f4b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

