### PR TITLE
chore(glint): adopt inspect.Analyzer pattern for deep-walk analyzers

### DIFF
--- a/.agents/skills/glint/SKILL.md
+++ b/.agents/skills/glint/SKILL.md
@@ -60,22 +60,61 @@ Reach for type assertions on `types.Type` (`*types.Named`, `*types.Pointer`, `*t
 When the rule is fundamentally about the _shape_ of code rather than its types, AST matching is fine. [glint/no_anonymous_defer.go](../../../glint/no_anonymous_defer.go) walks `*ast.DeferStmt` and asserts the call target is `*ast.FuncLit`:
 
 ```go
-ast.Inspect(file, func(node ast.Node) bool {
-    deferStmt, ok := node.(*ast.DeferStmt)
-    if !ok {
-        return true
-    }
+ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+ins.Preorder([]ast.Node{(*ast.DeferStmt)(nil)}, func(node ast.Node) {
+    deferStmt := node.(*ast.DeferStmt)
 
     if _, ok := deferStmt.Call.Fun.(*ast.FuncLit); !ok {
-        return true
+        return
     }
 
     pass.ReportRangef(deferStmt, "%s", message)
-    return true
 })
 ```
 
 There's no `*types.Type` that captures "anonymous deferred function" — the property only exists at the AST level — so AST matching is the right tool.
+
+### Traversal: depend on `inspect.Analyzer` for deep walks
+
+When a rule needs to find nodes anywhere in the tree (calls, defers, type specs nested in functions, etc.), declare a dependency on the shared inspector rather than hand-rolling `for _, file := range pass.Files { ast.Inspect(file, ...) }`. `inspect.Analyzer` parses each file once and shares the resulting `*inspector.Inspector` across every dependent analyzer, so the package's analyzers walk each file once collectively instead of once per analyzer. `Preorder` also filters by node type up front, replacing the `node.(*ast.T)` type-switch-and-`return true` boilerplate:
+
+```go
+import (
+    "go/ast"
+
+    "golang.org/x/tools/go/analysis"
+    "golang.org/x/tools/go/analysis/passes/inspect"
+    "golang.org/x/tools/go/ast/inspector"
+)
+
+return &analysis.Analyzer{
+    Name:     enforceO11yConventionsAnalyzer,
+    Doc:      enforceO11yConventionsDefaultMessage,
+    Requires: []*analysis.Analyzer{inspect.Analyzer},
+    Run: func(pass *analysis.Pass) (any, error) {
+        ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+        ins.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(node ast.Node) {
+            callExpr := node.(*ast.CallExpr)
+            // ...
+        })
+
+        return nil, nil
+    },
+}
+```
+
+Notes when adopting it:
+
+- The callback returns nothing, so there is no `return false` to prune a subtree the way `ast.Inspect` allows. If a rule genuinely depends on pruning descent (matching a node and deliberately skipping its children, for example), keep a manual `ast.Inspect` and say why in a comment.
+- `Preorder` walks every file in the package with no file boundary, so any per-file scoping has to happen per node instead of around a `pass.Files` loop. When a rule applies only to certain files, filter inside the callback via `pass.Fset.File(n.Pos()).Name()`. For example, [glint/no_testing_raw_sql.go](../../../glint/no_testing_raw_sql.go) checks for the `_test.go` suffix there because the test-only rule no longer has a file loop to gate.
+- Pulling the inspector from `pass.ResultOf` only works if the analyzer declared `inspect.Analyzer` in its `Requires`; otherwise the result is nil and the type assertion panics. This bites helpers shared across analyzers, since every caller must carry the dependency. For example, `findAnnotatedStructs` reads the inspector, so all four analyzers that call it list `inspect.Analyzer` in their `Requires`.
+
+Two situations where the manual walk is still the right call, and the inspector earns nothing:
+
+- **Per-file stateful detection.** When a rule accumulates state across a file and emits fixes scoped to that one `*ast.File` (an occurrence list, a "is this import used elsewhere" flag, import add/remove `SuggestedFixes`), the natural unit of work is the file, not the node. The shared inspector deliberately flattens that boundary, so adopting it would force re-bucketing nodes back by file to rebuild the same state, with no traversal saved. Keep the manual per-file `ast.Inspect` and leave a comment explaining the exemption. For example, [glint/no_sql_err_no_rows.go](../../../glint/no_sql_err_no_rows.go) collects each file's `ErrNoRows` occurrences alongside an `otherSqlUsage` flag before deciding which imports to rewrite.
+- **Top-level-declaration scans.** When a rule only cares about package-level declarations, iterating `file.Decls` directly is already a shallow single pass and expresses the intent precisely. Reaching for `Preorder` on `*ast.GenDecl` would additionally visit function-local declarations, widening the rule's scope, so the inspector is both unnecessary and subtly wrong here. For example, the `audit-*` analyzers (e.g. [glint/audit_event_urn_naming.go](../../../glint/audit_event_urn_naming.go)) walk `file.Decls` to inspect only package-level `*ast.GenDecl`/`*ast.TypeSpec`.
 
 ### Source-string matching is a last resort
 

--- a/glint/annotated_service.go
+++ b/glint/annotated_service.go
@@ -5,6 +5,8 @@ import (
 	"go/types"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
 )
 
 const (
@@ -24,69 +26,67 @@ type annotatedStruct struct {
 
 // findAnnotatedStructs scans the package's files for structs embedding
 // annotations.Service[ImplOf, AuthBy] and returns metadata about each one.
+//
+// Callers must declare a dependency on inspect.Analyzer in their Requires so
+// the shared inspector result is available on the pass.
 func findAnnotatedStructs(pass *analysis.Pass) []annotatedStruct {
 	var annotated []annotatedStruct
 
-	for _, file := range pass.Files {
-		ast.Inspect(file, func(node ast.Node) bool {
-			ts, ok := node.(*ast.TypeSpec)
+	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	ins.Preorder([]ast.Node{(*ast.TypeSpec)(nil)}, func(node ast.Node) {
+		ts := node.(*ast.TypeSpec)
+
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok {
+			return
+		}
+
+		for _, field := range st.Fields.List {
+			if len(field.Names) > 0 {
+				continue // not an embedded field
+			}
+
+			tv, ok := pass.TypesInfo.Types[field.Type]
 			if !ok {
-				return true
+				continue
 			}
 
-			st, ok := ts.Type.(*ast.StructType)
+			named, ok := tv.Type.(*types.Named)
 			if !ok {
-				return true
+				continue
 			}
 
-			for _, field := range st.Fields.List {
-				if len(field.Names) > 0 {
-					continue // not an embedded field
-				}
-
-				tv, ok := pass.TypesInfo.Types[field.Type]
-				if !ok {
-					continue
-				}
-
-				named, ok := tv.Type.(*types.Named)
-				if !ok {
-					continue
-				}
-
-				origin := named.Origin()
-				if origin.Obj().Pkg() == nil || origin.Obj().Pkg().Path() != annotationsPkgPath || origin.Obj().Name() != annotationsTypeName {
-					continue
-				}
-
-				targs := named.TypeArgs()
-				if targs == nil || targs.Len() < 2 {
-					continue
-				}
-
-				typeNameObj := pass.TypesInfo.Defs[ts.Name]
-				if typeNameObj == nil {
-					continue
-				}
-
-				tn, ok := typeNameObj.(*types.TypeName)
-				if !ok {
-					continue
-				}
-
-				annotated = append(annotated, annotatedStruct{
-					typeSpec:   ts,
-					structType: st,
-					name:       ts.Name.Name,
-					implOf:     targs.At(0),
-					authBy:     targs.At(1),
-					obj:        tn,
-				})
+			origin := named.Origin()
+			if origin.Obj().Pkg() == nil || origin.Obj().Pkg().Path() != annotationsPkgPath || origin.Obj().Name() != annotationsTypeName {
+				continue
 			}
 
-			return true
-		})
-	}
+			targs := named.TypeArgs()
+			if targs == nil || targs.Len() < 2 {
+				continue
+			}
+
+			typeNameObj := pass.TypesInfo.Defs[ts.Name]
+			if typeNameObj == nil {
+				continue
+			}
+
+			tn, ok := typeNameObj.(*types.TypeName)
+			if !ok {
+				continue
+			}
+
+			annotated = append(annotated, annotatedStruct{
+				typeSpec:   ts,
+				structType: st,
+				name:       ts.Name.Name,
+				implOf:     targs.At(0),
+				authBy:     targs.At(1),
+				obj:        tn,
+			})
+		}
+	})
 
 	return annotated
 }

--- a/glint/enforce_o11y_conventions.go
+++ b/glint/enforce_o11y_conventions.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
 )
 
 const (
@@ -39,39 +41,35 @@ func newEnforceO11yConventionsAnalyzer(rule enforceO11yConventionsSettings) *ana
 	}
 
 	return &analysis.Analyzer{
-		Name: enforceO11yConventionsAnalyzer,
-		Doc:  enforceO11yConventionsDefaultMessage,
+		Name:     enforceO11yConventionsAnalyzer,
+		Doc:      enforceO11yConventionsDefaultMessage,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
-			for _, file := range pass.Files {
-				ast.Inspect(file, func(node ast.Node) bool {
-					callExpr, ok := node.(*ast.CallExpr)
-					if !ok {
-						return true
-					}
+			ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-					selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
-					if !ok {
-						return true
-					}
+			ins.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(node ast.Node) {
+				callExpr := node.(*ast.CallExpr)
 
-					called, ok := pass.TypesInfo.Uses[selectorExpr.Sel].(*types.Func)
-					if !ok || called.Pkg() == nil {
-						return true
-					}
+				selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return
+				}
 
-					if called.Signature().Recv() != nil {
-						return true
-					}
+				called, ok := pass.TypesInfo.Uses[selectorExpr.Sel].(*types.Func)
+				if !ok || called.Pkg() == nil {
+					return
+				}
 
-					if called.Pkg().Path() != "log/slog" || !slices.Contains(bannedSlogFuncs, called.Name()) {
-						return true
-					}
+				if called.Signature().Recv() != nil {
+					return
+				}
 
-					pass.ReportRangef(callExpr, "%s", message)
+				if called.Pkg().Path() != "log/slog" || !slices.Contains(bannedSlogFuncs, called.Name()) {
+					return
+				}
 
-					return true
-				})
-			}
+				pass.ReportRangef(callExpr, "%s", message)
+			})
 
 			return nil, nil
 		},

--- a/glint/no_anonymous_defer.go
+++ b/glint/no_anonymous_defer.go
@@ -4,6 +4,8 @@ import (
 	"go/ast"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
 )
 
 const (
@@ -23,25 +25,21 @@ func newNoAnonymousDeferAnalyzer(rule noAnonymousDeferSettings) *analysis.Analyz
 	}
 
 	return &analysis.Analyzer{
-		Name: noAnonymousDeferAnalyzer,
-		Doc:  noAnonymousDeferDefaultMessage,
+		Name:     noAnonymousDeferAnalyzer,
+		Doc:      noAnonymousDeferDefaultMessage,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
-			for _, file := range pass.Files {
-				ast.Inspect(file, func(node ast.Node) bool {
-					deferStmt, ok := node.(*ast.DeferStmt)
-					if !ok {
-						return true
-					}
+			ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-					if _, ok := deferStmt.Call.Fun.(*ast.FuncLit); !ok {
-						return true
-					}
+			ins.Preorder([]ast.Node{(*ast.DeferStmt)(nil)}, func(node ast.Node) {
+				deferStmt := node.(*ast.DeferStmt)
 
-					pass.ReportRangef(deferStmt, "%s", message)
+				if _, ok := deferStmt.Call.Fun.(*ast.FuncLit); !ok {
+					return
+				}
 
-					return true
-				})
-			}
+				pass.ReportRangef(deferStmt, "%s", message)
+			})
 
 			return nil, nil
 		},

--- a/glint/no_direct_chat_message_insert.go
+++ b/glint/no_direct_chat_message_insert.go
@@ -5,6 +5,8 @@ import (
 	"go/types"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
 )
 
 const (
@@ -21,44 +23,40 @@ type noDirectChatMessageInsertSettings struct {
 
 func newNoDirectChatMessageInsertAnalyzer(rule noDirectChatMessageInsertSettings) *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name: noDirectChatMessageInsertAnalyzer,
-		Doc:  noDirectChatMessageInsertMessage,
+		Name:     noDirectChatMessageInsertAnalyzer,
+		Doc:      noDirectChatMessageInsertMessage,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
 			// Allow calls from within the chat package itself.
 			if pass.Pkg.Path() == chatPkgPath {
 				return nil, nil
 			}
 
-			for _, file := range pass.Files {
-				ast.Inspect(file, func(node ast.Node) bool {
-					callExpr, ok := node.(*ast.CallExpr)
-					if !ok {
-						return true
-					}
+			ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-					selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
-					if !ok {
-						return true
-					}
+			ins.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(node ast.Node) {
+				callExpr := node.(*ast.CallExpr)
 
-					if selectorExpr.Sel.Name != "CreateChatMessage" {
-						return true
-					}
+				selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return
+				}
 
-					called, ok := pass.TypesInfo.Uses[selectorExpr.Sel].(*types.Func)
-					if !ok || called.Pkg() == nil {
-						return true
-					}
+				if selectorExpr.Sel.Name != "CreateChatMessage" {
+					return
+				}
 
-					if called.Pkg().Path() != chatRepoPkgPath {
-						return true
-					}
+				called, ok := pass.TypesInfo.Uses[selectorExpr.Sel].(*types.Func)
+				if !ok || called.Pkg() == nil {
+					return
+				}
 
-					pass.ReportRangef(callExpr, "%s", noDirectChatMessageInsertMessage)
+				if called.Pkg().Path() != chatRepoPkgPath {
+					return
+				}
 
-					return true
-				})
-			}
+				pass.ReportRangef(callExpr, "%s", noDirectChatMessageInsertMessage)
+			})
 
 			return nil, nil
 		},

--- a/glint/no_repo_fields_in_service.go
+++ b/glint/no_repo_fields_in_service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
 )
 
 const (
@@ -21,8 +22,9 @@ type noRepoFieldsInServiceSettings struct {
 
 func newNoRepoFieldsInServiceAnalyzer(rule noRepoFieldsInServiceSettings) *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name: noRepoFieldsInServiceAnalyzer,
-		Doc:  noRepoFieldsInServiceDoc,
+		Name:     noRepoFieldsInServiceAnalyzer,
+		Doc:      noRepoFieldsInServiceDoc,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
 			annotated := findAnnotatedStructs(pass)
 			if len(annotated) == 0 {

--- a/glint/no_sql_err_no_rows.go
+++ b/glint/no_sql_err_no_rows.go
@@ -28,6 +28,15 @@ func newNoSqlErrNoRowsAnalyzer(_ noSqlErrNoRowsSettings) *analysis.Analyzer {
 	return &analysis.Analyzer{
 		Name: noSqlErrNoRowsAnalyzer,
 		Doc:  noSqlErrNoRowsDefaultMessage,
+		// This analyzer intentionally keeps the manual per-file ast.Inspect
+		// walk rather than depending on inspect.Analyzer like the other
+		// analyzers in this package. Its detection is per-file stateful: it
+		// accumulates the file's ErrNoRows occurrences alongside a single
+		// otherSqlUsage flag, then emits import add/remove SuggestedFixes scoped
+		// to that *ast.File. The shared inspector walks every file together with
+		// no file boundary, so adopting it would mean re-bucketing nodes back by
+		// file to rebuild that state, which is both slower to reason about and
+		// riskier for the SuggestedFix golden fixture, with no traversal saved.
 		Run: func(pass *analysis.Pass) (any, error) {
 			for _, file := range pass.Files {
 				inspectFileForSqlErrNoRows(pass, file)

--- a/glint/no_testing_raw_sql.go
+++ b/glint/no_testing_raw_sql.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
 )
 
 const (
@@ -32,47 +34,47 @@ type noTestingRawSqlSettings struct {
 
 func newNoTestingRawSqlAnalyzer(_ noTestingRawSqlSettings) *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name: noTestingRawSqlAnalyzer,
-		Doc:  noTestingRawSqlDefaultMessage,
+		Name:     noTestingRawSqlAnalyzer,
+		Doc:      noTestingRawSqlDefaultMessage,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
-			for _, file := range pass.Files {
-				if !strings.HasSuffix(pass.Fset.File(file.Pos()).Name(), "_test.go") {
-					continue
+			ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+			ins.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(node ast.Node) {
+				callExpr := node.(*ast.CallExpr)
+
+				// This rule only applies to test files. The shared inspector
+				// walks every file in the package, so filter by filename per
+				// node rather than per file.
+				if !strings.HasSuffix(pass.Fset.File(callExpr.Pos()).Name(), "_test.go") {
+					return
 				}
 
-				ast.Inspect(file, func(node ast.Node) bool {
-					callExpr, ok := node.(*ast.CallExpr)
-					if !ok {
-						return true
-					}
+				selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return
+				}
 
-					selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
-					if !ok {
-						return true
-					}
+				if !noTestingRawSqlMethods[selectorExpr.Sel.Name] {
+					return
+				}
 
-					if !noTestingRawSqlMethods[selectorExpr.Sel.Name] {
-						return true
-					}
+				fn, ok := pass.TypesInfo.Uses[selectorExpr.Sel].(*types.Func)
+				if !ok {
+					return
+				}
 
-					fn, ok := pass.TypesInfo.Uses[selectorExpr.Sel].(*types.Func)
-					if !ok {
-						return true
-					}
+				sig, ok := fn.Type().(*types.Signature)
+				if !ok || sig.Recv() == nil {
+					return
+				}
 
-					sig, ok := fn.Type().(*types.Signature)
-					if !ok || sig.Recv() == nil {
-						return true
-					}
+				if !isPgxReceiver(sig.Recv().Type()) {
+					return
+				}
 
-					if !isPgxReceiver(sig.Recv().Type()) {
-						return true
-					}
-
-					pass.ReportRangef(callExpr, "%s", noTestingRawSqlDefaultMessage)
-					return true
-				})
-			}
+				pass.ReportRangef(callExpr, "%s", noTestingRawSqlDefaultMessage)
+			})
 
 			return nil, nil
 		},

--- a/glint/service_has_attach_func.go
+++ b/glint/service_has_attach_func.go
@@ -5,6 +5,7 @@ import (
 	"go/types"
 
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
 )
 
 const (
@@ -18,8 +19,9 @@ type serviceHasAttachFuncSettings struct {
 
 func newServiceHasAttachFuncAnalyzer(rule serviceHasAttachFuncSettings) *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name: serviceHasAttachFuncAnalyzer,
-		Doc:  serviceHasAttachFuncDoc,
+		Name:     serviceHasAttachFuncAnalyzer,
+		Doc:      serviceHasAttachFuncDoc,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
 			annotated := findAnnotatedStructs(pass)
 			if len(annotated) == 0 {

--- a/glint/service_has_auther_assertion.go
+++ b/glint/service_has_auther_assertion.go
@@ -2,6 +2,7 @@ package glint
 
 import (
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
 )
 
 const (
@@ -15,8 +16,9 @@ type serviceHasAutherAssertionSettings struct {
 
 func newServiceHasAutherAssertionAnalyzer(rule serviceHasAutherAssertionSettings) *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name: serviceHasAutherAssertionAnalyzer,
-		Doc:  serviceHasAutherAssertionDoc,
+		Name:     serviceHasAutherAssertionAnalyzer,
+		Doc:      serviceHasAutherAssertionDoc,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
 			annotated := findAnnotatedStructs(pass)
 			if len(annotated) == 0 {

--- a/glint/service_has_service_assertion.go
+++ b/glint/service_has_service_assertion.go
@@ -2,6 +2,7 @@ package glint
 
 import (
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
 )
 
 const (
@@ -15,8 +16,9 @@ type serviceHasServiceAssertionSettings struct {
 
 func newServiceHasServiceAssertionAnalyzer(rule serviceHasServiceAssertionSettings) *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name: serviceHasServiceAssertionAnalyzer,
-		Doc:  serviceHasServiceAssertionDoc,
+		Name:     serviceHasServiceAssertionAnalyzer,
+		Doc:      serviceHasServiceAssertionDoc,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
 			annotated := findAnnotatedStructs(pass)
 			if len(annotated) == 0 {


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2083/adopt-inspectanalyzer-pattern-across-glint-analyzers

Migrate the analyzers that traverse the full AST to depend on the shared `inspect.Analyzer` and walk via `inspector.Preorder` instead of hand-rolling `for _, file := range pass.Files { ast.Inspect(file, ...) }`. The shared inspector parses each file once and reuses it across every dependent analyzer, so the package walks each file once collectively rather than once per analyzer.

No diagnostic-message or rule-key changes; behavior is unchanged and existing analysistest fixtures pass unmodified. Update the glint SKILL.md "Detection methodology" to recommend the inspector pattern and document when a manual walk is still correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopt the shared `inspect.Analyzer` across `glint` analyzers that deep-walk the AST so each package is traversed once instead of once per analyzer. No rule or message changes; fixtures pass unchanged. Addresses Linear AGE-2083.

- **Refactors**
  - Migrate deep-walk analyzers to use `inspect.Analyzer` and `inspector.Preorder` (e.g., `no_anonymous_defer`, `enforce_o11y_conventions`, `no_direct_chat_message_insert`, `no_testing_raw_sql`, and `service_has_*`).
  - Update `findAnnotatedStructs` to read from the shared inspector; all callers now `Require` `inspect.Analyzer` (e.g., `no_repo_fields_in_service`, `service_has_*`).
  - Keep manual `ast.Inspect` in `no_sql_err_no_rows` due to per-file state and fixes; added rationale in code.
  - Update `.agents/skills/glint/SKILL.md` to recommend the inspector pattern, note per-file filtering, and document when manual walks are correct.
  - For test-only checks, filter by filename per node in `no_testing_raw_sql` since the inspector walks all files together.

<sup>Written for commit 9cf7d26f59579980d9de2f30bf176937c722814d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

