### PR TITLE
feat(agent): return all published-project plugins to every org member

### DIFF
--- a/.changeset/agent-getplugins-all-project-plugins.md
+++ b/.changeset/agent-getplugins-all-project-plugins.md
@@ -1,0 +1,16 @@
+---
+"server": patch
+---
+
+Return every published-project plugin to all org members from `agent.getPlugins`.
+
+The endpoint previously returned only plugins assigned to the caller's exact
+email or the org wildcard, so assignments via `role:`/`user:` principals never
+reached a device — and there is no UI to create assignments yet. As an interim
+step pending RBAC-backed assignment management, the per-principal assignment
+filter (and the `@principal_urns` query param) is dropped: every non-deleted
+plugin in the org's published projects is now returned to every org member.
+
+The supplied email is still validated so the request contract is unchanged, and
+the view's existing collapse handling keeps colliding-name and cross-org
+isolation intact. No schema change.

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -43,44 +43,38 @@ func TestGetPlugins_ObservabilityWithoutAssignments(t *testing.T) {
 		"a published marketplace always yields observability, even with no assignments")
 }
 
-func TestGetPlugins_EmailAssignment(t *testing.T) {
+// TestGetPlugins_ReturnsAllPublishedProjectPlugins pins the loosened resolution
+// (DNO-239 interim): every non-deleted plugin in a published project is returned
+// to any org member, regardless of whether — or to whom — it is assigned. When
+// per-principal scoping returns, this expectation tightens back down.
+func TestGetPlugins_ReturnsAllPublishedProjectPlugins(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)
 
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
-	pid := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "engineering-tools")
-	assignPlugin(t, ctx, ti.conn, pid, ti.orgID, "email:"+mockidp.MockUserEmail)
+	// A plugin with no assignment at all.
+	seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "unassigned-tool")
+	// A plugin assigned only to a *different* principal — must still come back.
+	other := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "someone-elses-tool")
+	assignPlugin(t, ctx, ti.conn, other, ti.orgID, "email:someone-else@example.com")
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
 
 	require.Len(t, res.Marketplaces, 1)
-	require.ElementsMatch(t, []string{wantObservability, "engineering-tools"}, pluginSlugs(res))
-}
-
-func TestGetPlugins_WildcardAssignment(t *testing.T) {
-	t.Parallel()
-	ctx, ti := newTestAgentService(t)
-
-	publishMarketplace(t, ctx, ti.conn, ti.projectID, "tok")
-	pid := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "org-wide-tool")
-	assignPlugin(t, ctx, ti.conn, pid, ti.orgID, "*")
-
-	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
-	require.NoError(t, err)
-
-	require.ElementsMatch(t, []string{wantObservability, "org-wide-tool"}, pluginSlugs(res),
-		"a `*` assignment resolves for any email")
+	require.ElementsMatch(t,
+		[]string{wantObservability, "unassigned-tool", "someone-elses-tool"},
+		pluginSlugs(res),
+		"every published-project plugin is returned regardless of assignment")
 }
 
 func TestGetPlugins_UnpublishedProjectExcluded(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)
 
-	// Plugin assigned, but the project has no marketplace_token (never
-	// published) — so nothing is installable and the endpoint returns empty.
-	pid := seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "unpublished-tool")
-	assignPlugin(t, ctx, ti.conn, pid, ti.orgID, "*")
+	// The project has a plugin but no marketplace_token (never published) — so
+	// nothing is installable and the endpoint returns empty.
+	seedPlugin(t, ctx, ti.conn, ti.orgID, ti.projectID, "unpublished-tool")
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
@@ -130,14 +124,13 @@ func TestGetPlugins_CollidingNamesPreferDefault(t *testing.T) {
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
 
 	// "adam" sorts before the default project's "test-<hex>" slug, but overrides
-	// its name to collide with the default's bare org name. It also has an
-	// assigned plugin — which must NOT leak onto the winning marketplace, since
-	// adam's repo isn't the one served under that name.
+	// its name to collide with the default's bare org name. Its plugin (returned
+	// by the loosened resolution like any other) must NOT leak onto the winning
+	// marketplace, since adam's repo isn't the one served under that name.
 	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
 	setMarketplaceOverride(t, ctx, ti.conn, adam, wantMarketplace)
 	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
-	adamPlugin := seedPlugin(t, ctx, ti.conn, ti.orgID, adam, "adam-only-tool")
-	assignPlugin(t, ctx, ti.conn, adamPlugin, ti.orgID, "*")
+	seedPlugin(t, ctx, ti.conn, ti.orgID, adam, "adam-only-tool")
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -73,31 +73,25 @@ func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.A
 	return s.auth.Authorize(ctx, key, schema)
 }
 
-// GetPlugins returns every plugin assigned to the resolved principal set for
-// the supplied email within the caller's org. user: and role: resolution
-// lands in the follow-up ticket alongside email→user_id lookup and RBAC
-// role-membership reads.
+// GetPlugins returns every plugin in the published projects of the caller's
+// org. Per-principal assignment scoping is intentionally disabled for now (see
+// DNO-239): every org member receives every published-project plugin. The
+// supplied email is still validated and will drive principal resolution again
+// (user:/role: lookups) once RBAC-backed assignment management ships.
 func (s *Service) GetPlugins(ctx context.Context, payload *gen.GetPluginsPayload) (*gen.GetPluginsResult, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	// Validate the caller sent a well-formed email even though it does not yet
+	// scope the result, so the request contract stays stable for DNO-239.
 	email := conv.NormalizeEmail(payload.Email)
-	emailPrincipal, err := urn.ParsePrincipal(string(urn.PrincipalTypeEmail) + ":" + email)
-	if err != nil {
+	if _, err := urn.ParsePrincipal(string(urn.PrincipalTypeEmail) + ":" + email); err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid email")
 	}
 
-	principals := []string{
-		emailPrincipal.String(),
-		urn.PrincipalWildcard,
-	}
-
-	rows, err := s.repo.GetAgentPluginSet(ctx, repo.GetAgentPluginSetParams{
-		OrganizationID: authCtx.ActiveOrganizationID,
-		PrincipalUrns:  principals,
-	})
+	rows, err := s.repo.GetAgentPluginSet(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error resolving agent plugin set").Log(ctx, s.logger)
 	}

--- a/server/internal/agent/queries.sql
+++ b/server/internal/agent/queries.sql
@@ -4,9 +4,11 @@
 -- The base is every *published* marketplace in the org (a
 -- plugin_github_connections row with a marketplace_token), so a marketplace —
 -- and its always-required observability plugin, synthesized in the view layer —
--- is returned even when the user has no explicit assignments. Plugins the user
--- is assigned to (via principal_urn) are LEFT JOINed on top; projects with no
--- matching assignment still yield one row with null plugin columns.
+-- is returned for every published project. Every non-deleted plugin in those
+-- projects is LEFT JOINed on top and returned to every org member: per-principal
+-- assignment scoping is intentionally disabled for now (see DNO-239) and will be
+-- reinstated once RBAC-backed assignment management ships. Projects with no
+-- plugins still yield one row with null plugin columns.
 --
 -- Each project resolves to a marketplace name the way the publish path does:
 -- the per-project override (project_marketplace_settings.marketplace_name) when
@@ -56,11 +58,6 @@ LEFT JOIN project_marketplace_settings pms
 LEFT JOIN plugins p
   ON p.project_id = pr.id
   AND p.deleted IS FALSE
-  AND EXISTS (
-    SELECT 1 FROM plugin_assignments pa
-    WHERE pa.plugin_id = p.id
-      AND pa.principal_urn = ANY(@principal_urns::text[])
-  )
 WHERE pr.organization_id = @organization_id
   AND pgc.marketplace_token IS NOT NULL
 ORDER BY pr.id, p.slug;

--- a/server/internal/agent/repo/queries.sql.go
+++ b/server/internal/agent/repo/queries.sql.go
@@ -51,20 +51,10 @@ LEFT JOIN project_marketplace_settings pms
 LEFT JOIN plugins p
   ON p.project_id = pr.id
   AND p.deleted IS FALSE
-  AND EXISTS (
-    SELECT 1 FROM plugin_assignments pa
-    WHERE pa.plugin_id = p.id
-      AND pa.principal_urn = ANY($2::text[])
-  )
 WHERE pr.organization_id = $1
   AND pgc.marketplace_token IS NOT NULL
 ORDER BY pr.id, p.slug
 `
-
-type GetAgentPluginSetParams struct {
-	OrganizationID string
-	PrincipalUrns  []string
-}
 
 type GetAgentPluginSetRow struct {
 	ProjectID               uuid.UUID
@@ -85,9 +75,11 @@ type GetAgentPluginSetRow struct {
 // The base is every *published* marketplace in the org (a
 // plugin_github_connections row with a marketplace_token), so a marketplace —
 // and its always-required observability plugin, synthesized in the view layer —
-// is returned even when the user has no explicit assignments. Plugins the user
-// is assigned to (via principal_urn) are LEFT JOINed on top; projects with no
-// matching assignment still yield one row with null plugin columns.
+// is returned for every published project. Every non-deleted plugin in those
+// projects is LEFT JOINed on top and returned to every org member: per-principal
+// assignment scoping is intentionally disabled for now (see DNO-239) and will be
+// reinstated once RBAC-backed assignment management ships. Projects with no
+// plugins still yield one row with null plugin columns.
 //
 // Each project resolves to a marketplace name the way the publish path does:
 // the per-project override (project_marketplace_settings.marketplace_name) when
@@ -99,8 +91,8 @@ type GetAgentPluginSetRow struct {
 // one created at org setup) sorts first. When projects share a name and the view
 // collapses them, keeping the first row's token makes that collapse resolve to
 // the default project rather than the arbitrary alphabetically-first one.
-func (q *Queries) GetAgentPluginSet(ctx context.Context, arg GetAgentPluginSetParams) ([]GetAgentPluginSetRow, error) {
-	rows, err := q.db.Query(ctx, getAgentPluginSet, arg.OrganizationID, arg.PrincipalUrns)
+func (q *Queries) GetAgentPluginSet(ctx context.Context, organizationID string) ([]GetAgentPluginSetRow, error) {
+	rows, err := q.db.Query(ctx, getAgentPluginSet, organizationID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

Loosen `agent.getPlugins` so **every plugin in the org's published projects is returned to every org member**, dropping the per-principal assignment filter for now. Interim behavior pending RBAC-backed assignment management (**DNO-239**), which will fold the resolved principal set back into the query.

## Why

Today the endpoint only resolves `email:<email>` and `*` (wildcard) principals — plugins assigned via `role:`/`user:` never reach devices, and there's no dashboard UI to create assignments anyway (DNO-240). Rather than block on those, we return all published-project plugins to everyone for now and scope back down once RBAC assignment lands. Most orgs have a single project, so the practical blast radius is small.

## Changes

- **`queries.sql`** — drop the `EXISTS (… plugin_assignments … principal_urn = ANY(@principal_urns))` clause and the `@principal_urns` param from the `plugins` LEFT JOIN. Org scoping, published-only filter, default-project resolution, and `ORDER BY pr.id` are unchanged.
- **`repo/queries.sql.go`** — regenerated (sqlc v1.31.1); `GetAgentPluginSetParams` collapses to a single `organizationID` arg.
- **`impl.go`** — drop principal-set construction; call the single-arg query. Email is still validated so the request contract stays stable for DNO-239.
- **`getplugins_test.go`** — replace the two assignment-gated tests with `TestGetPlugins_ReturnsAllPublishedProjectPlugins` (an unassigned plugin **and** a plugin assigned to a different user both return); decouple the unpublished-exclusion and colliding-names tests from assignment.

No view change needed — `BuildAgentPluginsView` already drops collapsed-project plugins via the `marketplaceOwner` guard, so colliding-name and cross-org isolation stay intact.

## Note

This is an intentional **access broadening** (every org member receives every published-project plugin). Marked in code/comments as scoped down by DNO-239.

## Test plan

- [x] `go build ./server/...`, `go vet` — clean
- [x] `go test ./server/internal/mv/` (view) — pass
- [x] `go test ./server/internal/agent/` (DB-backed integration) — pass
- [x] `mise run lint:server` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return all plugins from published projects to every org member via `agent.getPlugins`, temporarily removing per-principal assignment scoping. This unblocks plugin delivery until RBAC-backed assignment management lands (DNO-239) and the assignment UI exists (DNO-240).

- **New Features**
  - Return every non-deleted plugin from each published project in the org to any member; org scoping and published-only filtering remain.
  - Remove the per-principal assignment filter and the `@principal_urns` param; repo `GetAgentPluginSet` now takes only `organizationID`.
  - Continue validating the email input but do not use it for scoping yet; principal-based scoping will return with RBAC (DNO-239).
  - Update tests to assert the broadened behavior; unpublished projects remain excluded and default-marketplace precedence is unchanged.
  - Add changeset entry for a `server` patch release.

<sup>Written for commit df9fa008c413d7a37b45383087c390e8fbca49a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

