### PR TITLE
feat(dashboard): remove beta label from security features

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -246,7 +246,6 @@ export function AppSidebar({
                 label="Secure"
                 Icon={(p) => <Icon {...p} name="shield" />}
                 defaultHref={routes.riskOverview.href()}
-                stage="beta"
               >
                 <ScopeGatedNavItem
                   item={routes.riskOverview}

--- a/client/dashboard/src/pages/security/ApprovalRequests.tsx
+++ b/client/dashboard/src/pages/security/ApprovalRequests.tsx
@@ -14,9 +14,7 @@ export default function ApprovalRequests(): JSX.Element {
       <Page.Body>
         <RequireScope scope="org:admin" level="page">
           <Page.Section>
-            <Page.Section.Title stage="beta">
-              Approval Requests
-            </Page.Section.Title>
+            <Page.Section.Title>Approval Requests</Page.Section.Title>
             <Page.Section.Description>
               Review blocked resource access requests and manage project-scoped
               access rules.

--- a/client/dashboard/src/pages/security/DetectionRules.tsx
+++ b/client/dashboard/src/pages/security/DetectionRules.tsx
@@ -108,7 +108,7 @@ function DetectionRulesContent() {
   return (
     <>
       <Page.Section>
-        <Page.Section.Title stage="beta">Detection Rules</Page.Section.Title>
+        <Page.Section.Title>Detection Rules</Page.Section.Title>
         <Page.Section.Description>
           Built-in detection rules grouped by category. Click a rule to view its
           description and try it against pasted text, or add your own custom

--- a/client/dashboard/src/pages/security/RiskOverviewCategoriesIndex.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewCategoriesIndex.tsx
@@ -83,7 +83,7 @@ function RiskOverviewCategoriesIndexContent() {
 
   return (
     <Page.Section>
-      <Page.Section.Title stage="beta">Risk categories</Page.Section.Title>
+      <Page.Section.Title>Risk categories</Page.Section.Title>
       <Page.Section.Description>
         All categories with finding counts
         {rangeLabel && ` across ${rangeLabel}.`}

--- a/client/dashboard/src/pages/security/RiskOverviewCategoryDetail.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewCategoryDetail.tsx
@@ -194,7 +194,7 @@ function RiskOverviewCategoryDetailContent() {
   return (
     <RevealAllProvider>
       <Page.Section>
-        <Page.Section.Title stage="beta">{categoryLabel}</Page.Section.Title>
+        <Page.Section.Title>{categoryLabel}</Page.Section.Title>
         <Page.Section.Description>
           {categoryMeta?.description ?? "Risk findings in this category"}
           {rangeLabel && ` across ${rangeLabel}.`}

--- a/client/dashboard/src/pages/security/RiskOverviewRulesIndex.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewRulesIndex.tsx
@@ -79,7 +79,7 @@ function RiskOverviewRulesIndexContent() {
 
   return (
     <Page.Section>
-      <Page.Section.Title stage="beta">Rules</Page.Section.Title>
+      <Page.Section.Title>Rules</Page.Section.Title>
       <Page.Section.Description>
         All rules with finding counts
         {rangeLabel && ` across ${rangeLabel}.`}

--- a/client/dashboard/src/pages/security/RiskOverviewUserDetail.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewUserDetail.tsx
@@ -131,7 +131,7 @@ function RiskOverviewUserDetailContent() {
   return (
     <>
       <Page.Section>
-        <Page.Section.Title stage="beta" className="normal-case">
+        <Page.Section.Title className="normal-case">
           {userLabel}
         </Page.Section.Title>
         <Page.Section.Description>

--- a/client/dashboard/src/pages/security/RiskOverviewUsersIndex.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewUsersIndex.tsx
@@ -82,7 +82,7 @@ function RiskOverviewUsersIndexContent() {
 
   return (
     <Page.Section>
-      <Page.Section.Title stage="beta">Users</Page.Section.Title>
+      <Page.Section.Title>Users</Page.Section.Title>
       <Page.Section.Description>
         All users with finding counts
         {rangeLabel && ` across ${rangeLabel}.`}

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -132,7 +132,7 @@ function RiskOverviewShell({
 }) {
   return (
     <Page.Section>
-      <Page.Section.Title stage="beta">Risk Overview</Page.Section.Title>
+      <Page.Section.Title>Risk Overview</Page.Section.Title>
       <Page.Section.Description>
         Risk analysis summary for policy findings
         {rangeLabel && ` across ${rangeLabel}.`}


### PR DESCRIPTION
## Summary

- Drops the `stage="beta"` label from the Secure sidebar group and the
  Risk Overview / Detection Rules / Approval Requests / Risk Categories
  / Rules / Users (index and detail) page titles.
- The `ReleaseStageBadge` component and `stage` prop on
  `Page.Section.Title` / `CollapsibleNavGroup` are unchanged. Security
  features are simply no longer marked as beta.

## Test plan

- [ ] Visual check: Secure group in the sidebar no longer shows the beta pill
- [ ] Visual check: each security page (Risk Overview, Detection Rules, Approval Requests, Risk Categories, Rules, Users, user/category detail) no longer shows the beta pill next to the section title

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the beta label from Security features in the dashboard so they appear GA. The Secure sidebar group and titles for Risk Overview, Detection Rules, Approval Requests, Risk Categories, Rules, Users, and their detail pages no longer show a beta badge.

<sup>Written for commit 50fbc2b5cc3f73c122d1efa4d38188d33ce3465b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

