### PR TITLE
feat(dashboard): split employees and unknown users on the insights employees view

### DIFF
--- a/client/dashboard/src/components/chart/MetricCard.tsx
+++ b/client/dashboard/src/components/chart/MetricCard.tsx
@@ -8,6 +8,8 @@ type AccentColor = "red" | "orange" | "yellow" | "green" | "blue" | "purple";
 export type MetricCardProps = {
   title: string;
   value: number;
+  /** Renders in place of the formatted value (e.g. "-" when not applicable). */
+  displayValue?: string;
   previousValue?: number;
   format?: "compact" | "number" | "currency" | "percent" | "ms" | "seconds";
   icon?: IconName;
@@ -23,6 +25,7 @@ export function MetricCard(props: MetricCardProps): JSX.Element {
   const {
     title,
     value,
+    displayValue,
     previousValue = 0,
     format = "compact",
     icon,
@@ -92,7 +95,7 @@ export function MetricCard(props: MetricCardProps): JSX.Element {
       </div>
       <div className="flex items-end justify-between">
         <span className={`text-3xl font-semibold tracking-tight ${valueColor}`}>
-          {formatValue(value)}
+          {displayValue ?? formatValue(value)}
         </span>
         {previousValue > 0 && delta !== 0 && (
           <div className="flex flex-col items-end gap-0.5">

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -106,6 +106,7 @@ function presetRangeLabel(preset: DateRangePreset): string {
 function EmployeeFilterBar({
   view,
   onViewChange,
+  dimensions,
   dimension,
   onDimensionChange,
   selectedValue,
@@ -115,6 +116,7 @@ function EmployeeFilterBar({
 }: {
   view: EmployeeView;
   onViewChange: (view: EmployeeView) => void;
+  dimensions: EmployeeFilterDimension[];
   dimension: EmployeeFilterDimension;
   onDimensionChange: (dimension: EmployeeFilterDimension) => void;
   selectedValue: string | null;
@@ -163,7 +165,7 @@ function EmployeeFilterBar({
         })}
 
         <div className="bg-border/50 mx-1 h-6 w-px" />
-        {EMPLOYEE_FILTER_DIMENSIONS.map((value) => {
+        {dimensions.map((value) => {
           const isSelected = dimension === value;
           return (
             <button
@@ -310,6 +312,10 @@ export function InsightsEmployeesContent(): JSX.Element {
         }
         return params;
       });
+      // Unknown users have no role, so the role dimension doesn't apply there.
+      if (next === "unattributed") {
+        setFilterDimension((prev) => (prev === "role" ? "all" : prev));
+      }
       // The selected user/role may not exist in the other view.
       setSelectedFilterValue(null);
     },
@@ -371,6 +377,15 @@ export function InsightsEmployeesContent(): JSX.Element {
       roleName ? item.role === roleName : false,
     );
   }, [viewEmployees, filterDimension, roleNameById, selectedFilterValue]);
+  // Unattributed rows carry a placeholder role, so role filtering would
+  // always come back empty in that view.
+  const filterDimensions = useMemo<EmployeeFilterDimension[]>(
+    () =>
+      isUnattributedView
+        ? EMPLOYEE_FILTER_DIMENSIONS.filter((value) => value !== "role")
+        : EMPLOYEE_FILTER_DIMENSIONS,
+    [isUnattributedView],
+  );
   const filterOptions = useMemo<FilterOption[]>(() => {
     if (filterDimension === "user") {
       return viewEmployees.map((item) => ({
@@ -490,6 +505,7 @@ export function InsightsEmployeesContent(): JSX.Element {
               <EmployeeFilterBar
                 view={view}
                 onViewChange={handleViewChange}
+                dimensions={filterDimensions}
                 dimension={filterDimension}
                 onDimensionChange={handleFilterDimensionChange}
                 selectedValue={selectedFilterValue}

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -290,7 +290,7 @@ export function InsightsEmployeesContent(): JSX.Element {
     to: Date;
   } | null>(null);
   const [customRangeLabel, setCustomRangeLabel] = useState<string | null>(null);
-  const [filterDimension, setFilterDimension] =
+  const [rawFilterDimension, setFilterDimension] =
     useState<EmployeeFilterDimension>("all");
   const [selectedFilterValue, setSelectedFilterValue] = useState<string | null>(
     null,
@@ -301,6 +301,13 @@ export function InsightsEmployeesContent(): JSX.Element {
       ? "unattributed"
       : "employees";
   const isUnattributedView = view === "unattributed";
+  // Unknown users have no role, so the role dimension doesn't apply there.
+  // Derived (rather than reset in the view-change handler) so it also holds
+  // when the view changes through the URL, e.g. back/forward navigation.
+  const filterDimension: EmployeeFilterDimension =
+    isUnattributedView && rawFilterDimension === "role"
+      ? "all"
+      : rawFilterDimension;
   const handleViewChange = useCallback(
     (next: EmployeeView) => {
       setSearchParams((prev) => {
@@ -312,10 +319,6 @@ export function InsightsEmployeesContent(): JSX.Element {
         }
         return params;
       });
-      // Unknown users have no role, so the role dimension doesn't apply there.
-      if (next === "unattributed") {
-        setFilterDimension((prev) => (prev === "role" ? "all" : prev));
-      }
       // The selected user/role may not exist in the other view.
       setSelectedFilterValue(null);
     },

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -22,14 +22,15 @@ import {
 import { SearchBar } from "@/components/ui/search-bar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
-import { dateTimeFormatters } from "@/lib/dates";
 import { cn } from "@/lib/utils";
+import {
+  buildEmployees,
+  type Employee,
+  type EmployeeStatus,
+  isUnattributedEmployee,
+} from "@/components/observe/insightsEmployeesData";
 import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
-import type {
-  AccessMember,
-  Role,
-  UserSummary,
-} from "@gram/client/models/components";
+import type { UserSummary } from "@gram/client/models/components";
 import { useGramContext, useMembers, useRoles } from "@gram/client/react-query";
 import { unwrapAsync } from "@gram/client/types/fp";
 import { type DateRangePreset, getPresetRange } from "@gram-ai/elements";
@@ -42,8 +43,8 @@ import {
   ChevronRight,
   Info,
 } from "lucide-react";
-import { useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router";
+import { useCallback, useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { useRoutes } from "@/routes";
 import { useSlugs } from "@/contexts/Sdk";
 import { slugify } from "@/lib/constants";
@@ -58,6 +59,16 @@ import { HooksSetupDialog } from "@/pages/hooks/HooksSetupDialog";
 
 type EmployeeFilterDimension = "all" | "user" | "role";
 type FilterOption = { id: string; label: string };
+
+type EmployeeView = "employees" | "unattributed";
+
+const VIEW_SEARCH_PARAM = "view";
+
+const EMPLOYEE_VIEWS: EmployeeView[] = ["employees", "unattributed"];
+const VIEW_LABELS: Record<EmployeeView, string> = {
+  employees: "Employees",
+  unattributed: "Unknown users",
+};
 
 const EMPLOYEE_FILTER_DIMENSIONS: EmployeeFilterDimension[] = [
   "all",
@@ -93,6 +104,8 @@ function presetRangeLabel(preset: DateRangePreset): string {
 }
 
 function EmployeeFilterBar({
+  view,
+  onViewChange,
   dimension,
   onDimensionChange,
   selectedValue,
@@ -100,6 +113,8 @@ function EmployeeFilterBar({
   options,
   disabled,
 }: {
+  view: EmployeeView;
+  onViewChange: (view: EmployeeView) => void;
   dimension: EmployeeFilterDimension;
   onDimensionChange: (dimension: EmployeeFilterDimension) => void;
   selectedValue: string | null;
@@ -125,6 +140,29 @@ function EmployeeFilterBar({
         Filter by
       </span>
       <div className="border-border flex h-[42px] items-center rounded-md border p-1">
+        {EMPLOYEE_VIEWS.map((value) => {
+          const isSelected = view === value;
+          return (
+            <button
+              key={value}
+              onClick={() => onViewChange(value)}
+              disabled={disabled}
+              className={`
+                h-8 rounded px-3 text-sm font-medium transition-all duration-150
+                ${
+                  isSelected
+                    ? "text-foreground bg-white shadow-sm dark:bg-gray-900"
+                    : "text-muted-foreground hover:text-foreground"
+                }
+                disabled:cursor-not-allowed
+              `}
+            >
+              {VIEW_LABELS[value]}
+            </button>
+          );
+        })}
+
+        <div className="bg-border/50 mx-1 h-6 w-px" />
         {EMPLOYEE_FILTER_DIMENSIONS.map((value) => {
           const isSelected = dimension === value;
           return (
@@ -215,20 +253,6 @@ function EmployeeFilterBar({
   );
 }
 
-type EmployeeStatus = "enrolled" | "not_enrolled";
-
-type Employee = {
-  id: string;
-  name: string;
-  email: string;
-  role: string;
-  status: EmployeeStatus;
-  tokenCount: number;
-  lastActivity: string;
-  lastActivityTimestamp: number | null;
-  photoUrl?: string | null;
-};
-
 const statusMeta: Record<
   EmployeeStatus,
   { label: string; variant: "success" | "destructive" }
@@ -269,6 +293,28 @@ export function InsightsEmployeesContent(): JSX.Element {
   const [selectedFilterValue, setSelectedFilterValue] = useState<string | null>(
     null,
   );
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view: EmployeeView =
+    searchParams.get(VIEW_SEARCH_PARAM) === "unattributed"
+      ? "unattributed"
+      : "employees";
+  const isUnattributedView = view === "unattributed";
+  const handleViewChange = useCallback(
+    (next: EmployeeView) => {
+      setSearchParams((prev) => {
+        const params = new URLSearchParams(prev);
+        if (next === "employees") {
+          params.delete(VIEW_SEARCH_PARAM);
+        } else {
+          params.set(VIEW_SEARCH_PARAM, next);
+        }
+        return params;
+      });
+      // The selected user/role may not exist in the other view.
+      setSelectedFilterValue(null);
+    },
+    [setSearchParams],
+  );
 
   const { from, to } = useMemo(
     () => customRange ?? getPresetRange(dateRange),
@@ -306,19 +352,28 @@ export function InsightsEmployeesContent(): JSX.Element {
     () => new Map(roles.map((role) => [role.id, role.name])),
     [roles],
   );
+  const viewEmployees = useMemo(
+    () =>
+      allEmployees.filter((item) =>
+        isUnattributedView
+          ? isUnattributedEmployee(item)
+          : !isUnattributedEmployee(item),
+      ),
+    [allEmployees, isUnattributedView],
+  );
   const employees = useMemo(() => {
-    if (filterDimension === "all" || !selectedFilterValue) return allEmployees;
+    if (filterDimension === "all" || !selectedFilterValue) return viewEmployees;
     if (filterDimension === "user") {
-      return allEmployees.filter((item) => item.id === selectedFilterValue);
+      return viewEmployees.filter((item) => item.id === selectedFilterValue);
     }
     const roleName = roleNameById.get(selectedFilterValue);
-    return allEmployees.filter((item) =>
+    return viewEmployees.filter((item) =>
       roleName ? item.role === roleName : false,
     );
-  }, [allEmployees, filterDimension, roleNameById, selectedFilterValue]);
+  }, [viewEmployees, filterDimension, roleNameById, selectedFilterValue]);
   const filterOptions = useMemo<FilterOption[]>(() => {
     if (filterDimension === "user") {
-      return allEmployees.map((item) => ({
+      return viewEmployees.map((item) => ({
         id: item.id,
         label: item.name,
       }));
@@ -330,7 +385,7 @@ export function InsightsEmployeesContent(): JSX.Element {
       }));
     }
     return [];
-  }, [allEmployees, filterDimension, roles]);
+  }, [viewEmployees, filterDimension, roles]);
   const totalEmployees = employees.length;
   const enrolledEmployees = employees.filter(
     (item) => item.status === "enrolled",
@@ -433,6 +488,8 @@ export function InsightsEmployeesContent(): JSX.Element {
               )}
             >
               <EmployeeFilterBar
+                view={view}
+                onViewChange={handleViewChange}
                 dimension={filterDimension}
                 onDimensionChange={handleFilterDimensionChange}
                 selectedValue={selectedFilterValue}
@@ -471,32 +528,50 @@ export function InsightsEmployeesContent(): JSX.Element {
                 )}
               >
                 <MetricCard
-                  title="Employees"
+                  title={isUnattributedView ? "Unknown users" : "Employees"}
                   value={totalEmployees}
                   icon="user"
                   accentColor="blue"
-                  subtext="Members plus unmatched usage"
+                  subtext={
+                    isUnattributedView
+                      ? "Usage not matched to a member"
+                      : "Organization members"
+                  }
                 />
                 <MetricCard
                   title="Enrolled"
                   value={enrolledEmployees}
+                  displayValue={isUnattributedView ? "-" : undefined}
                   icon="circle-check"
                   accentColor="green"
-                  subtext="Platform activity present"
+                  subtext={
+                    isUnattributedView
+                      ? "Not applicable to unknown users"
+                      : "Platform activity present"
+                  }
                 />
                 <MetricCard
                   title="Not Enrolled"
                   value={notEnrolledEmployees}
+                  displayValue={isUnattributedView ? "-" : undefined}
                   icon="triangle-alert"
                   accentColor="orange"
-                  subtext="No platform activity found"
+                  subtext={
+                    isUnattributedView
+                      ? "Not applicable to unknown users"
+                      : "No platform activity found"
+                  }
                 />
                 <MetricCard
                   title="Token Count"
                   value={totalTokenCount}
                   icon="gauge"
                   accentColor="purple"
-                  subtext={`${enrollmentRate.toFixed(0)}% enrolled`}
+                  subtext={
+                    isUnattributedView
+                      ? undefined
+                      : `${enrollmentRate.toFixed(0)}% enrolled`
+                  }
                 />
               </section>
 
@@ -718,7 +793,7 @@ function EmployeeTable({
 }
 
 function routeSegmentForEmployee(employee: Employee) {
-  if (employee.id.startsWith("usage:") && employee.name.includes("@")) {
+  if (isUnattributedEmployee(employee) && employee.name.includes("@")) {
     return encodeURIComponent(employee.name);
   }
   return slugify(employee.name);
@@ -817,84 +892,6 @@ function getInitials(name: string) {
     .toUpperCase();
 }
 
-function buildEmployees(
-  members: AccessMember[],
-  roles: Role[],
-  summaries: UserSummary[],
-): Employee[] {
-  const roleNameById = new Map(roles.map((role) => [role.id, role.name]));
-  const summaryByUserId = new Map(
-    summaries.map((summary) => [summary.userId, summary]),
-  );
-  const summaryByEmail = new Map(
-    summaries
-      .filter((summary) => summary.userId.includes("@"))
-      .map((summary) => [summary.userId.toLowerCase(), summary]),
-  );
-  const matchedSummaryIds = new Set<string>();
-
-  const employees = members.map((member) => {
-    const summary =
-      summaryByUserId.get(member.id) ??
-      summaryByEmail.get(member.email.toLowerCase());
-    if (summary) {
-      matchedSummaryIds.add(summary.userId);
-    }
-    const tokenCount =
-      (summary?.totalInputTokens ?? 0) + (summary?.totalOutputTokens ?? 0);
-    const status: EmployeeStatus =
-      summary != null ? "enrolled" : "not_enrolled";
-    const role =
-      member.roleIds
-        .map((id) => roleNameById.get(id))
-        .filter(Boolean)
-        .join(", ") || "Unknown";
-
-    return {
-      id: member.id,
-      name: member.name,
-      email: member.email,
-      role,
-      status,
-      tokenCount,
-      photoUrl: member.photoUrl,
-      lastActivityTimestamp: summary
-        ? Number(BigInt(summary.lastSeenUnixNano) / 1_000_000n)
-        : null,
-      lastActivity: summary
-        ? formatUnixNano(summary.lastSeenUnixNano)
-        : "No activity found",
-    };
-  });
-
-  const unmatchedUsage = summaries
-    .filter((summary) => !matchedSummaryIds.has(summary.userId))
-    .map((summary) => {
-      const tokenCount = summary.totalInputTokens + summary.totalOutputTokens;
-      return {
-        id: `usage:${summary.userId}`,
-        name: summary.userId,
-        email: summary.userId.includes("@") ? summary.userId : "",
-        role: "-",
-        status: "enrolled" as const,
-        tokenCount,
-        photoUrl: null,
-        lastActivityTimestamp: Number(
-          BigInt(summary.lastSeenUnixNano) / 1_000_000n,
-        ),
-        lastActivity: formatUnixNano(summary.lastSeenUnixNano),
-      };
-    });
-
-  return [...employees, ...unmatchedUsage].sort((a, b) => {
-    if (a.status !== b.status) {
-      return a.status === "not_enrolled" ? -1 : 1;
-    }
-
-    return a.name.localeCompare(b.name);
-  });
-}
-
 async function fetchEmployeeUsage(
   client: Parameters<typeof telemetrySearchUsers>[0],
   from: Date,
@@ -924,11 +921,4 @@ async function fetchEmployeeUsage(
   } while (cursor);
 
   return users;
-}
-
-function formatUnixNano(value: string) {
-  const nanos = BigInt(value);
-  const millis = Number(nanos / 1_000_000n);
-
-  return dateTimeFormatters.humanize(new Date(millis));
 }

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -575,7 +575,11 @@ export function InsightsEmployeesContent(): JSX.Element {
                 />
               </section>
 
-              <EmployeeTable employees={employees} onSelectUser={openUser} />
+              <EmployeeTable
+                key={view}
+                employees={employees}
+                onSelectUser={openUser}
+              />
               <EnrollmentLegend />
             </>
           )}

--- a/client/dashboard/src/components/observe/insightsEmployeesData.test.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AccessMember,
+  Role,
+  UserSummary,
+} from "@gram/client/models/components";
+import {
+  buildEmployees,
+  isUnattributedEmployee,
+} from "./insightsEmployeesData";
+
+const LAST_SEEN_UNIX_NANO = "1750000000000000000";
+
+function makeMember(
+  overrides: Partial<AccessMember> &
+    Pick<AccessMember, "id" | "email" | "name">,
+): AccessMember {
+  return {
+    joinedAt: new Date("2025-01-01T00:00:00Z"),
+    roleIds: [],
+    ...overrides,
+  };
+}
+
+function makeSummary(
+  overrides: Partial<UserSummary> & Pick<UserSummary, "userId">,
+): UserSummary {
+  return {
+    avgTokensPerRequest: 0,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    firstSeenUnixNano: LAST_SEEN_UNIX_NANO,
+    hookSources: [],
+    lastSeenUnixNano: LAST_SEEN_UNIX_NANO,
+    toolCallFailure: 0,
+    toolCallSuccess: 0,
+    tools: [],
+    totalChatRequests: 0,
+    totalChats: 0,
+    totalCost: 0,
+    totalInputTokens: 100,
+    totalOutputTokens: 50,
+    totalTokens: 150,
+    totalToolCalls: 0,
+    ...overrides,
+  };
+}
+
+const noRoles: Role[] = [];
+
+describe("buildEmployees attributed/unattributed split", () => {
+  it("keeps member ids for usage matched by user id", () => {
+    const member = makeMember({
+      id: "member-1",
+      email: "ada@example.com",
+      name: "Ada Lovelace",
+    });
+    const employees = buildEmployees([member], noRoles, [
+      makeSummary({ userId: "member-1" }),
+    ]);
+
+    expect(employees).toHaveLength(1);
+    expect(employees[0]!.id).toBe("member-1");
+    expect(employees[0]!.status).toBe("enrolled");
+    expect(isUnattributedEmployee(employees[0]!)).toBe(false);
+  });
+
+  it("matches usage to members by email, case-insensitively", () => {
+    const member = makeMember({
+      id: "member-1",
+      email: "Ada@Example.com",
+      name: "Ada Lovelace",
+    });
+    const employees = buildEmployees([member], noRoles, [
+      makeSummary({ userId: "ada@example.com" }),
+    ]);
+
+    expect(employees).toHaveLength(1);
+    expect(employees[0]!.id).toBe("member-1");
+    expect(employees[0]!.status).toBe("enrolled");
+    expect(isUnattributedEmployee(employees[0]!)).toBe(false);
+  });
+
+  it("creates unattributed rows with a usage: id for unmatched summaries", () => {
+    const employees = buildEmployees([], noRoles, [
+      makeSummary({ userId: "ghost@example.com" }),
+    ]);
+
+    expect(employees).toHaveLength(1);
+    expect(employees[0]!.id).toBe("usage:ghost@example.com");
+    expect(isUnattributedEmployee(employees[0]!)).toBe(true);
+  });
+
+  it("marks unattributed rows as not enrolled", () => {
+    const employees = buildEmployees([], noRoles, [
+      makeSummary({ userId: "ghost@example.com" }),
+    ]);
+
+    expect(employees[0]!.status).toBe("not_enrolled");
+  });
+
+  it("partitions a mixed list cleanly into the two views", () => {
+    const members = [
+      makeMember({
+        id: "member-1",
+        email: "ada@example.com",
+        name: "Ada Lovelace",
+      }),
+      makeMember({
+        id: "member-2",
+        email: "grace@example.com",
+        name: "Grace Hopper",
+      }),
+    ];
+    const summaries = [
+      makeSummary({ userId: "member-1" }),
+      makeSummary({ userId: "ghost@example.com" }),
+      makeSummary({ userId: "external-user-42" }),
+    ];
+
+    const employees = buildEmployees(members, noRoles, summaries);
+    const attributed = employees.filter((e) => !isUnattributedEmployee(e));
+    const unattributed = employees.filter(isUnattributedEmployee);
+
+    expect(employees).toHaveLength(4);
+    expect(attributed.map((e) => e.id).sort()).toEqual([
+      "member-1",
+      "member-2",
+    ]);
+    expect(unattributed.map((e) => e.id).sort()).toEqual([
+      "usage:external-user-42",
+      "usage:ghost@example.com",
+    ]);
+    // Member without activity stays attributed, just not enrolled.
+    expect(attributed.find((e) => e.id === "member-2")!.status).toBe(
+      "not_enrolled",
+    );
+  });
+});

--- a/client/dashboard/src/components/observe/insightsEmployeesData.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.ts
@@ -1,0 +1,111 @@
+import { dateTimeFormatters } from "@/lib/dates";
+import type {
+  AccessMember,
+  Role,
+  UserSummary,
+} from "@gram/client/models/components";
+
+export type EmployeeStatus = "enrolled" | "not_enrolled";
+
+export type Employee = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: EmployeeStatus;
+  tokenCount: number;
+  lastActivity: string;
+  lastActivityTimestamp: number | null;
+  photoUrl?: string | null;
+};
+
+// Unattributed identities are usage rows that matched no org member; they are
+// marked with a synthetic "usage:"-prefixed id by buildEmployees().
+export function isUnattributedEmployee(employee: Employee): boolean {
+  return employee.id.startsWith("usage:");
+}
+
+export function buildEmployees(
+  members: AccessMember[],
+  roles: Role[],
+  summaries: UserSummary[],
+): Employee[] {
+  const roleNameById = new Map(roles.map((role) => [role.id, role.name]));
+  const summaryByUserId = new Map(
+    summaries.map((summary) => [summary.userId, summary]),
+  );
+  const summaryByEmail = new Map(
+    summaries
+      .filter((summary) => summary.userId.includes("@"))
+      .map((summary) => [summary.userId.toLowerCase(), summary]),
+  );
+  const matchedSummaryIds = new Set<string>();
+
+  const employees = members.map((member) => {
+    const summary =
+      summaryByUserId.get(member.id) ??
+      summaryByEmail.get(member.email.toLowerCase());
+    if (summary) {
+      matchedSummaryIds.add(summary.userId);
+    }
+    const tokenCount =
+      (summary?.totalInputTokens ?? 0) + (summary?.totalOutputTokens ?? 0);
+    const status: EmployeeStatus =
+      summary != null ? "enrolled" : "not_enrolled";
+    const role =
+      member.roleIds
+        .map((id) => roleNameById.get(id))
+        .filter(Boolean)
+        .join(", ") || "Unknown";
+
+    return {
+      id: member.id,
+      name: member.name,
+      email: member.email,
+      role,
+      status,
+      tokenCount,
+      photoUrl: member.photoUrl,
+      lastActivityTimestamp: summary
+        ? Number(BigInt(summary.lastSeenUnixNano) / 1_000_000n)
+        : null,
+      lastActivity: summary
+        ? formatUnixNano(summary.lastSeenUnixNano)
+        : "No activity found",
+    };
+  });
+
+  const unmatchedUsage = summaries
+    .filter((summary) => !matchedSummaryIds.has(summary.userId))
+    .map((summary) => {
+      const tokenCount = summary.totalInputTokens + summary.totalOutputTokens;
+      return {
+        id: `usage:${summary.userId}`,
+        name: summary.userId,
+        email: summary.userId.includes("@") ? summary.userId : "",
+        role: "-",
+        status: "not_enrolled" as const,
+        tokenCount,
+        photoUrl: null,
+        lastActivityTimestamp: Number(
+          BigInt(summary.lastSeenUnixNano) / 1_000_000n,
+        ),
+        lastActivity: formatUnixNano(summary.lastSeenUnixNano),
+      };
+    });
+
+  return [...employees, ...unmatchedUsage].sort((a, b) => {
+    if (a.status !== b.status) {
+      return a.status === "not_enrolled" ? -1 : 1;
+    }
+
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function formatUnixNano(value: string) {
+  const nanos = BigInt(value);
+  const millis = Number(nanos / 1_000_000n);
+
+  return dateTimeFormatters.humanize(new Date(millis));
+}


### PR DESCRIPTION
Resolves DNO-227

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Insights > Employees page into two views: Employees and Unknown users, with a simple toggle and URL support. Updates metrics, filters, and routing to match the selected view and addresses DNO-227.

- New Features
  - Added view toggle for "Employees" and "Unknown users"; persists via `?view=unattributed`.
  - Metrics adapt by view; Enrolled/Not Enrolled show “-” for Unknown users.
  - Filters apply per view; role filter hidden for Unknown users; selection resets on view switch.

- Refactors
  - Moved attribution logic to `insightsEmployeesData.ts` with `buildEmployees` and `isUnattributedEmployee`; keyed `EmployeeTable` by view; added unit tests.
  - Unmatched usage now uses `usage:` ids and is marked `not_enrolled` for clearer partitioning and sorting.
  - `MetricCard` supports `displayValue` to render placeholders when a value isn’t applicable.

<sup>Written for commit 977a5ca2f1b1d852369b97e8ee5549ab019fefe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

