### PR TITLE
fix(elements): keep tool cards mounted as a streaming group grows

### DIFF
--- a/.changeset/stable-tool-group-rendering.md
+++ b/.changeset/stable-tool-group-rendering.md
@@ -1,0 +1,8 @@
+---
+"@gram-ai/elements": patch
+---
+
+Stop tool call cards from flashing while the assistant works. Cards no longer
+reset (collapsing and re-highlighting their code) when a streaming turn grows
+a single tool call into a group, and they no longer re-render on every text
+chunk.

--- a/elements/src/components/assistant-ui/tool-fallback.tsx
+++ b/elements/src/components/assistant-ui/tool-fallback.tsx
@@ -26,11 +26,15 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
 
   // Check if this specific tool call has a pending approval
   const pendingApproval = pendingApprovals.get(toolCallId);
-  const message = useAssistantState(({ message }) => message);
-  const toolParts = message.parts.filter((part) => part.type === "tool-call");
-  const matchingMessagePartIndex = toolParts.findIndex(
-    (part) => part.toolCallId === toolCallId,
-  );
+  // Select the derived boolean, not the message: useAssistantState re-renders
+  // on Object.is of the selected value, and the message object changes on
+  // every streamed chunk — subscribing to it re-renders every tool card per
+  // text delta.
+  const needsTrailingBorder = useAssistantState(({ message }) => {
+    const toolParts = message.parts.filter((part) => part.type === "tool-call");
+    const index = toolParts.findIndex((part) => part.toolCallId === toolCallId);
+    return index !== -1 && index !== toolParts.length - 1;
+  });
 
   const handleApproveOnce = () => {
     confirmPendingApproval(toolCallId);
@@ -89,9 +93,7 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
     <div
       className={cn(
         "aui-tool-fallback-root flex w-full flex-col",
-        matchingMessagePartIndex !== -1 &&
-          matchingMessagePartIndex !== toolParts.length - 1 &&
-          "border-b",
+        needsTrailingBorder && "border-b",
       )}
     >
       <ToolUI

--- a/elements/src/components/assistant-ui/tool-fallback.tsx
+++ b/elements/src/components/assistant-ui/tool-fallback.tsx
@@ -26,10 +26,8 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
 
   // Check if this specific tool call has a pending approval
   const pendingApproval = pendingApprovals.get(toolCallId);
-  // Select the derived boolean, not the message: useAssistantState re-renders
-  // on Object.is of the selected value, and the message object changes on
-  // every streamed chunk — subscribing to it re-renders every tool card per
-  // text delta.
+  // Selecting the whole message would re-render this card on every streamed
+  // chunk; select only the derived value.
   const needsTrailingBorder = useAssistantState(({ message }) => {
     const toolParts = message.parts.filter((part) => part.type === "tool-call");
     const index = toolParts.findIndex((part) => part.toolCallId === toolCallId);

--- a/elements/src/components/assistant-ui/tool-group.tsx
+++ b/elements/src/components/assistant-ui/tool-group.tsx
@@ -43,11 +43,9 @@ export const ToolGroup: FC<
     return children;
   }
 
-  // Single and multiple tool calls share one wrapper type (headerless hides
-  // the group chrome for a lone call): if the branches rendered different
-  // element types, a streaming turn growing a group from one call to two
-  // would remount every card in it, visibly resetting expansion and syntax
-  // highlighting.
+  // Single and multiple tool calls must share one wrapper element type —
+  // diverging branches would remount every card when a streaming turn grows
+  // the group.
   return (
     <div className="my-4 w-full max-w-xl">
       <ToolUIGroup

--- a/elements/src/components/assistant-ui/tool-group.tsx
+++ b/elements/src/components/assistant-ui/tool-group.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/lib/utils";
 import { useAssistantState } from "@assistant-ui/react";
 import { useMemo, type FC, type PropsWithChildren } from "react";
 import { useElements } from "@/hooks/useElements";
@@ -44,21 +43,15 @@ export const ToolGroup: FC<
     return children;
   }
 
-  // For single tool calls, render without the group wrapper
-  if (toolCount === 1) {
-    return (
-      <div className={cn("my-4 w-full max-w-xl")}>
-        <div className="overflow-hidden rounded-lg border border-border bg-card">
-          {children}
-        </div>
-      </div>
-    );
-  }
-
-  // For multiple tool calls, use the group component
+  // Single and multiple tool calls share one wrapper type (headerless hides
+  // the group chrome for a lone call): if the branches rendered different
+  // element types, a streaming turn growing a group from one call to two
+  // would remount every card in it, visibly resetting expansion and syntax
+  // highlighting.
   return (
     <div className="my-4 w-full max-w-xl">
       <ToolUIGroup
+        headerless={toolCount === 1}
         title={groupTitle}
         status={anyMessagePartsAreRunning ? "running" : "complete"}
         defaultExpanded={defaultExpanded}

--- a/elements/src/components/ui/tool-ui.tsx
+++ b/elements/src/components/ui/tool-ui.tsx
@@ -711,6 +711,13 @@ interface ToolUIGroupProps {
   status?: "running" | "complete";
   /** Whether the group starts expanded */
   defaultExpanded?: boolean;
+  /**
+   * Render without the group header, showing children directly. Lets a
+   * single tool call share this component with multi-call groups, so the
+   * subtree isn't remounted (losing expansion and highlighting state) when
+   * a streaming turn grows a lone call into a group.
+   */
+  headerless?: boolean;
   /** Child tool UI components */
   children: React.ReactNode;
   /** Additional class names */
@@ -722,10 +729,12 @@ function ToolUIGroup({
   icon,
   status = "complete",
   defaultExpanded = false,
+  headerless = false,
   children,
   className,
 }: ToolUIGroupProps): React.JSX.Element {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const showChildren = headerless || isExpanded;
 
   return (
     <div
@@ -736,40 +745,45 @@ function ToolUIGroup({
       )}
     >
       {/* Group header */}
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-accent/50"
-      >
-        {icon || (
-          <StatusIndicator
-            status={status === "running" ? "running" : "complete"}
+      {!headerless && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-accent/50"
+        >
+          {icon || (
+            <StatusIndicator
+              status={status === "running" ? "running" : "complete"}
+            />
+          )}
+          <span
+            className={cn(
+              "flex-1 text-sm font-medium",
+              status === "running" && "shimmer",
+            )}
+          >
+            {title}
+          </span>
+          <ChevronDownIcon
+            className={cn(
+              "size-4 text-muted-foreground transition-transform duration-200",
+              isExpanded && "rotate-180",
+            )}
           />
-        )}
-        <span
-          className={cn(
-            "flex-1 text-sm font-medium",
-            status === "running" && "shimmer",
-          )}
-        >
-          {title}
-        </span>
-        <ChevronDownIcon
-          className={cn(
-            "size-4 text-muted-foreground transition-transform duration-200",
-            isExpanded && "rotate-180",
-          )}
-        />
-      </button>
-
-      {/* Expandable children */}
-      {isExpanded && (
-        <div
-          data-slot="tool-ui-group-content"
-          className="border-t border-border"
-        >
-          {children}
-        </div>
+        </button>
       )}
+
+      {/* Children stay mounted while collapsed (CSS-hidden, not unmounted) so
+          expanding — or a collapsed group forming mid-stream — doesn't reset
+          their state (expansion, async syntax highlighting). */}
+      <div
+        data-slot="tool-ui-group-content"
+        className={cn(
+          !headerless && "border-t border-border",
+          !showChildren && "hidden",
+        )}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/elements/src/components/ui/tool-ui.tsx
+++ b/elements/src/components/ui/tool-ui.tsx
@@ -729,6 +729,16 @@ function ToolUIGroup({
   className,
 }: ToolUIGroupProps): React.JSX.Element {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  // A headerless group shows its children unconditionally; when it gains a
+  // header mid-stream, start expanded — collapsing would hide content the
+  // user was already looking at.
+  const [prevHeaderless, setPrevHeaderless] = useState(headerless);
+  if (prevHeaderless !== headerless) {
+    setPrevHeaderless(headerless);
+    if (prevHeaderless) setIsExpanded(true);
+  }
+
   const showChildren = headerless || isExpanded;
 
   return (
@@ -743,6 +753,7 @@ function ToolUIGroup({
       {!headerless && (
         <button
           onClick={() => setIsExpanded(!isExpanded)}
+          aria-expanded={isExpanded}
           className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-accent/50"
         >
           {icon || (

--- a/elements/src/components/ui/tool-ui.tsx
+++ b/elements/src/components/ui/tool-ui.tsx
@@ -711,12 +711,7 @@ interface ToolUIGroupProps {
   status?: "running" | "complete";
   /** Whether the group starts expanded */
   defaultExpanded?: boolean;
-  /**
-   * Render without the group header, showing children directly. Lets a
-   * single tool call share this component with multi-call groups, so the
-   * subtree isn't remounted (losing expansion and highlighting state) when
-   * a streaming turn grows a lone call into a group.
-   */
+  /** Render without the group header, showing children directly. */
   headerless?: boolean;
   /** Child tool UI components */
   children: React.ReactNode;
@@ -772,9 +767,8 @@ function ToolUIGroup({
         </button>
       )}
 
-      {/* Children stay mounted while collapsed (CSS-hidden, not unmounted) so
-          expanding — or a collapsed group forming mid-stream — doesn't reset
-          their state (expansion, async syntax highlighting). */}
+      {/* Collapsed children are hidden, not unmounted — unmounting would
+          reset their state (expansion, async syntax highlighting). */}
       <div
         data-slot="tool-ui-group-content"
         className={cn(


### PR DESCRIPTION
## Summary

- `ToolGroup` rendered a single tool call in a plain `div` but two or more inside `ToolUIGroup` — different element types, so when a streaming turn grew a group from one call to two, React remounted every card in it. That destroyed component state: async shiki highlighting repainted (plain → highlighted blink) and expansion reset, with the visible card vanishing into a collapsed group header.
- Both branches now render through `ToolUIGroup`, with a new `headerless` prop hiding the group chrome for a lone call (visual output unchanged). Collapsed group children are CSS-hidden instead of unmounted, so group formation and expand/collapse no longer reset card state.
- Also narrows `ToolFallback`'s `useAssistantState(({ message }) => message)` subscription to the derived border boolean — subscribing to the whole message re-rendered every tool card on every streamed text delta (~45×/sec at the dashboard transport's 22ms cadence), defeating assistant-ui's per-part memoization.

Surfaced by #3389, which made the Project Assistant render tool calls for the first time; the underlying behavior predates it.

Closes [DNO-243](https://linear.app/speakeasy/issue/DNO-243/bug-tooluigroup-replaces-root-div-when-tool-calls-go-from-1n-causing)

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flicker and state resets when a streaming turn grows a tool call group from 1 to many in `@gram-ai/elements`. Addresses DNO-243 by keeping tool cards mounted, reducing unnecessary re-renders, and ensuring content stays visible when a lone call becomes a group.

- **Bug Fixes**
  - Render single and multi-call groups through `ToolUIGroup`; add `headerless` to hide group chrome for a lone call, preventing remount on 1→N.
  - Keep collapsed children mounted (CSS-hidden) so expansion state and async syntax highlighting persist.
  - Auto-expand when a headerless group gains a header mid-stream to avoid hiding visible content; expose toggle state via `aria-expanded`.
  - Narrow `ToolFallback`’s `useAssistantState` selector to a border boolean to avoid per-chunk card re-renders.

<sup>Written for commit 4d111f7c231f4841eed645514185e067b15fcbc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

