### PR TITLE
fix: dedupe duplicate streamable-http remotes in catalog dialog

### DIFF
--- a/.changeset/dashboard-catalog-dedupe-remotes.md
+++ b/.changeset/dashboard-catalog-dedupe-remotes.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the catalog Add Server dialog rendering duplicate-looking endpoint checkboxes when a registry entry exposes the same streamable-http URL twice (e.g. Datadog publishes an OAuth variant and an API-key variant under one URL). Same-URL remotes are now collapsed in the UI, matching the backend's deploy-time behavior of picking the first URL match.

--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -34,6 +34,7 @@ import {
   type ServerToolsetStatus,
   useExternalMcpReleaseWorkflow,
 } from "./useExternalMcpReleaseWorkflow";
+import { filterToHttpRemotes } from "./remotes";
 
 /** Friendly display names and descriptions for known remote endpoints */
 const REMOTE_DISPLAY_INFO: Record<
@@ -206,15 +207,6 @@ export interface AddServerDialogProps {
   autoStartDeployment?: boolean;
   /** When true, runs the workflow without rendering the dialog UI. */
   headless?: boolean;
-}
-
-function filterToHttpRemotes(server: PulseMCPServer): PulseMCPServer {
-  return {
-    ...server,
-    remotes: server.remotes?.filter(
-      (r) => r.transportType === "streamable-http",
-    ),
-  };
 }
 
 /**

--- a/client/dashboard/src/pages/catalog/remotes.test.ts
+++ b/client/dashboard/src/pages/catalog/remotes.test.ts
@@ -1,0 +1,123 @@
+import type {
+  ExternalMCPRemote,
+  TransportType,
+} from "@gram/client/models/components";
+import { describe, expect, it } from "vitest";
+import { dedupeRemotesByUrl, filterToHttpRemotes } from "./remotes";
+import type { PulseMCPServer } from "./hooks";
+
+function remote(
+  url: string,
+  transportType: TransportType = "streamable-http",
+  headerNames: string[] = [],
+): ExternalMCPRemote {
+  return {
+    url,
+    transportType,
+    headers: headerNames.length
+      ? headerNames.map((name) => ({
+          name,
+          isSecret: true,
+          isRequired: true,
+        }))
+      : undefined,
+  };
+}
+
+function server(remotes: ExternalMCPRemote[]): PulseMCPServer {
+  return {
+    description: "test",
+    registrySpecifier: "test/server",
+    version: "0.1.0",
+    meta: {},
+    remotes,
+  };
+}
+
+describe("dedupeRemotesByUrl", () => {
+  it("returns input unchanged when all URLs are unique", () => {
+    const a = remote("https://a.example/mcp");
+    const b = remote("https://b.example/mcp");
+    expect(dedupeRemotesByUrl([a, b])).toEqual([a, b]);
+  });
+
+  it("keeps the first occurrence of each duplicate URL", () => {
+    const first = remote(
+      "https://mcp.datadoghq.com/v1/mcp?{TOOLSETS}",
+      "streamable-http",
+      [],
+    );
+    const second = remote(
+      "https://mcp.datadoghq.com/v1/mcp?{TOOLSETS}",
+      "streamable-http",
+      ["DD_API_KEY", "DD_APPLICATION_KEY"],
+    );
+    const result = dedupeRemotesByUrl([first, second]);
+    expect(result).toEqual([first]);
+  });
+
+  it("preserves order of first appearances across mixed duplicates", () => {
+    const a1 = remote("https://a.example/mcp", "streamable-http", []);
+    const b = remote("https://b.example/mcp");
+    const a2 = remote("https://a.example/mcp", "streamable-http", [
+      "Authorization",
+    ]);
+    expect(dedupeRemotesByUrl([a1, b, a2])).toEqual([a1, b]);
+  });
+
+  it("handles an empty list", () => {
+    expect(dedupeRemotesByUrl([])).toEqual([]);
+  });
+});
+
+describe("filterToHttpRemotes", () => {
+  it("drops non-streamable-http remotes", () => {
+    const http = remote("https://x.example/mcp", "streamable-http");
+    const sse = remote("https://x.example/sse", "sse");
+    const result = filterToHttpRemotes(server([http, sse]));
+    expect(result.remotes).toEqual([http]);
+  });
+
+  it("collapses duplicate URLs after filtering", () => {
+    const first = remote(
+      "https://mcp.cloudflare.com/mcp",
+      "streamable-http",
+      [],
+    );
+    const second = remote("https://mcp.cloudflare.com/mcp", "streamable-http", [
+      "Authorization",
+    ]);
+    const result = filterToHttpRemotes(server([first, second]));
+    expect(result.remotes).toEqual([first]);
+  });
+
+  it("preserves a single streamable-http remote unchanged", () => {
+    const only = remote("https://solo.example/mcp");
+    const result = filterToHttpRemotes(server([only]));
+    expect(result.remotes).toEqual([only]);
+  });
+
+  it("preserves all distinct streamable-http URLs (e.g. Postman regions)", () => {
+    const remotes = [
+      remote("https://mcp.postman.com/mcp", "streamable-http", [
+        "Authorization",
+      ]),
+      remote("https://mcp.postman.com/minimal", "streamable-http", [
+        "Authorization",
+      ]),
+      remote("https://mcp.eu.postman.com/mcp", "streamable-http", [
+        "Authorization",
+      ]),
+      remote("https://mcp.eu.postman.com/minimal", "streamable-http", [
+        "Authorization",
+      ]),
+    ];
+    const result = filterToHttpRemotes(server(remotes));
+    expect(result.remotes).toEqual(remotes);
+  });
+
+  it("returns undefined remotes when server has no remotes", () => {
+    const result = filterToHttpRemotes(server([]));
+    expect(result.remotes).toEqual([]);
+  });
+});

--- a/client/dashboard/src/pages/catalog/remotes.ts
+++ b/client/dashboard/src/pages/catalog/remotes.ts
@@ -1,0 +1,28 @@
+import type { PulseMCPServer } from "@/pages/catalog/hooks";
+import type { ExternalMCPRemote } from "@gram/client/models/components";
+
+export function filterToHttpRemotes(server: PulseMCPServer): PulseMCPServer {
+  const httpRemotes = server.remotes?.filter(
+    (r) => r.transportType === "streamable-http",
+  );
+  return {
+    ...server,
+    remotes: httpRemotes ? dedupeRemotesByUrl(httpRemotes) : httpRemotes,
+  };
+}
+
+// Some registry entries publish multiple remotes with the same URL that differ
+// only by their `headers` array (e.g. one variant for OAuth, another for
+// static API-key auth). At deploy time the backend re-fetches from the
+// registry and picks the first matching URL, so the second variant is
+// unreachable today — collapse the duplicate so users do not see two
+// identical-looking checkboxes.
+export function dedupeRemotesByUrl(
+  remotes: ExternalMCPRemote[],
+): ExternalMCPRemote[] {
+  const byUrl = new Map<string, ExternalMCPRemote>();
+  for (const r of remotes) {
+    if (!byUrl.has(r.url)) byUrl.set(r.url, r);
+  }
+  return Array.from(byUrl.values());
+}


### PR DESCRIPTION
## Summary

- The catalog Add Server dialog rendered duplicate-looking checkboxes when a Pulse registry entry exposes the same `streamable-http` URL twice (e.g. Datadog: OAuth variant + API-key variant — same URL, different `headers`).
- `selectedRemoteUrls` is keyed by URL, so the two checkboxes shared state and React warned on duplicate keys.
- Backend `externalmcp.GetServerDetails` already picks the first URL match at deploy time, so the second variant is unreachable today regardless of selection — collapsing the duplicate in the UI matches the deployed behavior.

## Changes

- New `client/dashboard/src/pages/catalog/remotes.ts` holding `filterToHttpRemotes` + `dedupeRemotesByUrl`. Pure helpers, no React/SDK imports, so they can be unit tested.
- `AddServerDialog.tsx` imports the helpers from `./remotes` instead of defining them inline.
- `remotes.test.ts` covers: unique URLs pass through; first-occurrence wins on duplicates; non-`streamable-http` transports are filtered; distinct same-host paths (Postman regions) are preserved.

Real-world dupes confirmed against live registry: Datadog, Cloudflare, GitHub, HuggingFace.

<img width="2370" height="2206" alt="CleanShot 2026-06-08 at 12 49 17@2x" src="https://github.com/user-attachments/assets/5e006a0c-fe93-4772-89e8-62a478fbe53f" />

## Test plan

- [x] `pnpm -F dashboard test src/pages/catalog/remotes.test.ts` — 9/9 pass.
- [x] `pnpm -F dashboard type-check` — no new errors (unrelated `detection-rules-data.ts` error pre-exists on `main`).
- [ ] Manual: open catalog, click **Add** on Datadog → one checkbox shown instead of two.

Linear: [FDE-23](https://linear.app/speakeasy/issue/FDE-23/bug-clarify-duplicate-datadog-endpoint-selection-in-catalog)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates identical `streamable-http` remotes in the Catalog Add Server dialog so providers like Datadog show one checkbox per URL, matching backend behavior and removing React key warnings. Addresses Linear FDE-23.

- **Bug Fixes**
  - Filter remotes to `streamable-http` and collapse same-URL entries; first occurrence wins to align with `externalmcp.GetServerDetails`.
  - Fixes shared selection state and duplicate React keys when providers publish OAuth and API-key variants to the same URL.

- **Refactors**
  - Moved `filterToHttpRemotes` and `dedupeRemotesByUrl` into `remotes.ts` (no React/SDK deps) and imported them in `AddServerDialog.tsx`.
  - Added `remotes.test.ts` with unit tests for unique, duplicate, and region-specific URLs.

<sup>Written for commit 595a689b993ccaf79481b9afdb47730907e87eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

