### PR TITLE
fix(plugins): probe for codex binary and write feature flags in [features] table

### DIFF
--- a/.changeset/codex-install-script-fixes.md
+++ b/.changeset/codex-install-script-fixes.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The Codex observability plugin install script now works on machines where the `codex` CLI is not on PATH: it probes well-known install locations, including the Codex desktop app bundle, before falling back to manual instructions. It also writes feature flags inside the `[features]` table instead of as root-level dotted keys, fixing a "duplicate key" config error on machines whose `config.toml` already has a `[features]` table, and cleans up dotted keys left behind by earlier versions of the script.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1407,17 +1407,43 @@ func renderCodexInstallScript(marketplaceURL, marketplace, plugin string, approv
 	fmt.Fprintf(&b, "MARKETPLACE_KEY=%q\n", marketplace)
 	fmt.Fprintf(&b, "PLUGIN_KEY=%q\n\n", plugin)
 
+	// Desktop-only and MDM-deployed machines run without codex on PATH; probe
+	// the managed-install and app-bundle locations. Candidate list mirrors
+	// find_codex in the generated hook script.
+	b.WriteString(`find_codex() {
+  if command -v codex >/dev/null 2>&1; then
+    command -v codex
+    return 0
+  fi
+  local codex_home="${CODEX_HOME:-$HOME/.codex}"
+  local candidate
+  for candidate in \
+    "${codex_home}/packages/standalone/current/bin/codex" \
+    "${HOME}/.local/bin/codex" \
+    /usr/local/bin/codex \
+    "/Applications/Codex.app/Contents/Resources/codex"; do
+    if [ -f "${candidate}" ] && [ -x "${candidate}" ]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+CODEX_BIN="$(find_codex || true)"
+
+`)
+
 	// Step 1: marketplace registration differs for remote vs local ZIP installs.
 	if marketplaceURL != "" {
 		fmt.Fprintf(&b, "MARKETPLACE_URL=%q\n\n", marketplaceURL)
 		b.WriteString(`# ── 1. Register & sync marketplace ──────────────────────────────────────────
 echo "→ Registering Speakeasy marketplace..."
-if command -v codex >/dev/null 2>&1; then
+if [ -n "${CODEX_BIN}" ]; then
   # add is idempotent (no-ops if already registered); upgrade pulls any new commits.
-  codex plugin marketplace add "${MARKETPLACE_URL}" || true
-  codex plugin marketplace upgrade "${MARKETPLACE_KEY}"
+  "${CODEX_BIN}" plugin marketplace add "${MARKETPLACE_URL}" || true
+  "${CODEX_BIN}" plugin marketplace upgrade "${MARKETPLACE_KEY}"
 else
-  echo "  ⚠  'codex' not found in PATH."
+  echo "  ⚠  'codex' executable not found."
   echo "     Run manually: codex plugin marketplace add '${MARKETPLACE_URL}'"
 fi
 
@@ -1426,10 +1452,10 @@ fi
 		b.WriteString(`# ── 1. Register marketplace (local ZIP install) ──────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "→ Registering Speakeasy marketplace from ${SCRIPT_DIR}..."
-if command -v codex >/dev/null 2>&1; then
-  codex plugin marketplace add "${SCRIPT_DIR}"
+if [ -n "${CODEX_BIN}" ]; then
+  "${CODEX_BIN}" plugin marketplace add "${SCRIPT_DIR}"
 else
-  echo "  ⚠  'codex' not found in PATH."
+  echo "  ⚠  'codex' executable not found."
   echo "     Run manually: codex plugin marketplace add '${SCRIPT_DIR}'"
 fi
 
@@ -1448,16 +1474,14 @@ config_path = os.path.expanduser("~/.codex/config.toml")
 os.makedirs(os.path.dirname(config_path), exist_ok=True)
 content = open(config_path).read() if os.path.exists(config_path) else ""
 
-def ensure_dotted_key(text, key, value):
-    if re.search(r'(?m)^' + re.escape(key) + r'\s*=', text):
-        return text
-    # Insert before the first table header so the key stays at root scope.
-    # Appending after a [table] section would silently nest it inside that table.
+# A root-level dotted key implicitly defines its parent table and conflicts
+# with an explicit [table] header elsewhere in the file. Only the region
+# before the first table header is touched.
+def strip_root_dotted_key(text, key):
     m = re.search(r'(?m)^\[', text)
-    if m:
-        before = text[:m.start()].rstrip('\n')
-        return before + '\n' + key + ' = ' + value + '\n\n' + text[m.start():]
-    return text.rstrip('\n') + '\n' + key + ' = ' + value + '\n'
+    root, rest = (text[:m.start()], text[m.start():]) if m else (text, "")
+    root = re.sub(r'(?m)^' + re.escape(key) + r'\s*=.*\n?', '', root)
+    return root + rest
 
 def ensure_table_entry(text, table_header, key, value):
     if re.search(r'(?m)^' + re.escape(table_header) + r'\s*\n(?:[^\[]*\n)*' + re.escape(key) + r'\s*=', text):
@@ -1473,8 +1497,10 @@ def ensure_table_entry(text, table_header, key, value):
 	fmt.Fprintf(&b, "PLUGIN_KEY = %q\n", plugin)
 	fmt.Fprintf(&b, "MARKETPLACE_KEY = %q\n\n", marketplace)
 
-	b.WriteString(`content = ensure_dotted_key(content, "features.hooks", "true")
-content = ensure_dotted_key(content, "features.plugin_hooks", "true")
+	b.WriteString(`content = strip_root_dotted_key(content, "features.hooks")
+content = strip_root_dotted_key(content, "features.plugin_hooks")
+content = ensure_table_entry(content, "[features]", "hooks", "true")
+content = ensure_table_entry(content, "[features]", "plugin_hooks", "true")
 
 if not re.search(r'(?m)^\[hooks\.state\]', content):
     content = content.rstrip('\n') + '\n\n[hooks.state]\n'

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1017,6 +1017,43 @@ func TestGenerateCodexObservabilityPluginScriptPostsToCodexEndpoint(t *testing.T
 	require.Contains(t, asyncScript, ") >/dev/null 2>&1 &", "hook_async.sh must run the sender in the background")
 }
 
+// runCodexInstallScript executes the generated install script under an
+// isolated HOME containing a stub codex at ~/.local/bin (off PATH), so binary
+// probing never reaches a real install on the host. The stub appends its
+// arguments to the returned call log.
+func runCodexInstallScript(t *testing.T, script []byte, existingConfig string) (home string, callLog string) {
+	t.Helper()
+
+	bashPath, err := exec.LookPath("bash")
+	require.NoError(t, err, "bash is required to run the generated install script")
+	pythonPath, err := exec.LookPath("python3")
+	require.NoError(t, err, "python3 is required by the generated install script")
+
+	home = t.TempDir()
+	callLog = filepath.Join(home, "codex-calls.log")
+	stub := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"" + callLog + "\"\n"
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".local", "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".local", "bin", "codex"), []byte(stub), 0o755))
+
+	if existingConfig != "" {
+		require.NoError(t, os.MkdirAll(filepath.Join(home, ".codex"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(home, ".codex", "config.toml"), []byte(existingConfig), 0o644))
+	}
+
+	scriptPath := filepath.Join(t.TempDir(), "install.sh")
+	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
+
+	cmd := exec.Command(bashPath, scriptPath)
+	cmd.Env = []string{
+		"HOME=" + home,
+		"PATH=" + filepath.Dir(pythonPath) + ":/usr/bin:/bin",
+	}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "install script failed: %s", out)
+
+	return home, callLog
+}
+
 // An upgraded install already carries [hooks.state] entries whose trusted_hash
 // was computed against the previous hook command. When the command changes
 // (e.g. SessionStart moving from hook.sh to hook_async.sh) the installer must
@@ -1024,11 +1061,6 @@ func TestGenerateCodexObservabilityPluginScriptPostsToCodexEndpoint(t *testing.T
 // and silently stops running telemetry until the user re-approves them.
 func TestGenerateCodexInstallScriptRefreshesStaleTrustedHashes(t *testing.T) {
 	t.Parallel()
-
-	bashPath, err := exec.LookPath("bash")
-	require.NoError(t, err, "bash is required to run the generated install script")
-	pythonPath, err := exec.LookPath("python3")
-	require.NoError(t, err, "python3 is required by the generated install script")
 
 	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
 	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
@@ -1045,34 +1077,78 @@ func TestGenerateCodexInstallScriptRefreshesStaleTrustedHashes(t *testing.T) {
 	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
 	require.NoError(t, err)
 
-	home := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(home, ".codex"), 0o755))
-	existing := "features.hooks = true\n\n" +
-		"[hooks.state.\"" + target.StateKey + "\"]\n" +
+	existing := "[hooks.state.\"" + target.StateKey + "\"]\n" +
 		"enabled = true\n" +
 		"trusted_hash = \"" + staleHash + "\"\n"
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
+	home, _ := runCodexInstallScript(t, script, existing)
 
-	scriptPath := filepath.Join(t.TempDir(), "install.sh")
-	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
-
-	cmd := exec.Command(bashPath, scriptPath)
-	// Exclude any installed `codex` binary so only the config.toml patch runs.
-	cmd.Env = []string{
-		"HOME=" + home,
-		"PATH=" + filepath.Dir(pythonPath) + ":/usr/bin:/bin",
-	}
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "install script failed: %s", out)
-
-	patched, err := os.ReadFile(configPath)
-	require.NoError(t, err)
+	patched := requireFileBytes(t, filepath.Join(home, ".codex", "config.toml"))
 	patchedStr := string(patched)
 
 	require.NotContains(t, patchedStr, staleHash, "stale trusted_hash must be replaced")
 	require.Contains(t, patchedStr, target.TrustedHash, "trusted_hash must be refreshed to the current command's hash")
 	require.Equal(t, 1, strings.Count(patchedStr, "[hooks.state.\""+target.StateKey+"\"]"), "refresh must not duplicate the entry")
+}
+
+// Desktop-only and MDM-deployed machines run without codex on PATH. The
+// install script must probe well-known install locations and use the binary
+// it finds there instead of skipping marketplace registration.
+func TestGenerateCodexInstallScriptProbesForCodexBinary(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	_, callLog := runCodexInstallScript(t, script, "")
+
+	calls := string(requireFileBytes(t, callLog))
+	require.Contains(t, calls, "plugin marketplace add https://example.com/gram-marketplace")
+	require.Contains(t, calls, "plugin marketplace upgrade "+conv.ToSlug(cfg.OrgName)+"-speakeasy")
+}
+
+// Root-level dotted keys (features.hooks = true) implicitly define the
+// [features] table and make Codex reject the whole config with a duplicate-key
+// error when an explicit [features] table is also present — which is the
+// default, since js_repl lives there. The flags must be written inside the
+// table, and dotted keys left behind by earlier script versions removed.
+func TestGenerateCodexInstallScriptWritesFeatureFlagsInFeaturesTable(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	existing := "features.hooks = true\n" +
+		"features.plugin_hooks = true\n\n" +
+		"[features]\n" +
+		"js_repl = true\n"
+	home, _ := runCodexInstallScript(t, script, existing)
+
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	require.NotRegexp(t, `(?m)^features\.`, patched, "root-level dotted feature keys must be removed")
+	require.Equal(t, 1, strings.Count(patched, "[features]"), "the existing [features] table must be reused")
+	require.Equal(t, 1, strings.Count(patched, "\nhooks = true"), "hooks flag must live in the [features] table")
+	require.Equal(t, 1, strings.Count(patched, "\nplugin_hooks = true"), "plugin_hooks flag must live in the [features] table")
+	require.Contains(t, patched, "js_repl = true", "pre-existing table entries must be preserved")
+}
+
+func TestGenerateCodexInstallScriptCreatesFeaturesTable(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	home, _ := runCodexInstallScript(t, script, "")
+
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	require.NotRegexp(t, `(?m)^features\.`, patched, "feature flags must not be written as root-level dotted keys")
+	require.Equal(t, 1, strings.Count(patched, "[features]"))
+	require.Equal(t, 1, strings.Count(patched, "\nhooks = true"))
+	require.Equal(t, 1, strings.Count(patched, "\nplugin_hooks = true"))
 }
 
 func TestGenerateReadmeIncludesCodexInstallation(t *testing.T) {


### PR DESCRIPTION
Fixes two blocking issues a customer hit deploying the Codex install script via Jamf.

## 1. `codex` binary not found on PATH

Desktop-only and MDM-deployed machines run the script without `codex` on PATH, so marketplace registration was skipped. The script now probes well-known install locations (`$CODEX_HOME/packages/standalone/current/bin`, `~/.local/bin`, `/usr/local/bin`, the Codex.app bundle) before falling back to manual instructions — same candidate list as the hook script's `find_codex` in #3357.

## 2. Duplicate-key TOML error in `config.toml`

Feature flags were written as root-level dotted keys (`features.hooks = true`), which implicitly define the `features` table. On configs that already carry an explicit `[features]` table (the default — `js_repl` lives there), Codex rejects the whole file with `failed to reload config … duplicate key` and stops loading plugins. Flags are now written inside the `[features]` table, and dotted keys left behind by earlier script versions are stripped so previously-touched configs get repaired instead of breaking on upgrade.

Test harness now runs the generated script under an isolated `$HOME` with a stub `codex` at `~/.local/bin`, so binary probing in tests can never reach a real install on the host.

✻ Clauded...


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Codex observability plugin install script so it works when the `codex` CLI isn’t on PATH and avoids duplicate-key errors in `config.toml`. The script now finds the binary in common locations and writes feature flags inside the `[features]` table, repairing older configs.

- **Bug Fixes**
  - Probe for `codex` in `$CODEX_HOME/packages/standalone/current/bin`, `~/.local/bin`, `/usr/local/bin`, and the `Codex.app` bundle; use it if found, otherwise show manual commands.
  - Write `hooks` and `plugin_hooks` inside the `[features]` table in `config.toml`; strip root-level dotted keys left by older scripts and preserve existing table entries.

<sup>Written for commit 43a3a694c9d779a2191756ea3c63f89b471fbd87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

