### PR TITLE
fix(dashboard): remove stale logs subnav tabs

### DIFF
--- a/client/dashboard/src/components/observe/ObserveTabNav.tsx
+++ b/client/dashboard/src/components/observe/ObserveTabNav.tsx
@@ -1,18 +1,10 @@
 import { cn } from "@/lib/utils";
 import { Link, useLocation } from "react-router";
 import { useSlugs } from "@/contexts/Sdk";
-import { RequireScope } from "@/components/require-scope";
-import type { Scope } from "@/hooks/useRBAC";
-import {
-  ReleaseStage,
-  ReleaseStageBadge,
-} from "@/components/release-stage-badge";
 
 type Tab = {
   label: string;
   href: string;
-  stage?: ReleaseStage;
-  scope?: Scope | Scope[];
 };
 
 export function ObserveTabNav({
@@ -27,17 +19,6 @@ export function ObserveTabNav({
   const tabs: Tab[] = [
     { label: "Tools", href: `${baseSlug}/tools` },
     { label: "MCP Servers", href: `${baseSlug}/mcp` },
-    ...(base === "logs"
-      ? ([
-          {
-            label: "Risk Events",
-            href: `${baseSlug}/risk-events`,
-            stage: "beta",
-            scope: "org:admin",
-          },
-          { label: "Agents", href: `${baseSlug}/agents` },
-        ] satisfies Tab[])
-      : []),
   ];
 
   return (
@@ -46,7 +27,7 @@ export function ObserveTabNav({
         const isActive =
           location.pathname === tab.href ||
           location.pathname.startsWith(tab.href + "/");
-        const link = (
+        return (
           <Link
             key={tab.href}
             to={tab.href}
@@ -60,19 +41,8 @@ export function ObserveTabNav({
             )}
           >
             {tab.label}
-            {tab.stage && <ReleaseStageBadge stage={tab.stage} noTooltip />}
           </Link>
         );
-
-        if (tab.scope) {
-          return (
-            <RequireScope key={tab.href} scope={tab.scope} level="section">
-              {link}
-            </RequireScope>
-          );
-        }
-
-        return link;
       })}
     </div>
   );


### PR DESCRIPTION
## Summary
- Removes the stale Risk Events and Agents entries from the Logs subnav.
- Keeps Logs aligned with its current route config: Tools and MCP Servers only.
- Leaves Risk Events and Agent Sessions on their migrated top-level routes.

## Test Plan
- [x] Code review verified the nav change against the route config.
- [x] git diff --check
- [x] Open a project Logs page and confirm the subnav only shows Tools and MCP Servers.
- [x] Confirm the top-level Risk Events and Agent Sessions routes remain accessible from project navigation.

## Notes
- No tests were added or run per request.
- pnpm -F dashboard type-check currently fails on an unrelated generated SDK mismatch: src/pages/triggers/Triggers.tsx imports missing TargetKind from @gram/client/models/components/createtriggerinstanceform.js.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale "Risk Events" and "Agents" tabs from the Logs subnav to match current routes; only "Tools" and "MCP Servers" are shown. Simplified `ObserveTabNav` by removing `RequireScope`, `ReleaseStageBadge`, and the `stage`/`scope` tab fields.

<sup>Written for commit 3e2a2b2c4d986597b435fd2fab92b289d2fd0715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

