### PR TITLE
feat(dashboard): change Project Assistant shortcut to Cmd+/ and add sidebar toggle tooltip

### DIFF
--- a/.changeset/assistant-cmd-slash-shortcut.md
+++ b/.changeset/assistant-cmd-slash-shortcut.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Change the Project Assistant keyboard shortcut from Option+Shift+W to Cmd+/ (Ctrl+/ on PC), updating the trigger's hover hint and tooltip to match, and add a hover tooltip to the sidebar collapse button showing its Cmd+B shortcut.

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -484,7 +484,7 @@ export function InsightsProvider({
     if (hideTrigger) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!e.metaKey && !e.ctrlKey) return;
-      if (e.altKey || e.shiftKey) return;
+      if (e.altKey) return;
       // KeyboardEvent.code is layout-independent, unlike e.key which varies
       // with keyboard layout and held modifiers.
       if (e.code !== "Slash") return;

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -5,7 +5,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { cn, isMacPlatform } from "@/lib/utils";
 import { useRoutes } from "@/routes.tsx";
 import speakeasyIcon from "@/assets/speakeasy-icon.svg";
 import { useAssistantRuntime } from "@assistant-ui/react";
@@ -115,19 +115,10 @@ function InsightsRainbowStyles() {
   );
 }
 
-/** Single source of truth for the trigger's keyboard shortcut. Cmd+W is
- *  reserved by the browser (closes the tab before JS sees the event), so we
- *  use Option+Shift+W which matches common app conventions and mirrors the
- *  reference design. */
-const INSIGHTS_SHORTCUT_LABEL_MAC = ["⌥", "⇧", "W"]; // ⌥ ⇧ W
-const INSIGHTS_SHORTCUT_LABEL_PC = ["Alt", "Shift", "W"];
-
-function isMacPlatform(): boolean {
-  if (typeof navigator === "undefined") return true;
-  return /mac|iphone|ipad|ipod/i.test(
-    navigator.platform || navigator.userAgent,
-  );
-}
+/** Single source of truth for the trigger's keyboard shortcut: Cmd+/ on Mac,
+ *  Ctrl+/ on PC — matching the common "open assistant" convention. */
+const INSIGHTS_SHORTCUT_LABEL_MAC = ["⌘", "/"];
+const INSIGHTS_SHORTCUT_LABEL_PC = ["Ctrl", "/"];
 
 /**
  * Header-bar trigger for opening the AI Insights sidebar. Renders only
@@ -187,7 +178,7 @@ export function InsightsTrigger({
   const shortcutKeys = isMacPlatform()
     ? INSIGHTS_SHORTCUT_LABEL_MAC
     : INSIGHTS_SHORTCUT_LABEL_PC;
-  const shortcutAria = isMacPlatform() ? "Option Shift W" : "Alt Shift W";
+  const shortcutAria = isMacPlatform() ? "Meta+/" : "Control+/";
 
   if (!available) return null;
 
@@ -483,22 +474,20 @@ export function InsightsProvider({
     setSessionKey((k) => k + 1);
   }, []);
 
-  // Global keyboard shortcut: Option+Shift+W (Mac) / Alt+Shift+W (PC) toggles
-  // the sidebar. Cmd+W is reserved by the browser (closes the tab before JS
-  // sees the event), so we deliberately don't bind it here.
+  // Global keyboard shortcut: Cmd+/ (Mac) / Ctrl+/ (PC) toggles the sidebar.
   //
   // Skips when the trigger is hidden via `hideTrigger`, when a modifier
-  // mismatch is detected (extra Cmd/Ctrl), or when the user is typing in a
-  // contentEditable region — letting Alt+Shift+W still work in plain inputs
-  // since modifier-heavy combos rarely conflict with text entry.
+  // mismatch is detected (extra Alt/Shift), or when the user is typing in a
+  // contentEditable region — letting Cmd+/ still work in plain inputs since
+  // the Cmd/Ctrl modifier means it never inserts text.
   useEffect(() => {
     if (hideTrigger) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (!e.altKey || !e.shiftKey) return;
-      if (e.metaKey || e.ctrlKey) return;
-      // KeyboardEvent.code is layout-independent; e.key on Mac with Option
-      // held returns "∑" (the Option+w glyph), which would never match "w".
-      if (e.code !== "KeyW") return;
+      if (!e.metaKey && !e.ctrlKey) return;
+      if (e.altKey || e.shiftKey) return;
+      // KeyboardEvent.code is layout-independent, unlike e.key which varies
+      // with keyboard layout and held modifiers.
+      if (e.code !== "Slash") return;
       const target = e.target as HTMLElement | null;
       if (target?.isContentEditable) return;
       e.preventDefault();

--- a/client/dashboard/src/components/ui/sidebar.tsx
+++ b/client/dashboard/src/components/ui/sidebar.tsx
@@ -6,8 +6,13 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { cn } from "@/lib/utils";
+import { cn, isMacPlatform } from "@/lib/utils";
 import { Button, Icon } from "@speakeasy-api/moonshine";
 import * as React from "react";
 import {
@@ -228,28 +233,37 @@ function SidebarTrigger({
   ...props
 }: React.ComponentProps<typeof Button>): React.JSX.Element {
   const { toggleSidebar } = useSidebar();
+  const shortcutLabel = isMacPlatform() ? "⌘B" : "Ctrl+B";
 
   return (
-    <Button
-      data-sidebar="trigger"
-      data-slot="sidebar-trigger"
-      variant="tertiary"
-      size="sm"
-      className={cn(
-        "text-muted-foreground hover:text-foreground size-7 cursor-pointer transition",
-        className,
-      )}
-      onClick={(event) => {
-        onClick?.(event);
-        toggleSidebar();
-      }}
-      {...props}
-    >
-      <Button.LeftIcon>
-        <Icon name="panel-left" />
-      </Button.LeftIcon>
-      <Button.Text className="sr-only">Toggle Sidebar</Button.Text>
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          data-sidebar="trigger"
+          data-slot="sidebar-trigger"
+          variant="tertiary"
+          size="sm"
+          aria-keyshortcuts={isMacPlatform() ? "Meta+B" : "Control+B"}
+          className={cn(
+            "text-muted-foreground hover:text-foreground size-7 cursor-pointer transition",
+            className,
+          )}
+          onClick={(event) => {
+            onClick?.(event);
+            toggleSidebar();
+          }}
+          {...props}
+        >
+          <Button.LeftIcon>
+            <Icon name="panel-left" />
+          </Button.LeftIcon>
+          <Button.Text className="sr-only">Toggle Sidebar</Button.Text>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        Toggle sidebar ({shortcutLabel})
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/client/dashboard/src/lib/utils.ts
+++ b/client/dashboard/src/lib/utils.ts
@@ -28,6 +28,17 @@ export function buildLoginRedirectURL(redirectTo: string | null): string {
   return href;
 }
 
+/**
+ * True on macOS/iOS — used to pick ⌘ vs Ctrl in keyboard shortcut hints.
+ * Defaults to true during SSR/tests where `navigator` is unavailable.
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return true;
+  return /mac|iphone|ipad|ipod/i.test(
+    navigator.platform || navigator.userAgent,
+  );
+}
+
 export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }


### PR DESCRIPTION
## Summary

Two keyboard-shortcut affordance updates in the dashboard:

1. **Project Assistant shortcut → Cmd+/** (Ctrl+/ on PC), replacing Option+Shift+W
   - Trigger button's hover-revealed kbd chips now show `⌘` `/`
   - Native `title` tooltip reads `Project Assistant (⌘+/)`
   - Global keydown handler matches Cmd+/ via layout-independent `e.code === "Slash"` and rejects extra Alt/Shift modifiers
   - `aria-keyshortcuts` updated to `Meta+/` / `Control+/`
   - Cmd+/ is safe to bind (unlike Cmd+W, which browsers consume before page JS), so the old workaround combo is no longer needed

2. **Sidebar collapse button gets a hover tooltip showing ⌘B** (Ctrl+B on PC)
   - Cmd+B already toggled the nav sidebar; the trigger just had no visible hint
   - Wraps `SidebarTrigger` in the app's global Radix tooltip and adds `aria-keyshortcuts`

Also hoists `isMacPlatform()` from `insights-sidebar.tsx` into `@/lib/utils` so both components share one platform check.

## Testing

- `pnpm -F dashboard type-check` passes
- `pnpm -F dashboard lint` (format + no-barrels + oxlint + tsc) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Change Project Assistant shortcut to Cmd+/ (Ctrl+/ on Windows/Linux) and add a hover tooltip to the sidebar toggle showing Cmd+B. This makes shortcuts easier to discover and matches common app patterns.

- **New Features**
  - Project Assistant: bind Cmd+/ (Ctrl+/) globally via layout-independent "Slash"; update hover kbd chips, title tooltip, and aria-keyshortcuts.
  - Sidebar toggle: add tooltip showing ⌘B (Ctrl+B) and set aria-keyshortcuts.

- **Refactors**
  - Hoist `isMacPlatform()` to `@/lib/utils` for shared platform checks.

<sup>Written for commit a2c2342daab9d3cf5c045567c6e5cdb0cc92b985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

