### PR TITLE
feat(assistants): stop reaping idle runtime VMs

### DIFF
--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -741,16 +741,29 @@ WHERE assistant_id = @assistant_id
   AND backend_metadata_json <> '{}'::jsonb;
 
 -- name: ListInactiveAssistantRuntimesForReap :many
--- Returns finalized (soft-deleted or ended) runtime rows that still carry
--- backend metadata whose owning assistant has had no runtime activity since
--- @inactive_before — orphaned backend apps whose Stop/Reap never completed.
--- Live rows are never candidates: an idle runtime keeps its VM until the
--- assistant is deleted. The state value itself is intentionally ignored
--- (a tombstone can carry any state, e.g. one stamped by a racing turn).
+-- Returns runtime rows that still carry backend metadata, are no longer
+-- supposed to have a backend app, and whose owning assistant has had no
+-- runtime activity since @inactive_before — orphans whose Stop/Reap never
+-- completed. A row qualifies when it is finalized (soft-deleted or ended;
+-- the state value is intentionally ignored since a tombstone can carry any
+-- state, e.g. one stamped by a racing turn) or when its owning assistant is
+-- soft-deleted (delete paths reap best-effort and rely on this janitor as
+-- the safety net). A live row under a live assistant is never a candidate:
+-- an idle runtime keeps its VM until the assistant is deleted.
 SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
 FROM assistant_runtimes r
 WHERE r.backend_metadata_json <> '{}'::jsonb
-  AND (r.deleted IS TRUE OR r.ended IS TRUE)
+  AND (
+    r.deleted IS TRUE
+    OR r.ended IS TRUE
+    OR EXISTS (
+      SELECT 1
+      FROM assistants a
+      WHERE a.id = r.assistant_id
+        AND a.project_id = r.project_id
+        AND a.deleted IS TRUE
+    )
+  )
   AND NOT EXISTS (
     SELECT 1
     FROM assistant_runtimes r2

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -1,11 +1,15 @@
 -- name: ReapStuckAssistantRuntimes :many
--- Short-horizon reaper for rows the happy-path can no longer move. Applies
--- to both v1 (per-thread VM) and v2 (single VM per assistant) rows: the
--- starting/active/expiring liveness markers it keys on are version-agnostic.
--- A v2 VM in active use updates warm_until and last_heartbeat_at via every
--- thread workflow, so an in-flight VM is never matched by the active branch;
--- only assistants whose entire thread set has gone idle past the cutoffs are
--- collected.
+-- Short-horizon reaper for rows the happy-path can no longer move — crash
+-- recovery only. Idle runtimes are deliberately not collected: a VM with no
+-- traffic stays up until its assistant is deleted. Both branches cover rows
+-- stranded by a dead process, and the next admit recreates the runtime:
+--   - 'starting' rows that never transitioned to active within the startup
+--     grace window (server crashed mid-boot).
+--   - 'expiring' rows older than the ExpireThreadRuntime activity's full
+--     retry budget (legacy expire workflows that gave up after CAS
+--     active->expiring without reaching Stop). Without this the partial
+--     unique indexes (v1 on assistant_thread_id, v2 on assistant_id) block
+--     new admits indefinitely.
 UPDATE assistant_runtimes
 SET
   state = @stopped_state,
@@ -14,16 +18,6 @@ SET
 WHERE deleted IS FALSE
   AND (
     (state = @starting_state AND updated_at < @starting_cutoff)
-    OR (
-      state = @active_state
-      AND warm_until IS NOT NULL
-      AND warm_until < @warm_cutoff
-      AND COALESCE(last_heartbeat_at, updated_at) < @heartbeat_cutoff
-    )
-    -- Backstop for activities that exhaust Temporal's retry budget after CAS
-    -- active->expiring without reaching Stop. Without this the partial unique
-    -- indexes (v1 on assistant_thread_id, v2 on assistant_id) block new
-    -- admits indefinitely.
     OR (state = @expiring_state AND updated_at < @expiring_cutoff)
   )
 RETURNING assistant_id;
@@ -747,13 +741,16 @@ WHERE assistant_id = @assistant_id
   AND backend_metadata_json <> '{}'::jsonb;
 
 -- name: ListInactiveAssistantRuntimesForReap :many
--- Returns runtime rows that still carry backend metadata whose owning
--- assistant has had no runtime activity since @inactive_before. Liveness is
--- judged solely by the EXISTS-on-updated_at join across the assistant's
--- runtime rows; row state is intentionally ignored.
+-- Returns finalized (soft-deleted or ended) runtime rows that still carry
+-- backend metadata whose owning assistant has had no runtime activity since
+-- @inactive_before — orphaned backend apps whose Stop/Reap never completed.
+-- Live rows are never candidates: an idle runtime keeps its VM until the
+-- assistant is deleted. The state value itself is intentionally ignored
+-- (a tombstone can carry any state, e.g. one stamped by a racing turn).
 SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
 FROM assistant_runtimes r
 WHERE r.backend_metadata_json <> '{}'::jsonb
+  AND (r.deleted IS TRUE OR r.ended IS TRUE)
   AND NOT EXISTS (
     SELECT 1
     FROM assistant_runtimes r2

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1307,7 +1307,17 @@ const listInactiveAssistantRuntimesForReap = `-- name: ListInactiveAssistantRunt
 SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
 FROM assistant_runtimes r
 WHERE r.backend_metadata_json <> '{}'::jsonb
-  AND (r.deleted IS TRUE OR r.ended IS TRUE)
+  AND (
+    r.deleted IS TRUE
+    OR r.ended IS TRUE
+    OR EXISTS (
+      SELECT 1
+      FROM assistants a
+      WHERE a.id = r.assistant_id
+        AND a.project_id = r.project_id
+        AND a.deleted IS TRUE
+    )
+  )
   AND NOT EXISTS (
     SELECT 1
     FROM assistant_runtimes r2
@@ -1335,12 +1345,15 @@ type ListInactiveAssistantRuntimesForReapRow struct {
 	WarmUntil           pgtype.Timestamptz
 }
 
-// Returns finalized (soft-deleted or ended) runtime rows that still carry
-// backend metadata whose owning assistant has had no runtime activity since
-// @inactive_before — orphaned backend apps whose Stop/Reap never completed.
-// Live rows are never candidates: an idle runtime keeps its VM until the
-// assistant is deleted. The state value itself is intentionally ignored
-// (a tombstone can carry any state, e.g. one stamped by a racing turn).
+// Returns runtime rows that still carry backend metadata, are no longer
+// supposed to have a backend app, and whose owning assistant has had no
+// runtime activity since @inactive_before — orphans whose Stop/Reap never
+// completed. A row qualifies when it is finalized (soft-deleted or ended;
+// the state value is intentionally ignored since a tombstone can carry any
+// state, e.g. one stamped by a racing turn) or when its owning assistant is
+// soft-deleted (delete paths reap best-effort and rely on this janitor as
+// the safety net). A live row under a live assistant is never a candidate:
+// an idle runtime keeps its VM until the assistant is deleted.
 func (q *Queries) ListInactiveAssistantRuntimesForReap(ctx context.Context, arg ListInactiveAssistantRuntimesForReapParams) ([]ListInactiveAssistantRuntimesForReapRow, error) {
 	rows, err := q.db.Query(ctx, listInactiveAssistantRuntimesForReap, arg.InactiveBefore, arg.LimitCount)
 	if err != nil {

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1307,6 +1307,7 @@ const listInactiveAssistantRuntimesForReap = `-- name: ListInactiveAssistantRunt
 SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
 FROM assistant_runtimes r
 WHERE r.backend_metadata_json <> '{}'::jsonb
+  AND (r.deleted IS TRUE OR r.ended IS TRUE)
   AND NOT EXISTS (
     SELECT 1
     FROM assistant_runtimes r2
@@ -1334,10 +1335,12 @@ type ListInactiveAssistantRuntimesForReapRow struct {
 	WarmUntil           pgtype.Timestamptz
 }
 
-// Returns runtime rows that still carry backend metadata whose owning
-// assistant has had no runtime activity since @inactive_before. Liveness is
-// judged solely by the EXISTS-on-updated_at join across the assistant's
-// runtime rows; row state is intentionally ignored.
+// Returns finalized (soft-deleted or ended) runtime rows that still carry
+// backend metadata whose owning assistant has had no runtime activity since
+// @inactive_before — orphaned backend apps whose Stop/Reap never completed.
+// Live rows are never candidates: an idle runtime keeps its VM until the
+// assistant is deleted. The state value itself is intentionally ignored
+// (a tombstone can carry any state, e.g. one stamped by a racing turn).
 func (q *Queries) ListInactiveAssistantRuntimesForReap(ctx context.Context, arg ListInactiveAssistantRuntimesForReapParams) ([]ListInactiveAssistantRuntimesForReapRow, error) {
 	rows, err := q.db.Query(ctx, listInactiveAssistantRuntimesForReap, arg.InactiveBefore, arg.LimitCount)
 	if err != nil {
@@ -1885,47 +1888,35 @@ SET
 WHERE deleted IS FALSE
   AND (
     (state = $2 AND updated_at < $3)
-    OR (
-      state = $4
-      AND warm_until IS NOT NULL
-      AND warm_until < $5
-      AND COALESCE(last_heartbeat_at, updated_at) < $6
-    )
-    -- Backstop for activities that exhaust Temporal's retry budget after CAS
-    -- active->expiring without reaching Stop. Without this the partial unique
-    -- indexes (v1 on assistant_thread_id, v2 on assistant_id) block new
-    -- admits indefinitely.
-    OR (state = $7 AND updated_at < $8)
+    OR (state = $4 AND updated_at < $5)
   )
 RETURNING assistant_id
 `
 
 type ReapStuckAssistantRuntimesParams struct {
-	StoppedState    string
-	StartingState   string
-	StartingCutoff  pgtype.Timestamptz
-	ActiveState     string
-	WarmCutoff      pgtype.Timestamptz
-	HeartbeatCutoff pgtype.Timestamptz
-	ExpiringState   string
-	ExpiringCutoff  pgtype.Timestamptz
+	StoppedState   string
+	StartingState  string
+	StartingCutoff pgtype.Timestamptz
+	ExpiringState  string
+	ExpiringCutoff pgtype.Timestamptz
 }
 
-// Short-horizon reaper for rows the happy-path can no longer move. Applies
-// to both v1 (per-thread VM) and v2 (single VM per assistant) rows: the
-// starting/active/expiring liveness markers it keys on are version-agnostic.
-// A v2 VM in active use updates warm_until and last_heartbeat_at via every
-// thread workflow, so an in-flight VM is never matched by the active branch;
-// only assistants whose entire thread set has gone idle past the cutoffs are
-// collected.
+// Short-horizon reaper for rows the happy-path can no longer move — crash
+// recovery only. Idle runtimes are deliberately not collected: a VM with no
+// traffic stays up until its assistant is deleted. Both branches cover rows
+// stranded by a dead process, and the next admit recreates the runtime:
+//   - 'starting' rows that never transitioned to active within the startup
+//     grace window (server crashed mid-boot).
+//   - 'expiring' rows older than the ExpireThreadRuntime activity's full
+//     retry budget (legacy expire workflows that gave up after CAS
+//     active->expiring without reaching Stop). Without this the partial
+//     unique indexes (v1 on assistant_thread_id, v2 on assistant_id) block
+//     new admits indefinitely.
 func (q *Queries) ReapStuckAssistantRuntimes(ctx context.Context, arg ReapStuckAssistantRuntimesParams) ([]uuid.UUID, error) {
 	rows, err := q.db.Query(ctx, reapStuckAssistantRuntimes,
 		arg.StoppedState,
 		arg.StartingState,
 		arg.StartingCutoff,
-		arg.ActiveState,
-		arg.WarmCutoff,
-		arg.HeartbeatCutoff,
 		arg.ExpiringState,
 		arg.ExpiringCutoff,
 	)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1030,10 +1030,11 @@ type ReapInactiveAssistantRuntimesParams struct {
 }
 
 // ReapInactiveAssistantRuntimes drives the long-inactivity janitor. It picks
-// finalized (soft-deleted or ended) runtime rows whose owning assistant has
-// had no recorded activity within InactivityThreshold and tears down the
-// backend resources their Stop/Reap left behind. Live rows are never
-// candidates: an idle runtime keeps its VM until the assistant is deleted.
+// runtime rows that are finalized (soft-deleted or ended) or belong to a
+// soft-deleted assistant, whose owning assistant has had no recorded
+// activity within InactivityThreshold, and tears down the backend resources
+// their Stop/Reap left behind. A live row under a live assistant is never a
+// candidate: an idle runtime keeps its VM until the assistant is deleted.
 func (s *ServiceCore) ReapInactiveAssistantRuntimes(ctx context.Context, params ReapInactiveAssistantRuntimesParams) (ReapAssistantRuntimesResult, error) {
 	if params.InactivityThreshold <= 0 {
 		return ReapAssistantRuntimesResult{}, fmt.Errorf("inactivity threshold must be positive")

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -63,9 +63,7 @@ const (
 	// loop forever.
 	maxEventAttempts = 5
 
-	runtimeStartupReapGrace     = 2 * time.Minute
-	runtimeWarmExpiryReapGrace  = 1 * time.Minute
-	runtimeProcessingLeaseGrace = 2 * time.Minute
+	runtimeStartupReapGrace = 2 * time.Minute
 	// runtimeExpiringReapGrace is the cushion the reaper waits before
 	// reclaiming a row stuck in `expiring`. It must exceed the worst-case
 	// total budget of the ExpireThreadRuntime activity (Temporal
@@ -476,24 +474,20 @@ func (s *ServiceCore) ReapStuckRuntimes(ctx context.Context) (ReapStuckRuntimesR
 	// process is gone or its driving workflow has given up:
 	//   - 'starting' rows that never transitioned to active within the
 	//     startup grace window (usually server crashed mid-boot).
-	//   - 'active' rows whose warm_until passed a grace window ago (usually
-	//     server crashed after a turn; unexpected-exit callback didn't fire
-	//     because the whole process died).
 	//   - 'expiring' rows whose updated_at is older than the activity's full
 	//     retry budget — the ExpireThreadRuntime activity exhausted Temporal
 	//     attempts after CAS active->expiring without reaching Stop or
 	//     Revert. Without this the row blocks the partial unique index
 	//     ReserveAssistantRuntime depends on.
+	// 'active' rows are never reaped: an idle runtime keeps its VM until the
+	// assistant is deleted.
 	queries := assistantrepo.New(s.db)
 	runtimeAssistantIDs, err := queries.ReapStuckAssistantRuntimes(ctx, assistantrepo.ReapStuckAssistantRuntimesParams{
-		StoppedState:    runtimeStateStopped,
-		StartingState:   runtimeStateStarting,
-		StartingCutoff:  conv.ToPGTimestamptz(now.Add(-runtimeStartupReapGrace)),
-		ActiveState:     runtimeStateActive,
-		WarmCutoff:      conv.ToPGTimestamptz(now.Add(-runtimeWarmExpiryReapGrace)),
-		HeartbeatCutoff: conv.ToPGTimestamptz(now.Add(-runtimeProcessingLeaseGrace)),
-		ExpiringState:   runtimeStateExpiring,
-		ExpiringCutoff:  conv.ToPGTimestamptz(now.Add(-runtimeExpiringReapGrace)),
+		StoppedState:   runtimeStateStopped,
+		StartingState:  runtimeStateStarting,
+		StartingCutoff: conv.ToPGTimestamptz(now.Add(-runtimeStartupReapGrace)),
+		ExpiringState:  runtimeStateExpiring,
+		ExpiringCutoff: conv.ToPGTimestamptz(now.Add(-runtimeExpiringReapGrace)),
 	})
 	if err != nil {
 		return out, fmt.Errorf("reap stuck assistant runtimes: %w", err)
@@ -1036,8 +1030,10 @@ type ReapInactiveAssistantRuntimesParams struct {
 }
 
 // ReapInactiveAssistantRuntimes drives the long-inactivity janitor. It picks
-// runtime rows whose owning assistant has had no recorded activity within
-// InactivityThreshold and tears down the corresponding backend resources.
+// finalized (soft-deleted or ended) runtime rows whose owning assistant has
+// had no recorded activity within InactivityThreshold and tears down the
+// backend resources their Stop/Reap left behind. Live rows are never
+// candidates: an idle runtime keeps its VM until the assistant is deleted.
 func (s *ServiceCore) ReapInactiveAssistantRuntimes(ctx context.Context, params ReapInactiveAssistantRuntimesParams) (ReapAssistantRuntimesResult, error) {
 	if params.InactivityThreshold <= 0 {
 		return ReapAssistantRuntimesResult{}, fmt.Errorf("inactivity threshold must be positive")

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -534,7 +534,7 @@ func TestServiceCoreReapStuckRuntimesSkipsLiveProcessingLease(t *testing.T) {
 	require.Equal(t, eventStatusProcessing, event.Status)
 }
 
-func TestServiceCoreReapStuckRuntimesReclaimsStaleProcessingLease(t *testing.T) {
+func TestServiceCoreReapStuckRuntimesLeavesIdleActiveRuntime(t *testing.T) {
 	t.Parallel()
 
 	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants")
@@ -548,8 +548,10 @@ func TestServiceCoreReapStuckRuntimesReclaimsStaleProcessingLease(t *testing.T) 
 	event, err := assistantsrepo.New(conn).GetLatestAssistantThreadEventByThreadID(ctx, threadKey)
 	require.NoError(t, err)
 
-	staleHeartbeat := time.Now().UTC().Add(-(runtimeProcessingLeaseGrace + time.Minute))
-	staleWarmUntil := time.Now().UTC().Add(-(runtimeWarmExpiryReapGrace + time.Minute))
+	// Long-idle active runtime: warm window long passed, no heartbeat in
+	// ages. Idle runtimes keep their VM — only the stale processing lease
+	// on the event gets requeued.
+	idleSince := time.Now().UTC().Add(-30 * time.Minute)
 	err = assistantsrepo.New(conn).CreateAssistantRuntime(ctx, assistantsrepo.CreateAssistantRuntimeParams{
 		ID:                  uuid.New(),
 		AssistantThreadID:   threadID,
@@ -558,9 +560,9 @@ func TestServiceCoreReapStuckRuntimesReclaimsStaleProcessingLease(t *testing.T) 
 		Backend:             runtimeBackendFlyIO,
 		BackendMetadataJson: []byte(`{}`),
 		State:               runtimeStateActive,
-		WarmUntil:           pgtype.Timestamptz{Time: staleWarmUntil, Valid: true},
-		LastHeartbeatAt:     pgtype.Timestamptz{Time: staleHeartbeat, Valid: true},
-		UpdatedAt:           pgtype.Timestamptz{Time: staleHeartbeat, Valid: true},
+		WarmUntil:           pgtype.Timestamptz{Time: idleSince, Valid: true},
+		LastHeartbeatAt:     pgtype.Timestamptz{Time: idleSince, Valid: true},
+		UpdatedAt:           pgtype.Timestamptz{Time: idleSince, Valid: true},
 		EndedAt:             pgtype.Timestamptz{},
 		DeletedAt:           pgtype.Timestamptz{},
 	})
@@ -578,13 +580,13 @@ func TestServiceCoreReapStuckRuntimesReclaimsStaleProcessingLease(t *testing.T) 
 
 	result, err := core.ReapStuckRuntimes(ctx)
 	require.NoError(t, err)
-	require.EqualValues(t, 1, result.StaleRuntimesStopped)
+	require.EqualValues(t, 0, result.StaleRuntimesStopped, "idle active runtimes must never be reaped")
 	require.EqualValues(t, 1, result.StaleEventsRequeued)
 
 	runtime, err := assistantsrepo.New(conn).GetLatestAssistantRuntimeByThreadID(ctx, runtimeKey)
 	require.NoError(t, err)
-	require.True(t, runtime.DeletedAt.Valid)
-	require.Equal(t, runtimeStateStopped, runtime.State)
+	require.False(t, runtime.DeletedAt.Valid)
+	require.Equal(t, runtimeStateActive, runtime.State)
 
 	event, err = assistantsrepo.New(conn).GetLatestAssistantThreadEventByThreadID(ctx, threadKey)
 	require.NoError(t, err)
@@ -1272,18 +1274,38 @@ func TestServiceCoreReapInactiveAssistantRuntimesReapsSiblingsAcrossSweeps(t *te
 	require.EqualValues(t, 2, reapCalls.Load())
 }
 
-func TestServiceCoreReapInactiveAssistantRuntimesReapsStaleRowsRegardlessOfState(t *testing.T) {
+func TestServiceCoreReapInactiveAssistantRuntimesSkipsLiveRowsCollectsFinalized(t *testing.T) {
 	t.Parallel()
 
 	conn, err := assistantsInfra.CloneTestDatabase(t, "reap_inactive_state_agnostic")
 	require.NoError(t, err)
 
 	stale := time.Now().UTC().Add(-30 * 24 * time.Hour)
-	projectID, assistantID, threadID := insertReapableProject(t, conn, "active-state")
-	insertReapableRuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, "gram-asst-active", stale)
 
-	startingProject, startingAssistantID, startingThreadID := insertReapableProject(t, conn, "starting-state")
-	insertReapableRuntimeRow(t, conn, startingProject, startingAssistantID, startingThreadID, runtimeStateStarting, "gram-asst-starting", stale)
+	// Live row: no matter how long idle, the VM stays until the assistant
+	// is deleted.
+	liveProject, liveAssistantID, liveThreadID := insertReapableProject(t, conn, "live-idle")
+	liveRuntimeID := insertReapableRuntimeRow(t, conn, liveProject, liveAssistantID, liveThreadID, runtimeStateActive, "gram-asst-live", stale)
+
+	// Finalized row that kept a live-looking state (a turn racing the
+	// teardown can re-stamp `active` post-delete): still collected.
+	tombProject, tombAssistantID, tombThreadID := insertReapableProject(t, conn, "tombstone")
+	tombRuntimeID := insertReapableRuntimeRow(t, conn, tombProject, tombAssistantID, tombThreadID, runtimeStateActive, "gram-asst-tomb", stale)
+	err = assistantsrepo.New(conn).StopAssistantRuntime(t.Context(), assistantsrepo.StopAssistantRuntimeParams{
+		State:         runtimeStateActive,
+		ProjectID:     tombProject,
+		RuntimeID:     tombRuntimeID,
+		StartingState: runtimeStateStarting,
+		ActiveState:   runtimeStateActive,
+		ExpiringState: runtimeStateExpiring,
+	})
+	require.NoError(t, err)
+	err = assistantsrepo.New(conn).BackdateAssistantRuntimeUpdatedAt(t.Context(), assistantsrepo.BackdateAssistantRuntimeUpdatedAtParams{
+		UpdatedAt:         pgtype.Timestamptz{Time: stale, Valid: true},
+		AssistantThreadID: tombThreadID,
+		State:             runtimeStateActive,
+	})
+	require.NoError(t, err)
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
@@ -1296,9 +1318,18 @@ func TestServiceCoreReapInactiveAssistantRuntimesReapsStaleRowsRegardlessOfState
 		OnRowProcessed:      func() { rowProcessed.Add(1) },
 	})
 	require.NoError(t, err)
-	require.Equal(t, 2, result.Reaped)
-	require.EqualValues(t, 2, reapCalls.Load())
-	require.EqualValues(t, 2, rowProcessed.Load(), "OnRowProcessed must fire once per row so the activity can heartbeat")
+	require.Equal(t, 1, result.Reaped)
+	require.EqualValues(t, 1, reapCalls.Load())
+	require.EqualValues(t, 1, rowProcessed.Load(), "OnRowProcessed must fire once per row so the activity can heartbeat")
+
+	liveRuntime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: liveRuntimeID, ProjectID: liveProject})
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateActive, liveRuntime.State, "live idle runtime must not be collected")
+	require.False(t, liveRuntime.DeletedAt.Valid)
+
+	tombRuntime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: tombRuntimeID, ProjectID: tombProject})
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateReaped, tombRuntime.State)
 }
 
 type testRuntimeBackend struct {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1307,6 +1307,16 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsLiveRowsCollectsFinalized(
 	})
 	require.NoError(t, err)
 
+	// Live row under a soft-deleted assistant: the delete path's inline reap
+	// is best-effort, so the janitor stays the safety net here.
+	orphanProject, orphanAssistantID, orphanThreadID := insertReapableProject(t, conn, "deleted-assistant")
+	orphanRuntimeID := insertReapableRuntimeRow(t, conn, orphanProject, orphanAssistantID, orphanThreadID, runtimeStateActive, "gram-asst-orphan", stale)
+	err = assistantsrepo.New(conn).DeleteAssistant(t.Context(), assistantsrepo.DeleteAssistantParams{
+		AssistantID: orphanAssistantID,
+		ProjectID:   orphanProject,
+	})
+	require.NoError(t, err)
+
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
 	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
@@ -1318,9 +1328,9 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsLiveRowsCollectsFinalized(
 		OnRowProcessed:      func() { rowProcessed.Add(1) },
 	})
 	require.NoError(t, err)
-	require.Equal(t, 1, result.Reaped)
-	require.EqualValues(t, 1, reapCalls.Load())
-	require.EqualValues(t, 1, rowProcessed.Load(), "OnRowProcessed must fire once per row so the activity can heartbeat")
+	require.Equal(t, 2, result.Reaped)
+	require.EqualValues(t, 2, reapCalls.Load())
+	require.EqualValues(t, 2, rowProcessed.Load(), "OnRowProcessed must fire once per row so the activity can heartbeat")
 
 	liveRuntime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: liveRuntimeID, ProjectID: liveProject})
 	require.NoError(t, err)
@@ -1330,6 +1340,10 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsLiveRowsCollectsFinalized(
 	tombRuntime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: tombRuntimeID, ProjectID: tombProject})
 	require.NoError(t, err)
 	require.Equal(t, runtimeStateReaped, tombRuntime.State)
+
+	orphanRuntime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: orphanRuntimeID, ProjectID: orphanProject})
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateReaped, orphanRuntime.State, "live row under deleted assistant must be collected")
 }
 
 type testRuntimeBackend struct {

--- a/server/internal/background/assistant_runtime_janitor.go
+++ b/server/internal/background/assistant_runtime_janitor.go
@@ -64,11 +64,12 @@ type AssistantRuntimeJanitorWorkflowResult struct {
 	Errors int
 }
 
-// AssistantRuntimeJanitorWorkflow reaps backend resources (Fly apps,
-// long-lived runner state) belonging to assistants that have had no runtime
-// activity for AssistantRuntimeJanitorInactivityThreshold. Active and
-// starting runtimes are filtered out at the SQL layer so an in-flight
-// admit is never collected mid-flight.
+// AssistantRuntimeJanitorWorkflow reaps orphaned backend resources (Fly
+// apps, long-lived runner state) left behind by finalized runtime rows whose
+// Stop/Reap never completed, once the owning assistant has had no runtime
+// activity for AssistantRuntimeJanitorInactivityThreshold. Live runtime rows
+// are never candidates — an idle runtime keeps its VM until the assistant is
+// deleted.
 func AssistantRuntimeJanitorWorkflow(ctx workflow.Context, params AssistantRuntimeJanitorWorkflowParams) (*AssistantRuntimeJanitorWorkflowResult, error) {
 	var a *Activities
 

--- a/server/internal/background/assistant_runtime_janitor.go
+++ b/server/internal/background/assistant_runtime_janitor.go
@@ -65,11 +65,12 @@ type AssistantRuntimeJanitorWorkflowResult struct {
 }
 
 // AssistantRuntimeJanitorWorkflow reaps orphaned backend resources (Fly
-// apps, long-lived runner state) left behind by finalized runtime rows whose
-// Stop/Reap never completed, once the owning assistant has had no runtime
-// activity for AssistantRuntimeJanitorInactivityThreshold. Live runtime rows
-// are never candidates — an idle runtime keeps its VM until the assistant is
-// deleted.
+// apps, long-lived runner state) whose Stop/Reap never completed — finalized
+// runtime rows, plus live rows under soft-deleted assistants — once the
+// owning assistant has had no runtime activity for
+// AssistantRuntimeJanitorInactivityThreshold. A live runtime row under a
+// live assistant is never a candidate: an idle runtime keeps its VM until
+// the assistant is deleted.
 func AssistantRuntimeJanitorWorkflow(ctx workflow.Context, params AssistantRuntimeJanitorWorkflowParams) (*AssistantRuntimeJanitorWorkflowResult, error) {
 	var a *Activities
 


### PR DESCRIPTION
## Summary

Stacked on #3376.

Since the v2 single-VM rewrite (#2835) removed workflow-driven warm expiry, the stuck-runtime reaper's `warm_until` branch — written as a crash backstop — had silently become the only teardown path for idle runtimes. Every idle cycle soft-deleted the row, signalled the coordinator, and re-created the VM on the next event, racing in-flight admissions against the tombstone (the prod incident #3376 fixes the symptom of).

Idle runtimes are not a resource we need to reclaim:

- Drop the warm-expiry branch from `ReapStuckAssistantRuntimes` entirely. An idle VM stays up until its assistant is deleted (`ReapAssistantRuntimes` on the delete path is unchanged). The reaper keeps its true crash-recovery branches — stuck `starting` and stuck `expiring` rows — where the next admit recreates the runtime.
- Scope the long-inactivity janitor (`ListInactiveAssistantRuntimesForReap`) to finalized (soft-deleted or ended) rows, so it only collects orphaned backend apps whose Stop/Reap never completed and can no longer tear down a live idle runtime's VM.

`warm_ttl_seconds` keeps its remaining meanings untouched: the thread workflow's listen window and admit's `MaxConcurrency` slot accounting.

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reaping idle assistant runtime VMs. The stuck-runtime reaper is now crash-recovery only (stuck `starting`/`expiring`), and the inactivity janitor only collects finalized rows or rows under soft-deleted assistants so idle VMs persist until the assistant is deleted.

- **Bug Fixes**
  - Removed the `warm_until` branch from `ReapStuckAssistantRuntimes`; `active` idle runtimes are never reaped.
  - Scoped `ListInactiveAssistantRuntimesForReap` to finalized rows (`deleted` or `ended`) and rows whose assistant is soft-deleted; live rows under live assistants are never candidates.
  - Updated comments, generated queries, and tests; `warm_ttl_seconds` behavior is unchanged.

<sup>Written for commit e4da08c90cd95e44dc7dc73b59fe3a07c1dc7d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

