### PR TITLE
fix: stop logging client cancellations as 500 errors in oops

### DIFF
--- a/.changeset/oops-client-cancellation-499.md
+++ b/.changeset/oops-client-cancellation-499.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Stop logging client cancellations (`context.Canceled`) as 500 server faults. When an HTTP client disconnects mid-request, `oops` now detects the cancellation at the error boundary, logs it at info level (no error log, no errored span, no exception event), and maps it to HTTP 499 instead of a 500 fault. Detection requires both a `context.Canceled` cause and a canceled request context, so server-initiated cancellations (e.g. graceful shutdown) and application-initiated cancellations (e.g. an `errgroup` or an explicitly cancelled derived context, whose parent request context is still live), along with `context.DeadlineExceeded` and all other errors, keep full error severity.

--- a/server/internal/background/activities/deploy_function_runners.go
+++ b/server/internal/background/activities/deploy_function_runners.go
@@ -58,7 +58,7 @@ func (d *DeployFunctionRunners) Do(ctx context.Context, args DeployFunctionRunne
 	err := d.do(ctx, args)
 	if err != nil {
 		var serr *oops.ShareableError
-		if errors.As(err, &serr) && serr.IsTemporary() {
+		if errors.As(err, &serr) && serr.IsTemporary(ctx) {
 			// Temporary errors (e.g. Fly machine startup timeout) are retryable via the Temporal retry policy.
 			return err
 		}

--- a/server/internal/middleware/errors.go
+++ b/server/internal/middleware/errors.go
@@ -15,7 +15,7 @@ func MapErrors() func(goa.Endpoint) goa.Endpoint {
 
 			var se *oops.ShareableError
 			if err != nil && errors.As(err, &se) {
-				return nil, se.AsGoa()
+				return nil, se.AsGoa(ctx)
 			}
 
 			return val, err

--- a/server/internal/middleware/recovery.go
+++ b/server/internal/middleware/recovery.go
@@ -44,8 +44,8 @@ func NewRecovery(logger *slog.Logger) func(http.Handler) http.Handler {
 					errID := payload.ID
 					var se *oops.ShareableError
 					if errors.As(maybeErr, &se) {
-						code = se.HTTPStatus()
-						payload = se.AsGoa()
+						code = se.HTTPStatus(ctx)
+						payload = se.AsGoa(ctx)
 						errID = payload.ID
 					}
 

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -20,6 +20,14 @@ const (
 	CodeNotImplemented      Code = "not_implemented"
 	CodeInsufficientCredits Code = "insufficient_credits"
 	CodeRateLimitExceeded   Code = "rate_limit_exceeded"
+	// CodeCanceled represents a request whose client disconnected mid-flight,
+	// surfacing as a context.Canceled cause while the request context is itself
+	// canceled. It is not a server fault. It is never authored directly:
+	// ShareableError.effectiveCode promotes such errors to this code so the
+	// logging, span, and HTTP status behavior is handled centrally. Server- and
+	// application-initiated cancellations, where the request context is still
+	// live, are left at their authored code.
+	CodeCanceled Code = "canceled"
 )
 
 var StatusCodes = map[Code]int{
@@ -38,6 +46,9 @@ var StatusCodes = map[Code]int{
 	CodeNotImplemented:      http.StatusNotImplemented,
 	CodeInsufficientCredits: http.StatusPaymentRequired,
 	CodeRateLimitExceeded:   http.StatusTooManyRequests,
+	// 499 (client closed request) is non-standard but matches the convention
+	// already used by the request access log middleware.
+	CodeCanceled: 499,
 }
 
 func (c Code) UserMessage() string {
@@ -66,6 +77,8 @@ func (c Code) UserMessage() string {
 		return "token balance exhausted"
 	case CodeRateLimitExceeded:
 		return "rate limit exceeded"
+	case CodeCanceled:
+		return "request was canceled"
 	default:
 		return "an unexpected error occurred"
 	}

--- a/server/internal/oops/http.go
+++ b/server/internal/oops/http.go
@@ -37,8 +37,8 @@ func ErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.Requ
 		var se *ShareableError
 		switch {
 		case errors.As(err, &se):
-			code = se.HTTPStatus()
-			payload = se.AsGoa()
+			code = se.HTTPStatus(r.Context())
+			payload = se.AsGoa(r.Context())
 		default:
 			stack := string(debug.Stack())
 			logger.ErrorContext(r.Context(), "unexpected error", attr.SlogErrorID(payload.ID), attr.SlogError(err), attr.SlogErrorStack(stack))

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -41,7 +41,7 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 		var shareableErr *ShareableError
 		switch {
 		case errors.As(err, &shareableErr):
-			code = shareableErr.HTTPStatus()
+			code = shareableErr.HTTPStatus(r.Context())
 			payload.Code = shareableErr.Code.MCPCode()
 			payload.Message = shareableErr.Error()
 		default:

--- a/server/internal/oops/pp.go
+++ b/server/internal/oops/pp.go
@@ -109,17 +109,61 @@ func (e *ShareableError) LogValue() slog.Value {
 	return slog.StringValue(e.Error())
 }
 
+// effectiveCode returns CodeCanceled only for a client-initiated cancellation:
+// the underlying cause is context.Canceled AND the inbound request context
+// (ctx) has itself been canceled. Otherwise it returns the authored Code.
+//
+// Requiring the request context to be canceled is what distinguishes a client
+// disconnect from server- and application-initiated cancellations, which all
+// surface the same context.Canceled sentinel:
+//
+//   - Client disconnect: net/http cancels the request context, so ctx.Err() is
+//     context.Canceled. Promoted.
+//   - Application-initiated (e.g. an errgroup or an explicitly cancelled child
+//     of the request context): only the derived context is canceled; the
+//     request context passed to the error boundary is still live, so
+//     ctx.Err() is nil. Not promoted, keeps full error severity.
+//   - Server-initiated (e.g. graceful Server.Shutdown): does not cancel
+//     in-flight request contexts, so ctx.Err() is nil. Not promoted.
+//
+// This mirrors the access log middleware, which classifies a request as 499 on
+// the same ctx.Err() signal. context.DeadlineExceeded and all other causes keep
+// their authored code. The authored Code field is left untouched so call sites
+// that branch on it still see what they constructed; only the logging, span,
+// and HTTP status outputs observe the promotion.
+func (e *ShareableError) effectiveCode(ctx context.Context) Code {
+	if errors.Is(e.cause, context.Canceled) && errors.Is(ctx.Err(), context.Canceled) {
+		return CodeCanceled
+	}
+	return e.Code
+}
+
 // Log logs the error using the provided logger and context. It also sets the
 // OpenTelemetry span status to error. Additional arguments can be provided to
 // include more context in the log entry.
+//
+// A client-initiated cancellation (context.Canceled cause with a canceled
+// request context) is not a server fault: it is logged at info level and does
+// not mark the span as errored or record an exception, to avoid drowning real
+// faults in disconnect noise. Server- and application-initiated cancellations,
+// where the request context is still live, keep full error severity.
 func (e *ShareableError) Log(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	canceled := e.effectiveCode(ctx) == CodeCanceled
+
 	span := trace.SpanFromContext(ctx)
-	span.SetStatus(codes.Error, e.String())
-	span.RecordError(e, trace.WithStackTrace(true))
+	if !canceled {
+		span.SetStatus(codes.Error, e.String())
+		span.RecordError(e, trace.WithStackTrace(true))
+	}
+
+	level := slog.LevelError
+	if canceled {
+		level = slog.LevelInfo
+	}
 
 	var pcs [1]uintptr
 	runtime.Callers(2, pcs[:]) // skip [Callers, Log]
-	r := slog.NewRecord(time.Now(), slog.LevelError, e.public, pcs[0])
+	r := slog.NewRecord(time.Now(), level, e.public, pcs[0])
 
 	if len(args) > 0 {
 		r.AddAttrs(append(args, attr.SlogErrorID(e.id), attr.SlogErrorMessage(e.String()))...)
@@ -131,26 +175,29 @@ func (e *ShareableError) Log(ctx context.Context, logger *slog.Logger, args ...s
 	return e
 }
 
-func (e *ShareableError) IsTemporary() bool {
-	return !errors.Is(e.cause, ErrPermanent) && e.Code.IsTemporary()
+func (e *ShareableError) IsTemporary(ctx context.Context) bool {
+	return !errors.Is(e.cause, ErrPermanent) && e.effectiveCode(ctx).IsTemporary()
 }
 
 // AsGoa converts the ShareableError to a goa.ServiceError, preserving the error
 // code, id, and cause. It also sets the timeout, temporary, and fault flags
-// based on the error code and cause.
-func (e *ShareableError) AsGoa() *goa.ServiceError {
+// based on the error code and cause. The context is used to detect a
+// client-initiated cancellation (see effectiveCode).
+func (e *ShareableError) AsGoa(ctx context.Context) *goa.ServiceError {
 	var timeout, temporary, fault bool
 
-	temporary = e.IsTemporary()
+	temporary = e.IsTemporary(ctx)
 
-	switch e.Code {
+	code := e.effectiveCode(ctx)
+
+	switch code {
 	case CodeUnexpected, CodeInvariantViolation:
 		fault = true
 	default:
 		fault = false
 	}
 
-	goaErr := goa.NewServiceError(e, string(e.Code), timeout, temporary, fault)
+	goaErr := goa.NewServiceError(e, string(code), timeout, temporary, fault)
 	goaErr.ID = e.id
 	return goaErr
 }
@@ -158,6 +205,6 @@ func (e *ShareableError) AsGoa() *goa.ServiceError {
 // HTTPStatus returns the appropriate HTTP status code for the error based on
 // its code. If the code is not recognized, it defaults to 500 Internal Server
 // Error.
-func (e *ShareableError) HTTPStatus() int {
-	return conv.Default(StatusCodes[e.Code], http.StatusInternalServerError)
+func (e *ShareableError) HTTPStatus(ctx context.Context) int {
+	return conv.Default(StatusCodes[e.effectiveCode(ctx)], http.StatusInternalServerError)
 }

--- a/server/internal/oops/pp_test.go
+++ b/server/internal/oops/pp_test.go
@@ -2,6 +2,9 @@ package oops
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,4 +41,111 @@ func TestShareableError_Log_LogsAtError(t *testing.T) {
 	require.Len(t, spans, 1)
 	require.Equal(t, codes.Error, spans[0].Status().Code)
 	require.Len(t, spans[0].Events(), 1, "Log should record the error as a span event")
+}
+
+func TestShareableError_Log_ClientCanceledLogsAtInfo(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	// A client disconnect cancels the request context itself.
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	// Wrap context.Canceled to prove detection is by sentinel, not identity.
+	cause := fmt.Errorf("list tool variations: %w", context.Canceled)
+	_ = E(CodeUnexpected, cause, "failed to list tool variations").Log(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "INFO", entries[0].Level, "client cancellation must not log at error level")
+	require.Equal(t, "failed to list tool variations", entries[0].Msg)
+	require.NotEmpty(t, entries[0].ErrorID)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code, "client cancellation must not mark the span as errored")
+	require.Empty(t, spans[0].Events(), "client cancellation must not record an exception event")
+}
+
+func TestShareableError_Log_AppCanceledWithLiveContextLogsAtError(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	// The request context is still live: the context.Canceled cause came from a
+	// derived context an errgroup or the handler itself canceled, not from the
+	// client disconnecting. This must keep full error severity.
+	ctx, recorder := startRecordedSpan(t)
+
+	cause := fmt.Errorf("errgroup sibling: %w", context.Canceled)
+	_ = E(CodeUnexpected, cause, "failed to fan out").Log(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "ERROR", entries[0].Level, "an application-initiated cancellation must stay at error level")
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Len(t, spans[0].Events(), 1)
+}
+
+func TestShareableError_Log_DeadlineExceededLogsAtError(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+
+	cause := fmt.Errorf("query row: %w", context.DeadlineExceeded)
+	_ = E(CodeUnexpected, cause, "query failed").Log(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "ERROR", entries[0].Level, "deadline exceeded must remain at error level")
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Len(t, spans[0].Events(), 1)
+}
+
+func TestShareableError_HTTPStatus_Canceled(t *testing.T) {
+	t.Parallel()
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	liveCtx := t.Context()
+
+	canceled := E(CodeUnexpected, fmt.Errorf("query row: %w", context.Canceled), "boom")
+	require.Equal(t, 499, canceled.HTTPStatus(canceledCtx), "client disconnect maps to 499")
+	require.Equal(t, http.StatusInternalServerError, canceled.HTTPStatus(liveCtx), "a canceled cause with a live request context stays a 500")
+
+	deadline := E(CodeUnexpected, fmt.Errorf("query row: %w", context.DeadlineExceeded), "boom")
+	require.Equal(t, http.StatusInternalServerError, deadline.HTTPStatus(canceledCtx))
+
+	plain := E(CodeUnexpected, errors.New("boom"), "boom")
+	require.Equal(t, http.StatusInternalServerError, plain.HTTPStatus(canceledCtx))
+}
+
+func TestShareableError_AsGoa_ClientCanceledIsNotFault(t *testing.T) {
+	t.Parallel()
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	canceled := E(CodeUnexpected, fmt.Errorf("query row: %w", context.Canceled), "boom").AsGoa(canceledCtx)
+	require.False(t, canceled.Fault, "client cancellation must not be a server fault")
+	require.False(t, canceled.Temporary, "client cancellation must not be retryable")
+	require.Equal(t, string(CodeCanceled), canceled.Name)
+
+	plain := E(CodeUnexpected, errors.New("boom"), "boom").AsGoa(canceledCtx)
+	require.True(t, plain.Fault, "a genuine unexpected error must remain a server fault")
+}
+
+func TestShareableError_AsGoa_AppCanceledWithLiveContextIsFault(t *testing.T) {
+	t.Parallel()
+
+	// context.Canceled cause but the request context is still live: an
+	// application-initiated cancellation that must keep its 500 fault behavior.
+	appCanceled := E(CodeUnexpected, fmt.Errorf("errgroup sibling: %w", context.Canceled), "boom").AsGoa(t.Context())
+	require.True(t, appCanceled.Fault, "application-initiated cancellation must remain a server fault")
+	require.True(t, appCanceled.Temporary, "an unexpected error stays retryable")
+	require.Equal(t, string(CodeUnexpected), appCanceled.Name)
 }


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2732/gram-server-client-cancellation-contextcanceled-logged-as-a-500-error

When an HTTP client disconnects mid-request, in-flight DB and downstream calls return `context.Canceled`, which `oops` wrapped as a `CodeUnexpected` error and logged at error level with a stacktrace, marked the span as errored, and classified the response as a 500 fault. This happened at 120+ call sites and produced ~4.6k error logs/week of pure disconnect noise that inflated the error rate.

Detect a client-initiated cancellation once at the `oops` boundary via a new `effectiveCode(ctx)` helper and promote it to a new `CodeCanceled` (HTTP 499, non-fault). Log such errors at info level and skip the span error status and exception event. Detection requires both a `context.Canceled` cause and a canceled request context, so server-initiated cancellations (for example graceful shutdown) and application-initiated cancellations (for example an `errgroup` or an explicitly cancelled derived context, whose parent request context is still live), along with `context.DeadlineExceeded` and all other errors, keep full error severity. The authored `Code` field is left untouched, so call sites that branch on it are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating client disconnects as server errors by handling `context.Canceled` centrally in `oops`. These now map to HTTP 499, log at info, and no longer mark spans as errors (Linear: AGE-2732).

- **Bug Fixes**
  - Added `CodeCanceled` and `effectiveCode(ctx)` to promote only client-initiated cancels (cause is `context.Canceled` and the request context is canceled) to 499, non-fault.
  - Log cancellations at info and skip span error/exception; authored codes stay unchanged, and `context.DeadlineExceeded` and other errors keep 5xx/error severity.
  - Made `ShareableError` context-aware: `AsGoa(ctx)`, `HTTPStatus(ctx)`, `IsTemporary(ctx)`; updated middleware (`MapErrors`, `Recovery`, HTTP/MCP handlers) and a background activity to pass `ctx`; tests cover log level, span status, `goa` flags, and 499 vs 500 behavior.

<sup>Written for commit e0af13536a2c3ecf469581c97744497b5e680c00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
