### PR TITLE
fix: allow shadow mcp access requests from any org member

### DIFF
--- a/.changeset/shadow-mcp-requester-guard.md
+++ b/.changeset/shadow-mcp-requester-guard.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix shadow MCP access requests failing with a 403 ("different requester") when the request link was minted for an agent-reported identity that differs from the authenticated dashboard user (multi-domain orgs, duplicate accounts, or a shared block link). `access.shadowMcp.requests.create` no longer gates on the token's requester; org-match and project-membership checks remain, and approval stays org-admin gated.

--- a/server/internal/access/shadow_mcp.go
+++ b/server/internal/access/shadow_mcp.go
@@ -102,9 +102,15 @@ func (s *Service) CreateShadowMCPApprovalRequest(ctx context.Context, payload *g
 	if claims.OrganizationID != ac.ActiveOrganizationID {
 		return nil, oops.E(oops.CodeForbidden, nil, "shadow mcp approval request token is for a different organization").Log(ctx, s.logger)
 	}
-	if claims.RequesterUserID != "" && claims.RequesterUserID != ac.UserID {
-		return nil, oops.E(oops.CodeForbidden, nil, "shadow mcp approval request token is for a different requester").Log(ctx, s.logger)
-	}
+	// Intentionally not gated on claims.RequesterUserID. The token's requester
+	// is minted from an agent-reported identity (e.g. the email Claude Code
+	// reports, resolved via resolveUserByEmail), which legitimately differs
+	// from the authenticated dashboard user under multi-domain orgs, duplicate
+	// accounts, or a shared block link. Filing a request is low-stakes — the
+	// stored requester is always the authenticated user (RequesterUserID below),
+	// and approval is org-admin gated — so binding the token to a single
+	// requester only blocked legitimate members. Org membership is enforced via
+	// the org-match check above and requireProjectInOrganization below.
 	projectID, err := uuid.Parse(claims.ProjectID)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)

--- a/server/internal/access/shadow_mcp_test.go
+++ b/server/internal/access/shadow_mcp_test.go
@@ -64,6 +64,48 @@ func TestService_CreateShadowMCPApprovalRequest_Idempotent(t *testing.T) {
 	require.Equal(t, beforeCount+1, afterCount)
 }
 
+func TestService_CreateShadowMCPApprovalRequest_AcceptsDifferentRequester(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx := testAccessAuthContext(t, ctx)
+	project := createShadowMCPProject(t, ctx, ti, authCtx.ActiveOrganizationID)
+	fullURL := "https://linear.example.com/mcp"
+
+	// Token minted for a different requester than the authenticated user — the
+	// common real-world case (agent-reported email resolving to another user,
+	// or a shared block link). This must still succeed and record the
+	// authenticated user as the requester.
+	request, err := ti.service.CreateShadowMCPApprovalRequest(ctx, &gen.CreateShadowMCPApprovalRequestPayload{
+		RequestToken: shadowMCPRequestToken(t, authCtx.ActiveOrganizationID, "some-other-user", project.ID.String(), ShadowMCPApprovalRequestTokenInput{
+			ObservedName:    conv.PtrEmpty("Linear"),
+			ObservedFullURL: &fullURL,
+		}),
+	})
+	require.NoError(t, err)
+	require.Equal(t, shadowMCPRequestStatusRequested, request.Status)
+	require.Equal(t, authCtx.UserID, conv.PtrValOr(request.RequesterUserID, ""))
+}
+
+func TestService_CreateShadowMCPApprovalRequest_RejectsDifferentOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx := testAccessAuthContext(t, ctx)
+	project := createShadowMCPProject(t, ctx, ti, authCtx.ActiveOrganizationID)
+	fullURL := "https://linear.example.com/mcp"
+
+	_, err := ti.service.CreateShadowMCPApprovalRequest(ctx, &gen.CreateShadowMCPApprovalRequestPayload{
+		RequestToken: shadowMCPRequestToken(t, "another-org", authCtx.UserID, project.ID.String(), ShadowMCPApprovalRequestTokenInput{
+			ObservedName:    conv.PtrEmpty("Linear"),
+			ObservedFullURL: &fullURL,
+		}),
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
 func TestService_CreateShadowMCPApprovalRequest_RejectsInvalidToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Drop the per-requester guard in `CreateShadowMCPApprovalRequest` that returned a
403 (`shadow mcp approval request token is for a different requester`) whenever
the request token's `RequesterUserID` didn't equal the authenticated user.

## Why

The token's requester is minted in the hooks layer from an **agent-reported
identity** — e.g. the email Claude Code reports, resolved via
`resolveUserByEmail` (and on the plugin path it can even override the
authenticated `authCtx.UserID`). That identity legitimately differs from the
dashboard user under:

- **multi-domain orgs** (e.g. `@speakeasy.com` vs `@speakeasyapi.dev`),
- **duplicate / near-duplicate accounts**, or
- a **shared block link** opened by a teammate.

When it did, a blocked developer clicking "Request access" got a hard 403. The
guard also served no downstream purpose: the stored requester is always the
authenticated user (`RequesterUserID: ac.UserID`), and approval is org-admin
gated — so the check only blocked legitimate members.

Observed in prod (`access.shadowMcp.requests.create`, `shadow_mcp.go:106`) for
`speakeasy-team` during internal dogfooding.

## Change

- Remove the `claims.RequesterUserID != ac.UserID` check; keep the org-match
  check and `requireProjectInOrganization`. Cross-org tokens still 403.
- Add regression tests: different-requester (now accepted, stored requester is
  the auth user) and different-organization (still 403).

Approve / deny / list remain org-admin gated — unchanged.

## Test

- `mise build:server` ✅
- `go test ./internal/access -run CreateShadowMCPApprovalRequest` ✅
- `mise lint:server` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow any member of the active org to request Shadow MCP access, fixing false 403s when the token’s requester differs from the signed-in user. Org and project checks still apply.

- **Bug Fixes**
  - Removed the per-requester check in `CreateShadowMCPApprovalRequest`; kept org-match and `requireProjectInOrganization`.
  - Requests record the authenticated user as the requester; admin approval flow unchanged.
  - Added tests (different requester accepted; cross-org still 403) and a changeset to release a `server` patch.

<sup>Written for commit 9e6804d14c9c1f1ccdaa75db083d55607f56b6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

