### PR TITLE
fix(server): use WorkOS SDK for directory/connection lookups

### DIFF
--- a/.changeset/fix-workos-sdk-directory-connection.md
+++ b/.changeset/fix-workos-sdk-directory-connection.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix `organizations.getOnboardingStatus` returning 500 in production by switching the WorkOS connection/directory lookups to the official WorkOS Go SDK (`sso.Client`, `directorysync.Client`). The previous raw-HTTP wrapper used the wrong path `/directory_sync/directories` (the correct WorkOS endpoint is `/directories`), which the type system could not catch.

--- a/dev-idp/internal/modes/mockworkos/workos.go
+++ b/dev-idp/internal/modes/mockworkos/workos.go
@@ -98,7 +98,7 @@ func (h *Handler) registerWorkosRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /portal", h.handleWorkosPortalPage)
 
 	mux.HandleFunc("GET /connections", h.handleWorkosListConnections)
-	mux.HandleFunc("GET /directory_sync/directories", h.handleWorkosListDirectories)
+	mux.HandleFunc("GET /directories", h.handleWorkosListDirectories)
 }
 
 // =============================================================================

--- a/server/internal/thirdparty/workos/client.go
+++ b/server/internal/thirdparty/workos/client.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/workos/workos-go/v6/pkg/directorysync"
 	"github.com/workos/workos-go/v6/pkg/events"
 	"github.com/workos/workos-go/v6/pkg/organizations"
+	"github.com/workos/workos-go/v6/pkg/sso"
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
 	"github.com/workos/workos-go/v6/pkg/workos_errors"
 
@@ -62,6 +64,8 @@ type Client struct {
 	orgs       *organizations.Client
 	um         *usermanagement.Client
 	events     *events.Client
+	sso        *sso.Client
+	dsync      *directorysync.Client
 }
 
 // ClientOpts configures optional overrides for New.
@@ -107,6 +111,8 @@ func NewClient(guardianPolicy *guardian.Policy, apiKey string, opts ...ClientOpt
 		orgs:       &organizations.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint, JSONEncode: nil},
 		um:         um,
 		events:     &events.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint},
+		sso:        &sso.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint, JSONEncode: nil, ClientID: opt.ClientID},
+		dsync:      &directorysync.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint},
 	}
 }
 

--- a/server/internal/thirdparty/workos/connection.go
+++ b/server/internal/thirdparty/workos/connection.go
@@ -2,76 +2,98 @@ package workos
 
 import (
 	"context"
-	"fmt"
-	"net/url"
+
+	"github.com/workos/workos-go/v6/pkg/directorysync"
+	"github.com/workos/workos-go/v6/pkg/sso"
 )
 
 // Connection represents a WorkOS SSO connection.
 type Connection struct {
-	ID             string `json:"id"`
-	OrganizationID string `json:"organization_id"`
-	ConnectionType string `json:"connection_type"`
-	Name           string `json:"name"`
-	State          string `json:"state"` // "active", "inactive", "draft"
-	ExternalKey    string `json:"external_key"`
-	CreatedAt      string `json:"created_at"`
-	UpdatedAt      string `json:"updated_at"`
-}
-
-// ListConnectionsResponse is the paginated response from the WorkOS List Connections API.
-type ListConnectionsResponse struct {
-	Data []Connection `json:"data"`
+	ID             string
+	OrganizationID string
+	ConnectionType string
+	Name           string
+	State          string // "active", "inactive", "draft", "validating"
+	CreatedAt      string
+	UpdatedAt      string
 }
 
 // ListConnections fetches SSO connections for an organization from WorkOS.
 // https://workos.com/docs/reference/sso/connection#list-connections
 func (wc *Client) ListConnections(ctx context.Context, organizationID string) ([]Connection, error) {
-	params := url.Values{}
-	params.Set("organization_id", organizationID)
-
-	var out ListConnectionsResponse
-	if err := wc.do(ctx, "GET", "/connections?"+params.Encode(), nil, &out); err != nil {
-		return nil, fmt.Errorf("list connections: %w", err)
+	resp, err := wc.sso.ListConnections(ctx, sso.ListConnectionsOpts{
+		OrganizationID: organizationID,
+		ConnectionType: "",
+		Domain:         "",
+		Limit:          0,
+		Order:          "",
+		Before:         "",
+		After:          "",
+	})
+	if err != nil {
+		return nil, wrapSDKError(err, "list connections")
 	}
 
-	return out.Data, nil
+	out := make([]Connection, 0, len(resp.Data))
+	for _, c := range resp.Data {
+		out = append(out, Connection{
+			ID:             c.ID,
+			OrganizationID: c.OrganizationID,
+			ConnectionType: string(c.ConnectionType),
+			Name:           c.Name,
+			State:          string(c.State),
+			CreatedAt:      c.CreatedAt,
+			UpdatedAt:      c.UpdatedAt,
+		})
+	}
+	return out, nil
 }
 
 // Directory represents a WorkOS Directory Sync directory.
 type Directory struct {
-	ID             string `json:"id"`
-	OrganizationID string `json:"organization_id"`
-	Type           string `json:"type"`
-	Name           string `json:"name"`
-	State          string `json:"state"` // "linked", "unlinked", "deleting"
-	ExternalKey    string `json:"external_key"`
-	CreatedAt      string `json:"created_at"`
-	UpdatedAt      string `json:"updated_at"`
-}
-
-// ListDirectoriesResponse is the paginated response from the WorkOS List Directories API.
-type ListDirectoriesResponse struct {
-	Data []Directory `json:"data"`
+	ID             string
+	OrganizationID string
+	Type           string
+	Name           string
+	State          string // "linked", "unlinked", "invalid_credentials"
+	CreatedAt      string
+	UpdatedAt      string
 }
 
 // ListDirectories fetches directory sync directories for an organization from WorkOS.
 // https://workos.com/docs/reference/directory-sync/directory#list-directories
 func (wc *Client) ListDirectories(ctx context.Context, organizationID string) ([]Directory, error) {
-	params := url.Values{}
-	params.Set("organization_id", organizationID)
-
-	var out ListDirectoriesResponse
-	if err := wc.do(ctx, "GET", "/directory_sync/directories?"+params.Encode(), nil, &out); err != nil {
-		return nil, fmt.Errorf("list directories: %w", err)
+	resp, err := wc.dsync.ListDirectories(ctx, directorysync.ListDirectoriesOpts{
+		OrganizationID: organizationID,
+		Search:         "",
+		Limit:          0,
+		Order:          "",
+		Before:         "",
+		After:          "",
+	})
+	if err != nil {
+		return nil, wrapSDKError(err, "list directories")
 	}
 
-	return out.Data, nil
+	out := make([]Directory, 0, len(resp.Data))
+	for _, d := range resp.Data {
+		out = append(out, Directory{
+			ID:             d.ID,
+			OrganizationID: d.OrganizationID,
+			Type:           string(d.Type),
+			Name:           d.Name,
+			State:          string(d.State),
+			CreatedAt:      d.CreatedAt,
+			UpdatedAt:      d.UpdatedAt,
+		})
+	}
+	return out, nil
 }
 
 // HasActiveConnection returns true if the organization has at least one active SSO connection.
 func HasActiveConnection(connections []Connection) bool {
 	for _, c := range connections {
-		if c.State == "active" {
+		if c.State == string(sso.Active) {
 			return true
 		}
 	}
@@ -81,7 +103,7 @@ func HasActiveConnection(connections []Connection) bool {
 // HasActiveDirectory returns true if the organization has at least one linked directory.
 func HasActiveDirectory(directories []Directory) bool {
 	for _, d := range directories {
-		if d.State == "linked" {
+		if d.State == string(directorysync.Linked) {
 			return true
 		}
 	}

--- a/server/internal/thirdparty/workos/connection_test.go
+++ b/server/internal/thirdparty/workos/connection_test.go
@@ -1,0 +1,188 @@
+package workos_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+)
+
+// newClientWithHandler builds a workos.Client pointed at an httptest server
+// driven by the supplied handler. Used by tests that need to assert request
+// paths or stub WorkOS responses without the broader fakeWorkOS state machine.
+func newClientWithHandler(t *testing.T, handler http.Handler) *workos.Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	return workos.NewClient(guardianPolicy, "test-api-key", workos.ClientOpts{
+		Endpoint:   srv.URL,
+		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+		ClientID:   "test-client-id",
+	})
+}
+
+// TestClient_ListConnections_HitsCorrectPath is a regression guard for the
+// "wrong WorkOS endpoint" class of bug. Asserts the SDK targets /connections
+// (NOT /sso/connections or any other variant) and forwards organization_id.
+func TestClient_ListConnections_HitsCorrectPath(t *testing.T) {
+	t.Parallel()
+	var gotPath, gotOrgID string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotOrgID = r.URL.Query().Get("organization_id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"list_metadata":{"before":"","after":""}}`))
+	})
+
+	client := newClientWithHandler(t, handler)
+	_, err := client.ListConnections(context.Background(), "org_test_123")
+	require.NoError(t, err)
+	require.Equal(t, "/connections", gotPath)
+	require.Equal(t, "org_test_123", gotOrgID)
+}
+
+// TestClient_ListDirectories_HitsCorrectPath is a regression guard for the
+// production bug fixed by this PR. The previous raw-HTTP wrapper hit the
+// non-existent /directory_sync/directories path and caused getOnboardingStatus
+// to 500 in production. The correct WorkOS endpoint is /directories.
+func TestClient_ListDirectories_HitsCorrectPath(t *testing.T) {
+	t.Parallel()
+	var gotPath, gotOrgID string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotOrgID = r.URL.Query().Get("organization_id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"list_metadata":{"before":"","after":""}}`))
+	})
+
+	client := newClientWithHandler(t, handler)
+	_, err := client.ListDirectories(context.Background(), "org_test_123")
+	require.NoError(t, err)
+	require.Equal(t, "/directories", gotPath)
+	require.Equal(t, "org_test_123", gotOrgID)
+}
+
+func TestClient_ListConnections_DecodesResponse(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id":"conn_a","organization_id":"org_1","connection_type":"OktaSAML","name":"Okta","state":"active","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z"},
+				{"id":"conn_b","organization_id":"org_1","connection_type":"GoogleOAuth","name":"Google","state":"inactive","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z"}
+			],
+			"list_metadata": {"before":"","after":""}
+		}`))
+	})
+
+	client := newClientWithHandler(t, handler)
+	conns, err := client.ListConnections(context.Background(), "org_1")
+	require.NoError(t, err)
+	require.Len(t, conns, 2)
+	require.Equal(t, "conn_a", conns[0].ID)
+	require.Equal(t, "active", conns[0].State)
+	require.Equal(t, "OktaSAML", conns[0].ConnectionType)
+	require.Equal(t, "inactive", conns[1].State)
+}
+
+func TestClient_ListDirectories_DecodesResponse(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id":"dir_a","organization_id":"org_1","type":"okta scim v2.0","name":"Okta Dsync","state":"linked","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z"},
+				{"id":"dir_b","organization_id":"org_1","type":"azure scim v2.0","name":"Azure Dsync","state":"unlinked","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z"}
+			],
+			"list_metadata": {"before":"","after":""}
+		}`))
+	})
+
+	client := newClientWithHandler(t, handler)
+	dirs, err := client.ListDirectories(context.Background(), "org_1")
+	require.NoError(t, err)
+	require.Len(t, dirs, 2)
+	require.Equal(t, "dir_a", dirs[0].ID)
+	require.Equal(t, "linked", dirs[0].State)
+	require.Equal(t, "unlinked", dirs[1].State)
+}
+
+func TestClient_ListConnections_NotFoundError(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found","error":"Not Found"}`))
+	})
+
+	client := newClientWithHandler(t, handler)
+	_, err := client.ListConnections(context.Background(), "org_missing")
+	require.Error(t, err)
+	require.True(t, workos.IsNotFound(err), "404 from WorkOS should be detectable via IsNotFound, got %v", err)
+}
+
+func TestClient_ListDirectories_NotFoundError(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found","error":"Not Found"}`))
+	})
+
+	client := newClientWithHandler(t, handler)
+	_, err := client.ListDirectories(context.Background(), "org_missing")
+	require.Error(t, err)
+	require.True(t, workos.IsNotFound(err), "404 from WorkOS should be detectable via IsNotFound, got %v", err)
+}
+
+func TestHasActiveConnection(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   []workos.Connection
+		want bool
+	}{
+		{name: "empty slice", in: nil, want: false},
+		{name: "only inactive", in: []workos.Connection{{State: "inactive"}, {State: "draft"}}, want: false},
+		{name: "single active", in: []workos.Connection{{State: "active"}}, want: true},
+		{name: "active among inactive", in: []workos.Connection{{State: "draft"}, {State: "active"}, {State: "inactive"}}, want: true},
+		{name: "validating is not active", in: []workos.Connection{{State: "validating"}}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, workos.HasActiveConnection(tc.in))
+		})
+	}
+}
+
+func TestHasActiveDirectory(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   []workos.Directory
+		want bool
+	}{
+		{name: "empty slice", in: nil, want: false},
+		{name: "only unlinked", in: []workos.Directory{{State: "unlinked"}}, want: false},
+		{name: "single linked", in: []workos.Directory{{State: "linked"}}, want: true},
+		{name: "linked among unlinked", in: []workos.Directory{{State: "unlinked"}, {State: "linked"}}, want: true},
+		{name: "invalid_credentials is not linked", in: []workos.Directory{{State: "invalid_credentials"}}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, workos.HasActiveDirectory(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Onboarding wizard endpoint `/rpc/organizations.getOnboardingStatus` returned 500 in prod. Root cause: wrong WorkOS path `/directory_sync/directories` (correct path is `/directories`). The custom raw-HTTP wrapper hid the typo from the compiler.
- Swapped the raw HTTP `ListConnections` / `ListDirectories` calls in `server/internal/thirdparty/workos/connection.go` to use the already-vendored WorkOS Go SDK (`sso.Client` + `directorysync.Client`). URL paths are now SDK-owned, so this class of typo can no longer ship.
- Updated `dev-idp` mock to register `GET /directories` (was `/directory_sync/directories`) so local dev + tests track prod.

Prod error before fix:

```
list directories: workos api GET /directory_sync/directories?organization_id=org_01J8K717C968A57DPCSN3X8NSE: status 404: {"message":"The requested resource was not found","error":"Not Found"}
```

Stacktrace pointed at `server/internal/organizations/impl.go:953` → `ListDirectories`, called from `GetOnboardingStatus`. Identified via Datadog APM traces, commit `4feb400b` (PR #3079 enterprise onboarding wizard).

## Test plan

- [x] `go build ./server/... ./dev-idp/...`
- [x] `go test ./server/internal/thirdparty/workos/... ./server/internal/organizations/...` (100 passed)
- [x] `mise lint:server`
- [ ] Verify in prod after deploy: `curl https://app.getgram.ai/rpc/organizations.getOnboardingStatus` returns 200
- [ ] Rotate `sk_test_...` WorkOS key shared during debug

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch directory and connection lookups to the WorkOS Go SDK and add path-regression tests, fixing 500s in the onboarding status endpoint and preventing path typos.

- **Bug Fixes**
  - Corrected directories endpoint to `/directories`, fixing 404s that led to 500 on `/rpc/organizations.getOnboardingStatus`; added tests to assert `/directories` and `/connections` paths and 404 propagation.
  - Updated `dev-idp` mock to serve `GET /directories` to match prod.

- **Refactors**
  - Replaced raw HTTP `ListConnections`/`ListDirectories` with `sso.Client` and `directorysync.Client` from `github.com/workos/workos-go/v6`.
  - Added SDK clients to our `workos.Client` so URL paths are SDK-owned, and added a patch changeset.

<sup>Written for commit 9b157346d753d020f607cca04ff7e8c8b2d8a72d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

