### PR TITLE
fix(assistants): survive runtime teardown racing turn dispatch

### DIFF
--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -703,6 +703,9 @@ WHERE id = @event_id
   AND project_id = @project_id;
 
 -- name: SetAssistantRuntimeActive :exec
+-- Guarded against finalized rows: the reaper can soft-delete a runtime row
+-- between a turn loading it and reaching this write, and re-stamping state
+-- on a tombstone would make it look live again.
 UPDATE assistant_runtimes
 SET
   state = @active_state,
@@ -710,7 +713,9 @@ SET
   last_heartbeat_at = clock_timestamp(),
   updated_at = clock_timestamp()
 WHERE id = @runtime_id
-  AND project_id = @project_id;
+  AND project_id = @project_id
+  AND deleted IS FALSE
+  AND ended IS FALSE;
 
 -- name: UpdateAssistantRuntimeMetadata :exec
 UPDATE assistant_runtimes
@@ -823,7 +828,9 @@ SET
   updated_at = clock_timestamp()
 WHERE id = @runtime_id
   AND project_id = @project_id
-  AND state = @expiring_state;
+  AND state = @expiring_state
+  AND deleted IS FALSE
+  AND ended IS FALSE;
 
 -- name: CreateAssistantRuntime :exec
 -- Inserts an assistant_runtimes row with caller-controlled id, timestamps,

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -703,9 +703,6 @@ WHERE id = @event_id
   AND project_id = @project_id;
 
 -- name: SetAssistantRuntimeActive :exec
--- Guarded against finalized rows: the reaper can soft-delete a runtime row
--- between a turn loading it and reaching this write, and re-stamping state
--- on a tombstone would make it look live again.
 UPDATE assistant_runtimes
 SET
   state = @active_state,

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -2291,9 +2291,6 @@ type SetAssistantRuntimeActiveParams struct {
 	ProjectID   uuid.UUID
 }
 
-// Guarded against finalized rows: the reaper can soft-delete a runtime row
-// between a turn loading it and reaching this write, and re-stamping state
-// on a tombstone would make it look live again.
 func (q *Queries) SetAssistantRuntimeActive(ctx context.Context, arg SetAssistantRuntimeActiveParams) error {
 	_, err := q.db.Exec(ctx, setAssistantRuntimeActive,
 		arg.ActiveState,

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -2248,6 +2248,8 @@ SET
 WHERE id = $3
   AND project_id = $4
   AND state = $5
+  AND deleted IS FALSE
+  AND ended IS FALSE
 `
 
 type RevertExpireAssistantRuntimeToActiveParams struct {
@@ -2278,6 +2280,8 @@ SET
   updated_at = clock_timestamp()
 WHERE id = $3
   AND project_id = $4
+  AND deleted IS FALSE
+  AND ended IS FALSE
 `
 
 type SetAssistantRuntimeActiveParams struct {
@@ -2287,6 +2291,9 @@ type SetAssistantRuntimeActiveParams struct {
 	ProjectID   uuid.UUID
 }
 
+// Guarded against finalized rows: the reaper can soft-delete a runtime row
+// between a turn loading it and reaching this write, and re-stamping state
+// on a tombstone would make it look live again.
 func (q *Queries) SetAssistantRuntimeActive(ctx context.Context, arg SetAssistantRuntimeActiveParams) error {
 	_, err := q.db.Exec(ctx, setAssistantRuntimeActive,
 		arg.ActiveState,

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1461,6 +1461,30 @@ func (s *ServiceCore) admitPendingThreadsV2(ctx context.Context, assistant assis
 func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, threadID uuid.UUID) (ProcessThreadEventsResult, error) {
 	bootstrappedRuntime := false
 	thread, assistant, runtimeRecord, err := s.loadThreadContext(ctx, projectID, threadID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The runtime row was retired (reaper, expire, manual stop) between
+		// this thread being admitted and the activity executing. The events
+		// are still pending, so hand back to the coordinator: re-admission
+		// reserves a fresh runtime row and re-dispatches. Failing the
+		// activity here instead would burn its retry budget against a
+		// tombstone and drop the turn.
+		row, rerr := assistantrepo.New(s.db).ResolveThreadCorrelation(ctx, assistantrepo.ResolveThreadCorrelationParams{
+			ThreadID:  threadID,
+			ProjectID: projectID,
+		})
+		if rerr != nil {
+			return ProcessThreadEventsResult{}, fmt.Errorf("resolve thread for retry admission: %w", errors.Join(err, rerr))
+		}
+		return ProcessThreadEventsResult{
+			AssistantID:         row.AssistantID,
+			WarmUntil:           time.Time{},
+			WarmTTLSeconds:      0,
+			RuntimeActive:       false,
+			RetryAdmission:      true,
+			ProcessedAnyEvent:   false,
+			BootstrappedRuntime: false,
+		}, nil
+	}
 	if err != nil {
 		return ProcessThreadEventsResult{}, err
 	}


### PR DESCRIPTION
## Summary

A thread admitted while its assistant's runtime row is live can execute `ProcessAssistantThread` after the reaper soft-deletes that row (observed in prod on 2026-06-11 ~20:58 UTC: 3 thread workflows failed, monitor `temporal_activity_execution_failed` fired, and the turns were dropped).

- `ProcessThreadEvents` now treats `loadThreadContext` returning no rows as a re-admission case (`RetryAdmission`) instead of a retryable activity error. The coordinator re-admits the thread, which reserves a fresh runtime row and re-dispatches — same handling the `Ensure`-failure branch already uses. Previously the activity burned its retry budget against a tombstone, failed the workflow, and dropped the user's turn.
- `SetAssistantRuntimeActive` and `RevertExpireAssistantRuntimeToActive` are now guarded with `deleted IS FALSE AND ended IS FALSE`. A turn racing the teardown could re-stamp `state = active` onto a soft-deleted row, making tombstones look live (we have rows in prod with exactly this shape).

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents dropped turns when a runtime is soft-deleted during dispatch by re-admitting the thread and guarding runtime updates so tombstones can’t be “revived.”

- **Bug Fixes**
  - `ProcessThreadEvents` treats `loadThreadContext` returning no rows as `RetryAdmission`, prompting the coordinator to reserve a fresh runtime and re-dispatch.
  - Added `deleted IS FALSE AND ended IS FALSE` guards to `SetAssistantRuntimeActive` and `RevertExpireAssistantRuntimeToActive` to block re-stamping `active` on soft-deleted `assistant_runtimes` rows.

<sup>Written for commit 7a4183de6a0fc3a3453acb3dc5c3d55267f463b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

