### PR TITLE
chore: improve breadcrumb display names

### DIFF
--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -4,7 +4,7 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useOrganization, useProject } from "@/contexts/Auth.tsx";
 import { useSlugs } from "@/contexts/Sdk.tsx";
 import { useRBAC } from "@/hooks/useRBAC";
-import { capitalize, cn } from "@/lib/utils.ts";
+import { cn, titleCaseSlug } from "@/lib/utils.ts";
 import React from "react";
 import { Link, useLocation, useParams } from "react-router";
 import { ReleaseStage, ReleaseStageBadge } from "./release-stage-badge.tsx";
@@ -59,24 +59,19 @@ function PageHeaderTitle({
   );
 }
 
+// Static path segments are auto Title-Cased (see `titleCaseSlug`), so this map
+// only needs to hold the exceptions where that produces the wrong text:
+//   - acronyms / non-standard casing (MCP, SDKs, OpenAPI, API)
+//   - lowercased connector words ("from")
+//   - rebrands where the display name differs from the URL segment. `slack` and
+//     `clis` are kept in the URL for backwards compatibility but were renamed.
 const breadcrumbSubstitutions = {
   mcp: "MCP",
   sdks: "SDKs",
   elements: "Chat Elements",
-  "custom-tools": "Custom Tools",
   "add-openapi": "Add OpenAPI",
-  "add-function": "Add Function",
   "add-from-catalog": "Add from Catalog",
-  "agent-sessions": "Agent Sessions",
   "api-keys": "API Keys",
-  "audit-logs": "Audit Logs",
-  "admin-settings": "Admin Settings",
-  "risk-overview": "Risk Overview",
-  "risk-events": "Risk Events",
-  "risk-policies": "Risk Policies",
-  // The URL segments `slack` and `clis` are preserved for backwards
-  // compatibility, but the sidebar/route titles were rebranded — map them
-  // here so breadcrumbs stay in sync with the rest of the UI.
   slack: "Assistants",
   clis: "Skills",
 };
@@ -144,9 +139,10 @@ function PageHeaderBreadcrumbs({
       } else if (subDecoded !== undefined) {
         display = subDecoded;
       } else if (!toPreserve.includes(decoded) && !decoded.includes("@")) {
-        // Only synthesize a Title-Case display for path-segment slugs.
-        // Route params and email-like identifiers keep their original casing.
-        display = capitalize(decoded);
+        // Only synthesize a Title-Case display for the static parts of the
+        // path. Route params (in toPreserve) and email-like identifiers are
+        // dynamic slugs and keep their original casing.
+        display = titleCaseSlug(decoded);
       }
 
       return {

--- a/client/dashboard/src/lib/utils.ts
+++ b/client/dashboard/src/lib/utils.ts
@@ -46,7 +46,7 @@ export function titleCaseSlug(slug: string) {
   return slug
     .split("-")
     .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .map(capitalize)
     .join(" ");
 }
 

--- a/client/dashboard/src/lib/utils.ts
+++ b/client/dashboard/src/lib/utils.ts
@@ -43,11 +43,7 @@ export function capitalize(str: string) {
  * identifiers, which should keep their original casing.
  */
 export function titleCaseSlug(slug: string) {
-  return slug
-    .split("-")
-    .filter(Boolean)
-    .map(capitalize)
-    .join(" ");
+  return slug.split("-").filter(Boolean).map(capitalize).join(" ");
 }
 
 export function assert(condition: unknown, message: string): asserts condition {

--- a/client/dashboard/src/lib/utils.ts
+++ b/client/dashboard/src/lib/utils.ts
@@ -36,6 +36,20 @@ export function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+/**
+ * Turn a URL slug into a Title Case display string, e.g.
+ * "custom-tools" -> "Custom Tools". Intended for the static (literal) segments
+ * of a route path — not for dynamic slug params like toolset or user
+ * identifiers, which should keep their original casing.
+ */
+export function titleCaseSlug(slug: string) {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 export function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);


### PR DESCRIPTION
Makes breadcrumbs better by default. Practically, fixes several pages which were missing display name overrides
 
<img width="894" height="266" alt="CleanShot 2026-06-03 at 15 56 29@2x" src="https://github.com/user-attachments/assets/02d73c55-ac1b-4287-b8ae-a8248961bf68" />
<img width="1020" height="214" alt="CleanShot 2026-06-03 at 15 56 39@2x" src="https://github.com/user-attachments/assets/f5634d09-f803-4583-a7ad-dfe591445873" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves breadcrumb display names by auto title-casing static path segments and adding clear overrides for acronyms, connector words, and rebrands. Fixes pages that were missing human-friendly breadcrumb text.

- **Refactors**
  - Added `titleCaseSlug` to convert slugs like "custom-tools" into "Custom Tools".
  - Breadcrumbs now title-case only static path segments; dynamic params and emails keep their original casing.
  - Trimmed the substitutions map to exceptions only (e.g., MCP, SDKs, API/OpenAPI, "from", Assistants, Skills).

<sup>Written for commit 3bfed1191dddb0f45e826f29616ab18f0731bc48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

