### PR TITLE
feat(assistants): complete the managed assistant's observability catalog (cross-service tools)

### DIFF
--- a/.changeset/managed-assistant-management-tools.md
+++ b/.changeset/managed-assistant-management-tools.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Complete the managed assistant's observability catalog with the cross-service tools the old AI Insights copilot had: `get_deployment_logs` (deployments), `list_chats`/`load_chat` (chat), `list_organization_users` (organizations), and `list_risk_policies`/`list_risk_results_for_agent`/`list_risk_results_by_chat`/`get_risk_policy_status` (risk). Each wraps the existing management-service method and enforces that service's own authz against the calling user's grants — dashboard turns are sender-scoped, so e.g. the risk tools resolve only for org admins, exactly as the old copilot behaved. Granted only to the managed assistant's platform toolset.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -82,6 +82,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/otelforwarding"
 	"github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	platforminsights "github.com/speakeasy-api/gram/server/internal/platformtools/insights"
 	platformtoolsruntime "github.com/speakeasy-api/gram/server/internal/platformtools/runtime"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	"github.com/speakeasy-api/gram/server/internal/projects"
@@ -770,13 +771,33 @@ func newStartCommand() *cli.Command {
 
 			platformFeatureChecker := productFeatures.PlatformFeatureCheck
 
+			// Forward-declared so the managed-assistant observability tools (built
+			// just below) can hold lazy providers over them. These services are
+			// constructed later in startup, and chat in particular depends
+			// transitively on the platform toolset we're about to build — the
+			// providers are only invoked at tool-call time, long after startup has
+			// assigned them.
+			var (
+				deploymentsSvc   *deployments.Service
+				chatService      *chat.Service
+				organizationsSvc *organizations.Service
+				riskService      *risk.Service
+			)
+
 			memoryTools := platformtoolsruntime.MemoryExternalTools(memorySvc)
 			triggerTools := platformtoolsruntime.TriggerExternalTools(db, triggerApp, auditLogger)
 			managedLogsTools := platformtoolsruntime.ManagedAssistantLogsTools(telemSvc)
+			managedMgmtTools := platformtoolsruntime.ManagedAssistantManagementTools(platformtoolsruntime.ManagedAssistantServiceProviders{
+				Deployments:   func() platforminsights.DeploymentsService { return deploymentsSvc },
+				Chat:          func() platforminsights.ChatService { return chatService },
+				Organizations: func() platforminsights.OrganizationsService { return organizationsSvc },
+				Risk:          func() platforminsights.RiskService { return riskService },
+			})
+			managedObservabilityTools := append(append([]platformtools.ExternalTool{}, managedLogsTools...), managedMgmtTools...)
 			platformToolsets := platformtools.BuildToolsets(platformtools.ToolsetDependencies{
 				AssistantMemoryTools:     memoryTools,
 				AssistantTriggerTools:    triggerTools,
-				ManagedAssistantLogTools: managedLogsTools,
+				ManagedAssistantLogTools: managedObservabilityTools,
 			})
 			// Runner-callable platform tools the runtime must be able to execute
 			// (trigger tools are wired separately via WithTriggerTools).
@@ -861,7 +882,7 @@ func newStartCommand() *cli.Command {
 				mcpclient.NewInternalMCPClient(mcpService),
 			)
 			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
-			chatService := chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo)
+			chatService = chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo)
 			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger, contextWindowResolver)
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsCore.SetDashboardIngestor(triggerApp)
@@ -1015,7 +1036,8 @@ func newStartCommand() *cli.Command {
 				posthogClient,
 				cache.NewRedisCacheAdapter(redisClient),
 			))
-			organizations.Attach(mux, organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, serverURL.String(), siteURL.String(), auditLogger, svixClient))
+			organizationsSvc = organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, serverURL.String(), siteURL.String(), auditLogger, svixClient)
+			organizations.Attach(mux, organizationsSvc)
 			projects.Attach(mux, projects.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			packages.Attach(mux, packages.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 
@@ -1040,7 +1062,8 @@ func newStartCommand() *cli.Command {
 			integrations.Attach(mux, integrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			templates.Attach(mux, templates.NewService(logger, tracerProvider, db, sessionManager, toolsetsSvc, authzEngine, auditLogger))
 			assets.Attach(mux, assets.NewService(logger, tracerProvider, guardianPolicy, db, sessionManager, chatSessionsManager, assetStorage, c.String(usersessions.JWTSigningKeyFlag), authzEngine, auditLogger))
-			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger))
+			deploymentsSvc = deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger)
+			deployments.Attach(mux, deploymentsSvc)
 			keys.Attach(mux, keys.NewService(logger, tracerProvider, db, sessionManager, c.String("environment"), authzEngine, auditLogger))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))
 			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, auditLogger))
@@ -1073,7 +1096,7 @@ func newStartCommand() *cli.Command {
 				logger,
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
-			riskService := risk.NewService(logger, tracerProvider, db, sessionManager, authzEngine, riskSignaler, completionsClient, shadowMCPClient, accessStore, auditLogger, c.String("pi-classifier-url") != "", hookPIIScanner, hookPIScanner)
+			riskService = risk.NewService(logger, tracerProvider, db, sessionManager, authzEngine, riskSignaler, completionsClient, shadowMCPClient, accessStore, auditLogger, c.String("pi-classifier-url") != "", hookPIIScanner, hookPIScanner)
 			chatWriter.AddObserver(riskService)
 			risk.Attach(mux, riskService)
 

--- a/server/internal/platformtools/insights/shared.go
+++ b/server/internal/platformtools/insights/shared.go
@@ -1,0 +1,88 @@
+// Package insights provides the managed assistant's observability tools that are
+// backed by management services other than telemetry (deployments, chat,
+// organizations, risk) — restoring the rest of the catalog the old client-side
+// AI Insights copilot had. Telemetry-backed tools live in the sibling logs
+// package.
+//
+// Each tool wraps a management-service method and passes nil auth tokens: the
+// assistant runtime supplies the project/org/user context (and, for dashboard
+// turns, the sending user's grants), so every wrapped method's own authz check
+// self-enforces per user. Services are injected as providers (func() Service)
+// rather than values because the managed-assistant toolset is built early at
+// startup — before chat (and friends) are constructed — to avoid a
+// toolset → mcpService → chatService → toolset construction cycle.
+package insights
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/chat"
+	"github.com/speakeasy-api/gram/server/gen/deployments"
+	"github.com/speakeasy-api/gram/server/gen/organizations"
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+type DeploymentsService interface {
+	GetDeploymentLogs(ctx context.Context, payload *deployments.GetDeploymentLogsPayload) (*deployments.GetDeploymentLogsResult, error)
+}
+
+type ChatService interface {
+	ListChats(ctx context.Context, payload *chat.ListChatsPayload) (*chat.ListChatsResult, error)
+	LoadChat(ctx context.Context, payload *chat.LoadChatPayload) (*chat.Chat, error)
+}
+
+type OrganizationsService interface {
+	ListUsers(ctx context.Context, payload *organizations.ListUsersPayload) (*organizations.ListUsersResult, error)
+}
+
+type RiskService interface {
+	ListRiskPolicies(ctx context.Context, payload *risk.ListRiskPoliciesPayload) (*risk.ListRiskPoliciesResult, error)
+	ListRiskResultsForAgent(ctx context.Context, payload *risk.ListRiskResultsForAgentPayload) (*risk.ListRiskResultsForAgentResult, error)
+	ListRiskResultsByChat(ctx context.Context, payload *risk.ListRiskResultsByChatPayload) (*risk.ListRiskResultsByChatResult, error)
+	GetRiskPolicyStatus(ctx context.Context, payload *risk.GetRiskPolicyStatusPayload) (*types.RiskPolicyStatus, error)
+}
+
+// readOnlyToolAnnotations is the annotation set shared by every tool here: safe
+// to call, non-destructive, idempotent, and closed-world.
+func readOnlyToolAnnotations() *types.ToolAnnotations {
+	readOnly := true
+	destructive := false
+	idempotent := true
+	openWorld := false
+	return &types.ToolAnnotations{
+		Title:           nil,
+		ReadOnlyHint:    &readOnly,
+		DestructiveHint: &destructive,
+		IdempotentHint:  &idempotent,
+		OpenWorldHint:   &openWorld,
+	}
+}
+
+// decodeToolInput reads a tool's JSON request body into dst, tolerating an empty
+// body so callers can rely on the defaults they pre-populate dst with.
+func decodeToolInput(payload io.Reader, dst any) error {
+	body, err := io.ReadAll(payload)
+	if err != nil {
+		return fmt.Errorf("read request body: %w", err)
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, dst); err != nil {
+		return fmt.Errorf("decode request body: %w", err)
+	}
+	return nil
+}
+
+// encodeToolResult writes a result as JSON. Results flow through an `any`, so
+// musttag can't (and doesn't need to) inspect the Goa-generated result types.
+func encodeToolResult(wr io.Writer, result any) error {
+	if err := json.NewEncoder(wr).Encode(result); err != nil {
+		return fmt.Errorf("encode response: %w", err)
+	}
+	return nil
+}

--- a/server/internal/platformtools/insights/tool_get_deployment_logs.go
+++ b/server/internal/platformtools/insights/tool_get_deployment_logs.go
@@ -1,0 +1,67 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/deployments"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type GetDeploymentLogs struct {
+	provider func() DeploymentsService
+}
+
+type getDeploymentLogsInput struct {
+	DeploymentID string  `json:"deployment_id" jsonschema:"The ID of the deployment to fetch logs for."`
+	Cursor       *string `json:"cursor,omitempty" jsonschema:"Cursor for pagination."`
+}
+
+func NewGetDeploymentLogsTool(provider func() DeploymentsService) *GetDeploymentLogs {
+	return &GetDeploymentLogs{provider: provider}
+}
+
+func (s *GetDeploymentLogs) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "insights",
+		HandlerName: "get_deployment_logs",
+		Name:        "platform_get_deployment_logs",
+		Description: "Fetch build/processing logs for a deployment in the current project. Requires a deployment ID.",
+		InputSchema: core.BuildInputSchema[getDeploymentLogsInput](),
+		Variables:   nil,
+		Annotations: readOnlyToolAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *GetDeploymentLogs) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	svc := s.provider()
+	if svc == nil {
+		return fmt.Errorf("deployments service not configured")
+	}
+
+	input := getDeploymentLogsInput{DeploymentID: "", Cursor: nil}
+	if err := decodeToolInput(payload, &input); err != nil {
+		return err
+	}
+	if input.DeploymentID == "" {
+		return fmt.Errorf("deployment_id is required")
+	}
+
+	result, err := svc.GetDeploymentLogs(ctx, &deployments.GetDeploymentLogsPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		DeploymentID:     input.DeploymentID,
+		Cursor:           input.Cursor,
+	})
+	if err != nil {
+		return fmt.Errorf("get deployment logs: %w", err)
+	}
+
+	return encodeToolResult(wr, result)
+}

--- a/server/internal/platformtools/insights/tool_get_risk_policy_status.go
+++ b/server/internal/platformtools/insights/tool_get_risk_policy_status.go
@@ -1,0 +1,65 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type GetRiskPolicyStatus struct {
+	provider func() RiskService
+}
+
+type getRiskPolicyStatusInput struct {
+	ID string `json:"id" jsonschema:"The risk policy ID to get analysis status for."`
+}
+
+func NewGetRiskPolicyStatusTool(provider func() RiskService) *GetRiskPolicyStatus {
+	return &GetRiskPolicyStatus{provider: provider}
+}
+
+func (s *GetRiskPolicyStatus) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "insights",
+		HandlerName: "get_risk_policy_status",
+		Name:        "platform_get_risk_policy_status",
+		Description: "Get the analysis progress (pending vs analyzed counts, workflow state) for a risk policy. Requires organization admin access.",
+		InputSchema: core.BuildInputSchema[getRiskPolicyStatusInput](),
+		Variables:   nil,
+		Annotations: readOnlyToolAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *GetRiskPolicyStatus) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	svc := s.provider()
+	if svc == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	input := getRiskPolicyStatusInput{ID: ""}
+	if err := decodeToolInput(payload, &input); err != nil {
+		return err
+	}
+	if input.ID == "" {
+		return fmt.Errorf("id is required")
+	}
+
+	result, err := svc.GetRiskPolicyStatus(ctx, &risk.GetRiskPolicyStatusPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		ID:               input.ID,
+	})
+	if err != nil {
+		return fmt.Errorf("get risk policy status: %w", err)
+	}
+
+	return encodeToolResult(wr, result)
+}

--- a/server/internal/platformtools/insights/tool_list_chats.go
+++ b/server/internal/platformtools/insights/tool_list_chats.go
@@ -1,0 +1,109 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/chat"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type ListChats struct {
+	provider func() ChatService
+}
+
+type listChatsInput struct {
+	Search         *string `json:"search,omitempty" jsonschema:"Search query (matches chat ID, user ID, and title)."`
+	ExternalUserID *string `json:"external_user_id,omitempty" jsonschema:"Filter by external user ID."`
+	AssistantID    *string `json:"assistant_id,omitempty" jsonschema:"Filter to chats produced by this assistant."`
+	HasRisk        *string `json:"has_risk,omitempty" jsonschema:"Filter by whether the chat has risk findings: 'true', 'false', or omit for no filter."`
+	From           *string `json:"from,omitempty" jsonschema:"Only chats created after this ISO 8601 timestamp."`
+	To             *string `json:"to,omitempty" jsonschema:"Only chats created before this ISO 8601 timestamp."`
+	Limit          int     `json:"limit,omitempty" jsonschema:"Number of results per page."`
+	Offset         int     `json:"offset,omitempty" jsonschema:"Pagination offset."`
+	SortBy         string  `json:"sort_by,omitempty" jsonschema:"Field to sort by."`
+	SortOrder      string  `json:"sort_order,omitempty" jsonschema:"Sort order."`
+}
+
+func NewListChatsTool(provider func() ChatService) *ListChats {
+	return &ListChats{provider: provider}
+}
+
+func (s *ListChats) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "insights",
+		HandlerName: "list_chats",
+		Name:        "platform_list_chats",
+		Description: "List agent/assistant chat conversations in the current project, with optional search and filters.",
+		InputSchema: core.BuildInputSchema[listChatsInput](
+			core.WithPropertyEnum("has_risk", "", "true", "false"),
+			core.WithPropertyEnum("sort_by", "created_at", "num_messages"),
+			core.WithPropertyEnum("sort_order", "asc", "desc"),
+			core.WithPropertyFormat("from", "date-time"),
+			core.WithPropertyFormat("to", "date-time"),
+			core.WithPropertyNumberRange("limit", 1, 100),
+		),
+		Variables:   nil,
+		Annotations: readOnlyToolAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *ListChats) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	svc := s.provider()
+	if svc == nil {
+		return fmt.Errorf("chat service not configured")
+	}
+
+	// Defaults mirror the telemetry/chat Goa transport defaults that direct
+	// service calls bypass.
+	input := listChatsInput{
+		Search:         nil,
+		ExternalUserID: nil,
+		AssistantID:    nil,
+		HasRisk:        nil,
+		From:           nil,
+		To:             nil,
+		Limit:          50,
+		Offset:         0,
+		SortBy:         "created_at",
+		SortOrder:      "desc",
+	}
+	if err := decodeToolInput(payload, &input); err != nil {
+		return err
+	}
+	if input.Limit == 0 {
+		input.Limit = 50
+	}
+	if input.SortBy == "" {
+		input.SortBy = "created_at"
+	}
+	if input.SortOrder == "" {
+		input.SortOrder = "desc"
+	}
+
+	result, err := svc.ListChats(ctx, &chat.ListChatsPayload{
+		SessionToken:      nil,
+		ProjectSlugInput:  nil,
+		ChatSessionsToken: nil,
+		Search:            input.Search,
+		ExternalUserID:    input.ExternalUserID,
+		AssistantID:       input.AssistantID,
+		HasRisk:           input.HasRisk,
+		From:              input.From,
+		To:                input.To,
+		Limit:             input.Limit,
+		Offset:            input.Offset,
+		SortBy:            input.SortBy,
+		SortOrder:         input.SortOrder,
+	})
+	if err != nil {
+		return fmt.Errorf("list chats: %w", err)
+	}
+
+	return encodeToolResult(wr, result)
+}

--- a/server/internal/platformtools/insights/tool_list_organization_users.go
+++ b/server/internal/platformtools/insights/tool_list_organization_users.go
@@ -1,0 +1,50 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/organizations"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type ListOrganizationUsers struct {
+	provider func() OrganizationsService
+}
+
+type listOrganizationUsersInput struct{}
+
+func NewListOrganizationUsersTool(provider func() OrganizationsService) *ListOrganizationUsers {
+	return &ListOrganizationUsers{provider: provider}
+}
+
+func (s *ListOrganizationUsers) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "insights",
+		HandlerName: "list_organization_users",
+		Name:        "platform_list_organization_users",
+		Description: "List the members (users) of the current organization. Requires organization read access.",
+		InputSchema: core.BuildInputSchema[listOrganizationUsersInput](),
+		Variables:   nil,
+		Annotations: readOnlyToolAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *ListOrganizationUsers) Call(ctx context.Context, _ toolconfig.ToolCallEnv, _ io.Reader, wr io.Writer) error {
+	svc := s.provider()
+	if svc == nil {
+		return fmt.Errorf("organizations service not configured")
+	}
+
+	result, err := svc.ListUsers(ctx, &organizations.ListUsersPayload{SessionToken: nil})
+	if err != nil {
+		return fmt.Errorf("list organization users: %w", err)
+	}
+
+	return encodeToolResult(wr, result)
+}

--- a/server/internal/platformtools/insights/tool_list_risk_policies.go
+++ b/server/internal/platformtools/insights/tool_list_risk_policies.go
@@ -1,0 +1,54 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type ListRiskPolicies struct {
+	provider func() RiskService
+}
+
+type listRiskPoliciesInput struct{}
+
+func NewListRiskPoliciesTool(provider func() RiskService) *ListRiskPolicies {
+	return &ListRiskPolicies{provider: provider}
+}
+
+func (s *ListRiskPolicies) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "insights",
+		HandlerName: "list_risk_policies",
+		Name:        "platform_list_risk_policies",
+		Description: "List the risk/safety policies configured for the current project. Requires organization admin access.",
+		InputSchema: core.BuildInputSchema[listRiskPoliciesInput](),
+		Variables:   nil,
+		Annotations: readOnlyToolAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *ListRiskPolicies) Call(ctx context.Context, _ toolconfig.ToolCallEnv, _ io.Reader, wr io.Writer) error {
+	svc := s.provider()
+	if svc == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	result, err := svc.ListRiskPolicies(ctx, &risk.ListRiskPoliciesPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("list risk policies: %w", err)
+	}
+
+	return encodeToolResult(wr, result)
+}

--- a/server/internal/platformtools/insights/tool_list_risk_results_by_chat.go
+++ b/server/internal/platformtools/insights/tool_list_risk_results_by_chat.go
@@ -1,0 +1,64 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type ListRiskResultsByChat struct {
+	provider func() RiskService
+}
+
+type listRiskResultsByChatInput struct {
+	Cursor *string `json:"cursor,omitempty" jsonschema:"Cursor for pagination."`
+	Limit  *int    `json:"limit,omitempty" jsonschema:"Maximum number of results per page."`
+}
+
+func NewListRiskResultsByChatTool(provider func() RiskService) *ListRiskResultsByChat {
+	return &ListRiskResultsByChat{provider: provider}
+}
+
+func (s *ListRiskResultsByChat) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "insights",
+		HandlerName: "list_risk_results_by_chat",
+		Name:        "platform_list_risk_results_by_chat",
+		Description: "List per-chat risk rollups (findings count and latest detection) across the project. Requires organization admin access.",
+		InputSchema: core.BuildInputSchema[listRiskResultsByChatInput](),
+		Variables:   nil,
+		Annotations: readOnlyToolAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *ListRiskResultsByChat) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	svc := s.provider()
+	if svc == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	input := listRiskResultsByChatInput{Cursor: nil, Limit: nil}
+	if err := decodeToolInput(payload, &input); err != nil {
+		return err
+	}
+
+	result, err := svc.ListRiskResultsByChat(ctx, &risk.ListRiskResultsByChatPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Cursor:           input.Cursor,
+		Limit:            input.Limit,
+	})
+	if err != nil {
+		return fmt.Errorf("list risk results by chat: %w", err)
+	}
+
+	return encodeToolResult(wr, result)
+}

--- a/server/internal/platformtools/insights/tool_list_risk_results_for_agent.go
+++ b/server/internal/platformtools/insights/tool_list_risk_results_for_agent.go
@@ -1,0 +1,94 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type ListRiskResultsForAgent struct {
+	provider func() RiskService
+}
+
+type listRiskResultsForAgentInput struct {
+	PolicyID    *string `json:"policy_id,omitempty" jsonschema:"Optional policy ID to filter by."`
+	ChatID      *string `json:"chat_id,omitempty" jsonschema:"Optional chat ID to filter by."`
+	Category    *string `json:"category,omitempty" jsonschema:"Optional rule category key to filter by (e.g. secrets, pii, financial)."`
+	RuleID      *string `json:"rule_id,omitempty" jsonschema:"Optional rule identifier substring to filter by (case-insensitive)."`
+	UserID      *string `json:"user_id,omitempty" jsonschema:"Optional user identifier substring (matched against the chat's external user id)."`
+	UniqueMatch *bool   `json:"unique_match,omitempty" jsonschema:"Collapse results to one row per (policy_id, rule_id, match), keeping the most recent occurrence."`
+	From        *string `json:"from,omitempty" jsonschema:"Only findings on messages created at or after this ISO 8601 timestamp."`
+	To          *string `json:"to,omitempty" jsonschema:"Only findings on messages created strictly before this ISO 8601 timestamp."`
+	Cursor      *string `json:"cursor,omitempty" jsonschema:"Cursor for pagination."`
+	Limit       *int    `json:"limit,omitempty" jsonschema:"Maximum number of results per page."`
+}
+
+func NewListRiskResultsForAgentTool(provider func() RiskService) *ListRiskResultsForAgent {
+	return &ListRiskResultsForAgent{provider: provider}
+}
+
+func (s *ListRiskResultsForAgent) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "insights",
+		HandlerName: "list_risk_results_for_agent",
+		Name:        "platform_list_risk_results_for_agent",
+		Description: "List individual risk/safety findings (secrets, PII, prompt injection, etc.) detected across the project's chats. Match values are redacted. Requires organization admin access.",
+		InputSchema: core.BuildInputSchema[listRiskResultsForAgentInput](
+			core.WithPropertyFormat("from", "date-time"),
+			core.WithPropertyFormat("to", "date-time"),
+		),
+		Variables:   nil,
+		Annotations: readOnlyToolAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *ListRiskResultsForAgent) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	svc := s.provider()
+	if svc == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	input := listRiskResultsForAgentInput{
+		PolicyID:    nil,
+		ChatID:      nil,
+		Category:    nil,
+		RuleID:      nil,
+		UserID:      nil,
+		UniqueMatch: nil,
+		From:        nil,
+		To:          nil,
+		Cursor:      nil,
+		Limit:       nil,
+	}
+	if err := decodeToolInput(payload, &input); err != nil {
+		return err
+	}
+
+	result, err := svc.ListRiskResultsForAgent(ctx, &risk.ListRiskResultsForAgentPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		PolicyID:         input.PolicyID,
+		ChatID:           input.ChatID,
+		Category:         input.Category,
+		RuleID:           input.RuleID,
+		UserID:           input.UserID,
+		UniqueMatch:      input.UniqueMatch,
+		From:             input.From,
+		To:               input.To,
+		Cursor:           input.Cursor,
+		Limit:            input.Limit,
+	})
+	if err != nil {
+		return fmt.Errorf("list risk results for agent: %w", err)
+	}
+
+	return encodeToolResult(wr, result)
+}

--- a/server/internal/platformtools/insights/tool_load_chat.go
+++ b/server/internal/platformtools/insights/tool_load_chat.go
@@ -1,0 +1,69 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/chat"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type LoadChat struct {
+	provider func() ChatService
+}
+
+type loadChatInput struct {
+	ID         string `json:"id" jsonschema:"The ID of the chat to load."`
+	Generation *int   `json:"generation,omitempty" jsonschema:"Transcript generation to load (0 = oldest). Omit for the latest generation."`
+}
+
+func NewLoadChatTool(provider func() ChatService) *LoadChat {
+	return &LoadChat{provider: provider}
+}
+
+func (s *LoadChat) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "insights",
+		HandlerName: "load_chat",
+		Name:        "platform_load_chat",
+		Description: "Load a single chat conversation's transcript by its ID. Use list_chats to discover chat IDs first.",
+		InputSchema: core.BuildInputSchema[loadChatInput](
+			core.WithPropertyNumberRange("generation", 0, 100000),
+		),
+		Variables:   nil,
+		Annotations: readOnlyToolAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *LoadChat) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	svc := s.provider()
+	if svc == nil {
+		return fmt.Errorf("chat service not configured")
+	}
+
+	input := loadChatInput{ID: "", Generation: nil}
+	if err := decodeToolInput(payload, &input); err != nil {
+		return err
+	}
+	if input.ID == "" {
+		return fmt.Errorf("id is required")
+	}
+
+	result, err := svc.LoadChat(ctx, &chat.LoadChatPayload{
+		SessionToken:      nil,
+		ProjectSlugInput:  nil,
+		ChatSessionsToken: nil,
+		ID:                input.ID,
+		Generation:        input.Generation,
+	})
+	if err != nil {
+		return fmt.Errorf("load chat: %w", err)
+	}
+
+	return encodeToolResult(wr, result)
+}

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/memory"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	platforminsights "github.com/speakeasy-api/gram/server/internal/platformtools/insights"
 	platformlogs "github.com/speakeasy-api/gram/server/internal/platformtools/logs"
 	platformmemory "github.com/speakeasy-api/gram/server/internal/platformtools/memory"
 	platformtriggers "github.com/speakeasy-api/gram/server/internal/platformtools/triggers"
@@ -139,6 +140,38 @@ func ManagedAssistantLogsTools(telemetrySvc platformtools.TelemetryService) []pl
 		{Executor: platformlogs.NewGetUserMetricsSummaryTool(telemetrySvc), RequiredFeature: ""},
 		{Executor: platformlogs.NewGetObservabilityOverviewTool(telemetrySvc), RequiredFeature: ""},
 		{Executor: platformlogs.NewListAttributeKeysTool(telemetrySvc), RequiredFeature: ""},
+	}
+}
+
+// ManagedAssistantServiceProviders supplies the management services that back
+// the managed assistant's non-telemetry observability tools. They are providers
+// (func() Service) rather than values because the managed-assistant toolset is
+// built early at startup — before some of these services exist — to avoid a
+// toolset → mcpService → chatService → toolset construction cycle. Each provider
+// is invoked lazily at tool-call time, by which point startup has populated it.
+type ManagedAssistantServiceProviders struct {
+	Deployments   func() platforminsights.DeploymentsService
+	Chat          func() platforminsights.ChatService
+	Organizations func() platforminsights.OrganizationsService
+	Risk          func() platforminsights.RiskService
+}
+
+// ManagedAssistantManagementTools returns the managed assistant's observability
+// tools that are backed by management services other than telemetry —
+// deployments, chats, organization users, and risk — completing the catalog the
+// old client-side AI Insights copilot exposed. Each wrapped method enforces its
+// own authz against the calling user's grants (dashboard turns are sender-
+// scoped), so e.g. the risk tools resolve only for org admins.
+func ManagedAssistantManagementTools(p ManagedAssistantServiceProviders) []platformtools.ExternalTool {
+	return []platformtools.ExternalTool{
+		{Executor: platforminsights.NewGetDeploymentLogsTool(p.Deployments), RequiredFeature: ""},
+		{Executor: platforminsights.NewListChatsTool(p.Chat), RequiredFeature: ""},
+		{Executor: platforminsights.NewLoadChatTool(p.Chat), RequiredFeature: ""},
+		{Executor: platforminsights.NewListOrganizationUsersTool(p.Organizations), RequiredFeature: ""},
+		{Executor: platforminsights.NewListRiskPoliciesTool(p.Risk), RequiredFeature: ""},
+		{Executor: platforminsights.NewListRiskResultsForAgentTool(p.Risk), RequiredFeature: ""},
+		{Executor: platforminsights.NewListRiskResultsByChatTool(p.Risk), RequiredFeature: ""},
+		{Executor: platforminsights.NewGetRiskPolicyStatusTool(p.Risk), RequiredFeature: ""},
 	}
 }
 

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
+	platforminsights "github.com/speakeasy-api/gram/server/internal/platformtools/insights"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -41,6 +42,35 @@ func TestManagedAssistantLogsToolsExposesObservabilityCatalog(t *testing.T) {
 		"platform_get_user_metrics_summary",
 		"platform_get_observability_overview",
 		"platform_list_attribute_keys",
+	}, got)
+}
+
+// The management-service-backed half of the catalog (deployments, chats, org
+// users, risk). Same regression guard for the cross-service tools.
+func TestManagedAssistantManagementToolsExposesCatalog(t *testing.T) {
+	t.Parallel()
+
+	tools := ManagedAssistantManagementTools(ManagedAssistantServiceProviders{
+		Deployments:   func() platforminsights.DeploymentsService { return nil },
+		Chat:          func() platforminsights.ChatService { return nil },
+		Organizations: func() platforminsights.OrganizationsService { return nil },
+		Risk:          func() platforminsights.RiskService { return nil },
+	})
+
+	got := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		got = append(got, tool.Executor.Descriptor().Name)
+	}
+
+	require.ElementsMatch(t, []string{
+		"platform_get_deployment_logs",
+		"platform_list_chats",
+		"platform_load_chat",
+		"platform_list_organization_users",
+		"platform_list_risk_policies",
+		"platform_list_risk_results_for_agent",
+		"platform_list_risk_results_by_chat",
+		"platform_get_risk_policy_status",
 	}, got)
 }
 


### PR DESCRIPTION
## What

**Tier 2** of the managed-assistant tool-gap fix. Stacked on #3218 (the telemetry tools). Together they fully restore the catalog the old client-side AI Insights copilot had.

Adds the **management-service-backed** tools:

| Tool | Service | Scope it enforces |
|---|---|---|
| `get_deployment_logs` | deployments | `ProjectRead` |
| `list_chats`, `load_chat` | chat | project + user-scoped |
| `list_organization_users` | organizations | `OrgRead` |
| `list_risk_policies`, `list_risk_results_for_agent`, `list_risk_results_by_chat`, `get_risk_policy_status` | risk | `OrgAdmin` |

New `server/internal/platformtools/insights` package wraps each method with nil auth tokens.

## Why this is safe (no privilege escalation)

Dashboard turns are **sender-scoped** (#3216): the runtime token resolves to the *calling user's* grants (`assistanttokens` → `users.GetUser(claims.UserID)` → `authz.PrepareContext`). So each wrapped method's existing `authz.Require` self-enforces against the user — the risk tools resolve **only for org admins**, org users only for org readers, and a non-privileged member's sidebar gets a clean `Forbidden` the model explains. This matches how the old copilot behaved (it ran as the user). No tool widens the assistant's own authority.

## The wiring problem this solves

The managed-assistant toolset is built early at startup, but `chat` depends transitively on it: **toolset → mcpService → chatClient → chatService → (chat tools) → toolset**. Rather than reorder production startup, the 4 services are **forward-declared and injected as lazy providers** (`func() Service`) resolved at *tool-call* time — long after startup has assigned them. No startup reordering; the cycle never materializes.

## Verification

- `mise build:server`, `mise lint:server` — clean.
- `mise test:server ./internal/platformtools/... ./internal/mcp/... ./internal/assistants/...` — 408 tests pass, incl. a new regression test (`TestManagedAssistantManagementToolsExposesCatalog`).

## Note

The risk tools expose risk/policy analysis through the sidebar (gated to admin senders by authz). This is a new surface even though it's authorization-equivalent to the old AI Insights — flagging for explicit review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the managed assistant’s observability catalog by adding cross-service tools for deployments, chat, org users, and risk, matching the old AI Insights sidebar. Supports AGE-2631; tools execute under the caller’s grants (sender‑scoped), so existing service authz applies and risk tools stay admin‑only.

- New Features
  - Added tools: `get_deployment_logs` (deployments); `list_chats`, `load_chat` (chat); `list_organization_users` (organizations); `list_risk_policies`, `list_risk_results_for_agent`, `list_risk_results_by_chat`, `get_risk_policy_status` (risk).
  - New package `server/internal/platformtools/insights` with read-only wrappers; exposed via `ManagedAssistantManagementTools` and merged with telemetry tools in the managed toolset; regression test guards catalog exposure.

- Refactors
  - Injected services as lazy providers (`func() Service`) to avoid the toolset ↔ chat startup cycle; forward-declared and wired in `server/cmd/gram/start.go` and `server/internal/platformtools/runtime`.

<sup>Written for commit 36330ac9aabc4caf5c300174c47f25e9631df9ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

