### PR TITLE
fix(plugins): default identity.sh to probe speakeasyd first

### DIFF
--- a/.changeset/identity-default-speakeasyd.md
+++ b/.changeset/identity-default-speakeasyd.md
@@ -1,0 +1,12 @@
+---
+"server": patch
+---
+
+Add `speakeasyd` to the default device-agent command list in the generated
+observability plugin `identity.sh`. The daemon ships as `speakeasyd`, which was
+absent from the previous default (`device-agent,speakeasy-device-agent`), so
+identity enrichment was skipped and hook events reached Gram anonymously
+(no `user_email`) on a standard install. The new default
+(`speakeasyd,device-agent,speakeasy-device-agent`) applies to the Claude Code,
+Cursor, and Codex plugin templates; legacy binary names are retained for
+compatibility.

--- a/.changeset/identity-default-speakeasyd.md
+++ b/.changeset/identity-default-speakeasyd.md
@@ -2,11 +2,10 @@
 "server": patch
 ---
 
-Add `speakeasyd` to the default device-agent command list in the generated
-observability plugin `identity.sh`. The daemon ships as `speakeasyd`, which was
-absent from the previous default (`device-agent,speakeasy-device-agent`), so
-identity enrichment was skipped and hook events reached Gram anonymously
-(no `user_email`) on a standard install. The new default
-(`speakeasyd,device-agent,speakeasy-device-agent`) applies to the Claude Code,
-Cursor, and Codex plugin templates; legacy binary names are retained for
-compatibility.
+Default the device-agent command list in the generated observability plugin
+`identity.sh` to `speakeasyd`, the binary the daemon actually ships as. The
+previous default (`device-agent,speakeasy-device-agent`) never resolved on a
+standard install, so identity enrichment was skipped and hook events reached
+Gram anonymously (no `user_email`). The fix applies to the Claude Code, Cursor,
+and Codex plugin templates. Installs that still use a differently-named binary
+can override via `GRAM_DEVICE_AGENT_COMMANDS`.

--- a/hooks/plugin-claude/hooks/identity.sh
+++ b/hooks/plugin-claude/hooks/identity.sh
@@ -3,7 +3,7 @@
 gram_enrich_identity_payload() {
   local payload="$1"
   local email=""
-  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd,device-agent,speakeasy-device-agent}"
+  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd}"
   local timeout_tenths="${GRAM_DEVICE_AGENT_TIMEOUT_TENTHS:-15}"
   local old_ifs="$IFS"
   local command output tmp pid elapsed prefix trimmed

--- a/hooks/plugin-claude/hooks/identity.sh
+++ b/hooks/plugin-claude/hooks/identity.sh
@@ -3,7 +3,7 @@
 gram_enrich_identity_payload() {
   local payload="$1"
   local email=""
-  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-device-agent,speakeasy-device-agent}"
+  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd,device-agent,speakeasy-device-agent}"
   local timeout_tenths="${GRAM_DEVICE_AGENT_TIMEOUT_TENTHS:-15}"
   local old_ifs="$IFS"
   local command output tmp pid elapsed prefix trimmed

--- a/hooks/plugin-cursor/hooks/identity.sh
+++ b/hooks/plugin-cursor/hooks/identity.sh
@@ -3,7 +3,7 @@
 gram_enrich_identity_payload() {
   local payload="$1"
   local email=""
-  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd,device-agent,speakeasy-device-agent}"
+  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd}"
   local timeout_tenths="${GRAM_DEVICE_AGENT_TIMEOUT_TENTHS:-15}"
   local old_ifs="$IFS"
   local command output tmp pid elapsed prefix trimmed

--- a/hooks/plugin-cursor/hooks/identity.sh
+++ b/hooks/plugin-cursor/hooks/identity.sh
@@ -3,7 +3,7 @@
 gram_enrich_identity_payload() {
   local payload="$1"
   local email=""
-  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-device-agent,speakeasy-device-agent}"
+  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd,device-agent,speakeasy-device-agent}"
   local timeout_tenths="${GRAM_DEVICE_AGENT_TIMEOUT_TENTHS:-15}"
   local old_ifs="$IFS"
   local command output tmp pid elapsed prefix trimmed

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -778,7 +778,7 @@ func renderDeviceAgentIdentityScript() []byte {
 gram_enrich_identity_payload() {
   local payload="$1"
   local email=""
-  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd,device-agent,speakeasy-device-agent}"
+  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd}"
   local timeout_tenths="${GRAM_DEVICE_AGENT_TIMEOUT_TENTHS:-15}"
   local old_ifs="$IFS"
   local command output tmp pid elapsed prefix trimmed

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -778,7 +778,7 @@ func renderDeviceAgentIdentityScript() []byte {
 gram_enrich_identity_payload() {
   local payload="$1"
   local email=""
-  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-device-agent,speakeasy-device-agent}"
+  local commands="${GRAM_DEVICE_AGENT_COMMANDS:-speakeasyd,device-agent,speakeasy-device-agent}"
   local timeout_tenths="${GRAM_DEVICE_AGENT_TIMEOUT_TENTHS:-15}"
   local old_ifs="$IFS"
   local command output tmp pid elapsed prefix trimmed


### PR DESCRIPTION
## Problem

Observability plugin hook events were sent to Gram **anonymously** (no `user_email`) on a standard install, because the identity-enrichment hook couldn't find the daemon binary.

The generated `identity.sh` resolves the enrolled user's email by probing a default list of device-agent binary names. The daemon ships as `speakeasyd`, which was **not** in that default list, so `command -v` missed, enrichment was skipped, and every event was anonymous.

## Fix

Default the command list to just `speakeasyd` — the binary the daemon actually ships as. Installs using a differently-named binary can still override via `GRAM_DEVICE_AGENT_COMMANDS`.

Applied in `renderDeviceAgentIdentityScript` (the generator template used by **all three** platform paths — Claude Code, Cursor, Codex) and in the checked-in `plugin-claude` / `plugin-cursor` `identity.sh` copies to keep them in sync.

Fixing it in the generator is the only durable cross-tool fix: Claude Code can be patched device-side via its `settings.json` `env` block, but Codex hook subprocesses have no config knob to inject env vars.

## Testing

- `go test ./server/internal/plugins/` → ok (existing tests override `GRAM_DEVICE_AGENT_COMMANDS` explicitly, so they're unaffected by the default change).

## Follow-ups (separate issues)

- Once republished, the device-agent's Claude Code `GRAM_DEVICE_AGENT_COMMANDS` env-var sync becomes redundant and can be removed.
- Published hooks currently route events to Gram project `adam` via a hardcoded `Gram-Key`/`Gram-Project` in `hook.sh` — needs a republish against the correct project.

Resolves DNO-226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)