### PR TITLE
feat(assistants): recycle runtime images ahead of time on deploy

### DIFF
--- a/.changeset/aot-assistant-runtime-image-recycle.md
+++ b/.changeset/aot-assistant-runtime-image-recycle.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Assistant runtime VMs are now rolled onto new runtime images right after a deploy, while they sit idle, so the next conversation turn no longer pays the image upgrade cost.

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -823,15 +823,24 @@ WHERE id = @runtime_id
 -- sweep can roll their machines onto the current runtime image. Only `active`
 -- rows qualify: `starting` rows are mid-boot and already pull the current
 -- image, while expiring/stopped rows are torn down or recycled lazily on the
--- next admission.
-SELECT id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
-FROM assistant_runtimes
-WHERE state = @active_state
-  AND runtime_version = 2
-  AND deleted IS FALSE
-  AND ended IS FALSE
-  AND backend_metadata_json <> '{}'::jsonb
-ORDER BY updated_at ASC;
+-- next admission. Rows orphaned by a deleted assistant are excluded: they
+-- belong to the deleted-assistant janitor, and recycling them would bump
+-- updated_at and postpone the inactivity-based reap.
+SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
+FROM assistant_runtimes r
+WHERE r.state = @active_state
+  AND r.runtime_version = 2
+  AND r.deleted IS FALSE
+  AND r.ended IS FALSE
+  AND r.backend_metadata_json <> '{}'::jsonb
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistants a
+    WHERE a.id = r.assistant_id
+      AND a.project_id = r.project_id
+      AND a.deleted IS TRUE
+  )
+ORDER BY r.updated_at ASC;
 
 -- name: MarkAssistantRuntimeReaped :exec
 -- Records that the backend resource (e.g. Fly app) for this runtime has

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -792,6 +792,18 @@ WHERE r.backend_metadata_json <> '{}'::jsonb
 ORDER BY r.updated_at ASC
 LIMIT @limit_count;
 
+-- name: CountInFlightAssistantThreadEvents :one
+-- Counts events that are queued for or currently using the assistant's
+-- runtime. The image recycle sweep skips assistants with any in-flight
+-- events: their turns are about to hit the VM (the runner's idle clock
+-- only clears on /turn enqueue) and their admissions recycle the image
+-- lazily anyway.
+SELECT COUNT(*)
+FROM assistant_thread_events
+WHERE project_id = @project_id
+  AND assistant_id = @assistant_id
+  AND status IN (@pending_status, @processing_status);
+
 -- name: UpdateActiveAssistantRuntimeMetadata :execrows
 -- Persists post-recycle backend metadata only while the row is still live.
 -- Zero rows affected means the warm timer expired the runtime mid-recycle;

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -802,6 +802,7 @@ SELECT COUNT(*)
 FROM assistant_thread_events
 WHERE project_id = @project_id
   AND assistant_id = @assistant_id
+  AND deleted IS FALSE
   AND status IN (@pending_status, @processing_status);
 
 -- name: UpdateActiveAssistantRuntimeMetadata :execrows

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -792,6 +792,19 @@ WHERE r.backend_metadata_json <> '{}'::jsonb
 ORDER BY r.updated_at ASC
 LIMIT @limit_count;
 
+-- name: UpdateActiveAssistantRuntimeMetadata :execrows
+-- Persists post-recycle backend metadata only while the row is still live.
+-- Zero rows affected means the warm timer expired the runtime mid-recycle;
+-- the caller must undo the machine restart instead of recording it.
+UPDATE assistant_runtimes
+SET
+  backend_metadata_json = @backend_metadata_json,
+  updated_at = clock_timestamp()
+WHERE id = @runtime_id
+  AND project_id = @project_id
+  AND state = @active_state
+  AND deleted IS FALSE;
+
 -- name: ListActiveAssistantRuntimesForImageRecycle :many
 -- Returns live v2 runtime rows that carry backend metadata so a deploy-time
 -- sweep can roll their machines onto the current runtime image. Only `active`

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -792,6 +792,21 @@ WHERE r.backend_metadata_json <> '{}'::jsonb
 ORDER BY r.updated_at ASC
 LIMIT @limit_count;
 
+-- name: ListActiveAssistantRuntimesForImageRecycle :many
+-- Returns live v2 runtime rows that carry backend metadata so a deploy-time
+-- sweep can roll their machines onto the current runtime image. Only `active`
+-- rows qualify: `starting` rows are mid-boot and already pull the current
+-- image, while expiring/stopped rows are torn down or recycled lazily on the
+-- next admission.
+SELECT id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
+FROM assistant_runtimes
+WHERE state = @active_state
+  AND runtime_version = 2
+  AND deleted IS FALSE
+  AND ended IS FALSE
+  AND backend_metadata_json <> '{}'::jsonb
+ORDER BY updated_at ASC;
+
 -- name: MarkAssistantRuntimeReaped :exec
 -- Records that the backend resource (e.g. Fly app) for this runtime has
 -- been torn down. Clearing backend_metadata_json removes it from the reap

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1085,6 +1085,62 @@ func (q *Queries) InsertAssistantThreadEvent(ctx context.Context, arg InsertAssi
 	return id, err
 }
 
+const listActiveAssistantRuntimesForImageRecycle = `-- name: ListActiveAssistantRuntimesForImageRecycle :many
+SELECT id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
+FROM assistant_runtimes
+WHERE state = $1
+  AND runtime_version = 2
+  AND deleted IS FALSE
+  AND ended IS FALSE
+  AND backend_metadata_json <> '{}'::jsonb
+ORDER BY updated_at ASC
+`
+
+type ListActiveAssistantRuntimesForImageRecycleRow struct {
+	ID                  uuid.UUID
+	AssistantThreadID   uuid.UUID
+	AssistantID         uuid.UUID
+	ProjectID           uuid.UUID
+	Backend             string
+	BackendMetadataJson []byte
+	State               string
+	WarmUntil           pgtype.Timestamptz
+}
+
+// Returns live v2 runtime rows that carry backend metadata so a deploy-time
+// sweep can roll their machines onto the current runtime image. Only `active`
+// rows qualify: `starting` rows are mid-boot and already pull the current
+// image, while expiring/stopped rows are torn down or recycled lazily on the
+// next admission.
+func (q *Queries) ListActiveAssistantRuntimesForImageRecycle(ctx context.Context, activeState string) ([]ListActiveAssistantRuntimesForImageRecycleRow, error) {
+	rows, err := q.db.Query(ctx, listActiveAssistantRuntimesForImageRecycle, activeState)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveAssistantRuntimesForImageRecycleRow
+	for rows.Next() {
+		var i ListActiveAssistantRuntimesForImageRecycleRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AssistantThreadID,
+			&i.AssistantID,
+			&i.ProjectID,
+			&i.Backend,
+			&i.BackendMetadataJson,
+			&i.State,
+			&i.WarmUntil,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAssistantPendingThreads = `-- name: ListAssistantPendingThreads :many
 SELECT t.id, t.project_id
 FROM assistant_threads t

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1119,14 +1119,21 @@ func (q *Queries) InsertAssistantThreadEvent(ctx context.Context, arg InsertAssi
 }
 
 const listActiveAssistantRuntimesForImageRecycle = `-- name: ListActiveAssistantRuntimesForImageRecycle :many
-SELECT id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
-FROM assistant_runtimes
-WHERE state = $1
-  AND runtime_version = 2
-  AND deleted IS FALSE
-  AND ended IS FALSE
-  AND backend_metadata_json <> '{}'::jsonb
-ORDER BY updated_at ASC
+SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
+FROM assistant_runtimes r
+WHERE r.state = $1
+  AND r.runtime_version = 2
+  AND r.deleted IS FALSE
+  AND r.ended IS FALSE
+  AND r.backend_metadata_json <> '{}'::jsonb
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistants a
+    WHERE a.id = r.assistant_id
+      AND a.project_id = r.project_id
+      AND a.deleted IS TRUE
+  )
+ORDER BY r.updated_at ASC
 `
 
 type ListActiveAssistantRuntimesForImageRecycleRow struct {
@@ -1144,7 +1151,9 @@ type ListActiveAssistantRuntimesForImageRecycleRow struct {
 // sweep can roll their machines onto the current runtime image. Only `active`
 // rows qualify: `starting` rows are mid-boot and already pull the current
 // image, while expiring/stopped rows are torn down or recycled lazily on the
-// next admission.
+// next admission. Rows orphaned by a deleted assistant are excluded: they
+// belong to the deleted-assistant janitor, and recycling them would bump
+// updated_at and postpone the inactivity-based reap.
 func (q *Queries) ListActiveAssistantRuntimesForImageRecycle(ctx context.Context, activeState string) ([]ListActiveAssistantRuntimesForImageRecycleRow, error) {
 	rows, err := q.db.Query(ctx, listActiveAssistantRuntimesForImageRecycle, activeState)
 	if err != nil {

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -351,6 +351,7 @@ SELECT COUNT(*)
 FROM assistant_thread_events
 WHERE project_id = $1
   AND assistant_id = $2
+  AND deleted IS FALSE
   AND status IN ($3, $4)
 `
 

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -346,6 +346,38 @@ func (q *Queries) CountActiveAssistantThreads(ctx context.Context, arg CountActi
 	return active_threads, err
 }
 
+const countInFlightAssistantThreadEvents = `-- name: CountInFlightAssistantThreadEvents :one
+SELECT COUNT(*)
+FROM assistant_thread_events
+WHERE project_id = $1
+  AND assistant_id = $2
+  AND status IN ($3, $4)
+`
+
+type CountInFlightAssistantThreadEventsParams struct {
+	ProjectID        uuid.UUID
+	AssistantID      uuid.UUID
+	PendingStatus    string
+	ProcessingStatus string
+}
+
+// Counts events that are queued for or currently using the assistant's
+// runtime. The image recycle sweep skips assistants with any in-flight
+// events: their turns are about to hit the VM (the runner's idle clock
+// only clears on /turn enqueue) and their admissions recycle the image
+// lazily anyway.
+func (q *Queries) CountInFlightAssistantThreadEvents(ctx context.Context, arg CountInFlightAssistantThreadEventsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countInFlightAssistantThreadEvents,
+		arg.ProjectID,
+		arg.AssistantID,
+		arg.PendingStatus,
+		arg.ProcessingStatus,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createAssistant = `-- name: CreateAssistant :one
 INSERT INTO assistants (
   project_id,

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -2541,6 +2541,40 @@ func (q *Queries) TouchProcessingLease(ctx context.Context, arg TouchProcessingL
 	return err
 }
 
+const updateActiveAssistantRuntimeMetadata = `-- name: UpdateActiveAssistantRuntimeMetadata :execrows
+UPDATE assistant_runtimes
+SET
+  backend_metadata_json = $1,
+  updated_at = clock_timestamp()
+WHERE id = $2
+  AND project_id = $3
+  AND state = $4
+  AND deleted IS FALSE
+`
+
+type UpdateActiveAssistantRuntimeMetadataParams struct {
+	BackendMetadataJson []byte
+	RuntimeID           uuid.UUID
+	ProjectID           uuid.UUID
+	ActiveState         string
+}
+
+// Persists post-recycle backend metadata only while the row is still live.
+// Zero rows affected means the warm timer expired the runtime mid-recycle;
+// the caller must undo the machine restart instead of recording it.
+func (q *Queries) UpdateActiveAssistantRuntimeMetadata(ctx context.Context, arg UpdateActiveAssistantRuntimeMetadataParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateActiveAssistantRuntimeMetadata,
+		arg.BackendMetadataJson,
+		arg.RuntimeID,
+		arg.ProjectID,
+		arg.ActiveState,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateAssistant = `-- name: UpdateAssistant :one
 UPDATE assistants
 SET

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -21,7 +21,18 @@ type RuntimeBackend interface {
 	// the runtime VM (not the host-facing --server-url, which may be
 	// loopback during local development).
 	ServerURL() *url.URL
+	// ImageRef returns the runtime image reference the backend launches
+	// machines with, in the "<repo>:<tag>" form. Stable for the lifetime
+	// of the process — the tag is stamped at build time.
+	ImageRef() string
 	Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error)
+	// RecycleImage rolls the runtime's existing machine onto the configured
+	// runtime image when it is running a stale one, without launching
+	// anything new: missing apps/machines are skipped, not created. Gated on
+	// the runner's idle clock so an in-flight turn is never interrupted — a
+	// busy machine is skipped and the next admission's Ensure picks the
+	// upgrade up lazily.
+	RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error)
 	// RunTurn delivers a turn for `threadID` to the runner backing
 	// `runtime`. The call lands on /threads/{threadID}/turn so the
 	// runner can dispatch to the right per-thread tokio task.
@@ -38,6 +49,16 @@ type RuntimeBackend interface {
 
 type RuntimeBackendEnsureResult struct {
 	ColdStart           bool
+	BackendMetadataJSON []byte
+}
+
+// RuntimeBackendRecycleResult reports one RecycleImage attempt. Recycled is
+// false for every skip (image already current, machine busy or gone) — those
+// are expected outcomes, not errors. BackendMetadataJSON is set only when a
+// recycle happened and carries the post-recycle machine identity for
+// persistence.
+type RuntimeBackendRecycleResult struct {
+	Recycled            bool
 	BackendMetadataJSON []byte
 }
 

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -668,7 +668,11 @@ func (f *FlyRuntimeBackend) RecycleImage(ctx context.Context, runtime assistantR
 		return skipped, nil
 	case err != nil:
 		return skipped, fmt.Errorf("load assistant fly runtime machine for recycle: %w", err)
-	case machine == nil || !machine.IsActive():
+	case machine == nil || machine.State != fly.MachineStateStarted:
+		// Only running machines are recycled. A stopped machine is either
+		// mid-expiry (the warm timer raced this sweep and Stop already
+		// landed) or cold — starting it here would resurrect a runtime the
+		// row no longer tracks. Both pick the new image up through Ensure.
 		return skipped, nil
 	}
 

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -221,6 +221,10 @@ func (f *FlyRuntimeBackend) ServerURL() *url.URL {
 	return f.config.ServerURL
 }
 
+func (f *FlyRuntimeBackend) ImageRef() string {
+	return f.desiredImageRef()
+}
+
 // Ensure does not auto-recreate the app on ensureExisting errors. Health and
 // configure timeouts must bubble so Temporal retries drive convergence.
 // Destructive app recreation churns Fly's allocated IPs and creates DNS-stale
@@ -631,6 +635,65 @@ func (f *FlyRuntimeBackend) maybeRecycleImage(
 		return nil, fmt.Errorf("wait for assistant fly runtime machine recycle: %w", err)
 	}
 	return updated, nil
+}
+
+// RecycleImage rolls an established runtime's machine onto the configured
+// image outside the admission path, so a deploy-time sweep can absorb the
+// image-pull + reboot cost while the runtime is idle instead of the next
+// turn paying it. Strictly non-creative: a missing app, machine or metadata
+// is a skip — Ensure owns provisioning.
+func (f *FlyRuntimeBackend) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+	skipped := RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}
+
+	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
+		return skipped, err
+	}
+
+	metadata, err := decodeFlyRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return skipped, err
+	}
+	if metadata.AppName == "" || metadata.MachineID == "" {
+		return skipped, nil
+	}
+
+	flapsClient, err := f.flapsFactory.New(ctx)
+	if err != nil {
+		return skipped, fmt.Errorf("create fly runtime flaps client: %w", err)
+	}
+
+	machine, err := flapsClient.Get(ctx, metadata.AppName, metadata.MachineID)
+	switch {
+	case isFlyNotFound(err):
+		return skipped, nil
+	case err != nil:
+		return skipped, fmt.Errorf("load assistant fly runtime machine for recycle: %w", err)
+	case machine == nil || !machine.IsActive():
+		return skipped, nil
+	}
+
+	appURL := firstNonEmpty(metadata.AppURL, flyRuntimeAppURL(metadata.AppName))
+	recycled, err := f.maybeRecycleImage(ctx, flapsClient, runtime, metadata.AppName, appURL, metadata.AppIP, machine)
+	if err != nil {
+		return skipped, err
+	}
+	if recycled == nil {
+		return skipped, nil
+	}
+
+	target := flyRuntimeTarget{URL: appURL, IP: metadata.AppIP, MachineID: recycled.ID}
+	if err := f.tracedWaitHealth(ctx, target, true); err != nil {
+		return skipped, fmt.Errorf("wait for assistant fly runtime health after recycle: %w", err)
+	}
+
+	metadata.MachineID = recycled.ID
+	metadata.Region = firstNonEmpty(recycled.Region, metadata.Region, f.config.DefaultFlyRegion)
+	metadata.LastBootID = recycled.InstanceID
+	rawMetadata, err := json.Marshal(metadata)
+	if err != nil {
+		return skipped, fmt.Errorf("marshal assistant fly runtime metadata: %w", err)
+	}
+	return RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: rawMetadata}, nil
 }
 
 // desiredImageRef returns the configured runtime image reference in the same

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -780,6 +780,191 @@ func TestFlyRuntimeBackendEnsureRecyclesStaleImageOnStoppedMachine(t *testing.T)
 	require.True(t, result.ColdStart)
 }
 
+func TestFlyRuntimeBackendRecycleImageUpgradesStaleIdleMachine(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServerWithState(t, runnerStateResponse{
+		AssistantID:   uuid.NewString(),
+		UptimeSeconds: 600,
+		Threads: []runnerThreadState{
+			{ThreadID: uuid.NewString(), ChatID: uuid.NewString(), IdleSeconds: 10},
+		},
+	})
+	backend, _, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	assistantID := uuid.New()
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "v0",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataAssistantID: assistantID.String()},
+		},
+	}
+	flapsClient.updateMachine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-2",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "dev",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataAssistantID: assistantID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.RecycleImage(t.Context(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Recycled)
+	require.Equal(t, 1, flapsClient.updateCalls)
+	require.GreaterOrEqual(t, flapsClient.startCalls, 1)
+
+	var metadata flyRuntimeMetadata
+	require.NoError(t, json.Unmarshal(result.BackendMetadataJSON, &metadata))
+	require.Equal(t, "machine-1", metadata.MachineID)
+	require.Equal(t, "boot-2", metadata.LastBootID)
+	require.Equal(t, "gram-asst-test", metadata.AppName)
+}
+
+func TestFlyRuntimeBackendRecycleImageSkipsCurrentImage(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t)
+	backend, _, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	assistantID := uuid.New()
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "dev",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataAssistantID: assistantID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.RecycleImage(t.Context(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
+	require.Nil(t, result.BackendMetadataJSON)
+	require.Equal(t, 0, flapsClient.updateCalls)
+}
+
+func TestFlyRuntimeBackendRecycleImageSkipsWhileTurnInFlight(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServerWithState(t, runnerStateResponse{
+		AssistantID:   uuid.NewString(),
+		UptimeSeconds: 600,
+		Threads: []runnerThreadState{
+			{ThreadID: uuid.NewString(), ChatID: uuid.NewString(), IdleSeconds: 0},
+		},
+	})
+	backend, _, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	assistantID := uuid.New()
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "v0",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataAssistantID: assistantID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.RecycleImage(t.Context(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
+	require.Equal(t, 0, flapsClient.updateCalls)
+}
+
+func TestFlyRuntimeBackendRecycleImageSkipsMissingMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t)
+	backend, _, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	result, err := backend.RecycleImage(t.Context(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
+	require.Equal(t, 0, flapsClient.updateCalls)
+	require.Equal(t, 0, flapsClient.startCalls)
+}
+
 func TestFlyRuntimeBackendRunTurnHitsThreadScopedRoute(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -946,6 +946,51 @@ func TestFlyRuntimeBackendRecycleImageSkipsWhileTurnInFlight(t *testing.T) {
 	require.Equal(t, 0, flapsClient.updateCalls)
 }
 
+func TestFlyRuntimeBackendRecycleImageSkipsStoppedMachine(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t)
+	backend, _, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	assistantID := uuid.New()
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStopped,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "v0",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataAssistantID: assistantID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.RecycleImage(t.Context(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
+	require.Equal(t, 0, flapsClient.updateCalls)
+	require.Equal(t, 0, flapsClient.startCalls)
+}
+
 func TestFlyRuntimeBackendRecycleImageSkipsMissingMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -125,6 +125,8 @@ func (t *telemetryRuntimeBackend) RecycleImage(ctx context.Context, runtime assi
 	}
 	if result.Recycled {
 		t.emit(ctx, runtime, "runtime_recycle", "runtime recycled onto current image", "INFO", nil)
+	} else {
+		t.emit(ctx, runtime, "runtime_recycle", "runtime image recycle skipped", "INFO", nil)
 	}
 	return result, nil
 }

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -113,6 +113,22 @@ func (t *telemetryRuntimeBackend) Ensure(ctx context.Context, runtime assistantR
 	return result, nil
 }
 
+func (t *telemetryRuntimeBackend) ImageRef() string {
+	return t.inner.ImageRef()
+}
+
+func (t *telemetryRuntimeBackend) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+	result, err := t.inner.RecycleImage(ctx, runtime)
+	if err != nil {
+		t.emit(ctx, runtime, "runtime_recycle", "runtime image recycle failed", "ERROR", err)
+		return result, fmt.Errorf("runtime recycle image: %w", err)
+	}
+	if result.Recycled {
+		t.emit(ctx, runtime, "runtime_recycle", "runtime recycled onto current image", "INFO", nil)
+	}
+	return result, nil
+}
+
 func (t *telemetryRuntimeBackend) RunTurn(
 	ctx context.Context,
 	runtime assistantRuntimeRecord,

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1118,7 +1118,7 @@ func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params Rec
 
 	result := RecycleAssistantRuntimeImagesResult{Recycled: 0, Skipped: 0, Errors: 0}
 	for _, row := range rows {
-		recycled, err := s.runtime.RecycleImage(ctx, assistantRuntimeRecord{
+		record := assistantRuntimeRecord{
 			ID:                  row.ID,
 			AssistantThreadID:   row.AssistantThreadID,
 			AssistantID:         row.AssistantID,
@@ -1127,7 +1127,8 @@ func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params Rec
 			BackendMetadataJSON: row.BackendMetadataJson,
 			State:               row.State,
 			WarmUntil:           row.WarmUntil,
-		})
+		}
+		recycled, err := s.runtime.RecycleImage(ctx, record)
 		switch {
 		case err != nil:
 			s.logger.WarnContext(ctx, "assistant runtime image recycle failed",
@@ -1137,21 +1138,38 @@ func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params Rec
 			)
 			result.Errors++
 		case recycled.Recycled:
-			// A persist failure only costs the next Ensure a cold-start
-			// health budget (LastBootID mismatch) — the machine itself is
-			// already on the new image, so still count the recycle.
-			if err := queries.UpdateAssistantRuntimeMetadata(ctx, assistantrepo.UpdateAssistantRuntimeMetadataParams{
+			affected, err := queries.UpdateActiveAssistantRuntimeMetadata(ctx, assistantrepo.UpdateActiveAssistantRuntimeMetadataParams{
 				BackendMetadataJson: recycled.BackendMetadataJSON,
 				RuntimeID:           row.ID,
 				ProjectID:           row.ProjectID,
-			}); err != nil {
+				ActiveState:         runtimeStateActive,
+			})
+			switch {
+			case err != nil:
+				// A persist failure only costs the next Ensure a cold-start
+				// health budget (LastBootID mismatch) — the machine itself
+				// is already on the new image, so still count the recycle.
 				s.logger.WarnContext(ctx, "persist recycled assistant runtime metadata failed",
 					attr.SlogAssistantID(row.AssistantID.String()),
 					attr.SlogProjectID(row.ProjectID.String()),
 					attr.SlogError(err),
 				)
+				result.Recycled++
+			case affected == 0:
+				// The warm timer expired the row mid-recycle and Stop already
+				// ran against the pre-recycle machine. Undo the restart so the
+				// sweep never leaves a machine running that no live row tracks.
+				if stopErr := s.runtime.Stop(ctx, record); stopErr != nil {
+					s.logger.WarnContext(ctx, "stop assistant runtime after raced image recycle failed",
+						attr.SlogAssistantID(row.AssistantID.String()),
+						attr.SlogProjectID(row.ProjectID.String()),
+						attr.SlogError(stopErr),
+					)
+				}
+				result.Skipped++
+			default:
+				result.Recycled++
 			}
-			result.Recycled++
 		default:
 			result.Skipped++
 		}

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1088,6 +1088,87 @@ func (s *ServiceCore) ReapInactiveAssistantRuntimes(ctx context.Context, params 
 	return result, nil
 }
 
+// RecycleAssistantRuntimeImagesResult summarises one deploy-time image sweep
+// at the runtime-row level. Skipped covers every expected non-recycle: image
+// already current, machine busy with a turn, or backend resource gone.
+type RecycleAssistantRuntimeImagesResult struct {
+	Recycled int
+	Skipped  int
+	Errors   int
+}
+
+// RecycleAssistantRuntimeImagesParams configures one image recycle sweep.
+type RecycleAssistantRuntimeImagesParams struct {
+	// OnRowProcessed, if set, fires once per row after the recycle attempt
+	// (success, skip or failure).
+	OnRowProcessed func()
+}
+
+// RecycleActiveRuntimeImages best-effort rolls every active v2 runtime onto
+// the currently configured runtime image, so deploys absorb the image-pull +
+// reboot cost while runtimes are idle instead of the next turn paying it.
+// Busy or failed rows are not chased — the per-admission recycle in Ensure
+// catches them lazily.
+func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params RecycleAssistantRuntimeImagesParams) (RecycleAssistantRuntimeImagesResult, error) {
+	queries := assistantrepo.New(s.db)
+	rows, err := queries.ListActiveAssistantRuntimesForImageRecycle(ctx, runtimeStateActive)
+	if err != nil {
+		return RecycleAssistantRuntimeImagesResult{}, fmt.Errorf("list active assistant runtimes for image recycle: %w", err)
+	}
+
+	result := RecycleAssistantRuntimeImagesResult{Recycled: 0, Skipped: 0, Errors: 0}
+	for _, row := range rows {
+		recycled, err := s.runtime.RecycleImage(ctx, assistantRuntimeRecord{
+			ID:                  row.ID,
+			AssistantThreadID:   row.AssistantThreadID,
+			AssistantID:         row.AssistantID,
+			ProjectID:           row.ProjectID,
+			Backend:             row.Backend,
+			BackendMetadataJSON: row.BackendMetadataJson,
+			State:               row.State,
+			WarmUntil:           row.WarmUntil,
+		})
+		switch {
+		case err != nil:
+			s.logger.WarnContext(ctx, "assistant runtime image recycle failed",
+				attr.SlogAssistantID(row.AssistantID.String()),
+				attr.SlogProjectID(row.ProjectID.String()),
+				attr.SlogError(err),
+			)
+			result.Errors++
+		case recycled.Recycled:
+			// A persist failure only costs the next Ensure a cold-start
+			// health budget (LastBootID mismatch) — the machine itself is
+			// already on the new image, so still count the recycle.
+			if err := queries.UpdateAssistantRuntimeMetadata(ctx, assistantrepo.UpdateAssistantRuntimeMetadataParams{
+				BackendMetadataJson: recycled.BackendMetadataJSON,
+				RuntimeID:           row.ID,
+				ProjectID:           row.ProjectID,
+			}); err != nil {
+				s.logger.WarnContext(ctx, "persist recycled assistant runtime metadata failed",
+					attr.SlogAssistantID(row.AssistantID.String()),
+					attr.SlogProjectID(row.ProjectID.String()),
+					attr.SlogError(err),
+				)
+			}
+			result.Recycled++
+		default:
+			result.Skipped++
+		}
+		if params.OnRowProcessed != nil {
+			params.OnRowProcessed()
+		}
+	}
+	return result, nil
+}
+
+// RuntimeImageRef returns the runtime image reference the configured backend
+// launches machines with. The deploy-time recycle workflow is keyed on it so
+// each image version triggers exactly one sweep.
+func (s *ServiceCore) RuntimeImageRef() string {
+	return s.runtime.ImageRef()
+}
+
 // reapRuntimeRow tears down the backend resource for one row and records the
 // outcome in DB. Returns true on success (including idempotent no-op when
 // the resource was already gone). Errors are logged here so callers can

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1128,6 +1128,36 @@ func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params Rec
 			State:               row.State,
 			WarmUntil:           row.WarmUntil,
 		}
+		// In-flight events mean turns are queued for or running on this VM —
+		// the runner's idle clock only clears on /turn enqueue, so the idle
+		// probe alone can miss a turn that admission is about to deliver.
+		// Those admissions recycle the image lazily through Ensure anyway.
+		inFlight, err := queries.CountInFlightAssistantThreadEvents(ctx, assistantrepo.CountInFlightAssistantThreadEventsParams{
+			ProjectID:        row.ProjectID,
+			AssistantID:      row.AssistantID,
+			PendingStatus:    eventStatusPending,
+			ProcessingStatus: eventStatusProcessing,
+		})
+		if err != nil {
+			s.logger.WarnContext(ctx, "count in-flight assistant thread events for image recycle failed",
+				attr.SlogAssistantID(row.AssistantID.String()),
+				attr.SlogProjectID(row.ProjectID.String()),
+				attr.SlogError(err),
+			)
+			result.Errors++
+			if params.OnRowProcessed != nil {
+				params.OnRowProcessed()
+			}
+			continue
+		}
+		if inFlight > 0 {
+			result.Skipped++
+			if params.OnRowProcessed != nil {
+				params.OnRowProcessed()
+			}
+			continue
+		}
+
 		recycled, err := s.runtime.RecycleImage(ctx, record)
 		switch {
 		case err != nil:

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1302,6 +1302,131 @@ func TestServiceCoreReapAssistantRuntimesSkipsRowsWithoutMetadata(t *testing.T) 
 	require.EqualValues(t, 0, reapCalls.Load())
 }
 
+// insertActiveV2RuntimeRow seeds an active v2 runtime row carrying backend
+// metadata, mirroring what a completed admit leaves behind, and returns the
+// row id.
+func insertActiveV2RuntimeRow(
+	t *testing.T,
+	conn *pgxpool.Pool,
+	projectID, assistantID, threadID uuid.UUID,
+	state string,
+	metadata string,
+) uuid.UUID {
+	t.Helper()
+
+	require.NoError(t, assistantsrepo.New(conn).ReserveAssistantRuntimeV2(t.Context(), assistantsrepo.ReserveAssistantRuntimeV2Params{
+		AssistantThreadID: threadID,
+		AssistantID:       assistantID,
+		ProjectID:         projectID,
+		Backend:           runtimeBackendFlyIO,
+		State:             state,
+	}))
+	row, err := assistantsrepo.New(conn).GetAssistantRuntimeV2(t.Context(), assistantsrepo.GetAssistantRuntimeV2Params{
+		ProjectID:   projectID,
+		AssistantID: assistantID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, assistantsrepo.New(conn).UpdateAssistantRuntimeMetadata(t.Context(), assistantsrepo.UpdateAssistantRuntimeMetadataParams{
+		BackendMetadataJson: []byte(metadata),
+		RuntimeID:           row.ID,
+		ProjectID:           projectID,
+	}))
+	return row.ID
+}
+
+func TestServiceCoreRecycleActiveRuntimeImagesRecyclesAndPersists(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images")
+	require.NoError(t, err)
+
+	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-stale","machine_id":"m-1"}`)
+
+	recycledMetadata := `{"app_name":"gram-asst-stale","machine_id":"m-1","last_boot_id":"boot-2"}`
+	recycleCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{
+		backend:      runtimeBackendFlyIO,
+		recycleCalls: recycleCalls,
+		recycleResult: RuntimeBackendRecycleResult{
+			Recycled:            true,
+			BackendMetadataJSON: []byte(recycledMetadata),
+		},
+	}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+
+	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Recycled)
+	require.Equal(t, 0, result.Skipped)
+	require.Equal(t, 0, result.Errors)
+	require.EqualValues(t, 1, recycleCalls.Load())
+
+	runtime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: runtimeID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.JSONEq(t, recycledMetadata, string(runtime.BackendMetadataJson))
+}
+
+func TestServiceCoreRecycleActiveRuntimeImagesSweepsOnlyActiveV2Rows(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_filter")
+	require.NoError(t, err)
+
+	// Candidate: active v2 row with metadata. The fake reports no recycle
+	// (image already current), so it must count as skipped.
+	activeProj, activeAssistant, activeThread := insertReapableProject(t, conn, "recycle-active")
+	insertActiveV2RuntimeRow(t, conn, activeProj, activeAssistant, activeThread, runtimeStateActive, `{"app_name":"gram-asst-current","machine_id":"m-1"}`)
+
+	// Non-candidates: a starting v2 row (mid-boot, already on the new
+	// image) and a v1 row (per-thread runtimes recycle on admission).
+	startingProj, startingAssistant, startingThread := insertReapableProject(t, conn, "recycle-starting")
+	insertActiveV2RuntimeRow(t, conn, startingProj, startingAssistant, startingThread, runtimeStateStarting, `{"app_name":"gram-asst-booting","machine_id":"m-2"}`)
+	v1Proj, v1Assistant, v1Thread := insertReapableProject(t, conn, "recycle-v1")
+	insertReapableRuntimeRow(t, conn, v1Proj, v1Assistant, v1Thread, runtimeStateActive, "gram-asst-v1", time.Now().UTC())
+
+	recycleCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{
+		backend:       runtimeBackendFlyIO,
+		recycleCalls:  recycleCalls,
+		recycleResult: RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil},
+	}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+
+	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Recycled)
+	require.Equal(t, 1, result.Skipped)
+	require.Equal(t, 0, result.Errors)
+	require.EqualValues(t, 1, recycleCalls.Load())
+}
+
+func TestServiceCoreRecycleActiveRuntimeImagesCountsBackendErrors(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_errors")
+	require.NoError(t, err)
+
+	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-flaky","machine_id":"m-1"}`)
+
+	backend := testRuntimeBackend{
+		backend:    runtimeBackendFlyIO,
+		recycleErr: errors.New("fly api 503"),
+	}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+
+	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Recycled)
+	require.Equal(t, 1, result.Errors)
+
+	// Metadata is untouched on failure.
+	runtime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: runtimeID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"app_name":"gram-asst-flaky","machine_id":"m-1"}`, string(runtime.BackendMetadataJson))
+}
+
 func TestServiceCoreReapInactiveAssistantRuntimesCollectsOnlyInactive(t *testing.T) {
 	t.Parallel()
 
@@ -1495,16 +1620,20 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsLiveRowsCollectsFinalized(
 }
 
 type testRuntimeBackend struct {
-	backend      string
-	ensureResult RuntimeBackendEnsureResult
-	ensureErr    error
-	runTurnErr   error
-	statusResult RuntimeBackendStatus
-	statusErr    error
-	stopErr      error
-	stopCalls    *atomic.Int64
-	reapCalls    *atomic.Int64
-	reapErr      error
+	backend       string
+	ensureResult  RuntimeBackendEnsureResult
+	ensureErr     error
+	runTurnErr    error
+	statusResult  RuntimeBackendStatus
+	statusErr     error
+	stopErr       error
+	stopCalls     *atomic.Int64
+	reapCalls     *atomic.Int64
+	reapErr       error
+	imageRef      string
+	recycleResult RuntimeBackendRecycleResult
+	recycleErr    error
+	recycleCalls  *atomic.Int64
 }
 
 func (t testRuntimeBackend) Backend() string {
@@ -1524,6 +1653,20 @@ func (t testRuntimeBackend) Ensure(context.Context, assistantRuntimeRecord) (Run
 		return RuntimeBackendEnsureResult{}, t.ensureErr
 	}
 	return t.ensureResult, nil
+}
+
+func (t testRuntimeBackend) ImageRef() string {
+	return t.imageRef
+}
+
+func (t testRuntimeBackend) RecycleImage(context.Context, assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+	if t.recycleCalls != nil {
+		t.recycleCalls.Add(1)
+	}
+	if t.recycleErr != nil {
+		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, t.recycleErr
+	}
+	return t.recycleResult, nil
 }
 
 func (t testRuntimeBackend) RunTurn(context.Context, assistantRuntimeRecord, uuid.UUID, string, string, string) error {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1401,6 +1401,52 @@ func TestServiceCoreRecycleActiveRuntimeImagesSweepsOnlyActiveV2Rows(t *testing.
 	require.EqualValues(t, 1, recycleCalls.Load())
 }
 
+func TestServiceCoreRecycleActiveRuntimeImagesUndoesRecycleWhenRowExpiresMidSweep(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_raced")
+	require.NoError(t, err)
+
+	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+	originalMetadata := `{"app_name":"gram-asst-raced","machine_id":"m-1"}`
+	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, originalMetadata)
+
+	// The fake recycles "successfully" but expires the row first, simulating
+	// the warm timer winning the race while the machine update was in flight.
+	stopCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{
+		backend:   runtimeBackendFlyIO,
+		stopCalls: stopCalls,
+		recycleFn: func(ctx context.Context, record assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+			require.NoError(t, assistantsrepo.New(conn).StopAssistantRuntime(ctx, assistantsrepo.StopAssistantRuntimeParams{
+				State:         runtimeStateStopped,
+				ProjectID:     record.ProjectID,
+				RuntimeID:     record.ID,
+				StartingState: runtimeStateStarting,
+				ActiveState:   runtimeStateActive,
+				ExpiringState: runtimeStateExpiring,
+			}))
+			return RuntimeBackendRecycleResult{
+				Recycled:            true,
+				BackendMetadataJSON: []byte(`{"app_name":"gram-asst-raced","machine_id":"m-1","last_boot_id":"boot-2"}`),
+			}, nil
+		},
+	}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+
+	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Recycled)
+	require.Equal(t, 1, result.Skipped)
+	require.Equal(t, 0, result.Errors)
+	// The restart was undone and the dead row's metadata left alone.
+	require.EqualValues(t, 1, stopCalls.Load())
+	runtime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: runtimeID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.JSONEq(t, originalMetadata, string(runtime.BackendMetadataJson))
+	require.Equal(t, runtimeStateStopped, runtime.State)
+}
+
 func TestServiceCoreRecycleActiveRuntimeImagesCountsBackendErrors(t *testing.T) {
 	t.Parallel()
 
@@ -1634,6 +1680,10 @@ type testRuntimeBackend struct {
 	recycleResult RuntimeBackendRecycleResult
 	recycleErr    error
 	recycleCalls  *atomic.Int64
+	// recycleFn, when set, replaces the canned recycleResult/recycleErr so a
+	// test can mutate DB state mid-sweep (e.g. expire the row) before the
+	// service persists the outcome.
+	recycleFn func(context.Context, assistantRuntimeRecord) (RuntimeBackendRecycleResult, error)
 }
 
 func (t testRuntimeBackend) Backend() string {
@@ -1659,9 +1709,12 @@ func (t testRuntimeBackend) ImageRef() string {
 	return t.imageRef
 }
 
-func (t testRuntimeBackend) RecycleImage(context.Context, assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+func (t testRuntimeBackend) RecycleImage(ctx context.Context, record assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
 	if t.recycleCalls != nil {
 		t.recycleCalls.Add(1)
+	}
+	if t.recycleFn != nil {
+		return t.recycleFn(ctx, record)
 	}
 	if t.recycleErr != nil {
 		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, t.recycleErr

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1430,6 +1430,38 @@ func TestServiceCoreRecycleActiveRuntimeImagesSkipsAssistantsWithInFlightEvents(
 	require.EqualValues(t, 0, recycleCalls.Load())
 }
 
+func TestServiceCoreRecycleActiveRuntimeImagesIgnoresDeletedAssistants(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_deleted_assistant")
+	require.NoError(t, err)
+
+	// An active row orphaned by a failed best-effort reap on assistant
+	// delete belongs to the janitor; recycling it would bump updated_at and
+	// postpone the inactivity-based collection.
+	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-deleted-assistant")
+	insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-orphan","machine_id":"m-1"}`)
+	require.NoError(t, assistantsrepo.New(conn).DeleteAssistant(t.Context(), assistantsrepo.DeleteAssistantParams{
+		AssistantID: assistantID,
+		ProjectID:   projectID,
+	}))
+
+	recycleCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{
+		backend:       runtimeBackendFlyIO,
+		recycleCalls:  recycleCalls,
+		recycleResult: RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: []byte(`{}`)},
+	}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+
+	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Recycled)
+	require.Equal(t, 0, result.Skipped)
+	require.Equal(t, 0, result.Errors)
+	require.EqualValues(t, 0, recycleCalls.Load())
+}
+
 func TestServiceCoreRecycleActiveRuntimeImagesUndoesRecycleWhenRowExpiresMidSweep(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1340,7 +1340,9 @@ func TestServiceCoreRecycleActiveRuntimeImagesRecyclesAndPersists(t *testing.T) 
 	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images")
 	require.NoError(t, err)
 
-	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+	// insertReapableProject seeds no thread events, so the runtime reads as
+	// fully idle to the sweep's in-flight guard.
+	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-persist")
 	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-stale","machine_id":"m-1"}`)
 
 	recycledMetadata := `{"app_name":"gram-asst-stale","machine_id":"m-1","last_boot_id":"boot-2"}`
@@ -1401,13 +1403,40 @@ func TestServiceCoreRecycleActiveRuntimeImagesSweepsOnlyActiveV2Rows(t *testing.
 	require.EqualValues(t, 1, recycleCalls.Load())
 }
 
+func TestServiceCoreRecycleActiveRuntimeImagesSkipsAssistantsWithInFlightEvents(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_in_flight")
+	require.NoError(t, err)
+
+	// insertAssistantFixture seeds a pending thread event, which is exactly
+	// the in-flight signal the sweep must respect.
+	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+	insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-busy","machine_id":"m-1"}`)
+
+	recycleCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{
+		backend:       runtimeBackendFlyIO,
+		recycleCalls:  recycleCalls,
+		recycleResult: RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: []byte(`{}`)},
+	}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+
+	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Recycled)
+	require.Equal(t, 1, result.Skipped)
+	require.Equal(t, 0, result.Errors)
+	require.EqualValues(t, 0, recycleCalls.Load())
+}
+
 func TestServiceCoreRecycleActiveRuntimeImagesUndoesRecycleWhenRowExpiresMidSweep(t *testing.T) {
 	t.Parallel()
 
 	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_raced")
 	require.NoError(t, err)
 
-	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-raced")
 	originalMetadata := `{"app_name":"gram-asst-raced","machine_id":"m-1"}`
 	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, originalMetadata)
 
@@ -1453,7 +1482,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesCountsBackendErrors(t *testing.T) 
 	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_errors")
 	require.NoError(t, err)
 
-	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-errors")
 	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-flaky","machine_id":"m-1"}`)
 
 	backend := testRuntimeBackend{

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -83,6 +83,7 @@ type Activities struct {
 	expireAssistantThreadRuntime    *activities.ExpireAssistantThreadRuntime
 	reapStuckAssistantRuntimes      *activities.ReapStuckAssistantRuntimes
 	reapInactiveAssistantRuntimes   *activities.ReapInactiveAssistantRuntimes
+	recycleAssistantRuntimeImages   *activities.RecycleAssistantRuntimeImages
 	reapSoftDeletedAssistantMems    *activities.ReapSoftDeletedAssistantMemories
 	signalAssistantCoordinator      *activities.SignalAssistantCoordinator
 	signalAssistantThread           *activities.SignalAssistantThread
@@ -177,6 +178,7 @@ func NewActivities(
 		expireAssistantThreadRuntime:    activities.NewExpireAssistantThreadRuntime(assistantsCore),
 		reapStuckAssistantRuntimes:      activities.NewReapStuckAssistantRuntimes(assistantsCore),
 		reapInactiveAssistantRuntimes:   activities.NewReapInactiveAssistantRuntimes(logger, assistantsCore),
+		recycleAssistantRuntimeImages:   activities.NewRecycleAssistantRuntimeImages(logger, assistantsCore),
 		reapSoftDeletedAssistantMems:    activities.NewReapSoftDeletedAssistantMemories(logger, db),
 		signalAssistantCoordinator:      activities.NewSignalAssistantCoordinator(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 		signalAssistantThread:           activities.NewSignalAssistantThread(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
@@ -394,6 +396,10 @@ func (a *Activities) ReapStuckAssistantRuntimes(ctx context.Context) (*activitie
 
 func (a *Activities) ReapInactiveAssistantRuntimes(ctx context.Context, req activities.ReapInactiveAssistantRuntimesRequest) (*activities.ReapInactiveAssistantRuntimesResult, error) {
 	return a.reapInactiveAssistantRuntimes.Do(ctx, req)
+}
+
+func (a *Activities) RecycleAssistantRuntimeImages(ctx context.Context) (*activities.RecycleAssistantRuntimeImagesResult, error) {
+	return a.recycleAssistantRuntimeImages.Do(ctx)
 }
 
 func (a *Activities) ReapSoftDeletedAssistantMemories(ctx context.Context, cutoff time.Time) (int64, error) {

--- a/server/internal/background/activities/recycle_assistant_runtime_images.go
+++ b/server/internal/background/activities/recycle_assistant_runtime_images.go
@@ -1,0 +1,57 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.temporal.io/sdk/activity"
+
+	"github.com/speakeasy-api/gram/server/internal/assistants"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+type RecycleAssistantRuntimeImagesResult struct {
+	Recycled int
+	Skipped  int
+	Errors   int
+}
+
+type RecycleAssistantRuntimeImages struct {
+	logger *slog.Logger
+	core   *assistants.ServiceCore
+}
+
+func NewRecycleAssistantRuntimeImages(logger *slog.Logger, core *assistants.ServiceCore) *RecycleAssistantRuntimeImages {
+	return &RecycleAssistantRuntimeImages{
+		logger: logger.With(attr.SlogComponent("assistant_runtime_image_recycle")),
+		core:   core,
+	}
+}
+
+func (r *RecycleAssistantRuntimeImages) Do(ctx context.Context) (*RecycleAssistantRuntimeImagesResult, error) {
+	if r.core == nil {
+		return nil, fmt.Errorf("assistants core not configured")
+	}
+
+	result, err := r.core.RecycleActiveRuntimeImages(ctx, assistants.RecycleAssistantRuntimeImagesParams{
+		OnRowProcessed: func() {
+			activity.RecordHeartbeat(ctx)
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("recycle assistant runtime images: %w", err)
+	}
+
+	if result.Recycled > 0 || result.Errors > 0 {
+		r.logger.InfoContext(ctx, fmt.Sprintf("assistant runtime image recycle swept recycled=%d skipped=%d errors=%d", result.Recycled, result.Skipped, result.Errors),
+			attr.SlogVisibilityInternal(),
+		)
+	}
+
+	return &RecycleAssistantRuntimeImagesResult{
+		Recycled: result.Recycled,
+		Skipped:  result.Skipped,
+		Errors:   result.Errors,
+	}, nil
+}

--- a/server/internal/background/assistant_runtime_image_recycle.go
+++ b/server/internal/background/assistant_runtime_image_recycle.go
@@ -40,7 +40,7 @@ type AssistantRuntimeImageRecycleWorkflowResult struct {
 // AssistantRuntimeImageRecycleWorkflow sweeps every active v2 assistant
 // runtime once and rolls idle machines onto the currently configured runtime
 // image. Kicked at worker startup with a workflow ID keyed on the image
-// reference, so each deployed image triggers exactly one fleet sweep; busy
+// reference, so concurrent replica kicks collapse into one fleet sweep; busy
 // machines are skipped and picked up lazily by the per-admission recycle.
 func AssistantRuntimeImageRecycleWorkflow(ctx workflow.Context) (*AssistantRuntimeImageRecycleWorkflowResult, error) {
 	var a *Activities
@@ -80,15 +80,22 @@ func AssistantRuntimeImageRecycleWorkflow(ctx workflow.Context) (*AssistantRunti
 }
 
 // KickAssistantRuntimeImageRecycle starts one image recycle sweep keyed on
-// the given image reference. The reject-duplicate reuse policy makes the kick
-// idempotent across worker replicas and restarts of the same build — only a
-// deploy that changes the image ref produces a fresh sweep.
+// the given image reference. Concurrent kicks from sibling worker replicas
+// collapse into a single run; once that run completes, a later kick (worker
+// restart, rollback to a previously swept image) starts a fresh sweep.
 func KickAssistantRuntimeImageRecycle(ctx context.Context, temporalEnv *tenv.Environment, imageRef string) error {
 	wfID := assistantRuntimeImageRecycleWorkflowIDPrefix + imageRef
+	// ALLOW_DUPLICATE rather than REJECT_DUPLICATE: a rollback re-deploys an
+	// image ref whose sweep already completed, and it still needs a fresh
+	// sweep to roll the fleet back. Concurrent kicks from sibling replicas
+	// are still collapsed — starting a workflow whose ID is currently
+	// running returns WorkflowExecutionAlreadyStarted regardless of reuse
+	// policy. The residual cost is a redundant sweep after a worker restart
+	// on an unchanged image, which no-ops row by row.
 	_, err := temporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		ID:                    wfID,
 		TaskQueue:             string(temporalEnv.Queue()),
-		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 		// Sized for the activity's full retry budget (2 attempts at the
 		// StartToClose ceiling) so the second attempt is never truncated.
 		WorkflowRunTimeout: 2*assistantRuntimeImageRecycleActivityTimeout + 15*time.Minute,

--- a/server/internal/background/assistant_runtime_image_recycle.go
+++ b/server/internal/background/assistant_runtime_image_recycle.go
@@ -1,0 +1,102 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	assistantRuntimeImageRecycleWorkflowIDPrefix = "v1:assistant-runtime-image-recycle:"
+
+	// assistantRuntimeImageRecycleActivityTimeout bounds one sweep. Each
+	// stale row pays an in-place machine update: image pull + reboot +
+	// health wait, serially. Liveness is enforced by the heartbeat timeout,
+	// not this ceiling.
+	assistantRuntimeImageRecycleActivityTimeout = 6 * time.Hour
+
+	// assistantRuntimeImageRecycleHeartbeatTimeout must comfortably exceed
+	// the worst-case time spent on a single row: a flaps update, a machine
+	// start, the started wait and the 45s health wait.
+	assistantRuntimeImageRecycleHeartbeatTimeout = 10 * time.Minute
+)
+
+type AssistantRuntimeImageRecycleWorkflowResult struct {
+	Recycled int
+	Skipped  int
+	Errors   int
+}
+
+// AssistantRuntimeImageRecycleWorkflow sweeps every active v2 assistant
+// runtime once and rolls idle machines onto the currently configured runtime
+// image. Kicked at worker startup with a workflow ID keyed on the image
+// reference, so each deployed image triggers exactly one fleet sweep; busy
+// machines are skipped and picked up lazily by the per-admission recycle.
+func AssistantRuntimeImageRecycleWorkflow(ctx workflow.Context) (*AssistantRuntimeImageRecycleWorkflowResult, error) {
+	var a *Activities
+
+	logger := workflow.GetLogger(ctx)
+
+	// MaximumAttempts is 2 so a transient DB error on the candidate list does
+	// not lose the deploy's only sweep; per-row Fly failures are swallowed
+	// inside the activity and never retry.
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: assistantRuntimeImageRecycleActivityTimeout,
+		HeartbeatTimeout:    assistantRuntimeImageRecycleHeartbeatTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    2,
+			InitialInterval:    5 * time.Second,
+			MaximumInterval:    1 * time.Minute,
+			BackoffCoefficient: 2,
+		},
+	})
+
+	var result activities.RecycleAssistantRuntimeImagesResult
+	if err := workflow.ExecuteActivity(ctx, a.RecycleAssistantRuntimeImages).Get(ctx, &result); err != nil {
+		return nil, fmt.Errorf("recycle assistant runtime images: %w", err)
+	}
+
+	logger.Info("assistant runtime image recycle completed",
+		"recycled", result.Recycled,
+		"skipped", result.Skipped,
+		"errors", result.Errors,
+	)
+
+	return &AssistantRuntimeImageRecycleWorkflowResult{
+		Recycled: result.Recycled,
+		Skipped:  result.Skipped,
+		Errors:   result.Errors,
+	}, nil
+}
+
+// KickAssistantRuntimeImageRecycle starts one image recycle sweep keyed on
+// the given image reference. The reject-duplicate reuse policy makes the kick
+// idempotent across worker replicas and restarts of the same build — only a
+// deploy that changes the image ref produces a fresh sweep.
+func KickAssistantRuntimeImageRecycle(ctx context.Context, temporalEnv *tenv.Environment, imageRef string) error {
+	wfID := assistantRuntimeImageRecycleWorkflowIDPrefix + imageRef
+	_, err := temporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    wfID,
+		TaskQueue:             string(temporalEnv.Queue()),
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+		WorkflowRunTimeout:    assistantRuntimeImageRecycleActivityTimeout + 15*time.Minute,
+	}, AssistantRuntimeImageRecycleWorkflow)
+	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+	if errors.As(err, &alreadyStarted) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("start assistant runtime image recycle workflow: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/assistant_runtime_image_recycle.go
+++ b/server/internal/background/assistant_runtime_image_recycle.go
@@ -89,7 +89,9 @@ func KickAssistantRuntimeImageRecycle(ctx context.Context, temporalEnv *tenv.Env
 		ID:                    wfID,
 		TaskQueue:             string(temporalEnv.Queue()),
 		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
-		WorkflowRunTimeout:    assistantRuntimeImageRecycleActivityTimeout + 15*time.Minute,
+		// Sized for the activity's full retry budget (2 attempts at the
+		// StartToClose ceiling) so the second attempt is never truncated.
+		WorkflowRunTimeout: 2*assistantRuntimeImageRecycleActivityTimeout + 15*time.Minute,
 	}, AssistantRuntimeImageRecycleWorkflow)
 	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
 	if errors.As(err, &alreadyStarted) {

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -318,6 +318,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.ExpireAssistantThreadRuntime)
 	temporalWorker.RegisterActivity(activities.ReapStuckAssistantRuntimes)
 	temporalWorker.RegisterActivity(activities.ReapInactiveAssistantRuntimes)
+	temporalWorker.RegisterActivity(activities.RecycleAssistantRuntimeImages)
 	temporalWorker.RegisterActivity(activities.ReapSoftDeletedAssistantMemories)
 	temporalWorker.RegisterActivity(activities.SignalAssistantCoordinator)
 	temporalWorker.RegisterActivity(activities.SignalAssistantThread)
@@ -372,6 +373,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(AssistantThreadWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantReaperWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantRuntimeJanitorWorkflow)
+	temporalWorker.RegisterWorkflow(AssistantRuntimeImageRecycleWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantMemoriesReaperWorkflow)
 	// WorkOS sync workflows
 	temporalWorker.RegisterWorkflow(ProcessWorkOSOrganizationEventsWorkflow)
@@ -428,6 +430,18 @@ func NewTemporalWorker(
 
 	if err := AddAssistantMemoriesReaperSchedule(context.Background(), env); err != nil {
 		logger.ErrorContext(context.Background(), "failed to add assistant memories reaper schedule", attr.SlogError(err))
+	}
+
+	// One image recycle sweep per deployed runtime image: a new worker build
+	// carries a new image ref, so kicking on startup is the deploy signal.
+	// Best-effort — a failed kick just leaves runtimes to the lazy
+	// per-admission recycle.
+	if opts.AssistantsCore != nil {
+		if imageRef := opts.AssistantsCore.RuntimeImageRef(); imageRef != "" {
+			if err := KickAssistantRuntimeImageRecycle(context.Background(), env, imageRef); err != nil {
+				logger.ErrorContext(context.Background(), "failed to kick assistant runtime image recycle", attr.SlogError(err))
+			}
+		}
 	}
 
 	if err := AddOutboxGCSchedule(context.Background(), env); err != nil {


### PR DESCRIPTION
## Summary

- Runtime image recycling previously only ran inside `Ensure` on thread admission, so after a deploy every warm assistant VM stayed on the stale image until the next user turn — and that turn paid the image pull + reboot + health wait (dormant assistants stayed stale for days).
- Worker startup now kicks a one-shot Temporal workflow keyed on the deployed image ref. The reject-duplicate reuse policy makes the kick idempotent across worker replicas and restarts of the same build: only a deploy that changes the image produces a fresh sweep.
- The sweep walks active v2 runtime rows and recycles each idle machine in place via the existing `maybeRecycleImage` path (same idle gate — a turn in flight is never interrupted), then persists the new boot identity. Strictly non-creative: missing apps/machines are skips, never launches.
- Best effort by design: busy or failed rows are not chased — the per-admission recycle in `Ensure` still catches them lazily on the next turn.

Stacked on #3364.

Closes [DNO-233](https://linear.app/speakeasy/issue/DNO-233/recycle-assistant-runtime-images-aot)

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recycle assistant runtime VMs onto the new image right after deploy so the next turn doesn’t pay the image pull + reboot + health wait. Implements DNO-233.

- **New Features**
  - Kick a one-shot workflow on worker startup keyed by runtime image ref; use allow-duplicate so rollbacks/restarts re-sweep while concurrent kicks collapse to one run.
  - Sweep active v2 runtimes with metadata; idle-gated, non-creative recycle with health wait; persist new boot ID; emit telemetry for recycled and skipped.
  - Add backend `ImageRef()` and `RecycleImage(...)`; new list/count/update queries; register activity/workflow with per-row heartbeats.

- **Bug Fixes**
  - Guard warm-expiry races: recycle only `started` machines; persist metadata only if row is still active; if it expired mid-sweep, undo the restart with a best-effort stop.
  - Skip assistants with in-flight (pending/processing) events, ignore soft-deleted events in the gate, and exclude deleted assistants from the sweep.
  - Size the workflow run timeout to cover the full retry budget so a second activity attempt isn’t truncated.

<sup>Written for commit 181e6864852107547c4361eef20044efeef6c20c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

