### PR TITLE
mig: add billing_metadata and chat_token_summaries tables for TUM

### DIFF
--- a/server/clickhouse/local/backfill/20260610201500_backfill-chat-token-summaries.sql
+++ b/server/clickhouse/local/backfill/20260610201500_backfill-chat-token-summaries.sql
@@ -1,0 +1,21 @@
+-- Clear any data the MV captured between its creation and this backfill
+TRUNCATE TABLE chat_token_summaries;
+
+-- Backfill chat_token_summaries with existing telemetry_logs data (bounded by
+-- the 30-day raw TTL — older history is unrecoverable, which is why this
+-- summary table exists going forward)
+INSERT INTO chat_token_summaries
+SELECT
+    gram_project_id,
+    toString(attributes.gen_ai.conversation.id) AS chat_id,
+    toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano)) AS time_bucket,
+    sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens,
+    toUInt64(countIf(
+        startsWith(gram_urn, 'tools:')
+        OR toString(attributes.gram.tool.urn) != ''
+        OR toString(attributes.gram.event.source) != ''
+        OR toString(attributes.gen_ai.usage.total_tokens) = ''
+    )) AS stored_event_count
+FROM telemetry_logs
+WHERE toString(attributes.gen_ai.conversation.id) != ''
+GROUP BY gram_project_id, chat_id, time_bucket;

--- a/server/clickhouse/local/golang_migrate/20260610201301_add-chat-token-summaries.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260610201301_add-chat-token-summaries.down.sql
@@ -1,0 +1,4 @@
+-- reverse: create "chat_token_summaries_mv" view
+DROP VIEW `chat_token_summaries_mv`;
+-- reverse: create "chat_token_summaries" table
+DROP TABLE `chat_token_summaries`;

--- a/server/clickhouse/local/golang_migrate/20260610201301_add-chat-token-summaries.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260610201301_add-chat-token-summaries.up.sql
@@ -1,0 +1,11 @@
+-- create "chat_token_summaries" table
+CREATE TABLE `chat_token_summaries` (
+  `gram_project_id` UUID,
+  `chat_id` String,
+  `time_bucket` DateTime('UTC'),
+  `total_tokens` SimpleAggregateFunction(sum, Int64),
+  `stored_event_count` SimpleAggregateFunction(sum, UInt64)
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`gram_project_id`, `chat_id`, `time_bucket`) ORDER BY (`gram_project_id`, `chat_id`, `time_bucket`) TTL time_bucket + toIntervalDay(730) SETTINGS index_granularity = 8192 COMMENT 'Per-chat daily token usage and stored-session evidence, retained beyond the raw telemetry TTL to support tokens-under-management billing across historical billing cycles';
+-- create "chat_token_summaries_mv" view
+CREATE MATERIALIZED VIEW `chat_token_summaries_mv` TO `chat_token_summaries` AS SELECT gram_project_id, toString(attributes.gen_ai.conversation.id) AS chat_id, toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano)) AS time_bucket, sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens, toUInt64(countIf(startsWith(gram_urn, 'tools:') OR (toString(attributes.gram.tool.urn) != '') OR (toString(attributes.gram.event.source) != '') OR (toString(attributes.gen_ai.usage.total_tokens) = ''))) AS stored_event_count FROM telemetry_logs WHERE toString(attributes.gen_ai.conversation.id) != '' GROUP BY gram_project_id, chat_id, time_bucket;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:WBjuovWQfWDNFlMiFXwzs7A+/MUS0LCABCgqu5EPCtg=
+h1:F5L5XN9IR7BiJ5QzKyI+V70Rlhx54kvHjQmZtkBIWY0=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -35,3 +35,4 @@ h1:WBjuovWQfWDNFlMiFXwzs7A+/MUS0LCABCgqu5EPCtg=
 20260428192411_fix-block-reason-merge.up.sql h1:wwVaPA93KqQ/rN62the3FDyQ2Blv4Z6F61q9w2oRjqE=
 20260430104153_add-authz-challenges-table.up.sql h1:xzosYIiO3fRbLIoIjkhqXnH0zxbhhusvO7HZ80u1w1M=
 20260508132129_add-remote-mcp-server-id-materialized-col.up.sql h1:ONn0mdquOH8+96lVqIInQ881GJ2lTMN+ldJ+LJ9O9KU=
+20260610201301_add-chat-token-summaries.up.sql h1:7Goi3IxTVdft+TIIMIdc/awuEoVKeG0ie2NBgK9dMm0=

--- a/server/clickhouse/migrations/20260610201256_add-chat-token-summaries.sql
+++ b/server/clickhouse/migrations/20260610201256_add-chat-token-summaries.sql
@@ -1,0 +1,11 @@
+-- Create "chat_token_summaries" table
+CREATE TABLE `chat_token_summaries` (
+  `gram_project_id` UUID,
+  `chat_id` String,
+  `time_bucket` DateTime('UTC'),
+  `total_tokens` SimpleAggregateFunction(sum, Int64),
+  `stored_event_count` SimpleAggregateFunction(sum, UInt64)
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`gram_project_id`, `chat_id`, `time_bucket`) ORDER BY (`gram_project_id`, `chat_id`, `time_bucket`) TTL time_bucket + toIntervalDay(730) SETTINGS index_granularity = 8192 COMMENT 'Per-chat daily token usage and stored-session evidence, retained beyond the raw telemetry TTL to support tokens-under-management billing across historical billing cycles';
+-- Create "chat_token_summaries_mv" view
+CREATE MATERIALIZED VIEW `chat_token_summaries_mv` TO `chat_token_summaries` AS SELECT gram_project_id, toString(attributes.gen_ai.conversation.id) AS chat_id, toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano)) AS time_bucket, sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens, toUInt64(countIf(startsWith(gram_urn, 'tools:') OR (toString(attributes.gram.tool.urn) != '') OR (toString(attributes.gram.event.source) != '') OR (toString(attributes.gen_ai.usage.total_tokens) = ''))) AS stored_event_count FROM telemetry_logs WHERE toString(attributes.gen_ai.conversation.id) != '' GROUP BY gram_project_id, chat_id, time_bucket;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:xQWfgO588JRN80LhFWCZqWe2Z+/QjLA1ZxyLu6fC03o=
+h1:NLFuXFXxO7P+SwNtuKP26j1YHfgNl8HPJUvPfkajccg=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -40,3 +40,4 @@ h1:xQWfgO588JRN80LhFWCZqWe2Z+/QjLA1ZxyLu6fC03o=
 20260428192408_fix-block-reason-merge.sql h1:bwCGH0lNK9KN4Utw7Bet0CUhtol0LX0BnMgofKKjOCo=
 20260430104149_add-authz-challenges-table.sql h1:1RrvgeCMeUvKN1I8R8whY46WfulVK85U/FZooAIhuu4=
 20260508132124_add-remote-mcp-server-id-materialized-col.sql h1:gmEL5G+Mnjf3KaYVglJ6xxHfCPR8R4Hk3wUn6Sib9sw=
+20260610201256_add-chat-token-summaries.sql h1:eSYSoO0mV5xGWnaTxAApgaj6MRfzuCgbZcdCEbeDEhU=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -300,6 +300,43 @@ SELECT
 FROM telemetry_logs
 GROUP BY gram_project_id, time_bucket;
 
+CREATE TABLE IF NOT EXISTS chat_token_summaries (
+    -- Key columns
+    gram_project_id UUID,
+    chat_id String,
+    time_bucket DateTime('UTC'),
+
+    -- Token usage reported for the chat during the bucket (rows carrying
+    -- gen_ai.usage.total_tokens, including OTEL-forwarded metrics)
+    total_tokens SimpleAggregateFunction(sum, Int64),
+
+    -- Count of non-metrics rows (tool calls, hook events, chat events without
+    -- token usage) evidencing that Gram stored session data for this chat.
+    -- Chats with zero stored events across a billing window are excluded from
+    -- tokens-under-management billing.
+    stored_event_count SimpleAggregateFunction(sum, UInt64)
+) ENGINE = AggregatingMergeTree
+ORDER BY (gram_project_id, chat_id, time_bucket)
+TTL time_bucket + INTERVAL 730 DAY
+SETTINGS index_granularity = 8192
+COMMENT 'Per-chat daily token usage and stored-session evidence, retained beyond the raw telemetry TTL to support tokens-under-management billing across historical billing cycles';
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS chat_token_summaries_mv TO chat_token_summaries AS
+SELECT
+    gram_project_id,
+    toString(attributes.gen_ai.conversation.id) AS chat_id,
+    toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano)) AS time_bucket,
+    sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens,
+    toUInt64(countIf(
+        startsWith(gram_urn, 'tools:')
+        OR toString(attributes.gram.tool.urn) != ''
+        OR toString(attributes.gram.event.source) != ''
+        OR toString(attributes.gen_ai.usage.total_tokens) = ''
+    )) AS stored_event_count
+FROM telemetry_logs
+WHERE toString(attributes.gen_ai.conversation.id) != ''
+GROUP BY gram_project_id, chat_id, time_bucket;
+
 CREATE TABLE IF NOT EXISTS attribute_keys (
     gram_project_id UUID,
     attribute_key String,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -76,6 +76,33 @@ CREATE TABLE IF NOT EXISTS organization_metadata (
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_workos_id_key
 ON organization_metadata (workos_id);
 
+-- Billing contract metadata for an organization. Currently holds the
+-- "tokens under management" (TUM) contract terms for enterprise accounts.
+CREATE TABLE IF NOT EXISTS billing_metadata (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+
+  -- Contracted monthly "tokens under management" allowance. NULL means no
+  -- contracted limit has been configured.
+  tum_monthly_token_limit BIGINT,
+  -- Email address to notify when TUM approaches or exceeds the contracted
+  -- limit. Alerting is not implemented yet; stored for future use.
+  alert_email TEXT CHECK (alert_email IS NULL OR alert_email <> ''),
+  -- Day of month (1-31) the billing cycle starts at 00:00 UTC. Clamped to the
+  -- last day of shorter months when computing cycle boundaries.
+  billing_cycle_anchor_day INT NOT NULL DEFAULT 1,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT billing_metadata_pkey PRIMARY KEY (id),
+  CONSTRAINT billing_metadata_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT billing_metadata_billing_cycle_anchor_day_check CHECK (billing_cycle_anchor_day >= 1 AND billing_cycle_anchor_day <= 31)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_organization_id_key
+ON billing_metadata (organization_id);
+
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
 ON organization_metadata (slug);
 

--- a/server/migrations/20260610231620_add-billing-metadata-table.sql
+++ b/server/migrations/20260610231620_add-billing-metadata-table.sql
@@ -1,0 +1,16 @@
+-- Create "billing_metadata" table
+CREATE TABLE "billing_metadata" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "tum_monthly_token_limit" bigint NULL,
+  "alert_email" text NULL,
+  "billing_cycle_anchor_day" integer NOT NULL DEFAULT 1,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "billing_metadata_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "billing_metadata_alert_email_check" CHECK ((alert_email IS NULL) OR (alert_email <> ''::text)),
+  CONSTRAINT "billing_metadata_billing_cycle_anchor_day_check" CHECK ((billing_cycle_anchor_day >= 1) AND (billing_cycle_anchor_day <= 31))
+);
+-- Create index "billing_metadata_organization_id_key" to table: "billing_metadata"
+CREATE UNIQUE INDEX "billing_metadata_organization_id_key" ON "billing_metadata" ("organization_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:InI3x4/pzNjY+43h+EffX5yzXFLDe2LNIbMMngyyMq0=
+h1:lfnkwKeqKPtxoKhWP9pbJdNZqfxAutAol16Iu58ttlg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -215,3 +215,4 @@ h1:InI3x4/pzNjY+43h+EffX5yzXFLDe2LNIbMMngyyMq0=
 20260610154004_add-remote-session-issuer-name-logo.sql h1:7DrxQzMDBGz/Ev6VWf/x92A4yxzM/lq4c8tXcS9M6HE=
 20260610205050_prompt-based-policies-extend-risk-policies.sql h1:KaqQWR4qItyOjW8jQPkFtYAni3ki3hOuQZ5fg5ZGDGY=
 20260610225502_remotesession-access-expires-nullable.sql h1:NMY/XoTX/Aj/oaFCpqX1GuPrp48oz3TsGHIn/hBSJzY=
+20260610231620_add-billing-metadata-table.sql h1:QtN9rqkm2eke8pugS7NNmlndanZj2mJ3axc5gqrY7/A=


### PR DESCRIPTION
## Summary

Schema groundwork for tokens under management (TUM) billing — migrations only, no app code. The feature PR stacks on top of this one.

### Postgres: `billing_metadata`

Per-organization billing contract terms:

- `tum_monthly_token_limit` (nullable bigint) — contracted monthly TUM allowance; NULL = unconfigured
- `alert_email` (nullable text) — threshold alert recipient (alerting itself ships later)
- `billing_cycle_anchor_day` (1–31, default 1) — billing cycle start day, 00:00 UTC

Unique on `organization_id`, FK to `organization_metadata` with cascade.

### ClickHouse: `chat_token_summaries` (+ MV)

Per-chat, per-UTC-day aggregate of `telemetry_logs` with a **2-year TTL** (raw logs only keep 30 days):

- `total_tokens` — sum of `gen_ai.usage.total_tokens` rows, including OTEL-forwarded metrics
- `stored_event_count` — count of non-metrics rows (tool calls, hook events, chat events) evidencing Gram actually stored the session

This is what lets TUM exclude OTEL-forwarded token usage from users without Gram installed, and keeps historical billing cycles computable after the raw TTL expires.

### Backfill

`server/clickhouse/local/backfill/...-backfill-chat-token-summaries.sql` follows the `backfill-metrics-summaries` precedent (#1579): **run manually after deploy**; it captures whatever raw data is still inside the 30-day TTL.

## Verification

- `mise db:diff` / `mise clickhouse:diff` generated; applied cleanly via `db:reset` + `db:migrate` + `clickhouse:migrate` locally
- DDL exercised by the feature PR's test suite (usage + telemetry packages, testenv Postgres + ClickHouse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
