### PR TITLE
chore(assistants): run cron compaction at turn end, not as an inline compactor

### DIFF
--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -75,6 +75,12 @@ impl CompactionPolicy {
             percent: FALLBACK_PERCENT,
         }
     }
+
+    /// Whether compaction runs terminally at turn end (persistence-only)
+    /// rather than inline before the next model turn.
+    pub fn runs_at_turn_end(&self) -> bool {
+        matches!(self, CompactionPolicy::OnTurnEnd)
+    }
 }
 
 impl Default for CompactionPolicy {

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -25,10 +25,10 @@ use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{OnceCell, oneshot};
 
-use agentkit_compaction::AgentBuilderCompactorExt;
+use agentkit_compaction::{AgentBuilderCompactorExt, CompactionReason, Compactor};
 
 use crate::clip::ClippedToolSource;
-use crate::compaction::build_compactor;
+use crate::compaction::{PersistingCompactor, build_compactor};
 use crate::errors::RunnerError;
 use crate::gram_client::GramBootstrapClient;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_bootstrap_client, build_http};
@@ -351,6 +351,14 @@ async fn spawn_thread(
         host.gram_client.clone(),
         tokens.clone(),
     )?;
+    // An inline agent compactor runs right before the next model request, so
+    // OnTurnEnd's persistence-only output would be sent upstream. Run it
+    // terminally instead (see `run_loop`); Threshold shrinks-to-fit, so inline.
+    let (inline_compactor, turn_end_compactor) = if bootstrap.compaction.runs_at_turn_end() {
+        (None, compactor)
+    } else {
+        (compactor, None)
+    };
 
     let mut transcript = Vec::new();
     if !bootstrap.instructions.is_empty() {
@@ -387,7 +395,7 @@ async fn spawn_thread(
         .observer(TracingReporter::new())
         .transcript(transcript);
 
-    if let Some(compactor) = compactor {
+    if let Some(compactor) = inline_compactor {
         builder = builder.compactor(compactor);
     }
 
@@ -410,7 +418,7 @@ async fn spawn_thread(
     let evict_thread_id = thread_id.clone();
 
     let task_handle = tokio::spawn(async move {
-        let outcome = AssertUnwindSafe(run_loop(driver, inbox_rx, loop_idle))
+        let outcome = AssertUnwindSafe(run_loop(driver, inbox_rx, loop_idle, turn_end_compactor))
             .catch_unwind()
             .await;
         match outcome {
@@ -585,6 +593,7 @@ async fn run_loop<S>(
     mut driver: LoopDriver<S>,
     mut inbox: UnboundedReceiver<String>,
     idle_since: Arc<Mutex<Option<Instant>>>,
+    turn_end_compactor: Option<PersistingCompactor>,
 ) -> Result<&'static str, RunnerError>
 where
     S: ModelSession,
@@ -592,6 +601,9 @@ where
     loop {
         match driver.next().await? {
             LoopStep::Finished(_turn) => {
+                if let Some(compactor) = &turn_end_compactor {
+                    compact_at_turn_end(compactor, &driver).await;
+                }
                 mark_idle(&idle_since);
             }
             LoopStep::Interrupt(LoopInterrupt::AwaitingInput(req)) => {
@@ -621,6 +633,26 @@ where
                 pending.approve(&mut driver)?;
             }
         }
+    }
+}
+
+/// Compacts and persists the finished transcript for the next cold bootstrap,
+/// discarding the result — it is never fed back to the model. Failures are
+/// logged, not propagated, so a persistence hiccup can't kill the thread loop.
+async fn compact_at_turn_end<S: ModelSession>(
+    compactor: &PersistingCompactor,
+    driver: &LoopDriver<S>,
+) {
+    let transcript = driver.snapshot().transcript;
+    if let Err(err) = compactor
+        .compact(
+            &transcript,
+            CompactionReason::Custom("on_turn_end".to_string()),
+            None,
+        )
+        .await
+    {
+        tracing::warn!(error = %err, "turn-end compaction failed; skipping persist for this turn");
     }
 }
 


### PR DESCRIPTION
## Summary

Cron assistant threads use the `OnTurnEnd` compaction policy, registered as the runner agent's inline `Compactor`. agentkit invokes a compactor at the `AfterTurnEnded` mutation point — immediately before the next model request — so the **post-compaction transcript was being sent to the model**. Once compaction summarised the cron prompt into the durable note, the transcript ended on an `assistant` message, and providers that reject assistant prefill (Google Vertex, Amazon Bedrock via OpenRouter) returned:

> 400 — This model does not support assistant message prefill. The conversation must end with a user message.

That wedged affected cron threads in a retry loop (one chat churned past 380 generations).

## Fix

`OnTurnEnd` compaction exists only to shrink the *persisted* transcript for the next cold bootstrap — its output must never reach the model. Make it terminal:

- `CompactionPolicy::runs_at_turn_end()` splits the wiring. `Threshold` stays inline (shrink-to-fit is a genuine pre-inference concern); `OnTurnEnd` is no longer attached to the agent.
- `run_loop` runs `compact_at_turn_end()` in the `LoopStep::Finished` arm on `driver.snapshot().transcript`: summarise, `record_compacted_generation`, discard the result. The model loop never sees the compacted transcript.

## Context

Root cause confirmed in prod — Datadog shows the exact 400 starting the hour the policy shipped (#3229); the read replica shows cron generations ending on `assistant`. The underlying enablers are two agentkit (0.8.1) bugs — a mutation-point mislabel and a missing guard against dispatching a turn with no valid trailing input — reproduced with failing tests upstream. This gram-side change resolves the incident independently of an agentkit release.

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run cron `OnTurnEnd` compaction terminally at turn end so its output never reaches the model. This fixes 400s from providers that reject assistant prefill and stops cron retry loops.

- **Bug Fixes**
  - Run `OnTurnEnd` compaction after the turn finishes (persist-only); keep `Threshold` inline.
  - Add `CompactionPolicy::runs_at_turn_end()` and split inline vs turn-end compactor wiring in `spawn_thread`.
  - Execute terminal compaction in `run_loop` on `LoopStep::Finished` via `compact_at_turn_end`: persist summary, discard it; warn on failure and continue.
  - Prevents assistant-prefill errors on providers like Vertex and Bedrock.

<sup>Written for commit d942e43eeaa6847de918fca797dbd0814d752188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

