### PR TITLE
chore(skills): document loops email template convention in golang skill

### DIFF
--- a/.agents/skills/golang/SKILL.md
+++ b/.agents/skills/golang/SKILL.md
@@ -218,6 +218,114 @@ Wire the real or stub implementation in `deps.go` so the service always receives
 
 </good-example>
 
+## Transactional email (Loops)
+
+Sending transactional email goes through `server/internal/email`. The package wraps Loops and enforces a strongly typed `Template` interface.
+
+### Adding a new template
+
+Follow these four steps:
+
+1. Add a `TransactionalID` constant to `server/internal/email/templates.go` — single registry, grep-friendly.
+2. Create `server/internal/email/template_<name>.go` with a struct implementing the `Template` interface (`TransactionalID()`, `Variables()`, `AddToAudience()`).
+3. Append a zero value of the struct to `RegisteredTemplates` in `templates.go` so tests catch duplicate IDs (e.g. `AccessRequestCreated{}`).
+4. Write `server/internal/email/template_<name>_test.go` covering: `TransactionalID` returns the expected constant, `Variables` returns the correct snake_case keys with all keys present, `AddToAudience` returns the expected bool.
+
+To send: call `s.emailSvc.Send(ctx, recipientEmail, tmpl)` where `tmpl` is your populated template struct.
+
+### Variable key naming
+
+`Variables()` must return **snake_case** keys. Loops substitutes these keys directly into template variables — camelCase keys silently render as blank fields in the delivered email.
+
+Every declared key must be present in the returned map even when the value is empty. A missing key causes partial template rendering.
+
+<bad-example>
+
+```go
+func (t MyTemplate) Variables() map[string]string {
+    return map[string]string{
+        "approvalUrl":    t.ApprovalURL,
+        "requesterEmail": t.RequesterEmail,
+    }
+}
+```
+
+camelCase keys silently render as blank fields in Loops — no error, no warning.
+
+</bad-example>
+
+<good-example>
+
+```go
+func (t MyTemplate) Variables() map[string]string {
+    return map[string]string{
+        "approval_url":    t.ApprovalURL,
+        "requester_email": t.RequesterEmail,
+    }
+}
+```
+
+</good-example>
+
+### `AddToAudience` semantics
+
+Controls whether Loops upserts the recipient as a contact in the audience when the email is sent.
+
+- Return `true` for user-facing emails that are part of the recipient's product journey (team invites, onboarding).
+- Return `false` for operational/admin emails where the recipient is incidental (admin alerts, system notifications).
+
+### Testing patterns
+
+**Base test setup — never pass `nil` for `*email.Service`:**
+
+```go
+loopsClient := loops.New(ctx, logger, nil, "") // nil guardian policy is safe when key is empty; returns noop client
+noopEmailSvc := email.NewService(logger, loopsClient)
+```
+
+**Asserting on sent emails — use a capture client:**
+
+`loops.Client` is our own interface (not a vendor type), so a hand-rolled capture client is appropriate here. The capture pattern lets tests assert on the exact payload sent — use it instead of `testify/mock` for Loops email assertions.
+
+```go
+type captureLoopsClient struct {
+    mu   sync.Mutex
+    sent []loops.SendTransactionalInput
+}
+
+func (c *captureLoopsClient) SendTransactional(_ context.Context, input loops.SendTransactionalInput) error {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    c.sent = append(c.sent, input)
+    return nil
+}
+
+func (c *captureLoopsClient) Sent() []loops.SendTransactionalInput {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    out := make([]loops.SendTransactionalInput, len(c.sent))
+    copy(out, c.sent)
+    return out
+}
+```
+
+To use it in a test, declare an instance and swap it into the service:
+
+```go
+captured := &captureLoopsClient{}
+svc.emailSvc = email.NewService(testenv.NewLogger(t), captured)
+```
+
+(This assigns an unexported field — works from within the same package, which is the convention for `access` package tests.)
+
+**Optional display fields — use `conv.Default`:**
+
+```go
+DisplayName: conv.Default(request.DisplayName, "(unknown resource)"),
+```
+
+Never send a template with a blank field that produces broken email copy. Apply a meaningful fallback at the Go layer, not in the Loops template.
+
 ## Function shape
 
 - Avoid helper functions and methods that only forward to another method with no meaningful logic.


### PR DESCRIPTION
## Summary

- Adds `## Transactional email (Loops)` section to the golang skill
- Documents the 4-step template-adding pattern, snake_case variable key requirement, `AddToAudience` semantics, and test patterns (noop client setup, capture client with justification, `conv.Default` fallback)

## Root cause

A code review on PR #3221 caught camelCase keys in `Variables()` — Loops silently renders these as blank fields with no error. This section prevents the same mistake in future PRs.

## Test plan

- [x] Skill section renders with correct ordering between `## Third-party clients` and `## Function shape`
- [x] Bad/good examples are syntactically valid Go

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents transactional email conventions in the Go skill to standardize `Loops` template usage and prevent blank renders from camelCase variables. Adds clear steps for creating templates, naming variables, audience behavior, and testing for `server/internal/email`.

- **New Features**
  - Added “Transactional email (Loops)” section to `.agents/skills/golang/SKILL.md`.
  - 4-step flow to add a template in `server/internal/email` (`TransactionalID`, `Template` struct, `RegisteredTemplates`, tests).
  - Enforced snake_case keys in `Variables()` with all keys present.
  - Clarified `AddToAudience` rules for user vs. operational emails.
  - Testing guidance: non-nil `*email.Service`, noop client via `loops.New`, capture client pattern, and `conv.Default` fallbacks.

<sup>Written for commit bfa48451ba3fcbf00f3aeeb30270915a065cf042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

