### PR TITLE
mig: feat/policy_exclusions

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2836,6 +2836,47 @@ CREATE UNIQUE INDEX IF NOT EXISTS risk_custom_detection_rules_project_rule_id_ke
 ON risk_custom_detection_rules (project_id, rule_id)
 WHERE deleted IS FALSE;
 
+-- Exclusions suppress false-positive risk findings. They are applied going
+-- forward (the scanner drops matching findings) and retroactively (a sweep
+-- flags matching rows in risk_results so the dashboard hides them).
+-- risk_policy_id is nullable: NULL = global (applies across every policy in the
+-- project); non-NULL = bound to a single policy.
+CREATE TABLE IF NOT EXISTS risk_exclusions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  organization_id TEXT NOT NULL,
+  risk_policy_id uuid,
+
+  -- How match_value is interpreted against a finding:
+  --   exact       -> finding.match = match_value
+  --   regex       -> finding.match ~ match_value
+  --   rule_id     -> finding.rule_id = match_value
+  --   source      -> finding.source = match_value
+  --   entity_type -> finding.rule_id = 'pii.' || match_value
+  match_type TEXT NOT NULL,
+  match_value TEXT NOT NULL,
+  -- Optional narrowing: an exact/regex exclusion only applies within this
+  -- rule_id and/or source. NULL means "any".
+  rule_id_filter TEXT,
+  source_filter TEXT,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT risk_exclusions_pkey PRIMARY KEY (id),
+  CONSTRAINT risk_exclusions_match_type_check CHECK (match_type IN ('exact', 'regex', 'rule_id', 'source', 'entity_type')),
+  CONSTRAINT risk_exclusions_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+  CONSTRAINT risk_exclusions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE,
+  CONSTRAINT risk_exclusions_risk_policy_id_fkey FOREIGN KEY (risk_policy_id) REFERENCES risk_policies(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS risk_exclusions_project_policy_idx
+ON risk_exclusions (project_id, risk_policy_id)
+WHERE deleted IS FALSE;
+
 -- Individual findings produced by scanning a chat message against a risk policy.
 -- No soft delete: results are regenerated when the policy version changes.
 CREATE TABLE IF NOT EXISTS risk_results (
@@ -2860,6 +2901,12 @@ CREATE TABLE IF NOT EXISTS risk_results (
   -- after exhausting its retry budget
   dead_letter_reason TEXT,
 
+  -- Set when an exclusion suppresses this finding. excluded_exclusion_id records
+  -- which exclusion flagged it so the flag can be reversed when that exclusion
+  -- is removed. Dashboard reads filter on excluded_at IS NULL.
+  excluded_at timestamptz,
+  excluded_exclusion_id uuid,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT risk_results_pkey PRIMARY KEY (id),
@@ -2877,7 +2924,16 @@ ON risk_results (project_id, chat_message_id);
 
 CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
-WHERE found IS TRUE;
+WHERE found IS TRUE AND excluded_at IS NULL;
+
+-- Drives the exact-match exclusion sweep.
+CREATE INDEX IF NOT EXISTS risk_results_policy_match_idx
+ON risk_results (project_id, risk_policy_id, rule_id, match);
+
+-- Reversal lookup: unflag rows previously excluded by a given exclusion.
+CREATE INDEX IF NOT EXISTS risk_results_excluded_exclusion_idx
+ON risk_results (excluded_exclusion_id)
+WHERE excluded_exclusion_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS authz_challenge_resolutions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1223,6 +1223,22 @@ type RiskCustomDetectionRule struct {
 	Deleted        bool
 }
 
+type RiskExclusion struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	OrganizationID string
+	RiskPolicyID   uuid.NullUUID
+	MatchType      string
+	MatchValue     string
+	RuleIDFilter   pgtype.Text
+	SourceFilter   pgtype.Text
+	Enabled        bool
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
+}
+
 type RiskPolicy struct {
 	ID                   uuid.UUID
 	ProjectID            uuid.UUID
@@ -1273,23 +1289,25 @@ type RiskPolicyBypassRequest struct {
 }
 
 type RiskResult struct {
-	ID                uuid.UUID
-	ProjectID         uuid.UUID
-	OrganizationID    string
-	RiskPolicyID      uuid.UUID
-	RiskPolicyVersion int64
-	ChatMessageID     uuid.UUID
-	Source            string
-	Found             bool
-	RuleID            pgtype.Text
-	Description       pgtype.Text
-	Match             pgtype.Text
-	StartPos          pgtype.Int4
-	EndPos            pgtype.Int4
-	Confidence        pgtype.Float8
-	Tags              []string
-	DeadLetterReason  pgtype.Text
-	CreatedAt         pgtype.Timestamptz
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	OrganizationID      string
+	RiskPolicyID        uuid.UUID
+	RiskPolicyVersion   int64
+	ChatMessageID       uuid.UUID
+	Source              string
+	Found               bool
+	RuleID              pgtype.Text
+	Description         pgtype.Text
+	Match               pgtype.Text
+	StartPos            pgtype.Int4
+	EndPos              pgtype.Int4
+	Confidence          pgtype.Float8
+	Tags                []string
+	DeadLetterReason    pgtype.Text
+	ExcludedAt          pgtype.Timestamptz
+	ExcludedExclusionID uuid.NullUUID
+	CreatedAt           pgtype.Timestamptz
 }
 
 type SlackApp struct {

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -1107,7 +1107,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 }
 
 const listRiskResultsByChatFound = `-- name: ListRiskResultsByChatFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -1132,27 +1132,29 @@ type ListRiskResultsByChatFoundParams struct {
 }
 
 type ListRiskResultsByChatFoundRow struct {
-	ID                uuid.UUID
-	ProjectID         uuid.UUID
-	OrganizationID    string
-	RiskPolicyID      uuid.UUID
-	RiskPolicyVersion int64
-	ChatMessageID     uuid.UUID
-	Source            string
-	Found             bool
-	RuleID            pgtype.Text
-	Description       pgtype.Text
-	Match             pgtype.Text
-	StartPos          pgtype.Int4
-	EndPos            pgtype.Int4
-	Confidence        pgtype.Float8
-	Tags              []string
-	DeadLetterReason  pgtype.Text
-	CreatedAt         pgtype.Timestamptz
-	ChatID            uuid.UUID
-	MessageCreatedAt  pgtype.Timestamptz
-	ChatTitle         pgtype.Text
-	ChatUserID        pgtype.Text
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	OrganizationID      string
+	RiskPolicyID        uuid.UUID
+	RiskPolicyVersion   int64
+	ChatMessageID       uuid.UUID
+	Source              string
+	Found               bool
+	RuleID              pgtype.Text
+	Description         pgtype.Text
+	Match               pgtype.Text
+	StartPos            pgtype.Int4
+	EndPos              pgtype.Int4
+	Confidence          pgtype.Float8
+	Tags                []string
+	DeadLetterReason    pgtype.Text
+	ExcludedAt          pgtype.Timestamptz
+	ExcludedExclusionID uuid.NullUUID
+	CreatedAt           pgtype.Timestamptz
+	ChatID              uuid.UUID
+	MessageCreatedAt    pgtype.Timestamptz
+	ChatTitle           pgtype.Text
+	ChatUserID          pgtype.Text
 }
 
 func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskResultsByChatFoundParams) ([]ListRiskResultsByChatFoundRow, error) {
@@ -1187,6 +1189,8 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 			&i.Confidence,
 			&i.Tags,
 			&i.DeadLetterReason,
+			&i.ExcludedAt,
+			&i.ExcludedExclusionID,
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.MessageCreatedAt,
@@ -1204,7 +1208,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 }
 
 const listRiskResultsByProjectAndPolicy = `-- name: ListRiskResultsByProjectAndPolicy :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -1229,27 +1233,29 @@ type ListRiskResultsByProjectAndPolicyParams struct {
 }
 
 type ListRiskResultsByProjectAndPolicyRow struct {
-	ID                uuid.UUID
-	ProjectID         uuid.UUID
-	OrganizationID    string
-	RiskPolicyID      uuid.UUID
-	RiskPolicyVersion int64
-	ChatMessageID     uuid.UUID
-	Source            string
-	Found             bool
-	RuleID            pgtype.Text
-	Description       pgtype.Text
-	Match             pgtype.Text
-	StartPos          pgtype.Int4
-	EndPos            pgtype.Int4
-	Confidence        pgtype.Float8
-	Tags              []string
-	DeadLetterReason  pgtype.Text
-	CreatedAt         pgtype.Timestamptz
-	ChatID            uuid.UUID
-	MessageCreatedAt  pgtype.Timestamptz
-	ChatTitle         pgtype.Text
-	ChatUserID        pgtype.Text
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	OrganizationID      string
+	RiskPolicyID        uuid.UUID
+	RiskPolicyVersion   int64
+	ChatMessageID       uuid.UUID
+	Source              string
+	Found               bool
+	RuleID              pgtype.Text
+	Description         pgtype.Text
+	Match               pgtype.Text
+	StartPos            pgtype.Int4
+	EndPos              pgtype.Int4
+	Confidence          pgtype.Float8
+	Tags                []string
+	DeadLetterReason    pgtype.Text
+	ExcludedAt          pgtype.Timestamptz
+	ExcludedExclusionID uuid.NullUUID
+	CreatedAt           pgtype.Timestamptz
+	ChatID              uuid.UUID
+	MessageCreatedAt    pgtype.Timestamptz
+	ChatTitle           pgtype.Text
+	ChatUserID          pgtype.Text
 }
 
 func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg ListRiskResultsByProjectAndPolicyParams) ([]ListRiskResultsByProjectAndPolicyRow, error) {
@@ -1284,6 +1290,8 @@ func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg Lis
 			&i.Confidence,
 			&i.Tags,
 			&i.DeadLetterReason,
+			&i.ExcludedAt,
+			&i.ExcludedExclusionID,
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.MessageCreatedAt,

--- a/server/internal/testenv/testrepo/models.go
+++ b/server/internal/testenv/testrepo/models.go
@@ -97,21 +97,23 @@ type HttpToolDefinition struct {
 }
 
 type RiskResult struct {
-	ID                uuid.UUID
-	ProjectID         uuid.UUID
-	OrganizationID    string
-	RiskPolicyID      uuid.UUID
-	RiskPolicyVersion int64
-	ChatMessageID     uuid.UUID
-	Source            string
-	Found             bool
-	RuleID            pgtype.Text
-	Description       pgtype.Text
-	Match             pgtype.Text
-	StartPos          pgtype.Int4
-	EndPos            pgtype.Int4
-	Confidence        pgtype.Float8
-	Tags              []string
-	DeadLetterReason  pgtype.Text
-	CreatedAt         pgtype.Timestamptz
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	OrganizationID      string
+	RiskPolicyID        uuid.UUID
+	RiskPolicyVersion   int64
+	ChatMessageID       uuid.UUID
+	Source              string
+	Found               bool
+	RuleID              pgtype.Text
+	Description         pgtype.Text
+	Match               pgtype.Text
+	StartPos            pgtype.Int4
+	EndPos              pgtype.Int4
+	Confidence          pgtype.Float8
+	Tags                []string
+	DeadLetterReason    pgtype.Text
+	ExcludedAt          pgtype.Timestamptz
+	ExcludedExclusionID uuid.NullUUID
+	CreatedAt           pgtype.Timestamptz
 }

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -350,7 +350,7 @@ func (q *Queries) ListDeploymentHTTPTools(ctx context.Context, deploymentID uuid
 }
 
 const listRiskResultsAll = `-- name: ListRiskResultsAll :many
-SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, dead_letter_reason, created_at
+SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, dead_letter_reason, excluded_at, excluded_exclusion_id, created_at
 FROM risk_results
 WHERE project_id = $1
   AND risk_policy_id = $2
@@ -391,6 +391,8 @@ func (q *Queries) ListRiskResultsAll(ctx context.Context, arg ListRiskResultsAll
 			&i.Confidence,
 			&i.Tags,
 			&i.DeadLetterReason,
+			&i.ExcludedAt,
+			&i.ExcludedExclusionID,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/server/migrations/20260605143925_add_risk_exclusions.sql
+++ b/server/migrations/20260605143925_add_risk_exclusions.sql
@@ -1,0 +1,35 @@
+-- atlas:txmode none
+
+-- Drop index "risk_results_project_found_idx" from table: "risk_results"
+DROP INDEX CONCURRENTLY "risk_results_project_found_idx";
+-- Modify "risk_results" table
+ALTER TABLE "risk_results" ADD COLUMN "excluded_at" timestamptz NULL, ADD COLUMN "excluded_exclusion_id" uuid NULL;
+-- Create index "risk_results_project_found_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_project_found_idx" ON "risk_results" ("project_id", "created_at" DESC) WHERE ((found IS TRUE) AND (excluded_at IS NULL));
+-- Create index "risk_results_excluded_exclusion_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_excluded_exclusion_idx" ON "risk_results" ("excluded_exclusion_id") WHERE (excluded_exclusion_id IS NOT NULL);
+-- Create index "risk_results_policy_match_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_policy_match_idx" ON "risk_results" ("project_id", "risk_policy_id", "rule_id", "match");
+-- Create "risk_exclusions" table
+CREATE TABLE "risk_exclusions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "organization_id" text NOT NULL,
+  "risk_policy_id" uuid NULL,
+  "match_type" text NOT NULL,
+  "match_value" text NOT NULL,
+  "rule_id_filter" text NULL,
+  "source_filter" text NULL,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "risk_exclusions_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_exclusions_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_exclusions_risk_policy_id_fkey" FOREIGN KEY ("risk_policy_id") REFERENCES "risk_policies" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_exclusions_match_type_check" CHECK (match_type = ANY (ARRAY['exact'::text, 'regex'::text, 'rule_id'::text, 'source'::text, 'entity_type'::text]))
+);
+-- Create index "risk_exclusions_project_policy_idx" to table: "risk_exclusions"
+CREATE INDEX "risk_exclusions_project_policy_idx" ON "risk_exclusions" ("project_id", "risk_policy_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Spr8WJmU18oViMyA7T+KQzyvYCIwLXsj4cWo/3NE1Nk=
+h1:bK/PxAnIVA4zCw7pEyzKXyyG7mF//NuHPmpYhVnuRx8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -207,3 +207,4 @@ h1:Spr8WJmU18oViMyA7T+KQzyvYCIwLXsj4cWo/3NE1Nk=
 20260603130426_risk-policies-add-message-types.sql h1:U9s5GPUuoojFLFjPnQyxftN10IUxFw+iTHuDgJ5voB4=
 20260603143315_age-2631-assistant-dashboard-messages.sql h1:cY9snSVnbLTFV+vKZ4pw5mH11TkZ2cBfb4IscJlQtkY=
 20260604141922_add-risk-policy-bypass-requests-table.sql h1:Ol7aa0m2r1gSObRbAJaqr6wdCs37y8qtvLlZYs6Q7pg=
+20260605143925_add_risk_exclusions.sql h1:u5YQre0OFPZ56F9gAy0K7kSsb5q+koeoJh49JOS3qjw=


### PR DESCRIPTION
Schema and migrations split off `feat/policy_exclusions` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds database support for risk policy exclusions so we can suppress false positives and track them. Introduces a `risk_exclusions` table and exclusion flags on `risk_results`, plus indexes and repo updates.

- **New Features**
  - New `risk_exclusions` table: scoped by `project_id`/`organization_id`, optional `risk_policy_id`, `match_type` (`exact`/`regex`/`rule_id`/`source`/`entity_type`), `match_value`, optional `rule_id_filter`/`source_filter`, soft delete; index on `(project_id, risk_policy_id)`.
  - `risk_results` now includes `excluded_at` and `excluded_exclusion_id`; updated `risk_results_project_found_idx` to ignore excluded rows; added `policy_match_idx` and `excluded_exclusion_idx` for sweeps and reversals.
  - Updated generated models and queries to surface the new exclusion fields in list result queries.

<sup>Written for commit 6d42573fed7ff411e9296a2fd309676de4eb76b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

