### PR TITLE
fix(dashboard): stop auth.info request storm from command palette recents

### DIFF
--- a/.changeset/fix-cmdk-authinfo-storm.md
+++ b/.changeset/fix-cmdk-authinfo-storm.md
@@ -1,0 +1,10 @@
+---
+"dashboard": patch
+---
+
+Fix a request storm of `GET /rpc/auth.info` 401s introduced by the command
+palette's Recently Visited feature. The user-id lookup issued an unconditional
+`auth.info` request from the always-mounted palette (including on the
+unauthenticated login page). The session lookup is now gated on the palette's
+open state, and the page-visit recorder reuses the session already fetched by
+the auth provider instead of issuing its own request.

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -20,10 +20,8 @@ import {
 } from "react-router";
 import { AppLayout, LoginCheck, OrgLayout } from "./components/app-layout.tsx";
 import { CommandPalette } from "./components/command-palette";
-import {
-  recordVisit,
-  useRecentsUserId,
-} from "./components/command-palette/recentlyVisited";
+import { recordVisit } from "./components/command-palette/recentlyVisited";
+import { useUser } from "./contexts/Auth";
 import { useProjectNavRoutes } from "./hooks/useProjectNavRoutes";
 import { useRBAC } from "./hooks/useRBAC";
 import { AuthProvider, ProjectProvider } from "./contexts/AuthProvider.tsx";
@@ -160,7 +158,9 @@ const RouteProvider = () => {
   const location = useLocation();
   const projectNavRoutes = useProjectNavRoutes();
   const { hasAnyScope } = useRBAC();
-  const recentsUserId = useRecentsUserId();
+  // RouteProvider is inside AuthProvider, so reuse the already-fetched session
+  // instead of issuing another auth.info request.
+  const recentsUserId = useUser().id || undefined;
 
   // Update document title based on active route
   usePageTitle(routes, orgRoutes);

--- a/client/dashboard/src/components/command-palette/CommandPalette.tsx
+++ b/client/dashboard/src/components/command-palette/CommandPalette.tsx
@@ -37,9 +37,10 @@ export function CommandPalette(): JSX.Element {
 
   // Recently visited pages (client-side; read only while the palette is open).
   // Scoped per user so a shared browser profile doesn't leak history. Gate the
-  // read on the user id resolving so we never read the shared anonymous key
-  // before the session loads.
-  const recentsUserId = useRecentsUserId();
+  // session lookup on `isOpen` so we don't poll auth.info on every page (it
+  // 401s when unauthenticated); gate the read on the user id resolving so we
+  // never read the shared anonymous key before the session loads.
+  const recentsUserId = useRecentsUserId(isOpen);
   const recents = useRecentlyVisited(
     recentsUserId,
     orgSlug,

--- a/client/dashboard/src/components/command-palette/recentlyVisited.ts
+++ b/client/dashboard/src/components/command-palette/recentlyVisited.ts
@@ -24,13 +24,17 @@ const UPDATED_EVENT = "gram:recents-updated";
 
 /**
  * The current user's id, used to scope recents per authenticated user. Derived
- * from the SDK session hook rather than `useUser()` so it works outside the
- * `AuthProvider` (the command palette is mounted above it). Both the write
- * (`recordVisit`) and read (`useRecentlyVisited`) paths resolve the id this way
- * so their storage keys always match.
+ * from the SDK session hook so it works outside the `AuthProvider` (the command
+ * palette is mounted above it).
+ *
+ * `enabled` gates the underlying `auth.info` request: the command palette passes
+ * its open state so we never poll `auth.info` on every page (including the
+ * unauthenticated login page, where it 401s). Inside `AuthProvider`, prefer
+ * `useUser()` instead — the session is already fetched there.
  */
-export function useRecentsUserId(): string | undefined {
+export function useRecentsUserId(enabled = true): string | undefined {
   const { data } = useSessionInfo(undefined, undefined, {
+    enabled,
     refetchOnWindowFocus: false,
     retry: false,
     throwOnError: false,


### PR DESCRIPTION
## Incident

After shipping the global command palette (#3285), prod showed a storm of `GET /rpc/auth.info` 401s on the network tab.

## Root cause

The Recently Visited feature scopes recents per user via a `useRecentsUserId()` hook that called `useSessionInfo()` **unconditionally**. That hook runs inside `CommandPalette`, which is mounted on **every** page — including the unauthenticated login page, where `auth.info` returns 401. On unauthenticated/redirecting pages this fired the request repeatedly.

## Fix

- **Read path (`CommandPalette`, outside `AuthProvider`):** gate the session lookup on the palette's open state (`useRecentsUserId(isOpen)`), so `auth.info` is only requested when the palette is actually opened — never passively on page load.
- **Write path (`RouteProvider`, inside `AuthProvider`):** use `useUser()` to read the session already fetched by the auth provider instead of issuing a second `auth.info` query.

Net effect: zero passive `auth.info` traffic from the palette; the request only happens (once, from cache) when a signed-in user opens the palette.

## Verification

- `pnpm -F dashboard type-check` ✅
- `pnpm -F dashboard lint` ✅
- `pnpm -F dashboard build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a storm of `GET /rpc/auth.info` 401s triggered by the global command palette’s Recently Visited feature. We now gate the session lookup on palette open and reuse the session inside `AuthProvider`, eliminating passive `auth.info` traffic.

- **Bug Fixes**
  - `CommandPalette`: pass `isOpen` to `useRecentsUserId(enabled)` to gate `useSessionInfo`, so `auth.info` only runs when the palette opens (prevents 401 loops on unauthenticated pages).
  - `RouteProvider`: use `useUser()` instead of `useSessionInfo` to reuse the session already fetched by `AuthProvider`.

<sup>Written for commit 83dae9afcdfd5925e5afb6bd567154ecd63a7ab1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

