### PR TITLE
mig: add workos metadata for directory attributes sync

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1763,6 +1763,9 @@ CREATE TABLE IF NOT EXISTS directory_user_group_memberships (
   deleted_at timestamptz,
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
 
+  -- WorkOS directory user group membership metadata
+  workos_created_at timestamptz NOT NULL,
+
   CONSTRAINT directory_user_group_memberships_pkey PRIMARY KEY (id),
   CONSTRAINT directory_user_group_memberships_directory_user_id_fkey FOREIGN KEY (directory_user_id) REFERENCES directory_users (id) ON DELETE CASCADE,
   CONSTRAINT directory_user_group_memberships_directory_group_id_fkey FOREIGN KEY (directory_group_id) REFERENCES directory_groups (id) ON DELETE CASCADE

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1700,6 +1700,13 @@ CREATE TABLE IF NOT EXISTS directory_groups (
   deleted_at timestamptz,
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
 
+  -- WorkOS directory group metadata
+  workos_created_at timestamptz NOT NULL,
+  workos_updated_at timestamptz NOT NULL,
+  workos_deleted_at timestamptz,
+  workos_deleted boolean NOT NULL GENERATED ALWAYS AS (workos_deleted_at IS NOT NULL) stored,
+  workos_last_event_id TEXT,
+
   CONSTRAINT directory_groups_pkey PRIMARY KEY (id),
   CONSTRAINT directory_groups_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
 );
@@ -1722,6 +1729,13 @@ CREATE TABLE IF NOT EXISTS directory_users (
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   deleted_at timestamptz,
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  -- WorkOS directory user metadata
+  workos_created_at timestamptz NOT NULL,
+  workos_updated_at timestamptz NOT NULL,
+  workos_deleted_at timestamptz,
+  workos_deleted boolean NOT NULL GENERATED ALWAYS AS (workos_deleted_at IS NOT NULL) stored,
+  workos_last_event_id TEXT,
 
   CONSTRAINT directory_users_pkey PRIMARY KEY (id),
   CONSTRAINT directory_users_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -441,6 +441,11 @@ type DirectoryGroup struct {
 	UpdatedAt              pgtype.Timestamptz
 	DeletedAt              pgtype.Timestamptz
 	Deleted                bool
+	WorkosCreatedAt        pgtype.Timestamptz
+	WorkosUpdatedAt        pgtype.Timestamptz
+	WorkosDeletedAt        pgtype.Timestamptz
+	WorkosDeleted          bool
+	WorkosLastEventID      pgtype.Text
 }
 
 type DirectoryUser struct {
@@ -454,6 +459,11 @@ type DirectoryUser struct {
 	UpdatedAt             pgtype.Timestamptz
 	DeletedAt             pgtype.Timestamptz
 	Deleted               bool
+	WorkosCreatedAt       pgtype.Timestamptz
+	WorkosUpdatedAt       pgtype.Timestamptz
+	WorkosDeletedAt       pgtype.Timestamptz
+	WorkosDeleted         bool
+	WorkosLastEventID     pgtype.Text
 }
 
 type DirectoryUserGroupMembership struct {
@@ -466,6 +476,7 @@ type DirectoryUserGroupMembership struct {
 	UpdatedAt              pgtype.Timestamptz
 	DeletedAt              pgtype.Timestamptz
 	Deleted                bool
+	WorkosCreatedAt        pgtype.Timestamptz
 }
 
 type Environment struct {

--- a/server/migrations/20260615112837_workos-metadata-for-directory-attributes-sync.sql
+++ b/server/migrations/20260615112837_workos-metadata-for-directory-attributes-sync.sql
@@ -1,0 +1,4 @@
+-- Modify "directory_groups" table
+ALTER TABLE "directory_groups" ADD COLUMN "workos_created_at" timestamptz NOT NULL, ADD COLUMN "workos_updated_at" timestamptz NOT NULL, ADD COLUMN "workos_deleted_at" timestamptz NULL, ADD COLUMN "workos_deleted" boolean NOT NULL GENERATED ALWAYS AS (workos_deleted_at IS NOT NULL) STORED, ADD COLUMN "workos_last_event_id" text NULL;
+-- Modify "directory_users" table
+ALTER TABLE "directory_users" ADD COLUMN "workos_created_at" timestamptz NOT NULL, ADD COLUMN "workos_updated_at" timestamptz NOT NULL, ADD COLUMN "workos_deleted_at" timestamptz NULL, ADD COLUMN "workos_deleted" boolean NOT NULL GENERATED ALWAYS AS (workos_deleted_at IS NOT NULL) STORED, ADD COLUMN "workos_last_event_id" text NULL;

--- a/server/migrations/20260615113504_workos-metadata-for-directory-attributes-sync.sql
+++ b/server/migrations/20260615113504_workos-metadata-for-directory-attributes-sync.sql
@@ -1,4 +1,6 @@
 -- Modify "directory_groups" table
 ALTER TABLE "directory_groups" ADD COLUMN "workos_created_at" timestamptz NOT NULL, ADD COLUMN "workos_updated_at" timestamptz NOT NULL, ADD COLUMN "workos_deleted_at" timestamptz NULL, ADD COLUMN "workos_deleted" boolean NOT NULL GENERATED ALWAYS AS (workos_deleted_at IS NOT NULL) STORED, ADD COLUMN "workos_last_event_id" text NULL;
+-- Modify "directory_user_group_memberships" table
+ALTER TABLE "directory_user_group_memberships" ADD COLUMN "workos_created_at" timestamptz NOT NULL;
 -- Modify "directory_users" table
 ALTER TABLE "directory_users" ADD COLUMN "workos_created_at" timestamptz NOT NULL, ADD COLUMN "workos_updated_at" timestamptz NOT NULL, ADD COLUMN "workos_deleted_at" timestamptz NULL, ADD COLUMN "workos_deleted" boolean NOT NULL GENERATED ALWAYS AS (workos_deleted_at IS NOT NULL) STORED, ADD COLUMN "workos_last_event_id" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lfnkwKeqKPtxoKhWP9pbJdNZqfxAutAol16Iu58ttlg=
+h1:iYGMyaD6h0NdyDOOfYl6MAV8i86yn5tCIoZ2qt4ix3k=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -216,3 +216,4 @@ h1:lfnkwKeqKPtxoKhWP9pbJdNZqfxAutAol16Iu58ttlg=
 20260610205050_prompt-based-policies-extend-risk-policies.sql h1:KaqQWR4qItyOjW8jQPkFtYAni3ki3hOuQZ5fg5ZGDGY=
 20260610225502_remotesession-access-expires-nullable.sql h1:NMY/XoTX/Aj/oaFCpqX1GuPrp48oz3TsGHIn/hBSJzY=
 20260610231620_add-billing-metadata-table.sql h1:QtN9rqkm2eke8pugS7NNmlndanZj2mJ3axc5gqrY7/A=
+20260615112837_workos-metadata-for-directory-attributes-sync.sql h1:l234ejaOzQwD9oxPwxUIv5zg+hdNlpAzaISozuVt0qM=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:iYGMyaD6h0NdyDOOfYl6MAV8i86yn5tCIoZ2qt4ix3k=
+h1:CAIuN82YTYdkneqrLZl94G3nndyfs0SO1UbgR2i63us=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -216,4 +216,4 @@ h1:iYGMyaD6h0NdyDOOfYl6MAV8i86yn5tCIoZ2qt4ix3k=
 20260610205050_prompt-based-policies-extend-risk-policies.sql h1:KaqQWR4qItyOjW8jQPkFtYAni3ki3hOuQZ5fg5ZGDGY=
 20260610225502_remotesession-access-expires-nullable.sql h1:NMY/XoTX/Aj/oaFCpqX1GuPrp48oz3TsGHIn/hBSJzY=
 20260610231620_add-billing-metadata-table.sql h1:QtN9rqkm2eke8pugS7NNmlndanZj2mJ3axc5gqrY7/A=
-20260615112837_workos-metadata-for-directory-attributes-sync.sql h1:l234ejaOzQwD9oxPwxUIv5zg+hdNlpAzaISozuVt0qM=
+20260615113504_workos-metadata-for-directory-attributes-sync.sql h1:YaY5VWzJ7Qfpp7n+TsPCF6s1FyoEO81tI2yvH+3pjTo=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:SJT0MxRTW7xIV6t+9P3LD0YHm0VafA+rDuFXFR5BHII=
+h1:HIriReMwNodAl5jTUyK3TfQdwN3T7ITKREaxyM616O0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -217,3 +217,4 @@ h1:SJT0MxRTW7xIV6t+9P3LD0YHm0VafA+rDuFXFR5BHII=
 20260610225502_remotesession-access-expires-nullable.sql h1:NMY/XoTX/Aj/oaFCpqX1GuPrp48oz3TsGHIn/hBSJzY=
 20260610231620_add-billing-metadata-table.sql h1:QtN9rqkm2eke8pugS7NNmlndanZj2mJ3axc5gqrY7/A=
 20260615104135_false_positive_sweep.sql h1:1jocVB88SQg/3BOArQIAbPECNrLXOIVDCI9VFpplmbY=
+20260615113504_workos-metadata-for-directory-attributes-sync.sql h1:sZiNf5tqa+2mqki7Xr4sUuF126gZBup1Kg92bX7AtkM=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add WorkOS metadata to `directory_groups`, `directory_users`, and `directory_user_group_memberships` to support reliable directory attribute sync and event replay. Groups/users now track created/updated/deleted timestamps, computed `workos_deleted`, and `workos_last_event_id`; memberships track `workos_created_at`. Go models expose these fields.

- **Migration**
  - Run the SQL migration.
  - Backfill: groups/users `workos_created_at`, `workos_updated_at`; set `workos_deleted_at` and `workos_last_event_id` if known. Memberships `workos_created_at`.

<sup>Written for commit 918e1a6fa1db5a2b61bad6aacaff3c95f860c413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

