### PR TITLE
fix(dashboard): onboarding dark mode visibility

### DIFF
--- a/.changeset/fix-onboarding-dark-mode.md
+++ b/.changeset/fix-onboarding-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix dark mode visibility in the enterprise onboarding flow. The onboarding stepper and the instrument-agents step now use theme-aware colors so text and controls remain legible in dark mode.

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -34,7 +34,7 @@ export function OnboardingStepper({
             {/* Vertical line connector - runs through all steps except last */}
             {!isLast && (
               <div
-                className="absolute top-[28px] left-[13px] h-[calc(100%-28px)] w-px bg-[#e0e0e0]"
+                className="absolute top-[28px] left-[13px] h-[calc(100%-28px)] w-px bg-border"
                 aria-hidden="true"
               />
             )}
@@ -43,14 +43,14 @@ export function OnboardingStepper({
             <div className="relative z-10 flex-shrink-0">
               {isCurrent ? (
                 /* Active step: dark filled rounded rectangle */
-                <div className="flex h-[28px] w-[28px] items-center justify-center rounded-[8px] bg-[#1a1a1a] text-sm font-semibold text-white">
+                <div className="flex h-[28px] w-[28px] items-center justify-center rounded-[8px] bg-foreground text-sm font-semibold text-background">
                   {index + 1}
                 </div>
               ) : isCompleted ? (
                 /* Completed step: dark circle with checkmark */
                 <button
                   onClick={() => onStepClick?.(index)}
-                  className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-full bg-[#1a1a1a] text-white transition-all duration-200 ease-out hover:scale-[1.2] hover:bg-[#333]"
+                  className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-full bg-foreground text-background transition-all duration-200 ease-out hover:scale-[1.2] hover:bg-foreground/80"
                 >
                   <Check className="h-3.5 w-3.5" strokeWidth={2.5} />
                 </button>
@@ -58,10 +58,10 @@ export function OnboardingStepper({
                 /* Upcoming step: light outlined circle with white fill to cover track */
                 <div
                   className={cn(
-                    "flex h-[28px] w-[28px] items-center justify-center rounded-full border bg-[#f7f7f5] text-sm font-normal",
+                    "flex h-[28px] w-[28px] items-center justify-center rounded-full border bg-background text-sm font-normal",
                     isLocked
-                      ? "border-[#e5e5e5] text-[#d4d4d4]"
-                      : "border-[#d9d9d9] text-[#b5b5b5]",
+                      ? "border-border text-muted-foreground/40"
+                      : "border-border text-muted-foreground",
                   )}
                 >
                   {index + 1}
@@ -74,9 +74,9 @@ export function OnboardingStepper({
               <h3
                 className={cn(
                   "text-sm leading-tight font-semibold",
-                  isCurrent && "text-[#0f0f0f]",
-                  isCompleted && "text-[#0f0f0f]",
-                  isUpcoming && "text-[#a3a3a3]",
+                  isCurrent && "text-foreground",
+                  isCompleted && "text-foreground",
+                  isUpcoming && "text-muted-foreground",
                 )}
               >
                 {step.title}
@@ -84,9 +84,9 @@ export function OnboardingStepper({
               <p
                 className={cn(
                   "mt-0.5 text-sm leading-snug",
-                  isCurrent && "text-[#737373]",
-                  isCompleted && "text-[#737373]",
-                  isUpcoming && "text-[#c4c4c4]",
+                  isCurrent && "text-muted-foreground",
+                  isCompleted && "text-muted-foreground",
+                  isUpcoming && "text-muted-foreground/60",
                 )}
               >
                 {step.description}

--- a/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
@@ -99,6 +99,10 @@ const PLATFORM_LOGOS: Record<string, string> = {
   cursor: "/icons/platforms/cursor.svg",
 };
 
+// Monochrome black logos that are invisible on a dark background — flip them in
+// dark mode. The Claude logo is full-color, so it must NOT be inverted.
+const INVERT_LOGO_IN_DARK = new Set<string>(["codex", "cursor"]);
+
 export function InstrumentAgentsStep({
   onComplete,
   onBack,
@@ -635,7 +639,10 @@ export function InstrumentAgentsStep({
                   <img
                     src={PLATFORM_LOGOS[platform.id]}
                     alt={platform.name}
-                    className="h-5 w-5"
+                    className={cn(
+                      "h-5 w-5",
+                      INVERT_LOGO_IN_DARK.has(platform.id) && "dark:invert",
+                    )}
                   />
                 ) : (
                   <span className="text-foreground text-sm font-semibold">


### PR DESCRIPTION
## What

Fixes three dark-mode visibility issues in the enterprise onboarding flow.

| Issue                           | Cause                                                                                        | Fix                                                                                        |
| ------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| Step nav titles invisible       | Stepper used hardcoded near-black hex (`#0f0f0f`) for titles that never flipped in dark mode | Swapped to `text-foreground` / `text-muted-foreground` theme tokens                        |
| Upcoming step numbers too faint | Literal `#b5b5b5` / `#d4d4d4` numbers + `#c4c4c4` descriptions                               | `text-muted-foreground` (locked → `/40`, descriptions → `/60`)                             |
| Codex & Cursor logos invisible  | `openai.svg` / `cursor.svg` are black monochrome — vanish on dark bg                         | `dark:invert` applied to monochrome logos only (Claude logo is full-color, left untouched) |

Also flipped the step indicator circles (`bg-[#1a1a1a] text-white` → `bg-foreground text-background`) and the connector line (`bg-[#e0e0e0]` → `bg-border`) so they invert with the theme.

## Why

The stepper bypassed the dashboard's theme tokens with literal hex values designed for light mode, so the whole left nav rendered black-on-black in dark mode.

## Scope

CSS class changes only — no logic or type-surface changes. The Claude logo is deliberately excluded from inversion; inverting a full-color SVG would corrupt it.

## Files

- `client/dashboard/src/pages/setup/components/onboarding-stepper.tsx`
- `client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark-mode visibility in the enterprise onboarding stepper by switching to theme tokens and inverting monochrome platform logos where needed. Text, step numbers, indicators, and the Codex/Cursor logos now render clearly in dark mode.

- **Bug Fixes**
  - Stepper: replaced hardcoded hex colors with `text-foreground`, `text-muted-foreground`, `bg-foreground`, `bg-background`, `bg-border`, and `border-border` so titles, descriptions, circles, and connector line invert with the theme.
  - Upcoming steps: adjusted colors for contrast (`text-muted-foreground` with `/40` and `/60` where appropriate).
  - Logos: applied `dark:invert` to `codex` and `cursor` monochrome SVGs; left Claude unchanged.

- **Dependencies**
  - Added changeset for a `dashboard` patch release.

<sup>Written for commit 37beb32126e587952f583666d965f52b1bdf4fee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

