### PR TITLE
fix(dashboard): filter Insights Employees to workspace members

### DIFF
--- a/.changeset/insights-employees-member-filter.md
+++ b/.changeset/insights-employees-member-filter.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Insights → Employees now only lists workspace members, hiding activity from impersonating superadmins that previously showed as a raw UUID.
+Insights now only counts workspace members across the Employees and Role views, excluding activity from impersonating superadmins that previously showed up as a raw UUID.

--- a/.changeset/insights-employees-member-filter.md
+++ b/.changeset/insights-employees-member-filter.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Insights → Employees now only lists workspace members, hiding activity from impersonating superadmins that previously showed as a raw UUID.

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -189,17 +189,10 @@ export function InsightsAgentsContent() {
     () => new Map((membersData?.members ?? []).map((m) => [m.id, m])),
     [membersData],
   );
-  const memberIdentifiers = useMemo(() => {
-    const ids = new Set<string>();
-    for (const m of membersData?.members ?? []) {
-      ids.add(m.id);
-      ids.add(m.email.toLowerCase());
-    }
-    return ids;
-  }, [membersData]);
-  const isOrgMember = (userId: string) =>
-    memberIdentifiers.has(userId) ||
-    memberIdentifiers.has(userId.toLowerCase());
+  const memberIds = useMemo(
+    () => (membersData?.members ?? []).map((m) => m.id),
+    [membersData],
+  );
 
   const usersQuery = useQuery({
     queryKey: [
@@ -208,8 +201,10 @@ export function InsightsAgentsContent() {
       "users",
       from.toISOString(),
       to.toISOString(),
+      memberIds,
     ],
-    queryFn: () => fetchAllUsers(client, from, to),
+    queryFn: () => fetchAllUsers(client, from, to, memberIds),
+    enabled: memberIds.length > 0,
     throwOnError: false,
   });
 
@@ -252,9 +247,10 @@ export function InsightsAgentsContent() {
       "roleUsage",
       from.toISOString(),
       to.toISOString(),
+      memberIds,
     ],
-    queryFn: () => fetchRoleUsage(client, from, to),
-    enabled: groupByDimension === "role",
+    queryFn: () => fetchRoleUsage(client, from, to, memberIds),
+    enabled: groupByDimension === "role" && memberIds.length > 0,
     throwOnError: false,
   });
 
@@ -273,9 +269,7 @@ export function InsightsAgentsContent() {
 
   const totalTokens = users.reduce((s, u) => s + effectiveTokens(u), 0);
   const totalCost = users.reduce((s, u) => s + u.totalCost, 0);
-  const activeUsers = users.filter(
-    (u) => effectiveTokens(u) > 0 && isOrgMember(u.userId),
-  ).length;
+  const activeUsers = users.filter((u) => effectiveTokens(u) > 0).length;
 
   const clientBreakdown = useMemo(() => {
     const map = new Map<
@@ -322,7 +316,7 @@ export function InsightsAgentsContent() {
   const userRows = useMemo(
     () =>
       users
-        .filter((u) => isOrgMember(u.userId))
+        .slice()
         .sort((a, b) =>
           valueMode === "cost"
             ? b.totalCost - a.totalCost
@@ -349,7 +343,7 @@ export function InsightsAgentsContent() {
                 : [],
           };
         }),
-    [users, memberMap, memberIdentifiers, valueMode, totalCost, totalTokens],
+    [users, memberMap, valueMode, totalCost, totalTokens],
   );
 
   // Unique client sources for filter dropdown
@@ -416,7 +410,7 @@ export function InsightsAgentsContent() {
     0,
   );
   const filteredActiveUsers = filteredUserRows.filter(
-    (u) => u.totalTokens > 0 && isOrgMember(u.userId),
+    (u) => u.totalTokens > 0,
   ).length;
 
   const isLoading =
@@ -1502,6 +1496,7 @@ async function fetchAllUsers(
   client: Parameters<typeof telemetrySearchUsers>[0],
   from: Date,
   to: Date,
+  memberIds: string[],
 ): Promise<UserSummary[]> {
   const users: UserSummary[] = [];
   let cursor: string | undefined;
@@ -1510,7 +1505,7 @@ async function fetchAllUsers(
       telemetrySearchUsers(client, {
         searchUsersPayload: {
           cursor,
-          filter: { from, to },
+          filter: { from, to, userIds: memberIds },
           limit: 1000,
           sort: "desc",
           userType: "internal",
@@ -1527,11 +1522,12 @@ async function fetchRoleUsage(
   client: Parameters<typeof telemetrySearchUsers>[0],
   from: Date,
   to: Date,
+  memberIds: string[],
 ): Promise<RoleSummary[]> {
   const result = await unwrapAsync(
     telemetrySearchUsers(client, {
       searchUsersPayload: {
-        filter: { from, to },
+        filter: { from, to, userIds: memberIds },
         groupBy: "role",
         limit: 1000,
         sort: "desc",

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -189,8 +189,14 @@ export function InsightsAgentsContent() {
     () => new Map((membersData?.members ?? []).map((m) => [m.id, m])),
     [membersData],
   );
-  const memberIds = useMemo(
-    () => (membersData?.members ?? []).map((m) => m.id),
+  // Telemetry groups by user_id with a user_email fallback, so match members
+  // on both their ID and email to avoid dropping email-keyed activity.
+  const memberIdentifiers = useMemo(
+    () =>
+      (membersData?.members ?? []).flatMap((m) => [
+        m.id,
+        m.email.toLowerCase(),
+      ]),
     [membersData],
   );
 
@@ -201,10 +207,10 @@ export function InsightsAgentsContent() {
       "users",
       from.toISOString(),
       to.toISOString(),
-      memberIds,
+      memberIdentifiers,
     ],
-    queryFn: () => fetchAllUsers(client, from, to, memberIds),
-    enabled: memberIds.length > 0,
+    queryFn: () => fetchAllUsers(client, from, to, memberIdentifiers),
+    enabled: memberIdentifiers.length > 0,
     throwOnError: false,
   });
 
@@ -247,10 +253,10 @@ export function InsightsAgentsContent() {
       "roleUsage",
       from.toISOString(),
       to.toISOString(),
-      memberIds,
+      memberIdentifiers,
     ],
-    queryFn: () => fetchRoleUsage(client, from, to, memberIds),
-    enabled: groupByDimension === "role" && memberIds.length > 0,
+    queryFn: () => fetchRoleUsage(client, from, to, memberIdentifiers),
+    enabled: groupByDimension === "role" && memberIdentifiers.length > 0,
     throwOnError: false,
   });
 
@@ -1496,7 +1502,7 @@ async function fetchAllUsers(
   client: Parameters<typeof telemetrySearchUsers>[0],
   from: Date,
   to: Date,
-  memberIds: string[],
+  userIds: string[],
 ): Promise<UserSummary[]> {
   const users: UserSummary[] = [];
   let cursor: string | undefined;
@@ -1505,7 +1511,7 @@ async function fetchAllUsers(
       telemetrySearchUsers(client, {
         searchUsersPayload: {
           cursor,
-          filter: { from, to, userIds: memberIds },
+          filter: { from, to, userIds },
           limit: 1000,
           sort: "desc",
           userType: "internal",
@@ -1522,12 +1528,12 @@ async function fetchRoleUsage(
   client: Parameters<typeof telemetrySearchUsers>[0],
   from: Date,
   to: Date,
-  memberIds: string[],
+  userIds: string[],
 ): Promise<RoleSummary[]> {
   const result = await unwrapAsync(
     telemetrySearchUsers(client, {
       searchUsersPayload: {
-        filter: { from, to, userIds: memberIds },
+        filter: { from, to, userIds },
         groupBy: "role",
         limit: 1000,
         sort: "desc",

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -184,7 +184,11 @@ export function InsightsAgentsContent() {
     return PRESET_RANGE_LABELS[dateRange] ?? "the selected range";
   }, [customRange, customRangeLabel, dateRange]);
 
-  const { data: membersData, isLoading: membersLoading } = useMembers();
+  const {
+    data: membersData,
+    isLoading: membersLoading,
+    error: membersError,
+  } = useMembers();
   const memberMap = useMemo(
     () => new Map((membersData?.members ?? []).map((m) => [m.id, m])),
     [membersData],
@@ -421,7 +425,7 @@ export function InsightsAgentsContent() {
 
   const isLoading =
     membersLoading || usersQuery.isLoading || projectQuery.isLoading;
-  const error = usersQuery.error ?? projectQuery.error;
+  const error = membersError ?? usersQuery.error ?? projectQuery.error;
 
   const handlePresetChange = (preset: DateRangePreset) => {
     setDateRange(preset);

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -322,7 +322,7 @@ export function InsightsAgentsContent() {
   const userRows = useMemo(
     () =>
       users
-        .slice()
+        .filter((u) => isOrgMember(u.userId))
         .sort((a, b) =>
           valueMode === "cost"
             ? b.totalCost - a.totalCost
@@ -349,7 +349,7 @@ export function InsightsAgentsContent() {
                 : [],
           };
         }),
-    [users, memberMap, valueMode, totalCost, totalTokens],
+    [users, memberMap, memberIdentifiers, valueMode, totalCost, totalTokens],
   );
 
   // Unique client sources for filter dropdown


### PR DESCRIPTION
## Summary

- Insights → Employees listed **all** telemetry users with no membership filter, so a non-member (e.g. an impersonating Speakeasy superadmin) rendered as a raw UUID.
- Applied the existing `isOrgMember(u.userId)` filter — already used by the active-users and leaderboard aggregations — to the employee table rows so non-members are excluded, consistent with the other Insights views.

Closes [AGE-2664](https://linear.app/speakeasy/issue/AGE-2664/investigate-why-the-uuid-is-appearing-in-insights-employees-and-see-if)

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter Insights → Employees and Role views to workspace members by scoping telemetry queries to member IDs and emails. Removes non-member UUID rows and fixes cost/token denominators. Closes AGE-2664.

- **Bug Fixes**
  - Pass member identifiers (IDs + lowercased emails) to `telemetrySearchUsers` (`userIds`) for both user and role queries, matching telemetry’s user_id-or-email grouping and excluding non‑members.
  - Enable queries only after members load, include identifiers in the `queryKey` for correct refresh, and surface member‑load errors instead of showing zeroed stats.

<sup>Written for commit 9588cf206c33caf13d850355347be7c337a3458d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

