### PR TITLE
mig: add provenance columns to assistant_memories

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2043,6 +2043,16 @@ CREATE TABLE IF NOT EXISTS assistant_memories (
   tags             TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
   origin_thread_id uuid,
   origin_chat_id   uuid,
+  -- Provenance of the memory for tracing ("why is the assistant remembering
+  -- this?"): the origin thread's source surface (slack|cron|wake|dashboard),
+  -- the external user who said it, the thread's correlation id (which encodes
+  -- the source conversation uniformly across surfaces), and when it was
+  -- recorded. Nullable because provenance is best-effort and rows written
+  -- before these columns existed have none.
+  source_kind           TEXT,
+  source_user_id        TEXT,
+  source_correlation_id TEXT,
+  source_timestamp      timestamptz,
   created_at       timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at       timestamptz NOT NULL DEFAULT clock_timestamp(),
   last_access      timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -122,23 +122,27 @@ type AssistantDashboardMessage struct {
 }
 
 type AssistantMemory struct {
-	ID             uuid.UUID
-	AssistantID    uuid.NullUUID
-	ProjectID      uuid.NullUUID
-	OrganizationID string
-	Content        string
-	Embedding      pgvector_go.HalfVector
-	SupersedesID   uuid.NullUUID
-	SupersededAt   pgtype.Timestamptz
-	ValidAt        pgtype.Timestamptz
-	Tags           []string
-	OriginThreadID uuid.NullUUID
-	OriginChatID   uuid.NullUUID
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
-	LastAccess     pgtype.Timestamptz
-	DeletedAt      pgtype.Timestamptz
-	Deleted        bool
+	ID                  uuid.UUID
+	AssistantID         uuid.NullUUID
+	ProjectID           uuid.NullUUID
+	OrganizationID      string
+	Content             string
+	Embedding           pgvector_go.HalfVector
+	SupersedesID        uuid.NullUUID
+	SupersededAt        pgtype.Timestamptz
+	ValidAt             pgtype.Timestamptz
+	Tags                []string
+	OriginThreadID      uuid.NullUUID
+	OriginChatID        uuid.NullUUID
+	SourceKind          pgtype.Text
+	SourceUserID        pgtype.Text
+	SourceCorrelationID pgtype.Text
+	SourceTimestamp     pgtype.Timestamptz
+	CreatedAt           pgtype.Timestamptz
+	UpdatedAt           pgtype.Timestamptz
+	LastAccess          pgtype.Timestamptz
+	DeletedAt           pgtype.Timestamptz
+	Deleted             bool
 }
 
 type AssistantRuntime struct {

--- a/server/migrations/20260621212127_add_memory_provenance.sql
+++ b/server/migrations/20260621212127_add_memory_provenance.sql
@@ -1,0 +1,2 @@
+-- Modify "assistant_memories" table
+ALTER TABLE "assistant_memories" ADD COLUMN "source_kind" text NULL, ADD COLUMN "source_user_id" text NULL, ADD COLUMN "source_correlation_id" text NULL, ADD COLUMN "source_timestamp" timestamptz NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8VrvJeWY1+wSE3tEAHVMJXnwraXipg1jBByQ84rciXw=
+h1:Phaj3I2YISiDbQjj5/K7YGJjNojIZ5rjTuUjWzzd8l4=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -223,3 +223,4 @@ h1:8VrvJeWY1+wSE3tEAHVMJXnwraXipg1jBByQ84rciXw=
 20260618145406_remotesession-clients-relax-issuer-binding.sql h1:Ilx2asUwFZi73cQMVj5yrXGc5aq6QihR2Sd4uaC4h6o=
 20260618194743_deployments-functions-add-infra-overrides.sql h1:MNR3+BYsl1tfjLes6MbKUWqGkw/nMs8HO2cfyZvTTPs=
 20260618215143_add_custom_rule_match_config.sql h1:ZALVgDTK3jWQrHREznqnbbQDNdfIuOZAWr3VnqLAgbo=
+20260621212127_add_memory_provenance.sql h1:TpiKQlABFZP5uVjxglvtuUnmmZmPABuN4+ufMQa6OV4=


### PR DESCRIPTION
Part of DNO-245 (migration-only PR — feature follows in the stacked PR #3399)

## Summary

Adds 4 nullable provenance columns to `assistant_memories`, so memories stored via `platform_memory_remember` can be traced back to the conversation they came from — answering "why is the assistant remembering this?":

- `source_kind TEXT` — `slack` | `dashboard` | `cron` | `wake` (open enum; contract lives in Go per project convention)
- `source_user_id TEXT` — the speaking user where one exists (Slack / dashboard), not the assistant owner
- `source_correlation_id TEXT` — the origin thread's correlation id (e.g. `slack:T123:C456:789.012`), stored verbatim for every source kind
- `source_timestamp timestamptz`

All nullable: writes outside an assistant thread carry no provenance. Expand-only. Migration generated by Atlas via `mise db:diff add_memory_provenance`; `atlas.sum` untouched by hand. No app code in this PR per migration rules.

Note: regenerated after review — `source_channel` was replaced by `source_correlation_id` per feedback on #3399 (channel conflates conversation threads; correlation id encodes the source surface uniformly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
