### PR TITLE
feat(assistants): add Triggers tabs and rename Audit log to Activity

### DIFF
--- a/.changeset/assistants-triggers-tabs.md
+++ b/.changeset/assistants-triggers-tabs.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+feat(assistants): surface Triggers as a tab on the Assistants page and a filtered Triggers tab per assistant, and rename the Assistants "Audit log" tab to "Activity"

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -35,6 +35,16 @@ import { MouseEvent } from "react";
 import { Outlet } from "react-router";
 
 import { AssistantsAuditLog } from "./AssistantAuditLog";
+import { TriggersPanel } from "../triggers/Triggers";
+
+const TOP_LEVEL_TABS = ["assistants", "triggers", "audit"] as const;
+type TopLevelTab = (typeof TOP_LEVEL_TABS)[number];
+
+function toTopLevelTab(value: string): TopLevelTab {
+  return (TOP_LEVEL_TABS as readonly string[]).includes(value)
+    ? (value as TopLevelTab)
+    : "assistants";
+}
 
 function stopLinkNavigation(e: MouseEvent<HTMLDivElement>) {
   e.preventDefault();
@@ -78,7 +88,7 @@ export default function AssistantsIndex(): JSX.Element {
   const routes = useRoutes();
   const [activeTab, setActiveTab] = useQueryState(
     "tab",
-    parseAsStringLiteral(["assistants", "audit"]).withDefault("assistants"),
+    parseAsStringLiteral(TOP_LEVEL_TABS).withDefault("assistants"),
   );
   const { data, isLoading } = useAssistantsList(undefined, undefined, {
     retry: false,
@@ -142,15 +152,14 @@ export default function AssistantsIndex(): JSX.Element {
       <Page.Body>
         <Tabs
           value={activeTab}
-          onValueChange={(value) => {
-            void setActiveTab(value === "audit" ? "audit" : "assistants");
-          }}
+          onValueChange={(value) => void setActiveTab(toTopLevelTab(value))}
           className="flex w-full flex-col"
         >
           <div className="border-b">
             <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
               <PageTabsTrigger value="assistants">Assistants</PageTabsTrigger>
-              <PageTabsTrigger value="audit">Audit log</PageTabsTrigger>
+              <PageTabsTrigger value="triggers">Triggers</PageTabsTrigger>
+              <PageTabsTrigger value="audit">Activity</PageTabsTrigger>
             </TabsList>
           </div>
           <TabsContent
@@ -159,6 +168,9 @@ export default function AssistantsIndex(): JSX.Element {
           >
             {content}
             <UsageSection />
+          </TabsContent>
+          <TabsContent value="triggers" className="mt-6 w-full">
+            <TriggersPanel />
           </TabsContent>
           <TabsContent value="audit" className="mt-6 w-full">
             <RequireScope scope="org:read" level="section">

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantDraftPanel.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantDraftPanel.tsx
@@ -42,10 +42,12 @@ export function AssistantDraftPanel(): JSX.Element {
   );
   const [editingInstructions, setEditingInstructions] = useState(false);
 
+  // Only fetch triggers when the Triggers tab is active — they are no longer
+  // surfaced on the Overview tab, so loading the panel shouldn't pay for them.
   const { data: triggersData } = useTriggers(undefined, undefined, {
     retry: false,
     throwOnError: false,
-    enabled: !!draft.assistantId,
+    enabled: !!draft.assistantId && activeTab === "triggers",
   });
 
   const triggers = (triggersData?.triggers ?? []).filter(

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantDraftPanel.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantDraftPanel.tsx
@@ -23,13 +23,22 @@ import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { useState } from "react";
 import { useAssistantDraft } from "./useAssistantDraft";
 
+const DETAIL_TABS = ["overview", "sessions", "triggers"] as const;
+type DetailTab = (typeof DETAIL_TABS)[number];
+
+function toDetailTab(value: string): DetailTab {
+  return (DETAIL_TABS as readonly string[]).includes(value)
+    ? (value as DetailTab)
+    : "overview";
+}
+
 export function AssistantDraftPanel(): JSX.Element {
   const draft = useAssistantDraft();
   const routes = useRoutes();
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useQueryState(
     "tab",
-    parseAsStringLiteral(["overview", "sessions"]).withDefault("overview"),
+    parseAsStringLiteral(DETAIL_TABS).withDefault("overview"),
   );
   const [editingInstructions, setEditingInstructions] = useState(false);
 
@@ -109,15 +118,14 @@ export function AssistantDraftPanel(): JSX.Element {
       ) : (
         <Tabs
           value={activeTab}
-          onValueChange={(value) => {
-            void setActiveTab(value === "sessions" ? "sessions" : "overview");
-          }}
+          onValueChange={(value) => void setActiveTab(toDetailTab(value))}
           className="flex min-h-0 flex-1 flex-col"
         >
           <div className="border-border border-b px-4">
             <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
               <PageTabsTrigger value="overview">Overview</PageTabsTrigger>
               <PageTabsTrigger value="sessions">Sessions</PageTabsTrigger>
+              <PageTabsTrigger value="triggers">Triggers</PageTabsTrigger>
             </TabsList>
           </div>
 
@@ -205,46 +213,6 @@ export function AssistantDraftPanel(): JSX.Element {
                   ))}
                 </Stack>
               </Section>
-
-              <Section
-                title={`Triggers (${triggers.length})`}
-                empty="No triggers wired up."
-                isEmpty={triggers.length === 0}
-              >
-                <Stack gap={2}>
-                  {triggers.map((t) => (
-                    <div
-                      key={t.id}
-                      className="border-border flex items-start justify-between gap-2 rounded-md border px-3 py-2"
-                    >
-                      <Stack gap={1} className="min-w-0">
-                        <Stack direction="horizontal" gap={2} align="center">
-                          <Type small className="font-medium">
-                            {t.name}
-                          </Type>
-                          <Badge variant="outline" className="text-[10px]">
-                            {t.definitionSlug}
-                          </Badge>
-                        </Stack>
-                        {t.webhookUrl && (
-                          <code className="text-muted-foreground truncate text-[10px]">
-                            {t.webhookUrl}
-                          </code>
-                        )}
-                      </Stack>
-                      {t.status === "active" ? (
-                        <Badge variant="default" className="text-[10px]">
-                          Active
-                        </Badge>
-                      ) : (
-                        <Badge variant="secondary" className="text-[10px]">
-                          Paused
-                        </Badge>
-                      )}
-                    </div>
-                  ))}
-                </Stack>
-              </Section>
             </Stack>
           </TabsContent>
 
@@ -253,6 +221,51 @@ export function AssistantDraftPanel(): JSX.Element {
             className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
           >
             <AssistantSessionsList assistantId={a.id} />
+          </TabsContent>
+
+          <TabsContent
+            value="triggers"
+            className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
+          >
+            {triggers.length === 0 ? (
+              <Type small muted>
+                No triggers wired up.
+              </Type>
+            ) : (
+              <Stack gap={2}>
+                {triggers.map((t) => (
+                  <div
+                    key={t.id}
+                    className="border-border flex items-start justify-between gap-2 rounded-md border px-3 py-2"
+                  >
+                    <Stack gap={1} className="min-w-0">
+                      <Stack direction="horizontal" gap={2} align="center">
+                        <Type small className="font-medium">
+                          {t.name}
+                        </Type>
+                        <Badge variant="outline" className="text-[10px]">
+                          {t.definitionSlug}
+                        </Badge>
+                      </Stack>
+                      {t.webhookUrl && (
+                        <code className="text-muted-foreground truncate text-[10px]">
+                          {t.webhookUrl}
+                        </code>
+                      )}
+                    </Stack>
+                    {t.status === "active" ? (
+                      <Badge variant="default" className="text-[10px]">
+                        Active
+                      </Badge>
+                    ) : (
+                      <Badge variant="secondary" className="text-[10px]">
+                        Paused
+                      </Badge>
+                    )}
+                  </div>
+                ))}
+              </Stack>
+            )}
           </TabsContent>
         </Tabs>
       )}

--- a/client/dashboard/src/pages/triggers/Triggers.tsx
+++ b/client/dashboard/src/pages/triggers/Triggers.tsx
@@ -795,7 +795,12 @@ function TriggerDialog({
   );
 }
 
-export default function TriggersIndex(): JSX.Element {
+/**
+ * Triggers list, dialog, and empty/loading states without a surrounding
+ * `Page` shell. Rendered standalone by the `/triggers` route (`TriggersIndex`)
+ * and embedded as a tab on the Assistants page.
+ */
+export function TriggersPanel(): JSX.Element {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingTrigger, setEditingTrigger] = useState<TriggerInstance | null>(
     null,
@@ -827,55 +832,63 @@ export default function TriggersIndex(): JSX.Element {
   };
 
   return (
+    <>
+      <Page.Section>
+        <Page.Section.Title>Triggers</Page.Section.Title>
+        <Page.Section.Description>
+          Connect external events to your assistants via webhooks or cron
+          schedules.
+        </Page.Section.Description>
+        <Page.Section.CTA>
+          {triggers.length > 0 && (
+            <Button onClick={openCreate}>
+              <Button.LeftIcon>
+                <Icon name="plus" className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>Create Trigger</Button.Text>
+            </Button>
+          )}
+        </Page.Section.CTA>
+        <Page.Section.Body>
+          {isLoading ? (
+            <Stack align="center" justify="center" className="py-16">
+              <Icon
+                name="loader-circle"
+                className="text-muted-foreground h-6 w-6 animate-spin"
+              />
+            </Stack>
+          ) : triggers.length === 0 ? (
+            <TriggersEmptyState onCreate={openCreate} />
+          ) : (
+            <TriggersTable
+              triggers={triggers}
+              definitions={definitions}
+              onEdit={openEdit}
+            />
+          )}
+        </Page.Section.Body>
+      </Page.Section>
+
+      <TriggerDialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) setEditingTrigger(null);
+        }}
+        editingTrigger={editingTrigger}
+      />
+    </>
+  );
+}
+
+export default function TriggersIndex(): JSX.Element {
+  return (
     <Page>
       <Page.Header>
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <Page.Section>
-          <Page.Section.Title>Triggers</Page.Section.Title>
-          <Page.Section.Description>
-            Connect external events to your assistants via webhooks or cron
-            schedules.
-          </Page.Section.Description>
-          <Page.Section.CTA>
-            {triggers.length > 0 && (
-              <Button onClick={openCreate}>
-                <Button.LeftIcon>
-                  <Icon name="plus" className="h-4 w-4" />
-                </Button.LeftIcon>
-                <Button.Text>Create Trigger</Button.Text>
-              </Button>
-            )}
-          </Page.Section.CTA>
-          <Page.Section.Body>
-            {isLoading ? (
-              <Stack align="center" justify="center" className="py-16">
-                <Icon
-                  name="loader-circle"
-                  className="text-muted-foreground h-6 w-6 animate-spin"
-                />
-              </Stack>
-            ) : triggers.length === 0 ? (
-              <TriggersEmptyState onCreate={openCreate} />
-            ) : (
-              <TriggersTable
-                triggers={triggers}
-                definitions={definitions}
-                onEdit={openEdit}
-              />
-            )}
-          </Page.Section.Body>
-        </Page.Section>
-
-        <TriggerDialog
-          open={dialogOpen}
-          onOpenChange={(open) => {
-            setDialogOpen(open);
-            if (!open) setEditingTrigger(null);
-          }}
-          editingTrigger={editingTrigger}
-        />
+        <TriggersPanel />
       </Page.Body>
     </Page>
   );


### PR DESCRIPTION
## Summary

Surfaces Triggers within the Assistants experience and tidies the top-level tab label.

- **Triggers tab on the Assistants page** — the full triggers list (same content as the `/triggers` route) now appears as a `Triggers` tab next to `Assistants`.
- **Per-assistant Triggers tab** — each assistant's detail panel gains a `Triggers` tab beside `Overview` and `Sessions`, showing only that assistant's triggers (`targetKind === "assistant"` & matching `targetRef`).
- **Renamed `Audit log` → `Activity`** — top-level tab label only; the `?tab=audit` URL param is unchanged so existing deep-links keep working.

## Implementation notes

- Extracted a reusable `TriggersPanel` from `TriggersIndex` (`Triggers.tsx`) — the list, create/edit dialog, and empty/loading states minus the `Page` shell. The `/triggers` route and the new Assistants tab both render it, so there's a single source of truth.
- The per-assistant filtered list already existed but was buried as a section inside `Overview`; it was **promoted** into its own tab rather than duplicated, with a "No triggers wired up." empty state.
- Tab state on both strips flows through `nuqs` `?tab=` params; the inline `onValueChange` ternaries were replaced with hoisted, typed `toTopLevelTab` / `toDetailTab` guards.

## Testing

- `pnpm -F dashboard type-check` (CI-equivalent `tsc -b --noEmit --force`) — clean.
- `pnpm -F dashboard lint` (oxfmt, no-barrels, oxlint type-aware, type-check) — clean.
- No tests reference the changed components or the old "Audit log" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Triggers tabs to the Assistants experience and renames the top-level “Audit log” tab to “Activity”, keeping `?tab=audit` deep links working. Also defers per-assistant trigger fetching until the Triggers tab is opened.

- **New Features**
  - Top-level Triggers tab on Assistants shows the full list (same as `/triggers`).
  - Triggers tab in each assistant shows only that assistant’s triggers.

- **Refactors**
  - Extracted `TriggersPanel` from `TriggersIndex` and reuse it in both the `/triggers` route and Assistants tab.
  - Centralized tab parsing with `toTopLevelTab` and `toDetailTab` using `nuqs` `?tab=` params.
  - Deferred per-assistant `useTriggers` query until the Triggers tab is active.

<sup>Written for commit 32dedfaf7bb22df8ec3e5db0ba144b8178d2dfc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

