### PR TITLE
chore: consolidate MCP tool-name parsing into internal/mcpname

### DIFF
--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/message"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/outbox"
@@ -690,7 +691,7 @@ func (a *AnalyzeBatch) scanMessageToolCalls(ctx context.Context, orgID string, r
 		}
 		// Native (non-MCP) tools don't carry the x-gram-toolset-id property
 		// and are out of scope for shadow-MCP enforcement.
-		if !IsMCPToolName(toolName) {
+		if !mcpname.IsMCPToolName(toolName) {
 			continue
 		}
 		var toolInput any
@@ -700,7 +701,7 @@ func (a *AnalyzeBatch) scanMessageToolCalls(ctx context.Context, orgID string, r
 				toolInput = nil
 			}
 		}
-		bareName := MCPFunctionOf(toolName)
+		bareName := mcpname.MCPFunctionOf(toolName)
 		if a.shadowMCPClient == nil {
 			continue
 		}
@@ -714,7 +715,7 @@ func (a *AnalyzeBatch) scanMessageToolCalls(ctx context.Context, orgID string, r
 		// attribute the hook recorded on the corresponding ClickHouse log,
 		// when one exists. The fallback keeps findings useful even if the
 		// CH lookup misses (no hook log yet, ClickHouse outage, ...).
-		match := MCPServerOf(toolName)
+		match := mcpname.MCPServerOf(toolName)
 		if match == "" {
 			match = toolName
 		}
@@ -761,7 +762,7 @@ func (a *AnalyzeBatch) scanMessageDestructiveToolCalls(ctx context.Context, orgI
 	var findings []Finding
 	for _, call := range calls {
 		toolName := call.Function.Name
-		if toolName == "" || !IsMCPToolName(toolName) {
+		if toolName == "" || !mcpname.IsMCPToolName(toolName) {
 			continue
 		}
 
@@ -772,7 +773,7 @@ func (a *AnalyzeBatch) scanMessageDestructiveToolCalls(ctx context.Context, orgI
 			}
 		}
 
-		bareName := MCPFunctionOf(toolName)
+		bareName := mcpname.MCPFunctionOf(toolName)
 		resolved, ok := a.shadowMCPClient.ResolveToolsetCall(ctx, toolInput, bareName, orgID)
 		if !ok || resolved.Tool.Annotations == nil || resolved.Tool.Annotations.DestructiveHint == nil || !*resolved.Tool.Annotations.DestructiveHint {
 			continue

--- a/server/internal/background/activities/risk_analysis/llm_judge.go
+++ b/server/internal/background/activities/risk_analysis/llm_judge.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/message"
 )
 
@@ -73,7 +74,7 @@ type JudgeToolCall struct {
 // so an MCP server/function is surfaced separately — a no-op for native tools
 // and non-tool messages, where toolName is "".
 func NewJudgeMessage(messageType message.Type, toolName, body string) JudgeMessage {
-	server, fn, _ := AttributeTool(toolName)
+	server, fn, _ := mcpname.AttributeTool(toolName)
 	return JudgeMessage{
 		Type:        messageType,
 		Body:        body,
@@ -101,7 +102,7 @@ func (m JudgeMessage) HasContent() bool {
 // NewJudgeToolCall destructures a tool name into its MCP components and pairs it
 // with the call's raw arguments, for one entry of a multi-call message.
 func NewJudgeToolCall(toolName, arguments string) JudgeToolCall {
-	server, fn, _ := AttributeTool(toolName)
+	server, fn, _ := mcpname.AttributeTool(toolName)
 	return JudgeToolCall{
 		ToolName:    toolName,
 		MCPServer:   server,

--- a/server/internal/background/activities/risk_analysis/mcp_match_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/mcp_match_internal_test.go
@@ -1,5 +1,0 @@
-package risk_analysis
-
-// The MCPServerOf coverage that lived here moved with the parser to the
-// internal/mcpname package (see mcpname_test.go: TestMCPServerOf). This file is
-// intentionally empty and should be deleted.

--- a/server/internal/background/activities/risk_analysis/mcp_match_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/mcp_match_internal_test.go
@@ -1,31 +1,5 @@
 package risk_analysis
 
-import "testing"
-
-// MCPServerOf feeds the `match` column on shadow_mcp findings from the
-// batch scanner. Cover the format variants the parser actually sees in chat
-// messages so a future tool-name format slip is caught at unit-test time
-// rather than as a malformed Recent Findings row.
-func TestMCPServerPrefixOf(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"claude code mcp tool", "mcp__mise__run_task", "mise"},
-		{"claude code nested server name", "mcp__claude_ai_Linear_Speakeasy__list_issues", "claude_ai_Linear_Speakeasy"},
-		{"cursor MCP prefix", "MCP:slack:send_message", "slack:send_message"},
-		{"native tool", "Bash", ""},
-		{"malformed mcp without server", "mcp__", ""},
-		{"malformed mcp without tool", "mcp__server__", "server"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := MCPServerOf(tc.in); got != tc.want {
-				t.Fatalf("MCPServerOf(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
+// The MCPServerOf coverage that lived here moved with the parser to the
+// internal/mcpname package (see mcpname_test.go: TestMCPServerOf). This file is
+// intentionally empty and should be deleted.

--- a/server/internal/background/activities/risk_analysis/tool_names.go
+++ b/server/internal/background/activities/risk_analysis/tool_names.go
@@ -1,63 +1,6 @@
 package risk_analysis
 
-import "strings"
-
-// Tool-call names arrive namespaced by the agent host. MCP-routed tools use
-// either the "mcp__<server>__<function>" convention (Claude Code) or a "MCP:"
-// prefix (Cursor); native tools are bare (e.g. "bash"). These helpers parse
-// those forms and are shared by the batch analyzer (shadow_mcp matching) and
-// the realtime scanner (judge attribution).
-
-// IsMCPToolName reports whether a tool-call name is MCP-routed.
-func IsMCPToolName(name string) bool {
-	if strings.HasPrefix(name, "mcp__") {
-		parts := strings.SplitN(name, "__", 3)
-		return len(parts) == 3 && parts[2] != ""
-	}
-	return strings.HasPrefix(name, "MCP:")
-}
-
-// MCPFunctionOf returns the bare function name with any MCP routing prefix
-// removed so it can be compared against the toolset's tool list (e.g.
-// "run_task" from "mcp__mise__run_task"). Returns the name unchanged for
-// non-MCP tools.
-func MCPFunctionOf(name string) string {
-	if strings.HasPrefix(name, "mcp__") {
-		rest := name[len("mcp__"):]
-		if _, after, ok := strings.Cut(rest, "__"); ok {
-			return after
-		}
-		return rest
-	}
-	return strings.TrimPrefix(name, "MCP:")
-}
-
-// MCPServerOf returns the <server> portion of an MCP-routed tool name — e.g.
-// "mise" from "mcp__mise__run_task" — for use as a stable, server-level
-// identifier. This is what the hook-time matcher computes from tool names too,
-// so a shadow_mcp finding's match column stays consistent across batch and
-// hook paths. Returns "" for non-MCP tool names.
-func MCPServerOf(name string) string {
-	if strings.HasPrefix(name, "mcp__") {
-		rest := name[len("mcp__"):]
-		if before, _, ok := strings.Cut(rest, "__"); ok {
-			return before
-		}
-		return ""
-	}
-	if after, ok := strings.CutPrefix(name, "MCP:"); ok {
-		return after
-	}
-	return ""
-}
-
-// AttributeTool destructures a tool-call name for policy attribution. For
-// MCP-routed names it returns the server and function components with isMCP
-// true; for native tools it returns ("", "", false) and callers use the raw
-// name as-is.
-func AttributeTool(name string) (server, function string, isMCP bool) {
-	if !IsMCPToolName(name) {
-		return "", "", false
-	}
-	return MCPServerOf(name), MCPFunctionOf(name), true
-}
+// The MCP tool-name parsers that lived here (IsMCPToolName, MCPFunctionOf,
+// MCPServerOf, AttributeTool) moved to the internal/mcpname package so the
+// hooks package can share them without depending on this Temporal-activity
+// package. This file is intentionally empty and should be deleted.

--- a/server/internal/background/activities/risk_analysis/tool_names.go
+++ b/server/internal/background/activities/risk_analysis/tool_names.go
@@ -1,6 +1,0 @@
-package risk_analysis
-
-// The MCP tool-name parsers that lived here (IsMCPToolName, MCPFunctionOf,
-// MCPServerOf, AttributeTool) moved to the internal/mcpname package so the
-// hooks package can share them without depending on this Temporal-activity
-// package. This file is intentionally empty and should be deleted.

--- a/server/internal/background/activities/risk_analysis/tool_names_test.go
+++ b/server/internal/background/activities/risk_analysis/tool_names_test.go
@@ -9,32 +9,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/message"
 )
 
-func TestAttributeTool(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name     string
-		in       string
-		server   string
-		function string
-		isMCP    bool
-	}{
-		{"claude code mcp", "mcp__github__create_issue", "github", "create_issue", true},
-		{"nested server name", "mcp__claude_ai_Linear__list_issues", "claude_ai_Linear", "list_issues", true},
-		{"cursor MCP prefix", "MCP:slack:send_message", "slack:send_message", "slack:send_message", true},
-		{"native tool", "Bash", "", "", false},
-		{"malformed mcp without function", "mcp__github__", "", "", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			server, function, isMCP := risk_analysis.AttributeTool(tc.in)
-			require.Equal(t, tc.isMCP, isMCP)
-			require.Equal(t, tc.server, server)
-			require.Equal(t, tc.function, function)
-		})
-	}
-}
-
 func TestNewJudgeMessage(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -15,6 +15,7 @@ import (
 	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
@@ -260,12 +261,9 @@ func (s *Service) buildCodexTelemetryAttributes(ctx context.Context, payload *ge
 	}
 
 	// Parse MCP tool names using the mcp__<server>__<tool> convention.
-	if strings.HasPrefix(toolName, "mcp__") {
-		parts := strings.SplitN(toolName, "__", 3)
-		if len(parts) == 3 {
-			attrs[attr.ToolCallSourceKey] = parts[1]
-			attrs[attr.ToolNameKey] = parts[2]
-		}
+	if server, fn, ok := mcpname.AttributeTool(toolName); ok {
+		attrs[attr.ToolCallSourceKey] = server
+		attrs[attr.ToolNameKey] = fn
 	}
 
 	return attrs

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -18,6 +18,7 @@ import (
 	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
@@ -420,12 +421,14 @@ func (s *Service) buildCursorTelemetryAttributes(ctx context.Context, payload *g
 		attrs[attr.HookIsInterruptKey] = *payload.IsInterrupt
 	}
 
-	// Parse MCP tool names (same mcp__ prefix convention)
+	// Parse MCP tool names (same mcp__ prefix convention). Match only the
+	// lowercase Claude-style "mcp__<server>__<tool>" form here; Cursor's own
+	// "MCP:" prefix (which AttributeTool also recognizes) is handled separately
+	// below, so guard on the mcp__ prefix to keep that split exclusive.
 	if strings.HasPrefix(toolName, "mcp__") {
-		parts := strings.SplitN(toolName, "__", 3)
-		if len(parts) == 3 {
-			attrs[attr.ToolCallSourceKey] = parts[1]
-			attrs[attr.ToolNameKey] = parts[2]
+		if server, fn, ok := mcpname.AttributeTool(toolName); ok {
+			attrs[attr.ToolCallSourceKey] = server
+			attrs[attr.ToolNameKey] = fn
 		}
 	}
 

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcpname"
 )
 
 // gramHostedMCPHost is the canonical host for Gram-managed MCP servers.
@@ -31,14 +32,14 @@ type parsedClaudeToolName struct {
 // convention; native Claude Code tools (Read, Edit, Bash, ...) return a
 // zero-value result with IsMCP=false.
 func parseClaudeToolName(rawName string) parsedClaudeToolName {
-	if !strings.HasPrefix(rawName, "mcp__") {
+	// Restrict to the Claude Code "mcp__<server>__<tool>" form with both parts
+	// present; the shared parser also accepts Cursor's "MCP:" prefix (which has
+	// no server) and an empty server, neither of which is a valid Claude entry.
+	server, tool, isMCP := mcpname.AttributeTool(rawName)
+	if !isMCP || server == "" || tool == "" {
 		return parsedClaudeToolName{Server: "", Tool: "", IsMCP: false}
 	}
-	parts := strings.SplitN(rawName, "__", 3)
-	if len(parts) != 3 || parts[1] == "" || parts[2] == "" {
-		return parsedClaudeToolName{Server: "", Tool: "", IsMCP: false}
-	}
-	return parsedClaudeToolName{Server: parts[1], Tool: parts[2], IsMCP: true}
+	return parsedClaudeToolName{Server: server, Tool: tool, IsMCP: true}
 }
 
 // mcpServerPrefix returns the tool-name prefix Claude Code derives for an

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -32,11 +32,15 @@ type parsedClaudeToolName struct {
 // convention; native Claude Code tools (Read, Edit, Bash, ...) return a
 // zero-value result with IsMCP=false.
 func parseClaudeToolName(rawName string) parsedClaudeToolName {
-	// Restrict to the Claude Code "mcp__<server>__<tool>" form with both parts
-	// present; the shared parser also accepts Cursor's "MCP:" prefix (which has
-	// no server) and an empty server, neither of which is a valid Claude entry.
+	// Claude Code uses the "mcp__<server>__<tool>" form. Restrict to that prefix
+	// so Cursor's "MCP:" names — which the shared parser also recognizes — don't
+	// match here. With the prefix present, AttributeTool only reports isMCP when
+	// both the server and tool segments are non-empty.
+	if !strings.HasPrefix(rawName, "mcp__") {
+		return parsedClaudeToolName{Server: "", Tool: "", IsMCP: false}
+	}
 	server, tool, isMCP := mcpname.AttributeTool(rawName)
-	if !isMCP || server == "" || tool == "" {
+	if !isMCP {
 		return parsedClaudeToolName{Server: "", Tool: "", IsMCP: false}
 	}
 	return parsedClaudeToolName{Server: server, Tool: tool, IsMCP: true}

--- a/server/internal/hooks/mcp_match_test.go
+++ b/server/internal/hooks/mcp_match_test.go
@@ -180,6 +180,8 @@ func TestParseClaudeToolName(t *testing.T) {
 		{"Bash", "", "", false},
 		{"mcp__only", "", "", false},
 		{"mcp__server__", "", "", false},
+		{"mcp____do_thing", "", "", false},
+		{"MCP:send_message", "", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.raw, func(t *testing.T) {

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 
@@ -150,12 +151,9 @@ func (s *Service) buildTelemetryAttributesWithMetadata(ctx context.Context, payl
 	}
 
 	// Parse MCP tool names
-	if strings.HasPrefix(toolName, "mcp__") {
-		parts := strings.SplitN(toolName, "__", 3)
-		if len(parts) == 3 {
-			attrs[attr.ToolCallSourceKey] = parts[1]
-			attrs[attr.ToolNameKey] = parts[2]
-		}
+	if server, fn, ok := mcpname.AttributeTool(toolName); ok {
+		attrs[attr.ToolCallSourceKey] = server
+		attrs[attr.ToolNameKey] = fn
 	}
 
 	// Annotate every MCP-routed tool call with the resolved server

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -2,11 +2,11 @@ package hooks
 
 import (
 	"context"
-	"strings"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 )
@@ -90,13 +90,9 @@ func claudeShadowMCPEvidence(rawToolName string) shadowmcp.AccessEvidence {
 	}
 }
 
+// mcpServerIdentityFromToolName extracts the MCP server identity from a Codex
+// or Claude tool name. Both hosts emit the "mcp__<server>__<tool>" form, so the
+// shared parser's Cursor "MCP:" branch never fires here.
 func mcpServerIdentityFromToolName(rawName string) string {
-	if !strings.HasPrefix(rawName, "mcp__") {
-		return ""
-	}
-	parts := strings.SplitN(rawName, "__", 3)
-	if len(parts) != 3 {
-		return ""
-	}
-	return parts[1]
+	return mcpname.MCPServerOf(rawName)
 }

--- a/server/internal/mcpname/mcpname.go
+++ b/server/internal/mcpname/mcpname.go
@@ -1,0 +1,64 @@
+// Package mcpname parses the namespaced tool-call names that agent hosts emit.
+//
+// MCP-routed tools use either the "mcp__<server>__<function>" convention
+// (Claude Code) or a "MCP:" prefix (Cursor); native tools are bare (e.g.
+// "bash"). These helpers are the single source of truth for that parsing,
+// shared by the hooks package (shadow_mcp matching, telemetry attribution) and
+// the risk_analysis package (batch analyzer + realtime judge attribution).
+package mcpname
+
+import "strings"
+
+// IsMCPToolName reports whether a tool-call name is MCP-routed.
+func IsMCPToolName(name string) bool {
+	if strings.HasPrefix(name, "mcp__") {
+		parts := strings.SplitN(name, "__", 3)
+		return len(parts) == 3 && parts[2] != ""
+	}
+	return strings.HasPrefix(name, "MCP:")
+}
+
+// MCPFunctionOf returns the bare function name with any MCP routing prefix
+// removed so it can be compared against the toolset's tool list (e.g.
+// "run_task" from "mcp__mise__run_task"). Returns the name unchanged for
+// non-MCP tools.
+func MCPFunctionOf(name string) string {
+	if strings.HasPrefix(name, "mcp__") {
+		rest := name[len("mcp__"):]
+		if _, after, ok := strings.Cut(rest, "__"); ok {
+			return after
+		}
+		return rest
+	}
+	return strings.TrimPrefix(name, "MCP:")
+}
+
+// MCPServerOf returns the <server> portion of an MCP-routed tool name — e.g.
+// "mise" from "mcp__mise__run_task" — for use as a stable, server-level
+// identifier. This is what the hook-time matcher computes from tool names too,
+// so a shadow_mcp finding's match column stays consistent across batch and
+// hook paths. Returns "" for non-MCP tool names.
+func MCPServerOf(name string) string {
+	if strings.HasPrefix(name, "mcp__") {
+		rest := name[len("mcp__"):]
+		if before, _, ok := strings.Cut(rest, "__"); ok {
+			return before
+		}
+		return ""
+	}
+	if after, ok := strings.CutPrefix(name, "MCP:"); ok {
+		return after
+	}
+	return ""
+}
+
+// AttributeTool destructures a tool-call name for policy attribution. For
+// MCP-routed names it returns the server and function components with isMCP
+// true; for native tools it returns ("", "", false) and callers use the raw
+// name as-is.
+func AttributeTool(name string) (server, function string, isMCP bool) {
+	if !IsMCPToolName(name) {
+		return "", "", false
+	}
+	return MCPServerOf(name), MCPFunctionOf(name), true
+}

--- a/server/internal/mcpname/mcpname.go
+++ b/server/internal/mcpname/mcpname.go
@@ -9,13 +9,17 @@ package mcpname
 
 import "strings"
 
-// IsMCPToolName reports whether a tool-call name is MCP-routed.
+// IsMCPToolName reports whether a tool-call name is MCP-routed. A well-formed
+// name needs both a server and a function: the "mcp__<server>__<function>" form
+// requires both segments non-empty, and the "MCP:<function>" form requires a
+// non-empty suffix. Malformed names (e.g. "mcp____x", a bare "MCP:") are not
+// MCP-routed, so they don't leak into MCP-only attribution/enforcement paths.
 func IsMCPToolName(name string) bool {
 	if strings.HasPrefix(name, "mcp__") {
 		parts := strings.SplitN(name, "__", 3)
-		return len(parts) == 3 && parts[2] != ""
+		return len(parts) == 3 && parts[1] != "" && parts[2] != ""
 	}
-	return strings.HasPrefix(name, "MCP:")
+	return strings.HasPrefix(name, "MCP:") && len(name) > len("MCP:")
 }
 
 // MCPFunctionOf returns the bare function name with any MCP routing prefix

--- a/server/internal/mcpname/mcpname_test.go
+++ b/server/internal/mcpname/mcpname_test.go
@@ -22,6 +22,8 @@ func TestAttributeTool(t *testing.T) {
 		{"cursor MCP prefix", "MCP:slack:send_message", "slack:send_message", "slack:send_message", true},
 		{"native tool", "Bash", "", "", false},
 		{"malformed mcp without function", "mcp__github__", "", "", false},
+		{"malformed mcp without server", "mcp____create_issue", "", "", false},
+		{"bare cursor prefix", "MCP:", "", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/mcpname/mcpname_test.go
+++ b/server/internal/mcpname/mcpname_test.go
@@ -1,0 +1,61 @@
+package mcpname_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcpname"
+)
+
+func TestAttributeTool(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		in       string
+		server   string
+		function string
+		isMCP    bool
+	}{
+		{"claude code mcp", "mcp__github__create_issue", "github", "create_issue", true},
+		{"nested server name", "mcp__claude_ai_Linear__list_issues", "claude_ai_Linear", "list_issues", true},
+		{"cursor MCP prefix", "MCP:slack:send_message", "slack:send_message", "slack:send_message", true},
+		{"native tool", "Bash", "", "", false},
+		{"malformed mcp without function", "mcp__github__", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server, function, isMCP := mcpname.AttributeTool(tc.in)
+			require.Equal(t, tc.isMCP, isMCP)
+			require.Equal(t, tc.server, server)
+			require.Equal(t, tc.function, function)
+		})
+	}
+}
+
+// MCPServerOf feeds the `match` column on shadow_mcp findings from the batch
+// scanner. Cover the format variants the parser actually sees in chat messages
+// so a future tool-name format slip is caught at unit-test time rather than as
+// a malformed Recent Findings row.
+func TestMCPServerOf(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"claude code mcp tool", "mcp__mise__run_task", "mise"},
+		{"claude code nested server name", "mcp__claude_ai_Linear_Speakeasy__list_issues", "claude_ai_Linear_Speakeasy"},
+		{"cursor MCP prefix", "MCP:slack:send_message", "slack:send_message"},
+		{"native tool", "Bash", ""},
+		{"malformed mcp without server", "mcp__", ""},
+		{"malformed mcp without tool", "mcp__server__", "server"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, mcpname.MCPServerOf(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
## What

Commit `2e738a79a` (AGE-2749) introduced the `mcp__<server>__<function>` / `MCP:` tool-name parsers, but they lived in the heavy `risk_analysis` Temporal-activity package while the **same `strings.SplitN(name, "__", 3)` logic was hand-rolled in 5 more places** in `hooks/` (the shadow-MCP guard + per-host telemetry attribution) — with subtle drift in empty-part handling.

This extracts the four parsers — `IsMCPToolName`, `MCPFunctionOf`, `MCPServerOf`, `AttributeTool` — into a new **dependency-free `internal/mcpname` package** (imports only `strings`) and routes every caller through it:

- **risk_analysis**: `llm_judge.go`, `analyze_batch.go`
- **hooks**: `mcp_match.go` (`parseClaudeToolName`), `shadow_mcp_access.go` (`mcpServerIdentityFromToolName`), `codex_hooks.go`, `cursor_hooks.go`, `pending_helpers.go`

The old `risk_analysis/tool_names.go` and its internal test are removed; their coverage now lives in `internal/mcpname/mcpname_test.go`.

## Notable details

- **Cursor `MCP:` collision** — `AttributeTool` recognizes **both** the Claude-style `mcp__` form and Cursor's `MCP:` prefix. `cursor_hooks.go` has dedicated downstream `MCP:` handling, so its telemetry block keeps an explicit `mcp__` guard; likewise `hooks.parseClaudeToolName` guards on the `mcp__` prefix so Cursor names aren't parsed as Claude entries.
- **Validation hardening** — a well-formed name now requires both segments: `mcp__<server>__<function>` needs a non-empty server *and* function, and `MCP:` needs a non-empty suffix. Malformed names (`mcp____x`, a bare `MCP:`) are no longer classified as MCP-routed, so they can't leak into MCP-only attribution/enforcement paths.

## Verification

- `go build ./...` ✅
- `internal/mcpname` + `hooks` MCP/shadow tests + `risk_analysis` judge tests ✅ (incl. new edge-case coverage)
- `mise lint:server` ✅
- No `SplitN(…, "__", 3)` copies remain outside `mcpname`

🤖 Generated with [Claude Code](https://claude.com/claude-code)