### PR TITLE
fix(assistants): replace rotating slack status with single honest phrase

### DIFF
--- a/.changeset/slack-single-status-phrase.md
+++ b/.changeset/slack-single-status-phrase.md
@@ -1,0 +1,13 @@
+---
+"server": patch
+---
+
+Replace the Slack assistant's rotating loading indicator with honest, single-phrase status.
+
+The thread indicator no longer cycles through a fake "Routing… → Calling tools… →
+Composing…" pipeline. On ingress it shows just "Routing…", and once the assistant is
+running it reports what it's actually doing through the set-thread-status tool — one
+phrase at a time, updated as the work progresses. The tool now also instructs the
+model to phrase the status mid-sentence (Slack renders it after the app's name) and
+pins the indicator to the status text when no loading message is given, instead of
+letting Slack rotate its own generic defaults.

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -1116,7 +1116,7 @@ func validateSlackSignature(body []byte, headers http.Header, signingSecret stri
 // assistant runtime is up to refine it via the set_thread_status platform tool.
 const slackThinkingStatus = "is thinking…"
 
-var slackInitialLoadingMessages = []string{"Routing…", "Calling tools…", "Composing…"}
+var slackInitialLoadingMessages = []string{"Routing…"}
 
 // slackThreadStatusTarget extracts the channel + thread to anchor a loading
 // status on. Returns ok=false for events without a threadable target (e.g.

--- a/server/internal/platformtools/slack/tool_set_thread_status.go
+++ b/server/internal/platformtools/slack/tool_set_thread_status.go
@@ -16,8 +16,8 @@ const toolNameSetThreadStatus = "platform_slack_set_thread_status"
 type setThreadStatusInput struct {
 	ChannelID       string   `json:"channel_id" jsonschema:"Channel containing the thread."`
 	ThreadTS        string   `json:"thread_ts" jsonschema:"Timestamp of the thread's parent message."`
-	Status          string   `json:"status" jsonschema:"Status text shown to the user, e.g. 'is thinking...'. Clears automatically when the app posts a reply, or after a two-minute timeout."`
-	LoadingMessages []string `json:"loading_messages,omitempty" jsonschema:"Optional messages (max 10) Slack rotates through as a loading indicator while the status is shown."`
+	Status          string   `json:"status" jsonschema:"The overarching task being worked on. Slack renders it mid-sentence after the app's name ('<App Name> <status>'), so phrase it like 'is ordering pizza...'. Clears automatically when the app posts a reply, or after a two-minute timeout."`
+	LoadingMessages []string `json:"loading_messages,omitempty" jsonschema:"A single message describing the current step, e.g. ['Calling DoorDash...']. Always pass exactly one — Slack rotates through multiple, which is distracting. Defaults to the status text when omitted."`
 }
 
 type setThreadStatusOutput struct {
@@ -35,7 +35,7 @@ func NewSetThreadStatusTool(httpClient *guardian.HTTPClient) core.PlatformToolEx
 			SourceSlug:  sourceSlack,
 			HandlerName: "set_thread_status",
 			Name:        toolNameSetThreadStatus,
-			Description: "Show a native AI loading indicator on a Slack thread via assistant.threads.setStatus, using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN. Slack clears the status automatically once the app posts its reply (or after a two-minute timeout). Accepts the chat:write scope.",
+			Description: "Show a native AI loading indicator on a Slack thread via assistant.threads.setStatus, using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN. Slack clears the status automatically once the app posts its reply (or after a two-minute timeout). Accepts the chat:write scope.\n\nAGENTS: Use this tool to communicate progress while working on a request. Set 'status' to the overarching task; Slack renders it mid-sentence after the app's name, so phrase it like 'is ordering pizza...'. Set 'loading_messages' to a single message describing the current step, e.g. ['Calling DoorDash...'] — never more than one, rotation is distracting. When calling other tools, pair them with a call to this tool that updates 'loading_messages' to reflect the new step, whenever it makes sense.",
 			InputSchema: core.BuildInputSchema[setThreadStatusInput](),
 			Variables:   nil,
 			Annotations: slackToolAnnotations(readOnly, destructive, idempotent, openWorld),
@@ -67,20 +67,24 @@ func callSetThreadStatus(ctx context.Context, client *apiClient, env toolconfig.
 		return err
 	}
 
-	request := map[string]any{
-		"channel_id": channelID,
-		"thread_ts":  threadTS,
-		"status":     status,
+	loadingMessages := input.LoadingMessages
+	if len(loadingMessages) == 0 {
+		// Slack rotates through its own default loading messages when none
+		// are given; pin the indicator to the status text instead.
+		loadingMessages = []string{status}
 	}
-	if len(input.LoadingMessages) > 0 {
-		// Slack expects the array param as a JSON-encoded string in a
-		// form-encoded request; pass it pre-marshaled so encodeFormValue
-		// doesn't comma-join it.
-		encoded, err := json.Marshal(input.LoadingMessages)
-		if err != nil {
-			return fmt.Errorf("encode loading_messages: %w", err)
-		}
-		request["loading_messages"] = string(encoded)
+	// Slack expects the array param as a JSON-encoded string in a
+	// form-encoded request; pass it pre-marshaled so encodeFormValue
+	// doesn't comma-join it.
+	encodedMessages, err := json.Marshal(loadingMessages)
+	if err != nil {
+		return fmt.Errorf("encode loading_messages: %w", err)
+	}
+	request := map[string]any{
+		"channel_id":       channelID,
+		"thread_ts":        threadTS,
+		"status":           status,
+		"loading_messages": string(encodedMessages),
 	}
 
 	body, err := client.Call(ctx, "assistant.threads.setStatus", request, tokenPreferBot, env)

--- a/server/internal/platformtools/slack/tool_set_thread_status.go
+++ b/server/internal/platformtools/slack/tool_set_thread_status.go
@@ -67,10 +67,14 @@ func callSetThreadStatus(ctx context.Context, client *apiClient, env toolconfig.
 		return err
 	}
 
+	// The indicator must stay a single static phrase: clamp extra messages
+	// (Slack rotates through multiples) and pin it to the status text when
+	// none are given (Slack rotates its own defaults otherwise).
 	loadingMessages := input.LoadingMessages
+	if len(loadingMessages) > 1 {
+		loadingMessages = loadingMessages[:1]
+	}
 	if len(loadingMessages) == 0 {
-		// Slack rotates through its own default loading messages when none
-		// are given; pin the indicator to the status text instead.
 		loadingMessages = []string{status}
 	}
 	// Slack expects the array param as a JSON-encoded string in a

--- a/server/internal/platformtools/slack/tool_set_thread_status_test.go
+++ b/server/internal/platformtools/slack/tool_set_thread_status_test.go
@@ -1,0 +1,85 @@
+package slack
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetThreadStatusTool_PostsToSetStatus(t *testing.T) {
+	t.Parallel()
+
+	var requestPath string
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestPayload = readForm(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewSetThreadStatusTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callSetThreadStatus,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C123",
+		"thread_ts":"123.456",
+		"status":"is ordering pizza...",
+		"loading_messages":["Calling DoorDash..."]
+	}`), &out)
+	require.NoError(t, err)
+
+	require.Equal(t, "/assistant.threads.setStatus", requestPath)
+	require.Equal(t, "C123", requestPayload.Get("channel_id"))
+	require.Equal(t, "123.456", requestPayload.Get("thread_ts"))
+	require.Equal(t, "is ordering pizza...", requestPayload.Get("status"))
+	require.JSONEq(t, `["Calling DoorDash..."]`, requestPayload.Get("loading_messages"))
+	require.JSONEq(t, `{"ok":true}`, out.String())
+}
+
+func TestSetThreadStatusTool_DefaultsLoadingMessagesToStatus(t *testing.T) {
+	t.Parallel()
+
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPayload = readForm(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewSetThreadStatusTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callSetThreadStatus,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C123",
+		"thread_ts":"123.456",
+		"status":"is ordering pizza..."
+	}`), &out)
+	require.NoError(t, err)
+
+	// Omitting loading_messages makes Slack rotate its own defaults, so the
+	// tool must pin the indicator to the status text.
+	require.JSONEq(t, `["is ordering pizza..."]`, requestPayload.Get("loading_messages"))
+}

--- a/server/internal/platformtools/slack/tool_set_thread_status_test.go
+++ b/server/internal/platformtools/slack/tool_set_thread_status_test.go
@@ -83,3 +83,36 @@ func TestSetThreadStatusTool_DefaultsLoadingMessagesToStatus(t *testing.T) {
 	// tool must pin the indicator to the status text.
 	require.JSONEq(t, `["is ordering pizza..."]`, requestPayload.Get("loading_messages"))
 }
+
+func TestSetThreadStatusTool_ClampsLoadingMessagesToOne(t *testing.T) {
+	t.Parallel()
+
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPayload = readForm(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewSetThreadStatusTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callSetThreadStatus,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C123",
+		"thread_ts":"123.456",
+		"status":"is ordering pizza...",
+		"loading_messages":["Calling DoorDash...","Tipping the driver...","Waiting at the door..."]
+	}`), &out)
+	require.NoError(t, err)
+
+	require.JSONEq(t, `["Calling DoorDash..."]`, requestPayload.Get("loading_messages"))
+}


### PR DESCRIPTION
## Summary

- Ingress loading indicator now shows a single `Routing…` message instead of cycling through a fake `Routing… → Calling tools… → Composing…` pipeline that implied restarts.
- `platform_slack_set_thread_status` gains an `AGENTS:` section in its description: `status` carries the overarching task phrased mid-sentence (Slack renders `<App Name> <status>`, so "is creating Linear issue…" not "Creating Linear issue"), `loading_messages` carries exactly one current-step phrase, and the model is told to update it alongside other tool calls.
- When `loading_messages` is omitted, the tool now pins the indicator to the status text. Verified empirically: Slack injects its own rotating defaults (`Generating response…`) when the param is absent — that string appears nowhere in our codebase yet showed up in threads.

Closes [DNO-241](https://linear.app/speakeasy/issue/DNO-241/replace-rotating-status-indicator-with-single-static-phrase-real-tool)

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the rotating Slack thread status with one clear phrase. Shows "Routing…" once on ingress, then a single step updated via `assistant.threads.setStatus` to match DNO-241.

- **Bug Fixes**
  - `slackInitialLoadingMessages` now only `["Routing…"]`.
  - `platform_slack_set_thread_status`: clamp `loading_messages` to exactly one; default to `status` when omitted; always send it as a JSON-encoded array to prevent Slack’s generic rotation.
  - Updated tool guidance to phrase `status` mid-sentence and to update it alongside tool calls; added tests for payload, defaulting, and clamping.

<sup>Written for commit fea9898eb28310030982b9a4850db83a9ac7c7c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

