### PR TITLE
feat(memory): tag assistant memories with source provenance

### DIFF
--- a/.changeset/memory-provenance-tagging.md
+++ b/.changeset/memory-provenance-tagging.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Tag assistant memories with provenance. `platform_memory_remember` now records which source surface the memory came from (slack, dashboard, cron, wake), the external user who said it, the channel it was said in, and when it was written. Recall surfaces this as a compact attribution line (e.g. "from slack user U123 in C456, 2026-06-12") so assistants can reason about how much to trust a memory and poisoned writes stay attributable.

--- a/.changeset/memory-provenance-tagging.md
+++ b/.changeset/memory-provenance-tagging.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Tag assistant memories with provenance. `platform_memory_remember` now records which source surface the memory came from (slack, dashboard, cron, wake), the external user who said it, the channel it was said in, and when it was written. Recall surfaces this as a compact attribution line (e.g. "from slack user U123 in C456, 2026-06-12") so assistants can reason about how much to trust a memory and poisoned writes stay attributable.
+Tag assistant memories with provenance for tracing. `platform_memory_remember` now records which source surface the memory came from (slack, dashboard, cron, wake), the external user who said it, the origin thread's correlation id, and when it was written. Recall surfaces this as a compact attribution line (e.g. "from slack user U123 (slack:T123:C456:789.012), 2026-06-12") so it is always possible to answer "why is the assistant remembering this?" and trace a memory back to the conversation it was written in.

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	slackclient "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	"github.com/speakeasy-api/gram/server/internal/threadsource"
 )
 
 const (
@@ -42,12 +43,12 @@ const (
 	StatusActive = "active"
 	StatusPaused = "paused"
 
-	sourceKindSlack     = bgtriggers.DefinitionSlugSlack
+	sourceKindSlack     = threadsource.KindSlack
 	sourceKindLinear    = bgtriggers.DefinitionSlugLinear
 	sourceKindGithub    = bgtriggers.DefinitionSlugGithub
-	sourceKindCron      = bgtriggers.DefinitionSlugCron
-	sourceKindWake      = bgtriggers.DefinitionSlugWake
-	sourceKindDashboard = bgtriggers.DefinitionSlugDashboard
+	sourceKindCron      = threadsource.KindCron
+	sourceKindWake      = threadsource.KindWake
+	sourceKindDashboard = threadsource.KindDashboard
 	// sourceKindWarmup marks the event-less thread that eager-boots the
 	// runtime at assistant creation. It has no source adapter — adapters are
 	// only consulted while processing events, and this thread never has any.

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	slackclient "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	"github.com/speakeasy-api/gram/server/internal/threadsource"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -37,12 +38,12 @@ const (
 	StatusFired         = "fired"
 	StatusCancelled     = "cancelled"
 
-	DefinitionSlugSlack     = "slack"
+	DefinitionSlugSlack     = threadsource.KindSlack
 	DefinitionSlugLinear    = "linear"
 	DefinitionSlugGithub    = "github"
-	DefinitionSlugCron      = "cron"
-	DefinitionSlugWake      = "wake"
-	DefinitionSlugDashboard = "dashboard"
+	DefinitionSlugCron      = threadsource.KindCron
+	DefinitionSlugWake      = threadsource.KindWake
+	DefinitionSlugDashboard = threadsource.KindDashboard
 )
 
 var (

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -122,27 +122,27 @@ type AssistantDashboardMessage struct {
 }
 
 type AssistantMemory struct {
-	ID              uuid.UUID
-	AssistantID     uuid.NullUUID
-	ProjectID       uuid.NullUUID
-	OrganizationID  string
-	Content         string
-	Embedding       pgvector_go.HalfVector
-	SupersedesID    uuid.NullUUID
-	SupersededAt    pgtype.Timestamptz
-	ValidAt         pgtype.Timestamptz
-	Tags            []string
-	OriginThreadID  uuid.NullUUID
-	OriginChatID    uuid.NullUUID
-	SourceKind      pgtype.Text
-	SourceUserID    pgtype.Text
-	SourceChannel   pgtype.Text
-	SourceTimestamp pgtype.Timestamptz
-	CreatedAt       pgtype.Timestamptz
-	UpdatedAt       pgtype.Timestamptz
-	LastAccess      pgtype.Timestamptz
-	DeletedAt       pgtype.Timestamptz
-	Deleted         bool
+	ID                  uuid.UUID
+	AssistantID         uuid.NullUUID
+	ProjectID           uuid.NullUUID
+	OrganizationID      string
+	Content             string
+	Embedding           pgvector_go.HalfVector
+	SupersedesID        uuid.NullUUID
+	SupersededAt        pgtype.Timestamptz
+	ValidAt             pgtype.Timestamptz
+	Tags                []string
+	OriginThreadID      uuid.NullUUID
+	OriginChatID        uuid.NullUUID
+	SourceKind          pgtype.Text
+	SourceUserID        pgtype.Text
+	SourceCorrelationID pgtype.Text
+	SourceTimestamp     pgtype.Timestamptz
+	CreatedAt           pgtype.Timestamptz
+	UpdatedAt           pgtype.Timestamptz
+	LastAccess          pgtype.Timestamptz
+	DeletedAt           pgtype.Timestamptz
+	Deleted             bool
 }
 
 type AssistantRuntime struct {

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -122,27 +122,27 @@ type AssistantDashboardMessage struct {
 }
 
 type AssistantMemory struct {
-	ID                  uuid.UUID
-	AssistantID         uuid.NullUUID
-	ProjectID           uuid.NullUUID
-	OrganizationID      string
-	Content             string
-	Embedding           pgvector_go.HalfVector
-	SupersedesID        uuid.NullUUID
-	SupersededAt        pgtype.Timestamptz
-	ValidAt             pgtype.Timestamptz
-	Tags                []string
-	OriginThreadID      uuid.NullUUID
-	OriginChatID        uuid.NullUUID
-	SourceKind          pgtype.Text
-	SourceUserID        pgtype.Text
-	SourceCorrelationID pgtype.Text
-	SourceTimestamp     pgtype.Timestamptz
-	CreatedAt           pgtype.Timestamptz
-	UpdatedAt           pgtype.Timestamptz
-	LastAccess          pgtype.Timestamptz
-	DeletedAt           pgtype.Timestamptz
-	Deleted             bool
+	ID              uuid.UUID
+	AssistantID     uuid.NullUUID
+	ProjectID       uuid.NullUUID
+	OrganizationID  string
+	Content         string
+	Embedding       pgvector_go.HalfVector
+	SupersedesID    uuid.NullUUID
+	SupersededAt    pgtype.Timestamptz
+	ValidAt         pgtype.Timestamptz
+	Tags            []string
+	OriginThreadID  uuid.NullUUID
+	OriginChatID    uuid.NullUUID
+	SourceKind      pgtype.Text
+	SourceUserID    pgtype.Text
+	SourceChannel   pgtype.Text
+	SourceTimestamp pgtype.Timestamptz
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+	LastAccess      pgtype.Timestamptz
+	DeletedAt       pgtype.Timestamptz
+	Deleted         bool
 }
 
 type AssistantRuntime struct {

--- a/server/internal/memory/provenance.go
+++ b/server/internal/memory/provenance.go
@@ -5,83 +5,60 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/threadsource"
 )
 
-// Source kinds mirror the assistant thread source surfaces defined by the
-// assistants package adapters (slack|cron|wake|dashboard). They are duplicated
-// here as plain strings because the assistants constants are unexported and
-// importing that package would invert the dependency direction.
-//
-// The set is an open enum: source_kind is TEXT with no database constraint,
-// and extractProvenance records any kind it is handed verbatim. Adding a new
-// source surface (e.g. email) therefore requires no migration — its memories
-// carry kind-only provenance (NULL user/channel, read as less-trusted) until
-// a case is added to extractProvenance to extract the richer fields.
-const (
-	sourceKindSlack     = "slack"
-	sourceKindCron      = "cron"
-	sourceKindWake      = "wake"
-	sourceKindDashboard = "dashboard"
-)
-
-// provenance captures who said the remembered fact, in what channel, and when
-// it was recorded. All fields are optional: rows written outside an assistant
-// thread (or before provenance existed) carry none, and each source surface
-// only fills the fields it can attest to.
+// provenance captures, for tracing, the conversational context a memory write
+// came from: the origin thread's source surface, the external user who said
+// it, the thread's correlation id, and when it was recorded. It exists to
+// answer "why is the assistant remembering this?" — note that it records the
+// conversation the write happened in, not necessarily the true origin of the
+// fact (the assistant may have learned it from e.g. a web page mid-turn).
+// All fields are optional: writes that happen outside an assistant thread
+// carry none.
 type provenance struct {
-	Kind      *string
-	UserID    *string
-	Channel   *string
-	Timestamp *time.Time
+	Kind          *string
+	UserID        *string
+	CorrelationID *string
+	Timestamp     *time.Time
 }
 
 // extractProvenance maps an origin thread's source surface onto memory
-// provenance. Per source kind:
+// provenance. The thread's correlation id is stored verbatim for every source
+// kind — it uniformly encodes the source conversation (e.g.
+// "slack:T123:C456:789.012") regardless of surface. A speaker is only
+// recorded where one exists: slack and dashboard source refs carry the
+// user_id of the human driving the turn; cron and wake turns are automated
+// and have none.
 //
-//   - slack: user_id is the Slack user who triggered the turn and channel_id
-//     is the Slack channel it happened in.
-//   - dashboard: user_id is the Gram dashboard user driving the conversation;
-//     there is no channel concept.
-//   - cron/wake: no human speaker; the trigger instance id is recorded as the
-//     channel so memories written by automated runs remain attributable to a
-//     specific trigger.
+// The kind set (threadsource.Kind*) is an open enum: source_kind is TEXT with
+// no database constraint, and extractProvenance records any kind it is handed
+// verbatim. Adding a new source surface (e.g. email) therefore requires no
+// migration — its memories carry kind and correlation id only, until a case
+// is added here to extract its speaker.
 //
 // Timestamp is the time of write: the triggering event's own timestamp is not
 // available at Remember() time (the tool call carries only the thread
 // principal), and the write happens within the same turn as the event, so the
 // write time is a faithful proxy.
-func extractProvenance(kind string, sourceRefJSON []byte) provenance {
+func extractProvenance(kind string, correlationID string, sourceRefJSON []byte) provenance {
 	now := time.Now()
 	out := provenance{
-		Kind:      conv.PtrEmpty(kind),
-		UserID:    nil,
-		Channel:   nil,
-		Timestamp: &now,
+		Kind:          conv.PtrEmpty(kind),
+		UserID:        nil,
+		CorrelationID: conv.PtrEmpty(correlationID),
+		Timestamp:     &now,
 	}
 
 	switch kind {
-	case sourceKindSlack:
-		var ref struct {
-			ChannelID string `json:"channel_id"`
-			UserID    string `json:"user_id"`
-		}
-		if err := json.Unmarshal(sourceRefJSON, &ref); err == nil {
-			out.UserID = conv.PtrEmpty(ref.UserID)
-			out.Channel = conv.PtrEmpty(ref.ChannelID)
-		}
-	case sourceKindDashboard:
+	case threadsource.KindSlack, threadsource.KindDashboard:
+		// Both surfaces carry the speaking user under the same key in their
+		// source ref payloads.
 		var ref struct {
 			UserID string `json:"user_id"`
 		}
 		if err := json.Unmarshal(sourceRefJSON, &ref); err == nil {
 			out.UserID = conv.PtrEmpty(ref.UserID)
-		}
-	case sourceKindCron, sourceKindWake:
-		var ref struct {
-			TriggerInstanceID string `json:"trigger_instance_id"`
-		}
-		if err := json.Unmarshal(sourceRefJSON, &ref); err == nil {
-			out.Channel = conv.PtrEmpty(ref.TriggerInstanceID)
 		}
 	}
 

--- a/server/internal/memory/provenance.go
+++ b/server/internal/memory/provenance.go
@@ -1,0 +1,83 @@
+package memory
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+// Source kinds mirror the assistant thread source surfaces defined by the
+// assistants package adapters (slack|cron|wake|dashboard). They are duplicated
+// here as plain strings because the assistants constants are unexported and
+// importing that package would invert the dependency direction.
+const (
+	sourceKindSlack     = "slack"
+	sourceKindCron      = "cron"
+	sourceKindWake      = "wake"
+	sourceKindDashboard = "dashboard"
+)
+
+// provenance captures who said the remembered fact, in what channel, and when
+// it was recorded. All fields are optional: rows written outside an assistant
+// thread (or before provenance existed) carry none, and each source surface
+// only fills the fields it can attest to.
+type provenance struct {
+	Kind      *string
+	UserID    *string
+	Channel   *string
+	Timestamp *time.Time
+}
+
+// extractProvenance maps an origin thread's source surface onto memory
+// provenance. Per source kind:
+//
+//   - slack: user_id is the Slack user who triggered the turn and channel_id
+//     is the Slack channel it happened in.
+//   - dashboard: user_id is the Gram dashboard user driving the conversation;
+//     there is no channel concept.
+//   - cron/wake: no human speaker; the trigger instance id is recorded as the
+//     channel so memories written by automated runs remain attributable to a
+//     specific trigger.
+//
+// Timestamp is the time of write: the triggering event's own timestamp is not
+// available at Remember() time (the tool call carries only the thread
+// principal), and the write happens within the same turn as the event, so the
+// write time is a faithful proxy.
+func extractProvenance(kind string, sourceRefJSON []byte) provenance {
+	now := time.Now()
+	out := provenance{
+		Kind:      conv.PtrEmpty(kind),
+		UserID:    nil,
+		Channel:   nil,
+		Timestamp: &now,
+	}
+
+	switch kind {
+	case sourceKindSlack:
+		var ref struct {
+			ChannelID string `json:"channel_id"`
+			UserID    string `json:"user_id"`
+		}
+		if err := json.Unmarshal(sourceRefJSON, &ref); err == nil {
+			out.UserID = conv.PtrEmpty(ref.UserID)
+			out.Channel = conv.PtrEmpty(ref.ChannelID)
+		}
+	case sourceKindDashboard:
+		var ref struct {
+			UserID string `json:"user_id"`
+		}
+		if err := json.Unmarshal(sourceRefJSON, &ref); err == nil {
+			out.UserID = conv.PtrEmpty(ref.UserID)
+		}
+	case sourceKindCron, sourceKindWake:
+		var ref struct {
+			TriggerInstanceID string `json:"trigger_instance_id"`
+		}
+		if err := json.Unmarshal(sourceRefJSON, &ref); err == nil {
+			out.Channel = conv.PtrEmpty(ref.TriggerInstanceID)
+		}
+	}
+
+	return out
+}

--- a/server/internal/memory/provenance.go
+++ b/server/internal/memory/provenance.go
@@ -11,6 +11,12 @@ import (
 // assistants package adapters (slack|cron|wake|dashboard). They are duplicated
 // here as plain strings because the assistants constants are unexported and
 // importing that package would invert the dependency direction.
+//
+// The set is an open enum: source_kind is TEXT with no database constraint,
+// and extractProvenance records any kind it is handed verbatim. Adding a new
+// source surface (e.g. email) therefore requires no migration — its memories
+// carry kind-only provenance (NULL user/channel, read as less-trusted) until
+// a case is added to extractProvenance to extract the richer fields.
 const (
 	sourceKindSlack     = "slack"
 	sourceKindCron      = "cron"

--- a/server/internal/memory/provenance_db_test.go
+++ b/server/internal/memory/provenance_db_test.go
@@ -1,0 +1,204 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+const provenanceTestOrgID = "org-test"
+
+// insertMemoryThreadFixture creates the project/assistant/chat/thread rows a
+// Remember call resolves provenance from. sourceKind and sourceRefJSON shape
+// the thread's source surface.
+func insertMemoryThreadFixture(t *testing.T, conn *pgxpool.Pool, sourceKind string, sourceRefJSON []byte) (projectID, assistantID, threadID uuid.UUID) {
+	t.Helper()
+	ctx := t.Context()
+
+	proj, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Project",
+		Slug:           "project",
+		OrganizationID: provenanceTestOrgID,
+	})
+	require.NoError(t, err)
+
+	assistant, err := assistantsrepo.New(conn).CreateAssistant(ctx, assistantsrepo.CreateAssistantParams{
+		ProjectID:       proj.ID,
+		OrganizationID:  provenanceTestOrgID,
+		CreatedByUserID: pgtype.Text{String: "", Valid: false},
+		Name:            "Assistant",
+		Model:           "openai/gpt-4o-mini",
+		Instructions:    "",
+		WarmTtlSeconds:  300,
+		MaxConcurrency:  1,
+		Status:          "active",
+	})
+	require.NoError(t, err)
+
+	chatID := uuid.New()
+	err = assistantsrepo.New(conn).UpsertAssistantChat(ctx, assistantsrepo.UpsertAssistantChatParams{
+		ChatID:         chatID,
+		ProjectID:      proj.ID,
+		OrganizationID: provenanceTestOrgID,
+		UserID:         pgtype.Text{String: "", Valid: false},
+		Title:          pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	threadID, err = assistantsrepo.New(conn).UpsertAssistantThread(ctx, assistantsrepo.UpsertAssistantThreadParams{
+		AssistantID:   assistant.ID,
+		ProjectID:     proj.ID,
+		CorrelationID: "corr-1",
+		ChatID:        chatID,
+		SourceKind:    sourceKind,
+		SourceRefJson: sourceRefJSON,
+	})
+	require.NoError(t, err)
+
+	return proj.ID, assistant.ID, threadID
+}
+
+// newMemoryServiceForDBTest wires a MemoryService against the cloned test
+// database with a mocked embeddings client that returns a fixed vector.
+func newMemoryServiceForDBTest(t *testing.T, conn *pgxpool.Pool) *MemoryService {
+	t.Helper()
+
+	vec := make([]float32, embeddingDimensions)
+	vec[0] = 1
+
+	client := &mockCompletionClient{}
+	client.On("CreateEmbeddings", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([][]float32{vec}, nil)
+
+	return NewMemoryService(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		conn,
+		client,
+		nil,
+	)
+}
+
+func authedAssistantContext(t *testing.T, projectID, assistantID, threadID uuid.UUID) context.Context {
+	t.Helper()
+
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID:  provenanceTestOrgID,
+		UserID:                "owner-user",
+		ExternalUserID:        "",
+		APIKeyID:              "",
+		SessionID:             nil,
+		ProjectID:             &projectID,
+		OrganizationSlug:      "",
+		Email:                 nil,
+		AccountType:           "",
+		HasActiveSubscription: false,
+		Whitelisted:           false,
+		ProjectSlug:           nil,
+		APIKeyScopes:          nil,
+		IsAdmin:               false,
+	})
+	return contextvalues.SetAssistantPrincipal(ctx, contextvalues.AssistantPrincipal{
+		AssistantID: assistantID,
+		ThreadID:    threadID,
+	})
+}
+
+func TestRememberStampsSlackProvenanceAndRecallReturnsIt(t *testing.T) {
+	t.Parallel()
+
+	conn, err := memoryInfra.CloneTestDatabase(t, "memory_provenance_slack")
+	require.NoError(t, err)
+
+	projectID, assistantID, threadID := insertMemoryThreadFixture(t, conn, "slack",
+		[]byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001","user_id":"U456"}`))
+
+	svc := newMemoryServiceForDBTest(t, conn)
+	ctx := authedAssistantContext(t, projectID, assistantID, threadID)
+
+	remembered, err := svc.Remember(ctx, assistantID, projectID, provenanceTestOrgID, "user prefers tea", nil)
+	require.NoError(t, err)
+	require.False(t, remembered.Deduped)
+
+	results, err := svc.Recall(ctx, assistantID, provenanceTestOrgID, "tea", 8, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	got := results[0]
+	require.Equal(t, remembered.ID, got.ID)
+	require.NotNil(t, got.SourceKind)
+	require.Equal(t, "slack", *got.SourceKind)
+	require.NotNil(t, got.SourceUserID)
+	require.Equal(t, "U456", *got.SourceUserID)
+	require.NotNil(t, got.SourceChannel)
+	require.Equal(t, "C123", *got.SourceChannel)
+	require.NotNil(t, got.SourceTimestamp, "source_timestamp records the time of write")
+	require.False(t, got.SourceTimestamp.IsZero())
+}
+
+func TestRememberStampsDashboardProvenance(t *testing.T) {
+	t.Parallel()
+
+	conn, err := memoryInfra.CloneTestDatabase(t, "memory_provenance_dashboard")
+	require.NoError(t, err)
+
+	projectID, assistantID, threadID := insertMemoryThreadFixture(t, conn, "dashboard",
+		[]byte(`{"user_id":"user_abc"}`))
+
+	svc := newMemoryServiceForDBTest(t, conn)
+	ctx := authedAssistantContext(t, projectID, assistantID, threadID)
+
+	_, err = svc.Remember(ctx, assistantID, projectID, provenanceTestOrgID, "user works at acme", nil)
+	require.NoError(t, err)
+
+	results, err := svc.Recall(ctx, assistantID, provenanceTestOrgID, "acme", 8, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	got := results[0]
+	require.NotNil(t, got.SourceKind)
+	require.Equal(t, "dashboard", *got.SourceKind)
+	require.NotNil(t, got.SourceUserID)
+	require.Equal(t, "user_abc", *got.SourceUserID)
+	require.Nil(t, got.SourceChannel, "dashboard has no channel concept")
+	require.NotNil(t, got.SourceTimestamp)
+}
+
+func TestRememberWithoutOriginThreadHasNoProvenance(t *testing.T) {
+	t.Parallel()
+
+	conn, err := memoryInfra.CloneTestDatabase(t, "memory_provenance_none")
+	require.NoError(t, err)
+
+	projectID, assistantID, _ := insertMemoryThreadFixture(t, conn, "slack",
+		[]byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001","user_id":"U456"}`))
+
+	svc := newMemoryServiceForDBTest(t, conn)
+	// Principal without a thread id: provenance cannot be resolved and must
+	// stay NULL rather than failing the write.
+	ctx := authedAssistantContext(t, projectID, assistantID, uuid.Nil)
+
+	_, err = svc.Remember(ctx, assistantID, projectID, provenanceTestOrgID, "fact with no origin", nil)
+	require.NoError(t, err)
+
+	results, err := svc.Recall(ctx, assistantID, provenanceTestOrgID, "fact", 8, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	got := results[0]
+	require.Nil(t, got.SourceKind)
+	require.Nil(t, got.SourceUserID)
+	require.Nil(t, got.SourceChannel)
+	require.Nil(t, got.SourceTimestamp)
+}

--- a/server/internal/memory/provenance_db_test.go
+++ b/server/internal/memory/provenance_db_test.go
@@ -14,14 +14,15 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/threadsource"
 )
 
 const provenanceTestOrgID = "org-test"
 
 // insertMemoryThreadFixture creates the project/assistant/chat/thread rows a
-// Remember call resolves provenance from. sourceKind and sourceRefJSON shape
-// the thread's source surface.
-func insertMemoryThreadFixture(t *testing.T, conn *pgxpool.Pool, sourceKind string, sourceRefJSON []byte) (projectID, assistantID, threadID uuid.UUID) {
+// Remember call resolves provenance from. sourceKind, correlationID and
+// sourceRefJSON shape the thread's source surface.
+func insertMemoryThreadFixture(t *testing.T, conn *pgxpool.Pool, sourceKind string, correlationID string, sourceRefJSON []byte) (projectID, assistantID, threadID uuid.UUID) {
 	t.Helper()
 	ctx := t.Context()
 
@@ -58,7 +59,7 @@ func insertMemoryThreadFixture(t *testing.T, conn *pgxpool.Pool, sourceKind stri
 	threadID, err = assistantsrepo.New(conn).UpsertAssistantThread(ctx, assistantsrepo.UpsertAssistantThreadParams{
 		AssistantID:   assistant.ID,
 		ProjectID:     proj.ID,
-		CorrelationID: "corr-1",
+		CorrelationID: correlationID,
 		ChatID:        chatID,
 		SourceKind:    sourceKind,
 		SourceRefJson: sourceRefJSON,
@@ -121,7 +122,8 @@ func TestRememberStampsSlackProvenanceAndRecallReturnsIt(t *testing.T) {
 	conn, err := memoryInfra.CloneTestDatabase(t, "memory_provenance_slack")
 	require.NoError(t, err)
 
-	projectID, assistantID, threadID := insertMemoryThreadFixture(t, conn, "slack",
+	projectID, assistantID, threadID := insertMemoryThreadFixture(t, conn, threadsource.KindSlack,
+		"slack:T1:C123:171.001",
 		[]byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001","user_id":"U456"}`))
 
 	svc := newMemoryServiceForDBTest(t, conn)
@@ -138,11 +140,11 @@ func TestRememberStampsSlackProvenanceAndRecallReturnsIt(t *testing.T) {
 	got := results[0]
 	require.Equal(t, remembered.ID, got.ID)
 	require.NotNil(t, got.SourceKind)
-	require.Equal(t, "slack", *got.SourceKind)
+	require.Equal(t, threadsource.KindSlack, *got.SourceKind)
 	require.NotNil(t, got.SourceUserID)
 	require.Equal(t, "U456", *got.SourceUserID)
-	require.NotNil(t, got.SourceChannel)
-	require.Equal(t, "C123", *got.SourceChannel)
+	require.NotNil(t, got.SourceCorrelationID)
+	require.Equal(t, "slack:T1:C123:171.001", *got.SourceCorrelationID)
 	require.NotNil(t, got.SourceTimestamp, "source_timestamp records the time of write")
 	require.False(t, got.SourceTimestamp.IsZero())
 }
@@ -153,7 +155,8 @@ func TestRememberStampsDashboardProvenance(t *testing.T) {
 	conn, err := memoryInfra.CloneTestDatabase(t, "memory_provenance_dashboard")
 	require.NoError(t, err)
 
-	projectID, assistantID, threadID := insertMemoryThreadFixture(t, conn, "dashboard",
+	projectID, assistantID, threadID := insertMemoryThreadFixture(t, conn, threadsource.KindDashboard,
+		"0d9e0001-aaaa-bbbb-cccc-000000000001",
 		[]byte(`{"user_id":"user_abc"}`))
 
 	svc := newMemoryServiceForDBTest(t, conn)
@@ -168,10 +171,11 @@ func TestRememberStampsDashboardProvenance(t *testing.T) {
 
 	got := results[0]
 	require.NotNil(t, got.SourceKind)
-	require.Equal(t, "dashboard", *got.SourceKind)
+	require.Equal(t, threadsource.KindDashboard, *got.SourceKind)
 	require.NotNil(t, got.SourceUserID)
 	require.Equal(t, "user_abc", *got.SourceUserID)
-	require.Nil(t, got.SourceChannel, "dashboard has no channel concept")
+	require.NotNil(t, got.SourceCorrelationID, "correlation id is recorded for every source kind")
+	require.Equal(t, "0d9e0001-aaaa-bbbb-cccc-000000000001", *got.SourceCorrelationID)
 	require.NotNil(t, got.SourceTimestamp)
 }
 
@@ -181,7 +185,8 @@ func TestRememberWithoutOriginThreadHasNoProvenance(t *testing.T) {
 	conn, err := memoryInfra.CloneTestDatabase(t, "memory_provenance_none")
 	require.NoError(t, err)
 
-	projectID, assistantID, _ := insertMemoryThreadFixture(t, conn, "slack",
+	projectID, assistantID, _ := insertMemoryThreadFixture(t, conn, threadsource.KindSlack,
+		"slack:T1:C123:171.001",
 		[]byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001","user_id":"U456"}`))
 
 	svc := newMemoryServiceForDBTest(t, conn)
@@ -199,6 +204,6 @@ func TestRememberWithoutOriginThreadHasNoProvenance(t *testing.T) {
 	got := results[0]
 	require.Nil(t, got.SourceKind)
 	require.Nil(t, got.SourceUserID)
-	require.Nil(t, got.SourceChannel)
+	require.Nil(t, got.SourceCorrelationID)
 	require.Nil(t, got.SourceTimestamp)
 }

--- a/server/internal/memory/provenance_unit_test.go
+++ b/server/internal/memory/provenance_unit_test.go
@@ -1,0 +1,91 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractProvenanceSlack(t *testing.T) {
+	t.Parallel()
+
+	got := extractProvenance(sourceKindSlack, []byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001","user_id":"U456"}`))
+
+	require.NotNil(t, got.Kind)
+	require.Equal(t, sourceKindSlack, *got.Kind)
+	require.NotNil(t, got.UserID)
+	require.Equal(t, "U456", *got.UserID)
+	require.NotNil(t, got.Channel)
+	require.Equal(t, "C123", *got.Channel)
+	require.NotNil(t, got.Timestamp)
+}
+
+func TestExtractProvenanceSlackMissingUser(t *testing.T) {
+	t.Parallel()
+
+	got := extractProvenance(sourceKindSlack, []byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001"}`))
+
+	require.Nil(t, got.UserID)
+	require.NotNil(t, got.Channel)
+	require.Equal(t, "C123", *got.Channel)
+}
+
+func TestExtractProvenanceDashboard(t *testing.T) {
+	t.Parallel()
+
+	got := extractProvenance(sourceKindDashboard, []byte(`{"user_id":"user_abc"}`))
+
+	require.NotNil(t, got.Kind)
+	require.Equal(t, sourceKindDashboard, *got.Kind)
+	require.NotNil(t, got.UserID)
+	require.Equal(t, "user_abc", *got.UserID)
+	require.Nil(t, got.Channel, "dashboard has no channel concept")
+	require.NotNil(t, got.Timestamp)
+}
+
+func TestExtractProvenanceCron(t *testing.T) {
+	t.Parallel()
+
+	got := extractProvenance(sourceKindCron, []byte(`{"trigger_instance_id":"f0e9d8c7-0000-0000-0000-000000000001","schedule":"0 * * * *"}`))
+
+	require.NotNil(t, got.Kind)
+	require.Equal(t, sourceKindCron, *got.Kind)
+	require.Nil(t, got.UserID, "automated triggers have no human speaker")
+	require.NotNil(t, got.Channel)
+	require.Equal(t, "f0e9d8c7-0000-0000-0000-000000000001", *got.Channel)
+}
+
+func TestExtractProvenanceWake(t *testing.T) {
+	t.Parallel()
+
+	got := extractProvenance(sourceKindWake, []byte(`{"trigger_instance_id":"f0e9d8c7-0000-0000-0000-000000000002"}`))
+
+	require.NotNil(t, got.Kind)
+	require.Equal(t, sourceKindWake, *got.Kind)
+	require.Nil(t, got.UserID)
+	require.NotNil(t, got.Channel)
+	require.Equal(t, "f0e9d8c7-0000-0000-0000-000000000002", *got.Channel)
+}
+
+func TestExtractProvenanceUnknownKindKeepsKindOnly(t *testing.T) {
+	t.Parallel()
+
+	got := extractProvenance("carrier-pigeon", []byte(`{"user_id":"who"}`))
+
+	require.NotNil(t, got.Kind)
+	require.Equal(t, "carrier-pigeon", *got.Kind)
+	require.Nil(t, got.UserID)
+	require.Nil(t, got.Channel)
+	require.NotNil(t, got.Timestamp)
+}
+
+func TestExtractProvenanceMalformedRefJSON(t *testing.T) {
+	t.Parallel()
+
+	got := extractProvenance(sourceKindSlack, []byte(`{not json`))
+
+	require.NotNil(t, got.Kind)
+	require.Equal(t, sourceKindSlack, *got.Kind)
+	require.Nil(t, got.UserID)
+	require.Nil(t, got.Channel)
+}

--- a/server/internal/memory/provenance_unit_test.go
+++ b/server/internal/memory/provenance_unit_test.go
@@ -4,88 +4,108 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/threadsource"
 )
 
 func TestExtractProvenanceSlack(t *testing.T) {
 	t.Parallel()
 
-	got := extractProvenance(sourceKindSlack, []byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001","user_id":"U456"}`))
+	got := extractProvenance(threadsource.KindSlack, "slack:T1:C123:171.001",
+		[]byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001","user_id":"U456"}`))
 
 	require.NotNil(t, got.Kind)
-	require.Equal(t, sourceKindSlack, *got.Kind)
+	require.Equal(t, threadsource.KindSlack, *got.Kind)
 	require.NotNil(t, got.UserID)
 	require.Equal(t, "U456", *got.UserID)
-	require.NotNil(t, got.Channel)
-	require.Equal(t, "C123", *got.Channel)
+	require.NotNil(t, got.CorrelationID)
+	require.Equal(t, "slack:T1:C123:171.001", *got.CorrelationID)
 	require.NotNil(t, got.Timestamp)
 }
 
 func TestExtractProvenanceSlackMissingUser(t *testing.T) {
 	t.Parallel()
 
-	got := extractProvenance(sourceKindSlack, []byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001"}`))
+	got := extractProvenance(threadsource.KindSlack, "slack:T1:C123:171.001",
+		[]byte(`{"team_id":"T1","channel_id":"C123","thread_id":"171.001"}`))
 
 	require.Nil(t, got.UserID)
-	require.NotNil(t, got.Channel)
-	require.Equal(t, "C123", *got.Channel)
+	require.NotNil(t, got.CorrelationID)
+	require.Equal(t, "slack:T1:C123:171.001", *got.CorrelationID)
 }
 
 func TestExtractProvenanceDashboard(t *testing.T) {
 	t.Parallel()
 
-	got := extractProvenance(sourceKindDashboard, []byte(`{"user_id":"user_abc"}`))
+	got := extractProvenance(threadsource.KindDashboard, "0d9e0001-aaaa-bbbb-cccc-000000000001",
+		[]byte(`{"user_id":"user_abc"}`))
 
 	require.NotNil(t, got.Kind)
-	require.Equal(t, sourceKindDashboard, *got.Kind)
+	require.Equal(t, threadsource.KindDashboard, *got.Kind)
 	require.NotNil(t, got.UserID)
 	require.Equal(t, "user_abc", *got.UserID)
-	require.Nil(t, got.Channel, "dashboard has no channel concept")
+	require.NotNil(t, got.CorrelationID)
+	require.Equal(t, "0d9e0001-aaaa-bbbb-cccc-000000000001", *got.CorrelationID)
 	require.NotNil(t, got.Timestamp)
 }
 
-func TestExtractProvenanceCron(t *testing.T) {
+func TestExtractProvenanceCronHasNoSpeaker(t *testing.T) {
 	t.Parallel()
 
-	got := extractProvenance(sourceKindCron, []byte(`{"trigger_instance_id":"f0e9d8c7-0000-0000-0000-000000000001","schedule":"0 * * * *"}`))
+	got := extractProvenance(threadsource.KindCron, "cron:f0e9d8c7-0000-0000-0000-000000000001",
+		[]byte(`{"trigger_instance_id":"f0e9d8c7-0000-0000-0000-000000000001","schedule":"0 * * * *"}`))
 
 	require.NotNil(t, got.Kind)
-	require.Equal(t, sourceKindCron, *got.Kind)
+	require.Equal(t, threadsource.KindCron, *got.Kind)
 	require.Nil(t, got.UserID, "automated triggers have no human speaker")
-	require.NotNil(t, got.Channel)
-	require.Equal(t, "f0e9d8c7-0000-0000-0000-000000000001", *got.Channel)
+	require.NotNil(t, got.CorrelationID)
+	require.Equal(t, "cron:f0e9d8c7-0000-0000-0000-000000000001", *got.CorrelationID)
 }
 
-func TestExtractProvenanceWake(t *testing.T) {
+func TestExtractProvenanceWakeHasNoSpeaker(t *testing.T) {
 	t.Parallel()
 
-	got := extractProvenance(sourceKindWake, []byte(`{"trigger_instance_id":"f0e9d8c7-0000-0000-0000-000000000002"}`))
+	got := extractProvenance(threadsource.KindWake, "wake:f0e9d8c7-0000-0000-0000-000000000002",
+		[]byte(`{"trigger_instance_id":"f0e9d8c7-0000-0000-0000-000000000002"}`))
 
 	require.NotNil(t, got.Kind)
-	require.Equal(t, sourceKindWake, *got.Kind)
+	require.Equal(t, threadsource.KindWake, *got.Kind)
 	require.Nil(t, got.UserID)
-	require.NotNil(t, got.Channel)
-	require.Equal(t, "f0e9d8c7-0000-0000-0000-000000000002", *got.Channel)
+	require.NotNil(t, got.CorrelationID)
+	require.Equal(t, "wake:f0e9d8c7-0000-0000-0000-000000000002", *got.CorrelationID)
 }
 
-func TestExtractProvenanceUnknownKindKeepsKindOnly(t *testing.T) {
+func TestExtractProvenanceUnknownKindKeepsKindAndCorrelation(t *testing.T) {
 	t.Parallel()
 
-	got := extractProvenance("carrier-pigeon", []byte(`{"user_id":"who"}`))
+	// source_kind is an open enum: unknown kinds are recorded verbatim with
+	// the correlation id but no speaker.
+	got := extractProvenance("carrier-pigeon", "pigeon:coop-7", []byte(`{"user_id":"who"}`))
 
 	require.NotNil(t, got.Kind)
 	require.Equal(t, "carrier-pigeon", *got.Kind)
 	require.Nil(t, got.UserID)
-	require.Nil(t, got.Channel)
+	require.NotNil(t, got.CorrelationID)
+	require.Equal(t, "pigeon:coop-7", *got.CorrelationID)
 	require.NotNil(t, got.Timestamp)
 }
 
 func TestExtractProvenanceMalformedRefJSON(t *testing.T) {
 	t.Parallel()
 
-	got := extractProvenance(sourceKindSlack, []byte(`{not json`))
+	got := extractProvenance(threadsource.KindSlack, "slack:T1:C123:171.001", []byte(`{not json`))
 
 	require.NotNil(t, got.Kind)
-	require.Equal(t, sourceKindSlack, *got.Kind)
+	require.Equal(t, threadsource.KindSlack, *got.Kind)
 	require.Nil(t, got.UserID)
-	require.Nil(t, got.Channel)
+	require.NotNil(t, got.CorrelationID, "correlation id does not depend on the ref payload")
+	require.Equal(t, "slack:T1:C123:171.001", *got.CorrelationID)
+}
+
+func TestExtractProvenanceEmptyCorrelationIDIsNil(t *testing.T) {
+	t.Parallel()
+
+	got := extractProvenance(threadsource.KindSlack, "", []byte(`{"user_id":"U1"}`))
+
+	require.Nil(t, got.CorrelationID)
 }

--- a/server/internal/memory/queries.sql
+++ b/server/internal/memory/queries.sql
@@ -13,7 +13,11 @@ INSERT INTO assistant_memories (
   tags,
   origin_thread_id,
   origin_chat_id,
-  supersedes_id
+  supersedes_id,
+  source_kind,
+  source_user_id,
+  source_channel,
+  source_timestamp
 ) VALUES (
   @assistant_id::uuid,
   @project_id::uuid,
@@ -23,9 +27,23 @@ INSERT INTO assistant_memories (
   @tags,
   @origin_thread_id,
   @origin_chat_id,
-  @supersedes_id
+  @supersedes_id,
+  @source_kind,
+  @source_user_id,
+  @source_channel,
+  @source_timestamp
 )
 RETURNING id, created_at;
+
+-- name: GetAssistantThreadSourceForMemory :one
+-- Resolve the origin thread's source surface and ref payload so Remember can
+-- stamp provenance (which surface, who said it, in what channel) onto the
+-- memory row.
+SELECT source_kind, source_ref_json
+  FROM assistant_threads
+ WHERE id = @id
+   AND project_id = @project_id::uuid
+   AND deleted IS FALSE;
 
 -- name: MarkAssistantMemorySuperseded :exec
 UPDATE assistant_memories
@@ -86,6 +104,10 @@ SELECT
     tags,
     created_at,
     last_access,
+    source_kind,
+    source_user_id,
+    source_channel,
+    source_timestamp,
     (1 - (embedding <=> @query_embedding))::float8 AS similarity
   FROM assistant_memories
  WHERE assistant_id = @assistant_id::uuid

--- a/server/internal/memory/queries.sql
+++ b/server/internal/memory/queries.sql
@@ -16,7 +16,7 @@ INSERT INTO assistant_memories (
   supersedes_id,
   source_kind,
   source_user_id,
-  source_channel,
+  source_correlation_id,
   source_timestamp
 ) VALUES (
   @assistant_id::uuid,
@@ -30,16 +30,16 @@ INSERT INTO assistant_memories (
   @supersedes_id,
   @source_kind,
   @source_user_id,
-  @source_channel,
+  @source_correlation_id,
   @source_timestamp
 )
 RETURNING id, created_at;
 
 -- name: GetAssistantThreadSourceForMemory :one
--- Resolve the origin thread's source surface and ref payload so Remember can
--- stamp provenance (which surface, who said it, in what channel) onto the
--- memory row.
-SELECT source_kind, source_ref_json
+-- Resolve the origin thread's source surface, correlation id and ref payload
+-- so Remember can stamp provenance (which surface, who said it, in which
+-- conversation) onto the memory row for tracing.
+SELECT source_kind, correlation_id, source_ref_json
   FROM assistant_threads
  WHERE id = @id
    AND project_id = @project_id::uuid
@@ -106,7 +106,7 @@ SELECT
     last_access,
     source_kind,
     source_user_id,
-    source_channel,
+    source_correlation_id,
     source_timestamp,
     (1 - (embedding <=> @query_embedding))::float8 AS similarity
   FROM assistant_memories

--- a/server/internal/memory/repo/queries.sql.go
+++ b/server/internal/memory/repo/queries.sql.go
@@ -110,6 +110,34 @@ func (q *Queries) GetAssistantMemoryByID(ctx context.Context, arg GetAssistantMe
 	return i, err
 }
 
+const getAssistantThreadSourceForMemory = `-- name: GetAssistantThreadSourceForMemory :one
+SELECT source_kind, source_ref_json
+  FROM assistant_threads
+ WHERE id = $1
+   AND project_id = $2::uuid
+   AND deleted IS FALSE
+`
+
+type GetAssistantThreadSourceForMemoryParams struct {
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+}
+
+type GetAssistantThreadSourceForMemoryRow struct {
+	SourceKind    string
+	SourceRefJson []byte
+}
+
+// Resolve the origin thread's source surface and ref payload so Remember can
+// stamp provenance (which surface, who said it, in what channel) onto the
+// memory row.
+func (q *Queries) GetAssistantThreadSourceForMemory(ctx context.Context, arg GetAssistantThreadSourceForMemoryParams) (GetAssistantThreadSourceForMemoryRow, error) {
+	row := q.db.QueryRow(ctx, getAssistantThreadSourceForMemory, arg.ID, arg.ProjectID)
+	var i GetAssistantThreadSourceForMemoryRow
+	err := row.Scan(&i.SourceKind, &i.SourceRefJson)
+	return i, err
+}
+
 const getNearestActiveAssistantMemory = `-- name: GetNearestActiveAssistantMemory :one
 SELECT
     id,
@@ -153,7 +181,11 @@ INSERT INTO assistant_memories (
   tags,
   origin_thread_id,
   origin_chat_id,
-  supersedes_id
+  supersedes_id,
+  source_kind,
+  source_user_id,
+  source_channel,
+  source_timestamp
 ) VALUES (
   $1::uuid,
   $2::uuid,
@@ -163,21 +195,29 @@ INSERT INTO assistant_memories (
   $6,
   $7,
   $8,
-  $9
+  $9,
+  $10,
+  $11,
+  $12,
+  $13
 )
 RETURNING id, created_at
 `
 
 type InsertAssistantMemoryParams struct {
-	AssistantID    uuid.UUID
-	ProjectID      uuid.UUID
-	OrganizationID string
-	Content        string
-	Embedding      pgvector_go.HalfVector
-	Tags           []string
-	OriginThreadID uuid.NullUUID
-	OriginChatID   uuid.NullUUID
-	SupersedesID   uuid.NullUUID
+	AssistantID     uuid.UUID
+	ProjectID       uuid.UUID
+	OrganizationID  string
+	Content         string
+	Embedding       pgvector_go.HalfVector
+	Tags            []string
+	OriginThreadID  uuid.NullUUID
+	OriginChatID    uuid.NullUUID
+	SupersedesID    uuid.NullUUID
+	SourceKind      pgtype.Text
+	SourceUserID    pgtype.Text
+	SourceChannel   pgtype.Text
+	SourceTimestamp pgtype.Timestamptz
 }
 
 type InsertAssistantMemoryRow struct {
@@ -196,6 +236,10 @@ func (q *Queries) InsertAssistantMemory(ctx context.Context, arg InsertAssistant
 		arg.OriginThreadID,
 		arg.OriginChatID,
 		arg.SupersedesID,
+		arg.SourceKind,
+		arg.SourceUserID,
+		arg.SourceChannel,
+		arg.SourceTimestamp,
 	)
 	var i InsertAssistantMemoryRow
 	err := row.Scan(&i.ID, &i.CreatedAt)
@@ -322,6 +366,10 @@ SELECT
     tags,
     created_at,
     last_access,
+    source_kind,
+    source_user_id,
+    source_channel,
+    source_timestamp,
     (1 - (embedding <=> $1))::float8 AS similarity
   FROM assistant_memories
  WHERE assistant_id = $2::uuid
@@ -340,12 +388,16 @@ type ListNearestAssistantMemoriesParams struct {
 }
 
 type ListNearestAssistantMemoriesRow struct {
-	ID         uuid.UUID
-	Content    string
-	Tags       []string
-	CreatedAt  pgtype.Timestamptz
-	LastAccess pgtype.Timestamptz
-	Similarity float64
+	ID              uuid.UUID
+	Content         string
+	Tags            []string
+	CreatedAt       pgtype.Timestamptz
+	LastAccess      pgtype.Timestamptz
+	SourceKind      pgtype.Text
+	SourceUserID    pgtype.Text
+	SourceChannel   pgtype.Text
+	SourceTimestamp pgtype.Timestamptz
+	Similarity      float64
 }
 
 // Top-K nearest active memories with an optional tag overlap filter. Caller
@@ -370,6 +422,10 @@ func (q *Queries) ListNearestAssistantMemories(ctx context.Context, arg ListNear
 			&i.Tags,
 			&i.CreatedAt,
 			&i.LastAccess,
+			&i.SourceKind,
+			&i.SourceUserID,
+			&i.SourceChannel,
+			&i.SourceTimestamp,
 			&i.Similarity,
 		); err != nil {
 			return nil, err

--- a/server/internal/memory/repo/queries.sql.go
+++ b/server/internal/memory/repo/queries.sql.go
@@ -111,7 +111,7 @@ func (q *Queries) GetAssistantMemoryByID(ctx context.Context, arg GetAssistantMe
 }
 
 const getAssistantThreadSourceForMemory = `-- name: GetAssistantThreadSourceForMemory :one
-SELECT source_kind, source_ref_json
+SELECT source_kind, correlation_id, source_ref_json
   FROM assistant_threads
  WHERE id = $1
    AND project_id = $2::uuid
@@ -125,16 +125,17 @@ type GetAssistantThreadSourceForMemoryParams struct {
 
 type GetAssistantThreadSourceForMemoryRow struct {
 	SourceKind    string
+	CorrelationID string
 	SourceRefJson []byte
 }
 
-// Resolve the origin thread's source surface and ref payload so Remember can
-// stamp provenance (which surface, who said it, in what channel) onto the
-// memory row.
+// Resolve the origin thread's source surface, correlation id and ref payload
+// so Remember can stamp provenance (which surface, who said it, in which
+// conversation) onto the memory row for tracing.
 func (q *Queries) GetAssistantThreadSourceForMemory(ctx context.Context, arg GetAssistantThreadSourceForMemoryParams) (GetAssistantThreadSourceForMemoryRow, error) {
 	row := q.db.QueryRow(ctx, getAssistantThreadSourceForMemory, arg.ID, arg.ProjectID)
 	var i GetAssistantThreadSourceForMemoryRow
-	err := row.Scan(&i.SourceKind, &i.SourceRefJson)
+	err := row.Scan(&i.SourceKind, &i.CorrelationID, &i.SourceRefJson)
 	return i, err
 }
 
@@ -184,7 +185,7 @@ INSERT INTO assistant_memories (
   supersedes_id,
   source_kind,
   source_user_id,
-  source_channel,
+  source_correlation_id,
   source_timestamp
 ) VALUES (
   $1::uuid,
@@ -205,19 +206,19 @@ RETURNING id, created_at
 `
 
 type InsertAssistantMemoryParams struct {
-	AssistantID     uuid.UUID
-	ProjectID       uuid.UUID
-	OrganizationID  string
-	Content         string
-	Embedding       pgvector_go.HalfVector
-	Tags            []string
-	OriginThreadID  uuid.NullUUID
-	OriginChatID    uuid.NullUUID
-	SupersedesID    uuid.NullUUID
-	SourceKind      pgtype.Text
-	SourceUserID    pgtype.Text
-	SourceChannel   pgtype.Text
-	SourceTimestamp pgtype.Timestamptz
+	AssistantID         uuid.UUID
+	ProjectID           uuid.UUID
+	OrganizationID      string
+	Content             string
+	Embedding           pgvector_go.HalfVector
+	Tags                []string
+	OriginThreadID      uuid.NullUUID
+	OriginChatID        uuid.NullUUID
+	SupersedesID        uuid.NullUUID
+	SourceKind          pgtype.Text
+	SourceUserID        pgtype.Text
+	SourceCorrelationID pgtype.Text
+	SourceTimestamp     pgtype.Timestamptz
 }
 
 type InsertAssistantMemoryRow struct {
@@ -238,7 +239,7 @@ func (q *Queries) InsertAssistantMemory(ctx context.Context, arg InsertAssistant
 		arg.SupersedesID,
 		arg.SourceKind,
 		arg.SourceUserID,
-		arg.SourceChannel,
+		arg.SourceCorrelationID,
 		arg.SourceTimestamp,
 	)
 	var i InsertAssistantMemoryRow
@@ -368,7 +369,7 @@ SELECT
     last_access,
     source_kind,
     source_user_id,
-    source_channel,
+    source_correlation_id,
     source_timestamp,
     (1 - (embedding <=> $1))::float8 AS similarity
   FROM assistant_memories
@@ -388,16 +389,16 @@ type ListNearestAssistantMemoriesParams struct {
 }
 
 type ListNearestAssistantMemoriesRow struct {
-	ID              uuid.UUID
-	Content         string
-	Tags            []string
-	CreatedAt       pgtype.Timestamptz
-	LastAccess      pgtype.Timestamptz
-	SourceKind      pgtype.Text
-	SourceUserID    pgtype.Text
-	SourceChannel   pgtype.Text
-	SourceTimestamp pgtype.Timestamptz
-	Similarity      float64
+	ID                  uuid.UUID
+	Content             string
+	Tags                []string
+	CreatedAt           pgtype.Timestamptz
+	LastAccess          pgtype.Timestamptz
+	SourceKind          pgtype.Text
+	SourceUserID        pgtype.Text
+	SourceCorrelationID pgtype.Text
+	SourceTimestamp     pgtype.Timestamptz
+	Similarity          float64
 }
 
 // Top-K nearest active memories with an optional tag overlap filter. Caller
@@ -424,7 +425,7 @@ func (q *Queries) ListNearestAssistantMemories(ctx context.Context, arg ListNear
 			&i.LastAccess,
 			&i.SourceKind,
 			&i.SourceUserID,
-			&i.SourceChannel,
+			&i.SourceCorrelationID,
 			&i.SourceTimestamp,
 			&i.Similarity,
 		); err != nil {

--- a/server/internal/memory/service.go
+++ b/server/internal/memory/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/memory/repo"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -204,6 +205,15 @@ type RecallResult struct {
 	Score      float64
 	Similarity float64
 	CreatedAt  time.Time
+
+	// Provenance of the memory write: which source surface it came from
+	// (slack|cron|wake|dashboard), the external user who said it, the channel
+	// it was said in, and when. Nil when unknown (e.g. rows written before
+	// provenance existed or outside an assistant thread).
+	SourceKind      *string
+	SourceUserID    *string
+	SourceChannel   *string
+	SourceTimestamp *time.Time
 }
 
 type ForgetCandidate struct {
@@ -366,21 +376,41 @@ func (s *MemoryService) Remember(
 		originThread = uuid.NullUUID{UUID: principal.ThreadID, Valid: true}
 	}
 
+	// Resolve provenance from the origin thread's source surface. Best-effort:
+	// a missing or unreadable thread leaves provenance NULL rather than failing
+	// the write, which downstream trust reasoning treats as least-trusted.
+	prov := provenance{Kind: nil, UserID: nil, Channel: nil, Timestamp: nil}
+	if originThread.Valid {
+		threadSource, srcErr := txq.GetAssistantThreadSourceForMemory(ctx, repo.GetAssistantThreadSourceForMemoryParams{
+			ID:        originThread.UUID,
+			ProjectID: projectID,
+		})
+		if srcErr != nil {
+			s.logger.WarnContext(ctx, "resolve memory provenance from origin thread", attr.SlogError(srcErr))
+		} else {
+			prov = extractProvenance(threadSource.SourceKind, threadSource.SourceRefJson)
+		}
+	}
+
 	insertTags := tags
 	if insertTags == nil {
 		insertTags = []string{}
 	}
 
 	inserted, err := txq.InsertAssistantMemory(ctx, repo.InsertAssistantMemoryParams{
-		AssistantID:    assistantID,
-		ProjectID:      projectID,
-		OrganizationID: organizationID,
-		Content:        content,
-		Embedding:      embedding,
-		Tags:           insertTags,
-		OriginThreadID: originThread,
-		OriginChatID:   uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-		SupersedesID:   supersedesID,
+		AssistantID:     assistantID,
+		ProjectID:       projectID,
+		OrganizationID:  organizationID,
+		Content:         content,
+		Embedding:       embedding,
+		Tags:            insertTags,
+		OriginThreadID:  originThread,
+		OriginChatID:    uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		SupersedesID:    supersedesID,
+		SourceKind:      conv.PtrToPGText(prov.Kind),
+		SourceUserID:    conv.PtrToPGText(prov.UserID),
+		SourceChannel:   conv.PtrToPGText(prov.Channel),
+		SourceTimestamp: conv.PtrToPGTimestamptz(prov.Timestamp),
 	})
 	if err != nil {
 		return zero, oops.E(oops.CodeUnexpected, err, "insert memory").LogError(ctx, s.logger)
@@ -512,13 +542,22 @@ func (s *MemoryService) Recall(
 		if row.LastAccess.Valid {
 			age = now.Sub(row.LastAccess.Time)
 		}
+		var sourceTimestamp *time.Time
+		if row.SourceTimestamp.Valid {
+			ts := row.SourceTimestamp.Time
+			sourceTimestamp = &ts
+		}
 		scored = append(scored, RecallResult{
-			ID:         row.ID,
-			Content:    row.Content,
-			Tags:       row.Tags,
-			Similarity: row.Similarity,
-			Score:      computeScore(row.Similarity, age, s.halfLife),
-			CreatedAt:  row.CreatedAt.Time,
+			ID:              row.ID,
+			Content:         row.Content,
+			Tags:            row.Tags,
+			Similarity:      row.Similarity,
+			Score:           computeScore(row.Similarity, age, s.halfLife),
+			CreatedAt:       row.CreatedAt.Time,
+			SourceKind:      conv.FromPGText[string](row.SourceKind),
+			SourceUserID:    conv.FromPGText[string](row.SourceUserID),
+			SourceChannel:   conv.FromPGText[string](row.SourceChannel),
+			SourceTimestamp: sourceTimestamp,
 		})
 	}
 

--- a/server/internal/memory/service.go
+++ b/server/internal/memory/service.go
@@ -206,14 +206,15 @@ type RecallResult struct {
 	Similarity float64
 	CreatedAt  time.Time
 
-	// Provenance of the memory write: which source surface it came from
-	// (slack|cron|wake|dashboard), the external user who said it, the channel
-	// it was said in, and when. Nil when unknown (e.g. rows written before
+	// Provenance of the memory write, for tracing which conversation it came
+	// from: the origin thread's source surface (threadsource.Kind*, an open
+	// enum), the external user who said it, the thread's correlation id, and
+	// when it was recorded. Nil when unknown (e.g. rows written before
 	// provenance existed or outside an assistant thread).
-	SourceKind      *string
-	SourceUserID    *string
-	SourceChannel   *string
-	SourceTimestamp *time.Time
+	SourceKind          *string
+	SourceUserID        *string
+	SourceCorrelationID *string
+	SourceTimestamp     *time.Time
 }
 
 type ForgetCandidate struct {
@@ -376,10 +377,10 @@ func (s *MemoryService) Remember(
 		originThread = uuid.NullUUID{UUID: principal.ThreadID, Valid: true}
 	}
 
-	// Resolve provenance from the origin thread's source surface. Best-effort:
-	// a missing or unreadable thread leaves provenance NULL rather than failing
-	// the write, which downstream trust reasoning treats as least-trusted.
-	prov := provenance{Kind: nil, UserID: nil, Channel: nil, Timestamp: nil}
+	// Resolve provenance from the origin thread so the write can be traced
+	// back to the conversation it happened in. Best-effort: a missing or
+	// unreadable thread leaves provenance NULL rather than failing the write.
+	prov := provenance{Kind: nil, UserID: nil, CorrelationID: nil, Timestamp: nil}
 	if originThread.Valid {
 		threadSource, srcErr := txq.GetAssistantThreadSourceForMemory(ctx, repo.GetAssistantThreadSourceForMemoryParams{
 			ID:        originThread.UUID,
@@ -388,7 +389,7 @@ func (s *MemoryService) Remember(
 		if srcErr != nil {
 			s.logger.WarnContext(ctx, "resolve memory provenance from origin thread", attr.SlogError(srcErr))
 		} else {
-			prov = extractProvenance(threadSource.SourceKind, threadSource.SourceRefJson)
+			prov = extractProvenance(threadSource.SourceKind, threadSource.CorrelationID, threadSource.SourceRefJson)
 		}
 	}
 
@@ -407,10 +408,10 @@ func (s *MemoryService) Remember(
 		OriginThreadID:  originThread,
 		OriginChatID:    uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		SupersedesID:    supersedesID,
-		SourceKind:      conv.PtrToPGText(prov.Kind),
-		SourceUserID:    conv.PtrToPGText(prov.UserID),
-		SourceChannel:   conv.PtrToPGText(prov.Channel),
-		SourceTimestamp: conv.PtrToPGTimestamptz(prov.Timestamp),
+		SourceKind:          conv.PtrToPGText(prov.Kind),
+		SourceUserID:        conv.PtrToPGText(prov.UserID),
+		SourceCorrelationID: conv.PtrToPGText(prov.CorrelationID),
+		SourceTimestamp:     conv.PtrToPGTimestamptz(prov.Timestamp),
 	})
 	if err != nil {
 		return zero, oops.E(oops.CodeUnexpected, err, "insert memory").LogError(ctx, s.logger)
@@ -548,16 +549,16 @@ func (s *MemoryService) Recall(
 			sourceTimestamp = &ts
 		}
 		scored = append(scored, RecallResult{
-			ID:              row.ID,
-			Content:         row.Content,
-			Tags:            row.Tags,
-			Similarity:      row.Similarity,
-			Score:           computeScore(row.Similarity, age, s.halfLife),
-			CreatedAt:       row.CreatedAt.Time,
-			SourceKind:      conv.FromPGText[string](row.SourceKind),
-			SourceUserID:    conv.FromPGText[string](row.SourceUserID),
-			SourceChannel:   conv.FromPGText[string](row.SourceChannel),
-			SourceTimestamp: sourceTimestamp,
+			ID:                  row.ID,
+			Content:             row.Content,
+			Tags:                row.Tags,
+			Similarity:          row.Similarity,
+			Score:               computeScore(row.Similarity, age, s.halfLife),
+			CreatedAt:           row.CreatedAt.Time,
+			SourceKind:          conv.FromPGText[string](row.SourceKind),
+			SourceUserID:        conv.FromPGText[string](row.SourceUserID),
+			SourceCorrelationID: conv.FromPGText[string](row.SourceCorrelationID),
+			SourceTimestamp:     sourceTimestamp,
 		})
 	}
 

--- a/server/internal/memory/setup_test.go
+++ b/server/internal/memory/setup_test.go
@@ -1,0 +1,33 @@
+package memory
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var memoryInfra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{
+		Postgres:   true,
+		Redis:      false,
+		ClickHouse: false,
+		Temporal:   false,
+		Presidio:   false,
+	})
+	if err != nil {
+		log.Fatalf("launch memory test infrastructure: %v", err)
+	}
+	memoryInfra = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("cleanup memory test infrastructure: %v", err)
+	}
+	os.Exit(code)
+}

--- a/server/internal/platformtools/memory/recall.go
+++ b/server/internal/platformtools/memory/recall.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/memory"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
@@ -31,6 +33,37 @@ type recallEntry struct {
 	Score     float64  `json:"score"`
 	Tags      []string `json:"tags"`
 	CreatedAt string   `json:"created_at"`
+	// Source is a compact provenance line, e.g.
+	// "from slack user U123 in C456, 2026-06-12". It identifies who originally
+	// said the remembered fact and where, so the assistant can weigh how much
+	// to trust the memory. Absent when the memory has no recorded provenance.
+	Source *string `json:"source,omitempty"`
+}
+
+// formatSource renders provenance as a compact human-readable attribution.
+// For slack: "from slack user U123 in C456, 2026-06-12". The channel slot
+// carries the trigger instance id for cron/wake sources.
+func formatSource(r memory.RecallResult) *string {
+	if r.SourceKind == nil {
+		return nil
+	}
+	var b strings.Builder
+	b.WriteString("from ")
+	b.WriteString(*r.SourceKind)
+	if r.SourceUserID != nil {
+		b.WriteString(" user ")
+		b.WriteString(*r.SourceUserID)
+	}
+	if r.SourceChannel != nil {
+		b.WriteString(" in ")
+		b.WriteString(*r.SourceChannel)
+	}
+	if r.SourceTimestamp != nil {
+		b.WriteString(", ")
+		b.WriteString(r.SourceTimestamp.UTC().Format(time.DateOnly))
+	}
+	s := b.String()
+	return &s
 }
 
 // RecallTool implements gram://memory/recall.
@@ -109,6 +142,7 @@ func (t *RecallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload
 			Score:     r.Score,
 			Tags:      r.Tags,
 			CreatedAt: r.CreatedAt.UTC().Format(time.RFC3339Nano),
+			Source:    formatSource(r),
 		})
 	}
 

--- a/server/internal/platformtools/memory/recall.go
+++ b/server/internal/platformtools/memory/recall.go
@@ -33,16 +33,20 @@ type recallEntry struct {
 	Score     float64  `json:"score"`
 	Tags      []string `json:"tags"`
 	CreatedAt string   `json:"created_at"`
-	// Source is a compact provenance line, e.g.
-	// "from slack user U123 in C456, 2026-06-12". It identifies who originally
-	// said the remembered fact and where, so the assistant can weigh how much
-	// to trust the memory. Absent when the memory has no recorded provenance.
+	// Source is a compact provenance line for tracing where the memory was
+	// written, e.g. "from slack user U123 (slack:T123:C456:789.012),
+	// 2026-06-12". The parenthesised value is the origin thread's correlation
+	// id, which encodes the source conversation uniformly across surfaces. It
+	// records the conversational context of the write — not necessarily the
+	// true origin of the fact, which the assistant may have picked up
+	// elsewhere mid-turn. Absent when the memory has no recorded provenance.
 	Source *string `json:"source,omitempty"`
 }
 
-// formatSource renders provenance as a compact human-readable attribution.
-// For slack: "from slack user U123 in C456, 2026-06-12". The channel slot
-// carries the trigger instance id for cron/wake sources.
+// formatSource renders provenance as a compact attribution line: the source
+// kind, the speaking user when one exists (slack/dashboard), the origin
+// thread's correlation id in parentheses, and the write date. For automated
+// surfaces: "from cron (cron:0d9e...), 2026-06-12".
 func formatSource(r memory.RecallResult) *string {
 	if r.SourceKind == nil {
 		return nil
@@ -54,9 +58,10 @@ func formatSource(r memory.RecallResult) *string {
 		b.WriteString(" user ")
 		b.WriteString(*r.SourceUserID)
 	}
-	if r.SourceChannel != nil {
-		b.WriteString(" in ")
-		b.WriteString(*r.SourceChannel)
+	if r.SourceCorrelationID != nil {
+		b.WriteString(" (")
+		b.WriteString(*r.SourceCorrelationID)
+		b.WriteString(")")
 	}
 	if r.SourceTimestamp != nil {
 		b.WriteString(", ")

--- a/server/internal/platformtools/memory/recall_test.go
+++ b/server/internal/platformtools/memory/recall_test.go
@@ -45,15 +45,24 @@ func TestRecallTool_DefaultsLimitAndShapesResponse(t *testing.T) {
 	created := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
 	memID := uuid.New()
 
+	sourceKind := "slack"
+	sourceUser := "U123"
+	sourceChannel := "C456"
+	sourceTime := time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC)
+
 	fake := &fakeMemoryService{
 		recallResult: []memory.RecallResult{
 			{
-				ID:         memID,
-				Content:    "lorem",
-				Tags:       []string{"x"},
-				Score:      0.87,
-				Similarity: 0.95,
-				CreatedAt:  created,
+				ID:              memID,
+				Content:         "lorem",
+				Tags:            []string{"x"},
+				Score:           0.87,
+				Similarity:      0.95,
+				CreatedAt:       created,
+				SourceKind:      &sourceKind,
+				SourceUserID:    &sourceUser,
+				SourceChannel:   &sourceChannel,
+				SourceTimestamp: &sourceTime,
 			},
 		},
 	}
@@ -93,6 +102,48 @@ func TestRecallTool_DefaultsLimitAndShapesResponse(t *testing.T) {
 	require.Equal(t, "lorem", resp[0].Content)
 	require.InDelta(t, 0.87, resp[0].Score, 1e-9)
 	require.Equal(t, []string{"x"}, resp[0].Tags)
+	require.NotNil(t, resp[0].Source)
+	require.Equal(t, "from slack user U123 in C456, 2026-06-12", *resp[0].Source)
+}
+
+func TestFormatSourceWithoutProvenanceIsNil(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, formatSource(memory.RecallResult{
+		ID:              uuid.New(),
+		Content:         "no provenance",
+		Tags:            nil,
+		Score:           0.5,
+		Similarity:      0.5,
+		CreatedAt:       time.Now(),
+		SourceKind:      nil,
+		SourceUserID:    nil,
+		SourceChannel:   nil,
+		SourceTimestamp: nil,
+	}))
+}
+
+func TestFormatSourceCronUsesTriggerChannelOnly(t *testing.T) {
+	t.Parallel()
+
+	kind := "cron"
+	trigger := "f0e9d8c7-0000-0000-0000-000000000001"
+	ts := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+
+	got := formatSource(memory.RecallResult{
+		ID:              uuid.New(),
+		Content:         "automated fact",
+		Tags:            nil,
+		Score:           0.5,
+		Similarity:      0.5,
+		CreatedAt:       ts,
+		SourceKind:      &kind,
+		SourceUserID:    nil,
+		SourceChannel:   &trigger,
+		SourceTimestamp: &ts,
+	})
+	require.NotNil(t, got)
+	require.Equal(t, "from cron in f0e9d8c7-0000-0000-0000-000000000001, 2026-06-12", *got)
 }
 
 func TestRecallTool_HonorsExplicitLimit(t *testing.T) {

--- a/server/internal/platformtools/memory/recall_test.go
+++ b/server/internal/platformtools/memory/recall_test.go
@@ -47,7 +47,7 @@ func TestRecallTool_DefaultsLimitAndShapesResponse(t *testing.T) {
 
 	sourceKind := "slack"
 	sourceUser := "U123"
-	sourceChannel := "C456"
+	sourceCorrelation := "slack:T123:C456:789.012"
 	sourceTime := time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC)
 
 	fake := &fakeMemoryService{
@@ -59,10 +59,10 @@ func TestRecallTool_DefaultsLimitAndShapesResponse(t *testing.T) {
 				Score:           0.87,
 				Similarity:      0.95,
 				CreatedAt:       created,
-				SourceKind:      &sourceKind,
-				SourceUserID:    &sourceUser,
-				SourceChannel:   &sourceChannel,
-				SourceTimestamp: &sourceTime,
+				SourceKind:          &sourceKind,
+				SourceUserID:        &sourceUser,
+				SourceCorrelationID: &sourceCorrelation,
+				SourceTimestamp:     &sourceTime,
 			},
 		},
 	}
@@ -103,47 +103,47 @@ func TestRecallTool_DefaultsLimitAndShapesResponse(t *testing.T) {
 	require.InDelta(t, 0.87, resp[0].Score, 1e-9)
 	require.Equal(t, []string{"x"}, resp[0].Tags)
 	require.NotNil(t, resp[0].Source)
-	require.Equal(t, "from slack user U123 in C456, 2026-06-12", *resp[0].Source)
+	require.Equal(t, "from slack user U123 (slack:T123:C456:789.012), 2026-06-12", *resp[0].Source)
 }
 
 func TestFormatSourceWithoutProvenanceIsNil(t *testing.T) {
 	t.Parallel()
 
 	require.Nil(t, formatSource(memory.RecallResult{
-		ID:              uuid.New(),
-		Content:         "no provenance",
-		Tags:            nil,
-		Score:           0.5,
-		Similarity:      0.5,
-		CreatedAt:       time.Now(),
-		SourceKind:      nil,
-		SourceUserID:    nil,
-		SourceChannel:   nil,
-		SourceTimestamp: nil,
+		ID:                  uuid.New(),
+		Content:             "no provenance",
+		Tags:                nil,
+		Score:               0.5,
+		Similarity:          0.5,
+		CreatedAt:           time.Now(),
+		SourceKind:          nil,
+		SourceUserID:        nil,
+		SourceCorrelationID: nil,
+		SourceTimestamp:     nil,
 	}))
 }
 
-func TestFormatSourceCronUsesTriggerChannelOnly(t *testing.T) {
+func TestFormatSourceCronHasNoSpeaker(t *testing.T) {
 	t.Parallel()
 
 	kind := "cron"
-	trigger := "f0e9d8c7-0000-0000-0000-000000000001"
+	correlation := "cron:f0e9d8c7-0000-0000-0000-000000000001"
 	ts := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
 
 	got := formatSource(memory.RecallResult{
-		ID:              uuid.New(),
-		Content:         "automated fact",
-		Tags:            nil,
-		Score:           0.5,
-		Similarity:      0.5,
-		CreatedAt:       ts,
-		SourceKind:      &kind,
-		SourceUserID:    nil,
-		SourceChannel:   &trigger,
-		SourceTimestamp: &ts,
+		ID:                  uuid.New(),
+		Content:             "automated fact",
+		Tags:                nil,
+		Score:               0.5,
+		Similarity:          0.5,
+		CreatedAt:           ts,
+		SourceKind:          &kind,
+		SourceUserID:        nil,
+		SourceCorrelationID: &correlation,
+		SourceTimestamp:     &ts,
 	})
 	require.NotNil(t, got)
-	require.Equal(t, "from cron in f0e9d8c7-0000-0000-0000-000000000001, 2026-06-12", *got)
+	require.Equal(t, "from cron (cron:f0e9d8c7-0000-0000-0000-000000000001), 2026-06-12", *got)
 }
 
 func TestRecallTool_HonorsExplicitLimit(t *testing.T) {

--- a/server/internal/threadsource/threadsource.go
+++ b/server/internal/threadsource/threadsource.go
@@ -1,0 +1,17 @@
+// Package threadsource defines the source surfaces an assistant thread can
+// originate from. It is a dependency-free leaf shared by the systems that key
+// off a thread's source kind — trigger definitions, the assistants ingress
+// adapters, and memory provenance — as a forcing function to keep them in
+// lockstep when a surface is added or renamed.
+package threadsource
+
+// Source kinds stamped on assistant_threads.source_kind. The set is an open
+// enum: the column is TEXT with no database constraint, so consumers must
+// tolerate kinds they do not know about (typically by recording or relaying
+// them verbatim) rather than rejecting them.
+const (
+	KindSlack     = "slack"
+	KindCron      = "cron"
+	KindWake      = "wake"
+	KindDashboard = "dashboard"
+)


### PR DESCRIPTION
Resolves DNO-245 · Stacked on the migration PR #3398 — merge that first

## Summary

When an assistant stores a memory via `platform_memory_remember`, it is now tagged with provenance — which conversation surface it came from, who was speaking, and when — and that provenance surfaces on recall. Provenance is **tracing/attribution**, answering "why is the assistant remembering this?"; it records the conversational context of the write, not necessarily the true origin of the fact (the assistant may have learned it from e.g. a web page mid-turn).

### Write path

- `Remember()` resolves the origin thread's `source_kind`, `correlation_id`, and `source_ref_json` inside the write transaction and stamps the provenance columns.
- `source_correlation_id` = the thread's correlation id verbatim, for **every** source kind (e.g. `slack:T123:C456:789.012`) — uniform, no per-kind extraction to maintain.
- `source_user_id` = the speaking user where one exists (Slack / dashboard source refs; deliberately *not* the auth context's `UserID`, which is the assistant owner). Cron/wake turns are automated and record no speaker.
- `source_timestamp` = time of write (the event's own timestamp isn't reachable from `Remember()`; the write happens within the same turn, so write time is a faithful proxy).
- Best-effort: a missing/unreadable origin thread logs a warning and stores NULLs rather than failing the write.

### Shared source-kind constants

New leaf package `server/internal/threadsource` exports `KindSlack|KindCron|KindWake|KindDashboard`, consumed by the trigger definitions, the assistants source adapters, and memory — a forcing function keeping dependent systems in sync. The set is an open enum (TEXT, no DB constraint): a new source surface needs no migration and its memories carry kind + correlation id until a speaker-extraction case is added.

### Read path

- `RecallResult` gains the provenance fields; the recall tool output renders a compact attribution line the model sees with each memory:
  - `from slack user U123 (slack:T123:C456:789.012), 2026-06-12`
  - `from cron (cron:f0e9d8c7-...), 2026-06-12`

## Testing

- `mise build:server` passes; custom golangci-lint clean across the five changed packages
- `go test ./internal/memory/... ./internal/platformtools/memory/... ./internal/assistants/... ./internal/background/triggers/...` — all pass, including DB-backed write→recall round-trips asserting the correlation id
- sqlc regenerated with the pinned v1.31.1 binary
- Changeset: `"server": patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
