### PR TITLE
chore: add fermat script to begin testing user feedback product

### DIFF
--- a/client/dashboard/index.html
+++ b/client/dashboard/index.html
@@ -29,6 +29,11 @@
       crossorigin
     />
     <link
+      rel="preconnect"
+      href="https://static.clairedefermat.com"
+      crossorigin
+    />
+    <link
       rel="preload"
       href="/fonts/diatype/ABCDiatype-Regular.woff2"
       as="font"

--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -6,7 +6,13 @@ import {
 import { SessionInfoResponse } from "@gram/client/models/operations";
 import { useSessionInfo } from "@gram/client/react-query";
 import { createContext, useContext, useEffect } from "react";
+import { useLocation } from "react-router";
 import { initializePylon, PYLON_APP_ID } from "@/lib/pylon";
+import {
+  initializeFermat,
+  setFermatProperties,
+  trackFermatEvent,
+} from "@/lib/fermat";
 
 // We don't include accountType here because it is actively confusing. See useProductTier
 type Session = Omit<
@@ -192,4 +198,37 @@ export function usePylonInAppChat(user: User | undefined) {
     localStorage.setItem("pylon_user_email", email);
     localStorage.setItem("pylon_user_display_name", displayName);
   }, [user]);
+}
+
+/**
+ * Boot the Claire de Fermat pixel and emit a `page_view` on each route
+ * change. The pixel is gated to production builds so we don't pollute
+ * Fermat with local/dev traffic (matching Pylon and PostHog).
+ */
+export function useFermatPixel(user: User | undefined, accountId: string) {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!import.meta.env.PROD) {
+      return;
+    }
+    initializeFermat();
+    trackFermatEvent("page_view", {
+      dashboard_route: location.pathname,
+      page_title: document.title,
+    });
+  }, [location.pathname]);
+
+  // Attach stable identifiers once the user is hydrated so Fermat can
+  // attribute activity to the user and their workspace across sessions.
+  useEffect(() => {
+    if (!import.meta.env.PROD || !user?.id) {
+      return;
+    }
+    initializeFermat();
+    setFermatProperties({
+      dashboard_user_id: user.id,
+      ...(accountId && { account_id: accountId }),
+    });
+  }, [user?.id, accountId]);
 }

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -37,6 +37,7 @@ import {
   useSessionData,
   useUser,
   usePylonInAppChat,
+  useFermatPixel,
 } from "./Auth";
 import type { ProjectEntry } from "@gram/client/models/components";
 
@@ -75,6 +76,7 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
 
   useIdentifyUserForTelemetry(session?.user);
   usePylonInAppChat(session?.user);
+  useFermatPixel(session?.user, session?.activeOrganizationId ?? "");
 
   // Sync isAdmin into the SDK fetcher so it can attach X-Gram-Scope-Override in production.
   isAdminRef.current = session?.user.isAdmin ?? false;

--- a/client/dashboard/src/lib/fermat.ts
+++ b/client/dashboard/src/lib/fermat.ts
@@ -1,0 +1,98 @@
+/**
+ * Claire de Fermat pixel initialization.
+ *
+ * Fermat reads from the `window.fermat.q` command queue once its async
+ * script finishes loading. We stub `window.fermat` as a queue-pusher
+ * before injecting the script so any `init`/`track` calls made during
+ * load are buffered and replayed — mirroring the snippet Fermat ships.
+ */
+
+const FERMAT_SCRIPT_SRC = "https://static.clairedefermat.com/pixel/v2/pixel.js";
+const FERMAT_SOURCE_ID = "speakeasy-com-6f500c49";
+
+type FermatCommand =
+  | {
+      method: "init";
+      config: {
+        id: string;
+        sourceType: string;
+        metadata?: { properties?: Record<string, unknown> };
+      };
+    }
+  | {
+      method: "track";
+      eventName: string;
+      properties?: Record<string, unknown>;
+    }
+  | {
+      method: "setProperties";
+      properties: Record<string, unknown>;
+    };
+
+type FermatFn = ((command: FermatCommand) => void) & {
+  q?: FermatCommand[];
+};
+
+declare global {
+  interface Window {
+    fermat?: FermatFn;
+  }
+}
+
+let initialized = false;
+
+/**
+ * Initialize the Fermat pixel. Idempotent — subsequent calls are no-ops
+ * so we never inject a second script tag (e.g. under React StrictMode or
+ * component remounts).
+ */
+export function initializeFermat(): void {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+
+  const fermatFn = function (command: FermatCommand) {
+    (fermatFn.q = fermatFn.q || []).push(command);
+  } as FermatFn;
+  window.fermat = window.fermat || fermatFn;
+
+  const script = document.createElement("script");
+  script.src = FERMAT_SCRIPT_SRC;
+  script.async = true;
+
+  const firstScript = document.getElementsByTagName("script")[0];
+  firstScript?.parentNode?.insertBefore(script, firstScript);
+
+  window.fermat({
+    method: "init",
+    config: {
+      id: FERMAT_SOURCE_ID,
+      sourceType: "external-b2b",
+      metadata: {
+        properties: {
+          app_name: "Speakeasy",
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Send a Fermat tracking event. No-op until `initializeFermat` has run.
+ */
+export function trackFermatEvent(
+  eventName: string,
+  properties?: Record<string, unknown>,
+): void {
+  window.fermat?.({ method: "track", eventName, properties });
+}
+
+/**
+ * Attach stable user/account identifiers so Fermat can attribute activity
+ * across sessions. Call after login or user hydration. No-op until
+ * `initializeFermat` has run.
+ */
+export function setFermatProperties(properties: Record<string, unknown>): void {
+  window.fermat?.({ method: "setProperties", properties });
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Claire de Fermat pixel to the dashboard to test the user feedback product. Runs only in production, tracks page views, and attributes activity to the signed-in user and account.

- New Features
  - Added `client/dashboard/src/lib/fermat.ts` to load the Fermat script once and queue `init`/`track`/`setProperties` calls.
  - Added `useFermatPixel` to initialize the pixel, emit `page_view` on route changes, and set `dashboard_user_id` and `account_id` when available (prod-only).
  - Hooked `useFermatPixel` into `AuthProvider` after user hydration.
  - Added `preconnect` to `https://static.clairedefermat.com` in `index.html` for faster script load.

<sup>Written for commit 03928b8d18b182c8bc3eb3f8f66a435d9c28b381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

