### PR TITLE
fix: align risk policies page with design system 

### DIFF
--- a/.changeset/frank-maps-eat.md
+++ b/.changeset/frank-maps-eat.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Align Risk Policies page title with design system

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -432,22 +432,7 @@ function PolicyCenterContent() {
     });
   };
 
-  if (isLoading) {
-    return (
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs />
-        </Page.Header>
-        <Page.Body>
-          <div className="flex items-center justify-center py-20">
-            <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
-          </div>
-        </Page.Body>
-      </Page>
-    );
-  }
-
-  if (policies.length === 0) {
+  if (!isLoading && policies.length === 0) {
     return (
       <Page>
         <Page.Header>
@@ -655,6 +640,33 @@ function PolicyCenterContent() {
     },
   ];
 
+  let sectionBody = (
+    <Table
+      columns={policyColumns}
+      data={policies}
+      rowKey={(policy) => policy.id}
+      onRowClick={handleEdit}
+    />
+  );
+  if (isLoading) {
+    sectionBody = (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  const cta = isLoading ? null : (
+    <Page.Section.CTA>
+      <Button onClick={handleCreate}>
+        <Button.LeftIcon>
+          <Plus className="mr-2 h-4 w-4" />
+        </Button.LeftIcon>
+        <Button.Text>New Policy</Button.Text>
+      </Button>
+    </Page.Section.CTA>
+  );
+
   return (
     <Page>
       <Page.Header>
@@ -667,28 +679,15 @@ function PolicyCenterContent() {
           title="Policy insights"
           subtitle="Ask about policy status, coverage, and detector capabilities. Match content is redacted before it reaches the assistant."
         />
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold">Risk Policies</h2>
-            <p className="text-muted-foreground text-sm">
-              Configure risk analysis rules to detect secrets and sensitive
-              information in agent session interactions.
-            </p>
-          </div>
-          <Button onClick={handleCreate}>
-            <Button.LeftIcon>
-              <Plus className="mr-2 h-4 w-4" />
-            </Button.LeftIcon>
-            <Button.Text>New Policy</Button.Text>
-          </Button>
-        </div>
-
-        <Table
-          columns={policyColumns}
-          data={policies}
-          rowKey={(policy) => policy.id}
-          onRowClick={handleEdit}
-        />
+        <Page.Section>
+          <Page.Section.Title stage="beta">Risk Policies</Page.Section.Title>
+          <Page.Section.Description>
+            Configure risk analysis rules to detect secrets and sensitive
+            information in agent session interactions.
+          </Page.Section.Description>
+          {cta}
+          <Page.Section.Body>{sectionBody}</Page.Section.Body>
+        </Page.Section>
 
         {/* Edit/Create Sheet */}
         <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>


### PR DESCRIPTION
## What

Brings the **Risk Policies** page title into line with every other dashboard page.

Three issues were reported, all rooted in one cause — the title was rendered as a raw `<h2 className="text-lg">` that bypassed the `Page.Section` slot system:

| Reported issue                            | Fix                                                                                                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| Missing beta label                        | `Page.Section.Title stage="beta"` renders the blue `ReleaseStageBadge`                                                                            |
| Font size differs from other pages        | `Page.Section.Title` uses `Heading variant="h3"` (text-xl), matching siblings like Risk Overview                                                  |
| Title position jumps when switching pages | Loading and populated states now share a single `Page.Section`, inheriting the standard `mt-3 mb-6` rhythm; the title keeps a stable DOM position |

## How

- Replaced the bespoke `<div>/<h2>/<p>/<Button>` header + sibling `<Table>` with the design-system `Page.Section` (`Title` / `Description` / `CTA` / `Body`) slots.
- Collapsed the separate `isLoading` early-return into the main render path: the spinner now swaps in as the section **body** (`sectionBody`) while the title stays mounted — eliminating the position shift between loading and loaded.
- The empty-state onboarding card is unchanged, only re-guarded with `!isLoading`.

## Scope

Single file: `client/dashboard/src/pages/security/PolicyCenter.tsx` (UI only, no behavior or data changes).

## Verification

- `oxfmt --check` ✓
- `oxlint --type-aware` ✓ (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the Risk Policies page header with the design system by replacing the bespoke header with `Page.Section` and `Page.Section.Title` (stage="beta").
This adds the beta badge, standard h3/text-xl heading, stabilizes the title during loading by swapping a spinner and table within one section body, and includes a changeset to release a `dashboard` patch.

<sup>Written for commit aeb953774acadb81d96225cf9bcc9ffb8d11a0b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

