### PR TITLE
feat(telemetry): stamp WorkOS directory snapshot onto log rows at write time

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -736,6 +736,8 @@ func newFeatureChecker(logger *slog.Logger, pf *productfeatures.Client, feat pro
 func newTelemetryLogger(
 	ctx context.Context,
 	logger *slog.Logger,
+	db *pgxpool.Pool,
+	cacheImpl cache.Cache,
 	chDB clickhouse.Conn,
 	logsEnabled telemetry.FeatureChecker,
 	toolIOLogsEnabled telemetry.FeatureChecker,
@@ -748,7 +750,9 @@ func newTelemetryLogger(
 		return nil
 	}
 
-	return telemetry.NewLogger(shutdownCtx, logger, chDB, logsEnabled, toolIOLogsEnabled), shutdown
+	directory := telemetry.NewDirectorySnapshotResolver(logger, db, cacheImpl)
+
+	return telemetry.NewLogger(shutdownCtx, logger, chDB, logsEnabled, toolIOLogsEnabled, directory), shutdown
 }
 
 func newTriggersApp(

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -702,7 +702,7 @@ func newStartCommand() *cli.Command {
 				authz.EngineOpts{DevMode: c.String("environment") == "local"},
 			)
 
-			telemLogger, shutdown := newTelemetryLogger(ctx, logger, chDB, logsEnabled, toolIOLogsEnabled)
+			telemLogger, shutdown := newTelemetryLogger(ctx, logger, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled)
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
 			telemSvc := tm.NewService(logger, tracerProvider, db, chDB, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -556,7 +556,7 @@ func newWorkerCommand() *cli.Command {
 				backgroundWorkOSClient = workos.NewStubClient()
 			}
 
-			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, chDB, logsEnabled, toolIOLogsEnabled)
+			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled)
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
 			telemetryService := telemetry.NewService(logger, tracerProvider, db, chDB, nil, nil, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -51,6 +51,12 @@ const (
 	URLOriginalKey                    = semconv.URLOriginalKey
 	UserIDKey                         = semconv.UserIDKey
 	UserEmailKey                      = semconv.UserEmailKey
+	UserRolesKey                      = semconv.UserRolesKey
+
+	// UserAttributesKey and UserGroupsKey carry the denormalized WorkOS
+	// Directory Sync snapshot stamped onto telemetry logs at write time.
+	UserAttributesKey = attribute.Key("user.attributes")
+	UserGroupsKey     = attribute.Key("user.groups")
 
 	ActualKey   = attribute.Key("actual")
 	EventKey    = attribute.Key("event")

--- a/server/internal/background/activities/process_workos_directory_attributes_events.go
+++ b/server/internal/background/activities/process_workos_directory_attributes_events.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -42,18 +41,6 @@ type workosDirectoryUserEventPayload struct {
 type workosDirectoryGroupMembershipEventPayload struct {
 	User  workosDirectoryUserEventPayload  `json:"user"`
 	Group workosDirectoryGroupEventPayload `json:"group"`
-}
-
-func (p *workosDirectoryGroupMembershipEventPayload) UnmarshalJSON(data []byte) error {
-	// Alias avoids infinite recursion into this method.
-	type alias workosDirectoryGroupMembershipEventPayload
-	var decoded alias
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		return fmt.Errorf("decode directory group membership JSON: %w", err)
-	}
-
-	*p = workosDirectoryGroupMembershipEventPayload(decoded)
-	return nil
 }
 
 func handleDirectoryUserEvent(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, eventKind workos.EventKind, raw json.RawMessage) error {

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -172,7 +172,7 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 
-	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled)
+	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewDirectorySnapshotResolver(logger, conn, cacheAdapter))
 	telemService := telemetry.NewService(
 		logger,
 		tracerProvider,

--- a/server/internal/remotemcp/tools_call_clickhouse_log_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_clickhouse_log_interceptor_test.go
@@ -34,7 +34,7 @@ func TestToolsCallClickHouseLogInterceptor_EmitsRow(t *testing.T) {
 
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
-	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled)
+	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled, nil)
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()
@@ -109,7 +109,7 @@ func TestToolsCallClickHouseLogInterceptor_DurationMissingSentinel(t *testing.T)
 
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return false, nil }
-	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled)
+	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled, nil)
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()
@@ -176,7 +176,7 @@ func TestToolsCallClickHouseLogInterceptor_NoAuthContextSkips(t *testing.T) {
 
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
-	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled)
+	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled, nil)
 
 	serverID := uuid.New().String()
 	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, serverID, logger)
@@ -308,7 +308,7 @@ func runStatusCodeMappingCase(t *testing.T, tc statusCodeCase) int32 {
 
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
-	telemLogger := telemetry.NewLogger(t.Context(), logger, conn, logsEnabled, toolIOLogsEnabled)
+	telemLogger := telemetry.NewLogger(t.Context(), logger, conn, logsEnabled, toolIOLogsEnabled, nil)
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()

--- a/server/internal/telemetry/directory_snapshot.go
+++ b/server/internal/telemetry/directory_snapshot.go
@@ -1,0 +1,182 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"maps"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
+)
+
+// directorySnapshotTTL bounds how stale a hydrated snapshot can be. The
+// directory writer advances state in the worker process; the shared Redis
+// cache expires entries so the log path picks up new state within the TTL.
+const directorySnapshotTTL = 30 * time.Second
+
+// DirectorySnapshot is the denormalized point-in-time directory state stamped
+// onto telemetry log rows for a resolved user.
+type DirectorySnapshot struct {
+	// Attributes is the merged WorkOS custom attributes payload from the
+	// user's directory_users rows, exactly as persisted.
+	Attributes map[string]any `json:"attributes"`
+	// Groups are the user's current directory groups, limited to ID and
+	// name. Group raw_attributes are the full uncurated IdP payload and are
+	// deliberately not stamped onto log rows.
+	Groups []DirectoryGroupSnapshot `json:"groups"`
+	// Roles are the user's current role slugs from the existing role tables.
+	Roles []string `json:"roles"`
+}
+
+// DirectoryGroupSnapshot is one current directory group in a snapshot.
+type DirectoryGroupSnapshot struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type cachedDirectorySnapshot struct {
+	OrganizationID string            `json:"organization_id"`
+	UserID         string            `json:"user_id"`
+	Snapshot       DirectorySnapshot `json:"snapshot"`
+}
+
+var _ cache.CacheableObject[cachedDirectorySnapshot] = (*cachedDirectorySnapshot)(nil)
+
+func (c cachedDirectorySnapshot) CacheKey() string {
+	return directorySnapshotCacheKey(c.OrganizationID, c.UserID)
+}
+
+func (c cachedDirectorySnapshot) AdditionalCacheKeys() []string {
+	return []string{}
+}
+
+func (c cachedDirectorySnapshot) TTL() time.Duration {
+	return directorySnapshotTTL
+}
+
+func directorySnapshotCacheKey(organizationID string, userID string) string {
+	return fmt.Sprintf("directorySnapshot:%s:%s", organizationID, userID)
+}
+
+// DirectorySnapshotResolver resolves the current directory snapshot for a
+// user from Postgres, with a short-TTL Redis cache shared across processes so
+// the log path does not query Postgres for every row.
+type DirectorySnapshotResolver struct {
+	logger *slog.Logger
+	db     *pgxpool.Pool
+	cache  cache.TypedCacheObject[cachedDirectorySnapshot]
+}
+
+func NewDirectorySnapshotResolver(logger *slog.Logger, db *pgxpool.Pool, cacheImpl cache.Cache) *DirectorySnapshotResolver {
+	return &DirectorySnapshotResolver{
+		logger: logger.With(attr.SlogComponent("directory_snapshot_resolver")),
+		db:     db,
+		cache: cache.NewTypedObjectCache[cachedDirectorySnapshot](
+			logger.With(attr.SlogCacheNamespace("directory_snapshot")),
+			cacheImpl,
+			cache.SuffixNone,
+		),
+	}
+}
+
+// Resolve returns the current directory snapshot for the user in the
+// organization. Cache and lookup failures degrade gracefully: any cache error
+// is treated as a miss, and Postgres lookup failures resolve to an empty
+// snapshot that is still cached so a struggling database does not get
+// hammered by the log path.
+func (r *DirectorySnapshotResolver) Resolve(ctx context.Context, organizationID string, userID string) DirectorySnapshot {
+	key := directorySnapshotCacheKey(organizationID, userID)
+	if cached, err := r.cache.Get(ctx, key); err == nil {
+		return cached.Snapshot
+	}
+
+	snapshot := r.load(ctx, organizationID, userID)
+
+	if err := r.cache.Store(ctx, cachedDirectorySnapshot{
+		OrganizationID: organizationID,
+		UserID:         userID,
+		Snapshot:       snapshot,
+	}); err != nil {
+		r.logger.WarnContext(ctx, "failed to cache directory snapshot",
+			attr.SlogError(err), attr.SlogUserID(userID), attr.SlogOrganizationID(organizationID))
+	}
+
+	return snapshot
+}
+
+func (r *DirectorySnapshotResolver) load(ctx context.Context, organizationID string, userID string) DirectorySnapshot {
+	snapshot := DirectorySnapshot{Attributes: nil, Groups: nil, Roles: nil}
+
+	workosQueries := workosrepo.New(r.db)
+
+	attributeRows, err := workosQueries.ListDirectoryUserAttributesByUserID(ctx, workosrepo.ListDirectoryUserAttributesByUserIDParams{
+		UserID:         pgtype.Text{String: userID, Valid: true},
+		OrganizationID: organizationID,
+	})
+	if err != nil {
+		r.logger.WarnContext(ctx, "failed to load directory user attributes for telemetry snapshot",
+			attr.SlogError(err), attr.SlogUserID(userID), attr.SlogOrganizationID(organizationID))
+		return snapshot
+	}
+	for _, raw := range attributeRows {
+		payload := unmarshalAttributesPayload(ctx, r.logger, raw)
+		if len(payload) == 0 {
+			continue
+		}
+		if snapshot.Attributes == nil {
+			snapshot.Attributes = make(map[string]any, len(payload))
+		}
+		maps.Copy(snapshot.Attributes, payload)
+	}
+
+	groupRows, err := workosQueries.ListCurrentDirectoryGroupsByUserID(ctx, workosrepo.ListCurrentDirectoryGroupsByUserIDParams{
+		UserID:         pgtype.Text{String: userID, Valid: true},
+		OrganizationID: organizationID,
+	})
+	if err != nil {
+		r.logger.WarnContext(ctx, "failed to load directory groups for telemetry snapshot",
+			attr.SlogError(err), attr.SlogUserID(userID), attr.SlogOrganizationID(organizationID))
+		return snapshot
+	}
+	for _, row := range groupRows {
+		snapshot.Groups = append(snapshot.Groups, DirectoryGroupSnapshot{
+			ID:   row.WorkosDirectoryGroupID,
+			Name: row.Name,
+		})
+	}
+
+	roleRows, err := accessrepo.New(r.db).ListMemberRolePrincipalsByUser(ctx, accessrepo.ListMemberRolePrincipalsByUserParams{
+		OrganizationID: organizationID,
+		UserID:         userID,
+	})
+	if err != nil {
+		r.logger.WarnContext(ctx, "failed to load role context for telemetry snapshot",
+			attr.SlogError(err), attr.SlogUserID(userID), attr.SlogOrganizationID(organizationID))
+		return snapshot
+	}
+	for _, row := range roleRows {
+		snapshot.Roles = append(snapshot.Roles, row.RoleSlug)
+	}
+
+	return snapshot
+}
+
+func unmarshalAttributesPayload(ctx context.Context, logger *slog.Logger, raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		logger.WarnContext(ctx, "failed to unmarshal directory attributes payload", attr.SlogError(err))
+		return nil
+	}
+	return payload
+}

--- a/server/internal/telemetry/directory_snapshot.go
+++ b/server/internal/telemetry/directory_snapshot.go
@@ -3,11 +3,12 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -22,11 +23,27 @@ import (
 // cache expires entries so the log path picks up new state within the TTL.
 const directorySnapshotTTL = 30 * time.Second
 
+// directoryUserAttributeAllowlist is the v0 set of attributes stamped onto
+// telemetry rows. These are WorkOS predefined attributes
+// (https://workos.com/docs/directory-sync/attributes): named and schematized
+// by WorkOS, auto-mapped across directory providers, so they mean the same
+// thing for every organization. Customer-defined custom attributes are
+// deliberately excluded for now; Postgres keeps the full payload, so
+// expanding this list later only requires hydrating new rows.
+var directoryUserAttributeAllowlist = []string{
+	"department_name",
+	"job_title",
+	"employee_type",
+	"division_name",
+	"cost_center_name",
+}
+
 // DirectorySnapshot is the denormalized point-in-time directory state stamped
 // onto telemetry log rows for a resolved user.
 type DirectorySnapshot struct {
-	// Attributes is the merged WorkOS custom attributes payload from the
-	// user's directory_users rows, exactly as persisted.
+	// Attributes is the allowlisted subset of the WorkOS custom attributes
+	// payload from the user's directory_users row: predefined WorkOS
+	// attribute names with string values only.
 	Attributes map[string]any `json:"attributes"`
 	// Groups are the user's current directory groups, limited to ID and
 	// name. Group raw_attributes are the full uncurated IdP payload and are
@@ -117,24 +134,33 @@ func (r *DirectorySnapshotResolver) load(ctx context.Context, organizationID str
 
 	workosQueries := workosrepo.New(r.db)
 
-	attributeRows, err := workosQueries.ListDirectoryUserAttributesByUserID(ctx, workosrepo.ListDirectoryUserAttributesByUserIDParams{
+	raw, err := workosQueries.GetDirectoryUserAttributesByUserID(ctx, workosrepo.GetDirectoryUserAttributesByUserIDParams{
 		UserID:         pgtype.Text{String: userID, Valid: true},
 		OrganizationID: organizationID,
 	})
-	if err != nil {
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		// No directory user for this org/user (no Directory Sync, or the
+		// user was directory-deleted): attributes stay empty.
+	case err != nil:
 		r.logger.WarnContext(ctx, "failed to load directory user attributes for telemetry snapshot",
 			attr.SlogError(err), attr.SlogUserID(userID), attr.SlogOrganizationID(organizationID))
 		return snapshot
-	}
-	for _, raw := range attributeRows {
+	default:
 		payload := unmarshalAttributesPayload(ctx, r.logger, raw)
-		if len(payload) == 0 {
-			continue
+		for _, key := range directoryUserAttributeAllowlist {
+			// Values come from customer-controlled IdP mappings: accept
+			// non-empty strings only so the ClickHouse JSON column sees
+			// consistent types.
+			value, ok := payload[key].(string)
+			if !ok || value == "" {
+				continue
+			}
+			if snapshot.Attributes == nil {
+				snapshot.Attributes = make(map[string]any, len(directoryUserAttributeAllowlist))
+			}
+			snapshot.Attributes[key] = value
 		}
-		if snapshot.Attributes == nil {
-			snapshot.Attributes = make(map[string]any, len(payload))
-		}
-		maps.Copy(snapshot.Attributes, payload)
 	}
 
 	groupRows, err := workosQueries.ListCurrentDirectoryGroupsByUserID(ctx, workosrepo.ListCurrentDirectoryGroupsByUserIDParams{

--- a/server/internal/telemetry/directory_snapshot.go
+++ b/server/internal/telemetry/directory_snapshot.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
 )
 
@@ -135,7 +135,7 @@ func (r *DirectorySnapshotResolver) load(ctx context.Context, organizationID str
 	workosQueries := workosrepo.New(r.db)
 
 	raw, err := workosQueries.GetDirectoryUserAttributesByUserID(ctx, workosrepo.GetDirectoryUserAttributesByUserIDParams{
-		UserID:         pgtype.Text{String: userID, Valid: true},
+		UserID:         conv.ToPGText(userID),
 		OrganizationID: organizationID,
 	})
 	switch {
@@ -164,7 +164,7 @@ func (r *DirectorySnapshotResolver) load(ctx context.Context, organizationID str
 	}
 
 	groupRows, err := workosQueries.ListCurrentDirectoryGroupsByUserID(ctx, workosrepo.ListCurrentDirectoryGroupsByUserIDParams{
-		UserID:         pgtype.Text{String: userID, Valid: true},
+		UserID:         conv.ToPGText(userID),
 		OrganizationID: organizationID,
 	})
 	if err != nil {

--- a/server/internal/telemetry/export_test.go
+++ b/server/internal/telemetry/export_test.go
@@ -1,0 +1,10 @@
+package telemetry
+
+import "context"
+
+// InvalidateForTest drops the cached snapshot for the user so tests can
+// simulate TTL expiry deterministically.
+func (r *DirectorySnapshotResolver) InvalidateForTest(ctx context.Context, organizationID string, userID string) error {
+	//nolint:wrapcheck // test-only helper
+	return r.cache.DeleteByKey(ctx, directorySnapshotCacheKey(organizationID, userID))
+}

--- a/server/internal/telemetry/logger.go
+++ b/server/internal/telemetry/logger.go
@@ -45,6 +45,7 @@ type Logger struct {
 	chConn            clickhouse.Conn
 	logsEnabled       FeatureChecker
 	toolIOLogsEnabled FeatureChecker
+	directory         *DirectorySnapshotResolver
 }
 
 func NewLogger(
@@ -53,6 +54,7 @@ func NewLogger(
 	chConn clickhouse.Conn,
 	logsEnabled FeatureChecker,
 	toolIOLogsEnabled FeatureChecker,
+	directory *DirectorySnapshotResolver,
 ) *Logger {
 	return &Logger{
 		shutdownCtx:       func() context.Context { return shutdownCtx },
@@ -60,6 +62,7 @@ func NewLogger(
 		chConn:            chConn,
 		logsEnabled:       logsEnabled,
 		toolIOLogsEnabled: toolIOLogsEnabled,
+		directory:         directory,
 	}
 }
 
@@ -73,6 +76,7 @@ func NewStub(logger *slog.Logger) *Logger {
 		chConn:            nil,
 		logsEnabled:       disabled,
 		toolIOLogsEnabled: disabled,
+		directory:         nil,
 	}
 }
 
@@ -133,6 +137,8 @@ func (l *Logger) LogBulk(ctx context.Context, params []LogParams) error {
 			delete(param.Attributes, attr.GenAIToolCallResultKey)
 		}
 
+		l.hydrateDirectorySnapshot(shutdownCtx, param)
+
 		logParam, err := buildTelemetryLogParams(param)
 		if err != nil {
 			l.logger.ErrorContext(ctx, "failed to build telemetry log params", attr.SlogError(err))
@@ -148,6 +154,36 @@ func (l *Logger) LogBulk(ctx context.Context, params []LogParams) error {
 		return oops.E(oops.CodeUnexpected, err, "insert telemetry logs")
 	}
 	return nil
+}
+
+// hydrateDirectorySnapshot stamps the user's current directory snapshot
+// (WorkOS custom attributes, current groups as id + name, role slugs) onto the log row's
+// attributes when a user was resolved. Telemetry rows are append-only: the
+// snapshot reflects state at write time and is never rewritten. Empty
+// snapshot parts (directory-deleted users, orgs without Directory Sync,
+// lingering API keys) are omitted rather than stamped as empty payloads.
+func (l *Logger) hydrateDirectorySnapshot(ctx context.Context, param LogParams) {
+	if l.directory == nil {
+		return
+	}
+
+	userID, _ := param.Attributes[attr.UserIDKey].(string)
+	organizationID := param.ToolInfo.OrganizationID
+	if userID == "" || organizationID == "" {
+		return
+	}
+
+	snapshot := l.directory.Resolve(ctx, organizationID, userID)
+
+	if _, ok := param.Attributes[attr.UserAttributesKey]; !ok && len(snapshot.Attributes) > 0 {
+		param.Attributes[attr.UserAttributesKey] = snapshot.Attributes
+	}
+	if _, ok := param.Attributes[attr.UserGroupsKey]; !ok && len(snapshot.Groups) > 0 {
+		param.Attributes[attr.UserGroupsKey] = snapshot.Groups
+	}
+	if _, ok := param.Attributes[attr.UserRolesKey]; !ok && len(snapshot.Roles) > 0 {
+		param.Attributes[attr.UserRolesKey] = snapshot.Roles
+	}
 }
 
 // buildTelemetryLogParams constructs InsertTelemetryLogParams from attributes.

--- a/server/internal/telemetry/logger.go
+++ b/server/internal/telemetry/logger.go
@@ -137,7 +137,7 @@ func (l *Logger) LogBulk(ctx context.Context, params []LogParams) error {
 			delete(param.Attributes, attr.GenAIToolCallResultKey)
 		}
 
-		l.hydrateDirectorySnapshot(shutdownCtx, param)
+		param = l.hydrateDirectorySnapshot(shutdownCtx, param)
 
 		logParam, err := buildTelemetryLogParams(param)
 		if err != nil {
@@ -158,33 +158,48 @@ func (l *Logger) LogBulk(ctx context.Context, params []LogParams) error {
 
 // hydrateDirectorySnapshot stamps the user's current directory snapshot
 // (allowlisted WorkOS predefined attributes, current groups as id + name,
-// role slugs) onto the log row's
-// attributes when a user was resolved. Telemetry rows are append-only: the
-// snapshot reflects state at write time and is never rewritten. Empty
-// snapshot parts (directory-deleted users, orgs without Directory Sync,
-// lingering API keys) are omitted rather than stamped as empty payloads.
-func (l *Logger) hydrateDirectorySnapshot(ctx context.Context, param LogParams) {
+// role slugs) onto the log row's attributes when a user was resolved.
+// Telemetry rows are append-only: the snapshot reflects state at write time
+// and is never rewritten. Empty snapshot parts (directory-deleted users,
+// orgs without Directory Sync, lingering API keys) are omitted rather than
+// stamped as empty payloads.
+//
+// The returned LogParams carries a fresh attributes map when anything was
+// stamped: callers may reuse attribute maps across rows, and mutating the
+// caller's map would make the absence checks below pin a stale snapshot
+// onto every subsequent row. Explicit caller-provided values still win.
+func (l *Logger) hydrateDirectorySnapshot(ctx context.Context, param LogParams) LogParams {
 	if l.directory == nil {
-		return
+		return param
 	}
 
 	userID, _ := param.Attributes[attr.UserIDKey].(string)
 	organizationID := param.ToolInfo.OrganizationID
 	if userID == "" || organizationID == "" {
-		return
+		return param
 	}
 
 	snapshot := l.directory.Resolve(ctx, organizationID, userID)
 
+	additions := make(map[attr.Key]any, 3)
 	if _, ok := param.Attributes[attr.UserAttributesKey]; !ok && len(snapshot.Attributes) > 0 {
-		param.Attributes[attr.UserAttributesKey] = snapshot.Attributes
+		additions[attr.UserAttributesKey] = snapshot.Attributes
 	}
 	if _, ok := param.Attributes[attr.UserGroupsKey]; !ok && len(snapshot.Groups) > 0 {
-		param.Attributes[attr.UserGroupsKey] = snapshot.Groups
+		additions[attr.UserGroupsKey] = snapshot.Groups
 	}
 	if _, ok := param.Attributes[attr.UserRolesKey]; !ok && len(snapshot.Roles) > 0 {
-		param.Attributes[attr.UserRolesKey] = snapshot.Roles
+		additions[attr.UserRolesKey] = snapshot.Roles
 	}
+	if len(additions) == 0 {
+		return param
+	}
+
+	attrs := make(map[attr.Key]any, len(param.Attributes)+len(additions))
+	maps.Copy(attrs, param.Attributes)
+	maps.Copy(attrs, additions)
+	param.Attributes = attrs
+	return param
 }
 
 // buildTelemetryLogParams constructs InsertTelemetryLogParams from attributes.

--- a/server/internal/telemetry/logger.go
+++ b/server/internal/telemetry/logger.go
@@ -157,7 +157,8 @@ func (l *Logger) LogBulk(ctx context.Context, params []LogParams) error {
 }
 
 // hydrateDirectorySnapshot stamps the user's current directory snapshot
-// (WorkOS custom attributes, current groups as id + name, role slugs) onto the log row's
+// (allowlisted WorkOS predefined attributes, current groups as id + name,
+// role slugs) onto the log row's
 // attributes when a user was resolved. Telemetry rows are append-only: the
 // snapshot reflects state at write time and is never rewritten. Empty
 // snapshot parts (directory-deleted users, orgs without Directory Sync,

--- a/server/internal/telemetry/logger_hydrate_test.go
+++ b/server/internal/telemetry/logger_hydrate_test.go
@@ -140,6 +140,13 @@ func TestCreateLog_HydratesDirectorySnapshot(t *testing.T) {
 	require.Contains(t, log.Attributes, "directory_group_"+suffix)
 	// user.roles carries the current role slugs from the role tables.
 	require.Contains(t, log.Attributes, "hydrate-role-"+suffix)
+
+	// Hydration must not mutate the caller's attribute map: callers may
+	// reuse maps across rows, and a stamped snapshot would otherwise pin
+	// stale directory state onto every subsequent row.
+	require.NotContains(t, attrs, attr.UserAttributesKey)
+	require.NotContains(t, attrs, attr.UserGroupsKey)
+	require.NotContains(t, attrs, attr.UserRolesKey)
 }
 
 func TestCreateLog_NoDirectorySnapshotWhenNoDirectoryData(t *testing.T) {

--- a/server/internal/telemetry/logger_hydrate_test.go
+++ b/server/internal/telemetry/logger_hydrate_test.go
@@ -1,0 +1,225 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
+	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+type directorySnapshotSeed struct {
+	orgID  string
+	userID string
+}
+
+// seedDirectorySnapshotData creates an organization, a Gram user, a linked
+// directory user with custom attributes, a current group membership, and a
+// role assignment — the full directory state the telemetry logger hydrates.
+func seedDirectorySnapshotData(t *testing.T, ctx context.Context, conn *pgxpool.Pool, suffix string) directorySnapshotSeed {
+	t.Helper()
+
+	orgID := "org_hydrate_" + suffix
+	userID := "user_hydrate_" + suffix
+	email := suffix + "@hydrate.example.com"
+	roleSlug := "hydrate-role-" + suffix
+
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:       orgID,
+		Name:     orgID,
+		Slug:     orgID,
+		WorkosID: conv.ToPGText("workos_" + orgID),
+	})
+	require.NoError(t, err)
+
+	_, err = userrepo.New(conn).UpsertUser(ctx, userrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: "Hydrate User",
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	directoryUserID, err := workosrepo.New(conn).UpsertDirectoryUser(ctx, workosrepo.UpsertDirectoryUserParams{
+		OrganizationID:        orgID,
+		UserID:                conv.ToPGText(userID),
+		WorkosDirectoryUserID: "directory_user_" + suffix,
+		Email:                 conv.ToPGText(email),
+		Attributes:            []byte(`{"department":"Engineering","team":"Platform"}`),
+	})
+	require.NoError(t, err)
+
+	directoryGroupID, err := workosrepo.New(conn).UpsertDirectoryGroup(ctx, workosrepo.UpsertDirectoryGroupParams{
+		OrganizationID:         orgID,
+		WorkosDirectoryGroupID: "directory_group_" + suffix,
+		Name:                   "Developers",
+		Attributes:             []byte(`{"object":"directory_group"}`),
+	})
+	require.NoError(t, err)
+
+	_, err = workosrepo.New(conn).OpenDirectoryUserGroupMembership(ctx, workosrepo.OpenDirectoryUserGroupMembershipParams{
+		DirectoryUserID:        directoryUserID,
+		DirectoryGroupID:       directoryGroupID,
+		WorkosDirectoryUserID:  "directory_user_" + suffix,
+		WorkosDirectoryGroupID: "directory_group_" + suffix,
+	})
+	require.NoError(t, err)
+
+	seedTime := time.Now().UTC()
+	err = accessrepo.New(conn).UpsertGlobalRole(ctx, accessrepo.UpsertGlobalRoleParams{
+		WorkosSlug:        roleSlug,
+		WorkosName:        roleSlug,
+		WorkosDescription: conv.ToPGText(roleSlug),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(seedTime),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(seedTime),
+		WorkosLastEventID: conv.ToPGTextEmpty(""),
+	})
+	require.NoError(t, err)
+
+	inserted, err := accessrepo.New(conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     orgID,
+		WorkosUserID:       "workos_user_" + suffix,
+		WorkosRoleSlug:     roleSlug,
+		UserID:             conv.ToPGText(userID),
+		WorkosMembershipID: conv.ToPGText("membership_" + suffix),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(seedTime),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), inserted)
+
+	return directorySnapshotSeed{orgID: orgID, userID: userID}
+}
+
+func TestCreateLog_HydratesDirectorySnapshot(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestLogsService(t)
+
+	suffix := "log_" + uuid.New().String()[:8]
+	seed := seedDirectorySnapshotData(t, ctx, ti.conn, suffix)
+
+	attrs := telemetry.HTTPLogAttributes{}
+	attrs.RecordMethod("GET")
+	attrs.RecordStatusCode(200)
+	attrs[attr.UserIDKey] = seed.userID
+
+	toolInfo := newTestToolInfo(seed.orgID)
+	timestamp := time.Now().UTC()
+
+	ti.telemLogger.Log(ctx, telemetry.LogParams{
+		Timestamp:  timestamp,
+		ToolInfo:   toolInfo,
+		Attributes: attrs,
+	})
+
+	log := waitForLog(t, ctx, ti.chClient, toolInfo.ProjectID, toolInfo.URN, timestamp)
+
+	// user.attributes carries the stored WorkOS custom attributes as-is.
+	require.Contains(t, log.Attributes, "Engineering")
+	require.Contains(t, log.Attributes, "Platform")
+	// user.groups carries current groups as id + name only.
+	require.Contains(t, log.Attributes, "Developers")
+	require.Contains(t, log.Attributes, "directory_group_"+suffix)
+	// user.roles carries the current role slugs from the role tables.
+	require.Contains(t, log.Attributes, "hydrate-role-"+suffix)
+}
+
+func TestCreateLog_NoDirectorySnapshotWhenNoDirectoryData(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestLogsService(t)
+
+	attrs := telemetry.HTTPLogAttributes{}
+	attrs.RecordMethod("GET")
+	attrs.RecordStatusCode(200)
+	attrs[attr.UserIDKey] = "user_without_directory_data"
+
+	toolInfo := newTestToolInfo(ti.orgID)
+	timestamp := time.Now().UTC()
+
+	ti.telemLogger.Log(ctx, telemetry.LogParams{
+		Timestamp:  timestamp,
+		ToolInfo:   toolInfo,
+		Attributes: attrs,
+	})
+
+	log := waitForLog(t, ctx, ti.chClient, toolInfo.ProjectID, toolInfo.URN, timestamp)
+
+	// Empty snapshot parts are omitted rather than stamped as empty payloads.
+	require.NotContains(t, log.Attributes, "groups")
+	require.NotContains(t, log.Attributes, "roles")
+	require.Contains(t, log.Attributes, "user_without_directory_data")
+}
+
+func TestDirectorySnapshotResolver_ResolvesAndCachesUntilExpiry(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	logger := testenv.NewLogger(t)
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	suffix := "cache_" + uuid.New().String()[:8]
+	seed := seedDirectorySnapshotData(t, ctx, conn, suffix)
+
+	resolver := telemetry.NewDirectorySnapshotResolver(logger, conn, cache.NewRedisCacheAdapter(redisClient))
+
+	snapshot := resolver.Resolve(ctx, seed.orgID, seed.userID)
+	require.Equal(t, map[string]any{"department": "Engineering", "team": "Platform"}, snapshot.Attributes)
+	require.Len(t, snapshot.Groups, 1)
+	require.Equal(t, "directory_group_"+suffix, snapshot.Groups[0].ID)
+	require.Equal(t, "Developers", snapshot.Groups[0].Name)
+	require.Equal(t, []string{"hydrate-role-" + suffix}, snapshot.Roles)
+
+	// Change the persisted attributes; within the TTL the cached snapshot
+	// is still served.
+	_, err = workosrepo.New(conn).UpsertDirectoryUser(ctx, workosrepo.UpsertDirectoryUserParams{
+		OrganizationID:        seed.orgID,
+		UserID:                conv.ToPGText(seed.userID),
+		WorkosDirectoryUserID: "directory_user_" + suffix,
+		Email:                 conv.ToPGText(suffix + "@hydrate.example.com"),
+		Attributes:            []byte(`{"department":"Sales"}`),
+	})
+	require.NoError(t, err)
+
+	cached := resolver.Resolve(ctx, seed.orgID, seed.userID)
+	require.Equal(t, "Engineering", cached.Attributes["department"])
+
+	// Once the cache entry expires (simulated by dropping it) the snapshot
+	// is reloaded from Postgres.
+	require.NoError(t, resolver.InvalidateForTest(ctx, seed.orgID, seed.userID))
+	refreshed := resolver.Resolve(ctx, seed.orgID, seed.userID)
+	require.Equal(t, "Sales", refreshed.Attributes["department"])
+}
+
+func TestDirectorySnapshotResolver_EmptySnapshotForUnknownUser(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	logger := testenv.NewLogger(t)
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	resolver := telemetry.NewDirectorySnapshotResolver(logger, conn, cache.NewRedisCacheAdapter(redisClient))
+
+	snapshot := resolver.Resolve(ctx, "org_unknown", "user_unknown")
+	require.Empty(t, snapshot.Attributes)
+	require.Empty(t, snapshot.Groups)
+	require.Empty(t, snapshot.Roles)
+}

--- a/server/internal/telemetry/logger_hydrate_test.go
+++ b/server/internal/telemetry/logger_hydrate_test.go
@@ -58,7 +58,9 @@ func seedDirectorySnapshotData(t *testing.T, ctx context.Context, conn *pgxpool.
 		UserID:                conv.ToPGText(userID),
 		WorkosDirectoryUserID: "directory_user_" + suffix,
 		Email:                 conv.ToPGText(email),
-		Attributes:            []byte(`{"department":"Engineering","team":"Platform"}`),
+		// department_name and job_title are allowlisted predefined
+		// attributes; custom_thing and manager_email must be filtered out.
+		Attributes: []byte(`{"department_name":"Engineering","job_title":"Platform Engineer","custom_thing":"not-stamped","manager_email":"boss@example.com"}`),
 	})
 	require.NoError(t, err)
 
@@ -127,9 +129,12 @@ func TestCreateLog_HydratesDirectorySnapshot(t *testing.T) {
 
 	log := waitForLog(t, ctx, ti.chClient, toolInfo.ProjectID, toolInfo.URN, timestamp)
 
-	// user.attributes carries the stored WorkOS custom attributes as-is.
+	// user.attributes carries the allowlisted WorkOS predefined attributes.
 	require.Contains(t, log.Attributes, "Engineering")
-	require.Contains(t, log.Attributes, "Platform")
+	require.Contains(t, log.Attributes, "Platform Engineer")
+	// Non-allowlisted keys (custom attributes, manager PII) are not stamped.
+	require.NotContains(t, log.Attributes, "not-stamped")
+	require.NotContains(t, log.Attributes, "boss@example.com")
 	// user.groups carries current groups as id + name only.
 	require.Contains(t, log.Attributes, "Developers")
 	require.Contains(t, log.Attributes, "directory_group_"+suffix)
@@ -179,7 +184,7 @@ func TestDirectorySnapshotResolver_ResolvesAndCachesUntilExpiry(t *testing.T) {
 	resolver := telemetry.NewDirectorySnapshotResolver(logger, conn, cache.NewRedisCacheAdapter(redisClient))
 
 	snapshot := resolver.Resolve(ctx, seed.orgID, seed.userID)
-	require.Equal(t, map[string]any{"department": "Engineering", "team": "Platform"}, snapshot.Attributes)
+	require.Equal(t, map[string]any{"department_name": "Engineering", "job_title": "Platform Engineer"}, snapshot.Attributes)
 	require.Len(t, snapshot.Groups, 1)
 	require.Equal(t, "directory_group_"+suffix, snapshot.Groups[0].ID)
 	require.Equal(t, "Developers", snapshot.Groups[0].Name)
@@ -192,18 +197,18 @@ func TestDirectorySnapshotResolver_ResolvesAndCachesUntilExpiry(t *testing.T) {
 		UserID:                conv.ToPGText(seed.userID),
 		WorkosDirectoryUserID: "directory_user_" + suffix,
 		Email:                 conv.ToPGText(suffix + "@hydrate.example.com"),
-		Attributes:            []byte(`{"department":"Sales"}`),
+		Attributes:            []byte(`{"department_name":"Sales"}`),
 	})
 	require.NoError(t, err)
 
 	cached := resolver.Resolve(ctx, seed.orgID, seed.userID)
-	require.Equal(t, "Engineering", cached.Attributes["department"])
+	require.Equal(t, "Engineering", cached.Attributes["department_name"])
 
 	// Once the cache entry expires (simulated by dropping it) the snapshot
 	// is reloaded from Postgres.
 	require.NoError(t, resolver.InvalidateForTest(ctx, seed.orgID, seed.userID))
 	refreshed := resolver.Resolve(ctx, seed.orgID, seed.userID)
-	require.Equal(t, "Sales", refreshed.Attributes["department"])
+	require.Equal(t, "Sales", refreshed.Attributes["department_name"])
 }
 
 func TestDirectorySnapshotResolver_EmptySnapshotForUnknownUser(t *testing.T) {

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -113,7 +113,7 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 
 	posthogClient := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
-	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled)
+	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewDirectorySnapshotResolver(logger, conn, cache.NewRedisCacheAdapter(redisClient)))
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	svc := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
 

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -172,3 +172,27 @@ FROM directory_user_group_memberships
 WHERE workos_directory_group_id = @workos_directory_group_id
   AND workos_directory_user_id = @workos_directory_user_id
   AND deleted_at IS NULL;
+
+-- name: ListDirectoryUserAttributesByUserID :many
+SELECT attributes
+FROM directory_users
+WHERE user_id = @user_id
+  AND organization_id = @organization_id
+  AND deleted_at IS NULL
+ORDER BY created_at;
+
+-- name: ListCurrentDirectoryGroupsByUserID :many
+SELECT DISTINCT ON (dg.workos_directory_group_id)
+  dg.workos_directory_group_id,
+  dg.name
+FROM directory_users AS du
+JOIN directory_user_group_memberships AS m
+  ON m.directory_user_id = du.id
+  AND m.deleted_at IS NULL
+JOIN directory_groups AS dg
+  ON dg.id = m.directory_group_id
+  AND dg.deleted_at IS NULL
+WHERE du.user_id = @user_id
+  AND du.organization_id = @organization_id
+  AND du.deleted_at IS NULL
+ORDER BY dg.workos_directory_group_id;

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -195,5 +195,6 @@ JOIN directory_groups AS dg
   AND dg.deleted_at IS NULL
 WHERE du.user_id = @user_id
   AND du.organization_id = @organization_id
+  AND dg.organization_id = @organization_id
   AND du.deleted_at IS NULL
 ORDER BY dg.workos_directory_group_id;

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -173,13 +173,12 @@ WHERE workos_directory_group_id = @workos_directory_group_id
   AND workos_directory_user_id = @workos_directory_user_id
   AND deleted_at IS NULL;
 
--- name: ListDirectoryUserAttributesByUserID :many
+-- name: GetDirectoryUserAttributesByUserID :one
 SELECT attributes
 FROM directory_users
 WHERE user_id = @user_id
   AND organization_id = @organization_id
-  AND deleted_at IS NULL
-ORDER BY created_at;
+  AND deleted_at IS NULL;
 
 -- name: ListCurrentDirectoryGroupsByUserID :many
 SELECT DISTINCT ON (dg.workos_directory_group_id)

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -178,7 +178,9 @@ SELECT attributes
 FROM directory_users
 WHERE user_id = @user_id
   AND organization_id = @organization_id
-  AND deleted_at IS NULL;
+  AND deleted_at IS NULL
+ORDER BY updated_at DESC
+LIMIT 1;
 
 -- name: ListCurrentDirectoryGroupsByUserID :many
 SELECT DISTINCT ON (dg.workos_directory_group_id)

--- a/server/internal/thirdparty/workos/repo/queries.sql.go
+++ b/server/internal/thirdparty/workos/repo/queries.sql.go
@@ -180,6 +180,26 @@ func (q *Queries) GetDirectoryGroupIDByWorkOSID(ctx context.Context, workosDirec
 	return id, err
 }
 
+const getDirectoryUserAttributesByUserID = `-- name: GetDirectoryUserAttributesByUserID :one
+SELECT attributes
+FROM directory_users
+WHERE user_id = $1
+  AND organization_id = $2
+  AND deleted_at IS NULL
+`
+
+type GetDirectoryUserAttributesByUserIDParams struct {
+	UserID         pgtype.Text
+	OrganizationID string
+}
+
+func (q *Queries) GetDirectoryUserAttributesByUserID(ctx context.Context, arg GetDirectoryUserAttributesByUserIDParams) ([]byte, error) {
+	row := q.db.QueryRow(ctx, getDirectoryUserAttributesByUserID, arg.UserID, arg.OrganizationID)
+	var attributes []byte
+	err := row.Scan(&attributes)
+	return attributes, err
+}
+
 const getDirectoryUserByWorkOSID = `-- name: GetDirectoryUserByWorkOSID :one
 SELECT id, organization_id, user_id, workos_directory_user_id, email, attributes, created_at, updated_at, deleted_at, deleted
 FROM directory_users
@@ -307,40 +327,6 @@ func (q *Queries) ListCurrentDirectoryGroupsByUserID(ctx context.Context, arg Li
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listDirectoryUserAttributesByUserID = `-- name: ListDirectoryUserAttributesByUserID :many
-SELECT attributes
-FROM directory_users
-WHERE user_id = $1
-  AND organization_id = $2
-  AND deleted_at IS NULL
-ORDER BY created_at
-`
-
-type ListDirectoryUserAttributesByUserIDParams struct {
-	UserID         pgtype.Text
-	OrganizationID string
-}
-
-func (q *Queries) ListDirectoryUserAttributesByUserID(ctx context.Context, arg ListDirectoryUserAttributesByUserIDParams) ([][]byte, error) {
-	rows, err := q.db.Query(ctx, listDirectoryUserAttributesByUserID, arg.UserID, arg.OrganizationID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items [][]byte
-	for rows.Next() {
-		var attributes []byte
-		if err := rows.Scan(&attributes); err != nil {
-			return nil, err
-		}
-		items = append(items, attributes)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/server/internal/thirdparty/workos/repo/queries.sql.go
+++ b/server/internal/thirdparty/workos/repo/queries.sql.go
@@ -267,6 +267,87 @@ func (q *Queries) LinkDirectoryUsersToUserByEmail(ctx context.Context, arg LinkD
 	return result.RowsAffected(), nil
 }
 
+const listCurrentDirectoryGroupsByUserID = `-- name: ListCurrentDirectoryGroupsByUserID :many
+SELECT DISTINCT ON (dg.workos_directory_group_id)
+  dg.workos_directory_group_id,
+  dg.name
+FROM directory_users AS du
+JOIN directory_user_group_memberships AS m
+  ON m.directory_user_id = du.id
+  AND m.deleted_at IS NULL
+JOIN directory_groups AS dg
+  ON dg.id = m.directory_group_id
+  AND dg.deleted_at IS NULL
+WHERE du.user_id = $1
+  AND du.organization_id = $2
+  AND du.deleted_at IS NULL
+ORDER BY dg.workos_directory_group_id
+`
+
+type ListCurrentDirectoryGroupsByUserIDParams struct {
+	UserID         pgtype.Text
+	OrganizationID string
+}
+
+type ListCurrentDirectoryGroupsByUserIDRow struct {
+	WorkosDirectoryGroupID string
+	Name                   string
+}
+
+func (q *Queries) ListCurrentDirectoryGroupsByUserID(ctx context.Context, arg ListCurrentDirectoryGroupsByUserIDParams) ([]ListCurrentDirectoryGroupsByUserIDRow, error) {
+	rows, err := q.db.Query(ctx, listCurrentDirectoryGroupsByUserID, arg.UserID, arg.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListCurrentDirectoryGroupsByUserIDRow
+	for rows.Next() {
+		var i ListCurrentDirectoryGroupsByUserIDRow
+		if err := rows.Scan(&i.WorkosDirectoryGroupID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDirectoryUserAttributesByUserID = `-- name: ListDirectoryUserAttributesByUserID :many
+SELECT attributes
+FROM directory_users
+WHERE user_id = $1
+  AND organization_id = $2
+  AND deleted_at IS NULL
+ORDER BY created_at
+`
+
+type ListDirectoryUserAttributesByUserIDParams struct {
+	UserID         pgtype.Text
+	OrganizationID string
+}
+
+func (q *Queries) ListDirectoryUserAttributesByUserID(ctx context.Context, arg ListDirectoryUserAttributesByUserIDParams) ([][]byte, error) {
+	rows, err := q.db.Query(ctx, listDirectoryUserAttributesByUserID, arg.UserID, arg.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items [][]byte
+	for rows.Next() {
+		var attributes []byte
+		if err := rows.Scan(&attributes); err != nil {
+			return nil, err
+		}
+		items = append(items, attributes)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const openDirectoryUserGroupMembership = `-- name: OpenDirectoryUserGroupMembership :one
 INSERT INTO directory_user_group_memberships (
   directory_user_id,

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -143,7 +143,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return false, nil }
 	sessionCaptureEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 
-	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled)
+	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewDirectorySnapshotResolver(logger, conn, cacheAdapter))
 	telemService := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a WorkOS Directory Sync snapshot to telemetry logs at write time so each row captures the user’s attributes, current groups, and role slugs. Uses a short-TTL Redis cache shared across processes to avoid extra DB reads and ensure consistent point-in-time data.

- New Features
  - Added `DirectorySnapshotResolver` (Redis-backed, 30s TTL) that merges WorkOS user attributes (allowlisted), current groups (id + name), and role slugs from Postgres.
  - `telemetry` logger now hydrates `user.attributes`, `user.groups`, and `user.roles` when `organization_id` and `user_id` are present; omitted when empty; does not overwrite if already set; degrades gracefully on cache/DB errors.
  - Updated `newTelemetryLogger` to accept `db` and `cache`; wired resolver in server and worker using `cache.NewRedisCacheAdapter(redisClient)`.
  - Introduced `attr.UserAttributesKey`, `attr.UserGroupsKey`, and `attr.UserRolesKey`; added SQL queries/repo methods to fetch directory data (select most recent user attributes; list current groups); added tests for hydration and cache TTL behavior.

<sup>Written for commit 7a3888dc2450c3acb9550df39686f024e1386042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

