### PR TITLE
fix: demote trigger webhook auth failures to warning

### DIFF
--- a/.changeset/demote-trigger-webhook-auth-warning.md
+++ b/.changeset/demote-trigger-webhook-auth-warning.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+demote trigger webhook auth failures to warning

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -464,7 +464,11 @@ func toTriggerError(ctx context.Context, logger *slog.Logger, err error, message
 		// reached when the input fails validation.
 		public = fmt.Sprintf("%s: %s", message, err.Error())
 	case errors.Is(err, bgtriggers.ErrAuthFailed):
-		code = oops.CodeUnauthorized
+		// Webhook signature failures are client faults: a 401 on a public
+		// endpoint, commonly a single trigger with a stale or wrong signing
+		// secret whose sender keeps retrying.
+		logger.WarnContext(ctx, "trigger webhook authentication failed", attr.SlogError(err))
+		return oops.E(oops.CodeUnauthorized, err, "%s", public)
 	case errors.Is(err, pgx.ErrNoRows):
 		code = oops.CodeNotFound
 	}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2772/trigger-webhook-auth-failures-logged-at-error-inflate-gram-server

Webhook signature/auth failures (`401`) were logged at `ERROR` and marked as APM errors, so a single misconfigured trigger could inflate `gram-server`'s error rate and bury real faults. A `401` on a public webhook endpoint is a client fault, not a server fault.

Log these failures at `WARN` in `toTriggerError` and return the `401` without calling `.Log()`, so the span is no longer marked errored. The error boundary (`oops.ErrHandle`) does not log `ShareableError`s, so the explicit warn is the only log emitted.