### PR TITLE
feat: open prompt-based risk policies to all message types

### DIFF
--- a/.changeset/prompt-policy-all-message-types.md
+++ b/.changeset/prompt-policy-all-message-types.md
@@ -1,0 +1,12 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Open prompt-based ("LLM-judge") risk policies to all message types.
+
+Previously the judge was hard-scoped to `tool_request` in both the realtime
+scanner and the batch analyzer, regardless of the policy's `message_types`. The
+judge now runs on whatever types a policy declares (`user_message`,
+`tool_request`, `tool_response`, `assistant_message`), and the policy form lets
+you choose them instead of locking to tool requests.

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -10,6 +10,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { TextArea } from "@/components/ui/textarea";
@@ -1324,7 +1331,7 @@ function PromptPolicySheetBody({
           rows={5}
         />
         {!isEditing && (
-          <PromptExamplesRadioGroup
+          <PromptExampleChips
             selectedExampleName={selectedExampleName}
             onSelect={(template) => {
               setSelectedExampleName(template.name);
@@ -1337,8 +1344,6 @@ function PromptPolicySheetBody({
         )}
       </div>
 
-      <PromptPolicyMessageTypesPicker />
-
       <JudgeConfigSection
         formModel={formModel}
         setFormModel={setFormModel}
@@ -1347,6 +1352,8 @@ function PromptPolicySheetBody({
         formFailOpen={formFailOpen}
         setFormFailOpen={setFormFailOpen}
       />
+
+      <PromptPolicyMessageTypesPicker />
 
       <ActionPicker formAction={formAction} setFormAction={setFormAction} />
 
@@ -1378,6 +1385,9 @@ const TEMPERATURE_TICKS = Array.from(
   { length: 11 },
   (_, i) => Math.round(i * TEMPERATURE_STEP * 10) / 10,
 );
+// Sentinel for the recommended (server-default) model in the Select, since
+// Radix disallows an empty-string item value. Maps to "" in form state.
+const RECOMMENDED_MODEL_VALUE = "__recommended__";
 
 // JUDGE_MODEL_OPTIONS lists the models a prompt policy may run its LLM judge on.
 // The recommended option uses the empty value, which follows the server's
@@ -1433,8 +1443,25 @@ function JudgeConfigSection({
   formFailOpen: boolean;
   setFormFailOpen: (v: boolean) => void;
 }) {
+  // Radix Select disallows an empty-string item value, so the recommended
+  // (default) model uses a sentinel in the dropdown and maps back to "".
+  const knownValues = JUDGE_MODEL_OPTIONS.map((o) => o.value);
+  const options =
+    formModel && !knownValues.includes(formModel)
+      ? [
+          ...JUDGE_MODEL_OPTIONS,
+          {
+            value: formModel,
+            label: formModel,
+            description: "Custom model configured via the API.",
+          },
+        ]
+      : JUDGE_MODEL_OPTIONS;
+  const selected = options.find((o) => o.value === formModel);
+  const toItemValue = (v: string) => v || RECOMMENDED_MODEL_VALUE;
+
   return (
-    <div className="border-border bg-muted/30 space-y-5 rounded-lg border p-4">
+    <div className="space-y-2">
       <div className="space-y-1">
         <Label className="text-sm font-medium">Judge configuration</Label>
         <p className="text-muted-foreground text-xs">
@@ -1442,107 +1469,86 @@ function JudgeConfigSection({
         </p>
       </div>
 
-      <JudgeModelPicker formModel={formModel} setFormModel={setFormModel} />
-
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label className="text-sm font-medium">Temperature</Label>
-          <span className="text-muted-foreground text-xs tabular-nums">
-            {formTemperature.toFixed(1)}
-            {formTemperature === DEFAULT_JUDGE_TEMPERATURE ? " · default" : ""}
-          </span>
+      <div className="border-border bg-muted/30 space-y-5 rounded-lg border p-4">
+        {/* Model */}
+        <div className="space-y-1.5">
+          <Label className="text-sm font-medium">Model</Label>
+          <Select
+            value={toItemValue(formModel)}
+            onValueChange={(v) =>
+              setFormModel(v === RECOMMENDED_MODEL_VALUE ? "" : v)
+            }
+          >
+            <SelectTrigger className="bg-background w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((opt) => (
+                <SelectItem
+                  key={toItemValue(opt.value)}
+                  value={toItemValue(opt.value)}
+                >
+                  <span className="flex items-center gap-2">
+                    {opt.label}
+                    {opt.recommended && (
+                      <Badge variant="neutral" className="text-[10px]">
+                        <Badge.Text>Recommended</Badge.Text>
+                      </Badge>
+                    )}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {selected?.description && (
+            <p className="text-muted-foreground text-xs">
+              {selected.description}
+            </p>
+          )}
         </div>
-        <Slider
-          value={formTemperature}
-          // Round to one decimal so float steps don't drift (e.g. 0.30000004).
-          onChange={(v) => setFormTemperature(Math.round(v * 10) / 10)}
-          min={TEMPERATURE_MIN}
-          max={TEMPERATURE_MAX}
-          step={TEMPERATURE_STEP}
-          ticks={TEMPERATURE_TICKS}
-        />
-        <div className="text-muted-foreground flex justify-between text-[10px]">
-          <span>0 · deterministic</span>
-          <span>1 · varied</span>
-        </div>
-        <p className="text-muted-foreground text-xs">
-          Lower is more consistent. 0 is recommended for repeatable verdicts.
-        </p>
-      </div>
 
-      <div className="flex items-center justify-between">
-        <div className="pr-4">
-          <Label className="text-sm font-medium">Fail open</Label>
+        {/* Temperature */}
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Label className="text-sm font-medium">Temperature</Label>
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {formTemperature.toFixed(1)}
+              {formTemperature === DEFAULT_JUDGE_TEMPERATURE
+                ? " · default"
+                : ""}
+            </span>
+          </div>
+          <Slider
+            value={formTemperature}
+            // Round to one decimal so float steps don't drift (e.g. 0.30000004).
+            onChange={(v) => setFormTemperature(Math.round(v * 10) / 10)}
+            min={TEMPERATURE_MIN}
+            max={TEMPERATURE_MAX}
+            step={TEMPERATURE_STEP}
+            ticks={TEMPERATURE_TICKS}
+          />
           <p className="text-muted-foreground text-xs">
-            When the judge errors or times out, allow the message instead of
-            blocking it.
+            Lower is more consistent. 0 is recommended for repeatable verdicts.
           </p>
         </div>
-        <Switch checked={formFailOpen} onCheckedChange={setFormFailOpen} />
+
+        {/* Fail open */}
+        <div className="flex items-center justify-between gap-4">
+          <div className="pr-2">
+            <Label className="text-sm font-medium">Fail open</Label>
+            <p className="text-muted-foreground text-xs">
+              When the judge errors or times out, allow the message instead of
+              blocking it.
+            </p>
+          </div>
+          <Switch checked={formFailOpen} onCheckedChange={setFormFailOpen} />
+        </div>
       </div>
     </div>
   );
 }
 
-function JudgeModelPicker({
-  formModel,
-  setFormModel,
-}: {
-  formModel: string;
-  setFormModel: (v: string) => void;
-}) {
-  // A model that's persisted on the policy but not one of the curated options
-  // (e.g. set via the API) still needs to round-trip, so surface it as selected.
-  const knownValues = JUDGE_MODEL_OPTIONS.map((o) => o.value);
-  const options = knownValues.includes(formModel)
-    ? JUDGE_MODEL_OPTIONS
-    : [
-        ...JUDGE_MODEL_OPTIONS,
-        {
-          value: formModel,
-          label: formModel,
-          description: "Custom model configured via the API.",
-        },
-      ];
-
-  return (
-    <div className="space-y-2">
-      <Label className="text-sm font-medium">Model</Label>
-      <RadioGroup value={formModel} onValueChange={setFormModel}>
-        <div className="border-border divide-border divide-y rounded-lg border">
-          {options.map((opt) => (
-            <label
-              key={opt.value || "recommended"}
-              htmlFor={`judge-model-${opt.value || "recommended"}`}
-              className="hover:bg-muted/50 flex cursor-pointer items-start gap-3 p-3"
-            >
-              <RadioGroupItem
-                value={opt.value}
-                id={`judge-model-${opt.value || "recommended"}`}
-                className="mt-0.5"
-              />
-              <div className="flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium">{opt.label}</span>
-                  {opt.recommended && (
-                    <Badge variant="neutral" className="text-[10px]">
-                      <Badge.Text>Recommended</Badge.Text>
-                    </Badge>
-                  )}
-                </div>
-                <div className="text-muted-foreground mt-1 text-xs">
-                  {opt.description}
-                </div>
-              </div>
-            </label>
-          ))}
-        </div>
-      </RadioGroup>
-    </div>
-  );
-}
-
-function PromptExamplesRadioGroup({
+function PromptExampleChips({
   selectedExampleName,
   onSelect,
 }: {
@@ -1550,43 +1556,27 @@ function PromptExamplesRadioGroup({
   onSelect: (template: (typeof PROMPT_POLICY_TEMPLATES)[number]) => void;
 }) {
   return (
-    <div className="space-y-2">
-      <Label className="text-sm font-medium">Prompt Examples</Label>
-      <RadioGroup
-        value={selectedExampleName}
-        onValueChange={(name) => {
-          const template = PROMPT_POLICY_TEMPLATES.find((t) => t.name === name);
-          if (template) {
-            onSelect(template);
-          }
-        }}
-      >
-        <div className="border-border divide-border divide-y rounded-lg border">
-          {PROMPT_POLICY_TEMPLATES.map((template, index) => {
-            const exampleId = `prompt-example-${index}`;
-
-            return (
-              <label
-                key={template.name}
-                htmlFor={exampleId}
-                className="hover:bg-muted/40 flex cursor-pointer items-start gap-3 px-4 py-3"
-              >
-                <RadioGroupItem
-                  value={template.name}
-                  id={exampleId}
-                  className="mt-0.5"
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm font-medium">{template.name}</div>
-                  <div className="text-muted-foreground text-xs">
-                    {template.prompt}
-                  </div>
-                </div>
-              </label>
-            );
-          })}
-        </div>
-      </RadioGroup>
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-muted-foreground text-xs">Try:</span>
+      {PROMPT_POLICY_TEMPLATES.map((template) => {
+        const active = selectedExampleName === template.name;
+        return (
+          <SimpleTooltip key={template.name} tooltip={template.prompt}>
+            <button
+              type="button"
+              onClick={() => onSelect(template)}
+              className={cn(
+                "rounded-full border px-2.5 py-1 text-xs transition-colors",
+                active
+                  ? "border-foreground/30 bg-muted text-foreground"
+                  : "border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+              )}
+            >
+              {template.name}
+            </button>
+          </SimpleTooltip>
+        );
+      })}
     </div>
   );
 }
@@ -1628,7 +1618,7 @@ function PromptPolicyHowItWorks({ isEditing }: { isEditing: boolean }) {
 
 function PromptPolicyMessageTypesPicker() {
   const selectedMessageTypes = promptPolicyMessageTypes();
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
 
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="space-y-3">

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -1546,6 +1546,7 @@ function PromptExampleChips({
           <SimpleTooltip key={template.name} tooltip={template.prompt}>
             <button
               type="button"
+              aria-pressed={active}
               onClick={() => onSelect(template)}
               className={cn(
                 "rounded-full border px-2.5 py-1 text-xs transition-colors",

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -1528,7 +1528,9 @@ function JudgeConfigSection({
             ticks={TEMPERATURE_TICKS}
           />
           <p className="text-muted-foreground text-xs">
-            Lower is more consistent. 0 is recommended for repeatable verdicts.
+            Lower is more consistent and repeatable (0 recommended). Higher adds
+            variation, which can surface borderline or unusual violations a
+            rigid read might miss.
           </p>
         </div>
 

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -10,13 +10,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { TextArea } from "@/components/ui/textarea";
@@ -135,7 +128,6 @@ const TOOL_CALL_MESSAGE_TYPES = new Set<PolicyMessageType>([
   "tool_request",
   "tool_response",
 ]);
-const PROMPT_POLICY_MESSAGE_TYPES: PolicyMessageType[] = ["tool_request"];
 
 const ALL_POLICY_MESSAGE_TYPES = Object.keys(
   POLICY_MESSAGE_TYPE_META,
@@ -288,10 +280,6 @@ function policyMessageTypesForDisplay(
   messageTypes?: string[],
 ): PolicyMessageType[] {
   return [...policyMessageTypesForForm(messageTypes)];
-}
-
-function promptPolicyMessageTypes(): Set<PolicyMessageType> {
-  return new Set(PROMPT_POLICY_MESSAGE_TYPES);
 }
 
 function hasOnlyToolCallMessageTypes(types: Set<PolicyMessageType>): boolean {
@@ -449,13 +437,6 @@ function PolicyCenterContent() {
 
   const configurePolicyKind = (kind: PolicyKind) => {
     setFormPolicyKind(kind);
-    if (kind === "prompt") {
-      setSelectedMessageTypes(promptPolicyMessageTypes());
-      setFormAction("flag");
-      setFormAutoName(true);
-      return;
-    }
-
     setSelectedMessageTypes(new Set(ALL_POLICY_MESSAGE_TYPES));
     setFormAction("flag");
     setFormAutoName(true);
@@ -472,11 +453,7 @@ function PolicyCenterContent() {
     setSelectedCategories(new Set<RuleCategory>(["secrets", "pii"]));
     setDisabledRules(new Set());
     setSelectedCustomRuleIds(new Set<string>());
-    setSelectedMessageTypes(
-      nextKind === "prompt"
-        ? promptPolicyMessageTypes()
-        : new Set(ALL_POLICY_MESSAGE_TYPES),
-    );
+    setSelectedMessageTypes(new Set(ALL_POLICY_MESSAGE_TYPES));
     setFormAction("flag");
     setFormAutoName(true);
     setFormUserMessage("");
@@ -504,7 +481,7 @@ function PolicyCenterContent() {
     setFormEnabled(policy.enabled);
     if (isPrompt) {
       setFormPromptInstruction(policy.prompt ?? "");
-      setSelectedMessageTypes(promptPolicyMessageTypes());
+      setSelectedMessageTypes(policyMessageTypesForForm(policy.messageTypes));
       setFormAction((policy.action as PolicyAction) ?? "flag");
       setFormAutoName(policy.autoName ?? true);
       setFormUserMessage(policy.userMessage ?? "");
@@ -555,11 +532,9 @@ function PolicyCenterContent() {
     if (formPolicyKind === "prompt") {
       const prompt = formPromptInstruction.trim();
       const name = formAutoName ? promptPolicyName(prompt) : formName;
-      // Only persist model_config when something diverges from the effective
-      // defaults (or the policy already had one). Otherwise omit it so an unset
-      // (NULL) config isn't rewritten to {}, which would bump the policy version
-      // on every edit. Each field is included only when non-default so we don't
-      // freeze today's defaults onto the policy.
+      // Persist model_config only when it diverges from defaults (or already
+      // existed), and include each field only when non-default, so an unset
+      // config stays NULL rather than churning the policy version on every edit.
       const temperatureIsCustom = formTemperature !== DEFAULT_JUDGE_TEMPERATURE;
       const hasModelConfig =
         !!editingPolicy?.modelConfig ||
@@ -576,6 +551,8 @@ function PolicyCenterContent() {
       const userMessagePayload = formUserMessage.trim()
         ? { userMessage: formUserMessage }
         : {};
+      const promptMessageTypes =
+        policyMessageTypesForPayload(selectedMessageTypes);
       if (editingPolicy) {
         updateMutation.mutate({
           request: {
@@ -584,7 +561,7 @@ function PolicyCenterContent() {
               name,
               enabled: formEnabled,
               prompt,
-              messageTypes: PROMPT_POLICY_MESSAGE_TYPES,
+              messageTypes: promptMessageTypes,
               action: formAction,
               autoName: formAutoName,
               ...(modelConfig ? { modelConfig } : {}),
@@ -600,7 +577,7 @@ function PolicyCenterContent() {
               policyType: "prompt_based",
               enabled: formEnabled,
               prompt,
-              messageTypes: PROMPT_POLICY_MESSAGE_TYPES,
+              messageTypes: promptMessageTypes,
               action: formAction,
               autoName: formAutoName,
               ...(modelConfig ? { modelConfig } : {}),
@@ -863,10 +840,7 @@ function PolicyCenterContent() {
       header: "Applies To",
       width: "2.1fr",
       render: (row) => {
-        const types =
-          row.kind === "prompt"
-            ? PROMPT_POLICY_MESSAGE_TYPES
-            : policyMessageTypesForDisplay(row.policy.messageTypes);
+        const types = policyMessageTypesForDisplay(row.policy.messageTypes);
         const typeSet = new Set(types);
         const tooltip = types
           .map((type) => POLICY_MESSAGE_TYPE_META[type].label)
@@ -1131,6 +1105,8 @@ function PolicyCenterContent() {
                     setFormTemperature={setFormTemperature}
                     formFailOpen={formFailOpen}
                     setFormFailOpen={setFormFailOpen}
+                    selectedMessageTypes={selectedMessageTypes}
+                    setSelectedMessageTypes={setSelectedMessageTypes}
                   />
                 )}
               </div>
@@ -1269,6 +1245,8 @@ function PromptPolicySheetBody({
   setFormTemperature,
   formFailOpen,
   setFormFailOpen,
+  selectedMessageTypes,
+  setSelectedMessageTypes,
 }: {
   isEditing: boolean;
   formName: string;
@@ -1287,6 +1265,8 @@ function PromptPolicySheetBody({
   setFormTemperature: (v: number) => void;
   formFailOpen: boolean;
   setFormFailOpen: (v: boolean) => void;
+  selectedMessageTypes: Set<PolicyMessageType>;
+  setSelectedMessageTypes: (v: Set<PolicyMessageType>) => void;
 }) {
   const [selectedExampleName, setSelectedExampleName] = useState(
     () => promptTemplateNameForInstruction(formPromptInstruction) ?? "",
@@ -1353,7 +1333,10 @@ function PromptPolicySheetBody({
         setFormFailOpen={setFormFailOpen}
       />
 
-      <PromptPolicyMessageTypesPicker />
+      <MessageTypesPicker
+        selectedMessageTypes={selectedMessageTypes}
+        setSelectedMessageTypes={setSelectedMessageTypes}
+      />
 
       <ActionPicker formAction={formAction} setFormAction={setFormAction} />
 
@@ -1385,9 +1368,6 @@ const TEMPERATURE_TICKS = Array.from(
   { length: 11 },
   (_, i) => Math.round(i * TEMPERATURE_STEP * 10) / 10,
 );
-// Sentinel for the recommended (server-default) model in the Select, since
-// Radix disallows an empty-string item value. Maps to "" in form state.
-const RECOMMENDED_MODEL_VALUE = "__recommended__";
 
 // JUDGE_MODEL_OPTIONS lists the models a prompt policy may run its LLM judge on.
 // The recommended option uses the empty value, which follows the server's
@@ -1425,9 +1405,6 @@ const JUDGE_MODEL_OPTIONS: {
   },
 ];
 
-// JudgeConfigSection fences the LLM-judge knobs (model, temperature, fail-open)
-// into one visually distinct block so they read as advanced config separate from
-// the core policy fields.
 function JudgeConfigSection({
   formModel,
   setFormModel,
@@ -1443,8 +1420,69 @@ function JudgeConfigSection({
   formFailOpen: boolean;
   setFormFailOpen: (v: boolean) => void;
 }) {
-  // Radix Select disallows an empty-string item value, so the recommended
-  // (default) model uses a sentinel in the dropdown and maps back to "".
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <Label className="text-sm font-medium">Judge configuration</Label>
+        <p className="text-muted-foreground text-xs">
+          How the LLM judge evaluates each in-scope message against this policy.
+        </p>
+      </div>
+
+      <JudgeModelPicker formModel={formModel} setFormModel={setFormModel} />
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Label className="text-sm font-medium">Temperature</Label>
+          <span className="text-muted-foreground text-xs tabular-nums">
+            {formTemperature.toFixed(1)}
+            {formTemperature === DEFAULT_JUDGE_TEMPERATURE ? " · default" : ""}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-muted-foreground text-xs tabular-nums">0</span>
+          <div className="flex-1">
+            <Slider
+              value={formTemperature}
+              onChange={(v) => setFormTemperature(Math.round(v * 10) / 10)}
+              min={TEMPERATURE_MIN}
+              max={TEMPERATURE_MAX}
+              step={TEMPERATURE_STEP}
+              ticks={TEMPERATURE_TICKS}
+            />
+          </div>
+          <span className="text-muted-foreground text-xs tabular-nums">1</span>
+        </div>
+        <p className="text-muted-foreground text-xs">
+          Lower is more consistent and repeatable (0 recommended). Higher adds
+          variation, which can surface borderline or unusual violations a rigid
+          read might miss.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <div className="pr-2">
+          <Label className="text-sm font-medium">Fail open</Label>
+          <p className="text-muted-foreground text-xs">
+            When the judge errors or times out, allow the message instead of
+            blocking it.
+          </p>
+        </div>
+        <Switch checked={formFailOpen} onCheckedChange={setFormFailOpen} />
+      </div>
+    </div>
+  );
+}
+
+function JudgeModelPicker({
+  formModel,
+  setFormModel,
+}: {
+  formModel: string;
+  setFormModel: (v: string) => void;
+}) {
+  // A model persisted via the API but not in the curated list still needs to
+  // round-trip, so surface it as a selectable option.
   const knownValues = JUDGE_MODEL_OPTIONS.map((o) => o.value);
   const options =
     formModel && !knownValues.includes(formModel)
@@ -1457,95 +1495,40 @@ function JudgeConfigSection({
           },
         ]
       : JUDGE_MODEL_OPTIONS;
-  const selected = options.find((o) => o.value === formModel);
-  const toItemValue = (v: string) => v || RECOMMENDED_MODEL_VALUE;
 
   return (
     <div className="space-y-2">
-      <div className="space-y-1">
-        <Label className="text-sm font-medium">Judge configuration</Label>
-        <p className="text-muted-foreground text-xs">
-          How the LLM judge evaluates each in-scope message against this policy.
-        </p>
-      </div>
-
-      <div className="border-border bg-muted/30 space-y-5 rounded-lg border p-4">
-        {/* Model */}
-        <div className="space-y-1.5">
-          <Label className="text-sm font-medium">Model</Label>
-          <Select
-            value={toItemValue(formModel)}
-            onValueChange={(v) =>
-              setFormModel(v === RECOMMENDED_MODEL_VALUE ? "" : v)
-            }
-          >
-            <SelectTrigger className="bg-background w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {options.map((opt) => (
-                <SelectItem
-                  key={toItemValue(opt.value)}
-                  value={toItemValue(opt.value)}
-                >
-                  <span className="flex items-center gap-2">
-                    {opt.label}
-                    {opt.recommended && (
-                      <Badge variant="neutral" className="text-[10px]">
-                        <Badge.Text>Recommended</Badge.Text>
-                      </Badge>
-                    )}
-                  </span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {selected?.description && (
-            <p className="text-muted-foreground text-xs">
-              {selected.description}
-            </p>
-          )}
+      <Label className="text-sm font-medium">Model</Label>
+      <RadioGroup value={formModel} onValueChange={setFormModel}>
+        <div className="border-border divide-border divide-y rounded-lg border">
+          {options.map((opt) => (
+            <label
+              key={opt.value || "recommended"}
+              htmlFor={`judge-model-${opt.value || "recommended"}`}
+              className="hover:bg-muted/50 flex cursor-pointer items-start gap-3 p-3"
+            >
+              <RadioGroupItem
+                value={opt.value}
+                id={`judge-model-${opt.value || "recommended"}`}
+                className="mt-0.5"
+              />
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{opt.label}</span>
+                  {opt.recommended && (
+                    <Badge variant="neutral" className="text-[10px]">
+                      <Badge.Text>Recommended</Badge.Text>
+                    </Badge>
+                  )}
+                </div>
+                <div className="text-muted-foreground mt-1 text-xs">
+                  {opt.description}
+                </div>
+              </div>
+            </label>
+          ))}
         </div>
-
-        {/* Temperature */}
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Label className="text-sm font-medium">Temperature</Label>
-            <span className="text-muted-foreground text-xs tabular-nums">
-              {formTemperature.toFixed(1)}
-              {formTemperature === DEFAULT_JUDGE_TEMPERATURE
-                ? " · default"
-                : ""}
-            </span>
-          </div>
-          <Slider
-            value={formTemperature}
-            // Round to one decimal so float steps don't drift (e.g. 0.30000004).
-            onChange={(v) => setFormTemperature(Math.round(v * 10) / 10)}
-            min={TEMPERATURE_MIN}
-            max={TEMPERATURE_MAX}
-            step={TEMPERATURE_STEP}
-            ticks={TEMPERATURE_TICKS}
-          />
-          <p className="text-muted-foreground text-xs">
-            Lower is more consistent and repeatable (0 recommended). Higher adds
-            variation, which can surface borderline or unusual violations a
-            rigid read might miss.
-          </p>
-        </div>
-
-        {/* Fail open */}
-        <div className="flex items-center justify-between gap-4">
-          <div className="pr-2">
-            <Label className="text-sm font-medium">Fail open</Label>
-            <p className="text-muted-foreground text-xs">
-              When the judge errors or times out, allow the message instead of
-              blocking it.
-            </p>
-          </div>
-          <Switch checked={formFailOpen} onCheckedChange={setFormFailOpen} />
-        </div>
-      </div>
+      </RadioGroup>
     </div>
   );
 }
@@ -1597,7 +1580,7 @@ function PromptPolicyHowItWorks({ isEditing }: { isEditing: boolean }) {
         <div className="min-w-0 flex-1">
           <div className="text-sm font-medium">How this works</div>
           <div className="text-muted-foreground text-xs">
-            LLM judging evaluates matching tool requests in real time.
+            An LLM judge evaluates each matching message against your prompt.
           </div>
         </div>
         <ChevronRight
@@ -1609,58 +1592,11 @@ function PromptPolicyHowItWorks({ isEditing }: { isEditing: boolean }) {
       </CollapsibleTrigger>
       <CollapsibleContent className="border-border border-t px-4 py-3">
         <p className="text-muted-foreground text-sm">
-          Prompt-based policies use an LLM judge, so each evaluated tool request
-          can add latency compared with standard detection rules. The judge sees
-          the tool name and inputs.
+          Prompt-based policies use an LLM judge, so each evaluated message can
+          add latency compared with standard detection rules. The judge sees one
+          message at a time — a tool call and its inputs, or message content.
         </p>
       </CollapsibleContent>
-    </Collapsible>
-  );
-}
-
-function PromptPolicyMessageTypesPicker() {
-  const selectedMessageTypes = promptPolicyMessageTypes();
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Collapsible open={open} onOpenChange={setOpen} className="space-y-3">
-      <div className="space-y-1">
-        <Label className="text-sm font-medium">Applies To</Label>
-        <p className="text-muted-foreground text-xs">
-          Prompt-based policies currently evaluate tool requests only.
-        </p>
-      </div>
-      <div className="border-border rounded-lg border">
-        <CollapsibleTrigger className="hover:bg-muted/40 flex w-full items-center gap-3 px-4 py-3 text-left transition-colors">
-          <ChevronRight
-            className={cn(
-              "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
-              open && "rotate-90",
-            )}
-          />
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium">
-              {messageTypesSummary(selectedMessageTypes)}
-            </div>
-            <div className="text-muted-foreground text-xs">
-              Evaluated on each Tool Request in real time
-            </div>
-          </div>
-        </CollapsibleTrigger>
-        <CollapsibleContent className="border-border data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden border-t">
-          <div className="divide-border divide-y">
-            {ALL_POLICY_MESSAGE_TYPES.map((type) => (
-              <MessageTypeOptionRow
-                key={type}
-                type={type}
-                checked={selectedMessageTypes.has(type)}
-                disabled={true}
-                onCheckedChange={() => undefined}
-              />
-            ))}
-          </div>
-        </CollapsibleContent>
-      </div>
     </Collapsible>
   );
 }

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -1213,7 +1213,7 @@ function PolicyKindChoice({
             </Badge>
           </div>
           <Type small muted className="mt-0.5">
-            Describe any behavior you want to detect in plain language — no
+            Describe any behavior you want to detect in plain language. No
             scanner configuration needed.
           </Type>
         </div>
@@ -1371,7 +1371,7 @@ const TEMPERATURE_TICKS = Array.from(
 
 // JUDGE_MODEL_OPTIONS lists the models a prompt policy may run its LLM judge on.
 // The recommended option uses the empty value, which follows the server's
-// default judge model — its label names that model and must stay in sync with
+// default judge model. Its label names that model and must stay in sync with
 // riskjudge.defaultJudgeModel. See server/cmd/riskjudgebench for the benchmark
 // behind these picks.
 const JUDGE_MODEL_OPTIONS: {
@@ -1422,53 +1422,50 @@ function JudgeConfigSection({
 }) {
   return (
     <div className="space-y-4">
-      <div className="space-y-1">
-        <Label className="text-sm font-medium">Judge configuration</Label>
-        <p className="text-muted-foreground text-xs">
-          How the LLM judge evaluates each in-scope message against this policy.
-        </p>
-      </div>
-
       <JudgeModelPicker formModel={formModel} setFormModel={setFormModel} />
 
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Label className="text-sm font-medium">Temperature</Label>
-          <span className="text-muted-foreground text-xs tabular-nums">
-            {formTemperature.toFixed(1)}
-            {formTemperature === DEFAULT_JUDGE_TEMPERATURE ? " · default" : ""}
-          </span>
-        </div>
-        <div className="flex items-center gap-3">
-          <span className="text-muted-foreground text-xs tabular-nums">0</span>
-          <div className="flex-1">
-            <Slider
-              value={formTemperature}
-              onChange={(v) => setFormTemperature(Math.round(v * 10) / 10)}
-              min={TEMPERATURE_MIN}
-              max={TEMPERATURE_MAX}
-              step={TEMPERATURE_STEP}
-              ticks={TEMPERATURE_TICKS}
-            />
+      <div className="border-border space-y-4 rounded-lg border p-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Label className="text-sm font-medium">Temperature</Label>
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {formTemperature.toFixed(1)}
+              {formTemperature === DEFAULT_JUDGE_TEMPERATURE
+                ? " · default"
+                : ""}
+            </span>
           </div>
-          <span className="text-muted-foreground text-xs tabular-nums">1</span>
-        </div>
-        <p className="text-muted-foreground text-xs">
-          Lower is more consistent and repeatable (0 recommended). Higher adds
-          variation, which can surface borderline or unusual violations a rigid
-          read might miss.
-        </p>
-      </div>
-
-      <div className="flex items-center justify-between gap-4">
-        <div className="pr-2">
-          <Label className="text-sm font-medium">Fail open</Label>
+          <div className="flex items-center gap-3">
+            <span className="text-foreground text-xs tabular-nums">0</span>
+            <div className="flex-1">
+              <Slider
+                value={formTemperature}
+                onChange={(v) => setFormTemperature(Math.round(v * 10) / 10)}
+                min={TEMPERATURE_MIN}
+                max={TEMPERATURE_MAX}
+                step={TEMPERATURE_STEP}
+                ticks={TEMPERATURE_TICKS}
+              />
+            </div>
+            <span className="text-foreground text-xs tabular-nums">1</span>
+          </div>
           <p className="text-muted-foreground text-xs">
-            When the judge errors or times out, allow the message instead of
-            blocking it.
+            Lower is more consistent and repeatable (0 recommended). Higher adds
+            variation, which can surface borderline or unusual violations a
+            rigid read might miss.
           </p>
         </div>
-        <Switch checked={formFailOpen} onCheckedChange={setFormFailOpen} />
+
+        <div className="border-border flex items-start justify-between gap-4 border-t pt-4">
+          <div className="space-y-2 pr-2">
+            <Label className="text-sm font-medium">Fail open</Label>
+            <p className="text-muted-foreground text-xs">
+              When the judge errors or times out, allow the message instead of
+              blocking it.
+            </p>
+          </div>
+          <Switch checked={formFailOpen} onCheckedChange={setFormFailOpen} />
+        </div>
       </div>
     </div>
   );
@@ -1580,7 +1577,7 @@ function PromptPolicyHowItWorks({ isEditing }: { isEditing: boolean }) {
         <div className="min-w-0 flex-1">
           <div className="text-sm font-medium">How this works</div>
           <div className="text-muted-foreground text-xs">
-            An LLM judge evaluates each matching message against your prompt.
+            An LLM judge checks each matching message against your prompt.
           </div>
         </div>
         <ChevronRight
@@ -1592,9 +1589,11 @@ function PromptPolicyHowItWorks({ isEditing }: { isEditing: boolean }) {
       </CollapsibleTrigger>
       <CollapsibleContent className="border-border border-t px-4 py-3">
         <p className="text-muted-foreground text-sm">
-          Prompt-based policies use an LLM judge, so each evaluated message can
-          add latency compared with standard detection rules. The judge sees one
-          message at a time — a tool call and its inputs, or message content.
+          Prompt-based policies use an LLM judge, so each evaluated message adds
+          some latency versus standard detection rules. The judge sees one
+          message at a time (a tool call and its inputs, or message content),
+          never a whole conversation. It runs on the message types you select
+          under Applies To.
         </p>
       </CollapsibleContent>
     </Collapsible>

--- a/client/dashboard/src/pages/security/prompt-policy-templates.ts
+++ b/client/dashboard/src/pages/security/prompt-policy-templates.ts
@@ -7,9 +7,9 @@ export const PROMPT_POLICY_TEMPLATES: PromptPolicyTemplate[] = [
       "Any tool call that performs a destructive operation (DELETE, DROP, TRUNCATE) against a production resource.",
   },
   {
-    name: "Data exfiltration",
+    name: "External data transfer",
     prompt:
-      "Tool-call sequences where sensitive data is read and then transmitted to an external destination.",
+      "A tool call that sends data to an external or third-party destination, such as an outbound network request, email, or file upload.",
   },
   {
     name: "PII exposure",

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -201,9 +201,10 @@ func (a *AnalyzeBatch) Do(ctx context.Context, args AnalyzeBatchArgs) (_ *Analyz
 	}
 
 	// prompt_based policies are evaluated by the LLM judge rather than the
-	// source-based scanners above. scanPromptJudge hard-scopes to tool-call
-	// messages for M0 (matching realtime enforcement), on top of the policy's
-	// message_types filter already applied by filterMessagesByMessageTypes.
+	// source-based scanners above. The judge runs on every message left after
+	// the policy's message_types filter (already applied by
+	// filterMessagesByMessageTypes), so it covers whatever types the policy
+	// declares.
 	if policy.PolicyType == "prompt_based" {
 		judgeFindings := a.scanPromptJudge(ctx, args, policy, messages)
 		for i := range findings {
@@ -440,10 +441,10 @@ const judgeConcurrency = 8
 // Returns all-empty results when the judge is unavailable or the policy has no
 // prompt.
 //
-// M0: like the realtime enforcement path, batch judging is hard-scoped to
-// tool-call messages regardless of the policy's message_types, so the judge is
-// never run on user/assistant/tool-response content yet. In-scope messages are
-// evaluated concurrently with a bounded worker pool.
+// The judge runs on every message passed in — the caller has already narrowed
+// them to the policy's message_types via filterMessagesByMessageTypes — so it
+// covers whatever types the policy declares. Messages are evaluated
+// concurrently with a bounded worker pool.
 func (a *AnalyzeBatch) scanPromptJudge(ctx context.Context, args AnalyzeBatchArgs, policy repo.RiskPolicy, messages []repo.GetMessageContentBatchRow) [][]Finding {
 	out := make([][]Finding, len(messages))
 	cfg := ParseJudgeConfig(policy.ModelConfig)
@@ -451,9 +452,9 @@ func (a *AnalyzeBatch) scanPromptJudge(ctx context.Context, args AnalyzeBatchArg
 		return out
 	}
 
-	var indices []int
+	indices := make([]int, 0, len(messages))
 	for i, msg := range messages {
-		if mt, ok := messageRowMessageType(msg); ok && mt == message.ToolRequest {
+		if _, ok := messageRowMessageType(msg); ok {
 			indices = append(indices, i)
 		}
 	}

--- a/server/internal/risk/prompt_policy_scanner_test.go
+++ b/server/internal/risk/prompt_policy_scanner_test.go
@@ -21,7 +21,7 @@ import (
 
 // fakePromptJudge is a stub ra.PromptJudge that returns a fixed verdict and
 // records how many times it was invoked, so tests can assert the scanner only
-// calls the judge for in-scope (tool-call) messages.
+// calls the judge for messages whose type the policy applies to.
 type fakePromptJudge struct {
 	verdict *risk_analysis.JudgeVerdict
 	calls   atomic.Int32
@@ -88,10 +88,10 @@ func TestScanner_PromptBasedPolicyBlocksToolRequest(t *testing.T) {
 	require.Equal(t, "destructive delete", res.Description)
 }
 
-// TestScanner_PromptBasedPolicyScopedToToolRequest verifies the M0 hard scope:
-// even a prompt_based policy with no message-type restriction is never judged
-// inline for non-tool-call messages.
-func TestScanner_PromptBasedPolicyScopedToToolRequest(t *testing.T) {
+// TestScanner_PromptBasedPolicyJudgesNonToolMessages verifies a prompt_based
+// policy with no message-type restriction is judged inline for non-tool-call
+// messages (e.g. a user prompt), not just tool calls.
+func TestScanner_PromptBasedPolicyJudgesNonToolMessages(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestRiskService(t)
 
@@ -104,8 +104,27 @@ func TestScanner_PromptBasedPolicyScopedToToolRequest(t *testing.T) {
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
 	res, err := scanner.ScanForEnforcement(ctx, *authCtx.ProjectID, "just a user prompt", message.User)
 	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, int32(1), judge.calls.Load(), "judge must run for non-tool-call messages the policy applies to")
+}
+
+// TestScanner_PromptBasedPolicyRespectsMessageTypes verifies a prompt_based
+// policy restricted to tool_request is not judged for other message types.
+func TestScanner_PromptBasedPolicyRespectsMessageTypes(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
+	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
+
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewMeterProvider(t))
+	require.NoError(t, err)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	res, err := scanner.ScanForEnforcement(ctx, *authCtx.ProjectID, "just a user prompt", message.User)
+	require.NoError(t, err)
 	require.Nil(t, res)
-	require.Equal(t, int32(0), judge.calls.Load(), "judge must not run for non-tool-call messages in M0")
+	require.Equal(t, int32(0), judge.calls.Load(), "judge must not run for a message type the policy excludes")
 }
 
 // TestScanner_PromptBasedPolicyNoMatch verifies a nil verdict (no match /

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -170,15 +170,14 @@ func (s *Scanner) ScanForEnforcement(ctx context.Context, projectID uuid.UUID, t
 	// Resolve the prompt-policy flag once per scan (on the parent ctx, before
 	// fan-out) so prompt_based policies don't each repeat the slug lookup and
 	// so the lookup is never cancelled by a sibling match. Gated on the exact
-	// conditions under which the fan-out would run the judge — a tool-request
-	// message and a prompt_based policy whose message_types apply to it — so
-	// the lookup is skipped entirely for scans that can never enforce one.
+	// condition under which the fan-out would run the judge — a prompt_based
+	// policy whose message_types apply to this message — so the lookup is
+	// skipped entirely for scans that can never enforce one.
 	promptPoliciesOn := false
-	if messageType == message.ToolRequest &&
-		slices.ContainsFunc(policies, func(p repo.RiskPolicy) bool {
-			return p.PolicyType == "prompt_based" &&
-				(len(p.MessageTypes) == 0 || slices.Contains(p.MessageTypes, messageType))
-		}) {
+	if slices.ContainsFunc(policies, func(p repo.RiskPolicy) bool {
+		return p.PolicyType == "prompt_based" &&
+			(len(p.MessageTypes) == 0 || slices.Contains(p.MessageTypes, messageType))
+	}) {
 		// All enforcing policies for a project belong to the same org.
 		promptPoliciesOn = s.promptPoliciesEnabled(ctx, policies[0].OrganizationID, projectID)
 	}
@@ -386,14 +385,11 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, text s
 }
 
 // scanPromptPolicy evaluates text against a prompt_based policy's guardrail
-// prompt via the LLM judge. For the M0 MVP, realtime judge enforcement is
-// hard-scoped to tool-call messages regardless of the policy's message_types,
-// so a misconfigured policy can never judge other message types inline. Returns
-// nil when the judge does not match (including fail-open on judge error).
+// prompt via the LLM judge. The caller (ScanForEnforcement) has already
+// filtered policies to those whose message_types apply to this message, so the
+// judge runs for whatever message types the policy declares. Returns nil when
+// the judge does not match (including fail-open on judge error).
 func (s *Scanner) scanPromptPolicy(ctx context.Context, policy repo.RiskPolicy, text string, messageType message.Type, promptPoliciesOn bool) *ScanResult {
-	if messageType != message.ToolRequest {
-		return nil
-	}
 	cfg := ra.ParseJudgeConfig(policy.ModelConfig)
 	if !promptPoliciesOn {
 		return nil


### PR DESCRIPTION
## What
Opens prompt-based ("LLM-judge") risk policies to **all message types**, and lands some judge-config UI polish(configurable model/temperature/fail-open controls).

## Open to all message types

Prompt policies were hard-scoped to `tool_request` in both the realtime scanner and the batch analyzer, regardless of the policy's `message_types`. This removes those gates so the judge runs on whatever types the policy declares — `user_message`, `tool_request`, `tool_response`, `assistant_message`. The surrounding code already filters policies/messages by `message_types`, so the gates were the only thing blocking it.

- **`scanner.go`** — drop the `tool_request`-only gate in `scanPromptPolicy`; relax the flag pre-filter to any applicable message type.
- **`analyze_batch.go`** — judge every message left after the `message_types` filter, not just tool calls.
- **Dashboard** — replace the locked tool-request-only "Applies To" picker with the editable `MessageTypesPicker`; new prompt policies default to all types; the list "Applies To" column reflects the policy's real types.
- **Tests** — `TestScanner_PromptBasedPolicyJudgesNonToolMessages` (judge runs on a user prompt) and `TestScanner_PromptBasedPolicyRespectsMessageTypes` (still skipped when the policy excludes the type).

### Enforcement note
Realtime hooks already produce `user_message` / `tool_request` / `tool_response`, so those enforce inline. `assistant_message` has no realtime hook, so a block policy on it flags via the batch analyzer rather than blocking inline. Judging is still gated behind the prompt-policies feature flag.

## Judge-config UI polish (carried from #3379 + this session's review)

- Model is a **radio group** (per-model trade-offs stay visible) with a **Recommended** tag on the default.
- Temperature **slider** flanked by **0 / 1** labels with discrete tick marks; default 0 (mirrors `riskjudge.defaultJudgeTemperature` and the benchmark).
- Dropped the fenced box; **Action** sits at the bottom (consistent with standard policies); prompt examples are compact chips; "Applies To" collapsed by default.
- Single-call **"External data transfer"** example (the old "Data exfiltration" needed cross-call context the judge doesn't get).

## Testing
- `go test ./server/internal/risk/ -run TestScanner_PromptBasedPolicy` — pass
- `go test ./server/internal/background/activities/risk_analysis/ -run 'PromptJudge|MessageType|FilteredMessages'` — pass
- `gcl` lint on changed Go packages — clean
- `pnpm -F dashboard lint` (oxfmt + oxlint + type-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open prompt-based risk policies to all message types so the LLM judge runs on whatever the policy declares, and polish the dashboard with an editable “Applies To” picker, a simpler judge-config, and accessible example chips.

- Realtime scanner and batch analyzer now judge any message type allowed by the policy’s `message_types`.
- Dashboard: editable `MessageTypesPicker` for prompt policies; new prompt policies default to all types; the list “Applies To” reflects the policy; prompt examples are compact chips with accessible selected state; “How this works” copy refreshed; replace “Data exfiltration” with “External data transfer”.
- Judge-config UI: model picker with a Recommended default; temperature slider with 0/1 end labels and ticks; Fail open on its own row; temperature and Fail open grouped in a bordered block.
- Enforcement: `user_message`/`tool_request`/`tool_response` enforce inline; `assistant_message` is flagged via batch until a realtime hook exists.
- Tests assert the judge runs on non-tool messages a policy applies to and skips types it excludes.
- Still gated behind the prompt-policies feature flag.

<sup>Written for commit 5126b5e84e60481f33276038c2c0295565ebfe21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


## Screenshots
<img width="511" height="1041" alt="image" src="https://github.com/user-attachments/assets/2b72d0e6-e2c1-4677-9bc2-2a5ddcf19a6d" />

<img width="1799" height="585" alt="image" src="https://github.com/user-attachments/assets/08d6faf6-ed0e-4ff5-9bf4-0fdd387415f4" />



