### PR TITLE
feat(dashboard): move agent sessions out of subnav

### DIFF
--- a/.changeset/promote-agent-sessions.md
+++ b/.changeset/promote-agent-sessions.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Promoted Agent Sessions to top-level Observe navigation.

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -12,7 +12,6 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import {
   BrowserRouter,
-  Navigate,
   Route,
   Routes,
   useLocation,
@@ -279,11 +278,6 @@ const RouteProvider = () => {
             {routesWithSubroutes(outsideStructureRoutes)}
           </Route>
           <Route path=":orgSlug/projects/:projectSlug" element={<AppLayout />}>
-            {/* Redirect legacy /chat-sessions bookmarks to the new /agent-sessions URL */}
-            <Route
-              path="chat-sessions"
-              element={<Navigate to="../agent-sessions" replace />}
-            />
             {routesWithSubroutes(authenticatedRoutes)}
           </Route>
           {/* Org routes that render without OrgLayout (full-screen standalone pages) */}

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -105,7 +105,11 @@ export function AppSidebar({
     ...(isAssistantsEnabled ? [routes.assistants] : []),
   ].some((r) => r.active);
 
-  const observeActive = [routes.insights, routes.logs].some((r) => r.active);
+  const observeActive = [
+    routes.insights,
+    routes.agentSessions,
+    routes.logs,
+  ].some((r) => r.active);
 
   const securityActive = [
     routes.riskOverview,
@@ -243,6 +247,10 @@ export function AppSidebar({
                 <ScopeGatedNavItem
                   item={routes.insights}
                   scope={scopeFor(routes.insights)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.agentSessions}
+                  scope={scopeFor(routes.agentSessions)}
                 />
                 <ScopeGatedNavItem
                   item={routes.logs}

--- a/client/dashboard/src/components/observe/ObserveRedirects.tsx
+++ b/client/dashboard/src/components/observe/ObserveRedirects.tsx
@@ -15,8 +15,3 @@ export function RedirectToLogTools(): JSX.Element {
   const routes = useRoutes();
   return <RedirectPreservingLocation to={routes.logs.tools.href()} />;
 }
-
-export function RedirectToLogAgents(): JSX.Element {
-  const routes = useRoutes();
-  return <RedirectPreservingLocation to={routes.logs.agents.href()} />;
-}

--- a/client/dashboard/src/components/observe/ObserveTabNav.tsx
+++ b/client/dashboard/src/components/observe/ObserveTabNav.tsx
@@ -27,9 +27,6 @@ export function ObserveTabNav({
   const tabs: Tab[] = [
     { label: "Tools", href: `${baseSlug}/tools` },
     { label: "MCP Servers", href: `${baseSlug}/mcp` },
-    ...(base === "logs"
-      ? ([{ label: "Agents", href: `${baseSlug}/agents` }] satisfies Tab[])
-      : []),
     ...(base === "insights"
       ? ([
           {

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -552,7 +552,7 @@ export function ProjectDashboard(): JSX.Element {
                                   !isProjectEmpty &&
                                     overview?.summary.totalChats === 0
                                   ? routes.insights.href()
-                                  : routes.logs.agents.href()
+                                  : routes.agentSessions.href()
                             }
                           />
                         </CardActions>

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -59,6 +59,7 @@ export function useProjectNavRoutes(): ProjectNavRoute[] {
       { route: routes.plugins, scope: readWrite },
       { route: routes.environments, scope: readWrite },
       { route: routes.insights, scope: read },
+      { route: routes.agentSessions, scope: read },
       { route: routes.logs, scope: read },
       { route: routes.riskOverview, scope: read },
       { route: routes.policyCenter, scope: readWrite },

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantDraftPanel.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantDraftPanel.tsx
@@ -66,13 +66,13 @@ export function AssistantDraftPanel(): JSX.Element {
           {a?.name ?? "Loading…"}
         </Type>
         <div className="flex shrink-0 items-center gap-1">
-          <routes.logs.agents.Link
+          <routes.agentSessions.Link
             queryParams={{ assistantId: draft.assistantId }}
             className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs no-underline transition-colors hover:no-underline"
           >
             <Icon name="activity" className="h-3 w-3" />
             Sessions
-          </routes.logs.agents.Link>
+          </routes.agentSessions.Link>
           <Button
             variant="ghost"
             size="sm"

--- a/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
@@ -1,10 +1,20 @@
 import { RequireScope } from "@/components/require-scope";
 import { LogsAgentsContent } from "@/components/observe/LogsAgents";
+import { Page } from "@/components/page-layout";
 
 export default function ChatLogs(): JSX.Element {
   return (
-    <RequireScope scope="project:read" level="page">
-      <LogsAgentsContent />
-    </RequireScope>
+    <div className="flex h-full flex-col">
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs fullWidth />
+        </Page.Header>
+        <Page.Body fullWidth fullHeight overflowHidden noPadding>
+          <RequireScope scope="project:read" level="page">
+            <LogsAgentsContent />
+          </RequireScope>
+        </Page.Body>
+      </Page>
+    </div>
   );
 }

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -543,7 +543,7 @@ function RiskActivitySection({ children }: { children: ReactNode }) {
 
   const agentsParams = new URLSearchParams(carriedRangeParams);
   agentsParams.set("has_risk", "true");
-  const agentsHref = `${routes.logs.agents.href()}?${agentsParams.toString()}`;
+  const agentsHref = `${routes.agentSessions.href()}?${agentsParams.toString()}`;
 
   const riskEventsHref = carriedRangeParams.toString()
     ? `${routes.riskEvents.href()}?${carriedRangeParams.toString()}`

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 import {
   RedirectToInsightsTools,
-  RedirectToLogAgents,
   RedirectToLogTools,
 } from "./components/observe/ObserveRedirects";
 import { ReleaseStage } from "./components/release-stage-badge";
@@ -451,18 +450,13 @@ const ROUTE_STRUCTURE = {
         url: "mcp",
         component: LogsMCPPage,
       },
-      agents: {
-        title: "Agent Sessions",
-        url: "agents",
-        component: ChatSessions,
-      },
     },
   },
-  chatSessions: {
-    // redirect to logs/agents. TODO: remove this in a month
+  agentSessions: {
     title: "Agent Sessions",
     url: "agent-sessions",
-    component: RedirectToLogAgents,
+    icon: "message-square",
+    component: ChatSessions,
   },
   riskOverview: {
     title: "Risk Overview",


### PR DESCRIPTION
## Summary
- Promote Agent Sessions out of Logs and into top-level Observe navigation.
- Keep logs/sidebar navigation aligned with the new page structure.
- Stack this on DNO-192 because both touch the Logs navigation surface.

Linear: DNO-197
Stacked on: #3366

## Test Plan
- [x] pnpm -F @gram/client build
- [x] pnpm -F dashboard type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted Agent Sessions from Logs into a top-level Observe page at `/agent-sessions` with its own sidebar item and breadcrumbs. Updated links and removed legacy redirects. Implements Linear DNO-197.

- **New Features**
  - Added `routes.agentSessions` (icon: `message-square`) rendering the sessions page with breadcrumbs.
  - Observe sidebar and project nav now include Agent Sessions (read scope).
  - Removed the Logs "Agents" tab.
  - Updated links: Assistant onboarding “Sessions,” Security Overview risk filter, and Project Dashboard CTA now point to `/agent-sessions`.

- **Migration**
  - Update bookmarks/docs from `/logs/agents` or `/chat-sessions` to `/agent-sessions` (removed `RedirectToLogAgents` and the in-app `/chat-sessions` redirect).

<sup>Written for commit 145e5cd0c0bc6c5cfc8464767a223482dc358a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

