### PR TITLE
chore(dependabot): add npm cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       ai-sdk:
         patterns:


### PR DESCRIPTION
## Summary
- Add a 7-day cooldown to Dependabot npm version updates.
- Align Dependabot update timing with pnpm's 7-day minimumReleaseAge policy.
- Prevent Dependabot from opening npm PRs for versions that pnpm refuses to resolve yet, which leaves stale lockfile importer entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 7-day cooldown for Dependabot npm updates. Aligns with `pnpm`’s 7-day minimumReleaseAge to prevent PRs `pnpm` won’t resolve and avoid stale lockfile entries.

<sup>Written for commit 94e3785d44390ce155e0e638113dad6af413b268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

