### PR TITLE
feat: add Distribute MCP servers onboarding step

### DIFF
--- a/.changeset/onboarding-distribute-servers.md
+++ b/.changeset/onboarding-distribute-servers.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Add a Distribute MCP servers step to onboarding. Teams can search the MCP catalog and distribute selected servers to their organization during setup, running the deploy → bundle → publish flow inline.
+Add a Distribute MCP servers step to onboarding. Teams can search the MCP catalog and distribute selected servers to their organization during setup, running the deploy → bundle → publish flow inline. Servers that require OAuth are auto-configured with Speakeasy OAuth, matching the catalog add-server flow.

--- a/.changeset/onboarding-distribute-servers.md
+++ b/.changeset/onboarding-distribute-servers.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add a Distribute MCP servers step to onboarding. Teams can search the MCP catalog and distribute selected servers to their organization during setup, running the deploy → bundle → publish flow inline.

--- a/.changeset/onboarding-distribute-servers.md
+++ b/.changeset/onboarding-distribute-servers.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Add a Distribute MCP servers step to onboarding. Teams can search the MCP catalog and distribute selected servers to their organization during setup, running the deploy → bundle → publish flow inline. Servers that require OAuth are auto-configured with Speakeasy OAuth, matching the catalog add-server flow.
+Add a Distribute MCP servers step to onboarding. Teams can search the MCP catalog and distribute selected servers to their organization during setup, running the deploy → bundle → publish flow inline. Servers that require OAuth are auto-configured with Speakeasy OAuth, matching the catalog add-server flow. The onboarding list shows only servers Gram can fully auto-configure (OAuth with dynamic client registration); servers needing manual setup (OAuth without DCR, API keys) remain available in the catalog.

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -9,6 +9,7 @@ import {
   ConnectIdpStep,
   DirectorySyncStep,
   CreateMarketplaceStep,
+  DistributeServersStep,
   InstrumentAgentsStep,
   ConfirmTrafficStep,
   ConfigurePoliciesStep,
@@ -29,6 +30,11 @@ const STEPS: Step[] = [
     id: "create-marketplace",
     title: "Create plugin marketplace",
     description: "For distributing servers to your users",
+  },
+  {
+    id: "distribute-servers",
+    title: "Distribute MCP servers",
+    description: "Choose some MCP Servers to distribute to your organization",
   },
   {
     id: "instrument-agents",
@@ -59,9 +65,10 @@ export function SetupWizard(): JSX.Element | null {
 
   // Server-side onboarding signals used to resume at the right step on reload.
   // `onboardingStatus` covers SSO + DSYNC; `publishStatus` covers the
-  // marketplace step. Steps after marketplace (instrument-agents,
-  // confirm-traffic) have no server signal — once marketplace is published we
-  // land on instrument-agents and let the user click forward.
+  // marketplace step. Steps after marketplace (distribute-servers,
+  // instrument-agents, confirm-traffic) have no server signal — once
+  // marketplace is published we land on distribute-servers and let the user
+  // click forward.
   const { data: onboardingStatus, isLoading: isOnboardingStatusLoading } =
     useOnboardingStatus();
   const { data: publishStatus, isLoading: isPublishStatusLoading } =
@@ -73,7 +80,7 @@ export function SetupWizard(): JSX.Element | null {
     if (statusLoading) return; // wait so we don't flash step 0 then jump
     let resumeStep = 0;
     if (publishStatus?.connected) {
-      resumeStep = 3; // marketplace done → instrument-agents
+      resumeStep = 3; // marketplace done → distribute-servers
     } else if (onboardingStatus?.dsyncConfigured) {
       resumeStep = 2; // dsync done → create-marketplace
     } else if (onboardingStatus?.ssoConfigured) {
@@ -176,19 +183,27 @@ export function SetupWizard(): JSX.Element | null {
         );
       case 3:
         return (
+          <DistributeServersStep
+            onComplete={completeCurrentStep}
+            onSkip={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      case 4:
+        return (
           <InstrumentAgentsStep
             onComplete={completeCurrentStep}
             onBack={goBack}
           />
         );
-      case 4:
+      case 5:
         return (
           <ConfirmTrafficStep
             onComplete={completeCurrentStep}
             onBack={goBack}
           />
         );
-      case 5:
+      case 6:
         return (
           <ConfigurePoliciesStep
             onComplete={completeCurrentStep}
@@ -215,7 +230,7 @@ export function SetupWizard(): JSX.Element | null {
             />
           </div>
 
-          <div className="max-w-xl flex-1">{renderStep()}</div>
+          <div className="min-w-0 flex-1">{renderStep()}</div>
         </div>
       </main>
 

--- a/client/dashboard/src/pages/setup/components/steps/auto-configurable-servers.ts
+++ b/client/dashboard/src/pages/setup/components/steps/auto-configurable-servers.ts
@@ -1,0 +1,74 @@
+/**
+ * Allowlist of catalog servers that Gram can fully auto-configure during
+ * onboarding — i.e. OAuth servers that support RFC 7591 dynamic client
+ * registration (DCR). For these, the distribute flow registers a Speakeasy
+ * OAuth client on the fly (see `onboardExternalMcpToUserSessions`), so the user
+ * never lands on "OAuth setup required".
+ *
+ * Servers NOT in this list need manual setup (OAuth 2.0 without DCR → manual
+ * client credentials via the OAuth proxy wizard; API-key servers → a secret),
+ * so onboarding hides them and points the user to the full catalog instead.
+ *
+ * ── How this list was generated ──────────────────────────────────────────
+ * Source of truth is the PulseMCP catalog (`gram-recommended` tenant). Each
+ * server's `_meta["com.pulsemcp/server-version"].remotes[*].authOptions[*]
+ * .detail.authorizationServerMetadata.registration_endpoint` is PulseMCP's
+ * embedded OAuth discovery result. A NON-EMPTY registration_endpoint means the
+ * upstream authorization server supports DCR (OAuth 2.1-style). This was
+ * validated against Gram's own deploy-time resolution
+ * (`external_mcp_tool_definitions.oauth_version`): zero false positives.
+ *
+ * NOTE: do NOT use PulseMCP's `clientRegistration.dynamic.supported` flag — it
+ * optimistically reports `true` for providers (Snowflake, Salesforce, Google,
+ * Gong) whose AS exposes no registration endpoint, which is the bug this guards
+ * against.
+ *
+ * This is a static snapshot. Regenerate when the recommended catalog changes by
+ * re-running the discovery sweep over the PulseMCP list endpoint.
+ * Last generated: 2026-06-11.
+ */
+const AUTO_CONFIGURABLE_SERVER_SPECIFIERS: readonly string[] = [
+  "app.linear/linear",
+  "co.huggingface/hf-mcp-server",
+  "com.amplitude/mcp-server",
+  "com.atlassian/atlassian-mcp-server",
+  "com.figma.mcp/mcp",
+  "com.getguru/mcp-server",
+  "com.grain/grain",
+  "com.monday/monday.com",
+  "com.notion/mcp",
+  "com.pulsemcp.mirror/asana-mcp",
+  "com.pulsemcp.mirror/canva-mcp",
+  "com.pulsemcp.mirror/clickup",
+  "com.pulsemcp.mirror/cloudflare",
+  "com.pulsemcp.mirror/datadog",
+  "com.pulsemcp.mirror/fireflies",
+  "com.pulsemcp.mirror/granola",
+  "com.pulsemcp.mirror/incident-io",
+  "com.pulsemcp.mirror/intercom",
+  "com.pulsemcp.mirror/klaviyo",
+  "com.pulsemcp.mirror/mercury",
+  "com.pulsemcp.mirror/moda",
+  "com.pulsemcp.mirror/pulumi-mcp-server",
+  "com.pulsemcp.mirror/pylon",
+  "com.pulsemcp.mirror/ramp",
+  "com.pulsemcp.mirror/tryordinal",
+  "com.stripe/mcp",
+  "com.supabase/mcp",
+  "com.vercel/vercel-mcp",
+  "com.webflow/mcp",
+  "io.github.getsentry/sentry-mcp",
+  "io.github.miroapp/mcp-server",
+];
+
+const AUTO_CONFIGURABLE_SERVERS: ReadonlySet<string> = new Set(
+  AUTO_CONFIGURABLE_SERVER_SPECIFIERS,
+);
+
+/**
+ * Whether a catalog server can be distributed during onboarding without any
+ * manual auth setup. Keyed on the registry specifier (e.g. "com.vercel/vercel-mcp").
+ */
+export function isAutoConfigurableServer(registrySpecifier: string): boolean {
+  return AUTO_CONFIGURABLE_SERVERS.has(registrySpecifier);
+}

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -8,6 +8,7 @@ import {
   Server as ServerIcon,
 } from "lucide-react";
 import { useSdkClient } from "@/contexts/Sdk";
+import { useTelemetry } from "@/contexts/Telemetry";
 import { StepContainer } from "../step-container";
 import {
   type PulseMCPServer,
@@ -39,6 +40,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { InstallInstructionsButton } from "@/pages/plugins/InstallInstructionsDialog";
+import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import { cn } from "@/lib/utils";
 
 /** Display name of the shared plugin bundle catalog servers are added to. */
@@ -65,6 +67,7 @@ export function DistributeServersStep({
   onBack,
 }: DistributeServersStepProps): JSX.Element {
   const client = useSdkClient();
+  const telemetry = useTelemetry();
   const queryClient = useQueryClient();
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
@@ -139,7 +142,15 @@ export function DistributeServersStep({
   // --- Deploy workflow (driven headlessly, no dialog) -----------------------
   // Raw catalog servers are fed in un-enriched, so each partitions as a
   // single-remote server and the backend resolves all remotes at deploy time.
-  const workflow = useExternalMcpReleaseWorkflow({ servers: serversToDeploy });
+  // Mirror the catalog AddServerDialog: gate Speakeasy OAuth user-session
+  // onboarding behind the same flag so distributed servers that require OAuth
+  // are auto-configured instead of surfacing "OAuth setup required" later.
+  const workflow = useExternalMcpReleaseWorkflow({
+    servers: serversToDeploy,
+    onboardExternalMcpToUserSessions:
+      telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
+      false,
+  });
   const startedRef = useRef(false);
   const finishedRef = useRef(false);
 

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -315,6 +315,10 @@ export function DistributeServersStep({
     selected.size > 0
       ? `Distribute ${selected.size} server${selected.size === 1 ? "" : "s"}`
       : "Distribute servers";
+  // Once at least one server has been distributed, the secondary action is no
+  // longer a skip — the user has done the step, so let them move on.
+  const skipLabel =
+    distributedSpecifiers.size > 0 ? "Continue" : "Skip for now";
 
   return (
     <StepContainer
@@ -327,7 +331,7 @@ export function DistributeServersStep({
       description="Choose some MCP Servers to distribute to your organization. Selected servers are deployed to your project, bundled into your Default plugin, and published to your marketplace so your team can install them."
       onContinue={handleDistribute}
       onSkip={onSkip}
-      skipLabel="Skip for now"
+      skipLabel={skipLabel}
       continueLabel={continueLabel}
       isLoading={drawerOpen && isAdding}
       canContinue={selected.size > 0}

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
+import { useRoutes } from "@/routes";
 import { StepContainer } from "../step-container";
 import {
   type PulseMCPServer,
@@ -42,6 +43,7 @@ import {
 import { InstallInstructionsButton } from "@/pages/plugins/InstallInstructionsDialog";
 import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import { cn } from "@/lib/utils";
+import { isAutoConfigurableServer } from "./auto-configurable-servers";
 
 /** Display name of the shared plugin bundle catalog servers are added to. */
 const DEFAULT_PLUGIN_NAME = "Default";
@@ -68,6 +70,7 @@ export function DistributeServersStep({
 }: DistributeServersStepProps): JSX.Element {
   const client = useSdkClient();
   const telemetry = useTelemetry();
+  const routes = useRoutes();
   const queryClient = useQueryClient();
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
@@ -115,7 +118,17 @@ export function DistributeServersStep({
     () => data?.pages.flatMap((page) => page.servers as PulseMCPServer[]) ?? [],
     [data],
   );
-  const visibleServers = showAll ? servers : servers.slice(0, INITIAL_VISIBLE);
+  // Onboarding only surfaces servers Gram can fully auto-configure (no-auth or
+  // OAuth with dynamic client registration). Everything else would dead-end on
+  // "OAuth setup required" or a missing API key, so we steer the user to the
+  // full catalog for those (see note below the list).
+  const autoConfigurableServers = useMemo(
+    () => servers.filter((s) => isAutoConfigurableServer(s.registrySpecifier)),
+    [servers],
+  );
+  const visibleServers = showAll
+    ? autoConfigurableServers
+    : autoConfigurableServers.slice(0, INITIAL_VISIBLE);
 
   const toggle = (key: string) => {
     setSelected((prev) => {
@@ -131,12 +144,12 @@ export function DistributeServersStep({
 
   const selectedServerObjects = useMemo(
     () =>
-      servers.filter(
+      autoConfigurableServers.filter(
         (s) =>
           selected.has(serverKey(s)) &&
           !distributedSpecifiers.has(s.registrySpecifier),
       ),
-    [servers, selected, distributedSpecifiers],
+    [autoConfigurableServers, selected, distributedSpecifiers],
   );
 
   // --- Deploy workflow (driven headlessly, no dialog) -----------------------
@@ -344,11 +357,11 @@ export function DistributeServersStep({
             <div className="flex items-center justify-center py-12">
               <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
             </div>
-          ) : servers.length === 0 ? (
+          ) : autoConfigurableServers.length === 0 ? (
             <p className="text-muted-foreground mt-3 text-sm">
               {query
-                ? `No servers match "${query}".`
-                : "No catalog servers available."}
+                ? `No auto-configurable servers match "${query}".`
+                : "No auto-configurable servers available."}
             </p>
           ) : (
             <div className="mt-3 grid grid-cols-2 gap-3">
@@ -413,7 +426,7 @@ export function DistributeServersStep({
             </div>
           )}
 
-          {!showAll && servers.length > INITIAL_VISIBLE && (
+          {!showAll && autoConfigurableServers.length > INITIAL_VISIBLE && (
             <button
               type="button"
               onClick={() => setShowAll(true)}
@@ -435,6 +448,18 @@ export function DistributeServersStep({
                 "Load more servers"
               )}
             </button>
+          )}
+
+          {!isLoading && (
+            <p className="text-muted-foreground mt-4 text-xs leading-relaxed">
+              Only servers Gram can configure automatically are shown here. More
+              servers — including those that need manual OAuth or API key setup
+              — are available in the{" "}
+              <routes.catalog.Link className="underline underline-offset-2 hover:text-foreground">
+                catalog
+              </routes.catalog.Link>
+              .
+            </p>
           )}
         </div>
       </div>

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -452,9 +452,10 @@ export function DistributeServersStep({
 
           {!isLoading && (
             <p className="text-muted-foreground mt-4 text-xs leading-relaxed">
-              Only servers Gram can configure automatically are shown here. More
-              servers — including those that need manual OAuth or API key setup
-              — are available in the{" "}
+              Only servers that support OAuth dynamic client registration (DCR)
+              are shown here — Gram can configure these automatically. More
+              servers, including those that need manual OAuth or API key setup,
+              are available in the{" "}
               <routes.catalog.Link className="underline underline-offset-2 hover:text-foreground">
                 catalog
               </routes.catalog.Link>

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -173,14 +173,21 @@ export function DistributeServersStep({
    */
   const finishDistribution = async () => {
     try {
-      const specifiers = new Set(
-        serversToDeploy.map((s) => s.registrySpecifier),
+      // Only reachable in the complete phase (the driving effect guards this);
+      // the check also narrows the workflow union so toolsetStatuses is typed.
+      if (workflow.phase !== "complete") return;
+      // Match on the exact toolset slugs the workflow just created, not on
+      // registrySpecifier — the org may already hold older or forked toolsets
+      // for the same specifier, and those must not be swept into this run's
+      // bundle.
+      const deployedSlugs = new Set(
+        workflow.toolsetStatuses
+          .filter((s) => s.status === "completed" && s.toolsetSlug)
+          .map((s) => s.toolsetSlug as string),
       );
       const { data: fresh } = await refetchToolsets();
-      const toAdd = (fresh?.toolsets ?? []).filter(
-        (t) =>
-          t.origin?.registrySpecifier &&
-          specifiers.has(t.origin.registrySpecifier),
+      const toAdd = (fresh?.toolsets ?? []).filter((t) =>
+        deployedSlugs.has(t.slug),
       );
       if (toAdd.length === 0) {
         setDrawerError("No servers were deployed. Try again.");
@@ -311,9 +318,13 @@ export function DistributeServersStep({
   const marketplaceCommand = publishStatus?.marketplaceUrl
     ? `/plugin marketplace add ${publishStatus.marketplaceUrl}`
     : null;
+  // Gate the action on actually-deployable servers, not the raw selection:
+  // already-distributed picks are filtered out of selectedServerObjects, so
+  // counting selected.size could enable a Continue that deploys nothing.
+  const deployableCount = selectedServerObjects.length;
   const continueLabel =
-    selected.size > 0
-      ? `Distribute ${selected.size} server${selected.size === 1 ? "" : "s"}`
+    deployableCount > 0
+      ? `Distribute ${deployableCount} server${deployableCount === 1 ? "" : "s"}`
       : "Distribute servers";
   // Once at least one server has been distributed, the secondary action is no
   // longer a skip — the user has done the step, so let them move on.
@@ -334,7 +345,7 @@ export function DistributeServersStep({
       skipLabel={skipLabel}
       continueLabel={continueLabel}
       isLoading={drawerOpen && isAdding}
-      canContinue={selected.size > 0}
+      canContinue={deployableCount > 0}
       showBack
       onBack={onBack}
     >
@@ -351,6 +362,15 @@ export function DistributeServersStep({
               onChange={(value) => {
                 setQuery(value);
                 setShowAll(false);
+              }}
+              onKeyDown={(e) => {
+                // Escape clears the query first; only let it bubble to parent
+                // Escape handlers (e.g. closing the drawer) once empty.
+                if (e.key === "Escape" && query) {
+                  e.stopPropagation();
+                  setQuery("");
+                  setShowAll(false);
+                }
               }}
               placeholder="Search MCP servers"
               className="pl-9"

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -383,7 +383,7 @@ export function DistributeServersStep({
                       }
                     }}
                     className={cn(
-                      "flex items-start gap-3 rounded-lg border p-4 text-left transition-all",
+                      "flex min-h-[118px] items-start gap-3 rounded-lg border p-4 text-left transition-all",
                       isSelected && !isDistributed
                         ? "border-foreground bg-secondary"
                         : "border-border bg-card hover:border-foreground/30",

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -563,7 +563,10 @@ export function DistributeServersStep({
                 {marketplaceCommand && (
                   <div className="space-y-2">
                     <p className="text-foreground text-sm font-medium">
-                      Add the marketplace in Claude Code
+                      Install for yourself in Claude Code
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      Registers the marketplace for your own account.
                     </p>
                     <div className="bg-muted/50 flex items-center justify-between gap-2 rounded-md border p-3">
                       <code className="text-foreground truncate text-xs">
@@ -574,9 +577,15 @@ export function DistributeServersStep({
                   </div>
                 )}
                 {publishStatus?.repoOwner && publishStatus?.repoName && (
-                  <div>
-                    <p className="text-muted-foreground mb-2 text-sm">
-                      For Cursor, Codex and other platforms:
+                  <div className="space-y-2">
+                    <p className="text-foreground text-sm font-medium">
+                      Roll out to your whole organization
+                    </p>
+                    <p className="text-muted-foreground text-xs leading-relaxed">
+                      Push the marketplace to every developer through Claude
+                      Code Managed Settings — no per-user install command
+                      required. The full guide also covers Claude Cowork,
+                      Cursor, and Codex.
                     </p>
                     <InstallInstructionsButton
                       repoOwner={publishStatus.repoOwner}

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -1,0 +1,576 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertCircle,
+  Boxes,
+  Check,
+  Loader2,
+  Search,
+  Server as ServerIcon,
+} from "lucide-react";
+import { useSdkClient } from "@/contexts/Sdk";
+import { StepContainer } from "../step-container";
+import {
+  type PulseMCPServer,
+  useInfiniteListMCPCatalog,
+} from "@/pages/catalog/hooks";
+import { useExternalMcpReleaseWorkflow } from "@/pages/catalog/useExternalMcpReleaseWorkflow";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  invalidateAllListToolsets,
+  useListToolsets,
+} from "@gram/client/react-query/listToolsets";
+import { usePublishStatus } from "@gram/client/react-query/publishStatus";
+import {
+  invalidateAllPlugins,
+  usePlugins,
+} from "@gram/client/react-query/plugins";
+import {
+  invalidateAllPlugin,
+  usePlugin,
+} from "@gram/client/react-query/plugin";
+import { Badge, Button } from "@speakeasy-api/moonshine";
+import { Input } from "@/components/ui/input";
+import { CopyButton } from "@/components/ui/copy-button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { InstallInstructionsButton } from "@/pages/plugins/InstallInstructionsDialog";
+import { cn } from "@/lib/utils";
+
+/** Display name of the shared plugin bundle catalog servers are added to. */
+const DEFAULT_PLUGIN_NAME = "Default";
+/** Max catalog servers shown before the user expands the list. */
+const INITIAL_VISIBLE = 10;
+
+interface DistributeServersStepProps {
+  onComplete: () => void;
+  onSkip: () => void;
+  onBack: () => void;
+}
+
+/** Stable selection key for a catalog server, matching the catalog page convention. */
+function serverKey(server: PulseMCPServer): string {
+  return `${server.registryId}-${server.registrySpecifier}`;
+}
+
+type DrawerStep = "adding" | "done";
+
+export function DistributeServersStep({
+  onComplete,
+  onSkip,
+  onBack,
+}: DistributeServersStepProps): JSX.Element {
+  const client = useSdkClient();
+  const queryClient = useQueryClient();
+  const [query, setQuery] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  // Drawer state: the deploy → bundle → publish flow runs entirely inside our
+  // own Sheet, not the catalog's AddServerDialog.
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerStep, setDrawerStep] = useState<DrawerStep>("adding");
+  const [drawerError, setDrawerError] = useState<string | null>(null);
+  // Servers handed to the release workflow once the user hits Distribute.
+  const [serversToDeploy, setServersToDeploy] = useState<PulseMCPServer[]>([]);
+
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteListMCPCatalog(query || undefined);
+  const { data: toolsetsData, refetch: refetchToolsets } = useListToolsets();
+  const { data: publishStatus } = usePublishStatus();
+
+  // Default-plugin membership: map its toolset-backed servers back to catalog
+  // registry specifiers so we can flag servers that are already distributed.
+  const { data: pluginsData } = usePlugins();
+  const defaultPlugin = pluginsData?.plugins.find(
+    (p) => p.name === DEFAULT_PLUGIN_NAME,
+  );
+  const { data: defaultPluginFull } = usePlugin(
+    { id: defaultPlugin?.id ?? "" },
+    undefined,
+    { enabled: !!defaultPlugin?.id },
+  );
+
+  const distributedSpecifiers = useMemo(() => {
+    const toolsetById = new Map(
+      (toolsetsData?.toolsets ?? []).map((t) => [t.id, t]),
+    );
+    const specs = new Set<string>();
+    for (const server of defaultPluginFull?.servers ?? []) {
+      if (!server.toolsetId) continue;
+      const spec = toolsetById.get(server.toolsetId)?.origin?.registrySpecifier;
+      if (spec) specs.add(spec);
+    }
+    return specs;
+  }, [defaultPluginFull?.servers, toolsetsData?.toolsets]);
+
+  const servers = useMemo(
+    () => data?.pages.flatMap((page) => page.servers as PulseMCPServer[]) ?? [],
+    [data],
+  );
+  const visibleServers = showAll ? servers : servers.slice(0, INITIAL_VISIBLE);
+
+  const toggle = (key: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const selectedServerObjects = useMemo(
+    () =>
+      servers.filter(
+        (s) =>
+          selected.has(serverKey(s)) &&
+          !distributedSpecifiers.has(s.registrySpecifier),
+      ),
+    [servers, selected, distributedSpecifiers],
+  );
+
+  // --- Deploy workflow (driven headlessly, no dialog) -----------------------
+  // Raw catalog servers are fed in un-enriched, so each partitions as a
+  // single-remote server and the backend resolves all remotes at deploy time.
+  const workflow = useExternalMcpReleaseWorkflow({ servers: serversToDeploy });
+  const startedRef = useRef(false);
+  const finishedRef = useRef(false);
+
+  /**
+   * Bundle the freshly deployed toolsets into the shared "Default" plugin and
+   * republish the marketplace so the org's users receive them.
+   */
+  const finishDistribution = async () => {
+    try {
+      const specifiers = new Set(
+        serversToDeploy.map((s) => s.registrySpecifier),
+      );
+      const { data: fresh } = await refetchToolsets();
+      const toAdd = (fresh?.toolsets ?? []).filter(
+        (t) =>
+          t.origin?.registrySpecifier &&
+          specifiers.has(t.origin.registrySpecifier),
+      );
+      if (toAdd.length === 0) {
+        setDrawerError("No servers were deployed. Try again.");
+        return;
+      }
+
+      const { plugins } = await client.plugins.listPlugins();
+      const plugin =
+        plugins.find((p) => p.name === DEFAULT_PLUGIN_NAME) ??
+        (await client.plugins.createPlugin({
+          createPluginForm: { name: DEFAULT_PLUGIN_NAME },
+        }));
+
+      const full = await client.plugins.getPlugin({ id: plugin.id });
+      const alreadyBundled = new Set(
+        (full.servers ?? [])
+          .map((s) => s.toolsetId)
+          .filter((id): id is string => !!id),
+      );
+
+      for (const toolset of toAdd) {
+        if (alreadyBundled.has(toolset.id)) continue;
+        await client.plugins.addPluginServer({
+          addPluginServerForm: {
+            pluginId: plugin.id,
+            toolsetId: toolset.id,
+            displayName: toolset.name,
+            policy: "required",
+          },
+        });
+      }
+
+      if (publishStatus?.connected) {
+        await client.plugins.publishPlugins({
+          publishPluginsRequestBody: { githubUsernames: [] },
+        });
+      }
+
+      // Refresh plugin + toolset state so the just-distributed servers flip to
+      // "Added" (disabled) in the grid, and drop them from the selection.
+      await Promise.all([
+        invalidateAllPlugins(queryClient),
+        invalidateAllPlugin(queryClient),
+        invalidateAllListToolsets(queryClient),
+      ]);
+      setSelected(new Set());
+
+      setDrawerStep("done");
+    } catch (error) {
+      setDrawerError(
+        error instanceof Error
+          ? error.message
+          : "Failed to add servers to your marketplace",
+      );
+    }
+  };
+
+  // Drive the workflow: auto-start the deploy, then bundle + publish once all
+  // toolsets are created. Guarded by refs so each fires exactly once per run.
+  useEffect(() => {
+    if (!drawerOpen || drawerError) return;
+
+    if (workflow.phase === "configure") {
+      if (
+        !startedRef.current &&
+        workflow.canDeploy &&
+        !workflow.isInstallStateLoading
+      ) {
+        startedRef.current = true;
+        void workflow.startDeployment();
+      }
+      return;
+    }
+
+    if (workflow.phase === "complete" && !finishedRef.current) {
+      const done =
+        workflow.toolsetStatuses.length > 0 &&
+        workflow.toolsetStatuses.every(
+          (s) => s.status === "completed" || s.status === "failed",
+        );
+      if (done) {
+        finishedRef.current = true;
+        void finishDistribution();
+      }
+      return;
+    }
+
+    if (workflow.phase === "error" && !finishedRef.current) {
+      finishedRef.current = true;
+      setDrawerError(workflow.error);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- guarded by refs; re-run on workflow identity to observe phase + toolset-status changes
+  }, [workflow, drawerOpen, drawerError]);
+
+  const handleDistribute = () => {
+    if (selectedServerObjects.length === 0) return;
+    startedRef.current = false;
+    finishedRef.current = false;
+    setDrawerError(null);
+    setDrawerStep("adding");
+    setServersToDeploy(selectedServerObjects);
+    setDrawerOpen(true);
+  };
+
+  // Open the drawer straight to the install-instructions step for a server
+  // that's already distributed — no deploy. Refs are pre-tripped so the
+  // workflow effect stays inert.
+  const showInstructions = () => {
+    startedRef.current = true;
+    finishedRef.current = true;
+    setServersToDeploy([]);
+    setDrawerError(null);
+    setDrawerStep("done");
+    setDrawerOpen(true);
+  };
+
+  const resetDrawer = () => {
+    setDrawerOpen(false);
+    setServersToDeploy([]);
+    setDrawerError(null);
+    startedRef.current = false;
+    finishedRef.current = false;
+    workflow.reset();
+  };
+
+  const isAdding = drawerStep === "adding" && !drawerError;
+  const drawerIdx = drawerStep === "done" ? 1 : 0;
+  const marketplaceCommand = publishStatus?.marketplaceUrl
+    ? `/plugin marketplace add ${publishStatus.marketplaceUrl}`
+    : null;
+  const continueLabel =
+    selected.size > 0
+      ? `Distribute ${selected.size} server${selected.size === 1 ? "" : "s"}`
+      : "Distribute servers";
+
+  return (
+    <StepContainer
+      icon={
+        <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded-lg">
+          <Boxes className="text-foreground h-6 w-6" />
+        </div>
+      }
+      title="Distribute MCP servers"
+      description="Choose some MCP Servers to distribute to your organization. Selected servers are deployed to your project, bundled into your Default plugin, and published to your marketplace so your team can install them."
+      onContinue={handleDistribute}
+      onSkip={onSkip}
+      skipLabel="Skip for now"
+      continueLabel={continueLabel}
+      isLoading={drawerOpen && isAdding}
+      canContinue={selected.size > 0}
+      showBack
+      onBack={onBack}
+    >
+      <div className="space-y-6">
+        <div>
+          <label className="text-foreground text-sm font-medium">
+            Select servers from the catalog
+          </label>
+          <div className="relative mt-3">
+            <Search className="text-muted-foreground pointer-events-none absolute top-[18px] left-3 h-4 w-4 -translate-y-1/2" />
+            <Input
+              type="search"
+              value={query}
+              onChange={(value) => {
+                setQuery(value);
+                setShowAll(false);
+              }}
+              placeholder="Search MCP servers"
+              className="pl-9"
+            />
+          </div>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+            </div>
+          ) : servers.length === 0 ? (
+            <p className="text-muted-foreground mt-3 text-sm">
+              {query
+                ? `No servers match "${query}".`
+                : "No catalog servers available."}
+            </p>
+          ) : (
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              {visibleServers.map((server) => {
+                const key = serverKey(server);
+                const isDistributed = distributedSpecifiers.has(
+                  server.registrySpecifier,
+                );
+                const isSelected = selected.has(key);
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => {
+                      if (isDistributed) {
+                        showInstructions();
+                      } else {
+                        toggle(key);
+                      }
+                    }}
+                    className={cn(
+                      "flex items-start gap-3 rounded-lg border p-4 text-left transition-all",
+                      isSelected && !isDistributed
+                        ? "border-foreground bg-secondary"
+                        : "border-border bg-card hover:border-foreground/30",
+                    )}
+                  >
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg bg-white">
+                      {server.iconUrl ? (
+                        <img
+                          src={server.iconUrl}
+                          alt=""
+                          className="h-6 w-6 rounded"
+                        />
+                      ) : (
+                        <ServerIcon className="h-5 w-5 text-neutral-600" />
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <span className="text-foreground block truncate text-sm font-medium">
+                        {server.title ?? server.registrySpecifier}
+                      </span>
+                      <span className="text-muted-foreground block text-xs">
+                        {server.description ?? server.registrySpecifier}
+                      </span>
+                    </div>
+                    {isDistributed ? (
+                      <Badge variant="success" className="flex-shrink-0">
+                        <Badge.LeftIcon>
+                          <Check className="h-3 w-3" />
+                        </Badge.LeftIcon>
+                        <Badge.Text>Added</Badge.Text>
+                      </Badge>
+                    ) : (
+                      isSelected && (
+                        <Check className="text-foreground h-4 w-4 flex-shrink-0" />
+                      )
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {!showAll && servers.length > INITIAL_VISIBLE && (
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="text-muted-foreground hover:text-foreground mt-2 flex w-full items-center justify-center gap-1.5 py-2 text-sm transition-colors"
+            >
+              Show more servers
+            </button>
+          )}
+          {showAll && hasNextPage && !query && (
+            <button
+              type="button"
+              onClick={() => void fetchNextPage()}
+              disabled={isFetchingNextPage}
+              className="text-muted-foreground hover:text-foreground mt-2 flex w-full items-center justify-center gap-1.5 py-2 text-sm transition-colors disabled:opacity-50"
+            >
+              {isFetchingNextPage ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                "Load more servers"
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <Sheet
+        open={drawerOpen}
+        onOpenChange={(open) => {
+          // Block dismissing mid-deploy so we don't orphan an in-flight run.
+          if (!open && isAdding) return;
+          if (!open) resetDrawer();
+        }}
+      >
+        <SheetContent
+          side="right"
+          className="flex w-full flex-col overflow-hidden p-0 sm:max-w-[662px]"
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Distribute MCP servers</SheetTitle>
+            <SheetDescription>
+              Deploy the selected servers and publish them to your marketplace.
+            </SheetDescription>
+          </SheetHeader>
+
+          {/* Step progress */}
+          <div className="flex items-center gap-1.5 px-6 pt-6 pr-14">
+            {[0, 1].map((idx) => (
+              <div
+                key={idx}
+                className={cn(
+                  "h-1 rounded-full transition-all",
+                  idx === drawerIdx
+                    ? "bg-foreground w-6"
+                    : idx < drawerIdx
+                      ? "bg-foreground/40 w-4"
+                      : "bg-border w-4",
+                )}
+              />
+            ))}
+            <span className="text-muted-foreground ml-auto text-[11px] tabular-nums">
+              {drawerIdx + 1}/2
+            </span>
+          </div>
+
+          {/* Sliding steps */}
+          <div className="relative flex-1 overflow-hidden">
+            <div
+              className="flex h-full transition-transform duration-300 ease-in-out"
+              style={{ transform: `translateX(-${drawerIdx * 100}%)` }}
+            >
+              {/* Step 1 — Adding */}
+              <div className="w-full shrink-0 space-y-3 overflow-y-auto px-6 pb-4">
+                <p className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
+                  Step 1
+                </p>
+                <h4 className="text-foreground text-base font-medium">
+                  Adding servers
+                </h4>
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  Deploying {serversToDeploy.length}{" "}
+                  {serversToDeploy.length === 1 ? "server" : "servers"} and
+                  publishing them to your marketplace. This can take a moment.
+                </p>
+                {drawerError ? (
+                  <div className="text-destructive bg-destructive/5 border-destructive/20 flex items-start gap-2 rounded-md border p-3 text-sm">
+                    <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                    <div>
+                      <p className="font-medium">Couldn't add your servers</p>
+                      <p className="text-muted-foreground mt-0.5">
+                        {drawerError}
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center justify-center gap-3 py-12">
+                    <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+                    <p className="text-muted-foreground text-sm">
+                      Adding to your Default plugin…
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {/* Step 2 — Distribute */}
+              <div className="w-full shrink-0 space-y-4 overflow-y-auto px-6 pb-4">
+                <p className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
+                  Step 2
+                </p>
+                <h4 className="text-foreground text-base font-medium">
+                  Distribute to your team
+                </h4>
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  Your servers are bundled in the Default plugin and published
+                  to your marketplace. Share these instructions so your
+                  organization can install them.
+                </p>
+                {marketplaceCommand && (
+                  <div className="space-y-2">
+                    <p className="text-foreground text-sm font-medium">
+                      Add the marketplace in Claude Code
+                    </p>
+                    <div className="bg-muted/50 flex items-center justify-between gap-2 rounded-md border p-3">
+                      <code className="text-foreground truncate text-xs">
+                        {marketplaceCommand}
+                      </code>
+                      <CopyButton text={marketplaceCommand} />
+                    </div>
+                  </div>
+                )}
+                {publishStatus?.repoOwner && publishStatus?.repoName && (
+                  <div>
+                    <p className="text-muted-foreground mb-2 text-sm">
+                      For Cursor, Codex and other platforms:
+                    </p>
+                    <InstallInstructionsButton
+                      repoOwner={publishStatus.repoOwner}
+                      repoName={publishStatus.repoName}
+                      marketplaceUrl={publishStatus.marketplaceUrl}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Footer — only when there's an action to take */}
+          {(drawerError || drawerStep === "done") && (
+            <div className="border-border flex items-center justify-end border-t px-6 py-4">
+              {drawerError ? (
+                <Button variant="secondary" size="sm" onClick={resetDrawer}>
+                  <Button.Text>Close</Button.Text>
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => {
+                    resetDrawer();
+                    onComplete();
+                  }}
+                >
+                  <Button.Text>Finish</Button.Text>
+                </Button>
+              )}
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+    </StepContainer>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/steps/index.ts
+++ b/client/dashboard/src/pages/setup/components/steps/index.ts
@@ -1,6 +1,7 @@
 export { ConnectIdpStep } from "./connect-idp-step";
 export { DirectorySyncStep } from "./directory-sync-step";
 export { CreateMarketplaceStep } from "./create-marketplace-step";
+export { DistributeServersStep } from "./distribute-servers-step";
 export { InstrumentAgentsStep } from "./instrument-agents-step";
 export { ConfirmTrafficStep } from "./confirm-traffic-step";
 export { ConfigurePoliciesStep } from "./configure-policies-step";


### PR DESCRIPTION
## What

Adds a **Distribute MCP servers** step to the onboarding wizard. Teams can search the MCP catalog and distribute selected servers to their organization during setup, running the deploy → bundle → publish flow inline (in a dedicated `Sheet` drawer) without leaving onboarding.

## Why

Closes the gap between SSO/dsync/marketplace setup and instrumenting agents — new orgs land here right after publishing their marketplace and can get real servers in front of their org before continuing.

## Changes

- New `DistributeServersStep` component (`steps/distribute-servers-step.tsx`):
  - Catalog search with infinite scroll, "already distributed" badges sourced from the Default plugin's toolset membership.
  - Selection → in-drawer deploy/bundle/publish via `useExternalMcpReleaseWorkflow`, with `adding`/`done` drawer states and error surfacing.
  - Skippable.
- `onboarding-wizard.tsx`: inserts the step at position 3; subsequent steps shift down (instrument-agents → 4, confirm-traffic → 5, configure-policies → 6). Resume logic and step comments updated. Content column widened (`max-w-xl` → `min-w-0 flex-1`).
- Changeset (`dashboard: patch`).

## Notes

- Dashboard `type-check` passes.
- Follows the same onboarding-step pattern as the prior Configure policies step (#3265).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Distribute MCP servers step to onboarding so teams can search the catalog, pick servers, and distribute them to their org in one flow. Auto-configures OAuth for supported servers, shows only auto-configurable servers, and surfaces org-wide rollout via Claude Code Managed Settings.

- **New Features**
  - New onboarding step with catalog search, selection, and inline deploy → bundle → publish in a `Sheet`; shows progress and errors; skippable.
  - Lists only auto-configurable servers (OAuth with dynamic client registration); others are hidden here and linked in the catalog.
  - Already-distributed servers are flagged; clicking them opens install instructions. Wizard order updated: this step is 3 → Instrument Agents 4 → Confirm Traffic 5 → Configure Policies 6; content column widened.
  - Added install command for individuals and an org rollout path via Claude Code Managed Settings (guide also covers Claude Cowork, Cursor, and Codex).

- **Bug Fixes**
  - Auto-configures Speakeasy OAuth during distribution (gated behind the same feature flag as AddServerDialog).
  - Gate Continue on deployable selection to prevent no-op deploy; Skip switches to Continue after at least one server is distributed.
  - Bundle only the toolsets created in this run (match workflow toolset slugs), avoiding older or forked toolsets.
  - Clear the search query on Escape before parent handlers run.
  - UI polish: uniform min-height on server cards; catalog note explicitly mentions OAuth dynamic client registration (DCR).

<sup>Written for commit 0b06aee0a17d9ae792617af14d445af6c118981b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

