### PR TITLE
feat(assistants): connect MCP servers in parallel with timeouts

### DIFF
--- a/.changeset/assistant-parallel-mcp-connect.md
+++ b/.changeset/assistant-parallel-mcp-connect.md
@@ -1,0 +1,9 @@
+---
+"server": patch
+---
+
+Assistants now connect to all of their MCP servers in parallel when a thread
+starts, so startup time no longer grows with the number of servers and one
+slow or unreachable server cannot stall the rest. Connection attempts are
+bounded by connect and handshake timeouts, so a hung server fails fast instead
+of blocking the assistant.

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "agentkit-adapter-completions"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0549a63045aefdfb2c916a9fa928ff39551532bc6c678e6a42a5532f7515de"
+checksum = "1ccf868fe81fc9cce7b9886e382104f8be17f7ae2c557432282256b27f01d2af"
 dependencies = [
  "agentkit-core",
  "agentkit-http",
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-capabilities"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a02d3d6cbf14371e66731b116fdcdab1e21808bf220b006ead26ddf20c8221"
+checksum = "0cd0668d77c0594ca03b33e1f8e45d8266959ff08bb6b437b9a1cadfb3010361"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-compaction"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccad3f42995ecc619549a90622bb716dd633b0fd90331838747ac7de2c266886"
+checksum = "c9506ff89d2a68604f5813aede539a8ad743c7cfa54fce0d0bcc127949b04f3c"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b301160b8265f1968c531343acc9f1c1d4339981d057caaa1384c5c83e55eb9c"
+checksum = "f183e70bd23e6662e4c6ebe6b0775c76a024c223153af188934e17c3b1401ca7"
 dependencies = [
  "futures-timer",
  "serde",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-http"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a6d64f820afbe9d15a601ff01c27706bd48aa5d7eae4e34a1d0459678d8767"
+checksum = "49de3d89a2b44934aae701ab40af56357f99b6ff9b9cb5a865b215e0c2c390e0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-loop"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab247f643b682cdd8ebb1934051030cab6e24ec2545cdd8faf4a4b87740e94e"
+checksum = "3f1d2ecf08e0703cf87a54e1395152038db28bf911dc72c3512a3004626b35fa"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-mcp"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f8d393ecb85414cbdb87dc4a272e15d89a717b079315c81da5904a238d9caf"
+checksum = "3d859a60b07c66618cb284aa833e3261fd05a8999596e01f393a8b653ee00e87"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-provider-openrouter"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5afff1ec07168bf6464d88c6c99d8b58f5b8cb137617e5417030534772d28e"
+checksum = "27d3c3422c7f36360e2932e6f938df36a8f028767d8fc15c79ca5dd833b6e6a1"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-reporting"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63189667f51d31c1d368ea177dc74857962245d068abe1108deda6067be9d34c"
+checksum = "088fcebbb834b5aced2f96b082eedacc80f765c1a73d523e25c37b37db68b992"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-task-manager"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5088e747c02acd5d4b134ce5c7cbfbe70ef942f2db7ed49adc99d8ca8abc2154"
+checksum = "9a2b8ebcc040a673abfd4e45a0fae91827e8d69a955b6ad849bcdf73154a3dee"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tool-fs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6692324d48d09a358de76ec48544b6b0303fa7815b7739b214a47b3c97c93871"
+checksum = "03443829a26c566be19076346a22e50d2dd73125a7a11897c761468c227299b9"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7040ef1537b0313bd8ce3d3f5a07e2bf63eea038189e902b6d7af908ebc834"
+checksum = "ee6bdbaed6a65d856f76bd36418ea6124031b09c3aecf82600a19d69530a0264"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef5b2ae417e60b6607c4b0eca727ecfcbf300d59653b41c9b8b81e09a51a85b"
+checksum = "de650ca60c7e911840515cdf424ed1741ffef3457a6a83ab8423e84a71c2d2b7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -9,17 +9,17 @@ name = "gram-assistant-runner"
 path = "src/main.rs"
 
 [dependencies]
-agentkit-adapter-completions = "0.8.0"
-agentkit-compaction = "0.8.0"
-agentkit-core = "0.8.0"
-agentkit-http = { version = "0.8.0", features = ["reqwest-middleware-client"] }
-agentkit-loop = "0.8.0"
-agentkit-mcp = "0.8.0"
-agentkit-provider-openrouter = "0.8.0"
-agentkit-reporting = { version = "0.8.0", features = ["tracing"] }
-agentkit-tool-fs = "0.8.0"
-agentkit-tools-core = { version = "0.8.0", features = ["schemars"] }
-agentkit-tools-derive = "0.8.0"
+agentkit-adapter-completions = "0.8.1"
+agentkit-compaction = "0.8.1"
+agentkit-core = "0.8.1"
+agentkit-http = { version = "0.8.1", features = ["reqwest-middleware-client"] }
+agentkit-loop = "0.8.1"
+agentkit-mcp = "0.8.1"
+agentkit-provider-openrouter = "0.8.1"
+agentkit-reporting = { version = "0.8.1", features = ["tracing"] }
+agentkit-tool-fs = "0.8.1"
+agentkit-tools-core = { version = "0.8.1", features = ["schemars"] }
+agentkit-tools-derive = "0.8.1"
 opentelemetry = "0.32"
 opentelemetry-otlp = { version = "0.32", default-features = false, features = [
   "grpc-tonic",

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -10,8 +10,8 @@ use agentkit_loop::{
     PromptCacheRetention, SessionConfig,
 };
 use agentkit_mcp::{
-    McpError, McpServerConfig, McpServerId, McpServerManager, McpTransportBinding,
-    StreamableHttpTransportConfig,
+    McpError, McpServerConfig, McpServerId, McpServerManager, McpServerOptions,
+    McpTransportBinding, StreamableHttpTransportConfig,
 };
 use agentkit_provider_openrouter::{OpenRouterConfig, OpenRouterProvider};
 use agentkit_reporting::TracingReporter;
@@ -38,6 +38,12 @@ use crate::workdir::ASSISTANT_WORKDIR;
 
 const TOOL_RESULT_SPILL_DIR: &str = "tool-results";
 const MCP_CMD_CAPACITY: usize = 32;
+
+/// TCP/TLS connect bound for runner-originated HTTP requests.
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Per-server bound on the MCP discovery handshake at connect time.
+const MCP_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// How long a thread's per-task state can sit idle before the host evicts
 /// it. The VM stays alive across all per-thread events; only individual
@@ -125,6 +131,7 @@ pub async fn build_host(
     let http_client = reqwest::Client::builder()
         .user_agent(concat!("gram-assistant-runner/", env!("CARGO_PKG_VERSION")))
         .default_headers(default_headers)
+        .connect_timeout(HTTP_CONNECT_TIMEOUT)
         .build()?;
 
     let spill_root = PathBuf::from(ASSISTANT_WORKDIR).join(TOOL_RESULT_SPILL_DIR);
@@ -447,28 +454,51 @@ async fn build_thread_mcp(
 
     for server in servers {
         let config = build_mcp_server_config(server, &host.http_client, tokens)?;
-        let server_id = McpServerId::new(server.id.clone());
-        manager.register_server(config);
-        if let Err(err) = connect_and_log(&mut manager, &server_id, "register").await
-            && err.auth_required
+        manager.register_server_with_options(
+            config,
+            McpServerOptions::new().with_timeout(MCP_HANDSHAKE_TIMEOUT),
+        );
+    }
+
+    let settled = manager.connect_all_settled().await;
+    for handle in settled.connected() {
+        tracing::info!(
+            server_id = %handle.server_id(),
+            tools = handle.snapshot().tools.len(),
+            action = "register",
+            "mcp connect ok"
+        );
+    }
+    for failure in settled.failed() {
+        let server_id = &failure.server_id;
+        tracing::warn!(
+            server_id = %server_id,
+            error = %failure.error,
+            action = "register",
+            "mcp connect failed"
+        );
+        if !matches!(failure.error, McpError::AuthRequired(_)) {
+            continue;
+        }
+        let Some(server) = servers.iter().find(|s| s.id == server_id.0) else {
+            continue;
+        };
+        match host
+            .gram_client
+            .create_mcp_auth_flow(thread_id, &server.id, &server.url, tokens)
+            .await
         {
-            match host
-                .gram_client
-                .create_mcp_auth_flow(thread_id, &server.id, &server.url, tokens)
-                .await
-            {
-                Ok(flow) => auth_notices.push(format!(
-                    "<message-context>\nEventType: assistant_mcp_auth_required\nMCPServerID: {server_id}\nMCPSlug: {mcp_slug}\nAuthURL: {auth_url}\n</message-context>",
-                    server_id = flow.server_id,
-                    mcp_slug = flow.mcp_slug,
-                    auth_url = flow.auth_url,
-                )),
-                Err(flow_err) => tracing::warn!(
-                    server_id = %server_id,
-                    error = %flow_err,
-                    "failed to create assistant mcp auth flow"
-                ),
-            }
+            Ok(flow) => auth_notices.push(format!(
+                "<message-context>\nEventType: assistant_mcp_auth_required\nMCPServerID: {server_id}\nMCPSlug: {mcp_slug}\nAuthURL: {auth_url}\n</message-context>",
+                server_id = flow.server_id,
+                mcp_slug = flow.mcp_slug,
+                auth_url = flow.auth_url,
+            )),
+            Err(flow_err) => tracing::warn!(
+                server_id = %server_id,
+                error = %flow_err,
+                "failed to create assistant mcp auth flow"
+            ),
         }
     }
 
@@ -477,16 +507,11 @@ async fn build_thread_mcp(
     Ok((cmd_tx, catalog, auth_notices))
 }
 
-struct McpConnectFailure {
-    message: String,
-    auth_required: bool,
-}
-
 async fn connect_and_log(
     manager: &mut McpServerManager,
     server_id: &McpServerId,
     action: &'static str,
-) -> Result<(), McpConnectFailure> {
+) -> Result<(), String> {
     match manager.connect_server(server_id).await {
         Ok(handle) => {
             tracing::info!(
@@ -498,12 +523,8 @@ async fn connect_and_log(
             Ok(())
         }
         Err(e) => {
-            let auth_required = matches!(e, McpError::AuthRequired(_));
             tracing::warn!(server_id = %server_id, error = %e, action, "mcp connect failed");
-            Err(McpConnectFailure {
-                message: e.to_string(),
-                auth_required,
-            })
+            Err(e.to_string())
         }
     }
 }
@@ -549,9 +570,7 @@ async fn run_mcp_actor(mut manager: McpServerManager, mut cmd_rx: mpsc::Receiver
                 if let Err(e) = manager.disconnect_server(&server_id).await {
                     tracing::debug!(server_id = %server_id, error = %e, "disconnect during force reconnect");
                 }
-                let result = connect_and_log(&mut manager, &server_id, "force_reconnect")
-                    .await
-                    .map_err(|err| err.message);
+                let result = connect_and_log(&mut manager, &server_id, "force_reconnect").await;
                 let _ = reply.send(result);
             }
         }

--- a/agents/runner/src/tools/mcp_force_reconnect.rs
+++ b/agents/runner/src/tools/mcp_force_reconnect.rs
@@ -101,7 +101,10 @@ impl Tool for McpForceReconnectTool {
         let total = senders.len();
         let (text, is_error) = if total == 0 {
             (
-                format!("no live threads to reconnect mcp server {}", input.server_id),
+                format!(
+                    "no live threads to reconnect mcp server {}",
+                    input.server_id
+                ),
                 true,
             )
         } else {


### PR DESCRIPTION
## Summary

- The assistant runner now connects a thread's MCP servers in parallel using `McpServerManager::connect_all_settled` from agentkit 0.8.0, instead of awaiting each server one at a time. Startup latency is now bounded by the slowest server rather than the sum of all of them, and one failing server no longer delays the rest.
- Connection failures are reported per server: each failure is logged, and `AuthRequired` failures still mint an assistant MCP auth flow notice exactly as before.
- The runner's shared reqwest client gains a 3s TCP/TLS connect timeout, and each MCP server's discovery handshake is bounded at 10s via `McpServerOptions`, so a hung server fails fast instead of stalling thread configuration.

Based on #3325 (agentkit 0.8.0 upgrade).

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connect MCP servers in parallel with per-server timeouts to speed up assistant thread startup. Also add optional OTLP trace export for assistant runtimes with a Fly-deployed collector forwarding to Datadog (DNO-115).

- **New Features**
  - Parallel MCP connect using `agentkit` 0.8.1 `McpServerManager::connect_all_settled`; each server is bounded by a 10s `McpServerOptions` timeout (transport + initialize + discovery) and a 3s HTTP connect timeout; failures are logged and only `AuthRequired` creates an auth flow notice.
  - Optional runtime OTLP tracing (gRPC or HTTP) via `--with-otel-tracing` and standard `OTEL_EXPORTER_OTLP_*`; spans include GenAI semconv and `mcp.call_tool` attribution, and resources are tagged with assistant, project, and environment. Fly runtime flags `--assistant-runtime-otlp-endpoint`, `--assistant-runtime-otlp-protocol`, and `--assistant-runtime-otlp-headers` wire env vars; a Fly `otel-collector` forwards to Datadog.

- **Dependencies**
  - Bump `agentkit-*` crates to `0.8.1`.

<sup>Written for commit a7c4eec27d89e9cb1b8dfa12020be70075f419b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

