### PR TITLE
fix(remotemcp): tolerate non-compliant OAuth discovery endpoints

### DIFF
--- a/server/internal/oauth/wellknown/discover.go
+++ b/server/internal/oauth/wellknown/discover.go
@@ -172,21 +172,16 @@ func DiscoverProtectedResourceMetadata(ctx context.Context, policy *guardian.Pol
 	client := policy.Client()
 
 	var lastErr *ProtectedResourceDiscoveryError
-	for i, probeURL := range candidates {
+	for _, probeURL := range candidates {
 		doc, attemptErr := attemptProtectedResourceProbe(reqCtx, client, probeURL)
 		if attemptErr == nil {
 			return doc, collectProtectedResourceWarnings(resourceURL, doc), nil
 		}
 
-		// Non-final candidates are speculative: the path-style URL is our own
-		// RFC 9728 §3.1 path-insertion guess, so any failure there just means
-		// "not advertised here" and we fall through to the canonical
-		// origin-style URL. Only the final candidate's error is surfaced, so a
-		// genuine fault at the real location is never masked by a fallback probe.
+		// Non-final candidates are speculative; only the final candidate's
+		// error survives the loop, so a genuine fault at the canonical
+		// origin-style URL is never masked by a fallback probe.
 		lastErr = attemptErr
-		if i == len(candidates)-1 {
-			return OAuthProtectedResourceMetadata{}, nil, attemptErr
-		}
 	}
 
 	return OAuthProtectedResourceMetadata{}, nil, lastErr

--- a/server/internal/oauth/wellknown/discover.go
+++ b/server/internal/oauth/wellknown/discover.go
@@ -147,12 +147,15 @@ func (e *ProtectedResourceDiscoveryError) UserMessage() string {
 // Per RFC 9728 §3.1, when the resource URL includes a path component the
 // well-known document may live at either "<origin>/.well-known/oauth-protected-resource<path>"
 // (path-style) or "<origin>/.well-known/oauth-protected-resource" (origin-style).
-// This helper attempts the path-style candidate first; a 404 falls through to
-// the origin-style candidate. Any other status (2xx, 5xx, etc.) returns the
-// first attempt's result directly — 5xx in particular must not be masked by a
-// fallback probe. Resource URLs without a path component skip straight to
-// origin-style. The whole sequence shares a single discoverProtectedResourceTimeout
-// budget.
+// This helper attempts the path-style candidate first; any failure there — 404,
+// other 4xx, 5xx, a malformed body, or a transport error — falls through to the
+// origin-style candidate. The path-style URL is our own speculative guess, not a
+// canonical location, and non-compliant upstreams (notably SPA catch-alls) answer
+// it with a 500 or an HTML page rather than a 404. Only the final, origin-style
+// candidate's error is surfaced, so a genuine fault at the canonical location is
+// never masked by a fallback probe. Resource URLs without a path component skip
+// straight to origin-style. The whole sequence shares a single
+// discoverProtectedResourceTimeout budget.
 func DiscoverProtectedResourceMetadata(ctx context.Context, policy *guardian.Policy, resourceURL string) (OAuthProtectedResourceMetadata, []string, error) {
 	candidates, err := protectedResourceProbeCandidates(resourceURL)
 	if err != nil {
@@ -169,19 +172,21 @@ func DiscoverProtectedResourceMetadata(ctx context.Context, policy *guardian.Pol
 	client := policy.Client()
 
 	var lastErr *ProtectedResourceDiscoveryError
-	for _, probeURL := range candidates {
+	for i, probeURL := range candidates {
 		doc, attemptErr := attemptProtectedResourceProbe(reqCtx, client, probeURL)
 		if attemptErr == nil {
 			return doc, collectProtectedResourceWarnings(resourceURL, doc), nil
 		}
 
-		// Only a 404 at one candidate falls through to the next. Every other
-		// failure mode — including 5xx, transport errors, and timeouts —
-		// returns immediately so the caller sees the upstream's real signal.
-		if attemptErr.Status != http.StatusNotFound {
+		// Non-final candidates are speculative: the path-style URL is our own
+		// RFC 9728 §3.1 path-insertion guess, so any failure there just means
+		// "not advertised here" and we fall through to the canonical
+		// origin-style URL. Only the final candidate's error is surfaced, so a
+		// genuine fault at the real location is never masked by a fallback probe.
+		lastErr = attemptErr
+		if i == len(candidates)-1 {
 			return OAuthProtectedResourceMetadata{}, nil, attemptErr
 		}
-		lastErr = attemptErr
 	}
 
 	return OAuthProtectedResourceMetadata{}, nil, lastErr

--- a/server/internal/oauth/wellknown/discover_test.go
+++ b/server/internal/oauth/wellknown/discover_test.go
@@ -156,12 +156,43 @@ func TestDiscoverProtectedResourceMetadata_PathStyleAndOriginBoth404(t *testing.
 	require.NotContains(t, probeErr.ProbeURL, "/mcp/foo")
 }
 
-func TestDiscoverProtectedResourceMetadata_PathStyle5xxDoesNotFallBack(t *testing.T) {
+func TestDiscoverProtectedResourceMetadata_PathStyle5xxFallsBackToOrigin(t *testing.T) {
 	t.Parallel()
 
-	// A 5xx at the path-style probe must NOT fall back to origin-style — the
-	// upstream told us something went wrong and masking that with a separate
-	// probe would lose the signal.
+	// A 5xx at the speculative path-style probe falls back to the canonical
+	// origin-style URL. Non-compliant SPA catch-alls answer the path-style
+	// guess with a 500 (e.g. "Only HTML requests are supported here") rather
+	// than a 404, so the path-style status must not block the origin-style
+	// probe that actually serves the document.
+	var probedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probedPaths = append(probedPaths, r.URL.Path)
+		if r.URL.Path != "/.well-known/oauth-protected-resource" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resource":              "http://" + r.Host,
+			"authorization_servers": []string{"https://auth.example.com"},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	doc, _, err := wellknown.DiscoverProtectedResourceMetadata(t.Context(), newProbeTestPolicy(t), server.URL+"/mcp/foo")
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://auth.example.com"}, doc.AuthorizationServers)
+	require.Equal(t, []string{
+		"/.well-known/oauth-protected-resource/mcp/foo",
+		"/.well-known/oauth-protected-resource",
+	}, probedPaths, "path-style 5xx falls through to origin-style")
+}
+
+func TestDiscoverProtectedResourceMetadata_PathStyle5xxAndOrigin5xxSurfacesOrigin(t *testing.T) {
+	t.Parallel()
+
+	// When both candidates fail, the surfaced error reflects the final,
+	// canonical origin-style attempt — not the speculative path-style guess.
 	var probedPaths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		probedPaths = append(probedPaths, r.URL.Path)
@@ -175,8 +206,9 @@ func TestDiscoverProtectedResourceMetadata_PathStyle5xxDoesNotFallBack(t *testin
 	require.ErrorAs(t, err, &probeErr)
 	require.Equal(t, "http_error", probeErr.Code())
 	require.Equal(t, http.StatusInternalServerError, probeErr.Status)
-	require.Len(t, probedPaths, 1, "5xx must not trigger a second probe")
-	require.Equal(t, "/.well-known/oauth-protected-resource/mcp/foo", probedPaths[0])
+	require.Len(t, probedPaths, 2, "path-style 5xx falls through, both probed")
+	require.Contains(t, probeErr.ProbeURL, "/.well-known/oauth-protected-resource")
+	require.NotContains(t, probeErr.ProbeURL, "/mcp/foo")
 }
 
 func TestDiscoverProtectedResourceMetadata_NoPathSkipsPathStyle(t *testing.T) {

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -479,14 +479,18 @@ func (e *discoveryError) UserMessage() string {
 	}
 }
 
-// discoverIssuerMetadata fetches and parses an RFC 8414
-// .well-known/oauth-authorization-server document, returning the parsed body
-// and any deviations from the spec callers should be aware of. The supplied
-// guardian.Policy gates the outbound dial. Failures are wrapped in a
-// *discoveryError so the handler can attach the upstream URL and status to
+// discoverIssuerMetadata fetches and parses an issuer's RFC 8414 / OpenID
+// Connect Discovery metadata document, returning the parsed body and any
+// deviations from the spec callers should be aware of. The supplied
+// guardian.Policy gates the outbound dial.
+//
+// It probes the well-known locations returned by issuerProbeCandidates in
+// order, returning the first that yields a valid document. When every probe
+// fails the first (canonical RFC 8414) candidate's error is surfaced, wrapped
+// in a *discoveryError so the handler can attach the upstream URL and status to
 // the user-facing error.
 func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuerURL string) (rfc8414Document, []string, error) {
-	wellKnown, err := wellKnownURL(issuerURL)
+	candidates, err := issuerProbeCandidates(issuerURL)
 	if err != nil {
 		return rfc8414Document{}, nil, &discoveryError{
 			WellKnownURL: "",
@@ -498,9 +502,29 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 	reqCtx, cancel := context.WithTimeout(ctx, discoveryHTTPTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, wellKnown, nil)
+	client := policy.Client()
+
+	var firstErr *discoveryError
+	for _, wellKnown := range candidates {
+		doc, attemptErr := attemptIssuerProbe(reqCtx, client, wellKnown)
+		if attemptErr == nil {
+			return doc, collectDiscoveryWarnings(issuerURL, doc), nil
+		}
+		if firstErr == nil {
+			firstErr = attemptErr
+		}
+	}
+
+	return rfc8414Document{}, nil, firstErr
+}
+
+// attemptIssuerProbe issues a single GET against an issuer well-known URL and
+// returns either the parsed RFC 8414 / OIDC document or a typed error annotated
+// with the probed URL and upstream status.
+func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKnown string) (rfc8414Document, *discoveryError) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnown, nil)
 	if err != nil {
-		return rfc8414Document{}, nil, &discoveryError{
+		return rfc8414Document{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       0,
 			cause:        fmt.Errorf("build discovery request: %w", err),
@@ -508,9 +532,9 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := policy.Client().Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		return rfc8414Document{}, nil, &discoveryError{
+		return rfc8414Document{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       0,
 			cause:        fmt.Errorf("fetch discovery document: %w", err),
@@ -519,7 +543,7 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
-		return rfc8414Document{}, nil, &discoveryError{
+		return rfc8414Document{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       resp.StatusCode,
 			cause:        fmt.Errorf("discovery returned status %d", resp.StatusCode),
@@ -528,7 +552,7 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return rfc8414Document{}, nil, &discoveryError{
+		return rfc8414Document{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       resp.StatusCode,
 			cause:        fmt.Errorf("read discovery body: %w", err),
@@ -537,37 +561,64 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 
 	var doc rfc8414Document
 	if err := json.Unmarshal(body, &doc); err != nil {
-		return rfc8414Document{}, nil, &discoveryError{
+		return rfc8414Document{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       resp.StatusCode,
 			cause:        fmt.Errorf("decode discovery document: %w", err),
 		}
 	}
 
-	warnings := collectDiscoveryWarnings(issuerURL, doc)
-
-	return doc, warnings, nil
+	return doc, nil
 }
 
-// wellKnownURL composes the RFC 8414 .well-known path for an issuer. RFC 8414
-// places the path immediately after the host (scheme://host/.well-known/...);
-// any path component on the issuer is appended to the well-known URL.
-func wellKnownURL(issuerURL string) (string, error) {
+// issuerProbeCandidates returns the ordered list of well-known metadata URLs to
+// probe for an issuer. The first candidate is the canonical RFC 8414 location;
+// the rest broaden coverage to OpenID Connect Discovery and to non-compliant
+// upstreams that only serve metadata at the origin root.
+//
+// RFC 8414 §3 inserts the well-known path between the host and the issuer path;
+// OpenID Connect Discovery appends "/.well-known/openid-configuration" after the
+// issuer. Many identity providers (Auth0, Okta, Google, Azure AD, Keycloak)
+// serve only the OIDC document, so it is always probed. When the issuer has a
+// path component we additionally fall back to the origin-style locations, since
+// some gateways and SPA catch-alls serve metadata at the root regardless of the
+// issuer path. Duplicate URLs (e.g. when the issuer has no path) are collapsed.
+func issuerProbeCandidates(issuerURL string) ([]string, error) {
 	u, err := url.Parse(issuerURL)
 	if err != nil {
-		return "", fmt.Errorf("parse issuer url: %w", err)
+		return nil, fmt.Errorf("parse issuer url: %w", err)
 	}
 	if u.Scheme == "" || u.Host == "" {
-		return "", fmt.Errorf("issuer url must include scheme and host")
+		return nil, fmt.Errorf("issuer url must include scheme and host")
 	}
 
+	origin := (&url.URL{Scheme: u.Scheme, Host: u.Host}).String()
 	path := strings.TrimSuffix(u.Path, "/")
-	wellKnown := *u
-	wellKnown.Path = "/.well-known/oauth-authorization-server" + path
-	wellKnown.RawQuery = ""
-	wellKnown.Fragment = ""
 
-	return wellKnown.String(), nil
+	seen := make(map[string]struct{})
+	candidates := make([]string, 0, 5)
+	add := func(raw string) {
+		if _, ok := seen[raw]; ok {
+			return
+		}
+		seen[raw] = struct{}{}
+		candidates = append(candidates, raw)
+	}
+
+	// RFC 8414 §3: well-known inserted between host and issuer path.
+	add(origin + "/.well-known/oauth-authorization-server" + path)
+	// RFC 8414 §3.1 OIDC-compatible form: openid-configuration inserted between
+	// host and issuer path.
+	add(origin + "/.well-known/openid-configuration" + path)
+	if path != "" {
+		// OpenID Connect Discovery: well-known appended after the issuer path.
+		add(origin + path + "/.well-known/openid-configuration")
+		// Origin-style fallback: strip the issuer path entirely.
+		add(origin + "/.well-known/oauth-authorization-server")
+		add(origin + "/.well-known/openid-configuration")
+	}
+
+	return candidates, nil
 }
 
 // collectDiscoveryWarnings reports RFC 8414 deviations on the parsed metadata

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -30,8 +30,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-// discoveryHTTPTimeout caps every outbound RFC 8414 discovery probe so a slow
-// upstream cannot tie up the request handler.
+// discoveryHTTPTimeout caps the whole issuer discovery sequence — every
+// candidate probe shares this single budget — so a slow upstream cannot tie up
+// the request handler.
 const discoveryHTTPTimeout = 10 * time.Second
 
 // rfc8414Document is the subset of the RFC 8414 / OpenID Connect Discovery
@@ -485,7 +486,12 @@ func (e *discoveryError) UserMessage() string {
 // guardian.Policy gates the outbound dial.
 //
 // It probes the well-known locations returned by issuerProbeCandidates in
-// order, returning the first that yields a valid document. When every probe
+// order, returning the first that yields a usable document — one carrying both
+// an authorization_endpoint and a token_endpoint. A 200 that parses but lacks
+// those endpoints is almost always a SPA/gateway catch-all answering our
+// speculative candidate rather than real metadata, so it is skipped in favor of
+// a later candidate (e.g. the origin-style fallback); it is surfaced only as a
+// last resort when no candidate yields a usable document. When every probe
 // fails the first (canonical RFC 8414) candidate's error is surfaced, wrapped
 // in a *discoveryError so the handler can attach the upstream URL and status to
 // the user-facing error.
@@ -505,14 +511,34 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 	client := policy.Client()
 
 	var firstErr *discoveryError
+	var fallbackDoc rfc8414Document
+	haveFallback := false
 	for _, wellKnown := range candidates {
 		doc, attemptErr := attemptIssuerProbe(reqCtx, client, wellKnown)
-		if attemptErr == nil {
-			return doc, collectDiscoveryWarnings(issuerURL, doc), nil
+		if attemptErr != nil {
+			if firstErr == nil {
+				firstErr = attemptErr
+			}
+			continue
 		}
-		if firstErr == nil {
-			firstErr = attemptErr
+
+		// A 200 that parses but advertises no usable OAuth endpoints is almost
+		// always a catch-all answering our speculative candidate, not real
+		// metadata. Remember the first such document but keep probing — a later
+		// candidate (e.g. the origin-style fallback) may carry the real one.
+		if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" {
+			if !haveFallback {
+				fallbackDoc = doc
+				haveFallback = true
+			}
+			continue
 		}
+
+		return doc, collectDiscoveryWarnings(issuerURL, doc), nil
+	}
+
+	if haveFallback {
+		return fallbackDoc, collectDiscoveryWarnings(issuerURL, fallbackDoc), nil
 	}
 
 	return rfc8414Document{}, nil, firstErr

--- a/server/internal/remotesessions/issuerhandlers_test.go
+++ b/server/internal/remotesessions/issuerhandlers_test.go
@@ -774,3 +774,79 @@ func TestDiscoverRemoteSessionIssuer_OriginStyleFallbackStripsPath(t *testing.T)
 		"/.well-known/oauth-authorization-server",
 	}, probedPaths, "path-aware candidates 404, fall back to origin-style")
 }
+
+func TestDiscoverRemoteSessionIssuer_SkipsCatchAll200WithoutEndpoints(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	// A SPA/gateway catch-all answers every path-aware candidate with a 200
+	// that parses but carries no usable OAuth endpoints. Discovery must treat
+	// those as misses and keep probing until it reaches the origin-style
+	// oauth-authorization-server URL that serves the real document.
+	var probedPaths []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probedPaths = append(probedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"jwks_uri":               server.URL + "/jwks",
+				"registration_endpoint":  server.URL + "/register",
+			})
+			return
+		}
+		// Catch-all: 200 with no authorization_endpoint / token_endpoint.
+		_ = json.NewEncoder(w).Encode(map[string]any{"issuer": server.URL})
+	}))
+	t.Cleanup(server.Close)
+
+	draft, err := ti.service.DiscoverRemoteSessionIssuer(ctx, &gen.DiscoverRemoteSessionIssuerPayload{
+		Issuer:           server.URL + "/tenant",
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, draft.AuthorizationEndpoint)
+	require.NotNil(t, draft.TokenEndpoint)
+	require.Equal(t, []string{
+		"/.well-known/oauth-authorization-server/tenant",
+		"/.well-known/openid-configuration/tenant",
+		"/tenant/.well-known/openid-configuration",
+		"/.well-known/oauth-authorization-server",
+	}, probedPaths, "incomplete catch-all 200s skipped until the real document")
+}
+
+func TestDiscoverRemoteSessionIssuer_IncompleteDocReturnedAsLastResort(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	// Every candidate answers 200 with a parseable but endpoint-less document.
+	// No candidate is usable, so discovery probes them all and surfaces the
+	// first incomplete document (with warnings) rather than failing outright.
+	var probedPaths []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probedPaths = append(probedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"issuer": server.URL})
+	}))
+	t.Cleanup(server.Close)
+
+	draft, err := ti.service.DiscoverRemoteSessionIssuer(ctx, &gen.DiscoverRemoteSessionIssuerPayload{
+		Issuer:           server.URL + "/tenant",
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Nil(t, draft.AuthorizationEndpoint)
+	require.Nil(t, draft.TokenEndpoint)
+	require.NotEmpty(t, draft.DiscoveryWarnings)
+	require.Len(t, probedPaths, 5, "all candidates probed before falling back to the incomplete document")
+}

--- a/server/internal/remotesessions/issuerhandlers_test.go
+++ b/server/internal/remotesessions/issuerhandlers_test.go
@@ -688,3 +688,89 @@ func TestDiscoverRemoteSessionIssuer_UnexpectedStatusSurfacesCode(t *testing.T) 
 	require.Contains(t, err.Error(), "Unexpected HTTP 503")
 	require.Contains(t, err.Error(), "/.well-known/oauth-authorization-server")
 }
+
+func TestDiscoverRemoteSessionIssuer_OpenIDConfigurationFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	// Upstream advertises metadata only under the OpenID Connect Discovery
+	// path. Many IdPs (Auth0, Okta, Google) serve no oauth-authorization-server
+	// document, so discovery must fall back to openid-configuration.
+	var probedPaths []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probedPaths = append(probedPaths, r.URL.Path)
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 server.URL,
+			"authorization_endpoint": server.URL + "/authorize",
+			"token_endpoint":         server.URL + "/token",
+			"jwks_uri":               server.URL + "/jwks",
+			"registration_endpoint":  server.URL + "/register",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	draft, err := ti.service.DiscoverRemoteSessionIssuer(ctx, &gen.DiscoverRemoteSessionIssuerPayload{
+		Issuer:           server.URL,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, draft.AuthorizationEndpoint)
+	require.NotNil(t, draft.TokenEndpoint)
+	require.Equal(t, []string{
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/openid-configuration",
+	}, probedPaths, "oauth-authorization-server first, then openid-configuration")
+}
+
+func TestDiscoverRemoteSessionIssuer_OriginStyleFallbackStripsPath(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	// Issuer carries a path component but the upstream serves metadata only at
+	// the origin-root well-known URL (a common gateway / SPA catch-all shape).
+	// The path-aware candidates 404, so discovery must fall back to the
+	// path-stripped origin-style location.
+	var probedPaths []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probedPaths = append(probedPaths, r.URL.Path)
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 server.URL,
+			"authorization_endpoint": server.URL + "/authorize",
+			"token_endpoint":         server.URL + "/token",
+			"jwks_uri":               server.URL + "/jwks",
+			"registration_endpoint":  server.URL + "/register",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	draft, err := ti.service.DiscoverRemoteSessionIssuer(ctx, &gen.DiscoverRemoteSessionIssuerPayload{
+		Issuer:           server.URL + "/tenant",
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, draft.AuthorizationEndpoint)
+	require.Equal(t, []string{
+		"/.well-known/oauth-authorization-server/tenant",
+		"/.well-known/openid-configuration/tenant",
+		"/tenant/.well-known/openid-configuration",
+		"/.well-known/oauth-authorization-server",
+	}, probedPaths, "path-aware candidates 404, fall back to origin-style")
+}


### PR DESCRIPTION
## What

Broadens remote MCP OAuth metadata discovery so servers that deviate from RFC 9728 / RFC 8414 still resolve in the "Attach Remote Identity Provider" flow.

## Why

`https://soniclight-mcp.onrender.com/mcp` could not be discovered. The metadata is fully reachable, but two narrow assumptions in our probes blocked it:

1. **Protected-resource probe bailed on the speculative candidate.** For a resource with a path we probe the RFC 9728 §3.1 path-style URL first, then fall back to origin-style — but the fallback only triggered on `404`. Soniclight's SPA returns **HTTP 500** (`{"error":"Only HTML requests are supported here"}`) for the non-existent path-style URL when `Accept: application/json` is sent. We returned that 500 immediately and never tried the origin-style URL, which serves a valid document with `200`.

2. **Issuer discovery probed a single well-known path.** `discoverIssuerMetadata` only fetched `/.well-known/oauth-authorization-server<path>` — no OpenID Connect Discovery fallback and no origin-style (path-stripped) fallback. IdPs that serve only the OIDC document (Auth0, Okta, Google, Azure AD) would fail.

## Changes

- **Protected-resource probe** (`oauth/wellknown/discover.go`): the path-style candidate is speculative, so any failure there (4xx, 5xx, malformed, transport) now falls through to the canonical origin-style URL. Only the final origin-style error is surfaced, so a genuine fault at the real location is never masked.
- **Issuer discovery** (`remotesessions/issuerhandlers.go`): probes an ordered, deduplicated candidate list — `oauth-authorization-server` + `openid-configuration`, both path-aware and origin-stripped. First valid document wins; the canonical RFC 8414 error is surfaced when all probes fail.

The upstream is still non-compliant (a missing well-known path should be `404`, not `500`), but Gram now tolerates it.

## Test plan

- `go test ./internal/oauth/wellknown/ ./internal/remotesessions/` — pass, including new cases:
  - path-style `5xx` falls through to origin-style; both-`5xx` surfaces the origin error
  - issuer discovery falls back to `openid-configuration`
  - issuer discovery strips the issuer path to reach origin-style metadata
- `mise lint:server` — clean
- Manual: verified the full soniclight chain resolves end-to-end (origin-style protected-resource `200` → AuthKit issuer `oauth-authorization-server` `200`).

Backend only. No frontend, schema, or migration changes.

Closes AIS-85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates non-compliant OAuth discovery endpoints in Remote MCP so the "Attach Remote Identity Provider" flow works for servers that 500 on path-style, serve only OIDC metadata, or return catch‑all 200s. Addresses Linear `AIS-85`.

- **Bug Fixes**
  - Protected-resource probe: treats path-style as speculative; falls back to origin-style on any failure and surfaces only the final origin-style error.
  - Issuer discovery: probes an ordered, deduped list of `/.well-known/oauth-authorization-server` and `/.well-known/openid-configuration` (path-aware and origin-stripped); first valid document wins, canonical error returned if all fail.
  - Catch-all 200s: a 200 without `authorization_endpoint` or `token_endpoint` is treated as a miss; probing continues, and if none are usable, the first incomplete document is returned with warnings.

<sup>Written for commit 6d008629c814c331fdbe3d6ec79480f01314389c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

