### PR TITLE
feat(dashboard): conversation-history clock on the minimized assistant dock pill

### DIFF
--- a/.changeset/insights-dock-pill-history.md
+++ b/.changeset/insights-dock-pill-history.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Add a conversation-history clock to the minimized Project Assistant dock pill. Previously the history list lived only inside the expanded chat panel, and the only way to open the panel from the pill was to submit a prompt — which always started a brand-new thread, so there was no way to return to a previous conversation from the collapsed dock. The pill now shows a clock button that opens the panel onto the current thread (no new conversation is minted) and reveals the existing conversation-history popover, letting the user jump straight back into a previous thread.

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -170,6 +170,10 @@ interface InsightsDockProps {
   onSubmitPrompt: (text: string) => void;
   /** Genies the dock down into the sidebar-footer resume button. */
   onDismiss: () => void;
+  /** Opens the chat panel and reveals the conversation-history list, letting
+   *  the user resume a previous thread straight from the minimized pill
+   *  instead of submitting (which would start a new conversation). */
+  onOpenHistory: () => void;
   /** Chat panel content, rendered inside the card when `open`. */
   panel: React.ReactNode;
   /** Stretch the open chat panel to fill the content area. */
@@ -211,6 +215,7 @@ function InsightsDock({
   focusKey,
   onSubmitPrompt,
   onDismiss,
+  onOpenHistory,
   panel,
   maximized,
 }: InsightsDockProps): ReactElement {
@@ -504,6 +509,16 @@ function InsightsDock({
                     className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm outline-none"
                   />
                   {value.trim() && <DockSubmitButton />}
+                  <button
+                    type="button"
+                    onClick={onOpenHistory}
+                    tabIndex={open ? -1 : 0}
+                    className={PANEL_ICON_BUTTON_CLASS}
+                    aria-label="Open conversation history"
+                    title="Previous conversations"
+                  >
+                    <HistoryIcon className="size-3.5" />
+                  </button>
                   <button
                     type="button"
                     onClick={onDismiss}
@@ -811,6 +826,15 @@ export function InsightsProvider({
     setSessionKey((k) => k + 1);
   }, []);
 
+  // Clock button on the minimized pill: open the chat panel onto the CURRENT
+  // thread (no sessionKey bump, so we don't mint a new conversation) and pop
+  // the history list open so the user can jump straight to a previous thread.
+  // Reuses the same `historyOpen` popover the in-panel header clock drives.
+  const handleOpenHistory = useCallback(() => {
+    setIsExpanded(true);
+    setHistoryOpen(true);
+  }, []);
+
   // Global keyboard shortcut: Cmd+/ (Mac) / Ctrl+/ (PC). With the chat panel
   // closed it focuses the docked composer; with it open it collapses the
   // panel back into the composer pill.
@@ -1003,6 +1027,7 @@ export function InsightsProvider({
             focusKey={focusComposerKey}
             onSubmitPrompt={handleDockSubmit}
             onDismiss={handleDockDismiss}
+            onOpenHistory={handleOpenHistory}
             panel={panelContent}
             maximized={panelMaximized}
           />

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -603,8 +603,16 @@ export function InsightsProvider({
   // Full-screen chat panel, toggled from the panel header. Reset on close so
   // the next open always starts at the regular panel size.
   const [panelMaximized, setPanelMaximized] = useState(false);
+  // Reset transient panel chrome whenever the panel collapses, so the next
+  // open starts clean: regular size, and no leftover history popover. Without
+  // the historyOpen reset, opening history from the pill and then closing the
+  // panel (close button, backdrop, Cmd+/, dismiss) would leave historyOpen
+  // true, so the popover would reappear on the next, unrelated open.
   useEffect(() => {
-    if (!isExpanded) setPanelMaximized(false);
+    if (!isExpanded) {
+      setPanelMaximized(false);
+      setHistoryOpen(false);
+    }
   }, [isExpanded]);
   const { theme } = useMoonshineConfig();
   const { pathname } = useLocation();


### PR DESCRIPTION
## What

Adds a conversation-history **clock** button to the minimized Project Assistant dock pill, so you can return to a previous thread without starting a new one.

## Why

The history list (`HistoryIcon` popover) lived **only** inside the expanded chat panel header. From the collapsed pill the only way to open the panel was to submit a prompt — which runs `handleDockSubmit` → `handleSendPrompt`, bumping `sessionKey` and **always minting a brand-new thread**. So returning to a prior conversation from the minimized dock was impossible: you had to start a new chat first, then open the in-panel clock.

Reported: _"On the new assistant floating dock I can't go back to previous threads without starting a new one. Would be nice to access previous threads right in the minimized state using the clock icon."_

## How

- New `onOpenHistory` prop on `InsightsDock`, rendered as a `HistoryIcon` button in the pill between the conditional submit arrow and the dismiss `X` (same `tabIndex={open ? -1 : 0}` pattern, so it leaves the tab order when the panel — with its own header clock — is open).
- Provider handler `handleOpenHistory` sets `isExpanded = true` and `historyOpen = true` **without** bumping `sessionKey`, so the panel opens onto the _current_ thread and the existing conversation-history popover is already showing. No new conversation is minted.
- Reuses the exact `historyOpen` state and `<ChatHistory>` popover the in-panel header clock already drives — no new thread-list UI.

## Scope

One file, +25 lines (`client/dashboard/src/components/insights-dock.tsx`) plus a changeset.

## Verification

- `tsc -b --noEmit --force` on the dashboard: **0 errors**.
- SDK + elements built clean.
- **Manual QA to confirm:** opening from a _cold_ pill (assistant not yet resolved) flips `historyOpen` true while the runtime is still mounting; the popover lives inside `GramElementsProvider`, so it mounts already-open once `assistantReady`. Radix controlled popovers render open on mount and this is the same `historyOpen` path the in-panel clock uses, so it should be seamless — worth eyeballing live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a conversation-history clock to the minimized Project Assistant dock pill so you can jump back to previous threads without starting a new chat. Opening from the pill expands to the current thread and shows the existing history popover.

- **New Features**
  - Adds `onOpenHistory` to `InsightsDock` and renders a clock button in the pill.
  - `handleOpenHistory` expands the panel and sets `historyOpen = true` without bumping `sessionKey`.
  - Reuses the existing `<ChatHistory>` popover and keeps the pill/tabIndex focus behavior.

- **Bug Fixes**
  - Resets `historyOpen` when the panel collapses to prevent the popover from reappearing on the next open.

<sup>Written for commit 694ba9937094a232c47fa5fbdbd075408c54288c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

