### PR TITLE
feat(assistant): full-window chat history with dated thread list

### DIFF
--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -1,10 +1,5 @@
 import { useNoToolsetsConfigured } from "@/hooks/useObservabilityMcpConfig";
 import { useServerAssistantTransport } from "@/hooks/useServerAssistantTransport";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { cn, isMacPlatform } from "@/lib/utils";
 import speakeasyIcon from "@/assets/speakeasy-icon.svg";
 import { useAssistantRuntime } from "@assistant-ui/react";
@@ -29,8 +24,8 @@ import {
 import { useMoonshineConfig } from "@speakeasy-api/moonshine";
 import type { UIMessage } from "ai";
 import {
+  ArrowLeft,
   ArrowUp,
-  ChevronDown,
   HistoryIcon,
   Loader2,
   Maximize2,
@@ -170,6 +165,8 @@ interface InsightsDockProps {
   onSubmitPrompt: (text: string) => void;
   /** Genies the dock down into the sidebar-footer resume button. */
   onDismiss: () => void;
+  /** Opens the chat panel straight into the full-window history view. */
+  onOpenHistory: () => void;
   /** Chat panel content, rendered inside the card when `open`. */
   panel: React.ReactNode;
   /** Stretch the open chat panel to fill the content area. */
@@ -211,6 +208,7 @@ function InsightsDock({
   focusKey,
   onSubmitPrompt,
   onDismiss,
+  onOpenHistory,
   panel,
   maximized,
 }: InsightsDockProps): ReactElement {
@@ -504,6 +502,17 @@ function InsightsDock({
                     className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm outline-none"
                   />
                   {value.trim() && <DockSubmitButton />}
+                  {composerExpanded && (
+                    <button
+                      type="button"
+                      onClick={onOpenHistory}
+                      className={PANEL_ICON_BUTTON_CLASS}
+                      aria-label="Conversation history"
+                      title="History"
+                    >
+                      <HistoryIcon className="size-3.5" />
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={onDismiss}
@@ -584,12 +593,24 @@ export function InsightsProvider({
   // calls in a long-lived runtime throw `tapLookupResources: Resource not
   // found for lookup: __LOCALID_…` during render.
   const [sessionKey, setSessionKey] = useState(0);
-  const [historyOpen, setHistoryOpen] = useState(false);
+  // History takes over the whole panel (replacing the chat) rather than
+  // dropping a popover, and is cancellable back to the chat. Reset on close
+  // and on a fresh conversation so reopening always lands on the chat.
+  const [historyView, setHistoryView] = useState(false);
+  // Whether the history view has a live conversation to return to. False when
+  // opened cold from the docked composer (no chat exists behind it yet), so
+  // the back affordance is hidden and only close is offered. True when opened
+  // from inside an active chat via the in-panel history button.
+  const [historyReturnable, setHistoryReturnable] = useState(false);
   // Full-screen chat panel, toggled from the panel header. Reset on close so
   // the next open always starts at the regular panel size.
   const [panelMaximized, setPanelMaximized] = useState(false);
   useEffect(() => {
-    if (!isExpanded) setPanelMaximized(false);
+    if (!isExpanded) {
+      setPanelMaximized(false);
+      setHistoryView(false);
+      setHistoryReturnable(false);
+    }
   }, [isExpanded]);
   const { theme } = useMoonshineConfig();
   const { pathname } = useLocation();
@@ -766,6 +787,8 @@ export function InsightsProvider({
   const handleSendPrompt = useCallback((text: string) => {
     setSessionKey((k) => k + 1);
     setPendingPrompt({ text, nonce: Date.now() });
+    // Sending always drops into the live conversation, never the history list.
+    setHistoryView(false);
   }, []);
 
   const consumePendingPrompt = useCallback(() => setPendingPrompt(null), []);
@@ -809,6 +832,17 @@ export function InsightsProvider({
   // the new thread gets its chat id from the server on the first send.
   const handleStartFresh = useCallback(() => {
     setSessionKey((k) => k + 1);
+    setHistoryView(false);
+  }, []);
+
+  // Opening history from the docked composer: open the panel (which lazily
+  // resolves the assistant transport the history list needs) straight into
+  // the full-window history view. No chat exists behind it yet, so the view
+  // is close-only — no back affordance.
+  const handleOpenHistory = useCallback(() => {
+    setIsExpanded(true);
+    setHistoryView(true);
+    setHistoryReturnable(false);
   }, []);
 
   // Global keyboard shortcut: Cmd+/ (Mac) / Ctrl+/ (PC). With the chat panel
@@ -863,6 +897,19 @@ export function InsightsProvider({
     </button>
   );
 
+  // Cancels the full-window history view back to the chat — reads "← Back".
+  const panelBackButton = (
+    <button
+      onClick={() => setHistoryView(false)}
+      className={cn(PANEL_ICON_BUTTON_CLASS, "flex items-center gap-1")}
+      aria-label="Back to conversation"
+      title="Back to conversation"
+    >
+      <ArrowLeft className="size-4" />
+      <span className="text-sm font-medium">Back</span>
+    </button>
+  );
+
   const panelNotices = (
     <>
       {/* Notice when the Project Assistant failed to connect */}
@@ -901,66 +948,97 @@ export function InsightsProvider({
             onConsume={consumePendingPrompt}
           />
           <div className="flex h-full min-h-0 flex-col">
-            {/* Header */}
-            <div className="flex shrink-0 items-center justify-between px-2 pt-2">
-              <Popover open={historyOpen} onOpenChange={setHistoryOpen}>
-                <PopoverTrigger asChild>
+            {/* History view: the conversation list takes over the whole panel
+                in place of the chat, cancellable via the back button. */}
+            {historyView && (
+              <>
+                <div
+                  className={cn(
+                    "flex shrink-0 items-center px-2 pt-2",
+                    historyReturnable ? "justify-between" : "justify-end",
+                  )}
+                >
+                  {historyReturnable && panelBackButton}
+                  {panelCloseButton}
+                </div>
+                {/* Picking a conversation (or "New Thread") switches the
+                    runtime's active thread; the list lives in a shadow root,
+                    so its click bubbles (composed) out to this wrapper and
+                    returns the user to the chat. */}
+                <div
+                  className="min-h-0 flex-1 overflow-y-auto"
+                  onClick={() => setHistoryView(false)}
+                >
+                  <ChatHistory className="min-h-full" />
+                </div>
+              </>
+            )}
+            {/* Chat view */}
+            {!historyView && (
+              <>
+                <div className="flex shrink-0 items-center justify-between px-2 pt-2">
                   <button
-                    className={cn(
-                      PANEL_ICON_BUTTON_CLASS,
-                      "flex items-center gap-0.5",
-                    )}
+                    onClick={() => {
+                      setHistoryReturnable(true);
+                      setHistoryView(true);
+                    }}
+                    className={PANEL_ICON_BUTTON_CLASS}
                     aria-label="Conversation history"
-                    title="Conversation history"
+                    title="History"
                   >
                     <HistoryIcon className="size-4" />
-                    <ChevronDown className="size-3" />
                   </button>
-                </PopoverTrigger>
-                <PopoverContent
-                  align="start"
-                  className="max-h-96 w-72 overflow-y-auto p-0"
-                >
-                  <ChatHistory className="max-h-96 overflow-y-auto" />
-                </PopoverContent>
-              </Popover>
-              <div className="flex items-center gap-0.5">
-                <button
-                  onClick={handleStartFresh}
-                  className={PANEL_ICON_BUTTON_CLASS}
-                  aria-label="Start a new conversation"
-                  title="Start a new conversation"
-                >
-                  <SquarePen className="size-4" />
-                </button>
-                <button
-                  onClick={() => setPanelMaximized((m) => !m)}
-                  className={PANEL_ICON_BUTTON_CLASS}
-                  aria-label={
-                    panelMaximized ? "Exit full screen" : "Full screen"
-                  }
-                  title={panelMaximized ? "Exit full screen" : "Full screen"}
-                >
-                  {panelMaximized ? (
-                    <Minimize2 className="size-4" />
-                  ) : (
-                    <Maximize2 className="size-4" />
-                  )}
-                </button>
-                {panelCloseButton}
-              </div>
-            </div>
-            {panelNotices}
-            <div className="min-h-0 flex-1 overflow-hidden">
-              <Chat />
-            </div>
+                  <div className="flex items-center gap-0.5">
+                    <button
+                      onClick={handleStartFresh}
+                      className={PANEL_ICON_BUTTON_CLASS}
+                      aria-label="Start a new conversation"
+                      title="Start a new conversation"
+                    >
+                      <SquarePen className="size-4" />
+                    </button>
+                    <button
+                      onClick={() => setPanelMaximized((m) => !m)}
+                      className={PANEL_ICON_BUTTON_CLASS}
+                      aria-label={
+                        panelMaximized ? "Exit full screen" : "Full screen"
+                      }
+                      title={
+                        panelMaximized ? "Exit full screen" : "Full screen"
+                      }
+                    >
+                      {panelMaximized ? (
+                        <Minimize2 className="size-4" />
+                      ) : (
+                        <Maximize2 className="size-4" />
+                      )}
+                    </button>
+                    {panelCloseButton}
+                  </div>
+                </div>
+                {panelNotices}
+                <div className="min-h-0 flex-1 overflow-hidden">
+                  <Chat />
+                </div>
+              </>
+            )}
           </div>
         </GramElementsProvider>
       ) : (
         <>
-          {/* Header (connecting state) — close only; history/new need the
-              chat runtime. */}
-          <div className="flex shrink-0 items-center justify-end px-2 pt-2">
+          {/* Header (connecting state) — close only; the conversation list
+              and new-chat need the chat runtime. The back affordance only
+              applies to history opened from a live chat (not a cold composer
+              open), so it tracks historyReturnable like the ready header. */}
+          <div
+            className={cn(
+              "flex shrink-0 items-center px-2 pt-2",
+              historyView && historyReturnable
+                ? "justify-between"
+                : "justify-end",
+            )}
+          >
+            {historyView && historyReturnable && panelBackButton}
             {panelCloseButton}
           </div>
           {panelNotices}
@@ -1003,6 +1081,7 @@ export function InsightsProvider({
             focusKey={focusComposerKey}
             onSubmitPrompt={handleDockSubmit}
             onDismiss={handleDockDismiss}
+            onOpenHistory={handleOpenHistory}
             panel={panelContent}
             maximized={panelMaximized}
           />

--- a/elements/src/components/assistant-ui/thread-list.tsx
+++ b/elements/src/components/assistant-ui/thread-list.tsx
@@ -4,13 +4,31 @@ import {
   ThreadListPrimitive,
   useAssistantState,
 } from "@assistant-ui/react";
-import { PlusIcon } from "lucide-react";
+import { MessageSquareTextIcon, PlusIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useRadius } from "@/hooks/useRadius";
 import { cn } from "@/lib/utils";
 import { useDensity } from "@/hooks/useDensity";
+import { useThreadMeta } from "@/contexts/ThreadMetaContext";
+
+/**
+ * Formats a chat's creation date for the list row: "Jun 14" within the current
+ * year, "Jun 14, 2025" otherwise. Returns null for missing/invalid dates so
+ * the row simply omits the date rather than rendering "Invalid Date".
+ */
+function formatThreadCreatedAt(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  const sameYear = date.getFullYear() === new Date().getFullYear();
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  });
+}
 
 interface ThreadListProps {
   className?: string;
@@ -107,12 +125,21 @@ const ThreadListItem: FC = () => {
     >
       <ThreadListItemPrimitive.Trigger
         className={cn(
-          "aui-thread-list-item-trigger flex min-w-0 grow cursor-pointer items-center text-start",
-          d("px-lg"),
+          // px-sm (not px-lg) so the row icon's left edge lines up with the
+          // "New Thread" + icon above: that button's padding resolves to the
+          // p-sm value, which equals px-sm at every density tier.
+          "aui-thread-list-item-trigger flex min-w-0 grow cursor-pointer items-center gap-2.5 text-start",
+          d("px-sm"),
           d("py-sm"),
         )}
       >
-        <ThreadListItemTitle />
+        <span className="aui-thread-list-item-icon flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-card text-muted-foreground">
+          <MessageSquareTextIcon className="size-3.5" />
+        </span>
+        <span className="flex min-w-0 flex-col">
+          <ThreadListItemTitle />
+          <ThreadListItemDate />
+        </span>
       </ThreadListItemPrimitive.Trigger>
       {/* Archive button hidden until feature is implemented */}
       {/* <ThreadListItemArchive /> */}
@@ -122,8 +149,26 @@ const ThreadListItem: FC = () => {
 
 const ThreadListItemTitle: FC = () => {
   return (
-    <span className="aui-thread-list-item-title text-sm break-words text-foreground">
+    <span className="aui-thread-list-item-title block truncate text-sm text-foreground">
       <ThreadListItemPrimitive.Title fallback="New Chat" />
+    </span>
+  );
+};
+
+const ThreadListItemDate: FC = () => {
+  // Both remoteId and externalId equal the chat id in the Gram adapter; the
+  // side-channel map is keyed by that id. New local threads have neither yet,
+  // so they simply render no date.
+  const id = useAssistantState(
+    ({ threadListItem }) =>
+      threadListItem.remoteId ?? threadListItem.externalId,
+  );
+  const meta = useThreadMeta(id ?? undefined);
+  const label = formatThreadCreatedAt(meta?.createdAt);
+  if (!label) return null;
+  return (
+    <span className="aui-thread-list-item-date text-xs text-muted-foreground">
+      {label}
     </span>
   );
 };

--- a/elements/src/contexts/ThreadMetaContext.ts
+++ b/elements/src/contexts/ThreadMetaContext.ts
@@ -1,0 +1,27 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Per-chat metadata that assistant-ui's thread list can't carry: its
+ * RemoteThreadMetadata is a closed shape ({@link
+ * https://github.com/Yonom/assistant-ui status/remoteId/externalId/title}), so
+ * fields like the creation date are dropped at the runtime boundary.
+ *
+ * The Gram thread-list adapter populates this side channel from `chat.list`
+ * (keyed by chat id, which equals the item's remoteId/externalId) and
+ * `ThreadListItem` reads it to render the date. React context crosses the
+ * shadow-root boundary the thread list renders into, so the provider lives up
+ * in the Elements runtime tree.
+ */
+export interface ThreadMeta {
+  /** ISO timestamp of when the chat was created. */
+  createdAt?: string;
+}
+
+export const ThreadMetaContext = createContext<Record<string, ThreadMeta>>({});
+
+/** Reads the metadata for one chat id, or undefined when unknown (e.g. a
+ *  brand-new local thread that isn't in `chat.list` yet). */
+export function useThreadMeta(id: string | undefined): ThreadMeta | undefined {
+  const map = useContext(ThreadMetaContext);
+  return id ? map[id] : undefined;
+}

--- a/elements/src/hooks/useGramThreadListAdapter.tsx
+++ b/elements/src/hooks/useGramThreadListAdapter.tsx
@@ -16,6 +16,10 @@ import {
 } from "@/lib/messageConverter";
 import { sleep } from "@/lib/utils";
 import {
+  ThreadMetaContext,
+  type ThreadMeta,
+} from "@/contexts/ThreadMetaContext";
+import {
   useCallback,
   useEffect,
   useMemo,
@@ -106,6 +110,18 @@ export interface ThreadListAdapterOptions {
 
 interface ListChatsResponse {
   chats: GramChatOverview[];
+}
+
+/**
+ * Reads a chat's creation timestamp from the `chat.list` payload. The wire
+ * format is snake_case (`created_at`) — the hand-written GramChatOverview type
+ * declares camelCase, which never matched the JSON — so check both and return
+ * an ISO string, or undefined when absent.
+ */
+function readChatCreatedAt(chat: GramChatOverview): string | undefined {
+  const raw = chat as unknown as Record<string, unknown>;
+  const value = raw["created_at"] ?? raw["createdAt"];
+  return typeof value === "string" ? value : undefined;
 }
 
 /**
@@ -293,6 +309,14 @@ export function useGramThreadListAdapter(
     optionsRef.current = options;
   }, [options]);
 
+  // Side channel for per-chat metadata (creation date) that assistant-ui's
+  // RemoteThreadMetadata can't carry. `list()` writes a fresh object into the
+  // ref and bumps the counter so the provider passes a new context value and
+  // ThreadListItem re-renders with the dates. A ref (not state) holds the data
+  // so the stable `list()` closure can write it without a re-created identity.
+  const metaRef = useRef<Record<string, ThreadMeta>>({});
+  const [, bumpMeta] = useState(0);
+
   // Create stable Provider component using useCallback
   const unstable_Provider = useCallback(function GramHistoryProvider({
     children,
@@ -300,9 +324,11 @@ export function useGramThreadListAdapter(
     const history = useGramThreadHistoryAdapter(optionsRef);
     const adapters = useMemo(() => ({ history }), [history]);
     return (
-      <RuntimeAdapterProvider adapters={adapters}>
-        {children}
-      </RuntimeAdapterProvider>
+      <ThreadMetaContext.Provider value={metaRef.current}>
+        <RuntimeAdapterProvider adapters={adapters}>
+          {children}
+        </RuntimeAdapterProvider>
+      </ThreadMetaContext.Provider>
     );
   }, []);
 
@@ -329,6 +355,15 @@ export function useGramThreadListAdapter(
           }
 
           const data = (await response.json()) as ListChatsResponse;
+          // Stash creation dates in the side channel before returning the
+          // assistant-ui metadata (which can't carry them) — keyed by chat id,
+          // the same value used for remoteId/externalId below.
+          const nextMeta: Record<string, ThreadMeta> = { ...metaRef.current };
+          for (const chat of data.chats) {
+            nextMeta[chat.id] = { createdAt: readChatCreatedAt(chat) };
+          }
+          metaRef.current = nextMeta;
+          bumpMeta((n) => n + 1);
           return {
             threads: data.chats.map((chat) => ({
               remoteId: chat.id,


### PR DESCRIPTION
## What

Reworks the Project Assistant dock's conversation history into a full-window view and gives the thread list a clearer per-row layout.

### Dashboard (`insights-dock.tsx`)

- **History is now a full-window view** that replaces the chat inside the dock panel, instead of a small dropdown popover. It's cancellable back to the chat.
- **History button added to the expanded composer**, so you can jump straight into history from the collapsed dock (it opens the panel and lazily resolves the assistant transport the list needs).
- **Context-aware back affordance**: opening history from inside a live chat shows a `← Back` control; opening it cold from the composer (nothing behind it yet) is close-only.

### Elements (`@gram-ai/elements`)

- **Thread list rows now show the chat's creation date** under the title, plus a bordered icon chip to the left.
- Dates travel through a small `ThreadMetaContext` side channel: assistant-ui's `RemoteThreadMetadata` is a closed shape and drops `created_at`, so the Gram thread-list adapter stashes it (keyed by chat id) and the row reads it back. Context crosses the shadow-root boundary the list renders into.
- Fixed a latent camel/snake mismatch — the adapter read `chat.createdAt` but the wire field is `created_at`.
- Row icon left edge is aligned with the "New Thread" `+` icon across all density tiers.

## Testing

- `pnpm -F dashboard type-check` + `lint` — green
- `pnpm -F @gram-ai/elements type-check` + `lint` — green
- Verified locally: full-window history opens from both the composer and an active chat; dates render; alignment matches the New Thread row.

## Notes

- `elements/dist` is gitignored; the published artifact is rebuilt by CI, not committed here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Project Assistant’s popover history with a full-window history view, and refreshes the thread list with creation dates and a clear row layout. Adds a composer shortcut to open history.

- **New Features**
  - Full-window history view with Back when opened from a live chat; close-only from composer.
  - Composer history button opens the panel and lazy-loads the assistant transport.
  - Thread list shows creation date under the title and adds a bordered icon; row icon aligns with “New Thread”.

- **Bug Fixes**
  - Reads `created_at` correctly in the Gram adapter and plumbs dates via a `ThreadMetaContext` side channel for `@assistant-ui/react`.
  - Resets history and fullscreen state on panel close or when starting a fresh chat.

<sup>Written for commit e4f39abeb61dd9dfd7dd9c9b9c43d256e44ee14a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

