### PR TITLE
chore: x/mcp tab routing

### DIFF
--- a/client/dashboard/src/components/mcp/MCPServerCard.tsx
+++ b/client/dashboard/src/components/mcp/MCPServerCard.tsx
@@ -31,7 +31,7 @@ export function MCPServerCard({
 
   return (
     <Link
-      to={routes.mcp.x.href(mcpServerRouteParam(server))}
+      to={routes.mcp.x.overview.href(mcpServerRouteParam(server))}
       className="focus-visible:ring-ring block rounded-xl no-underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
     >
       <DotCard icon={<Network className="text-muted-foreground h-8 w-8" />}>

--- a/client/dashboard/src/components/mcp/MCPServerTableRow.tsx
+++ b/client/dashboard/src/components/mcp/MCPServerTableRow.tsx
@@ -23,7 +23,7 @@ export function MCPServerTableRow({
   const routes = useRoutes();
 
   const handleClick = () => {
-    routes.mcp.x.goTo(mcpServerRouteParam(server));
+    routes.mcp.x.overview.goTo(mcpServerRouteParam(server));
   };
 
   const mcpEnabled = server.visibility !== "disabled";

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -36,13 +36,18 @@ import {
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, Network } from "lucide-react";
-import { useState } from "react";
-import { Navigate, useParams } from "react-router";
+import {
+  Link,
+  Navigate,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router";
 import { toast } from "sonner";
 import { MCPTeamAccessTab } from "../MCPTeamAccessTab";
 import { AuthenticationTab } from "./tabs/authentication/AuthenticationTab";
 import { OverviewTab } from "./tabs/OverviewTab";
-import { SettingsTab } from "./tabs/SettingsTab";
+import { MCP_SERVER_URL_SECTION_ID, SettingsTab } from "./tabs/SettingsTab";
 
 const VALID_TABS = [
   "overview",
@@ -56,28 +61,72 @@ function isValidTab(value: string): value is TabValue {
   return (VALID_TABS as readonly string[]).includes(value);
 }
 
+function decodePathSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function activeTabFromPath(
+  pathname: string,
+  mcpServerSlug: string,
+): TabValue | undefined {
+  const segments = pathname.split("/").filter(Boolean);
+  const lastSegment = decodePathSegment(segments[segments.length - 1] ?? "");
+
+  if (!mcpServerSlug || lastSegment === mcpServerSlug) {
+    return undefined;
+  }
+
+  return isValidTab(lastSegment) ? lastSegment : undefined;
+}
+
+function initialTabFromHash(hash: string, isRbacEnabled: boolean): TabValue {
+  const hashValue = hash.replace("#", "");
+  if (!isValidTab(hashValue)) return "overview";
+  if (hashValue === "team-access" && !isRbacEnabled) return "overview";
+  return hashValue;
+}
+
+function mcpServerTabHref(
+  routes: ReturnType<typeof useRoutes>,
+  mcpServerSlug: string,
+  tab: TabValue,
+): string {
+  switch (tab) {
+    case "overview":
+      return routes.mcp.x.overview.href(mcpServerSlug);
+    case "authentication":
+      return routes.mcp.x.authentication.href(mcpServerSlug);
+    case "team-access":
+      return routes.mcp.x.teamAccess.href(mcpServerSlug);
+    case "settings":
+      return routes.mcp.x.settings.href(mcpServerSlug);
+  }
+}
+
 export default function MCPServerDetails(): JSX.Element {
   const { mcpServerSlug } = useParams<{ mcpServerSlug: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
   const routes = useRoutes();
   const telemetry = useTelemetry();
   const isRemoteMcpEnabled =
     telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
   const isRbacEnabled = telemetry.isFeatureEnabled("gram-rbac") ?? false;
   const idOrSlug = mcpServerSlug ?? "";
+  const activeTab = activeTabFromPath(location.pathname, idOrSlug);
 
-  const [activeTab, setActiveTab] = useState<TabValue>(() => {
-    const hash = window.location.hash.replace("#", "");
-    if (!isValidTab(hash)) return "overview";
-    if (hash === "team-access" && !isRbacEnabled) return "overview";
-    return hash;
-  });
+  const handleShowServerUrlSettings = () => {
+    void navigate(
+      `${mcpServerTabHref(routes, idOrSlug, "settings")}#${MCP_SERVER_URL_SECTION_ID}`,
+    );
+  };
 
-  const handleTabChange = (value: string) => {
-    if (!isValidTab(value)) return;
-    setActiveTab(value);
-    const url = new URL(window.location.href);
-    url.hash = value;
-    window.history.replaceState(null, "", url.toString());
+  const handleShowAuthentication = () => {
+    void navigate(mcpServerTabHref(routes, idOrSlug, "authentication"));
   };
 
   const {
@@ -99,8 +148,28 @@ export default function MCPServerDetails(): JSX.Element {
   if (!isRemoteMcpEnabled) {
     return <Navigate to={routes.mcp.href()} replace />;
   }
+  if (!idOrSlug) {
+    return <Navigate to={routes.mcp.href()} replace />;
+  }
   if (isError || (!isLoading && !mcpServer)) {
     return <Navigate to={routes.mcp.href()} replace />;
+  }
+  if (!activeTab) {
+    return (
+      <Navigate
+        to={mcpServerTabHref(
+          routes,
+          idOrSlug,
+          initialTabFromHash(location.hash, isRbacEnabled),
+        )}
+        replace
+      />
+    );
+  }
+  if (activeTab === "team-access" && !isRbacEnabled) {
+    return (
+      <Navigate to={mcpServerTabHref(routes, idOrSlug, "overview")} replace />
+    );
   }
 
   return (
@@ -117,24 +186,36 @@ export default function MCPServerDetails(): JSX.Element {
       <Page.Body fullWidth noPadding className="gap-0">
         <MCPServerHero server={mcpServer} />
 
-        <Tabs
-          value={activeTab}
-          onValueChange={handleTabChange}
-          className="flex w-full flex-1 flex-col"
-        >
+        <Tabs value={activeTab} className="flex w-full flex-1 flex-col">
           <div className="shrink-0 border-b">
             <div className="mx-auto max-w-[1270px] px-8">
               <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
-                <PageTabsTrigger value="overview">Overview</PageTabsTrigger>
-                <PageTabsTrigger value="authentication">
-                  Authentication
+                <PageTabsTrigger value="overview" asChild>
+                  <Link to={mcpServerTabHref(routes, idOrSlug, "overview")}>
+                    Overview
+                  </Link>
+                </PageTabsTrigger>
+                <PageTabsTrigger value="authentication" asChild>
+                  <Link
+                    to={mcpServerTabHref(routes, idOrSlug, "authentication")}
+                  >
+                    Authentication
+                  </Link>
                 </PageTabsTrigger>
                 {isRbacEnabled && (
-                  <PageTabsTrigger value="team-access">
-                    Team Access
+                  <PageTabsTrigger value="team-access" asChild>
+                    <Link
+                      to={mcpServerTabHref(routes, idOrSlug, "team-access")}
+                    >
+                      Team Access
+                    </Link>
                   </PageTabsTrigger>
                 )}
-                <PageTabsTrigger value="settings">Settings</PageTabsTrigger>
+                <PageTabsTrigger value="settings" asChild>
+                  <Link to={mcpServerTabHref(routes, idOrSlug, "settings")}>
+                    Settings
+                  </Link>
+                </PageTabsTrigger>
               </TabsList>
             </div>
           </div>
@@ -147,8 +228,8 @@ export default function MCPServerDetails(): JSX.Element {
               mcpServer={mcpServer}
               endpoints={endpoints}
               isLoadingEndpoints={isLoadingEndpoints}
-              onShowEndpoints={() => handleTabChange("settings")}
-              onShowAuthentication={() => handleTabChange("authentication")}
+              onShowEndpoints={handleShowServerUrlSettings}
+              onShowAuthentication={handleShowAuthentication}
             />
           </TabsContent>
 

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -45,50 +45,14 @@ import {
 } from "react-router";
 import { toast } from "sonner";
 import { MCPTeamAccessTab } from "../MCPTeamAccessTab";
+import {
+  activeTabFromPath,
+  initialTabFromHash,
+  type TabValue,
+} from "./MCPServerDetailsRouting";
 import { AuthenticationTab } from "./tabs/authentication/AuthenticationTab";
 import { OverviewTab } from "./tabs/OverviewTab";
 import { MCP_SERVER_URL_SECTION_ID, SettingsTab } from "./tabs/SettingsTab";
-
-const VALID_TABS = [
-  "overview",
-  "authentication",
-  "team-access",
-  "settings",
-] as const;
-type TabValue = (typeof VALID_TABS)[number];
-
-function isValidTab(value: string): value is TabValue {
-  return (VALID_TABS as readonly string[]).includes(value);
-}
-
-function decodePathSegment(segment: string): string {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    return segment;
-  }
-}
-
-function activeTabFromPath(
-  pathname: string,
-  mcpServerSlug: string,
-): TabValue | undefined {
-  const segments = pathname.split("/").filter(Boolean);
-  const lastSegment = decodePathSegment(segments[segments.length - 1] ?? "");
-
-  if (!mcpServerSlug || lastSegment === mcpServerSlug) {
-    return undefined;
-  }
-
-  return isValidTab(lastSegment) ? lastSegment : undefined;
-}
-
-function initialTabFromHash(hash: string, isRbacEnabled: boolean): TabValue {
-  const hashValue = hash.replace("#", "");
-  if (!isValidTab(hashValue)) return "overview";
-  if (hashValue === "team-access" && !isRbacEnabled) return "overview";
-  return hashValue;
-}
 
 function mcpServerTabHref(
   routes: ReturnType<typeof useRoutes>,

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetailsRouting.test.ts
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetailsRouting.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { activeTabFromPath } from "./MCPServerDetailsRouting";
+
+describe("activeTabFromPath", () => {
+  it("returns no tab for the server details route without a tab segment", () => {
+    expect(
+      activeTabFromPath("/acme/projects/default/mcp/x/overview", "overview"),
+    ).toBeUndefined();
+  });
+
+  it.each(["overview", "authentication", "team-access", "settings"] as const)(
+    "reads the %s tab when the server slug has the same value",
+    (tab) => {
+      expect(
+        activeTabFromPath(`/acme/projects/default/mcp/x/${tab}/${tab}`, tab),
+      ).toBe(tab);
+    },
+  );
+
+  it("reads the tab segment after the matching server slug", () => {
+    expect(
+      activeTabFromPath(
+        "/acme/projects/default/mcp/x/overview/settings",
+        "overview",
+      ),
+    ).toBe("settings");
+  });
+
+  it("ignores route segments before x/:mcpServerSlug", () => {
+    expect(
+      activeTabFromPath(
+        "/overview/projects/default/mcp/x/default/settings",
+        "default",
+      ),
+    ).toBe("settings");
+  });
+
+  it("matches the mcp/x route marker instead of any x-prefixed segment", () => {
+    expect(
+      activeTabFromPath("/acme/projects/x/mcp/x/mcp/settings", "mcp"),
+    ).toBe("settings");
+  });
+
+  it("matches decoded server slug segments", () => {
+    expect(
+      activeTabFromPath(
+        "/acme/projects/default/mcp/x/my%20server/authentication",
+        "my server",
+      ),
+    ).toBe("authentication");
+  });
+
+  it("returns no tab for an invalid tab segment", () => {
+    expect(
+      activeTabFromPath(
+        "/acme/projects/default/mcp/x/my-server/nope",
+        "my-server",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetailsRouting.ts
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetailsRouting.ts
@@ -1,0 +1,54 @@
+const VALID_TABS = [
+  "overview",
+  "authentication",
+  "team-access",
+  "settings",
+] as const;
+
+export type TabValue = (typeof VALID_TABS)[number];
+
+function isValidTab(value: string): value is TabValue {
+  return (VALID_TABS as readonly string[]).includes(value);
+}
+
+function decodePathSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+export function activeTabFromPath(
+  pathname: string,
+  mcpServerSlug: string,
+): TabValue | undefined {
+  if (!mcpServerSlug) {
+    return undefined;
+  }
+
+  const segments = pathname.split("/").filter(Boolean).map(decodePathSegment);
+  const serverSlugIndex = segments.findIndex(
+    (segment, index) =>
+      segment === mcpServerSlug &&
+      segments[index - 1] === "x" &&
+      segments[index - 2] === "mcp",
+  );
+
+  if (serverSlugIndex === -1) {
+    return undefined;
+  }
+
+  const tabSegment = segments[serverSlugIndex + 1];
+  return tabSegment && isValidTab(tabSegment) ? tabSegment : undefined;
+}
+
+export function initialTabFromHash(
+  hash: string,
+  isRbacEnabled: boolean,
+): TabValue {
+  const hashValue = hash.replace("#", "");
+  if (!isValidTab(hashValue)) return "overview";
+  if (hashValue === "team-access" && !isRbacEnabled) return "overview";
+  return hashValue;
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/SettingsTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/SettingsTab.tsx
@@ -21,7 +21,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Type } from "@/components/ui/type";
 import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { useCustomDomains } from "@/hooks/useToolsetUrl";
@@ -1140,10 +1139,10 @@ function mcpServerVisibilityToast(visibility: McpServerVisibility) {
   switch (visibility) {
     case "disabled":
       return "MCP server disabled";
+    case "private":
+      return "MCP server enabled";
     case "public":
       return "MCP server set to public";
-    case "private":
-      return "MCP server set to private";
     default:
       return "MCP server updated";
   }
@@ -1184,8 +1183,6 @@ function DangerZoneCard({
   const routes = useRoutes();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [pendingAvailability, setPendingAvailability] =
-    useState<McpServerVisibility | null>(null);
-  const [pendingVisibility, setPendingVisibility] =
     useState<McpServerVisibility | null>(null);
   const queryClient = useQueryClient();
   const client = useSdkClient();
@@ -1246,23 +1243,7 @@ function DangerZoneCard({
     setPendingAvailability(null);
   };
 
-  const requestVisibilityChange = (visibility: string) => {
-    if (visibility !== "public" && visibility !== "private") return;
-    if (visibility === mcpServer.visibility) return;
-    setPendingVisibility(visibility);
-  };
-
-  const confirmVisibilityChange = () => {
-    if (!pendingVisibility) return;
-    void applyVisibility(pendingVisibility);
-    setPendingVisibility(null);
-  };
-
   const enabled = mcpServer.visibility !== "disabled";
-  let accessMode = "";
-  if (enabled) {
-    accessMode = mcpServer.visibility === "public" ? "public" : "private";
-  }
 
   return (
     <>
@@ -1270,7 +1251,7 @@ function DangerZoneCard({
         <DangerSettingsSection.Header>
           <DangerSettingsSection.Title>Danger Zone</DangerSettingsSection.Title>
           <DangerSettingsSection.Description>
-            Manage server availability, access, and destructive actions.
+            Manage server availability and destructive actions.
           </DangerSettingsSection.Description>
         </DangerSettingsSection.Header>
         <DangerSettingsSection.Panel>
@@ -1294,41 +1275,6 @@ function DangerZoneCard({
                     aria-label="Enable MCP server"
                     onCheckedChange={requestAvailabilityChange}
                   />
-                </RequireScope>
-              </ServerControlRow>
-
-              <ServerControlRow
-                title="Visibility"
-                description={
-                  enabled
-                    ? "Choose whether clients can use this server publicly or only through authenticated project access."
-                    : "Choose an access mode to enable this server as public or private."
-                }
-              >
-                <RequireScope scope="mcp:write" level="component">
-                  <ToggleGroup
-                    type="single"
-                    value={accessMode}
-                    variant="outline"
-                    size="sm"
-                    disabled={isUpdatingVisibility}
-                    onValueChange={requestVisibilityChange}
-                  >
-                    <ToggleGroupItem
-                      value="private"
-                      aria-label="Set MCP server private"
-                      className="px-3"
-                    >
-                      Private
-                    </ToggleGroupItem>
-                    <ToggleGroupItem
-                      value="public"
-                      aria-label="Set MCP server public"
-                      className="px-3"
-                    >
-                      Public
-                    </ToggleGroupItem>
-                  </ToggleGroup>
                 </RequireScope>
               </ServerControlRow>
 
@@ -1377,12 +1323,6 @@ function DangerZoneCard({
         onClose={() => setPendingAvailability(null)}
         onConfirm={confirmAvailabilityChange}
       />
-      <ServerVisibilityDialog
-        targetVisibility={pendingVisibility}
-        isLoading={isUpdatingVisibility}
-        onClose={() => setPendingVisibility(null)}
-        onConfirm={confirmVisibilityChange}
-      />
     </>
   );
 }
@@ -1423,78 +1363,6 @@ function ServerAvailabilityDialog({
           </Button>
           <Button
             variant={enabling ? "primary" : "destructive-primary"}
-            disabled={isLoading}
-            onClick={onConfirm}
-          >
-            {isLoading ? (
-              <>
-                <Button.LeftIcon>
-                  <Loader2 className="size-4 animate-spin" />
-                </Button.LeftIcon>
-                <Button.Text>Saving</Button.Text>
-              </>
-            ) : (
-              <Button.Text>Continue</Button.Text>
-            )}
-          </Button>
-        </Dialog.Footer>
-      </Dialog.Content>
-    </Dialog>
-  );
-}
-
-function ServerVisibilityDialog({
-  targetVisibility,
-  isLoading,
-  onClose,
-  onConfirm,
-}: {
-  targetVisibility: McpServerVisibility | null;
-  isLoading: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
-}) {
-  const isOpen = targetVisibility != null;
-  const makingPublic = targetVisibility === "public";
-  let title = "Make MCP server private?";
-  let confirmVariant: "primary" | "destructive-primary" = "primary";
-  let message = (
-    <>
-      You are about to make this MCP server private. Private MCP servers are
-      secured behind Speakeasy login and access controls, and thus not available
-      for use by the general public. Continue?
-    </>
-  );
-
-  if (makingPublic) {
-    title = "Make MCP server public?";
-    confirmVariant = "destructive-primary";
-    message = (
-      <>
-        You are about to make this MCP server public. This is only recommended
-        if you intend for it to be used by <em>anyone</em> who has its URL.{" "}
-        <span className="font-bold">
-          Public MCP servers are not secured behind Speakeasy&apos;s access
-          controls.
-        </span>
-        &nbsp;Continue?
-      </>
-    );
-  }
-
-  return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <Dialog.Content className="max-w-md">
-        <Dialog.Header>
-          <Dialog.Title>{title}</Dialog.Title>
-          <Dialog.Description>{message}</Dialog.Description>
-        </Dialog.Header>
-        <Dialog.Footer>
-          <Button variant="secondary" disabled={isLoading} onClick={onClose}>
-            <Button.Text>Cancel</Button.Text>
-          </Button>
-          <Button
-            variant={confirmVariant}
             disabled={isLoading}
             onClick={onConfirm}
           >

--- a/client/dashboard/src/pages/mcp/x/tabs/SettingsTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/SettingsTab.tsx
@@ -54,7 +54,7 @@ import { Alert, Button, Dialog, Stack } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2, Plus, SaveIcon, Trash2, XIcon } from "lucide-react";
 import { createContext, use, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useMcpEndpointSlugValidation } from "../useMcpEndpointSlugValidation";
 
@@ -65,6 +65,7 @@ const ADDRESS_INPUT_GROUP_CLASSNAME = "rounded-md";
 const ADDRESS_SLUG_INPUT_CLASSNAME = "font-mono pl-0! font-bold";
 const ADDRESS_RANDOM_SUFFIX_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
 const ADDRESS_RANDOM_SUFFIX_LENGTH = 5;
+export const MCP_SERVER_URL_SECTION_ID = "server-url";
 
 function generateAddressSuffix() {
   let suffix = "";
@@ -77,6 +78,23 @@ function generateAddressSuffix() {
   return suffix;
 }
 
+function useScrollToSettingsHash() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const targetId = location.hash.replace("#", "");
+    if (targetId !== MCP_SERVER_URL_SECTION_ID) return;
+
+    const animationFrame = window.requestAnimationFrame(() => {
+      document
+        .getElementById(targetId)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [location.hash]);
+}
+
 export function SettingsTab({
   mcpServer,
   endpoints,
@@ -86,6 +104,8 @@ export function SettingsTab({
   endpoints: McpEndpoint[];
   isLoadingEndpoints: boolean;
 }): JSX.Element {
+  useScrollToSettingsHash();
+
   return (
     <div className="mx-auto w-full max-w-[1270px] space-y-10 px-8 py-8">
       <DisplayNameCard mcpServer={mcpServer} />
@@ -119,10 +139,18 @@ const DANGER_SETTINGS_SECTION_CONTEXT: SettingsSectionContextValue = {
 };
 const SettingsSectionContext = createContext(DEFAULT_SETTINGS_SECTION_CONTEXT);
 
-function SettingsSectionRoot({ children }: { children: React.ReactNode }) {
+function SettingsSectionRoot({
+  children,
+  id,
+}: {
+  children: React.ReactNode;
+  id?: string;
+}) {
   return (
     <SettingsSectionContext.Provider value={DEFAULT_SETTINGS_SECTION_CONTEXT}>
-      <section className="space-y-3">{children}</section>
+      <section id={id} className="space-y-3 scroll-mt-4">
+        {children}
+      </section>
     </SettingsSectionContext.Provider>
   );
 }
@@ -348,7 +376,7 @@ function DisplayNameCard({ mcpServer }: { mcpServer: McpServer }) {
       // invalidating queries so the refetch uses the new lookup args and the
       // page-level not-found guard doesn't bounce the user back to /mcp.
       const nextParam = mcpServerRouteParam(updated);
-      void navigate(routes.mcp.x.href(nextParam), { replace: true });
+      void navigate(routes.mcp.x.settings.href(nextParam), { replace: true });
       await Promise.all([
         invalidateAllGetMcpServer(queryClient, { refetchType: "all" }),
         invalidateAllMcpServers(queryClient, { refetchType: "all" }),
@@ -487,7 +515,7 @@ function ServerUrlCard({
   }
 
   return (
-    <SettingsSection>
+    <SettingsSection id={MCP_SERVER_URL_SECTION_ID}>
       <SettingsSection.Header>
         <SettingsSection.Title>Server URL</SettingsSection.Title>
         <SettingsSection.Description>

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -500,7 +500,7 @@ function PluginServerCard({
     // Remote MCP servers live on the mcp_servers-backed details page (x/);
     // toolset-backed servers use the toolset details page.
     if (isRemote) {
-      if (mcpServer) routes.mcp.x.goTo(mcpServerRouteParam(mcpServer));
+      if (mcpServer) routes.mcp.x.overview.goTo(mcpServerRouteParam(mcpServer));
     } else if (toolset) {
       routes.mcp.details.goTo(toolset.slug);
     }

--- a/client/dashboard/src/pages/sources/remote-mcp/CreateRemoteMcp.tsx
+++ b/client/dashboard/src/pages/sources/remote-mcp/CreateRemoteMcp.tsx
@@ -83,7 +83,7 @@ function CreateRemoteMcpForm() {
         url: url.trim(),
       });
       toast.success("Remote MCP server added");
-      routes.mcp.x.goTo(mcpServerRouteParam(mcpServer));
+      routes.mcp.x.overview.goTo(mcpServerRouteParam(mcpServer));
     } catch (error) {
       const message =
         error instanceof Error

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -359,6 +359,24 @@ const ROUTE_STRUCTURE = {
         title: "MCP Server Details",
         url: "x/:mcpServerSlug",
         component: MCPServerDetails,
+        subPages: {
+          overview: {
+            title: "MCP Server Overview",
+            url: "overview",
+          },
+          authentication: {
+            title: "MCP Server Authentication",
+            url: "authentication",
+          },
+          teamAccess: {
+            title: "MCP Server Team Access",
+            url: "team-access",
+          },
+          settings: {
+            title: "MCP Server Settings",
+            url: "settings",
+          },
+        },
       },
       details: {
         title: "MCP Details",


### PR DESCRIPTION
## Summary

- Convert the experimental `/mcp/x/:mcpServerSlug` detail tabs from hash-backed state to proper sub-routes: `/overview`, `/authentication`, `/team-access`, and `/settings`.
- Preserve compatibility for bare detail routes and old tab hashes by redirecting into the matching sub-route.
- Make tab triggers real React Router links so browser Back updates the visible tab on the first click.
- Deep-link the Overview Server URL Configure action to `/settings#server-url` and scroll to the Server URL card.

Linear: https://linear.app/speakeasy/issue/AIS-112/fix-xmcp-tabs-history-and-section-navigation

## Root cause

After the tabs moved toward route-derived state, tab changes still flowed through Radix `Tabs.onValueChange`. Browser Back could update the route and document title while the tab component also attempted to drive navigation, producing an extra history/state step before visible content caught up.

## Validation

- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint:format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP server detail tabs by replacing hash-based state with nested routes so Back/Forward works on the first click and deep links are reliable. Removes the visibility toggle from Settings > Danger Zone; aligns with Linear AIS-112.

- **Bug Fixes**
  - Moved tabs to nested routes: `.../overview`, `.../authentication`, `.../team-access`, `.../settings`, and updated internal links to land on `overview`.
  - Redirects bare detail routes and legacy hashes to the right sub-route; `team-access` remains RBAC-gated.
  - Tab triggers are real `react-router` links; tab detection reads the segment after `mcp/x/:slug`, handles URL-decoded slugs, and avoids slug-vs-tab collisions.
  - Settings supports `#server-url` deep linking with smooth scroll; Overview’s “Configure” now targets `/settings#server-url`.
  - Removed Danger Zone visibility controls; only availability (enable/disable) and delete remain.

<sup>Written for commit 0e15dd53042cd60cc2e53622875d77426a754fe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

