### PR TITLE
chore(ci): gate PRs on hk formatting check

### DIFF
--- a/.agents/skills/mise-tasks/SKILL.md
+++ b/.agents/skills/mise-tasks/SKILL.md
@@ -307,3 +307,24 @@ async function run() {
 
 run();
 ```
+
+## Task Configuration for Python Tasks
+
+Python tasks use the same `#MISE`/`#USAGE` directive syntax as bash tasks (the pound-sign comment form), typically run via `uv` with an inline script header.
+
+The catch: our `ruff format` step (run by `hk`) normalizes comments to have a space after the `#`, which would rewrite `#MISE`/`#USAGE` into `# MISE`/`# USAGE`. mise parses those directives literally, so the rewrite silently breaks the task (the description and flags disappear). ruff has no setting to skip comment normalization on its own, so fence the directive block with `# fmt: off` / `# fmt: on`. This keeps the directives intact while ruff still formats the rest of the file.
+
+```python
+#!/usr/bin/env -S uv run --script
+# fmt: off
+# ruff must not add a space after the pound sign: the #MISE/#USAGE directives
+# below are parsed literally by mise and break if rewritten to "# MISE".
+#MISE description="Description of the task goes here"
+#USAGE flag "--out-file <file>" help="Help text for the flag goes here"
+# fmt: on
+# /// script
+# requires-python = ">=3.11"
+# ///
+
+# rest of task implementation goes here
+```

--- a/.github/scripts/risk-metrics-comment.py
+++ b/.github/scripts/risk-metrics-comment.py
@@ -32,7 +32,11 @@ def main() -> int:
         return 2
 
     pr = load_json(Path(sys.argv[1]))
-    baseline = load_json(Path(sys.argv[2])) if len(sys.argv) > 2 and Path(sys.argv[2]).is_file() else None
+    baseline = (
+        load_json(Path(sys.argv[2]))
+        if len(sys.argv) > 2 and Path(sys.argv[2]).is_file()
+        else None
+    )
     print(render(pr, baseline))
     return 0
 
@@ -55,7 +59,9 @@ def render(pr: dict[str, Any], baseline: dict[str, Any] | None) -> str:
         "",
     ]
 
-    corpus = f"Corpus: {summary['total']} cases ({malicious} malicious / {benign} benign)"
+    corpus = (
+        f"Corpus: {summary['total']} cases ({malicious} malicious / {benign} benign)"
+    )
     if baseline is not None:
         corpus_delta = summary["total"] - int(baseline["summary"]["total"])
         if corpus_delta:
@@ -65,7 +71,9 @@ def render(pr: dict[str, Any], baseline: dict[str, Any] | None) -> str:
     pr_sha = short_sha(str(pr.get("git_sha", "")))
     pr_ts = pr.get("timestamp", "-")
     if baseline is not None:
-        lines.append(f"Baseline: `{short_sha(str(baseline.get('git_sha', '')))}` (main) · This PR: `{pr_sha}` · {pr_ts}")
+        lines.append(
+            f"Baseline: `{short_sha(str(baseline.get('git_sha', '')))}` (main) · This PR: `{pr_sha}` · {pr_ts}"
+        )
     else:
         lines.append(f"This PR: `{pr_sha}` · {pr_ts}")
     lines.append("")
@@ -81,7 +89,11 @@ def render(pr: dict[str, Any], baseline: dict[str, Any] | None) -> str:
             lines.extend([f"L1 opt-in was not evaluated in this run: {reason}.", ""])
         elif l0 is not None and not l0.skipped:
             lines.extend(render_l1_delta(l0, l1))
-            lines.extend(render_source_delta("False-Positive Regressions By Source", l0, l1, "fp"))
+            lines.extend(
+                render_source_delta(
+                    "False-Positive Regressions By Source", l0, l1, "fp"
+                )
+            )
             lines.extend(render_source_delta("Recall Gains By Source", l0, l1, "tp"))
             lines.append(
                 f"Samples in artifact: {len(l1.new_false_positives)} new false positives, "
@@ -100,16 +112,21 @@ def render(pr: dict[str, Any], baseline: dict[str, Any] | None) -> str:
 
 def render_main_delta(pr: dict[str, Any], baseline: dict[str, Any] | None) -> list[str]:
     if baseline is None:
-        return ["_No main baseline artifact found yet; this comment shows the current run only._", ""]
+        return [
+            "_No main baseline artifact found yet; this comment shows the current run only._",
+            "",
+        ]
 
     pr_mode = primary_mode(pr["summary"])
     base_mode = primary_mode(baseline["summary"])
     deltas = {
         "tp": pr_mode.counts.get("tp", 0) - base_mode.counts.get("tp", 0),
         "fp": pr_mode.counts.get("fp", 0) - base_mode.counts.get("fp", 0),
-        "recall": pr_mode.overall.get("recall", 0.0) - base_mode.overall.get("recall", 0.0),
+        "recall": pr_mode.overall.get("recall", 0.0)
+        - base_mode.overall.get("recall", 0.0),
         "f1": pr_mode.overall.get("f1", 0.0) - base_mode.overall.get("f1", 0.0),
-        "fp_rate": pr_mode.overall.get("fp_rate", 0.0) - base_mode.overall.get("fp_rate", 0.0),
+        "fp_rate": pr_mode.overall.get("fp_rate", 0.0)
+        - base_mode.overall.get("fp_rate", 0.0),
     }
     if not any(deltas.values()):
         return ["Change vs main: none for the primary operational mode.", ""]
@@ -139,7 +156,9 @@ def render_modes(modes: list[Mode]) -> list[str]:
     ]
     for mode in modes:
         if mode.skipped:
-            lines.append(f"| {display_mode_name(mode.name)} | skipped | - | - | - | - | - | - | - | - |")
+            lines.append(
+                f"| {display_mode_name(mode.name)} | skipped | - | - | - | - | - | - | - | - |"
+            )
             continue
 
         lines.append(
@@ -246,7 +265,9 @@ def primary_mode(summary: dict[str, Any]) -> Mode:
     )
 
 
-def mode_by_name(modes: list[Mode], name: str, require_active: bool = False) -> Mode | None:
+def mode_by_name(
+    modes: list[Mode], name: str, require_active: bool = False
+) -> Mode | None:
     for mode in modes:
         if mode.name == name and (not require_active or not mode.skipped):
             return mode

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -178,6 +178,62 @@ jobs:
           examples=$(ls -d elements/examples/*/package.json 2>/dev/null | xargs -I{} dirname {} | xargs -I{} basename {} | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "examples=$examples" >> $GITHUB_OUTPUT
 
+  format-check:
+    name: Check formatting with hk
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        with:
+          # Full history so hk can diff against the PR merge base.
+          fetch-depth: 0
+
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Prepare GitHub Actions environment
+        run: mise run github
+
+      - name: Cache PNPM
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: ${{ env.GH_CACHE_PNPM_KEY }}
+          restore-keys: |
+            ${{ env.GH_CACHE_PNPM_KEY }}
+            ${{ env.GH_CACHE_PNPM_KEY_PARTIAL }}
+          path: |
+            ${{ env.PNPM_STORE_PATH }}
+
+      # hk's oxfmt step shells out to `pnpm oxfmt`, so node_modules must exist.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            from_ref=$(git merge-base "$BASE_SHA" HEAD)
+            echo "Checking files changed since merge base $from_ref"
+            args=(--from-ref "$from_ref" --to-ref HEAD)
+          else
+            echo "Checking all files"
+            args=(--all)
+          fi
+          if ! hk check "${args[@]}"; then
+            echo "::error::Formatting check failed. Run 'hk fix --all' locally and commit the result."
+            exit 1
+          fi
+
+      - name: Prune PNPM store
+        if: success()
+        run: pnpm store prune
+
   docker-build-server:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes, server-build-lint]

--- a/.mise-tasks/risk/report.py
+++ b/.mise-tasks/risk/report.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env -S uv run --script
+# fmt: off
 #MISE description="Run the prompt-injection risk report harness and print metrics"
 #USAGE flag "--classifier-url <url>" help="Base URL for the L1 prompt-injection classifier sidecar. Also reads PI_CLASSIFIER_URL."
 #USAGE flag "--metrics-file <path>" help="Path to the JSON metrics artifact. Defaults to server/risk_accuracy_metrics.json."
 #USAGE flag "--no-classifier" help="Disable classifier use even if PI_CLASSIFIER_URL is set by the environment."
 #USAGE flag "--no-run" help="Only print an existing metrics artifact without running the evaluator harness."
+# fmt: on
 # /// script
 # requires-python = ">=3.11"
 # ///
@@ -28,7 +30,11 @@ def main() -> int:
     metrics_file = args.metrics_file
 
     env = os.environ.copy()
-    classifier_url = None if args.no_classifier else first_nonempty(args.classifier_url, env.get("PI_CLASSIFIER_URL"))
+    classifier_url = (
+        None
+        if args.no_classifier
+        else first_nonempty(args.classifier_url, env.get("PI_CLASSIFIER_URL"))
+    )
 
     if classifier_url:
         env["PI_CLASSIFIER_URL"] = classifier_url
@@ -86,7 +92,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run_evaluator(env: dict[str, str], metrics_file: Path, classifier_url: str | None) -> int:
+def run_evaluator(
+    env: dict[str, str], metrics_file: Path, classifier_url: str | None
+) -> int:
     cmd = [
         "go",
         "run",
@@ -99,7 +107,9 @@ def run_evaluator(env: dict[str, str], metrics_file: Path, classifier_url: str |
     return subprocess.run(cmd, cwd=REPO_ROOT, env=env, check=False).returncode
 
 
-def print_report(payload: dict[str, Any], classifier_url: str | None, metrics_file: Path) -> None:
+def print_report(
+    payload: dict[str, Any], classifier_url: str | None, metrics_file: Path
+) -> None:
     summary = payload["summary"]
 
     print()
@@ -117,7 +127,20 @@ def print_report(payload: dict[str, Any], classifier_url: str | None, metrics_fi
     if modes:
         print("Operational comparison:")
         print_table(
-            ["mode", "status", "total", "tp", "fp", "tn", "fn", "precision", "recall", "f1", "accuracy", "fp_rate"],
+            [
+                "mode",
+                "status",
+                "total",
+                "tp",
+                "fp",
+                "tn",
+                "fn",
+                "precision",
+                "recall",
+                "f1",
+                "accuracy",
+                "fp_rate",
+            ],
             mode_rows(modes),
         )
         print()
@@ -128,11 +151,16 @@ def print_report(payload: dict[str, Any], classifier_url: str | None, metrics_fi
             print()
 
             print("Regression sources:")
-            print_table(["source", "fp_before", "fp_after", "delta"], regression_source_rows(modes))
+            print_table(
+                ["source", "fp_before", "fp_after", "delta"],
+                regression_source_rows(modes),
+            )
             print()
 
             print("Recall gain sources:")
-            print_table(["source", "tp_before", "tp_after", "delta"], recall_gain_rows(modes))
+            print_table(
+                ["source", "tp_before", "tp_after", "delta"], recall_gain_rows(modes)
+            )
             print()
 
         print("By source:")
@@ -149,11 +177,17 @@ def print_report(payload: dict[str, Any], classifier_url: str | None, metrics_fi
         l1 = maybe_mode_by_name(modes, "l1_opt_in")
         if l1:
             print("New false positives:")
-            print_table(["source", "id", "rule", "score", "text"], example_rows(l1.get("new_false_positives", [])))
+            print_table(
+                ["source", "id", "rule", "score", "text"],
+                example_rows(l1.get("new_false_positives", [])),
+            )
             print()
 
             print("Recovered true positives:")
-            print_table(["source", "id", "rule", "score", "text"], example_rows(l1.get("recovered_true_positives", [])))
+            print_table(
+                ["source", "id", "rule", "score", "text"],
+                example_rows(l1.get("recovered_true_positives", [])),
+            )
             print()
         return
 
@@ -182,7 +216,10 @@ def print_report(payload: dict[str, Any], classifier_url: str | None, metrics_fi
     print("By rule:")
     print_table(
         ["rule_id", "tp", "fp"],
-        [[item["rule_id"], item["tp_count"], item["fp_count"]] for item in summary.get("by_rule", [])],
+        [
+            [item["rule_id"], item["tp_count"], item["fp_count"]]
+            for item in summary.get("by_rule", [])
+        ],
     )
     print()
 
@@ -190,7 +227,9 @@ def print_report(payload: dict[str, Any], classifier_url: str | None, metrics_fi
 def print_counts(summary: dict[str, Any]) -> None:
     counts = summary["counts"]
     overall = summary["overall"]
-    print(f"total:     {summary['total']}  (TP={counts['tp']} FP={counts['fp']} TN={counts['tn']} FN={counts['fn']})")
+    print(
+        f"total:     {summary['total']}  (TP={counts['tp']} FP={counts['fp']} TN={counts['tn']} FN={counts['fn']})"
+    )
     print(f"precision: {fmt(overall.get('precision'))}")
     print(f"recall:    {fmt(overall.get('recall'))}")
     print(f"f1:        {fmt(overall.get('f1'))}")
@@ -285,7 +324,14 @@ def rule_rows(modes: list[dict[str, Any]]) -> list[list[Any]]:
         if mode.get("skipped"):
             continue
         for item in mode.get("by_rule", []):
-            rows.append([display_mode_name(mode["name"]), item["rule_id"], item["tp_count"], item["fp_count"]])
+            rows.append(
+                [
+                    display_mode_name(mode["name"]),
+                    item["rule_id"],
+                    item["tp_count"],
+                    item["fp_count"],
+                ]
+            )
     return rows
 
 
@@ -300,9 +346,15 @@ def delta_rows(modes: list[dict[str, Any]]) -> list[list[Any]]:
         ["true positives", signed(l1_counts["tp"] - l0_counts["tp"])],
         ["false negatives", signed(l1_counts["fn"] - l0_counts["fn"])],
         ["false positives", signed(l1_counts["fp"] - l0_counts["fp"])],
-        ["recall", signed_percentage_points(l1_overall["recall"] - l0_overall["recall"])],
+        [
+            "recall",
+            signed_percentage_points(l1_overall["recall"] - l0_overall["recall"]),
+        ],
         ["f1", signed_percentage_points(l1_overall["f1"] - l0_overall["f1"])],
-        ["fp_rate", signed_percentage_points(l1_overall["fp_rate"] - l0_overall["fp_rate"])],
+        [
+            "fp_rate",
+            signed_percentage_points(l1_overall["fp_rate"] - l0_overall["fp_rate"]),
+        ],
     ]
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Contains the main application code for the Gram server:
 - `mise build:server`: Build the server binary
 - `mise lint:server`: Run linters on the server code
 - `mise start:server --dev-single-process`: Run the server locally
+- `hk fix`: Runs formatters across changed files in the current branch.
 
 </commands>
 

--- a/examples/agentsapi/complex_async.py
+++ b/examples/agentsapi/complex_async.py
@@ -53,7 +53,7 @@ while True:
     poll_data = poll_resp.json()
     status = poll_data.get("status")
     print(f"Status: {status}")
-    
+
     if status != "in_progress":
         if "output" in poll_data and poll_data["output"]:
             for item in poll_data["output"]:
@@ -64,7 +64,7 @@ while True:
 
             print("\n=== Final Response ===")
             print(poll_data["output"][-1]["content"][-1]["text"])
-        
+
         if verbose:
             print("\nFull response:")
             print(json.dumps(poll_data, indent=2))

--- a/examples/agentsapi/complex_sub_agents.py
+++ b/examples/agentsapi/complex_sub_agents.py
@@ -40,8 +40,12 @@ payload = {
             "instructions": """You are a sub-agent that specializes in Speakeasy SDK operations. Use the provided toolsets to fetch organization details, workspaces, and user information as needed.
             When fetching information typically fetch the org first. Then from an org you can fetch workspaces by ID. Users also exist at the workspace level.""",
             "toolsets": [
-                {"toolset_slug": "speakeasy", "headers": {}, "environment_slug": "default"},
-            ]
+                {
+                    "toolset_slug": "speakeasy",
+                    "headers": {},
+                    "environment_slug": "default",
+                },
+            ],
         },
         {
             "name": "Stripe Sub-Agent",
@@ -69,7 +73,7 @@ while True:
     poll_data = poll_resp.json()
     status = poll_data.get("status")
     print(f"Status: {status}")
-    
+
     if status != "in_progress":
         if "output" in poll_data and poll_data["output"]:
             for item in poll_data["output"]:
@@ -80,7 +84,7 @@ while True:
 
             print("\n=== Final Response ===")
             print(poll_data["output"][-1]["content"][-1]["text"])
-        
+
         if verbose:
             print("\nFull response:")
             print(json.dumps(poll_data, indent=2))

--- a/examples/agentsapi/multi_turn_agent_example.py
+++ b/examples/agentsapi/multi_turn_agent_example.py
@@ -17,9 +17,7 @@ headers = {
     "Gram-Project": "default",
 }
 
-context = [
-  { "role": "role", "content": f"Get me a speakeasy org {org_slug}?" }
-]
+context = [{"role": "role", "content": f"Get me a speakeasy org {org_slug}?"}]
 
 payload = {
     "model": "openai/gpt-4o",
@@ -41,8 +39,8 @@ if verbose:
     print(json.dumps(data, indent=2))
 
 context = [
-  *data["output"],
-  { "role": "user", "content": "What are the workspaces in that org?" }
+    *data["output"],
+    {"role": "user", "content": "What are the workspaces in that org?"},
 ]
 
 payload["input"] = context

--- a/examples/agentsapi/multi_turn_response_style.py
+++ b/examples/agentsapi/multi_turn_response_style.py
@@ -38,7 +38,9 @@ if verbose:
 
 
 payload["previous_response_id"] = data["id"]
-payload["input"] = "What are the workspaces in that org? Also what was my secret word from previously"
+payload["input"] = (
+    "What are the workspaces in that org? Also what was my secret word from previously"
+)
 
 print("\n=== Turn 2 ===")
 resp = requests.post(url, headers=headers, json=payload)

--- a/examples/agentsapi/no_storage.py
+++ b/examples/agentsapi/no_storage.py
@@ -48,5 +48,3 @@ try:
     poll_resp.raise_for_status()
 except requests.exceptions.HTTPError as e:
     print(f"\nExpected error: {e}")
-
-

--- a/server/internal/mcpservers/deletemcpserver_test.go
+++ b/server/internal/mcpservers/deletemcpserver_test.go
@@ -26,14 +26,14 @@ func TestDeleteMcpServer(t *testing.T) {
 	serverID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
 
 	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		Name:                  "test mcp server",
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &serverID,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "test mcp server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &serverID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	require.NoError(t, err)
 
@@ -88,14 +88,14 @@ func TestDeleteMcpServer_CascadesSoftDeleteToSlugs(t *testing.T) {
 	// Create a frontend and two slugs that both point at it.
 	serverID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
 	frontend, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		Name:                  "test mcp server",
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &serverID,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "test mcp server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &serverID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	require.NoError(t, err)
 

--- a/server/internal/mcpservers/ownership_test.go
+++ b/server/internal/mcpservers/ownership_test.go
@@ -83,14 +83,14 @@ func TestCreateMcpServer_RejectsCrossTenantToolset(t *testing.T) {
 	otherToolsetID := seedOtherProjectToolset(t, ctx, ti.conn, authCtx.ActiveOrganizationID).String()
 
 	_, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		Name:                  "test mcp server",
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     nil,
-		ToolsetID:             &otherToolsetID,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "test mcp server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: nil,
+		ToolsetID:         &otherToolsetID,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	requireOopsCode(t, err, oops.CodeInvalid)
 }
@@ -106,14 +106,14 @@ func TestUpdateMcpServer_RejectsCrossTenantToolset(t *testing.T) {
 	// Start with a valid frontend pointing at a same-project remote MCP server.
 	ownServerID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
 	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		Name:                  "test mcp server",
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &ownServerID,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "test mcp server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &ownServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	require.NoError(t, err)
 
@@ -121,14 +121,14 @@ func TestUpdateMcpServer_RejectsCrossTenantToolset(t *testing.T) {
 	otherToolsetID := seedOtherProjectToolset(t, ctx, ti.conn, authCtx.ActiveOrganizationID).String()
 
 	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		ID:                    created.ID,
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     nil,
-		ToolsetID:             &otherToolsetID,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: nil,
+		ToolsetID:         &otherToolsetID,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	requireOopsCode(t, err, oops.CodeInvalid)
 }
@@ -145,14 +145,14 @@ func TestCreateMcpServer_RejectsCrossTenantRemoteMcpServer(t *testing.T) {
 	otherServerID := seedOtherProjectRemoteMcpServer(t, ctx, ti.conn, authCtx.ActiveOrganizationID).String()
 
 	_, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		Name:                  "test mcp server",
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &otherServerID,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "test mcp server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &otherServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	requireOopsCode(t, err, oops.CodeInvalid)
 }
@@ -168,14 +168,14 @@ func TestUpdateMcpServer_RejectsCrossTenantRemoteMcpServer(t *testing.T) {
 	// Start with a valid frontend in the caller's own project.
 	ownServerID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
 	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		Name:                  "test mcp server",
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &ownServerID,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "test mcp server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &ownServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	require.NoError(t, err)
 
@@ -183,14 +183,14 @@ func TestUpdateMcpServer_RejectsCrossTenantRemoteMcpServer(t *testing.T) {
 	otherServerID := seedOtherProjectRemoteMcpServer(t, ctx, ti.conn, authCtx.ActiveOrganizationID).String()
 
 	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		ID:                    created.ID,
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &otherServerID,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &otherServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	requireOopsCode(t, err, oops.CodeInvalid)
 }

--- a/server/internal/mcpservers/updatemcpserver_test.go
+++ b/server/internal/mcpservers/updatemcpserver_test.go
@@ -26,14 +26,14 @@ func TestUpdateMcpServer_FullReplace(t *testing.T) {
 	serverB := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
 
 	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		Name:                  "test mcp server",
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &serverA,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "test mcp server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &serverA,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	require.NoError(t, err)
 
@@ -43,14 +43,14 @@ func TestUpdateMcpServer_FullReplace(t *testing.T) {
 	// Full-record replace: swap backend to serverB, flip visibility, drop
 	// any optional fields.
 	updated, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		ID:                    created.ID,
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &serverB,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("public"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &serverB,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("public"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, created.ID, updated.ID)
@@ -79,27 +79,27 @@ func TestUpdateMcpServer_InvalidBackend(t *testing.T) {
 	serverID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
 
 	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		Name:                  "test mcp server",
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &serverID,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "test mcp server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &serverID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	require.NoError(t, err)
 
 	// Update with neither backend — should fail validation.
 	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		ID:                    created.ID,
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     nil,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: nil,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	requireOopsCode(t, err, oops.CodeInvalid)
 }
@@ -115,14 +115,14 @@ func TestUpdateMcpServer_NotFound(t *testing.T) {
 	serverID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
 
 	_, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		ID:                    uuid.NewString(),
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     &serverID,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                uuid.NewString(),
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &serverID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	requireOopsCode(t, err, oops.CodeNotFound)
 }
@@ -405,14 +405,14 @@ func TestUpdateMcpServer_RBACForbidden(t *testing.T) {
 	ctx = withExactAuthzGrants(t, ctx, ti.conn)
 
 	_, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
-		SessionToken:          nil,
-		ApikeyToken:           nil,
-		ProjectSlugInput:      nil,
-		ID:                    uuid.NewString(),
-		EnvironmentID:         nil,
-		RemoteMcpServerID:     nil,
-		ToolsetID:             nil,
-		Visibility:            types.McpServerVisibility("disabled"),
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                uuid.NewString(),
+		EnvironmentID:     nil,
+		RemoteMcpServerID: nil,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
 }

--- a/server/internal/usage/tum_test.go
+++ b/server/internal/usage/tum_test.go
@@ -134,9 +134,9 @@ func insertToolCallRow(t *testing.T, conn driver.Conn, projectID string, timesta
 	t.Helper()
 
 	insertTelemetryRow(t, conn, projectID, timestamp, "tools:http:petstore:listPets", map[string]any{
-		"gen_ai.conversation.id":     chatID,
-		"gram.tool.urn":              "tools:http:petstore:listPets",
-		"http.response.status_code":  200,
+		"gen_ai.conversation.id":    chatID,
+		"gram.tool.urn":             "tools:http:petstore:listPets",
+		"http.response.status_code": 200,
 	})
 }
 

--- a/services/pi-classifier/app.py
+++ b/services/pi-classifier/app.py
@@ -21,9 +21,17 @@ from optimum.onnxruntime import ORTModelForSequenceClassification
 from pydantic import BaseModel, Field, field_validator
 from transformers import AutoTokenizer
 
-MODEL_REPO = os.environ.get("MODEL_REPO", "protectai/deberta-v3-base-prompt-injection-v2")
-MODEL_REVISION = os.environ.get("MODEL_REVISION", "e6535ca4ce3ba852083e75ec585d7c8aeb4be4c5")
-HF_LOCAL_FILES_ONLY = os.environ.get("HF_LOCAL_FILES_ONLY", "").lower() in {"1", "true", "yes"}
+MODEL_REPO = os.environ.get(
+    "MODEL_REPO", "protectai/deberta-v3-base-prompt-injection-v2"
+)
+MODEL_REVISION = os.environ.get(
+    "MODEL_REVISION", "e6535ca4ce3ba852083e75ec585d7c8aeb4be4c5"
+)
+HF_LOCAL_FILES_ONLY = os.environ.get("HF_LOCAL_FILES_ONLY", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
 MAX_LENGTH = int(os.environ.get("MAX_LENGTH", "512"))
 MAX_BATCH = int(os.environ.get("MAX_BATCH", "64"))
 MAX_BODY_BYTES = int(os.environ.get("MAX_BODY_BYTES", str(2 * 1024 * 1024)))
@@ -71,22 +79,35 @@ async def lifespan(_app: FastAPI):
     id2label = {int(k): v for k, v in _State.model.config.id2label.items()}
     inj = next((i for i, lbl in id2label.items() if lbl.upper() == "INJECTION"), 1)
     _State.inj_idx = inj
-    log.info(f"model loaded in {time.perf_counter() - t0:.2f}s id2label={id2label} inj_idx={inj}")
+    log.info(
+        f"model loaded in {time.perf_counter() - t0:.2f}s id2label={id2label} inj_idx={inj}"
+    )
     yield
 
 
-app = FastAPI(title="gram-pi-classifier", version="1", description=API_DESCRIPTION, lifespan=lifespan)
+app = FastAPI(
+    title="gram-pi-classifier",
+    version="1",
+    description=API_DESCRIPTION,
+    lifespan=lifespan,
+)
 
 
 @app.middleware("http")
 async def _enforce_body_limit(request: Request, call_next):
     cl = request.headers.get("content-length")
     if cl is not None and cl.isdigit() and int(cl) > MAX_BODY_BYTES:
-        return JSONResponse({"detail": f"body too large (limit {MAX_BODY_BYTES} bytes)"}, status_code=413)
+        return JSONResponse(
+            {"detail": f"body too large (limit {MAX_BODY_BYTES} bytes)"},
+            status_code=413,
+        )
     if request.method == "POST" and cl is None:
         body = await request.body()
         if len(body) > MAX_BODY_BYTES:
-            return JSONResponse({"detail": f"body too large (limit {MAX_BODY_BYTES} bytes)"}, status_code=413)
+            return JSONResponse(
+                {"detail": f"body too large (limit {MAX_BODY_BYTES} bytes)"},
+                status_code=413,
+            )
 
         async def receive():
             return {"type": "http.request", "body": body, "more_body": False}


### PR DESCRIPTION
Add a format-check job so unformatted code can't merge, then bring the tree into compliance with what hk would produce. The job diffs against the PR merge base (or all files outside PRs) so contributors get the same result as running `hk fix` locally.

Most of the churn is mechanical: ruff reflows long Python lines and gofmt realigns struct field tabs in the mcpservers and usage tests. The risk-report task header is fenced with `# fmt: off`/`# fmt: on` because ruff would otherwise insert a space after `#` and silently break mise's literal `#MISE`/`#USAGE` directive parsing; the mise-tasks skill and CLAUDE.md now document the fence and the `hk fix` entry point.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI format gate that runs `hk check` to block unformatted code from merging. Reformatted Python and Go files to match `hk fix`, and documented the `# fmt: off/on` fence for Python `mise` tasks using `#MISE`/`#USAGE` directives.

- New Features
  - Added `format-check` job in CI to run `hk check` against the PR merge base (or all files outside PRs).
  - Job installs deps for `oxfmt` via `pnpm` and fails with a clear hint to run `hk fix`.

- Migration
  - Run `hk fix` locally before pushing to avoid CI failures.
  - For Python `mise` tasks, fence directive headers with `# fmt: off`/`# fmt: on` so `ruff` doesn’t rewrite `#MISE`/`#USAGE` (docs updated in `CLAUDE.md` and `.agents/skills/mise-tasks/SKILL.md`).

<sup>Written for commit b9b376865bcef3ec172f519a1b1a240fc7a4e418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

