### PR TITLE
feat(assistants): eagerly warm the Project Assistant runtime VM

### DIFF
--- a/.changeset/warm-managed-assistant-runtime.md
+++ b/.changeset/warm-managed-assistant-runtime.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Eagerly warm the Project Assistant's runtime VM. The dominant latency in the sidebar was a cold-start at send time — the runtime was only booted (`Ensure`) lazily when the first turn arrived, and went cold after a short warm window. `ensureManagedAssistant` (called on sidebar open) now also enqueues a no-op "warm" event that drives the coordinator to boot/refresh the VM without running a turn, and the dashboard keeps it warm with a periodic re-ensure while the sidebar stays open. So the VM is ready before the user's first message instead of booting after it.

--- a/client/dashboard/src/hooks/useServerAssistantTransport.ts
+++ b/client/dashboard/src/hooks/useServerAssistantTransport.ts
@@ -6,6 +6,11 @@ import {
 import { createServerAssistantTransport } from "@/lib/ServerAssistantTransport";
 import type { ElementsTransportFactory } from "@gram-ai/elements";
 
+// How often to re-warm the runtime while the sidebar stays open. Kept under the
+// server's warm TTL so the VM never goes cold between a user's messages while
+// they read — eager warming is the dominant latency win over the send path.
+const WARM_KEEPALIVE_MS = 45_000;
+
 export interface UseServerAssistantTransportResult {
   /**
    * Transport factory for `ElementsConfig.transport`, available once the managed
@@ -116,6 +121,23 @@ export function useServerAssistantTransport(
   }, [enabled, projectSlug, ensureManagedMutate]);
 
   const ready = assistantId !== "";
+
+  // Keepalive: while the sidebar stays open, periodically re-ensure — which
+  // re-warms the runtime VM and extends its warm window — so it doesn't go cold
+  // between messages while the user reads. Fire-and-forget; only runs once the
+  // assistant has resolved, and stops on close/unmount.
+  useEffect(() => {
+    if (!enabled || !ready || !projectSlug) {
+      return;
+    }
+    const id = setInterval(() => {
+      if (currentSlugRef.current !== projectSlug) {
+        return;
+      }
+      ensureManagedMutate({});
+    }, WARM_KEEPALIVE_MS);
+    return () => clearInterval(id);
+  }, [enabled, ready, projectSlug, ensureManagedMutate]);
 
   const transport = useMemo<ElementsTransportFactory | undefined>(() => {
     if (!ready) {

--- a/server/internal/assistants/dashboard_ingress_test.go
+++ b/server/internal/assistants/dashboard_ingress_test.go
@@ -153,6 +153,33 @@ func TestEnableManagedAssistantHealsMissingDashboardTrigger(t *testing.T) {
 	require.Len(t, instances, 1, "re-enable re-provisions the dashboard trigger")
 }
 
+func TestIsWarmDashboardEvent(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isWarmDashboardEvent(sourceKindDashboard, []byte(`{"warm":true}`)))
+	require.False(t, isWarmDashboardEvent(sourceKindDashboard, []byte(`{"text":"hi","user_id":"u1"}`)), "a real turn is not warm")
+	require.False(t, isWarmDashboardEvent("slack", []byte(`{"warm":true}`)), "warm only applies to the dashboard source")
+	require.False(t, isWarmDashboardEvent(sourceKindDashboard, []byte(`not json`)), "malformed payload is not warm")
+}
+
+// A warm event must keep its warm marker all the way through
+// buildAssistantEventPayload into the normalized payload — otherwise
+// processEventTurn would run a real (empty) turn instead of skipping it. This is
+// the round-trip that the earlier `hidden` flag lost.
+func TestBuildAssistantEventPayloadDashboardWarm(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"text":"","warm":true}`)
+	kind, _, normalized, _, err := buildAssistantEventPayload(bgtriggers.Task{
+		DefinitionSlug: sourceKindDashboard,
+		EventJSON:      payload,
+		RawPayload:     payload,
+	})
+	require.NoError(t, err)
+	require.Equal(t, sourceKindDashboard, kind)
+	require.True(t, isWarmDashboardEvent(kind, normalized), "warm survives into the normalized payload")
+}
+
 func mustDefinitionKind(t *testing.T, slug string) bgtriggers.Kind {
 	t.Helper()
 	def, ok := bgtriggers.GetDefinition(slug)

--- a/server/internal/assistants/impl.go
+++ b/server/internal/assistants/impl.go
@@ -301,6 +301,14 @@ func (s *Service) EnsureManagedAssistant(ctx context.Context, _ *gen.EnsureManag
 		}
 		return nil, mapAssistantStoreError(ctx, s.logger, err, "ensure project assistant")
 	}
+	// Eagerly warm the runtime VM so it's booted before the user's first turn —
+	// the dashboard calls this on sidebar open (and periodically while open).
+	// Best-effort: a warm failure just means a colder first turn, never a failed
+	// ensure.
+	if err := s.core.WarmManagedAssistant(ctx, *authCtx.ProjectID, record.ID); err != nil {
+		s.logger.WarnContext(ctx, "failed to warm project assistant runtime", attr.SlogError(err))
+	}
+
 	view, err := toHTTPAssistant(record)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").Log(ctx, s.logger)

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -320,6 +320,8 @@ type dashboardIngestPayload struct {
 	UserID         string `json:"user_id"`
 	CorrelationID  string `json:"correlation_id"`
 	IdempotencyKey string `json:"idempotency_key"`
+	// Warm marks a no-op runtime-warming event (see dashboardTriggerEvent.Warm).
+	Warm bool `json:"warm,omitempty"`
 }
 
 // DashboardSendResult is what the sendMessage endpoint returns to the dashboard.
@@ -391,6 +393,50 @@ func (s *ServiceCore) SendDashboardMessage(ctx context.Context, projectID, assis
 	}
 	result.ThreadID = threadID
 	return result, nil
+}
+
+// warmCorrelationID is the dedicated correlation for runtime-warming events.
+// All warm events for an assistant collapse onto a single internal warm chat
+// (owner-less, so ListChats — which filters by user_id — keeps it out of every
+// user's thread list), separate from real user conversations.
+const warmCorrelationID = "__warm__"
+
+// WarmManagedAssistant enqueues a no-op warm event that drives the coordinator
+// to Ensure (boot / refresh) the assistant's runtime VM, so it is ready before
+// the user's first real turn — the dominant latency in the dashboard sidebar is
+// a cold-start at send time. Best-effort and idempotent: fire it on sidebar
+// open and periodically while the sidebar stays open (each warm re-Ensures and
+// extends the warm window). The warm event runs no turn (see
+// isWarmDashboardEvent / processEventTurn).
+func (s *ServiceCore) WarmManagedAssistant(ctx context.Context, projectID, assistantID uuid.UUID) error {
+	assistant, err := s.GetAssistant(ctx, projectID, assistantID)
+	if err != nil {
+		return err
+	}
+
+	instanceID, err := s.resolveDashboardTriggerInstance(ctx, assistant.OrganizationID, projectID, assistant.ID, assistant.Name)
+	if err != nil {
+		return err
+	}
+
+	if s.dashboardIngestor == nil {
+		return fmt.Errorf("dashboard ingestor is not configured")
+	}
+
+	payload, err := json.Marshal(dashboardIngestPayload{
+		Warm:           true,
+		CorrelationID:  warmCorrelationID,
+		IdempotencyKey: uuid.NewString(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal warm message: %w", err)
+	}
+
+	if _, err := s.dashboardIngestor.IngestDirect(ctx, instanceID, payload, time.Now().UTC()); err != nil {
+		return fmt.Errorf("ingest warm message: %w", err)
+	}
+
+	return nil
 }
 
 // resolveDashboardTriggerInstance returns the managed assistant's dashboard

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1224,6 +1224,20 @@ func dashboardChatUserID(sourceKind string, normalizedPayloadJSON []byte) string
 	return dash.UserID
 }
 
+// isWarmDashboardEvent reports whether an event is a no-op runtime-warming
+// event. These carry no user turn; the runtime is Ensure'd by
+// ProcessThreadEvents before the event loop, so processEventTurn skips them.
+func isWarmDashboardEvent(sourceKind string, normalizedPayloadJSON []byte) bool {
+	if sourceKind != sourceKindDashboard {
+		return false
+	}
+	var dash dashboardEventPayload
+	if err := json.Unmarshal(normalizedPayloadJSON, &dash); err != nil {
+		return false
+	}
+	return dash.Warm
+}
+
 // CheckDashboardChatOwnership returns nil when callerUserID owns the chats row
 // for (projectID, chatID), pgx.ErrNoRows when they don't, and a wrapped error
 // otherwise. Callers gate sendMessage on this so a leaked or guessed chat_id
@@ -1708,6 +1722,13 @@ func (s *ServiceCore) processEventTurn(
 		if err := s.runtime.RunTurn(ctx, runtime, thread.ID, event.ID.String(), turnToken, prompt); err != nil {
 			return fmt.Errorf("run assistant turn: %w", err)
 		}
+		return nil
+	}
+
+	if isWarmDashboardEvent(thread.SourceKind, event.NormalizedPayloadJSON) {
+		// Warm event: ProcessThreadEvents already ran Ensure (booting/refreshing
+		// the runtime) before this loop, which is the entire point. There's no
+		// user turn to run — consuming the event keeps the VM warm with no work.
 		return nil
 	}
 

--- a/server/internal/assistants/source_adapter.go
+++ b/server/internal/assistants/source_adapter.go
@@ -291,6 +291,10 @@ type dashboardSourceRef struct {
 type dashboardEventPayload struct {
 	Text   string `json:"text"`
 	UserID string `json:"user_id,omitempty"`
+	// Warm marks a no-op runtime-warming event (see dashboardTriggerEvent.Warm).
+	// processEventTurn short-circuits these: the runtime is already Ensure'd by
+	// ProcessThreadEvents before the event loop, so warming needs no turn.
+	Warm bool `json:"warm,omitempty"`
 }
 
 type dashboardAdapter struct{}

--- a/server/internal/background/triggers/dashboard_definition_test.go
+++ b/server/internal/background/triggers/dashboard_definition_test.go
@@ -51,3 +51,26 @@ func TestDashboardDefinitionBuildDirectEvent(t *testing.T) {
 	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"text":"hi","user_id":"user-1","idempotency_key":"key-1"}`), receivedAt)
 	require.Error(t, err, "empty correlation id rejected")
 }
+
+func TestDashboardDefinitionBuildDirectEventWarm(t *testing.T) {
+	t.Parallel()
+
+	def := newDashboardDefinition()
+	instance := triggerrepo.TriggerInstance{ID: uuid.New(), DefinitionSlug: "dashboard"}
+	receivedAt := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	// Warm events carry no user message, so text/user_id are not required.
+	env, err := def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"warm":true,"correlation_id":"__warm__","idempotency_key":"w-1"}`), receivedAt)
+	require.NoError(t, err, "warm event accepted without text/user_id")
+	require.Equal(t, "__warm__", env.CorrelationID)
+
+	// Warm must survive into the envelope's Event, or it's lost before reaching
+	// the normalized payload (the bug that sank the earlier `hidden` flag).
+	ev, ok := env.Event.(dashboardTriggerEvent)
+	require.True(t, ok)
+	require.True(t, ev.Warm)
+
+	// Idempotency key is still required even for warm events.
+	_, err = def.BuildDirectEvent(instance, dashboardTriggerConfig{}, []byte(`{"warm":true,"correlation_id":"__warm__"}`), receivedAt)
+	require.Error(t, err, "warm still requires an idempotency key")
+}

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -196,6 +196,11 @@ type dashboardTriggerEvent struct {
 	UserID         string `json:"user_id,omitempty" cel:"user_id"`
 	CorrelationID  string `json:"correlation_id,omitempty" cel:"correlation_id"`
 	IdempotencyKey string `json:"idempotency_key,omitempty" cel:"idempotency_key"`
+	// Warm marks a no-op runtime-warming event: it carries no user message and
+	// exists only to drive the coordinator to Ensure (boot) the assistant's VM
+	// so it's ready before the user's first real turn. The assistant runtime
+	// short-circuits these without running a turn.
+	Warm bool `json:"warm,omitempty" cel:"warm"`
 }
 
 type slackEventRequest struct {
@@ -1004,11 +1009,15 @@ func newDashboardDefinition() Definition {
 			if err := json.Unmarshal(payload, &event); err != nil {
 				return nil, fmt.Errorf("decode dashboard message: %w", err)
 			}
-			if event.Text == "" {
-				return nil, fmt.Errorf("dashboard message text is required")
-			}
-			if event.UserID == "" {
-				return nil, fmt.Errorf("dashboard message user id is required")
+			// Warm events carry no user message — they only drive runtime
+			// warming — so text/user_id are not required for them.
+			if !event.Warm {
+				if event.Text == "" {
+					return nil, fmt.Errorf("dashboard message text is required")
+				}
+				if event.UserID == "" {
+					return nil, fmt.Errorf("dashboard message user id is required")
+				}
 			}
 			if event.IdempotencyKey == "" {
 				return nil, fmt.Errorf("dashboard message idempotency key is required")


### PR DESCRIPTION
## Summary

Part of **AGE-2718**. Cuts the dominant Project Assistant sidebar latency by **warming the runtime VM eagerly** instead of booting it at send time. (Per Daniel's steer: eager warming is a bigger win than the original poll→stream idea, which is demoted to a separate follow-up.)

**The problem:** the runtime VM is only `Ensure`'d *lazily* inside `ProcessThreadEvents` — i.e. after the user sends — and the managed assistant's warm window is short. So a user who reads the dashboard for a minute, then asks a question, waits on a cold VM boot.

**The fix:** `ensureManagedAssistant` (already called by the sidebar on open) now enqueues a no-op **warm event**. It rides the existing dashboard trigger + coordinator admission, which runs `Ensure` (boot/refresh the VM) *before* the event loop — but `processEventTurn` short-circuits warm events, so **no turn runs**. The dashboard re-ensures every 45s while the sidebar stays open to hold it warm.

## Mechanism
- **Warm marker** threads through `dashboardIngestPayload` → `dashboardTriggerEvent` (carried on `EventEnvelope.Event`, so it survives into the normalized payload — the round-trip the earlier `hidden` flag lost) → `dashboardEventPayload`.
- `BuildDirectEvent` relaxes the text/user_id requirements for warm events (idempotency key still required).
- `processEventTurn` skips warm events (`isWarmDashboardEvent`); `Ensure` has already run.
- Warm events collapse onto **one owner-less internal chat** (correlation `__warm__`). `ListChats` filters by `user_id`, so it stays out of every user's thread list.
- **Best-effort:** a warm failure logs a warning, never fails the ensure.

## Reviewer notes (touches the coordinator/trigger path — flagging for @danielkov)
- Warming reuses the *existing* admission/coordinator machinery (no new locks) — a warm event is just a turn-less event.
- Cost: warm VMs cost Fly machine-time, scoped to *presence* (sidebar open + 45s keepalive that stops when the user leaves). Acceptable at current project count (confirmed w/ Sagar).
- Open question: bump the 60s managed warm TTL vs. rely on the client keepalive (kept 60s for now).

## Verification
- `go build ./...` ✅, `go test ./internal/assistants/ ./internal/background/triggers/` ✅ (new tests: warm `BuildDirectEvent` accept + round-trip survival, `isWarmDashboardEvent`, `buildAssistantEventPayload` warm round-trip), gofmt clean
- dashboard type-check / eslint / format clean for the changed hook (3 pre-existing unrelated `tsc` errors remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eagerly warm the Project Assistant runtime VM to remove the cold-start on first message. The VM boots on sidebar open and is kept warm while the sidebar stays open.

- **New Features**
  - Dashboard: 45s keepalive in `useServerAssistantTransport` re-ensures the assistant while the sidebar is open.
  - Server: `WarmManagedAssistant` sends a no-op warm event via the existing dashboard trigger; invoked from `ensureManagedAssistant`.
  - Runtime: `processEventTurn` skips warm events; `BuildDirectEvent` accepts warm events without `text`/`user_id`.
  - Warm events consolidate under correlation `__warm__` and stay out of user chat lists.
  - Best-effort warming: failures log warnings and never fail ensure.
  - Tests added for warm event acceptance, round-trip survival, and short-circuiting.
  - Linear AGE-2718: addresses the dominant latency; SSE streaming remains a follow-up.

<sup>Written for commit 5f98ab361af8d1578e5dcbedd02cb7a9b96ad3bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

