### PR TITLE
chore(dependabot): add frontend package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,45 @@ updates:
       aws:
         patterns:
           - "github.com/aws/aws-sdk-go-v2/*"
+  - package-ecosystem: "npm"
+    directories:
+      - "/client/*"
+      - "/elements"
+      - "/elements/examples/*"
+    schedule:
+      interval: "weekly"
+    groups:
+      ai-sdk:
+        patterns:
+          - "@ai-sdk/*"
+          - "ai"
+      assistant-ui:
+        patterns:
+          - "@assistant-ui/*"
+      class-names:
+        patterns:
+          - "clsx"
+          - "tailwind-merge"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/postcss"
+          - "@tailwindcss/typography"
+          - "@tailwindcss/vite"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vitest"
   - package-ecosystem: "docker"
     directory: "/server"
     schedule:


### PR DESCRIPTION
## Summary
- Add weekly Dependabot npm updates for frontend pnpm workspaces under `client/*`, `elements`, and `elements/examples/*`.
- Group related frontend dependency families to keep update PRs reviewable.
- Keep coupled class-name utilities (`clsx` and `tailwind-merge`) on the same update cadence.

## Notes
- GitHub docs currently list pnpm support through v10; the first Dependabot run after merge will validate pnpm 11 behavior.

## Test Plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml: ok"'`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable weekly Dependabot `npm` updates for frontend pnpm workspaces and group related packages to keep update PRs small and readable. Keeps `clsx` and `tailwind-merge` in sync and batches React/Tailwind/Vite families.

- **Dependencies**
  - Targets `client/*`, `elements`, and `elements/examples/*` with a weekly schedule.
  - Groups updates by family: React, Tailwind, Vite/Vitest, `@tanstack/*`, `@ai-sdk/*`/`ai`, `@assistant-ui/*`, and class-name utils (`clsx` + `tailwind-merge`).
  - First run will confirm Dependabot behavior with pnpm 11.

<sup>Written for commit 3791ecfeca7db09fc2a233e456493b82f36d21ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

