### PR TITLE
fix(onboarding): WorkOS portal new-tab flow, brand rename, copy polish

### DIFF
--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -1005,7 +1005,7 @@ function OnboardingShortcutCard({ orgSlug }: { orgSlug: string | undefined }) {
             as="div"
             className="text-foreground text-sm font-semibold"
           >
-            Finish setting up your workspace
+            Finish setting up your organization
           </Type>
           <Type small muted className="mt-0.5 text-xs">
             Configure SSO, directory sync, your plugin marketplace, and agent

--- a/client/dashboard/src/pages/plugins/PublishDialog.tsx
+++ b/client/dashboard/src/pages/plugins/PublishDialog.tsx
@@ -10,6 +10,7 @@ interface PublishDialogProps {
   onOpenChange: (open: boolean) => void;
   onPublish: (githubUsernames: string[]) => void;
   isPending: boolean;
+  mode?: "publish" | "manage";
 }
 
 interface GithubUserResult {
@@ -44,7 +45,9 @@ export const PublishDialog = memo(function PublishDialog({
   onOpenChange,
   onPublish,
   isPending,
+  mode = "publish",
 }: PublishDialogProps) {
+  const isManage = mode === "manage";
   const [usernames, setUsernames] = useState<string[]>([]);
   const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -229,15 +232,35 @@ export const PublishDialog = memo(function PublishDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <Dialog.Content>
         <Dialog.Header>
-          <Dialog.Title>Publish Plugins</Dialog.Title>
-          <Dialog.Description>
-            Publish all plugins to a GitHub repository. Optionally add
-            collaborators who will receive read access to the repo.
-          </Dialog.Description>
-          <Dialog.Description>
-            At least one user in your organization will need to be given access
-            to connect the generated repository with Claude, Cursor, or Codex.
-          </Dialog.Description>
+          <Dialog.Title>
+            {isManage ? "Add collaborators" : "Publish Plugins"}
+          </Dialog.Title>
+          {isManage ? (
+            <>
+              <Dialog.Description>
+                Add new GitHub users as collaborators on the marketplace repo.
+                Existing collaborators are not shown here — anyone you add below
+                is granted access in addition to those already attached to the
+                repo.
+              </Dialog.Description>
+              <Dialog.Description>
+                To view or remove existing collaborators, open the repository on
+                GitHub.
+              </Dialog.Description>
+            </>
+          ) : (
+            <>
+              <Dialog.Description>
+                Publish all plugins to a GitHub repository. Optionally add
+                collaborators who will receive read access to the repo.
+              </Dialog.Description>
+              <Dialog.Description>
+                At least one user in your organization will need to be given
+                access to connect the generated repository with Claude, Cursor,
+                or Codex.
+              </Dialog.Description>
+            </>
+          )}
         </Dialog.Header>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
@@ -353,7 +376,13 @@ export const PublishDialog = memo(function PublishDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={isPending}>
-              {isPending ? "Publishing..." : "Publish"}
+              {isPending
+                ? isManage
+                  ? "Adding..."
+                  : "Publishing..."
+                : isManage
+                  ? "Add collaborators"
+                  : "Publish"}
             </Button>
           </Dialog.Footer>
         </form>

--- a/client/dashboard/src/pages/setup/components/onboarding-header.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-header.tsx
@@ -18,7 +18,7 @@ export function OnboardingHeader({ onLeave }: OnboardingHeaderProps) {
           <GramLogo variant="horizontal" className="w-32" />
           <div className="bg-border h-5 w-px" />
           <span className="text-foreground text-sm font-medium">
-            Set up workspace
+            Setup organization
           </span>
         </div>
         <div className="flex items-center gap-2">

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -50,7 +50,7 @@ export function OnboardingStepper({
                 /* Completed step: dark circle with checkmark */
                 <button
                   onClick={() => onStepClick?.(index)}
-                  className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-full bg-[#1a1a1a] text-white transition-colors hover:bg-[#333]"
+                  className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-full bg-[#1a1a1a] text-white transition-all duration-200 ease-out hover:scale-[1.2] hover:bg-[#333]"
                 >
                   <Check className="h-3.5 w-3.5" strokeWidth={2.5} />
                 </button>

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -27,7 +27,7 @@ const STEPS: Step[] = [
   {
     id: "create-marketplace",
     title: "Create plugin marketplace",
-    description: "Publish observability plugins to GitHub",
+    description: "For distributing servers to your users",
   },
   {
     id: "instrument-agents",

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -151,7 +151,12 @@ export function SetupWizard() {
   const renderStep = () => {
     switch (currentStep) {
       case 0:
-        return <ConnectIdpStep onSkip={completeCurrentStep} />;
+        return (
+          <ConnectIdpStep
+            onSkip={completeCurrentStep}
+            onComplete={completeCurrentStep}
+          />
+        );
       case 1:
         return (
           <DirectorySyncStep onComplete={completeCurrentStep} onBack={goBack} />

--- a/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
@@ -180,7 +180,7 @@ export function ConfirmTrafficStep({
         </div>
       }
       title="Confirm traffic"
-      description="We're polling Gram for new hook events. Trigger any action in Claude Code, Cursor, or Codex on a managed machine to confirm the instrumentation works."
+      description="We're listening for events from your agent platforms. Trigger any action in Claude Code, Cursor, or Codex on a managed machine to confirm the instrumentation works."
       onContinue={onComplete}
       continueLabel="Complete setup"
       showBack

--- a/client/dashboard/src/pages/setup/components/steps/connect-idp-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/connect-idp-step.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { useMoonshineConfig } from "@speakeasy-api/moonshine";
 import { useGenerateWorkOSAdminPortalLinkMutation } from "@gram/client/react-query";
+import { useOnboardingStatus } from "@gram/client/react-query/onboardingStatus";
 import { toast } from "sonner";
 import { StepContainer } from "../step-container";
 import { IDP_PROVIDERS } from "../../providers";
@@ -35,14 +36,18 @@ function ProviderIcon({
 
 interface ConnectIdpStepProps {
   onSkip: () => void;
+  onComplete: () => void;
 }
 
 const INITIAL_VISIBLE = 6;
 
-export function ConnectIdpStep({ onSkip }: ConnectIdpStepProps) {
+export function ConnectIdpStep({ onSkip, onComplete }: ConnectIdpStepProps) {
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
   const [query, setQuery] = useState("");
+  const [portalOpened, setPortalOpened] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const { refetch: refetchOnboardingStatus } = useOnboardingStatus();
 
   const filteredProviders = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -82,6 +87,7 @@ export function ConnectIdpStep({ onSkip }: ConnectIdpStepProps) {
           generateWorkOSAdminPortalLinkRequestBody: {
             intent: "sso",
             successUrl: `${getServerURL()}/v1/setup/callback?intent=sso`,
+            returnUrl: window.location.href,
             intentOptions: {
               sso: {
                 providerType: provider.providerType,
@@ -92,11 +98,38 @@ export function ConnectIdpStep({ onSkip }: ConnectIdpStepProps) {
       },
       {
         onSuccess: (data) => {
-          window.location.href = data.url;
+          window.open(data.url, "_blank", "noopener,noreferrer");
+          setPortalOpened(true);
         },
       },
     );
   };
+
+  const handleVerify = async () => {
+    setVerifying(true);
+    try {
+      const result = await refetchOnboardingStatus();
+      if (result.data?.ssoConfigured) {
+        onComplete();
+      } else {
+        toast.error(
+          "SSO connection not detected yet. Finish setup in the WorkOS tab, then try again.",
+        );
+      }
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const continueAction = portalOpened ? handleVerify : handleConnect;
+  const continueLabel = portalOpened
+    ? verifying
+      ? "Verifying..."
+      : "Continue"
+    : generatePortalLink.isPending
+      ? "Opening..."
+      : "Connect";
+  const isLoading = generatePortalLink.isPending || verifying;
 
   return (
     <StepContainer
@@ -107,11 +140,11 @@ export function ConnectIdpStep({ onSkip }: ConnectIdpStepProps) {
       }
       title="Connect identity provider"
       description="Connect your SSO provider to enable secure authentication for your team. This allows employees to sign in with their existing credentials."
-      onContinue={handleConnect}
+      onContinue={continueAction}
       onSkip={onSkip}
       skipLabel="Skip for now"
-      continueLabel={generatePortalLink.isPending ? "Opening..." : "Connect"}
-      isLoading={generatePortalLink.isPending}
+      continueLabel={continueLabel}
+      isLoading={isLoading}
       canContinue={!!selectedProvider}
     >
       <div className="space-y-6">
@@ -193,12 +226,12 @@ export function ConnectIdpStep({ onSkip }: ConnectIdpStepProps) {
               </div>
               <div>
                 <p className="text-foreground text-sm font-medium">
-                  {"You'll"} be redirected to complete setup
+                  Setup opens in a new tab
                 </p>
                 <p className="text-muted-foreground mt-1 text-sm">
-                  After clicking Connect, you will be redirected to configure
-                  your {provider?.name} SSO connection. Once complete, you will
-                  be returned to the next step automatically.
+                  After clicking Connect, the WorkOS portal opens in a new
+                  browser tab to configure your {provider?.name} SSO connection.
+                  Finish setup there, then return here and click Continue.
                 </p>
               </div>
             </div>

--- a/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
@@ -75,7 +75,7 @@ export function CreateMarketplaceStep({
         </div>
       }
       title="Create plugin marketplace"
-      description="Gram publishes a private GitHub repo that acts as your team's plugin marketplace for Claude Code, Cursor, and Codex. It ships with our core observability plugin, required for us to collect usage metrics and enforce authorization, and is also where any plugins you build in Gram later get published — so this only needs to be set up once per project."
+      description="Speakeasy publishes a private GitHub repo that acts as your team's plugin marketplace for Claude Code, Cursor, and Codex. It ships with our core observability plugin, required for us to collect usage metrics and enforce authorization, and is also where any plugins you build in Speakeasy later get published — so this only needs to be set up once per project."
       onContinue={primaryAction}
       continueLabel={primaryLabel}
       isLoading={publishMutation.isPending || isLoading}
@@ -123,7 +123,7 @@ export function CreateMarketplaceStep({
             </div>
             <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
               This repo is your team's plugin marketplace. The observability
-              plugins are already inside, and any plugins you build in Gram
+              plugins are already inside, and any plugins you build in Speakeasy
               later will be published here too.
             </p>
             <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
@@ -178,7 +178,7 @@ export function CreateMarketplaceStep({
           </div>
         )}
         {isConnected && (
-          <p className="text-muted-foreground text-sm leading-relaxed">
+          <p className="text-muted-foreground text-sm">
             At least one of your organization's users needs to be attached to
             the repository as a collaborator so that the repository is
             discoverable by Agent Platforms.

--- a/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Book, ExternalLink, GitBranch, Loader2 } from "lucide-react";
+import { Book, ExternalLink, GitBranch, Loader2, Users } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
@@ -123,16 +123,31 @@ export function CreateMarketplaceStep({
                   </span>
                 </div>
               </div>
-              <a
-                href={publishStatus.repoUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="border-border bg-background hover:bg-muted/50 inline-flex flex-shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-                Open repo
-              </a>
+              <div className="flex flex-shrink-0 flex-col gap-2">
+                <a
+                  href={publishStatus.repoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="border-border bg-background hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  Open repo
+                </a>
+                <button
+                  type="button"
+                  onClick={() => setDialogOpen(true)}
+                  className="border-border bg-background hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
+                >
+                  <Users className="h-3.5 w-3.5" />
+                  Manage collaborators
+                </button>
+              </div>
             </div>
+            <p className="text-muted-foreground mt-3 text-xs leading-relaxed">
+              At least one of your organization's users needs to be attached to
+              the repository as a collaborator so that the repository is
+              discoverable by Agent Platforms.
+            </p>
           </div>
         ) : (
           <div className="bg-card border-border rounded-lg border p-4">

--- a/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
@@ -58,7 +58,7 @@ export function CreateMarketplaceStep({
         </div>
       }
       title="Create plugin marketplace"
-      description="Gram publishes a private GitHub repo that acts as your team's plugin marketplace for Claude Code, Cursor, and Codex. It ships with the observability plugins out of the box and is also where any plugins you build in Gram later get published — so this only needs to be set up once per project."
+      description="Gram publishes a private GitHub repo that acts as your team's plugin marketplace for Claude Code, Cursor, and Codex. It ships with our core observability plugin, required for us to collect usage metrics and enforce authorization, and is also where any plugins you build in Gram later get published — so this only needs to be set up once per project."
       onContinue={primaryAction}
       continueLabel={primaryLabel}
       isLoading={publishMutation.isPending || isLoading}

--- a/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
@@ -156,11 +156,6 @@ export function CreateMarketplaceStep({
                 </button>
               </div>
             </div>
-            <p className="text-muted-foreground mt-3 text-xs leading-relaxed">
-              At least one of your organization's users needs to be attached to
-              the repository as a collaborator so that the repository is
-              discoverable by Agent Platforms.
-            </p>
           </div>
         ) : (
           <div className="bg-card border-border rounded-lg border p-4">
@@ -181,6 +176,13 @@ export function CreateMarketplaceStep({
               </div>
             </div>
           </div>
+        )}
+        {isConnected && (
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            At least one of your organization's users needs to be attached to
+            the repository as a collaborator so that the repository is
+            discoverable by Agent Platforms.
+          </p>
         )}
       </div>
 

--- a/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
@@ -21,18 +21,26 @@ export function CreateMarketplaceStep({
 }: CreateMarketplaceStepProps) {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<"publish" | "manage">("publish");
   const { data: publishStatus, isLoading } = usePublishStatus();
 
   const publishMutation = usePublishPluginsMutation({
     onSuccess: (data) => {
       setDialogOpen(false);
       invalidateAllPublishStatus(queryClient);
-      toast.success("Plugins published to GitHub", {
-        description: data.repoUrl,
-      });
+      toast.success(
+        dialogMode === "manage"
+          ? "Collaborators added"
+          : "Plugins published to GitHub",
+        { description: data.repoUrl },
+      );
     },
     onError: () => {
-      toast.error("Failed to publish plugins to GitHub");
+      toast.error(
+        dialogMode === "manage"
+          ? "Failed to add collaborators"
+          : "Failed to publish plugins to GitHub",
+      );
     },
   });
 
@@ -47,7 +55,16 @@ export function CreateMarketplaceStep({
 
   const isConnected = !!(publishStatus?.connected && publishStatus.repoUrl);
 
-  const primaryAction = isConnected ? onComplete : () => setDialogOpen(true);
+  const openPublishDialog = () => {
+    setDialogMode("publish");
+    setDialogOpen(true);
+  };
+  const openManageDialog = () => {
+    setDialogMode("manage");
+    setDialogOpen(true);
+  };
+
+  const primaryAction = isConnected ? onComplete : openPublishDialog;
   const primaryLabel = isConnected ? "Continue" : "Setup Plugin Marketplace";
 
   return (
@@ -73,72 +90,68 @@ export function CreateMarketplaceStep({
           </div>
         ) : isConnected ? (
           <div className="bg-card border-border rounded-md border p-4">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0 flex-1 space-y-2">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Book className="text-muted-foreground h-4 w-4 flex-shrink-0" />
-                  <span className="text-base">
-                    {publishStatus.repoOwner && (
-                      <a
-                        href={publishStatus.repoUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sky-500 hover:text-sky-600 hover:underline"
-                      >
-                        {publishStatus.repoOwner}
-                      </a>
-                    )}
-                    {publishStatus.repoOwner && publishStatus.repoName && (
-                      <span className="text-muted-foreground/60 mx-1">/</span>
-                    )}
-                    {publishStatus.repoName && (
-                      <a
-                        href={publishStatus.repoUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="font-semibold text-sky-500 hover:text-sky-600 hover:underline"
-                      >
-                        {publishStatus.repoName}
-                      </a>
-                    )}
-                  </span>
-                  <span className="border-border text-muted-foreground rounded-full border px-2 py-0 text-[10px] font-medium tracking-wider uppercase">
-                    Private
-                  </span>
-                </div>
-                <p className="text-muted-foreground text-sm leading-relaxed">
-                  This repo is your team's plugin marketplace. The observability
-                  plugins are already inside, and any plugins you build in Gram
-                  later will be published here too.
-                </p>
-                <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-                  <span className="inline-flex items-center gap-1.5">
-                    <span className="relative flex h-2 w-2">
-                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-40" />
-                      <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
-                    </span>
-                    <span className="font-medium text-emerald-700 dark:text-emerald-400">
-                      Marketplace set up
-                    </span>
-                  </span>
-                </div>
-              </div>
-              <div className="flex flex-shrink-0 flex-col gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <Book className="text-muted-foreground h-4 w-4 flex-shrink-0" />
+              <span className="min-w-0 truncate text-base">
+                {publishStatus.repoOwner && (
+                  <a
+                    href={publishStatus.repoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sky-500 hover:text-sky-600 hover:underline"
+                  >
+                    {publishStatus.repoOwner}
+                  </a>
+                )}
+                {publishStatus.repoOwner && publishStatus.repoName && (
+                  <span className="text-muted-foreground/60 mx-1">/</span>
+                )}
+                {publishStatus.repoName && (
+                  <a
+                    href={publishStatus.repoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-sky-500 hover:text-sky-600 hover:underline"
+                  >
+                    {publishStatus.repoName}
+                  </a>
+                )}
+              </span>
+              <span className="border-border text-muted-foreground rounded-full border px-2 py-0 text-[10px] font-medium tracking-wider uppercase">
+                Private
+              </span>
+            </div>
+            <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+              This repo is your team's plugin marketplace. The observability
+              plugins are already inside, and any plugins you build in Gram
+              later will be published here too.
+            </p>
+            <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+              <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+                <span className="relative flex h-2 w-2">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-40" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+                </span>
+                <span className="font-medium text-emerald-700 dark:text-emerald-400">
+                  Marketplace set up
+                </span>
+              </span>
+              <div className="flex flex-wrap items-center gap-2">
                 <a
                   href={publishStatus.repoUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="border-border bg-background hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
+                  className="border-border bg-background hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors"
                 >
-                  <ExternalLink className="h-3.5 w-3.5" />
-                  Open repo
+                  <ExternalLink className="h-3 w-3" />
+                  Open
                 </a>
                 <button
                   type="button"
-                  onClick={() => setDialogOpen(true)}
-                  className="border-border bg-background hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
+                  onClick={openManageDialog}
+                  className="border-border bg-background hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors"
                 >
-                  <Users className="h-3.5 w-3.5" />
+                  <Users className="h-3 w-3" />
                   Manage collaborators
                 </button>
               </div>
@@ -176,6 +189,7 @@ export function CreateMarketplaceStep({
         onOpenChange={setDialogOpen}
         onPublish={handlePublish}
         isPending={publishMutation.isPending}
+        mode={dialogMode}
       />
     </StepContainer>
   );

--- a/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
@@ -178,7 +178,7 @@ export function CreateMarketplaceStep({
           </div>
         )}
         {isConnected && (
-          <p className="text-muted-foreground text-xs leading-relaxed">
+          <p className="text-muted-foreground text-sm leading-relaxed">
             At least one of your organization's users needs to be attached to
             the repository as a collaborator so that the repository is
             discoverable by Agent Platforms.

--- a/client/dashboard/src/pages/setup/components/steps/directory-sync-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/directory-sync-step.tsx
@@ -83,7 +83,7 @@ export function DirectorySyncStep({
         </div>
       }
       title="Directory sync"
-      description="Connect your identity provider's directory to automatically sync users, groups, and roles. Changes in your IdP will be reflected in Gram."
+      description="Connect your identity provider's directory to automatically sync users, groups, and roles. Changes in your IdP will be reflected in Speakeasy."
       onContinue={continueAction}
       continueLabel={continueLabel}
       isLoading={isLoading}

--- a/client/dashboard/src/pages/setup/components/steps/directory-sync-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/directory-sync-step.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { Users, ExternalLink, Loader2 } from "lucide-react";
 import { useGenerateWorkOSAdminPortalLinkMutation } from "@gram/client/react-query";
+import { useOnboardingStatus } from "@gram/client/react-query/onboardingStatus";
 import { toast } from "sonner";
 import { StepContainer } from "../step-container";
 import { getServerURL } from "@/lib/utils";
@@ -13,6 +15,10 @@ export function DirectorySyncStep({
   onComplete,
   onBack,
 }: DirectorySyncStepProps) {
+  const [portalOpened, setPortalOpened] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const { refetch: refetchOnboardingStatus } = useOnboardingStatus();
+
   const generatePortalLink = useGenerateWorkOSAdminPortalLinkMutation({
     onError: (error) => {
       toast.error(
@@ -30,16 +36,44 @@ export function DirectorySyncStep({
           generateWorkOSAdminPortalLinkRequestBody: {
             intent: "dsync",
             successUrl: `${getServerURL()}/v1/setup/callback?intent=dsync`,
+            returnUrl: window.location.href,
           },
         },
       },
       {
         onSuccess: (data) => {
-          window.location.href = data.url;
+          window.open(data.url, "_blank", "noopener,noreferrer");
+          setPortalOpened(true);
         },
       },
     );
   };
+
+  const handleVerify = async () => {
+    setVerifying(true);
+    try {
+      const result = await refetchOnboardingStatus();
+      if (result.data?.dsyncConfigured) {
+        onComplete();
+      } else {
+        toast.error(
+          "Directory sync not detected yet. Finish setup in the WorkOS tab, then try again.",
+        );
+      }
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const continueAction = portalOpened ? handleVerify : handleConnect;
+  const continueLabel = portalOpened
+    ? verifying
+      ? "Verifying..."
+      : "Continue"
+    : generatePortalLink.isPending
+      ? "Opening..."
+      : "Connect directory";
+  const isLoading = generatePortalLink.isPending || verifying;
 
   return (
     <StepContainer
@@ -50,11 +84,9 @@ export function DirectorySyncStep({
       }
       title="Directory sync"
       description="Connect your identity provider's directory to automatically sync users, groups, and roles. Changes in your IdP will be reflected in Gram."
-      onContinue={handleConnect}
-      continueLabel={
-        generatePortalLink.isPending ? "Opening..." : "Connect directory"
-      }
-      isLoading={generatePortalLink.isPending}
+      onContinue={continueAction}
+      continueLabel={continueLabel}
+      isLoading={isLoading}
       showBack
       onBack={onBack}
       onSkip={onComplete}
@@ -68,12 +100,12 @@ export function DirectorySyncStep({
             </div>
             <div>
               <p className="text-foreground text-sm font-medium">
-                {"You'll"} be redirected to complete setup
+                Setup opens in a new tab
               </p>
               <p className="text-muted-foreground mt-1 text-sm">
-                After clicking Connect directory, you will be redirected to
-                configure your directory sync connection. Once complete, you
-                will be returned to the next step automatically.
+                After clicking Connect directory, the WorkOS portal opens in a
+                new browser tab. Finish configuring the connection there, then
+                return here and click Continue.
               </p>
             </div>
           </div>

--- a/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
@@ -594,7 +594,7 @@ export function InstrumentAgentsStep({
         </div>
       }
       title="Instrument agent platforms"
-      description="Set up Gram hooks for each AI coding assistant your team uses. Each platform has its own configuration steps."
+      description="Set up Speakeasy hooks for each AI coding assistant your team uses. Each platform has its own configuration steps."
       onContinue={onComplete}
       continueLabel="Continue"
       showBack

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -43,7 +43,7 @@ export const AGENT_PLATFORMS: AgentPlatform[] = [
       {
         title: "Update Managed settings on Claude.ai",
         description:
-          "Add your private marketplace to managed settings so every developer in your org gets the observability plugin automatically. The OTEL env block also pushes a Gram API key to every install so tool traffic lands in your dashboard. If you already have managed settings, merge this block into the existing JSON.",
+          "Add your private marketplace to managed settings so every developer in your org gets the observability plugin automatically. The OTEL env block also pushes a Speakeasy API key to every install so tool traffic lands in your dashboard. If you already have managed settings, merge this block into the existing JSON.",
         screenshot: {
           src: "/setup/claude-managed-settings-editor.png",
           alt: "Claude Code Managed settings JSON editor dialog with Update settings button",
@@ -124,7 +124,7 @@ export const AGENT_PLATFORMS: AgentPlatform[] = [
       {
         title: "Mark the observability plugin as Required",
         description:
-          "After the repo syncs, your plugins appear in a table on Claude.ai. Find the observability plugin row (slug below), open its Default access dropdown, and set it to Required. That pre-installs it for every org member and prevents them from disabling it — so tool events flow to Gram without per-user opt-in.",
+          "After the repo syncs, your plugins appear in a table on Claude.ai. Find the observability plugin row (slug below), open its Default access dropdown, and set it to Required. That pre-installs it for every org member and prevents them from disabling it — so tool events flow to Speakeasy without per-user opt-in.",
         screenshot: {
           src: "/setup/claude-cowork-set-required.png",
           alt: "Claude.ai plugin access dropdown showing four options (Available to install, Installed by default, Not available, Required) with Required selected",
@@ -144,9 +144,9 @@ export const AGENT_PLATFORMS: AgentPlatform[] = [
     connected: false,
     setupSteps: [
       {
-        title: "Register the Gram plugin marketplace",
+        title: "Register the Speakeasy plugin marketplace",
         description:
-          "Register your org's private marketplace with Codex. The repo URL points at the GitHub repository Gram just published for you.",
+          "Register your org's private marketplace with Codex. The repo URL points at the GitHub repository Speakeasy just published for you.",
         code: `codex plugin marketplace add {{GRAM_MARKETPLACE_URL}}`,
         language: "bash",
         helpLink: {
@@ -196,7 +196,7 @@ enabled = true`,
         },
       },
       {
-        title: "Import the Gram marketplace",
+        title: "Import the Speakeasy marketplace",
         description:
           "In the Cursor team dashboard, navigate to Settings → Plugins → Import and paste your private marketplace repo URL below. Cursor reads the plugin manifest from the repo and makes its plugins available to your team.",
         code: `{{GRAM_REPO_URL}}`,
@@ -205,7 +205,7 @@ enabled = true`,
       {
         title: "Mark the observability plugin as required",
         description:
-          "In Cursor's team marketplace settings, mark the observability plugin (slug below) as required so tool events flow to Gram for every team member without per-user setup.",
+          "In Cursor's team marketplace settings, mark the observability plugin (slug below) as required so tool events flow to Speakeasy for every team member without per-user setup.",
         code: `{{GRAM_CURSOR_PLUGIN_NAME}}`,
         language: "text",
       },

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -79,8 +79,7 @@ export const AGENT_PLATFORMS: AgentPlatform[] = [
   {
     id: "claude-cowork",
     name: "Claude Cowork",
-    description:
-      "Team Claude.ai workspace with admin-managed plugins, billing, and access",
+    description: "Autonomous AI desktop assistant",
     icon: "claude",
     connected: false,
     setupSteps: [

--- a/dev-idp/internal/modes/mockworkos/workos.go
+++ b/dev-idp/internal/modes/mockworkos/workos.go
@@ -1120,18 +1120,28 @@ func (h *Handler) handleWorkosListConnections(w http.ResponseWriter, r *http.Req
 	})
 }
 
-// handleWorkosListDirectories returns an empty list by default since directory
-// sync requires explicit setup. In local dev the DSYNC step is skippable.
+// handleWorkosListDirectories returns a mock linked directory for the
+// organization so the onboarding wizard's DSYNC verify step can progress after
+// the mock portal "Complete setup" click. Mirrors handleWorkosListConnections.
 func (h *Handler) handleWorkosListDirectories(w http.ResponseWriter, r *http.Request) {
 	orgID := r.URL.Query().Get("organization_id")
 	if orgID == "" {
 		writeWorkosError(w, http.StatusBadRequest, "organization_id is required")
 		return
 	}
-	_ = orgID
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"data": []map[string]any{},
+		"data": []map[string]any{
+			{
+				"id":              "directory_mock_" + orgID,
+				"organization_id": orgID,
+				"type":            "generic scim v2.0",
+				"name":            "Mock Directory",
+				"state":           "linked",
+				"created_at":      "2024-01-01T00:00:00Z",
+				"updated_at":      "2024-01-01T00:00:00Z",
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
## Summary
- WorkOS Admin Portal currently ignores `success_url` and `return_url`, so the in-page redirect flow strands users on the portal after setup. The wizard never advances.
- Open the SSO and DSYNC portals in a new tab via `window.open(url, "_blank", "noopener,noreferrer")`. The wizard tab stays on the step.
- After the portal opens, the step's Continue button flips into a verify action: it refetches `getOnboardingStatus` and only advances when `ssoConfigured` / `dsyncConfigured` is true; otherwise a toast asks the user to finish the WorkOS tab and retry.
- Still pass `returnUrl` to the WorkOS portal so it points back to the wizard once WorkOS fixes the redirect bug (no-op today).
- Mock dev-idp's `GET /directories` now returns a linked mock directory mirroring the existing connections mock so the DSYNC verify step works locally.
- Header copy tweak: "Set up workspace" → "Setup organization".

## Test plan
- [ ] Local: restart `dev-idp`, run the onboarding wizard end to end. Connect IDP step opens new tab, Continue verifies and advances.
- [ ] Local: same for Directory sync step (now passes because mock returns `state: "linked"`).
- [ ] Local: hit Continue *before* finishing the portal — expect the "not detected yet" toast and stay on the step.
- [ ] Prod-ish: confirm the new-tab flow works against real WorkOS, and that `returnUrl` is harmless while the WorkOS bug is live.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the WorkOS Admin Portal in a new tab and add a manual verify step so onboarding doesn’t stall when WorkOS ignores redirect URLs. Also adds a “Manage collaborators” flow and polishes copy/branding across the wizard.

- **New Features**
  - Add “Manage collaborators” button and dialog (reuse `PublishDialog` in manage mode) plus a note explaining at least one org user must be a collaborator for Agent Platforms to discover the repo.

- **Bug Fixes**
  - Open SSO and Directory Sync portals with `window.open(..., "_blank", "noopener,noreferrer")`.
  - Change Continue to a verify action that refetches onboarding status and only advances when `ssoConfigured`/`dsyncConfigured` is true; otherwise show a toast.
  - Pass `returnUrl` to the portal for future compatibility; `dev-idp` mock now returns a linked directory so DSYNC verify works locally.
  - Brand rename and copy polish: user-visible “Gram” → “Speakeasy”; confirm-traffic text now references agent platforms; OrgHome banner reads “organization”; marketplace step description clarified.
  - UX polish: stepper completed indicators scale on hover; collaborator access note moved outside the repo card and bumped to text-sm for better visibility.

<sup>Written for commit 69f72f2a1779ab2be23fffb11d519d6b6a1974a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

