### PR TITLE
chore: add grant expression set difference evaluation

### DIFF
--- a/server/internal/authz/checks.go
+++ b/server/internal/authz/checks.go
@@ -42,6 +42,18 @@ func RiskPolicyEvaluateCheck(policyID string) Check {
 	return Check{Scope: ScopeRiskPolicyEvaluate, ResourceKind: "", ResourceID: policyID, Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
 }
 
+// RiskPolicyApplies builds the runtime authorization rule for applying a risk
+// policy to a request.
+//
+// The rule is:
+//
+//	user can evaluate the policy for this request
+//	  unless user can bypass the same policy for this request
+//
+// The evaluate check is intentionally broad because audience grants may only
+// name the policy. The expression Instance is built from the bypass check so
+// both sides talk about the same concrete request dimensions, such as
+// server_url or server_identity.
 func RiskPolicyApplies(policyID string, bypassDims RiskPolicyDimensions) GrantExpression {
 	bypass := RiskPolicyBypassCheck(policyID, bypassDims)
 	instance := bypass.selector()

--- a/server/internal/authz/checks.go
+++ b/server/internal/authz/checks.go
@@ -33,12 +33,25 @@ func MCPCheck(scope Scope, resourceID, projectID string) Check {
 	return Check{Scope: scope, ResourceKind: "", ResourceID: resourceID, Dimensions: dimensions, selectorMatch: selectorMatchNormal, expanded: false}
 }
 
-type RiskPolicyBypassDimensions struct {
+type RiskPolicyDimensions struct {
 	ServerURL      string
 	ServerIdentity string
 }
 
-func RiskPolicyBypassCheck(policyID string, dims RiskPolicyBypassDimensions) Check {
+func RiskPolicyEvaluateCheck(policyID string) Check {
+	return Check{Scope: ScopeRiskPolicyEvaluate, ResourceKind: "", ResourceID: policyID, Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
+}
+
+func RiskPolicyApplies(policyID string, bypassDims RiskPolicyDimensions) GrantExpression {
+	bypass := RiskPolicyBypassCheck(policyID, bypassDims)
+	instance := bypass.selector()
+	return GrantDifference{
+		Base:      GrantCheck{Check: RiskPolicyEvaluateCheck(policyID), Instance: instance},
+		Exception: GrantCheck{Check: bypass, Instance: instance},
+	}
+}
+
+func RiskPolicyBypassCheck(policyID string, dims RiskPolicyDimensions) Check {
 	var dimensions map[string]string
 	if dims.ServerURL != "" {
 		dimensions = map[string]string{}

--- a/server/internal/authz/expressions.go
+++ b/server/internal/authz/expressions.go
@@ -9,43 +9,57 @@ import (
 	"strings"
 )
 
-// Grant expressions evaluate permissions that cannot be answered by one
-// standalone Check.
+// Grant expressions are reusable authorization rules built from normal Checks.
 //
-// A Check is still the unit of grant matching: it says which scope, resource,
-// and selector dimensions a grant must satisfy. The expression layer adds set
-// algebra on top of those checks. Each matching check proves a concrete
-// permission instance, represented by a selector key. Difference expressions
-// remove exception instances from base instances.
+// Use a Check when one grant is enough to answer the question:
 //
-// Example:
+//	"does this user have mcp:connect for this server?"
 //
-//	risk_policy applies =
-//	  instances proven by risk_policy:evaluate
-//	  minus instances proven by matching risk_policy:bypass
+// Use a GrantExpression when the rule also has exceptions or other grant-based
+// conditions:
 //
-// If a user has a broad evaluate grant for policy_123 and a bypass grant only
-// for server_url=abc, evaluating policy_123 for server_url=cde keeps the
-// evaluate instance. Evaluating policy_123 for server_url=abc removes it. This
-// is why GrantCheck separates Check, the grant-matching rule, from Instance,
-// the permission instance that participates in set difference.
+//	"does this user have mcp:connect for this server, unless they also have
+//	 a matching mcp:block grant?"
 //
-// Selectors remain the source of truth for matching behavior. Grant expressions
-// deliberately reuse Check expansion and selector matching so resource
-// matching, wildcards, strict matching, and runtime dimensions keep the same
-// semantics as normal RBAC checks.
+//	"does this risk policy apply to this request, unless the user also has
+//	 a matching risk_policy:bypass grant?"
+//
+// The expression still uses Check for matching grants. That keeps scope
+// expansion, selector matching, wildcards, strict matching, and dimensions in
+// the same code path as Require/RequireAny. The expression layer only decides
+// how matching grants combine.
+//
+// The main operation today is difference:
+//
+//	base permission - exception permission
+//
+// For risk policy evaluation this means:
+//
+//	risk_policy:evaluate(policy_123, server_url=abc)
+//	  - risk_policy:bypass(policy_123, server_url=abc)
+//
+// A broad evaluate grant can prove that policy_123 applies to server_url=abc.
+// A bypass grant removes that decision only when it proves the same policy and
+// runtime dimensions. A bypass for server_url=abc does not remove policy
+// evaluation for server_url=cde.
 
 // GrantExpression evaluates whether a loaded grant set satisfies a domain
-// permission. Operands are grounded in Check values so selector matching,
-// dimensions, wildcards, strict matching, and scope expansion remain centralized
-// in the existing authz primitives.
+// permission.
+//
+// Callers should normally use Evaluate. The unexported grantSet method exists
+// so expressions can compose with each other without exposing the internal set
+// representation outside this package.
 type GrantExpression interface {
-	// Evaluate is the public API for callers. It hides set details and reports
-	// whether the final expression result is non-empty.
+	// Evaluate answers the user-facing authorization question: did the loaded
+	// grants satisfy this expression?
+	//
+	// Implementations may build intermediate sets, but callers only need the
+	// boolean result and the high-level reason.
 	Evaluate(grants []Grant) (GrantExpressionResult, error)
 
-	// grantSet is intentionally unexported. It lets authz expression types
-	// compose internally without exposing set-key mechanics as public API.
+	// grantSet returns the concrete permission instances proven by this
+	// expression. It is deliberately private because the set shape is an
+	// implementation detail of expression composition, not public API.
 	grantSet(grants []Grant) (grantSet, error)
 }
 
@@ -64,33 +78,56 @@ type GrantExpressionResult struct {
 	Reason    GrantExpressionReason
 }
 
-// grantSet is the set of permission instances proven by a grant expression.
-// Keys are canonical selector encodings; values are kept for debugging or
-// future proof details.
+// grantSet is the internal result of evaluating an expression as "which concrete
+// permission instances did these grants prove?".
+//
+// A permission instance is represented by a Selector, for example:
+//
+//	{resource_kind:"risk_policy", resource_id:"policy_123", server_url:"abc"}
+//
+// The map key is a stable encoding of that selector so difference can delete
+// matching instances quickly and exactly. The selector is kept as the value so
+// future diagnostics can explain which instance survived or was removed.
 type grantSet map[string]grantSetMember
 
 type grantSetMember struct {
 	Selector Selector
 }
 
-// GrantCheck is the primitive grant expression.
+// GrantCheck turns one Check into a GrantExpression.
 //
-// Check defines what grant must match. Instance identifies the domain
-// permission instance that matching grant proves. If Instance is empty, the
-// check selector is used as the set member key.
+// Check is the grant-matching rule. It answers "does any loaded grant satisfy
+// this scope/resource/dimensions?" using the same matching behavior as normal
+// RBAC checks.
 //
-// This distinction matters when the matching grant is broader than the runtime
-// permission instance. For risk policy application, a generic
-// risk_policy:evaluate grant can prove "policy_123 applies to server_url=abc".
-// A bypass grant subtracts only if it proves that same instance.
+// Instance is the concrete permission instance that a matching grant proves. If
+// Instance is empty, the check selector is used.
+//
+// The two are separate because the grant that matches can be broader than the
+// runtime decision being made. Example: a user may have a generic
+// risk_policy:evaluate grant for policy_123, but the runtime decision is
+// "policy_123 applies to server_url=abc". In that case Check is generic, while
+// Instance includes server_url=abc so a bypass can subtract only that exact
+// runtime decision.
 type GrantCheck struct {
 	Check    Check
 	Instance Selector
 }
 
-// GrantDifference evaluates both operands as sets and returns Base - Exception.
-// It is satisfied when at least one base instance remains after removing all
-// matching exception instances.
+// GrantDifference represents "Base is allowed unless Exception also applies".
+//
+// It evaluates Base and Exception into sets of concrete permission instances,
+// removes every exception instance from the base set, and is satisfied when at
+// least one base instance remains.
+//
+// Examples:
+//
+//	risk_policy:evaluate - risk_policy:bypass
+//	mcp:connect - mcp:block
+//
+// The scopes on the two sides do not have to be the same. What matters is that
+// both sides produce the same Instance selector when the exception should
+// remove the base permission.
 type GrantDifference struct {
 	Base      GrantExpression
 	Exception GrantExpression
@@ -149,6 +186,9 @@ func (g GrantDifference) Evaluate(grants []Grant) (GrantExpressionResult, error)
 		return baseResult, nil
 	}
 
+	// Evaluate above gives us the best reason to return when the base is not
+	// satisfied. From here on we need the actual base and exception sets so the
+	// exception removes only matching permission instances.
 	base, err := g.Base.grantSet(grants)
 	if err != nil {
 		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonError}, fmt.Errorf("evaluate base expression set: %w", err)
@@ -190,11 +230,21 @@ func (s grantSet) add(member grantSetMember) {
 	s[grantSetKey(member.Selector)] = member
 }
 
-// subtract removes every instance from s that is also present in other.
-// This is the actual set-difference operation: exception instances remove only
-// base instances with the same canonical selector key. Other base instances
-// stay in the set, so an exception does not automatically make the whole
-// expression false.
+// subtract removes every permission instance from s that is also present in
+// other.
+//
+// This is the "unless" part of a GrantDifference. If the base set contains:
+//
+//	{risk_policy policy_123 server_url=abc}
+//	{risk_policy policy_123 server_url=cde}
+//
+// and the exception set contains:
+//
+//	{risk_policy policy_123 server_url=abc}
+//
+// then only the abc instance is removed. The cde instance remains, so the
+// expression is still satisfied for cde. We delete by canonical selector key
+// instead of comparing maps directly because Go maps are not comparable.
 func (s grantSet) subtract(other grantSet) {
 	for key := range other {
 		delete(s, key)

--- a/server/internal/authz/expressions.go
+++ b/server/internal/authz/expressions.go
@@ -1,0 +1,220 @@
+package authz
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Grant expressions model derived permissions over the grants already loaded
+// for a request.
+//
+// A plain Check answers "does any grant match this scope/resource/dimensions?".
+// A GrantExpression answers the richer question "which permission instances are
+// proven by those matching grants, and which of those instances are removed by
+// exceptions?". This is the piece we need for rules such as:
+//
+//	risk_policy applies = risk_policy:evaluate - risk_policy:bypass
+//
+// The expression layer deliberately reuses Check for all grant matching. That
+// keeps selector semantics in one place: resource_kind/resource_id, wildcards,
+// strict versus normal selector matching, scope expansion, and runtime
+// dimensions such as server_url, server_identity, tool, disposition, and
+// project_id.
+//
+// The only new concept here is the expression "instance": the set member a
+// matched check proves. Base and exception expressions subtract only when they
+// prove the same instance key.
+
+// GrantExpression evaluates whether a loaded grant set satisfies a domain
+// permission. Operands are grounded in Check values so selector matching,
+// dimensions, wildcards, strict matching, and scope expansion remain centralized
+// in the existing authz primitives.
+type GrantExpression interface {
+	// Evaluate is the public API for callers. It hides set details and reports
+	// whether the final expression result is non-empty.
+	Evaluate(grants []Grant) (GrantExpressionResult, error)
+
+	// grantSet is intentionally unexported. It lets authz expression types
+	// compose internally without exposing set-key mechanics as public API.
+	grantSet(grants []Grant) (grantSet, error)
+}
+
+type GrantExpressionReason string
+
+const (
+	GrantExpressionReasonMatched          GrantExpressionReason = "matched"
+	GrantExpressionReasonMissingBase      GrantExpressionReason = "missing_base"
+	GrantExpressionReasonExceptionMatched GrantExpressionReason = "exception_matched"
+	GrantExpressionReasonError            GrantExpressionReason = "error"
+)
+
+// GrantExpressionResult reports whether an expression was satisfied and why.
+type GrantExpressionResult struct {
+	Satisfied bool
+	Reason    GrantExpressionReason
+}
+
+// grantSet is the set of permission instances proven by a grant expression.
+// Keys are canonical selector encodings; values are kept for debugging or
+// future proof details.
+type grantSet map[string]grantSetMember
+
+type grantSetMember struct {
+	Selector Selector
+}
+
+// GrantCheck is the primitive grant expression.
+//
+// Check defines what grant must match. Instance identifies the domain
+// permission instance that matching grant proves. If Instance is empty, the
+// check selector is used as the set member key.
+//
+// This distinction matters when the matching grant is broader than the runtime
+// permission instance. For risk policy application, a generic
+// risk_policy:evaluate grant can prove "policy_123 applies to server_url=abc".
+// A bypass grant subtracts only if it proves that same instance.
+type GrantCheck struct {
+	Check    Check
+	Instance Selector
+}
+
+// GrantDifference evaluates both operands as sets and returns Base - Exception.
+// It is satisfied when at least one base instance remains after removing all
+// matching exception instances.
+type GrantDifference struct {
+	Base      GrantExpression
+	Exception GrantExpression
+}
+
+func (g GrantCheck) Evaluate(grants []Grant) (GrantExpressionResult, error) {
+	set, err := g.grantSet(grants)
+	if err != nil {
+		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonError}, err
+	}
+	if len(set) == 0 {
+		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonMissingBase}, nil
+	}
+	return GrantExpressionResult{Satisfied: true, Reason: GrantExpressionReasonMatched}, nil
+}
+
+func (g GrantCheck) grantSet(grants []Grant) (grantSet, error) {
+	if err := validateInput(g.Check); err != nil {
+		return nil, err
+	}
+
+	// matchingAllowGrant already applies Check expansion and the Check's
+	// selector match mode. Grant expressions do not reimplement selector logic.
+	grant, _ := matchingAllowGrant(grants, g.Check.expand())
+	if grant == nil {
+		return grantSet{}, nil
+	}
+
+	set := grantSet{}
+	set.add(grantSetMember{Selector: g.instanceSelector()})
+	return set, nil
+}
+
+func (g GrantCheck) instanceSelector() Selector {
+	if len(g.Instance) > 0 {
+		return maps.Clone(g.Instance)
+	}
+	// Defaulting to the check selector is correct when "what matched" and "what
+	// was proven" are the same permission instance.
+	return g.Check.selector()
+}
+
+func (g GrantDifference) Evaluate(grants []Grant) (GrantExpressionResult, error) {
+	if g.Base == nil {
+		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonError}, errors.New("grant difference requires a base expression")
+	}
+	if g.Exception == nil {
+		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonError}, errors.New("grant difference requires an exception expression")
+	}
+
+	baseResult, err := g.Base.Evaluate(grants)
+	if err != nil {
+		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonError}, fmt.Errorf("evaluate base expression: %w", err)
+	}
+	if !baseResult.Satisfied {
+		return baseResult, nil
+	}
+
+	base, err := g.Base.grantSet(grants)
+	if err != nil {
+		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonError}, fmt.Errorf("evaluate base expression set: %w", err)
+	}
+	exception, err := g.Exception.grantSet(grants)
+	if err != nil {
+		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonError}, fmt.Errorf("evaluate exception expression set: %w", err)
+	}
+
+	base.subtract(exception)
+	if len(base) == 0 {
+		return GrantExpressionResult{Satisfied: false, Reason: GrantExpressionReasonExceptionMatched}, nil
+	}
+
+	return GrantExpressionResult{Satisfied: true, Reason: GrantExpressionReasonMatched}, nil
+}
+
+func (g GrantDifference) grantSet(grants []Grant) (grantSet, error) {
+	if g.Base == nil {
+		return nil, errors.New("grant difference requires a base expression")
+	}
+	if g.Exception == nil {
+		return nil, errors.New("grant difference requires an exception expression")
+	}
+
+	base, err := g.Base.grantSet(grants)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate base expression: %w", err)
+	}
+	exception, err := g.Exception.grantSet(grants)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate exception expression: %w", err)
+	}
+	base.subtract(exception)
+	return base, nil
+}
+
+func (s grantSet) add(member grantSetMember) {
+	s[grantSetKey(member.Selector)] = member
+}
+
+// subtract removes every instance from s that is also present in other.
+// This is the actual set-difference operation: exception instances remove only
+// base instances with the same canonical selector key. Other base instances
+// stay in the set, so an exception does not automatically make the whole
+// expression false.
+func (s grantSet) subtract(other grantSet) {
+	for key := range other {
+		delete(s, key)
+	}
+}
+
+func grantSetKey(selector Selector) string {
+	keys := make([]string, 0, len(selector))
+	for key := range selector {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	var b strings.Builder
+	for _, key := range keys {
+		writeGrantSetKeyPart(&b, key)
+		writeGrantSetKeyPart(&b, selector[key])
+	}
+	return b.String()
+}
+
+func writeGrantSetKeyPart(b *strings.Builder, value string) {
+	// Length-prefixing prevents ambiguous concatenation between adjacent parts.
+	// For example ["ab", "c"] and ["a", "bc"] encode differently.
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
+	b.WriteByte('|')
+}

--- a/server/internal/authz/expressions.go
+++ b/server/internal/authz/expressions.go
@@ -9,25 +9,31 @@ import (
 	"strings"
 )
 
-// Grant expressions model derived permissions over the grants already loaded
-// for a request.
+// Grant expressions evaluate permissions that cannot be answered by one
+// standalone Check.
 //
-// A plain Check answers "does any grant match this scope/resource/dimensions?".
-// A GrantExpression answers the richer question "which permission instances are
-// proven by those matching grants, and which of those instances are removed by
-// exceptions?". This is the piece we need for rules such as:
+// A Check is still the unit of grant matching: it says which scope, resource,
+// and selector dimensions a grant must satisfy. The expression layer adds set
+// algebra on top of those checks. Each matching check proves a concrete
+// permission instance, represented by a selector key. Difference expressions
+// remove exception instances from base instances.
 //
-//	risk_policy applies = risk_policy:evaluate - risk_policy:bypass
+// Example:
 //
-// The expression layer deliberately reuses Check for all grant matching. That
-// keeps selector semantics in one place: resource_kind/resource_id, wildcards,
-// strict versus normal selector matching, scope expansion, and runtime
-// dimensions such as server_url, server_identity, tool, disposition, and
-// project_id.
+//	risk_policy applies =
+//	  instances proven by risk_policy:evaluate
+//	  minus instances proven by matching risk_policy:bypass
 //
-// The only new concept here is the expression "instance": the set member a
-// matched check proves. Base and exception expressions subtract only when they
-// prove the same instance key.
+// If a user has a broad evaluate grant for policy_123 and a bypass grant only
+// for server_url=abc, evaluating policy_123 for server_url=cde keeps the
+// evaluate instance. Evaluating policy_123 for server_url=abc removes it. This
+// is why GrantCheck separates Check, the grant-matching rule, from Instance,
+// the permission instance that participates in set difference.
+//
+// Selectors remain the source of truth for matching behavior. Grant expressions
+// deliberately reuse Check expansion and selector matching so resource
+// matching, wildcards, strict matching, and runtime dimensions keep the same
+// semantics as normal RBAC checks.
 
 // GrantExpression evaluates whether a loaded grant set satisfies a domain
 // permission. Operands are grounded in Check values so selector matching,

--- a/server/internal/authz/expressions_test.go
+++ b/server/internal/authz/expressions_test.go
@@ -1,0 +1,181 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrantExpressionEvaluate_riskPolicyAppliesWithoutBypass(t *testing.T) {
+	t.Parallel()
+
+	policyID := "policy_123"
+	grants := []Grant{
+		NewGrant(ScopeRiskPolicyEvaluate, policyID),
+	}
+
+	result, err := RiskPolicyApplies(policyID, RiskPolicyDimensions{}).Evaluate(grants)
+	require.NoError(t, err)
+	require.True(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonMatched, result.Reason)
+}
+
+func TestGrantExpressionEvaluate_missingBase(t *testing.T) {
+	t.Parallel()
+
+	policyID := "policy_123"
+
+	result, err := RiskPolicyApplies(policyID, RiskPolicyDimensions{}).Evaluate(nil)
+	require.NoError(t, err)
+	require.False(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonMissingBase, result.Reason)
+}
+
+func TestGrantExpressionEvaluate_differenceWorksForGenericChecks(t *testing.T) {
+	t.Parallel()
+
+	grants := []Grant{
+		NewGrant(ScopeProjectRead, "proj_123"),
+		NewGrant(ScopeProjectWrite, "proj_123"),
+	}
+	readCheck := Check{Scope: ScopeProjectRead, ResourceKind: "", ResourceID: "proj_123", Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
+	writeCheck := Check{Scope: ScopeProjectWrite, ResourceKind: "", ResourceID: "proj_123", Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
+
+	result, err := GrantDifference{
+		Base:      GrantCheck{Check: readCheck, Instance: nil},
+		Exception: GrantCheck{Check: writeCheck, Instance: nil},
+	}.Evaluate(grants)
+	require.NoError(t, err)
+	require.False(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonExceptionMatched, result.Reason)
+}
+
+func TestGrantExpressionEvaluate_differenceKeepsNonMatchingSetKey(t *testing.T) {
+	t.Parallel()
+
+	grants := []Grant{
+		NewGrant(ScopeProjectRead, "proj_123"),
+		NewGrant(ScopeProjectWrite, "proj_123"),
+	}
+	readCheck := Check{Scope: ScopeProjectRead, ResourceKind: "", ResourceID: "proj_123", Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
+	writeCheck := Check{Scope: ScopeProjectWrite, ResourceKind: "", ResourceID: "proj_123", Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
+
+	result, err := GrantDifference{
+		Base: GrantCheck{
+			Check:    readCheck,
+			Instance: Selector{SelectorKeyResourceKind: ResourceKindProject, SelectorKeyResourceID: "proj_123"},
+		},
+		Exception: GrantCheck{
+			Check:    writeCheck,
+			Instance: Selector{SelectorKeyResourceKind: ResourceKindProject, SelectorKeyResourceID: "proj_456"},
+		},
+	}.Evaluate(grants)
+	require.NoError(t, err)
+	require.True(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonMatched, result.Reason)
+}
+
+func TestGrantExpressionEvaluate_nestedDifferencePreservesExceptionReason(t *testing.T) {
+	t.Parallel()
+
+	grants := []Grant{
+		NewGrant(ScopeProjectRead, "proj_123"),
+		NewGrant(ScopeProjectWrite, "proj_123"),
+	}
+	readCheck := Check{Scope: ScopeProjectRead, ResourceKind: "", ResourceID: "proj_123", Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
+	writeCheck := Check{Scope: ScopeProjectWrite, ResourceKind: "", ResourceID: "proj_123", Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
+	otherCheck := Check{Scope: ScopeProjectRead, ResourceKind: "", ResourceID: "proj_other", Dimensions: nil, selectorMatch: selectorMatchNormal, expanded: false}
+	instance := Selector{SelectorKeyResourceKind: ResourceKindProject, SelectorKeyResourceID: "proj_123"}
+
+	result, err := GrantDifference{
+		Base: GrantDifference{
+			Base:      GrantCheck{Check: readCheck, Instance: instance},
+			Exception: GrantCheck{Check: writeCheck, Instance: instance},
+		},
+		Exception: GrantCheck{Check: otherCheck, Instance: Selector{SelectorKeyResourceKind: ResourceKindProject, SelectorKeyResourceID: "proj_other"}},
+	}.Evaluate(grants)
+	require.NoError(t, err)
+	require.False(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonExceptionMatched, result.Reason)
+}
+
+func TestGrantExpressionEvaluate_riskPolicyAppliesSubtractsWholePolicyBypass(t *testing.T) {
+	t.Parallel()
+
+	policyID := "policy_123"
+	grants := []Grant{
+		NewGrant(ScopeRiskPolicyEvaluate, policyID),
+		NewGrant(ScopeRiskPolicyBypass, policyID),
+	}
+
+	result, err := RiskPolicyApplies(policyID, RiskPolicyDimensions{}).Evaluate(grants)
+	require.NoError(t, err)
+	require.False(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonExceptionMatched, result.Reason)
+}
+
+func TestGrantExpressionEvaluate_riskPolicyAppliesSubtractsWildcardBypass(t *testing.T) {
+	t.Parallel()
+
+	policyID := "policy_123"
+	grants := []Grant{
+		NewGrant(ScopeRiskPolicyEvaluate, policyID),
+		NewGrantWithSelector(ScopeRiskPolicyBypass, Selector{
+			SelectorKeyResourceKind: ResourceKindRiskPolicy,
+			SelectorKeyResourceID:   WildcardResource,
+		}),
+	}
+
+	result, err := RiskPolicyApplies(policyID, RiskPolicyDimensions{}).Evaluate(grants)
+	require.NoError(t, err)
+	require.False(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonExceptionMatched, result.Reason)
+}
+
+func TestGrantExpressionEvaluate_riskPolicyAppliesIgnoresNonMatchingScopedBypass(t *testing.T) {
+	t.Parallel()
+
+	policyID := "policy_123"
+	grants := []Grant{
+		NewGrant(ScopeRiskPolicyEvaluate, policyID),
+		NewGrantWithSelector(ScopeRiskPolicyBypass, Selector{
+			SelectorKeyResourceKind: ResourceKindRiskPolicy,
+			SelectorKeyResourceID:   policyID,
+			SelectorKeyServerURL:    "https://api.example.com",
+		}),
+	}
+
+	result, err := RiskPolicyApplies(policyID, RiskPolicyDimensions{}).Evaluate(grants)
+	require.NoError(t, err)
+	require.True(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonMatched, result.Reason)
+
+	result, err = RiskPolicyApplies(policyID, RiskPolicyDimensions{ServerURL: "https://api.example.com"}).Evaluate(grants)
+	require.NoError(t, err)
+	require.False(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonExceptionMatched, result.Reason)
+}
+
+func TestGrantExpressionEvaluate_riskPolicyAppliesSubtractsMatchingServerIdentityBypass(t *testing.T) {
+	t.Parallel()
+
+	policyID := "policy_123"
+	grants := []Grant{
+		NewGrant(ScopeRiskPolicyEvaluate, policyID),
+		NewGrantWithSelector(ScopeRiskPolicyBypass, Selector{
+			SelectorKeyResourceKind:   ResourceKindRiskPolicy,
+			SelectorKeyResourceID:     policyID,
+			SelectorKeyServerIdentity: "github",
+		}),
+	}
+
+	result, err := RiskPolicyApplies(policyID, RiskPolicyDimensions{ServerIdentity: "gitlab"}).Evaluate(grants)
+	require.NoError(t, err)
+	require.True(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonMatched, result.Reason)
+
+	result, err = RiskPolicyApplies(policyID, RiskPolicyDimensions{ServerIdentity: "github"}).Evaluate(grants)
+	require.NoError(t, err)
+	require.False(t, result.Satisfied)
+	require.Equal(t, GrantExpressionReasonExceptionMatched, result.Reason)
+}

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -53,6 +53,15 @@ type ScopedGrant struct {
 	Selectors []Selector
 }
 
+// GrantsSatisfy reports whether the loaded grant set authorizes check.
+func GrantsSatisfy(grants []Grant, check Check) bool {
+	if err := validateInput(check); err != nil {
+		return false
+	}
+	allowGrant, _, _ := evaluateGrants(grants, check.expand())
+	return allowGrant != nil
+}
+
 // SystemRoleGrants defines the canonical grant sets for the built-in system
 // roles. These are seeded when RBAC is enabled and replace any existing grants
 // for these roles (idempotent, won't clobber custom roles).
@@ -420,6 +429,19 @@ func buildScopedGrants(keys []scopeEffectKey, grouped map[scopeEffectKey]scopeAg
 // Returns the first matching allow grant+check pair if permitted, nil otherwise.
 // Also returns whether a deny was matched (for logging).
 func evaluateGrants(grants []Grant, checks []Check) (allowGrant *Grant, allowCheck *Check, denied bool) {
+	if hasMatchingDenyGrant(grants, checks) {
+		return nil, nil, true
+	}
+
+	allowGrant, allowCheck = matchingAllowGrant(grants, checks)
+	if allowGrant == nil {
+		return nil, nil, false
+	}
+
+	return allowGrant, allowCheck, false
+}
+
+func hasMatchingDenyGrant(grants []Grant, checks []Check) bool {
 	for i := range grants {
 		grant := &grants[i]
 		if grant.Effect != PolicyEffectDeny {
@@ -437,11 +459,15 @@ func evaluateGrants(grants []Grant, checks []Check) (allowGrant *Grant, allowChe
 			// be present in the check. This prevents a tool-scoped deny
 			// from blocking a dimensionless server-level connect probe.
 			if !check.expanded && grant.Selector.StrictMatches(check.selector()) {
-				return nil, nil, true
+				return true
 			}
 		}
 	}
 
+	return false
+}
+
+func matchingAllowGrant(grants []Grant, checks []Check) (*Grant, *Check) {
 	for i := range grants {
 		grant := &grants[i]
 		if grant.Effect != PolicyEffectAllow {
@@ -457,11 +483,11 @@ func evaluateGrants(grants []Grant, checks []Check) (allowGrant *Grant, allowChe
 			if !check.matchesAllowSelector(grant.Selector) {
 				continue
 			}
-			return grant, check, false
+			return grant, check
 		}
 	}
 
-	return nil, nil, false
+	return nil, nil
 }
 
 // allScopeGrants returns wildcard grants for every defined scope. Used to give

--- a/server/internal/authz/scopes_test.go
+++ b/server/internal/authz/scopes_test.go
@@ -178,7 +178,7 @@ func TestEvaluateGrants_riskPolicyBypassRequiresCheckDimensionsForScopedGrant(t 
 		SelectorKeyResourceID:   "policy_123",
 		SelectorKeyServerURL:    "https://api.example.com",
 	})}
-	checks := RiskPolicyBypassCheck("policy_123", RiskPolicyBypassDimensions{ServerURL: "", ServerIdentity: ""}).expand()
+	checks := RiskPolicyBypassCheck("policy_123", RiskPolicyDimensions{ServerURL: "", ServerIdentity: ""}).expand()
 
 	allow, _, denied := evaluateGrants(grants, checks)
 	require.Nil(t, allow)
@@ -189,7 +189,7 @@ func TestEvaluateGrants_riskPolicyBypassWholePolicyGrantMatchesScopedCheck(t *te
 	t.Parallel()
 
 	grants := []Grant{NewGrant(ScopeRiskPolicyBypass, "policy_123")}
-	checks := RiskPolicyBypassCheck("policy_123", RiskPolicyBypassDimensions{ServerURL: "https://api.example.com", ServerIdentity: ""}).expand()
+	checks := RiskPolicyBypassCheck("policy_123", RiskPolicyDimensions{ServerURL: "https://api.example.com", ServerIdentity: ""}).expand()
 
 	allow, _, denied := evaluateGrants(grants, checks)
 	require.NotNil(t, allow)
@@ -204,7 +204,7 @@ func TestEvaluateGrants_riskPolicyBypassScopedGrantMatchesScopedCheck(t *testing
 		SelectorKeyResourceID:   "policy_123",
 		SelectorKeyServerURL:    "https://api.example.com",
 	})}
-	checks := RiskPolicyBypassCheck("policy_123", RiskPolicyBypassDimensions{ServerURL: "https://api.example.com", ServerIdentity: ""}).expand()
+	checks := RiskPolicyBypassCheck("policy_123", RiskPolicyDimensions{ServerURL: "https://api.example.com", ServerIdentity: ""}).expand()
 
 	allow, _, denied := evaluateGrants(grants, checks)
 	require.NotNil(t, allow)
@@ -219,7 +219,7 @@ func TestEvaluateGrants_riskPolicyBypassServerIdentityGrantMatchesScopedCheck(t 
 		SelectorKeyResourceID:     "policy_123",
 		SelectorKeyServerIdentity: "github",
 	})}
-	checks := RiskPolicyBypassCheck("policy_123", RiskPolicyBypassDimensions{ServerURL: "", ServerIdentity: "github"}).expand()
+	checks := RiskPolicyBypassCheck("policy_123", RiskPolicyDimensions{ServerURL: "", ServerIdentity: "github"}).expand()
 
 	allow, _, denied := evaluateGrants(grants, checks)
 	require.NotNil(t, allow)

--- a/server/internal/authz/selector_test.go
+++ b/server/internal/authz/selector_test.go
@@ -327,7 +327,7 @@ func TestValidateSelector_riskPolicyAllowsServerURL(t *testing.T) {
 func TestRiskPolicyBypassCheck_injectsServerURL(t *testing.T) {
 	t.Parallel()
 
-	check := RiskPolicyBypassCheck("policy_123", RiskPolicyBypassDimensions{ServerURL: "https://api.example.com", ServerIdentity: ""})
+	check := RiskPolicyBypassCheck("policy_123", RiskPolicyDimensions{ServerURL: "https://api.example.com", ServerIdentity: ""})
 	require.Equal(t, ScopeRiskPolicyBypass, check.Scope)
 	require.Equal(t, "policy_123", check.ResourceID)
 	require.Equal(t, "https://api.example.com", check.Dimensions[SelectorKeyServerURL])
@@ -336,7 +336,7 @@ func TestRiskPolicyBypassCheck_injectsServerURL(t *testing.T) {
 func TestRiskPolicyBypassCheck_injectsServerIdentity(t *testing.T) {
 	t.Parallel()
 
-	check := RiskPolicyBypassCheck("policy_123", RiskPolicyBypassDimensions{ServerURL: "", ServerIdentity: "github"})
+	check := RiskPolicyBypassCheck("policy_123", RiskPolicyDimensions{ServerURL: "", ServerIdentity: "github"})
 	require.Equal(t, ScopeRiskPolicyBypass, check.Scope)
 	require.Equal(t, "policy_123", check.ResourceID)
 	require.Equal(t, "github", check.Dimensions[SelectorKeyServerIdentity])
@@ -345,7 +345,7 @@ func TestRiskPolicyBypassCheck_injectsServerIdentity(t *testing.T) {
 func TestRiskPolicyBypassCheck_emptyServerURLOmitsDimension(t *testing.T) {
 	t.Parallel()
 
-	check := RiskPolicyBypassCheck("policy_123", RiskPolicyBypassDimensions{ServerURL: "", ServerIdentity: ""})
+	check := RiskPolicyBypassCheck("policy_123", RiskPolicyDimensions{ServerURL: "", ServerIdentity: ""})
 	require.Nil(t, check.Dimensions)
 }
 

--- a/server/internal/risk/policy_bypass_evaluator.go
+++ b/server/internal/risk/policy_bypass_evaluator.go
@@ -118,11 +118,11 @@ func (e *PolicyBypassEvaluator) loadGrants(ctx context.Context, input PolicyBypa
 	return grants, true
 }
 
-func policyBypassCheckDimensions(target *PolicyBypassTarget) authz.RiskPolicyBypassDimensions {
+func policyBypassCheckDimensions(target *PolicyBypassTarget) authz.RiskPolicyDimensions {
 	if target == nil {
-		return authz.RiskPolicyBypassDimensions{ServerURL: "", ServerIdentity: ""}
+		return authz.RiskPolicyDimensions{ServerURL: "", ServerIdentity: ""}
 	}
-	return authz.RiskPolicyBypassDimensions{
+	return authz.RiskPolicyDimensions{
 		ServerURL:      target.Dimensions[authz.SelectorKeyServerURL],
 		ServerIdentity: target.Dimensions[authz.SelectorKeyServerIdentity],
 	}


### PR DESCRIPTION
This adds a small grant-expression layer for derived RBAC decisions that need set subtraction.

The first use case is risk policy application:

risk_policy applies = risk_policy:evaluate - risk_policy:bypass

A plain Check still owns grant matching: scope expansion, resource selectors, wildcard handling, strict selector matching, and runtime dimensions such as server_url, server_identity, tool, disposition, and project_id.

The expression layer adds the notion of a proven permission instance. GrantCheck.Check says which grant must match, while GrantCheck.Instance says which domain permission instance that grant proves. GrantDifference evaluates both sides into internal sets and subtracts exception instances from base instances by canonical selector key.

This lets a broad grant, such as risk_policy:evaluate for a policy, prove a specific runtime application of that policy, while a bypass only removes the matching runtime instance. It keeps subtraction explicit and set-based without mixing it into the legacy allow/deny evaluator used by normal Require checks.

This is inspired by Zanzibar's own evaluation system, and something we've discussed on improving to gradually remove explicit deny semantics.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a grant-expression layer to derive RBAC permissions via set difference, enabling “risk_policy applies = risk_policy:evaluate - risk_policy:bypass” without changing existing grant matching.

- **New Features**
  - Introduces `GrantExpression` with `GrantCheck` and `GrantDifference` to prove instances and subtract exceptions by canonical selector key; returns reasons: matched, missing_base, exception_matched, error.
  - Adds `RiskPolicyEvaluateCheck` and `RiskPolicyApplies(policyID, dims)`, using `RiskPolicyDimensions`; includes tests for risk policy and generic difference cases.

- **Refactors**
  - Splits evaluation into `hasMatchingDenyGrant` and `matchingAllowGrant`; adds `GrantsSatisfy` for a simple allow check.
  - Renames `RiskPolicyBypassDimensions` to `RiskPolicyDimensions` and updates all call sites.
  - Documents grant expressions and set semantics with inline comments.

<sup>Written for commit be0bfaaea21edce884dfab45df1408589b930621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



