### PR TITLE
chore: make consent page respect expired sessions

### DIFF
--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -86,10 +86,17 @@ type consentTemplateData struct {
 // remoteSessionCard is the per-remote view rendered by the {{range}} block
 // in the consent template. ChallengeURL is the upstream provider's
 // authorize URL with PKCE + state bound for this consent session.
+//
+// Connected and Expired are mutually exclusive and reflect the stored
+// remote_session's usability: Connected means the runtime gate will accept
+// it; Expired means a stale link exists that must be re-established; both
+// false means never connected. Only Connected enables consent — an expired
+// link is no better than none until the user reconnects.
 type remoteSessionCard struct {
 	ClientID     string
 	IssuerSlug   string
 	Connected    bool
+	Expired      bool
 	ChallengeURL string
 }
 
@@ -427,14 +434,15 @@ func (s *Service) buildRemoteSessionCards(
 		return nil, nil
 	}
 
-	// Single round-trip for connected-state across all cards. Empty when
+	// Single round-trip for connection state across all cards. Empty when
 	// the subject hasn't been stamped yet (early render before IDP /
-	// anonymous late-bind); the per-card check below then resolves false.
-	var connectedIDs map[uuid.UUID]struct{}
+	// anonymous late-bind); the per-card check below then resolves to
+	// not-connected.
+	var statuses map[uuid.UUID]remotesessions.RemoteSessionStatus
 	if challengeState.Subject != nil && !challengeState.Subject.IsZero() {
-		connectedIDs, err = s.remoteChallengeMgr.ConnectedClientIDs(ctx, *challengeState.Subject, endpoint.UserSessionIssuerID)
+		statuses, err = s.remoteChallengeMgr.RemoteSessionStatuses(ctx, *challengeState.Subject, endpoint.UserSessionIssuerID)
 		if err != nil {
-			return nil, fmt.Errorf("connected client ids: %w", err)
+			return nil, fmt.Errorf("remote session statuses: %w", err)
 		}
 	}
 
@@ -454,11 +462,12 @@ func (s *Service) buildRemoteSessionCards(
 		if berr != nil {
 			return nil, fmt.Errorf("build authorization url for %s: %w", c.IssuerSlug, berr)
 		}
-		_, connected := connectedIDs[c.ID]
+		status := statuses[c.ID]
 		cards = append(cards, remoteSessionCard{
 			ClientID:     c.ID.String(),
 			IssuerSlug:   c.IssuerSlug,
-			Connected:    connected,
+			Connected:    status == remotesessions.RemoteSessionActive,
+			Expired:      status == remotesessions.RemoteSessionExpired,
 			ChallengeURL: challengeURL,
 		})
 	}

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -206,7 +206,8 @@
         color: var(--text-default-success);
       }
 
-      .remote-card .state.disconnected {
+      .remote-card .state.disconnected,
+      .remote-card .state.expired {
         color: var(--text-default-warning);
       }
 
@@ -350,6 +351,8 @@
               <div class="issuer">{{.IssuerSlug}}</div>
               {{if .Connected}}
               <div class="state connected">✓ Connected</div>
+              {{else if .Expired}}
+              <div class="state expired">⚠ Expired — reconnect</div>
               {{else}}
               <div class="state disconnected">Not connected</div>
               {{end}}
@@ -358,7 +361,7 @@
               class="btn-link {{if .Connected}}connected{{end}}"
               href="{{.ChallengeURL}}"
               data-connect-link
-              >{{if .Connected}}Reconnect{{else}}Connect{{end}}</a
+              >{{if or .Connected .Expired}}Reconnect{{else}}Connect{{end}}</a
             >
           </div>
           {{end}}

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -206,31 +206,48 @@ func (m *ChallengeManager) ListClients(
 	return out, nil
 }
 
-// ConnectedClientIDs returns the set of remote_session_client_ids that
-// have an active remote_sessions row for `subject` under the given
-// `userSessionIssuerID`. Single round-trip; the caller (consent
-// renderer) then does O(1) membership checks per card. Returns an empty
-// set for zero subjects so anonymous-pre-stamp renders are no-ops.
-func (m *ChallengeManager) ConnectedClientIDs(
+// RemoteSessionStatus is the usability of a subject's stored remote_session
+// for a single client, as surfaced to the consent renderer. A client with no
+// non-deleted remote_session is absent from the map entirely (disconnected);
+// only present rows carry a status.
+type RemoteSessionStatus string
+
+const (
+	// RemoteSessionActive: the access token is unexpired, or a refresh token
+	// exists to renew it — the runtime gate will accept it.
+	RemoteSessionActive RemoteSessionStatus = "active"
+	// RemoteSessionExpired: the row exists but the access token has expired
+	// with no refresh token, so the runtime gate rejects it
+	// (ErrNoValidToken). The user must re-link to recover.
+	RemoteSessionExpired RemoteSessionStatus = "expired"
+)
+
+// RemoteSessionStatuses returns, per remote_session_client_id, the usability
+// status of `subject`'s remote_session under the given `userSessionIssuerID`.
+// Clients with no non-deleted session are omitted (disconnected). Single
+// round-trip; the caller (consent renderer) then does O(1) lookups per card.
+// Returns an empty map for zero subjects so anonymous-pre-stamp renders are
+// no-ops.
+func (m *ChallengeManager) RemoteSessionStatuses(
 	ctx context.Context,
 	subject urn.SessionSubject,
 	userSessionIssuerID uuid.UUID,
-) (map[uuid.UUID]struct{}, error) {
+) (map[uuid.UUID]RemoteSessionStatus, error) {
 	if subject.IsZero() {
-		return map[uuid.UUID]struct{}{}, nil
+		return map[uuid.UUID]RemoteSessionStatus{}, nil
 	}
-	ids, err := remotesessions_repo.New(m.db).ListConnectedClientIDsForSubject(ctx, remotesessions_repo.ListConnectedClientIDsForSubjectParams{
+	rows, err := remotesessions_repo.New(m.db).ListRemoteSessionStatusesForSubject(ctx, remotesessions_repo.ListRemoteSessionStatusesForSubjectParams{
 		SubjectUrn:          subject,
 		UserSessionIssuerID: userSessionIssuerID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("list connected client ids: %w", err)
+		return nil, fmt.Errorf("list remote session statuses: %w", err)
 	}
-	set := make(map[uuid.UUID]struct{}, len(ids))
-	for _, id := range ids {
-		set[id] = struct{}{}
+	statuses := make(map[uuid.UUID]RemoteSessionStatus, len(rows))
+	for _, row := range rows {
+		statuses[row.RemoteSessionClientID] = RemoteSessionStatus(row.Status)
 	}
-	return set, nil
+	return statuses, nil
 }
 
 // BuildAuthorizationUrl mints a RemoteLoginState (with PKCE S256) for the

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -466,15 +466,20 @@ WHERE subject_urn = @subject_urn
 -- DISTINCT. A soft-deleted row is absent here entirely (truly disconnected).
 --
 -- The 'active' predicate mirrors validateAndRefresh in tokenservice.go: a
--- session is usable only when its access token is unexpired, or it has a
--- refresh token to renew with. A present-but-unusable row is 'expired' rather
--- than dropped, so the consent UI can distinguish "reconnect this expired
--- link" from "never connected" — and so the runtime gate (which rejects the
--- same row as ErrNoValidToken) stops disagreeing with a green "Connected" badge.
+-- session is usable only when its access token is unexpired, or it carries a
+-- refresh token that is not itself known-expired to renew with. A
+-- refresh_expires_at of NULL means no known expiry (non-expiring refresh
+-- token), so it still counts as usable. A present-but-unusable row is
+-- 'expired' rather than dropped, so the consent UI can distinguish "reconnect
+-- this expired link" from "never connected" — and so the runtime gate (which
+-- rejects the same row as ErrNoValidToken) stops disagreeing with a green
+-- "Connected" badge.
 SELECT
   remote_session_client_id,
   (CASE
-    WHEN access_expires_at > now() OR refresh_token_encrypted IS NOT NULL THEN 'active'
+    WHEN access_expires_at > now()
+      OR (refresh_token_encrypted IS NOT NULL
+          AND (refresh_expires_at IS NULL OR refresh_expires_at > now())) THEN 'active'
     ELSE 'expired'
   END)::text AS status
 FROM remote_sessions

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -456,15 +456,27 @@ WHERE subject_urn = @subject_urn
   AND remote_session_client_id = @remote_session_client_id
   AND deleted IS FALSE;
 
--- name: ListConnectedClientIDsForSubject :many
--- Bulk lookup for the consent renderer: returns the set of
--- remote_session_client_ids that have an active remote_sessions row for
--- the given subject under a single user_session_issuer. Folds the N
--- per-card IsConnected lookups into one round-trip. The partial unique
--- index on (subject_urn, remote_session_client_id) WHERE deleted IS
--- FALSE means at most one row per (subject, client), so the result set
--- doubles as a membership set without DISTINCT.
-SELECT remote_session_client_id
+-- name: ListRemoteSessionStatusesForSubject :many
+-- Bulk lookup for the consent renderer: returns each non-deleted
+-- remote_session for the given subject under a single user_session_issuer,
+-- tagged with whether it is still usable. Folds the N per-card lookups into
+-- one round-trip. The partial unique index on (subject_urn,
+-- remote_session_client_id) WHERE deleted IS FALSE means at most one row per
+-- (subject, client), so the result doubles as a per-client map without
+-- DISTINCT. A soft-deleted row is absent here entirely (truly disconnected).
+--
+-- The 'active' predicate mirrors validateAndRefresh in tokenservice.go: a
+-- session is usable only when its access token is unexpired, or it has a
+-- refresh token to renew with. A present-but-unusable row is 'expired' rather
+-- than dropped, so the consent UI can distinguish "reconnect this expired
+-- link" from "never connected" — and so the runtime gate (which rejects the
+-- same row as ErrNoValidToken) stops disagreeing with a green "Connected" badge.
+SELECT
+  remote_session_client_id,
+  (CASE
+    WHEN access_expires_at > now() OR refresh_token_encrypted IS NOT NULL THEN 'active'
+    ELSE 'expired'
+  END)::text AS status
 FROM remote_sessions
 WHERE subject_urn = @subject_urn
   AND user_session_issuer_id = @user_session_issuer_id

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -1401,7 +1401,9 @@ const listRemoteSessionStatusesForSubject = `-- name: ListRemoteSessionStatusesF
 SELECT
   remote_session_client_id,
   (CASE
-    WHEN access_expires_at > now() OR refresh_token_encrypted IS NOT NULL THEN 'active'
+    WHEN access_expires_at > now()
+      OR (refresh_token_encrypted IS NOT NULL
+          AND (refresh_expires_at IS NULL OR refresh_expires_at > now())) THEN 'active'
     ELSE 'expired'
   END)::text AS status
 FROM remote_sessions
@@ -1429,11 +1431,14 @@ type ListRemoteSessionStatusesForSubjectRow struct {
 // DISTINCT. A soft-deleted row is absent here entirely (truly disconnected).
 //
 // The 'active' predicate mirrors validateAndRefresh in tokenservice.go: a
-// session is usable only when its access token is unexpired, or it has a
-// refresh token to renew with. A present-but-unusable row is 'expired' rather
-// than dropped, so the consent UI can distinguish "reconnect this expired
-// link" from "never connected" — and so the runtime gate (which rejects the
-// same row as ErrNoValidToken) stops disagreeing with a green "Connected" badge.
+// session is usable only when its access token is unexpired, or it carries a
+// refresh token that is not itself known-expired to renew with. A
+// refresh_expires_at of NULL means no known expiry (non-expiring refresh
+// token), so it still counts as usable. A present-but-unusable row is
+// 'expired' rather than dropped, so the consent UI can distinguish "reconnect
+// this expired link" from "never connected" — and so the runtime gate (which
+// rejects the same row as ErrNoValidToken) stops disagreeing with a green
+// "Connected" badge.
 func (q *Queries) ListRemoteSessionStatusesForSubject(ctx context.Context, arg ListRemoteSessionStatusesForSubjectParams) ([]ListRemoteSessionStatusesForSubjectRow, error) {
 	rows, err := q.db.Query(ctx, listRemoteSessionStatusesForSubject, arg.SubjectUrn, arg.UserSessionIssuerID)
 	if err != nil {

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -847,46 +847,6 @@ func (q *Queries) InsertRemoteSession(ctx context.Context, arg InsertRemoteSessi
 	return i, err
 }
 
-const listConnectedClientIDsForSubject = `-- name: ListConnectedClientIDsForSubject :many
-SELECT remote_session_client_id
-FROM remote_sessions
-WHERE subject_urn = $1
-  AND user_session_issuer_id = $2
-  AND deleted IS FALSE
-`
-
-type ListConnectedClientIDsForSubjectParams struct {
-	SubjectUrn          urn.SessionSubject
-	UserSessionIssuerID uuid.UUID
-}
-
-// Bulk lookup for the consent renderer: returns the set of
-// remote_session_client_ids that have an active remote_sessions row for
-// the given subject under a single user_session_issuer. Folds the N
-// per-card IsConnected lookups into one round-trip. The partial unique
-// index on (subject_urn, remote_session_client_id) WHERE deleted IS
-// FALSE means at most one row per (subject, client), so the result set
-// doubles as a membership set without DISTINCT.
-func (q *Queries) ListConnectedClientIDsForSubject(ctx context.Context, arg ListConnectedClientIDsForSubjectParams) ([]uuid.UUID, error) {
-	rows, err := q.db.Query(ctx, listConnectedClientIDsForSubject, arg.SubjectUrn, arg.UserSessionIssuerID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []uuid.UUID
-	for rows.Next() {
-		var remote_session_client_id uuid.UUID
-		if err := rows.Scan(&remote_session_client_id); err != nil {
-			return nil, err
-		}
-		items = append(items, remote_session_client_id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listOrganizationRemoteSessionIssuers = `-- name: ListOrganizationRemoteSessionIssuers :many
 SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
 FROM remote_session_issuers
@@ -1427,6 +1387,63 @@ func (q *Queries) ListRemoteSessionIssuersByProjectID(ctx context.Context, arg L
 			&i.DeletedAt,
 			&i.Deleted,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRemoteSessionStatusesForSubject = `-- name: ListRemoteSessionStatusesForSubject :many
+SELECT
+  remote_session_client_id,
+  (CASE
+    WHEN access_expires_at > now() OR refresh_token_encrypted IS NOT NULL THEN 'active'
+    ELSE 'expired'
+  END)::text AS status
+FROM remote_sessions
+WHERE subject_urn = $1
+  AND user_session_issuer_id = $2
+  AND deleted IS FALSE
+`
+
+type ListRemoteSessionStatusesForSubjectParams struct {
+	SubjectUrn          urn.SessionSubject
+	UserSessionIssuerID uuid.UUID
+}
+
+type ListRemoteSessionStatusesForSubjectRow struct {
+	RemoteSessionClientID uuid.UUID
+	Status                string
+}
+
+// Bulk lookup for the consent renderer: returns each non-deleted
+// remote_session for the given subject under a single user_session_issuer,
+// tagged with whether it is still usable. Folds the N per-card lookups into
+// one round-trip. The partial unique index on (subject_urn,
+// remote_session_client_id) WHERE deleted IS FALSE means at most one row per
+// (subject, client), so the result doubles as a per-client map without
+// DISTINCT. A soft-deleted row is absent here entirely (truly disconnected).
+//
+// The 'active' predicate mirrors validateAndRefresh in tokenservice.go: a
+// session is usable only when its access token is unexpired, or it has a
+// refresh token to renew with. A present-but-unusable row is 'expired' rather
+// than dropped, so the consent UI can distinguish "reconnect this expired
+// link" from "never connected" — and so the runtime gate (which rejects the
+// same row as ErrNoValidToken) stops disagreeing with a green "Connected" badge.
+func (q *Queries) ListRemoteSessionStatusesForSubject(ctx context.Context, arg ListRemoteSessionStatusesForSubjectParams) ([]ListRemoteSessionStatusesForSubjectRow, error) {
+	rows, err := q.db.Query(ctx, listRemoteSessionStatusesForSubject, arg.SubjectUrn, arg.UserSessionIssuerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRemoteSessionStatusesForSubjectRow
+	for rows.Next() {
+		var i ListRemoteSessionStatusesForSubjectRow
+		if err := rows.Scan(&i.RemoteSessionClientID, &i.Status); err != nil {
 			return nil, err
 		}
 		items = append(items, i)


### PR DESCRIPTION
This makes the consent page render an expired status when we detect an access token that is no longer valid

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The consent page now flags expired remote sessions and prompts users to reconnect, preventing false “Connected” states when tokens aren’t usable. This aligns the UI with the runtime gate.

- **Bug Fixes**
  - Added `RemoteSessionStatuses` to return per-client status (`active` or `expired`); disconnected clients are omitted.
  - Introduced `ListRemoteSessionStatusesForSubject` to mark a session active only if the access token is unexpired or a refresh token exists and is not expired (NULL expiry allowed), matching the runtime gate.
  - Updated consent rendering to set `Expired` in card data and only enable consent when `Connected` is true.
  - Updated `consent_template.html` to show “Expired — reconnect” with warning styling and use “Reconnect” when a session is connected or expired.

<sup>Written for commit a5ae960c5fc7062e5662a8e450f18a5a0a6e44ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

