### PR TITLE
chore(ci): raise Node heap cap to 8GB for client builds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ permissions:
 env:
   REGISTRY: gcr.io/linen-analyst-344721 #gcr for speakeasy-common gcr registry
   DOCKER_REPOSITORY_OWNER: ${{github.repository_owner}}
-  NODE_OPTIONS: "--max-old-space-size=5120"
+  NODE_OPTIONS: "--max-old-space-size=8192"
 
 jobs:
   changes:


### PR DESCRIPTION
## What

Raises the workflow-wide Node heap cap (`NODE_OPTIONS: --max-old-space-size`) in `pr.yaml` from 5120 to 8192.

## Why

The `client/dashboard` `vite build` now peaks right at the 5 GB cap during chunk rendering, intermittently killing `docker-build-client` in the merge queue with `FATAL ERROR: ... JavaScript heap out of memory`:

- [Run 27409935200](https://github.com/speakeasy-api/gram/actions/runs/27409935200/job/81008676159) (2026-06-12) — heap at ~5013 MB at crash
- [Run 27382157399](https://github.com/speakeasy-api/gram/actions/runs/27382157399) (2026-06-11) — identical failure

Whether a given build passes is down to GC timing, and the failure rate will only climb as the dashboard bundle grows.

The jobs run on `blacksmith-4vcpu-ubuntu-2404` runners with 16 GB of RAM, and only the dashboard build approaches the cap (elements, dev-idp, and sdk builds stay well under), so 8 GB leaves comfortable headroom even with `pnpm -r build` running workspace builds in parallel.

✻ Clauded...


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Node heap cap in CI from 5 GB to 8 GB to stop OOM crashes during the dashboard `vite build` and stabilize merge queue builds. Updated `NODE_OPTIONS` in `.github/workflows/pr.yaml` to `--max-old-space-size=8192`.

<sup>Written for commit de287d7c3d2c93ed6710447e4fd150bea952f708. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

