### PR TITLE
chore(streams): make ping subscriber log level configurable

### DIFF
--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -23,6 +23,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/control"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/must"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/ping"
@@ -196,9 +197,11 @@ func newStreamsCommand() *cli.Command {
 				broker:     psbroker,
 			}
 
+			pingLogLevel := conv.Ternary(c.String("environment") == "local", slog.LevelInfo, slog.LevelDebug)
+
 			// Start subscription receivers in this block
 			{
-				mustReceive(rg, &pingv1.Message{}, &pingv1.Processor{}, ping.NewHandler(logger))
+				mustReceive(rg, &pingv1.Message{}, &pingv1.Processor{}, ping.NewHandler(logger, pingLogLevel))
 			}
 
 			// This is just a heartbeat publisher that validates the publisher-

--- a/server/internal/ping/handler.go
+++ b/server/internal/ping/handler.go
@@ -10,19 +10,21 @@ import (
 )
 
 type Handler struct {
-	logger *slog.Logger
+	logger   *slog.Logger
+	logLevel slog.Level
 }
 
-func NewHandler(logger *slog.Logger) *Handler {
+func NewHandler(logger *slog.Logger, level slog.Level) *Handler {
 	return &Handler{
-		logger: logger,
+		logger:   logger,
+		logLevel: level,
 	}
 }
 
 func (h *Handler) Handle(ctx context.Context, m *pingv1.Message, _ gcp.MessageMetadata) error {
 	logger := h.logger
 
-	logger.DebugContext(ctx, "ping subscriber received message", attr.SlogValueAny(map[string]any{
+	logger.LogAttrs(ctx, h.logLevel, "ping subscriber received message", attr.SlogValueAny(map[string]any{
 		"id":      m.GetId(),
 		"type":    m.GetType(),
 		"payload": string(m.GetPayload()),


### PR DESCRIPTION
The ping subscriber heartbeat fires continuously, so its per-message log was hardcoded to debug to avoid noise. In local development that hides useful confirmation that the streams pipeline is alive. Let the caller pick the level so local runs surface it at info while deployed environments keep it quiet at debug.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the ping subscriber’s log level configurable so local runs show heartbeats at info, while deployed environments keep them at debug. This improves dev visibility without adding noise in prod.

- **New Features**
  - `ping.NewHandler(logger, level)` now accepts a `slog.Level` and logs via `logger.LogAttrs` at that level.
  - The `streams` command sets level to `slog.LevelInfo` when `--environment=local`, else `slog.LevelDebug`.

<sup>Written for commit f337e90cd48b73aed630d5e383a7aeaa3a544661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

