### PR TITLE
mig: skills registry (restack of #2181, hooks work dropped)

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -76,33 +76,6 @@ CREATE TABLE IF NOT EXISTS organization_metadata (
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_workos_id_key
 ON organization_metadata (workos_id);
 
--- Billing contract metadata for an organization. Currently holds the
--- "tokens under management" (TUM) contract terms for enterprise accounts.
-CREATE TABLE IF NOT EXISTS billing_metadata (
-  id uuid NOT NULL DEFAULT generate_uuidv7(),
-  organization_id TEXT NOT NULL,
-
-  -- Contracted monthly "tokens under management" allowance. NULL means no
-  -- contracted limit has been configured.
-  tum_monthly_token_limit BIGINT,
-  -- Email address to notify when TUM approaches or exceeds the contracted
-  -- limit. Alerting is not implemented yet; stored for future use.
-  alert_email TEXT CHECK (alert_email IS NULL OR alert_email <> ''),
-  -- Day of month (1-31) the billing cycle starts at 00:00 UTC. Clamped to the
-  -- last day of shorter months when computing cycle boundaries.
-  billing_cycle_anchor_day INT NOT NULL DEFAULT 1,
-
-  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-
-  CONSTRAINT billing_metadata_pkey PRIMARY KEY (id),
-  CONSTRAINT billing_metadata_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT billing_metadata_billing_cycle_anchor_day_check CHECK (billing_cycle_anchor_day >= 1 AND billing_cycle_anchor_day <= 31)
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_organization_id_key
-ON billing_metadata (organization_id);
-
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
 ON organization_metadata (slug);
 
@@ -284,6 +257,162 @@ CREATE TABLE IF NOT EXISTS package_versions (
 CREATE UNIQUE INDEX IF NOT EXISTS package_versions_package_id_semver_key
 ON package_versions (package_id DESC, major DESC, minor DESC, patch DESC, prerelease, build)
 WHERE deleted IS FALSE;
+
+CREATE TABLE IF NOT EXISTS skills (
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  skill_uuid TEXT CHECK (skill_uuid <> '' AND CHAR_LENGTH(skill_uuid) <= 100),
+  slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 100),
+  description TEXT CHECK (description <> '' AND CHAR_LENGTH(description) <= 2000),
+  created_by_user_id TEXT NOT NULL,
+  name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 100),
+  organization_id TEXT NOT NULL,
+
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  active_version_id uuid,
+  project_id uuid NOT NULL,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT skills_pkey PRIMARY KEY (id),
+  CONSTRAINT skills_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS skills_project_id_slug_key
+ON skills (project_id, slug)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS skills_project_id_skill_uuid_key
+ON skills (project_id, skill_uuid)
+WHERE skill_uuid IS NOT NULL AND deleted IS FALSE;
+
+CREATE TABLE IF NOT EXISTS skill_versions (
+  size_bytes BIGINT NOT NULL CHECK (size_bytes >= 0),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  first_seen_at timestamptz,
+  skill_bytes BIGINT CHECK (skill_bytes >= 0),
+
+  content_sha256 TEXT NOT NULL,
+  asset_format TEXT NOT NULL CHECK (asset_format IN ('zip')),
+  state TEXT NOT NULL CHECK (state IN ('pending_review', 'active', 'superseded', 'rejected')),
+  captured_by_user_id TEXT NOT NULL,
+  author_name TEXT CHECK (author_name <> '' AND CHAR_LENGTH(author_name) <= 255),
+  rejected_by_user_id TEXT CHECK (rejected_by_user_id <> '' AND CHAR_LENGTH(rejected_by_user_id) <= 255),
+  rejected_reason TEXT CHECK (rejected_reason <> '' AND CHAR_LENGTH(rejected_reason) <= 2000),
+  rejected_at timestamptz,
+  CONSTRAINT skill_versions_rejected_fields_check CHECK (
+    (
+      state = 'rejected'
+      AND rejected_by_user_id IS NOT NULL
+      AND rejected_reason IS NOT NULL
+      AND rejected_at IS NOT NULL
+    )
+    OR (
+      state <> 'rejected'
+      AND rejected_by_user_id IS NULL
+      AND rejected_reason IS NULL
+      AND rejected_at IS NULL
+    )
+  ),
+  first_seen_trace_id TEXT CHECK (first_seen_trace_id <> '' AND CHAR_LENGTH(first_seen_trace_id) <= 100),
+  first_seen_session_id TEXT CHECK (first_seen_session_id <> '' AND CHAR_LENGTH(first_seen_session_id) <= 100),
+
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  asset_id uuid NOT NULL,
+  skill_id uuid NOT NULL,
+
+  CONSTRAINT skill_versions_pkey PRIMARY KEY (id),
+  CONSTRAINT skill_versions_skill_id_fkey FOREIGN KEY (skill_id) REFERENCES skills (id) ON DELETE CASCADE,
+  CONSTRAINT skill_versions_asset_id_fkey FOREIGN KEY (asset_id) REFERENCES assets (id) ON DELETE CASCADE,
+  CONSTRAINT skill_versions_skill_id_content_sha256_key UNIQUE (skill_id, content_sha256)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_active_skill_id_key
+ON skill_versions (skill_id)
+WHERE state = 'active';
+
+CREATE INDEX IF NOT EXISTS skill_versions_skill_id_created_at_idx
+ON skill_versions (skill_id, created_at DESC);
+
+ALTER TABLE skills
+ADD CONSTRAINT skills_active_version_id_fkey
+FOREIGN KEY (active_version_id)
+REFERENCES skill_versions (id)
+ON DELETE SET NULL;
+
+CREATE TABLE IF NOT EXISTS skills_capture_attempts (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid NOT NULL,
+  captured_by_user_id TEXT NOT NULL,
+
+  skill_name TEXT CHECK (skill_name <> '' AND CHAR_LENGTH(skill_name) <= 100),
+  skill_slug TEXT CHECK (skill_slug <> '' AND CHAR_LENGTH(skill_slug) <= 100),
+  scope TEXT NOT NULL CHECK (scope IN ('project', 'user')),
+  discovery_root TEXT NOT NULL CHECK (discovery_root <> '' AND CHAR_LENGTH(discovery_root) <= 60),
+  source_type TEXT NOT NULL CHECK (source_type <> '' AND CHAR_LENGTH(source_type) <= 60),
+  resolution_status TEXT NOT NULL CHECK (resolution_status <> '' AND CHAR_LENGTH(resolution_status) <= 60),
+  content_sha256 TEXT CHECK (content_sha256 ~ '^[a-fA-F0-9]{64}$'),
+  asset_format TEXT CHECK (asset_format IN ('zip')),
+  content_length BIGINT CHECK (content_length >= 0),
+
+  outcome TEXT NOT NULL CHECK (outcome IN ('accepted', 'duplicate', 'rejected')),
+  reason TEXT NOT NULL CHECK (reason <> '' AND CHAR_LENGTH(reason) <= 100),
+
+  skill_id uuid,
+  skill_version_id uuid,
+  asset_id uuid,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT skills_capture_attempts_pkey PRIMARY KEY (id),
+  CONSTRAINT skills_capture_attempts_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT skills_capture_attempts_skill_id_fkey FOREIGN KEY (skill_id) REFERENCES skills (id) ON DELETE SET NULL,
+  CONSTRAINT skills_capture_attempts_skill_version_id_fkey FOREIGN KEY (skill_version_id) REFERENCES skill_versions (id) ON DELETE SET NULL,
+  CONSTRAINT skills_capture_attempts_asset_id_fkey FOREIGN KEY (asset_id) REFERENCES assets (id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS skills_capture_attempts_project_id_created_at_idx
+ON skills_capture_attempts (project_id, created_at DESC)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS skills_capture_attempts_project_id_skill_slug_created_at_idx
+ON skills_capture_attempts (project_id, skill_slug, created_at DESC)
+WHERE deleted IS FALSE AND skill_slug IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS skills_capture_policies (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+
+  organization_id TEXT NOT NULL,
+  project_id uuid,
+  mode TEXT NOT NULL CHECK (mode IN ('disabled', 'project_only', 'user_only', 'project_and_user')),
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT skills_capture_policies_pkey PRIMARY KEY (id),
+  CONSTRAINT skills_capture_policies_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT skills_capture_policies_scope_check CHECK (
+    (project_id IS NULL AND organization_id <> '')
+    OR
+    (project_id IS NOT NULL AND organization_id <> '')
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS skills_capture_policies_org_default_key
+ON skills_capture_policies (organization_id)
+WHERE project_id IS NULL AND deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS skills_capture_policies_project_override_key
+ON skills_capture_policies (organization_id, project_id)
+WHERE project_id IS NOT NULL AND deleted IS FALSE;
 
 CREATE TABLE IF NOT EXISTS api_keys (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -246,16 +246,6 @@ type AuthzChallengeResolution struct {
 	CreatedAt  pgtype.Timestamptz
 }
 
-type BillingMetadatum struct {
-	ID                    uuid.UUID
-	OrganizationID        string
-	TumMonthlyTokenLimit  pgtype.Int8
-	AlertEmail            pgtype.Text
-	BillingCycleAnchorDay int32
-	CreatedAt             pgtype.Timestamptz
-	UpdatedAt             pgtype.Timestamptz
-}
-
 type Chat struct {
 	ID             uuid.UUID
 	ProjectID      uuid.UUID
@@ -1374,6 +1364,79 @@ type RiskResult struct {
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
 	CreatedAt           pgtype.Timestamptz
+}
+
+type Skill struct {
+	CreatedAt       pgtype.Timestamptz
+	DeletedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+	SkillUuid       pgtype.Text
+	Slug            string
+	Description     pgtype.Text
+	CreatedByUserID string
+	Name            string
+	OrganizationID  string
+	ID              uuid.UUID
+	ActiveVersionID uuid.NullUUID
+	ProjectID       uuid.UUID
+	Deleted         bool
+}
+
+type SkillVersion struct {
+	SizeBytes          int64
+	UpdatedAt          pgtype.Timestamptz
+	CreatedAt          pgtype.Timestamptz
+	FirstSeenAt        pgtype.Timestamptz
+	SkillBytes         pgtype.Int8
+	ContentSha256      string
+	AssetFormat        string
+	State              string
+	CapturedByUserID   string
+	AuthorName         pgtype.Text
+	RejectedByUserID   pgtype.Text
+	RejectedReason     pgtype.Text
+	RejectedAt         pgtype.Timestamptz
+	FirstSeenTraceID   pgtype.Text
+	FirstSeenSessionID pgtype.Text
+	ID                 uuid.UUID
+	AssetID            uuid.UUID
+	SkillID            uuid.UUID
+}
+
+type SkillsCaptureAttempt struct {
+	ID               uuid.UUID
+	OrganizationID   string
+	ProjectID        uuid.UUID
+	CapturedByUserID string
+	SkillName        pgtype.Text
+	SkillSlug        pgtype.Text
+	Scope            string
+	DiscoveryRoot    string
+	SourceType       string
+	ResolutionStatus string
+	ContentSha256    pgtype.Text
+	AssetFormat      pgtype.Text
+	ContentLength    pgtype.Int8
+	Outcome          string
+	Reason           string
+	SkillID          uuid.NullUUID
+	SkillVersionID   uuid.NullUUID
+	AssetID          uuid.NullUUID
+	CreatedAt        pgtype.Timestamptz
+	UpdatedAt        pgtype.Timestamptz
+	DeletedAt        pgtype.Timestamptz
+	Deleted          bool
+}
+
+type SkillsCapturePolicy struct {
+	ID             uuid.UUID
+	OrganizationID string
+	ProjectID      uuid.NullUUID
+	Mode           string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
 }
 
 type SlackApp struct {

--- a/server/migrations/20260611162802_skills_registry.sql
+++ b/server/migrations/20260611162802_skills_registry.sql
@@ -1,0 +1,129 @@
+-- Create "skill_versions" table
+CREATE TABLE "skill_versions" (
+  "size_bytes" bigint NOT NULL,
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "first_seen_at" timestamptz NULL,
+  "skill_bytes" bigint NULL,
+  "content_sha256" text NOT NULL,
+  "asset_format" text NOT NULL,
+  "state" text NOT NULL,
+  "captured_by_user_id" text NOT NULL,
+  "author_name" text NULL,
+  "rejected_by_user_id" text NULL,
+  "rejected_reason" text NULL,
+  "rejected_at" timestamptz NULL,
+  "first_seen_trace_id" text NULL,
+  "first_seen_session_id" text NULL,
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "asset_id" uuid NOT NULL,
+  "skill_id" uuid NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skill_versions_skill_id_content_sha256_key" UNIQUE ("skill_id", "content_sha256"),
+  CONSTRAINT "skill_versions_asset_format_check" CHECK (asset_format = 'zip'::text),
+  CONSTRAINT "skill_versions_author_name_check" CHECK ((author_name <> ''::text) AND (char_length(author_name) <= 255)),
+  CONSTRAINT "skill_versions_first_seen_session_id_check" CHECK ((first_seen_session_id <> ''::text) AND (char_length(first_seen_session_id) <= 100)),
+  CONSTRAINT "skill_versions_first_seen_trace_id_check" CHECK ((first_seen_trace_id <> ''::text) AND (char_length(first_seen_trace_id) <= 100)),
+  CONSTRAINT "skill_versions_rejected_by_user_id_check" CHECK ((rejected_by_user_id <> ''::text) AND (char_length(rejected_by_user_id) <= 255)),
+  CONSTRAINT "skill_versions_rejected_fields_check" CHECK (((state = 'rejected'::text) AND (rejected_by_user_id IS NOT NULL) AND (rejected_reason IS NOT NULL) AND (rejected_at IS NOT NULL)) OR ((state <> 'rejected'::text) AND (rejected_by_user_id IS NULL) AND (rejected_reason IS NULL) AND (rejected_at IS NULL))),
+  CONSTRAINT "skill_versions_rejected_reason_check" CHECK ((rejected_reason <> ''::text) AND (char_length(rejected_reason) <= 2000)),
+  CONSTRAINT "skill_versions_size_bytes_check" CHECK (size_bytes >= 0),
+  CONSTRAINT "skill_versions_skill_bytes_check" CHECK (skill_bytes >= 0),
+  CONSTRAINT "skill_versions_state_check" CHECK (state = ANY (ARRAY['pending_review'::text, 'active'::text, 'superseded'::text, 'rejected'::text]))
+);
+-- Create index "skill_versions_active_skill_id_key" to table: "skill_versions"
+CREATE UNIQUE INDEX "skill_versions_active_skill_id_key" ON "skill_versions" ("skill_id") WHERE (state = 'active'::text);
+-- Create index "skill_versions_skill_id_created_at_idx" to table: "skill_versions"
+CREATE INDEX "skill_versions_skill_id_created_at_idx" ON "skill_versions" ("skill_id", "created_at" DESC);
+-- Create "skills" table
+CREATE TABLE "skills" (
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "skill_uuid" text NULL,
+  "slug" text NOT NULL,
+  "description" text NULL,
+  "created_by_user_id" text NOT NULL,
+  "name" text NOT NULL,
+  "organization_id" text NOT NULL,
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "active_version_id" uuid NULL,
+  "project_id" uuid NOT NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skills_description_check" CHECK ((description <> ''::text) AND (char_length(description) <= 2000)),
+  CONSTRAINT "skills_name_check" CHECK ((name <> ''::text) AND (char_length(name) <= 100)),
+  CONSTRAINT "skills_skill_uuid_check" CHECK ((skill_uuid <> ''::text) AND (char_length(skill_uuid) <= 100)),
+  CONSTRAINT "skills_slug_check" CHECK ((slug <> ''::text) AND (char_length(slug) <= 100))
+);
+-- Create index "skills_project_id_skill_uuid_key" to table: "skills"
+CREATE UNIQUE INDEX "skills_project_id_skill_uuid_key" ON "skills" ("project_id", "skill_uuid") WHERE ((skill_uuid IS NOT NULL) AND (deleted IS FALSE));
+-- Create index "skills_project_id_slug_key" to table: "skills"
+CREATE UNIQUE INDEX "skills_project_id_slug_key" ON "skills" ("project_id", "slug") WHERE (deleted IS FALSE);
+-- Create "skills_capture_attempts" table
+CREATE TABLE "skills_capture_attempts" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NOT NULL,
+  "captured_by_user_id" text NOT NULL,
+  "skill_name" text NULL,
+  "skill_slug" text NULL,
+  "scope" text NOT NULL,
+  "discovery_root" text NOT NULL,
+  "source_type" text NOT NULL,
+  "resolution_status" text NOT NULL,
+  "content_sha256" text NULL,
+  "asset_format" text NULL,
+  "content_length" bigint NULL,
+  "outcome" text NOT NULL,
+  "reason" text NOT NULL,
+  "skill_id" uuid NULL,
+  "skill_version_id" uuid NULL,
+  "asset_id" uuid NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skills_capture_attempts_asset_format_check" CHECK (asset_format = 'zip'::text),
+  CONSTRAINT "skills_capture_attempts_content_length_check" CHECK (content_length >= 0),
+  CONSTRAINT "skills_capture_attempts_content_sha256_check" CHECK (content_sha256 ~ '^[a-fA-F0-9]{64}$'::text),
+  CONSTRAINT "skills_capture_attempts_discovery_root_check" CHECK ((discovery_root <> ''::text) AND (char_length(discovery_root) <= 60)),
+  CONSTRAINT "skills_capture_attempts_outcome_check" CHECK (outcome = ANY (ARRAY['accepted'::text, 'duplicate'::text, 'rejected'::text])),
+  CONSTRAINT "skills_capture_attempts_reason_check" CHECK ((reason <> ''::text) AND (char_length(reason) <= 100)),
+  CONSTRAINT "skills_capture_attempts_resolution_status_check" CHECK ((resolution_status <> ''::text) AND (char_length(resolution_status) <= 60)),
+  CONSTRAINT "skills_capture_attempts_scope_check" CHECK (scope = ANY (ARRAY['project'::text, 'user'::text])),
+  CONSTRAINT "skills_capture_attempts_skill_name_check" CHECK ((skill_name <> ''::text) AND (char_length(skill_name) <= 100)),
+  CONSTRAINT "skills_capture_attempts_skill_slug_check" CHECK ((skill_slug <> ''::text) AND (char_length(skill_slug) <= 100)),
+  CONSTRAINT "skills_capture_attempts_source_type_check" CHECK ((source_type <> ''::text) AND (char_length(source_type) <= 60))
+);
+-- Create index "skills_capture_attempts_project_id_created_at_idx" to table: "skills_capture_attempts"
+CREATE INDEX "skills_capture_attempts_project_id_created_at_idx" ON "skills_capture_attempts" ("project_id", "created_at" DESC) WHERE (deleted IS FALSE);
+-- Create index "skills_capture_attempts_project_id_skill_slug_created_at_idx" to table: "skills_capture_attempts"
+CREATE INDEX "skills_capture_attempts_project_id_skill_slug_created_at_idx" ON "skills_capture_attempts" ("project_id", "skill_slug", "created_at" DESC) WHERE ((deleted IS FALSE) AND (skill_slug IS NOT NULL));
+-- Create "skills_capture_policies" table
+CREATE TABLE "skills_capture_policies" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NULL,
+  "mode" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skills_capture_policies_mode_check" CHECK (mode = ANY (ARRAY['disabled'::text, 'project_only'::text, 'user_only'::text, 'project_and_user'::text])),
+  CONSTRAINT "skills_capture_policies_scope_check" CHECK (((project_id IS NULL) AND (organization_id <> ''::text)) OR ((project_id IS NOT NULL) AND (organization_id <> ''::text)))
+);
+-- Create index "skills_capture_policies_org_default_key" to table: "skills_capture_policies"
+CREATE UNIQUE INDEX "skills_capture_policies_org_default_key" ON "skills_capture_policies" ("organization_id") WHERE ((project_id IS NULL) AND (deleted IS FALSE));
+-- Create index "skills_capture_policies_project_override_key" to table: "skills_capture_policies"
+CREATE UNIQUE INDEX "skills_capture_policies_project_override_key" ON "skills_capture_policies" ("organization_id", "project_id") WHERE ((project_id IS NOT NULL) AND (deleted IS FALSE));
+-- Modify "skill_versions" table
+ALTER TABLE "skill_versions" ADD CONSTRAINT "skill_versions_asset_id_fkey" FOREIGN KEY ("asset_id") REFERENCES "assets" ("id") ON UPDATE NO ACTION ON DELETE CASCADE, ADD CONSTRAINT "skill_versions_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- Modify "skills" table
+ALTER TABLE "skills" ADD CONSTRAINT "skills_active_version_id_fkey" FOREIGN KEY ("active_version_id") REFERENCES "skill_versions" ("id") ON UPDATE NO ACTION ON DELETE SET NULL, ADD CONSTRAINT "skills_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- Modify "skills_capture_attempts" table
+ALTER TABLE "skills_capture_attempts" ADD CONSTRAINT "skills_capture_attempts_asset_id_fkey" FOREIGN KEY ("asset_id") REFERENCES "assets" ("id") ON UPDATE NO ACTION ON DELETE SET NULL, ADD CONSTRAINT "skills_capture_attempts_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE, ADD CONSTRAINT "skills_capture_attempts_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills" ("id") ON UPDATE NO ACTION ON DELETE SET NULL, ADD CONSTRAINT "skills_capture_attempts_skill_version_id_fkey" FOREIGN KEY ("skill_version_id") REFERENCES "skill_versions" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+-- Modify "skills_capture_policies" table
+ALTER TABLE "skills_capture_policies" ADD CONSTRAINT "skills_capture_policies_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lfnkwKeqKPtxoKhWP9pbJdNZqfxAutAol16Iu58ttlg=
+h1:noUgEnKAbzv6cyY4SqSSS3PfSGaB+IbNFWlgn5Tw2bw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -216,3 +216,4 @@ h1:lfnkwKeqKPtxoKhWP9pbJdNZqfxAutAol16Iu58ttlg=
 20260610205050_prompt-based-policies-extend-risk-policies.sql h1:KaqQWR4qItyOjW8jQPkFtYAni3ki3hOuQZ5fg5ZGDGY=
 20260610225502_remotesession-access-expires-nullable.sql h1:NMY/XoTX/Aj/oaFCpqX1GuPrp48oz3TsGHIn/hBSJzY=
 20260610231620_add-billing-metadata-table.sql h1:QtN9rqkm2eke8pugS7NNmlndanZj2mJ3axc5gqrY7/A=
+20260611162802_skills_registry.sql h1:fct8OWvCrVY9GQVA1WMhrOy7iOtMj0T4icngD0ZK/G4=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/3372 so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the database schema and migration for a skills registry with versioned assets, capture logs, and capture policies. Updates generated Go models to match.

- **New Features**
  - Added tables: `skills`, `skill_versions`, `skills_capture_attempts`, `skills_capture_policies`.
  - Enforced constraints: unique per-project slug/UUID, one active version per skill, valid states and formats, soft deletes.
  - Added indexes for active versions and recent activity; optimized lookups by skill and project/slug.
  - Linked to existing `projects` and `assets` via foreign keys.
  - Generated new Go models for the above tables.

- **Refactors**
  - Removed `billing_metadata` from schema and the `BillingMetadatum` Go model (covered by its own migration).

<sup>Written for commit 6117d7a76d64fa6c6f624e2a47fadd1f2b95c00a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

