### PR TITLE
feat(assistants): sender-scoped runtime tokens for dashboard turns

### DIFF
--- a/.changeset/assistant-sender-scoped-tokens.md
+++ b/.changeset/assistant-sender-scoped-tokens.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Project Assistant turns sent from the dashboard now run under the sender's user identity instead of the user who first enabled the assistant for the project. MCP tool calls, audit attribution, and any per-user RBAC inside a turn reflect the user who actually sent the message. Non-interactive sources (cron, wake), Slack-sourced turns, and system-initiated MCP-auth resumptions continue to run under the assistant's creator.

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1698,7 +1698,9 @@ func (s *ServiceCore) processEventTurn(
 	event assistantThreadEventRecord,
 ) error {
 	if prompt, ok := decodeMCPAuthTurn(ctx, s.logger, event); ok {
-		turnToken, err := s.MintThreadScopedRuntimeToken(assistant, thread.ID)
+		// MCP auth resumption is a system event with no human sender — act as
+		// the assistant's creator.
+		turnToken, err := s.MintThreadScopedRuntimeToken(assistant, thread.ID, assistant.CreatedByUserID)
 		if err != nil {
 			return err
 		}
@@ -1716,7 +1718,7 @@ func (s *ServiceCore) processEventTurn(
 	if err != nil {
 		return fmt.Errorf("decode assistant turn: %w", err)
 	}
-	turnToken, err := s.MintThreadScopedRuntimeToken(assistant, thread.ID)
+	turnToken, err := s.MintThreadScopedRuntimeToken(assistant, thread.ID, turnUserID(assistant, thread, event))
 	if err != nil {
 		return err
 	}
@@ -1724,6 +1726,22 @@ func (s *ServiceCore) processEventTurn(
 		return fmt.Errorf("run assistant turn: %w", err)
 	}
 	return nil
+}
+
+// turnUserID returns the Gram user whose identity a turn should act under.
+// Dashboard turns carry a Gram user id on the event payload (the sender), so
+// MCP calls, audit attribution, and per-user RBAC reflect the actual sender
+// rather than the assistant's creator. Other sources either don't carry a
+// Gram user identity (cron/wake) or carry an external one (Slack), so they
+// fall back to the creator — the historical behavior.
+func turnUserID(assistant assistantRecord, thread assistantThreadRecord, event assistantThreadEventRecord) string {
+	if thread.SourceKind == sourceKindDashboard {
+		var payload dashboardEventPayload
+		if err := json.Unmarshal(event.NormalizedPayloadJSON, &payload); err == nil && payload.UserID != "" {
+			return payload.UserID
+		}
+	}
+	return assistant.CreatedByUserID
 }
 
 func (s *ServiceCore) startProcessingLeaseHeartbeat(
@@ -1777,11 +1795,17 @@ func (s *ServiceCore) touchProcessingLease(ctx context.Context, projectID, runti
 // downstream, so platform tools that key on the calling thread (wake,
 // memory, telemetry) keep working under the v2 single-VM-per-assistant
 // runtime — the VM is shared but the auth identity is per-thread.
-func (s *ServiceCore) MintThreadScopedRuntimeToken(assistant assistantRecord, threadID uuid.UUID) (string, error) {
+//
+// userID is the Gram user whose identity the turn acts under. Dashboard
+// turns pass the sender so per-turn MCP calls, audit attribution, and
+// per-user RBAC line up with the actual user. Non-interactive sources
+// (cron/wake), external-id sources (Slack), and system events (MCP auth
+// resume) pass the assistant's creator.
+func (s *ServiceCore) MintThreadScopedRuntimeToken(assistant assistantRecord, threadID uuid.UUID, userID string) (string, error) {
 	token, err := s.assistantTokens.Generate(assistanttokens.GenerateInput{
 		OrgID:       assistant.OrganizationID,
 		ProjectID:   assistant.ProjectID,
-		UserID:      assistant.CreatedByUserID,
+		UserID:      userID,
 		AssistantID: assistant.ID,
 		ThreadID:    threadID,
 		TTL:         assistantRuntimeTokenTTL,

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1733,7 +1733,7 @@ func (s *ServiceCore) processEventTurn(
 // MCP calls, audit attribution, and per-user RBAC reflect the actual sender
 // rather than the assistant's creator. Other sources either don't carry a
 // Gram user identity (cron/wake) or carry an external one (Slack), so they
-// fall back to the creator — the historical behavior.
+// fall back to the creator.
 func turnUserID(assistant assistantRecord, thread assistantThreadRecord, event assistantThreadEventRecord) string {
 	if thread.SourceKind == sourceKindDashboard {
 		var payload dashboardEventPayload
@@ -1795,12 +1795,6 @@ func (s *ServiceCore) touchProcessingLease(ctx context.Context, projectID, runti
 // downstream, so platform tools that key on the calling thread (wake,
 // memory, telemetry) keep working under the v2 single-VM-per-assistant
 // runtime — the VM is shared but the auth identity is per-thread.
-//
-// userID is the Gram user whose identity the turn acts under. Dashboard
-// turns pass the sender so per-turn MCP calls, audit attribution, and
-// per-user RBAC line up with the actual user. Non-interactive sources
-// (cron/wake), external-id sources (Slack), and system events (MCP auth
-// resume) pass the assistant's creator.
 func (s *ServiceCore) MintThreadScopedRuntimeToken(assistant assistantRecord, threadID uuid.UUID, userID string) (string, error) {
 	token, err := s.assistantTokens.Generate(assistanttokens.GenerateInput{
 		OrgID:       assistant.OrganizationID,


### PR DESCRIPTION
## Summary

Follow-up to #3204. Dashboard turns now run under the **sender's** Gram user identity rather than the assistant's creator.

`MintThreadScopedRuntimeToken` takes an explicit `userID` instead of reading `assistant.CreatedByUserID`. `processEventTurn` extracts the sender from the dashboard event payload (already on the wire from `SendDashboardMessage`); other sources keep the existing creator behavior.

| Source | Token UserID | Why |
|---|---|---|
| Dashboard send | sender (from event payload) | Gram user is on the payload |
| Slack | creator | `slackEventPayload.UserID` is a Slack user id, not a Gram user; no mapping table |
| Cron / wake | creator | No human sender |
| MCP-auth resume | creator | System event, no sender |

## Why

In #3204 we added chat-ownership (`chats.user_id` + `CallerOwnsDashboardChat`) so user B can't inject into user A's *conversation*. But during a turn the runtime was still acting as the creator, which meant:

- MCP tool calls were attributed to the creator even when user B was the sender.
- Audit rows for any tool call surfaced the wrong actor.
- `assistant_mcp_auth_required` events minted AuthURLs bound to the creator's session — which is why the dashboard adapter currently tells the model NOT to render those URLs inline.

After this PR the auth URL corresponds to the actual viewer (since the JWT UserID IS the viewer), so the dashboard adapter can be relaxed back to inline-rendering in a follow-up.

## Scope notes

- No change to the revocation cache key in `assistanttokens.Manager` — the cache memoizes whether the (assistant, thread) is revoked, which is user-independent. Per-user tokens for the same (assistant, thread) all share the same revocation answer; cache stays correct.
- Runtime architecture confirmed safe: the runner is per-assistant but each thread has its own \`ConfiguredThread\` with its own \`TokenRegistry\` + MCP manager, and the JWT is delivered per-turn via the \`RunTurn\` body. MCP connections are per-thread, not per-assistant — so per-sender identity propagates through every outbound call on a turn without runtime changes.
- Bootstrap snapshot (\`BuildThreadBootstrap\`) is computed once per thread using the first turn's identity. Today nothing in the snapshot (history, instructions, toolset visibility) is user-scoped, so this is safe. The day a user-scoped RBAC gate gets added to a toolset, the snapshot will need to re-build on user switch — flagging as a future trap.

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dashboard turns now run under the sender’s Gram user identity, so MCP calls, audit rows, and auth URLs reflect the actual user. Non-interactive sources, Slack turns, and MCP-auth resumptions still use the creator identity. This supports AGE-2631 by ensuring the org assistant acts as the viewing user in the dashboard.

- **Refactors**
  - `MintThreadScopedRuntimeToken` now takes an explicit `userID` and mints per-sender tokens for dashboard turns.
  - `processEventTurn` selects the turn user via `turnUserID` from the dashboard event payload; other sources (Slack, cron/wake, MCP-auth resume) fall back to the creator.

<sup>Written for commit b473d9e159801296d03f2734ec262c2d6f506a39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

