### PR TITLE
chore: improve codex cli install instructions

### DIFF
--- a/server/internal/mcpmetadata/hosted_page.html.tmpl
+++ b/server/internal/mcpmetadata/hosted_page.html.tmpl
@@ -604,6 +604,11 @@
         font-size: 1rem;
         line-height: 150%;
         font-family: var(--font-diatype-mono);
+        /* Diatype Mono ships contextual alternates/ligatures (calt/liga) that
+           collide adjacent glyphs in commands — e.g. the space in `" --url` is
+           swallowed visually. Render commands literally. */
+        font-variant-ligatures: none;
+        font-feature-settings: "liga" 0, "calt" 0;
         overflow-x: auto;
         margin: 0;
       }
@@ -1196,7 +1201,10 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
         <h1>Instructions</h1>
         <ol>
           <li class="instruction-item">
-            Add this configuration to your ~/.codex/config.toml:
+            Ensure the Codex CLI executable is available in your path
+          </li>
+          <li class="instruction-item">
+            Execute the following snippet in your shell:
             <div class="card code-container">
               <button class="copy-button waiting">
                 <svg
@@ -1217,13 +1225,64 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
                 </svg>
               </button>
               <!-- prettier-ignore -->
-              <code class="code-snippet language-toml" data-scope-url-text>[mcp_servers.{{ .MCPSlug }}]
-url = "{{ .MCPURL }}"
-http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }}"{{ $input.SystemName | asHTTPHeader }}" = "your-{{ $input.DisplayName | asPosixName }}-value"{{- end }} }</code>
-            </div>
+              <code class="code-snippet language-sh" data-scope-url-text>codex mcp add "{{ .MCPSlug }}" --url "{{ .MCPURL }}"</code>
             </div>
           </li>
+          {{- if .IsOAuth }}
+          <li class="instruction-item">
+            This server uses OAuth, so authenticate with it before use:
+            <div class="card code-container">
+              <button class="copy-button waiting">
+                <svg
+                  class="icon icon-copy"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy"></use>
+                </svg>
+                <svg
+                  class="icon icon-copy-success"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy-check"></use>
+                </svg>
+              </button>
+              <!-- prettier-ignore -->
+              <code class="code-snippet language-sh">codex mcp login "{{ .MCPSlug }}"</code>
+            </div>
+          </li>
+          {{- end }}
           {{- if .SecurityInputs }}
+          <li class="instruction-item">
+            Codex CLI cannot set custom request headers from the command line, so
+            add them to the <code>[mcp_servers.{{ .MCPSlug }}]</code> entry that
+            the command above created in your <code>~/.codex/config.toml</code>:
+            <div class="card code-container">
+              <button class="copy-button waiting">
+                <svg
+                  class="icon icon-copy"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy"></use>
+                </svg>
+                <svg
+                  class="icon icon-copy-success"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy-check"></use>
+                </svg>
+              </button>
+              <!-- prettier-ignore -->
+              <code class="code-snippet language-toml">http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }}"{{ $input.SystemName | asHTTPHeader }}" = "your-{{ $input.DisplayName | asPosixName }}-value"{{- end }} }</code>
+            </div>
+          </li>
           <li class="instruction-item">
             (optional) If you would rather use variables from your system's
             environment, replace the <code>http_headers</code> key from the config
@@ -1248,7 +1307,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
                 </svg>
               </button>
               <!-- prettier-ignore -->
-          <code class="code-snippet language-sh">env_http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }}"{{ $input.SystemName | asHTTPHeader }}" = "{{ $input.DisplayName | asPosixName }}"{{- end }} }</code>
+              <code class="code-snippet language-toml">env_http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }}"{{ $input.SystemName | asHTTPHeader }}" = "{{ $input.DisplayName | asPosixName }}"{{- end }} }</code>
             </div>
           </li>
           {{- end }}

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -176,6 +176,10 @@ type hostedPageData struct {
 	DocsText          string
 	Instructions      string
 	IsPublic          bool
+	// IsOAuth is true when the server authenticates via OAuth (proxy, external,
+	// or user-session issuer). Drives the OAuth-only install steps (e.g. the
+	// Codex `codex mcp login` step).
+	IsOAuth bool
 	// FilteringEnabled gates the scope chip bar and related UI.
 	FilteringEnabled bool
 	// Scopes are the selectable filter tags rendered as chips.
@@ -1285,6 +1289,7 @@ func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseW
 		DocsText:         docsText,
 		Instructions:     instructions,
 		IsPublic:         ic.isPublic(),
+		IsOAuth:          securityMode == securityModeOAuth,
 		OrgName:          ic.organization.Name,
 		FilteringEnabled: filteringEnabled,
 		Scopes:           scopes,
@@ -1343,7 +1348,10 @@ func (s *Service) renderRemoteMcpInstallPage(ctx context.Context, w http.Respons
 		DocsText:       docsText,
 		Instructions:   instructions,
 		IsPublic:       ic.isPublic(),
-		OrgName:        ic.organization.Name,
+		// Remote-MCP-backed installs have no toolset, so OAuth is driven solely
+		// by the server's user-session issuer (mirrors resolveSecurityMode).
+		IsOAuth: mcpServer.UserSessionIssuerID.Valid,
+		OrgName: ic.organization.Name,
 		// Remote-MCP-backed installs have no tool list, so no filter scopes.
 		FilteringEnabled: false,
 		Scopes:           nil,
@@ -1364,7 +1372,10 @@ type hostedPageRenderInputs struct {
 	DocsText       string
 	Instructions   string
 	IsPublic       bool
-	OrgName        string
+	// IsOAuth is true when the server authenticates via OAuth (proxy, external,
+	// or user-session issuer).
+	IsOAuth bool
+	OrgName string
 	// FilteringEnabled is true when the install context resolves an explicit
 	// tool-variations group with at least one tag; it gates all scope UI.
 	FilteringEnabled bool
@@ -1465,6 +1476,7 @@ func (s *Service) writeInstallPage(ctx context.Context, w http.ResponseWriter, i
 		DocsText:          in.DocsText,
 		Instructions:      in.Instructions,
 		IsPublic:          in.IsPublic,
+		IsOAuth:           in.IsOAuth,
 		FilteringEnabled:  in.FilteringEnabled,
 		Scopes:            in.Scopes,
 		ScopeVariantsJSON: scopeVariantsJSON,


### PR DESCRIPTION
<img width="1092" height="684" alt="CleanShot 2026-06-08 at 11 09 58" src="https://github.com/user-attachments/assets/73cac642-f03e-4c15-9e76-e029e1bbbd0a" />

this PR improves the Codex CLI install instructions such that they render as a command line instruction rather than a suggested config edit.

Also improve the ligature behavior in codex blocks on the install page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the install flow to CLI-based commands using `codex mcp add`, with an OAuth-aware `codex mcp login` step, and fixes code block rendering so command text shows exactly as typed.

- **New Features**
  - Replace config copy-paste with a runnable command: `codex mcp add "<slug>" --url "<url>"`.
  - Show `codex mcp login "<slug>"` when the server uses OAuth.
  - Keep header setup guidance in `~/.codex/config.toml` under the created `[mcp_servers.<slug>]` entry.

- **Bug Fixes**
  - Disable ligatures in code blocks to stop characters merging (e.g., preserving the space before `--url`).
  - Mark `env_http_headers` snippet as TOML instead of shell.

<sup>Written for commit 30100e9a0fd1a7e37943c7107ab9446c89119ade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

