### PR TITLE
fix(dashboard): show risk events breadcrumbs

### DIFF
--- a/client/dashboard/src/pages/logs/Logs.tsx
+++ b/client/dashboard/src/pages/logs/Logs.tsx
@@ -4,7 +4,6 @@ import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { LogsTools } from "@/components/observe/LogsTools";
 import { ObserveTabNav } from "@/components/observe/ObserveTabNav";
-import RiskEvents from "@/pages/security/RiskEvents";
 
 export function LogsRoot(): JSX.Element {
   return (
@@ -35,14 +34,6 @@ export function LogsMCPPage(): JSX.Element {
   return (
     <RequireScope scope="project:read" level="page">
       <LogsMCPContent />
-    </RequireScope>
-  );
-}
-
-export function LogsRiskEventsPage(): JSX.Element {
-  return (
-    <RequireScope scope="org:admin" level="page">
-      <RiskEvents />
     </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/security/RiskEventsPage.test.tsx
+++ b/client/dashboard/src/pages/security/RiskEventsPage.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import RiskEventsPage from "./RiskEventsPage";
+
+vi.mock("@/components/page-layout", () => {
+  function Page({ children }: { children: ReactNode }) {
+    return <div data-testid="page">{children}</div>;
+  }
+
+  function Header({ children }: { children?: ReactNode }) {
+    return <div data-testid="page-header">{children}</div>;
+  }
+  Header.Breadcrumbs = ({ fullWidth }: { fullWidth?: boolean }) => (
+    <nav data-full-width={fullWidth ? "true" : "false"}>Breadcrumbs</nav>
+  );
+
+  function Body({ children }: { children: ReactNode }) {
+    return <main data-testid="page-body">{children}</main>;
+  }
+
+  return {
+    Page: Object.assign(Page, {
+      Header,
+      Body,
+    }),
+  };
+});
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("./RiskEvents", () => ({
+  default: () => <div>Risk Events Content</div>,
+}));
+
+afterEach(cleanup);
+
+describe("RiskEventsPage", () => {
+  it("renders the standalone risk events route with breadcrumbs", () => {
+    render(<RiskEventsPage />);
+
+    expect(screen.getByText("Breadcrumbs")).toBeTruthy();
+    expect(
+      screen.getByText("Breadcrumbs").getAttribute("data-full-width"),
+    ).toBe("true");
+    expect(screen.getByText("Risk Events Content")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/pages/security/RiskEventsPage.tsx
+++ b/client/dashboard/src/pages/security/RiskEventsPage.tsx
@@ -1,0 +1,20 @@
+import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
+import RiskEvents from "./RiskEvents";
+
+export default function RiskEventsPage(): JSX.Element {
+  return (
+    <div className="flex h-full flex-col">
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs fullWidth />
+        </Page.Header>
+        <Page.Body fullWidth fullHeight overflowHidden noPadding>
+          <RequireScope scope="org:admin" level="page">
+            <RiskEvents />
+          </RequireScope>
+        </Page.Body>
+      </Page>
+    </div>
+  );
+}

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -30,12 +30,7 @@ import Home from "./pages/home/Home";
 import Integrations from "./pages/integrations/Integrations";
 import Login from "./pages/login/Login";
 import Register from "./pages/login/Register";
-import {
-  LogsRoot,
-  LogsMCPPage,
-  LogsRiskEventsPage,
-  LogsToolsPage,
-} from "./pages/logs/Logs";
+import { LogsRoot, LogsMCPPage, LogsToolsPage } from "./pages/logs/Logs";
 import { BuiltInMCPDetailPage } from "./pages/mcp/BuiltInMCPDetailPage";
 import { MCPDetailPage, MCPDetailsRoot } from "./pages/mcp/MCPDetails";
 import { MCPPage, MCPRoot } from "./pages/mcp/MCP";
@@ -78,6 +73,7 @@ import TriggersIndex, { TriggersRoot } from "./pages/triggers/Triggers";
 import SecurityOverview, {
   RiskOverviewRoot,
 } from "./pages/security/SecurityOverview";
+import RiskEventsPage from "./pages/security/RiskEventsPage";
 import ApprovalRequests from "./pages/security/ApprovalRequests";
 import RiskOverviewCategoriesIndex from "./pages/security/RiskOverviewCategoriesIndex";
 import RiskOverviewCategoryDetail from "./pages/security/RiskOverviewCategoryDetail";
@@ -519,7 +515,7 @@ const ROUTE_STRUCTURE = {
     title: "Risk Events",
     url: "risk-events",
     icon: "flag",
-    component: LogsRiskEventsPage,
+    component: RiskEventsPage,
   },
   sdks: {
     title: "SDKs",


### PR DESCRIPTION
## Summary
- Add a dedicated Security page shell for Risk Events so the direct /risk-events route renders breadcrumbs.
- Route Risk Events to the new page while keeping the existing RiskEvents workbench content unchanged.
- Cover the page shell with a focused dashboard test.

## Test Plan
- [x] pnpm -F dashboard test src/pages/security/RiskEventsPage.test.tsx
- [x] pnpm -F dashboard lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show breadcrumbs on the Security > Risk Events route by introducing a dedicated page shell and cleaning up the old adapter. Keeps Risk Events content and admin access unchanged.

- **Bug Fixes**
  - Added RiskEventsPage with full-width breadcrumbs in Page.Header.
  - Routed `security/risk-events` to RiskEventsPage and removed the old LogsRiskEventsPage adapter.
  - Added a focused test to verify breadcrumbs render full-width.

<sup>Written for commit 111b941c015d079a02ad91cf83a7954a54fa5358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

