### PR TITLE
feat(dashboard): dim inactive access rules

### DIFF
--- a/.changeset/cruel-friends-study.md
+++ b/.changeset/cruel-friends-study.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Dim inactive access rules when no blocking Shadow MCP policy exists while keeping rule actions available

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.test.tsx
@@ -1021,6 +1021,83 @@ describe("ApprovalRequestsContent", () => {
     });
   });
 
+  it("dims access rule content but keeps actions active when no blocking policy exists", async () => {
+    const listShadowMCPApprovalRequests = vi.fn().mockResolvedValue({
+      requests: [],
+    });
+    const listShadowMCPAccessRules = vi.fn().mockResolvedValue({
+      rules: [
+        {
+          id: "rule-inactive",
+          displayName: "Inactive access rule",
+          resourceType: "shadow_mcp",
+          disposition: "allowed",
+          accessScope: "project",
+          projectId: "project-1",
+          matchBreadth: "url_host",
+          matchValue: "inactive.example.com",
+          updatedAt: new Date("2026-01-01"),
+        },
+      ],
+    });
+    mocks.useSdkClient.mockReturnValue({
+      access: {
+        listShadowMCPApprovalRequests,
+        listShadowMCPAccessRules,
+      },
+    });
+    mocks.useRBAC.mockReturnValue({
+      hasScope: (scope: string) => scope === "org:admin",
+      hasAnyScope: (scopes: string[]) => scopes.includes("org:admin"),
+      hasAllScopes: () => true,
+      isLoading: false,
+    });
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: {
+        policies: [
+          {
+            id: "policy-flag-only",
+            enabled: true,
+            action: "flag",
+            sources: ["shadow_mcp"],
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(screen.getByText("Inactive access rule")).toBeTruthy();
+    });
+    const inactiveRuleRow = screen
+      .getByText("Inactive access rule")
+      .closest("tr");
+    if (!inactiveRuleRow) throw new Error("Inactive rule row not found");
+
+    const ruleNameCell = screen
+      .getByText("Inactive access rule")
+      .closest("[data-inactive-rule-cell='true']");
+    expect(ruleNameCell).not.toBeNull();
+    expect(ruleNameCell?.className).toContain("opacity-50");
+
+    const deleteButton = within(inactiveRuleRow).getByRole("button", {
+      name: "Delete",
+    });
+    expect(deleteButton.closest("[data-inactive-rule-cell='true']")).toBeNull();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+    expect(
+      within(screen.getByRole("dialog")).getByText("Inactive access rule"),
+    ).toBeTruthy();
+  });
+
   it("confirms access rule deletion with a design system dialog", async () => {
     const deleteRule = vi.fn().mockResolvedValue({});
     const browserConfirm = vi.fn().mockReturnValue(true);

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
@@ -261,6 +261,23 @@ function RuleDispositionBadge({
   );
 }
 
+function AccessRuleTableCell({
+  inactive,
+  children,
+}: {
+  inactive: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      data-inactive-rule-cell={inactive ? "true" : undefined}
+      className={cn("min-w-0", inactive && "opacity-50")}
+    >
+      {children}
+    </div>
+  );
+}
+
 function Field({
   label,
   children,
@@ -925,6 +942,8 @@ export function ApprovalRequestsContent({
     canCreateAccessRules,
     isLoadingPolicies: policiesQuery.isLoading,
   });
+  const inactiveAccessRules =
+    accessRuleCreateAvailability.status === "missing_blocking_policy";
   const addRuleDisabledReason =
     accessRuleCreateAvailability.status === "available"
       ? undefined
@@ -1102,10 +1121,12 @@ export function ApprovalRequestsContent({
       header: "Server",
       width: "1.5fr",
       render: (rule) => (
-        <ServerCell
-          name={getRuleDisplayName(rule)}
-          detail={getRuleServerDetail(rule)}
-        />
+        <AccessRuleTableCell inactive={inactiveAccessRules}>
+          <ServerCell
+            name={getRuleDisplayName(rule)}
+            detail={getRuleServerDetail(rule)}
+          />
+        </AccessRuleTableCell>
       ),
     },
     {
@@ -1113,9 +1134,11 @@ export function ApprovalRequestsContent({
       header: "Type",
       width: "0.75fr",
       render: (rule) => (
-        <Badge variant="neutral">
-          <Badge.Text>{getResourceTypeLabel(rule.resourceType)}</Badge.Text>
-        </Badge>
+        <AccessRuleTableCell inactive={inactiveAccessRules}>
+          <Badge variant="neutral">
+            <Badge.Text>{getResourceTypeLabel(rule.resourceType)}</Badge.Text>
+          </Badge>
+        </AccessRuleTableCell>
       ),
     },
     {
@@ -1123,35 +1146,43 @@ export function ApprovalRequestsContent({
       header: "Match",
       width: "1.25fr",
       render: (rule) => (
-        <div className="min-w-0 space-y-1">
-          <Type variant="small" className="font-medium">
-            {getMatchBreadthLabel(rule.matchBreadth)}
-          </Type>
-          <Type
-            variant="small"
-            className="text-muted-foreground truncate text-xs"
-          >
-            {rule.matchValue}
-          </Type>
-        </div>
+        <AccessRuleTableCell inactive={inactiveAccessRules}>
+          <div className="min-w-0 space-y-1">
+            <Type variant="small" className="font-medium">
+              {getMatchBreadthLabel(rule.matchBreadth)}
+            </Type>
+            <Type
+              variant="small"
+              className="text-muted-foreground truncate text-xs"
+            >
+              {rule.matchValue}
+            </Type>
+          </div>
+        </AccessRuleTableCell>
       ),
     },
     {
       key: "disposition",
       header: "Status",
       width: "0.5fr",
-      render: (rule) => <RuleDispositionBadge disposition={rule.disposition} />,
+      render: (rule) => (
+        <AccessRuleTableCell inactive={inactiveAccessRules}>
+          <RuleDispositionBadge disposition={rule.disposition} />
+        </AccessRuleTableCell>
+      ),
     },
     {
       key: "scope",
       header: "Scope",
       width: "0.5fr",
       render: (rule) => (
-        <Type variant="small">
-          {rule.accessScope === "project"
-            ? projectName(organization.projects, rule.projectId)
-            : getAccessScopeLabel(rule.accessScope)}
-        </Type>
+        <AccessRuleTableCell inactive={inactiveAccessRules}>
+          <Type variant="small">
+            {rule.accessScope === "project"
+              ? projectName(organization.projects, rule.projectId)
+              : getAccessScopeLabel(rule.accessScope)}
+          </Type>
+        </AccessRuleTableCell>
       ),
     },
     {
@@ -1159,7 +1190,9 @@ export function ApprovalRequestsContent({
       header: "Updated",
       width: "0.75fr",
       render: (rule) => (
-        <Type variant="small">{formatShortDate(rule.updatedAt)}</Type>
+        <AccessRuleTableCell inactive={inactiveAccessRules}>
+          <Type variant="small">{formatShortDate(rule.updatedAt)}</Type>
+        </AccessRuleTableCell>
       ),
     },
     {

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
@@ -932,11 +932,13 @@ export function ApprovalRequestsContent({
   );
   const canCreateAccessRules = useMemo(
     () =>
-      policiesQuery.error
+      // Policies are only fetched for admins; without policy data we can't
+      // know rules are inactive, so default to treating them as active.
+      !canAdmin || policiesQuery.error
         ? true
         : (policiesQuery.data?.policies.some(policyEnablesAccessRules) ??
           false),
-    [policiesQuery.data?.policies, policiesQuery.error],
+    [canAdmin, policiesQuery.data?.policies, policiesQuery.error],
   );
   const accessRuleCreateAvailability = getAccessRuleCreateAvailability({
     canCreateAccessRules,


### PR DESCRIPTION
## Summary
- Dim non-action access-rule table cells when no enabled blocking Shadow MCP policy exists.
- Keep the actions column active so admins can still edit/delete rules.
- Add focused coverage for inactive rule display and active delete behavior.

## Test Plan
- [x] `pnpm -F dashboard test src/components/access/ApprovalRequestsContent.test.tsx`
- [x] `pnpm -F dashboard lint`

Linear: https://linear.app/speakeasy/issue/DNO-7/feat-handle-display-of-rules-when-no-blocks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dims non-action cells in the Access Rules table when no enabled blocking Shadow MCP policy exists, while keeping Actions active. If policy state is unknown or the viewer isn’t an admin, rules are not dimmed.

- **New Features**
  - Added `AccessRuleTableCell` to dim cells (`opacity-50`, `[data-inactive-rule-cell]`) when `accessRuleCreateAvailability.status === "missing_blocking_policy"`.
  - Added tests for the flag-only policy scenario and the active delete flow.

- **Bug Fixes**
  - Don’t dim rules when policy data isn’t available or the user lacks admin access (treat rules as active).

<sup>Written for commit 5b0f697db4ac1bdf544b9a35ca93f9ad89f7d4f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

