### PR TITLE
fix(assistants): project assistant titles, history framing, reply latency

### DIFF
--- a/.changeset/dashboard-assistant-adaptive-poll.md
+++ b/.changeset/dashboard-assistant-adaptive-poll.md
@@ -2,4 +2,7 @@
 "dashboard": patch
 ---
 
-Make the server-assistant transport poll adaptively for replies: poll quickly for the first few iterations (so short turns surface within a few hundred milliseconds instead of waiting a full fixed interval), then back off geometrically to the steady-state interval for long, tool-heavy turns. Reduces the perceived latency of the project assistant relative to the old streaming AI assistant.
+Two Project Assistant sidebar fixes:
+
+- Make the server-assistant transport poll adaptively for replies: poll quickly for the first few iterations (so short turns surface within a few hundred milliseconds instead of waiting a full fixed interval), then back off geometrically to the steady-state interval for long, tool-heavy turns. Reduces the perceived latency of the project assistant relative to the old streaming AI assistant.
+- Strip the backend's `<message-context>` framing (and drop framing-only turns) from the rendered transcript via Elements' new `history.transformChatMessage` hook, so reopening a historical thread no longer shows a raw block exposing internal event/MCP-auth metadata.

--- a/.changeset/dashboard-assistant-adaptive-poll.md
+++ b/.changeset/dashboard-assistant-adaptive-poll.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Make the server-assistant transport poll adaptively for replies: poll quickly for the first few iterations (so short turns surface within a few hundred milliseconds instead of waiting a full fixed interval), then back off geometrically to the steady-state interval for long, tool-heavy turns. Reduces the perceived latency of the project assistant relative to the old streaming AI assistant.

--- a/.changeset/elements-strip-message-context-history.md
+++ b/.changeset/elements-strip-message-context-history.md
@@ -1,5 +1,5 @@
 ---
-"@gram-ai/elements": patch
+"@gram-ai/elements": minor
 ---
 
-Strip `<message-context>` source-adapter framing when converting stored chat messages for display, and skip turns that are pure framing (e.g. an MCP auth event with no human text). Previously, reopening a historical assistant thread rendered the first message as a raw `<message-context>` block that exposed internal event/auth metadata.
+Add an optional `history.transformChatMessage` hook to `ElementsConfig`. It runs against every message loaded from `chat.load` before rendering: return a (possibly rewritten) message to render it, or `null` to omit it. This lets consumers keep product- or backend-specific transcript conventions (e.g. stripping a server-injected framing block, or hiding system events) out of the shared library — Elements itself stays agnostic to any such convention.

--- a/.changeset/elements-strip-message-context-history.md
+++ b/.changeset/elements-strip-message-context-history.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+Strip `<message-context>` source-adapter framing when converting stored chat messages for display, and skip turns that are pure framing (e.g. an MCP auth event with no human text). Previously, reopening a historical assistant thread rendered the first message as a raw `<message-context>` block that exposed internal event/auth metadata.

--- a/.changeset/project-assistant-title-message-context.md
+++ b/.changeset/project-assistant-title-message-context.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Strip `<message-context>` source-adapter framing from chat messages before generating thread titles. The framing (EventID/UserID lines, MCP auth events) is needed by the runner for replay but is noise for title generation — left in, the title model fixated on the boilerplate and produced the same generic title for every project-assistant thread.

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -14,6 +14,7 @@ import type {
   ElementsTransportFactory,
 } from "@gram-ai/elements";
 import { Chat, ChatHistory, GramElementsProvider } from "@gram-ai/elements";
+import { stripMessageContextFraming } from "@/lib/projectAssistantTranscript";
 import { useMoonshineConfig } from "@speakeasy-api/moonshine";
 import type { UIMessage } from "ai";
 import {
@@ -406,6 +407,10 @@ export function InsightsProvider({
         enabled: true,
         threadListFilters: { assistant_id: managedAssistantId },
         deferThreadIdMinting: true,
+        // The runtime persists each turn with a backend `<message-context>`
+        // framing block (needed for replay, noise for display). Strip it — and
+        // drop framing-only turns — before Elements renders the transcript.
+        transformChatMessage: stripMessageContextFraming,
       },
       api: {
         ...mcpConfig.api,

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -13,6 +13,20 @@ const DEFAULT_POLL_INTERVAL_MS = 1500;
 const DEFAULT_POLL_TIMEOUT_MS = 600_000;
 const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
+// Adaptive polling: a short turn (a one-line answer, no tool calls) often lands
+// within a couple of seconds, where a flat 1.5s interval adds up to a full
+// poll's worth of dead air. Poll quickly for the first few iterations to catch
+// those fast turns, then ramp toward the steady-state interval so long,
+// tool-heavy turns don't hammer chat.load. The ceiling is the configured
+// `pollIntervalMs`, so callers can still tune the upper bound.
+const FAST_POLL_INTERVAL_MS = 350;
+const POLL_BACKOFF_FACTOR = 1.6;
+
+function nextPollDelay(attempt: number, ceilingMs: number): number {
+  const delay = FAST_POLL_INTERVAL_MS * POLL_BACKOFF_FACTOR ** attempt;
+  return Math.min(Math.round(delay), ceilingMs);
+}
+
 export interface ServerAssistantTransportDeps {
   /** SDK client (from useGramContext) — already authenticated. */
   client: GramCore;
@@ -170,6 +184,7 @@ async function pollForReplies(args: {
   // undefined for the first iteration, then pin to the response's generation.
   let pinnedGeneration: number | undefined = snapshot?.generation;
   let consecutiveFailures = 0;
+  let attempt = 0;
 
   for (;;) {
     if (abortSignal?.aborted) {
@@ -219,7 +234,8 @@ async function pollForReplies(args: {
     if (Date.now() >= deadline) {
       throw new Error("Timed out waiting for the assistant's reply.");
     }
-    await sleep(pollIntervalMs, abortSignal);
+    await sleep(nextPollDelay(attempt, pollIntervalMs), abortSignal);
+    attempt++;
   }
 }
 

--- a/client/dashboard/src/lib/projectAssistantTranscript.test.ts
+++ b/client/dashboard/src/lib/projectAssistantTranscript.test.ts
@@ -1,0 +1,61 @@
+import type { GramChatMessage } from "@gram-ai/elements";
+import { describe, expect, it } from "vitest";
+import { stripMessageContextFraming } from "./projectAssistantTranscript";
+
+function userMessage(content: GramChatMessage["content"]): GramChatMessage {
+  return {
+    id: "m1",
+    model: "",
+    created_at: "2026-06-05T00:00:00Z",
+    role: "user",
+    content,
+  };
+}
+
+describe("stripMessageContextFraming", () => {
+  it("strips the leading framing block from string content", () => {
+    const result = stripMessageContextFraming(
+      userMessage(
+        "<message-context>\nEventID: e1\nUserID: u1\n</message-context>\n\nWhich agents call the weather tool most?",
+      ),
+    );
+    expect(result?.content).toBe("Which agents call the weather tool most?");
+  });
+
+  it("strips framing from a text content part", () => {
+    const result = stripMessageContextFraming(
+      userMessage([
+        {
+          type: "text",
+          text: "<message-context>\nEventID: e1\n</message-context>\n\nhello",
+        },
+      ]),
+    );
+    expect(result?.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("drops a user turn that is only a framing block", () => {
+    const result = stripMessageContextFraming(
+      userMessage(
+        "<message-context>\nEventType: assistant_mcp_auth_required\nAuthURL: https://example.test/oauth\n</message-context>\n",
+      ),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("only strips a leading block, leaving mid-text tags intact", () => {
+    const text = "why does my agent emit <message-context>x</message-context>?";
+    expect(stripMessageContextFraming(userMessage(text))?.content).toBe(text);
+  });
+
+  it("passes assistant messages through untouched", () => {
+    const assistant: GramChatMessage = {
+      id: "a1",
+      model: "",
+      created_at: "2026-06-05T00:00:00Z",
+      role: "assistant",
+      content: "The travel-planner agent leads with 1,204 calls.",
+    };
+    expect(stripMessageContextFraming(assistant)).toBe(assistant);
+  });
+});

--- a/client/dashboard/src/lib/projectAssistantTranscript.test.ts
+++ b/client/dashboard/src/lib/projectAssistantTranscript.test.ts
@@ -48,6 +48,24 @@ describe("stripMessageContextFraming", () => {
     expect(stripMessageContextFraming(userMessage(text))?.content).toBe(text);
   });
 
+  it("keeps a media turn whose text part is only framing", () => {
+    const result = stripMessageContextFraming(
+      userMessage([
+        {
+          type: "text",
+          text: "<message-context>\nEventID: e1\n</message-context>\n",
+        },
+        { type: "image_url", image_url: { url: "https://example.test/a.png" } },
+      ]),
+    );
+    // The whole turn must survive (the image is not lost); the framing text is stripped to empty.
+    expect(result).not.toBeNull();
+    expect(result?.content).toEqual([
+      { type: "text", text: "" },
+      { type: "image_url", image_url: { url: "https://example.test/a.png" } },
+    ]);
+  });
+
   it("passes assistant messages through untouched", () => {
     const assistant: GramChatMessage = {
       id: "a1",

--- a/client/dashboard/src/lib/projectAssistantTranscript.ts
+++ b/client/dashboard/src/lib/projectAssistantTranscript.ts
@@ -28,6 +28,11 @@ function userText(content: GramChatMessage["content"]): string {
     .join("");
 }
 
+/** True when the message carries a non-text part (image, audio, …). */
+function hasMediaPart(content: GramChatMessage["content"]): boolean {
+  return Array.isArray(content) && content.some((part) => part.type !== "text");
+}
+
 /**
  * Strips the backend's leading `<message-context>` framing from a persisted
  * message and drops user turns that are *only* framing (e.g. an injected
@@ -42,8 +47,15 @@ export function stripMessageContextFraming(
     return message;
   }
 
+  // Drop a turn only when it is *nothing but* framing. A turn that also carries
+  // media (image/audio) keeps its parts — the framing text is stripped below —
+  // so a user's image isn't lost just because its text part was an event block.
   const text = userText(message.content);
-  if (text.includes("<message-context>") && stripFraming(text).trim() === "") {
+  if (
+    !hasMediaPart(message.content) &&
+    text.includes("<message-context>") &&
+    stripFraming(text).trim() === ""
+  ) {
     return null;
   }
 

--- a/client/dashboard/src/lib/projectAssistantTranscript.ts
+++ b/client/dashboard/src/lib/projectAssistantTranscript.ts
@@ -1,0 +1,64 @@
+import type { GramChatMessage } from "@gram-ai/elements";
+
+// The Gram assistant runtime persists each turn's input with a
+// `<message-context>…</message-context>` framing block that the backend's source
+// adapter prepends when constructing the message for the runtime (EventID /
+// UserID lines, MCP auth events). The model needs that block on replay, but it
+// must never reach the dashboard transcript — left in, the first message of a
+// reopened thread renders as a raw bubble exposing internals like MCP AuthURLs.
+//
+// This is a Gram-product transcript convention, so it lives in the dashboard and
+// is handed to Elements via `history.transformChatMessage` rather than baked
+// into the shared `@gram-ai/elements` library.
+const MESSAGE_CONTEXT_RE =
+  /^\s*<message-context>[\s\S]*?<\/message-context>\s*/;
+
+function stripFraming(text: string): string {
+  return text.replace(MESSAGE_CONTEXT_RE, "");
+}
+
+function userText(content: GramChatMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (part): part is { type: "text"; text: string } => part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("");
+}
+
+/**
+ * Strips the backend's leading `<message-context>` framing from a persisted
+ * message and drops user turns that are *only* framing (e.g. an injected
+ * `assistant_mcp_auth_required` event with no human text), which would otherwise
+ * render as a raw bubble. Intended for `ElementsConfig.history.transformChatMessage`.
+ */
+export function stripMessageContextFraming(
+  message: GramChatMessage,
+): GramChatMessage | null {
+  // Framing only ever rides on the human turn; leave assistant/tool rows alone.
+  if (message.role !== "user") {
+    return message;
+  }
+
+  const text = userText(message.content);
+  if (text.includes("<message-context>") && stripFraming(text).trim() === "") {
+    return null;
+  }
+
+  if (typeof message.content === "string") {
+    return { ...message, content: stripFraming(message.content) };
+  }
+  if (Array.isArray(message.content)) {
+    return {
+      ...message,
+      content: message.content.map((part) =>
+        part.type === "text"
+          ? { ...part, text: stripFraming(part.text) }
+          : part,
+      ),
+    };
+  }
+  return message;
+}

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -717,6 +717,7 @@ const ElementsProviderWithHistory = ({
     localIdToUuidMap,
     threadListFilters: contextValue?.config.history?.threadListFilters,
     deferThreadIdMinting: contextValue?.config.history?.deferThreadIdMinting,
+    transformChatMessage: contextValue?.config.history?.transformChatMessage,
   });
   const initialThreadId = contextValue?.config.history?.initialThreadId;
 

--- a/elements/src/hooks/useGramThreadListAdapter.tsx
+++ b/elements/src/hooks/useGramThreadListAdapter.tsx
@@ -10,6 +10,7 @@ import { createAssistantStream, type AssistantStream } from "assistant-stream";
 import {
   GramChatOverview,
   GramChat,
+  GramChatMessage,
   convertGramMessagesToExported,
   convertGramMessagesToUIMessages,
 } from "@/lib/messageConverter";
@@ -78,6 +79,13 @@ export interface ThreadListAdapterOptions {
    * `crypto.randomUUID()`. Use this when the backend owns chat-id creation.
    */
   deferThreadIdMinting?: boolean;
+  /**
+   * Optional hook to transform or drop each persisted message before it is
+   * converted for rendering. Return a message to render it (possibly rewritten),
+   * or `null` to omit it. Keeps product-specific transcript conventions out of
+   * the library — see {@link HistoryConfig.transformChatMessage}.
+   */
+  transformChatMessage?: (message: GramChatMessage) => GramChatMessage | null;
 }
 
 interface ListChatsResponse {
@@ -93,15 +101,40 @@ class GramThreadHistoryAdapter {
   private apiUrl: string;
   private headers: Record<string, string>;
   private store: AssistantApi;
+  private transformChatMessage?: (
+    message: GramChatMessage,
+  ) => GramChatMessage | null;
 
   constructor(
     apiUrl: string,
     headers: Record<string, string>,
     store: AssistantApi,
+    transformChatMessage?: (message: GramChatMessage) => GramChatMessage | null,
   ) {
     this.apiUrl = apiUrl;
     this.headers = headers;
     this.store = store;
+    this.transformChatMessage = transformChatMessage;
+  }
+
+  /**
+   * Applies the consumer-supplied {@link transformChatMessage} hook to a loaded
+   * transcript: rewrites each message and drops any the hook returns `null` for.
+   * Without a hook configured the messages pass through untouched.
+   */
+  private applyTransform(messages: GramChatMessage[]): GramChatMessage[] {
+    const transform = this.transformChatMessage;
+    if (!transform) {
+      return messages;
+    }
+    const result: GramChatMessage[] = [];
+    for (const message of messages) {
+      const transformed = transform(message);
+      if (transformed) {
+        result.push(transformed);
+      }
+    }
+    return result;
   }
 
   async load() {
@@ -122,7 +155,7 @@ class GramThreadHistoryAdapter {
       }
 
       const chat = (await response.json()) as GramChat;
-      return convertGramMessagesToExported(chat.messages);
+      return convertGramMessagesToExported(this.applyTransform(chat.messages));
     } catch (error) {
       console.error("Error loading chat:", error);
       return { messages: [], headId: null };
@@ -156,7 +189,9 @@ class GramThreadHistoryAdapter {
         }
 
         const chat = (await response.json()) as GramChat;
-        return convertGramMessagesToUIMessages(chat.messages);
+        return convertGramMessagesToUIMessages(
+          this.applyTransform(chat.messages),
+        );
 
         // // Filter out system messages (assistant-ui doesn't support them in the import path)
         // const filteredMessages = chat.messages.filter(
@@ -211,6 +246,7 @@ function useGramThreadHistoryAdapter(
         optionsRef.current.apiUrl,
         optionsRef.current.headers,
         store,
+        optionsRef.current.transformChatMessage,
       ),
   );
   // Cast to ThreadHistoryAdapter - the withFormat generic doesn't match but works at runtime

--- a/elements/src/hooks/useGramThreadListAdapter.tsx
+++ b/elements/src/hooks/useGramThreadListAdapter.tsx
@@ -61,6 +61,14 @@ async function waitForMappedId(
   }
 }
 
+/**
+ * Transforms or drops a persisted chat message before it is rendered from
+ * history. Return the (possibly rewritten) message, or `null` to omit it.
+ */
+export type ChatMessageTransform = (
+  message: GramChatMessage,
+) => GramChatMessage | null;
+
 export interface ThreadListAdapterOptions {
   apiUrl: string;
   headers: Record<string, string>;
@@ -85,7 +93,7 @@ export interface ThreadListAdapterOptions {
    * or `null` to omit it. Keeps product-specific transcript conventions out of
    * the library — see {@link HistoryConfig.transformChatMessage}.
    */
-  transformChatMessage?: (message: GramChatMessage) => GramChatMessage | null;
+  transformChatMessage?: ChatMessageTransform;
 }
 
 interface ListChatsResponse {
@@ -101,29 +109,30 @@ class GramThreadHistoryAdapter {
   private apiUrl: string;
   private headers: Record<string, string>;
   private store: AssistantApi;
-  private transformChatMessage?: (
-    message: GramChatMessage,
-  ) => GramChatMessage | null;
+  // Read lazily rather than captured: the adapter is constructed once, but the
+  // consumer may swap `transformChatMessage` across renders, so resolve it from
+  // the live options on every load instead of snapshotting it here.
+  private getTransformChatMessage?: () => ChatMessageTransform | undefined;
 
   constructor(
     apiUrl: string,
     headers: Record<string, string>,
     store: AssistantApi,
-    transformChatMessage?: (message: GramChatMessage) => GramChatMessage | null,
+    getTransformChatMessage?: () => ChatMessageTransform | undefined,
   ) {
     this.apiUrl = apiUrl;
     this.headers = headers;
     this.store = store;
-    this.transformChatMessage = transformChatMessage;
+    this.getTransformChatMessage = getTransformChatMessage;
   }
 
   /**
-   * Applies the consumer-supplied {@link transformChatMessage} hook to a loaded
+   * Applies the consumer-supplied `transformChatMessage` hook to a loaded
    * transcript: rewrites each message and drops any the hook returns `null` for.
    * Without a hook configured the messages pass through untouched.
    */
   private applyTransform(messages: GramChatMessage[]): GramChatMessage[] {
-    const transform = this.transformChatMessage;
+    const transform = this.getTransformChatMessage?.();
     if (!transform) {
       return messages;
     }
@@ -246,7 +255,7 @@ function useGramThreadHistoryAdapter(
         optionsRef.current.apiUrl,
         optionsRef.current.headers,
         store,
-        optionsRef.current.transformChatMessage,
+        () => optionsRef.current.transformChatMessage,
       ),
   );
   // Cast to ThreadHistoryAdapter - the withFormat generic doesn't match but works at runtime

--- a/elements/src/lib/messageConverter.ts
+++ b/elements/src/lib/messageConverter.ts
@@ -115,12 +115,13 @@ function parseDate(date: Date | string): Date {
   return typeof date === "string" ? new Date(date) : date;
 }
 
-// The assistant runtime wraps each turn's input in a `<message-context>…</message-context>`
-// block (event metadata, MCP-auth events, etc.) that the model reads but the
-// user shouldn't see. It's persisted verbatim in the transcript, so strip the
-// leading block when rendering — and skip turns that are *only* a context block
-// (e.g. an injected `assistant_mcp_auth_required` event), which would otherwise
-// render as a raw bubble exposing internals like AuthURLs.
+// The backend wraps each turn's input in a `<message-context>…</message-context>`
+// block (event metadata, MCP-auth events, etc.) when constructing the message
+// the runtime consumes — the model reads it but the user shouldn't see it. It's
+// persisted verbatim in the transcript, so strip the leading block when
+// rendering — and skip turns that are *only* a context block (e.g. an injected
+// `assistant_mcp_auth_required` event), which would otherwise render as a raw
+// bubble exposing internals like AuthURLs.
 const MESSAGE_CONTEXT_RE = /^<message-context>[\s\S]*?<\/message-context>\s*/;
 
 function stripMessageContext(text: string): string {

--- a/elements/src/lib/messageConverter.ts
+++ b/elements/src/lib/messageConverter.ts
@@ -115,6 +115,40 @@ function parseDate(date: Date | string): Date {
   return typeof date === "string" ? new Date(date) : date;
 }
 
+// The assistant runtime wraps each turn's input in a `<message-context>…</message-context>`
+// block (event metadata, MCP-auth events, etc.) that the model reads but the
+// user shouldn't see. It's persisted verbatim in the transcript, so strip the
+// leading block when rendering — and skip turns that are *only* a context block
+// (e.g. an injected `assistant_mcp_auth_required` event), which would otherwise
+// render as a raw bubble exposing internals like AuthURLs.
+const MESSAGE_CONTEXT_RE = /^<message-context>[\s\S]*?<\/message-context>\s*/;
+
+function stripMessageContext(text: string): string {
+  return text.replace(MESSAGE_CONTEXT_RE, "");
+}
+
+function userMessageText(msg: GramChatMessage): string {
+  if (typeof msg.content === "string") return msg.content;
+  if (!Array.isArray(msg.content)) return "";
+  return msg.content
+    .filter((p): p is { type: "text"; text: string } => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+}
+
+/**
+ * True when a user message is nothing but an injected `<message-context>` event
+ * (no real user text after stripping the block) — these should not be rendered.
+ */
+function isPureMessageContextEvent(msg: GramChatMessage): boolean {
+  if (msg.role !== "user") return false;
+  const text = userMessageText(msg);
+  return (
+    text.includes("<message-context>") &&
+    stripMessageContext(text).trim() === ""
+  );
+}
+
 /**
  * Builds content parts for a user message.
  */
@@ -127,7 +161,7 @@ function buildUserContentParts(msg: GramChatMessage): ThreadUserMessagePart[] {
     return [
       {
         type: "text",
-        text: msg.content ?? "",
+        text: stripMessageContext(msg.content ?? ""),
       },
     ];
   }
@@ -139,7 +173,7 @@ function buildUserContentParts(msg: GramChatMessage): ThreadUserMessagePart[] {
       case "text":
         parts.push({
           type: "text",
-          text: item.text,
+          text: stripMessageContext(item.text),
         });
         break;
       case "image_url": {
@@ -334,7 +368,8 @@ export function convertGramMessagesToExported(
     if (
       msg.role === "system" ||
       msg.role === "developer" ||
-      msg.role === "tool"
+      msg.role === "tool" ||
+      isPureMessageContextEvent(msg)
     ) {
       continue;
     }
@@ -384,6 +419,9 @@ export function convertGramMessagesToUIMessages(messages: GramChatMessage[]): {
   const seenToolCallIds = new Set<string>();
 
   for (const msg of messages) {
+    if (isPureMessageContextEvent(msg)) {
+      continue;
+    }
     switch (msg.role) {
       case "developer":
       case "tool":

--- a/elements/src/lib/messageConverter.ts
+++ b/elements/src/lib/messageConverter.ts
@@ -115,41 +115,6 @@ function parseDate(date: Date | string): Date {
   return typeof date === "string" ? new Date(date) : date;
 }
 
-// The backend wraps each turn's input in a `<message-context>…</message-context>`
-// block (event metadata, MCP-auth events, etc.) when constructing the message
-// the runtime consumes — the model reads it but the user shouldn't see it. It's
-// persisted verbatim in the transcript, so strip the leading block when
-// rendering — and skip turns that are *only* a context block (e.g. an injected
-// `assistant_mcp_auth_required` event), which would otherwise render as a raw
-// bubble exposing internals like AuthURLs.
-const MESSAGE_CONTEXT_RE = /^<message-context>[\s\S]*?<\/message-context>\s*/;
-
-function stripMessageContext(text: string): string {
-  return text.replace(MESSAGE_CONTEXT_RE, "");
-}
-
-function userMessageText(msg: GramChatMessage): string {
-  if (typeof msg.content === "string") return msg.content;
-  if (!Array.isArray(msg.content)) return "";
-  return msg.content
-    .filter((p): p is { type: "text"; text: string } => p.type === "text")
-    .map((p) => p.text)
-    .join("");
-}
-
-/**
- * True when a user message is nothing but an injected `<message-context>` event
- * (no real user text after stripping the block) — these should not be rendered.
- */
-function isPureMessageContextEvent(msg: GramChatMessage): boolean {
-  if (msg.role !== "user") return false;
-  const text = userMessageText(msg);
-  return (
-    text.includes("<message-context>") &&
-    stripMessageContext(text).trim() === ""
-  );
-}
-
 /**
  * Builds content parts for a user message.
  */
@@ -162,7 +127,7 @@ function buildUserContentParts(msg: GramChatMessage): ThreadUserMessagePart[] {
     return [
       {
         type: "text",
-        text: stripMessageContext(msg.content ?? ""),
+        text: msg.content ?? "",
       },
     ];
   }
@@ -174,7 +139,7 @@ function buildUserContentParts(msg: GramChatMessage): ThreadUserMessagePart[] {
       case "text":
         parts.push({
           type: "text",
-          text: stripMessageContext(item.text),
+          text: item.text,
         });
         break;
       case "image_url": {
@@ -369,8 +334,7 @@ export function convertGramMessagesToExported(
     if (
       msg.role === "system" ||
       msg.role === "developer" ||
-      msg.role === "tool" ||
-      isPureMessageContextEvent(msg)
+      msg.role === "tool"
     ) {
       continue;
     }
@@ -420,9 +384,6 @@ export function convertGramMessagesToUIMessages(messages: GramChatMessage[]): {
   const seenToolCallIds = new Set<string>();
 
   for (const msg of messages) {
-    if (isPureMessageContextEvent(msg)) {
-      continue;
-    }
     switch (msg.role) {
       case "developer":
       case "tool":

--- a/elements/src/types/index.ts
+++ b/elements/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { GramChatMessage } from "@/lib/messageConverter";
 import { MODELS } from "@/lib/models";
 import type { FrontendTool } from "@/lib/tools";
 import {
@@ -1080,6 +1081,26 @@ export interface HistoryConfig {
    * `adoptChatId`). Use with a server-backed `transport`.
    */
   deferThreadIdMinting?: boolean;
+
+  /**
+   * Optional hook to transform or drop each persisted message before it is
+   * rendered from history. Return a (possibly rewritten) message to render it,
+   * or `null` to omit it entirely. Elements applies this to every message
+   * returned by `chat.load` before conversion.
+   *
+   * Use this to keep product- or backend-specific transcript conventions out of
+   * the library — e.g. stripping a server-injected framing block from a turn's
+   * text, or hiding system events that carry no user-facing content. Elements
+   * itself stays agnostic to any such convention.
+   *
+   * @example
+   * // Strip a server-injected framing block and hide framing-only turns.
+   * transformChatMessage: (msg) => {
+   *   const cleaned = stripFraming(msg);
+   *   return isFramingOnly(cleaned) ? null : cleaned;
+   * }
+   */
+  transformChatMessage?: (message: GramChatMessage) => GramChatMessage | null;
 
   /**
    * Whether to show the thread list sidebar/panel.

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -107,20 +107,27 @@ func (g *GenerateChatTitle) Do(ctx context.Context, args GenerateChatTitleArgs) 
 	return nil
 }
 
-// messageContextBlockRE matches the <message-context>…</message-context>
-// framing that the backend's source adapters prepend to a turn's input
-// (EventID / UserID lines, MCP auth events) when constructing the message for
-// the runtime. The runner needs that block for replay, but it is noise for
-// title generation — left in, the title model fixates on the structured
-// boilerplate and every thread ends up with the same generic title. Anchored
-// to the start so only the leading framing is removed; a user who happens to
-// type "<message-context>" mid-message keeps their text intact.
-var messageContextBlockRE = regexp.MustCompile(`(?s)^\s*<message-context>.*?</message-context>\s*`)
+// leadingEnvelopeRE matches one or more leading XML-ish "envelope" blocks that
+// agent harnesses prepend to a turn to steer the assistant toward the right
+// channel — e.g. <message-context>…</message-context> from our assistant
+// runtime (which source/surface the turn came from, MCP auth events) or
+// <notification>…</notification> from Claude Code background tasks. The harness
+// needs the block, but it is noise for title generation — left in, the title
+// model fixates on the structured boilerplate and every thread ends up with the
+// same generic title.
+//
+// Anchored to the start, so only leading framing is removed and a user who
+// types a tag mid-message keeps their text. Tag names are lowercase/kebab; the
+// non-greedy body stops at the first close tag. RE2 has no backreferences, so
+// the open and close tags aren't required to match — fine for well-formed
+// envelopes, and intentionally generic so envelopes we don't control are still
+// stripped.
+var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:\s*<[a-z][a-z0-9_-]*>.*?</[a-z][a-z0-9_-]*>\s*)+`)
 
-// stripMessageContext removes the leading source-adapter framing so the title
-// model sees only the human-authored turn text.
-func stripMessageContext(s string) string {
-	return strings.TrimSpace(messageContextBlockRE.ReplaceAllString(s, ""))
+// stripLeadingEnvelopes removes any leading harness framing so the title model
+// sees only the human-authored turn text.
+func stripLeadingEnvelopes(s string) string {
+	return strings.TrimSpace(leadingEnvelopeRE.ReplaceAllString(s, ""))
 }
 
 // buildTitleContext concatenates the last few user/assistant messages into a
@@ -130,7 +137,7 @@ func buildTitleContext(messages []repo.ChatMessage) string {
 	count := 0
 	for i := len(messages) - 1; i >= 0; i-- { // Start from the last message and work backwards to make sure we capture the most recent messages
 		msg := messages[i]
-		content := stripMessageContext(msg.Content)
+		content := stripLeadingEnvelopes(msg.Content)
 		if (msg.Role != "user" && msg.Role != "assistant") || content == "" {
 			continue
 		}

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -108,13 +108,16 @@ func (g *GenerateChatTitle) Do(ctx context.Context, args GenerateChatTitleArgs) 
 }
 
 // messageContextBlockRE matches the <message-context>…</message-context>
-// framing that assistant source adapters prepend to a turn's input (EventID /
-// UserID lines, MCP auth events). The runner needs that block for replay, but
-// it is noise for title generation — left in, the title model fixates on the
-// structured boilerplate and every thread ends up with the same generic title.
-var messageContextBlockRE = regexp.MustCompile(`(?s)<message-context>.*?</message-context>\s*`)
+// framing that the backend's source adapters prepend to a turn's input
+// (EventID / UserID lines, MCP auth events) when constructing the message for
+// the runtime. The runner needs that block for replay, but it is noise for
+// title generation — left in, the title model fixates on the structured
+// boilerplate and every thread ends up with the same generic title. Anchored
+// to the start so only the leading framing is removed; a user who happens to
+// type "<message-context>" mid-message keeps their text intact.
+var messageContextBlockRE = regexp.MustCompile(`(?s)^\s*<message-context>.*?</message-context>\s*`)
 
-// stripMessageContext removes any leading source-adapter framing so the title
+// stripMessageContext removes the leading source-adapter framing so the title
 // model sees only the human-authored turn text.
 func stripMessageContext(s string) string {
 	return strings.TrimSpace(messageContextBlockRE.ReplaceAllString(s, ""))

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -119,10 +119,12 @@ func (g *GenerateChatTitle) Do(ctx context.Context, args GenerateChatTitleArgs) 
 // The tag is an allowlist of envelopes we know about rather than any
 // <tag>…</tag>: a fully-generic match would also eat legitimate leading user
 // markup (a message that starts with <details> or a pasted code block), which
-// distorts the title. Add new harnesses to the alternation as they appear.
-// Anchored to the start, so a tag a user types mid-message is preserved; the
-// non-greedy body stops at the first close tag.
-var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:\s*<(?:message-context|notification)>.*?</(?:message-context|notification)>\s*)+`)
+// distorts the title. Add new harnesses as another `<tag>…</tag>` alternative.
+// Each alternative pairs an open tag with its own close tag (RE2 has no
+// backreferences), so a mismatched `<message-context>…</notification>` is left
+// alone. Anchored to the start, so a tag a user types mid-message is preserved;
+// the non-greedy body stops at the first close tag.
+var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:\s*<message-context>.*?</message-context>\s*|\s*<notification>.*?</notification>\s*)+`)
 
 // stripLeadingEnvelopes removes any leading harness framing so the title model
 // sees only the human-authored turn text.

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -107,22 +107,22 @@ func (g *GenerateChatTitle) Do(ctx context.Context, args GenerateChatTitleArgs) 
 	return nil
 }
 
-// leadingEnvelopeRE matches one or more leading XML-ish "envelope" blocks that
-// agent harnesses prepend to a turn to steer the assistant toward the right
-// channel — e.g. <message-context>…</message-context> from our assistant
-// runtime (which source/surface the turn came from, MCP auth events) or
+// leadingEnvelopeRE matches one or more leading "envelope" blocks that agent
+// harnesses prepend to a turn to steer the assistant toward the right channel —
+// e.g. <message-context>…</message-context> from our assistant runtime (which
+// source/surface the turn came from, MCP auth events) or
 // <notification>…</notification> from Claude Code background tasks. The harness
 // needs the block, but it is noise for title generation — left in, the title
 // model fixates on the structured boilerplate and every thread ends up with the
 // same generic title.
 //
-// Anchored to the start, so only leading framing is removed and a user who
-// types a tag mid-message keeps their text. Tag names are lowercase/kebab; the
-// non-greedy body stops at the first close tag. RE2 has no backreferences, so
-// the open and close tags aren't required to match — fine for well-formed
-// envelopes, and intentionally generic so envelopes we don't control are still
-// stripped.
-var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:\s*<[a-z][a-z0-9_-]*>.*?</[a-z][a-z0-9_-]*>\s*)+`)
+// The tag is an allowlist of envelopes we know about rather than any
+// <tag>…</tag>: a fully-generic match would also eat legitimate leading user
+// markup (a message that starts with <details> or a pasted code block), which
+// distorts the title. Add new harnesses to the alternation as they appear.
+// Anchored to the start, so a tag a user types mid-message is preserved; the
+// non-greedy body stops at the first close tag.
+var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:\s*<(?:message-context|notification)>.*?</(?:message-context|notification)>\s*)+`)
 
 // stripLeadingEnvelopes removes any leading harness framing so the title model
 // sees only the human-authored turn text.

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -106,6 +107,19 @@ func (g *GenerateChatTitle) Do(ctx context.Context, args GenerateChatTitleArgs) 
 	return nil
 }
 
+// messageContextBlockRE matches the <message-context>…</message-context>
+// framing that assistant source adapters prepend to a turn's input (EventID /
+// UserID lines, MCP auth events). The runner needs that block for replay, but
+// it is noise for title generation — left in, the title model fixates on the
+// structured boilerplate and every thread ends up with the same generic title.
+var messageContextBlockRE = regexp.MustCompile(`(?s)<message-context>.*?</message-context>\s*`)
+
+// stripMessageContext removes any leading source-adapter framing so the title
+// model sees only the human-authored turn text.
+func stripMessageContext(s string) string {
+	return strings.TrimSpace(messageContextBlockRE.ReplaceAllString(s, ""))
+}
+
 // buildTitleContext concatenates the last few user/assistant messages into a
 // single string suitable for LLM title generation.
 func buildTitleContext(messages []repo.ChatMessage) string {
@@ -113,10 +127,11 @@ func buildTitleContext(messages []repo.ChatMessage) string {
 	count := 0
 	for i := len(messages) - 1; i >= 0; i-- { // Start from the last message and work backwards to make sure we capture the most recent messages
 		msg := messages[i]
-		if (msg.Role != "user" && msg.Role != "assistant") || strings.TrimSpace(msg.Content) == "" {
+		content := stripMessageContext(msg.Content)
+		if (msg.Role != "user" && msg.Role != "assistant") || content == "" {
 			continue
 		}
-		fmt.Fprintf(&b, "%s: %s\n", msg.Role, strings.TrimSpace(msg.Content))
+		fmt.Fprintf(&b, "%s: %s\n", msg.Role, content)
 		count++
 		if count >= 6 {
 			break

--- a/server/internal/background/activities/generate_chat_title_test.go
+++ b/server/internal/background/activities/generate_chat_title_test.go
@@ -8,30 +8,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStripMessageContextRemovesAdapterFraming(t *testing.T) {
+func TestStripLeadingEnvelopesRemovesAssistantRuntimeFraming(t *testing.T) {
 	t.Parallel()
 
 	input := "<message-context>\nEventID: abc-123\nUserID: user-9\n</message-context>\n\nHow do I reduce my token usage?"
-	require.Equal(t, "How do I reduce my token usage?", stripMessageContext(input))
+	require.Equal(t, "How do I reduce my token usage?", stripLeadingEnvelopes(input))
 }
 
-func TestStripMessageContextLeavesPlainTextUntouched(t *testing.T) {
+// Other harnesses prepend their own envelopes (e.g. Claude Code background
+// tasks return <notification>…</notification>); the strip is generic so the
+// title model isn't polluted by envelopes we don't control.
+func TestStripLeadingEnvelopesRemovesForeignEnvelope(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "just a normal message", stripMessageContext("just a normal message"))
+	input := "<notification>background task completed</notification>\nThe migration finished without errors."
+	require.Equal(t, "The migration finished without errors.", stripLeadingEnvelopes(input))
 }
 
-// The regex is anchored to the start of the message: only the leading framing
-// the backend prepends is removed. A user who happens to type the literal tags
-// mid-message keeps that text — stripping it would distort the title.
-func TestStripMessageContextOnlyStripsLeadingBlock(t *testing.T) {
+func TestStripLeadingEnvelopesRemovesMultipleLeadingBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := "<message-context>\nEventID: e1\n</message-context>\n<notification>done</notification>\n\nWhat changed?"
+	require.Equal(t, "What changed?", stripLeadingEnvelopes(input))
+}
+
+func TestStripLeadingEnvelopesLeavesPlainTextUntouched(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "just a normal message", stripLeadingEnvelopes("just a normal message"))
+}
+
+// The regex is anchored to the start of the message: only leading framing is
+// removed. A user who happens to type tags mid-message keeps that text —
+// stripping it would distort the title.
+func TestStripLeadingEnvelopesOnlyStripsLeadingBlock(t *testing.T) {
 	t.Parallel()
 
 	input := "why does my agent emit <message-context>foo</message-context> in its output?"
-	require.Equal(t, input, stripMessageContext(input))
+	require.Equal(t, input, stripLeadingEnvelopes(input))
 }
 
-func TestBuildTitleContextStripsMessageContextFraming(t *testing.T) {
+func TestBuildTitleContextStripsLeadingEnvelopeFraming(t *testing.T) {
 	t.Parallel()
 
 	messages := []repo.ChatMessage{
@@ -54,11 +71,11 @@ func TestBuildTitleContextStripsMessageContextFraming(t *testing.T) {
 	require.Contains(t, got, "travel-planner agent")
 }
 
-func TestBuildTitleContextSkipsPureFramingMessages(t *testing.T) {
+func TestBuildTitleContextSkipsPureEnvelopeMessages(t *testing.T) {
 	t.Parallel()
 
-	// A turn that is *only* framing (e.g. an MCP auth event with no human text)
-	// must not contribute an empty "user: " line to the title context.
+	// A turn that is *only* an envelope (e.g. an MCP auth event with no human
+	// text) must not contribute an empty "user: " line to the title context.
 	messages := []repo.ChatMessage{
 		{
 			Role:    "user",

--- a/server/internal/background/activities/generate_chat_title_test.go
+++ b/server/internal/background/activities/generate_chat_title_test.go
@@ -38,6 +38,16 @@ func TestStripLeadingEnvelopesLeavesPlainTextUntouched(t *testing.T) {
 	require.Equal(t, "just a normal message", stripLeadingEnvelopes("just a normal message"))
 }
 
+// Only known harness envelopes are stripped. A message that legitimately opens
+// with user markup (a <details> block, a pasted snippet, etc.) must survive — a
+// fully-generic <tag>…</tag> match would eat it and distort the title.
+func TestStripLeadingEnvelopesLeavesUnknownLeadingTag(t *testing.T) {
+	t.Parallel()
+
+	input := "<details>my setup</details>\n\nwhy does the build fail?"
+	require.Equal(t, input, stripLeadingEnvelopes(input))
+}
+
 // The regex is anchored to the start of the message: only leading framing is
 // removed. A user who happens to type tags mid-message keeps that text —
 // stripping it would distort the title.

--- a/server/internal/background/activities/generate_chat_title_test.go
+++ b/server/internal/background/activities/generate_chat_title_test.go
@@ -21,6 +21,16 @@ func TestStripMessageContextLeavesPlainTextUntouched(t *testing.T) {
 	require.Equal(t, "just a normal message", stripMessageContext("just a normal message"))
 }
 
+// The regex is anchored to the start of the message: only the leading framing
+// the backend prepends is removed. A user who happens to type the literal tags
+// mid-message keeps that text — stripping it would distort the title.
+func TestStripMessageContextOnlyStripsLeadingBlock(t *testing.T) {
+	t.Parallel()
+
+	input := "why does my agent emit <message-context>foo</message-context> in its output?"
+	require.Equal(t, input, stripMessageContext(input))
+}
+
 func TestBuildTitleContextStripsMessageContextFraming(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/activities/generate_chat_title_test.go
+++ b/server/internal/background/activities/generate_chat_title_test.go
@@ -48,6 +48,16 @@ func TestStripLeadingEnvelopesLeavesUnknownLeadingTag(t *testing.T) {
 	require.Equal(t, input, stripLeadingEnvelopes(input))
 }
 
+// Each allowlisted envelope must match its own close tag — a mismatched pair
+// (open from one envelope, close from another) is not a real envelope and must
+// be left intact.
+func TestStripLeadingEnvelopesLeavesMismatchedTags(t *testing.T) {
+	t.Parallel()
+
+	input := "<message-context>hmm</notification> what is this?"
+	require.Equal(t, input, stripLeadingEnvelopes(input))
+}
+
 // The regex is anchored to the start of the message: only leading framing is
 // removed. A user who happens to type tags mid-message keeps that text —
 // stripping it would distort the title.

--- a/server/internal/background/activities/generate_chat_title_test.go
+++ b/server/internal/background/activities/generate_chat_title_test.go
@@ -1,0 +1,60 @@
+package activities
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripMessageContextRemovesAdapterFraming(t *testing.T) {
+	t.Parallel()
+
+	input := "<message-context>\nEventID: abc-123\nUserID: user-9\n</message-context>\n\nHow do I reduce my token usage?"
+	require.Equal(t, "How do I reduce my token usage?", stripMessageContext(input))
+}
+
+func TestStripMessageContextLeavesPlainTextUntouched(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "just a normal message", stripMessageContext("just a normal message"))
+}
+
+func TestBuildTitleContextStripsMessageContextFraming(t *testing.T) {
+	t.Parallel()
+
+	messages := []repo.ChatMessage{
+		{
+			Role:    "user",
+			Content: "<message-context>\nEventID: evt-1\nUserID: user-1\n</message-context>\n\nWhich agents call the weather tool most often?",
+		},
+		{
+			Role:    "assistant",
+			Content: "The travel-planner agent leads with 1,204 calls this week.",
+		},
+	}
+
+	got := buildTitleContext(messages)
+
+	require.NotContains(t, got, "message-context")
+	require.NotContains(t, got, "EventID")
+	require.NotContains(t, got, "UserID")
+	require.Contains(t, got, "Which agents call the weather tool most often?")
+	require.Contains(t, got, "travel-planner agent")
+}
+
+func TestBuildTitleContextSkipsPureFramingMessages(t *testing.T) {
+	t.Parallel()
+
+	// A turn that is *only* framing (e.g. an MCP auth event with no human text)
+	// must not contribute an empty "user: " line to the title context.
+	messages := []repo.ChatMessage{
+		{
+			Role:    "user",
+			Content: "<message-context>\nEventType: assistant_mcp_auth_required\nAuthURL: https://example.test/oauth\n</message-context>\n",
+		},
+	}
+
+	require.Empty(t, strings.TrimSpace(buildTitleContext(messages)))
+}


### PR DESCRIPTION
## Summary

Three production fixes for the server-side Project Assistant (AGE-2631), reported from Slack. All three trace back to one root cause: the `<message-context>` framing that source adapters prepend to every turn's input — `EventID`/`UserID` lines plus MCP auth events — is needed by the **runner** for replay, but leaks into two **presentation** surfaces where it's pure noise. The fix keeps the framing persisted (the runner needs it) and strips it at each presentation boundary.

### 1. Thread titles "always the same" (server)
`buildTitleContext` fed the raw, framing-prefixed user message to the title model, which fixated on the structured `EventID`/`UserID` boilerplate and produced the same generic title for every thread. Now strips the `<message-context>` block before building the title context, and skips turns that are *only* framing (e.g. an MCP auth event with no human text). Covered by new unit tests.

### 2. Raw `<message-context>` block on reopened threads (elements)
Reopening a historical assistant thread rendered the first message as a raw `<message-context>` block, exposing internal event/auth metadata (including an MCP `AuthURL`). The Elements `messageConverter` now strips the framing from displayed content and skips pure-framing turns, in **both** converters (`convertGramMessagesToExported` and `convertGramMessagesToUIMessages`).

### 3. Assistant "feels slower than the old AI assistant" (dashboard)
`ServerAssistantTransport` polled `chat.load` at a flat 1.5s interval, so a short turn that lands in ~2s could sit a full poll behind. Now polls adaptively — fast initial polls (`350ms`) ramping geometrically to the configured ceiling — so quick turns surface within a few hundred ms while long tool-heavy turns settle at the same steady rate.

> **Note:** #3 is a **mitigation**, not a full fix. The old assistant streamed tokens over SSE; the server runtime currently only exposes a poll-for-reply surface. True token streaming needs an SSE/WebSocket channel from the assistant runtime — a larger architectural change, tracked separately.

## Verification
- `go build ./...` ✅, `go test ./internal/background/activities/` ✅ (new title-context tests pass), `go vet` + `gofmt` clean
- `pnpm -F @gram-ai/elements type-check | lint | build` all ✅
- `ServerAssistantTransport.ts` type-checks clean (3 unrelated pre-existing dashboard `tsc` errors in `ChallengesTab`/`MCPTeamAccessTab`/`OrgWebhooks` are a Moonshine/React-19 `ReactPortal` type skew, untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three production issues with the project assistant: correct thread titles, clean history, and faster perceived replies. Supports AGE-2631 by improving the per‑org assistant in the dashboard sidebar.

- **Bug Fixes**
  - `server`: Strip leading, allowlisted envelope blocks (`<message-context>`, `<notification>`) before title generation; anchor to start; require matched tag pairs; skip pure‑envelope turns; add tests.
  - `@gram-ai/elements`: Add `history.transformChatMessage` to let products transform/drop loaded messages while keeping the library agnostic; read the hook live across renders.
  - `dashboard`: Use `stripMessageContextFraming` via the new hook to remove framing and drop framing‑only user turns; keep media turns; add tests.

- **Performance**
  - `dashboard`: Make `ServerAssistantTransport` poll adaptively (fast ~350ms initial polls with geometric backoff to the configured ceiling) so quick turns appear sooner.

<sup>Written for commit 8d66fef14bbf5f36519859f056aad2c85e64ca86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

