### PR TITLE
fix(dashboard): catalog detail server lookup for deep specifiers

### DIFF
--- a/.changeset/catalog-detail-deep-specifier-lookup.md
+++ b/.changeset/catalog-detail-deep-specifier-lookup.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix "Server not found" on the catalog detail page for servers whose `registrySpecifier` was not in the first page of the unfiltered catalog list (e.g. `com.pulsemcp.mirror/datadog`). The backend `ListCatalog` aggregates across registries and caps results at 100, and only emits a `nextCursor` for single-registry queries, so the detail page could never reach deep entries. The lookup now passes the specifier's last path segment as a `search` filter so the upstream registry narrows the result set and the target server lands in the first page.

--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -44,7 +44,14 @@ export default function CatalogDetail(): JSX.Element {
   const { serverSpecifier } = useParams<{ serverSpecifier: string }>();
   const routes = useRoutes();
   const client = useSdkClient();
-  const { data, isLoading } = useInfiniteListMCPCatalog();
+  const decodedSpecifier = serverSpecifier
+    ? decodeURIComponent(serverSpecifier)
+    : "";
+  // Scope the catalog list to a search hint derived from the specifier's last
+  // segment so the target server is in the first page (backend caps results
+  // at 100 across all registries and only paginates single-registry queries).
+  const searchHint = decodedSpecifier.split("/").pop() ?? "";
+  const { data, isLoading } = useInfiniteListMCPCatalog(searchHint);
   const [showAddDialog, setShowAddDialog] = useState(false);
 
   const { data: deploymentResult, refetch: refetchDeployment } =
@@ -54,16 +61,14 @@ export default function CatalogDetail(): JSX.Element {
   const { data: toolsetsResult } = useListToolsets();
 
   const server = useMemo(() => {
-    if (!data?.pages || !serverSpecifier) return null;
+    if (!data?.pages || !decodedSpecifier) return null;
     const allServers = data.pages.flatMap(
       (page) => page.servers as PulseMCPServer[],
     );
-    // The specifier is URL encoded, so we need to decode it
-    const decodedSpecifier = decodeURIComponent(serverSpecifier);
     return (
       allServers.find((s) => s.registrySpecifier === decodedSpecifier) ?? null
     );
-  }, [data, serverSpecifier]);
+  }, [data, decodedSpecifier]);
 
   const removeServerMutation = useMutation({
     mutationFn: async (slug: string) => {
@@ -99,9 +104,6 @@ export default function CatalogDetail(): JSX.Element {
   const versionMeta = server?.meta?.["com.pulsemcp/server-version"];
   const isOfficial = meta?.isOfficial;
   const visitorsTotal = meta?.visitorsEstimateLastFourWeeks;
-  const decodedSpecifier = serverSpecifier
-    ? decodeURIComponent(serverSpecifier)
-    : "";
   const displayName =
     server?.title ??
     server?.registrySpecifier?.split("/").pop() ??


### PR DESCRIPTION
## Summary

The catalog detail page returned **"Server not found"** for any server whose `registrySpecifier` was not in the first page of the unfiltered catalog list (e.g. `com.pulsemcp.mirror/datadog`).

### Root cause

`CatalogDetail` called `useInfiniteListMCPCatalog()` with no arguments. The backend (`server/internal/externalmcp/impl.go` `ListCatalog`) aggregates servers across all registries and **caps the response at 100**, and only emits `nextCursor` when exactly one registry is configured — so even paginating could never reach a deep entry. The detail page then scanned only page 1 of that capped slice and gave up.

### Fix

Derive a `searchHint` from the last segment of the decoded specifier (e.g. `datadog`) and pass it as the `search` argument to `useInfiniteListMCPCatalog`. The upstream Pulse MCP registry honors this as a name filter, so the result set shrinks well below the 100-server cap and the target server lands in page 1.

Also deduplicates the previously inlined `decodedSpecifier` computation.

### Follow-ups (not in this PR)

- Long-term: route `:registryId/:serverSpecifier` so we can call `getServerDetails` directly for deterministic lookups.
- Or: backend exposes a specifier-only lookup that iterates registries server-side.

## Test plan

- [ ] Visit `/<org>/projects/<project>/catalog/com.pulsemcp.mirror%2Fdatadog` — detail page renders instead of "Server not found".
- [ ] Visit a server that _was_ in the first page already (e.g. `com.figma.mcp/mcp`) — still works.
- [ ] Search hint with no upstream matches still renders the not-found state gracefully.
- [ ] Type-check: `pnpm -F dashboard type-check` — passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "Server not found" on the catalog detail page for deep specifiers by scoping the catalog query with a search hint from the specifier’s last segment, ensuring the server appears in the first page under the backend’s 100-item cap.

- **Bug Fixes**
  - `CatalogDetail` passes a `searchHint` to `useInfiniteListMCPCatalog`, derived from the decoded `serverSpecifier` (last segment).
  - Consolidated `decodedSpecifier` usage for server matching and added a `dashboard` patch changeset.

<sup>Written for commit c10d38ca081955270c0197f55d6b9ce8fef45aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

