### PR TITLE
mig: make remote_sessions.access_expires_at nullable

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -936,7 +936,9 @@ CREATE TABLE IF NOT EXISTS remote_sessions (
   remote_session_client_id uuid NOT NULL,
 
   access_token_encrypted TEXT NOT NULL,
-  access_expires_at timestamptz NOT NULL,
+  -- NULL when the upstream omitted expires_in: the token has no known expiry
+  -- (e.g. Slack non-rotating tokens). Readers treat NULL as non-expiring.
+  access_expires_at timestamptz,
   refresh_token_encrypted TEXT,
   refresh_expires_at timestamptz,
   scopes TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],

--- a/server/migrations/20260610225502_remotesession-access-expires-nullable.sql
+++ b/server/migrations/20260610225502_remotesession-access-expires-nullable.sql
@@ -1,0 +1,2 @@
+-- Modify "remote_sessions" table
+ALTER TABLE "remote_sessions" ALTER COLUMN "access_expires_at" DROP NOT NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WVBCLel1OZey/KSO/cDGclwEuNw69pcUM35iJn7MkD8=
+h1:InI3x4/pzNjY+43h+EffX5yzXFLDe2LNIbMMngyyMq0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -214,3 +214,4 @@ h1:WVBCLel1OZey/KSO/cDGclwEuNw69pcUM35iJn7MkD8=
 20260609184933_compliance-api-chat-messages.sql h1:Lmdvxf3k5Zoh8S/CBheqgC3DDuncZUNFuY0Ou6TBacE=
 20260610154004_add-remote-session-issuer-name-logo.sql h1:7DrxQzMDBGz/Ev6VWf/x92A4yxzM/lq4c8tXcS9M6HE=
 20260610205050_prompt-based-policies-extend-risk-policies.sql h1:KaqQWR4qItyOjW8jQPkFtYAni3ki3hOuQZ5fg5ZGDGY=
+20260610225502_remotesession-access-expires-nullable.sql h1:NMY/XoTX/Aj/oaFCpqX1GuPrp48oz3TsGHIn/hBSJzY=


### PR DESCRIPTION
Lets the column represent "no known expiry" as NULL, for upstreams that omit expires_in and ship no refresh token (e.g. Slack non-rotating xoxp tokens). Today such tokens get a fabricated now+1h expiry, so the issuer gate rejects a still-valid token once the synthetic hour lapses and the MCP client 401-loops hourly forever. Metadata-only expand step; readers treat NULL as non-expiring in the follow-up app change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `remote_sessions.access_expires_at` nullable to represent “no known expiry” when upstreams omit `expires_in` (e.g., Slack non-rotating `xoxp` tokens). This removes the synthetic 1h expiry and unblocks AIS-115; a follow-up app change will treat NULL as non-expiring.

- **Migration**
  - ALTER TABLE: drop NOT NULL on `access_expires_at` (schema-only, safe expand).
  - No data backfill; existing rows stay as-is.

<sup>Written for commit 2d079cbe714688e3d63cdac286bab3e501f0519f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

