### PR TITLE
fix(assistants): stop attaching all project MCPs to Project Assistant

### DIFF
--- a/.changeset/managed-assistant-no-default-mcps.md
+++ b/.changeset/managed-assistant-no-default-mcps.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The Project Assistant no longer adds all of a project's MCP servers when it's first set up. A new Project Assistant now starts with only its built-in and platform tools; admins attach the project MCP servers they want it to use.

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -14,7 +14,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
-	"github.com/speakeasy-api/gram/server/gen/types"
 	assistantrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -56,9 +55,9 @@ func managedAssistantName(projectName string) string {
 }
 
 // EnableManagedAssistant turns on the managed assistant for a project: it
-// creates the assistant (attaching every MCP-reachable project toolset) and
-// records it in project_managed_assistants. The managed assistant exists only
-// while this mapping row does — disabling or removing the project tears it down.
+// creates the assistant (with no toolsets attached) and records it in
+// project_managed_assistants. The managed assistant exists only while this
+// mapping row does — disabling or removing the project tears it down.
 //
 // Idempotent and safe under concurrency: the fast path returns the existing
 // managed assistant, and an enable that loses a race is recovered by re-reading
@@ -216,8 +215,10 @@ func (s *ServiceCore) ensureDashboardTrigger(ctx context.Context, db triggerrepo
 	return nil
 }
 
-// createManagedAssistant inserts the assistant, records the managed mapping, and
-// attaches all of the project's MCP-reachable toolsets in a single transaction.
+// createManagedAssistant inserts the assistant and records the managed mapping in
+// a single transaction. It attaches no toolsets: a new managed assistant starts
+// with only the built-in and platform tools, and an admin adds project MCP
+// servers deliberately afterwards.
 func (s *ServiceCore) createManagedAssistant(
 	ctx context.Context,
 	organizationID string,
@@ -225,20 +226,6 @@ func (s *ServiceCore) createManagedAssistant(
 	name string,
 	createdByUserID string,
 ) (assistantRecord, error) {
-	slugs, err := assistantrepo.New(s.db).ListProjectMCPToolsetSlugs(ctx, projectID)
-	if err != nil {
-		return assistantRecord{}, fmt.Errorf("list project toolsets for managed assistant: %w", err)
-	}
-	refs := make([]*types.AssistantToolsetRef, 0, len(slugs))
-	for _, slug := range slugs {
-		refs = append(refs, &types.AssistantToolsetRef{ToolsetSlug: slug, EnvironmentSlug: nil})
-	}
-
-	resolved, err := s.resolveToolsetRefsForWrite(ctx, projectID, refs)
-	if err != nil {
-		return assistantRecord{}, err
-	}
-
 	var createdBy pgtype.Text
 	if createdByUserID != "" {
 		createdBy = conv.ToPGText(createdByUserID)
@@ -278,19 +265,10 @@ func (s *ServiceCore) createManagedAssistant(
 		return assistantRecord{}, err
 	}
 
-	if err := writeAssistantToolsets(ctx, tx, record.ID, projectID, resolved); err != nil {
-		return assistantRecord{}, err
-	}
-
 	if err := tx.Commit(ctx); err != nil {
 		return assistantRecord{}, fmt.Errorf("commit managed assistant tx: %w", err)
 	}
 
-	refs2, err := s.loadAssistantToolsets(ctx, projectID, []uuid.UUID{record.ID})
-	if err != nil {
-		return assistantRecord{}, err
-	}
-	record.Toolsets = refs2[record.ID]
 	return record, nil
 }
 

--- a/server/internal/assistants/provisioning_test.go
+++ b/server/internal/assistants/provisioning_test.go
@@ -74,7 +74,7 @@ func TestEnableManagedAssistantIsIdempotent(t *testing.T) {
 	require.Len(t, triggers, 1, "re-enable must not duplicate the dashboard trigger")
 }
 
-func TestEnableManagedAssistantAttachesMCPReachableToolsets(t *testing.T) {
+func TestEnableManagedAssistantAttachesNoToolsets(t *testing.T) {
 	t.Parallel()
 
 	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_toolsets")
@@ -85,7 +85,9 @@ func TestEnableManagedAssistantAttachesMCPReachableToolsets(t *testing.T) {
 	projectID := newProvisioningProject(t, conn, "managed-toolsets")
 
 	toolsetsQ := toolsetsrepo.New(conn)
-	// MCP-reachable toolset — should be attached.
+	// An MCP-reachable toolset already exists in the project. The managed
+	// assistant must still start empty — admins add project MCP servers
+	// deliberately, not by default.
 	reachable, err := toolsetsQ.CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
 		OrganizationID:         "org-test",
 		ProjectID:              projectID,
@@ -97,32 +99,19 @@ func TestEnableManagedAssistantAttachesMCPReachableToolsets(t *testing.T) {
 		McpEnabled:             false,
 	})
 	require.NoError(t, err)
-	// Toolset without an mcp_slug — the runtime can't address it, so it must
-	// be excluded from the managed assistant.
-	_, err = toolsetsQ.CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
-		OrganizationID:         "org-test",
-		ProjectID:              projectID,
-		Name:                   "Internal",
-		Slug:                   "internal",
-		Description:            pgtype.Text{},
-		DefaultEnvironmentSlug: pgtype.Text{},
-		McpSlug:                pgtype.Text{Valid: false},
-		McpEnabled:             false,
-	})
-	require.NoError(t, err)
 
 	record, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
 	require.NoError(t, err)
 
-	require.Len(t, record.Toolsets, 1, "only the MCP-reachable toolset attaches")
-	require.Equal(t, reachable.Slug, record.Toolsets[0].ToolsetSlug)
+	require.Empty(t, record.Toolsets, "managed assistant must not attach project toolsets by default")
 
+	// Provisioning must not touch the project's toolsets — MCP stays as it was.
 	reloaded, err := toolsetsQ.GetToolset(ctx, toolsetsrepo.GetToolsetParams{
 		Slug:      reachable.Slug,
 		ProjectID: projectID,
 	})
 	require.NoError(t, err)
-	require.True(t, reloaded.McpEnabled, "attaching toolset to assistant must enable MCP")
+	require.False(t, reloaded.McpEnabled, "provisioning must not auto-enable MCP on project toolsets")
 }
 
 func TestDisableManagedAssistantTearsDown(t *testing.T) {

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -240,18 +240,6 @@ VALUES (@project_id, @assistant_id);
 DELETE FROM project_managed_assistants
 WHERE project_id = @project_id;
 
--- name: ListProjectMCPToolsetSlugs :many
--- Slugs of every MCP-reachable toolset in a project, used to attach all of a
--- project's toolsets to its managed assistant at provisioning time. Toolsets
--- without an mcp_slug can't be addressed by the runtime, so they're excluded
--- (mirrors the guard in EnableMCPForToolsets).
-SELECT slug
-FROM toolsets
-WHERE project_id = @project_id
-  AND mcp_slug IS NOT NULL
-  AND deleted IS FALSE
-ORDER BY created_at;
-
 -- name: UpdateAssistant :one
 UPDATE assistants
 SET

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1367,39 +1367,6 @@ func (q *Queries) ListInactiveAssistantRuntimesForReap(ctx context.Context, arg 
 	return items, nil
 }
 
-const listProjectMCPToolsetSlugs = `-- name: ListProjectMCPToolsetSlugs :many
-SELECT slug
-FROM toolsets
-WHERE project_id = $1
-  AND mcp_slug IS NOT NULL
-  AND deleted IS FALSE
-ORDER BY created_at
-`
-
-// Slugs of every MCP-reachable toolset in a project, used to attach all of a
-// project's toolsets to its managed assistant at provisioning time. Toolsets
-// without an mcp_slug can't be addressed by the runtime, so they're excluded
-// (mirrors the guard in EnableMCPForToolsets).
-func (q *Queries) ListProjectMCPToolsetSlugs(ctx context.Context, projectID uuid.UUID) ([]string, error) {
-	rows, err := q.db.Query(ctx, listProjectMCPToolsetSlugs, projectID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var slug string
-		if err := rows.Scan(&slug); err != nil {
-			return nil, err
-		}
-		items = append(items, slug)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listWarmPendingThreads = `-- name: ListWarmPendingThreads :many
 SELECT DISTINCT t.id
 FROM assistant_threads t


### PR DESCRIPTION
## Summary

- Provisioning the managed **Project Assistant** auto-attached every MCP-reachable toolset in the project, so a project with many MCP servers (13, in the reported case) got an assistant pre-loaded with all of them.
- The assistant is now provisioned with **no toolsets**. It starts with only its built-in and platform tools; admins attach the project MCP servers they want it to use.
- Removed the now-unused `ListProjectMCPToolsetSlugs` query and regenerated sqlc.

Closes [AGE-2727](https://linear.app/speakeasy/issue/AGE-2727/bug-project-assistant-includes-all-project-mcps-by-default)

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AGE-2727: provisioning the Project Assistant no longer auto-attaches all project MCP servers. New assistants start empty (only built-in and platform tools) so admins can add the MCP servers they want.

- **Bug Fixes**
  - Provisioning no longer auto-enables MCP on project toolsets; existing MCP settings stay unchanged.

- **Refactors**
  - Removed unused `ListProjectMCPToolsetSlugs` and regenerated `sqlc` outputs.

<sup>Written for commit 51886adef92880076e5a64850604b38616139987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

