### PR TITLE
mig: add mcp_server_id to plugin_servers

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2648,11 +2648,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS plugins_organization_id_project_id_slug_key
   ON plugins (organization_id, project_id, slug)
   WHERE deleted IS FALSE;
 
--- Links a plugin to a toolset-backed MCP server.
+-- Links a plugin to an MCP server, backed by either a toolset or an
+-- mcp_servers row (exactly one, enforced by the exclusivity check below).
 CREATE TABLE IF NOT EXISTS plugin_servers (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   plugin_id uuid NOT NULL,
-  toolset_id uuid NOT NULL,
+  toolset_id uuid,
+  mcp_server_id uuid,
   display_name TEXT NOT NULL CHECK (display_name <> ''),
   policy TEXT NOT NULL DEFAULT 'required',
   sort_order INT NOT NULL DEFAULT 0,
@@ -2669,7 +2671,13 @@ CREATE TABLE IF NOT EXISTS plugin_servers (
   -- If a hard-delete path is added later, it must purge soft-deleted
   -- plugin_servers referencing the target first.
   CONSTRAINT plugin_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
-  CONSTRAINT plugin_servers_policy_check CHECK (policy IN ('required', 'optional'))
+  -- RESTRICT mirrors the toolset_id FK above (not the CASCADE used by the
+  -- collections attachment table): mcp_servers soft-delete, so RESTRICT only
+  -- blocks manual hard deletes. SET NULL is not viable under the XOR check.
+  CONSTRAINT plugin_servers_mcp_server_id_fkey FOREIGN KEY (mcp_server_id) REFERENCES mcp_servers (id) ON DELETE RESTRICT,
+  CONSTRAINT plugin_servers_policy_check CHECK (policy IN ('required', 'optional')),
+  -- Exactly one backend must be set: either a toolset or an mcp_server.
+  CONSTRAINT plugin_servers_backend_exclusivity_check CHECK ((toolset_id IS NULL) != (mcp_server_id IS NULL))
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS plugin_servers_plugin_id_display_name_key
@@ -2678,6 +2686,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS plugin_servers_plugin_id_display_name_key
 
 CREATE UNIQUE INDEX IF NOT EXISTS plugin_servers_plugin_id_toolset_id_key
   ON plugin_servers (plugin_id, toolset_id)
+  WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS plugin_servers_plugin_id_mcp_server_id_key
+  ON plugin_servers (plugin_id, mcp_server_id)
   WHERE deleted IS FALSE;
 
 -- Controls who receives a plugin. Reuses the RBAC principal URN pattern

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1022,7 +1022,8 @@ type PluginGithubConnection struct {
 type PluginServer struct {
 	ID          uuid.UUID
 	PluginID    uuid.UUID
-	ToolsetID   uuid.UUID
+	ToolsetID   uuid.NullUUID
+	McpServerID uuid.NullUUID
 	DisplayName string
 	Policy      string
 	SortOrder   int32

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -565,7 +565,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 
 	row, err := s.repo.WithTx(tx).AddPluginServer(ctx, repo.AddPluginServerParams{
 		PluginID:    pluginID,
-		ToolsetID:   toolsetID,
+		ToolsetID:   uuid.NullUUID{UUID: toolsetID, Valid: true},
 		DisplayName: payload.DisplayName,
 		Policy:      payload.Policy,
 		SortOrder:   payload.SortOrder,
@@ -591,7 +591,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 		ServerDisplayName: row.DisplayName,
 		ServerPolicy:      row.Policy,
 		ServerSortOrder:   row.SortOrder,
-		ToolsetURN:        urn.NewToolset(row.ToolsetID),
+		ToolsetURN:        urn.NewToolset(row.ToolsetID.UUID),
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin server add").Log(ctx, s.logger)
 	}
@@ -1678,7 +1678,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 			// toolset without an mcp_metadata row simply has no user-provided
 			// env vars — UpsertMetadata is explicit, not auto-created on publish.
 			if r.ToolsetIsPublic {
-				metadata, metaErr := mcpMeta.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: r.ToolsetID, Valid: true})
+				metadata, metaErr := mcpMeta.GetMetadataForToolset(ctx, r.ToolsetID)
 				switch {
 				case errors.Is(metaErr, pgx.ErrNoRows):
 					// No metadata configured → no env configs to surface.
@@ -1701,7 +1701,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 						headerName := conv.FromPGText[string](ec.HeaderDisplayName)
 						if headerName == nil {
 							s.logger.WarnContext(ctx, "skipping user env config with no header name",
-								attr.SlogToolsetID(r.ToolsetID.String()),
+								attr.SlogToolsetID(r.ToolsetID.UUID.String()),
 								attr.SlogEnvVarName(ec.VariableName),
 							)
 							continue
@@ -1812,7 +1812,7 @@ func pluginToGen(p repo.Plugin, servers []repo.PluginServer, assignments []repo.
 func pluginServerToGen(s repo.PluginServer) *gen.PluginServer {
 	return &gen.PluginServer{
 		ID:          s.ID.String(),
-		ToolsetID:   s.ToolsetID.String(),
+		ToolsetID:   s.ToolsetID.UUID.String(),
 		DisplayName: s.DisplayName,
 		Policy:      s.Policy,
 		SortOrder:   s.SortOrder,

--- a/server/internal/plugins/repo/models.go
+++ b/server/internal/plugins/repo/models.go
@@ -46,7 +46,8 @@ type PluginGithubConnection struct {
 type PluginServer struct {
 	ID          uuid.UUID
 	PluginID    uuid.UUID
-	ToolsetID   uuid.UUID
+	ToolsetID   uuid.NullUUID
+	McpServerID uuid.NullUUID
 	DisplayName string
 	Policy      string
 	SortOrder   int32

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -49,12 +49,12 @@ VALUES (
   $4,
   $5
 )
-RETURNING id, plugin_id, toolset_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
+RETURNING id, plugin_id, toolset_id, mcp_server_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
 `
 
 type AddPluginServerParams struct {
 	PluginID    uuid.UUID
-	ToolsetID   uuid.UUID
+	ToolsetID   uuid.NullUUID
 	DisplayName string
 	Policy      string
 	SortOrder   int32
@@ -73,6 +73,7 @@ func (q *Queries) AddPluginServer(ctx context.Context, arg AddPluginServerParams
 		&i.ID,
 		&i.PluginID,
 		&i.ToolsetID,
+		&i.McpServerID,
 		&i.DisplayName,
 		&i.Policy,
 		&i.SortOrder,
@@ -345,7 +346,7 @@ func (q *Queries) ListPluginPublishCandidates(ctx context.Context, arg ListPlugi
 }
 
 const listPluginServers = `-- name: ListPluginServers :many
-SELECT id, plugin_id, toolset_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
+SELECT id, plugin_id, toolset_id, mcp_server_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
 FROM plugin_servers
 WHERE plugin_id = $1
   AND deleted IS FALSE
@@ -365,6 +366,7 @@ func (q *Queries) ListPluginServers(ctx context.Context, pluginID uuid.UUID) ([]
 			&i.ID,
 			&i.PluginID,
 			&i.ToolsetID,
+			&i.McpServerID,
 			&i.DisplayName,
 			&i.Policy,
 			&i.SortOrder,
@@ -481,7 +483,7 @@ type ListPluginsWithServersForProjectRow struct {
 	ServerDisplayName   string
 	ServerPolicy        string
 	ServerSortOrder     int32
-	ToolsetID           uuid.UUID
+	ToolsetID           uuid.NullUUID
 	ToolsetMcpSlug      pgtype.Text
 	ToolsetIsPublic     bool
 	ToolsetIsOauth      bool
@@ -626,7 +628,7 @@ SET display_name = $1,
 WHERE id = $4
   AND plugin_id = $5
   AND deleted IS FALSE
-RETURNING id, plugin_id, toolset_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
+RETURNING id, plugin_id, toolset_id, mcp_server_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdatePluginServerParams struct {
@@ -650,6 +652,7 @@ func (q *Queries) UpdatePluginServer(ctx context.Context, arg UpdatePluginServer
 		&i.ID,
 		&i.PluginID,
 		&i.ToolsetID,
+		&i.McpServerID,
 		&i.DisplayName,
 		&i.Policy,
 		&i.SortOrder,

--- a/server/migrations/20260605200300_plugin_servers_mcp_server_id.sql
+++ b/server/migrations/20260605200300_plugin_servers_mcp_server_id.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "plugin_servers" table
+ALTER TABLE "plugin_servers" ADD CONSTRAINT "plugin_servers_backend_exclusivity_check" CHECK ((toolset_id IS NULL) <> (mcp_server_id IS NULL)), ALTER COLUMN "toolset_id" DROP NOT NULL, ADD COLUMN "mcp_server_id" uuid NULL, ADD CONSTRAINT "plugin_servers_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT;
+-- Create index "plugin_servers_plugin_id_mcp_server_id_key" to table: "plugin_servers"
+CREATE UNIQUE INDEX CONCURRENTLY "plugin_servers_plugin_id_mcp_server_id_key" ON "plugin_servers" ("plugin_id", "mcp_server_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:QarK/HFevrFl5jiWc6iu+rTMIWAgZKdXttVRgSQCDuY=
+h1:u/TOliI3/8QMrnjL5ESIRAs0dXrhFC6kxGi9VYxXq2Y=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -209,3 +209,4 @@ h1:QarK/HFevrFl5jiWc6iu+rTMIWAgZKdXttVRgSQCDuY=
 20260604141922_add-risk-policy-bypass-requests-table.sql h1:Ol7aa0m2r1gSObRbAJaqr6wdCs37y8qtvLlZYs6Q7pg=
 20260605143925_add_risk_exclusions.sql h1:u5YQre0OFPZ56F9gAy0K7kSsb5q+koeoJh49JOS3qjw=
 20260605174513_risk-results-drop-verbatim-match-index-column.sql h1:Ans/oK8EWrCsPWdbfL9v/66RrUgIMYdlwEDEx9hwscc=
+20260605200300_plugin_servers_mcp_server_id.sql h1:3NUyToGuksyCGuOgltiB60ob8++hRSAKYDdrUHesOzg=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2695/migration-add-mcp-server-id-to-plugin-servers

Expand step (expand-contract) so a plugin server can be backed by either a toolset or an `mcp_servers` row. Relaxes `plugin_servers.toolset_id` to nullable, adds a nullable `mcp_server_id` column with an `ON DELETE RESTRICT` FK to `mcp_servers`, a backend-exclusivity XOR `CHECK`, and a unique `(plugin_id, mcp_server_id)` partial index. Mirrors the **AGE-2238** collections change.

`RESTRICT` (not the collections table's `CASCADE`) mirrors the existing `plugin_servers.toolset_id` FK; `mcp_servers` soft-delete, so it only blocks manual hard deletes.

Relaxing `toolset_id` flips its sqlc-generated type to `uuid.NullUUID`; this includes the minimum plugins repo regeneration plus param wrap / read unwrap edits to keep the build green. No new `mcp_server_id` queries or application/UI code — those are tracked in **AGE-2697**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable plugins to attach MCP servers backed by either a toolset or an `mcp_servers` row by adding `mcp_server_id` and making `toolset_id` nullable in `plugin_servers`. This is the expand step for AGE-2695; includes minimal `sqlc` updates to keep builds green with no feature behavior changes.

- **Migration**
  - Schema: add nullable `mcp_server_id` (FK `ON DELETE RESTRICT`), relax `toolset_id` to nullable, add XOR `CHECK` on backends, and a unique `(plugin_id, mcp_server_id)` partial index; existing `(plugin_id, toolset_id)` uniqueness stays.
  - Codegen: `ToolsetID` is now `uuid.NullUUID`; new `McpServerID` field; wrap `AddPluginServer` param and unwrap reads; queries now `RETURN`/`SELECT` `mcp_server_id`.
  - Notes: mirrors AGE-2238; follow-up queries/UI tracked in AGE-2697.

<sup>Written for commit 7863bbaa35a554d2e4e1b5604d2b8c24a53d5238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

