### PR TITLE
feat(dashboard): add Platform Status link to profile menu

### DIFF
--- a/.changeset/platform-status-menu-link.md
+++ b/.changeset/platform-status-menu-link.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add a "Platform Status" link to the profile menu, pointing to the Speakeasy status page.

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -81,4 +81,15 @@ describe("SidebarUserMenu", () => {
     expect(roadmap?.getAttribute("href")).toBe("https://roadmap.speakeasy.com");
     expect(screen.queryByText(/Bug or Feature Request/)).toBeNull();
   });
+
+  it("links Platform Status to status.speakeasyapi.dev in a new tab", () => {
+    render(<SidebarUserMenu />);
+    fireEvent.click(screen.getByTestId("user-menu-trigger"));
+    const status = screen.getByText("Platform Status").closest("a");
+    expect(status?.getAttribute("href")).toBe(
+      "https://status.speakeasyapi.dev/",
+    );
+    expect(status?.getAttribute("target")).toBe("_blank");
+    expect(status?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
 });

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -13,6 +13,7 @@ import {
   ThemeSwitcher,
 } from "@speakeasy-api/moonshine";
 import {
+  ActivityIcon,
   ArrowRightLeftIcon,
   BookOpenIcon,
   BuildingIcon,
@@ -206,6 +207,16 @@ export function SidebarUserMenu(): JSX.Element {
               >
                 <MapIcon className="mr-2 h-4 w-4" />
                 Roadmap
+              </a>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <a
+                href="https://status.speakeasyapi.dev/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ActivityIcon className="mr-2 h-4 w-4" />
+                Platform Status
               </a>
             </DropdownMenuItem>
           </DropdownMenuGroup>


### PR DESCRIPTION
## What

Adds a **Platform Status** link to the profile/account menu (`SidebarUserMenu`), pointing to https://status.speakeasyapi.dev/. It opens in a new tab and sits in the external-resources group alongside Docs, Changelog, and Roadmap.

## Why

Gives users a one-click path from the app to the public Speakeasy status page when they suspect a platform issue.

## Details

- Matches the existing external-link convention in the menu: `<DropdownMenuItem asChild>` wrapping a plain `<a target="_blank" rel="noopener noreferrer">`.
- Uses `ActivityIcon` (lucide) — the conventional glyph for a status page.
- Adds a focused test asserting the href, `target`, and `rel`, mirroring the existing Roadmap test.

## Verification

- `pnpm -F dashboard test sidebar-user-menu` → 3/3 pass
- `oxfmt --check` clean; `oxlint --type-aware` clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Platform Status link to the profile menu (`SidebarUserMenu`) that opens https://status.speakeasyapi.dev/ in a new tab, alongside Docs, Changelog, and Roadmap.

<sup>Written for commit e0e671b04323903dfda0e874545d6d201a05bc64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

