### PR TITLE
fix(rbac): role edit dialog shows 'All servers' after save instead of '1 server'

### DIFF
--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -575,11 +575,21 @@ export function CreateRoleDialog({
     setGrants((prev) => {
       const grant = prev[scopeSlug];
       if (!grant) return prev;
+      const removed = grant.rules[ruleIndex];
+      if (!removed) return prev;
+
       let rules = grant.rules.filter((_, i) => i !== ruleIndex);
-      // No allows left → denies are orphaned, clear everything
-      if (!rules.some((r) => r.effect === "allow")) {
-        rules = [];
+
+      // Removing the last allow chip falls back to unrestricted instead of
+      // unchecking the scope. Any remaining denies were exceptions to the
+      // prior narrower allow, so they get dropped along with it.
+      if (
+        removed.effect === "allow" &&
+        !rules.some((r) => r.effect === "allow")
+      ) {
+        rules = [{ id: crypto.randomUUID(), effect: "allow", selectors: null }];
       }
+
       if (rules.length === 0) {
         const next = { ...prev };
         delete next[scopeSlug];

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -362,11 +362,14 @@ export function CreateRoleDialog({
 
       let rules = grant.rules.filter((_, i) => i !== ruleIndex);
 
-      // Removing the last allow chip falls back to unrestricted instead of
+      // Removing a narrower allow chip falls back to unrestricted instead of
       // unchecking the scope. Any remaining denies were exceptions to the
-      // prior narrower allow, so they get dropped along with it.
+      // prior narrower allow, so they get dropped along with it. If the
+      // removed rule was already unrestricted, the X click means "uncheck
+      // this scope" — fall through to the empty-rules clear path.
       if (
         removed.effect === "allow" &&
+        removed.selectors !== null &&
         !rules.some((r) => r.effect === "allow")
       ) {
         rules = [{ id: crypto.randomUUID(), effect: "allow", selectors: null }];

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -64,9 +64,10 @@ import {
   computeRuleTooltip,
 } from "./roleDialogState";
 import {
+  applyRemoveRule,
+  diffGrants,
   grantsFromRole,
   sdkGrantsFromForm,
-  diffGrants,
 } from "./roleGrantTransform";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -357,30 +358,14 @@ export function CreateRoleDialog({
     setGrants((prev) => {
       const grant = prev[scopeSlug];
       if (!grant) return prev;
-      const removed = grant.rules[ruleIndex];
-      if (!removed) return prev;
-
-      let rules = grant.rules.filter((_, i) => i !== ruleIndex);
-
-      // Removing a narrower allow chip falls back to unrestricted instead of
-      // unchecking the scope. Any remaining denies were exceptions to the
-      // prior narrower allow, so they get dropped along with it. If the
-      // removed rule was already unrestricted, the X click means "uncheck
-      // this scope" — fall through to the empty-rules clear path.
-      if (
-        removed.effect === "allow" &&
-        removed.selectors !== null &&
-        !rules.some((r) => r.effect === "allow")
-      ) {
-        rules = [{ id: crypto.randomUUID(), effect: "allow", selectors: null }];
-      }
-
-      if (rules.length === 0) {
-        const next = { ...prev };
+      const result = applyRemoveRule(grant, ruleIndex);
+      const next = { ...prev };
+      if (result === null) {
         delete next[scopeSlug];
-        return next;
+      } else {
+        next[scopeSlug] = result;
       }
-      return { ...prev, [scopeSlug]: { ...grant, rules } };
+      return next;
     });
   };
 

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -16,7 +16,6 @@ import { Type } from "@/components/ui/type";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/contexts/Auth";
 import type { Role } from "@gram/client/models/components/role.js";
-import type { RoleGrant as SdkRoleGrant } from "@gram/client/models/components/rolegrant.js";
 import { useCreateRoleMutation } from "@gram/client/react-query/createRole.js";
 import {
   invalidateAllMembers,
@@ -52,14 +51,11 @@ import {
 import { GrantRuleDrawerContent } from "./GrantRuleDrawerContent";
 import type {
   ActivePanel,
-  AnnotationHint,
-  PolicyEffect,
   RoleGrant,
   Scope,
   ScopeRule,
+  Selector,
 } from "./types";
-import type { Selector } from "./types";
-import { DISPOSITION_TO_ANNOTATION } from "./types";
 import {
   isSaveDisabled,
   effectiveGrantCount,
@@ -67,96 +63,16 @@ import {
   computeRuleLabel,
   computeRuleTooltip,
 } from "./roleDialogState";
+import {
+  grantsFromRole,
+  sdkGrantsFromForm,
+  diffGrants,
+} from "./roleGrantTransform";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
-
-/** Human-readable label for a rule chip. */
-/** Split a flat selector array into groups by hierarchy level. */
-function groupSelectorsByLevel(selectors: Selector[]): Selector[][] {
-  const projects: Selector[] = [];
-  const servers: Selector[] = [];
-  const tools: Selector[] = [];
-  const annotations: Selector[] = [];
-
-  for (const s of selectors) {
-    if (s.disposition) annotations.push(s);
-    else if (s.tool) tools.push(s);
-    else if (s.projectId) projects.push(s);
-    else servers.push(s);
-  }
-
-  const groups: Selector[][] = [];
-  if (projects.length) groups.push(projects);
-  if (servers.length) groups.push(servers);
-  if (tools.length) groups.push(tools);
-  if (annotations.length) groups.push(annotations);
-  return groups;
-}
-
-/**
- * Detect the storage form of an unrestricted grant: a single selector with
- * only resource_kind + resource_id keys where resource_id is "*". The server
- * synthesizes this when a grant is created with nil selectors, so we collapse
- * it back to the unrestricted rule shape on read.
- */
-function isUnrestrictedSelectorList(selectors: Selector[]): boolean {
-  if (selectors.length !== 1) return false;
-  const s = selectors[0]!;
-  if (s.resourceId !== "*") return false;
-  return (
-    s.disposition == null &&
-    s.tool == null &&
-    s.projectId == null &&
-    s.serverUrl == null
-  );
-}
-
-/** Convert API Role grants to rules-based RoleGrant map. */
-function grantsFromRole(role: Role): Record<string, RoleGrant> {
-  const result: Record<string, RoleGrant> = {};
-
-  for (const g of role.grants) {
-    if (!result[g.scope]) {
-      result[g.scope] = { scope: g.scope, rules: [] };
-    }
-
-    const effect: PolicyEffect = (g.effect as PolicyEffect) ?? "allow";
-
-    if (
-      !g.selectors ||
-      g.selectors.length === 0 ||
-      isUnrestrictedSelectorList(g.selectors as Selector[])
-    ) {
-      // Unrestricted rule
-      result[g.scope].rules.push({
-        id: crypto.randomUUID(),
-        effect,
-        selectors: null,
-      });
-    } else {
-      // Split selectors by hierarchy level into separate rules
-      const groups = groupSelectorsByLevel(g.selectors as Selector[]);
-      for (const sels of groups) {
-        const rule: ScopeRule = {
-          id: crypto.randomUUID(),
-          effect,
-          selectors: sels,
-        };
-        // Detect annotation-based rules and restore UI hints
-        if (sels.some((s) => s.disposition)) {
-          rule.customTab = "auto-groups";
-          rule.annotations = sels
-            .filter((s) => s.disposition)
-            .map((s) => DISPOSITION_TO_ANNOTATION[s.disposition!])
-            .filter((a): a is AnnotationHint => !!a);
-        }
-        result[g.scope].rules.push(rule);
-      }
-    }
-  }
-
-  return result;
-}
+//
+// Grant ↔ form transforms live in ./roleGrantTransform — kept in a plain TS
+// module so they can be unit-tested without pulling in React/react-query.
 
 /** Determine the broadest allow level from a scope's rules. */
 function getAllowLevel(
@@ -184,140 +100,6 @@ function getDenyPanels(allowLevel: string | null): ActivePanel[] {
     default:
       return []; // tool/annotation — already most specific, no deny possible
   }
-}
-
-function sdkGrantsFromForm(grants: Record<string, RoleGrant>): SdkRoleGrant[] {
-  const sdkGrants: SdkRoleGrant[] = [];
-
-  for (const grant of Object.values(grants)) {
-    const allowSelectors: Selector[] = [];
-    const denySelectors: Selector[] = [];
-    let hasUnrestrictedAllow = false;
-
-    for (const rule of grant.rules) {
-      if (rule.effect === "allow") {
-        if (rule.selectors === null) hasUnrestrictedAllow = true;
-        else if (rule.selectors.length > 0) {
-          allowSelectors.push(...rule.selectors);
-        }
-      } else if (rule.selectors && rule.selectors.length > 0) {
-        denySelectors.push(...rule.selectors);
-      }
-    }
-
-    if (!hasUnrestrictedAllow && allowSelectors.length === 0) continue;
-
-    sdkGrants.push({
-      scope: grant.scope,
-      selectors: hasUnrestrictedAllow ? undefined : allowSelectors,
-    });
-
-    if (denySelectors.length > 0) {
-      sdkGrants.push({
-        scope: grant.scope,
-        effect: "deny",
-        selectors: denySelectors,
-      });
-    }
-  }
-
-  return sdkGrants;
-}
-
-type GrantIdentity = {
-  scope: SdkRoleGrant["scope"];
-  effect: "allow" | "deny";
-  selector?: Selector;
-};
-
-function selectorKey(selector: Selector | undefined): string {
-  if (!selector) return "*";
-  return JSON.stringify({
-    disposition: selector.disposition ?? "",
-    projectId: selector.projectId ?? "",
-    resourceId: selector.resourceId,
-    resourceKind: selector.resourceKind,
-    tool: selector.tool ?? "",
-  });
-}
-
-function grantIdentityKey(identity: GrantIdentity): string {
-  return `${identity.scope}\x00${identity.effect}\x00${selectorKey(identity.selector)}`;
-}
-
-function grantIdentities(grants: SdkRoleGrant[]): GrantIdentity[] {
-  return grants.flatMap((grant) => {
-    const effect = (grant.effect ?? "allow") as "allow" | "deny";
-    if (!grant.selectors || grant.selectors.length === 0) {
-      return [{ scope: grant.scope, effect }];
-    }
-    return grant.selectors.map((selector) => ({
-      scope: grant.scope,
-      effect,
-      selector: selector as Selector,
-    }));
-  });
-}
-
-function grantsFromIdentities(identities: GrantIdentity[]): SdkRoleGrant[] {
-  const unrestricted: SdkRoleGrant[] = [];
-  const grouped = new Map<string, SdkRoleGrant>();
-
-  for (const identity of identities) {
-    if (!identity.selector) {
-      unrestricted.push({
-        scope: identity.scope,
-        effect: identity.effect === "deny" ? "deny" : undefined,
-        selectors: undefined,
-      });
-      continue;
-    }
-
-    const key = `${identity.scope}\x00${identity.effect}`;
-    const existing = grouped.get(key);
-    if (existing) {
-      existing.selectors = [...(existing.selectors ?? []), identity.selector];
-      continue;
-    }
-
-    grouped.set(key, {
-      scope: identity.scope,
-      effect: identity.effect === "deny" ? "deny" : undefined,
-      selectors: [identity.selector],
-    });
-  }
-
-  return [...unrestricted, ...grouped.values()];
-}
-
-function diffGrants(
-  before: SdkRoleGrant[],
-  after: SdkRoleGrant[],
-): { addGrants: SdkRoleGrant[]; removeGrants: SdkRoleGrant[] } {
-  const beforeByKey = new Map(
-    grantIdentities(before).map((identity) => [
-      grantIdentityKey(identity),
-      identity,
-    ]),
-  );
-  const afterByKey = new Map(
-    grantIdentities(after).map((identity) => [
-      grantIdentityKey(identity),
-      identity,
-    ]),
-  );
-
-  const addIdentities = [...afterByKey]
-    .filter(([key]) => !beforeByKey.has(key))
-    .map(([, identity]) => identity);
-  const removeIdentities = [...beforeByKey]
-    .filter(([key]) => !afterByKey.has(key))
-    .map(([, identity]) => identity);
-
-  return {
-    addGrants: grantsFromIdentities(addIdentities),
-    removeGrants: grantsFromIdentities(removeIdentities),
-  };
 }
 
 // ─── Component ──────────────────────────────────────────────────────────────

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -93,6 +93,24 @@ function groupSelectorsByLevel(selectors: Selector[]): Selector[][] {
   return groups;
 }
 
+/**
+ * Detect the storage form of an unrestricted grant: a single selector with
+ * only resource_kind + resource_id keys where resource_id is "*". The server
+ * synthesizes this when a grant is created with nil selectors, so we collapse
+ * it back to the unrestricted rule shape on read.
+ */
+function isUnrestrictedSelectorList(selectors: Selector[]): boolean {
+  if (selectors.length !== 1) return false;
+  const s = selectors[0]!;
+  if (s.resourceId !== "*") return false;
+  return (
+    s.disposition == null &&
+    s.tool == null &&
+    s.projectId == null &&
+    s.serverUrl == null
+  );
+}
+
 /** Convert API Role grants to rules-based RoleGrant map. */
 function grantsFromRole(role: Role): Record<string, RoleGrant> {
   const result: Record<string, RoleGrant> = {};
@@ -104,7 +122,11 @@ function grantsFromRole(role: Role): Record<string, RoleGrant> {
 
     const effect: PolicyEffect = (g.effect as PolicyEffect) ?? "allow";
 
-    if (!g.selectors || g.selectors.length === 0) {
+    if (
+      !g.selectors ||
+      g.selectors.length === 0 ||
+      isUnrestrictedSelectorList(g.selectors as Selector[])
+    ) {
       // Unrestricted rule
       result[g.scope].rules.push({
         id: crypto.randomUUID(),

--- a/client/dashboard/src/pages/access/roleGrantTransform.ts
+++ b/client/dashboard/src/pages/access/roleGrantTransform.ts
@@ -1,0 +1,242 @@
+import type { Role } from "@gram/client/models/components/role.js";
+import type { RoleGrant as SdkRoleGrant } from "@gram/client/models/components/rolegrant.js";
+
+import type {
+  AnnotationHint,
+  PolicyEffect,
+  RoleGrant,
+  ScopeRule,
+  Selector,
+} from "./types";
+import { DISPOSITION_TO_ANNOTATION } from "./types";
+
+/** Split a flat selector array into groups by hierarchy level. */
+export function groupSelectorsByLevel(selectors: Selector[]): Selector[][] {
+  const projects: Selector[] = [];
+  const servers: Selector[] = [];
+  const tools: Selector[] = [];
+  const annotations: Selector[] = [];
+
+  for (const s of selectors) {
+    if (s.disposition) annotations.push(s);
+    else if (s.tool) tools.push(s);
+    else if (s.projectId) projects.push(s);
+    else servers.push(s);
+  }
+
+  const groups: Selector[][] = [];
+  if (projects.length) groups.push(projects);
+  if (servers.length) groups.push(servers);
+  if (tools.length) groups.push(tools);
+  if (annotations.length) groups.push(annotations);
+  return groups;
+}
+
+/**
+ * Detect the storage form of an unrestricted grant: a single selector with
+ * only resource_kind + resource_id keys where resource_id is "*". The server
+ * synthesizes this when a grant is created with nil selectors, so we collapse
+ * it back to the unrestricted rule shape on read.
+ */
+export function isUnrestrictedSelectorList(selectors: Selector[]): boolean {
+  if (selectors.length !== 1) return false;
+  const s = selectors[0]!;
+  if (s.resourceId !== "*") return false;
+  return (
+    s.disposition == null &&
+    s.tool == null &&
+    s.projectId == null &&
+    s.serverUrl == null
+  );
+}
+
+/** Convert API Role grants to rules-based RoleGrant map. */
+export function grantsFromRole(role: Role): Record<string, RoleGrant> {
+  const result: Record<string, RoleGrant> = {};
+
+  for (const g of role.grants) {
+    if (!result[g.scope]) {
+      result[g.scope] = { scope: g.scope, rules: [] };
+    }
+
+    const effect: PolicyEffect = (g.effect as PolicyEffect) ?? "allow";
+
+    // Only collapse the synthetic wildcard for allow grants. sdkGrantsFromForm
+    // re-emits unrestricted allow via selectors:undefined, but has no equivalent
+    // for deny — collapsing a deny wildcard to selectors:null would drop the
+    // deny on the next save. The backend intentionally keeps the explicit
+    // kind-scoped wildcard for deny grants (see scopeWildcardStaysExplicit in
+    // server/internal/authz/scopes_test.go).
+    if (
+      !g.selectors ||
+      g.selectors.length === 0 ||
+      (effect === "allow" &&
+        isUnrestrictedSelectorList(g.selectors as Selector[]))
+    ) {
+      result[g.scope].rules.push({
+        id: crypto.randomUUID(),
+        effect,
+        selectors: null,
+      });
+    } else {
+      // Split selectors by hierarchy level into separate rules
+      const groups = groupSelectorsByLevel(g.selectors as Selector[]);
+      for (const sels of groups) {
+        const rule: ScopeRule = {
+          id: crypto.randomUUID(),
+          effect,
+          selectors: sels,
+        };
+        // Detect annotation-based rules and restore UI hints
+        if (sels.some((s) => s.disposition)) {
+          rule.customTab = "auto-groups";
+          rule.annotations = sels
+            .filter((s) => s.disposition)
+            .map((s) => DISPOSITION_TO_ANNOTATION[s.disposition!])
+            .filter((a): a is AnnotationHint => !!a);
+        }
+        result[g.scope].rules.push(rule);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function sdkGrantsFromForm(
+  grants: Record<string, RoleGrant>,
+): SdkRoleGrant[] {
+  const sdkGrants: SdkRoleGrant[] = [];
+
+  for (const grant of Object.values(grants)) {
+    const allowSelectors: Selector[] = [];
+    const denySelectors: Selector[] = [];
+    let hasUnrestrictedAllow = false;
+
+    for (const rule of grant.rules) {
+      if (rule.effect === "allow") {
+        if (rule.selectors === null) hasUnrestrictedAllow = true;
+        else if (rule.selectors.length > 0) {
+          allowSelectors.push(...rule.selectors);
+        }
+      } else if (rule.selectors && rule.selectors.length > 0) {
+        denySelectors.push(...rule.selectors);
+      }
+    }
+
+    if (!hasUnrestrictedAllow && allowSelectors.length === 0) continue;
+
+    sdkGrants.push({
+      scope: grant.scope,
+      selectors: hasUnrestrictedAllow ? undefined : allowSelectors,
+    });
+
+    if (denySelectors.length > 0) {
+      sdkGrants.push({
+        scope: grant.scope,
+        effect: "deny",
+        selectors: denySelectors,
+      });
+    }
+  }
+
+  return sdkGrants;
+}
+
+export type GrantIdentity = {
+  scope: SdkRoleGrant["scope"];
+  effect: "allow" | "deny";
+  selector?: Selector;
+};
+
+export function selectorKey(selector: Selector | undefined): string {
+  if (!selector) return "*";
+  return JSON.stringify({
+    disposition: selector.disposition ?? "",
+    projectId: selector.projectId ?? "",
+    resourceId: selector.resourceId,
+    resourceKind: selector.resourceKind,
+    tool: selector.tool ?? "",
+  });
+}
+
+export function grantIdentityKey(identity: GrantIdentity): string {
+  return `${identity.scope}\x00${identity.effect}\x00${selectorKey(identity.selector)}`;
+}
+
+export function grantIdentities(grants: SdkRoleGrant[]): GrantIdentity[] {
+  return grants.flatMap((grant) => {
+    const effect = (grant.effect ?? "allow") as "allow" | "deny";
+    if (!grant.selectors || grant.selectors.length === 0) {
+      return [{ scope: grant.scope, effect }];
+    }
+    return grant.selectors.map((selector) => ({
+      scope: grant.scope,
+      effect,
+      selector: selector as Selector,
+    }));
+  });
+}
+
+export function grantsFromIdentities(
+  identities: GrantIdentity[],
+): SdkRoleGrant[] {
+  const unrestricted: SdkRoleGrant[] = [];
+  const grouped = new Map<string, SdkRoleGrant>();
+
+  for (const identity of identities) {
+    if (!identity.selector) {
+      unrestricted.push({
+        scope: identity.scope,
+        effect: identity.effect === "deny" ? "deny" : undefined,
+        selectors: undefined,
+      });
+      continue;
+    }
+
+    const key = `${identity.scope}\x00${identity.effect}`;
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.selectors = [...(existing.selectors ?? []), identity.selector];
+      continue;
+    }
+
+    grouped.set(key, {
+      scope: identity.scope,
+      effect: identity.effect === "deny" ? "deny" : undefined,
+      selectors: [identity.selector],
+    });
+  }
+
+  return [...unrestricted, ...grouped.values()];
+}
+
+export function diffGrants(
+  before: SdkRoleGrant[],
+  after: SdkRoleGrant[],
+): { addGrants: SdkRoleGrant[]; removeGrants: SdkRoleGrant[] } {
+  const beforeByKey = new Map(
+    grantIdentities(before).map((identity) => [
+      grantIdentityKey(identity),
+      identity,
+    ]),
+  );
+  const afterByKey = new Map(
+    grantIdentities(after).map((identity) => [
+      grantIdentityKey(identity),
+      identity,
+    ]),
+  );
+
+  const addIdentities = [...afterByKey]
+    .filter(([key]) => !beforeByKey.has(key))
+    .map(([, identity]) => identity);
+  const removeIdentities = [...beforeByKey]
+    .filter(([key]) => !afterByKey.has(key))
+    .map(([, identity]) => identity);
+
+  return {
+    addGrants: grantsFromIdentities(addIdentities),
+    removeGrants: grantsFromIdentities(removeIdentities),
+  };
+}

--- a/client/dashboard/src/pages/access/roleGrantTransform.ts
+++ b/client/dashboard/src/pages/access/roleGrantTransform.ts
@@ -11,7 +11,7 @@ import type {
 import { DISPOSITION_TO_ANNOTATION } from "./types";
 
 /** Split a flat selector array into groups by hierarchy level. */
-export function groupSelectorsByLevel(selectors: Selector[]): Selector[][] {
+function groupSelectorsByLevel(selectors: Selector[]): Selector[][] {
   const projects: Selector[] = [];
   const servers: Selector[] = [];
   const tools: Selector[] = [];
@@ -38,7 +38,7 @@ export function groupSelectorsByLevel(selectors: Selector[]): Selector[][] {
  * synthesizes this when a grant is created with nil selectors, so we collapse
  * it back to the unrestricted rule shape on read.
  */
-export function isUnrestrictedSelectorList(selectors: Selector[]): boolean {
+function isUnrestrictedSelectorList(selectors: Selector[]): boolean {
   if (selectors.length !== 1) return false;
   const s = selectors[0]!;
   if (s.resourceId !== "*") return false;
@@ -143,13 +143,13 @@ export function sdkGrantsFromForm(
   return sdkGrants;
 }
 
-export type GrantIdentity = {
+type GrantIdentity = {
   scope: SdkRoleGrant["scope"];
   effect: "allow" | "deny";
   selector?: Selector;
 };
 
-export function selectorKey(selector: Selector | undefined): string {
+function selectorKey(selector: Selector | undefined): string {
   if (!selector) return "*";
   return JSON.stringify({
     disposition: selector.disposition ?? "",
@@ -160,11 +160,11 @@ export function selectorKey(selector: Selector | undefined): string {
   });
 }
 
-export function grantIdentityKey(identity: GrantIdentity): string {
+function grantIdentityKey(identity: GrantIdentity): string {
   return `${identity.scope}\x00${identity.effect}\x00${selectorKey(identity.selector)}`;
 }
 
-export function grantIdentities(grants: SdkRoleGrant[]): GrantIdentity[] {
+function grantIdentities(grants: SdkRoleGrant[]): GrantIdentity[] {
   return grants.flatMap((grant) => {
     const effect = (grant.effect ?? "allow") as "allow" | "deny";
     if (!grant.selectors || grant.selectors.length === 0) {
@@ -178,9 +178,7 @@ export function grantIdentities(grants: SdkRoleGrant[]): GrantIdentity[] {
   });
 }
 
-export function grantsFromIdentities(
-  identities: GrantIdentity[],
-): SdkRoleGrant[] {
+function grantsFromIdentities(identities: GrantIdentity[]): SdkRoleGrant[] {
   const unrestricted: SdkRoleGrant[] = [];
   const grouped = new Map<string, SdkRoleGrant>();
 

--- a/client/dashboard/src/pages/access/roleGrantTransform.ts
+++ b/client/dashboard/src/pages/access/roleGrantTransform.ts
@@ -156,6 +156,7 @@ function selectorKey(selector: Selector | undefined): string {
     projectId: selector.projectId ?? "",
     resourceId: selector.resourceId,
     resourceKind: selector.resourceKind,
+    serverUrl: selector.serverUrl ?? "",
     tool: selector.tool ?? "",
   });
 }
@@ -237,4 +238,37 @@ export function diffGrants(
     addGrants: grantsFromIdentities(addIdentities),
     removeGrants: grantsFromIdentities(removeIdentities),
   };
+}
+
+/**
+ * Pure helper for the chip X-click behavior on a single scope's grant.
+ * Returns the next grant value, or null when the scope should be removed
+ * entirely from the form state.
+ *
+ *   - removing a narrower allow that leaves no allows → fall back to
+ *     unrestricted ("All servers"); orphaned denies are dropped.
+ *   - removing an unrestricted allow → orphan-clear: scope unchecks, any
+ *     denies go with it.
+ *   - removing a deny → just filter it out; allows preserved.
+ *   - removing one of several allows → just filter it out.
+ */
+export function applyRemoveRule(
+  grant: RoleGrant,
+  ruleIndex: number,
+): RoleGrant | null {
+  const removed = grant.rules[ruleIndex];
+  if (!removed) return grant;
+
+  let rules = grant.rules.filter((_, i) => i !== ruleIndex);
+  const hasAllow = rules.some((r) => r.effect === "allow");
+
+  if (removed.effect === "allow" && removed.selectors !== null && !hasAllow) {
+    rules = [{ id: crypto.randomUUID(), effect: "allow", selectors: null }];
+  } else if (!hasAllow) {
+    // No allows left — any remaining denies are orphaned, clear them too.
+    rules = [];
+  }
+
+  if (rules.length === 0) return null;
+  return { ...grant, rules };
 }

--- a/client/dashboard/src/pages/access/roundtrip.test.ts
+++ b/client/dashboard/src/pages/access/roundtrip.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 import type { Role } from "@gram/client/models/components/role.js";
-import { grantsFromRole, sdkGrantsFromForm } from "./roleGrantTransform";
+import type { RoleGrant } from "./types";
+import {
+  applyRemoveRule,
+  diffGrants,
+  grantsFromRole,
+  sdkGrantsFromForm,
+} from "./roleGrantTransform";
 
 function role(grants: Role["grants"]): Role {
   return {
@@ -62,5 +68,100 @@ describe("role grant round-trip (grantsFromRole → sdkGrantsFromForm)", () => {
         effect: "deny",
       }),
     );
+  });
+});
+
+describe("diffGrants", () => {
+  it("treats two risk-policy selectors differing only in serverUrl as distinct", () => {
+    // serverUrl is the differentiating dimension for risk_policy scopes.
+    // selectorKey must include it or the diff collapses both grants to the
+    // same identity and the change is silently dropped.
+    const before = [
+      {
+        scope: "risk_policy:evaluate" as const,
+        effect: "allow" as const,
+        selectors: [
+          {
+            resourceKind: "risk_policy" as const,
+            resourceId: "*",
+            serverUrl: "https://a.example.com",
+          },
+        ],
+      },
+    ];
+    const after = [
+      {
+        scope: "risk_policy:evaluate" as const,
+        effect: "allow" as const,
+        selectors: [
+          {
+            resourceKind: "risk_policy" as const,
+            resourceId: "*",
+            serverUrl: "https://b.example.com",
+          },
+        ],
+      },
+    ];
+
+    const { addGrants, removeGrants } = diffGrants(before, after);
+
+    expect(removeGrants).toHaveLength(1);
+    expect(addGrants).toHaveLength(1);
+  });
+});
+
+describe("applyRemoveRule", () => {
+  it("unchecks the scope when an unrestricted allow is removed, dropping orphaned denies", () => {
+    const grant: RoleGrant = {
+      scope: "mcp:connect",
+      rules: [
+        { id: "a", effect: "allow", selectors: null },
+        {
+          id: "d",
+          effect: "deny",
+          selectors: [{ resourceKind: "mcp", resourceId: "srv_1" }],
+        },
+      ],
+    };
+
+    expect(applyRemoveRule(grant, 0)).toBeNull();
+  });
+
+  it("falls back to unrestricted when the only narrower allow is removed", () => {
+    const grant: RoleGrant = {
+      scope: "mcp:connect",
+      rules: [
+        {
+          id: "a",
+          effect: "allow",
+          selectors: [{ resourceKind: "mcp", resourceId: "srv_1" }],
+        },
+      ],
+    };
+
+    const next = applyRemoveRule(grant, 0);
+    expect(next).not.toBeNull();
+    expect(next!.rules).toHaveLength(1);
+    expect(next!.rules[0]!.effect).toBe("allow");
+    expect(next!.rules[0]!.selectors).toBeNull();
+  });
+
+  it("filters a deny without touching surviving allows", () => {
+    const grant: RoleGrant = {
+      scope: "mcp:connect",
+      rules: [
+        { id: "a", effect: "allow", selectors: null },
+        {
+          id: "d",
+          effect: "deny",
+          selectors: [{ resourceKind: "mcp", resourceId: "srv_1" }],
+        },
+      ],
+    };
+
+    const next = applyRemoveRule(grant, 1);
+    expect(next).not.toBeNull();
+    expect(next!.rules).toHaveLength(1);
+    expect(next!.rules[0]!.effect).toBe("allow");
   });
 });

--- a/client/dashboard/src/pages/access/roundtrip.test.ts
+++ b/client/dashboard/src/pages/access/roundtrip.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import type { Role } from "@gram/client/models/components/role.js";
+import { grantsFromRole, sdkGrantsFromForm } from "./roleGrantTransform";
+
+function role(grants: Role["grants"]): Role {
+  return {
+    id: "role_test",
+    name: "Test",
+    slug: "org-test",
+    description: "",
+    isSystem: false,
+    grants,
+    memberCount: 0,
+    createdAt: new Date("2026-06-05T00:00:00Z"),
+    updatedAt: new Date("2026-06-05T00:00:00Z"),
+  };
+}
+
+describe("role grant round-trip (grantsFromRole → sdkGrantsFromForm)", () => {
+  it("collapses the synthetic wildcard allow to unrestricted (selectors:undefined)", () => {
+    // Server stores {kind:"mcp", id:"*"} for grants saved with nil selectors.
+    // The dialog must collapse this back to the unrestricted shape so the chip
+    // reads "All servers" instead of "1 server".
+    const r = role([
+      {
+        scope: "mcp:connect",
+        effect: "allow",
+        selectors: [{ resourceKind: "mcp", resourceId: "*" }],
+      },
+    ]);
+
+    const sdkGrants = sdkGrantsFromForm(grantsFromRole(r));
+
+    expect(sdkGrants).toEqual([{ scope: "mcp:connect", selectors: undefined }]);
+  });
+
+  it("preserves an explicit wildcard deny grant", () => {
+    // Backend stores the kind-scoped wildcard {kind:"mcp", id:"*"} for both
+    // allow and deny effects. Allow can be collapsed to unrestricted because
+    // sdkGrantsFromForm re-emits unrestricted via selectors:undefined.
+    // Deny has no such fallback — if we collapse it to selectors:null,
+    // sdkGrantsFromForm drops the rule entirely and the deny is lost on save.
+    const r = role([
+      {
+        scope: "mcp:connect",
+        effect: "allow",
+        selectors: [{ resourceKind: "mcp", resourceId: "*" }],
+      },
+      {
+        scope: "mcp:connect",
+        effect: "deny",
+        selectors: [{ resourceKind: "mcp", resourceId: "*" }],
+      },
+    ]);
+
+    const rules = grantsFromRole(r);
+    const sdkGrants = sdkGrantsFromForm(rules);
+
+    expect(sdkGrants).toContainEqual(
+      expect.objectContaining({
+        scope: "mcp:connect",
+        effect: "deny",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Role edit dialog rendered "All servers" grants as "1 server" after save and reopen.

## Root cause

Pure display round-trip bug:

- Frontend correctly sends `selectors: undefined` for unrestricted grants.
- Backend `flattenRoleGrants` synthesizes the storage selector `{resource_kind:"mcp", resource_id:"*"}` for nil selectors.
- `Selector.IsRestricted()` deliberately returns `true` for that shape (per existing test `TestSelector_IsRestricted/scope wildcard is still scoped`), so `collapseUnrestrictedSelectors` does not collapse it on read.
- API response returns the explicit kind-scoped wildcard verbatim.
- `grantsFromRole` saw `selectors.length === 1`, fell into the specific-servers branch, and `computeRuleLabel` rendered "1 server".

Verified via the Chrome DevTools payload: request sent `add_grants: [{effect:"allow", scope:"mcp:connect"}]` (no selectors), response listed `selectors: [{resource_kind:"mcp", resource_id:"*"}]`.

## Fix

Added `isUnrestrictedSelectorList` in `CreateRoleDialog.tsx`. It detects the storage form of an unrestricted grant — a single selector with `resourceId === "*"` and no other narrowing keys — and `grantsFromRole` now treats it as the unrestricted rule shape (`selectors: null`).

Frontend-only fix. Backend collapse semantics left intact because existing tests (`TestGrantsToScopedGrants_scopeWildcardStaysExplicit`, `TestCollapseUnrestrictedSelectors`) intentionally lock the current behavior for the deny path.


## Video


https://github.com/user-attachments/assets/09d73086-7cd1-4a8e-a8d4-2375feba496a



## Test plan

- [ ] Open a role configured with `mcp:connect` restricted to 1 server.
- [ ] Click the X on the server chip, re-check `mcp:connect` so it defaults to "All servers", save.
- [ ] Reopen the role — chip should now read "All servers" (was "1 server" before the fix).
- [ ] Existing roles with the synthetic wildcard already in the DB render as "All servers" without any migration.
- [ ] `pnpm vitest run pages/access` — 140 access tests pass.
- [ ] `pnpm -F dashboard type-check` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the role edit dialog showing “All servers” as “1 server”, preserves explicit wildcard deny grants, and keeps the scope state consistent when removing rules. Also fixes grant diffing by including `serverUrl` so `risk_policy` updates aren’t dropped; no migration needed.

- **Bug Fixes**
  - Collapse the synthetic wildcard to unrestricted only for allow grants in `grantsFromRole` (treat a single `resourceId: "*"` with no other keys as unrestricted), but keep deny wildcards explicit so they persist.
  - Chip removal behavior: removing the only narrower allow falls back to an unrestricted allow and drops deny carve-outs; removing an already-unrestricted allow clears the scope and any denies.
  - Include `serverUrl` in the grant diff identity to properly detect changes for `risk_policy` grants.

- **Refactors**
  - Moved grant transforms to roleGrantTransform.ts (`grantsFromRole`, `sdkGrantsFromForm`, `diffGrants`) with unit tests for wildcard round-trip, `serverUrl` diffing, and `applyRemoveRule`.
  - Kept transform internals unexported; public API remains `grantsFromRole`, `sdkGrantsFromForm`, and `diffGrants`.

<sup>Written for commit 8d4717b6a6970da61d6eebe27cee230980bc19d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



