### PR TITLE
fix(invites): invite email inviter name fallback

### DIFF
--- a/.changeset/invite-email-inviter-name-fallback.md
+++ b/.changeset/invite-email-inviter-name-fallback.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Use a non-empty inviter fallback for organization invite emails when the inviter's stored display name is blank, preventing Loops from rejecting invites that require `inviter_name`.

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -301,8 +301,14 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 		// Look up inviter display name + email and org name for the email template.
 		inviterName, inviterEmail := ac.UserID, ""
 		if u, err := userrepo.New(s.db).GetUser(ctx, ac.UserID); err == nil {
-			inviterName = u.DisplayName
-			inviterEmail = u.Email
+			inviterName = strings.TrimSpace(u.DisplayName)
+			inviterEmail = strings.TrimSpace(u.Email)
+			if inviterName == "" {
+				inviterName = inviterEmail
+			}
+			if inviterName == "" {
+				inviterName = ac.UserID
+			}
 		}
 		orgName := ac.ActiveOrganizationID
 		if org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID); err == nil {

--- a/server/internal/organizations/sendinvite_test.go
+++ b/server/internal/organizations/sendinvite_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	gen "github.com/speakeasy-api/gram/server/gen/organizations"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
@@ -13,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/stretchr/testify/mock"
@@ -256,6 +258,34 @@ func TestService_SendInvite_EmailSuccessReturnsInvite(t *testing.T) {
 	require.NotNil(t, invite)
 	require.Equal(t, "emailok@example.com", invite.Email)
 	require.Equal(t, "pending", invite.State)
+}
+
+func TestService_SendInvite_EmailFallsBackToInviterEmailWhenDisplayNameBlank(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsServiceWithEmail(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+	authEmail := *authCtx.Email
+
+	_, err := userrepo.New(ti.conn).UpsertUser(ctx, userrepo.UpsertUserParams{
+		ID:          authCtx.UserID,
+		Email:       authEmail,
+		DisplayName: "",
+		PhotoUrl:    pgtype.Text{String: "", Valid: false},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	ti.loops.On("SendTransactional", mock.Anything, mock.MatchedBy(func(input loops.SendTransactionalInput) bool {
+		return input.DataVariables["inviter_name"] == authEmail &&
+			input.DataVariables["inviter_email"] == authEmail
+	})).Return(nil).Once()
+
+	invite, err := ti.service.SendInvite(ctx, &gen.SendInvitePayload{Email: "blank-name@example.com"})
+	require.NoError(t, err)
+	require.NotNil(t, invite)
 }
 
 func TestService_SendInvite_ExpiredInviteAllowsReinvite(t *testing.T) {


### PR DESCRIPTION
## Summary
- fall back to inviter email/user id when display_name is blank before sending organization invite emails
- add a regression test for blank display_name Loops payloads
- add a server patch changeset

## Test plan
- GOCACHE=/tmp/gram-go-build go test ./server/internal/organizations
- mise lint:server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure organization invite emails always include a non-empty inviter name. When the inviter’s display name is blank, we now fall back to their email, then user ID, preventing `loops` transactional email rejections.

- Bug Fixes
  - Trim inviter display name and email; fallback order for inviter_name: display name → email → user ID.
  - Added regression test for blank display name.
  - Added patch changeset for `server`.

<sup>Written for commit 0fca976f4b07677ae7bf7fa1054d1d43b8200b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

