### PR TITLE
fix: avoid misrouted host port in redis test container

### DIFF
--- a/server/internal/testenv/redis.go
+++ b/server/internal/testenv/redis.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"runtime"
 	"testing"
 	"time"
 
@@ -29,59 +30,100 @@ func NewTestRedis(ctx context.Context) (*tcr.RedisContainer, RedisClientFunc, er
 		return nil, nil, fmt.Errorf("failed to start redis container: %w", err)
 	}
 
-	return container, newRedisClientFunc(container), nil
+	addr, err := resolveRedisAddr(ctx, container)
+	if err != nil {
+		tctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		_ = container.Terminate(tctx)
+		return nil, nil, fmt.Errorf("resolve redis address: %w", err)
+	}
+
+	return container, newRedisClientFunc(addr), nil
 }
 
-func newRedisClientFunc(container *tcr.RedisContainer) RedisClientFunc {
+// resolveRedisAddr picks the address test clients will dial, exactly once at
+// container startup. Docker's published host port can transiently route to a
+// different container when many containers run in parallel under CI load
+// (testcontainers-go#2749) — observed as the redis client receiving
+// "HTTP/1.1 400 Bad Request" from another container's HTTP port. On Linux
+// (i.e. CI) the container IP is routable from the host, so we bypass host
+// port mapping entirely; the address is verified with a real PING before
+// being adopted, falling back to the published port for environments where
+// container IPs are not reachable (e.g. remote Docker daemons, macOS).
+func resolveRedisAddr(ctx context.Context, container *tcr.RedisContainer) (string, error) {
+	if runtime.GOOS == "linux" {
+		if ip, err := container.ContainerIP(ctx); err == nil && ip != "" {
+			addr := net.JoinHostPort(ip, "6379")
+			if err := pingRedis(ctx, addr); err == nil {
+				return addr, nil
+			}
+		}
+	}
+
+	cstr, err := container.ConnectionString(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get redis connection string: %w", err)
+	}
+
+	uri, err := url.Parse(cstr)
+	if err != nil {
+		return "", fmt.Errorf("parse redis connection string: %w", err)
+	}
+
+	host, port, err := net.SplitHostPort(uri.Host)
+	if err != nil {
+		return "", fmt.Errorf("split redis host/port: %w", err)
+	}
+
+	// Avoid a DNS lookup for localhost inside synctest bubbles without
+	// changing arbitrary Docker/Testcontainers endpoints. Re-resolving the
+	// host here can pick an address that is not the actual published Redis
+	// endpoint (for example ::1 instead of Docker's IPv4 localhost binding).
+	if host == "localhost" {
+		host = "127.0.0.1"
+	}
+
+	addr := net.JoinHostPort(host, port)
+	if err := pingRedis(ctx, addr); err != nil {
+		return "", fmt.Errorf("ping redis at %s: %w", addr, err)
+	}
+
+	return addr, nil
+}
+
+func pingRedis(ctx context.Context, addr string) error {
+	client := redis.NewClient(&redis.Options{
+		Addr:         addr,
+		DialTimeout:  1 * time.Second,
+		ReadTimeout:  300 * time.Millisecond,
+		WriteTimeout: 1 * time.Second,
+		Protocol:     2,
+	})
+	defer func() { _ = client.Close() }()
+
+	var err error
+	for range 10 {
+		if err = client.Ping(ctx).Err(); err == nil {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return fmt.Errorf("redis not ready after retries: %w", err)
+}
+
+func newRedisClientFunc(addr string) RedisClientFunc {
 	return func(t *testing.T, db int) (*redis.Client, error) {
 		t.Helper()
 
-		cstr, err := container.ConnectionString(t.Context())
-		if err != nil {
-			return nil, fmt.Errorf("failed to get redis connection string: %w", err)
-		}
-
-		uri, err := url.Parse(cstr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse redis connection string: %w", err)
-		}
-
-		host, port, err := net.SplitHostPort(uri.Host)
-		if err != nil {
-			return nil, fmt.Errorf("split redis host/port: %w", err)
-		}
-
-		// Avoid a DNS lookup for localhost inside synctest bubbles without
-		// changing arbitrary Docker/Testcontainers endpoints. Re-resolving the
-		// host here can pick an address that is not the actual published Redis
-		// endpoint (for example ::1 instead of Docker's IPv4 localhost binding).
-		if host == "localhost" {
-			host = "127.0.0.1"
-		}
-
 		client := redis.NewClient(&redis.Options{
-			Addr:         net.JoinHostPort(host, port),
+			Addr:         addr,
 			DB:           db,
 			DialTimeout:  1 * time.Second,
 			ReadTimeout:  300 * time.Millisecond,
 			WriteTimeout: 1 * time.Second,
 			Protocol:     2,
 		})
-
-		// Verify the connection is alive before returning. Without this,
-		// the container's mapped port may be open before the Docker
-		// port-forwarding is fully routing to Redis, causing transient
-		// connection errors under CI load.
-		ctx := t.Context()
-		for attempt := range 10 {
-			if err := client.Ping(ctx).Err(); err == nil {
-				break
-			} else if attempt == 9 {
-				_ = client.Close()
-				return nil, fmt.Errorf("redis not ready after retries: %w", err)
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
 
 		t.Cleanup(func() {
 			if err := client.Close(); err != nil {


### PR DESCRIPTION
## Root cause

CI tests using the testenv Redis container failed intermittently with:

```
redis not ready after retries: redis: can't parse map reply: "HTTP/1.1 400 Bad Request"
```

The Redis client was TCP-connecting successfully but to something speaking **HTTP** — i.e. another test container's HTTP port. This is [testcontainers-go#2749](https://github.com/testcontainers/testcontainers-go/issues/2749): under heavy parallel container churn (every test package's `TestMain` launches its own postgres + redis + clickhouse set, and Go runs packages concurrently), Docker's published host port can transiently route to the wrong container. The existing 10×100ms ping retry loop could never recover because it redialed the same misrouted port.

Redis was uniquely exposed on two counts:

- Its readiness checks never touched the published port from the host: the module's default wait is log-based and our extra wait was `redis-cli ping` executed *inside* the container.
- The address was re-resolved from the Docker daemon on **every test** via `ConnectionString(t.Context())`.

## Fix

In `server/internal/testenv/redis.go`:

- Resolve the Redis address **once at container startup** instead of per test.
- On Linux (i.e. CI), dial the container IP directly on 6379, bypassing host port mapping entirely — the workaround that resolved the upstream issue.
- Verify whichever address is chosen with a real `PING` before adopting it, falling back to the published port where container IPs are not routable (macOS, remote Docker daemons).

## Why postgres and ClickHouse never flaked

- **Postgres** resolves its connection string once at startup and immediately connects through the mapped port to build the template database — the host→container route is proven before any test runs, and every test reuses that URI.
- **ClickHouse**'s testcontainers module wait strategy probes the container from the host through the mapped port (HTTP check on 8123), so the published port is validated by the time `Run` returns.

This change brings Redis in line with both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent Redis CI failures by avoiding misrouted host ports and verifying the connection upfront. We now lock the Redis address once at startup, prefer the container IP on Linux, and PING it before tests run.

- **Bug Fixes**
  - Resolve Redis address once when the container starts instead of per test.
  - On Linux, connect to the container IP on 6379, bypassing host port mapping; fallback to the published port where container IPs aren’t reachable.
  - Verify the chosen address with a real PING before adoption to prevent "HTTP/1.1 400 Bad Request" misroutes.

<sup>Written for commit adfcf69f679879f9d1c213913b024818c46bf5b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

