### PR TITLE
chore(dependabot): track Dockerfiles across all service directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,11 @@ updates:
           - "@vitejs/*"
           - "vitest"
   - package-ecosystem: "docker"
-    directory: "/server"
+    directories:
+      - "/server"
+      - "/agents/runtime-image"
+      - "/client/dashboard"
+      - "/otel-collector"
+      - "/services/pi-classifier"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot only watched /server for Docker base-image updates, leaving the runtime image, dashboard, otel-collector, and pi-classifier Dockerfiles unmonitored. Use a single docker entry with `directories` so every service gets weekly base-image update PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand Docker updates in `dependabot.yml` to monitor all service Dockerfiles, not just `/server`. Uses a single `docker` entry with `directories` for `/server`, `/agents/runtime-image`, `/client/dashboard`, `/otel-collector`, and `/services/pi-classifier` to get weekly base-image PRs.

<sup>Written for commit 754a81328cdbc94013d0243dc807074cb060d64a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

