### PR TITLE
fix(insights): Update page title and copy

### DIFF
--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -478,16 +478,19 @@ export function InsightsToolsContent(): JSX.Element {
     <>
       <InsightsConfig
         mcpConfig={mcpConfig}
-        title="Explore Tools"
-        subtitle="Ask me about your tools! Powered by Elements + platform MCP"
+        title="Explore MCP Servers & Tools"
+        subtitle="Ask me about your MCP servers and tools! Powered by Elements + platform MCP"
         hideTrigger={isLogsDisabled}
       />
       {isLogsDisabled ? (
         <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto p-8 pb-24">
           <div className="flex min-w-0 flex-col gap-1">
-            <h1 className="text-xl font-semibold">Tools</h1>
+            <h1 className="text-xl font-semibold">
+              MCP Servers & Tool Insights
+            </h1>
             <p className="text-muted-foreground text-sm">
-              Monitor tool events across all users and agents in your project
+              Monitor MCP servers and tool events across all users and agents in
+              your project
             </p>
           </div>
           <div className="relative flex-1">
@@ -613,9 +616,12 @@ function HooksInnerContent({
       <div className="flex min-h-0 flex-1 flex-col gap-6 px-8 pt-8">
         <div className="flex shrink-0 items-start justify-between gap-4">
           <div className="flex min-w-0 flex-col gap-1">
-            <h1 className="text-xl font-semibold">Tools</h1>
+            <h1 className="text-xl font-semibold">
+              MCP Servers & Tool Insights
+            </h1>
             <p className="text-muted-foreground text-sm">
-              Monitor tool events across all users and agents in your project
+              Monitor MCP servers and tool events across all users and agents in
+              your project
             </p>
           </div>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Update the page title and description to be more inline with the merged content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Insights page titles and copy for the unified MCP Servers + Tools view. Title now "Explore MCP Servers & Tools", heading "MCP Servers & Tool Insights", subtitle "Ask me about your MCP servers and tools! Powered by Elements + platform MCP", and description "Monitor MCP servers and tool events across all users and agents in your project" (DNO-199).

<sup>Written for commit 1d5c9c82d148603dfe74ee2b3971b6252764cfba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

