### PR TITLE
feat: show tool filtering on the public MCP install page

### DIFF
--- a/server/internal/mcpmetadata/hosted_page.html.tmpl
+++ b/server/internal/mcpmetadata/hosted_page.html.tmpl
@@ -854,6 +854,50 @@
       * {
         box-sizing: border-box;
       }
+
+      /****************
+       * Tool Scopes *
+       ****************/
+      .scope-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+      }
+
+      .scope-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.375rem 0.75rem;
+        border-radius: 999px;
+        border: solid 1px var(--border-neutral-softest);
+        background: var(--fill-neutral-default-inverse);
+        color: var(--text-default);
+        font-size: 0.8125rem;
+        cursor: pointer;
+        transition: background-color 200ms var(--ease-in-out-quad);
+      }
+
+      .scope-chip:hover {
+        background: var(--fill-neutral-highlight-inverse);
+      }
+
+      .scope-chip.active,
+      .scope-chip.active:visited {
+        border-color: var(--color-link-default);
+        color: var(--color-link-default);
+      }
+
+      .scope-chip:visited {
+        color: var(--text-default);
+      }
+
+      .scope-chip-count {
+        font-family: var(--font-diatype-mono);
+        font-size: 0.6875rem;
+        opacity: 0.7;
+      }
     </style>
     <template id="modal-template">
       <div class="modal">
@@ -908,7 +952,7 @@
                 </svg>
               </button>
               <!-- prettier-ignore -->
-              <code class="code-snippet language-sh">claude mcp add --transport http "{{ .MCPSlug }}" \
+              <code class="code-snippet language-sh" data-scope-url-text>claude mcp add --transport http "{{ .MCPSlug }}" \
     "{{ .MCPURL }}"{{- range .SecurityInputs }} \
     --header '{{ .SystemName | asHTTPHeader }}:{{ printf "${%s}" (.DisplayName | asPosixName) }}'{{- end }}</code>            </div>
           </li>
@@ -981,7 +1025,7 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
                 </svg>
               </button>
               <!-- prettier-ignore -->
-              <code class="code-snippet language-sh">gemini mcp add --transport http "{{ .MCPSlug }}" "{{ .MCPURL }}"{{- range .SecurityInputs }} \
+              <code class="code-snippet language-sh" data-scope-url-text>gemini mcp add --transport http "{{ .MCPSlug }}" "{{ .MCPURL }}"{{- range .SecurityInputs }} \
   --header '{{ .SystemName | asHTTPHeader }}:{{ printf "${%s}" (.DisplayName | asPosixName) }}'{{- end }}</code>
             </div>
           </li>
@@ -1060,7 +1104,7 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
                 </svg>
               </button>
               <!-- prettier-ignore -->
-              <code class="code-snippet language-json">{
+              <code class="code-snippet language-json" data-scope-url-text>{
   "mcpServers": {
     "{{ .MCPSlug }}": {
       "command": "npx",
@@ -1124,7 +1168,7 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
                 </svg>
               </button>
               <!-- prettier-ignore -->
-              <code class="code-snippet">{{ .MCPURL }}</code>
+              <code class="code-snippet" data-scope-url-text>{{ .MCPURL }}</code>
             </div>
           </li>
           <li class="instruction-item">
@@ -1173,7 +1217,7 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
                 </svg>
               </button>
               <!-- prettier-ignore -->
-              <code class="code-snippet language-toml">[mcp_servers.{{ .MCPSlug }}]
+              <code class="code-snippet language-toml" data-scope-url-text>[mcp_servers.{{ .MCPSlug }}]
 url = "{{ .MCPURL }}"
 http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }}"{{ $input.SystemName | asHTTPHeader }}" = "your-{{ $input.DisplayName | asPosixName }}-value"{{- end }} }</code>
             </div>
@@ -1282,6 +1326,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
                     class="popover-button install-link"
                     href="{{ .CursorInstallLink }}"
                     data-install-target="cursor"
+                    data-scope-cursor
                   >
                     Cursor
                   </a>
@@ -1303,6 +1348,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
                     class="popover-button install-link"
                     href="{{ .VSCodeInstallLink }}"
                     data-install-target="vscode"
+                    data-scope-vscode
                   >
                     VS Code
                   </a>
@@ -1328,6 +1374,29 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
           <div class="badge private-badge">private</div>
           {{- end }}
         </section>
+        {{- if .FilteringEnabled }}
+        <section class="scopes container">
+          <header class="section-title">Tool Groups</header>
+          <div class="section-description">
+            This server supports limiting the available tools given to your agent. By
+            default, all tools are returned. Select a group to reduce the
+            returned tools.
+          </div>
+          <div class="scope-chips">
+            <a class="scope-chip active" href="?" data-scope-tag="">All tools</a>
+            {{- range .Scopes }}
+            <a
+              class="scope-chip"
+              href="?tags={{ .Tag }}"
+              data-scope-tag="{{ .Tag }}"
+            >
+              {{ .Tag }}
+              <span class="scope-chip-count">{{ .ToolCount }}</span>
+            </a>
+            {{- end }}
+          </div>
+        </section>
+        {{- end }}
         <section class="install container">
           <header>
             <h1 class="section-title">Install</h1>
@@ -1340,6 +1409,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
               tabindex="0"
               class="card install-target install-link"
               href="{{ .CursorInstallLink }}"
+              data-scope-cursor
             >
               <div class="target">
                 <img src="https://cursor.com/assets/images/logo.svg" />
@@ -1394,6 +1464,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
               tabindex="0"
               class="card install-target install-link"
               href="{{ .VSCodeInstallLink }}"
+              data-scope-vscode
             >
               <div class="target">
                 <svg
@@ -1626,7 +1697,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
           {{- end }}
           <div class="tools-table{{ if gt (len .Tools) 20 }} scrollable{{ end }}">
             {{- range $i, $tool := .Tools }}
-            <div class="tool-row" data-tool-name="{{ $tool.Name }}">
+            <div class="tool-row" data-tool-name="{{ $tool.Name }}" data-tool-tags="{{ join $tool.Tags "," }}">
               <span class="tool-name">{{ $tool.Name }}</span>
               <span class="tool-desc">{{ $tool.Description }}</span>
               <span class="tool-chevron">&#9662;</span>
@@ -1692,7 +1763,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
                 <use href="#icon-copy-check"></use>
               </svg>
             </button>
-            <code class="code-snippet mcp-url">{{ .MCPURL }}</code>
+            <code class="code-snippet mcp-url" data-scope-url>{{ .MCPURL }}</code>
           </div>
         </section>
         <section class="raw-configuration container">
@@ -1724,7 +1795,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
                 <use href="#icon-copy-check"></use>
               </svg>
             </button>
-            <code class="code-snippet language-json">{{- .MCPConfig -}}</code>
+            <code class="code-snippet language-json" data-scope-config>{{- .MCPConfig -}}</code>
           </div>
         </section>
       </div>
@@ -1794,6 +1865,9 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
         </symbol>
       </defs>
     </svg>
+    {{- if .FilteringEnabled }}
+    <div id="scope-variants" data-variants="{{ .ScopeVariantsJSON }}" hidden></div>
+    {{- end }}
     <script
       type="module"
       src="{{ .ScriptURL }}"

--- a/server/internal/mcpmetadata/hosted_page.js
+++ b/server/internal/mcpmetadata/hosted_page.js
@@ -189,7 +189,9 @@ function updateToolCount() {
 
 function applyScope(tag) {
   if (!scopeVariants) return;
-  if (!(tag in scopeVariants)) tag = "";
+  // Use hasOwnProperty so prototype keys (constructor, __proto__, …) from a
+  // crafted ?tags= fall back to the unfiltered view instead of a bogus variant.
+  if (!Object.prototype.hasOwnProperty.call(scopeVariants, tag)) tag = "";
   activeScopeTag = tag;
 
   applyScopeToTree(document, tag);

--- a/server/internal/mcpmetadata/hosted_page.js
+++ b/server/internal/mcpmetadata/hosted_page.js
@@ -1,3 +1,12 @@
+// Tool-filtering scope state. scopeVariants is the JSON map (keyed by tag, with
+// the empty-string key holding the unfiltered defaults) emitted server-side when
+// filtering is enabled; it stays null on servers without a variations group, in
+// which case all scope behavior is inert and the page works exactly as before.
+let scopeVariants = null;
+let defaultScopeUrl = "";
+let activeScopeTag = "";
+let toolSearchQuery = "";
+
 function togglePopover(e) {
   const popoverRoot = e.currentTarget.parentElement;
   const menu = popoverRoot.querySelector(".popover-menu");
@@ -28,6 +37,10 @@ function closeModal() {
 function openModal(childContent) {
   const template = document.querySelector("#modal-template");
   const modalElement = template.content.cloneNode(true);
+
+  // The cloned snippets carry the unfiltered default URL; re-apply the active
+  // scope so the modal reflects the currently selected chip.
+  applyScopeToTree(childContent, activeScopeTag);
 
   modalElement.querySelector(".content-slot").appendChild(childContent);
   modalElement.querySelectorAll(".code-container").forEach((el) => {
@@ -70,18 +83,36 @@ function toggleToolDetail(row) {
   }
 }
 
-function filterTools(query) {
+function toolMatchesScope(row, tag) {
+  if (!tag) return true;
+  const tags = (row.getAttribute("data-tool-tags") || "")
+    .split(",")
+    .filter(Boolean);
+  return tags.includes(tag);
+}
+
+function toolMatchesSearch(row, query) {
+  if (!query) return true;
+  const name = row.getAttribute("data-tool-name") || "";
+  const desc = row.querySelector(".tool-desc");
+  const descText = desc ? desc.textContent : "";
+  return (
+    name.toLowerCase().includes(query) || descText.toLowerCase().includes(query)
+  );
+}
+
+// updateToolVisibility shows a tool only when it matches BOTH the active scope
+// and the search query, so the two filters compose instead of clobbering each
+// other's filtered-out class.
+function updateToolVisibility() {
   const table = document.querySelector(".tools-table");
   if (!table) return;
   const rows = table.querySelectorAll(".tool-row");
-  const q = query.toLowerCase();
+  const q = toolSearchQuery.toLowerCase();
   let visibleCount = 0;
   for (const row of rows) {
-    const name = row.getAttribute("data-tool-name") || "";
-    const desc = row.querySelector(".tool-desc");
-    const descText = desc ? desc.textContent : "";
     const match =
-      name.toLowerCase().includes(q) || descText.toLowerCase().includes(q);
+      toolMatchesScope(row, activeScopeTag) && toolMatchesSearch(row, q);
     row.classList.toggle("filtered-out", !match);
     const detail = row.nextElementSibling;
     if (detail && detail.classList.contains("tool-detail")) {
@@ -96,6 +127,116 @@ function filterTools(query) {
   const noResults = table.querySelector(".tools-no-results");
   if (noResults)
     noResults.style.display = visibleCount === 0 ? "block" : "none";
+}
+
+// parseScopeVariants reads the server-emitted scope/connection map from the
+// data-variants attribute. Returns null when the page has no scope filtering,
+// leaving all scope behavior inert.
+function parseScopeVariants() {
+  const el = document.getElementById("scope-variants");
+  if (!el) return null;
+  try {
+    return JSON.parse(el.dataset.variants);
+  } catch (err) {
+    console.error("Failed to parse scope variants:", err);
+    return null;
+  }
+}
+
+// applyScopeToTree swaps the connection strings for the given tag within root.
+// root is the document for the always-visible elements, or a freshly cloned
+// modal fragment (whose snippets start at the unfiltered default). Every value
+// comes from the server-built variant map, so the client never encodes a URL.
+function applyScopeToTree(root, tag) {
+  if (!scopeVariants) return;
+  const variant = scopeVariants[tag] || scopeVariants[""];
+  if (!variant) return;
+
+  root.querySelectorAll("[data-scope-url]").forEach((el) => {
+    el.textContent = variant.url;
+  });
+  root.querySelectorAll("[data-scope-config]").forEach((el) => {
+    el.textContent = variant.config;
+  });
+  root.querySelectorAll("[data-scope-cursor]").forEach((el) => {
+    el.setAttribute("href", variant.cursor);
+  });
+  root.querySelectorAll("[data-scope-vscode]").forEach((el) => {
+    el.setAttribute("href", variant.vscode);
+  });
+  // Command snippets embed the MCP URL inside a larger string; replace the
+  // unfiltered default URL with the scoped URL (both server-built). On a fresh
+  // modal clone the text starts at the default, so this single pass is correct.
+  root.querySelectorAll("[data-scope-url-text]").forEach((el) => {
+    if (defaultScopeUrl && variant.url !== defaultScopeUrl) {
+      el.textContent = el.textContent.split(defaultScopeUrl).join(variant.url);
+    }
+  });
+}
+
+// updateToolCount sets the "Available Tools (N)" header to the number of tools
+// in the active scope (ignoring the search box, which has its own empty state).
+function updateToolCount() {
+  const countEl = document.querySelector(".available-tools .tool-count");
+  if (!countEl) return;
+  const rows = document.querySelectorAll(".tools-table .tool-row");
+  let count = 0;
+  for (const row of rows) {
+    if (toolMatchesScope(row, activeScopeTag)) count++;
+  }
+  countEl.textContent = "(" + count + ")";
+}
+
+function applyScope(tag) {
+  if (!scopeVariants) return;
+  if (!(tag in scopeVariants)) tag = "";
+  activeScopeTag = tag;
+
+  applyScopeToTree(document, tag);
+
+  document.querySelectorAll(".scope-chip").forEach((chip) => {
+    chip.classList.toggle(
+      "active",
+      (chip.getAttribute("data-scope-tag") || "") === tag,
+    );
+  });
+
+  updateToolCount();
+  updateToolVisibility();
+}
+
+// scopeTagFromLocation reads the selected scope from the ?tags= query parameter.
+// The install page is single-select, so a shared multi-tag URL collapses to its
+// first tag.
+function scopeTagFromLocation() {
+  const raw = new URLSearchParams(window.location.search).get("tags");
+  if (!raw) return "";
+  return raw.split(",")[0].trim();
+}
+
+function initializeScopes() {
+  scopeVariants = parseScopeVariants();
+  if (!scopeVariants) return;
+  defaultScopeUrl = scopeVariants[""] ? scopeVariants[""].url : "";
+
+  document.querySelectorAll(".scope-chip").forEach((chip) => {
+    chip.addEventListener("click", (e) => {
+      e.preventDefault();
+      const tag = chip.getAttribute("data-scope-tag") || "";
+      applyScope(tag);
+      const nextURL = tag
+        ? "?tags=" + encodeURIComponent(tag)
+        : window.location.pathname;
+      window.history.pushState({ scopeTag: tag }, "", nextURL);
+    });
+  });
+
+  window.addEventListener("popstate", () => {
+    applyScope(scopeTagFromLocation());
+  });
+
+  // Restore the scope from the URL so shared ?tags= links open pre-selected.
+  applyScope(scopeTagFromLocation());
 }
 
 function copyContainerSnippet(e) {
@@ -178,8 +319,13 @@ function initializeHandlers() {
 
   const toolsSearch = document.querySelector(".tools-search");
   if (toolsSearch) {
-    toolsSearch.addEventListener("input", (e) => filterTools(e.target.value));
+    toolsSearch.addEventListener("input", (e) => {
+      toolSearchQuery = e.target.value;
+      updateToolVisibility();
+    });
   }
+
+  initializeScopes();
 
   registerCenterOffsetUpdaters(document.querySelector(".gram-brand-badge"));
 

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -12,8 +12,10 @@ import (
 	"fmt"
 	"html/template"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -41,6 +43,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	environments_repo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
@@ -105,6 +108,29 @@ type toolInfo struct {
 	DestructiveHint bool
 	IdempotentHint  bool
 	OpenWorldHint   bool
+	// Tags are the tool's effective filter tags (see toolfilter.EffectiveToolTags).
+	// Rendered onto each tool row so the install-page JS can filter the list by
+	// the selected scope without re-deriving tags client-side.
+	Tags []string
+}
+
+// scopeInfo is one selectable filter scope (a single tag) shown as a chip on the
+// install page, along with the number of tools that carry that tag.
+type scopeInfo struct {
+	Tag       string
+	ToolCount int
+}
+
+// scopeConnection holds the per-scope connection strings the install-page JS
+// swaps in when a scope chip is selected. Every value is built server-side from
+// the existing Go URL builders so the client performs no URL/encoding logic and
+// cannot drift from the runtime ?tags= behavior. The map emitted to the page is
+// keyed by tag, with the empty-string key holding the unfiltered defaults.
+type scopeConnection struct {
+	URL    string       `json:"url"`
+	Config string       `json:"config"`
+	Cursor template.URL `json:"cursor"`
+	VSCode template.URL `json:"vscode"`
 }
 
 func applyAnnotations(info *toolInfo, a *types.ToolAnnotations) {
@@ -150,6 +176,15 @@ type hostedPageData struct {
 	DocsText          string
 	Instructions      string
 	IsPublic          bool
+	// FilteringEnabled gates the scope chip bar and related UI.
+	FilteringEnabled bool
+	// Scopes are the selectable filter tags rendered as chips.
+	Scopes []scopeInfo
+	// ScopeVariantsJSON is a JSON object keyed by tag (empty-string key = the
+	// unfiltered default) mapping to that scope's connection strings. It is
+	// emitted into a data-* attribute and read by the install-page JS;
+	// html/template auto-escapes it in attribute context.
+	ScopeVariantsJSON string
 }
 
 type Service struct {
@@ -854,6 +889,20 @@ func buildVSCodeInstallURL(toolsetName, mcpURL string, inputs []securityInput) (
 	return u.String(), nil
 }
 
+// appendTagsQuery returns mcpURL with a ?tags=<tag> query parameter added. The
+// install-page MCP URLs are clean (no existing query), so this encodes the
+// single selected tag the same way the runtime ?tags= filter expects.
+func appendTagsQuery(mcpURL, tag string) string {
+	u, err := url.Parse(mcpURL)
+	if err != nil {
+		return mcpURL + "?tags=" + url.QueryEscape(tag)
+	}
+	q := u.Query()
+	q.Set("tags", tag)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
 // installContext is the resolved subject of an install-page request. When
 // resolution comes through mcp_endpoints, mcpServer is set. For toolset-backed
 // installs — whether routed via the legacy toolsets.mcp_slug path or via an
@@ -1080,7 +1129,23 @@ func (s *Service) loadInstallPageMetadata(ctx context.Context, ic *installContex
 func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseWriter, ic *installContext, mcpSlug string, metadataRecord *repo.McpMetadatum) error {
 	toolset := ic.toolset
 
-	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(toolset.ProjectID), mv.ToolsetSlug(toolset.Slug), &s.toolsetCache, nil)
+	// Resolve the effective tool-variations group with the same precedence chain
+	// as the runtime (mcp_servers value wins, then the toolset's own column).
+	// When a group is resolved we describe the toolset against it so the tools —
+	// and the tags we derive below — carry that group's variation overrides,
+	// matching exactly what the ?tags= runtime filter would return. A nil result
+	// means no explicit group (filtering disabled); the page renders as before.
+	var mcpServerGroupID *uuid.UUID
+	if ic.mcpServer != nil && ic.mcpServer.ToolVariationsGroupID.Valid {
+		mcpServerGroupID = &ic.mcpServer.ToolVariationsGroupID.UUID
+	}
+	var toolsetGroupID *uuid.UUID
+	if toolset.ToolVariationsGroupID.Valid {
+		toolsetGroupID = &toolset.ToolVariationsGroupID.UUID
+	}
+	resolvedGroupID := toolfilter.ResolveGroupID(mcpServerGroupID, toolsetGroupID)
+
+	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(toolset.ProjectID), mv.ToolsetSlug(toolset.Slug), &s.toolsetCache, resolvedGroupID)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "describe toolset").Log(ctx, s.logger)
 	}
@@ -1141,6 +1206,7 @@ func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseW
 				DestructiveHint: false,
 				IdempotentHint:  false,
 				OpenWorldHint:   false,
+				Tags:            toolfilter.EffectiveToolTags(toolDesc),
 			}
 			applyAnnotations(&info, toolDesc.ExternalMcpToolDefinition.Annotations)
 			tools = append(tools, info)
@@ -1160,9 +1226,31 @@ func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseW
 			DestructiveHint: false,
 			IdempotentHint:  false,
 			OpenWorldHint:   false,
+			Tags:            toolfilter.EffectiveToolTags(toolDesc),
 		}
 		applyAnnotations(&info, baseTool.Annotations)
 		tools = append(tools, info)
+	}
+
+	// Build the selectable scopes from the tools' effective tags (same source as
+	// the per-row Tags above, so chips and client-side filtering agree). Filtering
+	// is only surfaced when an explicit group is resolved AND it yields at least
+	// one tag; an empty group falls back to the unfiltered view (no chips).
+	filteringEnabled := false
+	scopes := []scopeInfo{}
+	if resolvedGroupID != nil {
+		tagCounts := map[string]int{}
+		for _, t := range tools {
+			for _, tag := range t.Tags {
+				tagCounts[tag]++
+			}
+		}
+		if len(tagCounts) > 0 {
+			for _, tag := range slices.Sorted(maps.Keys(tagCounts)) {
+				scopes = append(scopes, scopeInfo{Tag: tag, ToolCount: tagCounts[tag]})
+			}
+			filteringEnabled = true
+		}
 	}
 
 	mcpURL, err := s.resolveToolsetMCPURL(ctx, *toolset, mcpSlug)
@@ -1179,18 +1267,20 @@ func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseW
 	}
 
 	return s.writeInstallPage(ctx, w, hostedPageRenderInputs{
-		MCPName:        toolset.Name,
-		MCPSlug:        publicSlug,
-		MCPDescription: toolset.Description.String,
-		MCPURL:         mcpURL,
-		SecurityInputs: securityInputs,
-		Tools:          tools,
-		LogoAssetURL:   logoAssetURL,
-		DocsURL:        docsURL,
-		DocsText:       docsText,
-		Instructions:   instructions,
-		IsPublic:       ic.isPublic(),
-		OrgName:        ic.organization.Name,
+		MCPName:          toolset.Name,
+		MCPSlug:          publicSlug,
+		MCPDescription:   toolset.Description.String,
+		MCPURL:           mcpURL,
+		SecurityInputs:   securityInputs,
+		Tools:            tools,
+		LogoAssetURL:     logoAssetURL,
+		DocsURL:          docsURL,
+		DocsText:         docsText,
+		Instructions:     instructions,
+		IsPublic:         ic.isPublic(),
+		OrgName:          ic.organization.Name,
+		FilteringEnabled: filteringEnabled,
+		Scopes:           scopes,
 	})
 }
 
@@ -1247,6 +1337,9 @@ func (s *Service) renderRemoteMcpInstallPage(ctx context.Context, w http.Respons
 		Instructions:   instructions,
 		IsPublic:       ic.isPublic(),
 		OrgName:        ic.organization.Name,
+		// Remote-MCP-backed installs have no tool list, so no filter scopes.
+		FilteringEnabled: false,
+		Scopes:           nil,
 	})
 }
 
@@ -1265,6 +1358,11 @@ type hostedPageRenderInputs struct {
 	Instructions   string
 	IsPublic       bool
 	OrgName        string
+	// FilteringEnabled is true when the install context resolves an explicit
+	// tool-variations group with at least one tag; it gates all scope UI.
+	FilteringEnabled bool
+	// Scopes are the selectable filter tags (sorted), each with its tool count.
+	Scopes []scopeInfo
 }
 
 func (s *Service) writeInstallPage(ctx context.Context, w http.ResponseWriter, in hostedPageRenderInputs) error {
@@ -1282,36 +1380,76 @@ func (s *Service) writeInstallPage(ctx context.Context, w http.ResponseWriter, i
 		return oops.E(oops.CodeUnexpected, err, "parse config snippet template").Log(ctx, s.logger)
 	}
 
-	var configSnippet bytes.Buffer
-	if err := configSnippetTmpl.Execute(&configSnippet, configSnippetData); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "execute config snippet template").Log(ctx, s.logger)
+	// buildConn assembles the connection strings for a single MCP URL, reusing
+	// the same Go builders for every scope so the client never encodes a URL or
+	// deep link itself (no drift from the runtime ?tags= behavior).
+	buildConn := func(mcpURL string) (scopeConnection, error) {
+		snippetData := configSnippetData
+		snippetData.MCPURL = mcpURL
+
+		var configSnippet bytes.Buffer
+		if err := configSnippetTmpl.Execute(&configSnippet, snippetData); err != nil {
+			return scopeConnection{}, fmt.Errorf("execute config snippet template: %w", err)
+		}
+
+		cursorURL, err := buildCursorInstallURL(in.MCPName, mcpURL, in.SecurityInputs)
+		if err != nil {
+			return scopeConnection{}, fmt.Errorf("build cursor install URL: %w", err)
+		}
+		safeCursorURL, err := safeTemplateURL(cursorURL, "cursor")
+		if err != nil {
+			return scopeConnection{}, fmt.Errorf("sanitize cursor install URL: %w", err)
+		}
+
+		vsCodeURL, err := buildVSCodeInstallURL(in.MCPName, mcpURL, in.SecurityInputs)
+		if err != nil {
+			return scopeConnection{}, fmt.Errorf("build vscode install URL: %w", err)
+		}
+		safeVsCodeURL, err := safeTemplateURL(vsCodeURL, "vscode")
+		if err != nil {
+			return scopeConnection{}, fmt.Errorf("sanitize vscode install URL: %w", err)
+		}
+
+		return scopeConnection{
+			URL:    mcpURL,
+			Config: configSnippet.String(),
+			Cursor: safeCursorURL,
+			VSCode: safeVsCodeURL,
+		}, nil
 	}
 
-	cursorURL, err := buildCursorInstallURL(in.MCPName, in.MCPURL, in.SecurityInputs)
+	defaultConn, err := buildConn(in.MCPURL)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build cursor install URL").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "build default connection").Log(ctx, s.logger)
 	}
 
-	vsCodeURL, err := buildVSCodeInstallURL(in.MCPName, in.MCPURL, in.SecurityInputs)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build vscode install URL").Log(ctx, s.logger)
-	}
-
-	safeVsCodeURL, err := safeTemplateURL(vsCodeURL, "vscode")
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "sanitize vscode install URL").Log(ctx, s.logger)
-	}
-
-	safeCursorURL, err := safeTemplateURL(cursorURL, "cursor")
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "sanitize cursor install URL").Log(ctx, s.logger)
+	// When filtering is enabled, build one connection variant per scope (plus the
+	// unfiltered default under the empty-string key) and emit them as JSON for the
+	// install-page JS to swap in when a scope chip is selected.
+	var scopeVariantsJSON string
+	if in.FilteringEnabled {
+		variants := map[string]scopeConnection{"": defaultConn}
+		for _, scope := range in.Scopes {
+			conn, err := buildConn(appendTagsQuery(in.MCPURL, scope.Tag))
+			if err != nil {
+				return oops.E(oops.CodeUnexpected, err, "build scope connection").Log(ctx, s.logger)
+			}
+			variants[scope.Tag] = conn
+		}
+		encoded, err := json.Marshal(variants)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "marshal scope variants").Log(ctx, s.logger)
+		}
+		// Emitted into a data-* attribute (not a <script>), so html/template's
+		// attribute auto-escaping handles it — no template.JS / nosec needed.
+		scopeVariantsJSON = string(encoded)
 	}
 
 	data := hostedPageData{
 		jsonSnippetData:   configSnippetData,
-		MCPConfig:         configSnippet.String(),
-		CursorInstallLink: safeCursorURL,
-		VSCodeInstallLink: safeVsCodeURL,
+		MCPConfig:         defaultConn.Config,
+		CursorInstallLink: defaultConn.Cursor,
+		VSCodeInstallLink: defaultConn.VSCode,
 		OrganizationName:  in.OrgName,
 		SiteURL:           s.siteURL.String(),
 		ScriptURL:         "/mcp/install-page-" + s.installPageScriptHash + ".js",
@@ -1320,6 +1458,9 @@ func (s *Service) writeInstallPage(ctx context.Context, w http.ResponseWriter, i
 		DocsText:          in.DocsText,
 		Instructions:      in.Instructions,
 		IsPublic:          in.IsPublic,
+		FilteringEnabled:  in.FilteringEnabled,
+		Scopes:            in.Scopes,
+		ScopeVariantsJSON: scopeVariantsJSON,
 	}
 
 	hostedPageTmpl, err := template.New("hosted_page").Funcs(templatefuncs.FuncMap()).Parse(hostedPageTmplData)

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1241,7 +1241,14 @@ func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseW
 	if resolvedGroupID != nil {
 		tagCounts := map[string]int{}
 		for _, t := range tools {
+			// Dedupe a tool's tags so a tool that repeats a tag is counted once
+			// per scope, matching toolfilter.groupByEffectiveTags.
+			seen := map[string]struct{}{}
 			for _, tag := range t.Tags {
+				if _, ok := seen[tag]; ok {
+					continue
+				}
+				seen[tag] = struct{}{}
 				tagCounts[tag]++
 			}
 		}

--- a/server/internal/mcpmetadata/serve_install_page_scopes_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_scopes_test.go
@@ -1,0 +1,312 @@
+package mcpmetadata_test
+
+import (
+	"context"
+	"encoding/json"
+	"html"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	deployments_repo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/remotemcptest"
+	remotemcp_repo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	tools_repo "github.com/speakeasy-api/gram/server/internal/tools/repo"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	variations_repo "github.com/speakeasy-api/gram/server/internal/variations/repo"
+)
+
+// createPublicToolsetWithTools creates a completed deployment with the named
+// HTTP tools and a public, MCP-enabled toolset (slug == mcp slug) containing
+// them. It returns the toolset slug and the tool URNs in the order of names.
+func createPublicToolsetWithTools(t *testing.T, ctx context.Context, ti *testInstance, slug string, toolNames []string) (string, []urn.Tool) {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset, err := ti.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   slug,
+		Slug:                   slug,
+		McpSlug:                conv.ToPGText(slug),
+		Description:            conv.ToPGText("scopes test toolset"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	err = toolsets_repo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsets_repo.SetToolsetMCPPublicByIDParams{
+		McpIsPublic: true,
+		ID:          toolset.ID,
+		ProjectID:   toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	deploymentID, err := deployments_repo.New(ti.conn).InsertDeployment(ctx, deployments_repo.InsertDeploymentParams{
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         "test-user",
+		IdempotencyKey: uuid.New().String(),
+	})
+	require.NoError(t, err)
+
+	err = deployments_repo.New(ti.conn).CreateDeploymentStatus(ctx, deployments_repo.CreateDeploymentStatusParams{
+		DeploymentID: deploymentID,
+		Status:       "completed",
+	})
+	require.NoError(t, err)
+
+	toolURNs := make([]urn.Tool, 0, len(toolNames))
+	for _, name := range toolNames {
+		toolURN := urn.NewTool(urn.ToolKindHTTP, "scopes-api", uuid.New().String()[:8])
+		err = tools_repo.New(ti.conn).CreateHTTPToolDefinition(ctx, tools_repo.CreateHTTPToolDefinitionParams{
+			ProjectID:       *authCtx.ProjectID,
+			DeploymentID:    deploymentID,
+			ToolUrn:         toolURN,
+			Name:            name,
+			UntruncatedName: pgtype.Text{String: "", Valid: false},
+			Summary:         name,
+			Description:     "Description for " + name,
+			Tags:            []string{},
+			HttpMethod:      "GET",
+			Path:            "/api/" + name,
+			SchemaVersion:   "3.0.0",
+			Schema:          []byte(`{}`),
+			ServerEnvVar:    "TEST_SERVER_URL",
+			Security:        []byte(`[]`),
+			HeaderSettings:  []byte(`{}`),
+			QuerySettings:   []byte(`{}`),
+			PathSettings:    []byte(`{}`),
+			ReadOnlyHint:    pgtype.Bool{Bool: false, Valid: false},
+			IdempotentHint:  pgtype.Bool{Bool: false, Valid: false},
+			DestructiveHint: pgtype.Bool{Bool: false, Valid: false},
+			OpenWorldHint:   pgtype.Bool{Bool: false, Valid: false},
+		})
+		require.NoError(t, err)
+		toolURNs = append(toolURNs, toolURN)
+	}
+
+	_, err = toolsets_repo.New(ti.conn).CreateToolsetVersion(ctx, toolsets_repo.CreateToolsetVersionParams{
+		ToolsetID:     toolset.ID,
+		Version:       1,
+		ToolUrns:      toolURNs,
+		ResourceUrns:  []urn.Resource{},
+		PredecessorID: uuid.NullUUID{},
+	})
+	require.NoError(t, err)
+
+	return slug, toolURNs
+}
+
+// seedScopesToolVariationsGroup creates the project-default tool variations
+// group through the generated repo.
+func seedScopesToolVariationsGroup(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	groupID, err := variations_repo.New(ti.conn).InitGlobalToolVariationsGroup(ctx, variations_repo.InitGlobalToolVariationsGroupParams{
+		ProjectID:   projectID,
+		Name:        "Global tool variations",
+		Description: pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	return groupID
+}
+
+// seedScopesTaggedVariation upserts a variation carrying the given tags (and an
+// optional rename) for a tool URN into the group.
+func seedScopesTaggedVariation(t *testing.T, ctx context.Context, ti *testInstance, groupID uuid.UUID, toolURN urn.Tool, srcName, nameOverride string, tags []string) {
+	t.Helper()
+
+	_, err := variations_repo.New(ti.conn).UpsertToolVariation(ctx, variations_repo.UpsertToolVariationParams{
+		GroupID:         groupID,
+		SrcToolUrn:      toolURN,
+		SrcToolName:     srcName,
+		Confirm:         pgtype.Text{String: "", Valid: false},
+		ConfirmPrompt:   pgtype.Text{String: "", Valid: false},
+		Name:            pgtype.Text{String: nameOverride, Valid: nameOverride != ""},
+		Summary:         pgtype.Text{String: "", Valid: false},
+		Description:     pgtype.Text{String: "", Valid: false},
+		Tags:            tags,
+		Summarizer:      pgtype.Text{String: "", Valid: false},
+		Title:           pgtype.Text{String: "", Valid: false},
+		ReadOnlyHint:    pgtype.Bool{Bool: false, Valid: false},
+		DestructiveHint: pgtype.Bool{Bool: false, Valid: false},
+		IdempotentHint:  pgtype.Bool{Bool: false, Valid: false},
+		OpenWorldHint:   pgtype.Bool{Bool: false, Valid: false},
+	})
+	require.NoError(t, err)
+}
+
+func assignToolsetVariationsGroup(t *testing.T, ctx context.Context, ti *testInstance, slug string, projectID, groupID uuid.UUID) {
+	t.Helper()
+
+	_, err := toolsets_repo.New(ti.conn).UpdateToolsetToolVariationsGroup(ctx, toolsets_repo.UpdateToolsetToolVariationsGroupParams{
+		ToolVariationsGroupID: uuid.NullUUID{UUID: groupID, Valid: true},
+		Slug:                  slug,
+		ProjectID:             projectID,
+	})
+	require.NoError(t, err)
+}
+
+func serveInstallPageBody(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug string) string {
+	t.Helper()
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, ti.service.ServeInstallPage(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	return rr.Body.String()
+}
+
+// extractScopeVariants pulls the JSON map out of the install page's
+// scope-variants data-* attribute (HTML-escaped) and unmarshals it.
+func extractScopeVariants(t *testing.T, body string) map[string]map[string]string {
+	t.Helper()
+
+	marker := `data-variants="`
+	start := strings.Index(body, marker)
+	require.GreaterOrEqual(t, start, 0, "scope-variants attribute must be present")
+	start += len(marker)
+	end := strings.Index(body[start:], `"`)
+	require.GreaterOrEqual(t, end, 0)
+
+	raw := html.UnescapeString(body[start : start+end])
+
+	var variants map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(raw), &variants))
+	return variants
+}
+
+// TestServeInstallPage_Scopes_NoGroup_RendersUnchanged verifies that a toolset
+// with no assigned variations group renders without any scope UI (regression
+// guard for the existing single-list page).
+func TestServeInstallPage_Scopes_NoGroup_RendersUnchanged(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	slug, _ := createPublicToolsetWithTools(t, ctx, ti, "scopes-no-group", []string{"search_records"})
+
+	body := serveInstallPageBody(t, ctx, ti, slug)
+
+	require.Contains(t, body, "search_records", "tools should still render")
+	require.NotContains(t, body, `class="scopes container"`, "no scope panel without a group")
+	require.NotContains(t, body, `id="scope-variants"`, "no scope variants without a group")
+	// "scope-chip" also appears in the always-present CSS, so assert on the chip
+	// markup instead.
+	require.NotContains(t, body, "data-scope-tag", "no scope chips without a group")
+}
+
+// TestServeInstallPage_Scopes_WithGroup verifies that a toolset assigned a
+// variations group with tags renders the scope chips, group name, per-tool tag
+// attributes, variation renames, and a scope-variants map whose URLs carry the
+// ?tags= filter.
+func TestServeInstallPage_Scopes_WithGroup(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, toolURNs := createPublicToolsetWithTools(t, ctx, ti, "scopes-with-group", []string{"search_records", "delete_record"})
+
+	groupID := seedScopesToolVariationsGroup(t, ctx, ti, *authCtx.ProjectID)
+	// First tool: renamed, tagged read+admin. Second tool: explicit empty tag
+	// set, so it is excluded from every scope.
+	seedScopesTaggedVariation(t, ctx, ti, groupID, toolURNs[0], "search_records", "Renamed Search", []string{"read", "admin"})
+	seedScopesTaggedVariation(t, ctx, ti, groupID, toolURNs[1], "delete_record", "", []string{})
+	assignToolsetVariationsGroup(t, ctx, ti, slug, *authCtx.ProjectID, groupID)
+
+	body := serveInstallPageBody(t, ctx, ti, slug)
+
+	require.Contains(t, body, `class="scopes container"`, "scope panel should render")
+	require.Contains(t, body, `>All tools<`, "an unfiltered chip should render")
+	require.Contains(t, body, `data-scope-tag="read"`, "read scope chip should render")
+	require.Contains(t, body, `data-scope-tag="admin"`, "admin scope chip should render")
+	require.Contains(t, body, `data-tool-tags="read,admin"`, "tool rows should carry effective tags")
+	require.Contains(t, body, "Renamed Search", "variation rename should be reflected")
+
+	variants := extractScopeVariants(t, body)
+	require.Contains(t, variants, "", "unfiltered default variant must exist")
+	require.Contains(t, variants, "read")
+	require.Contains(t, variants, "admin")
+	require.NotContains(t, variants[""]["url"], "tags=", "default URL is unfiltered")
+	require.Contains(t, variants["read"]["url"], "tags=read", "scope URL carries the ?tags= filter")
+	require.Contains(t, variants["admin"]["url"], "tags=admin")
+	require.NotEmpty(t, variants["read"]["config"], "config snippet should be built per scope")
+	require.NotEmpty(t, variants["read"]["cursor"], "cursor deep link should be built per scope")
+	require.NotEmpty(t, variants["read"]["vscode"], "vscode deep link should be built per scope")
+	require.Contains(t, variants["read"]["config"], "tags=read", "config snippet URL carries the filter")
+}
+
+// TestServeInstallPage_Scopes_EmptyGroup_FallsBack verifies that assigning a
+// group that yields no tags (no tagged variations) falls back to the unfiltered
+// view with no scope UI.
+func TestServeInstallPage_Scopes_EmptyGroup_FallsBack(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _ := createPublicToolsetWithTools(t, ctx, ti, "scopes-empty-group", []string{"search_records"})
+
+	groupID := seedScopesToolVariationsGroup(t, ctx, ti, *authCtx.ProjectID)
+	assignToolsetVariationsGroup(t, ctx, ti, slug, *authCtx.ProjectID, groupID)
+
+	body := serveInstallPageBody(t, ctx, ti, slug)
+
+	require.Contains(t, body, "search_records", "tools should still render")
+	require.NotContains(t, body, `class="scopes container"`, "empty group must not render a scope panel")
+	require.NotContains(t, body, `id="scope-variants"`, "empty group must not emit scope variants")
+}
+
+// TestServeInstallPage_Scopes_RemoteBacked_NoScopes verifies that a
+// Remote-MCP-backed install (no toolset, no tools) renders no scope UI.
+func TestServeInstallPage_Scopes_RemoteBacked_NoScopes(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	remoteServer := remotemcptest.SeedServer(t, ctx, ti.conn, remotemcp_repo.CreateServerParams{
+		ProjectID:     *authCtx.ProjectID,
+		TransportType: "streamable-http",
+		Url:           "https://upstream.example.com/mcp",
+	})
+
+	endpointSlug := "scopes-remote-" + uuid.NewString()[:8]
+	createMcpServerWithEndpoint(t, ctx, ti, mcpServerFixtureOptions{
+		name:              "Remote MCP Scopes",
+		visibility:        mcpservers.VisibilityPublic,
+		endpointSlug:      endpointSlug,
+		remoteMcpServerID: uuid.NullUUID{UUID: remoteServer.ID, Valid: true},
+	})
+
+	body := serveInstallPageBody(t, ctx, ti, endpointSlug)
+
+	require.NotContains(t, body, `class="scopes container"`, "remote-backed installs have no scope panel")
+	require.NotContains(t, body, `id="scope-variants"`, "remote-backed installs emit no scope variants")
+}

--- a/server/internal/mcpmetadata/serve_install_page_scopes_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_scopes_test.go
@@ -196,6 +196,25 @@ func extractScopeVariants(t *testing.T, body string) map[string]map[string]strin
 	return variants
 }
 
+// scopeChipCount returns the rendered tool count shown on the scope chip for the
+// given tag.
+func scopeChipCount(t *testing.T, body, tag string) string {
+	t.Helper()
+
+	anchor := strings.Index(body, `data-scope-tag="`+tag+`"`)
+	require.GreaterOrEqual(t, anchor, 0, "scope chip for tag must be present")
+	rest := body[anchor:]
+
+	marker := `scope-chip-count">`
+	i := strings.Index(rest, marker)
+	require.GreaterOrEqual(t, i, 0)
+	rest = rest[i+len(marker):]
+
+	end := strings.Index(rest, "<")
+	require.GreaterOrEqual(t, end, 0)
+	return strings.TrimSpace(rest[:end])
+}
+
 // TestServeInstallPage_Scopes_NoGroup_RendersUnchanged verifies that a toolset
 // with no assigned variations group renders without any scope UI (regression
 // guard for the existing single-list page).
@@ -256,6 +275,29 @@ func TestServeInstallPage_Scopes_WithGroup(t *testing.T) {
 	require.NotEmpty(t, variants["read"]["cursor"], "cursor deep link should be built per scope")
 	require.NotEmpty(t, variants["read"]["vscode"], "vscode deep link should be built per scope")
 	require.Contains(t, variants["read"]["config"], "tags=read", "config snippet URL carries the filter")
+}
+
+// TestServeInstallPage_Scopes_DeduplicatesTagCounts verifies that a tool which
+// repeats a tag is counted once per scope, so chip counts are not inflated.
+func TestServeInstallPage_Scopes_DeduplicatesTagCounts(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, toolURNs := createPublicToolsetWithTools(t, ctx, ti, "scopes-dedupe", []string{"alpha", "beta"})
+
+	groupID := seedScopesToolVariationsGroup(t, ctx, ti, *authCtx.ProjectID)
+	// First tool repeats the "read" tag; it must still count once.
+	seedScopesTaggedVariation(t, ctx, ti, groupID, toolURNs[0], "alpha", "", []string{"read", "read"})
+	seedScopesTaggedVariation(t, ctx, ti, groupID, toolURNs[1], "beta", "", []string{"read"})
+	assignToolsetVariationsGroup(t, ctx, ti, slug, *authCtx.ProjectID, groupID)
+
+	body := serveInstallPageBody(t, ctx, ti, slug)
+
+	require.Equal(t, "2", scopeChipCount(t, body, "read"), "duplicate tags on one tool must not inflate the scope count")
 }
 
 // TestServeInstallPage_Scopes_EmptyGroup_FallsBack verifies that assigning a

--- a/server/internal/mcpmetadata/templatefuncs/funcs.go
+++ b/server/internal/mcpmetadata/templatefuncs/funcs.go
@@ -13,6 +13,7 @@ func FuncMap() template.FuncMap {
 		"indent":       Indent,
 		"asPosixName":  toolconfig.ToPosixName,
 		"asHTTPHeader": toolconfig.ToHTTPHeader,
+		"join":         strings.Join,
 	}
 }
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2356/mcp-installation-page-updates-for-mcp-server-filtering

When a toolset-backed MCP server resolves a non-null tool variations group, the public install page now renders a "Tool Groups" panel with selectable filter chips. Selecting a group filters the visible tool list and rewrites every connection snippet and one-click install link (Cursor, VS Code, Claude, Gemini, Codex, raw URL/config) to append the runtime `?tags=` filter; "All tools" restores the unfiltered view.

Connection variants are built server-side via the existing URL builders and emitted as a JSON map in a data attribute, so the client only swaps pre-built strings and cannot drift from the runtime filter. Tag derivation reuses the shared `toolfilter` package. Chips are `?tags=` links with `history.pushState` so per-group install URLs are shareable. Servers without a group (and remote-backed servers) render unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tool-group filtering to the public MCP install page when a toolset-backed server resolves a tool variations group. Picking a group filters the tool list and rewrites all install URLs/snippets with the `?tags=` scope; servers without a group render unchanged. Aligns with Linear AGE-2356.

- **New Features**
  - Show a “Tool Groups” chip bar when a non-null variations group is resolved; “All tools” keeps the unfiltered view.
  - Derive tags per tool using `toolfilter` and display counts; tools carry tags in the DOM for client-side filtering.
  - Build per-scope connection variants server-side (URL, config, Cursor, VS Code) and emit as JSON; the client only swaps strings.
  - Selecting a chip filters tools and updates all snippets/links (Cursor, VS Code, Claude, Gemini, Codex, raw URL/config) with `?tags=<tag>`.
  - Chips use `?tags=` URLs plus history for shareable links and back/forward navigation; empty groups and remote-backed servers omit scopes.

- **Bug Fixes**
  - Correct chip counts by counting a tool once per tag, even if it repeats the tag.
  - Validate selected `?tags=` with `Object.prototype.hasOwnProperty`; invalid keys fall back to the unfiltered view.

<sup>Written for commit 2ec326c5b02d3d4efd1fe362573eeb100241b90c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

