### PR TITLE
chore: capture client info on mcp initialize

### DIFF
--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -27,7 +31,42 @@ type serverInfo struct {
 	Version string `json:"version"`
 }
 
+// initializeParams captures the subset of the MCP initialize request params we
+// record: the requested protocol version, the client identity, and the
+// capabilities the client advertised.
+type initializeParams struct {
+	ProtocolVersion string `json:"protocolVersion"`
+	ClientInfo      struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"clientInfo"`
+	Capabilities map[string]json.RawMessage `json:"capabilities"`
+}
+
+// parseInitializeParams decodes the initialize request params we record. It
+// returns the parsed params, the sorted set of advertised capability keys, and
+// whether the params were well-formed. Malformed params must not fail the RPC,
+// so callers log and continue rather than surfacing the error.
+func parseInitializeParams(raw json.RawMessage) (initializeParams, []string, error) {
+	var params initializeParams
+	if len(raw) == 0 {
+		return params, nil, nil
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return initializeParams{}, nil, fmt.Errorf("unmarshal initialize params: %w", err)
+	}
+	return params, slices.Sorted(maps.Keys(params.Capabilities)), nil
+}
+
 func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest, payload *mcpInputs, productMetrics *posthog.Posthog, toolsetsRepoParam *toolsets_repo.Queries, metadataRepoParam *metadata_repo.Queries) (json.RawMessage, error) {
+	params, capabilities, err := parseInitializeParams(req.Params)
+	validParams := err == nil
+	if err != nil {
+		// Malformed params should not fail the RPC; we just lose the
+		// recorded client info for this request.
+		logger.WarnContext(ctx, "failed to parse mcp initialize params", attr.SlogError(err))
+	}
+
 	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
 		if err := productMetrics.CaptureEvent(ctx, "mcp_initialized", payload.sessionID, map[string]any{
 			"project_id":           payload.projectID.String(),
@@ -36,6 +75,10 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest,
 			"mcp_url":              requestContext.Host + requestContext.ReqURL,
 			"disable_notification": true,
 			"mcp_session_id":       payload.sessionID,
+			"protocol_version":     params.ProtocolVersion,
+			"client_name":          conv.PtrEmpty(conv.TruncateString(params.ClientInfo.Name, 100)),
+			"client_version":       conv.PtrEmpty(conv.TruncateString(params.ClientInfo.Version, 100)),
+			"capabilities":         conv.Ternary(validParams, capabilities, nil),
 		}); err != nil {
 			logger.ErrorContext(ctx, "failed to capture mcp_initialized event", attr.SlogError(err))
 		}

--- a/server/internal/mcp/rpc_initialize_test.go
+++ b/server/internal/mcp/rpc_initialize_test.go
@@ -1,0 +1,102 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseInitializeParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		raw              string
+		wantValid        bool
+		wantProtocol     string
+		wantClientName   string
+		wantClientVer    string
+		wantCapabilities []string
+	}{
+		{
+			name:             "empty params",
+			raw:              "",
+			wantValid:        true,
+			wantCapabilities: nil,
+		},
+		{
+			name:             "full params with sorted capabilities",
+			raw:              `{"protocolVersion":"2025-03-26","clientInfo":{"name":"cursor","version":"1.2.3"},"capabilities":{"tools":{},"roots":{},"sampling":{}}}`,
+			wantValid:        true,
+			wantProtocol:     "2025-03-26",
+			wantClientName:   "cursor",
+			wantClientVer:    "1.2.3",
+			wantCapabilities: []string{"roots", "sampling", "tools"},
+		},
+		{
+			name:             "no capabilities",
+			raw:              `{"protocolVersion":"2025-03-26","clientInfo":{"name":"claude","version":"1.0.0"}}`,
+			wantValid:        true,
+			wantProtocol:     "2025-03-26",
+			wantClientName:   "claude",
+			wantClientVer:    "1.0.0",
+			wantCapabilities: nil,
+		},
+		{
+			name:      "malformed params (array instead of object)",
+			raw:       `["not","an","object"]`,
+			wantValid: false,
+		},
+		{
+			name:      "malformed params (invalid json)",
+			raw:       `{not json`,
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			params, capabilities, err := parseInitializeParams(json.RawMessage(tt.raw))
+			if !tt.wantValid {
+				require.Error(t, err)
+				require.Empty(t, capabilities)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantProtocol, params.ProtocolVersion)
+			require.Equal(t, tt.wantClientName, params.ClientInfo.Name)
+			require.Equal(t, tt.wantClientVer, params.ClientInfo.Version)
+			require.Equal(t, tt.wantCapabilities, capabilities)
+		})
+	}
+}
+
+// TestParseInitializeParams_CapabilitiesAlwaysSorted guards against map
+// iteration order leaking into the recorded capability list.
+func TestParseInitializeParams_CapabilitiesAlwaysSorted(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"capabilities":{"zeta":{},"alpha":{},"mu":{},"beta":{}}}`
+	for range 20 {
+		_, capabilities, err := parseInitializeParams(json.RawMessage(raw))
+		require.NoError(t, err)
+		require.Equal(t, []string{"alpha", "beta", "mu", "zeta"}, capabilities)
+	}
+}
+
+func TestParseInitializeParams_DeepClientNameNotTruncatedAtParse(t *testing.T) {
+	t.Parallel()
+
+	// Truncation happens at capture time via conv.TruncateString; parsing
+	// itself preserves the raw client identity.
+	long := strings.Repeat("x", 250)
+	raw := `{"clientInfo":{"name":"` + long + `","version":"1.0.0"}}`
+	params, _, err := parseInitializeParams(json.RawMessage(raw))
+	require.NoError(t, err)
+	require.Len(t, params.ClientInfo.Name, 250)
+}

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -236,6 +236,62 @@ func TestServePublic_InitializeSucceeds(t *testing.T) {
 	require.NotNil(t, result["serverInfo"])
 }
 
+// TestServePublic_InitializeWithMalformedParamsSucceeds verifies the commit's
+// guarantee that capturing client info never breaks the RPC: even when the
+// initialize params can't be decoded into our recorded shape, the handshake
+// still returns a valid initialize result.
+func TestServePublic_InitializeWithMalformedParamsSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset, err := toolsetsRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Malformed Params MCP",
+		Slug:                   "malformed-params-mcp",
+		Description:            conv.ToPGText("A test MCP server"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText("malformed-params-mcp"),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	toolset, err = toolsetsRepo.UpdateToolset(ctx, toolsets_repo.UpdateToolsetParams{
+		Name:                   toolset.Name,
+		Description:            toolset.Description,
+		DefaultEnvironmentSlug: toolset.DefaultEnvironmentSlug,
+		McpSlug:                toolset.McpSlug,
+		McpIsPublic:            true,
+		McpEnabled:             toolset.McpEnabled,
+		Slug:                   toolset.Slug,
+		ProjectID:              toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	// params is an array rather than the expected object, so decoding into our
+	// recorded shape fails — but the RPC must still succeed.
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":["unexpected"]}`)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, body, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotEmpty(t, w.Header().Get("Mcp-Session-Id"))
+
+	var response map[string]any
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err, "response body: %s", w.Body.String())
+	require.Nil(t, response["error"])
+	result, ok := response["result"].(map[string]any)
+	require.True(t, ok, "result should be a map: %v", response)
+	require.Equal(t, "2025-03-26", result["protocolVersion"])
+}
+
 func TestServePublic_PrivateDisabledMCP_Returns404(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Knowing which MCP clients (and versions) connect, what protocol version they request, and which capabilities they advertise lets us understand real-world client usage and prioritize compatibility work. Malformed params are tolerated so analytics never break the RPC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record MCP client name/version, requested protocol version, and advertised capabilities during initialize to improve usage analytics and guide compatibility work. Params can be empty or malformed; we log and continue so the RPC always succeeds.

- **New Features**
  - Capture event fields on initialize: protocol_version, client_name, client_version, capabilities.
  - Capabilities are the sorted keys of the client’s capability map; set to null when absent or params are malformed.
  - Truncate client_name/client_version to 100 chars and send null when empty.

<sup>Written for commit 9251b218574f376a2b06178810a10e19b54236f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

