### PR TITLE
fix(dependabot): run npm updates from workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,10 +44,7 @@ updates:
         patterns:
           - "github.com/aws/aws-sdk-go-v2/*"
   - package-ecosystem: "npm"
-    directories:
-      - "/client/*"
-      - "/elements"
-      - "/elements/examples/*"
+    directory: "/"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## Summary
- Run the Dependabot npm updater from the pnpm workspace root.
- Allow Dependabot to see the root pnpm workspace and lockfile when generating dependency update PRs.
- Keep the existing npm dependency groups unchanged.

The previous PR for this restricted the locations and Dependabot couldn't update the lockfile so PR would fail in CI. e.g. https://github.com/speakeasy-api/gram/pull/3278

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `npm` Dependabot updates from the workspace root (`/`) so it sees the root `pnpm` workspace and lockfile and covers all packages. Existing `npm` dependency groups stay the same; no code changes or runtime impact.

<sup>Written for commit 5f51149ca7ef3a850703cf9f45918964a99775e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

