### PR TITLE
chore: simulate dropping topics and subscriptions

### DIFF
--- a/infra/cmd/infra/demo.go
+++ b/infra/cmd/infra/demo.go
@@ -2,21 +2,14 @@ package infra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/pubsub/v2"
-	"github.com/google/uuid"
-	"github.com/sourcegraph/conc/pool"
-	pingv1 "github.com/speakeasy-api/gram/infra/gen/gram/ping/v1"
 	"github.com/speakeasy-api/gram/infra/internal/attr"
-	gcppub "github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/urfave/cli/v2"
 	"google.golang.org/api/option"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func newDemoCommand() *cli.Command {
@@ -78,89 +71,91 @@ func newDemoCommand() *cli.Command {
 				return fmt.Errorf("failed to create pubsub client: %w", err)
 			}
 
+			_ = client
+
 			// --- DEMO BELOW - INTENDED FOR APPLICATIONS ---
 
-			group := pool.New()
+			// group := pool.New()
 
-			broker := gcppub.NewEmulatedPubSub(logger, projectID, client, descriptors)
+			// broker := gcppub.NewEmulatedPubSub(logger, projectID, client, descriptors)
 
-			// Get a publisher handle so we can publish messages
-			pub, err := gcppub.PubSubPublisherForMessage(ctx, broker, &pingv1.Message{})
-			if err != nil {
-				return fmt.Errorf("failed to get publisher: %w", err)
-			}
-			// Get a subscriber handle to receive messages
-			// Read this as: "Get a handler for the outbox processor subscription to receive pingv1.Message messages"
-			sub1, err := gcppub.PubSubSubscriberForMessage(ctx, broker, &pingv1.Message{}, &pingv1.Processor{})
-			if err != nil {
-				return fmt.Errorf("failed to get subscriber 1: %w", err)
-			}
-			// Get another subscriber handle to receive messages
-			sub2, err := gcppub.PubSubSubscriberForMessage(ctx, broker, &pingv1.Message{}, &pingv1.Processor{})
-			if err != nil {
-				return fmt.Errorf("failed to get subscriber 2: %w", err)
-			}
+			// // Get a publisher handle so we can publish messages
+			// pub, err := gcppub.PubSubPublisherForMessage(ctx, broker, &pingv1.Message{})
+			// if err != nil {
+			// 	return fmt.Errorf("failed to get publisher: %w", err)
+			// }
+			// // Get a subscriber handle to receive messages
+			// // Read this as: "Get a handler for the outbox processor subscription to receive pingv1.Message messages"
+			// sub1, err := gcppub.PubSubSubscriberForMessage(ctx, broker, &pingv1.Message{}, &pingv1.Processor{})
+			// if err != nil {
+			// 	return fmt.Errorf("failed to get subscriber 1: %w", err)
+			// }
+			// // Get another subscriber handle to receive messages
+			// sub2, err := gcppub.PubSubSubscriberForMessage(ctx, broker, &pingv1.Message{}, &pingv1.Processor{})
+			// if err != nil {
+			// 	return fmt.Errorf("failed to get subscriber 2: %w", err)
+			// }
 
-			group.Go(func() {
-				// Cancel the shared context on exit so the subscriber
-				// goroutines blocked in Receive unblock and group.Wait returns
-				// instead of hanging.
-				defer cancel()
-				for {
-					msg := pingv1.Message_builder{
-						Id:        new(uuid.Must(uuid.NewV7()).String()),
-						Type:      new("simulated"),
-						CreatedAt: timestamppb.Now(),
-						Payload:   []byte(`{"msg":"Hello, World!"}`),
-					}.Build()
+			// group.Go(func() {
+			// 	// Cancel the shared context on exit so the subscriber
+			// 	// goroutines blocked in Receive unblock and group.Wait returns
+			// 	// instead of hanging.
+			// 	defer cancel()
+			// 	for {
+			// 		msg := pingv1.Message_builder{
+			// 			Id:        new(uuid.Must(uuid.NewV7()).String()),
+			// 			Type:      new("simulated"),
+			// 			CreatedAt: timestamppb.Now(),
+			// 			Payload:   []byte(`{"msg":"Hello, World!"}`),
+			// 		}.Build()
 
-					_, err := pub.Publish(ctx, msg).Get(ctx)
-					switch {
-					case errors.Is(err, context.Canceled):
-						return
-					case err != nil:
-						logger.ErrorContext(ctx, "publish failed", attr.SlogError(err))
-						return
-					}
-					time.Sleep(1 * time.Second)
-				}
-			})
+			// 		_, err := pub.Publish(ctx, msg).Get(ctx)
+			// 		switch {
+			// 		case errors.Is(err, context.Canceled):
+			// 			return
+			// 		case err != nil:
+			// 			logger.ErrorContext(ctx, "publish failed", attr.SlogError(err))
+			// 			return
+			// 		}
+			// 		time.Sleep(1 * time.Second)
+			// 	}
+			// })
 
-			group.Go(func() {
-				defer cancel()
-				err := sub1.Receive(ctx, func(ctx context.Context, m *pingv1.Message, _ gcppub.MessageMetadata) error {
-					logger.InfoContext(ctx, "sub1: message", attr.SlogValueAny(map[string]any{
-						"id":      m.GetId(),
-						"type":    m.GetType(),
-						"payload": string(m.GetPayload()),
-					}))
+			// group.Go(func() {
+			// 	defer cancel()
+			// 	err := sub1.Receive(ctx, func(ctx context.Context, m *pingv1.Message, _ gcppub.MessageMetadata) error {
+			// 		logger.InfoContext(ctx, "sub1: message", attr.SlogValueAny(map[string]any{
+			// 			"id":      m.GetId(),
+			// 			"type":    m.GetType(),
+			// 			"payload": string(m.GetPayload()),
+			// 		}))
 
-					return nil
-				})
-				if err != nil {
-					logger.ErrorContext(ctx, "sub1: receive failed", attr.SlogError(err))
-					return
-				}
-			})
+			// 		return nil
+			// 	})
+			// 	if err != nil {
+			// 		logger.ErrorContext(ctx, "sub1: receive failed", attr.SlogError(err))
+			// 		return
+			// 	}
+			// })
 
-			group.Go(func() {
-				defer cancel()
-				err := sub2.Receive(ctx, func(ctx context.Context, m *pingv1.Message, _ gcppub.MessageMetadata) error {
-					logger.InfoContext(ctx, "sub2: message", attr.SlogValueAny(map[string]any{
-						"id":      m.GetId(),
-						"type":    m.GetType(),
-						"payload": string(m.GetPayload()),
-					}))
+			// group.Go(func() {
+			// 	defer cancel()
+			// 	err := sub2.Receive(ctx, func(ctx context.Context, m *pingv1.Message, _ gcppub.MessageMetadata) error {
+			// 		logger.InfoContext(ctx, "sub2: message", attr.SlogValueAny(map[string]any{
+			// 			"id":      m.GetId(),
+			// 			"type":    m.GetType(),
+			// 			"payload": string(m.GetPayload()),
+			// 		}))
 
-					return nil
-				})
-				if err != nil {
-					logger.ErrorContext(ctx, "sub2: receive failed", attr.SlogError(err))
-					return
-				}
-			})
+			// 		return nil
+			// 	})
+			// 	if err != nil {
+			// 		logger.ErrorContext(ctx, "sub2: receive failed", attr.SlogError(err))
+			// 		return
+			// 	}
+			// })
 
-			group.Wait()
+			// group.Wait()
 
 			return nil
 		},

--- a/infra/gen/gram/ping/v1/ping.pb.go
+++ b/infra/gen/gram/ping/v1/ping.pb.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/speakeasy-api/gram/infra/gen/gcp/pubsub/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	_ "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -22,200 +22,19 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type Message struct {
-	state                  protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Id          *string                `protobuf:"bytes,1,opt,name=id"`
-	xxx_hidden_Type        *string                `protobuf:"bytes,2,opt,name=type"`
-	xxx_hidden_CreatedAt   *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=created_at,json=createdAt"`
-	xxx_hidden_Payload     []byte                 `protobuf:"bytes,4,opt,name=payload"`
-	XXX_raceDetectHookData protoimpl.RaceDetectHookData
-	XXX_presence           [1]uint32
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
-}
-
-func (x *Message) Reset() {
-	*x = Message{}
-	mi := &file_gram_ping_v1_ping_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Message) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Message) ProtoMessage() {}
-
-func (x *Message) ProtoReflect() protoreflect.Message {
-	mi := &file_gram_ping_v1_ping_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *Message) GetId() string {
-	if x != nil {
-		if x.xxx_hidden_Id != nil {
-			return *x.xxx_hidden_Id
-		}
-		return ""
-	}
-	return ""
-}
-
-func (x *Message) GetType() string {
-	if x != nil {
-		if x.xxx_hidden_Type != nil {
-			return *x.xxx_hidden_Type
-		}
-		return ""
-	}
-	return ""
-}
-
-func (x *Message) GetCreatedAt() *timestamppb.Timestamp {
-	if x != nil {
-		return x.xxx_hidden_CreatedAt
-	}
-	return nil
-}
-
-func (x *Message) GetPayload() []byte {
-	if x != nil {
-		return x.xxx_hidden_Payload
-	}
-	return nil
-}
-
-func (x *Message) SetId(v string) {
-	x.xxx_hidden_Id = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 0, 4)
-}
-
-func (x *Message) SetType(v string) {
-	x.xxx_hidden_Type = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 4)
-}
-
-func (x *Message) SetCreatedAt(v *timestamppb.Timestamp) {
-	x.xxx_hidden_CreatedAt = v
-}
-
-func (x *Message) SetPayload(v []byte) {
-	if v == nil {
-		v = []byte{}
-	}
-	x.xxx_hidden_Payload = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 4)
-}
-
-func (x *Message) HasId() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 0)
-}
-
-func (x *Message) HasType() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
-}
-
-func (x *Message) HasCreatedAt() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_CreatedAt != nil
-}
-
-func (x *Message) HasPayload() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 3)
-}
-
-func (x *Message) ClearId() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 0)
-	x.xxx_hidden_Id = nil
-}
-
-func (x *Message) ClearType() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
-	x.xxx_hidden_Type = nil
-}
-
-func (x *Message) ClearCreatedAt() {
-	x.xxx_hidden_CreatedAt = nil
-}
-
-func (x *Message) ClearPayload() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 3)
-	x.xxx_hidden_Payload = nil
-}
-
-type Message_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	Id        *string
-	Type      *string
-	CreatedAt *timestamppb.Timestamp
-	Payload   []byte
-}
-
-func (b0 Message_builder) Build() *Message {
-	m0 := &Message{}
-	b, x := &b0, m0
-	_, _ = b, x
-	if b.Id != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 0, 4)
-		x.xxx_hidden_Id = b.Id
-	}
-	if b.Type != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 4)
-		x.xxx_hidden_Type = b.Type
-	}
-	x.xxx_hidden_CreatedAt = b.CreatedAt
-	if b.Payload != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 4)
-		x.xxx_hidden_Payload = b.Payload
-	}
-	return m0
-}
-
 var File_gram_ping_v1_ping_proto protoreflect.FileDescriptor
 
 const file_gram_ping_v1_ping_proto_rawDesc = "" +
 	"\n" +
-	"\x17gram/ping/v1/ping.proto\x12\fgram.ping.v1\x1a\x1bgcp/pubsub/v1/options.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8e\x01\n" +
-	"\aMessage\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
-	"\x04type\x18\x02 \x01(\tR\x04type\x129\n" +
-	"\n" +
-	"created_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x18\n" +
-	"\apayload\x18\x04 \x01(\fR\apayload:\n" +
-	"\x8a\xb5\x18\x06\x12\x04\b\x80\xa3\x05B=Z;github.com/speakeasy-api/gram/infra/gen/gram/ping/v1;pingv1b\beditionsp\xe9\a"
+	"\x17gram/ping/v1/ping.proto\x12\fgram.ping.v1\x1a\x1bgcp/pubsub/v1/options.proto\x1a\x1fgoogle/protobuf/timestamp.protoB=Z;github.com/speakeasy-api/gram/infra/gen/gram/ping/v1;pingv1b\beditionsp\xe9\a"
 
-var file_gram_ping_v1_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_gram_ping_v1_ping_proto_goTypes = []any{
-	(*Message)(nil),               // 0: gram.ping.v1.Message
-	(*timestamppb.Timestamp)(nil), // 1: google.protobuf.Timestamp
-}
+var file_gram_ping_v1_ping_proto_goTypes = []any{}
 var file_gram_ping_v1_ping_proto_depIdxs = []int32{
-	1, // 0: gram.ping.v1.Message.created_at:type_name -> google.protobuf.Timestamp
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	0, // [0:0] is the sub-list for method output_type
+	0, // [0:0] is the sub-list for method input_type
+	0, // [0:0] is the sub-list for extension type_name
+	0, // [0:0] is the sub-list for extension extendee
+	0, // [0:0] is the sub-list for field type_name
 }
 
 func init() { file_gram_ping_v1_ping_proto_init() }
@@ -229,13 +48,12 @@ func file_gram_ping_v1_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_gram_ping_v1_ping_proto_rawDesc), len(file_gram_ping_v1_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   0,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_gram_ping_v1_ping_proto_goTypes,
 		DependencyIndexes: file_gram_ping_v1_ping_proto_depIdxs,
-		MessageInfos:      file_gram_ping_v1_ping_proto_msgTypes,
 	}.Build()
 	File_gram_ping_v1_ping_proto = out.File
 	file_gram_ping_v1_ping_proto_goTypes = nil

--- a/infra/gen/gram/ping/v1/processor.pb.go
+++ b/infra/gen/gram/ping/v1/processor.pb.go
@@ -21,62 +21,13 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type Processor struct {
-	state         protoimpl.MessageState `protogen:"opaque.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *Processor) Reset() {
-	*x = Processor{}
-	mi := &file_gram_ping_v1_processor_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Processor) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Processor) ProtoMessage() {}
-
-func (x *Processor) ProtoReflect() protoreflect.Message {
-	mi := &file_gram_ping_v1_processor_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-type Processor_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-}
-
-func (b0 Processor_builder) Build() *Processor {
-	m0 := &Processor{}
-	b, x := &b0, m0
-	_, _ = b, x
-	return m0
-}
-
 var File_gram_ping_v1_processor_proto protoreflect.FileDescriptor
 
 const file_gram_ping_v1_processor_proto_rawDesc = "" +
 	"\n" +
-	"\x1cgram/ping/v1/processor.proto\x12\fgram.ping.v1\x1a\x1bgcp/pubsub/v1/options.proto\"?\n" +
-	"\tProcessor:2\x92\xb5\x18.\x12\x03\b\x90\x1c\"\x02\b\x1e2\t\n" +
-	"\x02\b\n" +
-	"\x12\x03\b\xd8\x04J\x02\x10\x05R\x14gram.ping.v1.MessageB=Z;github.com/speakeasy-api/gram/infra/gen/gram/ping/v1;pingv1b\beditionsp\xe9\a"
+	"\x1cgram/ping/v1/processor.proto\x12\fgram.ping.v1\x1a\x1bgcp/pubsub/v1/options.protoB=Z;github.com/speakeasy-api/gram/infra/gen/gram/ping/v1;pingv1b\beditionsp\xe9\a"
 
-var file_gram_ping_v1_processor_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_gram_ping_v1_processor_proto_goTypes = []any{
-	(*Processor)(nil), // 0: gram.ping.v1.Processor
-}
+var file_gram_ping_v1_processor_proto_goTypes = []any{}
 var file_gram_ping_v1_processor_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type
@@ -96,13 +47,12 @@ func file_gram_ping_v1_processor_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_gram_ping_v1_processor_proto_rawDesc), len(file_gram_ping_v1_processor_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   0,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_gram_ping_v1_processor_proto_goTypes,
 		DependencyIndexes: file_gram_ping_v1_processor_proto_depIdxs,
-		MessageInfos:      file_gram_ping_v1_processor_proto_msgTypes,
 	}.Build()
 	File_gram_ping_v1_processor_proto = out.File
 	file_gram_ping_v1_processor_proto_goTypes = nil

--- a/infra/gen/kcc.yaml
+++ b/infra/gen/kcc.yaml
@@ -3,35 +3,5 @@ pubsub:
   apis:
   - pubsub.googleapis.com
   enabled: true
-  subscriptions:
-  - labels:
-      managed_by: proto-pubsub-orchestrator
-      proto_message: gram-ping-v1-processor
-      topic_proto_message: gram-ping-v1-message
-    name: gram-ping-v1-processor
-    spec:
-      ackDeadlineSeconds: 30
-      deadLetterPolicy:
-        deadLetterTopicRef:
-          name: gram-ping-v1-processor-dlq
-        maxDeliveryAttempts: 5
-      messageRetentionDuration: 3600s
-      retainAckedMessages: false
-      retryPolicy:
-        maximumBackoff: 600s
-        minimumBackoff: 10s
-      topicRef:
-        name: gram-ping-v1-message
-  topics:
-  - labels:
-      managed_by: proto-pubsub-orchestrator
-      proto_message: gram-ping-v1-message
-    name: gram-ping-v1-message
-    spec:
-      messageRetentionDuration: 86400s
-  - labels:
-      dlq_for: gram-ping-v1-processor
-      managed_by: proto-pubsub-orchestrator
-      proto_message: gram-ping-v1-processor
-    name: gram-ping-v1-processor-dlq
-    spec: {}
+  subscriptions: []
+  topics: []

--- a/infra/proto/gram/ping/v1/ping.proto
+++ b/infra/proto/gram/ping/v1/ping.proto
@@ -7,15 +7,15 @@ import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/speakeasy-api/gram/infra/gen/gram/ping/v1;pingv1";
 
-message Message {
-  string id = 1;
-  string type = 2;
-  google.protobuf.Timestamp created_at = 3;
-  bytes payload = 4;
+// message Message {
+//   string id = 1;
+//   string type = 2;
+//   google.protobuf.Timestamp created_at = 3;
+//   bytes payload = 4;
 
-  option (gcp.pubsub.v1.topic) = {
-    retention_hint: {
-      seconds: 86400 /* 1 day */
-    }
-  };
-}
+//   option (gcp.pubsub.v1.topic) = {
+//     retention_hint: {
+//       seconds: 86400 /* 1 day */
+//     }
+//   };
+// }

--- a/infra/proto/gram/ping/v1/processor.proto
+++ b/infra/proto/gram/ping/v1/processor.proto
@@ -6,15 +6,15 @@ import "gcp/pubsub/v1/options.proto";
 
 option go_package = "github.com/speakeasy-api/gram/infra/gen/gram/ping/v1;pingv1";
 
-message Processor {
-  option (gcp.pubsub.v1.subscription) = {
-    topic: "gram.ping.v1.Message"
-    ack_deadline: {seconds: 30}
-    retention: {seconds: 3600}
-    retry_policy: {
-      minimum_backoff: {seconds: 10}
-      maximum_backoff: {seconds: 600}
-    }
-    dead_letter: {max_delivery_attempts: 5}
-  };
-}
+// message Processor {
+//   option (gcp.pubsub.v1.subscription) = {
+//     topic: "gram.ping.v1.Message"
+//     ack_deadline: {seconds: 30}
+//     retention: {seconds: 3600}
+//     retry_policy: {
+//       minimum_backoff: {seconds: 10}
+//       maximum_backoff: {seconds: 600}
+//     }
+//     dead_letter: {max_delivery_attempts: 5}
+//   };
+// }


### PR DESCRIPTION
This is a simple test where we drop proto messages to observe the consequences on downstream systems.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simulates removal of Pub/Sub topics and subscriptions by commenting out `gram.ping.v1.Message` and `Processor` protos, regenerating code to drop those types, and disabling the demo publisher/subscribers. This is to observe downstream behavior when a message/topic is removed.

- **Refactors**
  - Commented out `Message` and `Processor` in `infra/proto/gram/ping/v1` and regenerated to remove types in `ping.pb.go` and `processor.pb.go`.
  - Emptied Pub/Sub `topics` and `subscriptions` in `infra/gen/kcc.yaml`.
  - No-op demo in `infra/cmd/infra/demo.go` by commenting publisher/subscriber logic (client init remains).

<sup>Written for commit dd7aaddace9e0ce8b6826af6e7dc90e84e7fd937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

