### PR TITLE
feat(dashboard): embed demo calendar directly in signup gate

### DIFF
--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { CAL_DEMO_LINK } from "./demo-booking";
 
 type MockSession = { user: { email: string; displayName?: string } } | null;
 const { captureMock, sessionHolder } = vi.hoisted(() => ({
@@ -11,30 +12,21 @@ const { captureMock, sessionHolder } = vi.hoisted(() => ({
   },
 }));
 
-// moonshine's bundle can't resolve lucide dynamic icons in tests — render Button
-// as a plain <button>.
-vi.mock("@speakeasy-api/moonshine", () => ({
-  Button: ({
-    children,
-    type,
-    onClick,
-  }: {
-    children: React.ReactNode;
-    type?: "button" | "submit";
-    onClick?: () => void;
-    variant?: string;
-    className?: string;
-  }) => (
-    <button type={type} onClick={onClick}>
-      {children}
-    </button>
-  ),
-}));
-
-// Replace the Cal embed with a probe that exposes the calLink it received.
+// Replace the Cal embed with a probe that exposes the props it received.
 vi.mock("@calcom/embed-react", () => ({
-  default: ({ calLink }: { calLink: string }) => (
-    <div data-testid="cal-embed" data-cal-link={calLink} />
+  default: ({
+    calLink,
+    config,
+  }: {
+    calLink: string;
+    config?: Record<string, unknown>;
+  }) => (
+    <div
+      data-testid="cal-embed"
+      data-cal-link={calLink}
+      data-cal-name={String(config?.name ?? "")}
+      data-cal-email={String(config?.email ?? "")}
+    />
   ),
 }));
 
@@ -58,57 +50,30 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("DemoBookingFlow", () => {
+  it("embeds the demo calendar directly with no intermediate form", () => {
+    render(<DemoBookingFlow />);
+    const embed = screen.getByTestId("cal-embed");
+    expect(embed.getAttribute("data-cal-link")).toBe(CAL_DEMO_LINK);
+  });
+
   it("prefills name and email from the session", () => {
     render(<DemoBookingFlow />);
-    expect(
-      (screen.getByLabelText(/First name/i) as HTMLInputElement).value,
-    ).toBe("Jane");
-    expect(
-      (screen.getByLabelText(/Last name/i) as HTMLInputElement).value,
-    ).toBe("Smith");
-    expect(
-      (screen.getByLabelText(/Work email/i) as HTMLInputElement).value,
-    ).toBe("jane@acme.com");
-  });
-
-  it("blocks submission and shows an error when a required field is empty", () => {
-    render(<DemoBookingFlow />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue to booking/i }),
-    );
-    expect(screen.getByText("This field is required")).toBeTruthy();
-    expect(captureMock).not.toHaveBeenCalled();
-    expect(screen.queryByTestId("cal-embed")).toBeNull();
-  });
-
-  it("advances to the Cal embed with an encoded link and fires demo_form_submitted", () => {
-    render(<DemoBookingFlow />);
-    fireEvent.change(screen.getByLabelText(/How did you hear about us/i), {
-      target: { value: "Google" },
-    });
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue to booking/i }),
-    );
-
-    expect(captureMock).toHaveBeenCalledWith("demo_form_submitted", {
-      product: "AI Control Plane",
-    });
     const embed = screen.getByTestId("cal-embed");
-    const link = embed.getAttribute("data-cal-link") ?? "";
-    expect(link).toContain("first-name=Jane");
-    expect(link).toContain("heard-about-us=Google");
-    expect(link).toContain("interested-products=AI%20Control%20Plane");
+    expect(embed.getAttribute("data-cal-name")).toBe("Jane Smith");
+    expect(embed.getAttribute("data-cal-email")).toBe("jane@acme.com");
+  });
+
+  it("renders the embed even before the session resolves", () => {
+    sessionHolder.current = null;
+    render(<DemoBookingFlow />);
+    const embed = screen.getByTestId("cal-embed");
+    expect(embed.getAttribute("data-cal-link")).toBe(CAL_DEMO_LINK);
+    expect(embed.getAttribute("data-cal-name")).toBe("");
+    expect(embed.getAttribute("data-cal-email")).toBe("");
   });
 
   it("fires booked_demo on a Cal bookingSuccessful message", () => {
     render(<DemoBookingFlow />);
-    fireEvent.change(screen.getByLabelText(/How did you hear about us/i), {
-      target: { value: "Google" },
-    });
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue to booking/i }),
-    );
-    captureMock.mockClear();
 
     window.dispatchEvent(
       new MessageEvent("message", {
@@ -122,70 +87,22 @@ describe("DemoBookingFlow", () => {
     expect(captureMock).toHaveBeenCalledWith(
       "booked_demo",
       expect.objectContaining({
+        first_name: "Jane",
+        last_name: "Smith",
         email: "jane@acme.com",
-        product: "AI Control Plane",
       }),
     );
   });
 
-  it("returns to the form when Back is clicked", () => {
+  it("ignores non-Cal postMessages", () => {
     render(<DemoBookingFlow />);
-    fireEvent.change(screen.getByLabelText(/How did you hear about us/i), {
-      target: { value: "Google" },
-    });
-    fireEvent.click(
-      screen.getByRole("button", { name: /Continue to booking/i }),
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({ originator: "OTHER", fullType: "x" }),
+      }),
     );
-    fireEvent.click(screen.getByRole("button", { name: /Back/i }));
-    expect(screen.getByText("Talk to our experts")).toBeTruthy();
-    expect(screen.queryByTestId("cal-embed")).toBeNull();
-  });
 
-  it("backfills empty fields when the session arrives after mount", () => {
-    sessionHolder.current = null; // session still loading at mount
-    const { rerender } = render(<DemoBookingFlow />);
-    expect(
-      (screen.getByLabelText(/Work email/i) as HTMLInputElement).value,
-    ).toBe("");
-    expect(
-      (screen.getByLabelText(/First name/i) as HTMLInputElement).value,
-    ).toBe("");
-
-    sessionHolder.current = {
-      user: { email: "jane@acme.com", displayName: "Jane Smith" },
-    };
-    rerender(<DemoBookingFlow />);
-
-    expect(
-      (screen.getByLabelText(/Work email/i) as HTMLInputElement).value,
-    ).toBe("jane@acme.com");
-    expect(
-      (screen.getByLabelText(/First name/i) as HTMLInputElement).value,
-    ).toBe("Jane");
-    expect(
-      (screen.getByLabelText(/Last name/i) as HTMLInputElement).value,
-    ).toBe("Smith");
-  });
-
-  it("does not overwrite fields the user already edited when the session arrives", () => {
-    sessionHolder.current = null;
-    const { rerender } = render(<DemoBookingFlow />);
-    fireEvent.change(screen.getByLabelText(/First name/i), {
-      target: { value: "Custom" },
-    });
-
-    sessionHolder.current = {
-      user: { email: "jane@acme.com", displayName: "Jane Smith" },
-    };
-    rerender(<DemoBookingFlow />);
-
-    // user's edit is preserved...
-    expect(
-      (screen.getByLabelText(/First name/i) as HTMLInputElement).value,
-    ).toBe("Custom");
-    // ...while still-empty fields are backfilled
-    expect(
-      (screen.getByLabelText(/Work email/i) as HTMLInputElement).value,
-    ).toBe("jane@acme.com");
+    expect(captureMock).not.toHaveBeenCalled();
   });
 });

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
@@ -19,13 +19,13 @@ vi.mock("@calcom/embed-react", () => ({
     config,
   }: {
     calLink: string;
-    config?: Record<string, unknown>;
+    config?: { name?: string; email?: string };
   }) => (
     <div
       data-testid="cal-embed"
       data-cal-link={calLink}
-      data-cal-name={String(config?.name ?? "")}
-      data-cal-email={String(config?.email ?? "")}
+      data-cal-name={config?.name ?? ""}
+      data-cal-email={config?.email ?? ""}
     />
   ),
 }));

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -1,17 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import _Cal from "@calcom/embed-react";
-import { Button } from "@speakeasy-api/moonshine";
 import { useSessionData } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
-import { cn } from "@/lib/utils";
-import {
-  buildCalLink,
-  DemoFormData,
-  DemoFormErrors,
-  PRODUCT_OPTIONS,
-  splitDisplayName,
-  validateDemoForm,
-} from "./demo-booking";
+import { CAL_DEMO_LINK, splitDisplayName } from "./demo-booking";
 
 // Cal's .d.ts returns the legacy global `JSX.Element`, incompatible with
 // react-jsx/TS5. Widen only the return type; keep prop types intact so a
@@ -19,53 +10,15 @@ import {
 type CalProps = Parameters<typeof _Cal>[0];
 const Cal = _Cal as unknown as (props: CalProps) => React.ReactElement | null;
 
-type Step = "form" | "booking";
-
-const inputStyles = cn(
-  "w-full rounded-md border px-3 py-2.5 text-sm text-gray-900 transition-colors outline-none",
-  "border-gray-300 bg-white placeholder:text-gray-400 focus:border-gray-500",
-);
-
-const labelStyles = "mb-0.5 text-sm text-gray-700";
-const errorStyles = "mt-0.5 text-xs text-red-500";
-
 export function DemoBookingFlow(): JSX.Element {
   const { session } = useSessionData();
   const telemetry = useTelemetry();
-  const [step, setStep] = useState<Step>("form");
 
-  const [formData, setFormData] = useState<DemoFormData>(() => {
-    const { firstName, lastName } = splitDisplayName(session?.user.displayName);
-    return {
-      firstName,
-      lastName,
-      email: session?.user.email ?? "",
-      referralSource: "",
-      product: "AI Control Plane",
-    };
-  });
-  const [errors, setErrors] = useState<DemoFormErrors>({});
-
-  // The useState initializer above captures the session synchronously when it's
-  // already loaded (the gate that renders this only mounts after auth resolves).
-  // When this component is reused somewhere the session is still loading at
-  // mount, backfill any still-empty fields once it arrives — without clobbering
-  // anything the user has already typed (prev value wins).
-  const sessionEmail = session?.user.email;
-  const sessionDisplayName = session?.user.displayName;
-  useEffect(() => {
-    if (!sessionEmail && !sessionDisplayName) return;
-    const { firstName, lastName } = splitDisplayName(sessionDisplayName);
-    setFormData((prev) => ({
-      ...prev,
-      firstName: prev.firstName || firstName,
-      lastName: prev.lastName || lastName,
-      email: prev.email || sessionEmail || "",
-    }));
-  }, [sessionEmail, sessionDisplayName]);
+  const email = session?.user.email ?? "";
+  const { firstName, lastName } = splitDisplayName(session?.user.displayName);
+  const name = [firstName, lastName].filter(Boolean).join(" ");
 
   useEffect(() => {
-    if (step !== "booking") return;
     const handler = (e: MessageEvent) => {
       try {
         const data =
@@ -77,11 +30,9 @@ export function DemoBookingFlow(): JSX.Element {
           (data?.fullType as string)?.endsWith("bookingSuccessful")
         ) {
           telemetry.capture("booked_demo", {
-            first_name: formData.firstName.trim(),
-            last_name: formData.lastName.trim(),
-            email: formData.email.trim(),
-            referral_source: formData.referralSource.trim(),
-            product: formData.product,
+            first_name: firstName,
+            last_name: lastName,
+            email,
           });
         }
       } catch {
@@ -90,168 +41,35 @@ export function DemoBookingFlow(): JSX.Element {
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [step, formData, telemetry]);
-
-  const handleChange =
-    (field: keyof DemoFormData) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value;
-      setFormData((prev) => ({ ...prev, [field]: value }));
-      setErrors((prev) => {
-        if (!prev[field]) return prev;
-        const next = { ...prev };
-        delete next[field];
-        return next;
-      });
-    };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    const nextErrors = validateDemoForm(formData);
-    setErrors(nextErrors);
-    if (Object.keys(nextErrors).length > 0) return;
-    telemetry.capture("demo_form_submitted", { product: formData.product });
-    setStep("booking");
-  };
-
-  if (step === "booking") {
-    return (
-      <div className="flex w-full flex-col gap-3">
-        <button
-          type="button"
-          onClick={() => setStep("form")}
-          className="self-start text-sm text-[#8B8684] transition-colors hover:text-slate-600"
-        >
-          &larr; Back
-        </button>
-        <div className="h-[70vh] min-h-[520px] w-full overflow-auto">
-          <Cal
-            calLink={buildCalLink(formData)}
-            config={{
-              layout: "month_view",
-              theme: "light",
-              hideEventTypeDetails: "true",
-              cssVarsPerTheme: JSON.stringify({
-                light: { "cal-bg": "transparent" },
-                dark: { "cal-bg": "transparent" },
-              }),
-            }}
-            style={{ width: "100%", height: "100%", overflow: "auto" }}
-          />
-        </div>
-      </div>
-    );
-  }
+  }, [firstName, lastName, email, telemetry]);
 
   return (
-    <div className="flex w-full flex-col gap-4">
-      <h2 className="text-lg font-semibold text-gray-900">
-        Talk to our experts
-      </h2>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
-        <div className="flex flex-col gap-2.5 md:flex-row">
-          <div className="flex w-full flex-col">
-            <label htmlFor="demo-firstName" className={labelStyles}>
-              First name <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="demo-firstName"
-              type="text"
-              autoComplete="given-name"
-              value={formData.firstName}
-              onChange={handleChange("firstName")}
-              placeholder="Jane"
-              className={cn(inputStyles, errors.firstName && "border-red-300")}
-            />
-            {errors.firstName && (
-              <span className={errorStyles}>{errors.firstName}</span>
-            )}
-          </div>
-          <div className="flex w-full flex-col">
-            <label htmlFor="demo-lastName" className={labelStyles}>
-              Last name <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="demo-lastName"
-              type="text"
-              autoComplete="family-name"
-              value={formData.lastName}
-              onChange={handleChange("lastName")}
-              placeholder="Smith"
-              className={cn(inputStyles, errors.lastName && "border-red-300")}
-            />
-            {errors.lastName && (
-              <span className={errorStyles}>{errors.lastName}</span>
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-2.5 md:flex-row">
-          <div className="flex w-full flex-col">
-            <label htmlFor="demo-email" className={labelStyles}>
-              Work email <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="demo-email"
-              type="email"
-              autoComplete="email"
-              value={formData.email}
-              onChange={handleChange("email")}
-              placeholder="jane@example.com"
-              className={cn(inputStyles, errors.email && "border-red-300")}
-            />
-            {errors.email && (
-              <span className={errorStyles}>{errors.email}</span>
-            )}
-          </div>
-          <div className="flex w-full flex-col">
-            <label htmlFor="demo-referralSource" className={labelStyles}>
-              How did you hear about us? <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="demo-referralSource"
-              type="text"
-              value={formData.referralSource}
-              onChange={handleChange("referralSource")}
-              placeholder="e.g. Google, Twitter, a friend"
-              className={cn(
-                inputStyles,
-                errors.referralSource && "border-red-300",
-              )}
-            />
-            {errors.referralSource && (
-              <span className={errorStyles}>{errors.referralSource}</span>
-            )}
-          </div>
-        </div>
-
-        <fieldset className="flex flex-col gap-1.5">
-          <legend className={labelStyles}>
-            What are you interested in? <span className="text-red-500">*</span>
-          </legend>
-          <div className="grid grid-cols-2 gap-1.5">
-            {PRODUCT_OPTIONS.map((option) => (
-              <label
-                key={option}
-                className="flex cursor-pointer items-center gap-2"
-              >
-                <input
-                  type="radio"
-                  name="product"
-                  value={option}
-                  checked={formData.product === option}
-                  onChange={handleChange("product")}
-                  className="h-4 w-4 accent-gray-900"
-                />
-                <span className="text-sm text-gray-700">{option}</span>
-              </label>
-            ))}
-          </div>
-        </fieldset>
-
-        <Button type="submit" variant="brand" className="mt-2 w-fit">
-          Continue to booking
-        </Button>
-      </form>
+    <div className="flex w-full flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Looks like your company is new to Speakeasy
+        </h2>
+        <p className="text-sm text-gray-600">
+          Book time with our team to activate your account and get started.
+        </p>
+      </div>
+      <div className="h-[70vh] min-h-[520px] w-full overflow-auto">
+        <Cal
+          calLink={CAL_DEMO_LINK}
+          config={{
+            layout: "month_view",
+            theme: "light",
+            hideEventTypeDetails: "true",
+            name,
+            email,
+            cssVarsPerTheme: JSON.stringify({
+              light: { "cal-bg": "transparent" },
+              dark: { "cal-bg": "transparent" },
+            }),
+          }}
+          style={{ width: "100%", height: "100%", overflow: "auto" }}
+        />
+      </div>
     </div>
   );
 }

--- a/client/dashboard/src/pages/demo/components/demo-booking.test.ts
+++ b/client/dashboard/src/pages/demo/components/demo-booking.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildCalLink,
-  CAL_ROUTING_FORM_ID,
-  DemoFormData,
-  splitDisplayName,
-  validateDemoForm,
-} from "./demo-booking";
+import { splitDisplayName } from "./demo-booking";
 
 describe("splitDisplayName", () => {
   it("splits a two-part name", () => {
@@ -38,54 +32,5 @@ describe("splitDisplayName", () => {
       firstName: "Jane",
       lastName: "Smith",
     });
-  });
-});
-
-const validData: DemoFormData = {
-  firstName: "Jane",
-  lastName: "Smith",
-  email: "jane@acme.com",
-  referralSource: "Google",
-  product: "AI Control Plane",
-};
-
-describe("validateDemoForm", () => {
-  it("returns no errors for valid data", () => {
-    expect(validateDemoForm(validData)).toEqual({});
-  });
-  it("flags every required field when empty", () => {
-    const errors = validateDemoForm({
-      firstName: "",
-      lastName: "",
-      email: "",
-      referralSource: "",
-      product: "AI Control Plane",
-    });
-    expect(errors.firstName).toBeTruthy();
-    expect(errors.lastName).toBeTruthy();
-    expect(errors.email).toBeTruthy();
-    expect(errors.referralSource).toBeTruthy();
-  });
-  it("rejects a malformed email", () => {
-    expect(
-      validateDemoForm({ ...validData, email: "not-an-email" }).email,
-    ).toBeTruthy();
-  });
-  it("accepts an email with surrounding whitespace (validated trimmed, like buildCalLink)", () => {
-    expect(
-      validateDemoForm({ ...validData, email: "  jane@acme.com  " }).email,
-    ).toBeUndefined();
-  });
-});
-
-describe("buildCalLink", () => {
-  it("targets the routing form and URL-encodes fields", () => {
-    const link = buildCalLink(validData);
-    expect(link.startsWith(`router?form=${CAL_ROUTING_FORM_ID}`)).toBe(true);
-    expect(link).toContain("interested-products=AI%20Control%20Plane");
-    expect(link).toContain("email=jane%40acme.com");
-    expect(link).toContain("first-name=Jane");
-    expect(link).toContain("last-name=Smith");
-    expect(link).toContain("heard-about-us=Google");
   });
 });

--- a/client/dashboard/src/pages/demo/components/demo-booking.ts
+++ b/client/dashboard/src/pages/demo/components/demo-booking.ts
@@ -1,25 +1,6 @@
-// Cal.com routing-form UUID — same form the marketing site's /book-demo uses,
-// so in-app bookings route identically. Rotate here if the Cal form changes.
-export const CAL_ROUTING_FORM_ID = "80acef04-31fd-4b18-bcae-6ee91d352bb8";
-
-export const PRODUCT_OPTIONS = [
-  "AI Control Plane",
-  "SDK Generation",
-  "CLI Generation",
-  "Terraform Generation",
-] as const;
-
-type ProductInterest = (typeof PRODUCT_OPTIONS)[number];
-
-export interface DemoFormData {
-  firstName: string;
-  lastName: string;
-  email: string;
-  referralSource: string;
-  product: ProductInterest;
-}
-
-export type DemoFormErrors = Partial<Record<keyof DemoFormData, string>>;
+// Cal.com event link booked when an org isn't whitelisted yet — the calendar is
+// embedded directly (no routing form). Rotate here if the Cal event changes.
+export const CAL_DEMO_LINK = "team/speakeasy-com/ai-transformation";
 
 export function splitDisplayName(displayName?: string): {
   firstName: string;
@@ -33,34 +14,4 @@ export function splitDisplayName(displayName?: string): {
     firstName: trimmed.slice(0, spaceIndex),
     lastName: trimmed.slice(spaceIndex + 1).trim(),
   };
-}
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-export function validateDemoForm(data: DemoFormData): DemoFormErrors {
-  const errors: DemoFormErrors = {};
-  if (!data.firstName.trim()) errors.firstName = "First name is required";
-  if (!data.lastName.trim()) errors.lastName = "Last name is required";
-  if (!data.email.trim()) {
-    errors.email = "Work email is required";
-  } else if (!EMAIL_RE.test(data.email.trim())) {
-    errors.email = "Enter a valid email address";
-  }
-  if (!data.referralSource.trim())
-    errors.referralSource = "This field is required";
-  return errors;
-}
-
-// Mirrors the marketing site's encoding exactly (encodeURIComponent -> %20 for
-// spaces) so in-app bookings route through the same Cal routing form.
-export function buildCalLink(data: DemoFormData): string {
-  const query = [
-    `form=${CAL_ROUTING_FORM_ID}`,
-    `first-name=${encodeURIComponent(data.firstName.trim())}`,
-    `last-name=${encodeURIComponent(data.lastName.trim())}`,
-    `email=${encodeURIComponent(data.email.trim())}`,
-    `heard-about-us=${encodeURIComponent(data.referralSource.trim())}`,
-    `interested-products=${encodeURIComponent(data.product)}`,
-  ].join("&");
-  return `router?${query}`;
 }

--- a/client/dashboard/src/pages/login/components/login-section.tsx
+++ b/client/dashboard/src/pages/login/components/login-section.tsx
@@ -28,7 +28,7 @@ function getAuthErrorMessage(errorCode?: string | null): string {
   return authErrorMessages[errorCode] || unexpected;
 }
 
-const FEATURE_BADGES = ["Build", "Secure", "Observe", "Distribute"];
+const FEATURE_BADGES = ["Connect", "Secure", "Control", "Observe"];
 
 function FeatureBadges({ labels = FEATURE_BADGES }: { labels?: string[] }) {
   return (


### PR DESCRIPTION
## What

Replaces the in-app demo form + Cal routing form in the not-yet-whitelisted signup gate (`AuthProvider` → `BookDemo` → `DemoBookingFlow`) with the Cal calendar embedded **directly**, pointed at the AI Transformation event.

## Why

The two-step flow (collect name/email/referral/product → hand off to a Cal routing form) added friction before a new signup could grab time. Since we already have the user's name and email from their session, we can drop the intermediate form and show the calendar immediately, with those fields prefilled.

## Changes

- **`DemoBookingFlow.tsx`** — removed the form step, step state, and validation. Embeds `team/speakeasy-com/ai-transformation` directly, prefilling `name`/`email` from the session. `booked_demo` telemetry on Cal's `bookingSuccessful` postMessage is preserved.
- **`demo-booking.ts`** — dropped the now-unused routing-form helpers (`buildCalLink`, `validateDemoForm`, `PRODUCT_OPTIONS`, `CAL_ROUTING_FORM_ID`, form types). Added `CAL_DEMO_LINK`; kept `splitDisplayName`.
- **Copy** — gate heading now reads *"Looks like your company is new to Speakeasy"* with subline *"Book time with our team to activate your account and get started."*
- **`login-section.tsx`** — relabel sign-in feature badges to `Connect / Secure / Control / Observe`.
- Tests rewritten to assert on the direct embed (calLink, prefill, telemetry) — all passing.

## Testing

- `pnpm -F dashboard exec vitest run src/pages/demo/components` — 10/10 pass
- `pnpm -F dashboard type-check` — no errors in changed files
