### PR TITLE
feat(agent): project-scoped marketplaces in getPlugins (resolves DNO-228)

### DIFF
--- a/.changeset/agent-getplugins-default-project.md
+++ b/.changeset/agent-getplugins-default-project.md
@@ -2,20 +2,26 @@
 "server": patch
 ---
 
-Fix `agent.getPlugins` returning the wrong marketplace for orgs with multiple
-published projects, and make it honor per-project marketplace names.
+Give each published project its own device-agent marketplace instead of
+collapsing an org to one.
 
-The endpoint collapses projects that share a marketplace name into one and kept
-the first row's token, but the query ordered by project slug — so a multi-project
-org received whichever project sorted first alphabetically (e.g. `adam` instead
-of the org's default project), and the device's observability hooks then reported
-to that wrong project. The query now orders by project id, so a same-named
-collapse resolves to the org's default project (first by id ASC, created at org
-setup) rather than an arbitrary alphabetical winner.
+Previously `agent.getPlugins` derived the marketplace name from the org alone, so
+every project in an org computed the same name and all but one were dropped — and
+which one survived depended on alphabetical project-slug order, so a multi-project
+org could receive the wrong project's marketplace (its observability hooks then
+reporting to the wrong project). The view also ignored the per-project name
+override entirely.
 
-The view also now resolves each project's marketplace name the way the publish
-path does — the per-project override (`project_marketplace_settings`) when set,
-else the org-derived default — instead of always recomputing the org default.
-Projects published under distinct names now surface as distinct marketplaces
-rather than collapsing, and the agent stops emitting the org default for a
-project that published under an override name (which the device never installed).
+Marketplace names are now project-scoped: the org's default project (its oldest,
+by id ASC) keeps the bare `<org>-speakeasy` name it always had, and every other
+project gets `<org>-<project>-speakeasy`. The agent resolves each name exactly the
+way the publish path does — per-project override if set, else this default — so a
+device now receives every marketplace the org has published, each pointing at its
+own project. Names that still genuinely collide (e.g. two equal overrides) collapse
+deterministically to the default project.
+
+No schema change. Single-project orgs and every org's default project keep their
+existing name, so their installs don't churn; only non-default projects get a new
+name, and the automated generator rollout republishes them (their content
+fingerprint changes) so the published marketplace.json matches what the agent
+emits.

--- a/.changeset/agent-getplugins-default-project.md
+++ b/.changeset/agent-getplugins-default-project.md
@@ -1,0 +1,13 @@
+---
+"server": patch
+---
+
+Fix `agent.getPlugins` returning the wrong project's marketplace for orgs with
+multiple published projects. The endpoint collapses an org's projects to a
+single marketplace and kept the first row's token, but the query ordered by
+project slug — so a multi-project org received whichever project sorted first
+alphabetically (e.g. `adam` instead of the org's default project), and the
+device's observability hooks then reported to that wrong project. The query now
+orders by project id, so the collapse resolves to the org's default project
+(first by id ASC, created at org setup) rather than an arbitrary alphabetical
+winner.

--- a/.changeset/agent-getplugins-default-project.md
+++ b/.changeset/agent-getplugins-default-project.md
@@ -2,12 +2,20 @@
 "server": patch
 ---
 
-Fix `agent.getPlugins` returning the wrong project's marketplace for orgs with
-multiple published projects. The endpoint collapses an org's projects to a
-single marketplace and kept the first row's token, but the query ordered by
-project slug — so a multi-project org received whichever project sorted first
-alphabetically (e.g. `adam` instead of the org's default project), and the
-device's observability hooks then reported to that wrong project. The query now
-orders by project id, so the collapse resolves to the org's default project
-(first by id ASC, created at org setup) rather than an arbitrary alphabetical
-winner.
+Fix `agent.getPlugins` returning the wrong marketplace for orgs with multiple
+published projects, and make it honor per-project marketplace names.
+
+The endpoint collapses projects that share a marketplace name into one and kept
+the first row's token, but the query ordered by project slug — so a multi-project
+org received whichever project sorted first alphabetically (e.g. `adam` instead
+of the org's default project), and the device's observability hooks then reported
+to that wrong project. The query now orders by project id, so a same-named
+collapse resolves to the org's default project (first by id ASC, created at org
+setup) rather than an arbitrary alphabetical winner.
+
+The view also now resolves each project's marketplace name the way the publish
+path does — the per-project override (`project_marketplace_settings`) when set,
+else the org-derived default — instead of always recomputing the org default.
+Projects published under distinct names now surface as distinct marketplaces
+rather than collapsing, and the agent stops emitting the org default for a
+project that published under an override name (which the device never installed).

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -116,6 +116,38 @@ func TestGetPlugins_MultiProjectPrefersDefault(t *testing.T) {
 	require.NotContains(t, res.Marketplaces[0].URL, "adam-token")
 }
 
+// TestGetPlugins_DistinctOverridesYieldSeparateMarketplaces covers the
+// multi-marketplace path: when projects publish under *distinct* names (via the
+// per-project override), each surfaces as its own marketplace instead of
+// collapsing. Also pins that the agent honors the override at all — recomputing
+// the org default would emit a name the project never published under.
+func TestGetPlugins_DistinctOverridesYieldSeparateMarketplaces(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+
+	// Default project keeps the org-derived name.
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
+
+	// A second project published under a distinct override name.
+	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
+	setMarketplaceOverride(t, ctx, ti.conn, adam, "team-adam")
+	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	require.NoError(t, err)
+
+	require.Len(t, res.Marketplaces, 2, "distinct names must not collapse")
+
+	byName := make(map[string]string, len(res.Marketplaces))
+	for _, m := range res.Marketplaces {
+		byName[m.Name] = m.URL
+	}
+	require.Contains(t, byName, wantMarketplace, "default project keeps the org-derived name")
+	require.Contains(t, byName, "team-adam", "override project surfaces under its published name")
+	require.Contains(t, byName[wantMarketplace], "default-token")
+	require.Contains(t, byName["team-adam"], "adam-token")
+}
+
 func TestGetPlugins_CrossOrgIsolation(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -87,6 +87,35 @@ func TestGetPlugins_UnpublishedProjectExcluded(t *testing.T) {
 	require.Empty(t, res.Plugins)
 }
 
+// TestGetPlugins_MultiProjectPrefersDefault pins DNO-228: an org with multiple
+// published projects must collapse to the *default* project's marketplace (the
+// one created at org setup, lowest id), not the alphabetically-first one.
+//
+// The default project (from InitAuthContext) has slug "test-<hex>", so a second
+// project named "adam" sorts ahead of it alphabetically but is created later, so
+// it has a higher id. With the old `ORDER BY pr.slug` "adam" won; with the
+// id-ordered query the default project's token is the one returned.
+func TestGetPlugins_MultiProjectPrefersDefault(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+
+	// Default project: publish with a recognizable token.
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
+
+	// A second project in the same org that sorts first alphabetically.
+	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
+	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	require.NoError(t, err)
+
+	require.Len(t, res.Marketplaces, 1, "an org's projects collapse to one marketplace")
+	require.Equal(t, wantMarketplace, res.Marketplaces[0].Name)
+	require.Contains(t, res.Marketplaces[0].URL, "default-token",
+		"the default project's marketplace must win, not the alphabetically-first one")
+	require.NotContains(t, res.Marketplaces[0].URL, "adam-token")
+}
+
 func TestGetPlugins_CrossOrgIsolation(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -14,8 +14,10 @@ import (
 // helpers the publish path uses, so the test pins the actual cross-surface
 // contract rather than a hardcoded string.
 var (
-	wantMarketplace   = naming.MarketplaceName(mockidp.MockOrgName)   // local-dev-org-speakeasy
-	wantObservability = naming.ObservabilitySlug(mockidp.MockOrgName) // local-dev-org-observability
+	// The test instance's project is its org's default (oldest) project, so it
+	// keeps the bare org-derived name; slug is irrelevant when isDefault is true.
+	wantMarketplace   = naming.MarketplaceName(mockidp.MockOrgName, "", true) // local-dev-org-speakeasy
+	wantObservability = naming.ObservabilitySlug(mockidp.MockOrgName)         // local-dev-org-observability
 )
 
 func pluginSlugs(res *gen.GetPluginsResult) []string {
@@ -87,32 +89,59 @@ func TestGetPlugins_UnpublishedProjectExcluded(t *testing.T) {
 	require.Empty(t, res.Plugins)
 }
 
-// TestGetPlugins_MultiProjectPrefersDefault pins DNO-228: an org with multiple
-// published projects must collapse to the *default* project's marketplace (the
-// one created at org setup, lowest id), not the alphabetically-first one.
-//
-// The default project (from InitAuthContext) has slug "test-<hex>", so a second
-// project named "adam" sorts ahead of it alphabetically but is created later, so
-// it has a higher id. With the old `ORDER BY pr.slug` "adam" won; with the
-// id-ordered query the default project's token is the one returned.
-func TestGetPlugins_MultiProjectPrefersDefault(t *testing.T) {
+// TestGetPlugins_MultiProjectDistinctByDefault covers project-scoped naming: an
+// org with multiple published projects surfaces each as its own marketplace. The
+// default project (from InitAuthContext, the org's oldest) keeps the bare
+// org-derived name; a non-default project is scoped by its slug. Both are
+// returned, each with its own token.
+func TestGetPlugins_MultiProjectDistinctByDefault(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)
 
-	// Default project: publish with a recognizable token.
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
 
-	// A second project in the same org that sorts first alphabetically.
 	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
+	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
+	wantAdam := naming.MarketplaceName(mockidp.MockOrgName, "adam", false) // local-dev-org-adam-speakeasy
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	require.NoError(t, err)
+
+	require.Len(t, res.Marketplaces, 2, "distinct project-scoped names do not collapse")
+	byName := make(map[string]string, len(res.Marketplaces))
+	for _, m := range res.Marketplaces {
+		byName[m.Name] = m.URL
+	}
+	require.Contains(t, byName, wantMarketplace, "default project keeps the bare org name")
+	require.Contains(t, byName, wantAdam, "non-default project is scoped by slug")
+	require.Contains(t, byName[wantMarketplace], "default-token")
+	require.Contains(t, byName[wantAdam], "adam-token")
+}
+
+// TestGetPlugins_CollidingNamesPreferDefault pins the DNO-228 tiebreak that still
+// matters when names genuinely collide: if a non-default project's override is
+// set to the default project's name, they can't both exist on the device, so the
+// view collapses them and the `ORDER BY pr.id` ordering keeps the *default*
+// project's token (not whichever sorts first by slug).
+func TestGetPlugins_CollidingNamesPreferDefault(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
+
+	// "adam" sorts before the default project's "test-<hex>" slug, but overrides
+	// its name to collide with the default's bare org name.
+	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
+	setMarketplaceOverride(t, ctx, ti.conn, adam, wantMarketplace)
 	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
 
-	require.Len(t, res.Marketplaces, 1, "an org's projects collapse to one marketplace")
+	require.Len(t, res.Marketplaces, 1, "colliding names collapse to one")
 	require.Equal(t, wantMarketplace, res.Marketplaces[0].Name)
 	require.Contains(t, res.Marketplaces[0].URL, "default-token",
-		"the default project's marketplace must win, not the alphabetically-first one")
+		"the default project's token must win the collision, not the alphabetically-first one")
 	require.NotContains(t, res.Marketplaces[0].URL, "adam-token")
 }
 

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -130,10 +130,14 @@ func TestGetPlugins_CollidingNamesPreferDefault(t *testing.T) {
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
 
 	// "adam" sorts before the default project's "test-<hex>" slug, but overrides
-	// its name to collide with the default's bare org name.
+	// its name to collide with the default's bare org name. It also has an
+	// assigned plugin — which must NOT leak onto the winning marketplace, since
+	// adam's repo isn't the one served under that name.
 	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
 	setMarketplaceOverride(t, ctx, ti.conn, adam, wantMarketplace)
 	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
+	adamPlugin := seedPlugin(t, ctx, ti.conn, ti.orgID, adam, "adam-only-tool")
+	assignPlugin(t, ctx, ti.conn, adamPlugin, ti.orgID, "*")
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
@@ -143,6 +147,8 @@ func TestGetPlugins_CollidingNamesPreferDefault(t *testing.T) {
 	require.Contains(t, res.Marketplaces[0].URL, "default-token",
 		"the default project's token must win the collision, not the alphabetically-first one")
 	require.NotContains(t, res.Marketplaces[0].URL, "adam-token")
+	require.NotContains(t, pluginSlugs(res), "adam-only-tool",
+		"the collapsed project's plugin must not be attached to the winning marketplace")
 }
 
 // TestGetPlugins_DistinctOverridesYieldSeparateMarketplaces covers the

--- a/server/internal/agent/queries.sql
+++ b/server/internal/agent/queries.sql
@@ -7,6 +7,12 @@
 -- is returned even when the user has no explicit assignments. Plugins the user
 -- is assigned to (via principal_urn) are LEFT JOINed on top; projects with no
 -- matching assignment still yield one row with null plugin columns.
+--
+-- Rows are ordered by pr.id so the org's default project (first by id ASC, the
+-- one created at org setup) sorts first. The view collapses an org's published
+-- projects to a single marketplace and keeps the first row's token, so this
+-- ordering makes that collapse resolve to the default project rather than the
+-- arbitrary alphabetically-first one.
 SELECT
   pr.id AS project_id,
   pr.slug AS project_slug,
@@ -33,4 +39,4 @@ LEFT JOIN plugins p
   )
 WHERE pr.organization_id = @organization_id
   AND pgc.marketplace_token IS NOT NULL
-ORDER BY pr.slug, p.slug;
+ORDER BY pr.id, p.slug;

--- a/server/internal/agent/queries.sql
+++ b/server/internal/agent/queries.sql
@@ -32,9 +32,12 @@ SELECT
   -- match. The subquery spans unpublished projects too, so an unpublished default
   -- doesn't hand the bare name to a different project.
   (pr.id = (
+    -- Pinned to the @organization_id parameter (not pr.organization_id) so this
+    -- stays uncorrelated and Postgres evaluates the org's default project once,
+    -- not per row.
     SELECT p2.id
     FROM projects p2
-    WHERE p2.organization_id = pr.organization_id
+    WHERE p2.organization_id = @organization_id
       AND p2.deleted IS FALSE
     ORDER BY p2.id ASC
     LIMIT 1

--- a/server/internal/agent/queries.sql
+++ b/server/internal/agent/queries.sql
@@ -26,6 +26,19 @@ SELECT
   pgc.marketplace_token,
   pgc.updated_at AS marketplace_updated_at,
   pms.marketplace_name AS marketplace_name_override,
+  -- The org's default project (oldest, by id ASC over ALL non-deleted projects,
+  -- not just published ones) keeps the bare org-derived marketplace name; others
+  -- are project-scoped. Resolved the same way the publish path does so the names
+  -- match. The subquery spans unpublished projects too, so an unpublished default
+  -- doesn't hand the bare name to a different project.
+  (pr.id = (
+    SELECT p2.id
+    FROM projects p2
+    WHERE p2.organization_id = pr.organization_id
+      AND p2.deleted IS FALSE
+    ORDER BY p2.id ASC
+    LIMIT 1
+  )) AS is_default_project,
   p.id AS plugin_id,
   p.slug AS plugin_slug,
   p.updated_at AS plugin_updated_at

--- a/server/internal/agent/queries.sql
+++ b/server/internal/agent/queries.sql
@@ -8,11 +8,16 @@
 -- is assigned to (via principal_urn) are LEFT JOINed on top; projects with no
 -- matching assignment still yield one row with null plugin columns.
 --
+-- Each project resolves to a marketplace name the way the publish path does:
+-- the per-project override (project_marketplace_settings.marketplace_name) when
+-- set, else the org-derived default (computed in the view). Projects with
+-- distinct names surface as distinct marketplaces; projects that share a name
+-- (e.g. several on the org default) still collapse to one in the view.
+--
 -- Rows are ordered by pr.id so the org's default project (first by id ASC, the
--- one created at org setup) sorts first. The view collapses an org's published
--- projects to a single marketplace and keeps the first row's token, so this
--- ordering makes that collapse resolve to the default project rather than the
--- arbitrary alphabetically-first one.
+-- one created at org setup) sorts first. When projects share a name and the view
+-- collapses them, keeping the first row's token makes that collapse resolve to
+-- the default project rather than the arbitrary alphabetically-first one.
 SELECT
   pr.id AS project_id,
   pr.slug AS project_slug,
@@ -20,6 +25,7 @@ SELECT
   om.name AS organization_name,
   pgc.marketplace_token,
   pgc.updated_at AS marketplace_updated_at,
+  pms.marketplace_name AS marketplace_name_override,
   p.id AS plugin_id,
   p.slug AS plugin_slug,
   p.updated_at AS plugin_updated_at
@@ -29,6 +35,8 @@ JOIN projects pr
   AND pr.deleted IS FALSE
 JOIN organization_metadata om
   ON om.id = pr.organization_id
+LEFT JOIN project_marketplace_settings pms
+  ON pms.project_id = pr.id
 LEFT JOIN plugins p
   ON p.project_id = pr.id
   AND p.deleted IS FALSE

--- a/server/internal/agent/repo/queries.sql.go
+++ b/server/internal/agent/repo/queries.sql.go
@@ -20,6 +20,7 @@ SELECT
   om.name AS organization_name,
   pgc.marketplace_token,
   pgc.updated_at AS marketplace_updated_at,
+  pms.marketplace_name AS marketplace_name_override,
   p.id AS plugin_id,
   p.slug AS plugin_slug,
   p.updated_at AS plugin_updated_at
@@ -29,6 +30,8 @@ JOIN projects pr
   AND pr.deleted IS FALSE
 JOIN organization_metadata om
   ON om.id = pr.organization_id
+LEFT JOIN project_marketplace_settings pms
+  ON pms.project_id = pr.id
 LEFT JOIN plugins p
   ON p.project_id = pr.id
   AND p.deleted IS FALSE
@@ -48,15 +51,16 @@ type GetAgentPluginSetParams struct {
 }
 
 type GetAgentPluginSetRow struct {
-	ProjectID            uuid.UUID
-	ProjectSlug          string
-	OrganizationSlug     string
-	OrganizationName     string
-	MarketplaceToken     pgtype.Text
-	MarketplaceUpdatedAt pgtype.Timestamptz
-	PluginID             uuid.NullUUID
-	PluginSlug           pgtype.Text
-	PluginUpdatedAt      pgtype.Timestamptz
+	ProjectID               uuid.UUID
+	ProjectSlug             string
+	OrganizationSlug        string
+	OrganizationName        string
+	MarketplaceToken        pgtype.Text
+	MarketplaceUpdatedAt    pgtype.Timestamptz
+	MarketplaceNameOverride pgtype.Text
+	PluginID                uuid.NullUUID
+	PluginSlug              pgtype.Text
+	PluginUpdatedAt         pgtype.Timestamptz
 }
 
 // Returns the device agent's full plugin set for an org, marketplace-first.
@@ -68,11 +72,16 @@ type GetAgentPluginSetRow struct {
 // is assigned to (via principal_urn) are LEFT JOINed on top; projects with no
 // matching assignment still yield one row with null plugin columns.
 //
+// Each project resolves to a marketplace name the way the publish path does:
+// the per-project override (project_marketplace_settings.marketplace_name) when
+// set, else the org-derived default (computed in the view). Projects with
+// distinct names surface as distinct marketplaces; projects that share a name
+// (e.g. several on the org default) still collapse to one in the view.
+//
 // Rows are ordered by pr.id so the org's default project (first by id ASC, the
-// one created at org setup) sorts first. The view collapses an org's published
-// projects to a single marketplace and keeps the first row's token, so this
-// ordering makes that collapse resolve to the default project rather than the
-// arbitrary alphabetically-first one.
+// one created at org setup) sorts first. When projects share a name and the view
+// collapses them, keeping the first row's token makes that collapse resolve to
+// the default project rather than the arbitrary alphabetically-first one.
 func (q *Queries) GetAgentPluginSet(ctx context.Context, arg GetAgentPluginSetParams) ([]GetAgentPluginSetRow, error) {
 	rows, err := q.db.Query(ctx, getAgentPluginSet, arg.PrincipalUrns, arg.OrganizationID)
 	if err != nil {
@@ -89,6 +98,7 @@ func (q *Queries) GetAgentPluginSet(ctx context.Context, arg GetAgentPluginSetPa
 			&i.OrganizationName,
 			&i.MarketplaceToken,
 			&i.MarketplaceUpdatedAt,
+			&i.MarketplaceNameOverride,
 			&i.PluginID,
 			&i.PluginSlug,
 			&i.PluginUpdatedAt,

--- a/server/internal/agent/repo/queries.sql.go
+++ b/server/internal/agent/repo/queries.sql.go
@@ -39,7 +39,7 @@ LEFT JOIN plugins p
   )
 WHERE pr.organization_id = $2
   AND pgc.marketplace_token IS NOT NULL
-ORDER BY pr.slug, p.slug
+ORDER BY pr.id, p.slug
 `
 
 type GetAgentPluginSetParams struct {
@@ -67,6 +67,12 @@ type GetAgentPluginSetRow struct {
 // is returned even when the user has no explicit assignments. Plugins the user
 // is assigned to (via principal_urn) are LEFT JOINed on top; projects with no
 // matching assignment still yield one row with null plugin columns.
+//
+// Rows are ordered by pr.id so the org's default project (first by id ASC, the
+// one created at org setup) sorts first. The view collapses an org's published
+// projects to a single marketplace and keeps the first row's token, so this
+// ordering makes that collapse resolve to the default project rather than the
+// arbitrary alphabetically-first one.
 func (q *Queries) GetAgentPluginSet(ctx context.Context, arg GetAgentPluginSetParams) ([]GetAgentPluginSetRow, error) {
 	rows, err := q.db.Query(ctx, getAgentPluginSet, arg.PrincipalUrns, arg.OrganizationID)
 	if err != nil {

--- a/server/internal/agent/repo/queries.sql.go
+++ b/server/internal/agent/repo/queries.sql.go
@@ -27,9 +27,12 @@ SELECT
   -- match. The subquery spans unpublished projects too, so an unpublished default
   -- doesn't hand the bare name to a different project.
   (pr.id = (
+    -- Pinned to the @organization_id parameter (not pr.organization_id) so this
+    -- stays uncorrelated and Postgres evaluates the org's default project once,
+    -- not per row.
     SELECT p2.id
     FROM projects p2
-    WHERE p2.organization_id = pr.organization_id
+    WHERE p2.organization_id = $1
       AND p2.deleted IS FALSE
     ORDER BY p2.id ASC
     LIMIT 1
@@ -51,16 +54,16 @@ LEFT JOIN plugins p
   AND EXISTS (
     SELECT 1 FROM plugin_assignments pa
     WHERE pa.plugin_id = p.id
-      AND pa.principal_urn = ANY($1::text[])
+      AND pa.principal_urn = ANY($2::text[])
   )
-WHERE pr.organization_id = $2
+WHERE pr.organization_id = $1
   AND pgc.marketplace_token IS NOT NULL
 ORDER BY pr.id, p.slug
 `
 
 type GetAgentPluginSetParams struct {
-	PrincipalUrns  []string
 	OrganizationID string
+	PrincipalUrns  []string
 }
 
 type GetAgentPluginSetRow struct {
@@ -97,7 +100,7 @@ type GetAgentPluginSetRow struct {
 // collapses them, keeping the first row's token makes that collapse resolve to
 // the default project rather than the arbitrary alphabetically-first one.
 func (q *Queries) GetAgentPluginSet(ctx context.Context, arg GetAgentPluginSetParams) ([]GetAgentPluginSetRow, error) {
-	rows, err := q.db.Query(ctx, getAgentPluginSet, arg.PrincipalUrns, arg.OrganizationID)
+	rows, err := q.db.Query(ctx, getAgentPluginSet, arg.OrganizationID, arg.PrincipalUrns)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/agent/repo/queries.sql.go
+++ b/server/internal/agent/repo/queries.sql.go
@@ -21,6 +21,19 @@ SELECT
   pgc.marketplace_token,
   pgc.updated_at AS marketplace_updated_at,
   pms.marketplace_name AS marketplace_name_override,
+  -- The org's default project (oldest, by id ASC over ALL non-deleted projects,
+  -- not just published ones) keeps the bare org-derived marketplace name; others
+  -- are project-scoped. Resolved the same way the publish path does so the names
+  -- match. The subquery spans unpublished projects too, so an unpublished default
+  -- doesn't hand the bare name to a different project.
+  (pr.id = (
+    SELECT p2.id
+    FROM projects p2
+    WHERE p2.organization_id = pr.organization_id
+      AND p2.deleted IS FALSE
+    ORDER BY p2.id ASC
+    LIMIT 1
+  )) AS is_default_project,
   p.id AS plugin_id,
   p.slug AS plugin_slug,
   p.updated_at AS plugin_updated_at
@@ -58,6 +71,7 @@ type GetAgentPluginSetRow struct {
 	MarketplaceToken        pgtype.Text
 	MarketplaceUpdatedAt    pgtype.Timestamptz
 	MarketplaceNameOverride pgtype.Text
+	IsDefaultProject        bool
 	PluginID                uuid.NullUUID
 	PluginSlug              pgtype.Text
 	PluginUpdatedAt         pgtype.Timestamptz
@@ -99,6 +113,7 @@ func (q *Queries) GetAgentPluginSet(ctx context.Context, arg GetAgentPluginSetPa
 			&i.MarketplaceToken,
 			&i.MarketplaceUpdatedAt,
 			&i.MarketplaceNameOverride,
+			&i.IsDefaultProject,
 			&i.PluginID,
 			&i.PluginSlug,
 			&i.PluginUpdatedAt,

--- a/server/internal/agent/setup_test.go
+++ b/server/internal/agent/setup_test.go
@@ -115,6 +115,18 @@ func seedProject(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, s
 	return p.ID
 }
 
+// setMarketplaceOverride sets a project's per-project marketplace name override,
+// the same row UpdateMarketplaceSettings writes. Used to exercise the agent
+// emitting a project's published (override) name rather than the org default.
+func setMarketplaceOverride(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, name string) {
+	t.Helper()
+	_, err := pluginsrepo.New(conn).UpsertMarketplaceSettings(ctx, pluginsrepo.UpsertMarketplaceSettingsParams{
+		ProjectID:       projectID,
+		MarketplaceName: pgtype.Text{String: name, Valid: true},
+	})
+	require.NoError(t, err)
+}
+
 func seedPlugin(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, projectID uuid.UUID, slug string) uuid.UUID {
 	t.Helper()
 	p, err := pluginsrepo.New(conn).CreatePlugin(ctx, pluginsrepo.CreatePluginParams{

--- a/server/internal/agent/setup_test.go
+++ b/server/internal/agent/setup_test.go
@@ -102,6 +102,19 @@ func publishMarketplace(t *testing.T, ctx context.Context, conn *pgxpool.Pool, p
 	require.NoError(t, err)
 }
 
+// seedProject creates an additional project in an existing org, used to exercise
+// multi-project orgs (e.g. the default-project selection in GetAgentPluginSet).
+func seedProject(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, slug string) uuid.UUID {
+	t.Helper()
+	p, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           slug,
+		Slug:           slug,
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+	return p.ID
+}
+
 func seedPlugin(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, projectID uuid.UUID, slug string) uuid.UUID {
 	t.Helper()
 	p, err := pluginsrepo.New(conn).CreatePlugin(ctx, pluginsrepo.CreatePluginParams{

--- a/server/internal/mv/agent.go
+++ b/server/internal/mv/agent.go
@@ -21,18 +21,20 @@ import (
 // (`ORDER BY pr.id, p.slug`), one row per project even when the user has no
 // assignment there (null plugin columns).
 //
-// The marketplace name and observability slug come from the shared `naming`
-// package so they match exactly what the publish path wrote into the
-// marketplace.json — tools resolve marketplaces by that name, so any mismatch
-// silently fails to enable plugins.
+// Each project's marketplace name is resolved the same way the publish path
+// resolves it: the per-project override (project_marketplace_settings) when set,
+// else the org-derived default from the shared `naming` package. Matching the
+// publish path exactly matters because tools resolve marketplaces by that name —
+// any mismatch silently fails to enable plugins. The observability slug stays
+// org-derived; plugin slugs are scoped within a marketplace, so the same slug in
+// two differently-named marketplaces does not collide.
 //
-// Note: gram publishes one marketplace name per *org* (naming.MarketplaceName
-// is org-derived, not project-scoped), and a marketplace.json name is a single
-// identifier. So if an org publishes multiple projects, they collapse to a
-// single marketplace here — matching gram's existing publish limitation rather
-// than introducing a new one. The collapse keeps the first row's token, and the
-// query orders by pr.id so that first row is the org's default project (created
-// at org setup, lowest id) rather than an arbitrary alphabetically-first one.
+// Projects with distinct names surface as distinct marketplaces. Projects that
+// share a name still collapse to one (a marketplace.json name is a single
+// identifier, so two same-named marketplaces can't coexist on the device): the
+// collapse keeps the first row's token, and the query orders by pr.id so that
+// first row is the org's default project (created at org setup, lowest id)
+// rather than an arbitrary alphabetically-first one.
 //
 // marketplaceURL constructs the public marketplace git URL from a token; the
 // caller owns the URL shape so this builder stays free of server-side config.
@@ -47,7 +49,13 @@ func BuildAgentPluginsView(rows []repo.GetAgentPluginSetRow, marketplaceURL func
 			continue
 		}
 
+		// The per-project override, when set, is the name the project actually
+		// published under (UpdateMarketplaceSettings republishes on change), so
+		// prefer it over the org-derived default.
 		name := naming.MarketplaceName(row.OrganizationName)
+		if row.MarketplaceNameOverride.Valid && row.MarketplaceNameOverride.String != "" {
+			name = row.MarketplaceNameOverride.String
+		}
 		if _, ok := seenMarketplace[name]; !ok {
 			seenMarketplace[name] = struct{}{}
 			marketplaces = append(marketplaces, &gen.AgentMarketplace{

--- a/server/internal/mv/agent.go
+++ b/server/internal/mv/agent.go
@@ -23,18 +23,21 @@ import (
 //
 // Each project's marketplace name is resolved the same way the publish path
 // resolves it: the per-project override (project_marketplace_settings) when set,
-// else the org-derived default from the shared `naming` package. Matching the
-// publish path exactly matters because tools resolve marketplaces by that name —
-// any mismatch silently fails to enable plugins. The observability slug stays
-// org-derived; plugin slugs are scoped within a marketplace, so the same slug in
-// two differently-named marketplaces does not collide.
+// else the shared `naming` default — the bare org-derived name for the org's
+// default project, project-scoped (`<org>-<project>-speakeasy`) for the rest.
+// Matching the publish path exactly matters because tools resolve marketplaces
+// by that name — any mismatch silently fails to enable plugins. The
+// observability slug stays org-derived; plugin slugs are scoped within a
+// marketplace, so the same slug in two differently-named marketplaces does not
+// collide.
 //
-// Projects with distinct names surface as distinct marketplaces. Projects that
-// share a name still collapse to one (a marketplace.json name is a single
-// identifier, so two same-named marketplaces can't coexist on the device): the
-// collapse keeps the first row's token, and the query orders by pr.id so that
-// first row is the org's default project (created at org setup, lowest id)
-// rather than an arbitrary alphabetically-first one.
+// Because names are project-scoped, an org's projects now surface as distinct
+// marketplaces instead of collapsing. Projects can still share a name (e.g. two
+// overrides set to the same value), and a marketplace.json name is a single
+// identifier that can't coexist twice on the device — so same-named rows still
+// collapse to one, keeping the first row's token. The query orders by pr.id so
+// that first row is the org's default project (oldest, lowest id) rather than an
+// arbitrary alphabetically-first one.
 //
 // marketplaceURL constructs the public marketplace git URL from a token; the
 // caller owns the URL shape so this builder stays free of server-side config.
@@ -52,7 +55,7 @@ func BuildAgentPluginsView(rows []repo.GetAgentPluginSetRow, marketplaceURL func
 		// The per-project override, when set, is the name the project actually
 		// published under (UpdateMarketplaceSettings republishes on change), so
 		// prefer it over the org-derived default.
-		name := naming.MarketplaceName(row.OrganizationName)
+		name := naming.MarketplaceName(row.OrganizationName, row.ProjectSlug, row.IsDefaultProject)
 		if row.MarketplaceNameOverride.Valid && row.MarketplaceNameOverride.String != "" {
 			name = row.MarketplaceNameOverride.String
 		}

--- a/server/internal/mv/agent.go
+++ b/server/internal/mv/agent.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/google/uuid"
+
 	gen "github.com/speakeasy-api/gram/server/gen/agent"
 	"github.com/speakeasy-api/gram/server/internal/agent/repo"
 	"github.com/speakeasy-api/gram/server/internal/plugins/naming"
@@ -44,7 +46,12 @@ import (
 func BuildAgentPluginsView(rows []repo.GetAgentPluginSetRow, marketplaceURL func(token string) string) *gen.GetPluginsResult {
 	var marketplaces []*gen.AgentMarketplace
 	var plugins []*gen.AgentPlugin
-	seenMarketplace := make(map[string]struct{})
+	// marketplace name -> the project that owns it (the first/lowest-pr.id row to
+	// claim that name). Used to drop assigned plugins from projects whose name
+	// collided and collapsed: their plugins live in a different repo than the one
+	// served under this name, so emitting them would reference a marketplace that
+	// doesn't contain them.
+	marketplaceOwner := make(map[string]uuid.UUID)
 	etag := sha256.New()
 
 	for _, row := range rows {
@@ -59,8 +66,10 @@ func BuildAgentPluginsView(rows []repo.GetAgentPluginSetRow, marketplaceURL func
 		if row.MarketplaceNameOverride.Valid && row.MarketplaceNameOverride.String != "" {
 			name = row.MarketplaceNameOverride.String
 		}
-		if _, ok := seenMarketplace[name]; !ok {
-			seenMarketplace[name] = struct{}{}
+		owner, seen := marketplaceOwner[name]
+		if !seen {
+			owner = row.ProjectID
+			marketplaceOwner[name] = owner
 			marketplaces = append(marketplaces, &gen.AgentMarketplace{
 				Name: name,
 				URL:  marketplaceURL(row.MarketplaceToken.String),
@@ -83,8 +92,11 @@ func BuildAgentPluginsView(rows []repo.GetAgentPluginSetRow, marketplaceURL func
 			writeAgentPluginsETag(etag, "plugin\x00%s\x00%s\x00%d\n", name, observabilitySlug, int64(0))
 		}
 
-		// Assigned plugin for this project, if the LEFT JOIN matched one.
-		if row.PluginID.Valid && row.PluginSlug.Valid {
+		// Assigned plugin for this project, if the LEFT JOIN matched one — but
+		// only when this row's project owns the marketplace under this name. A
+		// collapsed (losing) project's marketplace isn't served, so its plugins
+		// would reference a repo that doesn't contain them.
+		if row.ProjectID == owner && row.PluginID.Valid && row.PluginSlug.Valid {
 			plugins = append(plugins, &gen.AgentPlugin{
 				Slug:            row.PluginSlug.String,
 				MarketplaceName: name,

--- a/server/internal/mv/agent.go
+++ b/server/internal/mv/agent.go
@@ -18,7 +18,7 @@ import (
 // For every published marketplace in the org it emits the marketplace and its
 // always-required observability plugin, then layers on the user's assigned
 // plugins (the non-null plugin rows). Rows arrive grouped by project
-// (`ORDER BY pr.slug, p.slug`), one row per project even when the user has no
+// (`ORDER BY pr.id, p.slug`), one row per project even when the user has no
 // assignment there (null plugin columns).
 //
 // The marketplace name and observability slug come from the shared `naming`
@@ -28,9 +28,11 @@ import (
 //
 // Note: gram publishes one marketplace name per *org* (naming.MarketplaceName
 // is org-derived, not project-scoped), and a marketplace.json name is a single
-// identifier. So if an org ever publishes multiple projects, they collapse to a
+// identifier. So if an org publishes multiple projects, they collapse to a
 // single marketplace here — matching gram's existing publish limitation rather
-// than introducing a new one.
+// than introducing a new one. The collapse keeps the first row's token, and the
+// query orders by pr.id so that first row is the org's default project (created
+// at org setup, lowest id) rather than an arbitrary alphabetically-first one.
 //
 // marketplaceURL constructs the public marketplace git URL from a token; the
 // caller owns the URL shape so this builder stays free of server-side config.

--- a/server/internal/mv/agent_test.go
+++ b/server/internal/mv/agent_test.go
@@ -108,12 +108,45 @@ func TestBuildAgentPluginsView_MultipleProjectsYieldDistinctMarketplaces(t *test
 	require.Equal(t, "https://app.getgram.ai/marketplace/tokA.git", byName["acme-corp-speakeasy"], "default project keeps the bare org name")
 	require.Equal(t, "https://app.getgram.ai/marketplace/tokB.git", byName["acme-corp-sales-speakeasy"], "non-default project is scoped by slug")
 
+	// Each marketplace gets its own observability plugin, attached to that
+	// marketplace's name — not just the right count of plugins.
+	obsByMarketplace := map[string]int{}
+	for _, p := range result.Plugins {
+		require.Equal(t, "acme-corp-observability", p.Slug)
+		obsByMarketplace[p.MarketplaceName]++
+	}
+	require.Equal(t, map[string]int{
+		"acme-corp-speakeasy":       1,
+		"acme-corp-sales-speakeasy": 1,
+	}, obsByMarketplace, "observability must be emitted once per marketplace, against the correct marketplace name")
+}
+
+func TestBuildAgentPluginsView_CollapsedProjectPluginsDropped(t *testing.T) {
+	t.Parallel()
+
+	// Two projects collide on a name (here both default-flagged, standing in for
+	// two equal overrides). The losing project's marketplace isn't served, so its
+	// assigned plugins must NOT be emitted — they'd reference the winner's repo,
+	// which doesn't contain them.
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	winner := marketplaceRow("acme", "Acme Corp", "default", true, "tokA", now)
+	loser := marketplaceRow("acme", "Acme Corp", "other", true, "tokB", now)
+	rows := []repo.GetAgentPluginSetRow{
+		withPlugin(winner, "winner-plugin", now),
+		withPlugin(loser, "loser-plugin", now),
+	}
+
+	result := mv.BuildAgentPluginsView(rows, testMarketplaceURL)
+
+	require.Len(t, result.Marketplaces, 1)
 	slugs := make([]string, 0, len(result.Plugins))
 	for _, p := range result.Plugins {
+		require.Equal(t, "acme-corp-speakeasy", p.MarketplaceName)
 		slugs = append(slugs, p.Slug)
 	}
-	require.ElementsMatch(t, []string{"acme-corp-observability", "acme-corp-observability"}, slugs,
-		"each marketplace gets its own observability plugin (same org-derived slug, distinct marketplace)")
+	require.ElementsMatch(t, []string{"acme-corp-observability", "winner-plugin"}, slugs,
+		"the collapsed project's plugin must be dropped, not attached to the winner's marketplace")
+	require.NotContains(t, slugs, "loser-plugin")
 }
 
 func TestBuildAgentPluginsView_SameNameRowsCollapseToDefault(t *testing.T) {

--- a/server/internal/mv/agent_test.go
+++ b/server/internal/mv/agent_test.go
@@ -19,7 +19,7 @@ func testMarketplaceURL(token string) string {
 // marketplaceRow is a published-marketplace row with no assigned plugin
 // (null plugin columns) — the shape the LEFT JOIN produces when the user has
 // no assignment in that project.
-func marketplaceRow(orgSlug, orgName, projectSlug, token string, now time.Time) repo.GetAgentPluginSetRow {
+func marketplaceRow(orgSlug, orgName, projectSlug string, isDefault bool, token string, now time.Time) repo.GetAgentPluginSetRow {
 	return repo.GetAgentPluginSetRow{
 		ProjectID:            uuid.New(),
 		ProjectSlug:          projectSlug,
@@ -27,6 +27,7 @@ func marketplaceRow(orgSlug, orgName, projectSlug, token string, now time.Time) 
 		OrganizationName:     orgName,
 		MarketplaceToken:     pgtype.Text{String: token, Valid: true},
 		MarketplaceUpdatedAt: pgtype.Timestamptz{Time: now, Valid: true},
+		IsDefaultProject:     isDefault,
 		PluginID:             uuid.NullUUID{},
 		PluginSlug:           pgtype.Text{},
 		PluginUpdatedAt:      pgtype.Timestamptz{},
@@ -46,7 +47,7 @@ func TestBuildAgentPluginsView_ObservabilityWithoutAssignments(t *testing.T) {
 	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
 	// One published marketplace, user has no assignments → one row, null plugin.
 	rows := []repo.GetAgentPluginSetRow{
-		marketplaceRow("acme", "Acme Corp", "default", "tokA", now),
+		marketplaceRow("acme", "Acme Corp", "default", true, "tokA", now),
 	}
 
 	result := mv.BuildAgentPluginsView(rows, testMarketplaceURL)
@@ -66,7 +67,7 @@ func TestBuildAgentPluginsView_ObservabilityPlusAssignments(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
-	base := marketplaceRow("acme", "Acme Corp", "default", "tokA", now)
+	base := marketplaceRow("acme", "Acme Corp", "default", true, "tokA", now)
 	rows := []repo.GetAgentPluginSetRow{
 		withPlugin(base, "engineering-tools", now),
 		withPlugin(base, "sales-tools", now),
@@ -85,26 +86,54 @@ func TestBuildAgentPluginsView_ObservabilityPlusAssignments(t *testing.T) {
 	require.Equal(t, []string{"acme-corp-observability", "engineering-tools", "sales-tools"}, slugs)
 }
 
-func TestBuildAgentPluginsView_MultipleProjectsCollapseToOneOrgMarketplace(t *testing.T) {
+func TestBuildAgentPluginsView_MultipleProjectsYieldDistinctMarketplaces(t *testing.T) {
 	t.Parallel()
 
-	// The marketplace name is org-derived (naming.MarketplaceName), and gram
-	// publishes one name per org. So two published projects in the same org
-	// collapse to a single marketplace (first token wins) — matching gram's
-	// publish limitation rather than inventing distinct per-project names.
+	// Names are project-scoped: the default project keeps the bare org name, the
+	// non-default project is suffixed by its slug. So two published projects in
+	// the same org surface as two distinct marketplaces, each with its own token.
 	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
 	rows := []repo.GetAgentPluginSetRow{
-		marketplaceRow("acme", "Acme Corp", "default", "tokA", now),
-		marketplaceRow("acme", "Acme Corp", "sales", "tokB", now),
+		marketplaceRow("acme", "Acme Corp", "default", true, "tokA", now),
+		marketplaceRow("acme", "Acme Corp", "sales", false, "tokB", now),
 	}
 
 	result := mv.BuildAgentPluginsView(rows, testMarketplaceURL)
 
-	require.Len(t, result.Marketplaces, 1, "both projects collapse to one org marketplace")
+	require.Len(t, result.Marketplaces, 2, "distinct project-scoped names do not collapse")
+	byName := map[string]string{}
+	for _, m := range result.Marketplaces {
+		byName[m.Name] = m.URL
+	}
+	require.Equal(t, "https://app.getgram.ai/marketplace/tokA.git", byName["acme-corp-speakeasy"], "default project keeps the bare org name")
+	require.Equal(t, "https://app.getgram.ai/marketplace/tokB.git", byName["acme-corp-sales-speakeasy"], "non-default project is scoped by slug")
+
+	slugs := make([]string, 0, len(result.Plugins))
+	for _, p := range result.Plugins {
+		slugs = append(slugs, p.Slug)
+	}
+	require.ElementsMatch(t, []string{"acme-corp-observability", "acme-corp-observability"}, slugs,
+		"each marketplace gets its own observability plugin (same org-derived slug, distinct marketplace)")
+}
+
+func TestBuildAgentPluginsView_SameNameRowsCollapseToDefault(t *testing.T) {
+	t.Parallel()
+
+	// Rows that resolve to the SAME name (here, two rows flagged default — the
+	// degenerate case, or two equal overrides) still collapse: a marketplace.json
+	// name can't appear twice on the device. The first row (lowest pr.id, ordered
+	// by the query) wins, so its token is the one kept.
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	rows := []repo.GetAgentPluginSetRow{
+		marketplaceRow("acme", "Acme Corp", "default", true, "tokA", now),
+		marketplaceRow("acme", "Acme Corp", "other", true, "tokB", now),
+	}
+
+	result := mv.BuildAgentPluginsView(rows, testMarketplaceURL)
+
+	require.Len(t, result.Marketplaces, 1, "same-named rows collapse to one")
 	require.Equal(t, "acme-corp-speakeasy", result.Marketplaces[0].Name)
-	require.Equal(t, "https://app.getgram.ai/marketplace/tokA.git", result.Marketplaces[0].URL, "first token wins")
-	require.Len(t, result.Plugins, 1, "one observability plugin for the one marketplace")
-	require.Equal(t, "acme-corp-observability", result.Plugins[0].Slug)
+	require.Equal(t, "https://app.getgram.ai/marketplace/tokA.git", result.Marketplaces[0].URL, "first row's token wins")
 }
 
 func TestBuildAgentPluginsView_EmptyRows(t *testing.T) {
@@ -121,7 +150,7 @@ func TestBuildAgentPluginsView_SkipsRowsWithMissingMarketplaceToken(t *testing.T
 	t.Parallel()
 
 	now := time.Now()
-	row := marketplaceRow("acme", "Acme Corp", "default", "", now)
+	row := marketplaceRow("acme", "Acme Corp", "default", true, "", now)
 	row.MarketplaceToken = pgtype.Text{Valid: false}
 
 	result := mv.BuildAgentPluginsView([]repo.GetAgentPluginSetRow{row}, testMarketplaceURL)
@@ -135,13 +164,15 @@ func TestBuildAgentPluginsView_ETagIgnoresRowsThatDoNotRender(t *testing.T) {
 
 	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
 	base := []repo.GetAgentPluginSetRow{
-		marketplaceRow("acme", "Acme Corp", "default", "tokA", now),
+		marketplaceRow("acme", "Acme Corp", "default", true, "tokA", now),
 	}
 
-	skipped := marketplaceRow("acme", "Acme Corp", "empty-token", "", now.Add(time.Hour))
+	skipped := marketplaceRow("acme", "Acme Corp", "empty-token", false, "", now.Add(time.Hour))
 	skipped.MarketplaceToken = pgtype.Text{Valid: false}
 
-	collapsed := marketplaceRow("acme", "Acme Corp", "sales", "tokB", now.Add(2*time.Hour))
+	// Resolves to the same name as base (also default), so it collapses rather
+	// than rendering a second marketplace — the case this test pins.
+	collapsed := marketplaceRow("acme", "Acme Corp", "other", true, "tokB", now.Add(2*time.Hour))
 
 	baseResult := mv.BuildAgentPluginsView(base, testMarketplaceURL)
 	withSkipped := mv.BuildAgentPluginsView(append(append([]repo.GetAgentPluginSetRow{}, base...), skipped), testMarketplaceURL)
@@ -158,7 +189,7 @@ func TestBuildAgentPluginsView_ETagStableAndSensitive(t *testing.T) {
 
 	t0 := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
 	rowsAt := func(ts time.Time) []repo.GetAgentPluginSetRow {
-		return []repo.GetAgentPluginSetRow{withPlugin(marketplaceRow("acme", "Acme Corp", "default", "tokA", ts), "eng", ts)}
+		return []repo.GetAgentPluginSetRow{withPlugin(marketplaceRow("acme", "Acme Corp", "default", true, "tokA", ts), "eng", ts)}
 	}
 
 	a := mv.BuildAgentPluginsView(rowsAt(t0), testMarketplaceURL).Etag

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -57,8 +57,14 @@ type GenerateConfig struct {
 	// is omitted.
 	HooksAPIKey string
 	// ProjectSlug is the publishing project's slug. The Cursor hooks endpoint
-	// requires it via the Gram-Project header (Claude's does not).
+	// requires it via the Gram-Project header (Claude's does not), and it scopes
+	// the default marketplace name for non-default projects.
 	ProjectSlug string
+	// IsDefaultProject reports whether this is the org's default project (its
+	// oldest, by id ASC). The default project keeps the bare org-derived
+	// marketplace name; non-default projects get a project-scoped one. Must be
+	// resolved identically to the device-agent endpoint (see naming.MarketplaceName).
+	IsDefaultProject bool
 	// Version is stamped into every plugin.json. Callers should bump this on
 	// every publish so platform marketplaces (Claude Code, Cursor, Codex) treat
 	// the manifest as new and refresh installed copies. Empty falls back to
@@ -81,13 +87,15 @@ type GenerateConfig struct {
 // Delegates to naming.MarketplaceName so the publish path and the device-agent
 // endpoint stay on the identical formula — the cross-surface contract that
 // package documents. A per-project override (resolveMarketplaceName) layers on
-// top of this default.
-func DefaultMarketplaceName(orgName string) string {
-	return naming.MarketplaceName(orgName)
+// top of this default. The default project keeps the bare org-derived name;
+// non-default projects are scoped by their slug so an org's projects don't
+// collide on a single marketplace identifier.
+func DefaultMarketplaceName(orgName, projectSlug string, isDefaultProject bool) string {
+	return naming.MarketplaceName(orgName, projectSlug, isDefaultProject)
 }
 
 func resolveMarketplaceName(cfg GenerateConfig) string {
-	return conv.Default(cfg.MarketplaceName, DefaultMarketplaceName(cfg.OrgName))
+	return conv.Default(cfg.MarketplaceName, DefaultMarketplaceName(cfg.OrgName, cfg.ProjectSlug, cfg.IsDefaultProject))
 }
 
 // pluginManifestVersion returns the version to stamp into generated

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -610,6 +610,36 @@ func TestGenerateMarketplaceManifestUsesMarketplaceNameOverride(t *testing.T) {
 	require.Equal(t, "acme-custom", codexManifest.Name)
 }
 
+func TestGenerateMarketplaceManifestScopesNonDefaultProject(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{{Name: "A", Slug: "a"}}
+
+	// Non-default project: the name is scoped by the project slug so it doesn't
+	// collide with the org's other projects.
+	scoped, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:          "Acme",
+		ServerURL:        "https://app.getgram.ai",
+		ProjectSlug:      "sales",
+		IsDefaultProject: false,
+	})
+	require.NoError(t, err)
+	var scopedManifest marketplaceManifest
+	require.NoError(t, json.Unmarshal(scoped[".claude-plugin/marketplace.json"], &scopedManifest))
+	require.Equal(t, "acme-sales-speakeasy", scopedManifest.Name)
+
+	// Default project keeps the bare org-derived name even with a slug set.
+	def, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:          "Acme",
+		ServerURL:        "https://app.getgram.ai",
+		ProjectSlug:      "sales",
+		IsDefaultProject: true,
+	})
+	require.NoError(t, err)
+	var defManifest marketplaceManifest
+	require.NoError(t, json.Unmarshal(def[".claude-plugin/marketplace.json"], &defManifest))
+	require.Equal(t, "acme-speakeasy", defManifest.Name)
+}
+
 func TestRenderHookScriptClaudeUsesGramKeyAndProjectHeaders(t *testing.T) {
 	t.Parallel()
 	// Claude's hook endpoint accepts Gram-Key + Gram-Project as optional

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1494,7 +1494,7 @@ func (s *Service) GetMarketplaceSettings(ctx context.Context, payload *gen.GetMa
 		return nil, oops.E(oops.CodeUnexpected, err, "get marketplace settings").Log(ctx, s.logger)
 	}
 
-	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug)
+	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, conv.PtrValOr(ac.ProjectSlug, ""), *ac.ProjectID)
 
 	effective := override
 	if effective == "" {
@@ -1568,7 +1568,7 @@ func (s *Service) UpdateMarketplaceSettings(ctx context.Context, payload *gen.Up
 		}
 	}
 
-	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug)
+	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, conv.PtrValOr(ac.ProjectSlug, ""), *ac.ProjectID)
 
 	effective := override
 	if effective == "" {
@@ -1585,11 +1585,12 @@ func (s *Service) UpdateMarketplaceSettings(ctx context.Context, payload *gen.Up
 	}, nil
 }
 
-// resolveDefaultMarketplaceName mirrors generateConfig's org-name resolution:
-// prefer the human-readable org name from organization_metadata so the
-// displayed default matches what the publish flow actually generates, falling
-// back to the org slug from the auth context if the lookup fails.
-func (s *Service) resolveDefaultMarketplaceName(ctx context.Context, orgID, orgSlug string) string {
+// resolveDefaultMarketplaceName mirrors generateConfig's name resolution: prefer
+// the human-readable org name from organization_metadata so the displayed
+// default matches what the publish flow actually generates, falling back to the
+// org slug from the auth context if the lookup fails. The default is
+// project-scoped for non-default projects, so it takes the project too.
+func (s *Service) resolveDefaultMarketplaceName(ctx context.Context, orgID, orgSlug, projectSlug string, projectID uuid.UUID) string {
 	orgName := orgSlug
 	switch fetched, err := s.repo.GetOrganizationName(ctx, orgID); {
 	case err == nil:
@@ -1602,7 +1603,7 @@ func (s *Service) resolveDefaultMarketplaceName(ctx context.Context, orgID, orgS
 			attr.SlogError(err),
 		)
 	}
-	return DefaultMarketplaceName(orgName)
+	return DefaultMarketplaceName(orgName, projectSlug, s.isDefaultProject(ctx, orgID, projectID))
 }
 
 // pluginAPIKeyCandidate is the in-memory shape of a generated plugin API key
@@ -1905,8 +1906,9 @@ func (s *Service) generateConfig(ctx context.Context, orgID, orgSlug, projectSlu
 		// 0.1.{epoch} stays strictly above the historical 0.1.0 manifests
 		// already in users' Claude/Cursor/Codex caches, so a re-publish is
 		// always seen as a newer version and triggers a refresh.
-		Version:         fmt.Sprintf("0.1.%d", time.Now().Unix()),
-		MarketplaceName: "",
+		Version:          fmt.Sprintf("0.1.%d", time.Now().Unix()),
+		MarketplaceName:  "",
+		IsDefaultProject: s.isDefaultProject(ctx, orgID, projectID),
 	}
 	orgName, err := s.repo.GetOrganizationName(ctx, orgID)
 	switch {
@@ -1929,6 +1931,25 @@ func (s *Service) generateConfig(ctx context.Context, orgID, orgSlug, projectSlu
 		)
 	}
 	return cfg
+}
+
+// isDefaultProject reports whether projectID is the org's default project (its
+// oldest, by id ASC). Resolved identically to the device-agent endpoint so the
+// project-scoped marketplace name the publish path stamps matches what the
+// endpoint emits. On error it treats the project as non-default — the safe
+// direction, since a stray bare org name colliding with the real default is
+// worse than an extra project-scoped one.
+func (s *Service) isDefaultProject(ctx context.Context, orgID string, projectID uuid.UUID) bool {
+	defaultID, err := s.repo.GetOrgDefaultProjectID(ctx, orgID)
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to resolve org default project; treating as non-default",
+			attr.SlogOrganizationID(orgID),
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogError(err),
+		)
+		return false
+	}
+	return defaultID == projectID
 }
 
 func (s *Service) authContext(ctx context.Context) (*contextvalues.AuthContext, error) {

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1921,7 +1921,7 @@ func (s *Service) generateConfig(ctx context.Context, orgID, orgSlug, projectSlu
 		// always seen as a newer version and triggers a refresh.
 		Version:          fmt.Sprintf("0.1.%d", time.Now().Unix()),
 		MarketplaceName:  "",
-		IsDefaultProject: s.isDefaultProject(ctx, orgID, projectID),
+		IsDefaultProject: s.isDefaultProject(ctx, projectID),
 	}
 	orgName, err := s.repo.GetOrganizationName(ctx, orgID)
 	switch {
@@ -1952,17 +1952,16 @@ func (s *Service) generateConfig(ctx context.Context, orgID, orgSlug, projectSlu
 // endpoint emits. On error it treats the project as non-default — the safe
 // direction, since a stray bare org name colliding with the real default is
 // worse than an extra project-scoped one.
-func (s *Service) isDefaultProject(ctx context.Context, orgID string, projectID uuid.UUID) bool {
-	defaultID, err := s.repo.GetOrgDefaultProjectID(ctx, orgID)
+func (s *Service) isDefaultProject(ctx context.Context, projectID uuid.UUID) bool {
+	pctx, err := s.repo.GetProjectMarketplaceNameContext(ctx, projectID)
 	if err != nil {
 		s.logger.WarnContext(ctx, "failed to resolve org default project; treating as non-default",
-			attr.SlogOrganizationID(orgID),
 			attr.SlogProjectID(projectID.String()),
 			attr.SlogError(err),
 		)
 		return false
 	}
-	return defaultID == projectID
+	return pctx.IsDefaultProject
 }
 
 func (s *Service) authContext(ctx context.Context) (*contextvalues.AuthContext, error) {

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1494,7 +1494,7 @@ func (s *Service) GetMarketplaceSettings(ctx context.Context, payload *gen.GetMa
 		return nil, oops.E(oops.CodeUnexpected, err, "get marketplace settings").Log(ctx, s.logger)
 	}
 
-	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, conv.PtrValOr(ac.ProjectSlug, ""), *ac.ProjectID)
+	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, *ac.ProjectID)
 
 	effective := override
 	if effective == "" {
@@ -1568,7 +1568,7 @@ func (s *Service) UpdateMarketplaceSettings(ctx context.Context, payload *gen.Up
 		}
 	}
 
-	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, conv.PtrValOr(ac.ProjectSlug, ""), *ac.ProjectID)
+	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, *ac.ProjectID)
 
 	effective := override
 	if effective == "" {
@@ -1588,9 +1588,11 @@ func (s *Service) UpdateMarketplaceSettings(ctx context.Context, payload *gen.Up
 // resolveDefaultMarketplaceName mirrors generateConfig's name resolution: prefer
 // the human-readable org name from organization_metadata so the displayed
 // default matches what the publish flow actually generates, falling back to the
-// org slug from the auth context if the lookup fails. The default is
-// project-scoped for non-default projects, so it takes the project too.
-func (s *Service) resolveDefaultMarketplaceName(ctx context.Context, orgID, orgSlug, projectSlug string, projectID uuid.UUID) string {
+// org slug from the auth context if the lookup fails. The project slug and
+// default-ness are read from the project row (not the auth context, which some
+// flows like project-scoped API keys leave unset) so non-default projects get
+// their correct project-scoped name.
+func (s *Service) resolveDefaultMarketplaceName(ctx context.Context, orgID, orgSlug string, projectID uuid.UUID) string {
 	orgName := orgSlug
 	switch fetched, err := s.repo.GetOrganizationName(ctx, orgID); {
 	case err == nil:
@@ -1603,7 +1605,18 @@ func (s *Service) resolveDefaultMarketplaceName(ctx context.Context, orgID, orgS
 			attr.SlogError(err),
 		)
 	}
-	return DefaultMarketplaceName(orgName, projectSlug, s.isDefaultProject(ctx, orgID, projectID))
+
+	pctx, err := s.repo.GetProjectMarketplaceNameContext(ctx, projectID)
+	if err != nil {
+		// Without the project row we can't safely scope the name; the bare
+		// org-derived default is the least-surprising fallback for display.
+		s.logger.WarnContext(ctx, "failed to resolve project marketplace context, falling back to org default name",
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogError(err),
+		)
+		return DefaultMarketplaceName(orgName, "", true)
+	}
+	return DefaultMarketplaceName(orgName, pctx.ProjectSlug, pctx.IsDefaultProject)
 }
 
 // pluginAPIKeyCandidate is the in-memory shape of a generated plugin API key

--- a/server/internal/plugins/marketplace_settings_test.go
+++ b/server/internal/plugins/marketplace_settings_test.go
@@ -83,7 +83,13 @@ func defaultMarketplaceNameForTest(t *testing.T, ctx context.Context, ti *testIn
 	if err != nil {
 		orgName = authCtx.OrganizationSlug
 	}
-	return plugins.DefaultMarketplaceName(orgName)
+	// The test instance's project is its org's only (hence default) project, so
+	// the default name is the bare org-derived one regardless of slug.
+	projectSlug := ""
+	if authCtx.ProjectSlug != nil {
+		projectSlug = *authCtx.ProjectSlug
+	}
+	return plugins.DefaultMarketplaceName(orgName, projectSlug, true)
 }
 
 func TestPluginsService_UpdateMarketplaceSettings_RejectsInvalidName(t *testing.T) {

--- a/server/internal/plugins/marketplace_settings_test.go
+++ b/server/internal/plugins/marketplace_settings_test.go
@@ -84,12 +84,8 @@ func defaultMarketplaceNameForTest(t *testing.T, ctx context.Context, ti *testIn
 		orgName = authCtx.OrganizationSlug
 	}
 	// The test instance's project is its org's only (hence default) project, so
-	// the default name is the bare org-derived one regardless of slug.
-	projectSlug := ""
-	if authCtx.ProjectSlug != nil {
-		projectSlug = *authCtx.ProjectSlug
-	}
-	return plugins.DefaultMarketplaceName(orgName, projectSlug, true)
+	// the default name is the bare org-derived one — the slug is ignored.
+	return plugins.DefaultMarketplaceName(orgName, "", true)
 }
 
 func TestPluginsService_UpdateMarketplaceSettings_RejectsInvalidName(t *testing.T) {

--- a/server/internal/plugins/naming/naming.go
+++ b/server/internal/plugins/naming/naming.go
@@ -13,10 +13,27 @@ package naming
 
 import "github.com/speakeasy-api/gram/server/internal/conv"
 
-// MarketplaceName is the marketplace.json "name" for an org's published
+// MarketplaceName is the marketplace.json "name" for a project's published
 // marketplace.
-func MarketplaceName(orgName string) string {
-	return conv.ToSlug(orgName) + "-speakeasy"
+//
+// An org can publish multiple projects, each its own marketplace, and a
+// marketplace.json name is a single identifier that must be unique on the
+// device. So names are project-scoped: `<org>-<project>-speakeasy`. The one
+// exception is the org's default project (and the no-project fallback), which
+// keeps the bare `<org>-speakeasy` name it has always had — so existing installs
+// for single-project orgs don't churn when this scoping lands; only an org's
+// non-default projects get a new, distinct name.
+//
+// isDefaultProject must be resolved the same way on both surfaces (the publish
+// path and the device-agent endpoint) — the org's oldest non-deleted project,
+// by id ASC — or the two will compute different names and silently fail to match.
+func MarketplaceName(orgName, projectSlug string, isDefaultProject bool) string {
+	base := conv.ToSlug(orgName)
+	slug := conv.ToSlug(projectSlug)
+	if isDefaultProject || slug == "" {
+		return base + "-speakeasy"
+	}
+	return base + "-" + slug + "-speakeasy"
 }
 
 // ObservabilitySlug is the slug of the always-required observability plugin

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -285,18 +285,6 @@ FROM projects pr
 WHERE pr.id = @project_id
   AND pr.deleted IS FALSE;
 
--- name: GetOrgDefaultProjectID :one
--- The org's default project is its oldest non-deleted project (lowest id; ids
--- are time-ordered uuidv7, so this is creation order). Used to decide whether a
--- project keeps the bare org-derived marketplace name or gets a project-scoped
--- one. Must match the device-agent endpoint's default-project resolution.
-SELECT id
-FROM projects
-WHERE organization_id = @organization_id
-  AND deleted IS FALSE
-ORDER BY id ASC
-LIMIT 1;
-
 -- name: UpsertMarketplaceSettings :one
 -- Sets the marketplace name override for a project. Pass NULL to clear the
 -- override and fall back to the server-side default.

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -266,6 +266,18 @@ SELECT *
 FROM project_marketplace_settings
 WHERE project_id = @project_id;
 
+-- name: GetOrgDefaultProjectID :one
+-- The org's default project is its oldest non-deleted project (lowest id; ids
+-- are time-ordered uuidv7, so this is creation order). Used to decide whether a
+-- project keeps the bare org-derived marketplace name or gets a project-scoped
+-- one. Must match the device-agent endpoint's default-project resolution.
+SELECT id
+FROM projects
+WHERE organization_id = @organization_id
+  AND deleted IS FALSE
+ORDER BY id ASC
+LIMIT 1;
+
 -- name: UpsertMarketplaceSettings :one
 -- Sets the marketplace name override for a project. Pass NULL to clear the
 -- override and fall back to the server-side default.

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -266,6 +266,25 @@ SELECT *
 FROM project_marketplace_settings
 WHERE project_id = @project_id;
 
+-- name: GetProjectMarketplaceNameContext :one
+-- Returns a project's slug and whether it's its org's default project (oldest by
+-- id ASC), the two inputs needed to resolve its marketplace name — read from the
+-- project row rather than trusting auth-context fields that some auth flows
+-- (e.g. project-scoped API keys) leave unset.
+SELECT
+  pr.slug AS project_slug,
+  (pr.id = (
+    SELECT p2.id
+    FROM projects p2
+    WHERE p2.organization_id = pr.organization_id
+      AND p2.deleted IS FALSE
+    ORDER BY p2.id ASC
+    LIMIT 1
+  )) AS is_default_project
+FROM projects pr
+WHERE pr.id = @project_id
+  AND pr.deleted IS FALSE;
+
 -- name: GetOrgDefaultProjectID :one
 -- The org's default project is its oldest non-deleted project (lowest id; ids
 -- are time-ordered uuidv7, so this is creation order). Used to decide whether a

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -265,6 +265,26 @@ func (q *Queries) GetMcpServerForPluginServer(ctx context.Context, arg GetMcpSer
 	return i, err
 }
 
+const getOrgDefaultProjectID = `-- name: GetOrgDefaultProjectID :one
+SELECT id
+FROM projects
+WHERE organization_id = $1
+  AND deleted IS FALSE
+ORDER BY id ASC
+LIMIT 1
+`
+
+// The org's default project is its oldest non-deleted project (lowest id; ids
+// are time-ordered uuidv7, so this is creation order). Used to decide whether a
+// project keeps the bare org-derived marketplace name or gets a project-scoped
+// one. Must match the device-agent endpoint's default-project resolution.
+func (q *Queries) GetOrgDefaultProjectID(ctx context.Context, organizationID string) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, getOrgDefaultProjectID, organizationID)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getOrganizationName = `-- name: GetOrganizationName :one
 SELECT name FROM organization_metadata WHERE id = $1
 `

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -329,6 +329,38 @@ func (q *Queries) GetPlugin(ctx context.Context, arg GetPluginParams) (Plugin, e
 	return i, err
 }
 
+const getProjectMarketplaceNameContext = `-- name: GetProjectMarketplaceNameContext :one
+SELECT
+  pr.slug AS project_slug,
+  (pr.id = (
+    SELECT p2.id
+    FROM projects p2
+    WHERE p2.organization_id = pr.organization_id
+      AND p2.deleted IS FALSE
+    ORDER BY p2.id ASC
+    LIMIT 1
+  )) AS is_default_project
+FROM projects pr
+WHERE pr.id = $1
+  AND pr.deleted IS FALSE
+`
+
+type GetProjectMarketplaceNameContextRow struct {
+	ProjectSlug      string
+	IsDefaultProject bool
+}
+
+// Returns a project's slug and whether it's its org's default project (oldest by
+// id ASC), the two inputs needed to resolve its marketplace name — read from the
+// project row rather than trusting auth-context fields that some auth flows
+// (e.g. project-scoped API keys) leave unset.
+func (q *Queries) GetProjectMarketplaceNameContext(ctx context.Context, projectID uuid.UUID) (GetProjectMarketplaceNameContextRow, error) {
+	row := q.db.QueryRow(ctx, getProjectMarketplaceNameContext, projectID)
+	var i GetProjectMarketplaceNameContextRow
+	err := row.Scan(&i.ProjectSlug, &i.IsDefaultProject)
+	return i, err
+}
+
 const listPluginAssignments = `-- name: ListPluginAssignments :many
 SELECT id, plugin_id, organization_id, principal_urn, created_at, updated_at
 FROM plugin_assignments

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -265,26 +265,6 @@ func (q *Queries) GetMcpServerForPluginServer(ctx context.Context, arg GetMcpSer
 	return i, err
 }
 
-const getOrgDefaultProjectID = `-- name: GetOrgDefaultProjectID :one
-SELECT id
-FROM projects
-WHERE organization_id = $1
-  AND deleted IS FALSE
-ORDER BY id ASC
-LIMIT 1
-`
-
-// The org's default project is its oldest non-deleted project (lowest id; ids
-// are time-ordered uuidv7, so this is creation order). Used to decide whether a
-// project keeps the bare org-derived marketplace name or gets a project-scoped
-// one. Must match the device-agent endpoint's default-project resolution.
-func (q *Queries) GetOrgDefaultProjectID(ctx context.Context, organizationID string) (uuid.UUID, error) {
-	row := q.db.QueryRow(ctx, getOrgDefaultProjectID, organizationID)
-	var id uuid.UUID
-	err := row.Scan(&id)
-	return id, err
-}
-
 const getOrganizationName = `-- name: GetOrganizationName :one
 SELECT name FROM organization_metadata WHERE id = $1
 `


### PR DESCRIPTION
## What

`agent.getPlugins` tells a device which plugin marketplaces to install. An org can publish multiple projects — each its own marketplace (own token, repo, `marketplace.json`) — but the endpoint derived the marketplace **name** from the org alone, so every project resolved to the same name and the view collapsed them to one. Problems that fell out:

1. **Wrong project survived the collapse.** The kept token was the *first row's*, and the query ordered by `pr.slug`, so a multi-project org got whichever project sorted first alphabetically (e.g. `adam` instead of the default project). Observability hooks then reported to that wrong project (`Gram-Project: adam`). *(DNO-228)*
2. **Per-project names were ignored.** The view recomputed the org-derived name and never read the per-project override (`project_marketplace_settings`), so a project published under an override name was emitted under the org default — a name the device never installed → plugins silently failed.

## Change

Marketplace names are now **project-scoped**, resolved identically on the publish path and the agent endpoint (the cross-surface contract):

- The org's **default project** (its oldest, by `id ASC`) keeps the bare `<org>-speakeasy` name it always had.
- Every **other project** gets `<org>-<project>-speakeasy`.
- A per-project **override** still wins when set.

So a device now receives **every marketplace the org has published**, each pointing at its own project — instead of one arbitrary winner. Names that *genuinely* collide (e.g. two equal overrides) still collapse, deterministically, to the default project (`ORDER BY pr.id` keeps that tiebreak).

Default-ness is computed the same way on both sides — the org's oldest non-deleted project — so the names can't drift.

### Also fixed (same surface)

3. **Colliding-name plugin leak.** When two projects collapse to one name, the view kept the winner's marketplace but still emitted the *losing* project's assigned plugins against that name — referencing a repo that doesn't contain them, so they'd silently fail. The view now tracks the owning project per name and only emits a row's plugins when it owns the marketplace.
4. **Settings default-name for project-scoped API keys.** `GetMarketplaceSettings`/`UpdateMarketplaceSettings` derived the displayed default name from `ac.ProjectSlug`, which project-scoped API keys leave nil even when `ProjectID` is set — so a non-default project showed the bare org name. It now resolves the slug + default-ness from the project row (`GetProjectMarketplaceNameContext`).

## Rollout — risk by cohort

No migration, no `pluginGeneratorVersion` bump, no manual republish. The existing 5-minute automated generator rollout (`plugin_generator_rollout`) republishes exactly the projects whose resolved name changed (the name is part of the content fingerprint).

- **Single-project orgs (the vast majority): zero impact.** Their only project is the default, so its name is unchanged, the fingerprint is unchanged, and it isn't even republished. Fully transparent — no reinstall, no churn.
- **Multi-project orgs, the default project: zero impact** throughout — its `<org>-speakeasy` name is unchanged on both the agent and the published file.
- **Multi-project orgs, non-default projects: a brief, self-healing window.** On deploy the agent emits the new `<org>-<project>-speakeasy` name immediately, but that project's published `marketplace.json` still carries the old name until the rollout republishes it (≤ a few minutes). During that gap the project's plugins don't resolve on-device; they enable automatically once the republish lands. No data loss, no permanent regression — and these projects end up *more* correct (each served from its own repo, observability attributed to the right project).

No marketplace name is ever removed or orphaned: `<org>-speakeasy` persists (re-pointed to the default project), new names are added, and the daemon reconciles to the full set each poll.

**To eliminate even the brief window**, force a full republish immediately after deploy (or simply let the 5-minute rollout drain) so every project's published file catches up to the new names before devices next poll.

> Device-side caveat: how a managed tool (Claude Code/Cursor/Codex) handles a same-named marketplace whose URL changed, or a delisted marketplace, lives outside this repo. Behavior here is reasoned from the agent contract (reconcile-by-name, ETag-driven polling); worth a quick daemon check before rollout if we want certainty.

## Tests

- View: distinct project-scoped names yield separate marketplaces; same-named rows collapse to the default; observability emitted once **per correct marketplace**; a collapsed project's assigned plugin is **dropped**, not leaked to the winner.
- Endpoint: `MultiProjectDistinctByDefault` (default + non-default → two marketplaces), `CollidingNamesPreferDefault` (override collision → default token wins **and** the loser's plugin is dropped), `DistinctOverridesYieldSeparateMarketplaces` (override honored).
- Generate: non-default project → `acme-sales-speakeasy`; default → `acme-speakeasy`.

Resolves DNO-228.
