### PR TITLE
chore: use pubsub emulator for local development

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -44,6 +44,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/speakeasy-api/gram/infra/gen"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/admin"
 	"github.com/speakeasy-api/gram/server/internal/assets"
@@ -882,11 +884,18 @@ func newSvixClient(c *cli.Context, logger *slog.Logger, guardianPolicy *guardian
 	return svixClient, shutdownFunc, nil
 }
 
-func newPubSubClient(ctx context.Context, c *cli.Context, logger *slog.Logger) (*pubsub.Client, func(ctx context.Context) error, error) {
+type pubSubBroker interface {
+	gcp.PublisherBroker
+	gcp.SubscriberBroker
+}
+
+func newPubSubClient(ctx context.Context, c *cli.Context, logger *slog.Logger) (*pubsub.Client, pubSubBroker, func(ctx context.Context) error, error) {
+	var emulated bool
 	var projectID string
 	opts := []option.ClientOption{option.WithLogger(logger)}
 	switch {
 	case c.String("pubsub-emulator-host") != "":
+		emulated = true
 		// The emulator speaks plaintext gRPC, so we must use insecure transport
 		// credentials. The pubsub library only injects these automatically when
 		// the PUBSUB_EMULATOR_HOST env var is set; supplying the host via the CLI
@@ -903,8 +912,15 @@ func newPubSubClient(ctx context.Context, c *cli.Context, logger *slog.Logger) (
 
 	client, err := pubsub.NewClient(ctx, projectID, opts...)
 	if err != nil {
-		return nil, func(context.Context) error { return nil }, fmt.Errorf("failed to create pubsub client: %w", err)
+		return nil, nil, func(context.Context) error { return nil }, fmt.Errorf("failed to create pubsub client: %w", err)
 	}
 
-	return client, func(context.Context) error { return client.Close() }, nil
+	var broker pubSubBroker
+	if emulated {
+		broker = gcp.NewEmulatedPubSub(logger, projectID, client, gen.Descriptors)
+	} else {
+		broker = gcp.NewPubSubBroker(logger, client, gen.Descriptors)
+	}
+
+	return client, broker, func(context.Context) error { return client.Close() }, nil
 }

--- a/server/cmd/gram/flags_gcp.go
+++ b/server/cmd/gram/flags_gcp.go
@@ -1,0 +1,16 @@
+package gram
+
+import "github.com/urfave/cli/v2"
+
+var gcpFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "gcp-project-id",
+		Usage:   "Google Cloud project ID",
+		EnvVars: []string{"GRAM_GCP_PROJECT_ID"},
+	},
+	&cli.StringFlag{
+		Name:    "pubsub-emulator-host",
+		Usage:   "Host to use for the PubSub emulator",
+		EnvVars: []string{"PUBSUB_EMULATOR_HOST"},
+	},
+}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -431,6 +431,7 @@ func newStartCommand() *cli.Command {
 	flags = append(flags, assistantRuntimeFlags...)
 	flags = append(flags, pulseMCPFlags...)
 	flags = append(flags, svixFlags...)
+	flags = append(flags, gcpFlags...)
 
 	return &cli.Command{
 		Name:  "start",

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -46,11 +46,6 @@ func newStreamsCommand() *cli.Command {
 			EnvVars:  []string{"GRAM_ENVIRONMENT"},
 		},
 		&cli.StringFlag{
-			Name:    "gcp-project-id",
-			Usage:   "Google Cloud project ID",
-			EnvVars: []string{"GRAM_GCP_PROJECT_ID"},
-		},
-		&cli.StringFlag{
 			Name:     "database-url",
 			Usage:    "Database URL",
 			EnvVars:  []string{"GRAM_DATABASE_URL"},
@@ -88,11 +83,6 @@ func newStreamsCommand() *cli.Command {
 			EnvVars:  []string{"GRAM_DISALLOWED_CIDR_BLOCKS"},
 			Required: false,
 		},
-		&cli.StringFlag{
-			Name:    "pubsub-emulator-host",
-			Usage:   "Host to use for the PubSub emulator",
-			EnvVars: []string{"PUBSUB_EMULATOR_HOST"},
-		},
 		&cli.PathFlag{
 			Name:     "config-file",
 			Usage:    "Path to a config file to load. Supported formats are JSON, TOML and YAML.",
@@ -100,6 +90,8 @@ func newStreamsCommand() *cli.Command {
 			Required: false,
 		},
 	}
+
+	flags = append(flags, gcpFlags...)
 
 	return &cli.Command{
 		Name:  "streams",
@@ -169,13 +161,11 @@ func newStreamsCommand() *cli.Command {
 			}
 			_ = redisClient
 
-			psclient, shutdown, err := newPubSubClient(ctx, c, logger)
+			_, psbroker, shutdown, err := newPubSubClient(ctx, c, logger)
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 			if err != nil {
 				return fmt.Errorf("failed to create pubsub client: %w", err)
 			}
-
-			broker := gcp.NewPubSubBroker(logger, psclient, gen.Descriptors)
 
 			{
 				controlServer := control.Server{
@@ -203,7 +193,7 @@ func newStreamsCommand() *cli.Command {
 				getContext: func() context.Context { return ctx },
 				tracer:     tracerProvider.Tracer("github.com/speakeasy-api/gram/server/cmd/gram/streams"),
 				logger:     logger,
-				broker:     broker,
+				broker:     psbroker,
 			}
 
 			// Start subscription receivers in this block
@@ -215,7 +205,7 @@ func newStreamsCommand() *cli.Command {
 			// subscriber flow is working by driving a simple message through
 			// the system every N seconds and logging it in the subscriber.
 			group.Go(func() error {
-				if err := ping.StartPublisher(ctx, logger, broker); err != nil {
+				if err := ping.StartPublisher(ctx, logger, psbroker); err != nil {
 					return fmt.Errorf("publish pings: %w", err)
 				}
 				return nil

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -330,6 +330,7 @@ func newWorkerCommand() *cli.Command {
 	flags = append(flags, assistantRuntimeFlags...)
 	flags = append(flags, svixFlags...)
 	flags = append(flags, pluginsFlags...)
+	flags = append(flags, gcpFlags...)
 
 	return &cli.Command{
 		Name:  "worker",


### PR DESCRIPTION
The streams process could already point at a Pub/Sub emulator, but the start and worker processes had no way to do so, and the emulator does not auto-create topics and subscriptions the way the real GCP broker setup does.

Centralize the GCP/Pub/Sub CLI flags (gcp-project-id, pubsub-emulator-host) in a shared gcpFlags slice and wire them into start, worker, and streams so every process can talk to the emulator locally. newPubSubClient now also returns a broker, selecting an emulated broker (which provisions topics/subscriptions on the fly) when an emulator host is configured and the real broker otherwise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let all processes (`start`, `worker`, `streams`) run against a Pub/Sub emulator for local development. Adds an emulated broker that auto-creates topics and subscriptions when an emulator host is set.

- **New Features**
  - Added shared `gcpFlags` with `gcp-project-id` and `pubsub-emulator-host` and wired them into `start`, `worker`, and `streams`.
  - Updated `newPubSubClient` to also return a broker. Chooses an emulated broker when `pubsub-emulator-host` is set; otherwise uses the real broker. The emulated broker provisions topics/subscriptions on the fly.

- **Migration**
  - Local: run with `--pubsub-emulator-host=localhost:8085` and `--gcp-project-id=<id>` (or set `PUBSUB_EMULATOR_HOST` and `GRAM_GCP_PROJECT_ID`).
  - No changes needed for production.

<sup>Written for commit 471c09e523051711bd07559fa23309169784f9db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

