### PR TITLE
mig: add mcp_server_id materialized column to telemetry_logs

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260614173910_add-mcp-server-id-materialized-col.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260614173910_add-mcp-server-id-materialized-col.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` DROP INDEX `idx_telemetry_logs_mat_mcp_server_id`;
+ALTER TABLE `telemetry_logs` DROP COLUMN `mcp_server_id`;

--- a/server/clickhouse/local/golang_migrate/20260614173910_add-mcp-server-id-materialized-col.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260614173910_add-mcp-server-id-materialized-col.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `mcp_server_id` String MATERIALIZED toString(attributes.gram.mcp_server.id) COMMENT 'MCP server ID (materialized from attributes.gram.mcp_server.id).';
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_mcp_server_id` ((mcp_server_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:tZi3FAaA8EZLf+Eoa5GQ9ExXeWKUJlADdMvL+wmhnOw=
+h1:HSJLrtxAy1i/8rsiNQ/yL6DAs2UgGWUtQrnOwe7qsdw=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -36,3 +36,4 @@ h1:tZi3FAaA8EZLf+Eoa5GQ9ExXeWKUJlADdMvL+wmhnOw=
 20260430104153_add-authz-challenges-table.up.sql h1:xzosYIiO3fRbLIoIjkhqXnH0zxbhhusvO7HZ80u1w1M=
 20260508132129_add-remote-mcp-server-id-materialized-col.up.sql h1:ONn0mdquOH8+96lVqIInQ881GJ2lTMN+ldJ+LJ9O9KU=
 20260611154940_add-chat-token-summaries.up.sql h1:/wApaqCHpQ3rWJSeu4z/cJgKz90Q6VkFxFp0buaWQcI=
+20260614173910_add-mcp-server-id-materialized-col.up.sql h1:mD5QaHWvmvtZn15AYqoGMPYC5o5Fr9l2boJBpUcYsM8=

--- a/server/clickhouse/migrations/20260614173905_add-mcp-server-id-materialized-col.sql
+++ b/server/clickhouse/migrations/20260614173905_add-mcp-server-id-materialized-col.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `mcp_server_id` String MATERIALIZED toString(attributes.gram.mcp_server.id) COMMENT 'MCP server ID (materialized from attributes.gram.mcp_server.id).';
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_mcp_server_id` ((mcp_server_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:l0Q/n02GdBlsd9XRjcW0DMlJEDV1PtKIRY4DBFMBaaI=
+h1:9TtVcfM9OGSyuhrwsKMOqjdldkZFMvqtLhG25MfMR9c=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -41,3 +41,4 @@ h1:l0Q/n02GdBlsd9XRjcW0DMlJEDV1PtKIRY4DBFMBaaI=
 20260430104149_add-authz-challenges-table.sql h1:1RrvgeCMeUvKN1I8R8whY46WfulVK85U/FZooAIhuu4=
 20260508132124_add-remote-mcp-server-id-materialized-col.sql h1:gmEL5G+Mnjf3KaYVglJ6xxHfCPR8R4Hk3wUn6Sib9sw=
 20260611154937_add-chat-token-summaries.sql h1:W0HEqPDacY3wOGw2r6nkbDQHYkQzlfWa/r/fQqBhLw4=
+20260614173905_add-mcp-server-id-materialized-col.sql h1:j2ExlzT0pQx+QBiHJJ1LTP34TMXR9hr+EMQno6qZOc8=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS telemetry_logs (
     hook_source String MATERIALIZED toString(attributes.gram.hook.source) COMMENT 'Hook source (materialized from attributes.gram.hook.source).',
     hook_block_reason String MATERIALIZED toString(attributes.gram.hook.block_reason) COMMENT 'Hook block reason set when the Gram hook denied a tool call (materialized from attributes.gram.hook.block_reason).',
     remote_mcp_server_id String MATERIALIZED toString(attributes.gram.remote_mcp_server.id) COMMENT 'Remote MCP server ID (materialized from attributes.gram.remote_mcp_server.id).',
+    mcp_server_id String MATERIALIZED toString(attributes.gram.mcp_server.id) COMMENT 'MCP server ID (materialized from attributes.gram.mcp_server.id).',
     skill_name String MATERIALIZED if(toString(attributes.gram.tool.name) = 'Skill', JSONExtractString(toString(attributes.gen_ai.tool.call.arguments), 'skill'), '') COMMENT 'Skill name extracted from tool arguments when tool_name is Skill (materialized).'
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))
@@ -89,6 +90,7 @@ CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_user_email ON telemetry_logs (
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_hook_source ON telemetry_logs (hook_source) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_hook_block_reason ON telemetry_logs (hook_block_reason) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_remote_mcp_server_id ON telemetry_logs (remote_mcp_server_id) TYPE bloom_filter(0.01) GRANULARITY 1;
+CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_mcp_server_id ON telemetry_logs (mcp_server_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_skill_name ON telemetry_logs (skill_name) TYPE bloom_filter(0.01) GRANULARITY 1;
 
 CREATE TABLE IF NOT EXISTS trace_summaries (

--- a/server/internal/telemetry/repo/materialized_columns_gen.go
+++ b/server/internal/telemetry/repo/materialized_columns_gen.go
@@ -23,4 +23,5 @@ var materializedColumns = map[string]string{
 	"gram.hook.source":              "hook_source",
 	"gram.hook.block_reason":        "hook_block_reason",
 	"gram.remote_mcp_server.id":     "remote_mcp_server_id",
+	"gram.mcp_server.id":            "mcp_server_id",
 }


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2758/migration-add-mcp-server-id-materialized-column-to-telemetry-logs

Adds a forward-only `mcp_server_id String MATERIALIZED toString(attributes.gram.mcp_server.id)` column plus a `bloom_filter(0.01)` index to the ClickHouse `telemetry_logs` table, mirroring the existing `remote_mcp_server_id` column. Prereq for recording the fronting `mcp_servers` id on `/mcp` runtime telemetry (AGE-2759). Migration only: no application or query changes. Historical rows stay empty.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a forward-only `mcp_server_id` materialized column to ClickHouse `telemetry_logs` from `attributes.gram.mcp_server.id`, with a `bloom_filter(0.01)` index. Mirrors `remote_mcp_server_id` and implements AGE-2758; no app or query changes.

<sup>Written for commit 7a3dcbcaa24cec2c0f42f44847b5c8f96a92a53c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

