### PR TITLE
fix(remotemcp): use mcp_servers id for per-tool mcp:connect RBAC checks

### DIFF
--- a/.changeset/remote-mcp-connect-rbac-mcp-server-id.md
+++ b/.changeset/remote-mcp-connect-rbac-mcp-server-id.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix the per-tool `mcp:connect` RBAC checks in the remote MCP proxy to use the `mcp_servers` id instead of the `remote_mcp_servers` id, so they resolve grants against the same resource as the server-level check and the toolset path.

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -379,7 +379,7 @@ func (s *Service) serveRemoteBackend(
 		return oops.E(oops.CodeUnexpected, err, "load remote mcp server headers").Log(ctx, logger)
 	}
 
-	p := s.remoteProxyManager.Build(logger, &server, headers, mcpServer.Visibility, endpoint.ProjectID.String(), upstreamAuth)
+	p := s.remoteProxyManager.Build(logger, &server, mcpServer.ID.String(), headers, mcpServer.Visibility, endpoint.ProjectID.String(), upstreamAuth)
 
 	r = r.WithContext(ctx)
 

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -522,14 +522,15 @@ func TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_ResolvesG
 
 	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
 	endpointSlug := "endpoint-" + uuid.NewString()
-	_, remoteServer := createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, upstream.URL, endpointSlug, "private", issuerID)
+	mcpServer, _ := createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, upstream.URL, endpointSlug, "private", issuerID)
 
 	// Grant the calling user a server-level mcp:connect grant. PrepareContext
 	// derives the user principal from the JWT subject (an active org member)
 	// and loads this grant; the interceptors then admit the tool. The grant
-	// resource is the remote_mcp_servers id — the resource the proxy's
-	// mcp:connect interceptors check (see ProxyManager.Build).
-	seedUserMCPConnectGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockidp.MockUserID, remoteServer.ID.String())
+	// resource is the mcp_servers row id (NOT the remote_mcp_servers id) — the
+	// resource the proxy's mcp:connect interceptors check (see ProxyManager.Build,
+	// whose mcpServerID parameter is the RBAC ResourceID).
+	seedUserMCPConnectGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockidp.MockUserID, mcpServer.ID.String())
 
 	// Mint a user-session JWT for the issuer-gated endpoint. The audience is
 	// the issuer URN (remote-backed endpoints bind the audience to the

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -98,9 +98,17 @@ func NewProxyManager(
 // private servers only since public servers bypass server-level RBAC.
 // projectID is forwarded to the per-tool authz interceptor as a dimension
 // so project-scoped grants can match.
+//
+// mcpServerID is the mcp_servers row id (NOT the remote_mcp_servers id on
+// server). It is the RBAC ResourceID for the per-tool `mcp:connect` checks
+// so they resolve grants against the same mcp_servers row that the handler's
+// upfront server-level `mcp:connect` check uses, keeping per-tool and
+// server-level authorization consistent for the same caller. server.ID still
+// drives telemetry/logging dimensions, which are keyed by remote_mcp_servers.
 func (f *ProxyManager) Build(
 	logger *slog.Logger,
 	server *remotemcprepo.RemoteMcpServer,
+	mcpServerID string,
 	headers []remotemcprepo.RemoteMcpServerHeader,
 	visibility string,
 	projectID string,
@@ -155,7 +163,7 @@ func (f *ProxyManager) Build(
 	}
 	if visibility == mcpservers.VisibilityPrivate {
 		toolsCallReqInterceptors = append(toolsCallReqInterceptors,
-			NewToolsCallAuthzInterceptor(f.authz, serverID, projectID, logger),
+			NewToolsCallAuthzInterceptor(f.authz, mcpServerID, projectID, logger),
 		)
 	}
 
@@ -167,7 +175,7 @@ func (f *ProxyManager) Build(
 	toolsListRespInterceptors := []proxy.ToolsListResponseInterceptor{}
 	if visibility == mcpservers.VisibilityPrivate {
 		toolsListRespInterceptors = append(toolsListRespInterceptors,
-			NewToolsListMCPConnectFilterInterceptor(f.authz, serverID, projectID, logger),
+			NewToolsListMCPConnectFilterInterceptor(f.authz, mcpServerID, projectID, logger),
 		)
 	}
 	toolsListRespInterceptors = append(toolsListRespInterceptors,

--- a/server/internal/remotemcp/tools_call_authz_interceptor.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor.go
@@ -22,10 +22,10 @@ import (
 // on the per-session tools/list response cache tracked separately, and is
 // added when that cache lands.
 type ToolsCallAuthzInterceptor struct {
-	authz     *authz.Engine
-	serverID  string
-	projectID string
-	logger    *slog.Logger
+	authz       *authz.Engine
+	mcpServerID string
+	projectID   string
+	logger      *slog.Logger
 }
 
 var _ proxy.ToolsCallRequestInterceptor = (*ToolsCallAuthzInterceptor)(nil)
@@ -33,14 +33,18 @@ var _ proxy.ToolsCallRequestInterceptor = (*ToolsCallAuthzInterceptor)(nil)
 // NewToolsCallAuthzInterceptor constructs an interceptor scoped to a single
 // Remote MCP Server. Callers build a fresh instance per request so the
 // resource ID for the authz check is captured without re-parsing routing
-// state. projectID is the owning project for the mcp_endpoint and is
-// forwarded as a dimension so project-scoped grants can match.
-func NewToolsCallAuthzInterceptor(authzEngine *authz.Engine, serverID, projectID string, logger *slog.Logger) *ToolsCallAuthzInterceptor {
+// state. mcpServerID is the mcp_servers row id (NOT the remote_mcp_servers
+// id) so the per-tool `mcp:connect` check resolves grants against the same
+// resource id the handler's upfront server-level `mcp:connect` check uses,
+// keeping per-tool and server-level authorization consistent. projectID is
+// the owning project for the mcp_endpoint and is forwarded as a dimension so
+// project-scoped grants can match.
+func NewToolsCallAuthzInterceptor(authzEngine *authz.Engine, mcpServerID, projectID string, logger *slog.Logger) *ToolsCallAuthzInterceptor {
 	return &ToolsCallAuthzInterceptor{
-		authz:     authzEngine,
-		serverID:  serverID,
-		projectID: projectID,
-		logger:    logger,
+		authz:       authzEngine,
+		mcpServerID: mcpServerID,
+		projectID:   projectID,
+		logger:      logger,
 	}
 }
 
@@ -59,9 +63,10 @@ func (i *ToolsCallAuthzInterceptor) Name() string {
 //
 // [authz.MCPToolCallCheck] names its first parameter `toolsetID` for legacy
 // reasons, but the helper only stores it as the opaque `ResourceID` on the
-// returned [authz.Check]; passing a Remote MCP Server UUID is semantically
-// correct and matches how the same scope is enforced for the server-level
-// check at [Service.ServeMCP].
+// returned [authz.Check]; passing the mcp_servers UUID is semantically
+// correct. It is the same resource id the handler runs the upfront
+// server-level `mcp:connect` check against, so per-tool and server-level
+// enforcement agree on what they are authorizing.
 func (i *ToolsCallAuthzInterceptor) InterceptToolsCallRequest(ctx context.Context, call *proxy.ToolsCallRequest) error {
 	// Defensive: the proxy's typed dispatch (toolsCallRequestFromUserRequest)
 	// only constructs a ToolsCallRequest with non-nil Params, so this branch
@@ -71,7 +76,7 @@ func (i *ToolsCallAuthzInterceptor) InterceptToolsCallRequest(ctx context.Contex
 		return nil
 	}
 
-	return i.authz.Require(ctx, authz.MCPToolCallCheck(i.serverID, authz.MCPToolCallDimensions{
+	return i.authz.Require(ctx, authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
 		Tool:        call.Params.Name,
 		Disposition: "",
 		ProjectID:   i.projectID,

--- a/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor.go
+++ b/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor.go
@@ -28,24 +28,26 @@ import (
 // tracked separately; until that cache lands the disposition dimension
 // would have nothing to read.
 type ToolsListMCPConnectFilterInterceptor struct {
-	authz     *authz.Engine
-	serverID  string
-	projectID string
-	logger    *slog.Logger
+	authz       *authz.Engine
+	mcpServerID string
+	projectID   string
+	logger      *slog.Logger
 }
 
 var _ proxy.ToolsListResponseInterceptor = (*ToolsListMCPConnectFilterInterceptor)(nil)
 
 // NewToolsListMCPConnectFilterInterceptor constructs an interceptor
-// scoped to a single Remote MCP Server. serverID is the [authz.Check]
-// ResourceID — same shape as [authz.MCPToolCallCheck] uses for the
-// paired tools/call enforcement.
-func NewToolsListMCPConnectFilterInterceptor(authzEngine *authz.Engine, serverID, projectID string, logger *slog.Logger) *ToolsListMCPConnectFilterInterceptor {
+// scoped to a single Remote MCP Server. mcpServerID is the [authz.Check]
+// ResourceID, the mcp_servers row id (NOT the remote_mcp_servers id), so
+// the filter resolves grants against the same mcp_servers row that the
+// handler's upfront server-level `mcp:connect` check uses, the same shape
+// [authz.MCPToolCallCheck] uses for the paired tools/call enforcement.
+func NewToolsListMCPConnectFilterInterceptor(authzEngine *authz.Engine, mcpServerID, projectID string, logger *slog.Logger) *ToolsListMCPConnectFilterInterceptor {
 	return &ToolsListMCPConnectFilterInterceptor{
-		authz:     authzEngine,
-		serverID:  serverID,
-		projectID: projectID,
-		logger:    logger,
+		authz:       authzEngine,
+		mcpServerID: mcpServerID,
+		projectID:   projectID,
+		logger:      logger,
 	}
 }
 
@@ -75,7 +77,7 @@ func (i *ToolsListMCPConnectFilterInterceptor) InterceptToolsListResponse(ctx co
 
 	checks := make([]authz.Check, len(tools))
 	for idx, t := range tools {
-		checks[idx] = authz.MCPToolCallCheck(i.serverID, authz.MCPToolCallDimensions{
+		checks[idx] = authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
 			Tool:        t.Name,
 			Disposition: "",
 			ProjectID:   i.projectID,


### PR DESCRIPTION
The per-tool `mcp:connect` checks in the remote MCP proxy (the tools/call authz interceptor and the tools/list filter) were keyed off the `remote_mcp_servers` id, while the upfront server-level `mcp:connect` check and the toolset path both enforce against the `mcp_servers` id. Grants scoped to the `mcp_servers` resource that passed the server-level gate would therefore fail the per-tool checks. Thread the `mcp_servers` id through `ProxyManager.Build` to the two authz interceptors; `server.ID` still keys telemetry/logging dimensions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-tool `mcp:connect` RBAC in the remote MCP proxy to use the `mcp_servers` id, matching the server-level check and toolset path so grants resolve consistently.

- **Bug Fixes**
  - Thread `mcpServer.ID` into `remoteProxyManager.Build` and down to the per-tool auth interceptors; align tests to seed grants with the `mcp_servers` id.
  - Update `ToolsCallAuthzInterceptor` and `ToolsListMCPConnectFilterInterceptor` to authorize via `authz.MCPToolCallCheck` using the `mcp_servers` id.
  - Keep telemetry/logging keyed by `server.ID` (`remote_mcp_servers`) only.

<sup>Written for commit 4f682d8e9266efb2f64eb2eba885c8e399b0274c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

