### PR TITLE
fix: dashboard scroll container

### DIFF
--- a/client/dashboard/src/components/ui/sidebar.tsx
+++ b/client/dashboard/src/components/ui/sidebar.tsx
@@ -261,7 +261,7 @@ function SidebarInset({
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-surface-primary relative flex min-w-0 flex-1 flex-col overflow-auto",
+        "bg-surface-primary relative flex min-w-0 flex-1 flex-col",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className,
       )}


### PR DESCRIPTION
## Summary

- Removes the `overflow-auto` behavior from `SidebarInset` so the app shell no longer becomes an unintended page-level scroll container.
- Leaves page-level scroll ownership with the existing `Page.Body` layout, preserving the desired fixed breadcrumb/rainbow header behavior.

## Root Cause

`SidebarInset` had a Gram-added `overflow-auto` class. On shorter viewports, wheel events over the breadcrumb/header or after inner content reached its bottom could scroll the inset itself, moving the otherwise fixed breadcrumb header out of view.

## Validation

- `pnpm -F dashboard lint:format`
- `pnpm -F dashboard type-check`
- Authenticated Playwright probe against `/speakeasy/projects/default/mcp/x/x-linear-yz-6836/settings` at 1147, 900, and 700 px heights:
  - header wheel leaves the shell scroll position at 0
  - scrolling below the header moves the page body content
  - tab content does not become a separate scroller

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard scroll behavior by removing `overflow-auto` from `SidebarInset` so the app shell no longer becomes a scroll container. Page scroll stays with `Page.Body`, keeping the breadcrumb/rainbow header fixed.

- **Bug Fixes**
  - Wheel events on the header no longer move the shell.
  - Only the page body scrolls; tab content doesn’t create a nested scroller.

<sup>Written for commit 8663bc36d8362c20a18a51c4228147ea6ceb44c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

