### PR TITLE
fix(assistants): generate unique titles for assistant threads

### DIFF
--- a/.changeset/fix-assistant-thread-titles.md
+++ b/.changeset/fix-assistant-thread-titles.md
@@ -2,9 +2,5 @@
 "server": patch
 ---
 
-Fix project-assistant thread titles all rendering identically. Each thread's
-chat was seeded with the assistant's name, which the async title generator
-treats as a deliberately-chosen title and refuses to overwrite (its guard only
-replaces recognized sentinel defaults). Threads are now seeded with the
-`"New Chat"` placeholder so the generator activates and produces a unique title
-per thread from the first turn's content.
+Fix project-assistant thread titles all rendering as the assistant's name. New
+threads now get a unique title generated from the conversation's first turn.

--- a/.changeset/fix-assistant-thread-titles.md
+++ b/.changeset/fix-assistant-thread-titles.md
@@ -1,0 +1,10 @@
+---
+"server": patch
+---
+
+Fix project-assistant thread titles all rendering identically. Each thread's
+chat was seeded with the assistant's name, which the async title generator
+treats as a deliberately-chosen title and refuses to overwrite (its guard only
+replaces recognized sentinel defaults). Threads are now seeded with the
+`"New Chat"` placeholder so the generator activates and produces a unique title
+per thread from the first turn's content.

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1164,7 +1164,14 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 		ProjectID:      assistant.ProjectID,
 		OrganizationID: assistant.OrganizationID,
 		UserID:         conv.ToPGTextEmpty(dashboardChatUserID(sourceKind, normalizedPayloadJSON)),
-		Title:          conv.ToPGText(assistant.Name),
+		// Seed the default placeholder ("New Chat"), NOT the assistant name. The
+		// async title generator only (re)titles a chat whose current title is one
+		// of its recognized sentinel defaults (see isDefaultChatTitle in
+		// background/activities/generate_chat_title.go); any other value is treated
+		// as a deliberately-chosen title and left alone. Seeding assistant.Name —
+		// identical across every thread of the same assistant — made the generator
+		// short-circuit, so all threads kept the assistant name as their title.
+		Title: conv.ToPGText("New Chat"),
 	}); err != nil {
 		return EnqueueResult{}, fmt.Errorf("upsert assistant chat: %w", err)
 	}

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1164,10 +1164,7 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 		ProjectID:      assistant.ProjectID,
 		OrganizationID: assistant.OrganizationID,
 		UserID:         conv.ToPGTextEmpty(dashboardChatUserID(sourceKind, normalizedPayloadJSON)),
-		// Seed the shared placeholder, not assistant.Name: the async title
-		// generator only overwrites a recognized sentinel, so a per-assistant name
-		// (identical across all its threads) would stick forever.
-		Title: conv.ToPGText(chat.DefaultChatTitle),
+		Title:          conv.ToPGText(chat.DefaultChatTitle),
 	}); err != nil {
 		return EnqueueResult{}, fmt.Errorf("upsert assistant chat: %w", err)
 	}

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1164,14 +1164,10 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 		ProjectID:      assistant.ProjectID,
 		OrganizationID: assistant.OrganizationID,
 		UserID:         conv.ToPGTextEmpty(dashboardChatUserID(sourceKind, normalizedPayloadJSON)),
-		// Seed the default placeholder ("New Chat"), NOT the assistant name. The
-		// async title generator only (re)titles a chat whose current title is one
-		// of its recognized sentinel defaults (see isDefaultChatTitle in
-		// background/activities/generate_chat_title.go); any other value is treated
-		// as a deliberately-chosen title and left alone. Seeding assistant.Name —
-		// identical across every thread of the same assistant — made the generator
-		// short-circuit, so all threads kept the assistant name as their title.
-		Title: conv.ToPGText("New Chat"),
+		// Seed the shared placeholder, not assistant.Name: the async title
+		// generator only overwrites a recognized sentinel, so a per-assistant name
+		// (identical across all its threads) would stick forever.
+		Title: conv.ToPGText(chat.DefaultChatTitle),
 	}); err != nil {
 		return EnqueueResult{}, fmt.Errorf("upsert assistant chat: %w", err)
 	}

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -43,8 +43,6 @@ type GenerateChatTitleArgs struct {
 }
 
 const (
-	// defaultChatTitle is the shared placeholder seeded at chat creation. It
-	// aliases chat.DefaultChatTitle so the seed site and this guard can't drift.
 	defaultChatTitle       = chat.DefaultChatTitle
 	DefaultClaudeChatTitle = "Claude Code Session"
 	DefaultCoworkChatTitle = "Cowork Session"
@@ -167,7 +165,7 @@ func (g *GenerateChatTitle) generateTitle(ctx context.Context, orgID, projectID 
 		"Return ONLY the title text, no quotes or explanation. " +
 		"IMPORTANT: The title must directly relate to the content of the messages. " +
 		"Do NOT expand, interpret, or replace abbreviations or acronyms — use the user's exact terminology. " +
-		"If the conversation is a greeting, vague, or lacks a clear topic, return exactly: New Chat"
+		"If the conversation is a greeting, vague, or lacks a clear topic, return exactly: " + defaultChatTitle
 
 	response, err := g.chatClient.GetCompletion(titleCtx, openrouter.CompletionRequest{
 		OrgID:     orgID,

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -42,7 +43,9 @@ type GenerateChatTitleArgs struct {
 }
 
 const (
-	defaultChatTitle       = "New Chat"
+	// defaultChatTitle is the shared placeholder seeded at chat creation. It
+	// aliases chat.DefaultChatTitle so the seed site and this guard can't drift.
+	defaultChatTitle       = chat.DefaultChatTitle
 	DefaultClaudeChatTitle = "Claude Code Session"
 	DefaultCoworkChatTitle = "Cowork Session"
 	DefaultClaudeAmbiguous = "Claude Session"

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -975,7 +975,7 @@ func (s *Service) GenerateTitle(ctx context.Context, payload *gen.GenerateTitleP
 
 	// Return current title from DB. Title generation happens asynchronously via
 	// Temporal after first completion; title will be available on next list()/fetch().
-	title := "New Chat"
+	title := DefaultChatTitle
 	if chat.Title.Valid && chat.Title.String != "" {
 		title = chat.Title.String
 	}

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -17,6 +17,15 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
+// DefaultChatTitle is the placeholder a chat is seeded with before the async
+// title generator produces a real one. It MUST stay one of the sentinels
+// recognized by that generator's isDefaultChatTitle guard
+// (background/activities/generate_chat_title.go) — any other value is treated as
+// a deliberately-chosen title and never overwritten. Callers creating a chat
+// should seed this constant rather than a literal so the seed and the guard
+// can't drift apart.
+const DefaultChatTitle = "New Chat"
+
 // ChatMessageCaptureStrategy captures completion messages to the database.
 // It implements the MessageCaptureStrategy interface.
 type ChatMessageCaptureStrategy struct {
@@ -74,7 +83,7 @@ func (s *ChatMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, requ
 		OrganizationID: orgID,
 		UserID:         conv.ToPGText(userID),
 		ExternalUserID: conv.ToPGText(externalUserID),
-		Title:          conv.ToPGText("New Chat"),
+		Title:          conv.ToPGText(DefaultChatTitle),
 	})
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to create chat", attr.SlogError(err))

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -17,13 +17,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
-// DefaultChatTitle is the placeholder a chat is seeded with before the async
-// title generator produces a real one. It MUST stay one of the sentinels
-// recognized by that generator's isDefaultChatTitle guard
-// (background/activities/generate_chat_title.go) — any other value is treated as
-// a deliberately-chosen title and never overwritten. Callers creating a chat
-// should seed this constant rather than a literal so the seed and the guard
-// can't drift apart.
+// DefaultChatTitle is the placeholder a chat is seeded with until the async
+// title generator produces a real one. It must be a sentinel recognized by
+// isDefaultChatTitle (background/activities/generate_chat_title.go), or the
+// chat is treated as deliberately titled and never retitled.
 const DefaultChatTitle = "New Chat"
 
 // ChatMessageCaptureStrategy captures completion messages to the database.


### PR DESCRIPTION
## What

Project-assistant thread titles all rendered identically (the assistant's name) instead of a unique per-thread summary. This makes the thread-history list unusable for distinguishing conversations.

## Root cause

A seed-vs-guard mismatch between the two halves of the title pipeline:

- **Seed** — every assistant thread's chat is created via `UpsertAssistantChat` with `Title: assistant.Name` (`server/internal/assistants/service.go`). That value is identical across all threads of a given assistant.
- **Guard** — the async title generator (`server/internal/background/activities/generate_chat_title.go`) only (re)titles a chat whose current title matches its allowlist of sentinel defaults (`isDefaultChatTitle`: `"New Chat"`, `"Claude Code Session"`, …). The assistant name isn't a sentinel, so the generator treated it as a deliberately-chosen title and early-returned on every turn — never calling the LLM.

`UpsertAssistantChat`'s `ON CONFLICT` intentionally doesn't touch `title`, so the seeded value was set once and stuck forever.

## Fix

Seed the chat with the `"New Chat"` placeholder (the same literal the regular chat-capture path uses) instead of the assistant name. The generator's guard now recognizes a sentinel, proceeds, strips the `<message-context>` envelope from the first turn, and produces a unique title per thread.

## Scope / caveats

- Fixes **new** threads going forward. Existing threads already titled with the assistant name are not retroactively re-titled (their title isn't a sentinel). A one-off backfill can be done separately if desired.

## Testing

- `mise build:server` — compiles clean
- `go test ./server/internal/background/activities/ -run Title` — pass
- `go test ./server/internal/assistants/` — full suite passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate unique titles for project-assistant threads by seeding new chats with `chat.DefaultChatTitle` instead of the assistant name. The sentinel is now a shared constant used by chat creation, the title guard, and the prompt to prevent drift; existing threads keep their current titles.

<sup>Written for commit 3803c7662e3089aaaa8acd42f3e86d24bc773770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

