### PR TITLE
chore: Instrument MCP OAuth handshake

### DIFF
--- a/.changeset/oauth-handshake-instrumentation.md
+++ b/.changeset/oauth-handshake-instrumentation.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add safe instrumentation for issuer-gated MCP OAuth registration, token exchange, and revocation flows to improve Datadog debugging of client credential and grant failures.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -174,15 +174,20 @@ const (
 	OAuthAuthorizationEndpointKey  = attribute.Key("gram.oauth.authorization_endpoint")
 	OAuthClientIDKey               = attribute.Key("gram.oauth.client_id")
 	OAuthClientNameKey             = attribute.Key("gram.oauth.client_name")
+	OAuthClientSecretGeneratedKey  = attribute.Key("gram.oauth.client_secret_generated")
 	// OAuthErrorKey / OAuthErrorDescriptionKey carry the `error` /
 	// `error_description` parameters from RFC 6749 / RFC 7591 error responses
 	// — used across DCR registration, /authorize, /token, and /revoke.
 	OAuthErrorKey                        = attribute.Key("gram.oauth.error")
 	OAuthErrorDescriptionKey             = attribute.Key("gram.oauth.error_description")
+	OAuthFailureReasonKey                = attribute.Key("gram.oauth.failure_reason")
 	OAuthGrantKey                        = attribute.Key("gram.oauth.grant")
 	OAuthIssuerKey                       = attribute.Key("gram.oauth.issuer")
+	OAuthPresentedAuthMethodKey          = attribute.Key("gram.oauth.presented_auth_method")
 	OAuthProviderKey                     = attribute.Key("gram.oauth.provider")
+	OAuthRedirectURICountKey             = attribute.Key("gram.oauth.redirect_uri.count")
 	OAuthRedirectURIFullKey              = attribute.Key("gram.oauth.redirect_uri.full")
+	OAuthRegisteredAuthMethodKey         = attribute.Key("gram.oauth.registered_auth_method")
 	OAuthRegistrationEndpointKey         = attribute.Key("gram.oauth.registration_endpoint")
 	OAuthRequiredKey                     = attribute.Key("gram.oauth.required")
 	OAuthScopeKey                        = attribute.Key("gram.oauth.scope")
@@ -865,6 +870,13 @@ func SlogOAuthClientID(v string) slog.Attr      { return slog.String(string(OAut
 func OAuthClientName(v string) attribute.KeyValue { return OAuthClientNameKey.String(v) }
 func SlogOAuthClientName(v string) slog.Attr      { return slog.String(string(OAuthClientNameKey), v) }
 
+func OAuthClientSecretGenerated(v bool) attribute.KeyValue {
+	return OAuthClientSecretGeneratedKey.Bool(v)
+}
+func SlogOAuthClientSecretGenerated(v bool) slog.Attr {
+	return slog.Bool(string(OAuthClientSecretGeneratedKey), v)
+}
+
 func OAuthError(v string) attribute.KeyValue { return OAuthErrorKey.String(v) }
 func SlogOAuthError(v string) slog.Attr      { return slog.String(string(OAuthErrorKey), v) }
 
@@ -876,18 +888,42 @@ func SlogOAuthErrorDescription(v string) slog.Attr {
 	return slog.String(string(OAuthErrorDescriptionKey), v)
 }
 
+func OAuthFailureReason(v string) attribute.KeyValue { return OAuthFailureReasonKey.String(v) }
+func SlogOAuthFailureReason(v string) slog.Attr {
+	return slog.String(string(OAuthFailureReasonKey), v)
+}
+
 func OAuthGrant(v string) attribute.KeyValue { return OAuthGrantKey.String(v) }
 func SlogOAuthGrant(v string) slog.Attr      { return slog.String(string(OAuthGrantKey), v) }
 
 func OAuthIssuer(v string) attribute.KeyValue { return OAuthIssuerKey.String(v) }
 func SlogOAuthIssuer(v string) slog.Attr      { return slog.String(string(OAuthIssuerKey), v) }
 
+func OAuthPresentedAuthMethod(v string) attribute.KeyValue {
+	return OAuthPresentedAuthMethodKey.String(v)
+}
+func SlogOAuthPresentedAuthMethod(v string) slog.Attr {
+	return slog.String(string(OAuthPresentedAuthMethodKey), v)
+}
+
 func OAuthProvider(v string) attribute.KeyValue { return OAuthProviderKey.String(v) }
 func SlogOAuthProvider(v string) slog.Attr      { return slog.String(string(OAuthProviderKey), v) }
+
+func OAuthRedirectURICount(v int) attribute.KeyValue { return OAuthRedirectURICountKey.Int(v) }
+func SlogOAuthRedirectURICount(v int) slog.Attr {
+	return slog.Int(string(OAuthRedirectURICountKey), v)
+}
 
 func OAuthRedirectURIFull(v string) attribute.KeyValue { return OAuthRedirectURIFullKey.String(v) }
 func SlogOAuthRedirectURIFull(v string) slog.Attr {
 	return slog.String(string(OAuthRedirectURIFullKey), v)
+}
+
+func OAuthRegisteredAuthMethod(v string) attribute.KeyValue {
+	return OAuthRegisteredAuthMethodKey.String(v)
+}
+func SlogOAuthRegisteredAuthMethod(v string) slog.Attr {
+	return slog.String(string(OAuthRegisteredAuthMethodKey), v)
 }
 
 func OAuthRegistrationEndpoint(v string) attribute.KeyValue {

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -24,12 +24,14 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
@@ -345,20 +347,51 @@ func (s *Service) RequireUserSessionIssuer(ctx context.Context, endpoint *Resolv
 	return nil
 }
 
-// extractClientCredentials returns the client_id + client_secret + ok from
-// either the Authorization header (client_secret_basic) or the form body
-// (client_secret_post). HTTP Basic wins when both are present, per RFC 6749
-// §2.3.1 ("the client MAY use only one authentication method").
-func extractClientCredentials(r *http.Request) (string, string, bool) {
+// extractClientCredentials returns the client_id + client_secret + presented
+// auth method + ok from either the Authorization header (client_secret_basic)
+// or the form body (client_secret_post / none). HTTP Basic still wins when
+// both are present; callers log the "multiple" presentation to surface client
+// misconfiguration without changing current compatibility behavior.
+func extractClientCredentials(r *http.Request) (string, string, string, bool) {
+	formID := r.PostForm.Get("client_id")
+	formSecret := r.PostForm.Get("client_secret")
+	hasFormCredentials := formID != "" || formSecret != ""
+
 	if id, secret, ok := r.BasicAuth(); ok && id != "" {
-		return id, secret, true
+		presentedMethod := "client_secret_basic"
+		if hasFormCredentials {
+			presentedMethod = "multiple"
+		}
+		return id, secret, presentedMethod, true
 	}
-	id := r.PostForm.Get("client_id")
-	secret := r.PostForm.Get("client_secret")
-	if id == "" {
-		return "", "", false
+	if formID == "" {
+		return "", "", "none", false
 	}
-	return id, secret, true
+	presentedMethod := "none"
+	if formSecret != "" {
+		presentedMethod = "client_secret_post"
+	}
+	return formID, formSecret, presentedMethod, true
+}
+
+func logOAuthClientCredentialEvent(ctx context.Context, logger *slog.Logger, r *http.Request, message, clientID, presentedMethod, grantType, failureReason string) {
+	args := []any{
+		attr.SlogURLOriginal(r.URL.Path),
+		attr.SlogHTTPRequestHeaderUserAgent(r.UserAgent()),
+	}
+	if clientID != "" {
+		args = append(args, attr.SlogOAuthClientID(clientID))
+	}
+	if presentedMethod != "" {
+		args = append(args, attr.SlogOAuthPresentedAuthMethod(presentedMethod))
+	}
+	if grantType != "" {
+		args = append(args, attr.SlogOAuthGrant(grantType))
+	}
+	if failureReason != "" {
+		args = append(args, attr.SlogOAuthFailureReason(failureReason))
+	}
+	logger.InfoContext(ctx, message, args...)
 }
 
 // sha256Hex returns the base64url-encoded SHA-256 of the input. (The name

--- a/server/internal/mcp/authnchallenge_register.go
+++ b/server/internal/mcp/authnchallenge_register.go
@@ -144,7 +144,7 @@ func (s *Service) ServeRegister(w http.ResponseWriter, r *http.Request, endpoint
 	logger.InfoContext(ctx, "user session client registered",
 		attr.SlogOAuthClientID(clientID),
 		attr.SlogOAuthClientName(req.ClientName),
-		attr.SlogToolsetMCPSlug(mcpSlug),
+		attr.SlogToolsetMCPSlug(endpoint.Slug),
 		attr.SlogOAuthRegisteredAuthMethod(req.TokenEndpointAuthMethod),
 		attr.SlogOAuthClientSecretGenerated(clientSecretHash.Valid),
 		attr.SlogOAuthRedirectURICount(len(req.RedirectURIs)),

--- a/server/internal/mcp/authnchallenge_register.go
+++ b/server/internal/mcp/authnchallenge_register.go
@@ -144,6 +144,12 @@ func (s *Service) ServeRegister(w http.ResponseWriter, r *http.Request, endpoint
 	logger.InfoContext(ctx, "user session client registered",
 		attr.SlogOAuthClientID(clientID),
 		attr.SlogOAuthClientName(req.ClientName),
+		attr.SlogToolsetMCPSlug(mcpSlug),
+		attr.SlogOAuthRegisteredAuthMethod(req.TokenEndpointAuthMethod),
+		attr.SlogOAuthClientSecretGenerated(clientSecretHash.Valid),
+		attr.SlogOAuthRedirectURICount(len(req.RedirectURIs)),
+		attr.SlogURLOriginal(r.URL.Path),
+		attr.SlogHTTPRequestHeaderUserAgent(r.UserAgent()),
 	)
 
 	// Confidential clients get client_secret + client_secret_expires_at=0

--- a/server/internal/mcp/authnchallenge_revoke.go
+++ b/server/internal/mcp/authnchallenge_revoke.go
@@ -68,8 +68,9 @@ func (s *Service) ServeRevoke(w http.ResponseWriter, r *http.Request, endpoint *
 
 	logger := endpoint.LogWith(s.logger)
 
-	clientID, clientSecret, _ := extractClientCredentials(r)
+	clientID, clientSecret, presentedAuthMethod, _ := extractClientCredentials(r)
 	if clientID == "" {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth revoke client authentication rejected", clientID, presentedAuthMethod, "", "missing_client_id")
 		return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "client_id is required")
 	}
 	clientRow, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
@@ -78,6 +79,7 @@ func (s *Service) ServeRevoke(w http.ResponseWriter, r *http.Request, endpoint *
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth revoke client authentication rejected", clientID, presentedAuthMethod, "", "unknown_client_id")
 			return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}
 		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
@@ -86,12 +88,15 @@ func (s *Service) ServeRevoke(w http.ResponseWriter, r *http.Request, endpoint *
 	// the token alone authenticates the revoke per RFC 7009 §2.1.
 	if clientRow.ClientSecretHash.Valid {
 		if err := bcrypt.CompareHashAndPassword([]byte(clientRow.ClientSecretHash.String), []byte(clientSecret)); err != nil {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth revoke client authentication rejected", clientID, presentedAuthMethod, "", "client_secret_mismatch")
 			return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "client secret mismatch")
 		}
 	}
+	logOAuthClientCredentialEvent(ctx, logger, r, "oauth revoke client authenticated", clientID, presentedAuthMethod, "", "")
 
 	token := r.PostForm.Get("token")
 	if token == "" {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth revoke request rejected", clientID, presentedAuthMethod, "", "missing_token")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_request", "token is required")
 	}
 	hint := r.PostForm.Get("token_type_hint")

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -114,9 +114,9 @@ func (s *Service) ServeToken(w http.ResponseWriter, r *http.Request, endpoint *R
 
 	switch grantType {
 	case "authorization_code":
-		return s.handleTokenAuthorizationCodeGrant(ctx, w, r, endpoint, &clientRow, baseURL, logger)
+		return s.handleTokenAuthorizationCodeGrant(ctx, w, r, endpoint, &clientRow, baseURL, presentedAuthMethod, logger)
 	case "refresh_token":
-		return s.handleTokenRefreshTokenGrant(ctx, w, r, endpoint, &clientRow, baseURL, logger)
+		return s.handleTokenRefreshTokenGrant(ctx, w, r, endpoint, &clientRow, baseURL, presentedAuthMethod, logger)
 	default:
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth token request rejected", clientID, presentedAuthMethod, grantType, "unsupported_grant_type")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "unsupported_grant_type", "unsupported grant_type")
@@ -138,12 +138,13 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	endpoint *ResolvedMcpEndpoint,
 	clientRow *usersessions_repo.UserSessionClient,
 	baseURL string,
+	presentedAuthMethod string,
 	logger *slog.Logger,
 ) error {
 	req := usersessions.AuthCodeTokenRequestFromForm(r.PostForm)
 	req.SetDefaults()
 	if err := req.Validate(); err != nil {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "invalid_request")
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "invalid_request")
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
@@ -153,20 +154,20 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	grantKey := "userSessionGrant:" + endpoint.UserSessionIssuerID.String() + ":" + req.Code
 	grant, err := s.userSessionGrantCache.GetAndDelete(ctx, grantKey)
 	if err != nil {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "code_not_found_or_expired")
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_not_found_or_expired")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
 	}
 
 	if grant.ClientID != clientRow.ClientID {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "code_client_mismatch")
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_client_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code was issued to a different client")
 	}
 	if grant.RedirectURI != req.RedirectURI {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "redirect_uri_mismatch")
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "redirect_uri_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "redirect_uri does not match the original request")
 	}
 	if !verifyPKCES256(req.CodeVerifier, grant.CodeChallenge) {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "pkce_mismatch")
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "pkce_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code_verifier does not match code_challenge")
 	}
 
@@ -190,12 +191,13 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	endpoint *ResolvedMcpEndpoint,
 	clientRow *usersessions_repo.UserSessionClient,
 	baseURL string,
+	presentedAuthMethod string,
 	logger *slog.Logger,
 ) error {
 	req := usersessions.RefreshTokenRequestFromForm(r.PostForm)
 	req.SetDefaults()
 	if err := req.Validate(); err != nil {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, "", "refresh_token", "invalid_request")
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "invalid_request")
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
@@ -208,7 +210,7 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, "", "refresh_token", "refresh_token_unknown_or_already_used")
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_unknown_or_already_used")
 			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token is unknown or already used")
 		}
 		return oops.E(oops.CodeUnexpected, err, "revoke old refresh token").Log(ctx, logger)
@@ -219,12 +221,12 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	// intentional, the alternative would let a leaking client poke at others'
 	// refresh tokens without invalidating them.
 	if !oldSession.UserSessionClientID.Valid || oldSession.UserSessionClientID.UUID != clientRow.ID {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, "", "refresh_token", "refresh_token_client_mismatch")
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_client_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token was issued to a different client")
 	}
 
 	if oldSession.RefreshExpiresAt.Valid && time.Now().After(oldSession.RefreshExpiresAt.Time) {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, "", "refresh_token", "refresh_token_expired")
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_expired")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token has expired")
 	}
 

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -80,8 +80,10 @@ func (s *Service) ServeToken(w http.ResponseWriter, r *http.Request, endpoint *R
 
 	logger := endpoint.LogWith(s.logger)
 
-	clientID, clientSecret, _ := extractClientCredentials(r)
+	grantType := r.PostForm.Get("grant_type")
+	clientID, clientSecret, presentedAuthMethod, _ := extractClientCredentials(r)
 	if clientID == "" {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth token client authentication rejected", clientID, presentedAuthMethod, grantType, "missing_client_id")
 		return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "client_id is required")
 	}
 	clientRow, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
@@ -90,6 +92,7 @@ func (s *Service) ServeToken(w http.ResponseWriter, r *http.Request, endpoint *R
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth token client authentication rejected", clientID, presentedAuthMethod, grantType, "unknown_client_id")
 			return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}
 		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
@@ -99,20 +102,23 @@ func (s *Service) ServeToken(w http.ResponseWriter, r *http.Request, endpoint *R
 	// Confidential clients MUST present a matching secret.
 	if clientRow.ClientSecretHash.Valid {
 		if err := bcrypt.CompareHashAndPassword([]byte(clientRow.ClientSecretHash.String), []byte(clientSecret)); err != nil {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth token client authentication rejected", clientID, presentedAuthMethod, grantType, "client_secret_mismatch")
 			return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "client secret mismatch")
 		}
 	}
+	logOAuthClientCredentialEvent(ctx, logger, r, "oauth token client authenticated", clientID, presentedAuthMethod, grantType, "")
 
 	// Base URL the AS metadata advertises — equals the JWT `iss` claim so
 	// the two sides of the contract stay aligned across custom domains.
 	baseURL := s.BaseURLForRequest(r)
 
-	switch r.PostForm.Get("grant_type") {
+	switch grantType {
 	case "authorization_code":
 		return s.handleTokenAuthorizationCodeGrant(ctx, w, r, endpoint, &clientRow, baseURL, logger)
 	case "refresh_token":
 		return s.handleTokenRefreshTokenGrant(ctx, w, r, endpoint, &clientRow, baseURL, logger)
 	default:
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth token request rejected", clientID, presentedAuthMethod, grantType, "unsupported_grant_type")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "unsupported_grant_type", "unsupported grant_type")
 	}
 }
@@ -137,6 +143,7 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	req := usersessions.AuthCodeTokenRequestFromForm(r.PostForm)
 	req.SetDefaults()
 	if err := req.Validate(); err != nil {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "invalid_request")
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
@@ -146,16 +153,20 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	grantKey := "userSessionGrant:" + endpoint.UserSessionIssuerID.String() + ":" + req.Code
 	grant, err := s.userSessionGrantCache.GetAndDelete(ctx, grantKey)
 	if err != nil {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "code_not_found_or_expired")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
 	}
 
 	if grant.ClientID != clientRow.ClientID {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "code_client_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code was issued to a different client")
 	}
 	if grant.RedirectURI != req.RedirectURI {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "redirect_uri_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "redirect_uri does not match the original request")
 	}
 	if !verifyPKCES256(req.CodeVerifier, grant.CodeChallenge) {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, "", "authorization_code", "pkce_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code_verifier does not match code_challenge")
 	}
 
@@ -184,6 +195,7 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	req := usersessions.RefreshTokenRequestFromForm(r.PostForm)
 	req.SetDefaults()
 	if err := req.Validate(); err != nil {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, "", "refresh_token", "invalid_request")
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
@@ -196,6 +208,7 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, "", "refresh_token", "refresh_token_unknown_or_already_used")
 			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token is unknown or already used")
 		}
 		return oops.E(oops.CodeUnexpected, err, "revoke old refresh token").Log(ctx, logger)
@@ -206,10 +219,12 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	// intentional, the alternative would let a leaking client poke at others'
 	// refresh tokens without invalidating them.
 	if !oldSession.UserSessionClientID.Valid || oldSession.UserSessionClientID.UUID != clientRow.ID {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, "", "refresh_token", "refresh_token_client_mismatch")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token was issued to a different client")
 	}
 
 	if oldSession.RefreshExpiresAt.Valid && time.Now().After(oldSession.RefreshExpiresAt.Time) {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, "", "refresh_token", "refresh_token_expired")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token has expired")
 	}
 


### PR DESCRIPTION
## Summary
- add safe OAuth handshake logging for issuer-gated MCP DCR, token, and revoke flows
- record credential presentation method and reason-coded token/revoke failures without logging secrets, auth codes, or tokens
- add typed OAuth attr builders for Datadog-friendly facets

## Verification
- GOCACHE=/tmp/gram-go-build go test ./server/internal/mcp
- mise lint:server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds safe, structured instrumentation for the MCP OAuth handshake across registration, token, and revoke. Improves debugging and Datadog facets by logging auth method (preserved through grant handling), grant type, and reason-coded failures without exposing secrets.

- New Features
  - Standardized OAuth event logs: path, user agent, client_id, presented auth method (carried through authorization_code/refresh_token handling), grant type, failure reason.
  - Credential extraction identifies client_secret_basic, client_secret_post, none, and flags multiple when both are sent.
  - Token/revoke flows log accepted/rejected auth with reasons (e.g., missing_client_id, unknown_client_id, client_secret_mismatch, unsupported_grant_type, invalid_request, code_not_found_or_expired, code_client_mismatch, redirect_uri_mismatch, pkce_mismatch, missing_token, refresh_token_*).
  - Registration logs include MCP slug, registered auth method, client_secret_generated, and redirect URI count.
  - New typed attrs in `server/internal/attr`: `gram.oauth.client_secret_generated`, `gram.oauth.failure_reason`, `gram.oauth.presented_auth_method`, `gram.oauth.redirect_uri.count`, `gram.oauth.registered_auth_method`.
  - Added changeset for a `server` patch release.

<sup>Written for commit e3384ed967601a6fe2f1d0820434c0d6daf6ed39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

