### PR TITLE
chore: add ruff for Python formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ flagged-chats.jsonl
 /server/riskjudgebench
 /results.json
 /finalists.json
+
+### Python ###
+__pycache__/
+*.py[cod]
+*$py.class
+.uv-cache

--- a/.mise-tasks/install/vscode.mts
+++ b/.mise-tasks/install/vscode.mts
@@ -39,7 +39,11 @@ if (!existsSync(".vscode")) {
 function amendSettings(settingsJSON: string): string {
   const edited = JSON.parse(settingsJSON);
 
-  edited["mise.configureExtensionsAutomaticallyIgnoreList"] ??= [];
+  edited["mise.configureExtensionsAutomaticallyIgnoreList"] = Array.isArray(
+    edited["mise.configureExtensionsAutomaticallyIgnoreList"],
+  )
+    ? edited["mise.configureExtensionsAutomaticallyIgnoreList"]
+    : [];
   edited["mise.configureExtensionsAutomaticallyIgnoreList"].push(
     // python is managed by uv virtual environment, not mise.
     "charliermarsh.ruff",

--- a/.mise-tasks/install/vscode.mts
+++ b/.mise-tasks/install/vscode.mts
@@ -39,7 +39,16 @@ if (!existsSync(".vscode")) {
 function amendSettings(settingsJSON: string): string {
   const edited = JSON.parse(settingsJSON);
 
-  edited["typescript.tsdk"] = "node_modules/typescript/lib";
+  edited["mise.configureExtensionsAutomaticallyIgnoreList"] ??= [];
+  edited["mise.configureExtensionsAutomaticallyIgnoreList"].push(
+    // python is managed by uv virtual environment, not mise.
+    "charliermarsh.ruff",
+  );
+  edited["mise.configureExtensionsAutomaticallyIgnoreList"] = [
+    ...new Set(edited["mise.configureExtensionsAutomaticallyIgnoreList"]),
+  ].sort();
+
+  edited["js/ts.tsdk.path"] = "node_modules/typescript/lib";
   edited["go.lintTool"] = "golangci-lint-v2";
   edited["go.lintFlags"] = [
     "run",

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -20,8 +20,6 @@ reviews:
   auto_approve: disabled
   ignore:
     files:
-      - "**/uv.lock"
-      - "**/pnpm-lock.yaml"
       - client/sdk/**/*
       - server/gen/**/*
       - "**/repo/*.go"

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -20,6 +20,8 @@ reviews:
   auto_approve: disabled
   ignore:
     files:
+      - "**/uv.lock"
+      - "**/pnpm-lock.yaml"
       - client/sdk/**/*
       - server/gen/**/*
       - "**/repo/*.go"

--- a/hk.pkl
+++ b/hk.pkl
@@ -62,6 +62,9 @@ local linters = new Mapping<String, Step> {
     check = "pnpm oxfmt --check {{files}}"
     fix = "pnpm oxfmt --write {{files}}"
   }
+  ["ruff-format"] = (Builtins.ruff_format) {
+    exclude = List("**/vendor/**", "**/node_modules/**", "**/dist/**", "**/*_pb2.*")
+  }
 }
 
 hooks {

--- a/mise.lock
+++ b/mise.lock
@@ -774,9 +774,79 @@ url = "https://github.com/apple/pkl/releases/download/0.31.0/pkl-windows-amd64.e
 version = "0.15.16"
 backend = "aqua:astral-sh/ruff"
 
+[tools.ruff."platforms.linux-arm64"]
+checksum = "sha256:3b39fc2608e12c554d42f6950a5ea131db8d8a0736c8949b3581c361f9f011d4"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.16/ruff-aarch64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruff."platforms.linux-arm64-musl"]
+checksum = "sha256:3b39fc2608e12c554d42f6950a5ea131db8d8a0736c8949b3581c361f9f011d4"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.16/ruff-aarch64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruff."platforms.linux-x64"]
+checksum = "sha256:f52d90f8a6b1b3ad7d74301c3c796652e851d8f05b6ba26d139f05f4838cf412"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.16/ruff-x86_64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruff."platforms.linux-x64-musl"]
+checksum = "sha256:f52d90f8a6b1b3ad7d74301c3c796652e851d8f05b6ba26d139f05f4838cf412"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.16/ruff-x86_64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruff."platforms.macos-arm64"]
+checksum = "sha256:9deb6c4c38c9324bfd98ea4efb40946aae99a987e7f9d1308a1291f14f6b46e2"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.16/ruff-aarch64-apple-darwin.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruff."platforms.macos-x64"]
+checksum = "sha256:a8a7a60182f66b5995bd16e1831cf013e89558edf52135a1b6646f155f491f98"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.16/ruff-x86_64-apple-darwin.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruff."platforms.windows-x64"]
+checksum = "sha256:b6c843fa84afb37af9d665a418324782ae18ea3dd1de775abfd7cf17f9431f85"
+url = "https://github.com/astral-sh/ruff/releases/download/0.15.16/ruff-x86_64-pc-windows-msvc.zip"
+provenance = "github-attestations"
+
 [[tools.uv]]
 version = "0.11.21"
 backend = "aqua:astral-sh/uv"
+
+[tools.uv."platforms.linux-arm64"]
+checksum = "sha256:e71badaed2a2c3a404a0a00974b51c7ed5f5bc7be947916846005b739c68a5a2"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-aarch64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.uv."platforms.linux-arm64-musl"]
+checksum = "sha256:e71badaed2a2c3a404a0a00974b51c7ed5f5bc7be947916846005b739c68a5a2"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-aarch64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.uv."platforms.linux-x64"]
+checksum = "sha256:9dadff5b9e7b1d2d011e41852a1cbca713d9d5d88194f2eb6bd240fa4fb0a719"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-x86_64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.uv."platforms.linux-x64-musl"]
+checksum = "sha256:9dadff5b9e7b1d2d011e41852a1cbca713d9d5d88194f2eb6bd240fa4fb0a719"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-x86_64-unknown-linux-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools.uv."platforms.macos-arm64"]
+checksum = "sha256:1f921d491ba5ffeea774eb04d6681ecee379101341cbb1500394993b541bf3f4"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-aarch64-apple-darwin.tar.gz"
+provenance = "github-attestations"
+
+[tools.uv."platforms.macos-x64"]
+checksum = "sha256:f3c8e5708a84b920c18b691214d54d2b0da6b984789caae95d47c95120cb7765"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-x86_64-apple-darwin.tar.gz"
+provenance = "github-attestations"
+
+[tools.uv."platforms.windows-x64"]
+checksum = "sha256:ace861f360c6de2babedc1607d0f454b6b09a820dbc8182dc15af927e4df9589"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.21/uv-x86_64-pc-windows-msvc.zip"
+provenance = "github-attestations"
 
 [[tools.watchexec]]
 version = "2.5.0"

--- a/mise.lock
+++ b/mise.lock
@@ -770,44 +770,13 @@ url = "https://github.com/apple/pkl/releases/download/0.31.0/pkl-macos-amd64"
 checksum = "sha256:37d35ce8a165766502fb13799071d4cefa84d39fb455c75c471b47b9b5d12b04"
 url = "https://github.com/apple/pkl/releases/download/0.31.0/pkl-windows-amd64.exe"
 
+[[tools.ruff]]
+version = "0.15.16"
+backend = "aqua:astral-sh/ruff"
+
 [[tools.uv]]
-version = "0.10.9"
+version = "0.11.21"
 backend = "aqua:astral-sh/uv"
-
-[tools.uv."platforms.linux-arm64"]
-checksum = "sha256:05b0d3087e913ebe11756365a90dd47c05d6728752fdbe129ad4c3ccd769826d"
-url = "https://github.com/astral-sh/uv/releases/download/0.10.9/uv-aarch64-unknown-linux-musl.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.linux-arm64-musl"]
-checksum = "sha256:05b0d3087e913ebe11756365a90dd47c05d6728752fdbe129ad4c3ccd769826d"
-url = "https://github.com/astral-sh/uv/releases/download/0.10.9/uv-aarch64-unknown-linux-musl.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.linux-x64"]
-checksum = "sha256:433e56874739e92c7cfd661ba9e5f287b376ca612c08c8194a41a98a13158aea"
-url = "https://github.com/astral-sh/uv/releases/download/0.10.9/uv-x86_64-unknown-linux-musl.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.linux-x64-musl"]
-checksum = "sha256:433e56874739e92c7cfd661ba9e5f287b376ca612c08c8194a41a98a13158aea"
-url = "https://github.com/astral-sh/uv/releases/download/0.10.9/uv-x86_64-unknown-linux-musl.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.macos-arm64"]
-checksum = "sha256:a92f61e9ac9b0f29668c15f56152e4a60143fca148ff5bfadb86718472c3f376"
-url = "https://github.com/astral-sh/uv/releases/download/0.10.9/uv-aarch64-apple-darwin.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.macos-x64"]
-checksum = "sha256:9cc2de7d195fa157f98b306a8a1cb151ded93f488939b93363cebc8b9d598c28"
-url = "https://github.com/astral-sh/uv/releases/download/0.10.9/uv-x86_64-apple-darwin.tar.gz"
-provenance = "github-attestations"
-
-[tools.uv."platforms.windows-x64"]
-checksum = "sha256:f58dc40896000229db7c52b8bdd931394040ef2ad59abd1eda841f6d70b13d7a"
-url = "https://github.com/astral-sh/uv/releases/download/0.10.9/uv-x86_64-pc-windows-msvc.zip"
-provenance = "github-attestations"
 
 [[tools.watchexec]]
 version = "2.5.0"

--- a/mise.toml
+++ b/mise.toml
@@ -20,7 +20,7 @@ melange = "0.40.4"
 nodejs = "24.16.0"
 "github:pnpm/pnpm" = "11.3.0"
 watchexec = "2.5.0"
-uv = "0.10.9"
+uv = "0.11.21"
 yq = "4.52.4"
 hk = "1.46.0"
 pkl = "0.31.0"
@@ -30,6 +30,7 @@ pkl = "0.31.0"
 "github:sqlc-dev/sqlc" = "1.31.1"
 "github:gotestyourself/gotestsum" = "1.13.0"
 buf = "1.69.0"
+ruff = "0.15.16"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.


### PR DESCRIPTION
Python sources are growing in the repo (pystreams, classifier tooling) but had no formatter wired into the dev toolchain. Add ruff as a managed mise tool and register ruff-format as an hk linter so Python is formatted consistently alongside the existing Go and JS formatters. Also bumps uv to 0.11.21 to stay current.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ruff` to the dev toolchain and wire it into `hk` as `ruff-format` so Python files auto-format like Go/JS. Also bump `uv` to 0.11.21, extend `.gitignore`, and update VS Code settings to ignore the Ruff extension and set the TS SDK path.

- New Features
  - Add `ruff` (0.15.16) via `mise` and register `hk` linter `ruff-format` (excludes: `vendor`, `node_modules`, `dist`, `*_pb2.*`).
  - Update VS Code installer: add `charliermarsh.ruff` to `mise.configureExtensionsAutomaticallyIgnoreList`; set `js/ts.tsdk.path` to `node_modules/typescript/lib`.
  - Extend `.gitignore` to ignore Python artifacts and `.uv-cache`.

- Dependencies
  - Bump `uv` to `0.11.21` and update `mise.lock`.

<sup>Written for commit 5375c41541e14168f46fcfd0e224d783e56f978b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



