### PR TITLE
feat(dashboard): add rule delete dialog

### DIFF
--- a/.changeset/salty-walls-study.md
+++ b/.changeset/salty-walls-study.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Improve confirmation dialog for deleting Shadow MCP access rules

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
@@ -1104,6 +1104,93 @@ describe("ApprovalRequestsContent", () => {
     });
   });
 
+  it("resets pending rule deletion when the project changes", async () => {
+    const listShadowMCPApprovalRequests = vi.fn().mockResolvedValue({
+      requests: [],
+    });
+    const listShadowMCPAccessRules = vi
+      .fn()
+      .mockImplementation(({ projectId }: { projectId: string }) => {
+        const rule =
+          projectId === "project-1"
+            ? {
+                id: "rule-project-1",
+                displayName: "Project one rule",
+                resourceType: "shadow_mcp",
+                disposition: "allowed",
+                accessScope: "project",
+                projectId: "project-1",
+                matchBreadth: "url_host",
+                matchValue: "one.example.com",
+                updatedAt: new Date("2026-01-01"),
+              }
+            : {
+                id: "rule-project-2",
+                displayName: "Project two rule",
+                resourceType: "shadow_mcp",
+                disposition: "allowed",
+                accessScope: "project",
+                projectId: "project-2",
+                matchBreadth: "url_host",
+                matchValue: "two.example.com",
+                updatedAt: new Date("2026-01-01"),
+              };
+
+        return Promise.resolve({ rules: [rule] });
+      });
+    mocks.useSdkClient.mockReturnValue({
+      access: {
+        listShadowMCPApprovalRequests,
+        listShadowMCPAccessRules,
+      },
+    });
+    mocks.useRBAC.mockReturnValue({
+      hasScope: (scope: string) => scope === "org:admin",
+      hasAnyScope: (scopes: string[]) => scopes.includes("org:admin"),
+      hasAllScopes: () => true,
+      isLoading: false,
+    });
+
+    const queryClient = new QueryClient();
+    const renderWithProject = (projectId: string) => (
+      <MemoryRouter
+        initialEntries={["/speakeasy/projects/project-1/approval-requests"]}
+      >
+        <Routes>
+          <Route
+            path="/:orgSlug/projects/:projectSlug/approval-requests"
+            element={
+              <QueryClientProvider client={queryClient}>
+                <ApprovalRequestsContent projectId={projectId} />
+              </QueryClientProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const view = render(renderWithProject("project-1"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Project one rule")).toBeTruthy();
+    });
+    const deleteRuleRow = screen.getByText("Project one rule").closest("tr");
+    if (!deleteRuleRow) throw new Error("Rule row not found");
+    fireEvent.click(
+      within(deleteRuleRow).getByRole("button", { name: "Delete" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+
+    view.rerender(renderWithProject("project-2"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
   it("renders a filtered empty state when a rule filter has no matches", async () => {
     const listShadowMCPApprovalRequests = vi.fn().mockResolvedValue({
       requests: [],

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
@@ -149,6 +149,23 @@ vi.mock("@speakeasy-api/moonshine", () => ({
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
+  Dialog: Object.assign(
+    ({
+      children,
+      open,
+    }: {
+      children: ReactNode;
+      open?: boolean;
+      onOpenChange?: (open: boolean) => void;
+    }) => (open ? <div role="dialog">{children}</div> : null),
+    {
+      Content: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+      Header: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+      Title: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+      Description: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+      Footer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    },
+  ),
   Table: ({
     columns,
     data,
@@ -362,6 +379,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   cleanup();
 });
 
@@ -1000,6 +1018,89 @@ describe("ApprovalRequestsContent", () => {
       projectId: "project-1",
       disposition: undefined,
       cursor: undefined,
+    });
+  });
+
+  it("confirms access rule deletion with a design system dialog", async () => {
+    const deleteRule = vi.fn().mockResolvedValue({});
+    const browserConfirm = vi.fn().mockReturnValue(true);
+    vi.stubGlobal("confirm", browserConfirm);
+    const listShadowMCPApprovalRequests = vi.fn().mockResolvedValue({
+      requests: [],
+    });
+    const listShadowMCPAccessRules = vi.fn().mockResolvedValue({
+      rules: [
+        {
+          id: "rule-delete",
+          displayName: "Delete me",
+          resourceType: "shadow_mcp",
+          disposition: "allowed",
+          accessScope: "project",
+          projectId: "project-1",
+          matchBreadth: "url_host",
+          matchValue: "delete.example.com",
+          updatedAt: new Date("2026-01-01"),
+        },
+      ],
+    });
+    mocks.useSdkClient.mockReturnValue({
+      access: {
+        listShadowMCPApprovalRequests,
+        listShadowMCPAccessRules,
+      },
+    });
+    mocks.useRBAC.mockReturnValue({
+      hasScope: (scope: string) => scope === "org:admin",
+      hasAnyScope: (scopes: string[]) => scopes.includes("org:admin"),
+      hasAllScopes: () => true,
+      isLoading: false,
+    });
+    mocks.mutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: deleteRule,
+    });
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete me")).toBeTruthy();
+    });
+    const deleteRuleRow = screen.getByText("Delete me").closest("tr");
+    if (!deleteRuleRow) throw new Error("Rule row not found");
+    fireEvent.click(
+      within(deleteRuleRow).getByRole("button", { name: "Delete" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+    expect(
+      screen.getByRole("heading", { name: "Delete access rule" }),
+    ).toBeTruthy();
+    const dialog = screen.getByRole("dialog");
+    const ruleName = within(dialog).getByText("Delete me");
+    expect(ruleName.tagName).toBe("CODE");
+    expect(ruleName.className).toContain("font-mono");
+    const header = screen.getByRole("heading", {
+      name: "Delete access rule",
+    }).parentElement;
+    expect(header?.contains(ruleName)).toBe(false);
+    expect(
+      within(dialog).getByText(/This action cannot be undone\./),
+    ).toBeTruthy();
+    expect(browserConfirm).not.toHaveBeenCalled();
+    expect(deleteRule).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      within(dialog).getByRole("button", {
+        name: "Delete",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(deleteRule).toHaveBeenCalledWith({
+        request: { id: "rule-delete" },
+      });
     });
   });
 

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
@@ -854,6 +854,10 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
   const [rulePendingDelete, setRulePendingDelete] =
     useState<ShadowMCPAccessRule | null>(null);
 
+  useEffect(() => {
+    setRulePendingDelete(null);
+  }, [projectId]);
+
   const ruleDisposition =
     ruleDispositionFilter === "all" ? undefined : ruleDispositionFilter;
   const hasActiveRuleFilter = ruleDispositionFilter !== "all";

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
@@ -40,6 +40,7 @@ import {
   Badge,
   Button,
   Column,
+  Dialog,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -52,7 +53,7 @@ import {
   TooltipTrigger,
 } from "@speakeasy-api/moonshine";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
-import { Ellipsis, Inbox, Plus, ShieldCheck } from "lucide-react";
+import { Ellipsis, Inbox, Loader2, Plus, ShieldCheck } from "lucide-react";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
@@ -850,6 +851,8 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
   const [editingRule, setEditingRule] = useState<ShadowMCPAccessRule | null>(
     null,
   );
+  const [rulePendingDelete, setRulePendingDelete] =
+    useState<ShadowMCPAccessRule | null>(null);
 
   const ruleDisposition =
     ruleDispositionFilter === "all" ? undefined : ruleDispositionFilter;
@@ -982,6 +985,24 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
         queryKey: APPROVAL_REQUEST_RULES_QUERY_KEY,
       }),
     ]);
+  };
+
+  const closeDeleteRuleDialog = () => {
+    if (deleteRule.isPending) return;
+    setRulePendingDelete(null);
+  };
+
+  const confirmDeleteRule = async () => {
+    if (!rulePendingDelete || deleteRule.isPending) return;
+
+    try {
+      await deleteRule.mutateAsync({ request: { id: rulePendingDelete.id } });
+      await refreshApprovalRequestsData();
+      toast.success("Access Rule deleted");
+      setRulePendingDelete(null);
+    } catch {
+      toast.error("Access Rule delete failed");
+    }
   };
 
   const requestColumns: Column<ShadowMCPApprovalRequest>[] = [
@@ -1135,19 +1156,7 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
             setEditingRule(rule);
             setIsRuleSheetOpen(true);
           }}
-          onDelete={async () => {
-            if (!window.confirm(`Delete Access Rule "${rule.displayName}"?`)) {
-              return;
-            }
-
-            try {
-              await deleteRule.mutateAsync({ request: { id: rule.id } });
-              await refreshApprovalRequestsData();
-              toast.success("Access Rule deleted");
-            } catch {
-              toast.error("Access Rule delete failed");
-            }
-          }}
+          onDelete={() => setRulePendingDelete(rule)}
         />
       ),
     },
@@ -1419,6 +1428,51 @@ export function ApprovalRequestsContent({ projectId }: { projectId: string }) {
           </div>
         )}
       </section>
+
+      <Dialog
+        open={rulePendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) closeDeleteRuleDialog();
+        }}
+      >
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Delete access rule</Dialog.Title>
+          </Dialog.Header>
+          <Type variant="small">
+            This action cannot be undone. Are you sure you want to delete{" "}
+            <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
+              {rulePendingDelete?.displayName ?? "this access rule"}
+            </code>
+            ?
+          </Type>
+          <Dialog.Footer>
+            <Button
+              variant="secondary"
+              onClick={closeDeleteRuleDialog}
+              disabled={deleteRule.isPending}
+            >
+              <Button.Text>Cancel</Button.Text>
+            </Button>
+            <Button
+              variant="destructive-primary"
+              onClick={confirmDeleteRule}
+              disabled={deleteRule.isPending}
+            >
+              {deleteRule.isPending ? (
+                <>
+                  <Button.LeftIcon>
+                    <Loader2 className="size-4 animate-spin" />
+                  </Button.LeftIcon>
+                  <Button.Text>Deleting</Button.Text>
+                </>
+              ) : (
+                <Button.Text>Delete</Button.Text>
+              )}
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the browser confirm for Shadow MCP access rule deletion with a Moonshine dialog.
- Keep the confirmation copy in dialog body content and render the rule name as inline code.
- Add regression coverage that verifies the design-system dialog appears before deletion.

## Test Plan
- [x] pnpm -F dashboard test ApprovalRequestsContent.test.tsx
- [x] pnpm -F dashboard type-check
- [x] pnpm -F dashboard lint:format
- [x] pnpm -F dashboard lint:eslint

Linear: https://linear.app/speakeasy/issue/DNO-185/feat-delete-rule-should-use-dialog

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the browser confirm with a `@speakeasy-api/moonshine` dialog for deleting Shadow MCP access rules and fixed stale pending deletions when switching projects. Implements DNO-185 and includes a `dashboard` patch changeset.

- **New Features**
  - Uses a Moonshine dialog with clear copy; rule name shown as inline code.
  - Cancel/Delete actions disable while pending; shows `Loader2` spinner with “Deleting”.
  - Tests verify the design-system dialog appears and browser `confirm` isn’t used.

- **Bug Fixes**
  - Clears any pending delete when `projectId` changes to avoid acting on the wrong rule.
  - Test added to confirm the dialog closes on project switch.

<sup>Written for commit 07552929b684478e18c44308f09d3a9f1f7233f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

