### PR TITLE
fix(assistants): shrink platform MCP server IDs to fit 64-char tool name cap

### DIFF
--- a/server/internal/assistants/resolve_mcp_servers_test.go
+++ b/server/internal/assistants/resolve_mcp_servers_test.go
@@ -21,7 +21,7 @@ func TestResolveAssistantMCPServers_EmptyUserToolsetsStillGetsPlatformServer(t *
 	servers := resolveAssistantMCPServers(context.Background(), testenv.NewLogger(t), serverURL, nil, []string{platformtools.AssistantsPlatformToolsetSlug})
 	require.Len(t, servers, 1)
 
-	require.Equal(t, "_"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
+	require.Equal(t, "_p-"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
 	require.Equal(t,
 		"https://gram.test/platform/mcp/"+platformtools.AssistantsPlatformToolsetSlug,
 		servers[0].URL,
@@ -51,7 +51,7 @@ func TestResolveAssistantMCPServers_UserToolsetsListedBeforePlatformServer(t *te
 	require.Equal(t, "https://gram.test/mcp/billing-mcp", servers[0].URL)
 	require.Equal(t, "prod", servers[0].Headers["Gram-Environment"])
 
-	require.Equal(t, "_"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
+	require.Equal(t, "_p-"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
 	require.Equal(t,
 		"https://gram.test/platform/mcp/"+platformtools.AssistantsPlatformToolsetSlug,
 		servers[1].URL,
@@ -92,7 +92,7 @@ func TestResolveAssistantMCPServers_MisconfiguredToolsetIsOmitted(t *testing.T) 
 	require.Equal(t, "billing", servers[0].ID)
 	require.Equal(t, "https://gram.test/mcp/billing-mcp", servers[0].URL)
 
-	require.Equal(t, "_"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
+	require.Equal(t, "_p-"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
 }
 
 // The managed assistant is granted the managed-assistant platform toolset (the
@@ -110,8 +110,8 @@ func TestResolveAssistantMCPServers_GrantsEachRequestedPlatformToolset(t *testin
 		platformtools.ManagedAssistantPlatformToolsetSlug,
 	})
 	require.Len(t, servers, 2)
-	require.Equal(t, "_"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
-	require.Equal(t, "_"+platformtools.ManagedAssistantPlatformToolsetSlug, servers[1].ID)
+	require.Equal(t, "_p-"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
+	require.Equal(t, "_p-"+platformtools.ManagedAssistantPlatformToolsetSlug, servers[1].ID)
 	require.Equal(t,
 		"https://gram.test/platform/mcp/"+platformtools.ManagedAssistantPlatformToolsetSlug,
 		servers[1].URL,

--- a/server/internal/assistants/resolve_mcp_servers_test.go
+++ b/server/internal/assistants/resolve_mcp_servers_test.go
@@ -21,7 +21,7 @@ func TestResolveAssistantMCPServers_EmptyUserToolsetsStillGetsPlatformServer(t *
 	servers := resolveAssistantMCPServers(context.Background(), testenv.NewLogger(t), serverURL, nil, []string{platformtools.AssistantsPlatformToolsetSlug})
 	require.Len(t, servers, 1)
 
-	require.Equal(t, "_platform-"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
+	require.Equal(t, "_"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
 	require.Equal(t,
 		"https://gram.test/platform/mcp/"+platformtools.AssistantsPlatformToolsetSlug,
 		servers[0].URL,
@@ -51,7 +51,7 @@ func TestResolveAssistantMCPServers_UserToolsetsListedBeforePlatformServer(t *te
 	require.Equal(t, "https://gram.test/mcp/billing-mcp", servers[0].URL)
 	require.Equal(t, "prod", servers[0].Headers["Gram-Environment"])
 
-	require.Equal(t, "_platform-"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
+	require.Equal(t, "_"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
 	require.Equal(t,
 		"https://gram.test/platform/mcp/"+platformtools.AssistantsPlatformToolsetSlug,
 		servers[1].URL,
@@ -92,7 +92,7 @@ func TestResolveAssistantMCPServers_MisconfiguredToolsetIsOmitted(t *testing.T) 
 	require.Equal(t, "billing", servers[0].ID)
 	require.Equal(t, "https://gram.test/mcp/billing-mcp", servers[0].URL)
 
-	require.Equal(t, "_platform-"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
+	require.Equal(t, "_"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
 }
 
 // The managed assistant is granted the managed-assistant platform toolset (the
@@ -110,8 +110,8 @@ func TestResolveAssistantMCPServers_GrantsEachRequestedPlatformToolset(t *testin
 		platformtools.ManagedAssistantPlatformToolsetSlug,
 	})
 	require.Len(t, servers, 2)
-	require.Equal(t, "_platform-"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
-	require.Equal(t, "_platform-"+platformtools.ManagedAssistantPlatformToolsetSlug, servers[1].ID)
+	require.Equal(t, "_"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
+	require.Equal(t, "_"+platformtools.ManagedAssistantPlatformToolsetSlug, servers[1].ID)
 	require.Equal(t,
 		"https://gram.test/platform/mcp/"+platformtools.ManagedAssistantPlatformToolsetSlug,
 		servers[1].URL,

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -2001,9 +2001,10 @@ func resolveAssistantMCPServers(ctx context.Context, logger *slog.Logger, server
 	// Platform toolsets granted to this runtime (caller-determined); not
 	// surfaced as user-managed toolsets and not persisted in
 	// assistant_toolsets so users can't detach them. The leading "_" in the
-	// runtime server ID is reserved for platform use; the platform slug
-	// constants are kept short because this ID is concatenated into the
-	// agentkit MCP tool name, which has a 64-char cap.
+	// runtime server ID is reserved for platform use. The URL slug stays
+	// the public platform slug so warm runners keep resolving across
+	// deploys; only the in-process server ID is shortened, since it is
+	// concatenated into the agentkit MCP tool name which has a 64-char cap.
 	for _, slug := range platformToolsets {
 		servers = append(servers, runtimeMCPServer{
 			ID:      "_" + slug,

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -2000,14 +2000,17 @@ func resolveAssistantMCPServers(ctx context.Context, logger *slog.Logger, server
 
 	// Platform toolsets granted to this runtime (caller-determined); not
 	// surfaced as user-managed toolsets and not persisted in
-	// assistant_toolsets so users can't detach them. The leading "_" in the
-	// runtime server ID is reserved for platform use. The URL slug stays
+	// assistant_toolsets so users can't detach them. The "_p-" prefix
+	// marks the runtime server ID as platform-issued and gives it enough
+	// distance from any plausible user toolset slug (the current SlugPattern
+	// still allows leading "_", so this is convention, not a hard fence —
+	// tightening the pattern is a separate follow-up). The URL slug stays
 	// the public platform slug so warm runners keep resolving across
 	// deploys; only the in-process server ID is shortened, since it is
 	// concatenated into the agentkit MCP tool name which has a 64-char cap.
 	for _, slug := range platformToolsets {
 		servers = append(servers, runtimeMCPServer{
-			ID:      "_" + slug,
+			ID:      "_p-" + slug,
 			URL:     platformtools.PlatformToolsetURL(serverURL, slug),
 			Headers: nil,
 		})

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -2000,12 +2000,13 @@ func resolveAssistantMCPServers(ctx context.Context, logger *slog.Logger, server
 
 	// Platform toolsets granted to this runtime (caller-determined); not
 	// surfaced as user-managed toolsets and not persisted in
-	// assistant_toolsets so users can't detach them. The "_platform-" ID
-	// prefix can't collide with user toolset slugs because the slug grammar
-	// strips underscores.
+	// assistant_toolsets so users can't detach them. The leading "_" in the
+	// runtime server ID is reserved for platform use; the platform slug
+	// constants are kept short because this ID is concatenated into the
+	// agentkit MCP tool name, which has a 64-char cap.
 	for _, slug := range platformToolsets {
 		servers = append(servers, runtimeMCPServer{
-			ID:      "_platform-" + slug,
+			ID:      "_" + slug,
 			URL:     platformtools.PlatformToolsetURL(serverURL, slug),
 			Headers: nil,
 		})

--- a/server/internal/platformtools/toolsets.go
+++ b/server/internal/platformtools/toolsets.go
@@ -3,14 +3,17 @@ package platformtools
 import "net/url"
 
 // AssistantsPlatformToolsetSlug is the reserved slug for the platform
-// toolset granted to every assistant runtime.
-const AssistantsPlatformToolsetSlug = "assistants"
+// toolset granted to every assistant runtime. Kept short because it
+// participates in the agentkit-side MCP tool name, which must fit the
+// provider 64-char `^[a-zA-Z0-9_-]$` cap.
+const AssistantsPlatformToolsetSlug = "a"
 
 // ManagedAssistantPlatformToolsetSlug is the reserved slug for the platform
 // toolset granted only to a project's managed assistant (the one powering the
 // dashboard sidebar). It carries tools that must not be reachable by any
-// other assistant.
-const ManagedAssistantPlatformToolsetSlug = "managed-assistant"
+// other assistant. Kept short for the same reason as
+// [AssistantsPlatformToolsetSlug].
+const ManagedAssistantPlatformToolsetSlug = "mas"
 
 // Toolset is a virtual collection of platform tools exposed at runtime via a
 // dedicated MCP endpoint. Platform toolsets are not persisted; the slug is

--- a/server/internal/platformtools/toolsets.go
+++ b/server/internal/platformtools/toolsets.go
@@ -3,17 +3,14 @@ package platformtools
 import "net/url"
 
 // AssistantsPlatformToolsetSlug is the reserved slug for the platform
-// toolset granted to every assistant runtime. Kept short because it
-// participates in the agentkit-side MCP tool name, which must fit the
-// provider 64-char `^[a-zA-Z0-9_-]$` cap.
-const AssistantsPlatformToolsetSlug = "a"
+// toolset granted to every assistant runtime.
+const AssistantsPlatformToolsetSlug = "assistants"
 
 // ManagedAssistantPlatformToolsetSlug is the reserved slug for the platform
 // toolset granted only to a project's managed assistant (the one powering the
 // dashboard sidebar). It carries tools that must not be reachable by any
-// other assistant. Kept short for the same reason as
-// [AssistantsPlatformToolsetSlug].
-const ManagedAssistantPlatformToolsetSlug = "mas"
+// other assistant.
+const ManagedAssistantPlatformToolsetSlug = "managed-assistant"
 
 // Toolset is a virtual collection of platform tools exposed at runtime via a
 // dedicated MCP endpoint. Platform toolsets are not persisted; the slug is


### PR DESCRIPTION
## Summary

The managed-assistant Project Assistant has been hanging mid-turn since #3218 because the agentkit-side MCP tool names overflow the OpenAI/Anthropic ``^[a-zA-Z0-9_-]{1,64}$`` cap that the completions adapter pre-flights locally.

Failure example from prod (`gram-asst-prod-019e94b2-…`):

```
ERROR gram_assistant_runner::runtime: thread loop exited with error
error=loop error: provider error: tool name
"mcp__platform-managed-assistant_platform_get_observability_overview"
does not match ^[a-zA-Z0-9_-]{1,64}$
```

That name is **67 chars** — `mcp_` (4) + `_platform-managed-assistant` (27) + `_` (1) + `platform_get_observability_overview` (35). #3218 added several `platform_get_*` and `platform_list_*` tools long enough to push the worst case over the cap; the shorter ones (`platform_search_logs` etc.) still squeak under.

The provider regex isn't going anywhere, so this PR shortens the **platform-side** of the name. The `platform-` segment in the runtime server ID was a redundant convention marker, not part of the toolset's identity. Drop it; the leading `_` is what reserves the namespace against user toolset slugs.

## Changes

- `server/internal/platformtools/toolsets.go`: shrink the two platform toolset slugs.
  - `AssistantsPlatformToolsetSlug`: `"assistants"` → `"a"`
  - `ManagedAssistantPlatformToolsetSlug`: `"managed-assistant"` → `"mas"`
  - Comments now explain why these are kept short (provider tool-name cap).
- `server/internal/assistants/service.go`: drop `_platform-` prefix in the runtime server ID concatenation — `"_" + slug` (= `_a`, `_mas`). Update the stale comment that claimed slug grammar protected the namespace.
- `server/internal/assistants/resolve_mcp_servers_test.go`: update assertions.

## Result

Worst-case affected name now:
`mcp__mas_platform_get_observability_overview` = **44 chars**. Headroom ~20.

## Safety

- The two slug constants are referenced only symbolically in code; no callers hardcode the old string values (verified via grep across `*.{go,ts,tsx,rs,sql,yaml}`).
- The chi route is `/platform/mcp/{toolsetSlug}` — slug-parameterized, so the URL automatically reflects the new constant.
- Neither value is persisted (`project_managed_assistants` join table stores assistant IDs, not the slug).
- The agentkit-side runtime server ID is never exposed to users (it appears in the runner's `assistant_mcp_auth_required` LLM context block where the model only relays it).

## Tests

- `go test ./internal/assistants/... ./internal/platformtools/... ./internal/mcp/... ./internal/chat/...` — all green.
- `mise build:server` — clean.
- `mise lint:server` — clean.

## Follow-ups (separate PRs)

- Tighten user slug pattern (`server/internal/constants/tools.go`) from `^[a-z0-9_-]{1,128}$` to `^[a-z0-9][a-z0-9_-]{0,127}$` to actually reserve the leading-`_` namespace. The current pattern lets a user-created toolset slug collide with the platform IDs. Pre-existing weakness, not introduced here, but worth fencing — pending a prod read-replica check that no existing user slug starts with `_`.
- Agentkit ergonomics: have `McpServerManager` fail fast at registration time with a clear "(server, tool, agentkit-name) exceeds 64" error instead of failing mid-turn through the completions adapter regex. Would have caught this in a unit test.

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mid-turn hangs in the managed assistant by shortening the in-process platform MCP server IDs so tool names stay under the 64-char provider cap. Public slugs and URLs stay the same to keep warm runners resolving.

- **Bug Fixes**
  - Runtime server ID: `_platform-<slug>` → `_p-<slug>` (e.g., `_p-managed-assistant`); worst-case tool name is now 60 chars and fits.
  - `_p-` keeps platform-issued IDs distinct from user slugs without reintroducing length.
  - Kept platform toolset slugs and URL paths (`assistants`, `managed-assistant`) unchanged; updated tests and comments. No persisted data or routes are affected.

<sup>Written for commit 367a812009a97fe080e7cb05e5a23c7dc0abd245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

