### PR TITLE
fix(slack): suppress stale thinking indicator on ambient events

### DIFF
--- a/.changeset/slack-stale-thinking-indicator.md
+++ b/.changeset/slack-stale-thinking-indicator.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix(slack): suppress the ingress "thinking" indicator for ambient events. Plain channel messages, reactions, and other passive Slack events that may end in a silent turn no longer light up the loading indicator, which previously stranded it until Slack's two-minute timeout. Only events the assistant always replies to (@-mentions, DMs, Block Kit interactions) show the indicator.

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -752,9 +752,15 @@ func (a *App) ProcessWebhook(ctx context.Context, instanceID uuid.UUID, body []b
 // moment a slack-triggered event is dispatched, so the user sees the assistant
 // is working while its (cold-starting) runtime spins up. The assistant refines
 // the status itself once it's running via the set_thread_status platform tool.
+// Only events the assistant always replies to get the indicator: ambient
+// events may end in a silent turn (no reply ever posted), which would strand
+// the indicator until Slack's two-minute timeout.
 // Best-effort: a failure here only costs the indicator.
 func (a *App) ackSlackThreadStatus(ctx context.Context, instance triggerrepo.TriggerInstance, env map[string]string, event EventEnvelope) {
 	if a.slackClient == nil || instance.DefinitionSlug != DefinitionSlugSlack {
+		return
+	}
+	if !slackEventExpectsReply(event) {
 		return
 	}
 	channelID, threadTS, ok := slackThreadStatusTarget(event)

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -1118,6 +1118,22 @@ const slackThinkingStatus = "is thinking…"
 
 var slackInitialLoadingMessages = []string{"Routing…"}
 
+// slackEventExpectsReply reports whether a slack event is one the assistant
+// always replies to: an explicit @-mention, a DM (channel IDs start with "D"),
+// or a Block Kit interaction. Ambient channel events (plain messages,
+// reactions, joins) may legitimately end in a silent turn, so the ingress
+// loading indicator is suppressed for them — a silent turn would otherwise
+// strand the indicator until Slack's two-minute timeout.
+func slackEventExpectsReply(event EventEnvelope) bool {
+	evt, isSlack := event.Event.(slackTriggerEvent)
+	if !isSlack {
+		return false
+	}
+	return evt.EventType == "app_mention" ||
+		evt.EnvelopeType == "interactive" ||
+		strings.HasPrefix(evt.ChannelID, "D")
+}
+
 // slackThreadStatusTarget extracts the channel + thread to anchor a loading
 // status on. Returns ok=false for events without a threadable target (e.g.
 // user_change, channel_created).

--- a/server/internal/background/triggers/definitions_test.go
+++ b/server/internal/background/triggers/definitions_test.go
@@ -473,3 +473,25 @@ func signedSlackHeaders(t *testing.T, body []byte, signingSecret string) http.He
 	headers.Set("X-Slack-Signature", "v0="+hex.EncodeToString(mac.Sum(nil)))
 	return headers
 }
+
+func TestSlackEventExpectsReply(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		event any
+		want  bool
+	}{
+		{"app mention", slackTriggerEvent{EnvelopeType: "event_callback", EventType: "app_mention", ChannelID: "C123"}, true},
+		{"direct message", slackTriggerEvent{EnvelopeType: "event_callback", EventType: "message", ChannelID: "D123"}, true},
+		{"block kit interaction", slackTriggerEvent{EnvelopeType: "interactive", EventType: "block_actions", ChannelID: "C123"}, true},
+		{"ambient channel message", slackTriggerEvent{EnvelopeType: "event_callback", EventType: "message", ChannelID: "C123"}, false},
+		{"reaction", slackTriggerEvent{EnvelopeType: "event_callback", EventType: "reaction_added", ChannelID: "C123"}, false},
+		{"non-slack event", cronTriggerEvent{Schedule: "* * * * *"}, false},
+	}
+
+	for _, tc := range cases {
+		got := slackEventExpectsReply(EventEnvelope{Event: tc.event})
+		require.Equal(t, tc.want, got, tc.name)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **AGE-2760** — the Slack app showing a stale "thinking" state.

The ingress "is thinking…" loading indicator (`ackSlackThreadStatus`) was set for **any** Slack event that has a channel + thread target, including *ambient* events — plain channel messages, reactions, joins — that may legitimately end in a **silent turn** with no reply posted. Because Slack's `assistant.threads.setStatus` API rejects an empty string, there is no programmatic way to clear the indicator; on a silent turn it stranded until Slack's ~2-minute auto-timeout, which is what users saw as a stale thinking state.

This gates the ingress indicator on a new `slackEventExpectsReply` check: only events the assistant **always** replies to — `app_mention`, DMs (channel IDs starting with `D`), and Block Kit interactions — light it up. Ambient events get no indicator, so a silent turn needs no cleanup.

## Context

This is the self-contained ingress-gating fix, extracted from the larger (still-open) PR #3395 so the bug fix can land independently of the "let Slack assistants stay silent" feature. The prompt-guidance and empty-status-clear changes from that work stay on #3395.

## Changes
- `triggers/app.go` — gate `ackSlackThreadStatus` on `slackEventExpectsReply`.
- `triggers/definitions.go` — add `slackEventExpectsReply`.
- `triggers/definitions_test.go` — table test covering mention / DM / interaction / ambient / reaction / non-slack cases.

## Testing
- `go test ./internal/background/triggers/ -run TestSlackEventExpectsReply` ✅
- `go build ./...` ✅
- `mise lint:server` ✅ (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress the Slack "is thinking…" indicator for ambient events to stop the stale thinking state. Only `app_mention`, DMs (channels starting with `D`), and Block Kit interactions now show the indicator, addressing Linear AGE-2760.

- **Bug Fixes**
  - Gated `ackSlackThreadStatus` behind new `slackEventExpectsReply`.
  - `slackEventExpectsReply` returns true for `app_mention`, DMs, and interactive events; false for ambient messages, reactions, joins.
  - Added table tests covering mention/DM/interaction/ambient/reaction/non-Slack cases.

<sup>Written for commit 72a1345594a8f895ba6bc973a9510fb65dcbb00d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

