### PR TITLE
fix: bug disable reconnect button during pending auth callback

### DIFF
--- a/.changeset/smart-ends-bet.md
+++ b/.changeset/smart-ends-bet.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Disable "Give Access" button while challenge resolution is pending.

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -10,6 +10,7 @@ import (
 	"crypto/subtle"
 	_ "embed"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"html/template"
@@ -35,6 +36,26 @@ var consentTemplateHTML string
 
 var consentTemplate = template.Must(template.New("consent").Parse(consentTemplateHTML))
 
+// consentScriptData is the consent page's client-side script. It is served
+// as an external file (not inlined into the template) because the ingress
+// CSP forbids inline scripts.
+//
+//go:embed consent_script.js
+var consentScriptData []byte
+
+// consentScriptHash is the first 8 hex chars of the SHA-256 of
+// consentScriptData, used to cache-bust the immutable script URL. Matches
+// the install-page script convention in the mcpmetadata package.
+var consentScriptHash = func() string {
+	sum := sha256.Sum256(consentScriptData)
+	return hex.EncodeToString(sum[:])[:8]
+}()
+
+// consentScriptURL is the path the consent template loads the script from.
+// Hardcoded to the /mcp surface (like the install-page script) so the
+// /x/mcp surface reuses the same route rather than registering its own.
+var consentScriptURL = "/mcp/consent-page-" + consentScriptHash + ".js"
+
 // remoteSetHashEmpty is the SHA-256 of an empty remote-set, used by the
 // consent record's remote_set_hash column when the issuer has no remote
 // session clients (the only case today). The empty case is NOT skipped —
@@ -54,6 +75,7 @@ type consentTemplateData struct {
 	CSRFToken          string
 	SubjectDisplay     string
 	RedirectURI        string
+	ScriptURL          string
 	RemoteSessionCards []remoteSessionCard
 	// ConsentEnabled gates the "Give Access" button. True when there are no
 	// remote-session challenges, or when at least one challenge has been
@@ -99,6 +121,24 @@ func (s *Service) HandleConsent(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 	return s.ServeConsent(w, r, endpoint)
+}
+
+// ServeConsentScript serves the consent page's client-side script with
+// immutable cache headers. Mounted at `GET /mcp/consent-page-{hash}.js`.
+// The hash in the path is content-derived, so a mismatch is a stale URL.
+func (s *Service) ServeConsentScript(w http.ResponseWriter, r *http.Request) error {
+	if chi.URLParam(r, "hash") != consentScriptHash {
+		w.WriteHeader(http.StatusNotFound)
+		return nil
+	}
+
+	w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(consentScriptData); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "write consent script response").Log(r.Context(), s.logger)
+	}
+	return nil
 }
 
 // ServeConsent is the post-resolution entry point for the consent UI
@@ -171,6 +211,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		CSRFToken:          challengeState.CSRFToken,
 		SubjectDisplay:     subjectDisplay,
 		RedirectURI:        challengeState.RedirectURI,
+		ScriptURL:          consentScriptURL,
 		RemoteSessionCards: cards,
 		ConsentEnabled:     consentEnabled,
 	}

--- a/server/internal/mcp/consent_script.js
+++ b/server/internal/mcp/consent_script.js
@@ -1,0 +1,64 @@
+// Served as an external file (not inline) because the ingress CSP forbids
+// inline scripts. Loaded by consent_template.html via a content-hashed
+// <script src>.
+//
+// Neutralises double-clicks on the consent controls. A second activation
+// while the first request is still pending sends the user to an authn
+// challenge that has already been consumed, producing "authn challenge
+// state not found or expired" (AIS-103). Both the "Give Access" submit and
+// the per-remote Connect/Reconnect links are guarded, and each swaps in a
+// loading spinner so the pending state is visible.
+(function () {
+  "use strict";
+
+  // Replace an element's contents with a spinner + label.
+  function showPending(el, label) {
+    el.textContent = "";
+    var spinner = document.createElement("span");
+    spinner.className = "spinner";
+    spinner.setAttribute("aria-hidden", "true");
+    el.appendChild(spinner);
+    el.appendChild(document.createTextNode(label));
+  }
+
+  // Give Access: block a repeat submit and show the pending state on the
+  // button. The first submit proceeds normally.
+  var form = document.querySelector("form[data-approve-form]");
+  if (form) {
+    var button = form.querySelector('button[type="submit"]');
+    var submitted = false;
+    form.addEventListener("submit", function (event) {
+      if (submitted) {
+        event.preventDefault();
+        return;
+      }
+      submitted = true;
+      if (!button) {
+        return;
+      }
+      // Defer disabling to the next tick so the button's name/value
+      // (action=approve) is still serialized into the outgoing form data —
+      // disabling synchronously in the handler drops it in some browsers.
+      window.setTimeout(function () {
+        button.disabled = true;
+        showPending(button, "Connecting…");
+      }, 0);
+    });
+  }
+
+  // Connect / Reconnect: each link navigates to a freshly minted upstream
+  // challenge. The first click navigates normally; a second click before
+  // the page unloads would target a challenge that is about to be (or has
+  // been) discarded, so we mark the link busy and swallow further clicks.
+  var links = document.querySelectorAll("a[data-connect-link]");
+  Array.prototype.forEach.call(links, function (link) {
+    link.addEventListener("click", function (event) {
+      if (link.getAttribute("aria-disabled") === "true") {
+        event.preventDefault();
+        return;
+      }
+      link.setAttribute("aria-disabled", "true");
+      showPending(link, "Connecting…");
+    });
+  });
+})();

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -237,6 +237,11 @@
         color: var(--fill-neutral-highlight);
       }
 
+      .remote-card a.btn-link[aria-disabled="true"] {
+        pointer-events: none;
+        opacity: 0.65;
+      }
+
       .actions {
         display: flex;
         gap: 0.75rem;
@@ -290,6 +295,30 @@
         background: var(--bg-surface-secondary-default);
         color: var(--fill-neutral-highlight);
       }
+
+      .spinner {
+        display: inline-block;
+        width: 0.85em;
+        height: 0.85em;
+        margin-right: 0.5em;
+        vertical-align: -0.15em;
+        border: 2px solid currentColor;
+        border-right-color: transparent;
+        border-radius: 50%;
+        animation: spin 0.6s linear infinite;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .spinner {
+          animation-duration: 1.5s;
+        }
+      }
     </style>
   </head>
   <body>
@@ -328,6 +357,7 @@
             <a
               class="btn-link {{if .Connected}}connected{{end}}"
               href="{{.ChallengeURL}}"
+              data-connect-link
               >{{if .Connected}}Reconnect{{else}}Connect{{end}}</a
             >
           </div>
@@ -336,7 +366,11 @@
         {{end}}
 
         <div class="actions">
-          <form method="POST" action="/{{.MCPRouteBase}}/{{.MCPSlug}}/connect">
+          <form
+            method="POST"
+            action="/{{.MCPRouteBase}}/{{.MCPSlug}}/connect"
+            data-approve-form
+          >
             <input type="hidden" name="state" value="{{.State}}" />
             <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
             <button
@@ -366,5 +400,6 @@
         </div>
       </div>
     </main>
+    <script src="{{.ScriptURL}}"></script>
   </body>
 </html>

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -294,6 +294,7 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/idp_callback", oops.ErrHandle(service.logger, service.HandleIDPCallback).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/connect", oops.ErrHandle(service.logger, service.HandleConsent).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/connect", oops.ErrHandle(service.logger, service.HandleConsent).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", "/mcp/consent-page-{hash}.js", oops.ErrHandle(service.logger, service.ServeConsentScript).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/token", oops.ErrHandle(service.logger, service.HandleToken).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/revoke", oops.ErrHandle(service.logger, service.HandleRevoke).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/remote_login_callback", oops.ErrHandle(service.logger, service.HandleRemoteLoginCallback).ServeHTTP)


### PR DESCRIPTION
In order to prevent challenge replay, our app revokes
challenges after each click, but this allows for a race
condition wherein if the user attempts a retry on the
same challenge page while the auth callbacks are
working, they will inadevertently encounter a failure
to find a challenge and observe an error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the consent page’s “Give Access” and “Connect/Reconnect” controls while an auth callback is pending to prevent challenge replay and the “authn challenge state not found or expired” error (AIS-103).

- **Bug Fixes**
  - Block repeat submits on “Give Access”; disable the button and show a “Connecting…” spinner.
  - Guard Connect/Reconnect links; set `aria-disabled="true"` on first click and show a spinner.
  - Add an external consent script (`consent_script.js`) loaded via a content-hashed URL with immutable cache headers.
  - Update the consent template to load the script and add `data-approve-form` and `data-connect-link` hooks, plus CSS for disabled link state.
  - Register `GET /mcp/consent-page-{hash}.js` to serve the script.

<sup>Written for commit 17c0f008de96749f1e4332fa528292460c7e17d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

