### PR TITLE
feat(assistants): stream Project Assistant replies and cycle thinking verbs

### DIFF
--- a/.changeset/assistant-thinking-verbs-streaming.md
+++ b/.changeset/assistant-thinking-verbs-streaming.md
@@ -1,0 +1,6 @@
+---
+"@gram-ai/elements": minor
+"dashboard": minor
+---
+
+The Project Assistant now cycles a set of whimsical "thinking" verbs while it works and types replies onto the screen token-by-token, emulating an SSE stream over the poll-based transport.

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -13,6 +13,17 @@ const DEFAULT_POLL_INTERVAL_MS = 1500;
 const DEFAULT_POLL_TIMEOUT_MS = 600_000;
 const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
+// Client-side streaming emulation. The server reply lands as one blob after
+// polling (there is no SSE endpoint), so we slice it into many `text-delta`
+// events to reproduce the token-by-token feel a real stream would have. Tuned
+// to feel responsive without dragging: short replies get a readable typing
+// cadence; long replies are paced to finish within the time budget instead of
+// crawling. assistant-ui can't tell these deltas apart from a real stream.
+const STREAM_BUDGET_MS = 1400; // target wall-clock to stream a whole reply
+const STREAM_TICK_MS = 22; // upper bound on delay between chunks
+const STREAM_MIN_CHARS = 12; // below this, just emit in one shot
+const STREAM_MAX_TICKS = 350; // cap on delta events per reply (huge messages)
+
 // Adaptive polling: a short turn (a one-line answer, no tool calls) often lands
 // within a couple of seconds, where a flat 1.5s interval adds up to a full
 // poll's worth of dead air. Poll quickly for the first few iterations to catch
@@ -216,9 +227,12 @@ async function pollForReplies(args: {
         lastNewAssistant = m;
         const text = contentText(m.content);
         if (text) {
-          writer.write({ type: "text-start", id: m.id });
-          writer.write({ type: "text-delta", id: m.id, delta: text });
-          writer.write({ type: "text-end", id: m.id });
+          await writeStreamedText({
+            writer,
+            id: m.id,
+            text,
+            abortSignal,
+          });
         }
       }
       if (lastNewAssistant && isTurnTerminal(lastNewAssistant)) {
@@ -237,6 +251,57 @@ async function pollForReplies(args: {
     await sleep(nextPollDelay(attempt, pollIntervalMs), abortSignal);
     attempt++;
   }
+}
+
+// Emits a finished assistant reply as a sequence of `text-delta` events so it
+// types onto the screen like a real stream instead of appearing all at once.
+// Words are kept intact (we split on whitespace) and the pace adapts to length:
+// the whole reply streams within `STREAM_BUDGET_MS`, capped at `STREAM_MAX_TICKS`
+// delta events so very long replies don't flood the writer. Honors
+// `prefers-reduced-motion` and skips emulation for trivially short replies.
+// On abort, `sleep` rejects and the partially-streamed text stays rendered,
+// matching how a real aborted stream behaves.
+async function writeStreamedText(args: {
+  writer: UIMessageStreamWriter<UIMessage>;
+  id: string;
+  text: string;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const { writer, id, text, abortSignal } = args;
+
+  writer.write({ type: "text-start", id });
+
+  if (text.length <= STREAM_MIN_CHARS || prefersReducedMotion()) {
+    writer.write({ type: "text-delta", id, delta: text });
+    writer.write({ type: "text-end", id });
+    return;
+  }
+
+  // Whitespace-preserving tokens keep words (and the spaces between them)
+  // intact, so chunks never split mid-word.
+  const tokens = text.match(/\s+|\S+/g) ?? [text];
+  const ticks = Math.min(tokens.length, STREAM_MAX_TICKS);
+  const groupSize = Math.ceil(tokens.length / ticks);
+  const delayMs = Math.min(STREAM_TICK_MS, STREAM_BUDGET_MS / ticks);
+
+  for (let i = 0; i < tokens.length; i += groupSize) {
+    const delta = tokens.slice(i, i + groupSize).join("");
+    writer.write({ type: "text-delta", id, delta });
+    // Skip the trailing sleep so the final chunk lands without dead air.
+    if (i + groupSize < tokens.length) {
+      await sleep(delayMs, abortSignal);
+    }
+  }
+
+  writer.write({ type: "text-end", id });
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
 }
 
 // Returns the assistant message ids and current generation for the chat. Used

--- a/elements/src/components/assistant-ui/thinking-indicator.tsx
+++ b/elements/src/components/assistant-ui/thinking-indicator.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useAssistantState } from "@assistant-ui/react";
+import { type FC, useEffect, useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Whimsical verbs cycled while the assistant is "thinking" — i.e. the message
+ * is running but no answer text has streamed in yet (or it is waiting on a tool
+ * call / reasoning). The word shown is cosmetic and NOT tied to the actual work
+ * being done, mirroring the playful verbs Claude shows while it works. To make
+ * them reflect the real action instead, map from the streamed tool name in
+ * `ThinkingIndicator` below.
+ */
+const THINKING_VERBS = [
+  "Thinking",
+  "Reasoning",
+  "Pondering",
+  "Synthesizing",
+  "Connecting",
+  "Analyzing",
+  "Inspecting",
+  "Correlating",
+  "Digging",
+  "Untangling",
+  "Assembling",
+  "Sketching",
+  "Reticulating",
+  "Wrangling",
+  "Distilling",
+  "Surveying",
+  "Mapping",
+  "Cross-referencing",
+  "Investigating",
+  "Considering",
+  "Formulating",
+  "Piecing",
+  "Tracing",
+  "Computing",
+  "Noodling",
+  "Percolating",
+  "Marshalling",
+  "Crunching",
+  "Orchestrating",
+  "Composing",
+] as const;
+
+// Cadence: hold each verb, then crossfade to the next.
+const HOLD_MS = 2000;
+const FADE_MS = 350;
+
+function shuffled<T>(items: readonly T[]): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j]!, copy[i]!];
+  }
+  return copy;
+}
+
+/**
+ * Cycles through a shuffled copy of {@link THINKING_VERBS} while `active`, with
+ * a brief opacity dip between words so they crossfade rather than snap.
+ */
+function useThinkingVerb(active: boolean): { verb: string; visible: boolean } {
+  const order = useMemo(() => shuffled(THINKING_VERBS), []);
+  const [index, setIndex] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (!active) return;
+
+    let outTimer: ReturnType<typeof setTimeout>;
+    let inTimer: ReturnType<typeof setTimeout>;
+
+    const tick = () => {
+      setVisible(false);
+      outTimer = setTimeout(() => {
+        setIndex((i) => (i + 1) % order.length);
+        setVisible(true);
+        inTimer = setTimeout(tick, HOLD_MS);
+      }, FADE_MS);
+    };
+
+    inTimer = setTimeout(tick, HOLD_MS);
+    return () => {
+      clearTimeout(outTimer);
+      clearTimeout(inTimer);
+    };
+  }, [active, order.length]);
+
+  return { verb: order[index]!, visible };
+}
+
+/**
+ * Shows a rainbow spinner alongside a cycling "thinking" verb whenever the
+ * assistant is running but has not yet produced visible answer text. Once text
+ * starts streaming, this hides and the inline trailing dot (see the
+ * `aui-md[data-status="running"]` rules in global.css) takes over.
+ */
+export const ThinkingIndicator: FC = () => {
+  const active = useAssistantState(({ message }) => {
+    if (message.status?.type !== "running") return false;
+    const parts = message.parts;
+    if (parts.length === 0) return true;
+    const last = parts[parts.length - 1];
+    if (!last) return true;
+    if (last.type === "tool-call" || last.type === "reasoning") return true;
+    if (last.type === "text") return last.text.trim().length === 0;
+    return false;
+  });
+
+  const { verb, visible } = useThinkingVerb(active);
+
+  if (!active) return null;
+
+  return (
+    <div
+      className="aui-thinking mt-2 flex items-center gap-2 text-sm text-muted-foreground"
+      role="status"
+    >
+      {/* Stable label for assistive tech — the rotating verb below is purely
+          decorative, so announcing each word would just be noise. */}
+      <span className="sr-only">Assistant is working…</span>
+      <span className="aui-thinking-dot" aria-hidden="true" />
+      <span
+        aria-hidden="true"
+        className={cn(
+          "aui-thinking-label transition-opacity duration-300 ease-out motion-reduce:transition-none",
+          visible ? "opacity-100" : "opacity-0",
+        )}
+      >
+        {verb}…
+      </span>
+    </div>
+  );
+};

--- a/elements/src/components/assistant-ui/thinking-indicator.tsx
+++ b/elements/src/components/assistant-ui/thinking-indicator.tsx
@@ -99,12 +99,13 @@ function useThinkingVerb(
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
-    if (!active || reduced) return;
-
-    // A prior cycle may have been torn down mid-fade (active flipped off while
-    // visible was false); restore full visibility so a fresh thinking window
-    // never starts on a hidden word.
+    // Restore visibility on every (de)activation and motion-preference change —
+    // only the cycling path below dims it. This runs before the early return so
+    // that flipping reduced-motion on (or deactivating) during a fade-out can't
+    // latch the verb at opacity-0 forever.
     setVisible(true);
+
+    if (!active || reduced) return;
 
     let outTimer: ReturnType<typeof setTimeout>;
     let inTimer: ReturnType<typeof setTimeout>;

--- a/elements/src/components/assistant-ui/thinking-indicator.tsx
+++ b/elements/src/components/assistant-ui/thinking-indicator.tsx
@@ -59,17 +59,52 @@ function shuffled<T>(items: readonly T[]): T[] {
   return copy;
 }
 
+/** Tracks the user's `prefers-reduced-motion` setting, updating if it changes. */
+function usePrefersReducedMotion(): boolean {
+  const query = "(prefers-reduced-motion: reduce)";
+  const [reduced, setReduced] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    )
+      return;
+    const mql = window.matchMedia(query);
+    const onChange = () => setReduced(mql.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return reduced;
+}
+
 /**
  * Cycles through a shuffled copy of {@link THINKING_VERBS} while `active`, with
- * a brief opacity dip between words so they crossfade rather than snap.
+ * a brief opacity dip between words so they crossfade rather than snap. When the
+ * user prefers reduced motion, a single verb is shown statically — no timer, no
+ * fade — so motion-sensitive users don't get text changing under them.
  */
-function useThinkingVerb(active: boolean): { verb: string; visible: boolean } {
+function useThinkingVerb(
+  active: boolean,
+  reduced: boolean,
+): { verb: string; visible: boolean } {
   const order = useMemo(() => shuffled(THINKING_VERBS), []);
   const [index, setIndex] = useState(0);
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
-    if (!active) return;
+    if (!active || reduced) return;
+
+    // A prior cycle may have been torn down mid-fade (active flipped off while
+    // visible was false); restore full visibility so a fresh thinking window
+    // never starts on a hidden word.
+    setVisible(true);
 
     let outTimer: ReturnType<typeof setTimeout>;
     let inTimer: ReturnType<typeof setTimeout>;
@@ -88,7 +123,7 @@ function useThinkingVerb(active: boolean): { verb: string; visible: boolean } {
       clearTimeout(outTimer);
       clearTimeout(inTimer);
     };
-  }, [active, order.length]);
+  }, [active, reduced, order.length]);
 
   return { verb: order[index]!, visible };
 }
@@ -111,7 +146,8 @@ export const ThinkingIndicator: FC = () => {
     return false;
   });
 
-  const { verb, visible } = useThinkingVerb(active);
+  const reducedMotion = usePrefersReducedMotion();
+  const { verb, visible } = useThinkingVerb(active, reducedMotion);
 
   if (!active) return null;
 

--- a/elements/src/components/assistant-ui/thread.tsx
+++ b/elements/src/components/assistant-ui/thread.tsx
@@ -55,6 +55,7 @@ import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { MentionedToolsBadges } from "@/components/assistant-ui/mentioned-tools-badges";
 import { MessageFeedback } from "@/components/assistant-ui/message-feedback";
 import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning";
+import { ThinkingIndicator } from "@/components/assistant-ui/thinking-indicator";
 import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
 import { ToolMentionAutocomplete } from "@/components/assistant-ui/tool-mention-autocomplete";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
@@ -1098,21 +1099,6 @@ const MessageError: FC = () => {
   );
 };
 
-/**
- * Shows the pulsing dot indicator when the message is still running but the
- * last rendered part is a tool call (not text). Without this, there's no
- * visual feedback that the model is still working after a tool call.
- */
-const ToolCallStreamingIndicator: FC = () => {
-  const show = useAssistantState(({ message }) => {
-    if (message.status?.type !== "running") return false;
-    const lastPart = message.parts[message.parts.length - 1];
-    return lastPart?.type === "tool-call";
-  });
-  if (!show) return null;
-  return <div className="aui-md mt-2" data-status="running" />;
-};
-
 const AssistantMessage: FC = () => {
   const { config } = useElements();
   const toolsConfig = config.tools ?? {};
@@ -1142,7 +1128,7 @@ const AssistantMessage: FC = () => {
       >
         <div className="aui-assistant-message-content mx-2 leading-7 wrap-break-word text-foreground">
           <MessagePrimitive.Parts components={partsComponents} />
-          <ToolCallStreamingIndicator />
+          <ThinkingIndicator />
           <MessageError />
         </div>
 

--- a/elements/src/global.css
+++ b/elements/src/global.css
@@ -274,6 +274,9 @@
     #9bc3ff,
     #320f1e
   );
+  /* Spin shorthand shared by both rainbow dots so a single reduced-motion
+     override (below) stops all of them at once. */
+  --aui-spin: aui-rainbow-spin 1.6s linear infinite;
 }
 
 @keyframes aui-rainbow-spin {
@@ -329,7 +332,7 @@
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
   mask-composite: exclude;
-  animation: aui-rainbow-spin 1.6s linear infinite;
+  animation: var(--aui-spin);
 }
 
 /* Standalone rainbow dot for the cycling "thinking" indicator (shown before
@@ -351,12 +354,13 @@
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
   mask-composite: exclude;
-  animation: aui-rainbow-spin 1.6s linear infinite;
+  animation: var(--aui-spin);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .gram-elements .aui-thinking-dot {
-    animation: none;
+  /* Stops both the trailing streaming dot and the standalone thinking dot. */
+  .gram-elements {
+    --aui-spin: none;
   }
 }
 

--- a/elements/src/global.css
+++ b/elements/src/global.css
@@ -258,14 +258,33 @@
 
 /* assistant-ui streaming indicator — rainbow gradient ring matches the
    Speakeasy brand palette used elsewhere (see `INSIGHTS_AI_RAINBOW_BORDER_CLASS`
-   and the login page's BrandGradientBar). */
+   and the login page's BrandGradientBar). Shared as a variable so the inline
+   trailing dot and the standalone "thinking" dot stay in sync. */
+.gram-elements {
+  --aui-rainbow: conic-gradient(
+    from 0deg,
+    #320f1e,
+    #c83228,
+    #fb873f,
+    #d2dc91,
+    #5a8250,
+    #002314,
+    #00143c,
+    #2873d7,
+    #9bc3ff,
+    #320f1e
+  );
+}
+
 @keyframes aui-rainbow-spin {
   to {
     transform: rotate(360deg);
   }
 }
 
-.gram-elements :where(.aui-md[data-status="running"]):empty::after,
+/* Trailing dot that follows answer text as it streams. The "before first
+   token" state is handled by <ThinkingIndicator> (cycling verbs), so there is
+   deliberately no `:empty::after` rule here. */
 .gram-elements
   :where(.aui-md[data-status="running"])
   > :where(:not(ol):not(ul):not(pre)):last-child::after,
@@ -301,19 +320,7 @@
   margin-right: 0.15rem;
   padding: 3px;
   border-radius: 50%;
-  background: conic-gradient(
-    from 0deg,
-    #320f1e,
-    #c83228,
-    #fb873f,
-    #d2dc91,
-    #5a8250,
-    #002314,
-    #00143c,
-    #2873d7,
-    #9bc3ff,
-    #320f1e
-  );
+  background: var(--aui-rainbow);
   -webkit-mask:
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
@@ -323,6 +330,34 @@
     linear-gradient(#fff 0 0);
   mask-composite: exclude;
   animation: aui-rainbow-spin 1.6s linear infinite;
+}
+
+/* Standalone rainbow dot for the cycling "thinking" indicator (shown before
+   the assistant streams any answer text). Same ring as the inline dot above. */
+.gram-elements .aui-thinking-dot {
+  display: inline-block;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  width: 0.95em;
+  height: 0.95em;
+  padding: 2.5px;
+  border-radius: 50%;
+  background: var(--aui-rainbow);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  animation: aui-rainbow-spin 1.6s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gram-elements .aui-thinking-dot {
+    animation: none;
+  }
 }
 
 /* Simple shimmer animation for title text */


### PR DESCRIPTION
## What

Two UX upgrades to the **Project Assistant** chat, bringing it closer to the Claude.ai "thinking → streaming" feel:

1. **Cycling thinking verbs.** While the assistant is running but before any answer text arrives (and during tool calls / reasoning), a rainbow spinner shows alongside a whimsical verb that crossfades through a canned set of 30 — `Pondering…`, `Synthesizing…`, `Reticulating…`, etc. Once the first token lands, the verbs vanish and the existing trailing rainbow dot follows the streamed text.

<img width="1308" height="358" alt="CleanShot 2026-06-11 at 17 04 50@2x" src="https://github.com/user-attachments/assets/9e876737-fc04-4c98-9b84-0615e42d3530" />

2. **Client-side streaming emulation.** The assistant transport is **poll-based — there is no SSE endpoint** — so a reply normally lands as one blob. We now slice each finished reply into many `text-delta` events with a time-budgeted cadence, so text types onto the screen token-by-token exactly as a real stream would. assistant-ui can't tell the difference (same AI SDK `text-start`/`text-delta`/`text-end` protocol).

## How

- **`elements/`** — new `ThinkingIndicator` component (`thinking-indicator.tsx`) owns the "before first token" window with a shuffled, crossfading verb list; replaces the old bare-dot `ToolCallStreamingIndicator`. The rainbow palette is hoisted to a `--aui-rainbow` CSS var shared by the inline trailing dot and the new standalone dot; the `:empty::after` rule is dropped so the two indicators never double up.
- **`dashboard/`** — `ServerAssistantTransport` gains `writeStreamedText`, which chunks the polled reply on whitespace-preserving tokens. Pacing adapts to length (whole reply within ~1.4s, capped at 350 delta events), honors `prefers-reduced-motion`, and on abort leaves the partial text rendered like a real cancelled stream.

## Accessibility

- Rotating verb is `aria-hidden`; a stable `sr-only` "Assistant is working…" carries status so screen readers aren't spammed every ~2s.
- `prefers-reduced-motion`: spinner + crossfade disabled; streaming falls back to a single shot.

## Verification

- `@gram-ai/elements`: type-check + lint pass; library builds.
- `dashboard`: type-check + lint pass (after building the worktree SDK).
- Not yet watched animating in a running dashboard — reviewers/QA should eyeball the live effect.

## Notes

- Verbs are **cosmetic**, not tied to the actual tool being called (matches Claude). Easy to switch to action-derived verbs later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Project Assistant now streams replies and shows a cycling “thinking” verb with a rainbow spinner before the first token. Emulates streaming over the poll-based transport for a smoother, Claude-like chat feel.

- New Features
  - Client-side streaming in `dashboard` via `ServerAssistantTransport.writeStreamedText`: splits polled replies into `text-delta`s, targets ~1.4s total, caps at 350 ticks, preserves words, skips very short texts, respects reduced motion, and keeps partial text on abort.
  - New `@gram-ai/elements` `ThinkingIndicator`: shows before any text or during tool/reasoning; cycles 30 verbs with a crossfade and rainbow spinner; replaces the old tool-call-only indicator in `thread.tsx`. Unified rainbow ring with `--aui-rainbow`; trailing inline dot follows streamed text; removed `:empty::after`. Accessibility: rotating verb is `aria-hidden` with a stable `sr-only` label.

- Bug Fixes
  - Reduced motion now stops both rainbow dots via shared `--aui-spin`.
  - Under reduced motion, show a single static verb (no timer/cycle).
  - Reset verb visibility on re-activation and when toggling reduced motion mid-fade so the next thinking window never starts hidden.

<sup>Written for commit 77335fffd18bf1bc7238b84f4f11a95c3cd3f3e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



