### PR TITLE
fix(risk): default the LLM judge to a cheap model

### DIFF
--- a/server/internal/background/activities/risk_analysis/llm_judge.go
+++ b/server/internal/background/activities/risk_analysis/llm_judge.go
@@ -14,6 +14,13 @@ const (
 	// finding. The policy that produced it carries the human-meaningful prompt;
 	// the rule_id just buckets the finding by detection mechanism.
 	RuleLLMJudge = "llm_judge"
+	// DefaultJudgeModel is the OpenRouter model used when a prompt_based policy
+	// does not pin its own model (JudgeConfig.Model == ""). The judge does a
+	// single, low-stakes binary classification against a short message, so a
+	// small, cheap, fast model is the right default — this avoids inheriting the
+	// (expensive) system-wide chat default for what is a high-volume,
+	// per-message billable call. Policies can override per-policy via model_config.
+	DefaultJudgeModel = "anthropic/claude-haiku-4.5"
 )
 
 // PromptJudge evaluates a single message against a natural-language guardrail

--- a/server/internal/riskjudge/judge.go
+++ b/server/internal/riskjudge/judge.go
@@ -224,13 +224,21 @@ func (j *Judge) call(ctx context.Context, in ra.JudgeInput) (matched bool, confi
 
 	userMessage := fmt.Sprintf("Policy:\n%s\n\nMessage to evaluate:\n%s", in.Prompt, in.Text)
 
+	// Empty model selects the judge default (a cheap, fast model) rather than
+	// inheriting the system-wide chat default, which is expensive for what is a
+	// high-volume per-message binary classification.
+	model := in.Config.Model
+	if model == "" {
+		model = ra.DefaultJudgeModel
+	}
+
 	callCtx, cancel := context.WithTimeout(ctx, judgeTimeout)
 	defer cancel()
 
 	response, err := j.client.GetObjectCompletion(callCtx, openrouter.ObjectCompletionRequest{
 		OrgID:          in.OrgID,
 		ProjectID:      in.ProjectID,
-		Model:          in.Config.Model,
+		Model:          model,
 		SystemPrompt:   systemPrompt,
 		Prompt:         userMessage,
 		Temperature:    &temperature,


### PR DESCRIPTION
## What

Pin a judge-specific default model (`anthropic/claude-haiku-4.5`) for prompt-based ("LLM-judge") risk policies that don't configure their own model.

## Why

When a `prompt_based` policy leaves `model_config.model` empty, `JudgeConfig.Model` is `""`. That fell through the unified OpenRouter client to the **system-wide** chat default:

- `riskjudge/judge.go` passed `Model: in.Config.Model` (`""`)
- `unified_client.go` (`initializeRequest`) defaults empty → `DefaultChatModel = "openai/gpt-5.4"`

The judge does a single, low-stakes **binary classification** against a short message, on a **high-volume, per-message billable** path. Inheriting a frontier general-purpose chat model as the default is needlessly expensive for that workload. Haiku is the cheapest Anthropic model in the OpenRouter allowlist and is well-suited to the task.

## How

- `risk_analysis/llm_judge.go` — add exported `DefaultJudgeModel = "anthropic/claude-haiku-4.5"`.
- `riskjudge/judge.go` — at the `GetObjectCompletion` call site, resolve empty `in.Config.Model` to `ra.DefaultJudgeModel` instead of letting it fall through to the system chat default.

`JudgeConfig.Model` semantics are unchanged — empty still means "use the judge default" — and policies can still override per-policy via `model_config`. Cost attribution is unaffected: judge calls already emit a `model_usage` billing event tagged with org id, model, source (`gram`), and cost.

## Test

- `go test ./internal/riskjudge/... ./internal/background/activities/risk_analysis/...` — 209 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the prompt-based risk judge to a cheap, fast model to avoid falling back to the expensive system chat default. This reduces per-message cost without changing policy behavior.

- **Bug Fixes**
  - When `model_config.model` is empty, use `anthropic/claude-haiku-4.5` instead of the system `openai/gpt-5.4`.
  - Added `DefaultJudgeModel` and resolve the model at the judge call site.
  - Policies can still override via `model_config`; billing events and semantics are unchanged.

<sup>Written for commit 64ac5886ad226e694352145331413041601de73a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

