### PR TITLE
feat(dashboard): dock dismissed onboarding banner to a sidebar resume button

### DIFF
--- a/client/dashboard/src/App.css
+++ b/client/dashboard/src/App.css
@@ -86,6 +86,128 @@
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* Onboarding CTA "genie": the dismissable banner and the sidebar resume button
+   share the `onboarding-cta` view-transition-name, so dismissing/resuming morphs
+   one box into the other (see `useOnboardingCta`). The UA keeps the position/size
+   morph on the group; the snapshots get squash-and-stretch keyframes so the swap
+   reads like the macOS genie rather than a flat slide. */
+::view-transition-group(onboarding-cta) {
+  animation-duration: 500ms;
+  animation-timing-function: cubic-bezier(0.65, 0, 0.25, 1);
+}
+
+/* Mid-flight sag on the snapshot pair — the whole thing droops while being
+   sucked toward the dock slot, instead of flying a straight line. Composes
+   with the UA's position/size morph on the parent group. */
+::view-transition-image-pair(onboarding-cta) {
+  animation: 500ms ease-in-out both onboarding-cta-genie-sag;
+}
+
+@keyframes onboarding-cta-genie-sag {
+  0%,
+  100% {
+    transform: none;
+  }
+  45% {
+    transform: translateY(7%) scaleY(1.1);
+  }
+}
+
+/* Old surface: the funnel. A perspective tilt tapers the bottom edge toward
+   the dock slot while the body stretches and leans, then pours through and
+   fades. Transform + opacity only — clip-path animation here forces main-thread
+   painting every frame and visibly stutters the skew, while transforms stay on
+   the compositor. Replaces the default cross-fade, so opacity must be animated
+   here too. */
+::view-transition-old(onboarding-cta) {
+  transform-origin: 50% 0%;
+  animation: 500ms cubic-bezier(0.65, 0, 0.25, 1) both onboarding-cta-genie-out;
+}
+
+@keyframes onboarding-cta-genie-out {
+  0% {
+    opacity: 1;
+    transform: none;
+  }
+  40% {
+    opacity: 1;
+    transform: perspective(500px) rotateX(28deg) scaleY(1.15);
+  }
+  75% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0;
+    transform: perspective(500px) rotateX(40deg) skewX(-8deg) scaleY(1.3);
+  }
+}
+
+/* New surface: stays hidden while the old one pours in, then unfurls out of
+   the slot. Uniform scale only — non-uniform scale visibly stretches the
+   banner's text when resuming from the docked button; the rotateX taper
+   supplies the genie warp without distorting glyph proportions. */
+::view-transition-new(onboarding-cta) {
+  transform-origin: 50% 0%;
+  animation: 500ms cubic-bezier(0.05, 0.7, 0.1, 1) both onboarding-cta-genie-in;
+}
+
+@keyframes onboarding-cta-genie-in {
+  0%,
+  55% {
+    opacity: 0;
+    transform: perspective(500px) rotateX(28deg) scale(0.9) skewX(-4deg);
+  }
+  82% {
+    opacity: 1;
+    transform: perspective(500px) rotateX(-3deg) scale(1.01);
+  }
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Content layer: the text/icons inside both surfaces carry their own
+   view-transition-name, which excludes them from the container snapshots —
+   the genie warps an empty surface. The content layer itself must not fly:
+   its group snaps to the destination geometry immediately (near-zero
+   duration), the outgoing text vanishes on click, and the incoming text
+   fades in at its final, static position — never scaled, never stretched. */
+::view-transition-group(onboarding-cta-content) {
+  animation-duration: 0.001s;
+}
+
+::view-transition-old(onboarding-cta-content) {
+  animation: none;
+  opacity: 0;
+}
+
+::view-transition-new(onboarding-cta-content) {
+  animation: 500ms linear both onboarding-cta-content-in;
+}
+
+@keyframes onboarding-cta-content-in {
+  0%,
+  86% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(onboarding-cta),
+  ::view-transition-image-pair(onboarding-cta),
+  ::view-transition-old(onboarding-cta),
+  ::view-transition-new(onboarding-cta),
+  ::view-transition-group(onboarding-cta-content),
+  ::view-transition-old(onboarding-cta-content),
+  ::view-transition-new(onboarding-cta-content) {
+    animation: none;
+  }
+}
+
 /* Dotted background scroll animation for catalog cards */
 @keyframes scroll-dots {
   from {

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -15,6 +15,8 @@ import {
 import { GramLogo } from "./gram-logo";
 import { CommandPaletteTrigger } from "./command-palette/CommandPaletteTrigger";
 import { WorkspaceSwitcher } from "./workspace-switcher";
+import { OnboardingResumeButton } from "./onboarding-resume-button";
+import { SidebarFooterAction } from "./sidebar-footer-action";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 import { useSidebar } from "@/components/ui/sidebar-context";
 import { useSlugs } from "@/contexts/Sdk";
@@ -26,7 +28,7 @@ import { useProjectNavRoutes } from "@/hooks/useProjectNavRoutes";
 import { AppRoute, useOrgRoutes, useRoutes } from "@/routes";
 import { useGetPeriodUsage } from "@gram/client/react-query";
 import { cn, Icon, Stack } from "@speakeasy-api/moonshine";
-import { MinusIcon, TestTube2Icon, Undo2 } from "lucide-react";
+import { MinusIcon, Settings, TestTube2Icon } from "lucide-react";
 import * as React from "react";
 import { useMemo, useState } from "react";
 import { Link } from "react-router";
@@ -280,22 +282,17 @@ export function AppSidebar({
             </SidebarMenu>
           </NavGroupProvider>
         )}
-
-        <div className="mt-auto px-2 py-3 group-data-[collapsible=icon]:px-0">
-          <Link
-            to={`/${orgSlug}`}
-            title="Back to org"
-            className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 px-2 py-1 text-sm transition-colors group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 hover:no-underline"
-          >
-            <Undo2 className="h-3.5 w-3.5" />
-            <span className="group-data-[collapsible=icon]:hidden">
-              Back to org
-            </span>
-          </Link>
-        </div>
       </SidebarContent>
       <SidebarFooter className="border-t">
         <FreeTierExceededNotification />
+        <div className="mb-2 flex flex-col gap-1.5">
+          <OnboardingResumeButton />
+          <SidebarFooterAction
+            to={`/${orgSlug}`}
+            icon={Settings}
+            label="Organization settings"
+          />
+        </div>
         <SidebarUserMenu />
       </SidebarFooter>
       <FeatureRequestModal

--- a/client/dashboard/src/components/onboarding-banner.tsx
+++ b/client/dashboard/src/components/onboarding-banner.tsx
@@ -1,54 +1,33 @@
 import { Button } from "@/components/ui/button";
 import { Type } from "@/components/ui/type";
-import { useSlugs } from "@/contexts/Sdk";
-import { useProductTier } from "@/hooks/useProductTier";
-import { useRBAC } from "@/hooks/useRBAC";
+import {
+  ONBOARDING_CTA_CONTENT_VT_CLASS,
+  ONBOARDING_CTA_VT_CLASS,
+  useOnboardingCta,
+} from "@/hooks/useOnboardingCta";
+import { cn } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
 import { ArrowRight, Wrench } from "lucide-react";
-import { useState } from "react";
-
-function storageKey(orgSlug: string) {
-  return `gram-onboarding-banner-dismissed:${orgSlug}`;
-}
-
-function getStoredDismissed(orgSlug: string): boolean {
-  try {
-    return localStorage.getItem(storageKey(orgSlug)) === "true";
-  } catch {
-    return false;
-  }
-}
-
-function storeDismissed(orgSlug: string) {
-  try {
-    localStorage.setItem(storageKey(orgSlug), "true");
-  } catch {
-    // localStorage unavailable
-  }
-}
 
 export function OnboardingBanner(): JSX.Element | null {
-  const { orgSlug } = useSlugs();
-  const { hasScope } = useRBAC();
-  const productTier = useProductTier();
   const orgRoutes = useOrgRoutes();
-  const [dismissed, setDismissed] = useState(() =>
-    orgSlug ? getStoredDismissed(orgSlug) : false,
-  );
+  const { eligible, dismissed, dismiss } = useOnboardingCta();
 
-  if (!orgSlug) return null;
-  if (productTier !== "enterprise") return null;
-  if (!hasScope("org:admin")) return null;
-  if (dismissed) return null;
-
-  const dismiss = () => {
-    storeDismissed(orgSlug);
-    setDismissed(true);
-  };
+  if (!eligible || dismissed) return null;
 
   return (
-    <div className="border-border/60 bg-muted/20 dark:bg-white/[0.03] w-full border-b">
-      <div className="mx-auto flex max-w-7xl items-center gap-4 px-8 py-5">
+    <div
+      className={cn(
+        "border-border/60 bg-muted/20 dark:bg-white/[0.03] w-full border-b",
+        ONBOARDING_CTA_VT_CLASS,
+      )}
+    >
+      <div
+        className={cn(
+          "mx-auto flex max-w-7xl items-center gap-4 px-8 py-5",
+          ONBOARDING_CTA_CONTENT_VT_CLASS,
+        )}
+      >
         <div className="bg-background border-border/60 flex size-10 shrink-0 items-center justify-center rounded-lg border shadow-sm">
           <Wrench className="text-foreground size-5" strokeWidth={1.75} />
         </div>

--- a/client/dashboard/src/components/onboarding-resume-button.tsx
+++ b/client/dashboard/src/components/onboarding-resume-button.tsx
@@ -1,0 +1,43 @@
+import {
+  ONBOARDING_CTA_CONTENT_VT_CLASS,
+  ONBOARDING_CTA_VT_CLASS,
+  useOnboardingCta,
+} from "@/hooks/useOnboardingCta";
+import { useOrgRoutes } from "@/routes";
+import { ArrowUpRight, Wrench } from "lucide-react";
+import { SidebarFooterAction } from "./sidebar-footer-action";
+
+/**
+ * Persistent entry point back into onboarding, shown as a standout item in the
+ * sidebar footer once the {@link OnboardingBanner} has been dismissed. It shares
+ * a view-transition name with the banner, so dismissing the banner genies it down
+ * into this button, and the arrow-up control genies it back to the top (see
+ * `useOnboardingCta`).
+ */
+export function OnboardingResumeButton(): JSX.Element | null {
+  const orgRoutes = useOrgRoutes();
+  const { eligible, dismissed, resume } = useOnboardingCta();
+
+  if (!eligible || !dismissed) return null;
+
+  return (
+    <SidebarFooterAction
+      to={orgRoutes.setup.href()}
+      icon={Wrench}
+      label="Finish setup"
+      className={ONBOARDING_CTA_VT_CLASS}
+      contentClassName={ONBOARDING_CTA_CONTENT_VT_CLASS}
+      trailing={
+        <button
+          type="button"
+          aria-label="Restore setup banner"
+          title="Restore setup banner"
+          onClick={resume}
+          className="text-muted-foreground hover:text-foreground hover:bg-background/80 shrink-0 rounded-md p-1 transition-colors group-data-[collapsible=icon]:hidden"
+        >
+          <ArrowUpRight className="size-3.5" />
+        </button>
+      }
+    />
+  );
+}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -23,6 +23,7 @@ import { Link } from "react-router";
 import { GramLogo } from "./gram-logo";
 import { CommandPaletteTrigger } from "./command-palette/CommandPaletteTrigger";
 import { SidebarNavSkeleton } from "./sidebar-nav-skeleton";
+import { OnboardingResumeButton } from "./onboarding-resume-button";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 import { WorkspaceSwitcher } from "./workspace-switcher";
 
@@ -213,6 +214,7 @@ export function OrgSidebar({
         )}
       </SidebarContent>
       <SidebarFooter className="border-t">
+        <OnboardingResumeButton />
         <SidebarUserMenu />
       </SidebarFooter>
     </Sidebar>

--- a/client/dashboard/src/components/sidebar-footer-action.tsx
+++ b/client/dashboard/src/components/sidebar-footer-action.tsx
@@ -1,0 +1,55 @@
+import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+
+/**
+ * A raised, bordered link card that stands out from the sidebar surface — used
+ * to stack standout actions (e.g. "Finish setup", "Organization settings") just
+ * above the user bar in the sidebar footer. Collapses to an icon when the
+ * sidebar does. `trailing` renders a secondary control (e.g. a restore button)
+ * on the card's right edge, outside the link's click area.
+ */
+export function SidebarFooterAction({
+  to,
+  icon: Icon,
+  label,
+  className,
+  contentClassName,
+  trailing,
+}: {
+  to: string;
+  icon: LucideIcon;
+  label: string;
+  className?: string;
+  contentClassName?: string;
+  trailing?: ReactNode;
+}): JSX.Element {
+  return (
+    <div
+      className={cn(
+        "hover:bg-accent border-border/60 text-foreground flex items-center gap-2 rounded-lg border bg-white px-2.5 py-1.5 text-sm shadow-sm transition-colors group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 dark:bg-zinc-900",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "flex w-full min-w-0 items-center gap-2 group-data-[collapsible=icon]:w-auto",
+          contentClassName,
+        )}
+      >
+        <Link
+          to={to}
+          title={label}
+          className="flex min-w-0 flex-1 items-center gap-2 hover:no-underline group-data-[collapsible=icon]:flex-none group-data-[collapsible=icon]:justify-center"
+        >
+          <Icon className="size-4 shrink-0" strokeWidth={1.75} />
+          <span className="truncate group-data-[collapsible=icon]:hidden">
+            {label}
+          </span>
+        </Link>
+        {trailing}
+      </div>
+    </div>
+  );
+}

--- a/client/dashboard/src/hooks/useOnboardingCta.ts
+++ b/client/dashboard/src/hooks/useOnboardingCta.ts
@@ -1,0 +1,112 @@
+import { useSlugs } from "@/contexts/Sdk";
+import { useProductTier } from "@/hooks/useProductTier";
+import { useRBAC } from "@/hooks/useRBAC";
+import { useSyncExternalStore } from "react";
+import { flushSync } from "react-dom";
+
+// Shared Tailwind class that tags BOTH the dismissable onboarding banner and the
+// sidebar resume button with the same view-transition-name. Because only one of
+// the two is rendered at a time (the dismissed flag decides which), the browser
+// morphs one into the other — the "genie" effect — when the flag flips.
+// Must stay a static string literal: Tailwind's scanner can't evaluate template
+// interpolation, so a computed class name would never be generated into the CSS.
+// The name must match the ::view-transition-*(onboarding-cta) rules in App.css.
+export const ONBOARDING_CTA_VT_CLASS = "[view-transition-name:onboarding-cta]";
+
+// Applied to the content INSIDE each surface. Giving the content its own
+// view-transition-name pulls it out of the container's snapshot, so the genie
+// animates an empty surface while the text simply fades at the endpoints —
+// otherwise the rasterized text visibly warps mid-flight.
+export const ONBOARDING_CTA_CONTENT_VT_CLASS =
+  "[view-transition-name:onboarding-cta-content]";
+
+function storageKey(orgSlug: string) {
+  return `gram-onboarding-banner-dismissed:${orgSlug}`;
+}
+
+function readDismissed(orgSlug: string): boolean {
+  try {
+    return localStorage.getItem(storageKey(orgSlug)) === "true";
+  } catch {
+    return false;
+  }
+}
+
+// Module-level pub/sub. The banner lives in the page header and the resume button
+// lives in the sidebar footer — different parts of the tree — so they sync off a
+// single localStorage-backed source of truth instead of a shared React context.
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function writeDismissed(orgSlug: string, value: boolean) {
+  try {
+    if (value) {
+      localStorage.setItem(storageKey(orgSlug), "true");
+    } else {
+      localStorage.removeItem(storageKey(orgSlug));
+    }
+  } catch {
+    // localStorage unavailable — listeners still fire so the in-memory UI updates
+  }
+  listeners.forEach((listener) => listener());
+}
+
+// Genie the banner into the resume button (or back). flushSync forces React to
+// apply the state change synchronously inside the transition callback so the
+// browser captures the post-update DOM; without it React 19 batches the update
+// until after the snapshot and no transition plays. Falls back to a plain update
+// where the View Transitions API is unavailable.
+function withCtaViewTransition(update: () => void) {
+  if (
+    typeof document !== "undefined" &&
+    typeof document.startViewTransition === "function"
+  ) {
+    document.startViewTransition(() => {
+      flushSync(update);
+    });
+    return;
+  }
+  update();
+}
+
+/**
+ * Coordinates the enterprise onboarding call-to-action across its two surfaces:
+ * the dismissable banner in the page header and the persistent resume button in
+ * the sidebar footer. Both gate on the same eligibility (enterprise org admin)
+ * and the same dismissed flag, and `dismiss`/`resume` animate the swap.
+ */
+export function useOnboardingCta(): {
+  eligible: boolean;
+  dismissed: boolean;
+  dismiss: () => void;
+  resume: () => void;
+} {
+  const { orgSlug } = useSlugs();
+  const { hasScope } = useRBAC();
+  const productTier = useProductTier();
+
+  const dismissed = useSyncExternalStore(
+    subscribe,
+    () => (orgSlug ? readDismissed(orgSlug) : false),
+    () => false,
+  );
+
+  const eligible =
+    Boolean(orgSlug) && productTier === "enterprise" && hasScope("org:admin");
+
+  const dismiss = () => {
+    if (orgSlug) withCtaViewTransition(() => writeDismissed(orgSlug, true));
+  };
+
+  const resume = () => {
+    if (orgSlug) withCtaViewTransition(() => writeDismissed(orgSlug, false));
+  };
+
+  return { eligible, dismissed, dismiss, resume };
+}


### PR DESCRIPTION
## Summary

Fixes [AIS-127](https://linear.app/speakeasy/issue/AIS-127/feat-add-a-static-onboarding-resume-button): after dismissing the onboarding banner there was no way back into onboarding.

Dismissing the banner now "genies" it (macOS Dock-style view transition) into a persistent **Finish setup** card in the sidebar footer. The card links to the setup wizard, and its arrow control restores the banner with the reverse transition.

## Changes

- **`useOnboardingCta` hook** — single source of truth for the CTA's two surfaces: eligibility (enterprise + `org:admin`), localStorage-backed dismissed flag shared via `useSyncExternalStore`, and `dismiss`/`resume` actions wrapped in `document.startViewTransition` + `flushSync` (React 19 batches state updates, so the DOM must be committed synchronously inside the transition callback).
- **`OnboardingBanner`** — refactored onto the hook; dismiss logic and gating removed from the component.
- **`SidebarFooterAction`** (new) — raised, bordered standout card for sidebar footer actions, with optional trailing control and collapsed-icon support.
- **`OnboardingResumeButton`** (new) — the docked "Finish setup" card, shown only when eligible + dismissed. Wired into both `app-sidebar` and `org-sidebar` footers.
- **"Back to org"** in the project sidebar moved from the scroll area into the footer as a standout card, relabeled **Organization settings**.
- **Genie transition CSS** — banner and card share a `view-transition-name`; the surface warps via compositor-only transforms (perspective taper, stretch, skew, mid-flight sag). Inner content carries a second `view-transition-name` so text is excluded from the warping snapshot and fades in at its final geometry instead of stretching. `prefers-reduced-motion` disables all of it.

## Notes for reviewers

- Transition is Chromium-only for now; other browsers get an instant swap (`startViewTransition` feature-detected).
- Pre-existing `tsc` errors on this branch base (collections / mcp publishing / logs-agents) are untouched and unrelated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent Finish setup button in the sidebar after the onboarding banner is dismissed, with a smooth “genie” transition between the banner and the button. Fixes AIS-127 by giving admins a clear way to resume onboarding.

- **New Features**
  - `useOnboardingCta` hook: single source of truth for eligibility (enterprise + `org:admin`) and a localStorage-backed dismissed flag via `useSyncExternalStore`; `dismiss`/`resume` use `document.startViewTransition` with `flushSync` for React 19.
  - Onboarding banner now uses the hook; logic and gating moved out of the component.
  - `OnboardingResumeButton`: docked “Finish setup” card in app/org sidebar footers, visible when eligible and dismissed; includes a trailing arrow to restore the banner.
  - `SidebarFooterAction`: reusable raised link card for footer actions; used for the resume button and a renamed “Organization settings” link (moved from the project sidebar list).
  - CSS view transitions for a macOS Dock-style morph (`onboarding-cta` + `onboarding-cta-content`), with `prefers-reduced-motion` support; non-Chromium falls back to an instant swap.

<sup>Written for commit 69b07ff64d50aa2bfead58a0a92363e0e8f3b9c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

