### PR TITLE
feat(observe): filter tool logs by source (agent type)

### DIFF
--- a/.changeset/tool-logs-source-filter.md
+++ b/.changeset/tool-logs-source-filter.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add a "Source" filter to the Tools logs/insights pages so tool traces can be narrowed by originating agent (Claude Code, Cursor, Codex, …).

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -183,6 +183,8 @@ export function InsightsToolsContent(): JSX.Element {
     handleServerSelectionChange,
     userEmailOptions,
     handleUserEmailSelectionChange,
+    hookSourceOptions,
+    handleHookSourceSelectionChange,
     addFilter,
     handleHookTypesChange,
     dateRange,
@@ -316,6 +318,8 @@ export function InsightsToolsContent(): JSX.Element {
           onServerSelectionChange={handleServerSelectionChange}
           userEmailOptions={userEmailOptions}
           onUserEmailSelectionChange={handleUserEmailSelectionChange}
+          sourceOptions={hookSourceOptions}
+          onSourceSelectionChange={handleHookSourceSelectionChange}
           activeFilters={activeFilters}
           addFilter={addFilter}
           selectedHookTypes={selectedHookTypes}
@@ -350,6 +354,8 @@ function HooksInnerContent({
   onServerSelectionChange,
   userEmailOptions,
   onUserEmailSelectionChange,
+  sourceOptions,
+  onSourceSelectionChange,
   activeFilters,
   addFilter,
   selectedHookTypes,
@@ -379,6 +385,8 @@ function HooksInnerContent({
   onServerSelectionChange: (values: string[]) => void;
   userEmailOptions: string[];
   onUserEmailSelectionChange: (values: string[]) => void;
+  sourceOptions: string[];
+  onSourceSelectionChange: (values: string[]) => void;
   activeFilters: FilterChip[];
   addFilter: (chip: FilterChip) => void;
   selectedHookTypes: TypesToInclude[];
@@ -437,6 +445,8 @@ function HooksInnerContent({
             onServerSelectionChange={onServerSelectionChange}
             userEmailOptions={userEmailOptions}
             onUserEmailSelectionChange={onUserEmailSelectionChange}
+            sourceOptions={sourceOptions}
+            onSourceSelectionChange={onSourceSelectionChange}
             activeFilters={activeFilters}
             selectedTypes={selectedHookTypes}
             onTypesChange={onHookTypesChange}

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -82,6 +82,8 @@ export function LogsTools(): JSX.Element {
     handleServerSelectionChange,
     userEmailOptions,
     handleUserEmailSelectionChange,
+    hookSourceOptions,
+    handleHookSourceSelectionChange,
     addFilter,
     handleHookTypesChange,
     dateRange,
@@ -221,6 +223,8 @@ export function LogsTools(): JSX.Element {
             onServerSelectionChange={handleServerSelectionChange}
             userEmailOptions={userEmailOptions}
             onUserEmailSelectionChange={handleUserEmailSelectionChange}
+            sourceOptions={hookSourceOptions}
+            onSourceSelectionChange={handleHookSourceSelectionChange}
             activeFilters={activeFilters}
             addFilter={addFilter}
             selectedHookTypes={selectedHookTypes}
@@ -261,6 +265,8 @@ function HooksInnerContent({
   onServerSelectionChange,
   userEmailOptions,
   onUserEmailSelectionChange,
+  sourceOptions,
+  onSourceSelectionChange,
   activeFilters,
   selectedHookTypes,
   onHookTypesChange,
@@ -294,6 +300,8 @@ function HooksInnerContent({
   onServerSelectionChange: (values: string[]) => void;
   userEmailOptions: string[];
   onUserEmailSelectionChange: (values: string[]) => void;
+  sourceOptions: string[];
+  onSourceSelectionChange: (values: string[]) => void;
   activeFilters: FilterChip[];
   addFilter: (chip: FilterChip) => void;
   selectedHookTypes: TypesToInclude[];
@@ -349,6 +357,8 @@ function HooksInnerContent({
             onServerSelectionChange={onServerSelectionChange}
             userEmailOptions={userEmailOptions}
             onUserEmailSelectionChange={onUserEmailSelectionChange}
+            sourceOptions={sourceOptions}
+            onSourceSelectionChange={onSourceSelectionChange}
             activeFilters={activeFilters}
             selectedTypes={selectedHookTypes}
             onTypesChange={onHookTypesChange}

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -20,6 +20,9 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import type { useServerNameMappings } from "@/hooks/useServerNameMappings";
+import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
+
+const HOOK_SOURCE_FILTER_PATH = "gram.hook.source";
 
 export interface FilterChip {
   display: string;
@@ -38,6 +41,8 @@ export function ObserveFilterBar({
   onServerSelectionChange,
   userEmailOptions,
   onUserEmailSelectionChange,
+  sourceOptions,
+  onSourceSelectionChange,
   roleOptions,
   selectedRoleIds,
   onRoleSelectionChange,
@@ -58,6 +63,8 @@ export function ObserveFilterBar({
   onServerSelectionChange: (values: string[]) => void;
   userEmailOptions: string[];
   onUserEmailSelectionChange: (values: string[]) => void;
+  sourceOptions: string[];
+  onSourceSelectionChange: (values: string[]) => void;
   roleOptions: Array<{ id: string; name: string }>;
   selectedRoleIds: string[];
   onRoleSelectionChange: (values: string[]) => void;
@@ -92,6 +99,15 @@ export function ObserveFilterBar({
     [activeFilters],
   );
 
+  const selectedSources = useMemo(
+    () =>
+      activeFilters
+        .filter((f) => f.path === HOOK_SOURCE_FILTER_PATH)
+        .flatMap((f) => f.filters)
+        .filter(Boolean),
+    [activeFilters],
+  );
+
   const serverOptionsWithDisplayNames = useMemo(() => {
     const rawToDisplay = serverNameMappings?.rawToDisplay;
     return serverOptions.map((rawName) => ({
@@ -99,6 +115,22 @@ export function ObserveFilterBar({
       value: rawName,
     }));
   }, [serverOptions, serverNameMappings?.rawToDisplay]);
+
+  // The raw hook_source value (e.g. "claude-code") is shown verbatim — matching
+  // the table row — and paired with its brand icon. HookSourceIcon needs a
+  // `source` prop, so bind it per option to satisfy MultiSelect's
+  // `icon: ComponentType<{ className }>` contract.
+  const sourceOptionsWithIcons = useMemo(
+    () =>
+      sourceOptions.map((source) => ({
+        label: source,
+        value: source,
+        icon: ({ className }: { className?: string }) => (
+          <HookSourceIcon source={source} className={className} />
+        ),
+      })),
+    [sourceOptions],
+  );
 
   return (
     <div
@@ -127,6 +159,15 @@ export function ObserveFilterBar({
         defaultValue={selectedRoleIds}
         onValueChange={onRoleSelectionChange}
         placeholder="Filter by role"
+        className="min-w-[160px] flex-1"
+        hideSelectAll
+        singleLine
+      />
+      <MultiSelect
+        options={sourceOptionsWithIcons}
+        defaultValue={selectedSources}
+        onValueChange={onSourceSelectionChange}
+        placeholder="Filter by source"
         className="min-w-[160px] flex-1"
         hideSelectAll
         singleLine

--- a/client/dashboard/src/components/observe/useObserveFilters.test.tsx
+++ b/client/dashboard/src/components/observe/useObserveFilters.test.tsx
@@ -264,4 +264,42 @@ describe("useObserveFilters", () => {
     act(() => result.current.filters.handleRoleSelectionChange([]));
     expect(result.current.filters.selectedRoleIds).toEqual([]);
   });
+
+  it("parses source URL param into a gram.hook.source chip and logFilters", () => {
+    const { result } = renderHook(() => useObserveFilters(), {
+      wrapper: makeWrapper("/?source=claude-code,codex"),
+    });
+    expect(result.current.activeFilters).toEqual([
+      {
+        display: "claude-code, codex",
+        filters: ["claude-code", "codex"],
+        path: "gram.hook.source",
+      },
+    ]);
+    expect(result.current.logFilters).toEqual([
+      {
+        path: "gram.hook.source",
+        operator: Operator.In,
+        values: ["claude-code", "codex"],
+      },
+    ]);
+  });
+
+  it("handleHookSourceSelectionChange sets and clears the source URL param", () => {
+    const { result } = renderHook(() => useObserveFiltersWithNavigation(), {
+      wrapper: makeWrapper("/"),
+    });
+    act(() =>
+      result.current.filters.handleHookSourceSelectionChange(["cursor"]),
+    );
+    expect(result.current.filters.activeFilters).toEqual([
+      {
+        display: "cursor",
+        filters: ["cursor"],
+        path: "gram.hook.source",
+      },
+    ]);
+    act(() => result.current.filters.handleHookSourceSelectionChange([]));
+    expect(result.current.filters.activeFilters).toEqual([]);
+  });
 });

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -21,6 +21,7 @@ import { useQuery } from "@tanstack/react-query";
 
 const SERVER_FILTER_PATH = "gram.tool_call.source";
 const USER_EMAIL_FILTER_PATH = "user.email";
+const HOOK_SOURCE_FILTER_PATH = "gram.hook.source";
 
 // Sentinel labels the hooks summary substitutes for empty values. They are
 // display-only ("local" for a missing server, "Unknown" for a missing email)
@@ -62,6 +63,7 @@ function buildActiveFilters(searchParams: URLSearchParams): FilterChip[] {
   return [
     parseFilterParam(searchParams.get("server"), SERVER_FILTER_PATH),
     parseFilterParam(searchParams.get("user"), USER_EMAIL_FILTER_PATH),
+    parseFilterParam(searchParams.get("source"), HOOK_SOURCE_FILTER_PATH),
   ].filter((filter): filter is FilterChip => filter !== null);
 }
 
@@ -212,6 +214,21 @@ function useObserveFiltersImpl() {
     return [...new Set([...known, ...selected])];
   }, [filterOptionsSummary, activeFilters]);
 
+  // The hooks summary breakdown carries hook_source ("claude-code", "cursor",
+  // "codex", ...) per (user, server, source, tool) row. Collapse it to the
+  // distinct set of agents seen in the window so the dropdown only offers
+  // sources that actually have data, mirroring serverOptions/userEmailOptions.
+  const hookSourceOptions = useMemo(() => {
+    const selected = activeFilters
+      .filter((f) => f.path === HOOK_SOURCE_FILTER_PATH)
+      .flatMap((f) => f.filters)
+      .filter(Boolean);
+    const known = (filterOptionsSummary?.breakdown ?? [])
+      .map((b) => b.hookSource)
+      .filter(Boolean);
+    return [...new Set([...known, ...selected])];
+  }, [filterOptionsSummary, activeFilters]);
+
   const handleUserEmailSelectionChange = useCallback(
     (values: string[]) => {
       setSearchParams(
@@ -239,6 +256,24 @@ function useObserveFiltersImpl() {
             next.set("server", values.join(","));
           } else {
             next.delete("server");
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleHookSourceSelectionChange = useCallback(
+    (values: string[]) => {
+      setSearchParams(
+        (urlPrev) => {
+          const next = new URLSearchParams(urlPrev);
+          if (values.length > 0) {
+            next.set("source", values.join(","));
+          } else {
+            next.delete("source");
           }
           return next;
         },
@@ -278,6 +313,8 @@ function useObserveFiltersImpl() {
             next.set("server", merged.filters.join(","));
           } else if (chip.path === USER_EMAIL_FILTER_PATH) {
             next.set("user", merged.filters.join(","));
+          } else if (chip.path === HOOK_SOURCE_FILTER_PATH) {
+            next.set("source", merged.filters.join(","));
           }
           return next;
         },
@@ -332,6 +369,8 @@ function useObserveFiltersImpl() {
     handleServerSelectionChange,
     userEmailOptions,
     handleUserEmailSelectionChange,
+    hookSourceOptions,
+    handleHookSourceSelectionChange,
     addFilter,
     handleHookTypesChange,
     setDateRangeParam,


### PR DESCRIPTION
## Summary

Adds a **Source** filter to the tool logs UI so traces can be narrowed by the
originating agent — `claude-code`, `cursor`, `codex`, etc. The control lands on
the shared `ObserveFilterBar`, so it appears on both **`/logs/tools`** and
**`/insights/tools`**.

Resolves [AGE-2483](https://linear.app/speakeasy/issue/AGE-2483).

## Why this is frontend-only

The agent identity is already captured and queryable end-to-end:

- `hook_source` (`attributes.gram.hook.source`) is a materialized ClickHouse
  column, populated per-agent by the hook handlers.
- `listHooksTraces` (which the Tools pages already call) accepts a generic
  `LogFilter[]`, and its paths resolve through `materializedColumns`
  (`gram.hook.source → hook_source`).
- The existing **server** and **email** filters already ride this exact
  pipeline: `FilterChip{path}` → `buildLogFilters()` → `LogFilter{operator:"in"}`
  → `listHooksTraces`.

The new filter just registers one more `path` (`gram.hook.source`) on that
pipeline plus one dropdown — **no backend, Goa, SQL, or SDK changes.**

## Changes

- `useObserveFilters.ts` — new `gram.hook.source` axis: `source` URL param →
  `FilterChip`, dynamic `hookSourceOptions` derived from the hooks-summary
  `breakdown`, a selection handler, and an `addFilter` branch. `logFilters`
  aggregates it automatically.
- `ObserveFilterBar.tsx` — "Filter by source" `MultiSelect`, options rendered
  with their brand icon via the existing `HookSourceIcon`.
- `LogsTools.tsx` / `InsightsTools.tsx` — prop threading.
- `useObserveFilters.test.tsx` — source param round-trip + handler tests.

## Decisions

- **Options are dynamic** — only agents present in the selected time window are
  offered (matches the server/email dropdowns; auto-handles new agents).
- **Labels are the raw `hook_source` value + icon** — identical to the table row.
- **Both Tools pages** get the filter (shared `ObserveFilterBar`), since they
  query the same underlying hook data.

## Testing

- `pnpm -F dashboard type-check` → pass
- `pnpm -F dashboard test useObserveFilters` → 9/9 pass (7 baseline + 2 new)
- `pnpm -F dashboard lint` → pass
