### PR TITLE
feat(dashboard): promote employees and costs

### DIFF
--- a/.changeset/promote-employees-costs.md
+++ b/.changeset/promote-employees-costs.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Promoted Employees and Costs to top-level navigation.

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -106,6 +106,8 @@ export function AppSidebar({
   ].some((r) => r.active);
 
   const observeActive = [
+    routes.employees,
+    routes.costs,
     routes.insights,
     routes.agentSessions,
     routes.logs,
@@ -242,8 +244,16 @@ export function AppSidebar({
               <CollapsibleNavGroup
                 label="Observe"
                 Icon={(p) => <Icon {...p} name="eye" />}
-                defaultHref={routes.insights.href()}
+                defaultHref={routes.employees.href()}
               >
+                <ScopeGatedNavItem
+                  item={routes.employees}
+                  scope={scopeFor(routes.employees)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.costs}
+                  scope={scopeFor(routes.costs)}
+                />
                 <ScopeGatedNavItem
                   item={routes.insights}
                   scope={scopeFor(routes.insights)}

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -271,7 +271,8 @@ const statusMeta: Record<
 
 export function InsightsEmployeesContent(): JSX.Element {
   const client = useGramContext();
-  const { orgSlug, projectSlug } = useSlugs();
+  const routes = useRoutes();
+  const { projectSlug } = useSlugs();
   const navigate = useNavigate();
   const { isExpanded: isInsightsOpen } = useInsightsState();
   const mcpConfig = useObservabilityMcpConfig({
@@ -413,7 +414,7 @@ export function InsightsEmployeesContent(): JSX.Element {
     (sum, item) => sum + item.tokenCount,
     0,
   );
-  const employeesBase = `/${orgSlug}/projects/${projectSlug}/insights/employees`;
+  const employeesBase = routes.employees.href();
   const openUser = (employee: Employee) => {
     void navigate(`${employeesBase}/${routeSegmentForEmployee(employee)}`);
   };

--- a/client/dashboard/src/components/observe/ObserveTabNav.tsx
+++ b/client/dashboard/src/components/observe/ObserveTabNav.tsx
@@ -27,14 +27,15 @@ export function ObserveTabNav({
   const tabs: Tab[] = [
     { label: "Tools", href: `${baseSlug}/tools` },
     { label: "MCP Servers", href: `${baseSlug}/mcp` },
-    ...(base === "insights"
+    ...(base === "logs"
       ? ([
           {
-            label: "Employees",
-            href: `${baseSlug}/employees`,
-            stage: "preview",
+            label: "Risk Events",
+            href: `${baseSlug}/risk-events`,
+            stage: "beta",
+            scope: "org:admin",
           },
-          { label: "Costs", href: `${baseSlug}/costs`, stage: "preview" },
+          { label: "Agents", href: `${baseSlug}/agents` },
         ] satisfies Tab[])
       : []),
   ];

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -456,7 +456,7 @@ export function ProjectDashboard(): JSX.Element {
                           })
                         }
                       />
-                      <ViewAllLink to={routes.insights.employees.href()} />
+                      <ViewAllLink to={routes.employees.href()} />
                     </CardActions>
                   }
                 >

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -58,6 +58,8 @@ export function useProjectNavRoutes(): ProjectNavRoute[] {
       { route: routes.clis, scope: read },
       { route: routes.plugins, scope: readWrite },
       { route: routes.environments, scope: readWrite },
+      { route: routes.employees, scope: read },
+      { route: routes.costs, scope: read },
       { route: routes.insights, scope: read },
       { route: routes.agentSessions, scope: read },
       { route: routes.logs, scope: read },

--- a/client/dashboard/src/pages/insights/Insights.tsx
+++ b/client/dashboard/src/pages/insights/Insights.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { Outlet, useParams } from "react-router";
 import { InsightsAgentsContent } from "@/components/observe/InsightsAgents";
@@ -12,24 +13,39 @@ import { useMembers } from "@gram/client/react-query";
 import { slugify } from "@/lib/constants";
 
 export function InsightsRoot(): JSX.Element {
-  const { userSlug } = useParams<{ userSlug: string }>();
-  const { data: membersData } = useMembers();
-  const substitutions = useMemo(() => {
-    if (!userSlug) return {};
-    const decodedUserSlug = decodeURIComponent(userSlug);
-    if (decodedUserSlug.includes("@")) {
-      return {
-        [userSlug]: decodedUserSlug,
-        [encodeURIComponent(decodedUserSlug)]: decodedUserSlug,
-      };
-    }
-    if (!membersData?.members) return {};
-    const member = membersData.members.find(
-      (m) => slugify(m.name) === userSlug,
-    );
-    return member ? { [userSlug]: member.email } : {};
-  }, [userSlug, membersData]);
+  return (
+    <ObservePageShell tabsBase="insights">
+      <Outlet />
+    </ObservePageShell>
+  );
+}
 
+function employeeBreadcrumbSubstitutions(
+  userSlug: string | undefined,
+  membersData: ReturnType<typeof useMembers>["data"],
+) {
+  if (!userSlug) return {};
+  const decodedUserSlug = decodeURIComponent(userSlug);
+  if (decodedUserSlug.includes("@")) {
+    return {
+      [userSlug]: decodedUserSlug,
+      [encodeURIComponent(decodedUserSlug)]: decodedUserSlug,
+    };
+  }
+  if (!membersData?.members) return {};
+  const member = membersData.members.find((m) => slugify(m.name) === userSlug);
+  return member ? { [userSlug]: member.email } : {};
+}
+
+function ObservePageShell({
+  children,
+  substitutions,
+  tabsBase,
+}: {
+  children: ReactNode;
+  substitutions?: Record<string, string | undefined>;
+  tabsBase?: "insights" | "logs";
+}) {
   return (
     <div className="flex h-full flex-col">
       {/* ^ Wrapper needed to fill page height, allow inner content scrolls. */}
@@ -37,12 +53,27 @@ export function InsightsRoot(): JSX.Element {
         <Page.Header>
           <Page.Header.Breadcrumbs fullWidth substitutions={substitutions} />
         </Page.Header>
-        <ObserveTabNav base="insights" />
+        {tabsBase && <ObserveTabNav base={tabsBase} />}
         <Page.Body fullWidth overflowHidden noPadding>
-          <Outlet />
+          {children}
         </Page.Body>
       </Page>
     </div>
+  );
+}
+
+export function InsightsEmployeesLayout(): JSX.Element {
+  const { userSlug } = useParams<{ userSlug: string }>();
+  const { data: membersData } = useMembers();
+  const substitutions = useMemo(
+    () => employeeBreadcrumbSubstitutions(userSlug, membersData),
+    [userSlug, membersData],
+  );
+
+  return (
+    <ObservePageShell substitutions={substitutions}>
+      <Outlet />
+    </ObservePageShell>
   );
 }
 
@@ -60,10 +91,6 @@ export function InsightsMCPPage(): JSX.Element {
       <InsightsMCPContent />
     </RequireScope>
   );
-}
-
-export function InsightsEmployeesLayout(): JSX.Element {
-  return <Outlet />;
 }
 
 export function InsightsEmployeesPage(): JSX.Element {
@@ -84,8 +111,10 @@ export function InsightsEmployeeDetailPage(): JSX.Element {
 
 export function InsightsAgentsPage(): JSX.Element {
   return (
-    <RequireScope scope="project:read" level="page">
-      <InsightsAgentsContent />
-    </RequireScope>
+    <ObservePageShell>
+      <RequireScope scope="project:read" level="page">
+        <InsightsAgentsContent />
+      </RequireScope>
+    </ObservePageShell>
   );
 }

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -397,11 +397,6 @@ const ROUTE_STRUCTURE = {
     component: InsightsRoot,
     indexComponent: RedirectToInsightsTools,
     subPages: {
-      costs: {
-        title: "Costs",
-        url: "costs",
-        component: InsightsAgentsPage,
-      },
       tools: {
         title: "Tools",
         url: "tools",
@@ -412,20 +407,27 @@ const ROUTE_STRUCTURE = {
         url: "mcp",
         component: InsightsMCPPage,
       },
-      employees: {
-        title: "Employees",
-        url: "employees",
-        component: InsightsEmployeesLayout,
-        indexComponent: InsightsEmployeesPage,
-        subPages: {
-          detail: {
-            title: "Employee Detail",
-            url: ":userSlug",
-            component: InsightsEmployeeDetailPage,
-          },
-        },
+    },
+  },
+  employees: {
+    title: "Employees",
+    url: "employees",
+    icon: "users",
+    component: InsightsEmployeesLayout,
+    indexComponent: InsightsEmployeesPage,
+    subPages: {
+      detail: {
+        title: "Employee Detail",
+        url: ":userSlug",
+        component: InsightsEmployeeDetailPage,
       },
     },
+  },
+  costs: {
+    title: "Costs",
+    url: "costs",
+    icon: "credit-card",
+    component: InsightsAgentsPage,
   },
   hooks: {
     // redirect to insights/tools. TODO: remove this in a month


### PR DESCRIPTION
## Summary
- Promote Employees and Costs out of Insights into top-level navigation.
- Preserve the existing page content while updating routes/sidebar placement.
- Keep the change independent from the Logs/Secure stack.

Linear: DNO-196

## Test Plan
- [x] pnpm -F dashboard type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted Employees and Costs from Insights to top-level Observe navigation with new routes, keeping page content intact. Aligns with Linear DNO-196 (Dashboard Navigation IA Improvements).

- **New Features**
  - Added top-level routes: `employees` (detail at `employees/:userSlug`) and `costs`, with icons in the sidebar.
  - Set Observe’s default link to `employees`; Observe highlights when `employees`, `costs`, `insights`, or `logs` are active.
  - Removed Employees/Costs from `ObserveTabNav`; when viewing Logs, show “Risk Events” (beta, `org:admin`) and “Agents” tabs.
  - Introduced `ObservePageShell` for consistent layout and breadcrumbs; added email/slug substitution for employee breadcrumbs.
  - Updated links to `routes.employees.href()` and `routes.costs.href()` (e.g., Project Dashboard “View all”); gated `employees` and `costs` behind project read in `useProjectNavRoutes`.

- **Migration**
  - Update links/bookmarks:
    - `/insights/employees` → `/employees`
    - `/insights/employees/:userSlug` → `/employees/:userSlug`
    - `/insights/costs` → `/costs`
  - No backend or Logs/Secure changes needed.

<sup>Written for commit a9c277b91c561149eeb9a2cc0044151504213dc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

