### PR TITLE
mig: drop the unused assistant_dashboard_messages table

### DIFF
--- a/.changeset/drop-assistant-dashboard-messages.md
+++ b/.changeset/drop-assistant-dashboard-messages.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Drop the unused `assistant_dashboard_messages` table (contract migration). It was the dashboard-assistant conversation log written via the `platform_dashboard_send_message` egress tool and read via `assistants.listMessages`; the #3204 rearchitecture replaced that path with rendering the real conversation through `chat.load`, leaving the table fully orphaned (no reads, writes, queries, or code references). Completes the expand-contract from that change.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1182,33 +1182,6 @@ CREATE TABLE IF NOT EXISTS project_managed_assistants (
 
 CREATE INDEX IF NOT EXISTS project_managed_assistants_assistant_id_idx ON project_managed_assistants (assistant_id);
 
--- assistant_dashboard_messages is the user-visible conversation log for a
--- dashboard assistant chat: the user's messages and the assistant's delivered
--- replies (written by the platform_dashboard_send_message egress tool). Kept
--- separate from chat_messages, which holds the raw model/tool transcript — the
--- dashboard renders only this clean log. Keyed by chat_id (the deterministic
--- assistant thread chat) with a monotonic seq for incremental polling. user_id
--- is the dashboard user the conversation belongs to, stamped on both the user's
--- messages and the assistant's replies so reads scope to their owner.
-CREATE TABLE IF NOT EXISTS assistant_dashboard_messages (
-  id uuid NOT NULL DEFAULT generate_uuidv7(),
-  project_id uuid NOT NULL,
-  chat_id uuid NOT NULL,
-  user_id TEXT NOT NULL,
-  role TEXT NOT NULL,
-  content TEXT NOT NULL,
-  seq BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY,
-
-  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-
-  CONSTRAINT assistant_dashboard_messages_pkey PRIMARY KEY (id),
-  CONSTRAINT assistant_dashboard_messages_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
-  CONSTRAINT assistant_dashboard_messages_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE
-);
-
--- (chat_id, seq) is the stable cursor for incremental polling.
-CREATE INDEX IF NOT EXISTS assistant_dashboard_messages_chat_id_seq_idx ON assistant_dashboard_messages (chat_id, seq);
-
 CREATE TABLE IF NOT EXISTS assistant_toolsets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   assistant_id uuid NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -99,17 +99,6 @@ type Assistant struct {
 	Deleted         bool
 }
 
-type AssistantDashboardMessage struct {
-	ID        uuid.UUID
-	ProjectID uuid.UUID
-	ChatID    uuid.UUID
-	UserID    string
-	Role      string
-	Content   string
-	Seq       int64
-	CreatedAt pgtype.Timestamptz
-}
-
 type AssistantMemory struct {
 	ID             uuid.UUID
 	AssistantID    uuid.NullUUID

--- a/server/migrations/20260607190432_drop_assistant_dashboard_messages.sql
+++ b/server/migrations/20260607190432_drop_assistant_dashboard_messages.sql
@@ -1,0 +1,4 @@
+-- atlas:nolint DS102
+
+-- Drop "assistant_dashboard_messages" table
+DROP TABLE "assistant_dashboard_messages";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:u/TOliI3/8QMrnjL5ESIRAs0dXrhFC6kxGi9VYxXq2Y=
+h1:FMk7Pvn55o8uetHu7MyfNAz8+aR/i4VaWIJj9tAEKA8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -210,3 +210,4 @@ h1:u/TOliI3/8QMrnjL5ESIRAs0dXrhFC6kxGi9VYxXq2Y=
 20260605143925_add_risk_exclusions.sql h1:u5YQre0OFPZ56F9gAy0K7kSsb5q+koeoJh49JOS3qjw=
 20260605174513_risk-results-drop-verbatim-match-index-column.sql h1:Ans/oK8EWrCsPWdbfL9v/66RrUgIMYdlwEDEx9hwscc=
 20260605200300_plugin_servers_mcp_server_id.sql h1:3NUyToGuksyCGuOgltiB60ob8++hRSAKYDdrUHesOzg=
+20260607190432_drop_assistant_dashboard_messages.sql h1:cWzckEkrvfa1uc3G9NZ814nT/6tIthd8tBjywwhjZqk=


### PR DESCRIPTION
## Summary

Closes **AGE-2724** (AGE-2631 follow-up). Contract migration dropping the now-orphaned `assistant_dashboard_messages` table.

The table (added in #3145) was the dashboard-assistant conversation log, written via the `platform_dashboard_send_message` egress tool (#3146) and read via `assistants.listMessages` (#3147). The #3204 rearchitecture replaced that whole path — the sidebar now renders the real conversation through `chat.load` — leaving the table fully orphaned. Per expand-contract, it was left in place at the time; this is the contract step.

## Verified unused before dropping
- No reads, writes, or SQLc queries reference it (all of `InsertDashboardMessage` / `GetDashboardChatOwner` / `GetDashboardThreadTarget` / `ListDashboardMessages` were removed in #3204).
- The generated `AssistantDashboardMessage` struct was referenced nowhere (only its definition) — removed by regen.
- No ClickHouse / audit / RBAC references; no other table FKs to it.
- `server build` passes with the struct gone.

## Contents (migration-only PR — no app code)
- `server/database/schema.sql` — table + index removed
- `server/migrations/20260607190432_drop_assistant_dashboard_messages.sql` — `DROP TABLE` (Atlas-generated)
- `server/migrations/atlas.sum` — updated by `db:diff` (stable under `db:hash`)
- `server/internal/database/models.go` — regenerated (struct removed), pinned sqlc 1.31.1, no header drift
- changeset (`server`: patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the unused `assistant_dashboard_messages` table via a contract migration. This table was replaced by the `chat.load` path; verified no reads, writes, or SQLc references remain (Linear AGE-2724).

- **Migration**
  - Atlas migration to drop the table; removed table and index from `server/database/schema.sql`.
  - Regenerated `server/internal/database/models.go` to remove `AssistantDashboardMessage`.
  - Updated `server/migrations/atlas.sum` and added a patch changeset for `server`.

<sup>Written for commit 00052b1b05c153108ed6597b1b6de05f84246dda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

