### PR TITLE
fix(dashboard): auto-select token endpoint auth method in proxy auto-configure

### DIFF
--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
@@ -78,7 +78,7 @@ export function parseScopes(raw: string): string[] {
 }
 
 /** Token endpoint auth methods, ordered by our preference. */
-export const TOKEN_AUTH_METHODS_PRIORITY = [
+const TOKEN_AUTH_METHODS_PRIORITY = [
   "client_secret_basic",
   "client_secret_post",
   "none",

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
@@ -76,3 +76,42 @@ export function parseScopes(raw: string): string[] {
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 }
+
+/** Token endpoint auth methods, ordered by our preference. */
+export const TOKEN_AUTH_METHODS_PRIORITY = [
+  "client_secret_basic",
+  "client_secret_post",
+  "none",
+] as const;
+
+// Picks the most preferred token endpoint auth method advertised by the issuer:
+// client_secret_basic > client_secret_post > none. Falls back to
+// client_secret_basic when the list is empty or holds no recognized method, so
+// DCR always sends one — upstreams like Make reject a registration that omits
+// it or sends an unsupported one ("No supported Token Endpoint Auth Method
+// provided.").
+export function pickAuthMethodFromList(supported: string[]): string {
+  for (const method of TOKEN_AUTH_METHODS_PRIORITY) {
+    if (supported.includes(method)) return method;
+  }
+  return "client_secret_basic";
+}
+
+// Origin (scheme://host) of the first parseable URL, or "" when none parse.
+// Used as the RFC 8414 issuer for live auth-method discovery: discover's first
+// probe candidate is `{origin}/.well-known/oauth-authorization-server`, where
+// the Authorization Server metadata (and its token_endpoint_auth_methods_supported
+// list) lives. Passing a path-bearing URL risks matching an OIDC document
+// first, which omits the methods.
+export function authServerOrigin(...candidates: string[]): string {
+  for (const candidate of candidates) {
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    try {
+      return new URL(trimmed).origin;
+    } catch {
+      // Not a parseable absolute URL — try the next candidate.
+    }
+  }
+  return "";
+}

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
@@ -11,7 +11,9 @@ import {
 } from "./guards";
 import { oauthWizardMachine } from "./machine";
 import {
+  authServerOrigin,
   parseScopes,
+  pickAuthMethodFromList,
   type Context,
   type DiscoveredOAuth,
   type Input,
@@ -785,6 +787,117 @@ describe("oauthWizardMachine — auto-configure from path selection", () => {
     expect(snap.matches({ proxy: "registering" })).toBe(true);
     expect(snap.context.autoRegistering).toBe(true);
     expect(snap.context.proxy.scopes).toBe("");
+  });
+
+  it("auto-select picks the preferred token endpoint auth method from discovery (basic > post > none)", () => {
+    const actor = makeActor({
+      ...baseInput,
+      discovered: {
+        ...DISCOVERED_2_1,
+        metadata: {
+          ...VALID_PROXY_METADATA,
+          token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+        },
+      },
+    });
+    actor.start();
+    actor.send({ type: "SELECT_PROXY_AUTO" });
+    expect(actor.getSnapshot().context.proxy.tokenAuthMethod).toBe(
+      "client_secret_post",
+    );
+  });
+
+  it("auto-select falls back to client_secret_basic when discovery advertises no methods", () => {
+    const actor = makeActor(inputWithDiscovered);
+    actor.start();
+    actor.send({ type: "SELECT_PROXY_AUTO" });
+    expect(actor.getSnapshot().context.proxy.tokenAuthMethod).toBe(
+      "client_secret_basic",
+    );
+  });
+
+  it("forwards the auto-selected token endpoint auth method into the DCR call", async () => {
+    let captured: RegisterClientInput | null = null;
+    const services = {
+      ...happyServices(),
+      registerClient: fromPromise<RegisterClientOutput, RegisterClientInput>(
+        async ({ input }) => {
+          captured = input;
+          return {
+            clientId: "auto-cid",
+            clientSecret: "auto-secret",
+            tokenAuthMethod: null,
+          };
+        },
+      ),
+    };
+    const actor = makeActor(
+      {
+        ...baseInput,
+        discovered: {
+          ...DISCOVERED_2_1,
+          metadata: {
+            ...VALID_PROXY_METADATA,
+            token_endpoint_auth_methods_supported: ["client_secret_post"],
+          },
+        },
+      },
+      services,
+    );
+    actor.start();
+    actor.send({ type: "SELECT_PROXY_AUTO" });
+
+    await waitFor(actor, (s) => s.matches({ result: "success" }), {
+      timeout: 1000,
+    });
+
+    expect(captured).not.toBeNull();
+    expect(captured!.tokenAuthMethod).toBe("client_secret_post");
+    // Issuer origin is derived from the discovered endpoints so the service
+    // can run live RFC 8414 discovery to recover the real supported methods.
+    expect(captured!.issuer).toBe("https://example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth-method helpers
+// ---------------------------------------------------------------------------
+
+describe("pickAuthMethodFromList", () => {
+  it("prefers client_secret_basic > client_secret_post > none", () => {
+    expect(
+      pickAuthMethodFromList([
+        "none",
+        "client_secret_post",
+        "client_secret_basic",
+      ]),
+    ).toBe("client_secret_basic");
+    expect(pickAuthMethodFromList(["none", "client_secret_post"])).toBe(
+      "client_secret_post",
+    );
+    expect(pickAuthMethodFromList(["none"])).toBe("none");
+  });
+
+  it("falls back to client_secret_basic when empty or unrecognized", () => {
+    expect(pickAuthMethodFromList([])).toBe("client_secret_basic");
+    expect(pickAuthMethodFromList(["private_key_jwt", "tls_client_auth"])).toBe(
+      "client_secret_basic",
+    );
+  });
+});
+
+describe("authServerOrigin", () => {
+  it("returns the origin of the first parseable URL", () => {
+    expect(authServerOrigin("https://www.make.com/oauth/v2/authorize")).toBe(
+      "https://www.make.com",
+    );
+    expect(authServerOrigin("", "not a url", "https://x.test/token")).toBe(
+      "https://x.test",
+    );
+  });
+
+  it("returns empty string when no candidate parses", () => {
+    expect(authServerOrigin("", "  ", "relative/path")).toBe("");
   });
 });
 

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
@@ -3,6 +3,8 @@ import { assign, fromPromise, setup, type SnapshotFrom } from "xstate";
 
 import { checkCreds, checkExternal, checkProxyMeta } from "./guards";
 import {
+  authServerOrigin,
+  pickAuthMethodFromList,
   type Context,
   type DiscoveredOAuth,
   type Input,
@@ -62,6 +64,19 @@ function externalFromDiscovered(
   };
 }
 
+// Picks the preferred token auth method from the discovered metadata's
+// advertised list, falling back to client_secret_basic. Note the synthesized
+// metadata in the remote-MCP wizard rarely carries the list, so this usually
+// returns the fallback; the auto-register service additionally runs a live RFC
+// 8414 discovery to recover the upstream's real methods before DCR.
+function pickTokenAuthMethod(m: Record<string, unknown>): string {
+  const raw = m.token_endpoint_auth_methods_supported;
+  const supported = Array.isArray(raw)
+    ? raw.filter((v): v is string => typeof v === "string")
+    : [];
+  return pickAuthMethodFromList(supported);
+}
+
 function proxyFieldsFromDiscovered(
   d: DiscoveredOAuth,
 ): Partial<Context["proxy"]> {
@@ -73,6 +88,7 @@ function proxyFieldsFromDiscovered(
     out.tokenEndpoint = m.token_endpoint;
   if (Array.isArray(m.scopes_supported))
     out.scopes = m.scopes_supported.join(", ");
+  out.tokenAuthMethod = pickTokenAuthMethod(m);
   return out;
 }
 
@@ -340,6 +356,16 @@ export const oauthWizardMachine = setup({
             input: ({ context }): RegisterClientInput => ({
               registrationEndpoint:
                 discoveredRegistrationEndpoint(context.discovered) ?? "",
+              tokenAuthMethod: context.proxy.tokenAuthMethod,
+              // Origin to run live auth-method discovery against. Derived from
+              // the discovered endpoints since the synthesized metadata omits
+              // the supported-methods list. Empty when no endpoint parses, in
+              // which case the service skips discovery and uses tokenAuthMethod.
+              issuer: authServerOrigin(
+                context.proxy.authorizationEndpoint,
+                context.proxy.tokenEndpoint,
+                discoveredRegistrationEndpoint(context.discovered) ?? "",
+              ),
             }),
             onDone: {
               target: "submitting",

--- a/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
@@ -11,7 +11,7 @@ import { fromPromise } from "xstate";
 
 import { proxyRegisterUpstreamClient } from "@/lib/proxyRegisterUpstreamClient";
 
-import { parseScopes } from "./machine-types";
+import { parseScopes, pickAuthMethodFromList } from "./machine-types";
 
 type SignalArg = { signal: AbortSignal };
 
@@ -49,6 +49,12 @@ export type DeleteEnvironmentInput = { envSlug: string };
 
 export type RegisterClientInput = {
   registrationEndpoint: string;
+  // Method derived from the (often empty) discovered metadata. Used as the
+  // fallback when live discovery is skipped or fails.
+  tokenAuthMethod: string;
+  // Origin to run live RFC 8414 discovery against to recover the upstream's
+  // real token_endpoint_auth_methods_supported. Empty disables discovery.
+  issuer: string;
 };
 
 export type RegisterClientOutput = {
@@ -168,9 +174,36 @@ export function createWizardServices(
 
   const registerClient = fromPromise<RegisterClientOutput, RegisterClientInput>(
     async ({ input, signal }) => {
+      // The synthesized remote-MCP metadata omits the supported-methods list,
+      // so run a live RFC 8414 discovery against the issuer origin to recover
+      // it (e.g. Make advertises only client_secret_post, and rejects DCR that
+      // omits it or sends client_secret_basic). Best-effort: any failure leaves
+      // the metadata-derived fallback method in place.
+      let authMethod = input.tokenAuthMethod;
+      if (input.issuer) {
+        try {
+          const draft = await client.remoteSessionIssuers.discover(
+            {
+              discoverRemoteSessionIssuerRequestBody: { issuer: input.issuer },
+            },
+            undefined,
+            { fetchOptions: { signal } },
+          );
+          const supported = draft.tokenEndpointAuthMethodsSupported ?? [];
+          if (supported.length > 0) {
+            authMethod = pickAuthMethodFromList(supported);
+          }
+        } catch {
+          // Keep the fallback method on discovery failure.
+        }
+      }
+
       const result = await proxyRegisterUpstreamClient(
         authedFetch,
-        { registrationEndpoint: input.registrationEndpoint },
+        {
+          registrationEndpoint: input.registrationEndpoint,
+          tokenEndpointAuthMethod: authMethod || undefined,
+        },
         { signal },
       );
       return {

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/issuerFormUtils.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/issuerFormUtils.ts
@@ -42,14 +42,17 @@ export function narrowTokenEndpointAuthMethod(
 
 // Picks the preferred auth method from the issuer's advertised list.
 // Preference order: client_secret_basic > client_secret_post > none.
-// Returns undefined when none of the preferred methods are advertised.
+// Falls back to client_secret_basic when the issuer advertises no recognized
+// method, so DCR always sends one — upstreams that require an explicit method
+// reject a registration that omits it ("No supported Token Endpoint Auth
+// Method provided."). This fallback was the pre-#2910 server-side default.
 export function pickPreferredAuthMethod(
   supported: string[],
-): CreateRemoteSessionClientFormTokenEndpointAuthMethod | undefined {
+): CreateRemoteSessionClientFormTokenEndpointAuthMethod {
   const { ClientSecretBasic, ClientSecretPost, None } =
     CreateRemoteSessionClientFormTokenEndpointAuthMethod;
   for (const preferred of [ClientSecretBasic, ClientSecretPost, None]) {
     if (supported.includes(preferred)) return preferred;
   }
-  return undefined;
+  return ClientSecretBasic;
 }


### PR DESCRIPTION
## Summary

Fixes [AIS-96](https://linear.app/speakeasy/issue/AIS-96). Setting up OAuth via the **Auto-Configure** path of the OAuth Proxy wizard failed for any upstream that requires an explicit `token_endpoint_auth_method`. Confirmed against **Make**, which only advertises `client_secret_post`.

Two problems compounded:

1. The auto-configure path never sent a `token_endpoint_auth_method` on the Dynamic Client Registration (DCR) call.
2. The wizard's discovery metadata is synthesized from the stored remote-MCP tool definition, which **omits the supported-methods list entirely** — so even picking a method client-side had nothing to pick from.

The upstream rejected the registration with `"No supported Token Endpoint Auth Method provided."`, which Gram wrapped as an opaque HTTP 502.

## What changed

- **Live discovery in the auto-register service.** Before the DCR, `registerClient` now runs an RFC 8414 discovery against the issuer origin (reusing the existing `remoteSessionIssuers.discover` RPC) to recover `token_endpoint_auth_methods_supported`, then picks the preferred method. The origin is derived from the discovered authorization/token/registration endpoints — passed as `issuer` on `RegisterClientInput`.
- **Preference + fallback.** Picks `client_secret_basic > client_secret_post > none`, falling back to `client_secret_basic` when discovery is unavailable or advertises nothing. This restores the server-side default that was removed in #2910. Shared helpers `pickAuthMethodFromList` and `authServerOrigin` live in `machine-types.ts`.
- **Sheet fallback.** `pickPreferredAuthMethod` (used by the Attach Remote Identity Provider sheet) now returns `client_secret_basic` instead of `undefined` when nothing is advertised, closing the same gap there.

## Testing

- `pnpm -F dashboard` oauth-wizard suite: 68 passing (new unit tests for `pickAuthMethodFromList`, `authServerOrigin`, and machine tests asserting the issuer is forwarded into the DCR).
- Lint clean on changed files.
- Verified end-to-end against Make's real registration endpoint: a DCR with `client_secret_post` and public redirect/client URIs returns **HTTP 201** with a `client_id`. (Local dev can't complete the flow because Make rejects `localhost` as the `client_uri` hostname — a dev-environment limitation only; production uses a public server URL.)

## Notes

- Discovery is best-effort and wrapped in try/catch, so it never blocks registration; a failed probe just leaves the fallback method in place.
- The pre-existing opaque-502 error surfacing (Gram hiding the upstream's message) is noted in the ticket as a separate follow-up and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-configure in the OAuth Proxy wizard now auto-selects and sends a `token_endpoint_auth_method` during client registration, fixing setup failures for issuers like Make. Resolves Linear AIS-96.

- **Bug Fixes**
  - Run best-effort live discovery against the issuer origin to read `token_endpoint_auth_methods_supported`, then pick `client_secret_basic > client_secret_post > none`.
  - Fall back to `client_secret_basic` when discovery is missing or empty; always send a method on every DCR.
  - Forward the selected method and issuer origin (derived from discovered endpoints) in the DCR request.
  - Apply the same fallback in the Attach Remote Identity Provider sheet.

<sup>Written for commit 06c78b6a975e5d3011d8e0c9406360a81514f0b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

