### PR TITLE
mig: MD5 on index

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2926,9 +2926,12 @@ CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
 WHERE found IS TRUE AND excluded_at IS NULL;
 
--- Drives the exact-match exclusion sweep.
+-- Narrows the exclusion sweeps (exact/rule_id/source) by project + policy +
+-- rule. The verbatim match column is intentionally NOT indexed: it can exceed
+-- the btree row-size limit (2704 bytes), and the sweep queries apply
+-- match = value as a recheck filter over this narrowed set.
 CREATE INDEX IF NOT EXISTS risk_results_policy_match_idx
-ON risk_results (project_id, risk_policy_id, rule_id, match);
+ON risk_results (project_id, risk_policy_id, rule_id);
 
 -- Reversal lookup: unflag rows previously excluded by a given exclusion.
 CREATE INDEX IF NOT EXISTS risk_results_excluded_exclusion_idx

--- a/server/migrations/20260605161734_add_risk_exclusions.sql
+++ b/server/migrations/20260605161734_add_risk_exclusions.sql
@@ -1,0 +1,35 @@
+-- atlas:txmode none
+
+-- Drop index "risk_results_project_found_idx" from table: "risk_results"
+DROP INDEX CONCURRENTLY "risk_results_project_found_idx";
+-- Modify "risk_results" table
+ALTER TABLE "risk_results" ADD COLUMN "excluded_at" timestamptz NULL, ADD COLUMN "excluded_exclusion_id" uuid NULL;
+-- Create index "risk_results_project_found_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_project_found_idx" ON "risk_results" ("project_id", "created_at" DESC) WHERE ((found IS TRUE) AND (excluded_at IS NULL));
+-- Create index "risk_results_excluded_exclusion_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_excluded_exclusion_idx" ON "risk_results" ("excluded_exclusion_id") WHERE (excluded_exclusion_id IS NOT NULL);
+-- Create index "risk_results_policy_match_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_policy_match_idx" ON "risk_results" ("project_id", "risk_policy_id", "rule_id");
+-- Create "risk_exclusions" table
+CREATE TABLE "risk_exclusions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "organization_id" text NOT NULL,
+  "risk_policy_id" uuid NULL,
+  "match_type" text NOT NULL,
+  "match_value" text NOT NULL,
+  "rule_id_filter" text NULL,
+  "source_filter" text NULL,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "risk_exclusions_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_exclusions_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_exclusions_risk_policy_id_fkey" FOREIGN KEY ("risk_policy_id") REFERENCES "risk_policies" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_exclusions_match_type_check" CHECK (match_type = ANY (ARRAY['exact'::text, 'regex'::text, 'rule_id'::text, 'source'::text, 'entity_type'::text]))
+);
+-- Create index "risk_exclusions_project_policy_idx" to table: "risk_exclusions"
+CREATE INDEX "risk_exclusions_project_policy_idx" ON "risk_exclusions" ("project_id", "risk_policy_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:bK/PxAnIVA4zCw7pEyzKXyyG7mF//NuHPmpYhVnuRx8=
+h1:pDVS/8RCv0XRFA3UTVP3cGfFvdBsiLowiH5HkQSjnZY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -208,3 +208,4 @@ h1:bK/PxAnIVA4zCw7pEyzKXyyG7mF//NuHPmpYhVnuRx8=
 20260603143315_age-2631-assistant-dashboard-messages.sql h1:cY9snSVnbLTFV+vKZ4pw5mH11TkZ2cBfb4IscJlQtkY=
 20260604141922_add-risk-policy-bypass-requests-table.sql h1:Ol7aa0m2r1gSObRbAJaqr6wdCs37y8qtvLlZYs6Q7pg=
 20260605143925_add_risk_exclusions.sql h1:u5YQre0OFPZ56F9gAy0K7kSsb5q+koeoJh49JOS3qjw=
+20260605161734_add_risk_exclusions.sql h1:zRbqqajTDz3VyKZfCIMI15C8kyZDM5SCMKbxZumPCeI=


### PR DESCRIPTION
Schema and migrations split off `feat/policy_exclusions` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce database support for policy-based risk exclusions. Adds a `risk_exclusions` table and updates `risk_results` and indexes to enable exclusion sweeps and fast lookups.

- New Features
  - Added risk_exclusions table with FKs to project, organization, and optional risk_policy; supports match types: exact, regex, rule_id, source, entity_type; partial index on (project_id, risk_policy_id) for active rows.
  - Updated risk_results: added excluded_at and excluded_exclusion_id; partial index for found and not-excluded rows; index on excluded_exclusion_id for reversal lookups.
  - Adjusted sweep index: risk_results_policy_match_idx now on (project_id, risk_policy_id, rule_id) only, dropping the verbatim match column to avoid btree size limits (match is applied as a recheck filter).

<sup>Written for commit 5f3315bb179f3942154fd3ce5ef03783fb8101b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

