### PR TITLE
chore(dashboard): scope onboarding banner to enterprise orgs

### DIFF
--- a/client/dashboard/src/components/onboarding-banner.tsx
+++ b/client/dashboard/src/components/onboarding-banner.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Type } from "@/components/ui/type";
 import { useSlugs } from "@/contexts/Sdk";
+import { useProductTier } from "@/hooks/useProductTier";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useOrgRoutes } from "@/routes";
 import { ArrowRight, Wrench } from "lucide-react";
@@ -29,12 +30,14 @@ function storeDismissed(orgSlug: string) {
 export function OnboardingBanner(): JSX.Element | null {
   const { orgSlug } = useSlugs();
   const { hasScope } = useRBAC();
+  const productTier = useProductTier();
   const orgRoutes = useOrgRoutes();
   const [dismissed, setDismissed] = useState(() =>
     orgSlug ? getStoredDismissed(orgSlug) : false,
   );
 
   if (!orgSlug) return null;
+  if (productTier !== "enterprise") return null;
   if (!hasScope("org:admin")) return null;
   if (dismissed) return null;
 


### PR DESCRIPTION
## What

Scopes the "Finish setup" onboarding banner so it only renders for **enterprise** orgs.

## Why

The setup banner walks through enterprise-only setup (SSO, Directory Sync, Plugin Marketplace, Agent Platforms, Policies). Non-enterprise orgs (`base`, `base_PAID`, deprecated `pro`) shouldn't see a prompt to configure features they can't use.

## How

Added a `useProductTier()` guard in `OnboardingBanner`:

```tsx
if (productTier !== "enterprise") return null;
```

Placed before the `org:admin` scope and dismissed checks. The hook runs at the top with the other hooks to satisfy the Rules of Hooks.

## Result

| Tier                         | Banner             |
| ---------------------------- | ------------------ |
| `enterprise` (admin)         | shown              |
| `base` / `base_PAID` / `pro` | hidden             |
| non-admin                    | hidden (unchanged) |

## Test

- `pnpm -F dashboard type-check` — no new errors in `onboarding-banner.tsx` (pre-existing errors in unrelated files remain).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped the "Finish setup" onboarding banner to enterprise orgs only, so base/pro tiers no longer see prompts for enterprise features. Non-admin behavior is unchanged (banner remains hidden).

<sup>Written for commit 29b32f91f1053f60801f3d480f5c0f9d36f85aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

