### PR TITLE
fix(dashboard): stop cmdk double-filtering MultiSelect search (AIS-84)

### DIFF
--- a/.changeset/ais-84-email-filter-search.md
+++ b/.changeset/ais-84-email-filter-search.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix inconsistent results in the filter dropdowns on the Insights and Logs pages (e.g. "Filter by user email"). `MultiSelect` filtered its own option list while cmdk's built-in filter was also enabled, so the two raced as the user typed: valid matches could fall into the "No results found" empty state and it could stay stuck when characters were deleted. The component's own filter is now the single source of truth.

--- a/client/dashboard/src/components/ui/multi-select.test.tsx
+++ b/client/dashboard/src/components/ui/multi-select.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// moonshine's bundle imports lucide-react/dynamicIconImports which can't be
+// resolved in the test environment. Mock it so the local Button renders plainly.
+vi.mock("@speakeasy-api/moonshine", () => ({
+  Icon: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+import { MultiSelect } from "./multi-select";
+
+// This vitest project does not enable `globals`, so RTL's automatic cleanup is
+// not registered. Without this, mounted popovers accumulate across tests.
+afterEach(cleanup);
+
+const EMAILS = [
+  "alex@fermatcommerce.com",
+  "alec@fermatcommerce.com",
+  "alice@fermatcommerce.com",
+  "bob@fermatcommerce.com",
+  "carol@fermatcommerce.com",
+];
+
+function openEmailSelect() {
+  const onValueChange = vi.fn();
+  render(
+    <MultiSelect
+      options={EMAILS.map((e) => ({ label: e, value: e }))}
+      onValueChange={onValueChange}
+      placeholder="Filter by user email"
+      hideSelectAll
+      singleLine
+    />,
+  );
+  fireEvent.click(screen.getByText("Filter by user email"));
+  const input = screen.getByPlaceholderText("Search options...");
+  return { onValueChange, input };
+}
+
+// Footer actions ("Close"/"Clear") are also role="option"; exclude them so we
+// assert on the actual data rows the user is filtering.
+const FOOTER_ACTIONS = new Set(["Close", "Clear"]);
+
+// Options that cmdk has filtered out are marked aria-hidden; the visible set is
+// what the user actually sees in the dropdown.
+function visibleOptionLabels(): string[] {
+  return screen
+    .queryAllByRole("option")
+    .filter((el) => el.getAttribute("aria-hidden") !== "true")
+    .map((el) => el.textContent?.trim() ?? "")
+    .filter((label) => !FOOTER_ACTIONS.has(label));
+}
+
+function type(input: HTMLElement, value: string) {
+  fireEvent.change(input, { target: { value } });
+}
+
+describe("MultiSelect search filtering (AIS-84)", () => {
+  it("shows exactly the substring matches as the query narrows", () => {
+    const { input } = openEmailSelect();
+
+    type(input, "al");
+    expect(visibleOptionLabels()).toEqual([
+      "alex@fermatcommerce.com",
+      "alec@fermatcommerce.com",
+      "alice@fermatcommerce.com",
+    ]);
+
+    type(input, "ale");
+    expect(visibleOptionLabels()).toEqual([
+      "alex@fermatcommerce.com",
+      "alec@fermatcommerce.com",
+    ]);
+
+    type(input, "alex");
+    expect(visibleOptionLabels()).toEqual(["alex@fermatcommerce.com"]);
+  });
+
+  it("restores broader results when characters are deleted", () => {
+    const { input } = openEmailSelect();
+
+    type(input, "alex");
+    type(input, "ale");
+
+    const labels = visibleOptionLabels();
+    expect(labels).toContain("alex@fermatcommerce.com");
+    expect(labels).toContain("alec@fermatcommerce.com");
+    expect(labels).not.toContain("alice@fermatcommerce.com"); // "ale" not in "alice"
+  });
+
+  it("keeps footer actions available while searching (cmdk filtering disabled)", () => {
+    // Regression guard: previously cmdk's own filter ran on top of our filter
+    // and removed every item that did not match the query — including the
+    // always-present "Close" action. With shouldFilter disabled, our list is
+    // the single source of truth and the footer stays put.
+    const { input } = openEmailSelect();
+
+    type(input, "alex");
+
+    expect(visibleOptionLabels()).toContain("alex@fermatcommerce.com");
+    expect(screen.getByText("Close")).toBeTruthy();
+  });
+
+  it("shows the empty state only for a genuine non-match", () => {
+    const { input } = openEmailSelect();
+
+    type(input, "alex");
+    expect(screen.queryByText("No results found.")).toBeNull();
+
+    type(input, "zzz");
+    expect(visibleOptionLabels()).toEqual([]);
+    expect(screen.getByText("No results found.")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/ui/multi-select.test.tsx
+++ b/client/dashboard/src/components/ui/multi-select.test.tsx
@@ -14,11 +14,11 @@ import { MultiSelect } from "./multi-select";
 afterEach(cleanup);
 
 const EMAILS = [
-  "alex@fermatcommerce.com",
-  "alec@fermatcommerce.com",
-  "alice@fermatcommerce.com",
-  "bob@fermatcommerce.com",
-  "carol@fermatcommerce.com",
+  "alex@speakeasyapi.dev",
+  "alec@speakeasyapi.dev",
+  "alice@speakeasyapi.dev",
+  "bob@speakeasyapi.dev",
+  "carol@speakeasyapi.dev",
 ];
 
 function openEmailSelect() {
@@ -61,19 +61,19 @@ describe("MultiSelect search filtering (AIS-84)", () => {
 
     type(input, "al");
     expect(visibleOptionLabels()).toEqual([
-      "alex@fermatcommerce.com",
-      "alec@fermatcommerce.com",
-      "alice@fermatcommerce.com",
+      "alex@speakeasyapi.dev",
+      "alec@speakeasyapi.dev",
+      "alice@speakeasyapi.dev",
     ]);
 
     type(input, "ale");
     expect(visibleOptionLabels()).toEqual([
-      "alex@fermatcommerce.com",
-      "alec@fermatcommerce.com",
+      "alex@speakeasyapi.dev",
+      "alec@speakeasyapi.dev",
     ]);
 
     type(input, "alex");
-    expect(visibleOptionLabels()).toEqual(["alex@fermatcommerce.com"]);
+    expect(visibleOptionLabels()).toEqual(["alex@speakeasyapi.dev"]);
   });
 
   it("restores broader results when characters are deleted", () => {
@@ -83,9 +83,9 @@ describe("MultiSelect search filtering (AIS-84)", () => {
     type(input, "ale");
 
     const labels = visibleOptionLabels();
-    expect(labels).toContain("alex@fermatcommerce.com");
-    expect(labels).toContain("alec@fermatcommerce.com");
-    expect(labels).not.toContain("alice@fermatcommerce.com"); // "ale" not in "alice"
+    expect(labels).toContain("alex@speakeasyapi.dev");
+    expect(labels).toContain("alec@speakeasyapi.dev");
+    expect(labels).not.toContain("alice@speakeasyapi.dev"); // "ale" not in "alice"
   });
 
   it("keeps footer actions available while searching (cmdk filtering disabled)", () => {
@@ -97,7 +97,7 @@ describe("MultiSelect search filtering (AIS-84)", () => {
 
     type(input, "alex");
 
-    expect(visibleOptionLabels()).toContain("alex@fermatcommerce.com");
+    expect(visibleOptionLabels()).toContain("alex@speakeasyapi.dev");
     expect(screen.getByText("Close")).toBeTruthy();
   });
 

--- a/client/dashboard/src/components/ui/multi-select.tsx
+++ b/client/dashboard/src/components/ui/multi-select.tsx
@@ -20,7 +20,6 @@ import {
 } from "@/components/ui/popover";
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
@@ -618,6 +617,23 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
       );
     }, [options, searchValue, searchable, isGroupedOptions]);
 
+    // We filter `options` into `filteredOptions` ourselves, so cmdk's built-in
+    // filtering is disabled (see <Command shouldFilter={false}> below). Leaving
+    // both filters enabled makes them race over a shrinking item set as the user
+    // types, which intermittently shows the empty state for valid matches and
+    // can leave it stuck when characters are deleted (AIS-84). Because
+    // shouldFilter={false} also disables cmdk's <CommandEmpty>, the empty state
+    // is derived from filteredOptions instead.
+    const filteredOptionCount = React.useMemo(() => {
+      if (isGroupedOptions(filteredOptions)) {
+        return filteredOptions.reduce(
+          (count, group) => count + group.options.length,
+          0,
+        );
+      }
+      return filteredOptions.length;
+    }, [filteredOptions, isGroupedOptions]);
+
     const handleInputKeyDown = (
       event: React.KeyboardEvent<HTMLInputElement>,
     ) => {
@@ -1061,7 +1077,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
             align="start"
             onEscapeKeyDown={() => setIsPopoverOpen(false)}
           >
-            <Command>
+            <Command shouldFilter={false}>
               {searchable && (
                 <CommandInput
                   placeholder="Search options..."
@@ -1084,9 +1100,14 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                   "overscroll-behavior-y-contain",
                 )}
               >
-                <CommandEmpty>
-                  {emptyIndicator || "No results found."}
-                </CommandEmpty>{" "}
+                {filteredOptionCount === 0 && !canCreateFromSearch && (
+                  <div
+                    data-slot="command-empty"
+                    className="py-6 text-center text-sm"
+                  >
+                    {emptyIndicator || "No results found."}
+                  </div>
+                )}{" "}
                 {canCreateFromSearch && (
                   <CommandGroup>
                     <CommandItem


### PR DESCRIPTION
## Summary

Fixes [AIS-84](https://linear.app/speakeasy/issue/AIS-84/bug-filter-by-user-email-search-returns-inconsistent-results) — the "Filter by user email" search on the Insights and Logs pages returned inconsistent results (reported by Fermatcommerce). Typing `ale` showed matches, but refining to `alex`/`alec` sometimes showed "No results found" for emails that exist, and deleting characters back could leave the empty state stuck.

## Root cause

`MultiSelect` (`client/dashboard/src/components/ui/multi-select.tsx`) filters its own option list into `filteredOptions`, but rendered those into cmdk's `<Command>`, whose **built-in filter is enabled by default**. Two filters then raced over an item set that changes on every keystroke. cmdk schedules its recompute off the search-value change and lags when the externally-rendered list grows back, so the empty state could appear for valid matches and stick on backspace.

Because `MultiSelect` already routes search through its own controlled `searchValue`, cmdk's filter was redundant for every consumer (server / user-email / role / type filters on both Insights and Logs).

## Fix

- `<Command shouldFilter={false}>` — `filteredOptions` is now the single source of truth.
- `shouldFilter={false}` also disables cmdk's `<CommandEmpty>` (its `filtered.count` is never 0 while the always-mounted "Close" footer item exists), so the empty state is now derived from the filtered-option count instead.

## Testing

- Added `multi-select.test.tsx` (happy-dom). The delete-back case and a footer-availability guard **fail without the fix and pass with it** — the forward-typing path alone does not reproduce, so the test asserts the backspace path.
- `eslint` clean on changed files; `tsc -p tsconfig.app.json` clean for `multi-select.*` (unrelated pre-existing `@gram-ai/elements` resolution errors exist in the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent results in the “Filter by user email” dropdowns on Insights and Logs (AIS-84) by making `MultiSelect` the single source of truth for search. Disables `cmdk` filtering and derives the empty state from the computed list so results behave correctly when typing or backspacing.

- **Bug Fixes**
  - Set `<Command shouldFilter={false}>` to stop double-filtering.
  - Empty state now checks the `filteredOptions` count; footer actions like “Close” remain visible.
  - Added `multi-select.test.tsx` for narrowing/backspacing/empty-state and a changeset for a patch release.

<sup>Written for commit 69df8212219683e821aedfa4419dbe101ef0124b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

