### PR TITLE
mig: risk-fp-sweep - to support queries required for false-positives sweep

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3066,6 +3066,14 @@ CREATE TABLE IF NOT EXISTS risk_results (
   excluded_at timestamptz,
   excluded_exclusion_id uuid,
 
+  -- Set when the offline false-positive sweep determines a Presidio finding is
+  -- noise (e.g. a reserved IP or placeholder email). false_positive_reason is
+  -- the catalog reason recorded for audit. Independent of excluded_at: a row
+  -- can be both. Dashboard reads filter on false_positive_at IS NULL so swept
+  -- rows are hidden, and clearing both columns reverses a bad sweep.
+  false_positive_at timestamptz,
+  false_positive_reason TEXT,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT risk_results_pkey PRIMARY KEY (id),
@@ -3083,7 +3091,7 @@ ON risk_results (project_id, chat_message_id);
 
 CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
-WHERE found IS TRUE AND excluded_at IS NULL;
+WHERE found IS TRUE AND excluded_at IS NULL AND false_positive_at IS NULL;
 
 -- Narrows the exclusion sweeps (exact/rule_id/source) by project + policy +
 -- rule. The verbatim match column is intentionally NOT indexed: it can exceed

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1373,6 +1373,8 @@ type RiskResult struct {
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
+	FalsePositiveAt     pgtype.Timestamptz
+	FalsePositiveReason pgtype.Text
 	CreatedAt           pgtype.Timestamptz
 }
 

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -1932,7 +1932,7 @@ func (q *Queries) ListRiskPolicyBypassRequests(ctx context.Context, arg ListRisk
 }
 
 const listRiskResultsByChatFound = `-- name: ListRiskResultsByChatFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -1975,6 +1975,8 @@ type ListRiskResultsByChatFoundRow struct {
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
+	FalsePositiveAt     pgtype.Timestamptz
+	FalsePositiveReason pgtype.Text
 	CreatedAt           pgtype.Timestamptz
 	ChatID              uuid.UUID
 	MessageCreatedAt    pgtype.Timestamptz
@@ -2016,6 +2018,8 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,
+			&i.FalsePositiveAt,
+			&i.FalsePositiveReason,
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.MessageCreatedAt,
@@ -2033,7 +2037,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 }
 
 const listRiskResultsByProjectAndPolicy = `-- name: ListRiskResultsByProjectAndPolicy :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -2076,6 +2080,8 @@ type ListRiskResultsByProjectAndPolicyRow struct {
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
+	FalsePositiveAt     pgtype.Timestamptz
+	FalsePositiveReason pgtype.Text
 	CreatedAt           pgtype.Timestamptz
 	ChatID              uuid.UUID
 	MessageCreatedAt    pgtype.Timestamptz
@@ -2117,6 +2123,8 @@ func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg Lis
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,
+			&i.FalsePositiveAt,
+			&i.FalsePositiveReason,
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.MessageCreatedAt,

--- a/server/internal/testenv/testrepo/models.go
+++ b/server/internal/testenv/testrepo/models.go
@@ -115,5 +115,7 @@ type RiskResult struct {
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
+	FalsePositiveAt     pgtype.Timestamptz
+	FalsePositiveReason pgtype.Text
 	CreatedAt           pgtype.Timestamptz
 }

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -350,7 +350,7 @@ func (q *Queries) ListDeploymentHTTPTools(ctx context.Context, deploymentID uuid
 }
 
 const listRiskResultsAll = `-- name: ListRiskResultsAll :many
-SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, dead_letter_reason, excluded_at, excluded_exclusion_id, created_at
+SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, dead_letter_reason, excluded_at, excluded_exclusion_id, false_positive_at, false_positive_reason, created_at
 FROM risk_results
 WHERE project_id = $1
   AND risk_policy_id = $2
@@ -393,6 +393,8 @@ func (q *Queries) ListRiskResultsAll(ctx context.Context, arg ListRiskResultsAll
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,
+			&i.FalsePositiveAt,
+			&i.FalsePositiveReason,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/server/migrations/20260615104135_false_positive_sweep.sql
+++ b/server/migrations/20260615104135_false_positive_sweep.sql
@@ -1,7 +1,7 @@
 -- atlas:txmode none
 
 -- Drop index "risk_results_project_found_idx" from table: "risk_results"
-DROP INDEX CONCURRENTLY "risk_results_project_found_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "risk_results_project_found_idx";
 -- Modify "risk_results" table
 ALTER TABLE "risk_results" ADD COLUMN "false_positive_at" timestamptz NULL, ADD COLUMN "false_positive_reason" text NULL;
 -- Create index "risk_results_project_found_idx" to table: "risk_results"

--- a/server/migrations/20260615104135_false_positive_sweep.sql
+++ b/server/migrations/20260615104135_false_positive_sweep.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Drop index "risk_results_project_found_idx" from table: "risk_results"
+DROP INDEX CONCURRENTLY "risk_results_project_found_idx";
+-- Modify "risk_results" table
+ALTER TABLE "risk_results" ADD COLUMN "false_positive_at" timestamptz NULL, ADD COLUMN "false_positive_reason" text NULL;
+-- Create index "risk_results_project_found_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_project_found_idx" ON "risk_results" ("project_id", "created_at" DESC) WHERE ((found IS TRUE) AND (excluded_at IS NULL) AND (false_positive_at IS NULL));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lfnkwKeqKPtxoKhWP9pbJdNZqfxAutAol16Iu58ttlg=
+h1:bvSZskejt+mxSFpIu60kal8pKUK8Cj2I37KtSqiTRXc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -216,3 +216,4 @@ h1:lfnkwKeqKPtxoKhWP9pbJdNZqfxAutAol16Iu58ttlg=
 20260610205050_prompt-based-policies-extend-risk-policies.sql h1:KaqQWR4qItyOjW8jQPkFtYAni3ki3hOuQZ5fg5ZGDGY=
 20260610225502_remotesession-access-expires-nullable.sql h1:NMY/XoTX/Aj/oaFCpqX1GuPrp48oz3TsGHIn/hBSJzY=
 20260610231620_add-billing-metadata-table.sql h1:QtN9rqkm2eke8pugS7NNmlndanZj2mJ3axc5gqrY7/A=
+20260615104135_false_positive_sweep.sql h1:H8reMmIu6QqwMF5Mtjwyf2/jiys/3mxOrfLXh+S3Ll4=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:bvSZskejt+mxSFpIu60kal8pKUK8Cj2I37KtSqiTRXc=
+h1:SJT0MxRTW7xIV6t+9P3LD0YHm0VafA+rDuFXFR5BHII=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -216,4 +216,4 @@ h1:bvSZskejt+mxSFpIu60kal8pKUK8Cj2I37KtSqiTRXc=
 20260610205050_prompt-based-policies-extend-risk-policies.sql h1:KaqQWR4qItyOjW8jQPkFtYAni3ki3hOuQZ5fg5ZGDGY=
 20260610225502_remotesession-access-expires-nullable.sql h1:NMY/XoTX/Aj/oaFCpqX1GuPrp48oz3TsGHIn/hBSJzY=
 20260610231620_add-billing-metadata-table.sql h1:QtN9rqkm2eke8pugS7NNmlndanZj2mJ3axc5gqrY7/A=
-20260615104135_false_positive_sweep.sql h1:H8reMmIu6QqwMF5Mtjwyf2/jiys/3mxOrfLXh+S3Ll4=
+20260615104135_false_positive_sweep.sql h1:1jocVB88SQg/3BOArQIAbPECNrLXOIVDCI9VFpplmbY=


### PR DESCRIPTION
Schema and migrations split off `risk-fp-sweep` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add false-positive sweep fields to risk results and update the partial index so swept findings are hidden from dashboards. Includes schema and generated code updates; feature logic will land separately.

- **Migration**
  - Add nullable columns false_positive_at and false_positive_reason to risk_results.
  - Rebuild partial index risk_results_project_found_idx to exclude rows with false_positive_at IS NOT NULL.
  - Regenerate Go models and list queries to include the new fields (repo and testenv).
  - Drop/create the index CONCURRENTLY with `atlas:txmode none`; update `atlas.sum`.

<sup>Written for commit 1e279ef728d1e773e52df4136adad52d90fdff61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

