### PR TITLE
feat(assistants): export runtime agent traces over OTLP

### DIFF
--- a/.changeset/assistant-runtime-otel-exporter.md
+++ b/.changeset/assistant-runtime-otel-exporter.md
@@ -1,0 +1,9 @@
+---
+"server": minor
+---
+
+Assistant runtimes can now export agent traces (turns, tool calls) over OTLP
+to any OpenTelemetry-compatible backend such as Sentry, Datadog, or Honeycomb.
+Export is enabled by configuring an OTLP endpoint for assistant runtimes, with
+gRPC and HTTP transports supported; traces are tagged with the assistant and
+project they belong to.

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -72,6 +72,9 @@ infra:
 webhooks-catalog:
   - "server/internal/outbox/events/catalog_gen.yaml"
 
+otel-collector:
+  - "otel-collector/**"
+
 # Subset of `server` that gates the prompt-injection risk report job.
 risk_accuracy:
   - ".github/scripts/risk-metrics-comment.*"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -417,7 +417,7 @@ jobs:
   otel-collector:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes]
-    if: needs.changes.outputs.otel-collector == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')
+    if: needs.changes.outputs.otel-collector == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork))
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,6 +51,7 @@ jobs:
       risk_accuracy: ${{ steps.gates.outputs.risk_accuracy }}
       pi_classifier: ${{ steps.gates.outputs.pi_classifier }}
       webhooks-catalog: ${{ steps.gates.outputs.webhooks-catalog }}
+      otel-collector: ${{ steps.gates.outputs.otel-collector }}
       elements-examples: ${{ steps.list-elements-examples.outputs.examples }}
     steps:
       - name: Checkout source code
@@ -163,6 +164,13 @@ jobs:
             echo "Webhooks catalog breaking-change check will run."
           else
             echo "Webhooks catalog breaking-change check will be skipped."
+          fi
+
+          if [[ "${{ steps.filter.outputs.otel-collector }}" == "true" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+            echo "otel-collector=true" >> $GITHUB_OUTPUT
+            echo "OTel collector jobs will run."
+          else
+            echo "OTel collector jobs will be skipped."
           fi
       - id: list-elements-examples
         name: List elements examples
@@ -405,6 +413,125 @@ jobs:
           push: true
           tags: ${{ steps.assistantMetaProd.outputs.tags }}
           labels: ${{ steps.assistantMetaProd.outputs.labels }}
+
+  otel-collector:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [changes]
+    if: needs.changes.outputs.otel-collector == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Prepare GitHub Actions environment
+        run: mise run github
+
+      - name: "[DEV] Create fly app"
+        id: collectorFlyCreateDev
+        shell: bash
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+          FLY_IMAGE: ${{ vars.FLY_OTEL_COLLECTOR_IMAGE_DEV }}
+        run: |
+          mise run fly:init-runner \
+            --org ${{ secrets.FLY_ORG_DEV }} \
+            --image $FLY_IMAGE \
+            --force
+
+      - name: "[PROD] Create fly app"
+        id: collectorFlyCreateProd
+        shell: bash
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
+          FLY_IMAGE: ${{ vars.FLY_OTEL_COLLECTOR_IMAGE_PROD }}
+        run: |
+          mise run fly:init-runner \
+            --org ${{ secrets.FLY_ORG_PROD }} \
+            --image $FLY_IMAGE \
+            --force
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: "[DEV] Login to Fly registry"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+        run: fly auth docker
+
+      - name: "[DEV] Extract collector metadata"
+        id: collectorMetaDev
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ steps.collectorFlyCreateDev.outputs.flyAppRegistry }}
+          tags: |
+            type=ref,event=branch,enable=${{ github.event_name != 'merge_group' }}
+            type=ref,event=pr
+            type=sha
+            type=sha,format=long
+
+      - name: "[DEV] Build and push collector image"
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ./otel-collector
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.collectorMetaDev.outputs.tags }}
+          labels: ${{ steps.collectorMetaDev.outputs.labels }}
+
+      - name: "[DEV] Deploy collector"
+        if: github.event_name == 'push'
+        shell: bash
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+        run: |
+          fly deploy \
+            --app ${{ steps.collectorFlyCreateDev.outputs.flyAppName }} \
+            --image ${{ steps.collectorFlyCreateDev.outputs.flyAppRegistry }}:sha-${{ github.sha }} \
+            --config otel-collector/fly.toml \
+            --yes
+
+      - name: "[PROD] Login to Fly registry"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
+        run: fly auth docker
+
+      - name: "[PROD] Extract collector metadata"
+        id: collectorMetaProd
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ steps.collectorFlyCreateProd.outputs.flyAppRegistry }}
+          tags: |
+            type=ref,event=branch,enable=${{ github.event_name != 'merge_group' }}
+            type=ref,event=pr
+            type=sha
+            type=sha,format=long
+
+      - name: "[PROD] Build and push collector image"
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ./otel-collector
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.collectorMetaProd.outputs.tags }}
+          labels: ${{ steps.collectorMetaProd.outputs.labels }}
+
+      - name: "[PROD] Deploy collector"
+        if: github.event_name == 'push'
+        shell: bash
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
+        run: |
+          fly deploy \
+            --app ${{ steps.collectorFlyCreateProd.outputs.flyAppName }} \
+            --image ${{ steps.collectorFlyCreateProd.outputs.flyAppRegistry }}:sha-${{ github.sha }} \
+            --config otel-collector/fly.toml \
+            --yes
 
   atlas-lint:
     name: Lint migrations with Atlas
@@ -1749,6 +1876,7 @@ jobs:
       - functions-build-host
       - functions-image
       - assistant-runtime-image
+      - otel-collector
       - ts-framework-test
       - elements-build-lint
       - elements-test

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "agentkit-adapter-completions"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd5f827b3e036dc093de98b82c8a7507dda53f49f557dad0b567468ba61c65f"
+checksum = "0b0549a63045aefdfb2c916a9fa928ff39551532bc6c678e6a42a5532f7515de"
 dependencies = [
  "agentkit-core",
  "agentkit-http",
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-capabilities"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56de7d5c22ecf8c8235a508fcce1079cecd02f16d7a6042cdd01a7820f862c64"
+checksum = "e3a02d3d6cbf14371e66731b116fdcdab1e21808bf220b006ead26ddf20c8221"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-compaction"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae94217a4767801eeacd561f92b2644e4eca9aff989a3152c53f334baf00bca"
+checksum = "ccad3f42995ecc619549a90622bb716dd633b0fd90331838747ac7de2c266886"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-core"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fbdacc5ad0b3b09537a5b675c3fa6ead70d11b97f017922f54a8d4be185b66"
+checksum = "b301160b8265f1968c531343acc9f1c1d4339981d057caaa1384c5c83e55eb9c"
 dependencies = [
  "futures-timer",
  "serde",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-http"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb281098f1988f0be5456345cf14ca76335c8682807293dd2e626089be288abf"
+checksum = "d4a6d64f820afbe9d15a601ff01c27706bd48aa5d7eae4e34a1d0459678d8767"
 dependencies = [
  "async-trait",
  "bytes",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-loop"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dd076256e49351fb87b654ebdf7e9675362ca2434eb4e20d8466446e48a484"
+checksum = "4ab247f643b682cdd8ebb1934051030cab6e24ec2545cdd8faf4a4b87740e94e"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-mcp"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fd97c6a3a7d61521526337ed1045324c1d7c3215130387d280b471348f077b"
+checksum = "64f8d393ecb85414cbdb87dc4a272e15d89a717b079315c81da5904a238d9caf"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -112,13 +112,14 @@ dependencies = [
  "sse-stream",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "agentkit-provider-openrouter"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549922b09c4895ff664a9ab777acffb02bfc828d01df2376443d20703073a1d2"
+checksum = "0d5afff1ec07168bf6464d88c6c99d8b58f5b8cb137617e5417030534772d28e"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",
@@ -133,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-reporting"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8398907ba14e29a987fe2c712ef2f0f45758e16ba51166eed44024839ff854"
+checksum = "63189667f51d31c1d368ea177dc74857962245d068abe1108deda6067be9d34c"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -147,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-task-manager"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd1a7f41762a4d9f08d1f85149560cc099675f031d11e454a3034696ebb2244"
+checksum = "5088e747c02acd5d4b134ce5c7cbfbe70ef942f2db7ed49adc99d8ca8abc2154"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -160,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tool-fs"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833058c7f899043be22da6e9f4823b6fff412796b35a306a5a7781dde91c58b1"
+checksum = "6692324d48d09a358de76ec48544b6b0303fa7815b7739b214a47b3c97c93871"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -176,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-core"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230b52e05923e868ae7fb3effd7471089b81457e190aaa01f0fa3d93a150c42"
+checksum = "cf7040ef1537b0313bd8ce3d3f5a07e2bf63eea038189e902b6d7af908ebc834"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -192,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-derive"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57caeccc00fdd270b6ddc7461aa62e50d22f47eb65c144a0daa63283dacb9097"
+checksum = "fef5b2ae417e60b6607c4b0eca727ecfcbf300d59653b41c9b8b81e09a51a85b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -571,6 +571,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +679,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -932,6 +950,9 @@ dependencies = [
  "dashmap",
  "futures",
  "http",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -943,6 +964,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -1071,6 +1093,19 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1265,6 +1300,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1500,6 +1544,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1658,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +1699,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1606,6 +1755,53 @@ dependencies = [
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1745,6 +1941,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +2004,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1952,6 +2158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2493,6 +2700,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,9 +2757,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2583,6 +2843,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2887,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -2851,6 +3133,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -20,12 +20,27 @@ agentkit-reporting = { version = "0.6.0", features = ["tracing"] }
 agentkit-tool-fs = "0.6.0"
 agentkit-tools-core = { version = "0.6.0", features = ["schemars"] }
 agentkit-tools-derive = "0.6.0"
+opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", default-features = false, features = [
+  "grpc-tonic",
+  "http-json",
+  "http-proto",
+  "internal-logs",
+  "reqwest-blocking-client",
+  "reqwest-rustls",
+  "tls-webpki-roots",
+  "trace",
+] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = [
+  "trace",
+] }
 rmcp = { version = "1.5.0", default-features = false, features = [
   "client",
   "transport-streamable-http-client-reqwest",
   "reqwest",
 ] }
 tracing = "0.1"
+tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 async-trait = "0.1"

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -9,17 +9,17 @@ name = "gram-assistant-runner"
 path = "src/main.rs"
 
 [dependencies]
-agentkit-adapter-completions = "0.6.0"
-agentkit-compaction = "0.6.0"
-agentkit-core = "0.6.0"
-agentkit-http = { version = "0.6.0", features = ["reqwest-middleware-client"] }
-agentkit-loop = "0.6.0"
-agentkit-mcp = "0.6.0"
-agentkit-provider-openrouter = "0.6.0"
-agentkit-reporting = { version = "0.6.0", features = ["tracing"] }
-agentkit-tool-fs = "0.6.0"
-agentkit-tools-core = { version = "0.6.0", features = ["schemars"] }
-agentkit-tools-derive = "0.6.0"
+agentkit-adapter-completions = "0.8.0"
+agentkit-compaction = "0.8.0"
+agentkit-core = "0.8.0"
+agentkit-http = { version = "0.8.0", features = ["reqwest-middleware-client"] }
+agentkit-loop = "0.8.0"
+agentkit-mcp = "0.8.0"
+agentkit-provider-openrouter = "0.8.0"
+agentkit-reporting = { version = "0.8.0", features = ["tracing"] }
+agentkit-tool-fs = "0.8.0"
+agentkit-tools-core = { version = "0.8.0", features = ["schemars"] }
+agentkit-tools-derive = "0.8.0"
 opentelemetry = "0.32"
 opentelemetry-otlp = { version = "0.32", default-features = false, features = [
   "grpc-tonic",

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -28,6 +28,7 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = [
   "internal-logs",
   "reqwest-blocking-client",
   "reqwest-rustls",
+  "tls-aws-lc",
   "tls-webpki-roots",
   "trace",
 ] }

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -12,7 +12,14 @@ mod workdir;
 use std::net::SocketAddr;
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::server::ServeConfig;
 
@@ -48,13 +55,36 @@ enum Mode {
         /// /turn brings the live token.
         #[arg(long, env = "GRAM_INITIAL_TOKEN", default_value = "")]
         initial_token: String,
+
+        /// Export spans over OTLP. The exporter reads the standard
+        /// OTEL_EXPORTER_OTLP_* environment variables (ENDPOINT, HEADERS,
+        /// TIMEOUT, ...) for everything except transport selection, which
+        /// comes from --otel-protocol.
+        #[arg(long, env = "GRAM_ENABLE_OTEL_TRACES")]
+        with_otel_tracing: bool,
+
+        /// OTLP transport used when --with-otel-tracing is set.
+        #[arg(
+            long,
+            value_enum,
+            env = "OTEL_EXPORTER_OTLP_PROTOCOL",
+            default_value = "grpc"
+        )]
+        otel_protocol: OtlpProtocol,
     },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum OtlpProtocol {
+    Grpc,
+    #[value(name = "http/protobuf")]
+    HttpProtobuf,
+    #[value(name = "http/json")]
+    HttpJson,
 }
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    init_tracing();
-
     let cli = Cli::parse();
     let result = match cli.mode {
         Mode::Serve {
@@ -62,14 +92,25 @@ async fn main() -> ExitCode {
             assistant_id,
             server_url,
             initial_token,
-        } => server::serve(ServeConfig {
-            addr,
-            assistant_id,
-            server_url,
-            initial_token,
-        })
-        .await
-        .map_err(|e| e.to_string()),
+            with_otel_tracing,
+            otel_protocol,
+        } => {
+            let tracer_provider = init_tracing(with_otel_tracing.then_some(otel_protocol));
+            let result = server::serve(ServeConfig {
+                addr,
+                assistant_id,
+                server_url,
+                initial_token,
+            })
+            .await
+            .map_err(|e| e.to_string());
+            if let Some(provider) = tracer_provider
+                && let Err(e) = provider.shutdown()
+            {
+                tracing::warn!(error = %e, "otel tracer provider shutdown failed");
+            }
+            result
+        }
     };
 
     match result {
@@ -81,16 +122,77 @@ async fn main() -> ExitCode {
     }
 }
 
-fn init_tracing() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                tracing_subscriber::EnvFilter::new(
-                    "info,agentkit=trace,agentkit_loop=trace,agentkit_reporting=trace,agentkit_mcp=trace",
-                )
-            }),
+/// Initializes the tracing subscriber, optionally layering an OTLP span
+/// exporter on top of the stderr log output. Returns the tracer provider so
+/// the caller can flush buffered spans via `shutdown` before process exit.
+///
+/// An exporter that fails to build degrades to log-only tracing rather than
+/// failing the process: the runner serves user traffic and a misconfigured
+/// collector endpoint should not take it down.
+fn init_tracing(otel_protocol: Option<OtlpProtocol>) -> Option<SdkTracerProvider> {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        tracing_subscriber::EnvFilter::new(
+            "info,agentkit=trace,agentkit_loop=trace,agentkit_reporting=trace,agentkit_mcp=trace",
         )
+    });
+    let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
-        .with_target(true)
+        .with_target(true);
+
+    let mut exporter_error = None;
+    let provider = otel_protocol.and_then(|protocol| match build_span_exporter(protocol) {
+        Ok(exporter) => {
+            let resource = Resource::builder()
+                .with_service_name("gram-assistant-runner")
+                .with_attribute(opentelemetry::KeyValue::new(
+                    "service.version",
+                    env!("CARGO_PKG_VERSION"),
+                ))
+                .build();
+            Some(
+                SdkTracerProvider::builder()
+                    .with_resource(resource)
+                    .with_batch_exporter(exporter)
+                    .build(),
+            )
+        }
+        Err(error) => {
+            exporter_error = Some(error);
+            None
+        }
+    });
+    // INFO floor keeps per-token ContentDelta and other debug/trace events
+    // out of exported spans; the stderr log keeps its env-driven verbosity.
+    let otel_layer = provider.as_ref().map(|p| {
+        tracing_opentelemetry::layer()
+            .with_tracer(p.tracer("gram-assistant-runner"))
+            .with_filter(tracing_subscriber::filter::LevelFilter::INFO)
+    });
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt_layer)
+        .with(otel_layer)
         .init();
+
+    if let Some(error) = exporter_error {
+        tracing::error!(error = %error, "failed to build OTLP span exporter; traces will not be exported");
+    }
+    provider
+}
+
+fn build_span_exporter(
+    protocol: OtlpProtocol,
+) -> Result<SpanExporter, opentelemetry_otlp::ExporterBuildError> {
+    match protocol {
+        OtlpProtocol::Grpc => SpanExporter::builder().with_tonic().build(),
+        OtlpProtocol::HttpProtobuf => SpanExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .build(),
+        OtlpProtocol::HttpJson => SpanExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpJson)
+            .build(),
+    }
 }

--- a/otel-collector/Dockerfile
+++ b/otel-collector/Dockerfile
@@ -1,3 +1,3 @@
-FROM otel/opentelemetry-collector-contrib:0.154.0
+FROM otel/opentelemetry-collector-contrib:0.154.0@sha256:e9d3163c8150012f06c61a0b4388569c0d2ca9648ac9591d8b5763717f2339e3
 
 COPY config.yaml /etc/otelcol-contrib/config.yaml

--- a/otel-collector/Dockerfile
+++ b/otel-collector/Dockerfile
@@ -1,0 +1,3 @@
+FROM otel/opentelemetry-collector-contrib:0.154.0
+
+COPY config.yaml /etc/otelcol-contrib/config.yaml

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -1,0 +1,38 @@
+# OpenTelemetry Collector for Gram's Fly-hosted workloads (assistant
+# runtimes and, later, function runners). VMs export OTLP to this app over
+# the org's private network; the collector forwards to the configured
+# backend using credentials that live only on this app as Fly secrets:
+#
+#   GRAM_OTLP_FORWARD_ENDPOINT       e.g. https://o1234.ingest.sentry.io/api/567/integration/otlp
+#   GRAM_OTLP_FORWARD_AUTHORIZATION  optional `authorization` header value
+#   GRAM_OTLP_FORWARD_SENTRY_AUTH    optional `x-sentry-auth` header value
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+  batch:
+    send_batch_size: 512
+    timeout: 5s
+
+exporters:
+  otlphttp/forward:
+    endpoint: ${env:GRAM_OTLP_FORWARD_ENDPOINT}
+    headers:
+      authorization: ${env:GRAM_OTLP_FORWARD_AUTHORIZATION:-}
+      x-sentry-auth: ${env:GRAM_OTLP_FORWARD_SENTRY_AUTH:-}
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp/forward]

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -1,11 +1,10 @@
 # OpenTelemetry Collector for Gram's Fly-hosted workloads (assistant
 # runtimes and, later, function runners). VMs export OTLP to this app over
-# the org's private network; the collector forwards to the configured
-# backend using credentials that live only on this app as Fly secrets:
+# the org's private network; the collector forwards traces to Datadog using
+# credentials that live only on this app as Fly secrets:
 #
-#   GRAM_OTLP_FORWARD_ENDPOINT       e.g. https://o1234.ingest.sentry.io/api/567/integration/otlp
-#   GRAM_OTLP_FORWARD_AUTHORIZATION  optional `authorization` header value
-#   GRAM_OTLP_FORWARD_SENTRY_AUTH    optional `x-sentry-auth` header value
+#   DD_API_KEY  Datadog API key
+#   DD_SITE     Datadog site (defaults to datadoghq.com)
 receivers:
   otlp:
     protocols:
@@ -24,15 +23,14 @@ processors:
     timeout: 5s
 
 exporters:
-  otlphttp/forward:
-    endpoint: ${env:GRAM_OTLP_FORWARD_ENDPOINT}
-    headers:
-      authorization: ${env:GRAM_OTLP_FORWARD_AUTHORIZATION:-}
-      x-sentry-auth: ${env:GRAM_OTLP_FORWARD_SENTRY_AUTH:-}
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: ${env:DD_SITE:-datadoghq.com}
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [otlphttp/forward]
+      exporters: [datadog]

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -5,13 +5,16 @@
 #
 #   DD_API_KEY  Datadog API key
 #   DD_SITE     Datadog site (defaults to datadoghq.com)
+# Receivers bind the IPv6 wildcard: Fly's .internal DNS resolves to the
+# machines' 6PN IPv6 addresses, which an IPv4-only 0.0.0.0 bind would
+# refuse. Go listens dual-stack on [::], so IPv4 paths keep working too.
 receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: "[::]:4317"
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: "[::]:4318"
 
 processors:
   memory_limiter:

--- a/otel-collector/fly.toml
+++ b/otel-collector/fly.toml
@@ -18,9 +18,15 @@ primary_region = "iad"
   auto_start_machines = true
   min_machines_running = 1
 
+  [[services.ports]]
+    port = 4317
+
 [[services]]
   protocol = "tcp"
   internal_port = 4318
   auto_stop_machines = "off"
   auto_start_machines = true
   min_machines_running = 1
+
+  [[services.ports]]
+    port = 4318

--- a/otel-collector/fly.toml
+++ b/otel-collector/fly.toml
@@ -1,0 +1,26 @@
+# Deployed by CI with `fly deploy --app <name> --image <ref>`; the app name
+# comes from the per-environment FLY_OTEL_COLLECTOR_IMAGE_* variable.
+#
+# No public ports are exposed: workloads on the org's default network reach
+# the collector directly at <app>.internal:4317/4318, and the service
+# definitions below make it addressable via Flycast from isolated tenant
+# networks once a private IP is allocated onto them.
+primary_region = "iad"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 4317
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 4318
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1

--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -121,6 +121,7 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 			OTLPEndpoint:       c.String("assistant-runtime-otlp-endpoint"),
 			OTLPProtocol:       c.String("assistant-runtime-otlp-protocol"),
 			OTLPHeaders:        c.String("assistant-runtime-otlp-headers"),
+			Environment:        c.String("environment"),
 		},
 	}, nil
 }

--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -60,6 +60,30 @@ var assistantRuntimeFlags = []cli.Flag{
 		Usage:   "The OCI image repository for the assistant runtime image. It must not include a tag.",
 		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OCI_IMAGE"},
 	},
+	&cli.StringFlag{
+		Name:    "assistant-runtime-otlp-endpoint",
+		Usage:   "OTLP endpoint assistant runtimes export traces to. Trace export is disabled when unset.",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_ENDPOINT"},
+	},
+	&cli.StringFlag{
+		Name:    "assistant-runtime-otlp-protocol",
+		Usage:   "OTLP transport for assistant runtime traces. Allowed values: grpc, http/protobuf, http/json.",
+		Value:   "grpc",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_PROTOCOL"},
+		Action: func(_ *cli.Context, val string) error {
+			switch val {
+			case "", "grpc", "http/protobuf", "http/json":
+				return nil
+			default:
+				return fmt.Errorf("invalid assistant runtime otlp protocol: %s", val)
+			}
+		},
+	},
+	&cli.StringFlag{
+		Name:    "assistant-runtime-otlp-headers",
+		Usage:   "Headers for the assistant runtime OTLP exporter as comma-separated key=value pairs.",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_HEADERS"},
+	},
 }
 
 func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistants.RuntimeBackendConfig, error) {
@@ -94,6 +118,9 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 			ImageTag:           AssistantRuntimeImageHash,
 			AppNamePrefix:      c.String("assistant-runtime-flyio-app-name-prefix"),
 			ServerURL:          resolvedServerURL,
+			OTLPEndpoint:       c.String("assistant-runtime-otlp-endpoint"),
+			OTLPProtocol:       c.String("assistant-runtime-otlp-protocol"),
+			OTLPHeaders:        c.String("assistant-runtime-otlp-headers"),
 		},
 	}, nil
 }

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -919,6 +919,20 @@ func (f *FlyRuntimeBackend) machineConfig(runtime assistantRuntimeRecord) *fly.M
 		"GRAM_ASSISTANT_PROJECT_ID": runtime.ProjectID.String(),
 		"GRAM_SERVER_URL":           f.config.ServerURL.String(),
 	}
+	if f.config.OTLPEndpoint != "" {
+		env["GRAM_ENABLE_OTEL_TRACES"] = "true"
+		env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f.config.OTLPEndpoint
+		env["OTEL_RESOURCE_ATTRIBUTES"] = fmt.Sprintf(
+			"gram.assistant.id=%s,gram.project.id=%s",
+			runtime.AssistantID, runtime.ProjectID,
+		)
+		if f.config.OTLPProtocol != "" {
+			env["OTEL_EXPORTER_OTLP_PROTOCOL"] = f.config.OTLPProtocol
+		}
+		if f.config.OTLPHeaders != "" {
+			env["OTEL_EXPORTER_OTLP_HEADERS"] = f.config.OTLPHeaders
+		}
+	}
 	metadata := map[string]string{
 		fly.MachineConfigMetadataKeyFlyPlatformVersion: "v2",
 		fly.MachineConfigMetadataKeyFlyProcessGroup:    flyMachineMetadataRoleAssistant,

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -922,10 +922,14 @@ func (f *FlyRuntimeBackend) machineConfig(runtime assistantRuntimeRecord) *fly.M
 	if f.config.OTLPEndpoint != "" {
 		env["GRAM_ENABLE_OTEL_TRACES"] = "true"
 		env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f.config.OTLPEndpoint
-		env["OTEL_RESOURCE_ATTRIBUTES"] = fmt.Sprintf(
+		attrs := fmt.Sprintf(
 			"gram.assistant.id=%s,gram.project.id=%s",
 			runtime.AssistantID, runtime.ProjectID,
 		)
+		if f.config.Environment != "" {
+			attrs += ",deployment.environment.name=" + f.config.Environment
+		}
+		env["OTEL_RESOURCE_ATTRIBUTES"] = attrs
 		if f.config.OTLPProtocol != "" {
 			env["OTEL_EXPORTER_OTLP_PROTOCOL"] = f.config.OTLPProtocol
 		}

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -839,6 +839,57 @@ func TestFlyRuntimeConfigValidateRequiresServerURL(t *testing.T) {
 	require.ErrorContains(t, err, "server URL")
 }
 
+func TestFlyRuntimeConfigValidateRejectsUnknownOTLPProtocol(t *testing.T) {
+	t.Parallel()
+
+	cfg := FlyRuntimeConfig{
+		FlyTokens:        tokens.Parse("test"),
+		DefaultFlyOrg:    "speakeasy-lab",
+		DefaultFlyRegion: "iad",
+		OCIImage:         "registry.fly.io/assistant-runtime",
+		ImageTag:         "dev",
+		ServerURL:        mustParseURL(t, "https://gram.example.com"),
+		OTLPProtocol:     "carrier-pigeon",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "assistant-runtime-otlp-protocol")
+}
+
+func TestFlyRuntimeBackendMachineConfigStampsOTLPEnv(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.NewServeMux())
+	t.Cleanup(srv.Close)
+
+	rec := assistantRuntimeRecord{
+		AssistantID: uuid.New(),
+		ProjectID:   uuid.New(),
+	}
+
+	backend, _, _ := newTestFlyRuntimeBackend(t, srv)
+	cfg := backend.machineConfig(rec)
+	require.NotContains(t, cfg.Env, "GRAM_ENABLE_OTEL_TRACES")
+	require.NotContains(t, cfg.Env, "OTEL_EXPORTER_OTLP_ENDPOINT")
+	require.NotContains(t, cfg.Env, "OTEL_EXPORTER_OTLP_PROTOCOL")
+	require.NotContains(t, cfg.Env, "OTEL_EXPORTER_OTLP_HEADERS")
+	require.NotContains(t, cfg.Env, "OTEL_RESOURCE_ATTRIBUTES")
+
+	backend.config.OTLPEndpoint = "https://otlp.example.com:4317"
+	backend.config.OTLPProtocol = "grpc"
+	backend.config.OTLPHeaders = "x-api-key=secret"
+	cfg = backend.machineConfig(rec)
+	require.Equal(t, "true", cfg.Env["GRAM_ENABLE_OTEL_TRACES"])
+	require.Equal(t, "https://otlp.example.com:4317", cfg.Env["OTEL_EXPORTER_OTLP_ENDPOINT"])
+	require.Equal(t, "grpc", cfg.Env["OTEL_EXPORTER_OTLP_PROTOCOL"])
+	require.Equal(t, "x-api-key=secret", cfg.Env["OTEL_EXPORTER_OTLP_HEADERS"])
+	require.Equal(
+		t,
+		fmt.Sprintf("gram.assistant.id=%s,gram.project.id=%s", rec.AssistantID, rec.ProjectID),
+		cfg.Env["OTEL_RESOURCE_ATTRIBUTES"],
+	)
+}
+
 type testFlyRuntimeAPIClient struct {
 	app               *fly.App
 	getAppErr         error

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -878,6 +878,7 @@ func TestFlyRuntimeBackendMachineConfigStampsOTLPEnv(t *testing.T) {
 	backend.config.OTLPEndpoint = "https://otlp.example.com:4317"
 	backend.config.OTLPProtocol = "grpc"
 	backend.config.OTLPHeaders = "x-api-key=secret"
+	backend.config.Environment = "test"
 	cfg = backend.machineConfig(rec)
 	require.Equal(t, "true", cfg.Env["GRAM_ENABLE_OTEL_TRACES"])
 	require.Equal(t, "https://otlp.example.com:4317", cfg.Env["OTEL_EXPORTER_OTLP_ENDPOINT"])
@@ -885,7 +886,10 @@ func TestFlyRuntimeBackendMachineConfigStampsOTLPEnv(t *testing.T) {
 	require.Equal(t, "x-api-key=secret", cfg.Env["OTEL_EXPORTER_OTLP_HEADERS"])
 	require.Equal(
 		t,
-		fmt.Sprintf("gram.assistant.id=%s,gram.project.id=%s", rec.AssistantID, rec.ProjectID),
+		fmt.Sprintf(
+			"gram.assistant.id=%s,gram.project.id=%s,deployment.environment.name=test",
+			rec.AssistantID, rec.ProjectID,
+		),
 		cfg.Env["OTEL_RESOURCE_ATTRIBUTES"],
 	)
 }

--- a/server/internal/assistants/runtime_provider.go
+++ b/server/internal/assistants/runtime_provider.go
@@ -35,6 +35,13 @@ type FlyRuntimeConfig struct {
 	ImageTag           string
 	AppNamePrefix      string
 	ServerURL          *url.URL
+
+	// OTLP exporter settings stamped into runtime machine env as standard
+	// OTEL_EXPORTER_OTLP_* variables so the runner exports agentkit spans.
+	// Trace export is disabled when OTLPEndpoint is empty.
+	OTLPEndpoint string
+	OTLPProtocol string
+	OTLPHeaders  string
 }
 
 func (c FlyRuntimeConfig) Validate() error {
@@ -52,6 +59,11 @@ func (c FlyRuntimeConfig) Validate() error {
 	}
 	if c.ServerURL.Hostname() == "" {
 		return fmt.Errorf("assistant fly runtime requires a public --assistant-runtime-server-url or --server-url; got %q", c.ServerURL.String())
+	}
+	switch c.OTLPProtocol {
+	case "", "grpc", "http/protobuf", "http/json":
+	default:
+		return fmt.Errorf("invalid --assistant-runtime-otlp-protocol: %s (allowed: grpc, http/protobuf, http/json)", c.OTLPProtocol)
 	}
 	return nil
 }

--- a/server/internal/assistants/runtime_provider.go
+++ b/server/internal/assistants/runtime_provider.go
@@ -42,6 +42,9 @@ type FlyRuntimeConfig struct {
 	OTLPEndpoint string
 	OTLPProtocol string
 	OTLPHeaders  string
+	// Environment is stamped into OTEL_RESOURCE_ATTRIBUTES as
+	// deployment.environment.name, matching the server's own resource tags.
+	Environment string
 }
 
 func (c FlyRuntimeConfig) Validate() error {


### PR DESCRIPTION
## Summary

- The assistant runner now layers an OTLP span exporter onto its `tracing` subscriber, so agentkit spans actually leave the process.
- With agentkit 0.8.0, exported spans carry the full OTel GenAI semantic conventions: `gen_ai.conversation.id` on agent/tool spans, a `chat` inference span with `gen_ai.request.model`/`response.model`/`response.id`/`response.finish_reasons` and token usage (streaming included), `error.type` on failed tool executions, and an `mcp.call_tool` span with server attribution — so Sentry's Conversations view and other GenAI dashboards work out of the box.
- Transport is selectable between gRPC and HTTP (protobuf or JSON) via `--otel-protocol` / `OTEL_EXPORTER_OTLP_PROTOCOL`; endpoint, headers, timeouts, and sampling come from the standard `OTEL_EXPORTER_OTLP_*` / `OTEL_*` environment variables read by the OTel SDK.
- Export is off unless enabled (`--with-otel-tracing` / `GRAM_ENABLE_OTEL_TRACES`), and an exporter that fails to build degrades to log-only tracing instead of taking the runner down.
- The server gains `--assistant-runtime-otlp-{endpoint,protocol,headers}` flags and stamps the corresponding `OTEL_*` env (including `OTEL_RESOURCE_ATTRIBUTES` with assistant/project ids) into Fly machine configs when an endpoint is configured.
- CI now maintains a per-environment `otel-collector` Fly app (mirroring the assistant-runtime-image pattern: ensure app, build/push image, deploy on main). Runtimes export to it over the org's private network (`<app>.internal:4317`); the collector forwards traces to Datadog with credentials held only as Fly secrets on the collector app — never stamped into tenant machines. Function runners can reach the same collector later via Flycast addresses allocated onto their isolated networks.

## Ops setup required

<img width="518" height="96" alt="Screenshot 2026-06-10 at 20 55 42" src="https://github.com/user-attachments/assets/921ab4dc-1b93-459e-8af7-334593deed90" />

- Fly secrets on each collector app: `DD_API_KEY` (and `DD_SITE` if not datadoghq.com)
- Server env: `GRAM_ASSISTANT_RUNTIME_OTLP_ENDPOINT=http://<collector-app>.internal:4317`

Closes [DNO-115](https://linear.app/speakeasy/issue/DNO-115/feat-add-opentelemetry-exporter-to-assistant-runtime)

✻ Clauded...
