### PR TITLE
feat(dashboard): org switcher + sidebar nav alignment

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -147,9 +147,9 @@ export function AppSidebar({
         <div className="flex items-center justify-between gap-2 group-data-[collapsible=icon]:justify-center">
           <Link
             to={`/${orgSlug}`}
-            className="flex h-(--header-height) items-center px-1 hover:no-underline group-data-[collapsible=icon]:h-auto group-data-[collapsible=icon]:justify-center"
+            className="flex h-(--header-height) items-center px-1 hover:no-underline group-data-[collapsible=icon]:hidden"
           >
-            <GramLogo className="w-28 group-data-[collapsible=icon]:hidden" />
+            <GramLogo className="w-28" />
           </Link>
           <CommandPaletteTrigger />
         </div>

--- a/client/dashboard/src/components/gradient-colors.ts
+++ b/client/dashboard/src/components/gradient-colors.ts
@@ -1,5 +1,5 @@
-// Generate colors from project label
-export function getProjectColors(label: string): {
+// Deterministic gradient colors from any string label (project/org/assistant id).
+export function getGradientColors(label: string): {
   from: string;
   to: string;
   angle: number;

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -117,9 +117,9 @@ export function OrgSidebar({
         <div className="flex items-center justify-between gap-2 group-data-[collapsible=icon]:justify-center">
           <Link
             to={orgRoutes.home.href()}
-            className="flex h-(--header-height) items-center px-1 hover:no-underline group-data-[collapsible=icon]:h-auto group-data-[collapsible=icon]:justify-center"
+            className="flex h-(--header-height) items-center px-1 hover:no-underline group-data-[collapsible=icon]:hidden"
           >
-            <GramLogo className="w-28 group-data-[collapsible=icon]:hidden" />
+            <GramLogo className="w-28" />
           </Link>
           <CommandPaletteTrigger />
         </div>

--- a/client/dashboard/src/components/project-menu.tsx
+++ b/client/dashboard/src/components/project-menu.tsx
@@ -9,7 +9,7 @@ import { Combobox } from "./ui/combobox.tsx";
 import { Skeleton } from "./ui/skeleton.tsx";
 import { Type } from "./ui/type.tsx";
 
-import { getProjectColors } from "@/components/project-colors";
+import { getGradientColors } from "@/components/gradient-colors";
 
 export function ProjectAvatar({
   project,
@@ -18,7 +18,7 @@ export function ProjectAvatar({
   project: Pick<ProjectEntry, "id">;
   className?: string;
 }): React.JSX.Element {
-  const colors = getProjectColors(project.id);
+  const colors = getGradientColors(project.id);
   return (
     <div
       className={cn("h-6 w-6 rounded-full bg-gradient-to-br", className)}

--- a/client/dashboard/src/components/workspace-switcher.tsx
+++ b/client/dashboard/src/components/workspace-switcher.tsx
@@ -1,7 +1,10 @@
-import { useOrganization, useProject } from "@/contexts/Auth";
+import { getGradientColors } from "@/components/gradient-colors";
+import { useOrganization, useProject, useSession } from "@/contexts/Auth";
 import { useSdkClient, useSlugs } from "@/contexts/Sdk";
-import { CheckIcon, ChevronsUpDown, PlusIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CheckIcon, ChevronDown, ChevronsUpDown, PlusIcon } from "lucide-react";
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import { InputDialog } from "./input-dialog";
 import { ProjectAvatar } from "./project-menu";
 import { Button } from "./ui/button";
@@ -18,8 +21,11 @@ import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 export function WorkspaceSwitcher(): JSX.Element {
   const organization = useOrganization();
   const project = useProject();
+  const session = useSession();
+  const navigate = useNavigate();
   const { projectSlug } = useSlugs();
   const client = useSdkClient();
+  const isMultiOrg = session.organizations.length > 1;
   const [open, setOpen] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newProjectName, setNewProjectName] = useState("");
@@ -42,14 +48,59 @@ export function WorkspaceSwitcher(): JSX.Element {
     project.switchProject(result.project.slug);
   };
 
-  // Org-level pages have no project — render org context only.
+  // Org-level pages have no project — render org context only. Collapsed,
+  // swap the truncated name for a gradient initial tile (mirrors ProjectAvatar).
+  // With multiple orgs the row becomes a button that opens the org switcher.
   if (!projectSlug) {
-    return (
-      <div className="flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm font-medium">
-        <span className="truncate">
-          {organization.name || organization.slug}
+    const orgLabel = organization.name || organization.slug;
+    const orgColors = getGradientColors(organization.id);
+    const orgInitial = orgLabel.charAt(0).toUpperCase();
+    const rowClass =
+      "flex w-full items-center gap-2 rounded-md border px-2 py-1.5 text-sm font-medium group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:border-0 group-data-[collapsible=icon]:p-0";
+    const content = (
+      <>
+        <div
+          className={cn(
+            "flex shrink-0 items-center justify-center transition-shadow",
+            "group-data-[collapsible=icon]:ring-border/50 group-data-[collapsible=icon]:bg-card group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:p-1 group-data-[collapsible=icon]:ring-1",
+            isMultiOrg &&
+              "group-data-[collapsible=icon]:hover:ring-foreground/15 group-data-[collapsible=icon]:hover:ring-2",
+          )}
+        >
+          <div
+            aria-label={orgLabel}
+            className="flex size-6 shrink-0 items-center justify-center rounded-md bg-gradient-to-br text-xs font-semibold text-white group-data-[collapsible=icon]:size-7"
+            style={{
+              backgroundImage: `linear-gradient(${orgColors.angle}deg, ${orgColors.from}, ${orgColors.to})`,
+            }}
+          >
+            {orgInitial}
+          </div>
+        </div>
+        <span className="truncate group-data-[collapsible=icon]:hidden">
+          {orgLabel}
         </span>
-      </div>
+        {isMultiOrg && (
+          <ChevronDown className="text-muted-foreground ml-auto h-4 w-4 shrink-0 group-data-[collapsible=icon]:hidden" />
+        )}
+      </>
+    );
+
+    if (!isMultiOrg) {
+      return <div className={rowClass}>{content}</div>;
+    }
+
+    return (
+      <button
+        type="button"
+        onClick={() => void navigate("/switch-org")}
+        className={cn(
+          rowClass,
+          "hover:bg-accent cursor-pointer text-left transition-colors group-data-[collapsible=icon]:hover:bg-transparent",
+        )}
+      >
+        {content}
+      </button>
     );
   }
 

--- a/client/dashboard/src/components/workspace-switcher.tsx
+++ b/client/dashboard/src/components/workspace-switcher.tsx
@@ -69,7 +69,7 @@ export function WorkspaceSwitcher(): JSX.Element {
         >
           <div
             aria-label={orgLabel}
-            className="flex size-6 shrink-0 items-center justify-center rounded-md bg-gradient-to-br text-xs font-semibold text-white group-data-[collapsible=icon]:size-7"
+            className="flex size-6 shrink-0 items-center justify-center rounded-md bg-gradient-to-br text-xs font-semibold text-white group-data-[collapsible=icon]:size-7 group-data-[collapsible=icon]:text-[14px]"
             style={{
               backgroundImage: `linear-gradient(${orgColors.angle}deg, ${orgColors.from}, ${orgColors.to})`,
             }}

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -1,6 +1,6 @@
 import { TopUpCTA, UsageProgress } from "@/components/billing/usage-controls";
 import { Page } from "@/components/page-layout";
-import { getProjectColors } from "@/components/project-colors";
+import { getGradientColors } from "@/components/gradient-colors";
 import { RequireScope } from "@/components/require-scope";
 import { CardContextMenu } from "@/components/card-context-menu";
 import { Badge } from "@/components/ui/badge";
@@ -231,7 +231,7 @@ function UsageSection() {
 // Each assistant gets a deterministic gradient tile behind its Bot icon,
 // derived from its id via the same hash that powers project avatar colors.
 function AssistantIcon({ assistant }: { assistant: Pick<Assistant, "id"> }) {
-  const colors = getProjectColors(assistant.id);
+  const colors = getGradientColors(assistant.id);
   return (
     <div
       className="flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br"


### PR DESCRIPTION
## What

Sidebar nav polish + an organization switcher entry point.

- **Search icon centering** — in collapsed (icon) mode the logo `<Link>` wrapper was emptied but left in flow, so `justify-center` centered `[empty link][gap][button]` and the search icon drifted right. The whole wrapper is now hidden when collapsed (`app-sidebar`, `org-sidebar`).
- **Org gradient tile** — org-level sidebar now renders a deterministic gradient initial tile (mirrors `ProjectAvatar`). Collapsed, it's framed to match the nav items (`ring-1 ring-border/50` + `bg-card` + `p-1`, zero layout growth) so it lines up with the icon column.
- **Org switcher** — when the user belongs to more than one org, the expanded org row becomes a button with a chevron that navigates to `/switch-org` (the page added in #2949). Single-org users keep a plain label.
- **Rename** — `getProjectColors` → `getGradientColors` and `project-colors.ts` → `gradient-colors.ts`; it was already being fed `assistant.id` / now `organization.id`, so the project-specific name was a misnomer.

## Why

The collapsed search icon was visibly off-center, and the org name truncated to "S.." in collapsed mode with no way to switch orgs from the sidebar.

## Notes

- Gating uses `session.organizations.length > 1` — same predicate as the existing "Switch Organization" item in `sidebar-user-menu`.
- Pure frontend; no API/schema changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the dashboard sidebars and added an org switcher from the org row for multi‑org users. Unified the gradient color helper (`getProjectColors` → `getGradientColors`) and centered the collapsed search icon.

- **New Features**
  - Org switcher from the org row for multi‑org users; opens `/switch-org`. Single‑org remains a label.
  - Org gradient initial tile in the sidebar (mirrors `ProjectAvatar`); framed and aligned when collapsed.

- **Bug Fixes**
  - Centered the search icon in collapsed mode by hiding the logo link wrapper.

<sup>Written for commit e439e0064a4a1b4c864b2d7544ddb0e0d802e1f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

