### PR TITLE
fix(assistants): tmpfs workdir + rootfs sandbox deps to fix ~1min cold start

### DIFF
--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -67,11 +67,7 @@ COPY --from=lightpanda /lightpanda /usr/local/bin/lightpanda
 COPY agents/runtime-image/lightpanda-supervise.sh /usr/local/bin/lightpanda-supervise
 COPY agents/runtime-image/init.sh /init
 
-# Read-only sandbox helpers (playwright-core + browser.ts) baked onto the
-# rootfs. init.sh bind-mounts them read-only into the tmpfs workdir at the
-# paths the runner expects. Keeping them on the rootfs (not in a loop-mounted
-# ext4 image) avoids a slow cold-disk mount at boot — they fault in lazily
-# only when a tool actually uses them.
+# Read-only sandbox helpers (playwright-core + browser.ts) used by `bun_run` tool
 COPY agents/runtime-image/sandbox/package.json /usr/share/gram/sandbox/package.json
 COPY agents/runtime-image/sandbox/browser.ts /usr/share/gram/sandbox/browser.ts
 COPY --from=sandbox-deps /sandbox/node_modules /usr/share/gram/sandbox/node_modules

--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -30,19 +30,6 @@ RUN target=node_modules/playwright-core/lib/utilsBundle.js \
  && sed -i "s|const ws = exports.ws = require('./utilsBundleImpl').ws;|const ws = exports.ws = 'Bun' in globalThis ? require('ws') : require('./utilsBundleImpl').ws;|" "$target" \
  && grep -q "'Bun' in globalThis ? require('ws')" "$target"
 
-FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS workdir-template
-# 256 MiB hard cap on assistant workspace + bundled sandbox helpers.
-ARG WORKDIR_IMAGE_SIZE=268435456
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends e2fsprogs util-linux \
-  && rm -rf /var/lib/apt/lists/*
-WORKDIR /staging
-COPY agents/runtime-image/sandbox/package.json /staging/package.json
-COPY agents/runtime-image/sandbox/browser.ts /staging/browser.ts
-COPY --from=sandbox-deps /sandbox/node_modules /staging/node_modules
-RUN fallocate -l "${WORKDIR_IMAGE_SIZE}" /workdir-template.ext4 \
- && mke2fs -t ext4 -d /staging -F /workdir-template.ext4
-
 FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS lightpanda
 ARG TARGETARCH
 ARG LIGHTPANDA_VERSION=0.2.8
@@ -80,10 +67,14 @@ COPY --from=lightpanda /lightpanda /usr/local/bin/lightpanda
 COPY agents/runtime-image/lightpanda-supervise.sh /usr/local/bin/lightpanda-supervise
 COPY agents/runtime-image/init.sh /init
 
-# Fixed-size ext4 prepopulated with the sandbox helpers; init.sh loop-mounts
-# it at /var/lib/gram-assistant/work so the assistant has a persistent
-# workdir whose disk usage is hard-capped by the image size.
-COPY --from=workdir-template /workdir-template.ext4 /usr/share/gram/workdir-template.ext4
+# Read-only sandbox helpers (playwright-core + browser.ts) baked onto the
+# rootfs. init.sh bind-mounts them read-only into the tmpfs workdir at the
+# paths the runner expects. Keeping them on the rootfs (not in a loop-mounted
+# ext4 image) avoids a slow cold-disk mount at boot — they fault in lazily
+# only when a tool actually uses them.
+COPY agents/runtime-image/sandbox/package.json /usr/share/gram/sandbox/package.json
+COPY agents/runtime-image/sandbox/browser.ts /usr/share/gram/sandbox/browser.ts
+COPY --from=sandbox-deps /sandbox/node_modules /usr/share/gram/sandbox/node_modules
 
 RUN chmod 0755 /init /usr/local/bin/gram-assistant-runner /usr/local/bin/bun /usr/local/bin/lightpanda /usr/local/bin/lightpanda-supervise
 

--- a/agents/runtime-image/init.sh
+++ b/agents/runtime-image/init.sh
@@ -2,14 +2,27 @@
 
 set -euo pipefail
 
-# Provision the assistant workdir from the prebuilt ext4 template. The rootfs
-# is per-machine so we can mount the template directly — any mutations stay
-# isolated to this machine and the loop mount enforces the hard size cap baked
-# into the template at image build time.
-workdir_image=/usr/share/gram/workdir-template.ext4
+# The assistant workdir is a RAM-backed tmpfs: it mounts instantly (no
+# cold-disk read), is per-machine and ephemeral like /tmp, and caps the
+# workspace at 256 MiB (against RAM — the VM has 1 GiB). The read-only sandbox
+# helpers (browser.ts, node_modules, package.json) live on the rootfs and are
+# bind-mounted in read-only at the paths the runner expects, so the agent's
+# scratch writes go to RAM while the deps fault in lazily from the rootfs only
+# when a tool actually uses them. This replaced a loop-mounted 256 MiB ext4
+# image whose cold-boot mount blocked the runner ~35s on throttled disk I/O.
 workdir_mount=/var/lib/gram-assistant/work
+sandbox_src=/usr/share/gram/sandbox
 mkdir -p "$workdir_mount"
-mount -o loop "$workdir_image" "$workdir_mount"
+mount -t tmpfs -o size=256m,mode=0755 tmpfs "$workdir_mount"
+for dep in browser.ts package.json node_modules; do
+  src="$sandbox_src/$dep"
+  dst="$workdir_mount/$dep"
+  [ -e "$src" ] || continue
+  # The bind target must exist inside the tmpfs first.
+  if [ -d "$src" ]; then mkdir -p "$dst"; else : >"$dst"; fi
+  mount --bind "$src" "$dst"
+  mount -o remount,bind,ro "$dst"
+done
 
 /usr/local/bin/lightpanda-supervise &
 

--- a/agents/runtime-image/init.sh
+++ b/agents/runtime-image/init.sh
@@ -2,14 +2,6 @@
 
 set -euo pipefail
 
-# The assistant workdir is a RAM-backed tmpfs: it mounts instantly (no
-# cold-disk read), is per-machine and ephemeral like /tmp, and caps the
-# workspace at 256 MiB (against RAM — the VM has 1 GiB). The read-only sandbox
-# helpers (browser.ts, node_modules, package.json) live on the rootfs and are
-# bind-mounted in read-only at the paths the runner expects, so the agent's
-# scratch writes go to RAM while the deps fault in lazily from the rootfs only
-# when a tool actually uses them. This replaced a loop-mounted 256 MiB ext4
-# image whose cold-boot mount blocked the runner ~35s on throttled disk I/O.
 workdir_mount=/var/lib/gram-assistant/work
 sandbox_src=/usr/share/gram/sandbox
 mkdir -p "$workdir_mount"


### PR DESCRIPTION
## What

On a cold boot, the assistant runtime VM took **~1 minute** to respond to the first message. This replaces the loop-mounted ext4 workdir with a **RAM-backed tmpfs** and moves the read-only sandbox deps onto the rootfs. Cold boot drops from **~38s to ~3s** (the runner-binary fault floor), with **no tool-readiness window**.

## Root cause

`agents/runtime-image/init.sh` loop-mounted the 256 MiB ext4 `workdir-template` **synchronously, before `exec`'ing the runner**:

```sh
mount -o loop "$workdir_image" "$workdir_mount"   # blocked ~35s
...
exec /usr/local/bin/gram-assistant-runner serve ...
```

The loop-mount reads the backing file off the **cold, I/O-throttled** Fly rootfs (~6.7 MB/s). The runner doesn't start — or bind `/healthz` — until that returns; meanwhile the server's `waitForRuntimeHealth` (45s budget) times out and the admit retries. That's the ~1-minute first response.

The ~35s breaks down (measured via `/proc/diskstats` on a cold boot):

| Phase             | ~Duration | What                                                                        |
| ----------------- | --------- | --------------------------------------------------------------------------- |
| 1. Throttled read | ~23s      | ~154 MB read from rootfs at ~6.7 MB/s (loop-mount pulling the backing file) |
| 2. Throttle stall | ~10s      | `mount` in `D`, **zero reads** — pure `rq_qos` backpressure                 |
| 3. Runner start   | ~2-3s     | mount returns, runner loads its 25 MB binary and binds `8081`               |

## Fix

RAM-backed tmpfs workdir (instant, no disk read, 256 MiB cap against RAM — the VM has 1 GiB). The read-only sandbox helpers (`browser.ts`, `node_modules`, `package.json`) are baked onto the **rootfs** and bind-mounted read-only into the workdir at the paths the runner already expects:

```sh
mount -t tmpfs -o size=256m,mode=0755 tmpfs "$workdir_mount"
for dep in browser.ts package.json node_modules; do
  mount --bind   "$sandbox_src/$dep" "$workdir_mount/$dep"
  mount -o remount,bind,ro "$workdir_mount/$dep"
done
```

This **eliminates phases 1 and 2 entirely**. Phase 3 (~3s) is the floor — the runner binary still faults off the same throttled disk. The deps fault in lazily only when a tool actually uses them.

**No runner code change:** the deps land at the existing `ASSISTANT_WORKDIR/{node_modules,browser.ts,package.json}` paths, so `bun_run`'s cwd, `browser.ts`'s relative `import './browser'`, and the sandbox `PathPolicy` read-only-roots all still resolve.

## Why not just background the mount?

An earlier version of this PR just backgrounded the loop-mount so the runner binds immediately. It worked (~4s) but introduced a **tool-readiness window**: for the ~35s until the mount landed, `bun_run`/`browser` tools would fail (the prepopulated `browser.ts`/`node_modules` weren't mounted yet), it lost fail-fast on mount errors, and risked write-shadowing. The tmpfs approach is strictly better — the workdir is ready _instantly_, so there's no window.

## Verification

- **Docker (local):** tmpfs mounts; deps bind read-only at `$workdir/{browser.ts,package.json,node_modules}` and are readable; scratch writes go to the tmpfs; writes to a dep are blocked (`Read-only file system`).
- **Fly cold-boot timing / landlock-at-tool-exec:** confirm in-app — provision a fresh VM, send a message (fast first response), then run a browse/code tool (confirms landlock allows the bind-mounted deps). I don't expect a landlock change since the paths are unchanged, but it's the one thing worth a real tool call.

## Prod gotchas found during the investigation (FYI, not blockers)

- The old workdir ext4 shipped **non-sparse** (256 MiB real); `truncate` at build doesn't help because Docker `COPY` materializes sparse holes. (Moot now — the ext4 is gone.)
- The runtime image deploys via the **`:dev` tag**, and Fly pins the digest at machine _create_ — existing dev machines don't pick up new pushes on stop/start; they must be **recreated**. `fly machine update --image :dev` is a no-op (same ref string) and the `@sha256:` form is rejected by flaps.

## Test plan

- Provision a fresh assistant runtime VM, send a first message — should be a few seconds, not ~1 minute.
- Run a browse/code-exec tool — confirm it can read `node_modules`/`browser.ts` (landlock honors the read-only bind).
- After the VM idles out (~60s) and stops, send another message (cold boot) — should be ~3-5s.
