### PR TITLE
feat: policy deletion cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -334,3 +334,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
+
+replace github.com/hashicorp/terraform-provider-google-beta => github.com/hashicorp/terraform-provider-google-beta v1.20.0

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1085,6 +1085,7 @@ func newStartCommand() *cli.Command {
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
 			riskReconciler := &background.TemporalRiskExclusionReconciler{TemporalEnv: temporalEnv, Logger: logger}
+			riskResultsCleaner := &background.TemporalRiskPolicyResultsCleaner{TemporalEnv: temporalEnv, Logger: logger}
 			riskService := risk.NewService(
 				logger,
 				tracerProvider,
@@ -1093,6 +1094,7 @@ func newStartCommand() *cli.Command {
 				authzEngine,
 				riskSignaler,
 				riskReconciler,
+				riskResultsCleaner,
 				completionsClient,
 				shadowMCPClient,
 				auditLogger,

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/background/activities/risk_exclusion"
+	risk_policy "github.com/speakeasy-api/gram/server/internal/background/activities/risk_policy"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -78,6 +79,7 @@ type Activities struct {
 	analyzeBatch                    *risk_analysis.AnalyzeBatch
 	markMessagesAnalyzed            *risk_analysis.MarkMessagesAnalyzed
 	reconcileExclusion              *risk_exclusion.Reconcile
+	cleanRiskPolicyResults          *risk_policy.Cleanup
 	admitAssistantThreads           *activities.AdmitAssistantThreads
 	processAssistantThread          *activities.ProcessAssistantThread
 	expireAssistantThreadRuntime    *activities.ExpireAssistantThreadRuntime
@@ -172,6 +174,7 @@ func NewActivities(
 		analyzeBatch:                    risk_analysis.NewAnalyzeBatch(logger, tracerProvider, meterProvider, db, piiScanner, piScanner, shadowMCPClient, telemetryrepo.New(chConn), riskjudge.New(logger, tracerProvider, meterProvider, chatClient), features),
 		markMessagesAnalyzed:            risk_analysis.NewMarkMessagesAnalyzed(logger, tracerProvider, db),
 		reconcileExclusion:              risk_exclusion.NewReconcile(logger, tracerProvider, db),
+		cleanRiskPolicyResults:          risk_policy.NewCleanup(logger, tracerProvider, db),
 		admitAssistantThreads:           activities.NewAdmitAssistantThreads(assistantsCore),
 		processAssistantThread:          activities.NewProcessAssistantThread(assistantsCore),
 		expireAssistantThreadRuntime:    activities.NewExpireAssistantThreadRuntime(assistantsCore),
@@ -372,6 +375,13 @@ func (a *Activities) MarkMessagesAnalyzed(ctx context.Context, input risk_analys
 func (a *Activities) ReconcileExclusion(ctx context.Context, input risk_exclusion.ReconcileArgs) error {
 	if err := a.reconcileExclusion.Do(ctx, input); err != nil {
 		return fmt.Errorf("reconcile exclusion: %w", err)
+	}
+	return nil
+}
+
+func (a *Activities) CleanRiskPolicyResults(ctx context.Context, input risk_policy.CleanArgs) error {
+	if err := a.cleanRiskPolicyResults.Do(ctx, input); err != nil {
+		return fmt.Errorf("clean risk policy results: %w", err)
 	}
 	return nil
 }

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -966,6 +966,22 @@ func (a *AnalyzeBatch) writeResults(ctx context.Context, args AnalyzeBatchArgs, 
 
 	txRepo := repo.New(a.db).WithTx(tx)
 
+	if _, err := txRepo.GetRiskPolicy(ctx, repo.GetRiskPolicyParams{
+		ID:        args.RiskPolicyID,
+		ProjectID: args.ProjectID,
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Policy was soft-deleted while analysis was running — drop results.
+			writeSpan.SetAttributes(attribute.Bool("risk.policy_deleted", true))
+			a.logger.InfoContext(ctx, "risk policy deleted mid-analysis, dropping results",
+				attr.SlogRiskPolicyID(args.RiskPolicyID.String()),
+			)
+			return nil
+		}
+		writeSpan.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("re-check risk policy before writing results: %w", err)
+	}
+
 	if err := txRepo.DeleteRiskResultsForMessages(ctx, repo.DeleteRiskResultsForMessagesParams{
 		RiskPolicyID: args.RiskPolicyID,
 		ProjectID:    args.ProjectID,

--- a/server/internal/background/activities/risk_policy/cleanup.go
+++ b/server/internal/background/activities/risk_policy/cleanup.go
@@ -44,16 +44,19 @@ func (a *Cleanup) Do(ctx context.Context, args CleanArgs) (err error) {
 		span.End()
 	}()
 
-	if err = repo.New(a.db).DeleteRiskResultsByPolicy(ctx, repo.DeleteRiskResultsByPolicyParams{
+	deleted, err := repo.New(a.db).DeleteRiskResultsByPolicy(ctx, repo.DeleteRiskResultsByPolicyParams{
 		RiskPolicyID: args.PolicyID,
 		ProjectID:    args.ProjectID,
-	}); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("delete risk results by policy: %w", err)
 	}
 
+	span.SetAttributes(attr.DBDeletedRowsCount(deleted))
 	a.logger.InfoContext(ctx, "deleted risk results for policy",
 		attr.SlogProjectID(args.ProjectID.String()),
 		attr.SlogRiskPolicyID(args.PolicyID.String()),
+		attr.SlogDBDeletedRowsCount(deleted),
 	)
 	return nil
 }

--- a/server/internal/background/activities/risk_policy/cleanup.go
+++ b/server/internal/background/activities/risk_policy/cleanup.go
@@ -1,0 +1,59 @@
+package risk_policy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+// CleanArgs identifies the policy whose results should be deleted.
+type CleanArgs struct {
+	ProjectID uuid.UUID
+	PolicyID  uuid.UUID
+}
+
+// Cleanup deletes risk_results rows for a soft-deleted policy.
+type Cleanup struct {
+	logger *slog.Logger
+	tracer trace.Tracer
+	db     *pgxpool.Pool
+}
+
+func NewCleanup(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool) *Cleanup {
+	return &Cleanup{
+		logger: logger.With(attr.SlogComponent("risk-policy-cleanup")),
+		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/risk_policy"),
+		db:     db,
+	}
+}
+
+func (a *Cleanup) Do(ctx context.Context, args CleanArgs) (err error) {
+	ctx, span := a.tracer.Start(ctx, "risk.cleanPolicyResults")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	if err = repo.New(a.db).DeleteRiskResultsByPolicy(ctx, repo.DeleteRiskResultsByPolicyParams{
+		RiskPolicyID: args.PolicyID,
+		ProjectID:    args.ProjectID,
+	}); err != nil {
+		return fmt.Errorf("delete risk results by policy: %w", err)
+	}
+
+	a.logger.InfoContext(ctx, "deleted risk results for policy",
+		attr.SlogProjectID(args.ProjectID.String()),
+		attr.SlogRiskPolicyID(args.PolicyID.String()),
+	)
+	return nil
+}

--- a/server/internal/background/risk_policy_cleanup.go
+++ b/server/internal/background/risk_policy_cleanup.go
@@ -1,0 +1,80 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	risk_policy "github.com/speakeasy-api/gram/server/internal/background/activities/risk_policy"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const riskPolicyCleanupTimeout = 30 * time.Minute
+
+// RiskPolicyCleanupParams identifies the policy whose results should be deleted.
+type RiskPolicyCleanupParams struct {
+	ProjectID uuid.UUID
+	PolicyID  uuid.UUID
+}
+
+// RiskPolicyCleanupWorkflow deletes risk_results for a soft-deleted policy.
+func RiskPolicyCleanupWorkflow(ctx workflow.Context, params RiskPolicyCleanupParams) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: riskPolicyCleanupTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    5,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    60 * time.Second,
+		},
+	})
+
+	var a *Activities
+	return workflow.ExecuteActivity(ctx, a.CleanRiskPolicyResults, risk_policy.CleanArgs{
+		ProjectID: params.ProjectID,
+		PolicyID:  params.PolicyID,
+	}).Get(ctx, nil)
+}
+
+func riskPolicyCleanupWorkflowID(policyID uuid.UUID) string {
+	return "risk-policy-cleanup:" + policyID.String()
+}
+
+// TemporalRiskPolicyResultsCleaner starts the cleanup workflow after a policy
+// is soft-deleted. Best-effort: a failed trigger is logged, not fatal.
+type TemporalRiskPolicyResultsCleaner struct {
+	TemporalEnv *tenv.Environment
+	Logger      *slog.Logger
+}
+
+func (c *TemporalRiskPolicyResultsCleaner) Clean(ctx context.Context, projectID, policyID uuid.UUID) error {
+	wfID := riskPolicyCleanupWorkflowID(policyID)
+
+	_, err := c.TemporalEnv.Client().ExecuteWorkflow(
+		ctx,
+		client.StartWorkflowOptions{
+			ID:                    wfID,
+			TaskQueue:             string(c.TemporalEnv.Queue()),
+			WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+		},
+		RiskPolicyCleanupWorkflow,
+		RiskPolicyCleanupParams{ProjectID: projectID, PolicyID: policyID},
+	)
+	if err != nil {
+		return fmt.Errorf("start risk policy cleanup: %w", err)
+	}
+
+	c.Logger.DebugContext(ctx, "risk policy cleanup started",
+		attr.SlogProjectID(projectID.String()),
+		attr.SlogTemporalWorkflowID(wfID),
+	)
+	return nil
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -311,6 +311,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.FetchUnanalyzedMessages)
 	temporalWorker.RegisterActivity(activities.MarkMessagesAnalyzed)
 	temporalWorker.RegisterActivity(activities.ReconcileExclusion)
+	temporalWorker.RegisterActivity(activities.CleanRiskPolicyResults)
 	riskWorker.RegisterActivity(activities.AnalyzeBatch)
 	// Assistant activities
 	temporalWorker.RegisterActivity(activities.AdmitAssistantThreads)
@@ -368,6 +369,7 @@ func NewTemporalWorker(
 	// Risk analysis coordinator workflow
 	temporalWorker.RegisterWorkflow(RiskAnalysisCoordinatorWorkflow)
 	temporalWorker.RegisterWorkflow(RiskExclusionReconcileWorkflow)
+	temporalWorker.RegisterWorkflow(RiskPolicyCleanupWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantCoordinatorWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantThreadWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantReaperWorkflow)

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -65,6 +65,12 @@ type RiskExclusionReconciler interface {
 	Reconcile(ctx context.Context, projectID, exclusionID uuid.UUID) error
 }
 
+// RiskPolicyResultsCleaner asynchronously deletes risk_results rows for a
+// soft-deleted policy. Best-effort: a failed trigger is logged, not fatal.
+type RiskPolicyResultsCleaner interface {
+	Clean(ctx context.Context, projectID, policyID uuid.UUID) error
+}
+
 type Service struct {
 	tracer           trace.Tracer
 	logger           *slog.Logger
@@ -74,6 +80,7 @@ type Service struct {
 	authz            *authz.Engine
 	signaler         RiskAnalysisSignaler
 	reconciler       RiskExclusionReconciler
+	resultsCleaner   RiskPolicyResultsCleaner
 	completionClient openrouter.CompletionClient
 	shadowMCPClient  *shadowmcp.Client
 	audit            *audit.Logger
@@ -112,6 +119,7 @@ func NewObserver(
 		authz:            nil,
 		signaler:         signaler,
 		reconciler:       nil,
+		resultsCleaner:   nil,
 		completionClient: nil,
 		shadowMCPClient:  nil,
 		audit:            auditLogger,
@@ -131,6 +139,7 @@ func NewService(
 	authzEngine *authz.Engine,
 	signaler RiskAnalysisSignaler,
 	reconciler RiskExclusionReconciler,
+	resultsCleaner RiskPolicyResultsCleaner,
 	completionClient openrouter.CompletionClient,
 	shadowMCPClient *shadowmcp.Client,
 	auditLogger *audit.Logger,
@@ -151,6 +160,7 @@ func NewService(
 		authz:            authzEngine,
 		signaler:         signaler,
 		reconciler:       reconciler,
+		resultsCleaner:   resultsCleaner,
 		completionClient: completionClient,
 		shadowMCPClient:  shadowMCPClient,
 		audit:            auditLogger,
@@ -681,15 +691,8 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		return oops.E(oops.CodeUnexpected, err, "delete risk policy bypass requests").Log(ctx, s.logger)
 	}
 
-	if err := q.DeleteRiskResultsByPolicy(ctx, repo.DeleteRiskResultsByPolicyParams{
-		RiskPolicyID: id,
-		ProjectID:    *authCtx.ProjectID,
-	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete risk results by policy").Log(ctx, s.logger)
-	}
-
 	if err := q.DeleteRiskExclusionsByPolicy(ctx, repo.DeleteRiskExclusionsByPolicyParams{
-		RiskPolicyID: id,
+		RiskPolicyID: uuid.NullUUID{UUID: id, Valid: true},
 		ProjectID:    *authCtx.ProjectID,
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "delete risk exclusions by policy").Log(ctx, s.logger)
@@ -715,7 +718,22 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		s.shadowMCPClient.Invalidate(ctx, *authCtx.ProjectID)
 	}
 
+	s.cleanPolicyResults(ctx, *authCtx.ProjectID, id)
+
 	return nil
+}
+
+func (s *Service) cleanPolicyResults(ctx context.Context, projectID, policyID uuid.UUID) {
+	if s.resultsCleaner == nil {
+		return
+	}
+	if err := s.resultsCleaner.Clean(ctx, projectID, policyID); err != nil {
+		s.logger.ErrorContext(ctx, "trigger risk policy results cleanup",
+			attr.SlogError(err),
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogRiskPolicyID(policyID.String()),
+		)
+	}
 }
 
 const riskDefaultPageSize = 50

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -681,6 +681,20 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		return oops.E(oops.CodeUnexpected, err, "delete risk policy bypass requests").Log(ctx, s.logger)
 	}
 
+	if err := q.DeleteRiskResultsByPolicy(ctx, repo.DeleteRiskResultsByPolicyParams{
+		RiskPolicyID: id,
+		ProjectID:    *authCtx.ProjectID,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "delete risk results by policy").Log(ctx, s.logger)
+	}
+
+	if err := q.DeleteRiskExclusionsByPolicy(ctx, repo.DeleteRiskExclusionsByPolicyParams{
+		RiskPolicyID: id,
+		ProjectID:    *authCtx.ProjectID,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "delete risk exclusions by policy").Log(ctx, s.logger)
+	}
+
 	if err := s.audit.LogRiskPolicyDelete(ctx, dbtx, audit.LogRiskPolicyDeleteEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -691,11 +691,18 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		return oops.E(oops.CodeUnexpected, err, "delete risk policy bypass requests").Log(ctx, s.logger)
 	}
 
-	if err := q.DeleteRiskExclusionsByPolicy(ctx, repo.DeleteRiskExclusionsByPolicyParams{
+	deletedExclusions, err := q.DeleteRiskExclusionsByPolicy(ctx, repo.DeleteRiskExclusionsByPolicyParams{
 		RiskPolicyID: uuid.NullUUID{UUID: id, Valid: true},
 		ProjectID:    *authCtx.ProjectID,
-	}); err != nil {
+	})
+	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "delete risk exclusions by policy").Log(ctx, s.logger)
+	}
+	if deletedExclusions > 0 {
+		s.logger.InfoContext(ctx, "deleted risk exclusions for policy",
+			attr.SlogRiskPolicyID(id.String()),
+			attr.SlogDBDeletedRowsCount(deletedExclusions),
+		)
 	}
 
 	if err := s.audit.LogRiskPolicyDelete(ctx, dbtx, audit.LogRiskPolicyDeleteEvent{

--- a/server/internal/risk/listgetdelete_test.go
+++ b/server/internal/risk/listgetdelete_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
 )
 
 func TestListRiskPolicies_Empty(t *testing.T) {
@@ -144,6 +145,98 @@ func TestDeleteRiskPolicy_DeletesBypassRequests(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, after.Requests)
+}
+
+func TestDeleteRiskPolicy_DeletesRiskResults(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Results Cleanup")})
+	require.NoError(t, err)
+
+	policyID, _ := uuid.Parse(policy.ID)
+	_, msgID := seedChatMessage(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID)
+	seedRiskResult(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, policyID, 1, msgID, true)
+
+	repo := riskrepo.New(ti.conn)
+	before, err := repo.CountRiskResultsByPolicyID(t.Context(), riskrepo.CountRiskResultsByPolicyIDParams{
+		RiskPolicyID: policyID,
+		ProjectID:    *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), before)
+
+	err = ti.service.DeleteRiskPolicy(ctx, &gen.DeleteRiskPolicyPayload{ID: policy.ID})
+	require.NoError(t, err)
+
+	after, err := repo.CountRiskResultsByPolicyID(t.Context(), riskrepo.CountRiskResultsByPolicyIDParams{
+		RiskPolicyID: policyID,
+		ProjectID:    *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), after)
+}
+
+func TestDeleteRiskPolicy_DeletesPolicyBoundExclusions(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Exclusions Cleanup")})
+	require.NoError(t, err)
+
+	policyID, _ := uuid.Parse(policy.ID)
+	repo := riskrepo.New(ti.conn)
+
+	// Policy-bound exclusion.
+	_, err = repo.CreateRiskExclusion(t.Context(), riskrepo.CreateRiskExclusionParams{
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		RiskPolicyID:   uuid.NullUUID{UUID: policyID, Valid: true},
+		MatchType:      "exact",
+		MatchValue:     "secret",
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	// Global exclusion — must survive deletion.
+	_, err = repo.CreateRiskExclusion(t.Context(), riskrepo.CreateRiskExclusionParams{
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		RiskPolicyID:   uuid.NullUUID{},
+		MatchType:      "exact",
+		MatchValue:     "global-secret",
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	err = ti.service.DeleteRiskPolicy(ctx, &gen.DeleteRiskPolicyPayload{ID: policy.ID})
+	require.NoError(t, err)
+
+	// Policy-bound exclusion must be gone.
+	bound, err := repo.ListRiskExclusionsByProject(t.Context(), riskrepo.ListRiskExclusionsByProjectParams{
+		ProjectID:    *authCtx.ProjectID,
+		RiskPolicyID: uuid.NullUUID{UUID: policyID, Valid: true},
+	})
+	require.NoError(t, err)
+	require.Empty(t, bound)
+
+	// Global exclusion must still exist.
+	global, err := repo.ListRiskExclusionsByProject(t.Context(), riskrepo.ListRiskExclusionsByProjectParams{
+		ProjectID:    *authCtx.ProjectID,
+		RiskPolicyID: uuid.NullUUID{},
+	})
+	require.NoError(t, err)
+	require.Len(t, global, 1)
 }
 
 func TestListRiskResults_EmptyProject(t *testing.T) {

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -136,12 +136,12 @@ WHERE risk_policy_id = @risk_policy_id
   AND project_id = @project_id
   AND deleted IS FALSE;
 
--- name: DeleteRiskResultsByPolicy :exec
+-- name: DeleteRiskResultsByPolicy :execrows
 DELETE FROM risk_results
 WHERE risk_policy_id = @risk_policy_id
   AND project_id = @project_id;
 
--- name: DeleteRiskExclusionsByPolicy :exec
+-- name: DeleteRiskExclusionsByPolicy :execrows
 DELETE FROM risk_exclusions
 WHERE risk_policy_id = @risk_policy_id
   AND project_id = @project_id;

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -136,6 +136,25 @@ WHERE risk_policy_id = @risk_policy_id
   AND project_id = @project_id
   AND deleted IS FALSE;
 
+-- name: DeleteRiskResultsByPolicy :exec
+DELETE FROM risk_results
+WHERE risk_policy_id = @risk_policy_id
+  AND project_id = @project_id;
+
+-- name: DeleteRiskExclusionsByPolicy :exec
+UPDATE risk_exclusions
+SET deleted_at = clock_timestamp()
+  , updated_at = clock_timestamp()
+WHERE risk_policy_id = @risk_policy_id
+  AND project_id = @project_id
+  AND deleted IS FALSE;
+
+-- name: CountRiskResultsByPolicyID :one
+SELECT COUNT(*)::BIGINT
+FROM risk_results
+WHERE risk_policy_id = @risk_policy_id
+  AND project_id = @project_id;
+
 -- name: UpsertRiskPolicyBypassRequest :one
 INSERT INTO risk_policy_bypass_requests (
     id

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -142,12 +142,9 @@ WHERE risk_policy_id = @risk_policy_id
   AND project_id = @project_id;
 
 -- name: DeleteRiskExclusionsByPolicy :exec
-UPDATE risk_exclusions
-SET deleted_at = clock_timestamp()
-  , updated_at = clock_timestamp()
+DELETE FROM risk_exclusions
 WHERE risk_policy_id = @risk_policy_id
-  AND project_id = @project_id
-  AND deleted IS FALSE;
+  AND project_id = @project_id;
 
 -- name: CountRiskResultsByPolicyID :one
 SELECT COUNT(*)::BIGINT

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -691,7 +691,7 @@ func (q *Queries) DeleteRiskExclusion(ctx context.Context, arg DeleteRiskExclusi
 	return err
 }
 
-const deleteRiskExclusionsByPolicy = `-- name: DeleteRiskExclusionsByPolicy :exec
+const deleteRiskExclusionsByPolicy = `-- name: DeleteRiskExclusionsByPolicy :execrows
 DELETE FROM risk_exclusions
 WHERE risk_policy_id = $1
   AND project_id = $2
@@ -702,9 +702,12 @@ type DeleteRiskExclusionsByPolicyParams struct {
 	ProjectID    uuid.UUID
 }
 
-func (q *Queries) DeleteRiskExclusionsByPolicy(ctx context.Context, arg DeleteRiskExclusionsByPolicyParams) error {
-	_, err := q.db.Exec(ctx, deleteRiskExclusionsByPolicy, arg.RiskPolicyID, arg.ProjectID)
-	return err
+func (q *Queries) DeleteRiskExclusionsByPolicy(ctx context.Context, arg DeleteRiskExclusionsByPolicyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteRiskExclusionsByPolicy, arg.RiskPolicyID, arg.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const deleteRiskPolicy = `-- name: DeleteRiskPolicy :exec
@@ -745,7 +748,7 @@ func (q *Queries) DeleteRiskPolicyBypassRequestsByPolicy(ctx context.Context, ar
 	return err
 }
 
-const deleteRiskResultsByPolicy = `-- name: DeleteRiskResultsByPolicy :exec
+const deleteRiskResultsByPolicy = `-- name: DeleteRiskResultsByPolicy :execrows
 DELETE FROM risk_results
 WHERE risk_policy_id = $1
   AND project_id = $2
@@ -756,9 +759,12 @@ type DeleteRiskResultsByPolicyParams struct {
 	ProjectID    uuid.UUID
 }
 
-func (q *Queries) DeleteRiskResultsByPolicy(ctx context.Context, arg DeleteRiskResultsByPolicyParams) error {
-	_, err := q.db.Exec(ctx, deleteRiskResultsByPolicy, arg.RiskPolicyID, arg.ProjectID)
-	return err
+func (q *Queries) DeleteRiskResultsByPolicy(ctx context.Context, arg DeleteRiskResultsByPolicyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteRiskResultsByPolicy, arg.RiskPolicyID, arg.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const deleteRiskResultsForMessages = `-- name: DeleteRiskResultsForMessages :exec

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -692,12 +692,9 @@ func (q *Queries) DeleteRiskExclusion(ctx context.Context, arg DeleteRiskExclusi
 }
 
 const deleteRiskExclusionsByPolicy = `-- name: DeleteRiskExclusionsByPolicy :exec
-UPDATE risk_exclusions
-SET deleted_at = clock_timestamp()
-  , updated_at = clock_timestamp()
+DELETE FROM risk_exclusions
 WHERE risk_policy_id = $1
   AND project_id = $2
-  AND deleted IS FALSE
 `
 
 type DeleteRiskExclusionsByPolicyParams struct {

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -379,6 +379,25 @@ func (q *Queries) CountFindingsByPolicy(ctx context.Context, arg CountFindingsBy
 	return column_1, err
 }
 
+const countRiskResultsByPolicyID = `-- name: CountRiskResultsByPolicyID :one
+SELECT COUNT(*)::BIGINT
+FROM risk_results
+WHERE risk_policy_id = $1
+  AND project_id = $2
+`
+
+type CountRiskResultsByPolicyIDParams struct {
+	RiskPolicyID uuid.UUID
+	ProjectID    uuid.UUID
+}
+
+func (q *Queries) CountRiskResultsByPolicyID(ctx context.Context, arg CountRiskResultsByPolicyIDParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countRiskResultsByPolicyID, arg.RiskPolicyID, arg.ProjectID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const countTotalMessages = `-- name: CountTotalMessages :one
 SELECT COUNT(*)::BIGINT
 FROM chat_messages cm
@@ -672,6 +691,25 @@ func (q *Queries) DeleteRiskExclusion(ctx context.Context, arg DeleteRiskExclusi
 	return err
 }
 
+const deleteRiskExclusionsByPolicy = `-- name: DeleteRiskExclusionsByPolicy :exec
+UPDATE risk_exclusions
+SET deleted_at = clock_timestamp()
+  , updated_at = clock_timestamp()
+WHERE risk_policy_id = $1
+  AND project_id = $2
+  AND deleted IS FALSE
+`
+
+type DeleteRiskExclusionsByPolicyParams struct {
+	RiskPolicyID uuid.NullUUID
+	ProjectID    uuid.UUID
+}
+
+func (q *Queries) DeleteRiskExclusionsByPolicy(ctx context.Context, arg DeleteRiskExclusionsByPolicyParams) error {
+	_, err := q.db.Exec(ctx, deleteRiskExclusionsByPolicy, arg.RiskPolicyID, arg.ProjectID)
+	return err
+}
+
 const deleteRiskPolicy = `-- name: DeleteRiskPolicy :exec
 UPDATE risk_policies
 SET deleted_at = clock_timestamp()
@@ -724,44 +762,6 @@ type DeleteRiskResultsByPolicyParams struct {
 func (q *Queries) DeleteRiskResultsByPolicy(ctx context.Context, arg DeleteRiskResultsByPolicyParams) error {
 	_, err := q.db.Exec(ctx, deleteRiskResultsByPolicy, arg.RiskPolicyID, arg.ProjectID)
 	return err
-}
-
-const deleteRiskExclusionsByPolicy = `-- name: DeleteRiskExclusionsByPolicy :exec
-UPDATE risk_exclusions
-SET deleted_at = clock_timestamp()
-  , updated_at = clock_timestamp()
-WHERE risk_policy_id = $1
-  AND project_id = $2
-  AND deleted IS FALSE
-`
-
-type DeleteRiskExclusionsByPolicyParams struct {
-	RiskPolicyID uuid.UUID
-	ProjectID    uuid.UUID
-}
-
-func (q *Queries) DeleteRiskExclusionsByPolicy(ctx context.Context, arg DeleteRiskExclusionsByPolicyParams) error {
-	_, err := q.db.Exec(ctx, deleteRiskExclusionsByPolicy, arg.RiskPolicyID, arg.ProjectID)
-	return err
-}
-
-const countRiskResultsByPolicyID = `-- name: CountRiskResultsByPolicyID :one
-SELECT COUNT(*)::BIGINT
-FROM risk_results
-WHERE risk_policy_id = $1
-  AND project_id = $2
-`
-
-type CountRiskResultsByPolicyIDParams struct {
-	RiskPolicyID uuid.UUID
-	ProjectID    uuid.UUID
-}
-
-func (q *Queries) CountRiskResultsByPolicyID(ctx context.Context, arg CountRiskResultsByPolicyIDParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countRiskResultsByPolicyID, arg.RiskPolicyID, arg.ProjectID)
-	var column_1 int64
-	err := row.Scan(&column_1)
-	return column_1, err
 }
 
 const deleteRiskResultsForMessages = `-- name: DeleteRiskResultsForMessages :exec

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -710,6 +710,60 @@ func (q *Queries) DeleteRiskPolicyBypassRequestsByPolicy(ctx context.Context, ar
 	return err
 }
 
+const deleteRiskResultsByPolicy = `-- name: DeleteRiskResultsByPolicy :exec
+DELETE FROM risk_results
+WHERE risk_policy_id = $1
+  AND project_id = $2
+`
+
+type DeleteRiskResultsByPolicyParams struct {
+	RiskPolicyID uuid.UUID
+	ProjectID    uuid.UUID
+}
+
+func (q *Queries) DeleteRiskResultsByPolicy(ctx context.Context, arg DeleteRiskResultsByPolicyParams) error {
+	_, err := q.db.Exec(ctx, deleteRiskResultsByPolicy, arg.RiskPolicyID, arg.ProjectID)
+	return err
+}
+
+const deleteRiskExclusionsByPolicy = `-- name: DeleteRiskExclusionsByPolicy :exec
+UPDATE risk_exclusions
+SET deleted_at = clock_timestamp()
+  , updated_at = clock_timestamp()
+WHERE risk_policy_id = $1
+  AND project_id = $2
+  AND deleted IS FALSE
+`
+
+type DeleteRiskExclusionsByPolicyParams struct {
+	RiskPolicyID uuid.UUID
+	ProjectID    uuid.UUID
+}
+
+func (q *Queries) DeleteRiskExclusionsByPolicy(ctx context.Context, arg DeleteRiskExclusionsByPolicyParams) error {
+	_, err := q.db.Exec(ctx, deleteRiskExclusionsByPolicy, arg.RiskPolicyID, arg.ProjectID)
+	return err
+}
+
+const countRiskResultsByPolicyID = `-- name: CountRiskResultsByPolicyID :one
+SELECT COUNT(*)::BIGINT
+FROM risk_results
+WHERE risk_policy_id = $1
+  AND project_id = $2
+`
+
+type CountRiskResultsByPolicyIDParams struct {
+	RiskPolicyID uuid.UUID
+	ProjectID    uuid.UUID
+}
+
+func (q *Queries) CountRiskResultsByPolicyID(ctx context.Context, arg CountRiskResultsByPolicyIDParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countRiskResultsByPolicyID, arg.RiskPolicyID, arg.ProjectID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const deleteRiskResultsForMessages = `-- name: DeleteRiskResultsForMessages :exec
 DELETE FROM risk_results
 WHERE risk_policy_id = $1

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -68,7 +68,7 @@ type syncResultsCleaner struct {
 }
 
 func (c *syncResultsCleaner) Clean(ctx context.Context, projectID, policyID uuid.UUID) error {
-	if err := riskrepo.New(c.conn).DeleteRiskResultsByPolicy(ctx, riskrepo.DeleteRiskResultsByPolicyParams{
+	if _, err := riskrepo.New(c.conn).DeleteRiskResultsByPolicy(ctx, riskrepo.DeleteRiskResultsByPolicyParams{
 		RiskPolicyID: policyID,
 		ProjectID:    projectID,
 	}); err != nil {

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -2,6 +2,7 @@ package risk_test
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -56,6 +58,22 @@ type signalerStub struct {
 
 func (s *signalerStub) Signal(_ context.Context, projectID uuid.UUID) error {
 	s.calls = append(s.calls, projectID)
+	return nil
+}
+
+// syncResultsCleaner implements risk.RiskPolicyResultsCleaner synchronously for
+// tests (no Temporal worker available).
+type syncResultsCleaner struct {
+	conn *pgxpool.Pool
+}
+
+func (c *syncResultsCleaner) Clean(ctx context.Context, projectID, policyID uuid.UUID) error {
+	if err := riskrepo.New(c.conn).DeleteRiskResultsByPolicy(ctx, riskrepo.DeleteRiskResultsByPolicyParams{
+		RiskPolicyID: policyID,
+		ProjectID:    projectID,
+	}); err != nil {
+		return fmt.Errorf("delete risk results by policy: %w", err)
+	}
 	return nil
 }
 
@@ -100,7 +118,7 @@ func newTestRiskService(t *testing.T) (context.Context, *testInstance) {
 	auditLogger := audit.NewLogger()
 	flags := &feature.InMemory{}
 
-	svc := risk.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, sig, nil, nil, shadowMCPClient, auditLogger, "test-jwt-secret", false, nil, nil, flags)
+	svc := risk.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, sig, nil, &syncResultsCleaner{conn: conn}, nil, shadowMCPClient, auditLogger, "test-jwt-secret", false, nil, nil, flags)
 
 	return ctx, &testInstance{
 		service:        svc,


### PR DESCRIPTION
This PR introduces cleanup of risk results for a deleted policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hard-delete risk results and policy-bound exclusions when a policy is deleted, and guard in-flight analysis from writing orphaned results. Cleanup runs asynchronously via Temporal to keep deletes fast.

- **Bug Fixes**
  - On delete: start Temporal cleanup that hard-deletes `risk_results`; also delete policy-bound `risk_exclusions` (global exclusions untouched).
  - During analysis: re-check policy; if deleted mid-run, drop results and set span attr `risk.policy_deleted`.
  - Added repo queries (`DeleteRiskResultsByPolicy`, `DeleteRiskExclusionsByPolicy`, `CountRiskResultsByPolicyID`) and tests.

- **New Features**
  - Added `RiskPolicyCleanupWorkflow` and `CleanRiskPolicyResults` activity (with retries and OTel/logging of deleted rows); registered in the worker and wired via `TemporalRiskPolicyResultsCleaner`.

<sup>Written for commit f5504e4066ce2f267867f90d801a7083b5ef3580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

