### PR TITLE
fix(dashboard): show assistant name in Cmd+K recently visited

### DIFF
--- a/.changeset/cmdk-assistant-recents-name.md
+++ b/.changeset/cmdk-assistant-recents-name.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the Cmd+K command palette's "Recently Visited" list showing an assistant's opaque id (e.g. "Assistant · 0190abcd") instead of its name. Visits are recorded centrally from the URL, which for the id-keyed assistant detail route fell back to the id. The assistant detail page now registers its name as the recents label, and `App` consults that override (re-recording when the name resolves asynchronously), so the palette shows the assistant name.

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -19,7 +19,11 @@ import {
 } from "react-router";
 import { AppLayout, LoginCheck, OrgLayout } from "./components/app-layout.tsx";
 import { CommandPalette } from "./components/command-palette";
-import { recordVisit } from "./components/command-palette/recentlyVisited";
+import {
+  getRecentLabelOverride,
+  recordVisit,
+  RECENTS_LABEL_OVERRIDE_EVENT,
+} from "./components/command-palette/recentlyVisited";
 import { useUser } from "./contexts/Auth";
 import { useProjectNavRoutes } from "./hooks/useProjectNavRoutes";
 import { useRBAC } from "./hooks/useRBAC";
@@ -181,14 +185,37 @@ const RouteProvider = () => {
       Object.values(orgRoutes).find((r) => r.active && !r.external);
     if (!active) return;
     const iconName = (active as unknown as { icon?: string }).icon;
-    recordVisit(recentsUserId, orgSlug, projectSlug, {
-      label: pageLabel(active.title, active.href(), location.pathname),
-      // Recents are page-level: record the pathname without query params so a
-      // page and its deep-linked item state (e.g. ?policy=<id>) collapse into a
-      // single entry instead of appearing as duplicates with the same label.
-      href: location.pathname,
-      icon: typeof iconName === "string" ? iconName : undefined,
-    });
+    // Recents are page-level: record the pathname without query params so a
+    // page and its deep-linked item state (e.g. ?policy=<id>) collapse into a
+    // single entry instead of appearing as duplicates with the same label.
+    const href = location.pathname;
+    const record = (label: string) =>
+      recordVisit(recentsUserId, orgSlug, projectSlug, {
+        label,
+        href,
+        icon: typeof iconName === "string" ? iconName : undefined,
+      });
+
+    // Prefer a label a detail page registered for this href (e.g. the assistant
+    // name) over the URL-derived fallback, which for id-keyed pages is an opaque
+    // id like "Assistant · 0190abcd".
+    record(
+      getRecentLabelOverride(href) ??
+        pageLabel(active.title, active.href(), location.pathname),
+    );
+
+    // A detail page may register its label *after* this first record (its data
+    // loads async). Re-record when that happens so the entry upgrades from the
+    // id fallback to the resource name.
+    const onOverride = (event: Event) => {
+      const detail = (event as CustomEvent<{ href: string }>).detail;
+      if (detail?.href !== href) return;
+      const label = getRecentLabelOverride(href);
+      if (label) record(label);
+    };
+    window.addEventListener(RECENTS_LABEL_OVERRIDE_EVENT, onOverride);
+    return () =>
+      window.removeEventListener(RECENTS_LABEL_OVERRIDE_EVENT, onOverride);
   }, [
     location.pathname,
     routes,

--- a/client/dashboard/src/components/command-palette/recentlyVisited.ts
+++ b/client/dashboard/src/components/command-palette/recentlyVisited.ts
@@ -22,6 +22,47 @@ export interface RecentEntry {
 const MAX_RECENTS = 6;
 const UPDATED_EVENT = "gram:recents-updated";
 
+// --- Human label overrides for opaque-id detail pages ----------------------
+//
+// Visits are recorded centrally in App from the active route, which can only
+// derive a label from the URL. For pages keyed by an opaque id — e.g. the
+// assistant detail page at /assistants/<uuid> — that yields "Assistant · <id>"
+// instead of the assistant's name. Such pages register a readable label here
+// once their data resolves; App consults it when recording the visit and
+// re-records when an override arrives asynchronously.
+const labelOverrides = new Map<string, string>();
+export const RECENTS_LABEL_OVERRIDE_EVENT = "gram:recents-label-override";
+
+/** Register a human label for a visited href (keyed by pathname). */
+export function setRecentLabelOverride(href: string, label: string): void {
+  if (labelOverrides.get(href) === label) return;
+  labelOverrides.set(href, label);
+  window.dispatchEvent(
+    new CustomEvent(RECENTS_LABEL_OVERRIDE_EVENT, { detail: { href } }),
+  );
+}
+
+/** Read a previously-registered label override for an href, if any. */
+export function getRecentLabelOverride(href: string): string | undefined {
+  return labelOverrides.get(href);
+}
+
+/**
+ * Register a readable Recents label for the current detail page. Pages keyed by
+ * an opaque id call this once their record loads so the command palette's
+ * "Recently Visited" list shows the resource name rather than a raw id. No-ops
+ * until `label` is available.
+ */
+export function useRecentLabelOverride(
+  href: string,
+  label: string | undefined,
+): void {
+  useEffect(() => {
+    if (!label) return;
+    setRecentLabelOverride(href, label);
+  }, [href, label]);
+}
+
 /**
  * The current user's id, used to scope recents per authenticated user. Derived
  * from the SDK session hook so it works outside the `AuthProvider` (the command

--- a/client/dashboard/src/components/command-palette/recentlyVisited.ts
+++ b/client/dashboard/src/components/command-palette/recentlyVisited.ts
@@ -34,7 +34,7 @@ const labelOverrides = new Map<string, string>();
 export const RECENTS_LABEL_OVERRIDE_EVENT = "gram:recents-label-override";
 
 /** Register a human label for a visited href (keyed by pathname). */
-export function setRecentLabelOverride(href: string, label: string): void {
+function setRecentLabelOverride(href: string, label: string): void {
   if (labelOverrides.get(href) === label) return;
   labelOverrides.set(href, label);
   window.dispatchEvent(

--- a/client/dashboard/src/pages/assistants/Assistant.tsx
+++ b/client/dashboard/src/pages/assistants/Assistant.tsx
@@ -18,6 +18,7 @@ function useRecordAssistantRecent(): void {
     enabled: Boolean(assistantId),
     retry: false,
     throwOnError: false,
+    refetchOnWindowFocus: false,
   });
   useRecentLabelOverride(pathname, data?.name);
 }

--- a/client/dashboard/src/pages/assistants/Assistant.tsx
+++ b/client/dashboard/src/pages/assistants/Assistant.tsx
@@ -1,5 +1,23 @@
+import { useLocation, useParams } from "react-router";
+import { useAssistantsGet } from "@gram/client/react-query/index.js";
+import { useRecentLabelOverride } from "@/components/command-palette/recentlyVisited";
 import { EditAssistantOnboarding } from "./onboarding/AssistantOnboarding";
 
 export default function AssistantPage(): JSX.Element {
+  useRecordAssistantRecent();
   return <EditAssistantOnboarding />;
+}
+
+// Register the assistant's name as this page's command-palette "Recently
+// Visited" label. Without it, the visit is recorded by App from the URL alone,
+// which for this id-keyed route falls back to an opaque "Assistant · <id>".
+function useRecordAssistantRecent(): void {
+  const { assistantId = "" } = useParams();
+  const { pathname } = useLocation();
+  const { data } = useAssistantsGet({ id: assistantId }, undefined, {
+    enabled: Boolean(assistantId),
+    retry: false,
+    throwOnError: false,
+  });
+  useRecentLabelOverride(pathname, data?.name);
 }


### PR DESCRIPTION
## What

The Cmd+K command palette's **Recently Visited** list showed an assistant's opaque id (e.g. `Assistant · 0190abcd`) instead of the assistant's name.

## Why

Recently-visited entries are recorded centrally in `App.tsx` from the active route, where the label can only be derived from the URL (`pageLabel`). The assistant detail route is keyed by a UUIDv7 (`/assistants/<uuid>`), so the URL-derived label fell back to the short-id form. (The palette's *resource search* group was unaffected — it fetches the assistant list and already uses `assistant.name`.)

## How

- **`recentlyVisited.ts`** — adds a small module-level label-override registry (`setRecentLabelOverride` / `getRecentLabelOverride` + a `useRecentLabelOverride` hook) plus a `RECENTS_LABEL_OVERRIDE_EVENT`.
- **`App.tsx`** — the single recents writer now prefers a registered override over the URL fallback, and re-records when an override arrives asynchronously (the assistant name loads after navigation).
- **`Assistant.tsx`** — the detail page fetches its assistant via `useAssistantsGet` and registers the real `name` as the override for its pathname.

### Why an override registry instead of "the page records its own visit"

React runs child effects before parent effects. If the assistant is already cached, the detail page (child) would write the name first and `App` (parent) would then clobber it with the id fallback. Keeping `App` as the single writer that *consults* a shared override avoids the race entirely. The design generalizes: any future opaque-id detail page can fix the same issue with one `useRecentLabelOverride(pathname, name)` call.

## Testing

- `tsc -b --noEmit --force` → clean
- `oxlint --type-aware` → clean
- `oxfmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cmd+K command palette “Recently Visited” list to show assistant names instead of opaque IDs. Keeps `App` as the single writer, upgrades entries when the name loads, and disables window-focus refetching for the label-only query.

- **Bug Fixes**
  - Added a label-override registry and `RECENTS_LABEL_OVERRIDE_EVENT` for opaque-id detail pages; made `setRecentLabelOverride` module-private.
  - `App.tsx` prefers the override for the current pathname and re-records when it arrives.
  - Assistant detail page fetches the assistant and registers its name for the current pathname.
  - Disabled `refetchOnWindowFocus` for the recents-label assistant query to avoid churn.

<sup>Written for commit 9d97a320f5fa5d90fd018646284471a220a16b4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

