### PR TITLE
feat(dashboard): move risk events to secure

### DIFF
--- a/.changeset/risk-events-secure.md
+++ b/.changeset/risk-events-secure.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Moved Risk Events into the Secure section.

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -110,6 +110,7 @@ export function AppSidebar({
   const securityActive = [
     routes.riskOverview,
     routes.policyCenter,
+    routes.riskEvents,
     routes.approvalRequests,
     routes.detectionRules,
   ].some((r) => r.active);
@@ -263,6 +264,10 @@ export function AppSidebar({
                 <ScopeGatedNavItem
                   item={routes.policyCenter}
                   scope={scopeFor(routes.policyCenter)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.riskEvents}
+                  scope={scopeFor(routes.riskEvents)}
                 />
                 <ScopeGatedNavItem
                   item={routes.approvalRequests}

--- a/client/dashboard/src/components/log-workbench.tsx
+++ b/client/dashboard/src/components/log-workbench.tsx
@@ -1,8 +1,13 @@
 import { cn } from "@/lib/utils";
+import {
+  ReleaseStageBadge,
+  type ReleaseStage,
+} from "@/components/release-stage-badge";
 import type React from "react";
 
 export interface LogWorkbenchProps {
   title: React.ReactNode;
+  stage?: ReleaseStage;
   description?: React.ReactNode;
   actions?: React.ReactNode;
   filters?: React.ReactNode;
@@ -20,6 +25,7 @@ export interface LogWorkbenchProps {
 
 export function LogWorkbench({
   title,
+  stage,
   description,
   actions,
   filters,
@@ -40,7 +46,10 @@ export function LogWorkbench({
         <div className="shrink-0 px-8 py-4">
           <div className="mb-4 flex items-start justify-between gap-4">
             <div className="flex min-w-0 flex-col gap-1">
-              <h1 className="text-xl font-semibold">{title}</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-xl font-semibold">{title}</h1>
+                {stage ? <ReleaseStageBadge stage={stage} /> : null}
+              </div>
               {description ? (
                 <p className="text-muted-foreground text-sm">{description}</p>
               ) : null}

--- a/client/dashboard/src/components/observe/ObserveTabNav.tsx
+++ b/client/dashboard/src/components/observe/ObserveTabNav.tsx
@@ -28,15 +28,7 @@ export function ObserveTabNav({
     { label: "Tools", href: `${baseSlug}/tools` },
     { label: "MCP Servers", href: `${baseSlug}/mcp` },
     ...(base === "logs"
-      ? ([
-          {
-            label: "Risk Events",
-            href: `${baseSlug}/risk-events`,
-            stage: "beta",
-            scope: "org:admin",
-          },
-          { label: "Agents", href: `${baseSlug}/agents` },
-        ] satisfies Tab[])
+      ? ([{ label: "Agents", href: `${baseSlug}/agents` }] satisfies Tab[])
       : []),
     ...(base === "insights"
       ? ([

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -62,6 +62,7 @@ export function useProjectNavRoutes(): ProjectNavRoute[] {
       { route: routes.logs, scope: read },
       { route: routes.riskOverview, scope: read },
       { route: routes.policyCenter, scope: readWrite },
+      { route: routes.riskEvents, scope: ["org:admin"] },
       { route: routes.approvalRequests, scope: readWrite },
       { route: routes.detectionRules, scope: readWrite },
       { route: routes.settings, scope: ["project:write"] },

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -1142,7 +1142,7 @@ function ChatDetailPanel({
   const isSuperAdmin = useIsAdmin();
   const { hasScope } = useRBAC();
   // Export + delete should be available to anyone with org:admin (the scope
-  // that already gates /risk-overview and /logs/risk-events). Falling back to
+  // that already gates /risk-overview and /risk-events). Falling back to
   // the platform super-admin flag locked out customer org admins who can
   // already see the data in this panel.
   const canManageChat = isSuperAdmin || hasScope("org:admin");

--- a/client/dashboard/src/pages/security/RiskEvents.tsx
+++ b/client/dashboard/src/pages/security/RiskEvents.tsx
@@ -221,6 +221,7 @@ export default function RiskEvents(): JSX.Element {
     <RevealAllProvider>
       <LogWorkbench
         title="Risk Events"
+        stage="beta"
         description="Review policy findings across recent analyzed chats."
         actions={
           <div className="flex items-center gap-2">

--- a/client/dashboard/src/pages/security/RiskOverviewRulesIndex.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewRulesIndex.tsx
@@ -63,7 +63,7 @@ function RiskOverviewRulesIndexContent() {
   const total = rules.reduce((acc, r) => acc + Number(r.findings), 0);
   const max = rules[0]?.findings ?? 0;
 
-  const riskEventsHref = routes.logs.riskEvents.href();
+  const riskEventsHref = routes.riskEvents.href();
 
   const controls = (
     <TimeRangePicker

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -257,7 +257,7 @@ function SecurityOverviewContent() {
   }, [overview?.topCategories, routes.riskOverview, location.search]);
 
   const topRules = useMemo<BarDatum[]>(() => {
-    const riskEventsHref = routes.logs.riskEvents.href();
+    const riskEventsHref = routes.riskEvents.href();
     return (overview?.topRules ?? []).map((r) => {
       const label = r.ruleId ? getRuleTitleFallback(r.ruleId) : "(no rule_id)";
       const ruleParams = new URLSearchParams();
@@ -275,7 +275,7 @@ function SecurityOverviewContent() {
         href,
       };
     });
-  }, [overview?.topRules, routes.logs.riskEvents, location.search]);
+  }, [overview?.topRules, routes.riskEvents, location.search]);
 
   const topUsers = useMemo<BarDatum[]>(() => {
     const userDetailRoute = (
@@ -546,8 +546,8 @@ function RiskActivitySection({ children }: { children: ReactNode }) {
   const agentsHref = `${routes.logs.agents.href()}?${agentsParams.toString()}`;
 
   const riskEventsHref = carriedRangeParams.toString()
-    ? `${routes.logs.riskEvents.href()}?${carriedRangeParams.toString()}`
-    : routes.logs.riskEvents.href();
+    ? `${routes.riskEvents.href()}?${carriedRangeParams.toString()}`
+    : routes.riskEvents.href();
 
   return (
     <Page.Section>

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -451,11 +451,6 @@ const ROUTE_STRUCTURE = {
         url: "mcp",
         component: LogsMCPPage,
       },
-      riskEvents: {
-        title: "Risk Events",
-        url: "risk-events",
-        component: LogsRiskEventsPage,
-      },
       agents: {
         title: "Agent Sessions",
         url: "agents",
@@ -520,6 +515,12 @@ const ROUTE_STRUCTURE = {
     url: "risk-policies",
     icon: "shield-check",
     component: PolicyCenter,
+  },
+  riskEvents: {
+    title: "Risk Events",
+    url: "risk-events",
+    icon: "flag",
+    component: LogsRiskEventsPage,
   },
   sdks: {
     title: "SDKs",


### PR DESCRIPTION
## Summary
- Move Risk Events out of Logs and into the Secure section.
- Keep the Secure page title/sidebar beta labeling consistent with the rest of Secure.
- Preserve the existing logs behavior without adding redirects.

Linear: DNO-192

## Test Plan
- [x] pnpm -F dashboard type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Risk Events from Logs to Secure as a top-level page with a Beta badge. Aligns with DNO-192 and updates nav/routes without redirects or changes to other Logs tabs.

- **New Features**
  - Added `routes.riskEvents` under Secure (between Policy Center and Approval Requests) with a flag icon.
  - Removed Risk Events from Logs tabs and updated links from `routes.logs.riskEvents` to `routes.riskEvents`.
  - Added Beta badge via `ReleaseStageBadge` in `LogWorkbench` for the Risk Events page.
  - Gated Risk Events behind `org:admin` in `useProjectNavRoutes` and the sidebar; other pages unaffected.

<sup>Written for commit 09297840d1ec28cd29f7efd404c565c848226c03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

