### PR TITLE
fix: export OTel metrics as delta temporality for Datadog

### DIFF
--- a/.changeset/otel-delta-temporality.md
+++ b/.changeset/otel-delta-temporality.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Export OTel metrics as delta temporality for Datadog. The exporter previously defaulted to cumulative temporality, which forced the per-node Datadog Agent to do a stateful cumulative-to-delta conversion that corrupted counter values in our horizontally scaled deployment. Counters now emit delta at the SDK (UpDownCounters stay cumulative), making each pod self-contained and the Agent a pass-through.

--- a/mock-oidc/internal/o11y/setup.go
+++ b/mock-oidc/internal/o11y/setup.go
@@ -16,6 +16,7 @@ import (
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
@@ -61,7 +62,21 @@ func SetupOTelSDK(ctx context.Context, logger *slog.Logger, options SetupOTelSDK
 	if options.EnableMetrics {
 		logger.InfoContext(ctx, "otel metrics enabled")
 
-		exp, err := otlpmetricgrpc.New(ctx)
+		// Emit delta aggregation temporality for monotonic sums and histograms.
+		// We ship to a per-node Datadog Agent OTLP receiver; the default
+		// cumulative temporality forces the Agent to do a stateful
+		// cumulative-to-delta conversion that is fragile in our horizontally
+		// scaled, pod-churning topology and corrupts counter values. Emitting
+		// delta at the SDK makes each pod self-contained and the Agent a
+		// pass-through. See Datadog's "Producing Delta Temporality Metrics with
+		// OpenTelemetry" guide.
+		//
+		// NOTE: this overrides OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE.
+		// The exporter applies env config before explicit options, so this
+		// selector wins regardless of that env var.
+		exp, err := otlpmetricgrpc.New(ctx,
+			otlpmetricgrpc.WithTemporalitySelector(instrumentKindTemporalitySelector),
+		)
 		if err != nil {
 			handleErr(err)
 			return nil, err
@@ -114,6 +129,19 @@ func SetupOTelSDK(ctx context.Context, logger *slog.Logger, options SetupOTelSDK
 	}
 
 	return
+}
+
+// instrumentKindTemporalitySelector reports delta aggregation temporality for every
+// instrument kind except UpDownCounters, which stay cumulative because delta is
+// meaningless for a non-monotonic running value. This matches Datadog's
+// recommended selector for OTLP metrics.
+func instrumentKindTemporalitySelector(kind sdkmetric.InstrumentKind) metricdata.Temporality {
+	switch kind {
+	case sdkmetric.InstrumentKindUpDownCounter, sdkmetric.InstrumentKindObservableUpDownCounter:
+		return metricdata.CumulativeTemporality
+	default:
+		return metricdata.DeltaTemporality
+	}
 }
 
 func newClueConfig(

--- a/server/internal/o11y/setup.go
+++ b/server/internal/o11y/setup.go
@@ -68,7 +68,21 @@ func SetupOTelSDK(ctx context.Context, logger *slog.Logger, options SetupOTelSDK
 	if options.EnableMetrics {
 		logger.InfoContext(ctx, "otel metrics enabled")
 
-		exp, err := otlpmetricgrpc.New(ctx)
+		// Emit delta aggregation temporality for monotonic sums and histograms.
+		// We ship to a per-node Datadog Agent OTLP receiver; the default
+		// cumulative temporality forces the Agent to do a stateful
+		// cumulative-to-delta conversion that is fragile in our horizontally
+		// scaled, pod-churning topology and corrupts counter values. Emitting
+		// delta at the SDK makes each pod self-contained and the Agent a
+		// pass-through. See Datadog's "Producing Delta Temporality Metrics with
+		// OpenTelemetry" guide.
+		//
+		// NOTE: this overrides OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE.
+		// The exporter applies env config before explicit options, so this
+		// selector wins regardless of that env var.
+		exp, err := otlpmetricgrpc.New(ctx,
+			otlpmetricgrpc.WithTemporalitySelector(instrumentKindTemporalitySelector),
+		)
 		if err != nil {
 			handleErr(err)
 			return nil, err

--- a/server/internal/o11y/temporality_selector.go
+++ b/server/internal/o11y/temporality_selector.go
@@ -1,0 +1,19 @@
+package o11y
+
+import (
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// instrumentKindTemporalitySelector reports delta aggregation temporality for every
+// instrument kind except UpDownCounters, which stay cumulative because delta is
+// meaningless for a non-monotonic running value. This matches Datadog's
+// recommended selector for OTLP metrics.
+func instrumentKindTemporalitySelector(kind metric.InstrumentKind) metricdata.Temporality {
+	switch kind {
+	case metric.InstrumentKindUpDownCounter, metric.InstrumentKindObservableUpDownCounter:
+		return metricdata.CumulativeTemporality
+	default:
+		return metricdata.DeltaTemporality
+	}
+}

--- a/server/internal/o11y/temporality_selector_test.go
+++ b/server/internal/o11y/temporality_selector_test.go
@@ -1,0 +1,31 @@
+package o11y
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestInstrumentKindTemporalitySelector(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		kind sdkmetric.InstrumentKind
+		want metricdata.Temporality
+	}{
+		{"counter", sdkmetric.InstrumentKindCounter, metricdata.DeltaTemporality},
+		{"histogram", sdkmetric.InstrumentKindHistogram, metricdata.DeltaTemporality},
+		{"gauge", sdkmetric.InstrumentKindGauge, metricdata.DeltaTemporality},
+		{"observable_counter", sdkmetric.InstrumentKindObservableCounter, metricdata.DeltaTemporality},
+		{"observable_gauge", sdkmetric.InstrumentKindObservableGauge, metricdata.DeltaTemporality},
+		{"up_down_counter", sdkmetric.InstrumentKindUpDownCounter, metricdata.CumulativeTemporality},
+		{"observable_up_down_counter", sdkmetric.InstrumentKindObservableUpDownCounter, metricdata.CumulativeTemporality},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, instrumentKindTemporalitySelector(tc.kind), "kind %s", tc.name)
+	}
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2734/otel-metrics-export-cumulative-temporality-corrupting-counters-in

The OTLP gRPC exporter defaulted to cumulative temporality. Cumulative monotonic sums shipped to the per-node Datadog Agent force a stateful cumulative-to-delta conversion that is fragile in our horizontally scaled, pod-churning topology and was corrupting counter values in prod (e.g. `oauth.flow.completed` inflated ~48x with a single-pod flat plateau).

Add a `WithTemporalitySelector` that emits delta for all instrument kinds except `UpDownCounter`s (kept cumulative per Datadog's recommendation), making each pod self-contained and the Agent a pass-through. Mirror the same selector in `mock-oidc` for local/dev parity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch OTel metrics export to delta temporality for Datadog to stop counter corruption in our scaled deployment (AGE-2734). `UpDownCounter`s stay cumulative, and each pod now emits self-contained deltas.

- **Bug Fixes**
  - Added `otlpmetricgrpc.WithTemporalitySelector` to emit delta for all instruments except `UpDownCounter`s.
  - Applied the selector in `server/internal/o11y/setup.go` and `mock-oidc/internal/o11y/setup.go`; added `server/internal/o11y/temporality_selector.go` and `server/internal/o11y/temporality_selector_test.go`.
  - Overrides `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` per Datadog’s delta guidance.

<sup>Written for commit a8eada7ca4872287663dc329fcdedf6c9be90af5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

