### PR TITLE
feat(dashboard): redesign assistants cards and rename AI Insights to Project Assistant

### DIFF
--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -187,10 +187,12 @@ export function InsightsTrigger({ className }: { className?: string }) {
         startSpin();
         setIsExpanded(!isExpanded);
       }}
-      aria-label={isExpanded ? "Close AI Insights" : "Open AI Insights"}
+      aria-label={
+        isExpanded ? "Close Project Assistant" : "Open Project Assistant"
+      }
       aria-keyshortcuts={shortcutAria}
       aria-pressed={isExpanded}
-      title={`AI Insights (${shortcutKeys.join("+")})`}
+      title={`Project Assistant (${shortcutKeys.join("+")})`}
       className={cn(
         "group border-border hover:bg-accent hover:text-accent-foreground inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors",
         isExpanded && "bg-accent text-accent-foreground",
@@ -201,7 +203,7 @@ export function InsightsTrigger({ className }: { className?: string }) {
       <Wand2
         className={cn("size-3.5", spinning && "insights-trigger-spinning")}
       />
-      <span className="font-medium">AI Insights</span>
+      <span className="font-medium">Project Assistant</span>
       {/* Hover-revealed shortcut hint. The outer wrapper animates between
           0fr and 1fr grid columns so the contents transition cleanly from
           width 0 to their natural width without us hardcoding a pixel value.

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -1,7 +1,9 @@
 import { TopUpCTA, UsageProgress } from "@/components/billing/usage-controls";
 import { Page } from "@/components/page-layout";
+import { getProjectColors } from "@/components/project-colors";
 import { RequireScope } from "@/components/require-scope";
-import { Card, Cards } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { DotCard } from "@/components/ui/dot-card";
 import { MoreActions } from "@/components/ui/more-actions";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
@@ -24,7 +26,7 @@ import {
 } from "@gram/client/react-query/index.js";
 import { Button, Icon, Stack } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { Info, Plus } from "lucide-react";
+import { Bot, Boxes, Cpu, Info, Plus } from "lucide-react";
 import { MouseEvent } from "react";
 import { Outlet } from "react-router";
 import { toast } from "sonner";
@@ -127,10 +129,10 @@ export default function AssistantsIndex() {
     ) : (
       <Page.Section>
         <Page.Section.Title stage="preview">Assistants</Page.Section.Title>
-        <Page.Section.Description>
-          Claude Code-inspired secure Assistants. Every assistant connects
-          through the MCPs and Skills your org already uses, with identity,
-          guardrails, and audit built in. Deployed to Slack.
+        <Page.Section.Description className="max-w-xl">
+          Openclaw-inspired secure Assistants. Every assistant connects through
+          the MCPs and Skills your org already uses, with identity, guardrails,
+          and audit built in. Deployed to Slack.
         </Page.Section.Description>
         <Page.Section.CTA>
           <RequireScope
@@ -156,11 +158,11 @@ export default function AssistantsIndex() {
               />
             </Stack>
           ) : (
-            <Cards>
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
               {assistants.map((assistant) => (
                 <AssistantCard key={assistant.id} assistant={assistant} />
               ))}
-            </Cards>
+            </div>
           )}
         </Page.Section.Body>
       </Page.Section>
@@ -225,6 +227,58 @@ function UsageSection() {
   );
 }
 
+// Each assistant gets a deterministic gradient tile behind its Bot icon,
+// derived from its id via the same hash that powers project avatar colors.
+function AssistantIcon({ assistant }: { assistant: Pick<Assistant, "id"> }) {
+  const colors = getProjectColors(assistant.id);
+  return (
+    <div
+      className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br"
+      style={{
+        backgroundImage: `linear-gradient(${colors.angle}deg, ${colors.from}, ${colors.to})`,
+      }}
+    >
+      <Bot className="h-7 w-7 text-white" />
+    </div>
+  );
+}
+
+const MAX_VISIBLE_TOOLSETS = 3;
+
+function AssistantToolsets({ assistant }: { assistant: Assistant }) {
+  if (assistant.toolsets.length === 0) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <Boxes className="text-muted-foreground/70 size-3.5 shrink-0" />
+        <Type muted small>
+          No MCP servers
+        </Type>
+      </div>
+    );
+  }
+
+  const visible = assistant.toolsets.slice(0, MAX_VISIBLE_TOOLSETS);
+  const overflow = assistant.toolsets.length - visible.length;
+
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      <Boxes className="text-muted-foreground/70 size-3.5 shrink-0" />
+      <div className="flex min-w-0 flex-wrap items-center gap-1">
+        {visible.map((toolset) => (
+          <Badge
+            key={toolset.toolsetSlug}
+            variant="outline"
+            className="max-w-[10rem] truncate"
+          >
+            {toolset.toolsetSlug}
+          </Badge>
+        ))}
+        {overflow > 0 && <Badge variant="outline">+{overflow}</Badge>}
+      </div>
+    </div>
+  );
+}
+
 function AssistantCard({ assistant }: { assistant: Assistant }) {
   const routes = useRoutes();
   const queryClient = useQueryClient();
@@ -235,50 +289,57 @@ function AssistantCard({ assistant }: { assistant: Assistant }) {
     },
   });
 
-  const toolsetLabel = `${assistant.toolsets.length} MCP server${
-    assistant.toolsets.length !== 1 ? "s" : ""
-  }`;
-
   return (
     <routes.assistants.detail.Link
       params={[assistant.id]}
-      className="hover:no-underline"
+      className="focus-visible:ring-ring block rounded-xl no-underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
     >
-      <Card>
-        <Card.Header>
-          <Card.Title className="normal-case">{assistant.name}</Card.Title>
-          <MoreActions
-            actions={[
-              {
-                label: "Delete",
-                destructive: true,
-                icon: "trash",
-                onClick: () => {
-                  if (confirm(`Delete assistant "${assistant.name}"?`)) {
-                    deleteAssistant.mutate({ request: { id: assistant.id } });
-                  }
-                },
-              },
-            ]}
-          />
-        </Card.Header>
-        <Card.Content>
-          <Card.Description>
-            <Stack direction="horizontal" gap={3} align="center">
-              <StatusToggle assistant={assistant} />
-              <Type muted small>
-                {assistant.model}
-              </Type>
-            </Stack>
-          </Card.Description>
-        </Card.Content>
-        <Card.Footer>
-          <Type muted small>
-            {toolsetLabel}
+      <DotCard icon={<AssistantIcon assistant={assistant} />}>
+        {/* Header row: name + actions */}
+        <div className="mb-3 flex items-start justify-between gap-2">
+          <Type
+            variant="subheading"
+            as="div"
+            className="text-md group-hover:text-primary flex-1 truncate normal-case transition-colors"
+            title={assistant.name}
+          >
+            {assistant.name}
           </Type>
+          <div onClick={stopLinkNavigation}>
+            <MoreActions
+              actions={[
+                {
+                  label: "Delete",
+                  destructive: true,
+                  icon: "trash",
+                  onClick: () => {
+                    if (confirm(`Delete assistant "${assistant.name}"?`)) {
+                      deleteAssistant.mutate({ request: { id: assistant.id } });
+                    }
+                  },
+                },
+              ]}
+            />
+          </div>
+        </div>
+
+        {/* Metadata: model + MCP servers */}
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-1.5">
+            <Cpu className="text-muted-foreground/70 size-3.5 shrink-0" />
+            <Type muted small className="truncate" title={assistant.model}>
+              {assistant.model}
+            </Type>
+          </div>
+          <AssistantToolsets assistant={assistant} />
+        </div>
+
+        {/* Footer row: status toggle + last updated */}
+        <div className="border-border/60 mt-auto flex items-center justify-between gap-2 border-t pt-3">
+          <StatusToggle assistant={assistant} />
           <UpdatedAt date={new Date(assistant.updatedAt)} />
-        </Card.Footer>
-      </Card>
+        </div>
+      </DotCard>
     </routes.assistants.detail.Link>
   );
 }


### PR DESCRIPTION
## What & why

Improves the UX of the **Assistants** page, taking visual cues from the better-designed MCP server cards, plus a small nav rename.

<img width="3134" height="846" alt="CleanShot 2026-06-07 at 16 06 42@2x" src="https://github.com/user-attachments/assets/4489bd97-7e68-4c4d-871a-f33e2957eb5e" />

## Changes

**Assistant cards (`pages/assistants/Assistants.tsx`)**

- Switched from the plain `Card` to the shared `DotCard` primitive (dot-pattern sidebar + frosted-glass icon) used by MCP/sources/catalog cards, and moved the grid to the roomy `grid-cols-1 … xl:grid-cols-2` layout the MCP page uses (the old 6-col `<Cards>` starved the wider card).
- Each assistant's `Bot` icon now sits on a **deterministic per-assistant gradient tile**, reusing `getProjectColors(assistant.id)` — the same hash that drives project avatar colors — so every assistant gets its own stable color.
- Card retains and improves the key info: **model** (with icon), **active/paused toggle**, **MCP servers** (upgraded from a bare count to server-slug chips with a `+N` overflow and a "No MCP servers" empty state), and **last-updated** time in a divider-separated footer.

**Page copy**

- Updated the description to the new "Openclaw-inspired secure Assistants…" wording, constrained to `max-w-xl` so it wraps before colliding with the **New Assistant** button.

**Nav rename (`components/insights-sidebar.tsx`)**

- Renamed the top-bar **"AI Insights"** trigger to **"Project Assistant"** (visible label, `title`, and both `aria-label` states). Functionality unchanged.

## Out of scope / follow-ups

- **"Updated by (who)"** — intentionally skipped; there's no actor field on the assistant today (would need a migration + actor tracking).
- **"Last response / last activity"** — investigated: `assistant_threads.last_event_at` is a cheap existing source (system-stamped per turn, already indexed). Surfacing it needs no migration — just a `MAX(last_event_at)` query + one optional field on the `listAssistants` response + SDK regen. Planned as a small follow-up; the card footer already has room for a "Last active" line.

## Verification

- `pnpm -F dashboard type-check` — clean for the edited files (only pre-existing `Table.Body`/`AppPortal` baselines remain on main).
- `pnpm -F dashboard lint:eslint` — no issues on edited files.
- `pnpm -F dashboard lint:format` — passes.

Frontend-only; no SDK/backend/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned Assistants cards for a clearer, consistent UI and renamed AI Insights to Project Assistant.

- **New Features**
  - Assistant cards now use `DotCard` with a 1-col → 2-col grid and a deterministic gradient `Bot` icon per assistant via `getProjectColors(id)`.
  - Cards show model, MCP servers as chips with +N overflow (or “No MCP servers”), a status toggle, and a last-updated footer; page description updated and constrained to `max-w-xl`.
  - Top-bar trigger renamed from “AI Insights” to “Project Assistant” (label, title, and `aria-label`).

<sup>Written for commit 2312d83893c528b9fec6426aac02b6dd67168366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

