### PR TITLE
mig: fixes index and column migration

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2926,9 +2926,12 @@ CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
 WHERE found IS TRUE AND excluded_at IS NULL;
 
--- Drives the exact-match exclusion sweep.
+-- Narrows the exclusion sweeps (exact/rule_id/source) by project + policy +
+-- rule. The verbatim match column is intentionally NOT indexed: it can exceed
+-- the btree row-size limit (2704 bytes), and the sweep queries apply
+-- match = value as a recheck filter over this narrowed set.
 CREATE INDEX IF NOT EXISTS risk_results_policy_match_idx
-ON risk_results (project_id, risk_policy_id, rule_id, match);
+ON risk_results (project_id, risk_policy_id, rule_id);
 
 -- Reversal lookup: unflag rows previously excluded by a given exclusion.
 CREATE INDEX IF NOT EXISTS risk_results_excluded_exclusion_idx

--- a/server/migrations/20260605174513_risk-results-drop-verbatim-match-index-column.sql
+++ b/server/migrations/20260605174513_risk-results-drop-verbatim-match-index-column.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Drop index "risk_results_policy_match_idx" from table: "risk_results"
+DROP INDEX CONCURRENTLY "risk_results_policy_match_idx";
+-- Create index "risk_results_policy_match_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_policy_match_idx" ON "risk_results" ("project_id", "risk_policy_id", "rule_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:bK/PxAnIVA4zCw7pEyzKXyyG7mF//NuHPmpYhVnuRx8=
+h1:QarK/HFevrFl5jiWc6iu+rTMIWAgZKdXttVRgSQCDuY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -208,3 +208,4 @@ h1:bK/PxAnIVA4zCw7pEyzKXyyG7mF//NuHPmpYhVnuRx8=
 20260603143315_age-2631-assistant-dashboard-messages.sql h1:cY9snSVnbLTFV+vKZ4pw5mH11TkZ2cBfb4IscJlQtkY=
 20260604141922_add-risk-policy-bypass-requests-table.sql h1:Ol7aa0m2r1gSObRbAJaqr6wdCs37y8qtvLlZYs6Q7pg=
 20260605143925_add_risk_exclusions.sql h1:u5YQre0OFPZ56F9gAy0K7kSsb5q+koeoJh49JOS3qjw=
+20260605174513_risk-results-drop-verbatim-match-index-column.sql h1:Ans/oK8EWrCsPWdbfL9v/66RrUgIMYdlwEDEx9hwscc=


### PR DESCRIPTION
Schema and migrations split off `feat/policy_exclusions` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Schema-only change split from the policy exclusions feature. Rebuilds `risk_results_policy_match_idx` without the `match` column to avoid btree row-size limits and keep exclusion sweeps fast by narrowing on project, policy, and rule.

- **Migration**
  - Drops and recreates the index concurrently; safe to run online.
  - Exclusion queries should narrow by `project_id`, `risk_policy_id`, `rule_id` and recheck `match = value`; no app code changes needed.

<sup>Written for commit 3b016d52cf478210d55c861d0a1e6669ebc310bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

