### PR TITLE
fix(dashboard): update useObserveFilters test setup

### DIFF
--- a/client/dashboard/src/components/observe/useObserveFilters.test.tsx
+++ b/client/dashboard/src/components/observe/useObserveFilters.test.tsx
@@ -5,6 +5,8 @@ import { MemoryRouter, useNavigate } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { AccessMember, Role } from "@gram/client/models/components";
 import { Operator } from "@gram/client/models/components";
+import { useMembers } from "@gram/client/react-query/members.js";
+import { useRoles } from "@gram/client/react-query/roles.js";
 import { DEFAULT_HOOK_TYPES } from "./observeFilterConstants";
 import { useObserveFilters } from "./useObserveFilters";
 
@@ -14,9 +16,15 @@ vi.mock("@gram/client/react-query/members.js", () => ({
 vi.mock("@gram/client/react-query/roles.js", () => ({
   useRoles: vi.fn(),
 }));
-
-import { useMembers } from "@gram/client/react-query/members.js";
-import { useRoles } from "@gram/client/react-query/roles.js";
+vi.mock("@gram/client/react-query", () => ({
+  useGramContext: () => ({}),
+}));
+vi.mock("@gram/client/funcs/telemetryGetHooksSummary", () => ({
+  telemetryGetHooksSummary: vi.fn().mockResolvedValue({
+    ok: true,
+    value: { servers: [], users: [] },
+  }),
+}));
 
 function useObserveFiltersWithNavigation() {
   const filters = useObserveFilters();


### PR DESCRIPTION
## Summary
- update useObserveFilters tests for the hook's SDK context dependency
- mock the telemetry hooks summary request used by the filter-options React Query path
- keep the test imports in the normal import block while preserving Vitest mock hoisting

## Verification
- pnpm -F dashboard test
- pnpm -F dashboard lint:format

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `useObserveFilters` tests to mock SDK context (`useGramContext` via `@gram/client/react-query`) and telemetry (`telemetryGetHooksSummary`) used by the filter-options React Query path. This removes network calls, stabilizes tests, and keeps normal import order (including `useMembers`/`useRoles`) while preserving `vitest` mock hoisting.

<sup>Written for commit 68efc85ec7469fc69168d81c44571c1e990c03a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

