### PR TITLE
chore: add google interceptor to transform request to google format

### DIFF
--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -47,6 +47,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/interceptors"
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -117,6 +118,10 @@ type ChallengeManager struct {
 	policy    *guardian.Policy
 	cache     cache.TypedCacheObject[RemoteLoginState]
 	serverURL *url.URL
+	// authorizeInterceptors adapt the outgoing upstream authorize request to
+	// per-provider, non-standard requirements (e.g. Google's offline access).
+	// Injected here rather than via a package-global registry.
+	authorizeInterceptors []interceptors.AuthorizeInterceptor
 }
 
 func NewChallengeManager(
@@ -139,6 +144,9 @@ func NewChallengeManager(
 			cache.SuffixNone,
 		),
 		serverURL: serverURL,
+		authorizeInterceptors: []interceptors.AuthorizeInterceptor{
+			interceptors.NewGoogle(logger),
+		},
 	}
 }
 
@@ -318,6 +326,11 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 	}
 	if client.Audience != "" {
 		q.Set("audience", client.Audience)
+	}
+	for _, ic := range m.authorizeInterceptors {
+		if ic.Match(client.IssuerURL) {
+			ic.ModifyAuthorize(ctx, q)
+		}
 	}
 	u.RawQuery = q.Encode()
 	return u.String(), nil

--- a/server/internal/remotesessions/interceptors/google.go
+++ b/server/internal/remotesessions/interceptors/google.go
@@ -1,0 +1,41 @@
+package interceptors
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+type google struct {
+	logger *slog.Logger
+}
+
+// NewGoogle builds the Google offline-access authorize interceptor.
+func NewGoogle(logger *slog.Logger) AuthorizeInterceptor {
+	return &google{logger: logger.With(attr.SlogComponent("remotesessions_interceptor_google"))}
+}
+
+var _ AuthorizeInterceptor = (*google)(nil)
+
+func (g *google) Name() string { return "google-offline-access" }
+
+func (g *google) Match(issuerURL string) bool {
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return false
+	}
+	return u.Hostname() == "accounts.google.com"
+}
+
+// ModifyAuthorize requests offline access. Google issues a refresh token only
+// with access_type=offline, and re-issues one on re-consent only with
+// prompt=consent — a Google-proprietary deviation from RFC 6749 / OIDC
+// offline_access.
+func (g *google) ModifyAuthorize(ctx context.Context, q url.Values) {
+	q.Set("access_type", "offline")
+	q.Set("prompt", "consent")
+	g.logger.InfoContext(ctx,
+		"applied authorize interceptor: requesting offline access (access_type=offline, prompt=consent)")
+}

--- a/server/internal/remotesessions/interceptors/google.go
+++ b/server/internal/remotesessions/interceptors/google.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"net/url"
+	"slices"
+	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 )
@@ -26,7 +28,9 @@ func (g *google) Match(issuerURL string) bool {
 	if err != nil {
 		return false
 	}
-	return u.Hostname() == "accounts.google.com"
+	// Hostnames are case-insensitive (url.Parse does not normalise case), so
+	// fold the comparison to catch mixed-case issuer URLs.
+	return strings.EqualFold(u.Hostname(), "accounts.google.com")
 }
 
 // ModifyAuthorize requests offline access. Google issues a refresh token only
@@ -35,7 +39,18 @@ func (g *google) Match(issuerURL string) bool {
 // offline_access.
 func (g *google) ModifyAuthorize(ctx context.Context, q url.Values) {
 	q.Set("access_type", "offline")
-	q.Set("prompt", "consent")
+
+	// prompt is a space-delimited list. Merge consent in rather than
+	// overwriting any value already carried on the authorization endpoint
+	// (e.g. select_account) so we don't silently drop other prompt behaviour.
+	// consent must always be present — Google omits the refresh token on a
+	// silent re-consent.
+	prompts := strings.Fields(q.Get("prompt"))
+	if !slices.Contains(prompts, "consent") {
+		prompts = append(prompts, "consent")
+	}
+	q.Set("prompt", strings.Join(prompts, " "))
+
 	g.logger.InfoContext(ctx,
 		"applied authorize interceptor: requesting offline access (access_type=offline, prompt=consent)")
 }

--- a/server/internal/remotesessions/interceptors/google_test.go
+++ b/server/internal/remotesessions/interceptors/google_test.go
@@ -18,6 +18,14 @@ func TestGoogleMatchesGoogleIssuer(t *testing.T) {
 	require.True(t, ic.Match("https://accounts.google.com/o/oauth2/v2/auth"))
 }
 
+func TestGoogleMatchesGoogleIssuerCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	ic := interceptors.NewGoogle(testenv.NewLogger(t))
+	require.True(t, ic.Match("https://Accounts.Google.com"))
+	require.True(t, ic.Match("https://ACCOUNTS.GOOGLE.COM/o/oauth2/v2/auth"))
+}
+
 func TestGoogleDoesNotMatchOtherIssuers(t *testing.T) {
 	t.Parallel()
 
@@ -42,6 +50,29 @@ func TestGoogleModifyAuthorizeRequestsOfflineAccess(t *testing.T) {
 
 	require.Equal(t, "offline", q.Get("access_type"))
 	require.Equal(t, "consent", q.Get("prompt"))
+}
+
+func TestGoogleModifyAuthorizePreservesExistingPrompt(t *testing.T) {
+	t.Parallel()
+
+	ic := interceptors.NewGoogle(testenv.NewLogger(t))
+	q := url.Values{}
+	q.Set("prompt", "select_account")
+	ic.ModifyAuthorize(t.Context(), q)
+
+	require.Equal(t, "offline", q.Get("access_type"))
+	require.Equal(t, "select_account consent", q.Get("prompt"))
+}
+
+func TestGoogleModifyAuthorizeDoesNotDuplicateConsent(t *testing.T) {
+	t.Parallel()
+
+	ic := interceptors.NewGoogle(testenv.NewLogger(t))
+	q := url.Values{}
+	q.Set("prompt", "consent select_account")
+	ic.ModifyAuthorize(t.Context(), q)
+
+	require.Equal(t, "consent select_account", q.Get("prompt"))
 }
 
 func TestGoogleName(t *testing.T) {

--- a/server/internal/remotesessions/interceptors/google_test.go
+++ b/server/internal/remotesessions/interceptors/google_test.go
@@ -1,0 +1,52 @@
+package interceptors_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/interceptors"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestGoogleMatchesGoogleIssuer(t *testing.T) {
+	t.Parallel()
+
+	ic := interceptors.NewGoogle(testenv.NewLogger(t))
+	require.True(t, ic.Match("https://accounts.google.com"))
+	require.True(t, ic.Match("https://accounts.google.com/o/oauth2/v2/auth"))
+}
+
+func TestGoogleDoesNotMatchOtherIssuers(t *testing.T) {
+	t.Parallel()
+
+	ic := interceptors.NewGoogle(testenv.NewLogger(t))
+	require.False(t, ic.Match("https://login.microsoftonline.com/common"))
+	require.False(t, ic.Match("https://accounts.google.com.evil.example/auth"))
+}
+
+func TestGoogleDoesNotMatchMalformedIssuer(t *testing.T) {
+	t.Parallel()
+
+	ic := interceptors.NewGoogle(testenv.NewLogger(t))
+	require.False(t, ic.Match("://not-a-url"))
+}
+
+func TestGoogleModifyAuthorizeRequestsOfflineAccess(t *testing.T) {
+	t.Parallel()
+
+	ic := interceptors.NewGoogle(testenv.NewLogger(t))
+	q := url.Values{}
+	ic.ModifyAuthorize(t.Context(), q)
+
+	require.Equal(t, "offline", q.Get("access_type"))
+	require.Equal(t, "consent", q.Get("prompt"))
+}
+
+func TestGoogleName(t *testing.T) {
+	t.Parallel()
+
+	ic := interceptors.NewGoogle(testenv.NewLogger(t))
+	require.Equal(t, "google-offline-access", ic.Name())
+}

--- a/server/internal/remotesessions/interceptors/interceptor.go
+++ b/server/internal/remotesessions/interceptors/interceptor.go
@@ -1,0 +1,32 @@
+// Package interceptors adapts the outgoing upstream authorize request to a
+// provider's non-standard requirements before the user is redirected to it.
+//
+// Each interceptor is a per-provider rule: it Matches an issuer and, on match,
+// Applies a mutation to the authorize query params. Selection is per-call
+// because the issuer is only known at request time (mirroring the
+// backend-selection Match in externalmcp). The per-type / Name() /
+// injected-slice shape follows the remotemcp/proxy interceptors — there is no
+// package-global registry; the set is assembled and injected at construction
+// time (see remotesessions.NewChallengeManager).
+package interceptors
+
+import (
+	"context"
+	"net/url"
+)
+
+// AuthorizeInterceptor adapts an upstream authorize request to a provider's
+// non-standard requirements. Selected per-issuer via Match (mirrors the
+// backend-selection Match in externalmcp); on match, ModifyAuthorize mutates the
+// authorize query params in place. Holds its own logger, like the
+// remotemcp/proxy interceptors.
+type AuthorizeInterceptor interface {
+	// Name is a stable id for log correlation / tracing.
+	Name() string
+	// Match reports whether this interceptor applies to the issuer. It
+	// receives the full issuer URL so an implementation can key on any
+	// property (host, scheme, path, …), not just the host.
+	Match(issuerURL string) bool
+	// ModifyAuthorize mutates the authorize query in place. Called only on Match.
+	ModifyAuthorize(ctx context.Context, q url.Values)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an authorization interceptor and a Google-specific rule that requests offline access and keeps existing prompts intact. Fixes missing refresh tokens for Google issuers and stops 401 loops after ~1h (AIS-113).

- New Features
  - Introduced `AuthorizeInterceptor` in `server/internal/remotesessions/interceptors` to let providers modify authorize query params.
  - Wired into `ChallengeManager.BuildAuthorizationUrl`; added a Google implementation that matches `accounts.google.com` case-insensitively and uses `ModifyAuthorize`.

- Bug Fixes
  - For Google, set `access_type=offline` and merge `consent` into the space-delimited `prompt` (no overwrite), ensuring refresh tokens are issued without dropping values like `select_account`.

<sup>Written for commit 24a8c19d674432a55ce9f7cffc789135b33ccb25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

