### PR TITLE
feat(mcp): correlate OAuth flow logs and add outcome metrics

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -182,9 +182,19 @@ const (
 	// OAuthErrorKey / OAuthErrorDescriptionKey carry the `error` /
 	// `error_description` parameters from RFC 6749 / RFC 7591 error responses
 	// — used across DCR registration, /authorize, /token, and /revoke.
-	OAuthErrorKey                        = attribute.Key("gram.oauth.error")
-	OAuthErrorDescriptionKey             = attribute.Key("gram.oauth.error_description")
-	OAuthFailureReasonKey                = attribute.Key("gram.oauth.failure_reason")
+	OAuthErrorKey            = attribute.Key("gram.oauth.error")
+	OAuthErrorDescriptionKey = attribute.Key("gram.oauth.error_description")
+	OAuthFailureReasonKey    = attribute.Key("gram.oauth.failure_reason")
+	// OAuthFlowIDKey is the stable correlation identifier for a single
+	// user-facing OAuth flow. Minted once at /authorize and threaded through
+	// every handler in the flow (idp_callback, consent, token) so the whole
+	// chain can be reconstructed from one log filter. Distinct from the
+	// AuthnChallengeState cache-key ID, which idp_callback rotates.
+	OAuthFlowIDKey = attribute.Key("gram.oauth.flow_id")
+	// OAuthFlowStageKey is the coarse, low-cardinality stage at which an OAuth
+	// flow terminated (see the oauthFlowStage enum in the mcp package). Used
+	// as a metric dimension on oauth.flow.failed and in failure logs.
+	OAuthFlowStageKey                    = attribute.Key("gram.oauth.flow_stage")
 	OAuthGrantKey                        = attribute.Key("gram.oauth.grant")
 	OAuthIssuerKey                       = attribute.Key("gram.oauth.issuer")
 	OAuthPresentedAuthMethodKey          = attribute.Key("gram.oauth.presented_auth_method")
@@ -883,6 +893,12 @@ func SlogOAuthClientSecretGenerated(v bool) slog.Attr {
 
 func OAuthError(v string) attribute.KeyValue { return OAuthErrorKey.String(v) }
 func SlogOAuthError(v string) slog.Attr      { return slog.String(string(OAuthErrorKey), v) }
+
+func OAuthFlowID(v string) attribute.KeyValue { return OAuthFlowIDKey.String(v) }
+func SlogOAuthFlowID(v string) slog.Attr      { return slog.String(string(OAuthFlowIDKey), v) }
+
+func OAuthFlowStage(v string) attribute.KeyValue { return OAuthFlowStageKey.String(v) }
+func SlogOAuthFlowStage(v string) slog.Attr      { return slog.String(string(OAuthFlowStageKey), v) }
 
 func OAuthErrorDescription(v string) attribute.KeyValue {
 	return OAuthErrorDescriptionKey.String(v)

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -89,7 +89,15 @@ type EndpointRef struct {
 // round-trip through the IDP and land on /connect, short enough that
 // abandoned flows don't pile up.
 type AuthnChallengeState struct {
-	ID                  string      `json:"id"`
+	ID string `json:"id"`
+	// FlowID is the stable correlation identifier for the whole OAuth flow,
+	// minted once at /authorize. Unlike ID — which idp_callback rotates to
+	// rotate the Redis cache key — FlowID is preserved across the rotation
+	// and copied into the UserSessionGrant so /token can log it too. Logged
+	// as attr.OAuthFlowID on every handler in the flow. Empty for in-flight
+	// states minted before this field landed (rolling deploy); callers treat
+	// empty as "unknown" and never depend on its presence.
+	FlowID              string      `json:"flow_id,omitempty"`
 	UserSessionIssuerID uuid.UUID   `json:"user_session_issuer_id"`
 	Endpoint            EndpointRef `json:"endpoint"`
 	ClientID            string      `json:"client_id"`
@@ -125,7 +133,12 @@ func (a AuthnChallengeState) TTL() time.Duration { return 10 * time.Minute }
 // grant. Stored in Redis under
 // `userSessionGrant:{user_session_issuer_id}:{code}` for ~10 minutes.
 type UserSessionGrant struct {
-	Code                string             `json:"code"`
+	Code string `json:"code"`
+	// FlowID carries the OAuth flow correlation identifier from the
+	// AuthnChallengeState into the grant so /token can stamp it on its logs,
+	// completing end-to-end correlation. Empty for grants minted before this
+	// field landed (rolling deploy).
+	FlowID              string             `json:"flow_id,omitempty"`
 	UserSessionIssuerID uuid.UUID          `json:"user_session_issuer_id"`
 	UserSessionClientID uuid.UUID          `json:"user_session_client_id"`
 	ClientID            string             `json:"client_id"`

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -96,6 +96,14 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	}
 
 	challengeID := uuid.NewString()
+	// flowID is the stable correlation key for this whole OAuth flow. It is
+	// minted once here and preserved across the idp_callback cache-key
+	// rotation and the consent→/token handoff, unlike challengeID which is
+	// the (rotating) Redis cache key. From here on the request logger carries
+	// it so every line in the flow shares one filterable value.
+	flowID := uuid.NewString()
+	logger = logger.With(attr.SlogOAuthFlowID(flowID))
+
 	csrfToken, err := generateOpaqueToken()
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "generate consent csrf token").Log(ctx, logger)
@@ -117,6 +125,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	baseURL := s.BaseURLForRequest(r)
 	challengeState := AuthnChallengeState{
 		ID:                  challengeID,
+		FlowID:              flowID,
 		UserSessionIssuerID: endpoint.UserSessionIssuerID,
 		Endpoint:            endpoint.EndpointRef(baseURL),
 		ClientID:            req.ClientID,
@@ -133,9 +142,15 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 		return oops.E(oops.CodeUnexpected, err, "store authn challenge state").Log(ctx, logger)
 	}
 
+	// Flow start: counted exactly once per minted challenge, the unit the
+	// companion completion-ratio monitor divides terminal outcomes against.
+	s.metrics.RecordOAuthFlowStarted(ctx, endpoint.UserSessionIssuerID.String(), endpoint.Slug)
+	logger.InfoContext(ctx, "oauth flow started", attr.SlogOAuthClientID(req.ClientID))
+
 	if forceIDP {
 		callbackURL, err := endpoint.IDPCallbackURL(s.serverURL.String())
 		if err != nil {
+			s.metrics.RecordOAuthFlowFailed(ctx, endpoint.UserSessionIssuerID.String(), endpoint.Slug, oauthFlowStageAuthorize)
 			return oops.E(oops.CodeUnexpected, err, "build IDP callback URL").Log(ctx, logger)
 		}
 		idpURL, err := s.identityResolver.BuildAuthorizationURL(ctx, identity.AuthorizationURLParams{
@@ -145,6 +160,9 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 			ScopesSupported: nil,
 		})
 		if err != nil {
+			// A failure to build the IDP authorization URL typically means the
+			// issuer's IDP wiring is misconfigured — a config-class flow failure.
+			s.metrics.RecordOAuthFlowFailed(ctx, endpoint.UserSessionIssuerID.String(), endpoint.Slug, oauthFlowStageAuthorize)
 			return oops.E(oops.CodeUnexpected, err, "build IDP authorization URL").Log(ctx, logger)
 		}
 		http.Redirect(w, r, idpURL.String(), http.StatusFound)
@@ -153,6 +171,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 
 	consentURL, err := endpoint.ConsentURL(baseURL, challengeID)
 	if err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, endpoint.UserSessionIssuerID.String(), endpoint.Slug, oauthFlowStageAuthorize)
 		return oops.E(oops.CodeUnexpected, err, "build consent URL").Log(ctx, logger)
 	}
 	http.Redirect(w, r, consentURL, http.StatusFound)

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -128,6 +128,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 	if err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
 	}
+	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
 	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").Log(ctx, logger)
 	}
@@ -207,6 +208,9 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	if err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
 	}
+	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
+	issuerID := endpoint.UserSessionIssuerID.String()
+	mcpSlug := endpoint.Slug
 	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").Log(ctx, logger)
 	}
@@ -223,8 +227,11 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		// fall through
 	case "deny":
 		// Cancel: 303 (POST → GET) the MCP client back to its redirect_uri
-		// with access_denied per RFC 6749 §4.1.2.1, preserving the
-		// original state.
+		// with access_denied per RFC 6749 §4.1.2.1, preserving the original
+		// state. The user reached the consent screen and chose "no" — a
+		// decline, not an errant config.
+		s.metrics.RecordOAuthFlowDeclined(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
+		logger.InfoContext(ctx, "oauth flow declined at consent", attr.SlogOAuthError("access_denied"))
 		denyURL := buildClientRedirect(challengeState.RedirectURI, "", challengeState.State, "access_denied", "user denied consent")
 		http.Redirect(w, r, denyURL, http.StatusSeeOther)
 		return nil
@@ -233,6 +240,9 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	}
 
 	if challengeState.Subject == nil || challengeState.Subject.IsZero() {
+		// Reaching an approved consent POST with no resolved subject is a code
+		// invariant break, not a user action — a config/code-class failure.
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
 		return oops.E(oops.CodeUnauthorized, nil, "authn challenge subject is not resolved").Log(ctx, logger)
 	}
 	subject := *challengeState.Subject
@@ -243,6 +253,9 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		ClientID:            challengeState.ClientID,
 	})
 	if err != nil {
+		// Client revoked mid-flow (config change) or DB error — either way the
+		// approved flow can't complete.
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeUnauthorized, err, "user session client revoked").Log(ctx, logger)
 		}
@@ -258,16 +271,19 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		UserSessionClientID: clientRow.ID,
 		RemoteSetHash:       remoteSetHashEmpty,
 	}); err != nil && !isUniqueViolation(err) {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
 		return oops.E(oops.CodeUnexpected, err, "record consent").Log(ctx, logger)
 	}
 
 	code, err := generateOpaqueToken()
 	if err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
 		return oops.E(oops.CodeUnexpected, err, "generate authorization code").Log(ctx, logger)
 	}
 
 	grant := UserSessionGrant{
 		Code:                code,
+		FlowID:              challengeState.FlowID,
 		UserSessionIssuerID: endpoint.UserSessionIssuerID,
 		UserSessionClientID: clientRow.ID,
 		ClientID:            challengeState.ClientID,
@@ -278,6 +294,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		CreatedAt:           time.Now(),
 	}
 	if err := s.userSessionGrantCache.Store(ctx, grant); err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
 		return oops.E(oops.CodeUnexpected, err, "store user session grant").Log(ctx, logger)
 	}
 

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -211,6 +211,12 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
 	issuerID := endpoint.UserSessionIssuerID.String()
 	mcpSlug := endpoint.Slug
+
+	// The guards below (state-confusion ref check, CSRF, and the unknown-action
+	// default) consume the challenge but are deliberately NOT counted as flow
+	// failures: they are attacker-controllable, so emitting `failed` here would
+	// let crafted requests pollute a config's health signal. A legitimate user
+	// never trips them; the rare case lands in the started-without-terminal gap.
 	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").Log(ctx, logger)
 	}

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -63,7 +64,11 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		return err
 	}
 
-	logger = endpoint.LogWith(s.logger)
+	logger = endpoint.LogWith(s.logger).With(attr.SlogOAuthFlowID(challengeState.FlowID))
+	issuerID := endpoint.UserSessionIssuerID.String()
+	// mcpSlug was set from the cached ref above; re-point it at the resolved
+	// endpoint's canonical slug for the flow-metric dimension.
+	mcpSlug = endpoint.Slug
 
 	// If the IDP returned an error (user cancelled at the IDP, IDP refused
 	// to authenticate, etc.) per OAuth 2.0, forward it back to the MCP
@@ -72,6 +77,17 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	// required" 400.
 	if idpErr := q.Get("error"); idpErr != "" {
 		errDescription := q.Get("error_description")
+		// access_denied is the user opting out at the IDP — a decline, not an
+		// errant config. Any other IDP error code (server_error, invalid_scope,
+		// ...) points at IDP/config trouble. Both are terminal; bucket them
+		// accordingly before bouncing the error back to the client.
+		if idpErr == "access_denied" {
+			s.metrics.RecordOAuthFlowDeclined(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
+			logger.InfoContext(ctx, "oauth flow declined at idp", attr.SlogOAuthError(idpErr), attr.SlogOAuthErrorDescription(errDescription))
+		} else {
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
+			logger.InfoContext(ctx, "oauth flow failed at idp callback", attr.SlogOAuthError(idpErr), attr.SlogOAuthErrorDescription(errDescription))
+		}
 		clientRedirect := buildClientRedirect(challengeState.RedirectURI, "", challengeState.State, idpErr, errDescription)
 		http.Redirect(w, r, clientRedirect, http.StatusFound)
 		return nil
@@ -79,12 +95,15 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 
 	code := q.Get("code")
 	if code == "" {
+		// IDP returned neither code nor error — a broken IDP redirect.
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 		return oops.E(oops.CodeBadRequest, nil, "code is required").Log(ctx, logger)
 	}
 
 	// Exchange the authorization code for user identity via WorkOS.
 	idpUser, err := s.identityResolver.ExchangeCodeForTokens(ctx, code)
 	if err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 		return oops.E(oops.CodeUnauthorized, err, "failed to exchange IDP code").Log(ctx, logger)
 	}
 
@@ -93,13 +112,17 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	// session manager runs on dashboard logins.
 	gramUserID, err := s.identityResolver.UpsertUserFromIDP(ctx, idpUser)
 	if err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 		return oops.E(oops.CodeUnexpected, err, "failed to bootstrap user").Log(ctx, logger)
 	}
 
 	// Validate the user belongs to the endpoint's organization before
 	// issuing a token. The mcp:connect RBAC policy operates at org level;
-	// this is the first gate.
+	// this is the first gate. The user wanted in but policy refused — a
+	// config-relevant failure (e.g. the toolset is exposed to the wrong
+	// audience), not a user decline.
 	if _, _, ok := s.identityResolver.HasAccessToOrganization(ctx, endpoint.OrganizationID, gramUserID); !ok {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 		return oops.E(oops.CodeForbidden, nil, "user is not a member of this MCP server's organization").Log(ctx, logger)
 	}
 
@@ -107,9 +130,13 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	// same value that just bounced through the IDP. The IDP-returned state
 	// is consumed; the new ID is what /connect's GetAndDelete will burn.
 	subject := urn.NewUserSubject(gramUserID)
+	// Rotate only the cache-key ID (replay protection). challengeState.FlowID
+	// is deliberately left untouched so the flow stays correlatable across the
+	// rotation — do not regenerate it here.
 	challengeState.ID = uuid.NewString()
 	challengeState.Subject = &subject
 	if err := s.authnChallengeCache.Store(ctx, challengeState); err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 		return oops.E(oops.CodeUnexpected, err, "failed to update authn challenge state").Log(ctx, logger)
 	}
 
@@ -126,6 +153,7 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	}
 	consentURL, err := endpoint.ConsentURL(baseURL, challengeState.ID)
 	if err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 		return oops.E(oops.CodeUnexpected, err, "build consent URL").Log(ctx, logger)
 	}
 	http.Redirect(w, r, consentURL, http.StatusFound)

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -48,26 +48,42 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	// substitute their own Subject on the victim's in-flight challenge.
 	challengeState, err := s.authnChallengeCache.GetAndDelete(ctx, "authnChallenge:"+stateID)
 	if err != nil {
+		// No challenge in hand (expired / replayed / never existed): nothing to
+		// attribute to an issuer, and an expired state is closer to abandonment
+		// than a flow failure, so it is left to the started-without-terminal gap.
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
 	}
 
+	// Challenge in hand: correlate every subsequent log line by flow_id, and
+	// use the cached ref's issuer/slug for flow metrics until the endpoint is
+	// re-resolved below.
+	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
+	issuerID := challengeState.UserSessionIssuerID.String()
 	mcpSlug := challengeState.Endpoint.McpSlug
+
 	if mcpSlug == "" {
+		// Corrupted in-flight state (a code/data integrity failure), terminal
+		// for the flow.
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 		return oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from authn challenge state").Log(ctx, logger)
 	}
 	if routeMcpSlug != "" && routeMcpSlug != mcpSlug {
+		// State-confusion guard (state minted for a different route). Attacker-
+		// controllable, so deliberately NOT counted as a flow failure.
 		return oops.E(oops.CodeUnauthorized, nil, "authn challenge state does not match this MCP server").Log(ctx, logger)
 	}
 
 	endpoint, err := s.loadResolvedMcpEndpointByRef(ctx, challengeState.Endpoint)
 	if err != nil {
+		// The endpoint backing an in-flight challenge could not be re-resolved
+		// (e.g. toolset removed mid-flow) — a config-class terminal failure.
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 		return err
 	}
 
-	logger = endpoint.LogWith(s.logger).With(attr.SlogOAuthFlowID(challengeState.FlowID))
-	issuerID := endpoint.UserSessionIssuerID.String()
-	// mcpSlug was set from the cached ref above; re-point it at the resolved
-	// endpoint's canonical slug for the flow-metric dimension.
+	logger = endpoint.LogWith(logger)
+	// issuerID is unchanged (same issuer the ref resolved to); re-point mcpSlug
+	// at the resolved endpoint's canonical slug for the flow-metric dimension.
 	mcpSlug = endpoint.Slug
 
 	// If the IDP returned an error (user cancelled at the IDP, IDP refused

--- a/server/internal/mcp/authnchallenge_test.go
+++ b/server/internal/mcp/authnchallenge_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
@@ -403,6 +404,63 @@ func TestHandleConsentPost_ApproveWithCSRFRedirectsWithCode(t *testing.T) {
 	require.NotEmpty(t, loc.Query().Get("code"))
 }
 
+// TestHandleConsentPost_PropagatesFlowIDIntoGrant asserts the flow id is
+// carried from the AuthnChallengeState into the UserSessionGrant minted on
+// consent approval, so the terminal /token leg (which only reads the grant)
+// can still log the same flow_id.
+func TestHandleConsentPost_PropagatesFlowIDIntoGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	subject := urn.NewUserSubject("consent-user-" + uuid.NewString())
+	stateID := uuid.NewString()
+	csrfToken := "csrf-" + uuid.NewString()
+	flowID := "flow-" + uuid.NewString()
+
+	require.NoError(t, ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  stateID,
+		FlowID:              flowID,
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		Endpoint: mcp.EndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
+		ClientID:            client.ClientID,
+		RedirectURI:         client.RedirectUris[0],
+		State:               "client-state",
+		CodeChallenge:       "abc",
+		CodeChallengeMethod: "S256",
+		CSRFToken:           csrfToken,
+		Subject:             &subject,
+		CreatedAt:           time.Now(),
+	}))
+
+	form := url.Values{}
+	form.Set("state", stateID)
+	form.Set("csrf_token", csrfToken)
+	form.Set("action", "approve")
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+toolset.McpSlug.String+"/connect", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", toolset.McpSlug.String)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleConsent(w, req))
+	require.Equal(t, http.StatusSeeOther, w.Code)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	code := loc.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	grantCache := cache.NewTypedObjectCache[mcp.UserSessionGrant](ti.logger, ti.cacheAdapter, cache.SuffixNone)
+	grant, err := grantCache.Get(ctx, "userSessionGrant:"+toolset.UserSessionIssuerID.UUID.String()+":"+code)
+	require.NoError(t, err)
+	require.Equal(t, flowID, grant.FlowID, "flow id must propagate into the grant")
+}
+
 func TestHandleIDPCallback_ExchangesCodeAndRedirectsToConsent(t *testing.T) {
 	t.Parallel()
 
@@ -465,6 +523,74 @@ func TestHandleIDPCallback_ExchangesCodeAndRedirectsToConsent(t *testing.T) {
 	require.Contains(t, loc, "state=", "consent redirect should carry new challenge state")
 	// The state in the redirect should NOT be the original challengeID (it gets rotated)
 	require.NotContains(t, loc, challengeID, "challenge state should be rotated after IDP callback")
+}
+
+// TestHandleIDPCallback_PreservesFlowIDAcrossRotation asserts the stable
+// flow correlation id survives the deliberate cache-key (ID) rotation in
+// HandleIDPCallback. Without preservation, the private-toolset leg of a flow
+// would be uncorrelatable from the rest (AC: one flow_id reconstructs the
+// whole chain).
+func TestHandleIDPCallback_PreservesFlowIDAcrossRotation(t *testing.T) {
+	t.Parallel()
+
+	gramUserID := "user-" + uuid.New().String()[:8]
+	mock := &mockIdentityResolver{
+		exchangeResult: &identity.IDPUserInfo{
+			Sub:   "workos-user-123",
+			Email: "test@example.com",
+			Name:  "Test User",
+		},
+		upsertResult: gramUserID,
+		hasAccessResult: &sessions.Organization{
+			ID:   "org-id-placeholder",
+			Name: "Test Org",
+		},
+		hasAccessEmail: "test@example.com",
+		hasAccessOK:    true,
+	}
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, mock)
+	toolset, _, _ := seedPrivateToolsetWithIssuer(t, ctx, ti)
+
+	flowID := "flow-" + uuid.NewString()
+	challengeID := uuid.NewString()
+	require.NoError(t, ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  challengeID,
+		FlowID:              flowID,
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		Endpoint: mcp.EndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
+		ClientID:            "test-client",
+		RedirectURI:         "http://localhost:3000/callback",
+		State:               "client-state",
+		CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-token",
+		CreatedAt:           time.Now(),
+	}))
+
+	mcpSlug := toolset.McpSlug.String
+	q := url.Values{"state": {challengeID}, "code": {"idp-auth-code-123"}}
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+mcpSlug+"/idp_callback?"+q.Encode(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleIDPCallback(w, req))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	rotatedID := loc.Query().Get("state")
+	require.NotEmpty(t, rotatedID)
+	require.NotEqual(t, challengeID, rotatedID, "cache-key id must rotate")
+
+	rotated, err := ti.authnChallengeCache.Get(ctx, "authnChallenge:"+rotatedID)
+	require.NoError(t, err)
+	require.Equal(t, flowID, rotated.FlowID, "flow id must survive the rotation")
 }
 
 // TestHandleIDPCallback_UsesBaseURLFromCachedState verifies that the

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -141,10 +141,19 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	presentedAuthMethod string,
 	logger *slog.Logger,
 ) error {
+	// Flow-outcome dimensions. This is the authorization_code grant
+	// — the terminal leg of a user-facing OAuth flow — so every rejection
+	// below is a flow failure at the token stage, and the success path is the
+	// single point that counts a completion. The refresh_token grant handler
+	// deliberately records neither: refresh is not part of an initial flow.
+	issuerID := endpoint.UserSessionIssuerID.String()
+	mcpSlug := endpoint.Slug
+
 	req := usersessions.AuthCodeTokenRequestFromForm(r.PostForm)
 	req.SetDefaults()
 	if err := req.Validate(); err != nil {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "invalid_request")
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageToken)
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
@@ -155,23 +164,47 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	grant, err := s.userSessionGrantCache.GetAndDelete(ctx, grantKey)
 	if err != nil {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_not_found_or_expired")
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageToken)
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
 	}
 
+	// Grant in hand: stamp the flow id so the token leg shares the correlation
+	// key minted at /authorize and carried through the grant.
+	logger = logger.With(attr.SlogOAuthFlowID(grant.FlowID))
+
 	if grant.ClientID != clientRow.ClientID {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_client_mismatch")
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageToken)
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code was issued to a different client")
 	}
 	if grant.RedirectURI != req.RedirectURI {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "redirect_uri_mismatch")
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageToken)
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "redirect_uri does not match the original request")
 	}
 	if !verifyPKCES256(req.CodeVerifier, grant.CodeChallenge) {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "pkce_mismatch")
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageToken)
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code_verifier does not match code_challenge")
 	}
 
-	return s.mintSessionAndRespond(ctx, w, endpoint, clientRow, grant.Subject, baseURL, logger)
+	if err := s.mintSessionAndRespond(ctx, w, endpoint, clientRow, grant.Subject, baseURL, logger); err != nil {
+		// Almost all errors here occur before the 200 is written — issuer
+		// lookup, session_duration validation, signing, or persisting the
+		// user_sessions row — so no token reached the client and failed is
+		// correct. The lone post-commit case is a failure writing the response
+		// body after a 200 + persisted session (e.g. the client dropped the
+		// connection): we still count failed, because the client received no
+		// usable token, so the flow did not complete from its perspective.
+		// Conservatively bucketing this rare case as failed (not completed)
+		// keeps completed meaning "a token the client could actually use."
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageToken)
+		return err
+	}
+
+	s.metrics.RecordOAuthFlowCompleted(ctx, issuerID, mcpSlug)
+	logger.InfoContext(ctx, "oauth flow completed")
+	return nil
 }
 
 // handleTokenRefreshTokenGrant implements RFC 6749 §6 (and OAuth 2.1's

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -164,7 +164,12 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	grant, err := s.userSessionGrantCache.GetAndDelete(ctx, grantKey)
 	if err != nil {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_not_found_or_expired")
-		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageToken)
+		// Deliberately NOT counted as a flow failure: a missing/expired code is
+		// ambiguous. An expired code is closer to abandonment than an errant
+		// config, and a replayed or retried code would double-count an outcome
+		// already recorded on the first redemption. It falls into the
+		// started-without-terminal gap instead, keeping `failed` to unambiguous
+		// config/code/client errors.
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
 	}
 

--- a/server/internal/mcp/metrics.go
+++ b/server/internal/mcp/metrics.go
@@ -11,9 +11,56 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 )
 
+// oauthFlowStage is the closed set of coarse stages at which a user-facing
+// OAuth flow can terminally resolve to a non-completion outcome (failed or
+// declined). It names the handler leg where the flow ended. Kept as a bounded
+// enum — and deliberately decoupled from the free-form reason strings the
+// handlers log — so the `gram.oauth.flow_stage` metric dimension stays
+// low-cardinality. Add a value here only when a new terminal point is
+// instrumented.
+type oauthFlowStage string
+
+const (
+	// oauthFlowStageAuthorize: the flow died in /authorize after the challenge
+	// was minted (e.g. building the IDP authorization URL failed, which
+	// surfaces a misconfigured IDP).
+	oauthFlowStageAuthorize oauthFlowStage = "authorize"
+	// oauthFlowStageIDPCallback: the flow ended on the private-toolset IDP
+	// return leg (HandleIDPCallback) — an IDP error, a failed code exchange,
+	// an org-membership denial, or the user cancelling at the IDP.
+	oauthFlowStageIDPCallback oauthFlowStage = "idp_callback"
+	// oauthFlowStageConsent: the flow ended at the consent step (HandleConsent
+	// POST) — the user declined, or the approval could not be persisted.
+	oauthFlowStageConsent oauthFlowStage = "consent"
+	// oauthFlowStageToken: the authorization_code token exchange was rejected
+	// (HandleToken). Refresh-token grants are NOT part of a flow and never
+	// record here.
+	oauthFlowStageToken oauthFlowStage = "token"
+)
+
 type metrics struct {
 	mcpToolCallCounter metric.Int64Counter
 	mcpRequestDuration metric.Float64Histogram
+
+	// oauthFlow{Started,Completed,Failed,Declined}Counter instrument the
+	// user-facing OAuth flow as a unit. They decompose a flow's terminal
+	// outcome by intent:
+	//   - started:   /authorize minted a challenge (fires once per flow).
+	//   - completed: a token was issued (authorization_code grant succeeded).
+	//   - failed:    the user wanted in but config/code/policy refused or
+	//     errored (grant/PKCE/redirect mismatch, IDP error, org-membership
+	//     denial, internal 5xx) — the alertable bucket, tagged by stage.
+	//   - declined:  the user reached a decision point and chose "no" (consent
+	//     deny, IDP access_denied) — the machinery worked; not alertable.
+	// The remainder (started - completed - failed - declined) is silent
+	// abandonment (user vanished mid-flow), observable only as a ratio gap.
+	// The companion Datadog monitor can therefore alert on a clean signal
+	// (failed/started, or completed/(completed+failed)) instead of per-URL
+	// status.
+	oauthFlowStartedCounter   metric.Int64Counter
+	oauthFlowCompletedCounter metric.Int64Counter
+	oauthFlowFailedCounter    metric.Int64Counter
+	oauthFlowDeclinedCounter  metric.Int64Counter
 }
 
 func newMetrics(meter metric.Meter, logger *slog.Logger) *metrics {
@@ -36,9 +83,49 @@ func newMetrics(meter metric.Meter, logger *slog.Logger) *metrics {
 		logger.ErrorContext(context.Background(), "failed to create mcp request duration", attr.SlogError(err))
 	}
 
+	oauthFlowStartedCounter, err := meter.Int64Counter(
+		"oauth.flow.started",
+		metric.WithDescription("User-facing OAuth flow initiated at /authorize"),
+		metric.WithUnit("{flow}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create oauth flow started counter", attr.SlogError(err))
+	}
+
+	oauthFlowCompletedCounter, err := meter.Int64Counter(
+		"oauth.flow.completed",
+		metric.WithDescription("User-facing OAuth flow completed via successful authorization_code token exchange"),
+		metric.WithUnit("{flow}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create oauth flow completed counter", attr.SlogError(err))
+	}
+
+	oauthFlowFailedCounter, err := meter.Int64Counter(
+		"oauth.flow.failed",
+		metric.WithDescription("User-facing OAuth flow terminally failed after a challenge was minted (config/code/policy)"),
+		metric.WithUnit("{flow}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create oauth flow failed counter", attr.SlogError(err))
+	}
+
+	oauthFlowDeclinedCounter, err := meter.Int64Counter(
+		"oauth.flow.declined",
+		metric.WithDescription("User-facing OAuth flow declined by the user at a decision point (consent deny, IDP access_denied)"),
+		metric.WithUnit("{flow}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create oauth flow declined counter", attr.SlogError(err))
+	}
+
 	return &metrics{
-		mcpToolCallCounter: mcpToolCallCounter,
-		mcpRequestDuration: mcpRequestDuration,
+		mcpToolCallCounter:        mcpToolCallCounter,
+		mcpRequestDuration:        mcpRequestDuration,
+		oauthFlowStartedCounter:   oauthFlowStartedCounter,
+		oauthFlowCompletedCounter: oauthFlowCompletedCounter,
+		oauthFlowFailedCounter:    oauthFlowFailedCounter,
+		oauthFlowDeclinedCounter:  oauthFlowDeclinedCounter,
 	}
 }
 
@@ -66,4 +153,59 @@ func (m *metrics) RecordMCPRequestDuration(ctx context.Context, mcpMethod string
 	}
 
 	m.mcpRequestDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(kv...))
+}
+
+// oauthFlowDimensions are the low-cardinality attributes shared by every
+// OAuth flow counter — enough to group by OAuth configuration without tagging
+// per-flow / per-user / per-client values (those belong in logs, not metrics).
+func oauthFlowDimensions(issuerID, mcpSlug string) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attr.UserSessionIssuerID(issuerID),
+		attr.ToolsetMCPSlug(mcpSlug),
+	}
+}
+
+// RecordOAuthFlowStarted records that a user-facing OAuth flow was initiated
+// — emitted once per minted challenge at /authorize.
+func (m *metrics) RecordOAuthFlowStarted(ctx context.Context, issuerID, mcpSlug string) {
+	if m.oauthFlowStartedCounter == nil {
+		return
+	}
+	m.oauthFlowStartedCounter.Add(ctx, 1, metric.WithAttributes(oauthFlowDimensions(issuerID, mcpSlug)...))
+}
+
+// RecordOAuthFlowCompleted records that a user-facing OAuth flow resolved
+// successfully — emitted when the authorization_code token exchange succeeds.
+func (m *metrics) RecordOAuthFlowCompleted(ctx context.Context, issuerID, mcpSlug string) {
+	if m.oauthFlowCompletedCounter == nil {
+		return
+	}
+	m.oauthFlowCompletedCounter.Add(ctx, 1, metric.WithAttributes(oauthFlowDimensions(issuerID, mcpSlug)...))
+}
+
+// RecordOAuthFlowFailed records that a user-facing OAuth flow terminally
+// failed after a challenge was minted — the user wanted in but config, code,
+// or policy refused or errored — tagged with the coarse stage where it died.
+// Not emitted for pre-mint /authorize rejections (no started counted), for
+// deliberate user declines (see RecordOAuthFlowDeclined), or for refresh_token
+// grants (not part of a flow).
+func (m *metrics) RecordOAuthFlowFailed(ctx context.Context, issuerID, mcpSlug string, stage oauthFlowStage) {
+	if m.oauthFlowFailedCounter == nil {
+		return
+	}
+	kv := append(oauthFlowDimensions(issuerID, mcpSlug), attr.OAuthFlowStage(string(stage)))
+	m.oauthFlowFailedCounter.Add(ctx, 1, metric.WithAttributes(kv...))
+}
+
+// RecordOAuthFlowDeclined records that a user-facing OAuth flow ended because
+// the user deliberately declined at a decision point (consent deny, IDP
+// access_denied), tagged with the coarse stage. The machinery worked; this is
+// a user choice, not an errant config — kept separate from failed so the
+// alertable failure signal stays clean.
+func (m *metrics) RecordOAuthFlowDeclined(ctx context.Context, issuerID, mcpSlug string, stage oauthFlowStage) {
+	if m.oauthFlowDeclinedCounter == nil {
+		return
+	}
+	kv := append(oauthFlowDimensions(issuerID, mcpSlug), attr.OAuthFlowStage(string(stage)))
+	m.oauthFlowDeclinedCounter.Add(ctx, 1, metric.WithAttributes(kv...))
 }

--- a/server/internal/mcp/metrics_test.go
+++ b/server/internal/mcp/metrics_test.go
@@ -72,3 +72,64 @@ func TestMetrics_RecordMCPRequestDuration(t *testing.T) {
 		m.RecordMCPRequestDuration(context.Background(), "tools/call", "https://mcp.example.com", 100*time.Millisecond)
 	})
 }
+
+func TestNewMetrics_CreatesOAuthFlowCounters(t *testing.T) {
+	t.Parallel()
+
+	meter := testenv.NewMeterProvider(t).Meter("test")
+	m := newMetrics(meter, testenv.NewLogger(t))
+	require.NotNil(t, m)
+	require.NotNil(t, m.oauthFlowStartedCounter)
+	require.NotNil(t, m.oauthFlowCompletedCounter)
+	require.NotNil(t, m.oauthFlowFailedCounter)
+	require.NotNil(t, m.oauthFlowDeclinedCounter)
+}
+
+func TestMetrics_RecordOAuthFlowStarted(t *testing.T) {
+	t.Parallel()
+
+	meter := testenv.NewMeterProvider(t).Meter("test")
+	m := newMetrics(meter, testenv.NewLogger(t))
+
+	// Should not panic with a valid counter.
+	m.RecordOAuthFlowStarted(t.Context(), "issuer-1", "mcp-slug-1")
+}
+
+func TestMetrics_RecordOAuthFlowCompleted(t *testing.T) {
+	t.Parallel()
+
+	meter := testenv.NewMeterProvider(t).Meter("test")
+	m := newMetrics(meter, testenv.NewLogger(t))
+
+	m.RecordOAuthFlowCompleted(t.Context(), "issuer-1", "mcp-slug-1")
+}
+
+func TestMetrics_RecordOAuthFlowFailed(t *testing.T) {
+	t.Parallel()
+
+	meter := testenv.NewMeterProvider(t).Meter("test")
+	m := newMetrics(meter, testenv.NewLogger(t))
+
+	m.RecordOAuthFlowFailed(t.Context(), "issuer-1", "mcp-slug-1", oauthFlowStageToken)
+}
+
+func TestMetrics_RecordOAuthFlowDeclined(t *testing.T) {
+	t.Parallel()
+
+	meter := testenv.NewMeterProvider(t).Meter("test")
+	m := newMetrics(meter, testenv.NewLogger(t))
+
+	m.RecordOAuthFlowDeclined(t.Context(), "issuer-1", "mcp-slug-1", oauthFlowStageConsent)
+}
+
+func TestMetrics_RecordOAuthFlow_NilCountersDoNotPanic(t *testing.T) {
+	t.Parallel()
+
+	m := &metrics{}
+
+	// All four must be nil-safe (counter construction can fail at startup).
+	m.RecordOAuthFlowStarted(t.Context(), "issuer-1", "mcp-slug-1")
+	m.RecordOAuthFlowCompleted(t.Context(), "issuer-1", "mcp-slug-1")
+	m.RecordOAuthFlowFailed(t.Context(), "issuer-1", "mcp-slug-1", oauthFlowStageConsent)
+	m.RecordOAuthFlowDeclined(t.Context(), "issuer-1", "mcp-slug-1", oauthFlowStageIDPCallback)
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-101/oauth-flow-correlated-logging-startcompletedfailed-metrics

Thread a stable `gram.oauth.flow_id` through every handler in the issuer-gated OAuth flow (`authorize`, `idp_callback`, `consent`, `token`), preserved across the `idp_callback` cache-key rotation and carried into the grant, so a whole flow can be reconstructed from one log filter.

Add four OpenTelemetry counters that decompose a flow's terminal outcome by intent: `oauth.flow.started`, `oauth.flow.completed` (token issued), `oauth.flow.failed` (config, code, or policy refused or errored), and `oauth.flow.declined` (user opted out at consent or the IDP). `failed` and `declined` carry a low-cardinality `gram.oauth.flow_stage`; all carry `gram.user_session_issuer.id` and `gram.toolset.mcp_slug`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end OAuth flow correlation with `gram.oauth.flow_id` and outcome metrics, with refined failure accounting, so flows are observable and completion-ratio monitoring is possible. Addresses Linear AIS-101.

- **New Features**
  - Thread a stable `gram.oauth.flow_id` through `authorize`, `idp_callback`, `consent`, and `token`; preserve across IDP rotation; store on `AuthnChallengeState` and `UserSessionGrant`; log via new helpers in `server/internal/attr`.
  - Add `gram.oauth.flow_stage` with bounded values: authorize, idp_callback, consent, token.
  - Counters: `oauth.flow.started` (mint at `/authorize`), `oauth.flow.completed` (successful authorization_code exchange), `oauth.flow.failed` (config/code/policy errors), `oauth.flow.declined` (user denies at consent or IDP `access_denied`).
  - Metric attrs: all include `gram.user_session_issuer.id` and `gram.toolset.mcp_slug`; `failed`/`declined` also include `gram.oauth.flow_stage`. Do not count `code_not_found_or_expired` token rejections or attacker-controlled consent guards; instrument corrupted-state and endpoint-resolution failures at `idp_callback`.

<sup>Written for commit e7bad1d282d0086fe4037b2fefa9fdda2d7b4688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

