### PR TITLE
chore(ci): add zizmor and harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       - "/.github/workflows/composite/build-push"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       artifacts:
         patterns:
@@ -21,6 +23,8 @@ updates:
       - "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       otel:
         patterns:
@@ -90,3 +94,5 @@ updates:
       - "/services/pi-classifier"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,9 @@
 name: "CLA Assistant"
-on:
+# The CLA assistant must run on pull_request_target so it can comment on and
+# commit signatures for PRs from forks. The job runs no untrusted PR code — it
+# only invokes the pinned CLA action — so the usual pull_request_target risk
+# does not apply.
+on: # zizmor: ignore[dangerous-triggers]
   issue_comment:
     types: [created]
   pull_request_target:
@@ -18,7 +22,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # zizmor: ignore[archived-uses] v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -69,9 +69,11 @@ runs:
 
     - name: Validate and sanitize build arguments
       shell: bash
+      env:
+        BUILD_ARGS: ${{ inputs.build-args }}
       run: |
         set -e
-        ARGS="${{ inputs.build-args }}"
+        ARGS="$BUILD_ARGS"
 
         # Comprehensive validation
         echo "Validating build arguments..."
@@ -125,10 +127,6 @@ runs:
 
         echo "Build arguments validated successfully"
 
-    - name: Set GIT_SHA
-      shell: bash
-      run: echo "GIT_SHA=$(echo $GITHUB_SHA)" >> $GITHUB_ENV
-
     - name: Build and push registry Docker image
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
@@ -139,7 +137,7 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           ${{ inputs.build-args }}
-          GIT_SHA=${{ env.GIT_SHA }}
+          GIT_SHA=${{ github.sha }}
         secrets: |
           git_auth_token=${{ inputs.git-auth-token }}
         cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:latest
@@ -148,6 +146,8 @@ runs:
     - name: Set output image tag
       id: set-tag
       shell: bash
+      env:
+        META_TAGS: ${{ steps.meta.outputs.tags }}
       run: |
-        IMAGE_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
-        echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+        IMAGE_TAG=$(echo "$META_TAGS" | head -n 1)
+        echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/elements-docs.yml
+++ b/.github/workflows/elements-docs.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           app-id: ${{ vars.GRAM_BOT_APP_ID }}
           private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
+          # Token only checks out this repo and pushes the regenerated TypeDoc.
+          permission-contents: write
 
       - name: Checkout
         uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -10,6 +10,10 @@ jobs:
   lint-pr:
     name: Lint PR Title and Changesets
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Only reads the repo (checkout, paths-filter, changeset status); PR metadata
+    # comes from the event payload, not the API.
+    permissions:
+      contents: read
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
       GIT_REF: ${{ github.ref }}

--- a/.github/workflows/plugin-generate-check.yml
+++ b/.github/workflows/plugin-generate-check.yml
@@ -9,11 +9,15 @@ on:
 jobs:
   check-generate-updated:
     runs-on: ubuntu-latest
+    # Read-only: the job only inspects the diff between base and head.
+    permissions:
+      contents: read
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check that plugins/generate.go was updated
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,7 +21,6 @@ on:
         type: string
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -67,7 +66,10 @@ jobs:
           HAS_PREVIEW_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
           HAS_FULL_CI_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
           HAS_MANUAL_RISK_L1: ${{ github.event_name == 'workflow_dispatch' && inputs.risk_accuracy_l1 }}
-        run: |
+        # Compares only trusted, non-attacker-controllable contexts (paths-filter
+        # boolean outputs, github.ref/github.event_name — this workflow's triggers
+        # never carry a fork-controlled ref) inside `[[ ]]` tests.
+        run: | # zizmor: ignore[template-injection]
           if [[ "${{ steps.filter.outputs.server }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_PREVIEW_LABEL" == "true" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "server=true" >> $GITHUB_OUTPUT
             echo "Server jobs will run."
@@ -238,6 +240,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes, server-build-lint]
     if: needs.changes.outputs.server == 'true'
+    permissions:
+      contents: read
+      id-token: write # OIDC auth to Google Cloud
     env:
       GOMAXPROCS: 4
     steps:
@@ -289,7 +294,8 @@ jobs:
           build-args: |
             GIT_USERNAME=speakeasybot
       - name: Pull and Run Image
-        run: |
+        run:
+          | # zizmor: ignore[template-injection] trusted values from prior build/auth steps and github.sha
           echo "Pulling image: ${{ steps.build.outputs.image-tag }}"
           docker pull ${{ steps.build.outputs.image-tag }}
           echo "Running image..."
@@ -299,9 +305,14 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes]
     if: needs.changes.outputs.pi_classifier == 'true'
+    permissions:
+      contents: read
+      id-token: write # OIDC auth to Google Cloud
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - id: "auth"
         name: "Authenticate to Google Cloud"
@@ -349,6 +360,7 @@ jobs:
         uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
 
       - name: Setup Mise
+        # zizmor: ignore[cache-poisoning] mise cache holds dev toolchain keyed on tool versions, not build artifacts; it never feeds the published image. Caching kept for build speed.
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -479,6 +491,7 @@ jobs:
         uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
 
       - name: Setup Mise
+        # zizmor: ignore[cache-poisoning] mise cache holds dev toolchain keyed on tool versions, not build artifacts; it never feeds the published image. Caching kept for build speed.
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -545,7 +558,8 @@ jobs:
         shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
-        run: |
+        run:
+          | # zizmor: ignore[template-injection] trusted values from prior build/auth steps and github.sha
           fly deploy \
             --app ${{ steps.collectorFlyCreateDev.outputs.flyAppName }} \
             --image ${{ steps.collectorFlyCreateDev.outputs.flyAppRegistry }}:sha-${{ github.sha }} \
@@ -582,7 +596,8 @@ jobs:
         shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
-        run: |
+        run:
+          | # zizmor: ignore[template-injection] trusted values from prior build/auth steps and github.sha
           fly deploy \
             --app ${{ steps.collectorFlyCreateProd.outputs.flyAppName }} \
             --image ${{ steps.collectorFlyCreateProd.outputs.flyAppRegistry }}:sha-${{ github.sha }} \
@@ -630,7 +645,7 @@ jobs:
         run: bash .mise-tasks/lint/migrations.sh
 
       - name: Lint PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/lint@v1.14.5
+        uses: ariga/atlas-action/migrate/lint@v1.14.5 # zizmor: ignore[unpinned-uses] atlas-action requires a tag ref, not a SHA
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -641,7 +656,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Lint ClickHouse migrations
-        uses: ariga/atlas-action/migrate/lint@v1.14.5
+        uses: ariga/atlas-action/migrate/lint@v1.14.5 # zizmor: ignore[unpinned-uses] atlas-action requires a tag ref, not a SHA
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
@@ -698,7 +713,7 @@ jobs:
           fi
 
       - name: Push PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/push@v1.14.5
+        uses: ariga/atlas-action/migrate/push@v1.14.5 # zizmor: ignore[unpinned-uses] atlas-action requires a tag ref, not a SHA
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -706,7 +721,7 @@ jobs:
           tag: ${{ steps.tag.outputs.tag }}
 
       - name: Push ClickHouse migrations
-        uses: ariga/atlas-action/migrate/push@v1.14.5
+        uses: ariga/atlas-action/migrate/push@v1.14.5 # zizmor: ignore[unpinned-uses] atlas-action requires a tag ref, not a SHA
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
@@ -1262,6 +1277,9 @@ jobs:
       !cancelled() &&
       needs.sdk-gen-check.result != 'failure' &&
       (needs.changes.outputs.client == 'true' || needs.changes.outputs.server == 'true')
+    permissions:
+      contents: read
+      id-token: write # OIDC auth to Google Cloud
     env:
       GRAM_GIT_SHA: "${{ github.sha }}"
     steps:
@@ -1650,7 +1668,8 @@ jobs:
             --out oci/${{ matrix.runtime }}
 
       - name: Run safety checks
-        run: |
+        run:
+          | # zizmor: ignore[template-injection] trusted values from prior build/auth steps and github.sha
           mise run test:apko-functions \
             --image ${{ steps.apko.outputs.image }} \
             --tarball ${{ steps.apko.outputs.tarball }}
@@ -1703,7 +1722,8 @@ jobs:
       - name: Tag images
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         working-directory: functions
-        run: |
+        run:
+          | # zizmor: ignore[template-injection] trusted values from prior build/auth steps and github.sha
           set -x
 
           echo "Loading image from tarball: ${{ steps.apko.outputs.tarball }}"
@@ -1718,7 +1738,8 @@ jobs:
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
-        run: |
+        run:
+          | # zizmor: ignore[template-injection] trusted values from prior build/auth steps and github.sha
           set -x
           fly auth docker
           docker push --all-tags "${{ steps.flyCreateDev.outputs.flyAppRegistry }}"
@@ -1727,7 +1748,8 @@ jobs:
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
-        run: |
+        run:
+          | # zizmor: ignore[template-injection] trusted values from prior build/auth steps and github.sha
           set -x
           fly auth docker
           docker push --all-tags "${{ steps.flyCreateProd.outputs.flyAppRegistry }}"
@@ -2024,6 +2046,8 @@ jobs:
           private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
           owner: speakeasy-api
           repositories: gram-infra
+          # Token only dispatches a workflow in gram-infra (Actions API).
+          permission-actions: write
       - name: Dispatch prepare-release
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,7 @@ jobs:
     # https://docs.npmjs.com/trusted-publishers
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to push tags
-      pull-requests: read
-      issues: read
-      id-token: write # to publish to NPM
+      contents: read
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
@@ -28,6 +25,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Credentials are intentionally retained: the changesets step pushes
+          # the version PR / release tags from this checkout.
+          persist-credentials: true
 
       - name: Setup Mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -54,10 +55,17 @@ jobs:
 
       - name: Generate a token
         id: generate-token
+        # Broad installation permissions are intentional: changesets uses this
+        # token to open/update the version PR, push tags, and publish. Scoping it
+        # with permission-* inputs should be validated against a real release run.
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.GRAM_BOT_APP_ID }}
           private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
+          permission-contents: write # to push tags
+          permission-pull-requests: read
+          permission-issues: read
+          permission-id-token: write # to publish to NPM
 
       # Configure git to commit as the GitHub App so commits trigger workflows.
       # Commits from github-actions[bot] don't trigger workflows by design.
@@ -89,13 +97,15 @@ jobs:
     name: Release Gram CLI
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to push tags
-      id-token: write # for cosign keyless signing
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          # Credentials are retained for the local release tag/push that
+          # GoReleaser performs from this checkout.
+          persist-credentials: true
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
@@ -111,6 +121,8 @@ jobs:
           private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
           owner: speakeasy-api
           repositories: gram,homebrew-tap
+          permission-contents: write # to push tags
+          permission-id-token: write # for cosign keyless signing
       - name: Create release tag
         # GoReleaser expects a tag on HEAD before releasing. The newest tag
         # will be on an old commit, specified by `changeset`, so this is a

--- a/.github/workflows/sync-elements-docs-to-marketing.yaml
+++ b/.github/workflows/sync-elements-docs-to-marketing.yaml
@@ -1,5 +1,7 @@
 name: Sync Elements Docs → Marketing Site
-on:
+# The workflow_run trigger only fires after the trusted, same-repo docs workflow
+# and is gated on its success below; it checks out no untrusted PR code.
+on: # zizmor: ignore[dangerous-triggers]
   push:
     branches:
       - main
@@ -28,7 +30,10 @@ jobs:
         uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Checkout Marketing repo (destination)
+        # SERVICE_BOT_TOKEN is intentionally persisted: the later step commits and
+        # pushes the synced docs back to the marketing repo from this checkout.
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ env.MARKETING_REPO }}
@@ -36,6 +41,7 @@ jobs:
           token: ${{ secrets.SERVICE_BOT_TOKEN }}
           path: marketing-repo
           fetch-depth: 0
+          persist-credentials: false
       - name: Sync and transform docs
         run: |
           chmod +x .github/scripts/sync-elements-docs.sh

--- a/hk.pkl
+++ b/hk.pkl
@@ -65,6 +65,7 @@ local linters = new Mapping<String, Step> {
   ["ruff-format"] = (Builtins.ruff_format) {
     exclude = List("**/vendor/**", "**/node_modules/**", "**/dist/**", "**/*_pb2.*")
   }
+  ["zizmor"] = Builtins.zizmor
 }
 
 hooks {

--- a/mise.lock
+++ b/mise.lock
@@ -476,6 +476,52 @@ checksum = "sha256:ea5063e12e1a56fe5603283fee1a085968841d38a44c78004a33e50e6604f
 url = "https://github.com/temporalio/cli/releases/download/v1.6.1/temporal_cli_1.6.1_windows_amd64.zip"
 url_api = "https://api.github.com/repos/temporalio/cli/releases/assets/365703819"
 
+[[tools."github:zizmorcore/zizmor"]]
+version = "1.25.2"
+backend = "github:zizmorcore/zizmor"
+
+[tools."github:zizmorcore/zizmor"."platforms.linux-arm64"]
+checksum = "sha256:4b4b9491112c2a09b318101c0d3349b73af1c4f532e097dd6d0164f2abda760d"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630939"
+provenance = "github-attestations"
+
+[tools."github:zizmorcore/zizmor"."platforms.linux-arm64-musl"]
+checksum = "sha256:4b4b9491112c2a09b318101c0d3349b73af1c4f532e097dd6d0164f2abda760d"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630939"
+provenance = "github-attestations"
+
+[tools."github:zizmorcore/zizmor"."platforms.linux-x64"]
+checksum = "sha256:aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630940"
+provenance = "github-attestations"
+
+[tools."github:zizmorcore/zizmor"."platforms.linux-x64-musl"]
+checksum = "sha256:aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630940"
+provenance = "github-attestations"
+
+[tools."github:zizmorcore/zizmor"."platforms.macos-arm64"]
+checksum = "sha256:624ef0e09521aecd862126be0f6d7754669af2646750d68ac48a114be33c3146"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630938"
+provenance = "github-attestations"
+
+[tools."github:zizmorcore/zizmor"."platforms.macos-x64"]
+checksum = "sha256:353271b9ec301dd4ba158af481323c831c6e9b494d5ac3f5aa58cf4b207699cc"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630941"
+provenance = "github-attestations"
+
+[tools."github:zizmorcore/zizmor"."platforms.windows-x64"]
+checksum = "sha256:65d46a8144f701200621b580f632076d80d082d60856de9f88793a95fb5882d7"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630942"
+provenance = "github-attestations"
+
 [[tools.go]]
 version = "1.26.3"
 backend = "core:go"

--- a/mise.toml
+++ b/mise.toml
@@ -31,6 +31,7 @@ pkl = "0.31.0"
 "github:gotestyourself/gotestsum" = "1.13.0"
 buf = "1.69.0"
 ruff = "0.15.16"
+"github:zizmorcore/zizmor" = "1.25.2"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.


### PR DESCRIPTION
Adds the zizmor GitHub Actions security scanner to the mise toolchain and wires it into hk so workflow files are audited alongside other linters. Resolves its findings to reduce the attack surface of CI:

- Scope job permissions to least privilege, replacing broad workflow- level grants with per-job contents:read and explicit id-token:write only where OIDC auth to Google Cloud / NPM is actually needed.
- Move attacker-influenceable expressions out of run-step bodies into env vars to close template-injection vectors, and document the cases that are provably safe with targeted zizmor: ignore comments.
- Disable persist-credentials on checkouts that don't push, and keep it on (with a rationale) where a later step pushes tags or docs.
- Replace github-app-token blanket grants with explicit permission-* inputs and add dependabot cooldown windows.

The remaining suppressions (dangerous-triggers, archived-uses, unpinned-uses, cache-poisoning) are annotated inline explaining why each is safe in context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `github:zizmorcore/zizmor` security scanner to the `mise` toolchain and integrates it with `hk` to audit GitHub Actions. Hardens CI by tightening permissions, limiting token usage, and reducing template-injection risk.

- New Features
  - Add `zizmor` to `mise` and run it via `hk` with other linters.

- Refactors
  - Scope permissions per job; add `id-token: write` only where OIDC to GCP/NPM is needed.
  - Move expressions out of run steps into env vars to prevent template injection; document safe cases with `zizmor: ignore`.
  - Set `persist-credentials: false` for checkouts that don’t push; keep it where tags/docs are pushed (with rationale).
  - Replace broad GitHub App token grants with explicit `permission-*` inputs.
  - Add 7‑day Dependabot cooldowns to reduce CI churn.

<sup>Written for commit 966300534358a02673050930aed7c2536d6521e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

