### PR TITLE
feat(dashboard): make manual access rules allow-only

### DIFF
--- a/.changeset/large-mammals-wave.md
+++ b/.changeset/large-mammals-wave.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Shadow MCP access rule creation now creates allow rules only, while request review and existing deny rules remain supported

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
@@ -312,7 +312,10 @@ vi.mock("@/components/moon/textarea", () => ({
   ),
 }));
 
-import { ApprovalRequestsContent } from "./ApprovalRequestsContent";
+import {
+  ApprovalRequestsContent,
+  DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION,
+} from "./ApprovalRequestsContent";
 
 function renderContent(projectId = "project-1") {
   const queryClient = new QueryClient();
@@ -404,9 +407,7 @@ describe("ApprovalRequestsContent", () => {
     ).toBeTruthy();
     expect(screen.getByText("No access rules")).toBeTruthy();
     expect(
-      screen.getByText(
-        "Create a rule manually or approve a request to allow or deny matching resources.",
-      ),
+      screen.getByText(DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION),
     ).toBeTruthy();
     expect(screen.getAllByRole("button", { name: "Add Rule" })).toHaveLength(1);
     expect(screen.queryByText("Requested")).toBeNull();
@@ -476,9 +477,7 @@ describe("ApprovalRequestsContent", () => {
       expect(screen.getByText("No access rules")).toBeTruthy();
     });
     expect(
-      screen.getByText(
-        "Create a rule manually or approve a request to allow or deny matching resources.",
-      ),
+      screen.getByText(DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Add Rule" })).toHaveProperty(
       "disabled",
@@ -506,9 +505,7 @@ describe("ApprovalRequestsContent", () => {
       expect(screen.getByText("No access rules")).toBeTruthy();
     });
     expect(
-      screen.getByText(
-        "Create a rule manually or approve a request to allow or deny matching resources.",
-      ),
+      screen.getByText(DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Add Rule" })).toHaveProperty(
       "disabled",
@@ -848,6 +845,11 @@ describe("ApprovalRequestsContent", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Add Rule" }));
     expect(screen.queryByText("Select project")).toBeNull();
+    expect(
+      screen.getByText("Configure an allow rule for matching requests."),
+    ).toBeTruthy();
+    expect(screen.getByText("Allow matching calls.")).toBeTruthy();
+    expect(screen.queryByText("Deny")).toBeNull();
     fireEvent.change(screen.getByLabelText("Rule name"), {
       target: { value: "New project rule" },
     });
@@ -862,6 +864,7 @@ describe("ApprovalRequestsContent", () => {
           createShadowMCPAccessRuleForm: expect.objectContaining({
             displayName: "New project rule",
             accessScope: "project",
+            disposition: "allowed",
             projectIds: ["project-1"],
             matchBreadth: "full_url",
             matchValue: "https://new.example.com/mcp",

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
@@ -92,8 +92,8 @@ const ACCESS_RULE_BLOCKING_POLICY_REQUIREMENTS = [
 ] as const;
 const CREATE_BLOCKING_POLICY_MESSAGE =
   "Create a blocking Shadow MCP policy before adding access rules.";
-const DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION =
-  "Create a rule manually or approve a request to allow or deny matching resources.";
+export const DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION =
+  "Create a rule manually or approve a request to allow matching resources.";
 
 type AccessRuleCreateAvailability =
   | { status: "available" }
@@ -204,6 +204,22 @@ function getAccessRulesEmptyDescription(
   }
 
   return DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION;
+}
+
+function getAccessRuleSheetDescription(isCreatingRule: boolean) {
+  if (isCreatingRule) {
+    return "Configure an allow rule for matching requests.";
+  }
+
+  return "Configure an allow or deny decision for matching requests.";
+}
+
+function getAccessRuleDetailsLabel(disposition: ShadowMCPDisposition) {
+  if (disposition === "allowed") {
+    return "Allow rule details";
+  }
+
+  return "Deny rule details";
 }
 
 function ServerCell({
@@ -609,6 +625,7 @@ function AccessRuleSheet({
   }, [rule, open]);
 
   const projectIds = [projectId];
+  const isCreatingRule = !rule;
   const canSubmit =
     displayName.trim().length > 0 &&
     matchValue.trim().length > 0 &&
@@ -640,7 +657,7 @@ function AccessRuleSheet({
             {rule ? "Edit Access Rule" : "Add Access Rule"}
           </SheetTitle>
           <SheetDescription>
-            Configure an allow or deny decision for matching requests.
+            {getAccessRuleSheetDescription(isCreatingRule)}
           </SheetDescription>
         </SheetHeader>
 
@@ -650,7 +667,10 @@ function AccessRuleSheet({
             onValueChange={(value) =>
               setDisposition(value as ShadowMCPDisposition)
             }
-            className="border-border bg-muted/20 grid grid-cols-2 gap-1 rounded-md border p-1"
+            className={cn(
+              "border-border bg-muted/20 grid gap-1 rounded-md border p-1",
+              isCreatingRule ? "grid-cols-1" : "grid-cols-2",
+            )}
           >
             <label
               className={cn(
@@ -668,22 +688,24 @@ function AccessRuleSheet({
                 </Type>
               </span>
             </label>
-            <label
-              className={cn(
-                "flex cursor-pointer items-start gap-3 rounded-sm px-3 py-2.5 transition-colors",
-                disposition === "denied" && "bg-background shadow-xs",
-              )}
-            >
-              <RadioGroupItem value="denied" className="mt-0.5" />
-              <span>
-                <Badge variant="destructive">
-                  <Badge.Text>Deny</Badge.Text>
-                </Badge>
-                <Type muted small>
-                  Block matching calls.
-                </Type>
-              </span>
-            </label>
+            {!isCreatingRule && (
+              <label
+                className={cn(
+                  "flex cursor-pointer items-start gap-3 rounded-sm px-3 py-2.5 transition-colors",
+                  disposition === "denied" && "bg-background shadow-xs",
+                )}
+              >
+                <RadioGroupItem value="denied" className="mt-0.5" />
+                <span>
+                  <Badge variant="destructive">
+                    <Badge.Text>Deny</Badge.Text>
+                  </Badge>
+                  <Type muted small>
+                    Block matching calls.
+                  </Type>
+                </span>
+              </label>
+            )}
           </RadioGroup>
 
           <section className="border-border space-y-4 rounded-md border px-4 py-4">
@@ -692,9 +714,7 @@ function AccessRuleSheet({
                 Rule
               </Type>
               <Type muted small>
-                {disposition === "allowed"
-                  ? "Allow rule details"
-                  : "Deny rule details"}
+                {getAccessRuleDetailsLabel(disposition)}
               </Type>
             </div>
 
@@ -1347,7 +1367,7 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
           <div>
             <Heading variant="h5">Access Rules</Heading>
             <Type muted small className="mt-1">
-              Manage resources that are explicitly allowed or denied.
+              Manage resources that are explicitly allowed.
             </Type>
           </div>
 


### PR DESCRIPTION
## Summary
- Manual Shadow MCP access rule creation now creates allow rules only, while request review and existing deny rules remain supported.
- Update Access Rules copy to describe allow matching resources and reuse the shared copy constant in tests.

## Test Plan
- [x] `pnpm -F dashboard test src/components/access/ApprovalRequestsContent.test.tsx`
- [x] `pnpm -F dashboard lint:format`
- [x] `pnpm -F dashboard lint:eslint`
- [x] `pnpm -F dashboard type-check`

Linear: https://linear.app/speakeasy/issue/DNO-8/feat-change-the-request-option-for-block-to-deny


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make manual Shadow MCP access rules allow-only and shift UI copy to “Allow,” aligning with Linear DNO-8’s approve/deny language. Also fixes the Approval Requests breadcrumb label.

- **New Features**
  - New rule creation hides Deny and defaults `disposition` to allowed; Deny remains available when editing rules or approving requests.
  - Update empty state to “allow matching resources” and export `DEFAULT_ACCESS_RULES_EMPTY_STATE_DESCRIPTION` for tests; sheet description now says “Configure an allow rule…” on create and “allow or deny…” on edit; header and rule details labels focus on allowing.
  - Adjust radio layout to one column when Deny is hidden.

- **Bug Fixes**
  - Format the “Approval Requests” breadcrumb.

<sup>Written for commit 8ff5440f3af8688bd86ad7de351ca7dd3956f744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



