### PR TITLE
chore: onboarding confirm-traffic shows real hook events

### DIFF
--- a/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
@@ -24,6 +24,7 @@ const ROW_HEIGHT = 32;
 const SOURCE_ICONS: Record<string, string> = {
   "claude-code": "/icons/platforms/claude.svg",
   "claude-code-desktop": "/icons/platforms/claude.svg",
+  cowork: "/icons/platforms/claude.svg",
   cursor: "/icons/platforms/cursor.svg",
   codex: "/icons/platforms/openai.svg",
 };

--- a/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
@@ -22,7 +22,8 @@ const PLAYBACK_INTERVAL_MS = 400;
 const ROW_HEIGHT = 32;
 
 const SOURCE_ICONS: Record<string, string> = {
-  claude_code: "/icons/platforms/claude.svg",
+  "claude-code": "/icons/platforms/claude.svg",
+  "claude-code-desktop": "/icons/platforms/claude.svg",
   cursor: "/icons/platforms/cursor.svg",
   codex: "/icons/platforms/openai.svg",
 };
@@ -35,12 +36,16 @@ function eventKey(ev: OnboardingHookEvent): string {
 
 function sourceLabel(source: string): string {
   switch (source) {
-    case "claude_code":
+    case "claude-code":
       return "Claude Code";
+    case "claude-code-desktop":
+      return "Claude Desktop";
     case "cursor":
       return "Cursor";
     case "codex":
       return "Codex";
+    case "cowork":
+      return "Cowork";
     default:
       return source;
   }

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -1027,7 +1027,7 @@ func (s *Service) VerifyOnboardingHooksSetup(ctx context.Context, payload *gen.V
 		}
 		ev := &gen.OnboardingHookEvent{
 			TimeUnixNano: strconv.FormatInt(r.TimeUnixNano, 10),
-			Source:       r.ServiceVersion,
+			Source:       r.HookSource,
 			ProjectSlug:  slugByID[r.GramProjectID],
 			ToolName:     r.ToolName,
 			EventName:    r.EventName,

--- a/server/internal/telemetry/repo/models.go
+++ b/server/internal/telemetry/repo/models.go
@@ -100,14 +100,14 @@ type HookTraceSummary struct {
 // RecentHookEvent represents a single hook event row from telemetry_logs,
 // shaped for the onboarding wizard's confirm-traffic verification step.
 type RecentHookEvent struct {
-	TimeUnixNano   int64   `ch:"time_unix_nano"`
-	GramProjectID  string  `ch:"gram_project_id"`
-	GramChatID     *string `ch:"gram_chat_id"`
-	ServiceVersion string  `ch:"service_version"` // "claude_code", "cursor", "codex"
-	ToolName       *string `ch:"tool_name"`       // materialized
-	UserEmail      *string `ch:"user_email"`      // materialized
-	EventName      *string `ch:"event_name"`      // extracted from attributes.gram.hook.event_name
-	Status         string  `ch:"status"`          // "blocked" if hook_block_reason set, else "received"
+	TimeUnixNano  int64   `ch:"time_unix_nano"`
+	GramProjectID string  `ch:"gram_project_id"`
+	GramChatID    *string `ch:"gram_chat_id"`
+	HookSource    string  `ch:"hook_source"` // materialized from attributes.gram.hook.source — "claude-code", "cursor", "codex"
+	ToolName      *string `ch:"tool_name"`   // materialized
+	UserEmail     *string `ch:"user_email"`  // materialized
+	EventName     *string `ch:"event_name"`  // extracted from attributes.gram.hook.event_name
+	Status        string  `ch:"status"`      // "blocked" if hook_block_reason set, else "received"
 }
 
 // ChatSummary represents an aggregated view of a chat session (one row per gram_chat_id).

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -2719,15 +2719,16 @@ func (q *Queries) ListRecentHookEventsForOnboarding(ctx context.Context, arg Lis
 		"time_unix_nano",
 		"gram_project_id",
 		"gram_chat_id",
-		"service_version",
+		"hook_source",
 		"tool_name",
 		"user_email",
-		"toString(attributes.`gram.hook.event_name`) AS event_name",
+		"toString(attributes.gram.hook.event) AS event_name",
 		"multiIf(hook_block_reason IS NOT NULL AND hook_block_reason != '', 'blocked', 'received') AS status",
 	).
 		From("telemetry_logs").
 		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
-		Where("event_source = 'hook'")
+		Where("event_source = 'hook'").
+		Where("toString(attributes.gram.hook.event) != ''")
 
 	if arg.SinceUnixNano > 0 {
 		sb = sb.Where("time_unix_nano > ?", arg.SinceUnixNano)
@@ -2777,7 +2778,8 @@ func (q *Queries) CountRecentHookEventsForOnboarding(ctx context.Context, projec
 	sb := sq.Select("count() AS cnt").
 		From("telemetry_logs").
 		Where(squirrel.Eq{"gram_project_id": projectIDs}).
-		Where("event_source = 'hook'")
+		Where("event_source = 'hook'").
+		Where("toString(attributes.gram.hook.event) != ''")
 
 	if sinceUnixNano > 0 {
 		sb = sb.Where("time_unix_nano > ?", sinceUnixNano)


### PR DESCRIPTION
## Summary

Fixes the onboarding wizard's confirm-traffic step so it shows real hook events with correct source attribution and icons. Four bugs in `ListRecentHookEventsForOnboarding` masked one another, causing every row to render as `"Tool call: claude-code"` with no platform icon.

## Bugs fixed

| #   | Bug                                                                                              | Fix                                                                             |
| --- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
| 1   | `Source` mapped from `service_version` (nullable, populated by OTEL collector — empty in prod)   | Map from materialized `hook_source` column (from `attributes.gram.hook.source`) |
| 2   | Frontend icon/label keys used `claude_code` (underscore) but real value is `claude-code` (kebab) | Switch keys to kebab; add `claude-code-desktop` + `cowork`                      |
| 3   | Query selected `attributes.gram.hook.event_name` — no such attribute                             | Use `attributes.gram.hook.event` (matches `attr.HookEventKey`)                  |
| 4   | Backticks around `gram.hook.event` treated dotted path as a single flat column name              | Drop backticks — matches the `chAttr` helper used everywhere else in this file  |

Also adds a filter — `attributes.gram.hook.event != ''` — to exclude the synthetic `*:usage:metrics` rows written by `writeMetricsToClickHouse`. Those rows set `tool_name = "claude-code"` as a placeholder, which were dominating the wizard's recent-activity feed (2860 metrics rows vs ~1800 real tool calls in a 30-minute window). All real hook event types (`PostToolUse`, `PreToolUse`, `SessionStart`, `UserPromptSubmit`, `Stop`, etc.) still pass.

## Test plan

- [x] Local build: `go build ./server/...` succeeds
- [x] Local typecheck: `pnpm -F dashboard type-check` clean
- [x] Verified against prod ClickHouse: query now returns populated `event_name`, `hook_source`, and real `tool_name` values; metrics rows excluded
- [ ] Manual smoke of onboarding wizard confirm-traffic step in dev — events render with correct icons + labels

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the onboarding wizard’s confirm-traffic step to show real hook events with correct platform labels and icons. Also filters out synthetic metrics entries so recent activity is accurate.

- **Bug Fixes**
  - Map event source from `hook_source` instead of nullable `service_version`.
  - Use kebab-case keys in the UI; add icon + label mappings for `claude-code-desktop` and `cowork`.
  - Select `attributes.gram.hook.event` and remove backticks on dotted paths in queries.
  - Exclude `*:usage:metrics` rows to prevent placeholder `tool_name` values from flooding the feed.

<sup>Written for commit 47d39d4fad3a45ca9a4af4a04f4660cb0e62f93d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

