### PR TITLE
fix: sanitize generated Pub/Sub labels to valid GCP label values

### DIFF
--- a/infra/gen/kcc.yaml
+++ b/infra/gen/kcc.yaml
@@ -5,9 +5,9 @@ pubsub:
   enabled: true
   subscriptions:
   - labels:
-      managed_by: proto_pubsub_orchestrator
-      proto_message: gram.ping.v1.Processor
-      topic_proto_message: gram.ping.v1.Message
+      managed_by: proto-pubsub-orchestrator
+      proto_message: gram-ping-v1-processor
+      topic_proto_message: gram-ping-v1-message
     name: gram-ping-v1-processor
     spec:
       ackDeadlineSeconds: 30
@@ -24,14 +24,14 @@ pubsub:
         name: gram-ping-v1-message
   topics:
   - labels:
-      managed_by: proto_pubsub_orchestrator
-      proto_message: gram.ping.v1.Message
+      managed_by: proto-pubsub-orchestrator
+      proto_message: gram-ping-v1-message
     name: gram-ping-v1-message
     spec:
       messageRetentionDuration: 86400s
   - labels:
       dlq_for: gram-ping-v1-processor
-      managed_by: proto_pubsub_orchestrator
-      proto_message: gram.ping.v1.Processor
+      managed_by: proto-pubsub-orchestrator
+      proto_message: gram-ping-v1-processor
     name: gram-ping-v1-processor-dlq
     spec: {}

--- a/infra/internal/gcp/cc_pubsub.go
+++ b/infra/internal/gcp/cc_pubsub.go
@@ -8,6 +8,7 @@ import (
 
 	kccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	pubsubv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/pubsub/v1beta1"
+	"github.com/ettle/strcase"
 )
 
 // protoMessageLabel is the metadata label key carrying the fully qualified
@@ -45,7 +46,7 @@ func buildPubSubValues(topics []DesiredTopic, subs []DesiredSubscription) pubSub
 	for _, sub := range sortedSubs {
 		labels := labelsWithProtoMessage(sub.Labels, sub.ProtoMessage)
 		if sub.TopicMessage != "" {
-			labels[topicMessageLabel] = sub.TopicMessage
+			labels[topicMessageLabel] = sanitizeLabelValue(sub.TopicMessage)
 		}
 		subValues = append(subValues, pubSubSubscriptionValue{
 			Name:   sub.Name,
@@ -73,9 +74,18 @@ func labelsWithProtoMessage(labels map[string]string, protoMessage string) map[s
 		out = map[string]string{}
 	}
 	if protoMessage != "" {
-		out[protoMessageLabel] = protoMessage
+		out[protoMessageLabel] = sanitizeLabelValue(protoMessage)
 	}
 	return out
+}
+
+// sanitizeLabelValue converts a fully qualified protobuf message name into a
+// valid GCP label value. Label values must match [\p{Ll}\p{Lo}\p{N}_-]{0,63},
+// so the dotted, mixed-case proto full name (e.g. "gram.ping.v1.Message") is
+// kebab-cased to "gram-ping-v1-message" — the same transform used to derive
+// topic and subscription IDs, keeping resources traceable to their declaration.
+func sanitizeLabelValue(protoMessage string) string {
+	return strcase.ToKebab(protoMessage)
 }
 
 func topicSpec(desired DesiredTopic) pubsubv1beta1.PubSubTopicSpec {

--- a/infra/internal/gcp/cc_pubsub_test.go
+++ b/infra/internal/gcp/cc_pubsub_test.go
@@ -76,21 +76,21 @@ func TestBuildPubSubValues_StableOrder(t *testing.T) {
 	require.Nil(t, doc.PubSub.Topics[0].Spec.MessageRetentionDuration)
 	require.NotNil(t, doc.PubSub.Topics[1].Spec.MessageRetentionDuration)
 	require.Equal(t, "86400s", *doc.PubSub.Topics[1].Spec.MessageRetentionDuration)
-	// proto_message label carries the fully qualified protobuf message name
-	// alongside the existing managed_by label.
-	require.Equal(t, "example.v1.Alpha", doc.PubSub.Topics[0].Labels[protoMessageLabel])
-	require.Equal(t, "example.v1.Zebra", doc.PubSub.Topics[1].Labels[protoMessageLabel])
+	// proto_message label carries the protobuf message name sanitized into a
+	// valid GCP label value (kebab-cased) alongside the existing managed_by label.
+	require.Equal(t, "example-v1-alpha", doc.PubSub.Topics[0].Labels[protoMessageLabel])
+	require.Equal(t, "example-v1-zebra", doc.PubSub.Topics[1].Labels[protoMessageLabel])
 	require.Equal(t, managedByLabel, doc.PubSub.Topics[0].Labels["managed_by"])
 
 	// Subscriptions sorted alphabetically.
 	require.Len(t, doc.PubSub.Subscriptions, 2)
 	require.Equal(t, "alpha-sub", doc.PubSub.Subscriptions[0].Name)
 	require.Equal(t, "zebra-sub", doc.PubSub.Subscriptions[1].Name)
-	require.Equal(t, "example.v1.AlphaProcessor", doc.PubSub.Subscriptions[0].Labels[protoMessageLabel])
-	require.Equal(t, "example.v1.ZebraProcessor", doc.PubSub.Subscriptions[1].Labels[protoMessageLabel])
+	require.Equal(t, "example-v1-alpha-processor", doc.PubSub.Subscriptions[0].Labels[protoMessageLabel])
+	require.Equal(t, "example-v1-zebra-processor", doc.PubSub.Subscriptions[1].Labels[protoMessageLabel])
 	// Subscriptions also carry the consumed topic's message name.
-	require.Equal(t, "example.v1.Event", doc.PubSub.Subscriptions[0].Labels[topicMessageLabel])
-	require.Equal(t, "example.v1.Event", doc.PubSub.Subscriptions[1].Labels[topicMessageLabel])
+	require.Equal(t, "example-v1-event", doc.PubSub.Subscriptions[0].Labels[topicMessageLabel])
+	require.Equal(t, "example-v1-event", doc.PubSub.Subscriptions[1].Labels[topicMessageLabel])
 	// Topics do not get a topic_message label.
 	require.NotContains(t, doc.PubSub.Topics[0].Labels, topicMessageLabel)
 
@@ -140,9 +140,9 @@ func TestCCPubSub_WriteValues(t *testing.T) {
 	require.Contains(t, content, "outbox-processor")
 	require.Contains(t, content, "604800s")
 	require.Contains(t, content, "ackDeadlineSeconds: 30")
-	require.Contains(t, content, "proto_message: gram.outbox.v1.Event")
-	require.Contains(t, content, "proto_message: gram.outbox.v1.Processor")
-	require.Contains(t, content, "topic_proto_message: gram.outbox.v1.Event")
+	require.Contains(t, content, "proto_message: gram-outbox-v1-event")
+	require.Contains(t, content, "proto_message: gram-outbox-v1-processor")
+	require.Contains(t, content, "topic_proto_message: gram-outbox-v1-event")
 
 	// Per-resource metadata now lives in the chart template, not the values doc.
 	require.NotContains(t, content, "{{ .Values")

--- a/infra/internal/gcp/pubsub_discover.go
+++ b/infra/internal/gcp/pubsub_discover.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	managedByLabel = "proto_pubsub_orchestrator"
+	managedByLabel = "proto-pubsub-orchestrator"
 	dlqSuffix      = "-dlq"
 	maxTopicIDLen  = 255
 


### PR DESCRIPTION
GCP rejects label values that don't match [\p{Ll}\p{Lo}\p{N}_-]{0,63}, so topic/subscription creation failed with "Invalid labels" because the proto_message and topic_proto_message labels carried raw protobuf full names (dots and uppercase, e.g. gram.ping.v1.Message). Kebab-case those values at emission time so they conform while staying traceable to their declaration, and switch managed_by to dashes for consistency. The label values now mirror the resource names derived from the same messages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pub/Sub topic and subscription creation by sanitizing generated label values to meet GCP rules. We now kebab-case protobuf message names and standardize the `managed_by` label so resources are created reliably.

- **Bug Fixes**
  - Kebab-cased `proto_message` and `topic_proto_message` values (e.g., gram.ping.v1.Message -> gram-ping-v1-message) to meet GCP label requirements.
  - Changed `managed_by` to `proto-pubsub-orchestrator` for consistency with other IDs.

- **Migration**
  - Update any filters or policies matching `managed_by=proto_pubsub_orchestrator` to `managed_by=proto-pubsub-orchestrator`.

<sup>Written for commit ed1bf4002e6b34149393c5be50af5008a1abd4ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

