### PR TITLE
chore: Remove references to rolled out gram-user-session-management feature flag

### DIFF
--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -65,16 +65,12 @@ export default function MCPServerDetails() {
   const isRemoteMcpEnabled =
     telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
   const isRbacEnabled = telemetry.isFeatureEnabled("gram-rbac") ?? false;
-  const isUserSessionManagementEnabled =
-    telemetry.isFeatureEnabled("gram-user-session-management") ?? false;
   const idOrSlug = mcpServerSlug ?? "";
 
   const [activeTab, setActiveTab] = useState<TabValue>(() => {
     const hash = window.location.hash.replace("#", "");
     if (!isValidTab(hash)) return "overview";
     if (hash === "team-access" && !isRbacEnabled) return "overview";
-    if (hash === "authentication" && !isUserSessionManagementEnabled)
-      return "overview";
     return hash;
   });
 
@@ -142,11 +138,9 @@ export default function MCPServerDetails() {
                   Endpoints
                   {endpoints.length > 0 && ` (${endpoints.length})`}
                 </PageTabsTrigger>
-                {isUserSessionManagementEnabled && (
-                  <PageTabsTrigger value="authentication">
-                    Authentication
-                  </PageTabsTrigger>
-                )}
+                <PageTabsTrigger value="authentication">
+                  Authentication
+                </PageTabsTrigger>
                 {isRbacEnabled && (
                   <PageTabsTrigger value="team-access">
                     Team Access
@@ -166,7 +160,6 @@ export default function MCPServerDetails() {
               endpoints={endpoints}
               isLoadingEndpoints={isLoadingEndpoints}
               onShowEndpoints={() => handleTabChange("endpoints")}
-              showAuthentication={isUserSessionManagementEnabled}
               onShowAuthentication={() => handleTabChange("authentication")}
             />
           </TabsContent>
@@ -184,7 +177,7 @@ export default function MCPServerDetails() {
             )}
           </TabsContent>
 
-          {isUserSessionManagementEnabled && mcpServer && (
+          {mcpServer && (
             <TabsContent
               value="authentication"
               className="mt-0 min-h-0 flex-1 overflow-y-auto"

--- a/client/dashboard/src/pages/mcp/x/tabs/OverviewTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/OverviewTab.tsx
@@ -40,14 +40,12 @@ export function OverviewTab({
   endpoints,
   isLoadingEndpoints,
   onShowEndpoints,
-  showAuthentication,
   onShowAuthentication,
 }: {
   mcpServer: McpServer | undefined;
   endpoints: McpEndpoint[];
   isLoadingEndpoints: boolean;
   onShowEndpoints: () => void;
-  showAuthentication: boolean;
   onShowAuthentication: () => void;
 }) {
   return (
@@ -60,7 +58,7 @@ export function OverviewTab({
           onShowEndpoints={onShowEndpoints}
         />
       ) : null}
-      {showAuthentication && mcpServer && (
+      {mcpServer && (
         <AuthenticationOverviewSection
           mcpServer={mcpServer}
           onNavigate={onShowAuthentication}


### PR DESCRIPTION
Cleaning up the now unnecessary feature flag check code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `gram-user-session-management` flag checks so the Authentication tab and overview are always available when an MCP server exists. This simplifies tab initialization and navigation.

- **Refactors**
  - Removed `isUserSessionManagementEnabled` and related conditional rendering in `MCPServerDetails`.
  - Dropped `showAuthentication` prop from `OverviewTab`; render `AuthenticationOverviewSection` when `mcpServer` is present.
  - Allow `#authentication` to set the active tab without flag gating.

<sup>Written for commit 8d093d66ff9346c7c82cf81f646e10e397ea42f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

