### PR TITLE
fix(dashboard): correct side nav badge sizing

### DIFF
--- a/.changeset/blue-dots-cut.md
+++ b/.changeset/blue-dots-cut.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix dashboard release-stage badges so preview/beta labels render consistently in side nav and tab navigation.

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -421,7 +421,7 @@ export function NavButton({
         target={target}
         onClick={handleClick}
         className={cn(
-          "relative z-[1] flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm transition-colors hover:no-underline",
+          "relative z-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm transition-colors hover:no-underline",
           "group-data-[collapsible=icon]:min-w-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-2!",
           active
             ? "text-foreground font-semibold"
@@ -501,7 +501,7 @@ export function CollapsibleNavGroup({
             to={defaultHref ?? "#"}
             onClick={handleClick}
             className={cn(
-              "relative z-[1] flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors hover:no-underline",
+              "relative z-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors hover:no-underline",
               "group-data-[collapsible=icon]:min-w-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-2!",
               "cursor-pointer outline-hidden",
               isOpen
@@ -604,7 +604,7 @@ export function CollapsibleNavItem({
           to={item.href()}
           onClick={handleClick}
           className={cn(
-            "relative z-[1] flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:no-underline",
+            "relative z-1 flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:no-underline",
             item.active
               ? "text-foreground font-semibold"
               : "text-muted-foreground hover:text-foreground",

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -450,9 +450,8 @@ export function NavButton({
         {stage && (
           <ReleaseStageBadge
             stage={stage}
-            size="xs"
             noTooltip
-            className="-my-1 origin-left scale-75 group-data-[collapsible=icon]:hidden"
+            className="group-data-[collapsible=icon]:hidden"
           />
         )}
       </Link>
@@ -523,7 +522,7 @@ export function CollapsibleNavGroup({
               <ReleaseStageBadge
                 stage={stage}
                 noTooltip
-                className="-my-1 origin-left scale-75 transition-opacity duration-150 ease-out group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:opacity-0"
+                className="transition-opacity duration-150 ease-out group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:opacity-0"
               />
             )}
           </Link>
@@ -616,12 +615,7 @@ export function CollapsibleNavItem({
           </span>
           {item.title === "Billing" && <ProductTierBadge />}
           {(stage ?? item.stage) && (
-            <ReleaseStageBadge
-              stage={(stage ?? item.stage)!}
-              size="xs"
-              noTooltip
-              className="-my-1 origin-left scale-75"
-            />
+            <ReleaseStageBadge stage={(stage ?? item.stage)!} noTooltip />
           )}
         </Link>
       </div>

--- a/client/dashboard/src/components/observe/ObserveTabNav.tsx
+++ b/client/dashboard/src/components/observe/ObserveTabNav.tsx
@@ -66,9 +66,7 @@ export function ObserveTabNav({ base }: { base: "insights" | "logs" }) {
             )}
           >
             {tab.label}
-            {tab.stage && (
-              <ReleaseStageBadge stage={tab.stage} size="xs" noTooltip />
-            )}
+            {tab.stage && <ReleaseStageBadge stage={tab.stage} noTooltip />}
           </Link>
         );
 

--- a/client/dashboard/src/components/release-stage-badge.tsx
+++ b/client/dashboard/src/components/release-stage-badge.tsx
@@ -5,8 +5,6 @@ export type ReleaseStage = "preview" | "beta";
 
 type ReleaseStageBadgeProps = {
   stage: ReleaseStage;
-  /** Size is kept for API back-compat; both values map to the same Moonshine Badge. */
-  size?: "xs" | "sm";
   /** When true, omit the tooltip wrapper (e.g., inside a parent that already has a tooltip). */
   noTooltip?: boolean;
   className?: string;
@@ -40,6 +38,7 @@ export function ReleaseStageBadge({
 }: ReleaseStageBadgeProps) {
   const pill = (
     <Badge
+      size="sm"
       variant={stageVariant[stage]}
       background
       className={className}


### PR DESCRIPTION
## Summary
- Removes side-nav badge styles using scaling.
- Cleans up the remaining stale `ReleaseStageBadge` size call site.
- The new badge styles matches the older version that was scaled down to 75%

## Root Cause
The use of scale-75 had an unintended side effect with flex spacing and truncation. It would hold the space of the full size of the badge. Even with it smaller it would cause truncation to kick in for nav items. This was surfaced when Device Agent is added. 

<img width="564" height="230" alt="Untitled" src="https://github.com/user-attachments/assets/de7ae357-084d-49d4-9580-df01c5e75803" />

## Realated PR
- https://github.com/speakeasy-api/gram/pull/3181

## Test Plan
- [x] `pnpm -F dashboard type-check`
- [x] `pnpm -F dashboard lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release-stage badge sizing in the side nav and Observe tabs so preview/beta labels render consistently and no longer cause text truncation. Addresses Linear AGE-2644.

- **Bug Fixes**
  - Remove scaling, negative margins, and transforms from badge call sites; use internal `Badge` with `size="sm"`.
  - Remove the `size` prop from `ReleaseStageBadge` and delete call-site usages in side nav and `ObserveTabNav`.
  - Replace arbitrary `z-[1]` with `z-1` on nav links.

<sup>Written for commit 3d8dbfe0c161f581598b5a55549c75f078f6c6ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



