### PR TITLE
chore: add dashboard grant reference

### DIFF
--- a/.agents/skills/gram-rbac/SKILL.md
+++ b/.agents/skills/gram-rbac/SKILL.md
@@ -139,6 +139,8 @@ The dashboard pages under `client/dashboard/src/pages/access/` render membership
 
 **Scope vocabulary import.** `useRBAC` and `RequireScope` both consume the `Scope` union from `client/dashboard/src/pages/access/types.ts` (covered under "Server-client contract"). Keeping that file in lockstep with the server is what makes the client gates work.
 
+**Dashboard grant reference.** [docs/rbac.md](../../../docs/rbac.md) contains the "Dashboard Grant Reference" table that maps dashboard pages and actions to the grants required to use them. Whenever adding a new scope, changing a system-role grant default, adding a new dashboard RBAC gate, or changing the grant required by a dashboard feature, update that table in the same change. The table is the first place to answer questions like "what grant is required to create a project?"
+
 ### Non-generated files
 
 | File                                                                                                     | Purpose                                                                                         |
@@ -173,8 +175,9 @@ Use this when the resource type is already represented (e.g. adding a new verb o
 6. Update the three enums in `server/design/access/design.go` that have to stay in lockstep.
 7. Add the new slug to the `Scope` union in `client/dashboard/src/pages/access/types.ts`.
 8. Bump `expectedFullAccessScopes` in `server/internal/access/listusergrants_test.go` and the `require.Len(t, result.Scopes, N)` assertion in `server/internal/access/listscopes_test.go`.
-9. Run `mise run gen:goa-server`, then `mise run gen:sdk`.
-10. Run `mise run lint:server` and `mise run test:server`.
+9. Update the "Dashboard Grant Reference" table in [docs/rbac.md](../../../docs/rbac.md) if the new scope affects any dashboard route, action, or user-facing grant question.
+10. Run `mise run gen:goa-server`, then `mise run gen:sdk`.
+11. Run `mise run lint:server` and `mise run test:server`.
 
 ### How to add a new resource type
 
@@ -190,8 +193,9 @@ Use this when adjusting what `admin` or `member` gets out of the box. Prefer add
 
 1. Edit `SystemRoleGrants` in `server/internal/authz/grants.go`.
 2. Update `expectedFullAccessScopes` in `server/internal/access/listusergrants_test.go` if the admin set changed.
-3. Consider whether existing orgs' grant tables need a migration to reflect the new defaults; new orgs pick up defaults automatically via `SeedSystemRoleGrants` when RBAC is enabled.
-4. Run `mise run lint:server` and `mise run test:server`.
+3. Update the "Dashboard Grant Reference" table in [docs/rbac.md](../../../docs/rbac.md) if the default grant change affects what a built-in role can do in the dashboard.
+4. Consider whether existing orgs' grant tables need a migration to reflect the new defaults; new orgs pick up defaults automatically via `SeedSystemRoleGrants` when RBAC is enabled.
+5. Run `mise run lint:server` and `mise run test:server`.
 
 ### How to narrow an MCP check by tool or disposition
 
@@ -240,6 +244,8 @@ Dashboard code should never hand-roll scope checks — use the shared primitives
    ```
 
 5. **The `Scope` string you pass must match the server.** Import from `client/dashboard/src/pages/access/types.ts` (re-exported via `useRBAC` for convenience). If TypeScript complains about an unknown scope, you're missing the union update from the server scope add (see "How to add a new scope to an existing resource type").
+
+6. **Update the dashboard grant reference.** Any new or changed dashboard gate must update the "Dashboard Grant Reference" table in [docs/rbac.md](../../../docs/rbac.md), including page-level access, component/action-level access, resource selector target, and any notable server-side check that differs from the visible UI gate.
 
 ### How to inspect the caller's grants
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -68,14 +68,18 @@ Scopes are code, not database rows. The current vocabulary lives in `server/inte
 
 ```go
 const (
-	ScopeRoot         Scope = "root"
-	ScopeOrgRead      Scope = "org:read"
-	ScopeOrgAdmin     Scope = "org:admin"
-	ScopeProjectRead  Scope = "project:read"
-	ScopeProjectWrite Scope = "project:write"
-	ScopeMCPRead      Scope = "mcp:read"
-	ScopeMCPWrite     Scope = "mcp:write"
-	ScopeMCPConnect   Scope = "mcp:connect"
+	ScopeRoot               Scope = "root"
+	ScopeOrgRead            Scope = "org:read"
+	ScopeOrgAdmin           Scope = "org:admin"
+	ScopeProjectRead        Scope = "project:read"
+	ScopeProjectWrite       Scope = "project:write"
+	ScopeMCPRead            Scope = "mcp:read"
+	ScopeMCPWrite           Scope = "mcp:write"
+	ScopeMCPConnect         Scope = "mcp:connect"
+	ScopeEnvironmentRead    Scope = "environment:read"
+	ScopeEnvironmentWrite   Scope = "environment:write"
+	ScopeRiskPolicyEvaluate Scope = "risk_policy:evaluate"
+	ScopeRiskPolicyBypass   Scope = "risk_policy:bypass"
 )
 ```
 
@@ -87,18 +91,22 @@ Some scopes imply lower-privilege scopes. The expansion rules also live in `serv
 
 ```go
 var scopeExpansions = map[Scope][]Scope{
-	ScopeRoot:         nil,
-	ScopeOrgRead:      {ScopeOrgAdmin},
-	ScopeOrgAdmin:     nil,
-	ScopeProjectRead:  {ScopeProjectWrite},
-	ScopeProjectWrite: nil,
-	ScopeMCPRead:      {ScopeMCPWrite},
-	ScopeMCPWrite:     nil,
-	ScopeMCPConnect:   {ScopeMCPRead, ScopeMCPWrite},
+	ScopeRoot:               nil,
+	ScopeOrgRead:            {ScopeOrgAdmin},
+	ScopeOrgAdmin:           nil,
+	ScopeProjectRead:        {ScopeProjectWrite},
+	ScopeProjectWrite:       nil,
+	ScopeMCPRead:            {ScopeMCPWrite},
+	ScopeMCPWrite:           nil,
+	ScopeMCPConnect:         {ScopeMCPRead, ScopeMCPWrite},
+	ScopeEnvironmentRead:    {ScopeEnvironmentWrite},
+	ScopeEnvironmentWrite:   nil,
+	ScopeRiskPolicyEvaluate: nil,
+	ScopeRiskPolicyBypass:   nil,
 }
 ```
 
-Read this map as "if a handler requires the key scope, any scope in the value list also satisfies the check." A `project:write` grant satisfies a `project:read` check. An `mcp:write` grant satisfies `mcp:read`, and both `mcp:read` and `mcp:write` satisfy `mcp:connect`. `org:admin` satisfies `org:read`, and `root` satisfies every check.
+Read this map as "if a handler requires the key scope, any scope in the value list also satisfies the check." A `project:write` grant satisfies a `project:read` check. An `mcp:write` grant satisfies `mcp:read`, and both `mcp:read` and `mcp:write` satisfy `mcp:connect`. `environment:write` satisfies `environment:read`. `org:admin` satisfies `org:read`, and `root` satisfies every check.
 
 Expansion happens when the engine evaluates a check. If code asks for `project:read`, the engine checks for `root`, `project:read`, and `project:write` against the same resource selector. The API also exposes the inverse relationship as `sub_scopes` so role UIs can show what a broader grant implies; those sub-scopes are derived from code and are not additional database rows.
 
@@ -336,6 +344,8 @@ project:write
 mcp:read
 mcp:write
 mcp:connect
+environment:read
+environment:write
 ```
 
 `member` receives read and connect access by default:
@@ -345,9 +355,45 @@ org:read
 project:read
 mcp:read
 mcp:connect
+environment:read
 ```
 
 System roles are seeded when RBAC is enabled for an organization. They are not meant to be edited like custom roles. Changing the default grants of a system role is a product behavior change and should be treated carefully, especially for existing organizations.
+
+## Dashboard Grant Reference
+
+Use this table when answering "what grant is required to use this dashboard feature?" It records the dashboard's page and action gates, but server-side checks remain authoritative. When a row lists multiple scopes separated by `OR`, any one of those grants can open the surface. Scope expansion still applies: `org:admin` implies `org:read`, `project:write` implies `project:read`, `mcp:write` implies `mcp:read` and `mcp:connect`, and `environment:write` implies `environment:read`.
+
+Selectors matter. A project-scoped feature needs the grant selector to match the active project. An MCP feature needs the selector to match the target MCP server or toolset. An unrestricted selector for the scope family covers every resource in that family.
+
+| Dashboard feature or question                                                       | Required grant(s)                           | Selector target                                                       | Notes                                                                                                                                                                                                            |
+| ----------------------------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Open organization home and see project entry points                                 | `org:read` OR `project:read` OR `org:admin` | Org or project selector, depending on grant                           | The page can render for org readers, project readers, or admins. Project visibility still depends on backend filtering and loaded organization data.                                                             |
+| Create a project                                                                    | `org:admin`                                 | Organization ID                                                       | The `/rpc/projects.create` handler requires `org:admin`. `project:write` is not enough because the project does not exist yet.                                                                                   |
+| Invite members, change member roles, create/update/delete roles                     | `org:admin`                                 | Organization ID                                                       | Access management mutations are organization administration.                                                                                                                                                     |
+| Open Access / RBAC page                                                             | `org:read` OR `org:admin`                   | Organization ID                                                       | Viewing access state can be read-only; role, grant, member-role, and challenge-resolution actions are `org:admin`.                                                                                               |
+| Open Team page and manage members                                                   | `org:admin`                                 | Organization ID                                                       | The current Team page is page-gated on `org:admin`.                                                                                                                                                              |
+| Open Billing                                                                        | `org:read` OR `org:admin`                   | Organization ID                                                       | Billing management sections and portal actions are `org:admin`.                                                                                                                                                  |
+| Manage organization API keys or generate agent tokens                               | `org:admin`                                 | Organization ID                                                       | API key listing and creation are admin-only in the dashboard.                                                                                                                                                    |
+| View organization domains, org logs, webhooks, identity, audit logs, device agent   | `org:read` OR `org:admin`                   | Organization ID                                                       | Mutating settings on these pages, including domains, forwarding, webhooks, identity providers, and device-agent token generation, requires `org:admin`.                                                          |
+| View organization collections                                                       | `org:read` OR `org:admin`                   | Organization ID                                                       | Collection create/update/delete and MCP server attach/detach actions require `org:admin`. Adding collection content to a project can additionally require `project:write` for that project.                      |
+| Open project home                                                                   | `project:read`                              | Project ID                                                            | `project:write` also opens it through scope expansion.                                                                                                                                                           |
+| Open Sources and source detail pages                                                | `project:read` OR `project:write`           | Project ID                                                            | Creating, importing, reconnecting, deleting, or editing sources requires `project:write`. Creating custom remote MCP servers is gated by `mcp:write`.                                                            |
+| Add OpenAPI, add Function, or add from Catalog through Sources                      | `project:write`                             | Project ID                                                            | These routes create project-owned resources.                                                                                                                                                                     |
+| Open Catalog                                                                        | `project:read` OR `mcp:write`               | Project ID or MCP selector, depending on entry point                  | Browsing from the main nav can be available to project readers. Adding a catalog server to a project is a write action and is gated at the add flow.                                                             |
+| Open Playground                                                                     | `mcp:connect` OR `mcp:read` OR `mcp:write`  | MCP server or toolset ID                                              | Runtime calls should use `mcp:connect`; editing saved playground/server configuration requires `mcp:write`.                                                                                                      |
+| Open MCP server/toolset pages                                                       | `mcp:read` OR `mcp:write`                   | MCP server or toolset ID                                              | Creating, editing, deleting, publishing, authentication, team-access, prompt/resource, OAuth, tool filtering, and settings actions generally require `mcp:write`; collection publishing can require `org:admin`. |
+| Create a custom remote MCP server                                                   | `mcp:write`                                 | MCP selector, usually unrestricted or target server ID after creation | The create route is page-gated on `mcp:write`.                                                                                                                                                                   |
+| Open Deployments                                                                    | `project:read` OR `project:write`           | Project ID                                                            | Deployment-triggering and failed-source retry actions require `project:write`.                                                                                                                                   |
+| Open Assistants                                                                     | `project:read`                              | Project ID                                                            | Creating or editing assistants is gated by `project:write` OR `mcp:write`; admin-only assistant management sections are `org:admin`.                                                                             |
+| Open Skills / CLIs                                                                  | `project:read`                              | Project ID                                                            | This is a read-only project surface.                                                                                                                                                                             |
+| Open Plugins                                                                        | `project:read` OR `project:write`           | Project ID                                                            | Plugin install, update, delete, or configuration actions require `project:write`.                                                                                                                                |
+| Open Environments list                                                              | `project:read` OR `project:write`           | Project ID                                                            | Creating a new environment is currently `project:write`; environment card clone actions are `environment:write`.                                                                                                 |
+| Open an Environment detail page                                                     | `project:read`                              | Project ID                                                            | Adding, editing, deleting, or filling variables is currently `project:write`. Environment-specific clone checks use `environment:read` for the source and `environment:write` for the destination.               |
+| Open Insights                                                                       | `project:read`                              | Project ID                                                            | Some nested insights routes accept `project:write` too, but `project:read` is the intended read grant.                                                                                                           |
+| Open Logs / Agent Sessions                                                          | `project:read`                              | Project ID                                                            | Project log tabs are read surfaces. Risk-event logs are `org:admin`.                                                                                                                                             |
+| Open Project Settings                                                               | `project:write`                             | Project ID                                                            | Settings are treated as project mutation/admin surface.                                                                                                                                                          |
+| Open Secure pages: Risk Overview, Risk Policies, Approval Requests, Detection Rules | `org:admin`                                 | Organization ID                                                       | The dashboard pages are admin-only today. `risk_policy:evaluate` and `risk_policy:bypass` are policy runtime/request-flow scopes, not general dashboard page grants.                                             |
 
 ## Enforcing RBAC in Code
 


### PR DESCRIPTION
## Summary
- add a Dashboard Grant Reference table to docs/rbac.md
- document that creating a project requires org:admin
- add gram-rbac skill guidance to keep the table updated when grants or dashboard gates change

## Validation
- not run; documentation-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Dashboard Grant Reference” table to `docs/rbac.md` that maps dashboard pages/actions to required grants and selector targets, and clarifies that creating a project requires `org:admin`. Also documents the new `environment:*` and `risk_policy:*` scopes (with expansions) and updates `gram-rbac` guidance to keep the table in sync, addressing Linear U63V.

<sup>Written for commit 585054bcc46150a3481f936aaf2a1b64d28b88cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

