### PR TITLE
chore(infra): migrate pubsub logging to structlog

### DIFF
--- a/infra/gram_infra/demos/_common.py
+++ b/infra/gram_infra/demos/_common.py
@@ -15,6 +15,7 @@ import uuid
 from typing import Awaitable, Callable
 
 import anyio
+import structlog
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -26,8 +27,20 @@ from gram_infra.pubsub.publisher import Publisher
 PUBLISH_INTERVAL_SECONDS = 0.2
 
 
+def configure_logging() -> None:
+    """Configure structlog for the demos: leveled, timestamped console output."""
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.dev.ConsoleRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+    )
+
+
 def make_emulator_broker(
-    logger: logging.Logger, *, script_name: str
+    logger: structlog.stdlib.BoundLogger, *, script_name: str
 ) -> EmulatedPubSubBroker:
     """Build a broker against the local emulator, or exit with guidance."""
     if not os.environ.get("PUBSUB_EMULATOR_HOST"):
@@ -42,7 +55,7 @@ def make_emulator_broker(
     project_id = os.environ.get("GOOGLE_CLOUD_PROJECT") or (
         f"gram-infra-demo-{uuid.uuid4().hex[:8]}"
     )
-    logger.info("using emulator project %s", project_id)
+    logger.info("using emulator project", project=project_id)
     return EmulatedPubSubBroker(
         project_id, PublisherClient(), SubscriberClient(), logger=logger
     )
@@ -65,7 +78,7 @@ async def publish_forever(publisher: Publisher[ping_pb2.Message]) -> None:
 
 
 async def shutdown_on_signal(
-    cancel_scope: anyio.CancelScope, logger: logging.Logger
+    cancel_scope: anyio.CancelScope, logger: structlog.stdlib.BoundLogger
 ) -> None:
     """Cancel the surrounding task group when SIGINT/SIGTERM arrives."""
     with anyio.open_signal_receiver(signal.SIGINT, signal.SIGTERM) as signals:
@@ -88,4 +101,5 @@ def run_demo(demo: Callable[[str], Awaitable[None]]) -> None:
         raise SystemExit(
             f"PUBSUB_DEMO_BACKEND must be 'asyncio' or 'trio', got {backend!r}"
         )
+    configure_logging()
     anyio.run(demo, backend, backend=backend)

--- a/infra/gram_infra/demos/pubsub.py
+++ b/infra/gram_infra/demos/pubsub.py
@@ -17,9 +17,8 @@ topic on demand, so no Config Connector / GCP resources are needed locally.
 
 from __future__ import annotations
 
-import logging
-
 import anyio
+import structlog
 
 from gram.ping.v1 import ping_pb2, processor_pb2
 from gram_infra.pubsub import (
@@ -29,28 +28,25 @@ from gram_infra.pubsub import (
 
 from ._common import make_emulator_broker, publish_forever, run_demo, shutdown_on_signal
 
-logger = logging.getLogger("gram-infra-pubsub-demo")
+logger = structlog.get_logger("gram-infra-pubsub-demo")
 
 
 def make_handler(receiver_id: str):
     async def handle(message: ping_pb2.Message, meta) -> None:
         logger.info(
-            "%s received message id=%s type=%s payload=%s (delivery_attempt=%s)",
-            receiver_id,
-            message.id,
-            message.type,
-            message.payload.decode("utf-8", "replace"),
-            meta.delivery_attempt,
+            "received message",
+            receiver_id=receiver_id,
+            id=message.id,
+            type=message.type,
+            payload=message.payload.decode("utf-8", "replace"),
+            delivery_attempt=meta.delivery_attempt,
         )
 
     return handle
 
 
 async def _main(backend: str) -> None:
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
-    )
-    logger.info("running on %s backend", backend)
+    logger.info("running", backend=backend)
 
     with make_emulator_broker(logger, script_name="pubsub-demo") as broker:
         # Publisher for the topic declared by gram.ping.v1.Message.

--- a/infra/gram_infra/demos/pubsub_stream.py
+++ b/infra/gram_infra/demos/pubsub_stream.py
@@ -18,9 +18,8 @@ topic on demand, so no Config Connector / GCP resources are needed locally.
 
 from __future__ import annotations
 
-import logging
-
 import anyio
+import structlog
 
 from gram.ping.v1 import ping_pb2, processor_pb2
 from gram_infra.pubsub import (
@@ -31,7 +30,7 @@ from gram_infra.pubsub import (
 
 from ._common import make_emulator_broker, publish_forever, run_demo, shutdown_on_signal
 
-logger = logging.getLogger("gram-infra-pubsub-stream-demo")
+logger = structlog.get_logger("gram-infra-pubsub-stream-demo")
 
 
 async def _consume_stream(
@@ -46,21 +45,18 @@ async def _consume_stream(
     async with subscriber.stream() as messages:
         async for received in messages:
             logger.info(
-                "%s received message id=%s type=%s payload=%s (delivery_attempt=%s)",
-                receiver_id,
-                received.message.id,
-                received.message.type,
-                received.message.payload.decode("utf-8", "replace"),
-                received.metadata.delivery_attempt,
+                "received message",
+                receiver_id=receiver_id,
+                id=received.message.id,
+                type=received.message.type,
+                payload=received.message.payload.decode("utf-8", "replace"),
+                delivery_attempt=received.metadata.delivery_attempt,
             )
             received.ack()
 
 
 async def _main(backend: str) -> None:
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
-    )
-    logger.info("running on %s backend", backend)
+    logger.info("running", backend=backend)
 
     with make_emulator_broker(logger, script_name="pubsub-stream-demo") as broker:
         # Publisher for the topic declared by gram.ping.v1.Message.

--- a/infra/gram_infra/pubsub/broker.py
+++ b/infra/gram_infra/pubsub/broker.py
@@ -25,7 +25,6 @@ bounds and raises ``ValueError`` at reconcile time.
 from __future__ import annotations
 
 import concurrent.futures
-import logging
 import threading
 from contextlib import ExitStack
 from dataclasses import dataclass, field
@@ -33,6 +32,7 @@ from datetime import timedelta
 from types import TracebackType
 from typing import Protocol, Self, runtime_checkable
 
+import structlog
 from google.api_core.exceptions import AlreadyExists
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from google.protobuf.duration_pb2 import Duration
@@ -148,12 +148,12 @@ class PubSubBroker:
         *,
         publisher_client: PublisherClient | None = None,
         subscriber_client: SubscriberClient | None = None,
-        logger: logging.Logger | None = None,
+        logger: structlog.stdlib.BoundLogger | None = None,
     ) -> None:
         self._project_id = project_id
         self._publisher = publisher_client or PublisherClient()
         self._subscriber = subscriber_client or SubscriberClient()
-        self._logger = logger or logging.getLogger(__name__)
+        self._logger = logger or structlog.get_logger(__name__)
         self._exit_stack = None
         self._closed = False
         self._inflight = _InflightPublishes()
@@ -292,7 +292,7 @@ class EmulatedPubSubBroker(PubSubBroker):
         publisher_client: PublisherClient,
         subscriber_client: SubscriberClient,
         *,
-        logger: logging.Logger | None = None,
+        logger: structlog.stdlib.BoundLogger | None = None,
     ) -> None:
         super().__init__(
             project_id,
@@ -339,9 +339,9 @@ class EmulatedPubSubBroker(PubSubBroker):
 
         try:
             self._publisher.create_topic(request=request)
-            self._logger.info("topic created", extra={"topic": topic_path})
+            self._logger.info("topic created", topic=topic_path)
         except AlreadyExists:
-            self._logger.info("topic already exists", extra={"topic": topic_path})
+            self._logger.info("topic already exists", topic=topic_path)
         self._reconciled_topics.add(topic_id)
 
     def _reconcile_subscription(self, sub_id: str, topic_id: str, options) -> None:
@@ -373,9 +373,7 @@ class EmulatedPubSubBroker(PubSubBroker):
             and options.expiration_ttl.ToNanoseconds() != 0
         ):
             _validate_expiration_ttl(options.expiration_ttl, sub_id)
-            request["expiration_policy"] = {
-                "ttl": options.expiration_ttl.ToTimedelta()
-            }
+            request["expiration_policy"] = {"ttl": options.expiration_ttl.ToTimedelta()}
         if options.filter:
             request["filter"] = options.filter
         if options.HasField("retry_policy"):
@@ -407,11 +405,9 @@ class EmulatedPubSubBroker(PubSubBroker):
 
         try:
             self._subscriber.create_subscription(request=request)
-            self._logger.info("subscription created", extra={"subscription": sub_path})
+            self._logger.info("subscription created", subscription=sub_path)
         except AlreadyExists:
-            self._logger.info(
-                "subscription already exists", extra={"subscription": sub_path}
-            )
+            self._logger.info("subscription already exists", subscription=sub_path)
         self._reconciled_subscriptions.add(sub_id)
 
 

--- a/infra/gram_infra/pubsub/subscriber.py
+++ b/infra/gram_infra/pubsub/subscriber.py
@@ -27,7 +27,6 @@ its ack deadline to lapse — mirroring how the Go library and the stock
 
 from __future__ import annotations
 
-import logging
 import queue as queue_module
 import threading
 from concurrent.futures import CancelledError as FutureCancelledError
@@ -47,6 +46,7 @@ from typing import (
 import anyio
 import anyio.from_thread
 import anyio.to_thread
+import structlog
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from google.cloud.pubsub_v1.subscriber.scheduler import Scheduler
 from google.protobuf.message import Message
@@ -63,6 +63,7 @@ __all__ = [
 ]
 
 M = TypeVar("M", bound=Message)
+
 
 def _unwrap_single(eg: BaseExceptionGroup) -> BaseException:
     """Peel single-member exception groups down to the lone leaf exception.
@@ -304,7 +305,7 @@ class Subscriber(Generic[M]):
         handle: SubscriberHandle,
         message_type: type[M],
         *,
-        logger: logging.Logger,
+        logger: structlog.stdlib.BoundLogger,
         topic_proto_name: str,
         subscription_proto_name: str,
         max_concurrency: int = _DEFAULT_MAX_CONCURRENCY,
@@ -376,7 +377,9 @@ class Subscriber(Generic[M]):
         ``future.result()``, so a single ``to_thread`` slot stays parked per
         subscriber waiting for the stream to end.
         """
-        limit = max_concurrency if max_concurrency is not None else self._max_concurrency
+        limit = (
+            max_concurrency if max_concurrency is not None else self._max_concurrency
+        )
         limiter = anyio.CapacityLimiter(limit) if limit > 0 else None
 
         try:
@@ -508,11 +511,9 @@ class Subscriber(Generic[M]):
             self._logger.warning(
                 "failed to unmarshal pubsub message",
                 exc_info=True,
-                extra={
-                    "topic_proto_name": self._topic_proto_name,
-                    "subscription_proto_name": self._subscription_proto_name,
-                    "message_id": message.message_id,
-                },
+                topic_proto_name=self._topic_proto_name,
+                subscription_proto_name=self._subscription_proto_name,
+                message_id=message.message_id,
             )
             message.nack()
             return None
@@ -548,15 +549,13 @@ class Subscriber(Generic[M]):
             # failing.
             self._logger.error(
                 "error processing pubsub message",
-                exc_info=True,
-                extra={
-                    "topic_proto_name": self._topic_proto_name,
-                    "subscription_proto_name": self._subscription_proto_name,
-                    "message_id": metadata.id,
-                    "delivery_attempt": metadata.delivery_attempt
-                    if metadata.delivery_attempt is not None
-                    else 0,
-                },
+                exc_info=exc,
+                topic_proto_name=self._topic_proto_name,
+                subscription_proto_name=self._subscription_proto_name,
+                message_id=metadata.id,
+                delivery_attempt=metadata.delivery_attempt
+                if metadata.delivery_attempt is not None
+                else 0,
             )
             message.nack()
             return
@@ -627,7 +626,7 @@ def pubsub_subscriber_for_message(
     message_type: type[M],
     subscription_type: type[Message],
     *,
-    logger: logging.Logger | None = None,
+    logger: structlog.stdlib.BoundLogger | None = None,
 ) -> Subscriber[M]:
     """Return a subscriber for ``subscription_type`` delivering ``message_type`` messages.
 
@@ -643,7 +642,7 @@ def pubsub_subscriber_for_message(
     return Subscriber(
         handle,
         message_type,
-        logger=logger or logging.getLogger(__name__),
+        logger=logger or structlog.get_logger(__name__),
         topic_proto_name=message_type.DESCRIPTOR.full_name,
         subscription_proto_name=subscription_type.DESCRIPTOR.full_name,
     )

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "protobuf>=7.35.0,<8",
   "google-cloud-pubsub>=2.31.0",
   "anyio>=4.13.0",
+  "structlog>=26.1.0",
 ]
 
 [project.scripts]

--- a/infra/tests/test_backends.py
+++ b/infra/tests/test_backends.py
@@ -11,12 +11,12 @@ uses, and proves the library does not secretly depend on asyncio internals
 from __future__ import annotations
 
 import concurrent.futures as cf
-import logging
 import threading
 from typing import Any, cast
 
 import anyio
 import pytest
+import structlog
 
 from datetime import timedelta
 
@@ -208,6 +208,7 @@ def test_emulated_reconcile_is_memoized() -> None:
     assert len(topic_names) == len(set(topic_names))
     assert len(subscriber.requests) == 1
 
+
 # Both anyio backends. trio is a dev dependency (anyio[trio]).
 BACKENDS = ["asyncio", "trio"]
 
@@ -308,7 +309,7 @@ def test_receive_acks_messages_on_backend(backend) -> None:
     subscriber = Subscriber(
         SubscriberHandle(cast(Any, client), "subscriptions/test"),
         ping_pb2.Message,
-        logger=logging.getLogger("gram_infra.test"),
+        logger=structlog.get_logger("gram_infra.test"),
         topic_proto_name=TOPIC_PROTO,
         subscription_proto_name=SUB_PROTO,
     )

--- a/infra/tests/test_handle.py
+++ b/infra/tests/test_handle.py
@@ -11,14 +11,15 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
-import logging
 import threading
 from typing import Any, cast
 
 import anyio
 import anyio.to_thread
 import pytest
+import structlog
 from google.api_core.exceptions import NotFound
+from structlog.testing import capture_logs
 
 from conftest import FakeMessage, FakeSubscriberClient
 from gram.ping.v1 import ping_pb2
@@ -35,7 +36,7 @@ def make_subscriber(logger=None) -> Subscriber:
     return Subscriber(
         cast(SubscriberHandle, None),
         ping_pb2.Message,
-        logger=logger or logging.getLogger("gram_infra.test"),
+        logger=logger or structlog.get_logger("gram_infra.test"),
         topic_proto_name=TOPIC_PROTO,
         subscription_proto_name=SUB_PROTO,
     )
@@ -92,7 +93,7 @@ async def test_unmarshal_non_decode_error_is_nacked_and_skips_callback() -> None
     subscriber = Subscriber(
         cast(SubscriberHandle, None),
         cast(Any, ExplodingProto),
-        logger=logging.getLogger("gram_infra.test"),
+        logger=structlog.get_logger("gram_infra.test"),
         topic_proto_name=TOPIC_PROTO,
         subscription_proto_name=SUB_PROTO,
     )
@@ -111,44 +112,41 @@ async def test_unmarshal_non_decode_error_is_nacked_and_skips_callback() -> None
     assert not called
 
 
-async def test_callback_exception_is_logged_and_nacked(caplog) -> None:
+async def test_callback_exception_is_logged_and_nacked() -> None:
     data = ping_pb2.Message(id="x").SerializeToString()
     message = FakeMessage(data, message_id="msg-123", delivery_attempt=3)
 
     async def callback(msg, meta) -> None:
         raise RuntimeError("boom")
 
-    with caplog.at_level(logging.ERROR, logger="gram_infra.test"):
+    with capture_logs() as logs:
         await make_subscriber()._handle_message(message, callback)
 
     assert message.nacked is True
     assert message.acked is False
 
-    record = next(
-        r for r in caplog.records if r.msg == "error processing pubsub message"
-    )
-    assert "boom" in record.exc_text
-    assert record.topic_proto_name == TOPIC_PROTO
-    assert record.subscription_proto_name == SUB_PROTO
-    assert record.message_id == "msg-123"
-    assert record.delivery_attempt == 3
+    entry = next(e for e in logs if e["event"] == "error processing pubsub message")
+    # The handler's exception is logged via exc_info so it stays inspectable.
+    assert "boom" in str(entry["exc_info"])
+    assert entry["topic_proto_name"] == TOPIC_PROTO
+    assert entry["subscription_proto_name"] == SUB_PROTO
+    assert entry["message_id"] == "msg-123"
+    assert entry["delivery_attempt"] == 3
 
 
-async def test_nil_delivery_attempt_logs_zero(caplog) -> None:
+async def test_nil_delivery_attempt_logs_zero() -> None:
     data = ping_pb2.Message(id="x").SerializeToString()
     message = FakeMessage(data, message_id="msg-nil", delivery_attempt=None)
 
     async def callback(msg, meta) -> None:
         raise RuntimeError("kaboom")
 
-    with caplog.at_level(logging.ERROR, logger="gram_infra.test"):
+    with capture_logs() as logs:
         await make_subscriber()._handle_message(message, callback)
 
     assert message.nacked is True
-    record = next(
-        r for r in caplog.records if r.msg == "error processing pubsub message"
-    )
-    assert record.delivery_attempt == 0
+    entry = next(e for e in logs if e["event"] == "error processing pubsub message")
+    assert entry["delivery_attempt"] == 0
 
 
 def make_client_subscriber(messages) -> tuple[FakeSubscriberClient, Subscriber]:
@@ -156,7 +154,7 @@ def make_client_subscriber(messages) -> tuple[FakeSubscriberClient, Subscriber]:
     subscriber = Subscriber(
         SubscriberHandle(cast(Any, client), "subscriptions/test"),
         ping_pb2.Message,
-        logger=logging.getLogger("gram_infra.test"),
+        logger=structlog.get_logger("gram_infra.test"),
         topic_proto_name=TOPIC_PROTO,
         subscription_proto_name=SUB_PROTO,
     )
@@ -322,9 +320,7 @@ async def test_stream_yields_messages_with_explicit_ack() -> None:
 
 
 async def test_stream_explicit_nack() -> None:
-    message = FakeMessage(
-        ping_pb2.Message(id="x").SerializeToString(), message_id="x"
-    )
+    message = FakeMessage(ping_pb2.Message(id="x").SerializeToString(), message_id="x")
     subscriber = make_stream_subscriber([message])
 
     async with subscriber.stream() as stream:
@@ -393,7 +389,7 @@ async def test_stream_raises_terminal_stream_error() -> None:
     subscriber = Subscriber(
         SubscriberHandle(cast(Any, client), "subscriptions/test"),
         ping_pb2.Message,
-        logger=logging.getLogger("gram_infra.test"),
+        logger=structlog.get_logger("gram_infra.test"),
         topic_proto_name=TOPIC_PROTO,
         subscription_proto_name=SUB_PROTO,
     )
@@ -453,9 +449,7 @@ async def test_scheduler_close_nacks_buffered_and_is_idempotent() -> None:
     # buffered-but-undispatched message a nack (the manager's own shutdown nacks
     # only what shutdown() returns, which is nothing here) and stay safe to call
     # again from any of the teardown paths.
-    send, recv = anyio.create_memory_object_stream[object](
-        max_buffer_size=float("inf")
-    )
+    send, recv = anyio.create_memory_object_stream[object](max_buffer_size=float("inf"))
     scheduler = _PortalScheduler(cast(Any, None), send, recv)
 
     buffered = [FakeMessage(b"", message_id=str(i)) for i in range(3)]
@@ -479,9 +473,7 @@ async def test_scheduler_close_nacks_buffered_and_is_idempotent() -> None:
 async def test_stream_tears_down_cleanly_on_cancel() -> None:
     # Mirrors the streaming demo's shutdown: a stream consumed inside a task that
     # is cancelled must unwind through `async with`/`async for` without hanging.
-    message = FakeMessage(
-        ping_pb2.Message(id="x").SerializeToString(), message_id="x"
-    )
+    message = FakeMessage(ping_pb2.Message(id="x").SerializeToString(), message_id="x")
     subscriber = make_stream_subscriber([message])
 
     seen = asyncio.Event()
@@ -530,9 +522,7 @@ async def test_message_scheduled_after_teardown_is_nacked() -> None:
 
 
 async def test_received_message_disposition_is_idempotent() -> None:
-    message = FakeMessage(
-        ping_pb2.Message(id="x").SerializeToString(), message_id="x"
-    )
+    message = FakeMessage(ping_pb2.Message(id="x").SerializeToString(), message_id="x")
     subscriber = make_stream_subscriber([message])
 
     async with subscriber.stream() as stream:

--- a/infra/uv.lock
+++ b/infra/uv.lock
@@ -315,6 +315,7 @@ dependencies = [
     { name = "anyio" },
     { name = "google-cloud-pubsub" },
     { name = "protobuf" },
+    { name = "structlog" },
 ]
 
 [package.dev-dependencies]
@@ -332,6 +333,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.13.0" },
     { name = "google-cloud-pubsub", specifier = ">=2.31.0" },
     { name = "protobuf", specifier = ">=7.35.0,<8" },
+    { name = "structlog", specifier = ">=26.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -643,6 +645,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stdlib logging forced every diagnostic through positional %-format strings and `extra={...}` dicts, which are awkward to read and lose structure once rendered. structlog lets the library and demos emit key/value pairs that stay machine-parseable in production and human-readable in the console, which matters as the Pub/Sub library moves toward real GCP usage.

Bound-logger types replace `logging.Logger` across the broker, subscriber, and demo helpers. The error-processing path now passes the caught exception via `exc_info=exc` rather than `exc_info=True` so the traceback stays inspectable regardless of the active handler, and tests assert on captured structlog events via `capture_logs` instead of `caplog` records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Pub/Sub logging to `structlog` for structured, machine-readable logs and clearer console output. Replaces stdlib logging across broker, subscriber, and demos, configures console logging in demos, and updates tests.

- **Refactors**
  - Replaced `logging.Logger` with `structlog.stdlib.BoundLogger` across broker, subscriber, and demos (public logger params now expect a bound logger).
  - Switched to key/value logging; pass exceptions with `exc_info=exc` for inspectable tracebacks.
  - Demos configure a leveled, timestamped console logger via `configure_logging()` (called by `run_demo()`); tests assert logs with `structlog.testing.capture_logs`.

- **Dependencies**
  - Added `structlog>=26.1.0` and updated `uv.lock`.

<sup>Written for commit f909555a97184ae77a800b7965279356726cc284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

