### PR TITLE
chore: Mechanical (*oops.ShareableError).Log() rename to LogError()

### DIFF
--- a/.agents/skills/golang/SKILL.md
+++ b/.agents/skills/golang/SKILL.md
@@ -420,7 +420,7 @@ func (s *Service) ListDeployments(ctx context.Context, form *gen.ListDeployments
 	if form.Cursor != nil {
 		c, err := uuid.Parse(*form.Cursor)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 		}
 
 		cursor = uuid.NullUUID{UUID: c, Valid: true}
@@ -529,7 +529,7 @@ Use `NoLogDefer` when a cleanup operation's error can be **silently discarded** 
 ```go
 dbtx, err := s.repo.DB().Begin(ctx)
 if err != nil {
-    return nil, oops.E(oops.CodeUnexpected, err, "error accessing resource").Log(ctx, logger)
+    return nil, oops.E(oops.CodeUnexpected, err, "error accessing resource").LogError(ctx, logger)
 }
 defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 ```

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -40,7 +40,7 @@ return fmt.Errorf("save user: %w", err)
 - In HTTP handlers, use the `oops` package for user-facing error mapping:
 
 ```go
-return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 ```
 
 ### Logging

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -242,7 +242,7 @@ linters:
         - end
         - set-status
       ignore-check-signatures:
-        - '\(\*github\.com/speakeasy-api/gram/server/internal/oops\.ShareableError\)\.Log\('
+        - '\(\*github\.com/speakeasy-api/gram/server/internal/oops\.ShareableError\)\.LogError\('
     gocritic:
       disabled-checks:
         - ifElseChain

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -227,7 +227,7 @@ func (s *Service) DeleteRole(ctx context.Context, payload *gen.DeleteRolePayload
 func (s *Service) ListScopes(ctx context.Context, _ *gen.ListScopesPayload) (*gen.ListScopesResult, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgRead, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return nil, err
@@ -315,16 +315,16 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 	principals, err := authz.ResolveUserPrincipals(ctx, s.db, ac.ActiveOrganizationID, ac.UserID)
 	switch {
 	case errors.Is(err, authz.ErrPrincipalInvalid):
-		return nil, oops.E(oops.CodeUnauthorized, err, "invalid user principal").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "invalid user principal").LogError(ctx, logger)
 	case errors.Is(err, authz.ErrPrincipalNotFound):
-		return nil, oops.E(oops.CodeNotFound, nil, "current user has not joined this organization").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, nil, "current user has not joined this organization").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "resolve user principals").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve user principals").LogError(ctx, logger)
 	}
 
 	grants, err := authz.LoadGrants(ctx, s.db, ac.ActiveOrganizationID, principals)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "load effective user grants").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load effective user grants").LogError(ctx, logger)
 	}
 
 	return &gen.ListUserGrantsResult{Grants: listRoleGrantsFromGrants(grants)}, nil
@@ -342,7 +342,7 @@ func (s *Service) UpdateMemberRoles(ctx context.Context, payload *gen.UpdateMemb
 		return nil, err
 	}
 	if len(payload.RoleIds) == 0 {
-		return nil, oops.E(oops.CodeBadRequest, nil, "at least one role is required").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "at least one role is required").LogError(ctx, s.logger)
 	}
 	trace.SpanFromContext(ctx).SetAttributes(
 		attr.OrganizationID(ac.ActiveOrganizationID),
@@ -377,15 +377,15 @@ func (s *Service) authContext(ctx context.Context) (*contextvalues.AuthContext, 
 func (s *Service) roleOrgContext(ctx context.Context) (*contextvalues.AuthContext, string, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, "", oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, "", oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, "", oops.E(oops.CodeUnexpected, err, "get organization metadata").Log(ctx, s.logger)
+		return nil, "", oops.E(oops.CodeUnexpected, err, "get organization metadata").LogError(ctx, s.logger)
 	}
 	if !org.WorkosID.Valid || org.WorkosID.String == "" {
-		return nil, "", oops.E(oops.CodeBadRequest, nil, "organization is not linked to WorkOS").Log(ctx, s.logger)
+		return nil, "", oops.E(oops.CodeBadRequest, nil, "organization is not linked to WorkOS").LogError(ctx, s.logger)
 	}
 	trace.SpanFromContext(ctx).SetAttributes(
 		attr.OrganizationID(ac.ActiveOrganizationID),
@@ -545,7 +545,7 @@ func (s *Service) GetRBACStatus(ctx context.Context, _ *gen.GetRBACStatusPayload
 		FeatureName:    string(productfeatures.FeatureRBAC),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "check RBAC feature flag").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "check RBAC feature flag").LogError(ctx, s.logger)
 	}
 
 	return &gen.RBACStatus{RbacEnabled: enabled}, nil
@@ -559,7 +559,7 @@ func (s *Service) EnableRBAC(ctx context.Context, _ *gen.EnableRBACPayload) erro
 	logger := s.logger.With(attr.SlogOrganizationID(ac.ActiveOrganizationID))
 
 	if err := authz.SeedSystemRoleGrants(ctx, s.db, ac.ActiveOrganizationID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "seed system role grants").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "seed system role grants").LogError(ctx, logger)
 	}
 
 	if _, err := pfRepo.New(s.db).EnableFeature(ctx, pfRepo.EnableFeatureParams{
@@ -572,7 +572,7 @@ func (s *Service) EnableRBAC(ctx context.Context, _ *gen.EnableRBACPayload) erro
 			s.featureCache.UpdateFeatureCache(ctx, ac.ActiveOrganizationID, productfeatures.FeatureRBAC, true)
 			return nil
 		}
-		return oops.E(oops.CodeUnexpected, err, "enable RBAC feature flag").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "enable RBAC feature flag").LogError(ctx, logger)
 	}
 
 	s.featureCache.UpdateFeatureCache(ctx, ac.ActiveOrganizationID, productfeatures.FeatureRBAC, true)
@@ -594,7 +594,7 @@ func (s *Service) DisableRBAC(ctx context.Context, _ *gen.DisableRBACPayload) er
 			// Already disabled — no active feature row to soft-delete.
 			return nil
 		}
-		return oops.E(oops.CodeUnexpected, err, "disable RBAC feature flag").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "disable RBAC feature flag").LogError(ctx, logger)
 	}
 
 	s.featureCache.UpdateFeatureCache(ctx, ac.ActiveOrganizationID, productfeatures.FeatureRBAC, false)
@@ -610,7 +610,7 @@ func (s *Service) DisableRBAC(ctx context.Context, _ *gen.DisableRBACPayload) er
 func (s *Service) requireSuperAdmin(ctx context.Context) (*contextvalues.AuthContext, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 	email := ""
 	if ac.Email != nil {
@@ -621,7 +621,7 @@ func (s *Service) requireSuperAdmin(ctx context.Context) (*contextvalues.AuthCon
 	}
 	user, err := usersrepo.New(s.db).GetUser(ctx, ac.UserID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "get user for admin check").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get user for admin check").LogError(ctx, s.logger)
 	}
 	if !user.Admin {
 		return nil, oops.C(oops.CodeForbidden)
@@ -678,7 +678,7 @@ func (s *Service) ListChallenges(ctx context.Context, payload *gen.ListChallenge
 	if len(payload.Ids) > 0 {
 		challenges, err := chQueries.ListChallengesByIDs(ctx, authCtx.ActiveOrganizationID, payload.Ids)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "list challenges by ids from clickhouse").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "list challenges by ids from clickhouse").LogError(ctx, s.logger)
 		}
 		return s.buildChallengeResult(ctx, authCtx, challenges, len(challenges))
 	}
@@ -702,7 +702,7 @@ func (s *Service) ListChallenges(ctx context.Context, payload *gen.ListChallenge
 	if !skipPagination {
 		count, err := chQueries.CountChallenges(ctx, filters)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "count challenges from clickhouse").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "count challenges from clickhouse").LogError(ctx, s.logger)
 		}
 		if count == 0 {
 			return &gen.ListChallengesResult{Challenges: []*gen.AuthzChallenge{}, Total: 0}, nil
@@ -712,7 +712,7 @@ func (s *Service) ListChallenges(ctx context.Context, payload *gen.ListChallenge
 
 	challenges, err := chQueries.ListChallenges(ctx, filters)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list challenges from clickhouse").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list challenges from clickhouse").LogError(ctx, s.logger)
 	}
 
 	if len(challenges) == 0 {
@@ -760,7 +760,7 @@ func (s *Service) lookupResolutions(ctx context.Context, orgID string, challenge
 		ChallengeIds:   ids,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list challenge resolutions").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list challenge resolutions").LogError(ctx, s.logger)
 	}
 	m := make(map[string]repo.AuthzChallengeResolution, len(resolutions))
 	for _, r := range resolutions {
@@ -907,7 +907,7 @@ func (s *Service) ListChallengeBuckets(ctx context.Context, payload *gen.ListCha
 	if !skipPagination {
 		count, err := chQueries.CountChallengeBuckets(ctx, filters)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "count challenge buckets from clickhouse").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "count challenge buckets from clickhouse").LogError(ctx, s.logger)
 		}
 		if count == 0 {
 			return &gen.ListChallengeBucketsResult{Buckets: []*gen.ChallengeBucket{}, Total: 0}, nil
@@ -917,7 +917,7 @@ func (s *Service) ListChallengeBuckets(ctx context.Context, payload *gen.ListCha
 
 	buckets, err := chQueries.ListChallengeBuckets(ctx, filters)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list challenge buckets from clickhouse").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list challenge buckets from clickhouse").LogError(ctx, s.logger)
 	}
 
 	if len(buckets) == 0 {
@@ -935,7 +935,7 @@ func (s *Service) ListChallengeBuckets(ctx context.Context, payload *gen.ListCha
 		ChallengeIds:   allChallengeIDs,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list challenge resolutions").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list challenge resolutions").LogError(ctx, s.logger)
 	}
 	resolutionMap := make(map[string]repo.AuthzChallengeResolution, len(resolutions))
 	for _, r := range resolutions {
@@ -1079,15 +1079,15 @@ func (s *Service) ResolveChallenge(ctx context.Context, payload *gen.ResolveChal
 	)
 
 	if len(payload.ChallengeIds) == 0 {
-		return nil, oops.E(oops.CodeBadRequest, nil, "challenge_ids must not be empty").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "challenge_ids must not be empty").LogError(ctx, s.logger)
 	}
 
 	// Validate: role_assigned requires role_slug.
 	if payload.ResolutionType == "role_assigned" && (payload.RoleSlug == nil || *payload.RoleSlug == "") {
-		return nil, oops.E(oops.CodeBadRequest, nil, "role_slug is required when resolution_type is role_assigned").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "role_slug is required when resolution_type is role_assigned").LogError(ctx, s.logger)
 	}
 	if payload.ResolutionType == "dismissed" && payload.RoleSlug != nil && *payload.RoleSlug != "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "role_slug must be empty when resolution_type is dismissed").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "role_slug must be empty when resolution_type is dismissed").LogError(ctx, s.logger)
 	}
 
 	resolvedBy := fmt.Sprintf("user:%s", authCtx.UserID)
@@ -1103,7 +1103,7 @@ func (s *Service) ResolveChallenge(ctx context.Context, payload *gen.ResolveChal
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -1119,7 +1119,7 @@ func (s *Service) ResolveChallenge(ctx context.Context, payload *gen.ResolveChal
 		ResolvedBy:     resolvedBy,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "insert challenge resolutions").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "insert challenge resolutions").LogError(ctx, s.logger)
 	}
 
 	resolutions := make([]*gen.ChallengeResolution, 0, len(rows))
@@ -1148,12 +1148,12 @@ func (s *Service) ResolveChallenge(ctx context.Context, payload *gen.ResolveChal
 			ResolutionType:   row.ResolutionType,
 			RoleSlug:         payload.RoleSlug,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "log access challenge resolve").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "log access challenge resolve").LogError(ctx, s.logger)
 		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
 	return &gen.ResolveChallengesResult{Resolutions: resolutions}, nil

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -67,7 +67,7 @@ func NewRoleManager(logger *slog.Logger, db *pgxpool.Pool, roles RoleProvider, a
 func (r *RoleManager) ListRoles(ctx context.Context, gramOrgID string) (*gen.ListRolesResult, error) {
 	rows, err := repo.New(r.db).ListActiveOrganizationRoles(ctx, gramOrgID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list roles").Log(ctx, r.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list roles").LogError(ctx, r.logger)
 	}
 
 	roles := make([]*gen.Role, 0, len(rows))
@@ -105,7 +105,7 @@ func (r *RoleManager) GetRoleByID(ctx context.Context, gramOrgID, id string) (*g
 func (r *RoleManager) ListMembers(ctx context.Context, gramOrgID string) (*gen.ListMembersResult, error) {
 	rows, err := repo.New(r.db).ListAccessMembers(ctx, gramOrgID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list members").Log(ctx, r.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list members").LogError(ctx, r.logger)
 	}
 
 	memberMap := make(map[string]*gen.AccessMember, len(rows))
@@ -157,7 +157,7 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").Log(ctx, r.logger)
+		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -174,12 +174,12 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 	var pgErr *pgconn.PgError
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return roleCreateResult{}, oops.E(oops.CodeConflict, err, "role %q already exists", payload.Name).Log(ctx, r.logger)
+		return roleCreateResult{}, oops.E(oops.CodeConflict, err, "role %q already exists", payload.Name).LogError(ctx, r.logger)
 	case errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation:
-		return roleCreateResult{}, oops.E(oops.CodeConflict, err, "role %q already exists", payload.Name).Log(ctx, r.logger)
+		return roleCreateResult{}, oops.E(oops.CodeConflict, err, "role %q already exists", payload.Name).LogError(ctx, r.logger)
 	case err != nil:
 		trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "create local role record").Log(ctx, r.logger)
+		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "create local role record").LogError(ctx, r.logger)
 	}
 
 	createdRole := localRole{
@@ -195,7 +195,7 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleID(createdRole.ID))
 
 	if _, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, roleSlug, createdRole.PrincipalURN, roleGrantPayloads(payload.Grants), nil); err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "add grants for created role").Log(ctx, r.logger)
+		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "add grants for created role").LogError(ctx, r.logger)
 	}
 
 	workosSyncs := []workosSync{func(ctx context.Context) {
@@ -237,11 +237,11 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 		RoleName:         createdRole.Name,
 		RoleSlug:         createdRole.Slug,
 	}); err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "log access role creation").Log(ctx, r.logger)
+		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "log access role creation").LogError(ctx, r.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").Log(ctx, r.logger)
+		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").LogError(ctx, r.logger)
 	}
 
 	r.runWorkOSSyncs(ctx, workosSyncs)
@@ -284,10 +284,10 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 
 	sysRole := isSystemRole(currentRole.Slug)
 	if sysRole && (payload.Name != nil || payload.Description != nil || payload.AddGrants != nil || payload.RemoveGrants != nil) {
-		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "system role properties cannot be updated, only member assignment is allowed").Log(ctx, r.logger)
+		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "system role properties cannot be updated, only member assignment is allowed").LogError(ctx, r.logger)
 	}
 	if sysRole && payload.MemberIds == nil {
-		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "system role update requires member_ids").Log(ctx, r.logger)
+		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "system role update requires member_ids").LogError(ctx, r.logger)
 	}
 	if payload.Name != nil {
 		if _, err := slugify(*payload.Name); err != nil {
@@ -297,7 +297,7 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
-		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").Log(ctx, r.logger)
+		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -324,7 +324,7 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 		})
 		if err != nil {
 			trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-			return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "upsert local role record").Log(ctx, r.logger)
+			return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "upsert local role record").LogError(ctx, r.logger)
 		}
 		updatedRole = localRole{
 			ID:           updatedRow.ID.String(),
@@ -340,7 +340,7 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 		if payload.AddGrants != nil || payload.RemoveGrants != nil {
 			syncedGrants, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, currentRole.Slug, currentRole.PrincipalURN, roleGrantPayloads(payload.AddGrants), roleGrantPayloads(payload.RemoveGrants))
 			if err != nil {
-				return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "patch grants for updated role").Log(ctx, r.logger)
+				return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "patch grants for updated role").LogError(ctx, r.logger)
 			}
 			updatedGrants = make([]*gen.RoleGrant, 0, len(syncedGrants))
 			for _, grant := range syncedGrants {
@@ -400,11 +400,11 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 		RoleSnapshotBefore: existingRole,
 		RoleSnapshotAfter:  updatedRoleView,
 	}); err != nil {
-		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "log access role update").Log(ctx, r.logger)
+		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "log access role update").LogError(ctx, r.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").Log(ctx, r.logger)
+		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").LogError(ctx, r.logger)
 	}
 
 	r.runWorkOSSyncs(ctx, workosSyncs)
@@ -419,12 +419,12 @@ func (r *RoleManager) DeleteRole(ctx context.Context, gramOrgID, workosOrgID, ro
 		return localRole{}, err
 	}
 	if isSystemRole(currentRole.Slug) {
-		return localRole{}, oops.E(oops.CodeBadRequest, nil, "system roles cannot be deleted").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeBadRequest, nil, "system roles cannot be deleted").LogError(ctx, r.logger)
 	}
 
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
-		return localRole{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -433,7 +433,7 @@ func (r *RoleManager) DeleteRole(ctx context.Context, gramOrgID, workosOrgID, ro
 		WorkosRoleSlug: currentRole.Slug,
 	})
 	if err != nil {
-		return localRole{}, oops.E(oops.CodeUnexpected, err, "list members").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeUnexpected, err, "list members").LogError(ctx, r.logger)
 	}
 	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSource("db"))
 
@@ -448,7 +448,7 @@ func (r *RoleManager) DeleteRole(ctx context.Context, gramOrgID, workosOrgID, ro
 				WorkosRoleSlug: currentRole.Slug,
 			}); err != nil {
 				trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-				return localRole{}, oops.E(oops.CodeUnexpected, err, "soft-delete role assignment for deleted role").Log(ctx, r.logger)
+				return localRole{}, oops.E(oops.CodeUnexpected, err, "soft-delete role assignment for deleted role").LogError(ctx, r.logger)
 			}
 
 			// Collect remaining role slugs for WorkOS sync.
@@ -457,7 +457,7 @@ func (r *RoleManager) DeleteRole(ctx context.Context, gramOrgID, workosOrgID, ro
 				WorkosUserID:   row.WorkosUserID,
 			})
 			if err != nil {
-				return localRole{}, oops.E(oops.CodeUnexpected, err, "list remaining role assignments").Log(ctx, r.logger)
+				return localRole{}, oops.E(oops.CodeUnexpected, err, "list remaining role assignments").LogError(ctx, r.logger)
 			}
 			remainingSlugs := make([]string, 0, len(remaining))
 			for _, r := range remaining {
@@ -477,7 +477,7 @@ func (r *RoleManager) DeleteRole(ctx context.Context, gramOrgID, workosOrgID, ro
 					WorkosLastEventID:  conv.ToPGTextEmpty(""),
 				}); err != nil {
 					trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-					return localRole{}, oops.E(oops.CodeUnexpected, err, "assign default member role").Log(ctx, r.logger)
+					return localRole{}, oops.E(oops.CodeUnexpected, err, "assign default member role").LogError(ctx, r.logger)
 				}
 			}
 
@@ -499,14 +499,14 @@ func (r *RoleManager) DeleteRole(ctx context.Context, gramOrgID, workosOrgID, ro
 	})
 	if err != nil {
 		trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-		return localRole{}, oops.E(oops.CodeUnexpected, err, "mark local role record deleted").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeUnexpected, err, "mark local role record deleted").LogError(ctx, r.logger)
 	}
 	if deletedCount == 0 {
-		return localRole{}, oops.E(oops.CodeNotFound, nil, "role not found").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeNotFound, nil, "role not found").LogError(ctx, r.logger)
 	}
 
 	if err := authz.DeleteRoleGrants(ctx, repo.New(tx), gramOrgID, currentRole.Slug, currentRole.PrincipalURN); err != nil {
-		return localRole{}, oops.E(oops.CodeUnexpected, err, "delete grants for deleted role").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeUnexpected, err, "delete grants for deleted role").LogError(ctx, r.logger)
 	}
 
 	if err := r.audit.LogAccessRoleDelete(ctx, tx, audit.LogAccessRoleDeleteEvent{
@@ -518,11 +518,11 @@ func (r *RoleManager) DeleteRole(ctx context.Context, gramOrgID, workosOrgID, ro
 		RoleName:         currentRole.Name,
 		RoleSlug:         currentRole.Slug,
 	}); err != nil {
-		return localRole{}, oops.E(oops.CodeUnexpected, err, "log access role deletion").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeUnexpected, err, "log access role deletion").LogError(ctx, r.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return localRole{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").LogError(ctx, r.logger)
 	}
 
 	workosSyncs = append(workosSyncs, func(ctx context.Context) {
@@ -552,7 +552,7 @@ type memberRoleUpdateContext struct {
 func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID string, roleIDs []string, actor accessAuditActor) (memberRoleUpdateContext, error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
-		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -569,12 +569,12 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 	connectedUser, err := connectedUser(ctx, tx, gramOrgID, userID)
 	switch {
 	case errors.Is(err, errConnectedUserNotFound):
-		return memberRoleUpdateContext{}, oops.E(oops.CodeNotFound, nil, "member has not joined this organization").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeNotFound, nil, "member has not joined this organization").LogError(ctx, r.logger)
 	case err != nil:
-		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "load connected user").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "load connected user").LogError(ctx, r.logger)
 	}
 	if !connectedUser.WorkosID.Valid || connectedUser.WorkosID.String == "" {
-		return memberRoleUpdateContext{}, oops.E(oops.CodeBadRequest, nil, "member is not linked to WorkOS").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeBadRequest, nil, "member is not linked to WorkOS").LogError(ctx, r.logger)
 	}
 
 	existing, err := repo.New(tx).GetOrganizationRoleAssignmentByWorkosUser(ctx, repo.GetOrganizationRoleAssignmentByWorkosUserParams{
@@ -583,15 +583,15 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return memberRoleUpdateContext{}, oops.E(oops.CodeNotFound, nil, "member not found").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeNotFound, nil, "member not found").LogError(ctx, r.logger)
 	case err != nil:
-		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "load member role assignment").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "load member role assignment").LogError(ctx, r.logger)
 	}
 	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSource("db"))
 
 	membershipID := conv.FromPGTextOrEmpty[string](existing.WorkosMembershipID)
 	if membershipID == "" {
-		return memberRoleUpdateContext{}, oops.E(oops.CodeNotFound, nil, "member is missing local WorkOS membership linkage").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeNotFound, nil, "member is missing local WorkOS membership linkage").LogError(ctx, r.logger)
 	}
 
 	// Snapshot existing role IDs before any mutations.
@@ -600,7 +600,7 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 		WorkosUserID:   connectedUser.WorkosID.String,
 	})
 	if err != nil {
-		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "list existing role assignments").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "list existing role assignments").LogError(ctx, r.logger)
 	}
 
 	// Snapshot existing role slugs to detect admin removal.
@@ -609,7 +609,7 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 		WorkosUserID:   connectedUser.WorkosID.String,
 	})
 	if err != nil {
-		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "list existing role slugs").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "list existing role slugs").LogError(ctx, r.logger)
 	}
 	hadAdmin := slices.ContainsFunc(existingRolePrincipals, func(rp repo.ListMemberRolePrincipalsByWorkosUserRow) bool {
 		return rp.RoleSlug == authz.SystemRoleAdmin
@@ -621,7 +621,7 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 		WorkosUserID:   connectedUser.WorkosID.String,
 	}); err != nil {
 		trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "soft-delete existing role assignments").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "soft-delete existing role assignments").LogError(ctx, r.logger)
 	}
 
 	afterRoleIDs := make([]string, 0, len(roles))
@@ -638,11 +638,11 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 		})
 		if err != nil {
 			trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-			return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "insert role assignment").Log(ctx, r.logger)
+			return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "insert role assignment").LogError(ctx, r.logger)
 		}
 		if inserted == 0 {
 			trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-			return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, nil, "insert role assignment").Log(ctx, r.logger)
+			return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, nil, "insert role assignment").LogError(ctx, r.logger)
 		}
 		afterRoleIDs = append(afterRoleIDs, role.ID)
 		roleSlugs = append(roleSlugs, role.Slug)
@@ -656,10 +656,10 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 			WorkosRoleSlug: authz.SystemRoleAdmin,
 		})
 		if err != nil {
-			return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "count remaining admins").Log(ctx, r.logger)
+			return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "count remaining admins").LogError(ctx, r.logger)
 		}
 		if len(remainingAdmins) == 0 {
-			return memberRoleUpdateContext{}, oops.E(oops.CodeBadRequest, nil, "cannot remove admin role: this is the last admin in the organization").Log(ctx, r.logger)
+			return memberRoleUpdateContext{}, oops.E(oops.CodeBadRequest, nil, "cannot remove admin role: this is the last admin in the organization").LogError(ctx, r.logger)
 		}
 	}
 
@@ -698,11 +698,11 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 		MemberSnapshotBefore: result.Before,
 		MemberSnapshotAfter:  result.After,
 	}); err != nil {
-		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "log access member role update").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "log access member role update").LogError(ctx, r.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").Log(ctx, r.logger)
+		return memberRoleUpdateContext{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").LogError(ctx, r.logger)
 	}
 
 	r.runWorkOSSyncs(ctx, []workosSync{
@@ -731,7 +731,7 @@ func (r *RoleManager) MemberRolePrincipals(ctx context.Context, gramOrgID, worko
 		WorkosUserID:   workosUserID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list member roles").Log(ctx, r.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list member roles").LogError(ctx, r.logger)
 	}
 
 	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSource("db"))
@@ -746,7 +746,7 @@ func (r *RoleManager) getLocalRoleByID(ctx context.Context, gramOrgID, id string
 func (r *RoleManager) getLocalRoleByIDTx(ctx context.Context, dbtx repo.DBTX, gramOrgID, id string) (localRole, error) {
 	roleID, err := uuid.Parse(id)
 	if err != nil {
-		return localRole{}, oops.E(oops.CodeBadRequest, err, "invalid role ID").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeBadRequest, err, "invalid role ID").LogError(ctx, r.logger)
 	}
 
 	row, err := repo.New(dbtx).GetOrganizationRoleByID(ctx, repo.GetOrganizationRoleByIDParams{
@@ -755,9 +755,9 @@ func (r *RoleManager) getLocalRoleByIDTx(ctx context.Context, dbtx repo.DBTX, gr
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return localRole{}, oops.E(oops.CodeNotFound, ErrRoleNotFound, "role not found").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeNotFound, ErrRoleNotFound, "role not found").LogError(ctx, r.logger)
 	case err != nil:
-		return localRole{}, oops.E(oops.CodeUnexpected, err, "get role").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeUnexpected, err, "get role").LogError(ctx, r.logger)
 	}
 
 	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSource("db"))
@@ -780,9 +780,9 @@ func (r *RoleManager) getLocalRoleBySlugTx(ctx context.Context, dbtx repo.DBTX, 
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return localRole{}, oops.E(oops.CodeNotFound, ErrRoleNotFound, "role not found").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeNotFound, ErrRoleNotFound, "role not found").LogError(ctx, r.logger)
 	case err != nil:
-		return localRole{}, oops.E(oops.CodeUnexpected, err, "get role").Log(ctx, r.logger)
+		return localRole{}, oops.E(oops.CodeUnexpected, err, "get role").LogError(ctx, r.logger)
 	}
 
 	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSource("db"))
@@ -817,7 +817,7 @@ func (r *RoleManager) memberAssignmentTargetsTx(ctx context.Context, dbtx repo.D
 
 	users, err := usersrepo.New(dbtx).GetUsersByIDs(ctx, memberIDs)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "resolve users by ids").Log(ctx, r.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve users by ids").LogError(ctx, r.logger)
 	}
 	usersByID := make(map[string]usersrepo.User, len(users))
 	for _, user := range users {
@@ -838,7 +838,7 @@ func (r *RoleManager) memberAssignmentTargetsTx(ctx context.Context, dbtx repo.D
 		if user, ok := usersByID[id]; ok {
 			userID = user.ID
 			if !user.WorkosID.Valid || user.WorkosID.String == "" {
-				return nil, oops.E(oops.CodeBadRequest, nil, "member %s is not linked to WorkOS", id).Log(ctx, r.logger)
+				return nil, oops.E(oops.CodeBadRequest, nil, "member %s is not linked to WorkOS", id).LogError(ctx, r.logger)
 			}
 			workosID = user.WorkosID.String
 		}
@@ -866,7 +866,7 @@ func (r *RoleManager) memberAssignmentTargetsTx(ctx context.Context, dbtx repo.D
 		WorkosUserIds:  workosIDs,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list members").Log(ctx, r.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list members").LogError(ctx, r.logger)
 	}
 	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSource("db"))
 	targets := make([]memberAssignmentTarget, 0, len(memberIDs))
@@ -895,7 +895,7 @@ func (r *RoleManager) memberAssignmentTargetsTx(ctx context.Context, dbtx repo.D
 		})
 	}
 	if len(resolvedInputs) != len(requestedInputs) {
-		return nil, oops.E(oops.CodeBadRequest, nil, "member is missing local WorkOS membership linkage").Log(ctx, r.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "member is missing local WorkOS membership linkage").LogError(ctx, r.logger)
 	}
 
 	return targets, nil
@@ -922,11 +922,11 @@ func (r *RoleManager) assignMembersToRoleTx(ctx context.Context, dbtx repo.DBTX,
 			})
 			if err != nil {
 				trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-				return 0, nil, oops.E(oops.CodeUnexpected, err, "upsert local role assignment record").Log(ctx, r.logger)
+				return 0, nil, oops.E(oops.CodeUnexpected, err, "upsert local role assignment record").LogError(ctx, r.logger)
 			}
 			if inserted == 0 {
 				trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-				return 0, nil, oops.E(oops.CodeUnexpected, nil, "upsert local role assignment record").Log(ctx, r.logger)
+				return 0, nil, oops.E(oops.CodeUnexpected, nil, "upsert local role assignment record").LogError(ctx, r.logger)
 			}
 
 			// Collect all current role slugs for WorkOS sync.
@@ -935,7 +935,7 @@ func (r *RoleManager) assignMembersToRoleTx(ctx context.Context, dbtx repo.DBTX,
 				WorkosUserID:   target.WorkosUserID,
 			})
 			if err != nil {
-				return 0, nil, oops.E(oops.CodeUnexpected, err, "list member roles for workos sync").Log(ctx, r.logger)
+				return 0, nil, oops.E(oops.CodeUnexpected, err, "list member roles for workos sync").LogError(ctx, r.logger)
 			}
 			allSlugs := make([]string, 0, len(allRoles))
 			for _, r := range allRoles {
@@ -1015,7 +1015,7 @@ func (r *RoleManager) roleViewFromLocalRole(ctx context.Context, organizationID 
 	// legacy role slugs until old principal_grants rows are backfilled.
 	grants, err := authz.GrantsForRole(ctx, r.logger, r.db, organizationID, role.Slug, role.PrincipalURN)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "load role grants").Log(ctx, r.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load role grants").LogError(ctx, r.logger)
 	}
 	genGrants := make([]*gen.RoleGrant, 0, len(grants))
 	for _, g := range grants {

--- a/server/internal/access/shadow_mcp.go
+++ b/server/internal/access/shadow_mcp.go
@@ -55,7 +55,7 @@ func (s *Service) ListShadowMCPApprovalRequests(ctx context.Context, payload *ge
 	}
 	cursor, err := decodeShadowMCPCursorParam(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	result, err := s.accessStore.ListRequests(ctx, accesscontrol.RequestFilters{
@@ -67,7 +67,7 @@ func (s *Service) ListShadowMCPApprovalRequests(ctx context.Context, payload *ge
 		Limit:          limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list shadow mcp approval requests").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list shadow mcp approval requests").LogError(ctx, s.logger)
 	}
 
 	var nextCursor *string
@@ -90,17 +90,17 @@ func (s *Service) ListShadowMCPApprovalRequests(ctx context.Context, payload *ge
 func (s *Service) CreateShadowMCPApprovalRequest(ctx context.Context, payload *gen.CreateShadowMCPApprovalRequestPayload) (*gen.ShadowMCPApprovalRequest, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 	if ac.UserID == "" {
-		return nil, oops.E(oops.CodeUnauthorized, nil, "missing requester user").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, nil, "missing requester user").LogError(ctx, s.logger)
 	}
 	claims, err := parseShadowMCPApprovalRequestToken(s.jwtSecret, payload.RequestToken)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid shadow mcp approval request token").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid shadow mcp approval request token").LogError(ctx, s.logger)
 	}
 	if claims.OrganizationID != ac.ActiveOrganizationID {
-		return nil, oops.E(oops.CodeForbidden, nil, "shadow mcp approval request token is for a different organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeForbidden, nil, "shadow mcp approval request token is for a different organization").LogError(ctx, s.logger)
 	}
 	// Intentionally not gated on claims.RequesterUserID. The token's requester
 	// is minted from an agent-reported identity (e.g. the email Claude Code
@@ -113,17 +113,17 @@ func (s *Service) CreateShadowMCPApprovalRequest(ctx context.Context, payload *g
 	// the org-match check above and requireProjectInOrganization below.
 	projectID, err := uuid.Parse(claims.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 	}
 	if err := s.requireProjectInOrganization(ctx, ac.ActiveOrganizationID, projectID); err != nil {
 		return nil, err
 	}
 
 	if _, err := conv.PtrToNullUUID(claims.RiskPolicyID); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid risk policy id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid risk policy id").LogError(ctx, s.logger)
 	}
 	if _, err := conv.PtrToNullUUID(claims.RiskResultID); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid risk result id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid risk result id").LogError(ctx, s.logger)
 	}
 
 	summary := shadowMCPSummaryFromClaims(claims)
@@ -152,13 +152,13 @@ func (s *Service) CreateShadowMCPApprovalRequest(ctx context.Context, payload *g
 		UpdatedAt:            now,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "upsert shadow mcp approval request").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "upsert shadow mcp approval request").LogError(ctx, s.logger)
 	}
 	requestView := buildShadowMCPApprovalRequest(request)
 	if wasCreated {
 		requestUUID, err := uuid.Parse(request.ID)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp approval request id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp approval request id").LogError(ctx, s.logger)
 		}
 		s.logShadowMCPAuditBestEffort(ctx, "log shadow mcp approval request create", func(dbtx pgx.Tx) error {
 			return s.audit.LogShadowMCPApprovalRequestCreate(ctx, dbtx, audit.LogShadowMCPApprovalRequestEvent{
@@ -186,7 +186,7 @@ func (s *Service) ApproveShadowMCPApprovalRequest(ctx context.Context, payload *
 	}
 	requestID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid request id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid request id").LogError(ctx, s.logger)
 	}
 	matchValue, err := normalizeShadowMCPMatchValue(payload.MatchBreadth, payload.MatchValue)
 	if err != nil {
@@ -198,11 +198,11 @@ func (s *Service) ApproveShadowMCPApprovalRequest(ctx context.Context, payload *
 		return nil, shadowMCPStoreErr(ctx, s, err, "get shadow mcp approval request")
 	}
 	if request.Status != shadowMCPRequestStatusRequested {
-		return nil, oops.E(oops.CodeConflict, nil, "shadow mcp approval request has already been decided").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeConflict, nil, "shadow mcp approval request has already been decided").LogError(ctx, s.logger)
 	}
 	requestProjectID, err := uuid.Parse(request.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp approval request project id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp approval request project id").LogError(ctx, s.logger)
 	}
 	ruleProjectIDs, err := s.shadowMCPRuleProjectIDs(ctx, ac.ActiveOrganizationID, payload.AccessScope, payload.ProjectIds, nil, requestProjectID)
 	if err != nil {
@@ -250,7 +250,7 @@ func (s *Service) ApproveShadowMCPApprovalRequest(ctx context.Context, payload *
 		if ruleResult.Created {
 			ruleUUID, err := uuid.Parse(ruleResult.Rule.ID)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp access rule id").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp access rule id").LogError(ctx, s.logger)
 			}
 			ruleAuditEvents = append(ruleAuditEvents, audit.LogShadowMCPAccessRuleEvent{
 				OrganizationID:           ac.ActiveOrganizationID,
@@ -303,11 +303,11 @@ func (s *Service) DenyShadowMCPApprovalRequest(ctx context.Context, payload *gen
 	}
 	requestID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid request id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid request id").LogError(ctx, s.logger)
 	}
 	if payload.CreateDenyRule {
 		if payload.MatchBreadth == nil || payload.MatchValue == nil || payload.DisplayName == nil {
-			return nil, oops.E(oops.CodeBadRequest, nil, "match_breadth, match_value, and display_name are required when creating a deny rule").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "match_breadth, match_value, and display_name are required when creating a deny rule").LogError(ctx, s.logger)
 		}
 		if _, err := normalizeShadowMCPMatchValue(*payload.MatchBreadth, *payload.MatchValue); err != nil {
 			return nil, err
@@ -319,11 +319,11 @@ func (s *Service) DenyShadowMCPApprovalRequest(ctx context.Context, payload *gen
 		return nil, shadowMCPStoreErr(ctx, s, err, "get shadow mcp approval request")
 	}
 	if request.Status != shadowMCPRequestStatusRequested {
-		return nil, oops.E(oops.CodeConflict, nil, "shadow mcp approval request has already been decided").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeConflict, nil, "shadow mcp approval request has already been decided").LogError(ctx, s.logger)
 	}
 	requestProjectID, err := uuid.Parse(request.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp approval request project id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp approval request project id").LogError(ctx, s.logger)
 	}
 
 	ruleAuditEvents := make([]audit.LogShadowMCPAccessRuleEvent, 0)
@@ -386,7 +386,7 @@ func (s *Service) DenyShadowMCPApprovalRequest(ctx context.Context, payload *gen
 		if ruleResult.Created {
 			ruleUUID, err := uuid.Parse(ruleResult.Rule.ID)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp access rule id").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp access rule id").LogError(ctx, s.logger)
 			}
 			ruleAuditEvents = append(ruleAuditEvents, audit.LogShadowMCPAccessRuleEvent{
 				OrganizationID:           ac.ActiveOrganizationID,
@@ -447,7 +447,7 @@ func (s *Service) ListShadowMCPAccessRules(ctx context.Context, payload *gen.Lis
 	}
 	cursor, err := decodeShadowMCPCursorParam(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 	result, err := s.accessStore.ListRules(ctx, accesscontrol.RuleFilters{
 		OrganizationID: ac.ActiveOrganizationID,
@@ -459,7 +459,7 @@ func (s *Service) ListShadowMCPAccessRules(ctx context.Context, payload *gen.Lis
 		Limit:          limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list shadow mcp access rules").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list shadow mcp access rules").LogError(ctx, s.logger)
 	}
 
 	var nextCursor *string
@@ -529,7 +529,7 @@ func (s *Service) CreateShadowMCPAccessRule(ctx context.Context, payload *gen.Cr
 		ruleView := buildShadowMCPAccessRule(rule)
 		ruleUUID, err := uuid.Parse(rule.ID)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp access rule id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "parse shadow mcp access rule id").LogError(ctx, s.logger)
 		}
 		ruleAuditEvents = append(ruleAuditEvents, audit.LogShadowMCPAccessRuleEvent{
 			OrganizationID:           ac.ActiveOrganizationID,
@@ -565,7 +565,7 @@ func (s *Service) UpdateShadowMCPAccessRule(ctx context.Context, payload *gen.Up
 	}
 	ruleID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid rule id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid rule id").LogError(ctx, s.logger)
 	}
 	matchValue, err := normalizeShadowMCPMatchValue(payload.MatchBreadth, payload.MatchValue)
 	if err != nil {
@@ -632,7 +632,7 @@ func (s *Service) DeleteShadowMCPAccessRule(ctx context.Context, payload *gen.De
 	}
 	ruleID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid rule id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid rule id").LogError(ctx, s.logger)
 	}
 
 	rule, err := s.accessStore.DeleteRule(ctx, ac.ActiveOrganizationID, shadowMCPResourceType, payload.ID)
@@ -661,7 +661,7 @@ func (s *Service) DeleteShadowMCPAccessRule(ctx context.Context, payload *gen.De
 func (s *Service) requireOrgAdmin(ctx context.Context) (*contextvalues.AuthContext, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return nil, err
@@ -672,7 +672,7 @@ func (s *Service) requireOrgAdmin(ctx context.Context) (*contextvalues.AuthConte
 func (s *Service) requireOrgRead(ctx context.Context) (*contextvalues.AuthContext, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgRead, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return nil, err
@@ -684,11 +684,11 @@ func (s *Service) requireProjectInOrganization(ctx context.Context, organization
 	project, err := projectsrepo.New(s.db).GetProjectByID(ctx, projectID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return oops.E(oops.CodeNotFound, nil, "project not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, nil, "project not found").LogError(ctx, s.logger)
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "get project").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "get project").LogError(ctx, s.logger)
 	case project.OrganizationID != organizationID:
-		return oops.E(oops.CodeNotFound, nil, "project not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, nil, "project not found").LogError(ctx, s.logger)
 	default:
 		return nil
 	}
@@ -883,19 +883,19 @@ func (s *Service) shadowMCPRuleProjectID(ctx context.Context, organizationID str
 		if projectID != nil && *projectID != "" {
 			parsed, err := uuid.Parse(*projectID)
 			if err != nil {
-				return uuid.NullUUID{}, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+				return uuid.NullUUID{}, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 			}
 			id = parsed
 		}
 		if id == uuid.Nil {
-			return uuid.NullUUID{}, oops.E(oops.CodeBadRequest, nil, "project_id is required for project-scoped shadow mcp access rules").Log(ctx, s.logger)
+			return uuid.NullUUID{}, oops.E(oops.CodeBadRequest, nil, "project_id is required for project-scoped shadow mcp access rules").LogError(ctx, s.logger)
 		}
 		if err := s.requireProjectInOrganization(ctx, organizationID, id); err != nil {
 			return uuid.NullUUID{}, err
 		}
 		return uuid.NullUUID{UUID: id, Valid: true}, nil
 	default:
-		return uuid.NullUUID{}, oops.E(oops.CodeBadRequest, nil, "invalid access_scope").Log(ctx, s.logger)
+		return uuid.NullUUID{}, oops.E(oops.CodeBadRequest, nil, "invalid access_scope").LogError(ctx, s.logger)
 	}
 }
 
@@ -912,7 +912,7 @@ func (s *Service) shadowMCPRuleProjectIDs(ctx context.Context, organizationID st
 			}
 			parsed, err := uuid.Parse(rawID)
 			if err != nil {
-				return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 			}
 			if _, ok := seen[parsed]; ok {
 				continue
@@ -923,7 +923,7 @@ func (s *Service) shadowMCPRuleProjectIDs(ctx context.Context, organizationID st
 		if len(ids) == 0 && projectID != nil && *projectID != "" {
 			parsed, err := uuid.Parse(*projectID)
 			if err != nil {
-				return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 			}
 			ids = append(ids, parsed)
 		}
@@ -931,7 +931,7 @@ func (s *Service) shadowMCPRuleProjectIDs(ctx context.Context, organizationID st
 			ids = append(ids, fallbackProjectID)
 		}
 		if len(ids) == 0 {
-			return nil, oops.E(oops.CodeBadRequest, nil, "project_id is required for project-scoped shadow mcp access rules").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "project_id is required for project-scoped shadow mcp access rules").LogError(ctx, s.logger)
 		}
 
 		ruleProjectIDs := make([]uuid.NullUUID, 0, len(ids))
@@ -943,7 +943,7 @@ func (s *Service) shadowMCPRuleProjectIDs(ctx context.Context, organizationID st
 		}
 		return ruleProjectIDs, nil
 	default:
-		return nil, oops.E(oops.CodeBadRequest, nil, "invalid access_scope").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "invalid access_scope").LogError(ctx, s.logger)
 	}
 }
 
@@ -977,15 +977,15 @@ func shadowMCPStoreErr(ctx context.Context, s *Service, err error, message strin
 
 func shadowMCPStoreErrWithConflict(ctx context.Context, s *Service, err error, message, conflictMessage string) error {
 	if errors.Is(err, accesscontrol.ErrNotFound) {
-		return oops.E(oops.CodeNotFound, nil, "%s", message).Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, nil, "%s", message).LogError(ctx, s.logger)
 	}
 	if errors.Is(err, accesscontrol.ErrRequestAlreadyDecided) {
-		return oops.E(oops.CodeConflict, nil, "shadow mcp approval request has already been decided").Log(ctx, s.logger)
+		return oops.E(oops.CodeConflict, nil, "shadow mcp approval request has already been decided").LogError(ctx, s.logger)
 	}
 	if errors.Is(err, accesscontrol.ErrConflict) {
-		return oops.E(oops.CodeConflict, nil, "%s", conflictMessage).Log(ctx, s.logger)
+		return oops.E(oops.CodeConflict, nil, "%s", conflictMessage).LogError(ctx, s.logger)
 	}
-	return oops.E(oops.CodeUnexpected, err, "%s", message).Log(ctx, s.logger)
+	return oops.E(oops.CodeUnexpected, err, "%s", message).LogError(ctx, s.logger)
 }
 
 func formatTimePtr(ts time.Time) *string {

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -102,11 +102,11 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 
 	state, err := randomString(32)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate oauth state").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate oauth state").LogError(ctx, logger)
 	}
 	verifier, err := randomString(32)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate pkce verifier").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate pkce verifier").LogError(ctx, logger)
 	}
 	challenge := pkceChallenge(verifier)
 
@@ -120,7 +120,7 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 		CreatedAt:    time.Now().UTC(),
 	}
 	if err := s.loginStates.Store(ctx, rec); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to persist login state").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to persist login state").LogError(ctx, logger)
 	}
 
 	return &gen.LoginResult{
@@ -148,7 +148,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 
 	rec, err := s.loginStates.Get(ctx, LoginStateCacheKey(payload.StateParam))
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "unknown or expired login state").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "unknown or expired login state").LogError(ctx, logger)
 	}
 
 	if err := s.loginStates.DeleteByKey(ctx, LoginStateCacheKey(payload.StateParam)); err != nil {
@@ -171,20 +171,20 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 
 	tok, err := s.oidc.Exchange(ctx, conv.PtrValOrEmpty(payload.Code, ""), rec.CodeVerifier)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "oauth code exchange failed").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "oauth code exchange failed").LogError(ctx, logger)
 	}
 
 	idToken, err := ExtractIDToken(tok)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "oidc id_token missing").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "oidc id_token missing").LogError(ctx, logger)
 	}
 
 	identity, err := s.oidc.VerifyIDToken(ctx, idToken)
 	switch {
 	case errors.Is(err, ErrAdminDomainNotAllowed):
-		return nil, oops.E(oops.CodeForbidden, err, "oidc account is not authorized for admin access").Log(ctx, logger)
+		return nil, oops.E(oops.CodeForbidden, err, "oidc account is not authorized for admin access").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnauthorized, err, "oidc id_token verification failed").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "oidc id_token verification failed").LogError(ctx, logger)
 	}
 
 	sessionID, err := s.sessions.Store(ctx, StoreParams{
@@ -197,7 +197,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		ExpiresAt:    tok.Expiry,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to persist admin session").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to persist admin session").LogError(ctx, logger)
 	}
 
 	s.logger.InfoContext(ctx, "admin session created", attr.SlogAuthUserEmail(identity.Email))
@@ -212,7 +212,7 @@ func (s *Service) Logout(ctx context.Context, payload *gen.LogoutPayload) error 
 	sessionID := conv.PtrValOrEmpty(payload.SessionID, "")
 	if sessionID != "" {
 		if err := s.sessions.Delete(ctx, sessionID); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to delete admin session").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to delete admin session").LogError(ctx, s.logger)
 		}
 	}
 
@@ -221,7 +221,7 @@ func (s *Service) Logout(ctx context.Context, payload *gen.LogoutPayload) error 
 	// session identified by a foreign cookie).
 	if tok, ok := contextvalues.GetAdminSessionTokenFromContext(ctx); ok && tok != "" {
 		if err := s.sessions.Delete(ctx, tok); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to delete injected admin session").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to delete injected admin session").LogError(ctx, s.logger)
 		}
 	}
 
@@ -237,7 +237,7 @@ func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload
 		case errors.Is(err, pgx.ErrNoRows):
 			return nil, oops.C(oops.CodeNotFound)
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "lookup project detail by id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "lookup project detail by id").LogError(ctx, s.logger)
 		}
 		return adminProjectDetailFromIDRow(row), nil
 	}
@@ -247,7 +247,7 @@ func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "lookup project detail by slug").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "lookup project detail by slug").LogError(ctx, s.logger)
 	}
 	return adminProjectDetailFromSlugRow(row), nil
 }
@@ -330,7 +330,7 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 		PageLimit:       limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list organizations").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list organizations").LogError(ctx, s.logger)
 	}
 
 	orgs := make([]*gen.AdminOrganization, len(rows))
@@ -353,7 +353,7 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 func (s *Service) ListOrganizationMembers(ctx context.Context, payload *gen.ListOrganizationMembersPayload) (*gen.AdminListOrganizationMembersResult, error) {
 	rows, err := repo.New(s.db).AdminListOrganizationMembers(ctx, payload.OrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list members for organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list members for organization").LogError(ctx, s.logger)
 	}
 
 	members := make([]*gen.AdminOrganizationMember, len(rows))
@@ -379,7 +379,7 @@ func (s *Service) ListOrganizationMembers(ctx context.Context, payload *gen.List
 func (s *Service) ListOrganizationProjects(ctx context.Context, payload *gen.ListOrganizationProjectsPayload) (*gen.AdminListOrganizationProjectsResult, error) {
 	rows, err := repo.New(s.db).AdminListProjectsForOrganization(ctx, payload.OrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list projects for organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list projects for organization").LogError(ctx, s.logger)
 	}
 
 	projects := make([]*gen.AdminProject, len(rows))
@@ -407,7 +407,7 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 		AccountType: conv.PtrToPGText(payload.AccountType),
 		Whitelisted: conv.PtrToPGBool(payload.Whitelisted),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "update organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update organization").LogError(ctx, s.logger)
 	}
 
 	row, err := queries.AdminGetOrganizationByIDOrSlug(ctx, payload.ID)
@@ -415,7 +415,7 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "fetch organization after update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "fetch organization after update").LogError(ctx, s.logger)
 	}
 	return adminOrganizationFromGetRow(row), nil
 }
@@ -426,7 +426,7 @@ func (s *Service) GetOrganization(ctx context.Context, payload *gen.GetOrganizat
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "lookup organization by id or slug").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "lookup organization by id or slug").LogError(ctx, s.logger)
 	}
 	return adminOrganizationFromGetRow(row), nil
 }

--- a/server/internal/admin/verifier.go
+++ b/server/internal/admin/verifier.go
@@ -37,7 +37,7 @@ func NewVerifier(logger *slog.Logger, sessions *SessionStore, oidc *OIDCClient) 
 // the Auther interface on the admin service.
 func (v *Verifier) Authorize(ctx context.Context, key string, scheme *security.APIKeyScheme) (context.Context, error) {
 	if scheme == nil || scheme.Name != constants.AdminAuthSecurityScheme {
-		return ctx, oops.E(oops.CodeUnauthorized, nil, "unsupported security scheme").Log(ctx, v.logger)
+		return ctx, oops.E(oops.CodeUnauthorized, nil, "unsupported security scheme").LogError(ctx, v.logger)
 	}
 
 	if key == "" {
@@ -56,13 +56,13 @@ func (v *Verifier) Authorize(ctx context.Context, key string, scheme *security.A
 
 	accessToken, err := v.sessions.DecryptAccessToken(session)
 	if err != nil {
-		return ctx, oops.E(oops.CodeUnexpected, err, "decrypt admin session").Log(ctx, v.logger)
+		return ctx, oops.E(oops.CodeUnexpected, err, "decrypt admin session").LogError(ctx, v.logger)
 	}
 
 	if NeedsRefresh(session.AccessTokenExpiresAt) {
 		refreshToken, err := v.sessions.DecryptRefreshToken(session)
 		if err != nil {
-			return ctx, oops.E(oops.CodeUnexpected, err, "decrypt admin session").Log(ctx, v.logger)
+			return ctx, oops.E(oops.CodeUnexpected, err, "decrypt admin session").LogError(ctx, v.logger)
 		}
 		if refreshToken == "" {
 			// No refresh token captured at login; re-auth required.
@@ -72,11 +72,11 @@ func (v *Verifier) Authorize(ctx context.Context, key string, scheme *security.A
 		tok, err := v.oidc.Refresh(ctx, refreshToken)
 		if err != nil {
 			_ = v.sessions.Delete(ctx, session.SessionID)
-			return ctx, oops.C(oops.CodeUnauthorized).Log(ctx, v.logger, attr.SlogError(err))
+			return ctx, oops.C(oops.CodeUnauthorized).LogError(ctx, v.logger, attr.SlogError(err))
 		}
 		session, err = v.sessions.UpdateAccessToken(ctx, session, tok.AccessToken, tok.Expiry)
 		if err != nil {
-			return ctx, oops.E(oops.CodeUnexpected, err, "persist refreshed admin session").Log(ctx, v.logger)
+			return ctx, oops.E(oops.CodeUnexpected, err, "persist refreshed admin session").LogError(ctx, v.logger)
 		}
 		accessToken = tok.AccessToken
 	}
@@ -85,16 +85,16 @@ func (v *Verifier) Authorize(ctx context.Context, key string, scheme *security.A
 	switch {
 	case errors.Is(err, ErrOIDCUnauthenticated), errors.Is(err, ErrAdminDomainNotAllowed):
 		_ = v.sessions.Delete(ctx, session.SessionID)
-		return ctx, oops.C(oops.CodeUnauthorized).Log(ctx, v.logger, attr.SlogError(err))
+		return ctx, oops.C(oops.CodeUnauthorized).LogError(ctx, v.logger, attr.SlogError(err))
 	case err != nil:
-		return ctx, oops.E(oops.CodeUnexpected, err, "validate admin session with oidc provider").Log(ctx, v.logger)
+		return ctx, oops.E(oops.CodeUnexpected, err, "validate admin session with oidc provider").LogError(ctx, v.logger)
 	}
 
 	if info.OIDCSubject != session.OIDCSubject {
 		// Token belongs to a different user than the cached session —
 		// treat as hostile and invalidate the session immediately.
 		_ = v.sessions.Delete(ctx, session.SessionID)
-		return ctx, oops.C(oops.CodeUnauthorized).Log(ctx, v.logger)
+		return ctx, oops.C(oops.CodeUnauthorized).LogError(ctx, v.logger)
 	}
 
 	authCtx := &contextvalues.AdminAuthContext{

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -93,7 +93,7 @@ func (s *Service) GetPlugins(ctx context.Context, payload *gen.GetPluginsPayload
 
 	rows, err := s.repo.GetAgentPluginSet(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error resolving agent plugin set").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error resolving agent plugin set").LogError(ctx, s.logger)
 	}
 
 	base := strings.TrimRight(s.serverURL, "/")

--- a/server/internal/aiintegrations/impl.go
+++ b/server/internal/aiintegrations/impl.go
@@ -157,7 +157,7 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -185,11 +185,11 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 		SnapshotBefore:   beforeSnap,
 		SnapshotAfter:    &afterSnap,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log ai integration upsert").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log ai integration upsert").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit ai integration upsert").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit ai integration upsert").LogError(ctx, logger)
 	}
 
 	if result.CreatedNewGeneration && cfg.Enabled {
@@ -230,7 +230,7 @@ func (s *Service) DeleteConfig(ctx context.Context, payload *gen.DeleteConfigPay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -246,11 +246,11 @@ func (s *Service) DeleteConfig(ctx context.Context, payload *gen.DeleteConfigPay
 		ActorSlug:        nil,
 		ConfigURN:        urn.NewAIIntegrationConfig(row.ID),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log ai integration delete").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log ai integration delete").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit ai integration delete").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit ai integration delete").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -250,7 +250,7 @@ func (s *Service) UploadImage(ctx context.Context, payload *gen.UploadImageForm,
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing image assets").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing image assets").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -266,7 +266,7 @@ func (s *Service) UploadImage(ctx context.Context, payload *gen.UploadImageForm,
 		ContentLength: payload.ContentLength,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
@@ -280,11 +280,11 @@ func (s *Service) UploadImage(ctx context.Context, payload *gen.UploadImageForm,
 		AssetURN:  urn.NewAsset(urn.AssetKindImage, asset.ID),
 		AssetName: asset.Name,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save image asset creation audit log").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save image asset creation audit log").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save image asset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save image asset").LogError(ctx, logger)
 	}
 
 	return &gen.UploadImageResult{
@@ -350,7 +350,7 @@ func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFuncti
 	}
 
 	if err := validateFunctionsArchive(ctx, s.logger, result.file.Name()); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid functions archive: %s", err.Error()).Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid functions archive: %s", err.Error()).LogError(ctx, logger)
 	}
 
 	filename := fmt.Sprintf("functions-%s%s", result.hash, ext)
@@ -367,7 +367,7 @@ func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFuncti
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing function assets").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing function assets").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -383,7 +383,7 @@ func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFuncti
 		ContentLength: payload.ContentLength,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
@@ -397,11 +397,11 @@ func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFuncti
 		AssetURN:  urn.NewAsset(urn.AssetKindFunction, asset.ID),
 		AssetName: asset.Name,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save function asset creation audit log").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save function asset creation audit log").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save function asset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save function asset").LogError(ctx, logger)
 	}
 
 	return &gen.UploadFunctionsResult{
@@ -480,7 +480,7 @@ func (s *Service) UploadOpenAPIv3(ctx context.Context, payload *gen.UploadOpenAP
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OpenAPI assets").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OpenAPI assets").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -496,7 +496,7 @@ func (s *Service) UploadOpenAPIv3(ctx context.Context, payload *gen.UploadOpenAP
 		ContentLength: payload.ContentLength,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
@@ -510,11 +510,11 @@ func (s *Service) UploadOpenAPIv3(ctx context.Context, payload *gen.UploadOpenAP
 		AssetURN:  urn.NewAsset(urn.AssetKindOpenAPI, asset.ID),
 		AssetName: asset.Name,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save OpenAPI asset creation audit log").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save OpenAPI asset creation audit log").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save OpenAPI asset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save OpenAPI asset").LogError(ctx, logger)
 	}
 
 	return &gen.UploadOpenAPIv3Result{
@@ -741,7 +741,7 @@ func (s *Service) ServeOpenAPIv3(ctx context.Context, payload *gen.ServeOpenAPIv
 
 	projectID, err := uuid.Parse(payload.ProjectID)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 	}
 	if projectID == uuid.Nil {
 		return nil, nil, oops.E(oops.CodeBadRequest, nil, "project id cannot be empty")
@@ -765,17 +765,17 @@ func (s *Service) ServeOpenAPIv3(ctx context.Context, payload *gen.ServeOpenAPIv
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get openapiv3 asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get openapiv3 asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	assetURL, err := url.Parse(row.Url)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("parse asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("parse asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	exists, err := s.storage.Exists(ctx, assetURL)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("check if asset exists: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("check if asset exists: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	if !exists {
@@ -784,7 +784,7 @@ func (s *Service) ServeOpenAPIv3(ctx context.Context, payload *gen.ServeOpenAPIv
 
 	body, err := s.storage.Read(ctx, assetURL)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("read asset: %w", err), "error fetching asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("read asset: %w", err), "error fetching asset").LogError(ctx, logger)
 	}
 
 	return &gen.ServeOpenAPIv3Result{
@@ -940,7 +940,7 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OpenAPI assets").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OpenAPI assets").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -956,7 +956,7 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 		ContentLength: actualContentLength,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
@@ -970,11 +970,11 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 		AssetURN:  urn.NewAsset(urn.AssetKindOpenAPI, asset.ID),
 		AssetName: asset.Name,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save OpenAPI asset creation audit log").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save OpenAPI asset creation audit log").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save OpenAPI asset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save OpenAPI asset").LogError(ctx, logger)
 	}
 
 	return &gen.UploadOpenAPIv3Result{
@@ -1006,7 +1006,7 @@ func (s *Service) ServeFunction(ctx context.Context, payload *gen.ServeFunctionF
 
 	projectID, err := uuid.Parse(payload.ProjectID)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 	}
 	if projectID == uuid.Nil {
 		return nil, nil, oops.E(oops.CodeBadRequest, nil, "project id cannot be empty")
@@ -1030,17 +1030,17 @@ func (s *Service) ServeFunction(ctx context.Context, payload *gen.ServeFunctionF
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get function asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get function asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	assetURL, err := url.Parse(row.Url)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("parse asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("parse asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	exists, err := s.storage.Exists(ctx, assetURL)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("check if asset exists: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("check if asset exists: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	if !exists {
@@ -1049,7 +1049,7 @@ func (s *Service) ServeFunction(ctx context.Context, payload *gen.ServeFunctionF
 
 	body, err := s.storage.Read(ctx, assetURL)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("read asset: %w", err), "error fetching asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("read asset: %w", err), "error fetching asset").LogError(ctx, logger)
 	}
 
 	return &gen.ServeFunctionResult{
@@ -1202,7 +1202,7 @@ func (s *Service) ServeChatAttachment(ctx context.Context, payload *gen.ServeCha
 
 	projectID, err := uuid.Parse(payload.ProjectID)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 	}
 	if projectID == uuid.Nil {
 		return nil, nil, oops.E(oops.CodeBadRequest, nil, "project id cannot be empty")
@@ -1225,17 +1225,17 @@ func (s *Service) ServeChatAttachment(ctx context.Context, payload *gen.ServeCha
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	assetURL, err := url.Parse(row.Url)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("parse asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("parse asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	exists, err := s.storage.Exists(ctx, assetURL)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("check if asset exists: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("check if asset exists: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	if !exists {
@@ -1244,7 +1244,7 @@ func (s *Service) ServeChatAttachment(ctx context.Context, payload *gen.ServeCha
 
 	body, err := s.storage.Read(ctx, assetURL)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("read asset: %w", err), "error fetching asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("read asset: %w", err), "error fetching asset").LogError(ctx, logger)
 	}
 
 	return &gen.ServeChatAttachmentResult{
@@ -1275,7 +1275,7 @@ func (s *Service) CreateSignedChatAttachmentURL(ctx context.Context, payload *ge
 
 	projectID, err := uuid.Parse(payload.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 	}
 	if projectID == uuid.Nil {
 		return nil, oops.E(oops.CodeBadRequest, nil, "project id cannot be empty")
@@ -1299,7 +1299,7 @@ func (s *Service) CreateSignedChatAttachmentURL(ctx context.Context, payload *ge
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	// Determine TTL
@@ -1312,7 +1312,7 @@ func (s *Service) CreateSignedChatAttachmentURL(ctx context.Context, payload *ge
 	// Generate signed token
 	token, expiresAt, err := GenerateSignedAssetToken(s.jwtSecret, assetID, projectID, ttl)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("generate signed token: %w", err), "error creating signed url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("generate signed token: %w", err), "error creating signed url").LogError(ctx, logger)
 	}
 
 	// Build URL
@@ -1364,17 +1364,17 @@ func (s *Service) ServeChatAttachmentSigned(ctx context.Context, payload *gen.Se
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	assetURL, err := url.Parse(row.Url)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("parse asset url: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("parse asset url: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	exists, err := s.storage.Exists(ctx, assetURL)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("check if asset exists: %w", err), "error loading asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("check if asset exists: %w", err), "error loading asset").LogError(ctx, logger)
 	}
 
 	if !exists {
@@ -1383,7 +1383,7 @@ func (s *Service) ServeChatAttachmentSigned(ctx context.Context, payload *gen.Se
 
 	body, err := s.storage.Read(ctx, assetURL)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("read asset: %w", err), "error fetching asset").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("read asset: %w", err), "error fetching asset").LogError(ctx, logger)
 	}
 
 	return &gen.ServeChatAttachmentSignedResult{

--- a/server/internal/assistantmemories/impl.go
+++ b/server/internal/assistantmemories/impl.go
@@ -42,12 +42,12 @@ func (s *Service) ListAssistantMemories(ctx context.Context, payload *gen.ListAs
 
 	assistantID, err := uuid.Parse(payload.AssistantID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid assistant id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid assistant id").LogError(ctx, s.logger)
 	}
 
 	cursorCreatedAt, cursorID, err := decodeListCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	limit := conv.SafeInt32(payload.Limit)
@@ -92,7 +92,7 @@ func (s *Service) GetAssistantMemory(ctx context.Context, payload *gen.GetAssist
 
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid memory id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid memory id").LogError(ctx, s.logger)
 	}
 
 	mem, err := s.memory.Get(ctx, *authCtx.ProjectID, id)
@@ -111,7 +111,7 @@ func (s *Service) DeleteAssistantMemory(ctx context.Context, payload *gen.Delete
 
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid memory id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid memory id").LogError(ctx, s.logger)
 	}
 
 	if err := s.memory.DeleteByID(ctx, *authCtx.ProjectID, id); err != nil {

--- a/server/internal/assistants/compaction_persist.go
+++ b/server/internal/assistants/compaction_persist.go
@@ -70,13 +70,13 @@ func (s *ServiceCore) RecordCompactedGeneration(ctx context.Context, projectID, 
 		attr.SlogAssistantThreadID(threadID.String()),
 	}
 	if s.chatWriter == nil {
-		return oops.E(oops.CodeUnexpected, nil, "chat writer not configured").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeUnexpected, nil, "chat writer not configured").LogError(ctx, s.logger, logAttrs...)
 	}
 	if len(messages) == 0 {
-		return oops.E(oops.CodeBadRequest, nil, "compacted transcript is empty").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeBadRequest, nil, "compacted transcript is empty").LogError(ctx, s.logger, logAttrs...)
 	}
 	if err := validateCompactedMessages(messages); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "validate compacted transcript").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeBadRequest, err, "validate compacted transcript").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	threadRow, err := assistantrepo.New(s.db).LoadAssistantThreadForBootstrap(ctx, assistantrepo.LoadAssistantThreadForBootstrapParams{
@@ -85,20 +85,20 @@ func (s *ServiceCore) RecordCompactedGeneration(ctx context.Context, projectID, 
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeNotFound, nil, "assistant thread not found").Log(ctx, s.logger, logAttrs...)
+			return oops.E(oops.CodeNotFound, nil, "assistant thread not found").LogError(ctx, s.logger, logAttrs...)
 		}
-		return oops.E(oops.CodeUnexpected, err, "load assistant thread").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeUnexpected, err, "load assistant thread").LogError(ctx, s.logger, logAttrs...)
 	}
 	if threadRow.AssistantID != principalAssistantID {
-		return oops.E(oops.CodeForbidden, nil, "thread does not belong to assistant").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeForbidden, nil, "thread does not belong to assistant").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	chatRow, err := chatrepo.New(s.db).GetChat(ctx, threadRow.ChatID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeNotFound, nil, "assistant chat not found").Log(ctx, s.logger, logAttrs...)
+			return oops.E(oops.CodeNotFound, nil, "assistant chat not found").LogError(ctx, s.logger, logAttrs...)
 		}
-		return oops.E(oops.CodeUnexpected, err, "load assistant chat").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeUnexpected, err, "load assistant chat").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	// Concurrent compaction posts for the same chat must serialize so they
@@ -108,17 +108,17 @@ func (s *ServiceCore) RecordCompactedGeneration(ctx context.Context, projectID, 
 	// non-locking reader, and the lock releases on COMMIT/ROLLBACK.
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin compaction transaction").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeUnexpected, err, "begin compaction transaction").LogError(ctx, s.logger, logAttrs...)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	if _, err := tx.Exec(ctx, "SELECT 1 FROM chats WHERE id = $1 FOR UPDATE", threadRow.ChatID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "lock chat for compaction").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeUnexpected, err, "lock chat for compaction").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	currentGen, err := chatrepo.New(tx).GetMaxGenerationForChat(ctx, threadRow.ChatID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "load chat generation").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeUnexpected, err, "load chat generation").LogError(ctx, s.logger, logAttrs...)
 	}
 	nextGen := currentGen + 1
 
@@ -126,7 +126,7 @@ func (s *ServiceCore) RecordCompactedGeneration(ctx context.Context, projectID, 
 	for _, m := range messages {
 		toolCallsJSON, err := encodeRuntimeToolCalls(m.ToolCalls)
 		if err != nil {
-			return oops.E(oops.CodeBadRequest, err, "encode tool_calls").Log(ctx, s.logger, logAttrs...)
+			return oops.E(oops.CodeBadRequest, err, "encode tool_calls").LogError(ctx, s.logger, logAttrs...)
 		}
 		empty := pgtype.Text{String: "", Valid: false}
 		params = append(params, chatrepo.CreateChatMessageParams{
@@ -158,11 +158,11 @@ func (s *ServiceCore) RecordCompactedGeneration(ctx context.Context, projectID, 
 
 	n, err := s.chatWriter.WriteInTx(ctx, tx, params)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "write compacted chat messages").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeUnexpected, err, "write compacted chat messages").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit compaction transaction").Log(ctx, s.logger, logAttrs...)
+		return oops.E(oops.CodeUnexpected, err, "commit compaction transaction").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	if n > 0 {

--- a/server/internal/assistants/impl.go
+++ b/server/internal/assistants/impl.go
@@ -92,14 +92,14 @@ func (s *Service) ListAssistants(ctx context.Context, _ *gen.ListAssistantsPaylo
 
 	items, err := s.core.ListAssistants(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list assistants").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list assistants").LogError(ctx, s.logger)
 	}
 
 	result := &gen.ListAssistantsResult{Assistants: make([]*types.Assistant, 0, len(items))}
 	for _, item := range items {
 		view, err := toHTTPAssistant(item)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").LogError(ctx, s.logger)
 		}
 		result.Assistants = append(result.Assistants, view)
 	}
@@ -116,7 +116,7 @@ func (s *Service) GetAssistant(ctx context.Context, payload *gen.GetAssistantPay
 	}
 	assistantID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid assistant id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid assistant id").LogError(ctx, s.logger)
 	}
 
 	record, err := s.core.GetAssistant(ctx, *authCtx.ProjectID, assistantID)
@@ -125,7 +125,7 @@ func (s *Service) GetAssistant(ctx context.Context, payload *gen.GetAssistantPay
 	}
 	view, err := toHTTPAssistant(record)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").LogError(ctx, s.logger)
 	}
 	return view, nil
 }
@@ -139,7 +139,7 @@ func (s *Service) CreateAssistant(ctx context.Context, payload *gen.CreateAssist
 		return nil, err
 	}
 	if authCtx.UserID == "" {
-		return nil, oops.E(oops.CodeUnauthorized, nil, "create assistant requires a user identity").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, nil, "create assistant requires a user identity").LogError(ctx, s.logger)
 	}
 	record, err := s.core.CreateAssistant(
 		ctx,
@@ -160,7 +160,7 @@ func (s *Service) CreateAssistant(ctx context.Context, payload *gen.CreateAssist
 	s.startRuntimeWarmup(ctx, record)
 	view, err := toHTTPAssistant(record)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").LogError(ctx, s.logger)
 	}
 	return view, nil
 }
@@ -175,7 +175,7 @@ func (s *Service) UpdateAssistant(ctx context.Context, payload *gen.UpdateAssist
 	}
 	assistantID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid assistant id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid assistant id").LogError(ctx, s.logger)
 	}
 
 	record, err := s.core.UpdateAssistant(
@@ -195,7 +195,7 @@ func (s *Service) UpdateAssistant(ctx context.Context, payload *gen.UpdateAssist
 	}
 	view, err := toHTTPAssistant(record)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").LogError(ctx, s.logger)
 	}
 	return view, nil
 }
@@ -210,7 +210,7 @@ func (s *Service) DeleteAssistant(ctx context.Context, payload *gen.DeleteAssist
 	}
 	assistantID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid assistant id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid assistant id").LogError(ctx, s.logger)
 	}
 	if err := s.core.DeleteAssistant(ctx, *authCtx.ProjectID, assistantID); err != nil {
 		return mapAssistantStoreError(ctx, s.logger, err, "delete assistant")
@@ -228,12 +228,12 @@ func (s *Service) SendMessage(ctx context.Context, payload *gen.SendMessagePaylo
 	}
 	// Messages are sent as the calling user, so a user identity is required.
 	if authCtx.UserID == "" {
-		return nil, oops.E(oops.CodeUnauthorized, nil, "sending a message requires a user identity").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, nil, "sending a message requires a user identity").LogError(ctx, s.logger)
 	}
 
 	assistantID, err := uuid.Parse(payload.AssistantID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid assistant id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid assistant id").LogError(ctx, s.logger)
 	}
 
 	// chat_id names the conversation to continue; omit it to start a new one (the
@@ -242,7 +242,7 @@ func (s *Service) SendMessage(ctx context.Context, payload *gen.SendMessagePaylo
 	if payload.ChatID != nil && *payload.ChatID != "" {
 		chatID, err = uuid.Parse(*payload.ChatID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid chat id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid chat id").LogError(ctx, s.logger)
 		}
 	}
 
@@ -253,9 +253,9 @@ func (s *Service) SendMessage(ctx context.Context, payload *gen.SendMessagePaylo
 	if chatID != uuid.Nil {
 		if err := s.core.CheckDashboardChatOwnership(ctx, *authCtx.ProjectID, chatID, authCtx.UserID); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "chat not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "chat not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "resolve chat access").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "resolve chat access").LogError(ctx, s.logger)
 		}
 	}
 
@@ -267,7 +267,7 @@ func (s *Service) SendMessage(ctx context.Context, payload *gen.SendMessagePaylo
 	result, err := s.core.SendDashboardMessage(ctx, *authCtx.ProjectID, assistantID, authCtx.UserID, chatID, payload.Message, idempotencyKey)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "assistant not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "assistant not found").LogError(ctx, s.logger)
 		}
 		return nil, mapAssistantStoreError(ctx, s.logger, err, "send assistant message")
 	}
@@ -293,20 +293,20 @@ func (s *Service) EnsureManagedAssistant(ctx context.Context, _ *gen.EnsureManag
 	}
 	// Provisioning records the creating user, so a user identity is required.
 	if authCtx.UserID == "" {
-		return nil, oops.E(oops.CodeUnauthorized, nil, "the project assistant requires a user identity").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, nil, "the project assistant requires a user identity").LogError(ctx, s.logger)
 	}
 
 	record, err := s.core.EnableManagedAssistant(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID)
 	if err != nil {
 		if errors.Is(err, ErrManagedAssistantNameTaken) {
-			return nil, oops.E(oops.CodeConflict, err, "an assistant with the project assistant's name already exists — rename it to enable the built-in assistant").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeConflict, err, "an assistant with the project assistant's name already exists — rename it to enable the built-in assistant").LogError(ctx, s.logger)
 		}
 		return nil, mapAssistantStoreError(ctx, s.logger, err, "ensure project assistant")
 	}
 	s.startRuntimeWarmup(ctx, record)
 	view, err := toHTTPAssistant(record)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build assistant view").LogError(ctx, s.logger)
 	}
 	return view, nil
 }
@@ -365,10 +365,10 @@ func (s *Service) startRuntimeWarmup(ctx context.Context, record assistantRecord
 func mapAssistantStoreError(ctx context.Context, logger *slog.Logger, err error, message string) error {
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return oops.E(oops.CodeNotFound, err, "%s", message).Log(ctx, logger)
+		return oops.E(oops.CodeNotFound, err, "%s", message).LogError(ctx, logger)
 	case errors.Is(err, errAssistantValidation):
-		return oops.E(oops.CodeBadRequest, err, "%s", message).Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "%s", message).LogError(ctx, logger)
 	default:
-		return oops.E(oops.CodeUnexpected, err, "%s", message).Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "%s", message).LogError(ctx, logger)
 	}
 }

--- a/server/internal/assistants/mcp_auth_handler.go
+++ b/server/internal/assistants/mcp_auth_handler.go
@@ -130,33 +130,33 @@ func (s *Service) handleCreateMCPAuthFlow(w http.ResponseWriter, r *http.Request
 
 	flowID := uuid.NewString()
 	if s.core.serverURL == nil {
-		return oops.E(oops.CodeUnexpected, nil, "assistant mcp auth callback base url not configured").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, nil, "assistant mcp auth callback base url not configured").LogError(ctx, s.logger)
 	}
 	redirectURI := s.core.serverURL.JoinPath("rpc", "assistantMcpAuth", flowID, "oauth", "callback").String()
 	codeVerifier, codeChallenge, err := newPKCEPair()
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "generate PKCE verifier").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "generate PKCE verifier").LogError(ctx, s.logger)
 	}
 	encryptedVerifier, err := s.core.encryptionClient.Encrypt([]byte(codeVerifier))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "encrypt pkce verifier").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "encrypt pkce verifier").LogError(ctx, s.logger)
 	}
 
 	metadata, err := externalmcp.DiscoverOAuthMetadata(ctx, s.logger, s.core.guardianPolicy, "", mcpURL.String())
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "discover mcp authorization server metadata").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "discover mcp authorization server metadata").LogError(ctx, s.logger)
 	}
 	if metadata.AuthorizationEndpoint == "" || metadata.TokenEndpoint == "" || metadata.RegistrationEndpoint == "" {
-		return oops.E(oops.CodeUnexpected, nil, "mcp authorization server does not advertise RFC 8414 endpoints").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, nil, "mcp authorization server does not advertise RFC 8414 endpoints").LogError(ctx, s.logger)
 	}
 
 	registration, err := s.registerMCPAuthClient(ctx, metadata.RegistrationEndpoint, redirectURI)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "register assistant mcp oauth client").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "register assistant mcp oauth client").LogError(ctx, s.logger)
 	}
 	encryptedSecret, err := s.core.encryptionClient.Encrypt([]byte(registration.ClientSecret))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "encrypt mcp client secret").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "encrypt mcp client secret").LogError(ctx, s.logger)
 	}
 
 	state, err := s.core.assistantTokens.GenerateMCPAuthFlow(assistanttokens.MCPAuthFlowInput{
@@ -176,12 +176,12 @@ func (s *Service) handleCreateMCPAuthFlow(w http.ResponseWriter, r *http.Request
 		TTL:           mcpAuthFlowTTL,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "sign mcp auth flow state").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "sign mcp auth flow state").LogError(ctx, s.logger)
 	}
 
 	authURL, err := buildMCPAuthURL(metadata.AuthorizationEndpoint, registration.ClientID, redirectURI, state, codeChallenge)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build mcp auth url").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "build mcp auth url").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "assistant mcp auth flow created",
@@ -204,31 +204,31 @@ func (s *Service) handleMCPAuthCallback(w http.ResponseWriter, r *http.Request) 
 	state := r.URL.Query().Get("state")
 	claims, err := s.core.assistantTokens.ValidateMCPAuthFlow(state)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid mcp auth callback state").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid mcp auth callback state").LogError(ctx, s.logger)
 	}
 	if claims.FlowID != flowID {
-		return oops.E(oops.CodeBadRequest, nil, "mcp auth callback flow mismatch").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "mcp auth callback flow mismatch").LogError(ctx, s.logger)
 	}
 
 	projectID, err := uuid.Parse(claims.ProjectID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid callback project id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid callback project id").LogError(ctx, s.logger)
 	}
 	assistantID, err := uuid.Parse(claims.AssistantID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid callback assistant id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid callback assistant id").LogError(ctx, s.logger)
 	}
 	threadID, err := uuid.Parse(claims.ThreadID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid callback thread id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid callback thread id").LogError(ctx, s.logger)
 	}
 	mcpURL, err := url.Parse(claims.McpURL)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid callback mcp url").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid callback mcp url").LogError(ctx, s.logger)
 	}
 	mcpSlug, err := mcpSlugFromURL(mcpURL)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "callback mcp url missing slug").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "callback mcp url missing slug").LogError(ctx, s.logger)
 	}
 
 	payload := mcpAuthEventPayload{
@@ -288,17 +288,17 @@ func (s *Service) enqueueMCPAuthEvent(ctx context.Context, projectID, assistantI
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return false, oops.E(oops.CodeNotFound, err, "assistant thread not found").Log(ctx, s.logger)
+			return false, oops.E(oops.CodeNotFound, err, "assistant thread not found").LogError(ctx, s.logger)
 		}
-		return false, oops.E(oops.CodeUnexpected, err, "load assistant thread for mcp auth event").Log(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "load assistant thread for mcp auth event").LogError(ctx, s.logger)
 	}
 	if thread.AssistantID != assistantID {
-		return false, oops.E(oops.CodeForbidden, nil, "assistant thread assistant mismatch").Log(ctx, s.logger)
+		return false, oops.E(oops.CodeForbidden, nil, "assistant thread assistant mismatch").LogError(ctx, s.logger)
 	}
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "marshal mcp auth event").Log(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "marshal mcp auth event").LogError(ctx, s.logger)
 	}
 	_, err = repo.InsertAssistantThreadEvent(ctx, assistantrepo.InsertAssistantThreadEventParams{
 		AssistantThreadID:     threadID,
@@ -315,7 +315,7 @@ func (s *Service) enqueueMCPAuthEvent(ctx context.Context, projectID, assistantI
 	case errors.Is(err, pgx.ErrNoRows):
 		return false, nil
 	case err != nil:
-		return false, oops.E(oops.CodeUnexpected, err, "insert mcp auth assistant event").Log(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "insert mcp auth assistant event").LogError(ctx, s.logger)
 	default:
 		return true, nil
 	}

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -2121,12 +2121,12 @@ func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threa
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return threadBootstrap{}, oops.E(oops.CodeNotFound, nil, "assistant thread not found").Log(ctx, s.logger, logAttrs...)
+			return threadBootstrap{}, oops.E(oops.CodeNotFound, nil, "assistant thread not found").LogError(ctx, s.logger, logAttrs...)
 		}
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant thread").Log(ctx, s.logger, logAttrs...)
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant thread").LogError(ctx, s.logger, logAttrs...)
 	}
 	if row.AssistantID != principalAssistantID {
-		return threadBootstrap{}, oops.E(oops.CodeForbidden, nil, "thread does not belong to assistant").Log(ctx, s.logger, logAttrs...)
+		return threadBootstrap{}, oops.E(oops.CodeForbidden, nil, "thread does not belong to assistant").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	thread := assistantThreadRecord{
@@ -2157,13 +2157,13 @@ func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threa
 	}
 	toolsets, err := s.loadAssistantToolsets(ctx, assistant.ProjectID, []uuid.UUID{assistant.ID})
 	if err != nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant toolsets").Log(ctx, s.logger, logAttrs...)
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant toolsets").LogError(ctx, s.logger, logAttrs...)
 	}
 	assistant.Toolsets = toolsets[assistant.ID]
 
 	runtimeServerURL := s.runtime.ServerURL()
 	if runtimeServerURL == nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, nil, "assistant runtime server url not configured").Log(ctx, s.logger, logAttrs...)
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, nil, "assistant runtime server url not configured").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	// The managed-assistant platform toolset is granted only to the project's
@@ -2178,7 +2178,7 @@ func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threa
 	case errors.Is(mErr, pgx.ErrNoRows):
 		// Project has no managed assistant; managed-only tools stay ungranted.
 	default:
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, mErr, "resolve managed assistant").Log(ctx, s.logger, logAttrs...)
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, mErr, "resolve managed assistant").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	// Misconfigured toolsets (no MCP slug, MCP disabled) are surfaced as
@@ -2189,12 +2189,12 @@ func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threa
 
 	instructions, err := composeInstructions(assistant.Instructions, thread)
 	if err != nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "compose assistant instructions").Log(ctx, s.logger, logAttrs...)
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "compose assistant instructions").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	history, err := s.loadChatHistory(ctx, thread.ChatID, thread.ProjectID)
 	if err != nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant chat history").Log(ctx, s.logger, logAttrs...)
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant chat history").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	completionsEndpoint := runtimeServerURL.JoinPath("chat", "completions")
@@ -2204,7 +2204,7 @@ func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threa
 
 	compaction := compactionPolicyFor(thread.SourceKind)
 	if err := compaction.Validate(); err != nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "build compaction policy").Log(ctx, s.logger, logAttrs...)
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "build compaction policy").LogError(ctx, s.logger, logAttrs...)
 	}
 
 	return threadBootstrap{

--- a/server/internal/auditapi/impl.go
+++ b/server/internal/auditapi/impl.go
@@ -102,21 +102,21 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 	if payload.Cursor != nil && *payload.Cursor != "" {
 		seq, err := decodeCursor(*payload.Cursor)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 		}
 		params.CursorSeq = pgtype.Int8{Int64: seq, Valid: true}
 	}
 
 	rows, err := repo.New(s.db).ListAuditLogs(ctx, params)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing audit logs").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing audit logs").LogError(ctx, s.logger)
 	}
 
 	logs := make([]*gen.AuditLog, 0, min(len(rows), listAuditLogsPageSize))
 	for _, row := range rows[:min(len(rows), listAuditLogsPageSize)] {
 		log, err := toAuditLog(row)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error building audit log response").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error building audit log response").LogError(ctx, s.logger)
 		}
 		logs = append(logs, log)
 	}
@@ -154,7 +154,7 @@ func (s *Service) ListFacets(ctx context.Context, payload *gen.ListFacetsPayload
 		ProjectID:      projectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing audit actor facets").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing audit actor facets").LogError(ctx, s.logger)
 	}
 
 	actionRows, err := queries.ListAuditActionFacets(ctx, repo.ListAuditActionFacetsParams{
@@ -162,7 +162,7 @@ func (s *Service) ListFacets(ctx context.Context, payload *gen.ListFacetsPayload
 		ProjectID:      projectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing audit action facets").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing audit action facets").LogError(ctx, s.logger)
 	}
 
 	return &gen.ListAuditLogFacetsResult{
@@ -184,7 +184,7 @@ func (s *Service) resolveProjectID(ctx context.Context, organizationID string, p
 	case errors.Is(err, pgx.ErrNoRows):
 		return uuid.NullUUID{}, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return uuid.NullUUID{}, oops.E(oops.CodeUnexpected, err, "error getting project by slug").Log(ctx, s.logger, attr.SlogProjectSlug(projectSlug), attr.SlogOrganizationID(organizationID))
+		return uuid.NullUUID{}, oops.E(oops.CodeUnexpected, err, "error getting project by slug").LogError(ctx, s.logger, attr.SlogProjectSlug(projectSlug), attr.SlogOrganizationID(organizationID))
 	default:
 		return uuid.NullUUID{UUID: project.ID, Valid: true}, nil
 	}

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -66,7 +66,7 @@ func (s *Auth) Authorize(ctx context.Context, key string, scheme *security.APIKe
 	}
 	ctx, err = s.authz.PrepareContext(ctx)
 	if err != nil {
-		return ctx, oops.E(oops.CodeUnexpected, err, "load access grants").Log(ctx, s.logger)
+		return ctx, oops.E(oops.CodeUnexpected, err, "load access grants").LogError(ctx, s.logger)
 	}
 
 	return ctx, nil
@@ -83,7 +83,7 @@ func (s *Auth) checkProjectAccess(ctx context.Context, logger *slog.Logger, proj
 	case errors.Is(err, pgx.ErrNoRows):
 		return ctx, oops.E(oops.CodeForbidden, nil, "no projects found")
 	case err != nil:
-		return ctx, oops.E(oops.CodeUnexpected, err, "error checking project access").Log(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return ctx, oops.E(oops.CodeUnexpected, err, "error checking project access").LogError(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	if projectSlug == "" && len(projects) == 1 {
@@ -107,7 +107,7 @@ func (s *Auth) checkProjectAccess(ctx context.Context, logger *slog.Logger, proj
 	logger = logger.With(attr.SlogProjectSlug(projectSlug), attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 
 	if !hasProjectAccess {
-		return ctx, oops.C(oops.CodeForbidden).Log(ctx, logger)
+		return ctx, oops.C(oops.CodeForbidden).LogError(ctx, logger)
 	}
 
 	ctx = contextvalues.SetAuthContext(ctx, authCtx)
@@ -126,14 +126,14 @@ func (s *Auth) CheckProjectAccess(ctx context.Context, logger *slog.Logger, proj
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return oops.C(oops.CodeForbidden).Log(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.C(oops.CodeForbidden).LogError(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "error checking project access").Log(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeUnexpected, err, "error checking project access").LogError(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	if id == uuid.Nil {
 		err := errors.New("check project access by id: database returned nil project id")
-		return oops.E(oops.CodeForbidden, err, "%s", oops.CodeForbidden.UserMessage()).Log(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeForbidden, err, "%s", oops.CodeForbidden.UserMessage()).LogError(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	return nil

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -231,7 +231,7 @@ func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.A
 	}
 	ctx, err = s.authz.PrepareContext(ctx)
 	if err != nil {
-		return ctx, oops.E(oops.CodeUnexpected, err, "load access grants").Log(ctx, s.logger)
+		return ctx, oops.E(oops.CodeUnexpected, err, "load access grants").LogError(ctx, s.logger)
 	}
 	return ctx, nil
 }
@@ -431,13 +431,13 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 
 	nonce, err := generateNonce()
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error generating login nonce").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error generating login nonce").LogError(ctx, s.logger)
 	}
 	// Store the nonce binding (cookie value set by middleware) so the
 	// callback can verify the same browser that started login finishes it.
 	binding := nonceBindingFromContext(ctx)
 	if err := s.nonceStore.Set(ctx, nonceKey(nonce), binding, nonceTTL); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error storing login nonce").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error storing login nonce").LogError(ctx, s.logger)
 	}
 
 	state := encodeStateParam(payload, nonce)
@@ -449,7 +449,7 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 		ScopesSupported: nil,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error building authorization URL").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error building authorization URL").LogError(ctx, s.logger)
 	}
 
 	return &gen.LoginResult{
@@ -524,7 +524,7 @@ func (s *Service) SwitchScopes(ctx context.Context, payload *gen.SwitchScopesPay
 
 	userInfo, _, err := s.sessions.GetUserInfo(ctx, authCtx.UserID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting user info").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting user info").LogError(ctx, s.logger)
 	}
 
 	selectedOrg := authCtx.ActiveOrganizationID
@@ -553,16 +553,16 @@ func (s *Service) SwitchScopes(ctx context.Context, payload *gen.SwitchScopesPay
 		WorkosID:    conv.PtrToPGText(selected.WorkosID),
 		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error upserting organization metadata").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error upserting organization metadata").LogError(ctx, s.logger)
 	}
 
 	existingSession, err := s.sessions.GetSession(ctx, *authCtx.SessionID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error loading existing session").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error loading existing session").LogError(ctx, s.logger)
 	}
 	existingSession.ActiveOrganizationID = authCtx.ActiveOrganizationID
 	if err := s.sessions.UpdateSession(ctx, existingSession); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error updating auth session").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error updating auth session").LogError(ctx, s.logger)
 	}
 
 	return &gen.SwitchScopesResult{
@@ -579,7 +579,7 @@ func (s *Service) Logout(ctx context.Context, payload *gen.LogoutPayload) (res *
 	}
 
 	if err := s.sessions.InvalidateUserInfoCache(ctx, authCtx.UserID); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error invalidating user").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error invalidating user").LogError(ctx, s.logger)
 	}
 
 	if err := s.sessions.ClearSession(ctx, sessions.Session{
@@ -588,7 +588,7 @@ func (s *Service) Logout(ctx context.Context, payload *gen.LogoutPayload) (res *
 		UserID:               authCtx.UserID,
 		WorkOSSessionID:      "",
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error clearing session").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error clearing session").LogError(ctx, s.logger)
 	}
 	return &gen.LogoutResult{SessionCookie: ""}, nil
 }
@@ -601,7 +601,7 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 
 	userInfo, _, err := s.sessions.GetUserInfo(ctx, authCtx.UserID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting user info").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting user info").LogError(ctx, s.logger)
 	}
 
 	// For admins overriding into a foreign org (one not in their own membership list),
@@ -724,13 +724,13 @@ func (s *Service) Register(ctx context.Context, payload *gen.RegisterPayload) (e
 
 	slug, err := orgslug.FindUnique(ctx, s.orgRepo, orgslug.Slugify(payload.OrgName))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error finding unique slug").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error finding unique slug").LogError(ctx, s.logger)
 	}
 
 	// Provision the WorkOS org first, then derive a deterministic UUIDv5 org ID from the WorkOS ID.
 	workosOrgID, gramOrgID, err := s.identity.ProvisionOrgInWorkOS(ctx, payload.OrgName, authCtx.UserID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error provisioning organization in WorkOS").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error provisioning organization in WorkOS").LogError(ctx, s.logger)
 	}
 
 	org, err := s.orgRepo.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
@@ -741,27 +741,27 @@ func (s *Service) Register(ctx context.Context, payload *gen.RegisterPayload) (e
 		Whitelisted: pgtype.Bool{Bool: false, Valid: true},
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error creating organization").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error creating organization").LogError(ctx, s.logger)
 	}
 
 	if _, err := s.orgRepo.UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
 		OrganizationID: org.ID,
 		UserID:         conv.ToPGText(authCtx.UserID),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error creating organization user relationship").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error creating organization user relationship").LogError(ctx, s.logger)
 	}
 
 	if err := s.sessions.InvalidateUserInfoCache(ctx, authCtx.UserID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error invalidating user info cache").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error invalidating user info cache").LogError(ctx, s.logger)
 	}
 
 	existingSession, err := s.sessions.GetSession(ctx, *authCtx.SessionID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error loading existing session").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error loading existing session").LogError(ctx, s.logger)
 	}
 	existingSession.ActiveOrganizationID = org.ID
 	if err := s.sessions.UpdateSession(ctx, existingSession); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error storing session").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error storing session").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -859,7 +859,7 @@ func dispositionFromState(payload *gen.CallbackPayload) string {
 func (s *Service) getProjectsOrSetupDefaults(ctx context.Context, organizationID string) ([]projectsRepo.Project, error) {
 	projects, err := s.projectsRepo.ListProjectsByOrganization(ctx, organizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing projects").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing projects").LogError(ctx, s.logger)
 	}
 
 	if len(projects) == 0 {
@@ -876,7 +876,7 @@ func (s *Service) getProjectsOrSetupDefaults(ctx context.Context, organizationID
 			Description:    conv.ToPGText("Default project for organization"),
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error creating default environment").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error creating default environment").LogError(ctx, s.logger)
 		}
 
 		projects = append(projects, project)
@@ -897,7 +897,7 @@ func (s *Service) createDefaultProject(ctx context.Context, organizationID strin
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 			return empty, oops.E(oops.CodeConflict, nil, "project already exists")
 		}
-		return empty, oops.E(oops.CodeUnexpected, err, "error creating default project").Log(ctx, s.logger)
+		return empty, oops.E(oops.CodeUnexpected, err, "error creating default project").LogError(ctx, s.logger)
 	}
 
 	return project, nil

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -121,10 +121,10 @@ func (s *Manager) Authenticate(ctx context.Context, key string) (context.Context
 
 	orgMetadata, err := mv.DescribeOrganization(ctx, s.logger, s.orgRepo, s.billingRepo, session.ActiveOrganizationID)
 	if err != nil {
-		return ctx, oops.E(oops.CodeUnexpected, err, "error getting organization metadata").Log(ctx, s.logger)
+		return ctx, oops.E(oops.CodeUnexpected, err, "error getting organization metadata").LogError(ctx, s.logger)
 	}
 	if orgMetadata.DisabledAt.Valid {
-		return ctx, oops.E(oops.CodeUnauthorized, nil, "this organization is disabled, please reach out to support@speakeasy.com for more information").Log(ctx, s.logger)
+		return ctx, oops.E(oops.CodeUnauthorized, nil, "this organization is disabled, please reach out to support@speakeasy.com for more information").LogError(ctx, s.logger)
 	}
 
 	authCtx.AccountType = orgMetadata.GramAccountType

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -523,7 +523,7 @@ func (e *Engine) ShouldEnforce(ctx context.Context) (bool, error) {
 
 	enabled, err := e.isEnabled(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "check RBAC feature").Log(ctx, e.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "check RBAC feature").LogError(ctx, e.logger)
 	}
 
 	return enabled, nil
@@ -545,10 +545,10 @@ func (e *Engine) mapError(ctx context.Context, err error) error {
 	case errors.Is(err, ErrDenied):
 		return oops.C(oops.CodeForbidden)
 	case errors.Is(err, ErrMissingGrants):
-		return oops.E(oops.CodeUnexpected, err, "authz grants missing from prepared context").Log(ctx, e.logger)
+		return oops.E(oops.CodeUnexpected, err, "authz grants missing from prepared context").LogError(ctx, e.logger)
 	case errors.Is(err, ErrInvalidCheck), errors.Is(err, ErrNoChecks):
-		return oops.E(oops.CodeUnexpected, err, "invalid authz check").Log(ctx, e.logger)
+		return oops.E(oops.CodeUnexpected, err, "invalid authz check").LogError(ctx, e.logger)
 	default:
-		return oops.E(oops.CodeUnexpected, err, "check authz").Log(ctx, e.logger)
+		return oops.E(oops.CodeUnexpected, err, "check authz").LogError(ctx, e.logger)
 	}
 }

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -275,11 +275,11 @@ func GrantsForRole(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, o
 	// role:<kind>:<uuid> principal and the legacy role:<slug> principal.
 	rp, err := newRolePrincipals(roleSlug, rolePrincipalURN)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build role principals").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build role principals").LogError(ctx, logger)
 	}
 	principalURNs, err := principalURNStrings(rp.MatchPrincipals)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build role principals").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build role principals").LogError(ctx, logger)
 	}
 
 	rows, err := repo.New(db).GetPrincipalGrants(ctx, repo.GetPrincipalGrantsParams{
@@ -287,12 +287,12 @@ func GrantsForRole(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, o
 		PrincipalUrns:  principalURNs,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list grants for role").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list grants for role").LogError(ctx, logger)
 	}
 
 	scoped, err := scopedGrantsFromGrantRows(rows)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "unmarshal grant selector").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "unmarshal grant selector").LogError(ctx, logger)
 	}
 
 	return scoped, nil

--- a/server/internal/background/activities/backfill_workos_global_roles.go
+++ b/server/internal/background/activities/backfill_workos_global_roles.go
@@ -34,7 +34,7 @@ func NewBackfillWorkOSGlobalRoles(logger *slog.Logger, db *pgxpool.Pool, workosC
 func (b *BackfillWorkOSGlobalRoles) Do(ctx context.Context) error {
 	roles, err := b.workos.ListGlobalRoles(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "list WorkOS global roles").Log(ctx, b.logger)
+		return oops.E(oops.CodeUnexpected, err, "list WorkOS global roles").LogError(ctx, b.logger)
 	}
 
 	tx, err := b.db.Begin(ctx)

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -62,21 +62,21 @@ func (b *BackfillWorkOSOrganization) Do(ctx context.Context, params BackfillWork
 
 	workosOrg, err := b.workos.GetOrganization(ctx, params.WorkOSOrganizationID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "get WorkOS organization").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "get WorkOS organization").LogError(ctx, logger)
 	}
 	orgUpdatedAt, err := parseWorkOSTime(workosOrg.UpdatedAt)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "parse WorkOS organization updated_at").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "parse WorkOS organization updated_at").LogError(ctx, logger)
 	}
 
 	roles, err := b.workos.ListRoles(ctx, params.WorkOSOrganizationID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "list WorkOS organization roles").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "list WorkOS organization roles").LogError(ctx, logger)
 	}
 
 	members, err := b.workos.ListOrgMemberships(ctx, params.WorkOSOrganizationID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "list WorkOS organization memberships").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "list WorkOS organization memberships").LogError(ctx, logger)
 	}
 	parsedMembers := make([]backfillWorkOSMember, 0, len(members))
 	for _, member := range members {

--- a/server/internal/background/activities/cancel_assistants_subscription.go
+++ b/server/internal/background/activities/cancel_assistants_subscription.go
@@ -26,7 +26,7 @@ type CancelAssistantsSubscriptionArgs struct {
 
 func (a *CancelAssistantsSubscription) Do(ctx context.Context, args CancelAssistantsSubscriptionArgs) error {
 	if err := a.billingRepo.CancelSubscriptionAtPeriodEnd(ctx, args.SubscriptionID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "cancel assistants subscription at period end").Log(ctx, a.logger)
+		return oops.E(oops.CodeUnexpected, err, "cancel assistants subscription at period end").LogError(ctx, a.logger)
 	}
 	return nil
 }

--- a/server/internal/background/activities/custom_domain_ingress.go
+++ b/server/internal/background/activities/custom_domain_ingress.go
@@ -93,11 +93,11 @@ func (c *CustomDomainIngress) Do(ctx context.Context, args CustomDomainIngressAr
 			resourceName = args.IngressName
 		}
 		if resourceName == "" {
-			return oops.E(oops.CodeUnexpected, errors.New("resource name is empty"), "resource name is empty").Log(ctx, c.logger)
+			return oops.E(oops.CodeUnexpected, errors.New("resource name is empty"), "resource name is empty").LogError(ctx, c.logger)
 		}
 
 		if err := provisioner.Delete(ctx, resourceName, args.CertSecretName); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to delete custom domain resource").Log(ctx, c.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to delete custom domain resource").LogError(ctx, c.logger)
 		}
 
 		return nil
@@ -105,11 +105,11 @@ func (c *CustomDomainIngress) Do(ctx context.Context, args CustomDomainIngressAr
 
 	customDomain, err := c.domains.GetCustomDomainByDomain(ctx, args.Domain)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get custom domain").Log(ctx, c.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get custom domain").LogError(ctx, c.logger)
 	}
 
 	if customDomain.OrganizationID != args.OrgID {
-		return oops.E(oops.CodeUnauthorized, errors.New("custom domain does not belong to organization"), "custom domain does not belong to organization").Log(ctx, c.logger)
+		return oops.E(oops.CodeUnauthorized, errors.New("custom domain does not belong to organization"), "custom domain does not belong to organization").LogError(ctx, c.logger)
 	}
 
 	if args.Action == CustomDomainIngressActionReapply {
@@ -123,7 +123,7 @@ func (c *CustomDomainIngress) Do(ctx context.Context, args CustomDomainIngressAr
 		// and its cert already exist, so there is no convergence wait and no
 		// verified/activated flip.
 		if _, err := provisioner.Setup(ctx, customDomain.Domain, args.IPAllowlist); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to re-apply custom domain ip allowlist").Log(ctx, c.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to re-apply custom domain ip allowlist").LogError(ctx, c.logger)
 		}
 
 		return nil
@@ -137,7 +137,7 @@ func (c *CustomDomainIngress) Do(ctx context.Context, args CustomDomainIngressAr
 
 		result, err := provisioner.Setup(ctx, customDomain.Domain, customDomain.IpAllowlist)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to provision custom domain resource").Log(ctx, c.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to provision custom domain resource").LogError(ctx, c.logger)
 		}
 
 		// Wait for resource convergence — cert issuance and LB propagation.
@@ -145,7 +145,7 @@ func (c *CustomDomainIngress) Do(ctx context.Context, args CustomDomainIngressAr
 		time.Sleep(c.setupSleep)
 
 		if err := provisioner.Get(ctx, result.ResourceName); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to verify custom domain resource exists").Log(ctx, c.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to verify custom domain resource exists").LogError(ctx, c.logger)
 		}
 
 		_, err = c.domains.UpdateCustomDomain(ctx, customdomainsRepo.UpdateCustomDomainParams{
@@ -157,7 +157,7 @@ func (c *CustomDomainIngress) Do(ctx context.Context, args CustomDomainIngressAr
 			ProvisionerKind: string(kind),
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to update custom domain").Log(ctx, c.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to update custom domain").LogError(ctx, c.logger)
 		}
 
 		return nil

--- a/server/internal/background/activities/deploy_function_runners.go
+++ b/server/internal/background/activities/deploy_function_runners.go
@@ -72,7 +72,7 @@ func (d *DeployFunctionRunners) do(ctx context.Context, args DeployFunctionRunne
 
 	dbtx, err := d.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error starting transaction").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "error starting transaction").LogError(ctx, d.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -86,7 +86,7 @@ func (d *DeployFunctionRunners) do(ctx context.Context, args DeployFunctionRunne
 		DeploymentID: args.DeploymentID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error fetching deployment functions").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "error fetching deployment functions").LogError(ctx, d.logger)
 	}
 
 	ids := make([]uuid.UUID, 0, len(depfuncs))
@@ -102,7 +102,7 @@ func (d *DeployFunctionRunners) do(ctx context.Context, args DeployFunctionRunne
 		FunctionIds:  ids,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error fetching function credentials").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "error fetching function credentials").LogError(ctx, d.logger)
 	}
 
 	creds := make(map[uuid.UUID]repo.GetFunctionCredentialsBatchRow, len(credrows))
@@ -115,7 +115,7 @@ func (d *DeployFunctionRunners) do(ctx context.Context, args DeployFunctionRunne
 		Ids:       assetids,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error reading function asset URLs").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "error reading function asset URLs").LogError(ctx, d.logger)
 	}
 
 	assetURLs := make(map[uuid.UUID]assetsrepo.GetAssetsByIDRow, len(urlrows))
@@ -133,7 +133,7 @@ func (d *DeployFunctionRunners) do(ctx context.Context, args DeployFunctionRunne
 		}
 	}
 	if stop {
-		return oops.E(oops.CodeInvalid, nil, "one or more functions failed preflight checks").Log(ctx, d.logger)
+		return oops.E(oops.CodeInvalid, nil, "one or more functions failed preflight checks").LogError(ctx, d.logger)
 	}
 
 	workers := pool.New().WithErrors().WithMaxGoroutines(runtime.GOMAXPROCS(0))
@@ -165,7 +165,7 @@ func (d *DeployFunctionRunners) do(ctx context.Context, args DeployFunctionRunne
 			case errors.As(err, &serr):
 				return serr
 			case err != nil:
-				return oops.E(oops.CodeUnexpected, err, "error deploying function runner").Log(ctx, d.logger)
+				return oops.E(oops.CodeUnexpected, err, "error deploying function runner").LogError(ctx, d.logger)
 			}
 			return nil
 		})
@@ -175,7 +175,7 @@ func (d *DeployFunctionRunners) do(ctx context.Context, args DeployFunctionRunne
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error committing transaction").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "error committing transaction").LogError(ctx, d.logger)
 	}
 
 	return nil
@@ -208,52 +208,52 @@ func (d *DeployFunctionRunners) preflightFunction(
 	var empty deployFunctionRunnerTask
 
 	if !functions.IsSupportedRuntime(fnc.Runtime) {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has unsupported runtime %q", fnc.Runtime).Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has unsupported runtime %q", fnc.Runtime).LogError(ctx, logger)
 	}
 
 	fa, ok := fncAssets[fnc.AssetID]
 	if !ok {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "function is missing asset URL").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "function is missing asset URL").LogError(ctx, logger)
 	}
 	if fa.Url == "" {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has empty asset URL").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has empty asset URL").LogError(ctx, logger)
 	}
 	if fa.Sha256 == "" {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has empty asset integrity hash").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has empty asset integrity hash").LogError(ctx, logger)
 	}
 
 	mem := int(fnc.MemoryMib.Int32)
 	if mem < 0 || mem > constants.MaxFunctionMemoryMiB {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has invalid memory configuration").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has invalid memory configuration").LogError(ctx, logger)
 	}
 
 	scale := int(fnc.Scale.Int32)
 	if scale < 0 || scale > constants.MaxFunctionScale {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has invalid scale configuration").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has invalid scale configuration").LogError(ctx, logger)
 	}
 
 	assetURL, err := url.Parse(fa.Url)
 	if err != nil {
-		return empty, oops.E(oops.CodeInvariantViolation, err, "function has malformed asset URL").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, err, "function has malformed asset URL").LogError(ctx, logger)
 	}
 
 	c, ok := credentials[fnc.ID]
 	if !ok {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "function is missing credentials").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "function is missing credentials").LogError(ctx, logger)
 	}
 
 	enckey := c.EncryptionKey.Reveal()
 	if len(enckey) == 0 || c.BearerFormat.String == "" {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "malformed credentials generated for function").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "malformed credentials generated for function").LogError(ctx, logger)
 	}
 
 	sec, err := d.enc.Decrypt(string(enckey))
 	if err != nil {
-		return empty, oops.E(oops.CodeInvariantViolation, err, "failed to unseal function credentials").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, err, "failed to unseal function credentials").LogError(ctx, logger)
 	}
 
 	if len(sec) == 0 {
-		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has empty credentials").Log(ctx, logger)
+		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has empty credentials").LogError(ctx, logger)
 	}
 
 	return deployFunctionRunnerTask{

--- a/server/internal/background/activities/get_all_organizations.go
+++ b/server/internal/background/activities/get_all_organizations.go
@@ -25,7 +25,7 @@ func NewGetAllOrganizations(logger *slog.Logger, db *pgxpool.Pool) *GetAllOrgani
 func (g *GetAllOrganizations) Do(ctx context.Context) ([]string, error) {
 	orgs, err := g.repo.GetAllOrganizationsWithToolsets(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get all organization").Log(ctx, g.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get all organization").LogError(ctx, g.logger)
 	}
 
 	orgIDs := make([]string, len(orgs))

--- a/server/internal/background/activities/list_workos_organizations.go
+++ b/server/internal/background/activities/list_workos_organizations.go
@@ -23,7 +23,7 @@ func NewListWorkOSOrganizations(logger *slog.Logger, workosClient WorkOSClient) 
 func (l *ListWorkOSOrganizations) Do(ctx context.Context) ([]string, error) {
 	orgs, err := l.workos.ListOrganizations(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list WorkOS organizations").Log(ctx, l.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list WorkOS organizations").LogError(ctx, l.logger)
 	}
 
 	orgIDs := make([]string, 0, len(orgs))

--- a/server/internal/background/activities/platform_usage_metrics.go
+++ b/server/internal/background/activities/platform_usage_metrics.go
@@ -39,7 +39,7 @@ func (c *CollectPlatformUsageMetrics) Do(ctx context.Context) ([]PlatformUsageMe
 
 	rows, err := c.repo.GetPlatformUsageMetrics(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get platform usage metrics").Log(ctx, c.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get platform usage metrics").LogError(ctx, c.logger)
 	}
 
 	metrics := make([]PlatformUsageMetrics, 0, len(rows))

--- a/server/internal/background/activities/process_deployment.go
+++ b/server/internal/background/activities/process_deployment.go
@@ -97,7 +97,7 @@ func (p *ProcessDeployment) Do(ctx context.Context, projectID uuid.UUID, deploym
 
 	orgData, err := p.projects.GetProjectWithOrganizationMetadata(ctx, uuid.MustParse(deployment.ProjectID))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error loading organization metadata").Log(ctx, p.logger)
+		return oops.E(oops.CodeUnexpected, err, "error loading organization metadata").LogError(ctx, p.logger)
 	}
 
 	numOpenAPISources := len(deployment.Openapiv3Assets)
@@ -150,7 +150,7 @@ func (p *ProcessDeployment) Do(ctx context.Context, projectID uuid.UUID, deploym
 		Limit:        1,
 	})
 	if err != nil {
-		err = oops.E(oops.CodeUnexpected, err, "failed to read list of tools in deployment").Log(ctx, p.logger)
+		err = oops.E(oops.CodeUnexpected, err, "failed to read list of tools in deployment").LogError(ctx, p.logger)
 		return temporal.NewApplicationErrorWithOptions("deployment tools could not be verified", "deployment_error", temporal.ApplicationErrorOptions{
 			NonRetryable: true,
 			Cause:        err,
@@ -165,7 +165,7 @@ func (p *ProcessDeployment) Do(ctx context.Context, projectID uuid.UUID, deploym
 		Limit:        1,
 	})
 	if err != nil {
-		err = oops.E(oops.CodeUnexpected, err, "failed to read list of function tools in deployment").Log(ctx, p.logger)
+		err = oops.E(oops.CodeUnexpected, err, "failed to read list of function tools in deployment").LogError(ctx, p.logger)
 		return temporal.NewApplicationErrorWithOptions("deployment function tools could not be verified", "deployment_error", temporal.ApplicationErrorOptions{
 			NonRetryable: true,
 			Cause:        err,
@@ -179,7 +179,7 @@ func (p *ProcessDeployment) Do(ctx context.Context, projectID uuid.UUID, deploym
 		Limit:        1,
 	})
 	if err != nil {
-		err = oops.E(oops.CodeUnexpected, err, "failed to read list of function resources in deployment").Log(ctx, p.logger)
+		err = oops.E(oops.CodeUnexpected, err, "failed to read list of function resources in deployment").LogError(ctx, p.logger)
 		return temporal.NewApplicationErrorWithOptions("deployment function resources could not be verified", "deployment_error", temporal.ApplicationErrorOptions{
 			NonRetryable: true,
 			Cause:        err,
@@ -189,7 +189,7 @@ func (p *ProcessDeployment) Do(ctx context.Context, projectID uuid.UUID, deploym
 	// Get external MCPs to check if deployment has any
 	externalMCPs, err := p.repo.ListDeploymentExternalMCPs(ctx, deploymentID)
 	if err != nil {
-		err = oops.E(oops.CodeUnexpected, err, "failed to read list of external mcps in deployment").Log(ctx, p.logger)
+		err = oops.E(oops.CodeUnexpected, err, "failed to read list of external mcps in deployment").LogError(ctx, p.logger)
 		return temporal.NewApplicationErrorWithOptions("deployment external mcps could not be verified", "deployment_error", temporal.ApplicationErrorOptions{
 			NonRetryable: true,
 			Cause:        err,
@@ -203,7 +203,7 @@ func (p *ProcessDeployment) Do(ctx context.Context, projectID uuid.UUID, deploym
 	hasResources := len(functionResources) > 0
 	hasExternalMCPs := len(externalMCPs) > 0
 	if expectsTools && !hasTools && !hasResources && !hasExternalMCPs {
-		err = oops.E(oops.CodeUnexpected, err, "no tools were created for deployment").Log(ctx, p.logger)
+		err = oops.E(oops.CodeUnexpected, err, "no tools were created for deployment").LogError(ctx, p.logger)
 		return temporal.NewApplicationErrorWithOptions("empty deployment was not expected", "deployment_error", temporal.ApplicationErrorOptions{
 			NonRetryable: true,
 			Cause:        err,
@@ -237,12 +237,12 @@ func (p *ProcessDeployment) doOpenAPIv3(
 
 		openapiDocID, err := uuid.Parse(docInfo.ID)
 		if err != nil {
-			return oops.E(oops.CodeInvariantViolation, err, "error parsing openapi document id").Log(ctx, logger)
+			return oops.E(oops.CodeInvariantViolation, err, "error parsing openapi document id").LogError(ctx, logger)
 		}
 
 		assetID, err := uuid.Parse(docInfo.AssetID)
 		if err != nil {
-			return oops.E(oops.CodeInvariantViolation, err, "error parsing openapit asset id").Log(ctx, logger)
+			return oops.E(oops.CodeInvariantViolation, err, "error parsing openapit asset id").LogError(ctx, logger)
 		}
 
 		asset, err := p.assets.GetProjectAsset(ctx, assetsRepo.GetProjectAssetParams{
@@ -250,12 +250,12 @@ func (p *ProcessDeployment) doOpenAPIv3(
 			ProjectID: projectID,
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "error reading openapi asset url").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "error reading openapi asset url").LogError(ctx, logger)
 		}
 
 		u, err := url.Parse(asset.Url)
 		if err != nil {
-			return oops.E(oops.CodeBadRequest, err, "error parsing openapi asset URL").Log(ctx, logger)
+			return oops.E(oops.CodeBadRequest, err, "error parsing openapi asset URL").LogError(ctx, logger)
 		}
 
 		pool.Go(func() (err error) {
@@ -341,12 +341,12 @@ func (p *ProcessDeployment) doFunctions(
 
 		attachmentID, err := uuid.Parse(attachment.ID)
 		if err != nil {
-			return oops.E(oops.CodeInvariantViolation, err, "error parsing functions attachment id").Log(ctx, logger)
+			return oops.E(oops.CodeInvariantViolation, err, "error parsing functions attachment id").LogError(ctx, logger)
 		}
 
 		assetID, err := uuid.Parse(attachment.AssetID)
 		if err != nil {
-			return oops.E(oops.CodeInvariantViolation, err, "error parsing functions asset id").Log(ctx, logger)
+			return oops.E(oops.CodeInvariantViolation, err, "error parsing functions asset id").LogError(ctx, logger)
 		}
 
 		asset, err := p.assets.GetProjectAsset(ctx, assetsRepo.GetProjectAssetParams{
@@ -354,12 +354,12 @@ func (p *ProcessDeployment) doFunctions(
 			ProjectID: projectID,
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "error reading functions asset url").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "error reading functions asset url").LogError(ctx, logger)
 		}
 
 		u, err := url.Parse(asset.Url)
 		if err != nil {
-			return oops.E(oops.CodeBadRequest, err, "error parsing functions asset URL").Log(ctx, logger)
+			return oops.E(oops.CodeBadRequest, err, "error parsing functions asset URL").LogError(ctx, logger)
 		}
 
 		pool.Go(func() (err error) {
@@ -428,7 +428,7 @@ func (p *ProcessDeployment) doExternalMCPs(
 ) error {
 	externalMCPs, err := p.repo.ListDeploymentExternalMCPs(ctx, deploymentID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error listing external mcps for deployment").Log(ctx, p.logger)
+		return oops.E(oops.CodeUnexpected, err, "error listing external mcps for deployment").LogError(ctx, p.logger)
 	}
 
 	for _, mcp := range externalMCPs {

--- a/server/internal/background/activities/process_workos_global_role_events.go
+++ b/server/internal/background/activities/process_workos_global_role_events.go
@@ -62,7 +62,7 @@ func (p *ProcessWorkOSGlobalRoleEvents) Do(ctx context.Context, params ProcessWo
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "get global role sync cursor").Log(ctx, p.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get global role sync cursor").LogError(ctx, p.logger)
 		default:
 			sinceEventID = cursor
 		}
@@ -81,7 +81,7 @@ func (p *ProcessWorkOSGlobalRoleEvents) Do(ctx context.Context, params ProcessWo
 		RangeEnd:       "",
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list WorkOS global role events").Log(ctx, p.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list WorkOS global role events").LogError(ctx, p.logger)
 	}
 
 	lastEventID, err := p.handlePage(ctx, resp.Data)
@@ -106,7 +106,7 @@ func (p *ProcessWorkOSGlobalRoleEvents) handlePage(ctx context.Context, page []e
 
 		eventID, err := p.handleEvent(ctx, eventLogger, event)
 		if err != nil {
-			return lastEventID, oops.E(oops.CodeUnexpected, err, "handle WorkOS global role event").Log(ctx, eventLogger)
+			return lastEventID, oops.E(oops.CodeUnexpected, err, "handle WorkOS global role event").LogError(ctx, eventLogger)
 		}
 		if eventID != "" {
 			lastEventID = eventID

--- a/server/internal/background/activities/process_workos_org_events.go
+++ b/server/internal/background/activities/process_workos_org_events.go
@@ -75,7 +75,7 @@ func (p *ProcessWorkOSOrganizationEvents) Do(ctx context.Context, params Process
 		case errors.Is(err, pgx.ErrNoRows):
 			// No cursor yet — full sync from the beginning.
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get organization sync last event ID").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get organization sync last event ID").LogError(ctx, logger)
 		default:
 			sinceEventID = cursor
 		}
@@ -109,7 +109,7 @@ func (p *ProcessWorkOSOrganizationEvents) Do(ctx context.Context, params Process
 		RangeEnd:       "",
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list WorkOS events").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list WorkOS events").LogError(ctx, logger)
 	}
 
 	lastEventID, err := p.handlePage(ctx, logger, workOSOrgID, resp.Data)
@@ -145,7 +145,7 @@ func (p *ProcessWorkOSOrganizationEvents) handlePage(ctx context.Context, logger
 
 		var orgEvent workosOrgEvent
 		if err := json.Unmarshal(event.Data, &orgEvent); err != nil {
-			return lastEventID, oops.E(oops.CodeUnexpected, err, "failed to unmarshal workos organization event data").Log(ctx, eventLogger)
+			return lastEventID, oops.E(oops.CodeUnexpected, err, "failed to unmarshal workos organization event data").LogError(ctx, eventLogger)
 		}
 
 		// Resolve the WorkOS organization ID from the payload for logging.
@@ -158,7 +158,7 @@ func (p *ProcessWorkOSOrganizationEvents) handlePage(ctx context.Context, logger
 
 		eventID, err := p.handleEvent(ctx, eventLogger, workosOrgID, event)
 		if err != nil {
-			return lastEventID, oops.E(oops.CodeUnexpected, err, "failed to handle WorkOS event").Log(ctx, eventLogger)
+			return lastEventID, oops.E(oops.CodeUnexpected, err, "failed to handle WorkOS event").LogError(ctx, eventLogger)
 		}
 		lastEventID = eventID
 	}

--- a/server/internal/background/activities/process_workos_user_events.go
+++ b/server/internal/background/activities/process_workos_user_events.go
@@ -55,7 +55,7 @@ func NewProcessWorkOSUserEvents(logger *slog.Logger, db *pgxpool.Pool, workosCli
 func (p *ProcessWorkOSUserEvents) Do(ctx context.Context, params ProcessWorkOSUserEventsParams) (*ProcessWorkOSUserEventsResult, error) {
 	logger := p.logger.With(attr.SlogWorkOSUserID(params.WorkOSUserID))
 	if params.WorkOSUserID == "" {
-		return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("missing WorkOS user ID"), "missing WorkOS user ID").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("missing WorkOS user ID"), "missing WorkOS user ID").LogError(ctx, logger)
 	}
 
 	sinceEventID := conv.PtrValOr(params.SinceEventID, "")
@@ -64,7 +64,7 @@ func (p *ProcessWorkOSUserEvents) Do(ctx context.Context, params ProcessWorkOSUs
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "get user sync cursor").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get user sync cursor").LogError(ctx, logger)
 		default:
 			sinceEventID = cursor
 		}
@@ -83,7 +83,7 @@ func (p *ProcessWorkOSUserEvents) Do(ctx context.Context, params ProcessWorkOSUs
 		RangeEnd:       "",
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list WorkOS user events").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list WorkOS user events").LogError(ctx, logger)
 	}
 
 	lastEventID, err := p.handlePage(ctx, logger, params.WorkOSUserID, resp.Data)
@@ -108,7 +108,7 @@ func (p *ProcessWorkOSUserEvents) handlePage(ctx context.Context, logger *slog.L
 
 		eventID, err := p.handleEvent(ctx, eventLogger, workosUserID, event)
 		if err != nil {
-			return lastEventID, oops.E(oops.CodeUnexpected, err, "handle WorkOS user event").Log(ctx, eventLogger)
+			return lastEventID, oops.E(oops.CodeUnexpected, err, "handle WorkOS user event").LogError(ctx, eventLogger)
 		}
 		if eventID != "" {
 			lastEventID = eventID

--- a/server/internal/background/activities/provision_functions_access.go
+++ b/server/internal/background/activities/provision_functions_access.go
@@ -46,12 +46,12 @@ func (p *ProvisionFunctionsAccess) Do(ctx context.Context, projectID uuid.UUID, 
 		"project id cannot be nil", projectID != uuid.Nil,
 		"deployment id cannot be nil", deploymentID != uuid.Nil,
 	); err != nil {
-		return oops.E(oops.CodeInvalid, err, "invalid inputs").Log(ctx, logger)
+		return oops.E(oops.CodeInvalid, err, "invalid inputs").LogError(ctx, logger)
 	}
 
 	dbtx, err := p.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error accessing database").Log(ctx, p.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing database").LogError(ctx, p.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -63,18 +63,18 @@ func (p *ProvisionFunctionsAccess) Do(ctx context.Context, projectID uuid.UUID, 
 		ProjectID:    projectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get functions missing access").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get functions missing access").LogError(ctx, logger)
 	}
 
 	for _, aid := range attachments {
 		key := make([]byte, 32)
 		if _, err := rand.Read(key); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to generate encryption key").Log(ctx, logger, attr.SlogDeploymentFunctionsID(aid.String()))
+			return oops.E(oops.CodeUnexpected, err, "failed to generate encryption key").LogError(ctx, logger, attr.SlogDeploymentFunctionsID(aid.String()))
 		}
 
 		sealedKey, err := p.encryption.Encrypt(key)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to encrypt functions access key").Log(ctx, logger, attr.SlogDeploymentFunctionsID(aid.String()))
+			return oops.E(oops.CodeUnexpected, err, "failed to encrypt functions access key").LogError(ctx, logger, attr.SlogDeploymentFunctionsID(aid.String()))
 		}
 
 		_, err = deprepo.CreateDeploymentFunctionsAccess(ctx, repo.CreateDeploymentFunctionsAccessParams{
@@ -85,12 +85,12 @@ func (p *ProvisionFunctionsAccess) Do(ctx context.Context, projectID uuid.UUID, 
 			BearerFormat:  conv.ToPGText("v01"),
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to create functions access").Log(ctx, logger, attr.SlogDeploymentFunctionsID(aid.String()))
+			return oops.E(oops.CodeUnexpected, err, "failed to create functions access").LogError(ctx, logger, attr.SlogDeploymentFunctionsID(aid.String()))
 		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error committing functions access creation").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "error committing functions access creation").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/background/activities/reap_functions.go
+++ b/server/internal/background/activities/reap_functions.go
@@ -79,7 +79,7 @@ func (r *ReapFlyApps) Do(ctx context.Context, req ReapFlyAppsRequest) (*ReapFlyA
 		ProjectID: req.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to query apps to reap").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to query apps to reap").LogError(ctx, logger)
 	}
 
 	if len(appsToReap) == 0 {

--- a/server/internal/background/activities/refresh_billing_usage.go
+++ b/server/internal/background/activities/refresh_billing_usage.go
@@ -58,7 +58,7 @@ func (r *RefreshBillingUsage) Do(ctx context.Context, orgIDs []string) error {
 	}
 
 	if err := workers.Wait(); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to refresh billing usage").Log(ctx, r.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to refresh billing usage").LogError(ctx, r.logger)
 	}
 
 	return nil

--- a/server/internal/background/activities/refresh_open_router_key.go
+++ b/server/internal/background/activities/refresh_open_router_key.go
@@ -30,7 +30,7 @@ type RefreshOpenRouterKeyArgs struct {
 func (o *RefreshOpenRouterKey) Do(ctx context.Context, args RefreshOpenRouterKeyArgs) error {
 	limit, err := o.openRouter.RefreshAPIKeyLimit(ctx, args.OrgID, args.Limit)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error updating openrouter key").Log(ctx, o.logger)
+		return oops.E(oops.CodeUnexpected, err, "error updating openrouter key").LogError(ctx, o.logger)
 	}
 
 	o.logger.InfoContext(ctx, "refreshed openrouter key limit", attr.SlogOpenRouterKeyLimit(limit))

--- a/server/internal/background/activities/transition_deployment.go
+++ b/server/internal/background/activities/transition_deployment.go
@@ -39,7 +39,7 @@ func (t *TransitionDeployment) Do(ctx context.Context, projectID uuid.UUID, depl
 		Message:      fmt.Sprintf("Deployment moved to %s state", status),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error transitioning deployment").Log(ctx, t.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error transitioning deployment").LogError(ctx, t.logger)
 	}
 
 	return &TransitionDeploymentResult{

--- a/server/internal/background/activities/validate_deployment.go
+++ b/server/internal/background/activities/validate_deployment.go
@@ -47,12 +47,12 @@ func (v *ValidateDeployment) Do(ctx context.Context, projectID uuid.UUID, deploy
 
 	orgData, err := projRepo.GetProjectWithOrganizationMetadata(ctx, uuid.MustParse(deployment.ProjectID))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error loading organization metadata").Log(ctx, v.logger)
+		return oops.E(oops.CodeUnexpected, err, "error loading organization metadata").LogError(ctx, v.logger)
 	}
 
 	org, err := mv.DescribeOrganization(ctx, v.logger, orgRepo, v.billingRepo, orgData.ID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error loading organization metadata").Log(ctx, v.logger)
+		return oops.E(oops.CodeUnexpected, err, "error loading organization metadata").LogError(ctx, v.logger)
 	}
 
 	var validationError *oops.ShareableError
@@ -60,18 +60,18 @@ func (v *ValidateDeployment) Do(ctx context.Context, projectID uuid.UUID, deploy
 	switch billing.Tier(org.GramAccountType) {
 	case billing.TierBase:
 		if len(deployment.FunctionsAssets) > 5 {
-			validationError = oops.E(oops.CodeForbidden, nil, "Free tier only allows up to 5 function sources. Please contact Speakeasy support for assistance.").Log(ctx, v.logger)
+			validationError = oops.E(oops.CodeForbidden, nil, "Free tier only allows up to 5 function sources. Please contact Speakeasy support for assistance.").LogError(ctx, v.logger)
 		}
 	case billing.TierPro:
 		if len(deployment.FunctionsAssets) > 10 {
-			validationError = oops.E(oops.CodeForbidden, nil, "Pro tier only allows up to 10 function sources. Please contact Speakeasy support for assistance.").Log(ctx, v.logger)
+			validationError = oops.E(oops.CodeForbidden, nil, "Pro tier only allows up to 10 function sources. Please contact Speakeasy support for assistance.").LogError(ctx, v.logger)
 		}
 	case billing.TierEnterprise:
 		if len(deployment.FunctionsAssets) > 25 {
-			validationError = oops.E(oops.CodeForbidden, nil, "Enterprise tier only allows up to 25 function sources. Please contact Speakeasy support for assistance.").Log(ctx, v.logger)
+			validationError = oops.E(oops.CodeForbidden, nil, "Enterprise tier only allows up to 25 function sources. Please contact Speakeasy support for assistance.").LogError(ctx, v.logger)
 		}
 	default:
-		validationError = oops.E(oops.CodeForbidden, nil, "Unsupported organization tier").Log(ctx, v.logger)
+		validationError = oops.E(oops.CodeForbidden, nil, "Unsupported organization tier").LogError(ctx, v.logger)
 	}
 
 	if validationError != nil {

--- a/server/internal/background/activities/verify_custom_domain.go
+++ b/server/internal/background/activities/verify_custom_domain.go
@@ -78,18 +78,18 @@ var domainRegex = regexp.MustCompile(`^(?i)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(?:
 
 func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs) error {
 	if !domainRegex.MatchString(args.Domain) {
-		return oops.E(oops.CodeBadRequest, errors.New("domain is invalid"), "domain is invalid %s", args.Domain).Log(ctx, d.logger)
+		return oops.E(oops.CodeBadRequest, errors.New("domain is invalid"), "domain is invalid %s", args.Domain).LogError(ctx, d.logger)
 	}
 
 	for _, root := range prohibitedDomainRoots {
 		if strings.Contains(args.Domain, root) && !slices.Contains(specialTestDomains, args.Domain) { // Temporarily allowed test domain
-			return oops.E(oops.CodeBadRequest, errors.New("domain is prohibited"), "domain %s is prohibited", args.Domain).Log(ctx, d.logger)
+			return oops.E(oops.CodeBadRequest, errors.New("domain is prohibited"), "domain %s is prohibited", args.Domain).LogError(ctx, d.logger)
 		}
 	}
 
 	dbtx, err := d.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to access custom domains").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to access custom domains").LogError(ctx, d.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -118,7 +118,7 @@ func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs
 			IpAllowlist:     ipAllowlist,
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "error creating custom domain").Log(ctx, d.logger)
+			return oops.E(oops.CodeUnexpected, err, "error creating custom domain").LogError(ctx, d.logger)
 		}
 
 		if err := d.audit.LogCustomDomainCreate(ctx, dbtx, audit.LogCustomDomainCreateEvent{
@@ -129,18 +129,18 @@ func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs
 			CustomDomainURN:  urn.NewCustomDomain(domain.ID),
 			DomainName:       domain.Domain,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to create custom domain creation audit log").Log(ctx, d.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to create custom domain creation audit log").LogError(ctx, d.logger)
 		}
 	default:
-		return oops.E(oops.CodeUnexpected, err, "failed to get custom domain").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get custom domain").LogError(ctx, d.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to save custom domain creation").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to save custom domain creation").LogError(ctx, d.logger)
 	}
 
 	if domain.OrganizationID != args.OrgID {
-		return oops.E(oops.CodeUnauthorized, errors.New("custom domain does not belong to organization"), "custom domain does not belong to organization").Log(ctx, d.logger)
+		return oops.E(oops.CodeUnauthorized, errors.New("custom domain does not belong to organization"), "custom domain does not belong to organization").LogError(ctx, d.logger)
 	}
 
 	cname, err := d.resolver.LookupCNAME(ctx, domain.Domain)
@@ -156,13 +156,13 @@ func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs
 				d.logger.InfoContext(ctx, "custom domain DNS not found, terminating non-retryable", attr.SlogURLDomain(domain.Domain), attr.SlogError(err))
 				return newDNSNotFoundError(err, domain.Domain)
 			}
-			return oops.E(oops.CodeUnexpected, err, "failed to find custom domain mapping for %s", domain.Domain).Log(ctx, d.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to find custom domain mapping for %s", domain.Domain).LogError(ctx, d.logger)
 		}
 	} else {
 		actualCNAMEFQDN := strings.TrimSuffix(cname, ".") + "."
 
 		if actualCNAMEFQDN != d.expectedTargetCNAME {
-			return oops.E(oops.CodeUnexpected, errors.New("custom domain is not pointing to expected target"), "custom domain %s is not pointing to %s", domain.Domain, d.expectedTargetCNAME).Log(ctx, d.logger)
+			return oops.E(oops.CodeUnexpected, errors.New("custom domain is not pointing to expected target"), "custom domain %s is not pointing to %s", domain.Domain, d.expectedTargetCNAME).LogError(ctx, d.logger)
 		}
 	}
 
@@ -174,12 +174,12 @@ func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs
 			d.logger.InfoContext(ctx, "custom domain verification TXT record not found, terminating non-retryable", attr.SlogURLDomain(domain.Domain), attr.SlogError(err))
 			return newDNSNotFoundError(err, txtName)
 		}
-		return oops.E(oops.CodeUnexpected, err, "failed to find TXT record for %s", txtName).Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to find TXT record for %s", txtName).LogError(ctx, d.logger)
 	}
 	expectedTXT := fmt.Sprintf("gram-domain-verify=%s,%s", domain.Domain, args.OrgID)
 	found := slices.Contains(txts, expectedTXT)
 	if !found {
-		return oops.E(oops.CodeUnexpected, errors.New("TXT record does not match expected value"), "TXT record for %s does not match expected value", txtName).Log(ctx, d.logger)
+		return oops.E(oops.CodeUnexpected, errors.New("TXT record does not match expected value"), "TXT record for %s does not match expected value", txtName).LogError(ctx, d.logger)
 	}
 
 	return nil

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -204,7 +204,7 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 		var err error
 		userInfo, _, err = s.sessions.GetUserInfo(ctx, authCtx.UserID)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error getting user info").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error getting user info").LogError(ctx, s.logger)
 		}
 	}
 
@@ -217,14 +217,14 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 	if payload.From != nil {
 		t, err := time.Parse(time.RFC3339, *payload.From)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid from timestamp").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid from timestamp").LogError(ctx, s.logger)
 		}
 		fromTime = pgtype.Timestamptz{Time: t, InfinityModifier: pgtype.Finite, Valid: true}
 	}
 	if payload.To != nil {
 		t, err := time.Parse(time.RFC3339, *payload.To)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid to timestamp").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid to timestamp").LogError(ctx, s.logger)
 		}
 		toTime = pgtype.Timestamptz{Time: t, InfinityModifier: pgtype.Finite, Valid: true}
 	}
@@ -260,7 +260,7 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 
 	total, err := s.repo.CountChats(ctx, baseParams)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "count chats").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "count chats").LogError(ctx, s.logger)
 	}
 
 	rows, err := s.repo.ListChats(ctx, repo.ListChatsParams{
@@ -278,7 +278,7 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 		PageOffset:     conv.SafeInt32(payload.Offset),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list chats").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list chats").LogError(ctx, s.logger)
 	}
 
 	result := make([]*gen.ChatOverview, 0, len(rows))
@@ -329,7 +329,7 @@ func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").LogError(ctx, s.logger)
 	}
 
 	// older chat_messages may not have project_id in the model, but it will always exist on the chat
@@ -349,7 +349,7 @@ func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*
 
 	maxGeneration, err := s.repo.GetMaxGenerationForChat(ctx, chat.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat generation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat generation").LogError(ctx, s.logger)
 	}
 
 	generation := maxGeneration
@@ -367,7 +367,7 @@ func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*
 		Generation: generation,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat messages").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat messages").LogError(ctx, s.logger)
 	}
 
 	resultMessages := make([]*gen.ChatMessage, len(messages))
@@ -399,7 +399,7 @@ func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat message stats").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat message stats").LogError(ctx, s.logger)
 	}
 
 	lastMessageTimestamp := chat.CreatedAt.Time.Format(time.RFC3339)
@@ -510,7 +510,7 @@ func (s *Service) checkCreditBalance(ctx context.Context, orgID, accountType str
 	}
 
 	if pu.IncludedCredits > 0 && pu.Credits >= pu.IncludedCredits {
-		return oops.C(oops.CodeInsufficientCredits).Log(
+		return oops.C(oops.CodeInsufficientCredits).LogError(
 			ctx, s.logger,
 			attr.SlogOrganizationID(orgID),
 		)
@@ -538,11 +538,11 @@ func IsHistoryCorrupted(err error) bool {
 func (s *Service) classifyCompletionError(ctx context.Context, label string, err error) error {
 	switch {
 	case openrouter.IsInsufficientCredits(err):
-		return oops.C(oops.CodeInsufficientCredits).Log(ctx, s.logger)
+		return oops.C(oops.CodeInsufficientCredits).LogError(ctx, s.logger)
 	case openrouter.IsHistoryCorruptionCandidate(err):
-		return oops.E(oops.CodeInvalid, err, historyCorruptedMarker).Log(ctx, s.logger)
+		return oops.E(oops.CodeInvalid, err, historyCorruptedMarker).LogError(ctx, s.logger)
 	default:
-		return oops.E(oops.CodeGatewayError, err, "%s", label).Log(ctx, s.logger)
+		return oops.E(oops.CodeGatewayError, err, "%s", label).LogError(ctx, s.logger)
 	}
 }
 
@@ -602,7 +602,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	// Read the request body
 	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, s.logger)
 	}
 
 	// Create a new reader with the same content for the proxy
@@ -610,7 +610,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 
 	var chatRequest openrouter.OpenAIChatRequest
 	if err := json.Unmarshal(reqBody, &chatRequest); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to parse request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to parse request body").LogError(ctx, s.logger)
 	}
 
 	// Defense-in-depth: reject any single tool-result message larger than the
@@ -633,7 +633,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 				nil,
 				"tool message %d exceeds %d bytes; truncate tool output client-side",
 				i, maxToolMessageBytes,
-			).Log(ctx, s.logger)
+			).LogError(ctx, s.logger)
 		}
 	}
 
@@ -646,7 +646,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	if chatIDHeader != "" {
 		chatID, err = uuid.Parse(chatIDHeader)
 		if err != nil {
-			return oops.E(oops.CodeInvalid, err, "invalid chat ID").Log(ctx, s.logger)
+			return oops.E(oops.CodeInvalid, err, "invalid chat ID").LogError(ctx, s.logger)
 		}
 	}
 
@@ -784,7 +784,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	// Write response
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(openAIResp); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "encode response").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "encode response").LogError(ctx, s.logger)
 	}
 
 	eventProperties["success"] = true
@@ -827,7 +827,7 @@ func (s *Service) streamCompletion(ctx context.Context, w http.ResponseWriter, s
 		}
 
 		if _, err := io.WriteString(w, text); err != nil {
-			return oops.E(oops.CodeGatewayError, err, "stream write failed").Log(ctx, s.logger)
+			return oops.E(oops.CodeGatewayError, err, "stream write failed").LogError(ctx, s.logger)
 		}
 		if canFlush {
 			flusher.Flush()
@@ -860,7 +860,7 @@ func (s *Service) streamCompletion(ctx context.Context, w http.ResponseWriter, s
 				return nil
 			}
 			s.logger.ErrorContext(ctx, "stream read error", attr.SlogError(err))
-			return oops.E(oops.CodeGatewayError, err, "stream read failed").Log(ctx, s.logger)
+			return oops.E(oops.CodeGatewayError, err, "stream read failed").LogError(ctx, s.logger)
 		}
 	}
 }
@@ -940,7 +940,7 @@ func (s *Service) CreditUsage(ctx context.Context, payload *gen.CreditUsagePaylo
 
 	creditsUsed, creditLimit, err := s.openRouter.GetCreditsUsed(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get credit usage").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get credit usage").LogError(ctx, s.logger)
 	}
 
 	return &gen.CreditUsageResult{
@@ -966,7 +966,7 @@ func (s *Service) GenerateTitle(ctx context.Context, payload *gen.GenerateTitleP
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").LogError(ctx, s.logger)
 	}
 
 	if chat.ProjectID != *authCtx.ProjectID {
@@ -990,7 +990,7 @@ func (s *Service) DeleteChat(ctx context.Context, payload *gen.DeleteChatPayload
 
 	chatID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid chat id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid chat id").LogError(ctx, s.logger)
 	}
 
 	err = s.repo.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{
@@ -998,7 +998,7 @@ func (s *Service) DeleteChat(ctx context.Context, payload *gen.DeleteChatPayload
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "soft delete chat").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "soft delete chat").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -1021,7 +1021,7 @@ func (s *Service) SubmitFeedback(ctx context.Context, payload *gen.SubmitFeedbac
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").LogError(ctx, s.logger)
 	}
 
 	if chat.ProjectID != *authCtx.ProjectID {
@@ -1038,7 +1038,7 @@ func (s *Service) SubmitFeedback(ctx context.Context, payload *gen.SubmitFeedbac
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list messages").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list messages").LogError(ctx, s.logger)
 	}
 
 	var lastMessageID uuid.NullUUID
@@ -1058,7 +1058,7 @@ func (s *Service) SubmitFeedback(ctx context.Context, payload *gen.SubmitFeedbac
 		ChatResolutionID:    uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to store feedback").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to store feedback").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "user feedback submitted",
@@ -1331,7 +1331,7 @@ func storeMessages(ctx context.Context, logger *slog.Logger, tx repo.DBTX, asset
 	// Batch insert all messages.
 	crepo := repo.New(tx)
 	if _, err := crepo.CreateChatMessage(ctx, dbrows); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to insert chat messages").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to insert chat messages").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -67,7 +67,7 @@ func (s *ChatMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, requ
 
 	projectID, err := uuid.Parse(request.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "parse project ID").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "parse project ID").LogError(ctx, s.logger)
 	}
 	orgID := request.OrgID
 	userID := request.UserID

--- a/server/internal/chatsessions/impl.go
+++ b/server/internal/chatsessions/impl.go
@@ -68,10 +68,10 @@ func (s *Service) Create(ctx context.Context, p *gen.CreatePayload) (*gen.Create
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
-		return nil, oops.C(oops.CodeUnauthorized).Log(ctx, s.logger)
+		return nil, oops.C(oops.CodeUnauthorized).LogError(ctx, s.logger)
 	}
 	if authCtx.ProjectID == nil {
-		return nil, oops.C(oops.CodeUnauthorized).Log(ctx, s.logger)
+		return nil, oops.C(oops.CodeUnauthorized).LogError(ctx, s.logger)
 	}
 
 	// Extract user identity from the caller's auth context. When the dashboard
@@ -103,7 +103,7 @@ func (s *Service) Create(ctx context.Context, p *gen.CreatePayload) (*gen.Create
 		p.ExpiresAfter, // Min/max validated by Goa
 	)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate chat session token").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate chat session token").LogError(ctx, s.logger)
 	}
 
 	result := &gen.CreateResult{
@@ -128,27 +128,27 @@ func (s *Service) Revoke(ctx context.Context, p *gen.RevokePayload) error {
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
-		return oops.C(oops.CodeUnauthorized).Log(ctx, s.logger)
+		return oops.C(oops.CodeUnauthorized).LogError(ctx, s.logger)
 	}
 	if authCtx.ProjectID == nil {
-		return oops.C(oops.CodeUnauthorized).Log(ctx, s.logger)
+		return oops.C(oops.CodeUnauthorized).LogError(ctx, s.logger)
 	}
 
 	// Validate the token and extract JTI
 	claims, err := s.chatSessionsManager.ValidateToken(ctx, p.Token)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid token").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid token").LogError(ctx, s.logger)
 	}
 
 	// Verify the token belongs to the same org/project
 	if claims.OrgID != authCtx.ActiveOrganizationID || claims.ProjectID != authCtx.ProjectID.String() {
-		return oops.E(oops.CodeForbidden, nil, "token does not belong to this project").Log(ctx, s.logger)
+		return oops.E(oops.CodeForbidden, nil, "token does not belong to this project").LogError(ctx, s.logger)
 	}
 
 	// Revoke the token
 	err = s.chatSessionsManager.RevokeToken(ctx, claims.ID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to revoke token").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to revoke token").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "revoked chat session",

--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -107,7 +107,7 @@ func (s *Service) Create(ctx context.Context, payload *gen.CreatePayload) (*type
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collections").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collections").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -125,7 +125,7 @@ func (s *Service) Create(ctx context.Context, payload *gen.CreatePayload) (*type
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 			return nil, oops.E(oops.CodeConflict, err, "collection slug already exists")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create collection").Log(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create collection").LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	_, err = cr.CreateOrganizationMcpCollectionRegistry(ctx, repo.CreateOrganizationMcpCollectionRegistryParams{
@@ -137,28 +137,28 @@ func (s *Service) Create(ctx context.Context, payload *gen.CreatePayload) (*type
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 			return nil, oops.E(oops.CodeConflict, err, "registry namespace already exists")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create collection registry").Log(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create collection registry").LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	for _, idStr := range payload.ToolsetIds {
 		toolsetID, parseErr := uuid.Parse(idStr)
 		if parseErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid toolset_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid toolset_id").LogError(ctx, s.logger)
 		}
 		backend := serverBackend{toolsetID: uuid.NullUUID{UUID: toolsetID, Valid: true}, mcpServerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}}
 		if err := s.attachServerToCollection(ctx, cr, collection.ID, backend, authCtx.ActiveOrganizationID, authCtx.UserID); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to attach toolset to collection").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to attach toolset to collection").LogError(ctx, s.logger)
 		}
 	}
 
 	for _, idStr := range payload.McpServerIds {
 		mcpServerID, parseErr := uuid.Parse(idStr)
 		if parseErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid mcp_server_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid mcp_server_id").LogError(ctx, s.logger)
 		}
 		backend := serverBackend{toolsetID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, mcpServerID: uuid.NullUUID{UUID: mcpServerID, Valid: true}}
 		if err := s.attachServerToCollection(ctx, cr, collection.ID, backend, authCtx.ActiveOrganizationID, authCtx.UserID); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to attach mcp server to collection").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to attach mcp server to collection").LogError(ctx, s.logger)
 		}
 	}
 
@@ -171,11 +171,11 @@ func (s *Service) Create(ctx context.Context, payload *gen.CreatePayload) (*type
 		CollectionName:   collection.Name,
 		CollectionSlug:   collection.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log collection creation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log collection creation").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection").LogError(ctx, s.logger)
 	}
 
 	return toMCPCollection(collection, payload.McpRegistryNamespace), nil
@@ -195,7 +195,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 	if orgSlug == "" {
 		orgMeta, err := s.orgRepo.GetOrganizationMetadata(ctx, authCtx.ActiveOrganizationID)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error accessing organization metadata").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error accessing organization metadata").LogError(ctx, s.logger)
 		}
 		orgSlug = orgMeta.Slug
 	}
@@ -209,7 +209,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 		if errors.Is(err, pgx.ErrNoRows) {
 			return &gen.ListResult{Collections: []*types.MCPCollection{}}, nil
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list collections").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list collections").LogError(ctx, s.logger)
 	}
 
 	result := make([]*types.MCPCollection, 0, len(collections))
@@ -219,7 +219,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 			OrganizationID: authCtx.ActiveOrganizationID,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").LogError(ctx, s.logger)
 		}
 		result = append(result, toMCPCollection(repo.CreateOrganizationMcpCollectionRow(c), reg.Namespace))
 	}
@@ -239,12 +239,12 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 
 	collectionID, err := uuid.Parse(payload.CollectionID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid collection_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid collection_id").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collections").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collections").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -258,7 +258,7 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection").LogError(ctx, s.logger)
 	}
 
 	reg, err := tx.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
@@ -266,7 +266,7 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").LogError(ctx, s.logger)
 	}
 
 	before := toMCPCollection(repo.CreateOrganizationMcpCollectionRow(existing), reg.Namespace)
@@ -282,7 +282,7 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to update collection").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to update collection").LogError(ctx, s.logger)
 	}
 
 	after := toMCPCollection(repo.CreateOrganizationMcpCollectionRow(updated), reg.Namespace)
@@ -298,11 +298,11 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		CollectionSnapshotBefore: before,
 		CollectionSnapshotAfter:  after,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log collection update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log collection update").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection update").LogError(ctx, s.logger)
 	}
 
 	return after, nil
@@ -320,12 +320,12 @@ func (s *Service) Delete(ctx context.Context, payload *gen.DeletePayload) error 
 
 	collectionID, err := uuid.Parse(payload.CollectionID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid collection_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid collection_id").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error accessing collections").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing collections").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -339,7 +339,7 @@ func (s *Service) Delete(ctx context.Context, payload *gen.DeletePayload) error 
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
-		return oops.E(oops.CodeUnexpected, err, "error accessing collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing collection").LogError(ctx, s.logger)
 	}
 
 	if collection.Slug == defaultCollectionSlug {
@@ -350,19 +350,19 @@ func (s *Service) Delete(ctx context.Context, payload *gen.DeletePayload) error 
 		CollectionID:   collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to delete collection registries").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete collection registries").LogError(ctx, s.logger)
 	}
 	if err := tx.DeleteOrganizationMcpCollectionServerAttachmentsByID(ctx, repo.DeleteOrganizationMcpCollectionServerAttachmentsByIDParams{
 		CollectionID:   collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to delete collection server attachments").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete collection server attachments").LogError(ctx, s.logger)
 	}
 	if err := tx.DeleteOrganizationMcpCollection(ctx, repo.DeleteOrganizationMcpCollectionParams{
 		ID:             collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to delete collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete collection").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogMcpCollectionDelete(ctx, dbtx, audit.LogMcpCollectionDeleteEvent{
@@ -374,11 +374,11 @@ func (s *Service) Delete(ctx context.Context, payload *gen.DeletePayload) error 
 		CollectionName:   collection.Name,
 		CollectionSlug:   collection.Slug,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log collection deletion").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "log collection deletion").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error saving collection deletion").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error saving collection deletion").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -396,7 +396,7 @@ func (s *Service) AttachServer(ctx context.Context, payload *gen.AttachServerPay
 
 	collectionID, err := uuid.Parse(payload.CollectionID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid collection_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid collection_id").LogError(ctx, s.logger)
 	}
 
 	backend, err := parseServerBackend(payload.ToolsetID, payload.McpServerID)
@@ -406,7 +406,7 @@ func (s *Service) AttachServer(ctx context.Context, payload *gen.AttachServerPay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collections").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collections").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -420,7 +420,7 @@ func (s *Service) AttachServer(ctx context.Context, payload *gen.AttachServerPay
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection").LogError(ctx, s.logger)
 	}
 
 	if err := s.attachServerToCollection(ctx, tx, collectionID, backend, authCtx.ActiveOrganizationID, authCtx.UserID); err != nil {
@@ -432,7 +432,7 @@ func (s *Service) AttachServer(ctx context.Context, payload *gen.AttachServerPay
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").LogError(ctx, s.logger)
 	}
 
 	toolsetURN, mcpServerURN := backend.auditURNs()
@@ -447,11 +447,11 @@ func (s *Service) AttachServer(ctx context.Context, payload *gen.AttachServerPay
 		ToolsetURN:       toolsetURN,
 		McpServerURN:     mcpServerURN,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log collection server attachment").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log collection server attachment").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection server attachment").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection server attachment").LogError(ctx, s.logger)
 	}
 
 	return toMCPCollection(repo.CreateOrganizationMcpCollectionRow(collection), reg.Namespace), nil
@@ -469,7 +469,7 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 
 	collectionID, err := uuid.Parse(payload.CollectionID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid collection_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid collection_id").LogError(ctx, s.logger)
 	}
 
 	backend, err := parseServerBackend(payload.ToolsetID, payload.McpServerID)
@@ -479,7 +479,7 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error accessing collections").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing collections").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -493,7 +493,7 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
-		return oops.E(oops.CodeUnexpected, err, "error accessing collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing collection").LogError(ctx, s.logger)
 	}
 
 	var attached bool
@@ -511,7 +511,7 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 		})
 	}
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error checking collection server attachment").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error checking collection server attachment").LogError(ctx, s.logger)
 	}
 	if !attached {
 		return nil
@@ -531,7 +531,7 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 		})
 	}
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to detach server from collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to detach server from collection").LogError(ctx, s.logger)
 	}
 
 	toolsetURN, mcpServerURN := backend.auditURNs()
@@ -546,11 +546,11 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 		ToolsetURN:       toolsetURN,
 		McpServerURN:     mcpServerURN,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log collection server detachment").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "log collection server detachment").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error saving collection server detachment").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error saving collection server detachment").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -574,7 +574,7 @@ func (s *Service) ListServers(ctx context.Context, payload *gen.ListServersPaylo
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection").LogError(ctx, s.logger)
 	}
 
 	registry, err := s.repo.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
@@ -582,7 +582,7 @@ func (s *Service) ListServers(ctx context.Context, payload *gen.ListServersPaylo
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").LogError(ctx, s.logger)
 	}
 
 	toolsets, err := s.repo.ListOrganizationMcpCollectionServerAttachments(ctx, repo.ListOrganizationMcpCollectionServerAttachmentsParams{
@@ -590,7 +590,7 @@ func (s *Service) ListServers(ctx context.Context, payload *gen.ListServersPaylo
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list collection servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list collection servers").LogError(ctx, s.logger)
 	}
 
 	mcpServerRows, err := s.repo.ListOrganizationMcpCollectionMcpServerAttachments(ctx, repo.ListOrganizationMcpCollectionMcpServerAttachmentsParams{
@@ -598,7 +598,7 @@ func (s *Service) ListServers(ctx context.Context, payload *gen.ListServersPaylo
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list collection mcp servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list collection mcp servers").LogError(ctx, s.logger)
 	}
 
 	collectionRegistryIDStr := registry.ID.String()
@@ -741,12 +741,12 @@ func (s *Service) collectionRemoteHeaders(ctx context.Context, mcpMetaRepo *mcpm
 	case errors.Is(err, pgx.ErrNoRows):
 		return headers, nil
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "load mcp metadata for collection server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load mcp metadata for collection server").LogError(ctx, s.logger)
 	}
 
 	metadata, err := mcpmetadata.ToMCPMetadata(ctx, mcpMetaRepo, metadataRecord)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "convert mcp metadata for collection server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "convert mcp metadata for collection server").LogError(ctx, s.logger)
 	}
 
 	for _, config := range metadata.EnvironmentConfigs {
@@ -843,10 +843,10 @@ func (s *Service) attachServerToCollection(ctx context.Context, queries *repo.Qu
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
-		return oops.E(oops.CodeUnexpected, err, "error accessing toolset").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing toolset").LogError(ctx, s.logger)
 	}
 	if !toolset.McpEnabled || !toolset.McpSlug.Valid {
-		return oops.E(oops.CodeInvalid, nil, "cannot attach a toolset that is not enabled as an MCP server").Log(ctx, s.logger)
+		return oops.E(oops.CodeInvalid, nil, "cannot attach a toolset that is not enabled as an MCP server").LogError(ctx, s.logger)
 	}
 
 	_, err = queries.AttachServerToOrganizationMcpCollection(ctx, repo.AttachServerToOrganizationMcpCollectionParams{
@@ -858,9 +858,9 @@ func (s *Service) attachServerToCollection(ctx context.Context, queries *repo.Qu
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return oops.E(oops.CodeConflict, err, "toolset already attached to collection").Log(ctx, s.logger)
+			return oops.E(oops.CodeConflict, err, "toolset already attached to collection").LogError(ctx, s.logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "failed to attach server to collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to attach server to collection").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -875,10 +875,10 @@ func (s *Service) attachMcpServerToCollection(ctx context.Context, queries *repo
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
-		return oops.E(oops.CodeUnexpected, err, "error accessing mcp server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing mcp server").LogError(ctx, s.logger)
 	}
 	if server.Visibility == mcpservers.VisibilityDisabled || !server.HasEndpoint {
-		return oops.E(oops.CodeInvalid, nil, "cannot attach an mcp server that is disabled or has no endpoint").Log(ctx, s.logger)
+		return oops.E(oops.CodeInvalid, nil, "cannot attach an mcp server that is disabled or has no endpoint").LogError(ctx, s.logger)
 	}
 
 	_, err = queries.AttachMcpServerToOrganizationMcpCollection(ctx, repo.AttachMcpServerToOrganizationMcpCollectionParams{
@@ -890,9 +890,9 @@ func (s *Service) attachMcpServerToCollection(ctx context.Context, queries *repo
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return oops.E(oops.CodeConflict, err, "mcp server already attached to collection").Log(ctx, s.logger)
+			return oops.E(oops.CodeConflict, err, "mcp server already attached to collection").LogError(ctx, s.logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "failed to attach mcp server to collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to attach mcp server to collection").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -906,7 +906,7 @@ func (s *Service) ensureDefaultRegistryCollection(ctx context.Context, organizat
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error starting transaction for default collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error starting transaction for default collection").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -919,7 +919,7 @@ func (s *Service) ensureDefaultRegistryCollection(ctx context.Context, organizat
 		Visibility:     defaultVisibility,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error ensuring default registry collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error ensuring default registry collection").LogError(ctx, s.logger)
 	}
 
 	if _, err := tx.EnsureOrganizationMcpCollectionRegistry(ctx, repo.EnsureOrganizationMcpCollectionRegistryParams{
@@ -927,11 +927,11 @@ func (s *Service) ensureDefaultRegistryCollection(ctx context.Context, organizat
 		OrganizationID: organizationID,
 		Namespace:      defaultRegistryNamespace(organizationSlug, organizationID),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error ensuring default registry namespace").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error ensuring default registry namespace").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error committing default registry collection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error committing default registry collection").LogError(ctx, s.logger)
 	}
 
 	return nil

--- a/server/internal/customdomains/impl.go
+++ b/server/internal/customdomains/impl.go
@@ -98,7 +98,7 @@ func (s *Service) GetDomain(ctx context.Context, payload *gen.GetDomainPayload) 
 
 	domain, err := repo.GetCustomDomainByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "no custom domain found for organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "no custom domain found for organization").LogError(ctx, s.logger)
 	}
 
 	isUpdating := false
@@ -119,7 +119,7 @@ func (s *Service) CreateDomain(ctx context.Context, payload *gen.CreateDomainPay
 	}
 
 	if !slices.Contains([]string{"pro", "enterprise"}, authCtx.AccountType) {
-		return oops.E(oops.CodeUnauthorized, err, "custom domain registration is not supported for free account").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, err, "custom domain registration is not supported for free account").LogError(ctx, s.logger)
 	}
 
 	ipAllowlist := payload.IPAllowlist
@@ -127,7 +127,7 @@ func (s *Service) CreateDomain(ctx context.Context, payload *gen.CreateDomainPay
 		ipAllowlist = []string{}
 	}
 	if err := validateIPAllowlist(ipAllowlist); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid ip_allowlist entry").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid ip_allowlist entry").LogError(ctx, s.logger)
 	}
 
 	_, err = s.temporalClient.ExecuteCustomDomainRegistration(
@@ -140,7 +140,7 @@ func (s *Service) CreateDomain(ctx context.Context, payload *gen.CreateDomainPay
 		ipAllowlist,
 	)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error executing custom domain registration").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error executing custom domain registration").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -160,14 +160,14 @@ func (s *Service) UpdateDomain(ctx context.Context, payload *gen.UpdateDomainPay
 		ipAllowlist = []string{}
 	}
 	if err := validateIPAllowlist(ipAllowlist); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid ip_allowlist entry").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid ip_allowlist entry").LogError(ctx, s.logger)
 	}
 
 	repository := repo.New(s.db)
 
 	domain, err := repository.GetCustomDomainByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "no custom domain found for organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "no custom domain found for organization").LogError(ctx, s.logger)
 	}
 
 	// Reconcile the live k8s resource BEFORE persisting so a reconcile failure
@@ -179,10 +179,10 @@ func (s *Service) UpdateDomain(ctx context.Context, payload *gen.UpdateDomainPay
 	if domain.Activated && domain.IngressName.Valid {
 		run, err := s.temporalClient.ExecuteCustomDomainUpdate(ctx, authCtx.ActiveOrganizationID, domain.Domain, k8s.ProvisionerKind(domain.ProvisionerKind), ipAllowlist)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to start custom domain update workflow").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to start custom domain update workflow").LogError(ctx, s.logger)
 		}
 		if err := run.Get(ctx, nil); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "custom domain update workflow failed").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "custom domain update workflow failed").LogError(ctx, s.logger)
 		}
 	}
 
@@ -191,7 +191,7 @@ func (s *Service) UpdateDomain(ctx context.Context, payload *gen.UpdateDomainPay
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to update custom domain ip allowlist").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to update custom domain ip allowlist").LogError(ctx, s.logger)
 	}
 
 	isUpdating := false
@@ -213,22 +213,22 @@ func (s *Service) DeleteDomain(ctx context.Context, _ *gen.DeleteDomainPayload) 
 
 	domain, err := repo.New(s.db).GetCustomDomainByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return oops.E(oops.CodeNotFound, err, "no custom domain found for organization").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, err, "no custom domain found for organization").LogError(ctx, s.logger)
 	}
 
 	if domain.Activated && domain.IngressName.Valid {
 		run, err := s.temporalClient.ExecuteCustomDomainDeletion(ctx, authCtx.ActiveOrganizationID, domain.Domain, domain.IngressName.String, domain.CertSecretName.String, k8s.ProvisionerKind(domain.ProvisionerKind))
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to start custom domain deletion workflow").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to start custom domain deletion workflow").LogError(ctx, s.logger)
 		}
 		if err := run.Get(ctx, nil); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "custom domain deletion workflow failed").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "custom domain deletion workflow failed").LogError(ctx, s.logger)
 		}
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to access custom domains").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to access custom domains").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -239,7 +239,7 @@ func (s *Service) DeleteDomain(ctx context.Context, _ *gen.DeleteDomainPayload) 
 	// so the org:admin gate above authorizes the entire fan-out.
 	deletedEndpoints, err := mcpendpointsrepo.New(dbtx).SoftDeleteMCPEndpointsByCustomDomainID(ctx, domain.ID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete child mcp endpoints").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "delete child mcp endpoints").LogError(ctx, s.logger)
 	}
 
 	for _, endpoint := range deletedEndpoints {
@@ -252,12 +252,12 @@ func (s *Service) DeleteDomain(ctx context.Context, _ *gen.DeleteDomainPayload) 
 			McpEndpointURN:   urn.NewMcpEndpoint(endpoint.ID),
 			Slug:             endpoint.Slug,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "log mcp endpoint deletion").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "log mcp endpoint deletion").LogError(ctx, s.logger)
 		}
 	}
 
 	if err := repo.New(dbtx).DeleteCustomDomain(ctx, authCtx.ActiveOrganizationID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to delete custom domain").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete custom domain").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogCustomDomainDelete(ctx, dbtx, audit.LogCustomDomainDeleteEvent{
@@ -269,11 +269,11 @@ func (s *Service) DeleteDomain(ctx context.Context, _ *gen.DeleteDomainPayload) 
 		CustomDomainURN: urn.NewCustomDomain(domain.ID),
 		DomainName:      domain.Domain,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to create custom domain deletion audit log").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to create custom domain deletion audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to commit custom domain deletion").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to commit custom domain deletion").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "custom domain deleted",
@@ -295,12 +295,12 @@ func (s *Service) ListMcpEndpoints(ctx context.Context, _ *gen.ListMcpEndpointsP
 
 	domain, err := repo.New(s.db).GetCustomDomainByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "no custom domain found for organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "no custom domain found for organization").LogError(ctx, s.logger)
 	}
 
 	rows, err := mcpendpointsrepo.New(s.db).ListMCPEndpointsByCustomDomainID(ctx, domain.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list mcp endpoints by custom domain").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list mcp endpoints by custom domain").LogError(ctx, s.logger)
 	}
 
 	return &gen.ListCustomDomainMcpEndpointsResult{McpEndpoints: mv.BuildCustomDomainMcpEndpointListView(rows)}, nil

--- a/server/internal/customdomains/middleware.go
+++ b/server/internal/customdomains/middleware.go
@@ -35,7 +35,7 @@ func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *ur
 			}
 
 			if host == "" {
-				serr := oops.E(oops.CodeBadRequest, nil, "request host is not set").Log(ctx, logger, attr.SlogHostName(host))
+				serr := oops.E(oops.CodeBadRequest, nil, "request host is not set").LogError(ctx, logger, attr.SlogHostName(host))
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusBadRequest)
 				if err := json.NewEncoder(w).Encode(serr); err != nil {
@@ -56,7 +56,7 @@ func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *ur
 				http.Error(w, "invalid domain", http.StatusForbidden)
 				return
 			case err != nil:
-				serr := oops.E(oops.CodeUnexpected, err, "domain check failed").Log(ctx, logger, attr.SlogHostName(host), attr.SlogError(err))
+				serr := oops.E(oops.CodeUnexpected, err, "domain check failed").LogError(ctx, logger, attr.SlogHostName(host), attr.SlogError(err))
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
 				if err := json.NewEncoder(w).Encode(serr); err != nil {

--- a/server/internal/deployments/crud.go
+++ b/server/internal/deployments/crud.go
@@ -83,7 +83,7 @@ func createDeployment(
 	}
 
 	if err := validateUpserts(openAPIv3ToUpsert, functionsToUpsert, externalMCPsToUpsert); err != nil {
-		return uuid.Nil, oops.E(oops.CodeInvalid, err, "one or more deployment assets are invalid:\n%s", err.Error()).Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeInvalid, err, "one or more deployment assets are invalid:\n%s", err.Error()).LogError(ctx, logger)
 	}
 
 	cmd, err := tx.CreateDeployment(ctx, repo.CreateDeploymentParams{
@@ -99,7 +99,7 @@ func createDeployment(
 		ExternalUrl: conv.ToPGTextEmpty(fields.externalURL),
 	})
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error creating deployment").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error creating deployment").LogError(ctx, logger)
 	}
 
 	created := cmd.RowsAffected() > 0
@@ -109,7 +109,7 @@ func createDeployment(
 		ProjectID:      fields.projectID,
 	})
 	if err != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error reading deployment").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error reading deployment").LogError(ctx, logger)
 	}
 
 	newID := d.Deployment.ID
@@ -142,7 +142,7 @@ func createDeployment(
 		Message:      "Deployment created",
 	})
 	if err != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error logging deployment creation").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error logging deployment creation").LogError(ctx, logger)
 	}
 
 	return newID, nil
@@ -169,7 +169,7 @@ func cloneDeployment(
 	defer span.SetStatus(codes.Ok, "deployment cloned")
 
 	if err := validateUpserts(openAPIv3ToUpsert, functionsToUpsert, externalMCPsToUpsert); err != nil {
-		return uuid.Nil, oops.E(oops.CodeInvalid, err, "one or more deployment assets are invalid:\n%s", err.Error()).Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeInvalid, err, "one or more deployment assets are invalid:\n%s", err.Error()).LogError(ctx, logger)
 	}
 
 	srcDepID := uuid.UUID(srcDeploymentID)
@@ -180,7 +180,7 @@ func cloneDeployment(
 		ProjectID: projID,
 	})
 	if err != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment").LogError(ctx, logger)
 	}
 
 	logger = logger.With(attr.SlogDeploymentID(newID.String()))
@@ -192,7 +192,7 @@ func cloneDeployment(
 		ExcludedIds:          packagesToExclude,
 	})
 	if err != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment openapi v3 assets").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment openapi v3 assets").LogError(ctx, logger)
 	}
 
 	_, err = depRepo.CloneDeploymentOpenAPIv3Assets(ctx, repo.CloneDeploymentOpenAPIv3AssetsParams{
@@ -201,7 +201,7 @@ func cloneDeployment(
 		ExcludedIds:          openAPIv3ToExclude,
 	})
 	if err != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment openapi v3 assets").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment openapi v3 assets").LogError(ctx, logger)
 	}
 
 	_, err = depRepo.CloneDeploymentFunctionsAssets(ctx, repo.CloneDeploymentFunctionsAssetsParams{
@@ -212,7 +212,7 @@ func cloneDeployment(
 		DefaultMemoryMib:     constants.DefaultFunctionMemoryMiB,
 	})
 	if err != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment functions assets").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment functions assets").LogError(ctx, logger)
 	}
 
 	_, err = depRepo.CloneDeploymentExternalMCPs(ctx, repo.CloneDeploymentExternalMCPsParams{
@@ -221,7 +221,7 @@ func cloneDeployment(
 		ExcludedSlugs:        externalMCPsToExclude,
 	})
 	if err != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment external mcps").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment external mcps").LogError(ctx, logger)
 	}
 
 	err = amendDeployment(ctx, logger, depRepo, DeploymentID(newID), openAPIv3ToUpsert, functionsToUpsert, packagesToUpsert, externalMCPsToUpsert)
@@ -237,7 +237,7 @@ func cloneDeployment(
 		Message:      "Deployment created",
 	})
 	if err != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error logging deployment creation").Log(ctx, logger)
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error logging deployment creation").LogError(ctx, logger)
 	}
 
 	return newID, nil
@@ -263,7 +263,7 @@ func amendDeployment(
 			Slug:         a.slug,
 		})
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeUnexpected, err, "error adding deployment openapi v3 asset").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "error adding deployment openapi v3 asset").LogError(ctx, logger)
 		}
 	}
 
@@ -290,7 +290,7 @@ func amendDeployment(
 			Scale:        scale,
 		})
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeUnexpected, err, "error adding deployment functions asset").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "error adding deployment functions asset").LogError(ctx, logger)
 		}
 	}
 
@@ -301,7 +301,7 @@ func amendDeployment(
 			VersionID:    p.versionID,
 		})
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeUnexpected, err, "error adding deployment package").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "error adding deployment package").LogError(ctx, logger)
 		}
 	}
 
@@ -316,7 +316,7 @@ func amendDeployment(
 			SelectedRemotes:                     e.selectedRemotes,
 		})
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeUnexpected, err, "error adding deployment external mcp").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "error adding deployment external mcp").LogError(ctx, logger)
 		}
 	}
 

--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -130,7 +130,7 @@ func (s *Service) GetDeployment(ctx context.Context, form *gen.GetDeploymentPayl
 
 	id, err := uuid.Parse(form.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "error parsing deployment id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "error parsing deployment id").LogError(ctx, s.logger)
 	}
 
 	dep, err := mv.DescribeDeployment(ctx, s.logger, s.repo, mv.ProjectID(*authCtx.ProjectID), mv.DeploymentID(id))
@@ -178,14 +178,14 @@ func (s *Service) GetDeploymentLogs(ctx context.Context, form *gen.GetDeployment
 
 	id, err := uuid.Parse(form.DeploymentID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "bad deployment id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "bad deployment id").LogError(ctx, s.logger)
 	}
 
 	var cursorSeq pgtype.Int8
 	if form.Cursor != nil && *form.Cursor != "" {
 		seq, _, err := decodeCursor(*form.Cursor)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 		}
 		cursorSeq = pgtype.Int8{Int64: seq, Valid: true}
 	}
@@ -196,7 +196,7 @@ func (s *Service) GetDeploymentLogs(ctx context.Context, form *gen.GetDeployment
 		CursorSeq:    cursorSeq,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting deployment logs").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting deployment logs").LogError(ctx, s.logger)
 	}
 
 	status := "unknown"
@@ -246,7 +246,7 @@ func (s *Service) GetLatestDeployment(ctx context.Context, _ *gen.GetLatestDeplo
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -261,7 +261,7 @@ func (s *Service) GetLatestDeployment(ctx context.Context, _ *gen.GetLatestDeplo
 				Deployment: nil,
 			}, nil
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting latest deployment id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting latest deployment id").LogError(ctx, s.logger)
 	}
 
 	if id == uuid.Nil {
@@ -292,7 +292,7 @@ func (s *Service) GetActiveDeployment(ctx context.Context, _ *gen.GetActiveDeplo
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -307,7 +307,7 @@ func (s *Service) GetActiveDeployment(ctx context.Context, _ *gen.GetActiveDeplo
 				Deployment: nil,
 			}, nil
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting active deployment id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting active deployment id").LogError(ctx, s.logger)
 	}
 
 	if id == uuid.Nil {
@@ -340,7 +340,7 @@ func (s *Service) ListDeployments(ctx context.Context, form *gen.ListDeployments
 	if form.Cursor != nil {
 		c, err := uuid.Parse(*form.Cursor)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 		}
 
 		cursor = uuid.NullUUID{UUID: c, Valid: true}
@@ -351,7 +351,7 @@ func (s *Service) ListDeployments(ctx context.Context, form *gen.ListDeployments
 		Cursor:    cursor,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing deployments").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing deployments").LogError(ctx, s.logger)
 	}
 
 	items := make([]*gen.DeploymentSummary, 0, len(rows))
@@ -407,7 +407,7 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -419,7 +419,7 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 	for _, add := range form.Openapiv3Assets {
 		assetID, err := uuid.Parse(add.AssetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "error parsing openapi asset id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "error parsing openapi asset id").LogError(ctx, s.logger)
 		}
 
 		newOpenAPIAssets = append(newOpenAPIAssets, upsertOpenAPIv3{
@@ -433,7 +433,7 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 	for _, add := range form.Functions {
 		assetID, err := uuid.Parse(add.AssetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "error parsing functions asset id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "error parsing functions asset id").LogError(ctx, s.logger)
 		}
 
 		newFunctions = append(newFunctions, upsertFunctions{
@@ -472,11 +472,11 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 	for _, add := range form.ExternalMcps {
 		registryID, err := conv.PtrToNullUUID(add.RegistryID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
 		}
 		collectionRegistryID, err := conv.PtrToNullUUID(add.OrganizationMcpCollectionRegistryID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid organization_mcp_collection_registry_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid organization_mcp_collection_registry_id").LogError(ctx, s.logger)
 		}
 		newExternalMCPs = append(newExternalMCPs, upsertExternalMCP{
 			registryID:                          registryID,
@@ -489,7 +489,7 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 	}
 
 	if len(newPackages) == 0 && len(newOpenAPIAssets) == 0 && len(newFunctions) == 0 && len(newExternalMCPs) == 0 {
-		return nil, oops.E(oops.CodeInvalid, nil, "at least one openapi document, functions file, package, or external mcp is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "at least one openapi document, functions file, package, or external mcp is required").LogError(ctx, logger)
 	}
 
 	newID, err := createDeployment(
@@ -530,11 +530,11 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 		ActorSlug:        nil,
 		DeploymentURN:    urn.NewDeployment(newID),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error adding deployment creation audit log").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error adding deployment creation audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving deployment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving deployment").LogError(ctx, logger)
 	}
 
 	status := dep.Status
@@ -546,7 +546,7 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 
 		status = s
 		if status == "" {
-			return nil, oops.E(oops.CodeInvariantViolation, nil, "error resolving deployment status").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvariantViolation, nil, "error resolving deployment status").LogError(ctx, logger)
 		}
 
 		dep.Status = status
@@ -584,7 +584,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -597,7 +597,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 	for _, add := range form.UpsertOpenapiv3Assets {
 		assetID, err := uuid.Parse(add.AssetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "error parsing openapiv3 asset id to upsert").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "error parsing openapiv3 asset id to upsert").LogError(ctx, s.logger)
 		}
 
 		openapiv3ToUpsert = append(openapiv3ToUpsert, upsertOpenAPIv3{
@@ -611,7 +611,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 	for _, assetID := range form.ExcludeOpenapiv3Assets {
 		id, err := uuid.Parse(assetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "error parsing openapiv3 asset id to exclude").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "error parsing openapiv3 asset id to exclude").LogError(ctx, s.logger)
 		}
 		openapiv3ToExclude = append(openapiv3ToExclude, id)
 	}
@@ -620,7 +620,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 	for _, add := range form.UpsertFunctions {
 		assetID, err := uuid.Parse(add.AssetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "error parsing functions asset id to upsert").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "error parsing functions asset id to upsert").LogError(ctx, s.logger)
 		}
 
 		functionsToUpsert = append(functionsToUpsert, upsertFunctions{
@@ -637,7 +637,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 	for _, assetID := range form.ExcludeFunctions {
 		id, err := uuid.Parse(assetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "error parsing functions asset id to exclude").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "error parsing functions asset id to exclude").LogError(ctx, s.logger)
 		}
 		functionsToExclude = append(functionsToExclude, id)
 	}
@@ -668,7 +668,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 	for _, pkgID := range form.ExcludePackages {
 		id, err := uuid.Parse(pkgID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "error parsing package id to exclude").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "error parsing package id to exclude").LogError(ctx, s.logger)
 		}
 		packagesToExclude = append(packagesToExclude, id)
 	}
@@ -677,11 +677,11 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 	for _, add := range form.UpsertExternalMcps {
 		registryID, err := conv.PtrToNullUUID(add.RegistryID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
 		}
 		collectionRegistryID, err := conv.PtrToNullUUID(add.OrganizationMcpCollectionRegistryID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid organization_mcp_collection_registry_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid organization_mcp_collection_registry_id").LogError(ctx, s.logger)
 		}
 		externalMCPsToUpsert = append(externalMCPsToUpsert, upsertExternalMCP{
 			registryID:                          registryID,
@@ -702,7 +702,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 	externalMCPsChanged := len(externalMCPsToUpsert) > 0 || len(externalMCPsToExclude) > 0
 
 	if !packagesChanged && !openapiChanged && !functionsChanged && !externalMCPsChanged {
-		return nil, oops.E(oops.CodeInvalid, nil, "at least one asset, package, or external mcp to upsert or exclude is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "at least one asset, package, or external mcp to upsert or exclude is required").LogError(ctx, logger)
 	}
 
 	var cloneID uuid.UUID
@@ -736,7 +736,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 
 		ierr := inv.Check("initial deployment state", "deployment id cannot be nil", newID != uuid.Nil)
 		if ierr != nil {
-			return nil, oops.E(oops.CodeInvariantViolation, ierr, "error cloning deployment").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvariantViolation, ierr, "error cloning deployment").LogError(ctx, logger)
 		}
 
 		logger = logger.With(attr.SlogDeploymentID(newID.String()))
@@ -745,7 +745,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 		cloneID = newID
 	// 2️⃣ Something went wrong querying for the latest deployment
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting latest deployment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting latest deployment").LogError(ctx, logger)
 	// 3️⃣ We found a latest deployment, we need to clone it
 	default:
 		previousDeployment, err = mv.DescribeDeployment(ctx, logger, tx, mv.ProjectID(projectID), mv.DeploymentID(latestDeploymentID))
@@ -766,12 +766,12 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 			externalMCPsToExclude,
 		)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment").LogError(ctx, logger)
 		}
 
 		ierr := inv.Check("cloned deployment state", "deployment id cannot be nil", newID != uuid.Nil)
 		if ierr != nil {
-			return nil, oops.E(oops.CodeInvariantViolation, ierr, "error cloning deployment").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvariantViolation, ierr, "error cloning deployment").LogError(ctx, logger)
 		}
 
 		logger = logger.With(attr.SlogDeploymentID(newID.String()))
@@ -798,11 +798,11 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 		Ancestor: previousDeployment,
 		Current:  dep,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error adding deployment evolve audit log").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error adding deployment evolve audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving deployment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving deployment").LogError(ctx, logger)
 	}
 
 	status := dep.Status
@@ -814,7 +814,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 
 		status = s
 		if status == "" {
-			return nil, oops.E(oops.CodeInvariantViolation, nil, "unable to resolve deployment status").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvariantViolation, nil, "unable to resolve deployment status").LogError(ctx, logger)
 		}
 
 		dep.Status = status
@@ -843,7 +843,7 @@ func (s *Service) Redeploy(ctx context.Context, payload *gen.RedeployPayload) (*
 	}
 
 	if payload.DeploymentID == "" {
-		return nil, oops.E(oops.CodeInvalid, nil, "deployment id is required").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "deployment id is required").LogError(ctx, s.logger)
 	}
 
 	organizationID := authCtx.ActiveOrganizationID
@@ -854,7 +854,7 @@ func (s *Service) Redeploy(ctx context.Context, payload *gen.RedeployPayload) (*
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing deployments").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -864,7 +864,7 @@ func (s *Service) Redeploy(ctx context.Context, payload *gen.RedeployPayload) (*
 
 	deploymentID, err := uuid.Parse(payload.DeploymentID)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid deployment id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid deployment id").LogError(ctx, logger)
 	}
 
 	newID, err := cloneDeployment(
@@ -880,12 +880,12 @@ func (s *Service) Redeploy(ctx context.Context, payload *gen.RedeployPayload) (*
 		[]string{},
 	)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error cloning deployment").LogError(ctx, logger)
 	}
 
 	ierr := inv.Check("cloned deployment state", "deployment id cannot be nil", newID != uuid.Nil)
 	if ierr != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, ierr, "error cloning deployment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, ierr, "error cloning deployment").LogError(ctx, logger)
 	}
 
 	logger = logger.With(attr.SlogDeploymentID(newID.String()))
@@ -908,11 +908,11 @@ func (s *Service) Redeploy(ctx context.Context, payload *gen.RedeployPayload) (*
 
 		SourceDeploymentURN: urn.NewDeployment(deploymentID),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error adding deployment redeploy audit log").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error adding deployment redeploy audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving deployment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving deployment").LogError(ctx, logger)
 	}
 
 	status := dep.Status
@@ -924,7 +924,7 @@ func (s *Service) Redeploy(ctx context.Context, payload *gen.RedeployPayload) (*
 
 		status = s
 		if status == "" {
-			return nil, oops.E(oops.CodeInvariantViolation, nil, "unable to resolve deployment status").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvariantViolation, nil, "unable to resolve deployment status").LogError(ctx, logger)
 		}
 
 		dep.Status = status
@@ -954,10 +954,10 @@ func (s *Service) resolvePackages(ctx context.Context, tx *packagesRepo.Queries,
 		if version == "" {
 			row, err := tx.PeekLatestPackageVersionByName(ctx, name)
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeBadRequest, err, "no versions found for package: %s", name).Log(ctx, s.logger, attr.SlogPackageName(name))
+				return nil, oops.E(oops.CodeBadRequest, err, "no versions found for package: %s", name).LogError(ctx, s.logger, attr.SlogPackageName(name))
 			}
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "error getting latest package version").Log(ctx, s.logger, attr.SlogPackageName(name))
+				return nil, oops.E(oops.CodeUnexpected, err, "error getting latest package version").LogError(ctx, s.logger, attr.SlogPackageName(name))
 			}
 
 			packageID = row.PackageID
@@ -966,11 +966,11 @@ func (s *Service) resolvePackages(ctx context.Context, tx *packagesRepo.Queries,
 		} else {
 			semver, err := semver.ParseSemver(version)
 			if err != nil {
-				return nil, oops.E(oops.CodeBadRequest, err, "error parsing semver").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeBadRequest, err, "error parsing semver").LogError(ctx, s.logger)
 			}
 
 			if err := inv.Check("semver", "semver must be valid", semver.Valid); err != nil {
-				return nil, oops.E(oops.CodeInvariantViolation, err, "package version incorrectly parsed").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeInvariantViolation, err, "package version incorrectly parsed").LogError(ctx, s.logger)
 			}
 
 			row, err := tx.PeekPackageByNameAndVersion(ctx, packagesRepo.PeekPackageByNameAndVersionParams{
@@ -982,10 +982,10 @@ func (s *Service) resolvePackages(ctx context.Context, tx *packagesRepo.Queries,
 				Build:      conv.ToPGTextEmpty(semver.Build),
 			})
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeBadRequest, err, "package version not found: %s@%s", name, version).Log(ctx, s.logger, attr.SlogPackageName(name), attr.SlogPackageVersion(version))
+				return nil, oops.E(oops.CodeBadRequest, err, "package version not found: %s@%s", name, version).LogError(ctx, s.logger, attr.SlogPackageName(name), attr.SlogPackageVersion(version))
 			}
 			if err != nil {
-				return nil, oops.E(oops.CodeBadRequest, err, "error getting package by name and version").Log(ctx, s.logger, attr.SlogPackageName(name), attr.SlogPackageVersion(version))
+				return nil, oops.E(oops.CodeBadRequest, err, "error getting package by name and version").LogError(ctx, s.logger, attr.SlogPackageName(name), attr.SlogPackageVersion(version))
 			}
 
 			packageID = row.PackageID
@@ -994,7 +994,7 @@ func (s *Service) resolvePackages(ctx context.Context, tx *packagesRepo.Queries,
 		}
 
 		if packageID == uuid.Nil || versionID == uuid.Nil {
-			return nil, oops.E(oops.CodeBadRequest, nil, "could not resolve package version: %s@%s", name, conv.Default(version, "latest")).Log(ctx, s.logger, attr.SlogPackageName(name), attr.SlogPackageVersion(conv.Default(version, "latest")))
+			return nil, oops.E(oops.CodeBadRequest, nil, "could not resolve package version: %s@%s", name, conv.Default(version, "latest")).LogError(ctx, s.logger, attr.SlogPackageName(name), attr.SlogPackageVersion(conv.Default(version, "latest")))
 		}
 
 		res = append(res, resolvedPackage{
@@ -1025,7 +1025,7 @@ func (s *Service) startDeployment(ctx context.Context, logger *slog.Logger, proj
 		IdempotencyKey: conv.PtrValOr(dep.IdempotencyKey, ""),
 	})
 	if err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "error starting deployment").Log(ctx, logger)
+		return "", oops.E(oops.CodeUnexpected, err, "error starting deployment").LogError(ctx, logger)
 	}
 
 	if nonBlocking {
@@ -1034,7 +1034,7 @@ func (s *Service) startDeployment(ctx context.Context, logger *slog.Logger, proj
 
 	var res background.ProcessDeploymentWorkflowResult
 	if err := wr.Get(ctx, &res); err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "error getting deployment status").Log(ctx, logger)
+		return "", oops.E(oops.CodeUnexpected, err, "error getting deployment status").LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, "processed deployment", attr.SlogDeploymentID(deploymentID.String()), attr.SlogDeploymentStatus(res.Status), attr.SlogProjectID(projectID.String()))
@@ -1051,10 +1051,10 @@ func validatePackageInclusion(ctx context.Context, logger *slog.Logger, targetPr
 		"package id cannot be nil", resolved.packageID != uuid.Nil,
 		"version id cannot be nil", resolved.versionID != uuid.Nil,
 	); err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "error resolving package: %s@%s", requirement[0], requirement[1]).Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "error resolving package: %s@%s", requirement[0], requirement[1]).LogError(ctx, logger)
 	}
 	if resolved.projectID == targetProjectID {
-		return oops.E(oops.CodeInvalid, nil, "cannot add package to its own project: %s", requirement[0]).Log(ctx, logger)
+		return oops.E(oops.CodeInvalid, nil, "cannot add package to its own project: %s", requirement[0]).LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/environments/impl.go
+++ b/server/internal/environments/impl.go
@@ -106,7 +106,7 @@ func (s *Service) CreateEnvironment(ctx context.Context, payload *gen.CreateEnvi
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to access environments").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to access environments").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -115,7 +115,7 @@ func (s *Service) CreateEnvironment(ctx context.Context, payload *gen.CreateEnvi
 
 	environment, err := er.CreateEnvironment(ctx, input)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create environment").LogError(ctx, logger)
 	}
 
 	names := make([]string, len(payload.Entries))
@@ -131,7 +131,7 @@ func (s *Service) CreateEnvironment(ctx context.Context, payload *gen.CreateEnvi
 		Values:        values,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create environment entries").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create environment entries").LogError(ctx, logger)
 	}
 
 	environmentView := buildEnvironmentView(environment, rows)
@@ -146,11 +146,11 @@ func (s *Service) CreateEnvironment(ctx context.Context, payload *gen.CreateEnvi
 		EnvironmentName:  environment.Name,
 		EnvironmentSlug:  environment.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log environment creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log environment creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create environment").LogError(ctx, logger)
 	}
 
 	return environmentView, nil
@@ -168,14 +168,14 @@ func (s *Service) ListEnvironments(ctx context.Context, payload *gen.ListEnviron
 
 	environments, err := s.repo.ListEnvironments(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environments").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environments").LogError(ctx, s.logger)
 	}
 
 	var result []*types.Environment
 	for _, environment := range environments {
 		entries, err := s.entries.ListEnvironmentEntries(ctx, *authCtx.ProjectID, environment.ID, true)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").LogError(ctx, s.logger)
 		}
 
 		result = append(result, buildEnvironmentView(environment, entries))
@@ -199,7 +199,7 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to access environments").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to access environments").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -211,12 +211,12 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "environment not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "environment not found").LogError(ctx, logger)
 	}
 
 	beforeEntries, err := entriesRepo.ListEnvironmentEntries(ctx, *authCtx.ProjectID, environment.ID, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").LogError(ctx, logger)
 	}
 	beforeView := buildEnvironmentView(environment, beforeEntries)
 
@@ -236,7 +236,7 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 
 	updatedEnvironment, err := er.UpdateEnvironment(ctx, updateInput)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to update environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to update environment").LogError(ctx, logger)
 	}
 
 	projectID := *authCtx.ProjectID
@@ -250,7 +250,7 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 			Name:          updatedEntry.Name,
 			Value:         updatedEntry.Value, // This is the actual environment value to update too, do not redact it
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to update environment entry").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to update environment entry").LogError(ctx, logger)
 		}
 	}
 	for _, removedEntry := range payload.EntriesToRemove {
@@ -258,7 +258,7 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 			EnvironmentID: environment.ID,
 			Name:          removedEntry,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to delete environment entry").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to delete environment entry").LogError(ctx, logger)
 		}
 	}
 
@@ -268,12 +268,12 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 		ProjectID: projectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to re-fetch environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to re-fetch environment").LogError(ctx, logger)
 	}
 
 	entries, err := entriesRepo.ListEnvironmentEntries(ctx, projectID, environment.ID, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").LogError(ctx, logger)
 	}
 
 	afterView := buildEnvironmentView(environment, entries)
@@ -290,11 +290,11 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 		EnvironmentSnapshotBefore: beforeView,
 		EnvironmentSnapshotAfter:  afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log environment update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log environment update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to update environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to update environment").LogError(ctx, logger)
 	}
 
 	return afterView, nil
@@ -319,7 +319,7 @@ func (s *Service) CloneEnvironment(ctx context.Context, payload *gen.CloneEnviro
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "environment not found")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch source environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch source environment").LogError(ctx, logger)
 	}
 
 	// Authz: env:write on the source env with project_id as a constraining
@@ -338,7 +338,7 @@ func (s *Service) CloneEnvironment(ctx context.Context, payload *gen.CloneEnviro
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to access environments").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to access environments").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -360,7 +360,7 @@ func (s *Service) CloneEnvironment(ctx context.Context, payload *gen.CloneEnviro
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 			return nil, oops.E(oops.CodeConflict, err, "an environment with this name already exists in this project")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create cloned environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create cloned environment").LogError(ctx, logger)
 	}
 
 	copyValues := payload.CopyValues != nil && *payload.CopyValues
@@ -370,12 +370,12 @@ func (s *Service) CloneEnvironment(ctx context.Context, payload *gen.CloneEnviro
 			SourceEnvironmentID: sourceEnv.ID,
 			ProjectID:           *authCtx.ProjectID,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to clone environment entries").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to clone environment entries").LogError(ctx, logger)
 		}
 	} else {
 		placeholder, err := s.entries.enc.Encrypt([]byte(""))
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to prepare placeholder value").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to prepare placeholder value").LogError(ctx, logger)
 		}
 		if err := er.CloneEnvironmentEntryNames(ctx, repo.CloneEnvironmentEntryNamesParams{
 			NewEnvironmentID:    newEnv.ID,
@@ -383,13 +383,13 @@ func (s *Service) CloneEnvironment(ctx context.Context, payload *gen.CloneEnviro
 			PlaceholderValue:    placeholder,
 			ProjectID:           *authCtx.ProjectID,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to clone environment entry names").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to clone environment entry names").LogError(ctx, logger)
 		}
 	}
 
 	entries, err := entriesRepo.ListEnvironmentEntries(ctx, *authCtx.ProjectID, newEnv.ID, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list cloned environment entries").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list cloned environment entries").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogEnvironmentCreate(ctx, dbtx, audit.LogEnvironmentCreateEvent{
@@ -402,11 +402,11 @@ func (s *Service) CloneEnvironment(ctx context.Context, payload *gen.CloneEnviro
 		EnvironmentName:  newEnv.Name,
 		EnvironmentSlug:  newEnv.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log environment clone").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log environment clone").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to clone environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to clone environment").LogError(ctx, logger)
 	}
 
 	return buildEnvironmentView(newEnv, entries), nil
@@ -426,7 +426,7 @@ func (s *Service) DeleteEnvironment(ctx context.Context, payload *gen.DeleteEnvi
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to access environments").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to access environments").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -440,7 +440,7 @@ func (s *Service) DeleteEnvironment(ctx context.Context, payload *gen.DeleteEnvi
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
-		return oops.E(oops.CodeUnexpected, err, "failed to delete environment").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete environment").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogEnvironmentDelete(ctx, dbtx, audit.LogEnvironmentDeleteEvent{
@@ -453,11 +453,11 @@ func (s *Service) DeleteEnvironment(ctx context.Context, payload *gen.DeleteEnvi
 		EnvironmentName:  deleted.Name,
 		EnvironmentSlug:  deleted.Slug,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to save environment delete audit log event").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to save environment delete audit log event").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to delete environment").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete environment").LogError(ctx, logger)
 	}
 
 	return nil
@@ -503,7 +503,7 @@ func (s *Service) SetSourceEnvironmentLink(ctx context.Context, payload *gen.Set
 
 	environmentID, err := uuid.Parse(payload.EnvironmentID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid environment_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid environment_id").LogError(ctx, s.logger)
 	}
 
 	// Verify the environment exists and belongs to the project
@@ -512,7 +512,7 @@ func (s *Service) SetSourceEnvironmentLink(ctx context.Context, payload *gen.Set
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "environment not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "environment not found").LogError(ctx, s.logger)
 	}
 
 	link, err := s.repo.SetSourceEnvironment(ctx, repo.SetSourceEnvironmentParams{
@@ -522,7 +522,7 @@ func (s *Service) SetSourceEnvironmentLink(ctx context.Context, payload *gen.Set
 		EnvironmentID: environmentID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to set source environment link").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to set source environment link").LogError(ctx, s.logger)
 	}
 
 	return &gen.SourceEnvironmentLink{
@@ -549,7 +549,7 @@ func (s *Service) DeleteSourceEnvironmentLink(ctx context.Context, payload *gen.
 		ProjectID:  *authCtx.ProjectID,
 	})
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return oops.E(oops.CodeUnexpected, err, "failed to delete source environment link").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete source environment link").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -573,14 +573,14 @@ func (s *Service) GetSourceEnvironment(ctx context.Context, payload *gen.GetSour
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "environment not found for source").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "environment not found for source").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment for source").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment for source").LogError(ctx, s.logger)
 	}
 
 	entries, err := s.entries.ListEnvironmentEntries(ctx, *authCtx.ProjectID, environment.ID, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").LogError(ctx, s.logger)
 	}
 
 	return buildEnvironmentView(environment, entries), nil
@@ -598,12 +598,12 @@ func (s *Service) SetToolsetEnvironmentLink(ctx context.Context, payload *gen.Se
 
 	toolsetID, err := uuid.Parse(payload.ToolsetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, s.logger)
 	}
 
 	environmentID, err := uuid.Parse(payload.EnvironmentID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid environment_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid environment_id").LogError(ctx, s.logger)
 	}
 
 	// Verify the environment exists and belongs to the project
@@ -612,7 +612,7 @@ func (s *Service) SetToolsetEnvironmentLink(ctx context.Context, payload *gen.Se
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "environment not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "environment not found").LogError(ctx, s.logger)
 	}
 
 	link, err := s.repo.SetToolsetEnvironment(ctx, repo.SetToolsetEnvironmentParams{
@@ -621,7 +621,7 @@ func (s *Service) SetToolsetEnvironmentLink(ctx context.Context, payload *gen.Se
 		EnvironmentID: environmentID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to set toolset environment link").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to set toolset environment link").LogError(ctx, s.logger)
 	}
 
 	return &gen.ToolsetEnvironmentLink{
@@ -643,7 +643,7 @@ func (s *Service) DeleteToolsetEnvironmentLink(ctx context.Context, payload *gen
 
 	toolsetID, err := uuid.Parse(payload.ToolsetID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, s.logger)
 	}
 
 	err = s.repo.DeleteToolsetEnvironment(ctx, repo.DeleteToolsetEnvironmentParams{
@@ -651,7 +651,7 @@ func (s *Service) DeleteToolsetEnvironmentLink(ctx context.Context, payload *gen
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return oops.E(oops.CodeUnexpected, err, "failed to delete toolset environment link").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete toolset environment link").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -669,7 +669,7 @@ func (s *Service) GetToolsetEnvironment(ctx context.Context, payload *gen.GetToo
 
 	toolsetID, err := uuid.Parse(payload.ToolsetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, s.logger)
 	}
 
 	environment, err := s.repo.GetEnvironmentForToolset(ctx, repo.GetEnvironmentForToolsetParams{
@@ -679,14 +679,14 @@ func (s *Service) GetToolsetEnvironment(ctx context.Context, payload *gen.GetToo
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "environment not found for toolset").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "environment not found for toolset").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment for toolset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment for toolset").LogError(ctx, s.logger)
 	}
 
 	entries, err := s.entries.ListEnvironmentEntries(ctx, *authCtx.ProjectID, environment.ID, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list environment entries").LogError(ctx, s.logger)
 	}
 
 	return buildEnvironmentView(environment, entries), nil

--- a/server/internal/external/impl.go
+++ b/server/internal/external/impl.go
@@ -99,7 +99,7 @@ func (h *WebhookHandler) ReceiveWorkOSWebhook(ctx context.Context, payload *gen.
 
 	bodyBytes, err := io.ReadAll(body)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, h.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, h.logger)
 	}
 
 	if _, err := h.webhooksClient.ValidatePayload(*payload.WorkosSignature, string(bodyBytes)); err != nil {
@@ -108,7 +108,7 @@ func (h *WebhookHandler) ReceiveWorkOSWebhook(ctx context.Context, payload *gen.
 
 	var event webhookEvent
 	if err := json.Unmarshal(bodyBytes, &event); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid webhook payload").Log(ctx, h.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid webhook payload").LogError(ctx, h.logger)
 	}
 
 	logger := h.logger.With(attr.SlogWorkOSEventType(event.Event))
@@ -140,7 +140,7 @@ func (h *WebhookHandler) dispatch(ctx context.Context, logger *slog.Logger, even
 		if _, err := background.ExecuteProcessWorkOSOrganizationEventsWorkflowDebounced(ctx, h.temporalEnv, background.ProcessWorkOSEventsParams{
 			WorkOSOrganizationID: orgID,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to enqueue WorkOS organization sync").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to enqueue WorkOS organization sync").LogError(ctx, logger)
 		}
 		return nil
 
@@ -148,7 +148,7 @@ func (h *WebhookHandler) dispatch(ctx context.Context, logger *slog.Logger, even
 		string(workos.EventKindRoleUpdated),
 		string(workos.EventKindRoleDeleted):
 		if _, err := background.ExecuteProcessWorkOSGlobalRoleEventsWorkflowDebounced(ctx, h.temporalEnv); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to enqueue WorkOS global role sync").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to enqueue WorkOS global role sync").LogError(ctx, logger)
 		}
 		return nil
 
@@ -158,7 +158,7 @@ func (h *WebhookHandler) dispatch(ctx context.Context, logger *slog.Logger, even
 		if _, err := background.ExecuteProcessWorkOSUserEventsWorkflowDebounced(ctx, h.temporalEnv, background.ProcessWorkOSUserEventsWorkflowParams{
 			WorkOSUserID: event.Data.ID,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to enqueue WorkOS user sync").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to enqueue WorkOS user sync").LogError(ctx, logger)
 		}
 		return nil
 

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -81,7 +81,7 @@ func (s *Service) ClearCache(ctx context.Context, payload *gen.ClearCachePayload
 
 	userInfo, _, err := s.sessions.GetUserInfo(ctx, authCtx.UserID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "fetch user info").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "fetch user info").LogError(ctx, s.logger)
 	}
 	if userInfo == nil || !userInfo.Admin {
 		return oops.C(oops.CodeForbidden)
@@ -89,7 +89,7 @@ func (s *Service) ClearCache(ctx context.Context, payload *gen.ClearCachePayload
 
 	registryID, err := uuid.Parse(payload.RegistryID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid registry_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
 	}
 
 	registry, err := s.repo.GetMCPRegistryByID(ctx, registryID)
@@ -97,11 +97,11 @@ func (s *Service) ClearCache(ctx context.Context, payload *gen.ClearCachePayload
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
-		return oops.E(oops.CodeUnexpected, err, "get registry").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "get registry").LogError(ctx, s.logger)
 	}
 
 	if err := s.registryClient.ClearCache(ctx, registry.Url); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "clear registry cache").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "clear registry cache").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "registry cache cleared",
@@ -120,7 +120,7 @@ func (s *Service) ListRegistries(ctx context.Context, payload *gen.ListRegistrie
 
 	userInfo, _, err := s.sessions.GetUserInfo(ctx, authCtx.UserID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "fetch user info").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "fetch user info").LogError(ctx, s.logger)
 	}
 	if userInfo == nil || !userInfo.Admin {
 		return nil, oops.C(oops.CodeForbidden)
@@ -128,7 +128,7 @@ func (s *Service) ListRegistries(ctx context.Context, payload *gen.ListRegistrie
 
 	registries, err := s.repo.ListMCPRegistries(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list registries").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list registries").LogError(ctx, s.logger)
 	}
 
 	result := make([]*types.MCPRegistry, 0, len(registries))
@@ -159,7 +159,7 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 	if payload.RegistryID != nil {
 		registryID, err := uuid.Parse(*payload.RegistryID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
 		}
 
 		registry, err := s.repo.GetMCPRegistryByID(ctx, registryID)
@@ -167,7 +167,7 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, oops.C(oops.CodeNotFound)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get registry").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get registry").LogError(ctx, s.logger)
 		}
 
 		result, err := s.registryClient.ListServers(ctx, Registry{
@@ -178,7 +178,7 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 			Cursor: payload.Cursor,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch servers from registry").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch servers from registry").LogError(ctx, s.logger)
 		}
 
 		return &gen.ListCatalogResult{
@@ -190,7 +190,7 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 	// Fetch all registries from the database
 	registries, err := s.repo.ListMCPRegistries(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list registries").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list registries").LogError(ctx, s.logger)
 	}
 
 	// Aggregate servers from all registries
@@ -246,7 +246,7 @@ func (s *Service) GetServerDetails(ctx context.Context, payload *gen.GetServerDe
 
 	registryID, err := uuid.Parse(payload.RegistryID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
 	}
 
 	registry, err := s.repo.GetMCPRegistryByID(ctx, registryID)
@@ -254,13 +254,13 @@ func (s *Service) GetServerDetails(ctx context.Context, payload *gen.GetServerDe
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get registry").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get registry").LogError(ctx, s.logger)
 	}
 
 	// Fetch all server details in a single HTTP call
 	details, err := s.fetchServerDetails(ctx, registry, payload.ServerSpecifier)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch server details from registry").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch server details from registry").LogError(ctx, s.logger)
 	}
 
 	registryIDStr := registryID.String()

--- a/server/internal/externalmcp/process.go
+++ b/server/internal/externalmcp/process.go
@@ -102,7 +102,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 	if task.MCP.OrganizationMcpCollectionRegistryID.Valid {
 		// Internal Gram-hosted server — build ServerDetails directly from selected_remotes
 		if len(task.MCP.SelectedRemotes) == 0 {
-			return oops.E(oops.CodeBadRequest, nil, "[%s] internal mcp server has no selected remotes", task.MCP.Name).Log(ctx, logger)
+			return oops.E(oops.CodeBadRequest, nil, "[%s] internal mcp server has no selected remotes", task.MCP.Name).LogError(ctx, logger)
 		}
 		serverDetails = &ServerDetails{
 			Name:          task.MCP.Name,
@@ -118,7 +118,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 		// External registry server — look up registry and fetch details via HTTP
 		registry, err := te.repo.GetMCPRegistryByID(ctx, task.MCP.RegistryID.UUID)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "[%s] error getting registry for mcp server", task.MCP.Name).Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "[%s] error getting registry for mcp server", task.MCP.Name).LogError(ctx, logger)
 		}
 
 		serverDetails, err = te.registryClient.GetServerDetails(ctx, Registry{
@@ -126,7 +126,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 			URL: registry.Url,
 		}, task.MCP.RegistryServerSpecifier, task.MCP.SelectedRemotes)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "[%s] error fetching server details from registry", task.MCP.Name).Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "[%s] error fetching server details from registry", task.MCP.Name).LogError(ctx, logger)
 		}
 	}
 
@@ -141,7 +141,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 
 		oauthDiscovery, err = DiscoverOAuthMetadata(ctx, internalLogger, te.guardianPolicy, authErr.WWWAuthenticate, serverDetails.RemoteURL)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "[%s] error discovering OAuth metadata", task.MCP.Name).Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "[%s] error discovering OAuth metadata", task.MCP.Name).LogError(ctx, logger)
 		}
 
 		switch oauthDiscovery.Version {
@@ -183,7 +183,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 			})
 		}
 	} else if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "[%s] external mcp server unavailable", task.MCP.Name).Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "[%s] external mcp server unavailable", task.MCP.Name).LogError(ctx, logger)
 	} else {
 		defer o11y.LogDefer(ctx, logger, mcpClient.Close)
 	}
@@ -211,7 +211,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 	if len(serverDetails.Headers) > 0 {
 		headerDefinitions, err = json.Marshal(serverDetails.Headers)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "[%s] error marshaling header definitions", task.MCP.Name).Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "[%s] error marshaling header definitions", task.MCP.Name).LogError(ctx, logger)
 		}
 	}
 
@@ -221,7 +221,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 		for _, tool := range serverDetails.Tools {
 			toolURN := urn.NewTool(urn.ToolKindExternalMCP, task.MCP.Slug, tool.Name)
 			if err := toolURN.Validate(); err != nil {
-				return oops.E(oops.CodeInvalid, err, "[%s] invalid external mcp tool name %s", task.MCP.Name, tool.Name).Log(ctx, logger)
+				return oops.E(oops.CodeInvalid, err, "[%s] invalid external mcp tool name %s", task.MCP.Name, tool.Name).LogError(ctx, logger)
 			}
 
 			_, err = te.repo.CreateExternalMCPToolDefinition(ctx, repo.CreateExternalMCPToolDefinitionParams{
@@ -247,7 +247,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 				OpenWorldHint:              extractAnnotationBool(tool.Annotations, "openWorldHint"),
 			})
 			if err != nil {
-				return oops.E(oops.CodeUnexpected, err, "[%s] error creating external mcp tool definition for %s", task.MCP.Name, tool.Name).Log(ctx, logger)
+				return oops.E(oops.CodeUnexpected, err, "[%s] error creating external mcp tool definition for %s", task.MCP.Name, tool.Name).LogError(ctx, logger)
 			}
 		}
 
@@ -259,7 +259,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 		// Fallback to proxy tool when no tools are defined in the registry
 		toolURN := urn.NewTool(urn.ToolKindExternalMCP, task.MCP.Slug, "proxy")
 		if err := toolURN.Validate(); err != nil {
-			return oops.E(oops.CodeInvalid, err, "[%s] invalid external mcp proxy tool name", task.MCP.Name).Log(ctx, logger)
+			return oops.E(oops.CodeInvalid, err, "[%s] invalid external mcp proxy tool name", task.MCP.Name).LogError(ctx, logger)
 		}
 
 		_, err = te.repo.CreateExternalMCPToolDefinition(ctx, repo.CreateExternalMCPToolDefinitionParams{
@@ -285,7 +285,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 			OpenWorldHint:              pgtype.Bool{Bool: false, Valid: false},
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "[%s] error creating external mcp tool definition", task.MCP.Name).Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "[%s] error creating external mcp tool definition", task.MCP.Name).LogError(ctx, logger)
 		}
 
 		logger.InfoContext(ctx, fmt.Sprintf("[%s] created external mcp proxy tool", task.MCP.Name),

--- a/server/internal/functions/auth.go
+++ b/server/internal/functions/auth.go
@@ -92,18 +92,18 @@ func jwtAuth(ctx context.Context, logger *slog.Logger, db deprepo.DBTX, enc *enc
 	}, jwt.WithExpirationRequired(), jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
 	if err != nil {
 		err = fmt.Errorf("parse runner jwt: %w", err)
-		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).LogError(ctx, logger)
 	}
 
 	if !t.Valid {
 		err = fmt.Errorf("invalid runner jwt claims")
-		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).LogError(ctx, logger)
 	}
 
 	exp, err := t.Claims.GetExpirationTime()
 	if err != nil {
 		err = fmt.Errorf("get token exp claim: %w", err)
-		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).LogError(ctx, logger)
 	}
 	if exp.After(time.Now().Add(time.Hour)) {
 		logger.WarnContext(ctx, "runner jwt exp claim is greater than an hour")
@@ -112,7 +112,7 @@ func jwtAuth(ctx context.Context, logger *slog.Logger, db deprepo.DBTX, enc *enc
 	projectID, deploymentID, functionID, err := parseRunnerJWTSubjectClaim(t)
 	if err != nil {
 		err = fmt.Errorf("parse validated subject claim: %w", err)
-		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).LogError(ctx, logger)
 	}
 
 	authCtx := &RunnerAuthContext{
@@ -122,7 +122,7 @@ func jwtAuth(ctx context.Context, logger *slog.Logger, db deprepo.DBTX, enc *enc
 	}
 	if err := authCtx.Validate(); err != nil {
 		err = fmt.Errorf("validate runner auth context: %w", err)
-		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "%s", oops.CodeUnauthorized.UserMessage()).LogError(ctx, logger)
 	}
 
 	return PushRunnerAuthContext(ctx, authCtx), nil

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -150,24 +150,24 @@ func (f *FlyRunner) prepareFunctionAuth(ctx context.Context, logger *slog.Logger
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return "", nil, oops.E(oops.CodeNotFound, err, "no function runner available").Log(ctx, logger)
+		return "", nil, oops.E(oops.CodeNotFound, err, "no function runner available").LogError(ctx, logger)
 	case err != nil:
-		return "", nil, oops.E(oops.CodeUnexpected, err, "failed to fetch function runner").Log(ctx, logger)
+		return "", nil, oops.E(oops.CodeUnexpected, err, "failed to fetch function runner").LogError(ctx, logger)
 	}
 
 	format := row.BearerFormat.String
 	sec := row.EncryptionKey.Reveal()
 	if format == "" || len(sec) == 0 {
-		return "", nil, oops.E(oops.CodeInvariantViolation, nil, "function runner does not have credentials").Log(ctx, logger)
+		return "", nil, oops.E(oops.CodeInvariantViolation, nil, "function runner does not have credentials").LogError(ctx, logger)
 	}
 
 	unsealedAuthKey, err := f.encryption.Decrypt(string(sec))
 	if err != nil {
-		return "", nil, oops.E(oops.CodeUnexpected, err, "failed to access credentials").Log(ctx, logger)
+		return "", nil, oops.E(oops.CodeUnexpected, err, "failed to access credentials").LogError(ctx, logger)
 	}
 	enc, err = encryption.NewWithBytes([]byte(unsealedAuthKey))
 	if err != nil {
-		return "", nil, oops.E(oops.CodeUnexpected, err, "failed to create encryption client").Log(ctx, logger)
+		return "", nil, oops.E(oops.CodeUnexpected, err, "failed to create encryption client").LogError(ctx, logger)
 	}
 
 	return row.AppUrl, enc, nil
@@ -193,7 +193,7 @@ func (f *FlyRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (ht
 		"tool urn cannot be empty", !req.ToolURN.IsZero(),
 		"tool name cannot be empty", req.ToolName != "",
 	); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed tool call request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed tool call request").LogError(ctx, logger)
 	}
 
 	appURL, enc, err := f.prepareFunctionAuth(ctx, logger, req.RunnerBaseRequest)
@@ -203,7 +203,7 @@ func (f *FlyRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (ht
 
 	endpoint, err := url.JoinPath(appURL, "/tool-call")
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse function tool url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse function tool url").LogError(ctx, logger)
 	}
 
 	token, err := TokenV1(enc, TokenRequestV1{
@@ -212,7 +212,7 @@ func (f *FlyRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (ht
 		Subject: req.ToolURN.String(),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create bearer token for function tool call").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create bearer token for function tool call").LogError(ctx, logger)
 	}
 
 	payload, err := json.Marshal(CallToolPayload{
@@ -221,12 +221,12 @@ func (f *FlyRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (ht
 		Environment: req.Environment,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal function tool payload").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal function tool payload").LogError(ctx, logger)
 	}
 
 	httpreq, err = http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create function tool request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create function tool request").LogError(ctx, logger)
 	}
 
 	httpreq.Header.Set("Authorization", "Bearer "+token)
@@ -255,7 +255,7 @@ func (f *FlyRunner) ReadResource(ctx context.Context, req RunnerResourceReadRequ
 		"resource urn cannot be empty", !req.ResourceURN.IsZero(),
 		"resource uri cannot be empty", req.ResourceURI != "",
 	); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed read resource request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed read resource request").LogError(ctx, logger)
 	}
 
 	appURL, enc, err := f.prepareFunctionAuth(ctx, logger, req.RunnerBaseRequest)
@@ -265,7 +265,7 @@ func (f *FlyRunner) ReadResource(ctx context.Context, req RunnerResourceReadRequ
 
 	endpoint, err := url.JoinPath(appURL, "/resource-request")
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse function resource request url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse function resource request url").LogError(ctx, logger)
 	}
 
 	token, err := TokenV1(enc, TokenRequestV1{
@@ -274,7 +274,7 @@ func (f *FlyRunner) ReadResource(ctx context.Context, req RunnerResourceReadRequ
 		Subject: req.ResourceURN.String(),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create bearer token for function read resource call").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create bearer token for function read resource call").LogError(ctx, logger)
 	}
 
 	payload, err := json.Marshal(ReadResourcePayload{
@@ -283,12 +283,12 @@ func (f *FlyRunner) ReadResource(ctx context.Context, req RunnerResourceReadRequ
 		Environment: req.Environment,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal function read resource payload").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal function read resource payload").LogError(ctx, logger)
 	}
 
 	httpreq, err = http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create function read resource request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create function read resource request").LogError(ctx, logger)
 	}
 
 	httpreq.Header.Set("Authorization", "Bearer "+token)
@@ -336,7 +336,7 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 		"deployment function id cannot be nil", req.FunctionID != uuid.Nil,
 		"runner version cannot be empty", req.Version != "",
 	); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid function runner deploy request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid function runner deploy request").LogError(ctx, logger)
 	}
 
 	if err := f.reap(ctx, logger, appsRepo, ReapRequest{
@@ -366,7 +366,7 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 	case errors.As(err, &serr):
 		return nil, err
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to encode machine files").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to encode machine files").LogError(ctx, logger)
 	}
 
 	image, err := f.imgSelector.Select(ctx, ImageRequest{
@@ -381,7 +381,7 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 			oops.CodeUnexpected,
 			err,
 			"failed select runner image",
-		).Log(ctx, logger, attr.SlogFunctionsRunnerVersion(runnerVersion))
+		).LogError(ctx, logger, attr.SlogFunctionsRunnerVersion(runnerVersion))
 	}
 
 	machineConfig := f.newMachineConfig(req, image, files, sharedMetadata)
@@ -395,7 +395,7 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 
 	org, err := f.client.GetOrganizationBySlug(ctx, orgSlug)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to resolve runner target organization id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to resolve runner target organization id").LogError(ctx, logger)
 	}
 
 	appFull, err := f.client.CreateApp(ctx, fly.CreateAppInput{
@@ -405,7 +405,7 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 		Network:         &networkName,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create app").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create app").LogError(ctx, logger)
 	}
 
 	appName := appFull.Name
@@ -437,7 +437,7 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 		PrimaryRegion: region,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save app details").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save app details").LogError(ctx, logger)
 	}
 
 	logger = logger.With(
@@ -455,7 +455,7 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 			oops.CodeUnexpected,
 			fmt.Errorf("%s: %w", appFull.AppURL, err),
 			"failed to parse fly app url",
-		).Log(ctx, logger)
+		).LogError(ctx, logger)
 	}
 
 	flapsc, err := flaps.NewWithOptions(ctx, flaps.NewClientOpts{
@@ -469,12 +469,12 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create flaps client").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create flaps client").LogError(ctx, logger)
 	}
 
 	minSecretVersion, err := f.setSecrets(ctx, logger, appName, map[string]string{functionAuthSecretVar: req.BearerSecret})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to set function runner secrets").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to set function runner secrets").LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, "Starting runner machines")
@@ -486,13 +486,13 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 			span.RecordError(err)
 			logger.WarnContext(ctx, "failed to spin up some function runner machines", attr.SlogError(err))
 		} else {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to spin up function runner machines").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to spin up function runner machines").LogError(ctx, logger)
 		}
 	}
 
 	_, err = f.client.AllocateSharedIPAddress(ctx, appName)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to allocate shared IP address").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to allocate shared IP address").LogError(ctx, logger)
 	}
 
 	machineIDs := make([]string, 0, len(ms))
@@ -509,7 +509,7 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 		ReapedAt:     pgtype.Timestamptz{Valid: false, Time: time.Time{}, InfinityModifier: 0},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to mark app as ready").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to mark app as ready").LogError(ctx, logger)
 	}
 
 	var mem int
@@ -543,7 +543,7 @@ func (f *FlyRunner) Reap(ctx context.Context, req ReapRequest) error {
 	appsRepo := repo.New(f.db)
 
 	if err := f.reap(ctx, logger, appsRepo, req); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to reap app").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to reap app").LogError(ctx, logger)
 	}
 
 	return nil
@@ -898,7 +898,7 @@ func (f *FlyRunner) serializeAssets(
 	for _, asset := range assets {
 		rdr, err := f.assetStore.Read(ctx, asset.AssetURL)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch function asset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch function asset").LogError(ctx, logger)
 		}
 		defer o11y.LogDefer(ctx, f.logger, func() error {
 			if cerr := rdr.Close(); cerr != nil {
@@ -911,7 +911,7 @@ func (f *FlyRunner) serializeAssets(
 		if useTigris {
 			wr, _, err := f.tigrisStore.Write(ctx, asset.AssetURL.Path, asset.ContentType, asset.ContentLength)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to create writer for function asset").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to create writer for function asset").LogError(ctx, logger)
 			}
 			defer o11y.LogDefer(ctx, f.logger, func() error {
 				if werr := wr.Close(); werr != nil {
@@ -922,7 +922,7 @@ func (f *FlyRunner) serializeAssets(
 			})
 
 			if _, err := io.Copy(wr, rdr); err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to copy function asset to blob storage").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to copy function asset to blob storage").LogError(ctx, logger)
 			}
 
 			encoded := base64.StdEncoding.EncodeToString([]byte(asset.AssetID.String()))
@@ -934,7 +934,7 @@ func (f *FlyRunner) serializeAssets(
 		} else {
 			data, err := io.ReadAll(rdr)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to read function asset").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to read function asset").LogError(ctx, logger)
 			}
 
 			encoded := base64.StdEncoding.EncodeToString(data)

--- a/server/internal/functions/deploy_local.go
+++ b/server/internal/functions/deploy_local.go
@@ -98,17 +98,17 @@ func (l *LocalRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (
 	)
 
 	if err := invCheckLocalToolCall(req); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed local tool call request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed local tool call request").LogError(ctx, logger)
 	}
 
 	deployment, err := l.loadDeployment(req.FunctionsID)
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "local function runner not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "local function runner not found").LogError(ctx, logger)
 	}
 
 	enc, err := encryption.New(deployment.BearerSecret)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create local function auth client").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create local function auth client").LogError(ctx, logger)
 	}
 
 	token, err := TokenV1(enc, TokenRequestV1{
@@ -117,7 +117,7 @@ func (l *LocalRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (
 		Subject: req.ToolURN.String(),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create bearer token for local function tool call").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create bearer token for local function tool call").LogError(ctx, logger)
 	}
 
 	payload, err := json.Marshal(CallToolPayload{
@@ -126,17 +126,17 @@ func (l *LocalRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (
 		Environment: req.Environment,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "marshal local function tool payload").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "marshal local function tool payload").LogError(ctx, logger)
 	}
 
 	endpoint, err := l.proxyEndpoint(req.FunctionsID, "tool-call")
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "resolve local proxy endpoint").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve local proxy endpoint").LogError(ctx, logger)
 	}
 
 	httpreq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create local function tool request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create local function tool request").LogError(ctx, logger)
 	}
 
 	httpreq.Header.Set("Authorization", "Bearer "+token)
@@ -156,17 +156,17 @@ func (l *LocalRunner) ReadResource(ctx context.Context, req RunnerResourceReadRe
 	)
 
 	if err := invCheckLocalReadResource(req); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed local read resource request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed local read resource request").LogError(ctx, logger)
 	}
 
 	deployment, err := l.loadDeployment(req.FunctionsID)
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "local function runner not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "local function runner not found").LogError(ctx, logger)
 	}
 
 	enc, err := encryption.New(deployment.BearerSecret)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create local function auth client").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create local function auth client").LogError(ctx, logger)
 	}
 
 	token, err := TokenV1(enc, TokenRequestV1{
@@ -175,7 +175,7 @@ func (l *LocalRunner) ReadResource(ctx context.Context, req RunnerResourceReadRe
 		Subject: req.ResourceURN.String(),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create bearer token for local function read resource call").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create bearer token for local function read resource call").LogError(ctx, logger)
 	}
 
 	payload, err := json.Marshal(ReadResourcePayload{
@@ -184,17 +184,17 @@ func (l *LocalRunner) ReadResource(ctx context.Context, req RunnerResourceReadRe
 		Environment: req.Environment,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "marshal local function read resource payload").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "marshal local function read resource payload").LogError(ctx, logger)
 	}
 
 	endpoint, err := l.proxyEndpoint(req.FunctionsID, "resource-request")
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "resolve local proxy endpoint").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve local proxy endpoint").LogError(ctx, logger)
 	}
 
 	httpreq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create local function resource request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create local function resource request").LogError(ctx, logger)
 	}
 
 	httpreq.Header.Set("Authorization", "Bearer "+token)
@@ -214,20 +214,20 @@ func (l *LocalRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (*Run
 	)
 
 	if err := invCheckLocalDeploy(req); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed local function deployment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed local function deployment").LogError(ctx, logger)
 	}
 
 	functionDir := l.functionDir(req.FunctionID)
 	if err := os.RemoveAll(functionDir); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "clear local function directory").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "clear local function directory").LogError(ctx, logger)
 	}
 	if err := os.MkdirAll(functionDir, 0750); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create local function directory").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create local function directory").LogError(ctx, logger)
 	}
 
 	codePath := filepath.Join(functionDir, localRunnerCodeZipName)
 	if err := l.copyAsset(ctx, req.Assets[0].AssetURL, codePath); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "copy local function asset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "copy local function asset").LogError(ctx, logger)
 	}
 
 	deployment := localRunnerDeployment{
@@ -238,7 +238,7 @@ func (l *LocalRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (*Run
 		Runtime:      req.Runtime,
 	}
 	if err := writeJSONAtomic(filepath.Join(functionDir, localRunnerMetadataName), deployment, 0600); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "write local function deployment metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "write local function deployment metadata").LogError(ctx, logger)
 	}
 
 	name := fmt.Sprintf("dev-%s", req.FunctionID.String())
@@ -261,11 +261,11 @@ func (l *LocalRunner) Reap(ctx context.Context, req ReapRequest) error {
 	)
 
 	if req.FunctionID == uuid.Nil {
-		return oops.E(oops.CodeInvariantViolation, nil, "local function reap request is missing function id").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, nil, "local function reap request is missing function id").LogError(ctx, logger)
 	}
 
 	if err := os.RemoveAll(l.functionDir(req.FunctionID)); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "remove local function deployment").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "remove local function deployment").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/functions/impl.go
+++ b/server/internal/functions/impl.go
@@ -75,11 +75,11 @@ func (s *Service) GetSignedAssetURL(ctx context.Context, p *gen.GetSignedAssetUR
 
 	assetID, err := uuid.Parse(p.AssetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid asset id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid asset id").LogError(ctx, logger)
 	}
 
 	if assetID == uuid.Nil {
-		return nil, oops.E(oops.CodeInvalid, nil, "asset id cannot be nil").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "asset id cannot be nil").LogError(ctx, logger)
 	}
 
 	fr := repo.New(s.db)
@@ -93,17 +93,17 @@ func (s *Service) GetSignedAssetURL(ctx context.Context, p *gen.GetSignedAssetUR
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get function asset url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get function asset url").LogError(ctx, logger)
 	}
 
 	parsed, err := url.Parse(tu)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse function asset url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse function asset url").LogError(ctx, logger)
 	}
 
 	signed, err := s.tigrisStore.PresignRead(ctx, parsed.Path, 10*time.Minute)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to presign function asset url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to presign function asset url").LogError(ctx, logger)
 	}
 
 	return &gen.GetSignedAssetURLResult{

--- a/server/internal/functions/process.go
+++ b/server/internal/functions/process.go
@@ -115,7 +115,7 @@ func (p *ToolExtractor) Do(
 		"functions attachment id set", attachementID != uuid.Nil,
 		"functions attachement info set", attachement != nil && attachement.Name != "" && attachement.Slug != "",
 	); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, oops.Permanent(err), "unable to verify functions attachement").Log(ctx, p.logger)
+		return nil, oops.E(oops.CodeInvariantViolation, oops.Permanent(err), "unable to verify functions attachement").LogError(ctx, p.logger)
 	}
 
 	slug := attachement.Slug
@@ -156,7 +156,7 @@ func (p *ToolExtractor) Do(
 			oops.CodeBadRequest,
 			nil,
 			"%s: unsupported functions runtime: %s (allowed: %s)", slug, attachement.Runtime, supportedRuntimes,
-		).Log(ctx, logger, attrError)
+		).LogError(ctx, logger, attrError)
 	}
 
 	var validEntrypoint map[string]struct{}
@@ -166,13 +166,13 @@ func (p *ToolExtractor) Do(
 	case strings.HasPrefix(attachement.Runtime, "python:"):
 		validEntrypoint = pythonEntrypoints
 	default:
-		return nil, oops.E(oops.CodeBadRequest, nil, "%s: unrecognized functions runtime", slug).Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "%s: unrecognized functions runtime", slug).LogError(ctx, logger)
 	}
 	entrypointKeys := slices.Sorted(maps.Keys(validEntrypoint))
 
 	rc, size, err := p.assetStorage.ReadAt(ctx, assetURL)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "%s: error fetching functions zip file", slug).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "%s: error fetching functions zip file", slug).LogError(ctx, logger)
 	}
 	defer o11y.LogDefer(ctx, logger, func() error {
 		return rc.Close()
@@ -180,7 +180,7 @@ func (p *ToolExtractor) Do(
 
 	rdr, err := zip.NewReader(rc, size)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "%s: error opening functions zip file", slug).Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "%s: error opening functions zip file", slug).LogError(ctx, logger)
 	}
 
 	foundEntrypoint := false
@@ -196,16 +196,16 @@ func (p *ToolExtractor) Do(
 	}
 
 	if !foundEntrypoint {
-		return nil, oops.E(oops.CodeBadRequest, errPermanent, "%s: functions zip file is missing entrypoint file: %v", entrypointKeys, slug).Log(ctx, logger, attrError)
+		return nil, oops.E(oops.CodeBadRequest, errPermanent, "%s: functions zip file is missing entrypoint file: %v", entrypointKeys, slug).LogError(ctx, logger, attrError)
 	}
 
 	if manifestFile == nil {
-		return nil, oops.E(oops.CodeBadRequest, errPermanent, "%s: functions zip file is missing manifest.json file", slug).Log(ctx, logger, attrError)
+		return nil, oops.E(oops.CodeBadRequest, errPermanent, "%s: functions zip file is missing manifest.json file", slug).LogError(ctx, logger, attrError)
 	}
 
 	manifestRdr, err := manifestFile.Open()
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "%s: error opening manifest file", slug).Log(ctx, logger, attrError)
+		return nil, oops.E(oops.CodeBadRequest, err, "%s: error opening manifest file", slug).LogError(ctx, logger, attrError)
 	}
 	defer o11y.LogDefer(ctx, logger, func() error {
 		return manifestRdr.Close()
@@ -213,17 +213,17 @@ func (p *ToolExtractor) Do(
 
 	manifestBs, err := io.ReadAll(manifestRdr)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "%s: error reading manifest file", slug).Log(ctx, logger, attrError)
+		return nil, oops.E(oops.CodeBadRequest, err, "%s: error reading manifest file", slug).LogError(ctx, logger, attrError)
 	}
 
 	var manifest Manifest
 	if err := manifest.UnmarshalJSON(manifestBs); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "%s: error parsing manifest file", slug).Log(ctx, logger, attrError)
+		return nil, oops.E(oops.CodeBadRequest, err, "%s: error parsing manifest file", slug).LogError(ctx, logger, attrError)
 	}
 
 	dbtx, err := p.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "%s: error opening database transaction", slug).Log(ctx, p.logger, attrError)
+		return nil, oops.E(oops.CodeUnexpected, err, "%s: error opening database transaction", slug).LogError(ctx, p.logger, attrError)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -282,7 +282,7 @@ func (p *ToolExtractor) Do(
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "%s: error saving tools and resources", slug).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "%s: error saving tools and resources", slug).LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, fmt.Sprintf("[%s] processed function source: %d tools created, %d tools skipped, %d resources created, %d resources skipped", slug, numTools, numToolsSkipped, numResources, numResourcesSkipped))

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -176,7 +176,7 @@ func (tp *ToolProxy) Do(
 
 	switch plan.Kind {
 	case "":
-		return oops.E(oops.CodeInvariantViolation, nil, "tool kind is not set").Log(ctx, tp.logger)
+		return oops.E(oops.CodeInvariantViolation, nil, "tool kind is not set").LogError(ctx, tp.logger)
 	case ToolKindFunction:
 		return tp.doFunction(ctx, logger, w, requestBody, env, plan.Descriptor, plan.Function, attrs)
 	case ToolKindHTTP:
@@ -203,7 +203,7 @@ func (tp *ToolProxy) doPlatform(
 ) error {
 	span := trace.SpanFromContext(ctx)
 	if tp.platformTools == nil {
-		return oops.E(oops.CodeUnexpected, nil, "platform tool executor not configured").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "platform tool executor not configured").LogError(ctx, logger)
 	}
 
 	attrRecorder.RecordMethod(http.MethodPost)
@@ -221,12 +221,12 @@ func (tp *ToolProxy) doPlatform(
 
 	bodyBytes, err := io.ReadAll(requestBody)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, logger)
 	}
 
 	payloadBytes, err := extractPlatformPayload(bodyBytes)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid request body").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid request body").LogError(ctx, logger)
 	}
 
 	if len(plan.Platform.InputSchema) > 0 {
@@ -350,29 +350,29 @@ func (tp *ToolProxy) doFunction(
 	span := trace.SpanFromContext(ctx)
 	invocationID, err := uuid.NewV7()
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to generate function invocation ID").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to generate function invocation ID").LogError(ctx, logger)
 	}
 
 	projectID, err := uuid.Parse(descriptor.ProjectID)
 	if err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "invalid project id received for function tool call").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "invalid project id received for function tool call").LogError(ctx, logger)
 	}
 	deploymentID, err := uuid.Parse(descriptor.DeploymentID)
 	if err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "invalid deployment id received for function tool call").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "invalid deployment id received for function tool call").LogError(ctx, logger)
 	}
 	functionID, err := uuid.Parse(plan.FunctionID)
 	if err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "invalid function id received for function tool call").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "invalid function id received for function tool call").LogError(ctx, logger)
 	}
 	accessID, err := uuid.Parse(plan.FunctionsAccessID)
 	if err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "invalid function access id received for function tool call").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "invalid function access id received for function tool call").LogError(ctx, logger)
 	}
 
 	var input json.RawMessage
 	if err := json.NewDecoder(requestBody).Decode(&input); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, logger)
 	}
 
 	payloadEnv := make(map[string]string)
@@ -419,7 +419,7 @@ func (tp *ToolProxy) doFunction(
 		ToolName: descriptor.Name,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to create function tool call request").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to create function tool call request").LogError(ctx, logger)
 	}
 
 	var responseStatusCode int
@@ -507,7 +507,7 @@ func (tp *ToolProxy) doHTTP(
 
 	bodyBytes, err := io.ReadAll(requestBody)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, logger)
 	}
 
 	var toolCallBody ToolCallBody
@@ -516,7 +516,7 @@ func (tp *ToolProxy) doHTTP(
 	dec.UseNumber()
 
 	if err := dec.Decode(&toolCallBody); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid request body").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid request body").LogError(ctx, logger)
 	}
 
 	if len(plan.Schema) > 0 {
@@ -578,7 +578,7 @@ func (tp *ToolProxy) doHTTP(
 		urlStr := insertPathParams(requestPath, pathParams)
 		parsedURL, parseErr := url.Parse(urlStr)
 		if parseErr != nil {
-			return oops.E(oops.CodeUnexpected, parseErr, "failed to parse URL with path parameters").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, parseErr, "failed to parse URL with path parameters").LogError(ctx, logger)
 		}
 		requestPath = parsedURL.String()
 	}
@@ -595,18 +595,18 @@ func (tp *ToolProxy) doHTTP(
 
 	if serverURL == "" {
 		logger.ErrorContext(ctx, "no server URL provided for tool", attr.SlogToolName(descriptor.Name))
-		return oops.E(oops.CodeInvalid, nil, "no server URL provided for tool").Log(ctx, logger)
+		return oops.E(oops.CodeInvalid, nil, "no server URL provided for tool").LogError(ctx, logger)
 	}
 
 	fullURL, err := url.JoinPath(serverURL, requestPath)
 	var urlErr *url.Error
 	switch {
 	case errors.As(err, &urlErr) && urlErr.Err != nil:
-		return oops.E(oops.CodeInvalid, err, "error parsing server url: %s", urlErr.Err.Error()).Log(ctx, logger)
+		return oops.E(oops.CodeInvalid, err, "error parsing server url: %s", urlErr.Err.Error()).LogError(ctx, logger)
 	case err != nil:
 		// we do not want to print the full err here because it may leak the server URL which can contain
 		// sensitive information like usernames, passwords, etc.
-		return oops.E(oops.CodeInvalid, err, "error parsing server url").Log(ctx, logger)
+		return oops.E(oops.CodeInvalid, err, "error parsing server url").LogError(ctx, logger)
 	}
 
 	var req *http.Request
@@ -616,7 +616,7 @@ func (tp *ToolProxy) doHTTP(
 			// Assume toolCallBody.Body is a JSON object (map[string]interface{})
 			var formMap map[string]any
 			if err := json.Unmarshal(toolCallBody.Body, &formMap); err != nil {
-				return oops.E(oops.CodeBadRequest, err, "failed to parse form body").Log(ctx, logger)
+				return oops.E(oops.CodeBadRequest, err, "failed to parse form body").LogError(ctx, logger)
 			}
 			values := url.Values{}
 			for k, v := range formMap {
@@ -631,7 +631,7 @@ func (tp *ToolProxy) doHTTP(
 			strings.NewReader(encoded),
 		)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to build url-encoded request").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to build url-encoded request").LogError(ctx, logger)
 		}
 		req.Header.Set("Content-Type", plan.RequestContentType.Value)
 	} else {
@@ -642,7 +642,7 @@ func (tp *ToolProxy) doHTTP(
 			bytes.NewReader(toolCallBody.Body),
 		)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to build json request").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to build json request").LogError(ctx, logger)
 		}
 		if plan.RequestContentType.Value != "" {
 			req.Header.Set("Content-Type", plan.RequestContentType.Value)
@@ -744,18 +744,18 @@ type promptGetParams struct {
 func (tp *ToolProxy) doPrompt(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, requestBody io.Reader, env toolconfig.ToolCallEnv, descriptor *ToolDescriptor, plan *PromptToolCallPlan) error {
 	var params promptGetParams
 	if err := json.NewDecoder(requestBody).Decode(&params); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to parse get prompt request").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to parse get prompt request").LogError(ctx, logger)
 	}
 
 	promptData, err := templates.RenderTemplate(ctx, logger, plan.Prompt, plan.Kind, plan.Engine, params.Arguments)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to render template").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to render template").LogError(ctx, logger)
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte(promptData)); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write prompt data").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write prompt data").LogError(ctx, logger)
 	}
 
 	return nil
@@ -771,7 +771,7 @@ func (tp *ToolProxy) doExternalMCP(
 ) error {
 	arguments, err := io.ReadAll(requestBody)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to read tool arguments").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read tool arguments").LogError(ctx, logger)
 	}
 
 	// Use the tool name from the plan (set by Match for proxy tools, or directly for materialized tools)
@@ -793,14 +793,14 @@ func (tp *ToolProxy) doExternalMCP(
 	// Connect to the external MCP server
 	client, err := externalmcp.NewClient(ctx, logger, tp.policy, plan.RemoteURL, plan.TransportType, opts)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to connect to external MCP server").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to connect to external MCP server").LogError(ctx, logger)
 	}
 	defer o11y.LogDefer(ctx, logger, client.Close)
 
 	// Call the tool on the external MCP server
 	callResult, err := client.CallTool(ctx, toolName, arguments)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to call external MCP tool").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to call external MCP tool").LogError(ctx, logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -815,7 +815,7 @@ func (tp *ToolProxy) doExternalMCP(
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write external MCP tool result").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write external MCP tool result").LogError(ctx, logger)
 	}
 
 	return nil
@@ -983,7 +983,7 @@ func reverseProxyRequest(ctx context.Context, opts ReverseProxyOptions) error {
 	}, executeRequest)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		return oops.E(oops.CodeGatewayError, err, "failed to execute request").Log(ctx, opts.Logger)
+		return oops.E(oops.CodeGatewayError, err, "failed to execute request").LogError(ctx, opts.Logger)
 	}
 
 	defer o11y.LogDefer(ctx, opts.Logger, func() error {
@@ -992,7 +992,7 @@ func reverseProxyRequest(ctx context.Context, opts ReverseProxyOptions) error {
 
 	if err := opts.VerifyResponse(resp); err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		return oops.E(oops.CodeGatewayError, err, "response verification failed").Log(ctx, opts.Logger)
+		return oops.E(oops.CodeGatewayError, err, "response verification failed").LogError(ctx, opts.Logger)
 	}
 
 	if len(resp.Trailer) > 0 {

--- a/server/internal/gateway/resources.go
+++ b/server/internal/gateway/resources.go
@@ -52,7 +52,7 @@ func (tp *ToolProxy) ReadResource(
 
 	switch plan.Kind {
 	case "":
-		return oops.E(oops.CodeInvariantViolation, nil, "resource kind is not set").Log(ctx, tp.logger)
+		return oops.E(oops.CodeInvariantViolation, nil, "resource kind is not set").LogError(ctx, tp.logger)
 	case ResourceKindFunction:
 		return tp.doFunctionResource(ctx, logger, w, requestBody, env, plan.Descriptor, plan.Function, attrRecorder)
 	default:
@@ -73,28 +73,28 @@ func (tp *ToolProxy) doFunctionResource(
 	span := trace.SpanFromContext(ctx)
 	invocationID, err := uuid.NewV7()
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to generate function invocation ID").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to generate function invocation ID").LogError(ctx, logger)
 	}
 	projectID, err := uuid.Parse(descriptor.ProjectID)
 	if err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "invalid project id received for function resource call").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "invalid project id received for function resource call").LogError(ctx, logger)
 	}
 	deploymentID, err := uuid.Parse(descriptor.DeploymentID)
 	if err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "invalid deployment id received for function resource call").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "invalid deployment id received for function resource call").LogError(ctx, logger)
 	}
 	functionID, err := uuid.Parse(plan.FunctionID)
 	if err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "invalid function id received for function resource call").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "invalid function id received for function resource call").LogError(ctx, logger)
 	}
 	accessID, err := uuid.Parse(plan.FunctionsAccessID)
 	if err != nil {
-		return oops.E(oops.CodeInvariantViolation, err, "invalid function access id received for function resource call").Log(ctx, logger)
+		return oops.E(oops.CodeInvariantViolation, err, "invalid function access id received for function resource call").LogError(ctx, logger)
 	}
 
 	var input json.RawMessage
 	if err := json.NewDecoder(requestBody).Decode(&input); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, logger)
 	}
 
 	payloadEnv := make(map[string]string)
@@ -129,7 +129,7 @@ func (tp *ToolProxy) doFunctionResource(
 		ResourceName: descriptor.Name,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to create function resource call request").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to create function resource call request").LogError(ctx, logger)
 	}
 
 	var responseStatusCode int

--- a/server/internal/hooks/server_names_impl.go
+++ b/server/internal/hooks/server_names_impl.go
@@ -46,7 +46,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) ([]*gen.Se
 			oops.CodeUnexpected,
 			err,
 			"failed to list hooks server name overrides",
-		).Log(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
+		).LogError(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
 	}
 
 	result := make([]*gen.ServerNameOverride, len(rows))
@@ -94,7 +94,7 @@ func (s *Service) Upsert(ctx context.Context, payload *gen.UpsertPayload) (*gen.
 			oops.CodeUnexpected,
 			err,
 			"failed to upsert hooks server name override",
-		).Log(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
+		).LogError(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
 	}
 
 	return &gen.ServerNameOverride{
@@ -133,7 +133,7 @@ func (s *Service) Delete(ctx context.Context, payload *gen.DeletePayload) error 
 			oops.CodeUnexpected,
 			err,
 			"failed to delete hooks server name override",
-		).Log(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogHookServerNameOverrideID(payload.OverrideID))
+		).LogError(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogHookServerNameOverrideID(payload.OverrideID))
 	}
 
 	return nil

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -184,7 +184,7 @@ func (s *Service) GetInstance(ctx context.Context, payload *gen.GetInstanceForm)
 	if toolset.CustomDomainID != nil {
 		customDomain, err := s.customDomainsRepo.GetCustomDomainByID(ctx, uuid.MustParse(*toolset.CustomDomainID))
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get custom domain").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get custom domain").LogError(ctx, s.logger)
 		}
 		baseURL = fmt.Sprintf("https://%s", customDomain.Domain)
 	}
@@ -236,7 +236,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 			}
 			ctx, err = s.auth.Authorize(r.Context(), r.Header.Get(constants.APIKeyHeader), &sc)
 			if err != nil {
-				return oops.E(oops.CodeUnauthorized, err, "failed to authorize").Log(ctx, logger)
+				return oops.E(oops.CodeUnauthorized, err, "failed to authorize").LogError(ctx, logger)
 			}
 		}
 	}
@@ -249,21 +249,21 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 
 	ctx, err = s.auth.Authorize(ctx, r.Header.Get(constants.ProjectHeader), &sc)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "failed to authorize").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "failed to authorize").LogError(ctx, logger)
 	}
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.ProjectID == nil {
-		return oops.E(oops.CodeUnauthorized, nil, "project ID is required").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, nil, "project ID is required").LogError(ctx, logger)
 	}
 
 	toolURNParam := r.URL.Query().Get(toolUrnQueryParam)
 	if toolURNParam == "" {
-		return oops.E(oops.CodeBadRequest, nil, "tool_urn query parameter is required").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "tool_urn query parameter is required").LogError(ctx, logger)
 	}
 	toolURN, err := urn.ParseTool(toolURNParam)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to parse tool URN").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to parse tool URN").LogError(ctx, logger)
 	}
 
 	// These variables will come in our playground chats
@@ -277,12 +277,12 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 			Slug:      strings.ToLower(environmentSlug),
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to load environment").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to load environment").LogError(ctx, logger)
 		}
 
 		environmentEntries, err := s.env.ListEnvironmentEntries(ctx, *authCtx.ProjectID, envModel.ID, false)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to load environment entries").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to load environment entries").LogError(ctx, logger)
 		}
 
 		for _, entry := range environmentEntries {
@@ -292,7 +292,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 
 	plan, err := s.toolset.GetToolCallPlanByURN(ctx, toolURN, *authCtx.ProjectID)
 	if err != nil || plan == nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to load tool call plan").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load tool call plan").LogError(ctx, logger)
 	}
 
 	descriptor := plan.Descriptor
@@ -310,20 +310,20 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 		} else if toolset != nil {
 			toolsetUUID, err = uuid.Parse(toolset.ID)
 			if err != nil {
-				return oops.E(oops.CodeUnexpected, err, "failed to parse toolset ID").Log(ctx, logger)
+				return oops.E(oops.CodeUnexpected, err, "failed to parse toolset ID").LogError(ctx, logger)
 			}
 		}
 	}
 
 	systemConfig, err := s.env.LoadSystemEnv(ctx, *authCtx.ProjectID, toolsetUUID, string(toolURN.Kind), toolURN.Source)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to load system environment").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load system environment").LogError(ctx, logger)
 	}
 
 	requestBody := r.Body
 	requestBodyBytes, err := io.ReadAll(requestBody)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to read request body").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to read request body").LogError(ctx, logger)
 	}
 
 	requestNumBytes := int64(len(requestBodyBytes))

--- a/server/internal/integrations/impl.go
+++ b/server/internal/integrations/impl.go
@@ -77,7 +77,7 @@ func (s *Service) Get(ctx context.Context, form *gen.GetPayload) (res *gen.GetIn
 	if form.ID != nil {
 		id, err := uuid.Parse(*form.ID)
 		if err != nil {
-			return nil, oops.E(oops.CodeInvalid, err, "invalid package id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeInvalid, err, "invalid package id").LogError(ctx, s.logger)
 		}
 
 		pid = uuid.NullUUID{UUID: id, Valid: id != uuid.Nil}
@@ -95,7 +95,7 @@ func (s *Service) Get(ctx context.Context, form *gen.GetPayload) (res *gen.GetIn
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting integration").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting integration").LogError(ctx, s.logger)
 	}
 
 	v := semver.Semver{
@@ -112,7 +112,7 @@ func (s *Service) Get(ctx context.Context, form *gen.GetPayload) (res *gen.GetIn
 		PackageName: pname,
 	})
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing integration versions").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing integration versions").LogError(ctx, s.logger)
 	}
 
 	versions := make([]*gen.IntegrationVersion, 0, len(versionRows))
@@ -152,7 +152,7 @@ func (s *Service) Get(ctx context.Context, form *gen.GetPayload) (res *gen.GetIn
 func (s *Service) List(ctx context.Context, form *gen.ListPayload) (res *gen.ListIntegrationsResult, err error) {
 	rows, err := s.repo.ListIntegrations(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing integrations").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing integrations").LogError(ctx, s.logger)
 	}
 
 	integrations := make([]*gen.IntegrationEntry, 0, len(rows))

--- a/server/internal/keys/impl.go
+++ b/server/internal/keys/impl.go
@@ -109,7 +109,7 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 
 	keyHash, err := auth.GetAPIKeyHash(fullKey)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error hashing api key").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error hashing api key").LogError(ctx, s.logger)
 	}
 
 	var projectID uuid.NullUUID
@@ -123,7 +123,7 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 	for _, rawscope := range payload.Scopes {
 		scope, ok := auth.APIKeyScopes[rawscope]
 		if !ok || scope == auth.APIKeyScopeInvalid {
-			return nil, oops.E(oops.CodeBadRequest, nil, "invalid api key scope: %s", scope).Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "invalid api key scope: %s", scope).LogError(ctx, s.logger)
 		}
 
 		scopes[scope.String()] = struct{}{}
@@ -139,7 +139,7 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing api keys").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing api keys").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -155,7 +155,7 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 		ProjectID:       projectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error creating api key").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating api key").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogKeyCreate(ctx, dbtx, audit.LogKeyCreateEvent{
@@ -168,11 +168,11 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 		KeyName:          payload.Name,
 		Scopes:           finalScopes,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error adding api key creation audit log").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error adding api key creation audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving api key creation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving api key creation").LogError(ctx, s.logger)
 	}
 
 	return &gen.Key{
@@ -201,7 +201,7 @@ func (s *Service) ListKeys(ctx context.Context, payload *gen.ListKeysPayload) (*
 
 	keys, err := s.repo.ListAPIKeysByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing api keys").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing api keys").LogError(ctx, s.logger)
 	}
 
 	var result []*gen.Key
@@ -241,7 +241,7 @@ func (s *Service) RevokeKey(ctx context.Context, payload *gen.RevokeKeyPayload) 
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error accessing api keys").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing api keys").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -260,7 +260,7 @@ func (s *Service) RevokeKey(ctx context.Context, payload *gen.RevokeKeyPayload) 
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "error revoking api key").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error revoking api key").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogKeyRevoke(ctx, dbtx, audit.LogKeyRevokeEvent{
@@ -273,11 +273,11 @@ func (s *Service) RevokeKey(ctx context.Context, payload *gen.RevokeKeyPayload) 
 		KeyName:          deleted.Name,
 		Scopes:           deleted.Scopes,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error adding api key revocation audit log").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error adding api key revocation audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error saving api key revocation").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error saving api key revocation").LogError(ctx, s.logger)
 	}
 
 	return nil

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -297,7 +297,7 @@ func (s *Service) ApplyIssuerGate(
 ) (context.Context, string, error) {
 	protectedResourceURL, err := endpoint.ProtectedResourceURL(baseURL)
 	if err != nil {
-		return ctx, "", oops.E(oops.CodeUnexpected, err, "build protected-resource URL").Log(ctx, s.logger)
+		return ctx, "", oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, s.logger)
 	}
 
 	newCtx, subject, ok := s.validateUserSessionToken(ctx, authToken, endpoint)
@@ -329,7 +329,7 @@ func (s *Service) ApplyIssuerGate(
 		case errors.Is(rerr, remotesessions.ErrNoValidToken):
 			return ctx, "", WriteAuthenticateChallenge(w, protectedResourceURL, "")
 		case rerr != nil:
-			return ctx, "", oops.E(oops.CodeUnexpected, rerr, "resolve remote session").Log(newCtx, s.logger)
+			return ctx, "", oops.E(oops.CodeUnexpected, rerr, "resolve remote session").LogError(newCtx, s.logger)
 		}
 		upstreamToken = upstream
 	}
@@ -355,7 +355,7 @@ func (s *Service) RequireUserSessionIssuer(ctx context.Context, endpoint *Resolv
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, err, "user_session_issuer not found")
 		}
-		return oops.E(oops.CodeUnexpected, err, "load user_session_issuer").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "load user_session_issuer").LogError(ctx, s.logger)
 	}
 	return nil
 }

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -43,7 +43,7 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
 	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
@@ -79,7 +79,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 		if errors.Is(err, pgx.ErrNoRows) {
 			return writeAuthorizeError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}
-		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
 	}
 	if !slices.Contains(client.RedirectUris, req.RedirectURI) {
 		return writeAuthorizeError(ctx, w, logger, http.StatusBadRequest, "invalid_request", "redirect_uri is not registered for this client")
@@ -106,7 +106,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 
 	csrfToken, err := generateOpaqueToken()
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "generate consent csrf token").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "generate consent csrf token").LogError(ctx, logger)
 	}
 	// Ambient cookies / Bearer tokens MUST NOT identify the caller on
 	// this endpoint — /authorize is reachable cross-site, so honouring
@@ -139,7 +139,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	}
 
 	if err := s.authnChallengeCache.Store(ctx, challengeState); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "store authn challenge state").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "store authn challenge state").LogError(ctx, logger)
 	}
 
 	// Flow start: counted exactly once per minted challenge, the unit the
@@ -151,7 +151,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 		callbackURL, err := endpoint.IDPCallbackURL(s.serverURL.String())
 		if err != nil {
 			s.metrics.RecordOAuthFlowFailed(ctx, endpoint.UserSessionIssuerID.String(), endpoint.Slug, oauthFlowStageAuthorize)
-			return oops.E(oops.CodeUnexpected, err, "build IDP callback URL").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "build IDP callback URL").LogError(ctx, logger)
 		}
 		idpURL, err := s.identityResolver.BuildAuthorizationURL(ctx, identity.AuthorizationURLParams{
 			CallbackURL:     callbackURL,
@@ -163,7 +163,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 			// A failure to build the IDP authorization URL typically means the
 			// issuer's IDP wiring is misconfigured — a config-class flow failure.
 			s.metrics.RecordOAuthFlowFailed(ctx, endpoint.UserSessionIssuerID.String(), endpoint.Slug, oauthFlowStageAuthorize)
-			return oops.E(oops.CodeUnexpected, err, "build IDP authorization URL").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "build IDP authorization URL").LogError(ctx, logger)
 		}
 		http.Redirect(w, r, idpURL.String(), http.StatusFound)
 		return nil
@@ -172,7 +172,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	consentURL, err := endpoint.ConsentURL(baseURL, challengeID)
 	if err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, endpoint.UserSessionIssuerID.String(), endpoint.Slug, oauthFlowStageAuthorize)
-		return oops.E(oops.CodeUnexpected, err, "build consent URL").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "build consent URL").LogError(ctx, logger)
 	}
 	http.Redirect(w, r, consentURL, http.StatusFound)
 	return nil
@@ -222,7 +222,7 @@ func writeAuthorizeError(ctx context.Context, w http.ResponseWriter, logger *slo
 		"error_description": description,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to marshal authorize error").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal authorize error").LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, "authorize request rejected",
@@ -235,7 +235,7 @@ func writeAuthorizeError(ctx context.Context, w http.ResponseWriter, logger *slo
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(status)
 	if _, werr := w.Write(body); werr != nil {
-		return oops.E(oops.CodeUnexpected, werr, "failed to write authorize error body").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, werr, "failed to write authorize error body").LogError(ctx, logger)
 	}
 	return nil
 }

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -120,7 +120,7 @@ func (s *Service) HandleConsent(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
 	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
@@ -143,7 +143,7 @@ func (s *Service) ServeConsentScript(w http.ResponseWriter, r *http.Request) err
 	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(consentScriptData); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "write consent script response").Log(r.Context(), s.logger)
+		return oops.E(oops.CodeUnexpected, err, "write consent script response").LogError(r.Context(), s.logger)
 	}
 	return nil
 }
@@ -158,7 +158,7 @@ func (s *Service) ServeConsent(w http.ResponseWriter, r *http.Request, endpoint 
 	case http.MethodPost:
 		return s.serveConsentPost(w, r, endpoint)
 	default:
-		return oops.E(oops.CodeBadRequest, nil, "method not allowed").Log(r.Context(), s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "method not allowed").LogError(r.Context(), s.logger)
 	}
 }
 
@@ -168,16 +168,16 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 
 	stateID := r.URL.Query().Get("state")
 	if stateID == "" {
-		return oops.E(oops.CodeBadRequest, nil, "state is required").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "state is required").LogError(ctx, logger)
 	}
 
 	challengeState, err := s.authnChallengeCache.Get(ctx, "authnChallenge:"+stateID)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").LogError(ctx, logger)
 	}
 	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
 	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").LogError(ctx, logger)
 	}
 
 	client, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
@@ -186,20 +186,20 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeUnauthorized, err, "user session client revoked").Log(ctx, logger)
+			return oops.E(oops.CodeUnauthorized, err, "user session client revoked").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
 	}
 
 	if challengeState.Subject == nil || challengeState.Subject.IsZero() {
-		return oops.E(oops.CodeUnauthorized, nil, "authn challenge subject is not resolved").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, nil, "authn challenge subject is not resolved").LogError(ctx, logger)
 	}
 
 	subjectDisplay := resolveSubjectDisplay(ctx, s.db, *challengeState.Subject)
 
 	cards, err := s.buildRemoteSessionCards(ctx, endpoint, challengeState)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build remote session cards").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "build remote session cards").LogError(ctx, logger)
 	}
 
 	consentEnabled := len(cards) == 0
@@ -226,7 +226,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	if err := consentTemplate.Execute(w, data); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "render consent template").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "render consent template").LogError(ctx, logger)
 	}
 	return nil
 }
@@ -238,14 +238,14 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	// consent form has a few short fields; 16 KiB is generous.
 	r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
 	if err := r.ParseForm(); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to parse form").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to parse form").LogError(ctx, s.logger)
 	}
 
 	logger := endpoint.LogWith(s.logger)
 
 	stateID := r.PostForm.Get("state")
 	if stateID == "" {
-		return oops.E(oops.CodeBadRequest, nil, "state is required").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "state is required").LogError(ctx, logger)
 	}
 
 	// Atomic GETDEL: a consent POST consumes the authn-challenge state
@@ -254,7 +254,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	// authorization request.
 	challengeState, err := s.authnChallengeCache.GetAndDelete(ctx, "authnChallenge:"+stateID)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").LogError(ctx, logger)
 	}
 	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
 	issuerID := endpoint.UserSessionIssuerID.String()
@@ -266,11 +266,11 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	// let crafted requests pollute a config's health signal. A legitimate user
 	// never trips them; the rare case lands in the started-without-terminal gap.
 	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").LogError(ctx, logger)
 	}
 
 	if challengeState.CSRFToken == "" || subtle.ConstantTimeCompare([]byte(r.PostForm.Get("csrf_token")), []byte(challengeState.CSRFToken)) != 1 {
-		return oops.E(oops.CodeUnauthorized, nil, "invalid consent csrf token").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, nil, "invalid consent csrf token").LogError(ctx, logger)
 	}
 
 	// Explicit action required: fail closed on missing / unknown values so
@@ -290,14 +290,14 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		http.Redirect(w, r, denyURL, http.StatusSeeOther)
 		return nil
 	default:
-		return oops.E(oops.CodeBadRequest, nil, `action must be "approve" or "deny"`).Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, `action must be "approve" or "deny"`).LogError(ctx, logger)
 	}
 
 	if challengeState.Subject == nil || challengeState.Subject.IsZero() {
 		// Reaching an approved consent POST with no resolved subject is a code
 		// invariant break, not a user action — a config/code-class failure.
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
-		return oops.E(oops.CodeUnauthorized, nil, "authn challenge subject is not resolved").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, nil, "authn challenge subject is not resolved").LogError(ctx, logger)
 	}
 	subject := *challengeState.Subject
 
@@ -311,9 +311,9 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		// approved flow can't complete.
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeUnauthorized, err, "user session client revoked").Log(ctx, logger)
+			return oops.E(oops.CodeUnauthorized, err, "user session client revoked").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
 	}
 
 	// Persist the consent record. The unique index on
@@ -326,13 +326,13 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		RemoteSetHash:       remoteSetHashEmpty,
 	}); err != nil && !isUniqueViolation(err) {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
-		return oops.E(oops.CodeUnexpected, err, "record consent").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "record consent").LogError(ctx, logger)
 	}
 
 	code, err := generateOpaqueToken()
 	if err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
-		return oops.E(oops.CodeUnexpected, err, "generate authorization code").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "generate authorization code").LogError(ctx, logger)
 	}
 
 	grant := UserSessionGrant{
@@ -349,7 +349,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	}
 	if err := s.userSessionGrantCache.Store(ctx, grant); err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
-		return oops.E(oops.CodeUnexpected, err, "store user session grant").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "store user session grant").LogError(ctx, logger)
 	}
 
 	clientRedirect := buildClientRedirect(challengeState.RedirectURI, code, challengeState.State, "", "")

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -38,7 +38,7 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	q := r.URL.Query()
 	stateID := q.Get("state")
 	if stateID == "" {
-		return oops.E(oops.CodeBadRequest, nil, "state is required").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "state is required").LogError(ctx, logger)
 	}
 
 	// Atomic GETDEL: the IDP-returned state URL is single-use. The fresh
@@ -51,7 +51,7 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		// No challenge in hand (expired / replayed / never existed): nothing to
 		// attribute to an issuer, and an expired state is closer to abandonment
 		// than a flow failure, so it is left to the started-without-terminal gap.
-		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").LogError(ctx, logger)
 	}
 
 	// Challenge in hand: correlate every subsequent log line by flow_id, and
@@ -65,12 +65,12 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		// Corrupted in-flight state (a code/data integrity failure), terminal
 		// for the flow.
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-		return oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from authn challenge state").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from authn challenge state").LogError(ctx, logger)
 	}
 	if routeMcpSlug != "" && routeMcpSlug != mcpSlug {
 		// State-confusion guard (state minted for a different route). Attacker-
 		// controllable, so deliberately NOT counted as a flow failure.
-		return oops.E(oops.CodeUnauthorized, nil, "authn challenge state does not match this MCP server").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, nil, "authn challenge state does not match this MCP server").LogError(ctx, logger)
 	}
 
 	endpoint, err := s.loadResolvedMcpEndpointByRef(ctx, challengeState.Endpoint)
@@ -113,14 +113,14 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	if code == "" {
 		// IDP returned neither code nor error — a broken IDP redirect.
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-		return oops.E(oops.CodeBadRequest, nil, "code is required").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "code is required").LogError(ctx, logger)
 	}
 
 	// Exchange the authorization code for user identity via WorkOS.
 	idpUser, err := s.identityResolver.ExchangeCodeForTokens(ctx, code)
 	if err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-		return oops.E(oops.CodeUnauthorized, err, "failed to exchange IDP code").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "failed to exchange IDP code").LogError(ctx, logger)
 	}
 
 	// Run the standard post-IDP user bootstrap: UpsertUser + posthog
@@ -129,7 +129,7 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	gramUserID, err := s.identityResolver.UpsertUserFromIDP(ctx, idpUser)
 	if err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-		return oops.E(oops.CodeUnexpected, err, "failed to bootstrap user").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to bootstrap user").LogError(ctx, logger)
 	}
 
 	// Validate the user belongs to the endpoint's organization before
@@ -139,7 +139,7 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	// audience), not a user decline.
 	if _, _, ok := s.identityResolver.HasAccessToOrganization(ctx, endpoint.OrganizationID, gramUserID); !ok {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-		return oops.E(oops.CodeForbidden, nil, "user is not a member of this MCP server's organization").Log(ctx, logger)
+		return oops.E(oops.CodeForbidden, nil, "user is not a member of this MCP server's organization").LogError(ctx, logger)
 	}
 
 	// Mint a fresh state ID so the /connect URL we redirect to is NOT the
@@ -153,7 +153,7 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	challengeState.Subject = &subject
 	if err := s.authnChallengeCache.Store(ctx, challengeState); err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-		return oops.E(oops.CodeUnexpected, err, "failed to update authn challenge state").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to update authn challenge state").LogError(ctx, logger)
 	}
 
 	// challengeState.Endpoint.BaseURL was stamped at mint time. New
@@ -170,7 +170,7 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	consentURL, err := endpoint.ConsentURL(baseURL, challengeState.ID)
 	if err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-		return oops.E(oops.CodeUnexpected, err, "build consent URL").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "build consent URL").LogError(ctx, logger)
 	}
 	http.Redirect(w, r, consentURL, http.StatusFound)
 	return nil

--- a/server/internal/mcp/authnchallenge_register.go
+++ b/server/internal/mcp/authnchallenge_register.go
@@ -59,7 +59,7 @@ func (s *Service) HandleRegister(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
 	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
@@ -105,7 +105,7 @@ func (s *Service) ServeRegister(w http.ResponseWriter, r *http.Request, endpoint
 		if errors.As(err, &oauthErr) {
 			return writeDCRError(ctx, w, logger, oauthErr.Code, oauthErr.Description)
 		}
-		return oops.E(oops.CodeUnexpected, err, "validate DCR request").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "validate DCR request").LogError(ctx, logger)
 	}
 
 	clientID := "client_" + uuid.NewString()
@@ -119,11 +119,11 @@ func (s *Service) ServeRegister(w http.ResponseWriter, r *http.Request, endpoint
 		var err error
 		clientSecret, err = generateClientSecret()
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to generate client secret").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to generate client secret").LogError(ctx, logger)
 		}
 		hashed, hashErr := bcrypt.GenerateFromPassword([]byte(clientSecret), bcrypt.DefaultCost)
 		if hashErr != nil {
-			return oops.E(oops.CodeUnexpected, hashErr, "failed to hash client secret").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, hashErr, "failed to hash client secret").LogError(ctx, logger)
 		}
 		clientSecretHash = pgtype.Text{String: string(hashed), Valid: true}
 	}
@@ -138,7 +138,7 @@ func (s *Service) ServeRegister(w http.ResponseWriter, r *http.Request, endpoint
 		ClientSecretExpiresAt: pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: 0, Valid: false},
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to create user session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to create user session client").LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, "user session client registered",
@@ -175,7 +175,7 @@ func (s *Service) ServeRegister(w http.ResponseWriter, r *http.Request, endpoint
 
 	body, err := json.Marshal(resp)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to marshal registration response").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal registration response").LogError(ctx, logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -183,7 +183,7 @@ func (s *Service) ServeRegister(w http.ResponseWriter, r *http.Request, endpoint
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusCreated)
 	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").LogError(ctx, logger)
 	}
 	return nil
 }
@@ -196,7 +196,7 @@ func writeDCRError(ctx context.Context, w http.ResponseWriter, logger *slog.Logg
 		"error_description": description,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to marshal DCR error").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal DCR error").LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, "DCR registration rejected",
@@ -209,7 +209,7 @@ func writeDCRError(ctx context.Context, w http.ResponseWriter, logger *slog.Logg
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusBadRequest)
 	if _, werr := w.Write(body); werr != nil {
-		return oops.E(oops.CodeUnexpected, werr, "failed to write DCR error body").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, werr, "failed to write DCR error body").LogError(ctx, logger)
 	}
 	return nil
 }

--- a/server/internal/mcp/authnchallenge_revoke.go
+++ b/server/internal/mcp/authnchallenge_revoke.go
@@ -28,7 +28,7 @@ func (s *Service) HandleRevoke(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
 	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
@@ -82,7 +82,7 @@ func (s *Service) ServeRevoke(w http.ResponseWriter, r *http.Request, endpoint *
 			logOAuthClientCredentialEvent(ctx, logger, r, "oauth revoke client authentication rejected", clientID, presentedAuthMethod, "", "unknown_client_id")
 			return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}
-		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
 	}
 	// Public clients (NULL hash) skip the secret check; their possession of
 	// the token alone authenticates the revoke per RFC 7009 §2.1.

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -53,7 +53,7 @@ func (s *Service) HandleToken(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
 	endpoint, err := s.LoadResolvedMcpEndpointBySlug(ctx, logger, mcpSlug, "mcp")
@@ -95,7 +95,7 @@ func (s *Service) ServeToken(w http.ResponseWriter, r *http.Request, endpoint *R
 			logOAuthClientCredentialEvent(ctx, logger, r, "oauth token client authentication rejected", clientID, presentedAuthMethod, grantType, "unknown_client_id")
 			return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}
-		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
 	}
 	// Public clients (token_endpoint_auth_method=none) have a NULL hash:
 	// PKCE / refresh-token possession is the integrity proof, no secret check.
@@ -251,7 +251,7 @@ func (s *Service) handleTokenRefreshTokenGrant(
 			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_unknown_or_already_used")
 			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refresh_token is unknown or already used")
 		}
-		return oops.E(oops.CodeUnexpected, err, "revoke old refresh token").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "revoke old refresh token").LogError(ctx, logger)
 	}
 
 	// Client binding: refuse if the original session was minted for a
@@ -325,31 +325,31 @@ func (s *Service) mintSessionAndRespond(
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, err, "user_session_issuer not found")
 		}
-		return oops.E(oops.CodeUnexpected, err, "lookup user session issuer").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "lookup user session issuer").LogError(ctx, logger)
 	}
 	if !issuer.SessionDuration.Valid {
-		return oops.E(oops.CodeUnexpected, nil, "issuer session_duration is not set").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "issuer session_duration is not set").LogError(ctx, logger)
 	}
 	if issuer.SessionDuration.Months != 0 || issuer.SessionDuration.Days != 0 {
-		return oops.E(oops.CodeUnexpected, nil, "issuer session_duration carries Months/Days; only Microseconds intervals are supported").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "issuer session_duration carries Months/Days; only Microseconds intervals are supported").LogError(ctx, logger)
 	}
 	refreshLifetime := time.Duration(issuer.SessionDuration.Microseconds) * time.Microsecond
 	if refreshLifetime <= 0 {
-		return oops.E(oops.CodeUnexpected, nil, "issuer session_duration is non-positive").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "issuer session_duration is non-positive").LogError(ctx, logger)
 	}
 
 	issuerURL, err := endpoint.RootURL(baseURL)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build issuer URL").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "build issuer URL").LogError(ctx, logger)
 	}
 	access, jti, err := s.userSessionSigner.Mint(subject, endpoint.AudienceURN, issuerURL, accessTokenLifetime)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "mint session jwt").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "mint session jwt").LogError(ctx, logger)
 	}
 
 	refreshTokenRaw, err := generateOpaqueToken()
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "generate refresh token").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "generate refresh token").LogError(ctx, logger)
 	}
 
 	now := time.Now()
@@ -362,7 +362,7 @@ func (s *Service) mintSessionAndRespond(
 		ExpiresAt:           pgtype.Timestamptz{Time: now.Add(accessTokenLifetime), InfinityModifier: 0, Valid: true},
 		RefreshExpiresAt:    pgtype.Timestamptz{Time: now.Add(refreshLifetime), InfinityModifier: 0, Valid: true},
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "persist user session").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "persist user session").LogError(ctx, logger)
 	}
 
 	body, err := json.Marshal(tokenResponse{
@@ -372,7 +372,7 @@ func (s *Service) mintSessionAndRespond(
 		RefreshToken: refreshTokenRaw,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "marshal token response").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "marshal token response").LogError(ctx, logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -380,7 +380,7 @@ func (s *Service) mintSessionAndRespond(
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "write token response").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "write token response").LogError(ctx, logger)
 	}
 	return nil
 }
@@ -406,7 +406,7 @@ func writeTokenError(ctx context.Context, w http.ResponseWriter, logger *slog.Lo
 		"error_description": description,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "marshal token error").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "marshal token error").LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, "token request rejected",
@@ -419,7 +419,7 @@ func writeTokenError(ctx context.Context, w http.ResponseWriter, logger *slog.Lo
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(status)
 	if _, werr := w.Write(body); werr != nil {
-		return oops.E(oops.CodeUnexpected, werr, "write token error body").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, werr, "write token error body").LogError(ctx, logger)
 	}
 	return nil
 }

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -80,7 +80,7 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
@@ -105,7 +105,7 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 	case errors.Is(err, errToolsetNotFound):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
 
 	if toolset.UserSessionIssuerID.Valid {
@@ -118,7 +118,7 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 
 	resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), "mcp", mcpSlug)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build legacy resource URL").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "build legacy resource URL").LogError(ctx, s.logger)
 	}
 	return s.serveLegacyToolsetProtectedResource(ctx, w, logger, toolset, resourceURL)
 }
@@ -132,7 +132,7 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
@@ -157,7 +157,7 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 	case errors.Is(err, errToolsetNotFound):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
 
 	if toolset.UserSessionIssuerID.Valid {
@@ -212,11 +212,11 @@ func (s *Service) ServeWellKnownProtectedResourceForServer(
 		}
 		resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), routeBase, mcpEndpoint.Slug)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "build resource URL").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, logger)
 		}
 		return s.serveLegacyToolsetProtectedResource(ctx, w, logger, toolset, resourceURL)
 	default:
-		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").LogError(ctx, logger)
 	}
 }
 
@@ -259,7 +259,7 @@ func (s *Service) ServeWellKnownAuthorizationServerForServer(
 		}
 		return s.serveLegacyToolsetAuthorizationServer(ctx, w, r, logger, toolset, oauthSlug)
 	default:
-		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").LogError(ctx, logger)
 	}
 }
 
@@ -275,7 +275,7 @@ func (s *Service) loadToolsetForServer(ctx context.Context, logger *slog.Logger,
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "toolset not found")
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load toolset").LogError(ctx, logger)
 	}
 	return &toolset, nil
 }
@@ -288,7 +288,7 @@ func (s *Service) loadToolsetForServer(ctx context.Context, logger *slog.Logger,
 func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, toolset *toolsets_repo.Toolset, resourceURL string) error {
 	metadata, err := wellknown.ResolveOAuthProtectedResourceFromToolset(ctx, logger, s.db, &s.toolsetCache, toolset, resourceURL)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").LogError(ctx, logger)
 	}
 	if metadata == nil {
 		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
@@ -305,7 +305,7 @@ func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w htt
 func (s *Service) serveLegacyToolsetAuthorizationServer(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, toolset *toolsets_repo.Toolset, oauthSlug string) error {
 	result, err := wellknown.ResolveOAuthServerMetadataFromToolset(ctx, logger, s.db, s.oauthRepo, &s.toolsetCache, toolset, s.BaseURLForRequest(r), oauthSlug)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").LogError(ctx, logger)
 	}
 	if result == nil {
 		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
@@ -314,7 +314,7 @@ func (s *Service) serveLegacyToolsetAuthorizationServer(ctx context.Context, w h
 	if result.Kind == wellknown.OAuthServerMetadataResultKindProxy {
 		target, parseErr := url.Parse(result.ProxyURL)
 		if parseErr != nil {
-			return oops.E(oops.CodeUnexpected, parseErr, "failed to parse well-known URL").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, parseErr, "failed to parse well-known URL").LogError(ctx, logger)
 		}
 		proxy := &httputil.ReverseProxy{
 			Director: nil,
@@ -346,7 +346,7 @@ func (s *Service) ServeGetProtectedResource(w http.ResponseWriter, r *http.Reque
 	baseURL := s.BaseURLForRequest(r)
 	resource, err := endpoint.RootURL(baseURL)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build resource URL").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, s.logger)
 	}
 	return writeJSONMetadata(ctx, w, s.logger, oauthProtectedResourceMetadata{
 		Resource:               resource,
@@ -367,7 +367,7 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 	baseURL := s.BaseURLForRequest(r)
 	urls, err := endpoint.AuthorizationServerURLs(baseURL)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build OAuth server URLs").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "build OAuth server URLs").LogError(ctx, s.logger)
 	}
 	return writeJSONMetadata(ctx, w, s.logger, oauthAuthorizationServerMetadata{
 		Issuer:                            urls.Issuer,
@@ -388,12 +388,12 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 func writeJSONMetadata(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, v any) error {
 	body, err := json.Marshal(v)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to marshal metadata").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal metadata").LogError(ctx, logger)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").LogError(ctx, logger)
 	}
 	return nil
 }

--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -159,19 +159,19 @@ func handleSearchToolsCall(
 	temporalEnv *temporal.Environment,
 ) (json.RawMessage, error) {
 	if err := waitForIndexing(ctx, logger, toolset, vectorToolStore, temporalEnv); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to index toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to index toolset").LogError(ctx, logger)
 	}
 
 	var args searchToolsArguments
 	if len(argsRaw) > 0 {
 		if err := json.Unmarshal(argsRaw, &args); err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "failed to parse search_tools arguments").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "failed to parse search_tools arguments").LogError(ctx, logger)
 		}
 	}
 
 	query := strings.TrimSpace(args.Query)
 	if query == "" {
-		return nil, oops.E(oops.CodeInvalid, errors.New("missing query"), "query is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, errors.New("missing query"), "query is required").LogError(ctx, logger)
 	}
 
 	searchOptions := rag.SearchToolsOptions{
@@ -183,7 +183,7 @@ func handleSearchToolsCall(
 
 	searchResults, err := vectorToolStore.SearchToolsetTools(ctx, *toolset, searchOptions)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to search tools").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to search tools").LogError(ctx, logger)
 	}
 
 	// Build a map of tools by name for quick lookup
@@ -235,7 +235,7 @@ func handleSearchToolsCall(
 
 	payload, err := json.Marshal(toolsListResultTools{Tools: results})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tool search result").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tool search result").LogError(ctx, logger)
 	}
 
 	chunk, err := json.Marshal(contentChunk[string, json.RawMessage]{
@@ -246,7 +246,7 @@ func handleSearchToolsCall(
 		Meta:     nil,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tool search chunk").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tool search chunk").LogError(ctx, logger)
 	}
 
 	response, err := json.Marshal(result[toolCallResult]{
@@ -257,7 +257,7 @@ func handleSearchToolsCall(
 		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize find_tools response").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize find_tools response").LogError(ctx, logger)
 	}
 
 	return response, nil
@@ -307,12 +307,12 @@ func handleDescribeToolsCall(
 	var args describeToolsArguments
 	if len(argsRaw) > 0 {
 		if err := json.Unmarshal(argsRaw, &args); err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "failed to parse describe_tools arguments").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "failed to parse describe_tools arguments").LogError(ctx, logger)
 		}
 	}
 
 	if len(args.ToolNames) == 0 {
-		return nil, oops.E(oops.CodeInvalid, errors.New("missing tool_names"), "tool_names are required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, errors.New("missing tool_names"), "tool_names are required").LogError(ctx, logger)
 	}
 
 	// Build a map of tools by name for quick lookup
@@ -349,7 +349,7 @@ func handleDescribeToolsCall(
 
 	payload, err := json.Marshal(toolsListResultTools{Tools: entries})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tool description result").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tool description result").LogError(ctx, logger)
 	}
 
 	chunk, err := json.Marshal(contentChunk[string, json.RawMessage]{
@@ -360,7 +360,7 @@ func handleDescribeToolsCall(
 		Meta:     nil,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tool description chunk").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tool description chunk").LogError(ctx, logger)
 	}
 
 	response, err := json.Marshal(result[toolCallResult]{
@@ -371,7 +371,7 @@ func handleDescribeToolsCall(
 		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize describe_tools response").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize describe_tools response").LogError(ctx, logger)
 	}
 
 	return response, nil

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -346,16 +346,16 @@ func writeOAuthServerMetadataResponse(ctx context.Context, logger *slog.Logger, 
 		var marshalErr error
 		body, marshalErr = json.Marshal(result.Static)
 		if marshalErr != nil {
-			return oops.E(oops.CodeUnexpected, marshalErr, "failed to marshal OAuth server metadata").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, marshalErr, "failed to marshal OAuth server metadata").LogError(ctx, logger)
 		}
 	default:
-		return oops.E(oops.CodeUnexpected, nil, "unexpected OAuth server metadata result kind").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "unexpected OAuth server metadata result kind").LogError(ctx, logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").LogError(ctx, logger)
 	}
 
 	return nil
@@ -368,13 +368,13 @@ func writeOAuthServerMetadataResponse(ctx context.Context, logger *slog.Logger, 
 func writeOAuthProtectedResourceMetadataResponse(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, metadata *wellknown.OAuthProtectedResourceMetadata) error {
 	body, err := json.Marshal(metadata)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth protected resource metadata").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth protected resource metadata").LogError(ctx, logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").LogError(ctx, logger)
 	}
 
 	return nil
@@ -437,7 +437,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	case errors.Is(err, errToolsetNotFound):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
 
 	if err := s.enforceCustomDomainLockdown(ctx, logger, toolset.ProjectID); err != nil {
@@ -536,11 +536,11 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			},
 		)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to load OAuth proxy providers").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to load OAuth proxy providers").LogError(ctx, s.logger)
 		}
 
 		if len(providers) == 0 {
-			return oops.E(oops.CodeUnexpected, nil, "no OAuth proxy providers found").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, nil, "no OAuth proxy providers found").LogError(ctx, s.logger)
 		}
 
 		oAuthProxyProvider = &providers[0]
@@ -591,7 +591,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 
 	oauthProtectedResourceURL, err := url.JoinPath(baseURL, wellknown.OAuthProtectedResourcePath, mcpRouteBase, mcpSlug)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to build OAuth protected resource URL").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to build OAuth protected resource URL").LogError(ctx, s.logger)
 	}
 
 	if !runInToolsetGate && !callerAlreadyGated {
@@ -658,9 +658,9 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		projects, err := s.authRepo.ListProjectsByOrganization(ctx, authCtx.ActiveOrganizationID)
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
-			return oops.E(oops.CodeForbidden, nil, "no projects found").Log(ctx, s.logger)
+			return oops.E(oops.CodeForbidden, nil, "no projects found").LogError(ctx, s.logger)
 		case err != nil:
-			return oops.E(oops.CodeUnexpected, err, "error checking project access").Log(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+			return oops.E(oops.CodeUnexpected, err, "error checking project access").LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 		}
 
 		projectInOrg := false
@@ -694,7 +694,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			// if grants are already in context.
 			ctx, err = s.authz.PrepareContext(ctx)
 			if err != nil {
-				return oops.E(oops.CodeUnexpected, err, "failed to load access grants").Log(ctx, s.logger)
+				return oops.E(oops.CodeUnexpected, err, "failed to load access grants").LogError(ctx, s.logger)
 			}
 			if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, toolset.ID.String(), toolset.ProjectID.String())); err != nil {
 				return err
@@ -713,19 +713,19 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	case errors.Is(bodyReadErr, io.EOF) || len(bodyBytes) == 0:
 		return nil
 	case bodyReadErr != nil:
-		return oops.E(oops.CodeBadRequest, bodyReadErr, "failed to read request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, bodyReadErr, "failed to read request body").LogError(ctx, s.logger)
 	}
 
 	// Reject batch (array) requests — batch is deprecated in the MCP spec
 	if err := inv.Check("mcp request",
 		"not a batch request", len(bodyBytes) == 0 || bodyBytes[0] != '[',
 	); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "batch requests are not supported").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "batch requests are not supported").LogError(ctx, s.logger)
 	}
 
 	var req rawRequest
 	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to decode request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to decode request body").LogError(ctx, s.logger)
 	}
 
 	sessionID := parseMcpSessionID(r.Header)
@@ -800,7 +800,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		}
 		bs, merr := json.Marshal(oops.NewMCPErrorFromCause(mcpID, err))
 		if merr != nil {
-			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").LogError(ctx, s.logger)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -830,7 +830,7 @@ func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_re
 	// requirements, so this does not weaken the auth gate.
 	described, err := mv.DescribeToolset(ctx, s.logger, s.db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), &s.toolsetCache, nil, s.platformExtras...)
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "failed to describe toolset for security check").Log(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "failed to describe toolset for security check").LogError(ctx, s.logger)
 	}
 
 	schemes := describeToolSecurity(described.SecurityVariables)
@@ -853,7 +853,7 @@ func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_re
 
 	systemEnv, err := s.env.LoadSystemEnv(ctx, payload.projectID, toolset.ID, "", "")
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "failed to load system environment").Log(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "failed to load system environment").LogError(ctx, s.logger)
 	}
 
 	mergedEnv := toolconfig.NewCaseInsensitiveEnv()
@@ -1132,7 +1132,7 @@ func (s *Service) TryPublicIdentityAuth(ctx context.Context, r *http.Request, is
 	}
 
 	if authCtx, ok := contextvalues.GetAuthContext(authedCtx); !ok || authCtx == nil {
-		return ctx, oops.E(oops.CodeUnauthorized, nil, "no auth context found").Log(ctx, s.logger)
+		return ctx, oops.E(oops.CodeUnauthorized, nil, "no auth context found").LogError(ctx, s.logger)
 	}
 	return authedCtx, nil
 }

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -303,7 +303,7 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 		case errors.Is(err, pgx.ErrNoRows):
 			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found")
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "load mcp endpoint").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "load mcp endpoint").LogError(ctx, s.logger)
 		}
 		mcpServer, err := mcpservers_repo.New(s.db).GetMCPServerByID(ctx, mcpservers_repo.GetMCPServerByIDParams{
 			ID:        mcpEndpoint.McpServerID,
@@ -313,7 +313,7 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 		case errors.Is(err, pgx.ErrNoRows):
 			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found")
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "load mcp server").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger)
 		}
 		if !mcpServer.UserSessionIssuerID.Valid {
 			return nil, oops.E(oops.CodeNotFound, nil, "not found")
@@ -329,7 +329,7 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 		case errors.Is(err, pgx.ErrNoRows):
 			return nil, oops.E(oops.CodeNotFound, err, "project not found")
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "load project").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "load project").LogError(ctx, s.logger)
 		}
 		return NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID), nil
 	}
@@ -339,7 +339,7 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 	case errors.Is(err, errToolsetNotFound):
 		return nil, oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "load mcp server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger)
 	}
 	if !toolset.UserSessionIssuerID.Valid {
 		return nil, oops.E(oops.CodeNotFound, nil, "not found")
@@ -373,7 +373,7 @@ func (s *Service) loadResolvedMcpEndpointByToolsetSlug(ctx context.Context, mcpS
 	case errors.Is(err, errToolsetNotFound):
 		return nil, oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
 	if !toolset.UserSessionIssuerID.Valid {
 		return nil, oops.E(oops.CodeNotFound, nil, "not found")

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -105,7 +105,7 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest,
 
 	bs, err := json.Marshal(result)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize initialize response").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize initialize response").LogError(ctx, logger)
 	}
 
 	return bs, nil

--- a/server/internal/mcp/rpc_ping.go
+++ b/server/internal/mcp/rpc_ping.go
@@ -15,7 +15,7 @@ func handlePing(ctx context.Context, logger *slog.Logger, id mcpjsonrpc.ID) (jso
 		Result: struct{}{},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize ping response").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize ping response").LogError(ctx, logger)
 	}
 
 	return bs, nil

--- a/server/internal/mcp/rpc_prompt_get.go
+++ b/server/internal/mcp/rpc_prompt_get.go
@@ -29,11 +29,11 @@ type promptGetResult struct {
 func handlePromptsGet(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, payload *mcpInputs, req *rawRequest) (json.RawMessage, error) {
 	var params prompGetParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse get prompt request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse get prompt request").LogError(ctx, logger)
 	}
 
 	if params.Name == "" {
-		return nil, oops.E(oops.CodeInvalid, nil, "promp name is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "promp name is required").LogError(ctx, logger)
 	}
 
 	tr := templatesRepo.New(db)
@@ -42,12 +42,12 @@ func handlePromptsGet(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool
 		Name:      params.Name,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "prompt not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "prompt not found").LogError(ctx, logger)
 	}
 
 	promptData, err := templates.RenderTemplate(ctx, logger, prompt.Prompt, prompt.Kind.String, prompt.Engine.String, params.Arguments)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "failed to execute prompt").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "failed to execute prompt").LogError(ctx, logger)
 	}
 
 	description := ""
@@ -63,7 +63,7 @@ func handlePromptsGet(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool
 		Meta:     nil,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal content chunk").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal content chunk").LogError(ctx, logger)
 	}
 
 	bs, err := json.Marshal(result[promptGetResult]{
@@ -74,7 +74,7 @@ func handlePromptsGet(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool
 		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize prompts/get result").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize prompts/get result").LogError(ctx, logger)
 	}
 
 	return bs, nil

--- a/server/internal/mcp/rpc_prompts_list.go
+++ b/server/internal/mcp/rpc_prompts_list.go
@@ -103,7 +103,7 @@ func handlePromptsList(ctx context.Context, logger *slog.Logger, db *pgxpool.Poo
 
 	bs, err := json.Marshal(result)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize prompts/list response").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize prompts/list response").LogError(ctx, logger)
 	}
 
 	return bs, nil

--- a/server/internal/mcp/rpc_resources_list.go
+++ b/server/internal/mcp/rpc_resources_list.go
@@ -58,7 +58,7 @@ func handleResourcesList(ctx context.Context, logger *slog.Logger, db *pgxpool.P
 
 	bs, err := json.Marshal(result)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize resources/list response").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize resources/list response").LogError(ctx, logger)
 	}
 
 	return bs, nil

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -66,11 +66,11 @@ func handleResourcesRead(
 ) (json.RawMessage, error) {
 	var params resourceReadParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse get resource request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse get resource request").LogError(ctx, logger)
 	}
 
 	if params.URI == "" {
-		return nil, oops.E(oops.CodeInvalid, nil, "resource URI is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "resource URI is required").LogError(ctx, logger)
 	}
 
 	projectID := mv.ProjectID(payload.projectID)
@@ -78,7 +78,7 @@ func handleResourcesRead(
 	toolsetHelpers := toolsets.NewToolsets(db, platformExtras...)
 	toolset, err := mv.DescribeToolset(ctx, logger, db, projectID, mv.ToolsetSlug(conv.ToLower(payload.toolset)), nil, nil, platformExtras...)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset").LogError(ctx, logger)
 	}
 
 	var resourceURN urn.Resource
@@ -86,7 +86,7 @@ func handleResourcesRead(
 	for _, resource := range toolset.Resources {
 		if resource.FunctionResourceDefinition != nil && resource.FunctionResourceDefinition.URI == params.URI {
 			if err := resourceURN.UnmarshalText([]byte(resource.FunctionResourceDefinition.ResourceUrn)); err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to parse resource URN").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to parse resource URN").LogError(ctx, logger)
 			}
 			resourceDef = resource.FunctionResourceDefinition
 			break
@@ -94,12 +94,12 @@ func handleResourcesRead(
 	}
 
 	if resourceURN.Kind == "" {
-		return nil, oops.E(oops.CodeNotFound, nil, "resource not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, nil, "resource not found").LogError(ctx, logger)
 	}
 
 	plan, err := toolsetHelpers.GetResourceCallPlanByURN(ctx, resourceURN, uuid.UUID(projectID))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get resource call plan").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get resource call plan").LogError(ctx, logger)
 	}
 
 	descriptor := plan.Descriptor
@@ -113,12 +113,12 @@ func handleResourcesRead(
 
 	toolsetID, err := uuid.Parse(toolset.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").LogError(ctx, logger)
 	}
 
 	systemConfig, err := env.LoadSystemEnv(ctx, payload.projectID, toolsetID, string(resourceURN.Kind), resourceURN.Source)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load system environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load system environment").LogError(ctx, logger)
 	}
 
 	rw := &resourceResponseWriter{
@@ -213,7 +213,7 @@ func handleResourcesRead(
 		GramEmail:  "",
 	}, plan, logAttrs)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute resource call").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute resource call").LogError(ctx, logger)
 	}
 
 	outputBytes = int64(rw.body.Len())
@@ -243,7 +243,7 @@ func handleResourcesRead(
 			Result: json.RawMessage(rw.body.Bytes()),
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize MCP passthrough result").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize MCP passthrough result").LogError(ctx, logger)
 		}
 
 		return bs, nil
@@ -278,7 +278,7 @@ func handleResourcesRead(
 		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize resources/read result").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize resources/read result").LogError(ctx, logger)
 	}
 
 	return bs, nil

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -82,11 +82,11 @@ func handleToolsCall(
 ) (json.RawMessage, error) {
 	var params toolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse tool call request").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse tool call request").LogError(ctx, logger)
 	}
 
 	if params.Name == "" {
-		return nil, oops.E(oops.CodeInvalid, nil, "tool name is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "tool name is required").LogError(ctx, logger)
 	}
 
 	projectID := mv.ProjectID(payload.projectID)
@@ -130,7 +130,7 @@ func handleToolsCall(
 	// call.
 	stripped, err := shadowmcp.StripToolsetIDProperty(params.Arguments)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse tool arguments").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse tool arguments").LogError(ctx, logger)
 	}
 	params.Arguments = stripped
 
@@ -144,7 +144,7 @@ func handleToolsCall(
 
 	toolsetID, err := uuid.Parse(toolset.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").LogError(ctx, logger)
 	}
 
 	executor := externalmcp.BuildProxyToolExecutor(logger, guardianPolicy, toolset.Tools)
@@ -165,7 +165,7 @@ func handleToolsCall(
 
 	planInputs, err := executor.MatchPlanInputs(ctx, params.Name, uuid.UUID(projectID), resolve)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to match proxy tool").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to match proxy tool").LogError(ctx, logger)
 	}
 
 	var tool *types.Tool
@@ -193,18 +193,18 @@ func handleToolsCall(
 		}
 
 		if tool == nil {
-			return nil, oops.E(oops.CodeNotFound, errors.New("tool not found"), "tool not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, errors.New("tool not found"), "tool not found").LogError(ctx, logger)
 		}
 
 		urn, err := conv.GetToolURN(*tool)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get tool urn").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get tool urn").LogError(ctx, logger)
 		}
 		toolURN = *urn
 
 		plan, err = toolsetHelpers.GetToolCallPlanByURN(ctx, toolURN, uuid.UUID(projectID))
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed get tool call plan").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed get tool call plan").LogError(ctx, logger)
 		}
 	}
 
@@ -237,7 +237,7 @@ func handleToolsCall(
 
 	systemConfig, err := env.LoadSystemEnv(ctx, payload.projectID, toolsetID, string(toolURN.Kind), toolURN.Source)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load system environment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load system environment").LogError(ctx, logger)
 	}
 
 	// Extract general OAuth token (no security-key binding)
@@ -265,7 +265,7 @@ func handleToolsCall(
 
 	err = filterOmittedEnvVars(ctx, toolCallEnv, mcpMetadataRepo, toolsetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to filter omitted environment variables").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to filter omitted environment variables").LogError(ctx, logger)
 	}
 
 	descriptor := plan.Descriptor
@@ -378,7 +378,7 @@ func handleToolsCall(
 
 	err = toolProxy.Do(ctx, rw, bytes.NewBuffer(params.Arguments), toolCallEnv, plan, logAttrs)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute tool call").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute tool call").LogError(ctx, logger)
 	}
 
 	outputBytes = int64(rw.body.Len())
@@ -412,7 +412,7 @@ func handleToolsCall(
 			Result: json.RawMessage(rw.body.Bytes()),
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize MCP result").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize MCP result").LogError(ctx, logger)
 		}
 
 		return bs, nil
@@ -420,7 +420,7 @@ func handleToolsCall(
 
 	chunk, err := formatResult(*rw, plan.Kind)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed format tool call result").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed format tool call result").LogError(ctx, logger)
 	}
 
 	bs, err := json.Marshal(result[toolCallResult]{
@@ -431,7 +431,7 @@ func handleToolsCall(
 		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").LogError(ctx, logger)
 	}
 
 	return bs, nil
@@ -452,9 +452,9 @@ func resolveUserConfiguration(
 		storedEnvVars, err := env.Load(ctx, payload.projectID, toolconfig.Slug(payload.environment))
 		switch {
 		case errors.Is(err, toolconfig.ErrNotFound):
-			return nil, oops.E(oops.CodeBadRequest, err, "environment not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "environment not found").LogError(ctx, logger)
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to load environment").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to load environment").LogError(ctx, logger)
 		}
 
 		for k, v := range storedEnvVars {
@@ -517,7 +517,7 @@ func checkToolUsageLimits(ctx context.Context, logger *slog.Logger, orgID string
 	}
 
 	if periodUsage.ToolCalls >= hardToolCallsLimit {
-		return oops.E(oops.CodeForbidden, errors.New("tool usage limit reached"), "tool usage limit reached").Log(ctx, logger)
+		return oops.E(oops.CodeForbidden, errors.New("tool usage limit reached"), "tool usage limit reached").LogError(ctx, logger)
 	}
 
 	return nil
@@ -546,15 +546,15 @@ type executeToolArguments struct {
 func processExecuteToolCall(ctx context.Context, logger *slog.Logger, argsRaw json.RawMessage) (string, json.RawMessage, error) {
 	var args executeToolArguments
 	if len(argsRaw) == 0 {
-		return "", nil, oops.E(oops.CodeInvalid, errors.New("missing execute arguments"), "execute_tool arguments are required").Log(ctx, logger)
+		return "", nil, oops.E(oops.CodeInvalid, errors.New("missing execute arguments"), "execute_tool arguments are required").LogError(ctx, logger)
 	}
 	if err := json.Unmarshal(argsRaw, &args); err != nil {
-		return "", nil, oops.E(oops.CodeBadRequest, err, "failed to parse execute_tool arguments").Log(ctx, logger)
+		return "", nil, oops.E(oops.CodeBadRequest, err, "failed to parse execute_tool arguments").LogError(ctx, logger)
 	}
 
 	name := strings.TrimSpace(args.Name)
 	if name == "" {
-		return "", nil, oops.E(oops.CodeInvalid, errors.New("missing tool name"), "name is required for execute_tool").Log(ctx, logger)
+		return "", nil, oops.E(oops.CodeInvalid, errors.New("missing tool name"), "name is required for execute_tool").LogError(ctx, logger)
 	}
 
 	payload := args.Arguments
@@ -563,12 +563,12 @@ func processExecuteToolCall(ctx context.Context, logger *slog.Logger, argsRaw js
 		if len(trimmed) > 0 && trimmed[0] == '"' {
 			var payloadString string
 			if err := json.Unmarshal(payload, &payloadString); err != nil {
-				return "", nil, oops.E(oops.CodeBadRequest, err, "failed to parse execute_tool payload").Log(ctx, logger)
+				return "", nil, oops.E(oops.CodeBadRequest, err, "failed to parse execute_tool payload").LogError(ctx, logger)
 			}
 			payload = json.RawMessage(payloadString)
 		}
 		if !json.Valid(payload) {
-			return "", nil, oops.E(oops.CodeBadRequest, errors.New("invalid payload"), "arguments must be valid JSON").Log(ctx, logger)
+			return "", nil, oops.E(oops.CodeBadRequest, errors.New("invalid payload"), "arguments must be valid JSON").LogError(ctx, logger)
 		}
 	}
 

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -100,7 +100,7 @@ func handleToolsList(
 	case ToolModeDynamic:
 		tools, err = buildDynamicSessionTools(ctx, logger, toolset, vectorToolStore, temporalEnv)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to build dynamic session tools").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to build dynamic session tools").LogError(ctx, logger)
 		}
 	case ToolModeStatic:
 		fallthrough
@@ -127,7 +127,7 @@ func handleToolsList(
 				if errors.As(err, &oopsErr) && oopsErr.Code == oops.CodeForbidden {
 					continue
 				}
-				return nil, oops.E(oops.CodeUnexpected, err, "check tool-level authz for tools/list").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "check tool-level authz for tools/list").LogError(ctx, logger)
 			}
 			allowed = append(allowed, t)
 		}
@@ -157,7 +157,7 @@ func handleToolsList(
 
 	bs, err := json.Marshal(result)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/list response").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/list response").LogError(ctx, logger)
 	}
 
 	return bs, nil
@@ -177,7 +177,7 @@ func buildToolListEntries(
 
 	toolsetID, err := uuid.Parse(toolset.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse toolset ID").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse toolset ID").LogError(ctx, logger)
 	}
 
 	userConfig := toolconfig.CIEnvFrom(payload.mcpEnvVariables)
@@ -212,7 +212,7 @@ func buildToolListEntries(
 
 		proxyTools, err := executor.DoList(ctx, payload.projectID, userConfig, oauthToken, loadSystemEnv, resolve)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to list proxy tools").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to list proxy tools").LogError(ctx, logger)
 		}
 
 		for _, extTool := range proxyTools {

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -58,13 +58,13 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 
 	authedCtx, _, err := s.assistantTokens.Authorize(ctx, token)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "failed to authorize platform toolset request").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, err, "failed to authorize platform toolset request").LogError(ctx, s.logger)
 	}
 	ctx = authedCtx
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		return oops.E(oops.CodeUnauthorized, nil, "no project auth context").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, nil, "no project auth context").LogError(ctx, s.logger)
 	}
 
 	if err := s.authorizePlatformToolset(ctx, slug, authCtx); err != nil {
@@ -76,19 +76,19 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 	case errors.Is(err, io.EOF) || len(bodyBytes) == 0:
 		return nil
 	case err != nil:
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, s.logger)
 	}
 
 	if len(bodyBytes) > 0 && bodyBytes[0] == '[' {
-		return oops.E(oops.CodeBadRequest, nil, "batch requests are not supported").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "batch requests are not supported").LogError(ctx, s.logger)
 	}
 
 	var req rawRequest
 	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to decode request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to decode request body").LogError(ctx, s.logger)
 	}
 	if req.JSONRPC != "2.0" {
-		return oops.E(oops.CodeBadRequest, errInvalidJSONRPCVersion, "unsupported JSON-RPC version").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, errInvalidJSONRPCVersion, "unsupported JSON-RPC version").LogError(ctx, s.logger)
 	}
 
 	body, err := s.handlePlatformToolsetRequest(ctx, authCtx, toolset, &req, r.Header.Get("Gram-Chat-ID"))
@@ -98,12 +98,12 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 	case err != nil:
 		bs, merr := json.Marshal(oops.NewMCPErrorFromCause(req.ID, err))
 		if merr != nil {
-			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").LogError(ctx, s.logger)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if _, writeErr := w.Write(bs); writeErr != nil {
-			return oops.E(oops.CodeUnexpected, writeErr, "failed to write error response body").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, writeErr, "failed to write error response body").LogError(ctx, s.logger)
 		}
 		return nil
 	}
@@ -136,7 +136,7 @@ func (s *Service) authorizePlatformToolset(ctx context.Context, slug string, aut
 	case errors.Is(err, pgx.ErrNoRows):
 		return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "resolve managed assistant").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "resolve managed assistant").LogError(ctx, s.logger)
 	}
 
 	if managed.ID != principal.AssistantID {
@@ -193,7 +193,7 @@ func handlePlatformInitialize(ctx context.Context, logger *slog.Logger, req *raw
 	}
 	bs, err := json.Marshal(result)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize initialize response").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize initialize response").LogError(ctx, logger)
 	}
 	return bs, nil
 }
@@ -231,7 +231,7 @@ func (s *Service) listPlatformToolsetTools(
 		Result: toolsListResultTools{Tools: tools},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/list response").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/list response").LogError(ctx, s.logger)
 	}
 	return bs, nil
 }
@@ -245,10 +245,10 @@ func (s *Service) callPlatformToolsetTool(
 ) (json.RawMessage, error) {
 	var params toolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse tool call request").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse tool call request").LogError(ctx, s.logger)
 	}
 	if params.Name == "" {
-		return nil, oops.E(oops.CodeInvalid, nil, "tool name is required").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "tool name is required").LogError(ctx, s.logger)
 	}
 
 	var matched platformtools.ExternalTool
@@ -264,10 +264,10 @@ func (s *Service) callPlatformToolsetTool(
 		}
 	}
 	if !found {
-		return nil, oops.E(oops.CodeNotFound, errors.New("tool not found"), "tool not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, errors.New("tool not found"), "tool not found").LogError(ctx, s.logger)
 	}
 	if !s.platformToolFeatureAvailable(ctx, authCtx.ActiveOrganizationID, matched.RequiredFeature, nil) {
-		return nil, oops.E(oops.CodeNotFound, nil, "tool not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, nil, "tool not found").LogError(ctx, s.logger)
 	}
 
 	desc := matched.Executor.Descriptor()
@@ -405,13 +405,13 @@ func (s *Service) callPlatformToolsetTool(
 	}()
 
 	if err := s.toolProxy.Do(ctx, rw, bytes.NewReader(requestBodyBytes), toolCallEnv, plan, logAttrs); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute platform tool call").Log(ctx, logger, attr.SlogToolName(params.Name))
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute platform tool call").LogError(ctx, logger, attr.SlogToolName(params.Name))
 	}
 	outputBytes = int64(rw.body.Len())
 
 	chunk, err := formatResult(*rw, plan.Kind)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to format platform tool call result").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to format platform tool call result").LogError(ctx, logger)
 	}
 
 	bs, err := json.Marshal(result[toolCallResult]{
@@ -422,7 +422,7 @@ func (s *Service) callPlatformToolsetTool(
 		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").Log(ctx, logger, attr.SlogToolName(params.Name))
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").LogError(ctx, logger, attr.SlogToolName(params.Name))
 	}
 	return bs, nil
 }

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -78,7 +78,7 @@ func (s *Service) enforceCustomDomainLockdown(ctx context.Context, logger *slog.
 	case errors.Is(err, pgx.ErrNoRows):
 		return oops.E(oops.CodeNotFound, err, "project not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "load project for custom domain lockdown").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "load project for custom domain lockdown").LogError(ctx, logger)
 	}
 
 	domain, err := customdomainsrepo.New(s.db).GetCustomDomainByOrganization(ctx, project.OrganizationID)
@@ -86,7 +86,7 @@ func (s *Service) enforceCustomDomainLockdown(ctx context.Context, logger *slog.
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "load custom domain for lockdown").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "load custom domain for lockdown").LogError(ctx, logger)
 	}
 
 	if len(domain.IpAllowlist) > 0 {
@@ -153,7 +153,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 		case errors.Is(err, pgx.ErrNoRows):
 			return oops.E(oops.CodeNotFound, err, "toolset not found")
 		case err != nil:
-			return oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "load toolset").LogError(ctx, logger)
 		}
 
 		// The mcp_servers row's variation group, when set, overrides the
@@ -172,7 +172,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 	default:
 		// CHECK constraint mcp_servers_backend_exclusivity_check guarantees
 		// exactly one backend is set; this is defensive.
-		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").LogError(ctx, logger)
 	}
 }
 
@@ -252,7 +252,7 @@ func (s *Service) BuildResolvedMcpEndpointForServer(
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "project not found")
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "load project").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load project").LogError(ctx, logger)
 	}
 	resolved := NewResolvedMcpEndpointFromMcpServer(mcpEndpoint, mcpServer, project.OrganizationID)
 	resolved.RouteBase = mcpRouteBase
@@ -314,7 +314,7 @@ func (s *Service) serveRemoteBackend(
 
 			project, err := projectsrepo.New(s.db).GetProjectByID(ctx, endpoint.ProjectID)
 			if err != nil {
-				return oops.E(oops.CodeUnexpected, err, "load mcp server project").Log(ctx, logger)
+				return oops.E(oops.CodeUnexpected, err, "load mcp server project").LogError(ctx, logger)
 			}
 			authCtx, ok := contextvalues.GetAuthContext(ctx)
 			if !ok || authCtx == nil || project.OrganizationID != authCtx.ActiveOrganizationID {
@@ -335,7 +335,7 @@ func (s *Service) serveRemoteBackend(
 		var prepErr error
 		ctx, prepErr = s.authz.PrepareContext(ctx)
 		if prepErr != nil {
-			return oops.E(oops.CodeUnexpected, prepErr, "load access grants").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, prepErr, "load access grants").LogError(ctx, logger)
 		}
 
 		// Non-issuer-gated callers get an upfront mcp:connect fail-fast before
@@ -360,7 +360,7 @@ func (s *Service) serveRemoteBackend(
 			}
 		}
 	default:
-		return oops.E(oops.CodeUnexpected, nil, "unrecognized mcp server visibility %q", mcpServer.Visibility).Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "unrecognized mcp server visibility %q", mcpServer.Visibility).LogError(ctx, logger)
 	}
 
 	server, err := remotemcprepo.New(s.db).GetServerByID(ctx, remotemcprepo.GetServerByIDParams{
@@ -369,14 +369,14 @@ func (s *Service) serveRemoteBackend(
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return oops.E(oops.CodeNotFound, err, "remote mcp server not found").Log(ctx, logger)
+		return oops.E(oops.CodeNotFound, err, "remote mcp server not found").LogError(ctx, logger)
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "load remote mcp server").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "load remote mcp server").LogError(ctx, logger)
 	}
 
 	headers, err := remotemcp.NewHeaders(s.logger, s.db, s.enc).ListHeaders(ctx, server.ID, false)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "load remote mcp server headers").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "load remote mcp server headers").LogError(ctx, logger)
 	}
 
 	p := s.remoteProxyManager.Build(logger, &server, headers, mcpServer.Visibility, endpoint.ProjectID.String(), upstreamAuth)

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -96,29 +96,29 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 
 	customDomainID, err := conv.PtrToNullUUID(payload.CustomDomainID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").LogError(ctx, logger)
 	}
 
 	mcpServerID, err := uuid.Parse(payload.McpServerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp_server_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp_server_id").LogError(ctx, logger)
 	}
 
 	slug := string(payload.Slug)
 	if err := validateSlugPrefix(slug, customDomainID, authCtx.OrganizationSlug); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid slug").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid slug").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	txRepo := repo.New(dbtx)
 
 	if err := verifyEndpointReferenceOwnership(ctx, dbtx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, mcpServerID, customDomainID); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp endpoint").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp endpoint").LogError(ctx, logger)
 	}
 
 	created, err := txRepo.CreateMCPEndpoint(ctx, repo.CreateMCPEndpointParams{
@@ -130,9 +130,9 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return nil, oops.E(oops.CodeConflict, err, "mcp endpoint slug already exists for this domain").Log(ctx, logger)
+			return nil, oops.E(oops.CodeConflict, err, "mcp endpoint slug already exists for this domain").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "create mcp endpoint").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create mcp endpoint").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogMcpEndpointCreate(ctx, dbtx, audit.LogMcpEndpointCreateEvent{
@@ -144,11 +144,11 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 		McpEndpointURN:   urn.NewMcpEndpoint(created.ID),
 		Slug:             created.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log mcp endpoint creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log mcp endpoint creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return mv.BuildMcpEndpointView(created), nil
@@ -168,11 +168,11 @@ func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpoin
 	hasSlug := payload.Slug != nil && *payload.Slug != ""
 
 	if hasID == hasSlug {
-		return nil, oops.E(oops.CodeInvalid, nil, "provide exactly one of id or slug").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "provide exactly one of id or slug").LogError(ctx, s.logger)
 	}
 
 	if hasID && payload.CustomDomainID != nil {
-		return nil, oops.E(oops.CodeInvalid, nil, "custom_domain_id cannot be combined with id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "custom_domain_id cannot be combined with id").LogError(ctx, s.logger)
 	}
 
 	txRepo := repo.New(s.db)
@@ -180,7 +180,7 @@ func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpoin
 	if hasID {
 		endpointID, err := uuid.Parse(*payload.ID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp endpoint id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp endpoint id").LogError(ctx, s.logger)
 		}
 
 		row, err := txRepo.GetMCPEndpointByID(ctx, repo.GetMCPEndpointByIDParams{
@@ -189,9 +189,9 @@ func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpoin
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").LogError(ctx, s.logger)
 		}
 
 		return mv.BuildMcpEndpointView(row), nil
@@ -199,7 +199,7 @@ func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpoin
 
 	customDomainID, err := conv.PtrToNullUUID(payload.CustomDomainID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").LogError(ctx, s.logger)
 	}
 
 	row, err := txRepo.GetMCPEndpointByProjectAndCustomDomainAndSlug(ctx, repo.GetMCPEndpointByProjectAndCustomDomainAndSlugParams{
@@ -209,9 +209,9 @@ func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpoin
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").LogError(ctx, s.logger)
 	}
 
 	return mv.BuildMcpEndpointView(row), nil
@@ -232,7 +232,7 @@ func (s *Service) ListMcpEndpoints(ctx context.Context, payload *gen.ListMcpEndp
 	if payload.McpServerID != nil && *payload.McpServerID != "" {
 		serverID, err := uuid.Parse(*payload.McpServerID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp_server_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp_server_id").LogError(ctx, s.logger)
 		}
 
 		rows, err := r.ListMCPEndpointsByMCPServerID(ctx, repo.ListMCPEndpointsByMCPServerIDParams{
@@ -240,7 +240,7 @@ func (s *Service) ListMcpEndpoints(ctx context.Context, payload *gen.ListMcpEndp
 			McpServerID: serverID,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "list mcp endpoints by server").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "list mcp endpoints by server").LogError(ctx, s.logger)
 		}
 
 		return &gen.ListMcpEndpointsResult{McpEndpoints: mv.BuildMcpEndpointListView(rows)}, nil
@@ -248,7 +248,7 @@ func (s *Service) ListMcpEndpoints(ctx context.Context, payload *gen.ListMcpEndp
 
 	rows, err := r.ListMCPEndpointsByProject(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list mcp endpoints").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list mcp endpoints").LogError(ctx, s.logger)
 	}
 
 	return &gen.ListMcpEndpointsResult{McpEndpoints: mv.BuildMcpEndpointListView(rows)}, nil
@@ -268,27 +268,27 @@ func (s *Service) UpdateMcpEndpoint(ctx context.Context, payload *gen.UpdateMcpE
 
 	endpointID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp endpoint id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp endpoint id").LogError(ctx, logger)
 	}
 
 	customDomainID, err := conv.PtrToNullUUID(payload.CustomDomainID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").LogError(ctx, logger)
 	}
 
 	mcpServerID, err := uuid.Parse(payload.McpServerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp_server_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp_server_id").LogError(ctx, logger)
 	}
 
 	slug := string(payload.Slug)
 	if err := validateSlugPrefix(slug, customDomainID, authCtx.OrganizationSlug); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid slug").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid slug").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -300,15 +300,15 @@ func (s *Service) UpdateMcpEndpoint(ctx context.Context, payload *gen.UpdateMcpE
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").LogError(ctx, logger)
 	}
 
 	beforeView := mv.BuildMcpEndpointView(existing)
 
 	if err := verifyEndpointReferenceOwnership(ctx, dbtx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, mcpServerID, customDomainID); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp endpoint").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp endpoint").LogError(ctx, logger)
 	}
 
 	updated, err := txRepo.UpdateMCPEndpoint(ctx, repo.UpdateMCPEndpointParams{
@@ -320,13 +320,13 @@ func (s *Service) UpdateMcpEndpoint(ctx context.Context, payload *gen.UpdateMcpE
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").LogError(ctx, logger)
 		}
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return nil, oops.E(oops.CodeConflict, err, "mcp endpoint slug already exists for this domain").Log(ctx, logger)
+			return nil, oops.E(oops.CodeConflict, err, "mcp endpoint slug already exists for this domain").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update mcp endpoint").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update mcp endpoint").LogError(ctx, logger)
 	}
 
 	afterView := mv.BuildMcpEndpointView(updated)
@@ -342,11 +342,11 @@ func (s *Service) UpdateMcpEndpoint(ctx context.Context, payload *gen.UpdateMcpE
 		McpEndpointSnapshotBefore: beforeView,
 		McpEndpointSnapshotAfter:  afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log mcp endpoint update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log mcp endpoint update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return afterView, nil
@@ -366,7 +366,7 @@ func (s *Service) CheckMcpEndpointSlugAvailability(ctx context.Context, payload 
 
 	customDomainID, err := conv.PtrToNullUUID(payload.CustomDomainID)
 	if err != nil {
-		return false, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").Log(ctx, logger)
+		return false, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").LogError(ctx, logger)
 	}
 
 	// The query folds in a custom-domain ownership check: when
@@ -381,7 +381,7 @@ func (s *Service) CheckMcpEndpointSlugAvailability(ctx context.Context, payload 
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "check mcp endpoint slug availability").Log(ctx, logger)
+		return false, oops.E(oops.CodeUnexpected, err, "check mcp endpoint slug availability").LogError(ctx, logger)
 	}
 
 	// available.Valid is always true for this query (boolean expression with
@@ -404,12 +404,12 @@ func (s *Service) DeleteMcpEndpoint(ctx context.Context, payload *gen.DeleteMcpE
 
 	endpointID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid mcp endpoint id").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid mcp endpoint id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -421,9 +421,9 @@ func (s *Service) DeleteMcpEndpoint(ctx context.Context, payload *gen.DeleteMcpE
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, logger)
+			return oops.E(oops.CodeNotFound, err, "mcp endpoint not found").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "delete mcp endpoint").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete mcp endpoint").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogMcpEndpointDelete(ctx, dbtx, audit.LogMcpEndpointDeleteEvent{
@@ -435,11 +435,11 @@ func (s *Service) DeleteMcpEndpoint(ctx context.Context, payload *gen.DeleteMcpE
 		McpEndpointURN:   urn.NewMcpEndpoint(deleted.ID),
 		Slug:             deleted.Slug,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log mcp endpoint deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log mcp endpoint deletion").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/mcpendpoints/resolve.go
+++ b/server/internal/mcpendpoints/resolve.go
@@ -41,7 +41,7 @@ func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.L
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found")
 	case err != nil:
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp endpoint").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp endpoint").LogError(ctx, logger)
 	}
 
 	server, err := mcpservers_repo.New(db).GetMCPServerByID(ctx, mcpservers_repo.GetMCPServerByIDParams{
@@ -52,7 +52,7 @@ func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.L
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp server").Log(ctx, logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, logger)
 	}
 
 	if server.Visibility == mcpservers.VisibilityDisabled {

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -296,12 +296,12 @@ func (s *Service) GetMcpMetadata(ctx context.Context, payload *gen.GetMcpMetadat
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "no MCP install page metadata for this backend")
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "fetch MCP install page metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "fetch MCP install page metadata").LogError(ctx, logger)
 	}
 
 	metadata, err := ToMCPMetadata(ctx, s.repo, record)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "convert metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "convert metadata").LogError(ctx, logger)
 	}
 
 	return &gen.GetMcpMetadataResult{
@@ -322,7 +322,7 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "access mcp server metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "access mcp server metadata").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -359,7 +359,7 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 	case errors.Is(err, pgx.ErrNoRows):
 		// No existing metadata, proceed with creation
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "fetch existing MCP server metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "fetch existing MCP server metadata").LogError(ctx, logger)
 	default:
 		existing, err = ToMCPMetadata(ctx, mcpr, existingRow)
 		if err != nil {
@@ -371,7 +371,7 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 	if payload.LogoAssetID != nil {
 		parsedLogoID, err := uuid.Parse(*payload.LogoAssetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset ID").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset ID").LogError(ctx, logger)
 		}
 		logoID = uuid.NullUUID{UUID: parsedLogoID, Valid: true}
 	}
@@ -394,12 +394,12 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 	var defaultEnvironmentID uuid.NullUUID
 	if payload.DefaultEnvironmentID != nil {
 		if backend.mcpServer != nil {
-			return nil, oops.E(oops.CodeBadRequest, nil, "default_environment_id is not yet supported for mcp_server-backed install pages").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "default_environment_id is not yet supported for mcp_server-backed install pages").LogError(ctx, logger)
 		}
 
 		parsedDefaultEnvironmentID, err := uuid.Parse(*payload.DefaultEnvironmentID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid default environment ID (not a valid UUID)").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid default environment ID (not a valid UUID)").LogError(ctx, logger)
 		}
 
 		envr := environments_repo.New(dbtx)
@@ -409,9 +409,9 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 		})
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
-			return nil, oops.E(oops.CodeBadRequest, err, "default environment not found in this project").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "default environment not found in this project").LogError(ctx, logger)
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "validate default environment ID").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "validate default environment ID").LogError(ctx, logger)
 		}
 
 		defaultEnvironmentID = uuid.NullUUID{UUID: parsedDefaultEnvironmentID, Valid: true}
@@ -448,14 +448,14 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 		})
 	}
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "upsert MCP server metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "upsert MCP server metadata").LogError(ctx, logger)
 	}
 
 	// Update environment entries
 	if payload.EnvironmentConfigs != nil {
 		// Delete all existing entries
 		if err := mcpr.DeleteAllEnvironmentConfigs(ctx, result.ID); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "delete existing environment configs").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "delete existing environment configs").LogError(ctx, logger)
 		}
 
 		for _, config := range payload.EnvironmentConfigs {
@@ -472,7 +472,7 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 				ProvidedBy:        config.ProvidedBy,
 			})
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "upsert environment config").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "upsert environment config").LogError(ctx, logger)
 			}
 		}
 	}
@@ -499,7 +499,7 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 			MCPMetadataSnapshotBefore: existing,
 			MCPMetadataSnapshotAfter:  metadata,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "log MCP server metadata update event").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "log MCP server metadata update event").LogError(ctx, logger)
 		}
 	default:
 		if err := s.audit.LogMCPMetadataUpdateForMcpServer(ctx, dbtx, audit.LogMCPMetadataUpdateForMcpServerEvent{
@@ -517,12 +517,12 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 			MCPMetadataSnapshotBefore: existing,
 			MCPMetadataSnapshotAfter:  metadata,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "log MCP server metadata update event").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "log MCP server metadata update event").LogError(ctx, logger)
 		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "save MCP server metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "save MCP server metadata").LogError(ctx, logger)
 	}
 
 	return metadata, nil
@@ -543,7 +543,7 @@ func (s *Service) ExportMcpMetadata(ctx context.Context, payload *gen.ExportMcpM
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "MCP server not found")
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch MCP server").Log(ctx, s.logger, attr.SlogToolsetMCPSlug(mcpSlug))
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch MCP server").LogError(ctx, s.logger, attr.SlogToolsetMCPSlug(mcpSlug))
 	}
 
 	if !toolset.McpEnabled {
@@ -562,7 +562,7 @@ func (s *Service) ExportMcpMetadata(ctx context.Context, payload *gen.ExportMcpM
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(toolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe toolset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe toolset").LogError(ctx, s.logger)
 	}
 
 	// Load MCP metadata (logo, docs, instructions)
@@ -592,7 +592,7 @@ func (s *Service) ExportMcpMetadata(ctx context.Context, payload *gen.ExportMcpM
 
 		metadata, err := ToMCPMetadata(ctx, s.repo, metadataRecord)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to convert metadata").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to convert metadata").LogError(ctx, s.logger)
 		}
 		for _, config := range metadata.EnvironmentConfigs {
 			variableProvidedBy[config.VariableName] = config.ProvidedBy
@@ -607,7 +607,7 @@ func (s *Service) ExportMcpMetadata(ctx context.Context, payload *gen.ExportMcpM
 	// Build MCP URL
 	mcpURL, err := s.resolveMCPURLFromContext(ctx, toolset, s.serverURL.String())
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to resolve MCP URL").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to resolve MCP URL").LogError(ctx, s.logger)
 	}
 
 	// Collect security inputs
@@ -726,9 +726,9 @@ func resolveMetadataBackend(
 
 	switch {
 	case !toolsetProvided && !mcpServerProvided:
-		return nil, oops.E(oops.CodeBadRequest, nil, "toolset_slug or mcp_server_id is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "toolset_slug or mcp_server_id is required").LogError(ctx, logger)
 	case toolsetProvided && mcpServerProvided:
-		return nil, oops.E(oops.CodeBadRequest, nil, "toolset_slug and mcp_server_id are mutually exclusive").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "toolset_slug and mcp_server_id are mutually exclusive").LogError(ctx, logger)
 	case toolsetProvided:
 		slug := conv.ToLower(string(*toolsetSlug))
 		toolset, err := toolsetQueries.GetToolset(ctx, toolsets_repo.GetToolsetParams{
@@ -737,15 +737,15 @@ func resolveMetadataBackend(
 		})
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
-			return nil, oops.E(oops.CodeBadRequest, err, "toolset not found").Log(ctx, logger, attr.SlogToolsetSlug(slug))
+			return nil, oops.E(oops.CodeBadRequest, err, "toolset not found").LogError(ctx, logger, attr.SlogToolsetSlug(slug))
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "fetch toolset").Log(ctx, logger, attr.SlogToolsetSlug(slug))
+			return nil, oops.E(oops.CodeUnexpected, err, "fetch toolset").LogError(ctx, logger, attr.SlogToolsetSlug(slug))
 		}
 		return &resolvedMetadataBackend{toolset: &toolset, mcpServer: nil}, nil
 	default:
 		parsedID, err := uuid.Parse(*mcpServerID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp_server_id (not a valid UUID)").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp_server_id (not a valid UUID)").LogError(ctx, logger)
 		}
 		server, err := mcpServerQueries.GetMCPServerByID(ctx, mcpservers_repo.GetMCPServerByIDParams{
 			ID:        parsedID,
@@ -753,9 +753,9 @@ func resolveMetadataBackend(
 		})
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
-			return nil, oops.E(oops.CodeBadRequest, err, "mcp server not found").Log(ctx, logger, attr.SlogMcpServerID(parsedID.String()))
+			return nil, oops.E(oops.CodeBadRequest, err, "mcp server not found").LogError(ctx, logger, attr.SlogMcpServerID(parsedID.String()))
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "fetch mcp server").Log(ctx, logger, attr.SlogMcpServerID(parsedID.String()))
+			return nil, oops.E(oops.CodeUnexpected, err, "fetch mcp server").LogError(ctx, logger, attr.SlogMcpServerID(parsedID.String()))
 		}
 		return &resolvedMetadataBackend{toolset: nil, mcpServer: &server}, nil
 	}
@@ -948,7 +948,7 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 
 	sessionToken, _ := contextvalues.GetSessionTokenFromContext(ctx)
@@ -968,7 +968,7 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 	case errors.Is(err, errToolsetNotFound):
 		return s.serveNotFoundPage(w, mcpSlug)
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "load mcp server").Log(ctx, s.logger, attr.SlogToolsetMCPSlug(mcpSlug))
+		return oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger, attr.SlogToolsetMCPSlug(mcpSlug))
 	}
 
 	if !ic.isPublic() {
@@ -1151,7 +1151,7 @@ func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseW
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(toolset.ProjectID), mv.ToolsetSlug(toolset.Slug), &s.toolsetCache, resolvedGroupID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "describe toolset").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "describe toolset").LogError(ctx, s.logger)
 	}
 
 	logoAssetURL := s.siteURL.String() + "/external/sticker-logo.png"
@@ -1266,7 +1266,7 @@ func (s *Service) renderToolsetInstallPage(ctx context.Context, w http.ResponseW
 
 	mcpURL, err := s.resolveToolsetMCPURL(ctx, *toolset, mcpSlug)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "resolve toolset mcp url").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "resolve toolset mcp url").LogError(ctx, s.logger)
 	}
 
 	// Public install slug: prefer the slug from the URL path (which honours the
@@ -1304,7 +1304,7 @@ func (s *Service) renderRemoteMcpInstallPage(ctx context.Context, w http.Respons
 	// Belt-and-suspenders so a future change to the dispatcher can't silently
 	// nil-deref through here.
 	if mcpServer == nil || endpoint == nil {
-		return oops.E(oops.CodeUnexpected, nil, "remote mcp install context missing backend or endpoint").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, nil, "remote mcp install context missing backend or endpoint").LogError(ctx, s.logger)
 	}
 
 	logoAssetURL := s.siteURL.String() + "/external/sticker-logo.png"
@@ -1331,7 +1331,7 @@ func (s *Service) renderRemoteMcpInstallPage(ctx context.Context, w http.Respons
 
 	mcpURL, err := s.resolveMcpEndpointURL(ctx, endpoint)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "resolve mcp endpoint url").Log(ctx, s.logger, attr.SlogMcpServerID(mcpServer.ID.String()))
+		return oops.E(oops.CodeUnexpected, err, "resolve mcp endpoint url").LogError(ctx, s.logger, attr.SlogMcpServerID(mcpServer.ID.String()))
 	}
 
 	return s.writeInstallPage(ctx, w, hostedPageRenderInputs{
@@ -1395,7 +1395,7 @@ func (s *Service) writeInstallPage(ctx context.Context, w http.ResponseWriter, i
 
 	configSnippetTmpl, err := template.New("config_snippet").Funcs(templatefuncs.FuncMap()).Parse(configSnippetTmplData)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "parse config snippet template").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "parse config snippet template").LogError(ctx, s.logger)
 	}
 
 	// buildConn assembles the connection strings for a single MCP URL, reusing
@@ -1438,7 +1438,7 @@ func (s *Service) writeInstallPage(ctx context.Context, w http.ResponseWriter, i
 
 	defaultConn, err := buildConn(in.MCPURL)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build default connection").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "build default connection").LogError(ctx, s.logger)
 	}
 
 	// When filtering is enabled, build one connection variant per scope (plus the
@@ -1450,13 +1450,13 @@ func (s *Service) writeInstallPage(ctx context.Context, w http.ResponseWriter, i
 		for _, scope := range in.Scopes {
 			conn, err := buildConn(appendTagsQuery(in.MCPURL, scope.Tag))
 			if err != nil {
-				return oops.E(oops.CodeUnexpected, err, "build scope connection").Log(ctx, s.logger)
+				return oops.E(oops.CodeUnexpected, err, "build scope connection").LogError(ctx, s.logger)
 			}
 			variants[scope.Tag] = conn
 		}
 		encoded, err := json.Marshal(variants)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "marshal scope variants").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "marshal scope variants").LogError(ctx, s.logger)
 		}
 		// Emitted into a data-* attribute (not a <script>), so html/template's
 		// attribute auto-escaping handles it — no template.JS / nosec needed.
@@ -1484,7 +1484,7 @@ func (s *Service) writeInstallPage(ctx context.Context, w http.ResponseWriter, i
 
 	hostedPageTmpl, err := template.New("hosted_page").Funcs(templatefuncs.FuncMap()).Parse(hostedPageTmplData)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "parse hosted page template").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "parse hosted page template").LogError(ctx, s.logger)
 	}
 
 	buf := &bytes.Buffer{}
@@ -1574,7 +1574,7 @@ func (s *Service) ServeInstallPageScript(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusOK)
 
 	if _, err := w.Write(s.installPageScriptData); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write script response").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write script response").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -1593,7 +1593,7 @@ func safeTemplateURL(rawURL string, allowedScheme string) (template.URL, error) 
 				nil,
 				"%s scheme is not allowed",
 				dangerousScheme,
-			).Log(context.Background(), nil)
+			).LogError(context.Background(), nil)
 		}
 	}
 
@@ -1603,7 +1603,7 @@ func safeTemplateURL(rawURL string, allowedScheme string) (template.URL, error) 
 			oops.CodeBadRequest,
 			err,
 			"invalid URL",
-		).Log(context.Background(), nil)
+		).LogError(context.Background(), nil)
 	}
 
 	if u.Scheme != allowedScheme {
@@ -1612,7 +1612,7 @@ func safeTemplateURL(rawURL string, allowedScheme string) (template.URL, error) 
 			nil,
 			"invalid URL scheme: %s",
 			u.Scheme,
-		).Log(context.Background(), nil)
+		).LogError(context.Background(), nil)
 	}
 
 	return template.URL(u.String()), nil // #nosec G203 // This has been checked and escaped

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -101,7 +101,7 @@ func (s *Service) CreateMcpServer(ctx context.Context, payload *gen.CreateMcpSer
 
 	name := strings.TrimSpace(payload.Name)
 	if name == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "name must be non-empty").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "name must be non-empty").LogError(ctx, logger)
 	}
 
 	ids, err := parseServerIDs(
@@ -112,34 +112,34 @@ func (s *Service) CreateMcpServer(ctx context.Context, payload *gen.CreateMcpSer
 		payload.ToolVariationsGroupID,
 	)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp server").LogError(ctx, logger)
 	}
 	if err := validateServerBackendExclusivity(ids.RemoteMcpServerID, ids.ToolsetID); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogError(ctx, logger)
 	}
 
 	// Generate the server ID up front so the slug can include its suffix and
 	// the row can be inserted in a single statement (no insert-then-update).
 	serverID, err := uuid.NewV7()
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "generate server id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "generate server id").LogError(ctx, logger)
 	}
 
 	slug, err := computeServerSlug(name, serverID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "compute server slug").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "compute server slug").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	txRepo := repo.New(dbtx)
 
 	if err := verifyServerReferenceOwnership(ctx, dbtx, *authCtx.ProjectID, ids); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogError(ctx, logger)
 	}
 
 	server, err := txRepo.CreateMCPServer(ctx, repo.CreateMCPServerParams{
@@ -157,9 +157,9 @@ func (s *Service) CreateMcpServer(ctx context.Context, payload *gen.CreateMcpSer
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return nil, oops.E(oops.CodeConflict, err, "mcp server slug already in use").Log(ctx, logger)
+			return nil, oops.E(oops.CodeConflict, err, "mcp server slug already in use").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "create mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create mcp server").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogMcpServerCreate(ctx, dbtx, audit.LogMcpServerCreateEvent{
@@ -172,11 +172,11 @@ func (s *Service) CreateMcpServer(ctx context.Context, payload *gen.CreateMcpSer
 		McpServerName:    name,
 		McpServerSlug:    slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log mcp server creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log mcp server creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return mv.BuildMcpServerView(server), nil
@@ -195,10 +195,10 @@ func (s *Service) GetMcpServer(ctx context.Context, payload *gen.GetMcpServerPay
 	idProvided := payload.ID != nil && *payload.ID != ""
 	slugProvided := payload.Slug != nil && *payload.Slug != ""
 	if !idProvided && !slugProvided {
-		return nil, oops.E(oops.CodeBadRequest, nil, "id or slug is required").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "id or slug is required").LogError(ctx, s.logger)
 	}
 	if idProvided && slugProvided {
-		return nil, oops.E(oops.CodeBadRequest, nil, "id and slug are mutually exclusive").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "id and slug are mutually exclusive").LogError(ctx, s.logger)
 	}
 
 	r := repo.New(s.db)
@@ -208,7 +208,7 @@ func (s *Service) GetMcpServer(ctx context.Context, payload *gen.GetMcpServerPay
 	if idProvided {
 		serverID, parseErr := uuid.Parse(*payload.ID)
 		if parseErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid mcp server id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid mcp server id").LogError(ctx, s.logger)
 		}
 		server, err = r.GetMCPServerByID(ctx, repo.GetMCPServerByIDParams{
 			ID:        serverID,
@@ -222,9 +222,9 @@ func (s *Service) GetMcpServer(ctx context.Context, payload *gen.GetMcpServerPay
 	}
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").LogError(ctx, s.logger)
 	}
 
 	return mv.BuildMcpServerView(server), nil
@@ -243,10 +243,10 @@ func (s *Service) ListToolFilters(ctx context.Context, payload *gen.ListToolFilt
 	idProvided := payload.ID != nil && *payload.ID != ""
 	slugProvided := payload.Slug != nil && *payload.Slug != ""
 	if !idProvided && !slugProvided {
-		return nil, oops.E(oops.CodeBadRequest, nil, "id or slug is required").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "id or slug is required").LogError(ctx, s.logger)
 	}
 	if idProvided && slugProvided {
-		return nil, oops.E(oops.CodeBadRequest, nil, "id and slug are mutually exclusive").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "id and slug are mutually exclusive").LogError(ctx, s.logger)
 	}
 
 	r := repo.New(s.db)
@@ -256,7 +256,7 @@ func (s *Service) ListToolFilters(ctx context.Context, payload *gen.ListToolFilt
 	if idProvided {
 		serverID, parseErr := uuid.Parse(*payload.ID)
 		if parseErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid mcp server id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid mcp server id").LogError(ctx, s.logger)
 		}
 		server, err = r.GetMCPServerByID(ctx, repo.GetMCPServerByIDParams{
 			ID:        serverID,
@@ -270,9 +270,9 @@ func (s *Service) ListToolFilters(ctx context.Context, payload *gen.ListToolFilt
 	}
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").LogError(ctx, s.logger)
 	}
 
 	// Only toolset-backed servers expose a tool list to filter. Remote-backed
@@ -288,9 +288,9 @@ func (s *Service) ListToolFilters(ctx context.Context, payload *gen.ListToolFilt
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "mcp server backing toolset not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "mcp server backing toolset not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server backing toolset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server backing toolset").LogError(ctx, s.logger)
 	}
 
 	// Resolution chain: the mcp_servers value takes precedence over the
@@ -337,14 +337,14 @@ func (s *Service) ListMcpServers(ctx context.Context, payload *gen.ListMcpServer
 
 	remoteMcpServerID, err := conv.PtrToNullUUID(payload.RemoteMcpServerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_mcp_server_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_mcp_server_id").LogError(ctx, logger)
 	}
 	toolsetID, err := conv.PtrToNullUUID(payload.ToolsetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, logger)
 	}
 	if remoteMcpServerID.Valid && toolsetID.Valid {
-		return nil, oops.E(oops.CodeInvalid, nil, "at most one of remote_mcp_server_id or toolset_id may be provided").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, nil, "at most one of remote_mcp_server_id or toolset_id may be provided").LogError(ctx, logger)
 	}
 
 	servers, err := repo.New(s.db).ListMCPServersByProjectID(ctx, repo.ListMCPServersByProjectIDParams{
@@ -353,7 +353,7 @@ func (s *Service) ListMcpServers(ctx context.Context, payload *gen.ListMcpServer
 		ToolsetID:         toolsetID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list mcp servers").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list mcp servers").LogError(ctx, logger)
 	}
 
 	return &gen.ListMcpServersResult{McpServers: mv.BuildMcpServerListView(servers)}, nil
@@ -373,7 +373,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 
 	serverID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp server id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp server id").LogError(ctx, logger)
 	}
 
 	ids, err := parseServerIDs(
@@ -384,15 +384,15 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		payload.ToolVariationsGroupID,
 	)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid mcp server").LogError(ctx, logger)
 	}
 	if err := validateServerBackendExclusivity(ids.RemoteMcpServerID, ids.ToolsetID); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -404,15 +404,15 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").LogError(ctx, logger)
 	}
 
 	beforeView := mv.BuildMcpServerView(existing)
 
 	if err := verifyServerReferenceOwnership(ctx, dbtx, *authCtx.ProjectID, ids); err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogError(ctx, logger)
 	}
 
 	// Resolve name: nil = leave existing; non-nil = trim and require non-empty.
@@ -420,7 +420,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	if payload.Name != nil {
 		trimmed := strings.TrimSpace(*payload.Name)
 		if trimmed == "" {
-			return nil, oops.E(oops.CodeBadRequest, nil, "name must be non-empty").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "name must be non-empty").LogError(ctx, logger)
 		}
 		name = conv.ToPGText(trimmed)
 	}
@@ -429,7 +429,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	// even when the name didn't change (idempotent).
 	slug, err := computeServerSlug(conv.FromPGTextOrEmpty[string](name), serverID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "compute server slug").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "compute server slug").LogError(ctx, logger)
 	}
 
 	updated, err := txRepo.UpdateMCPServer(ctx, repo.UpdateMCPServerParams{
@@ -447,12 +447,12 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return nil, oops.E(oops.CodeConflict, err, "mcp server slug already in use").Log(ctx, logger)
+			return nil, oops.E(oops.CodeConflict, err, "mcp server slug already in use").LogError(ctx, logger)
 		}
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update mcp server").LogError(ctx, logger)
 	}
 
 	afterView := mv.BuildMcpServerView(updated)
@@ -469,11 +469,11 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		McpServerSnapshotBefore: beforeView,
 		McpServerSnapshotAfter:  afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log mcp server update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log mcp server update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return afterView, nil
@@ -493,12 +493,12 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 
 	serverID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid mcp server id").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid mcp server id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -510,9 +510,9 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, logger)
+			return oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "delete mcp server").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete mcp server").LogError(ctx, logger)
 	}
 
 	// The mcp_endpoints.mcp_server_id FK has ON DELETE CASCADE, but that only
@@ -523,7 +523,7 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 		ProjectID:   *authCtx.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete child mcp endpoints").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete child mcp endpoints").LogError(ctx, logger)
 	}
 
 	for _, endpoint := range deletedEndpoints {
@@ -536,7 +536,7 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 			McpEndpointURN:   urn.NewMcpEndpoint(endpoint.ID),
 			Slug:             endpoint.Slug,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "log mcp endpoint deletion").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "log mcp endpoint deletion").LogError(ctx, logger)
 		}
 	}
 
@@ -550,11 +550,11 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 		McpServerName:    conv.FromPGTextOrEmpty[string](deleted.Name),
 		McpServerSlug:    conv.FromPGTextOrEmpty[string](deleted.Slug),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log mcp server deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log mcp server deletion").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/memory/service.go
+++ b/server/internal/memory/service.go
@@ -266,7 +266,7 @@ func (s *MemoryService) Remember(
 	zero := RememberResult{ID: uuid.Nil, CreatedAt: time.Time{}, Deduped: false, SupersededID: nil}
 
 	if assistantID == uuid.Nil {
-		return zero, oops.E(oops.CodeBadRequest, nil, "assistant id is required").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeBadRequest, nil, "assistant id is required").LogError(ctx, s.logger)
 	}
 	if strings.TrimSpace(content) == "" {
 		return zero, oops.E(oops.CodeBadRequest, nil, "memory content is required")
@@ -289,28 +289,28 @@ func (s *MemoryService) Remember(
 		))
 	}
 	if err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "create memory embedding").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "create memory embedding").LogError(ctx, s.logger)
 	}
 	if len(vectors) != 1 {
-		return zero, oops.E(oops.CodeUnexpected, nil, "embedding response had %d vectors, expected 1", len(vectors)).Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, nil, "embedding response had %d vectors, expected 1", len(vectors)).LogError(ctx, s.logger)
 	}
 	embedding := pgvector_go.NewHalfVector(vectors[0])
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "begin remember transaction").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "begin remember transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	txq := repo.New(tx)
 
 	if err := txq.LockAssistantForMemoryWrite(ctx, assistantID.String()); err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "lock assistant for memory write").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "lock assistant for memory write").LogError(ctx, s.logger)
 	}
 
 	count, err := txq.CountActiveAssistantMemories(ctx, assistantID)
 	if err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "count active memories").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "count active memories").LogError(ctx, s.logger)
 	}
 	if count >= int64(s.hardCap) {
 		return zero, oops.E(oops.CodeConflict, nil, "memory cap reached for assistant; call forget first")
@@ -322,7 +322,7 @@ func (s *MemoryService) Remember(
 	})
 	hasNearest := nearestErr == nil
 	if !hasNearest && !errors.Is(nearestErr, pgx.ErrNoRows) {
-		return zero, oops.E(oops.CodeUnexpected, nearestErr, "find nearest memory").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, nearestErr, "find nearest memory").LogError(ctx, s.logger)
 	}
 
 	supersedesID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
@@ -332,7 +332,7 @@ func (s *MemoryService) Remember(
 		switch {
 		case nearest.Similarity >= s.dedupeUpper:
 			if err := tx.Commit(ctx); err != nil {
-				return zero, oops.E(oops.CodeUnexpected, err, "commit dedupe").Log(ctx, s.logger)
+				return zero, oops.E(oops.CodeUnexpected, err, "commit dedupe").LogError(ctx, s.logger)
 			}
 			s.recordRememberOutcome(ctx, rememberOutcomeDeduped)
 			return RememberResult{
@@ -353,7 +353,7 @@ func (s *MemoryService) Remember(
 					attr.SlogError(contradictErr))
 			} else if contradicts {
 				if err := txq.MarkAssistantMemorySuperseded(ctx, nearest.ID); err != nil {
-					return zero, oops.E(oops.CodeUnexpected, err, "mark memory superseded").Log(ctx, s.logger)
+					return zero, oops.E(oops.CodeUnexpected, err, "mark memory superseded").LogError(ctx, s.logger)
 				}
 				supersedesID = uuid.NullUUID{UUID: nearest.ID, Valid: true}
 				outcome = rememberOutcomeSuperseded
@@ -383,11 +383,11 @@ func (s *MemoryService) Remember(
 		SupersedesID:   supersedesID,
 	})
 	if err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "insert memory").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "insert memory").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "commit remember transaction").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "commit remember transaction").LogError(ctx, s.logger)
 	}
 
 	if outcome == rememberOutcomeSuperseded && s.metrics.supersedeDepth != nil {
@@ -498,7 +498,7 @@ func (s *MemoryService) Recall(
 		ResultLimit:    int32(limit),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list nearest memories").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list nearest memories").LogError(ctx, s.logger)
 	}
 
 	if len(rows) == 0 {
@@ -610,14 +610,14 @@ func (s *MemoryService) Forget(
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "begin forget transaction").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "begin forget transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	txq := repo.New(tx)
 
 	if err := txq.LockAssistantForMemoryWrite(ctx, assistantID.String()); err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "lock assistant for forget").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "lock assistant for forget").LogError(ctx, s.logger)
 	}
 
 	tagFilter := tags
@@ -632,7 +632,7 @@ func (s *MemoryService) Forget(
 		ResultLimit:    int32(forgetCandidateLimit),
 	})
 	if err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "list forget candidates").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "list forget candidates").LogError(ctx, s.logger)
 	}
 
 	decision := decideForgetSelection(candidates, s.dedupeLower, s.forgetAmbiguityGap)
@@ -657,11 +657,11 @@ func (s *MemoryService) Forget(
 			s.recordForgetOutcome(ctx, forgetOutcomeNoMatch)
 			return noMatch, nil
 		}
-		return zero, oops.E(oops.CodeUnexpected, err, "soft delete memory").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "soft delete memory").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return zero, oops.E(oops.CodeUnexpected, err, "commit forget transaction").Log(ctx, s.logger)
+		return zero, oops.E(oops.CodeUnexpected, err, "commit forget transaction").LogError(ctx, s.logger)
 	}
 
 	id := target.ID
@@ -728,7 +728,7 @@ func (s *MemoryService) DeleteByID(ctx context.Context, projectID uuid.UUID, id 
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin delete transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "begin delete transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -742,11 +742,11 @@ func (s *MemoryService) DeleteByID(ctx context.Context, projectID uuid.UUID, id 
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, nil, "memory not found")
 		}
-		return oops.E(oops.CodeUnexpected, err, "soft delete memory").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "soft delete memory").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit delete transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "commit delete transaction").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -784,7 +784,7 @@ func (s *MemoryService) List(ctx context.Context, projectID uuid.UUID, params Li
 		PageLimit:       limit,
 	})
 	if err != nil {
-		return ListResult{}, oops.E(oops.CodeUnexpected, err, "list memories").Log(ctx, s.logger)
+		return ListResult{}, oops.E(oops.CodeUnexpected, err, "list memories").LogError(ctx, s.logger)
 	}
 
 	return ListResult{Memories: rows}, nil
@@ -801,7 +801,7 @@ func (s *MemoryService) Get(ctx context.Context, projectID uuid.UUID, id uuid.UU
 		if errors.Is(err, pgx.ErrNoRows) {
 			return repo.GetAssistantMemoryByIDRow{}, oops.E(oops.CodeNotFound, nil, "memory not found")
 		}
-		return repo.GetAssistantMemoryByIDRow{}, oops.E(oops.CodeUnexpected, err, "fetch memory").Log(ctx, s.logger)
+		return repo.GetAssistantMemoryByIDRow{}, oops.E(oops.CodeUnexpected, err, "fetch memory").LogError(ctx, s.logger)
 	}
 
 	return mem, nil

--- a/server/internal/mv/deployment.go
+++ b/server/internal/mv/deployment.go
@@ -25,7 +25,7 @@ func DescribeDeployment(ctx context.Context, logger *slog.Logger, depRepo *repo.
 	case errors.Is(err, pgx.ErrNoRows), err == nil && len(rows) == 0:
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting deployment with assets").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting deployment with assets").LogError(ctx, logger)
 	}
 
 	deployment := rows[0].Deployment
@@ -51,7 +51,7 @@ func DescribeDeployment(ctx context.Context, logger *slog.Logger, depRepo *repo.
 				"valid asset name", r.DeploymentsOpenapiv3AssetName.Valid && r.DeploymentsOpenapiv3AssetName.String != "",
 				"valid asset slug", r.DeploymentsOpenapiv3AssetSlug.Valid && r.DeploymentsOpenapiv3AssetSlug.String != "",
 			); err != nil {
-				return nil, oops.E(oops.CodeInvariantViolation, err, "invalid state for deployment openapiv3 asset").Log(ctx, logger)
+				return nil, oops.E(oops.CodeInvariantViolation, err, "invalid state for deployment openapiv3 asset").LogError(ctx, logger)
 			}
 
 			attachedOpenAPIv3 = append(attachedOpenAPIv3, &types.OpenAPIv3DeploymentAsset{
@@ -72,7 +72,7 @@ func DescribeDeployment(ctx context.Context, logger *slog.Logger, depRepo *repo.
 				"valid asset slug", r.DeploymentsFunctionsSlug.Valid && r.DeploymentsFunctionsSlug.String != "",
 				"valid functions runtime", r.DeploymentsFunctionsRuntime.Valid && r.DeploymentsFunctionsRuntime.String != "",
 			); err != nil {
-				return nil, oops.E(oops.CodeInvariantViolation, err, "invalid state for deployment functions").Log(ctx, logger)
+				return nil, oops.E(oops.CodeInvariantViolation, err, "invalid state for deployment functions").LogError(ctx, logger)
 			}
 
 			scale := new(r.DeploymentsFunctionsScale.Int32)
@@ -126,7 +126,7 @@ func DescribeDeployment(ctx context.Context, logger *slog.Logger, depRepo *repo.
 				"valid slug", r.ExternalMcpSlug.Valid && r.ExternalMcpSlug.String != "",
 				"valid registry server specifier", r.ExternalMcpRegistryServerSpecifier.Valid && r.ExternalMcpRegistryServerSpecifier.String != "",
 			); err != nil {
-				return nil, oops.E(oops.CodeInvariantViolation, err, "invalid state for deployment external mcp").Log(ctx, logger)
+				return nil, oops.E(oops.CodeInvariantViolation, err, "invalid state for deployment external mcp").LogError(ctx, logger)
 			}
 
 			mcp := &types.DeploymentExternalMCP{

--- a/server/internal/mv/templates.go
+++ b/server/internal/mv/templates.go
@@ -43,19 +43,19 @@ func DescribePromptTemplate(
 			Name:      *pname,
 		})
 	} else {
-		return nil, oops.E(oops.CodeBadRequest, err, "id or name is required to lookup template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "id or name is required to lookup template").LogError(ctx, logger)
 	}
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, nil, "template not found")
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").LogError(ctx, logger)
 	}
 
 	pt := fromPromptTemplateRow(row)
 	err = ApplyVariations(ctx, logger, tx, pid, nil, []*types.Tool{{PromptTemplate: pt}})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to prompt template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to prompt template").LogError(ctx, logger)
 	}
 
 	return pt, nil
@@ -73,13 +73,13 @@ func DescribePromptTemplates(
 		"describe prompt template inputs",
 		"project id is set", pid != uuid.Nil,
 	); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "not enough information to get prompt template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "not enough information to get prompt template").LogError(ctx, logger)
 	}
 
 	r := repo.New(tx)
 	rows, err := r.ListTemplates(ctx, pid)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").LogError(ctx, logger)
 	}
 
 	templates := make([]*types.PromptTemplate, 0, len(rows))
@@ -87,7 +87,7 @@ func DescribePromptTemplates(
 		pt := fromPromptTemplateRow(row)
 		err = ApplyVariations(ctx, logger, tx, pid, nil, []*types.Tool{{PromptTemplate: pt}})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to prompt template").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to prompt template").LogError(ctx, logger)
 		}
 		templates = append(templates, pt)
 	}

--- a/server/internal/mv/toolfilters.go
+++ b/server/internal/mv/toolfilters.go
@@ -25,7 +25,7 @@ func ToolVariationsGroupName(ctx context.Context, logger *slog.Logger, tx DBTX, 
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "get tool variations group").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get tool variations group").LogError(ctx, logger)
 	default:
 		return &group.Name, nil
 	}

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -75,7 +75,7 @@ func DescribeToolsetEntry(
 		"project id is set", pid != uuid.Nil,
 		"toolset slug is set", toolsetSlug != "",
 	); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "not enough information to describe toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "not enough information to describe toolset").LogError(ctx, logger)
 	}
 
 	toolset, err := toolsetRepo.GetToolset(ctx, tsr.GetToolsetParams{
@@ -84,9 +84,9 @@ func DescribeToolsetEntry(
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset").LogError(ctx, logger)
 	}
 
 	// Get tool URNs and resource URNs from latest toolset version
@@ -120,7 +120,7 @@ func DescribeToolsetEntry(
 			Urns:      toolUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to list tools in toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to list tools in toolset").LogError(ctx, logger)
 		}
 
 		allVariations, err := variationsRepo.FindGlobalVariationsByToolURNs(ctx, vr.FindGlobalVariationsByToolURNsParams{
@@ -128,7 +128,7 @@ func DescribeToolsetEntry(
 			ToolUrns:  toolUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to list global tool variations").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to list global tool variations").LogError(ctx, logger)
 		}
 
 		urnToVariedName := make(map[string]string)
@@ -176,7 +176,7 @@ func DescribeToolsetEntry(
 			Urns:      toolUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to list function tools in toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to list function tools in toolset").LogError(ctx, logger)
 		}
 		for _, tool := range funcTools {
 			tools = append(tools, &types.ToolEntry{
@@ -190,7 +190,7 @@ func DescribeToolsetEntry(
 
 			envVars, err := extractFunctionEnvVars(ctx, logger, tool.Variables, tool.AuthInput)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract function environment variables").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract function environment variables").LogError(ctx, logger)
 			}
 			functionEnvVars = append(functionEnvVars, envVars...)
 		}
@@ -200,7 +200,7 @@ func DescribeToolsetEntry(
 			Urns:      toolUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get prompt templates").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get prompt templates").LogError(ctx, logger)
 		}
 
 		for _, pt := range promptTools {
@@ -247,7 +247,7 @@ func DescribeToolsetEntry(
 
 			headerDefs, err := extractExternalMCPHeaderDefinitions(ctx, logger, externalMCPTool.HeaderDefinitions, externalMCPTool.Slug)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract external mcp header definitions").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract external mcp header definitions").LogError(ctx, logger)
 			}
 			externalMCPHeaderDefinitions = append(externalMCPHeaderDefinitions, headerDefs...)
 
@@ -255,7 +255,7 @@ func DescribeToolsetEntry(
 
 		securityVars, serverVars, err = environmentVariablesForTools(ctx, tx, toolset.ID, envQueries)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment variables for toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment variables for toolset").LogError(ctx, logger)
 		}
 	}
 
@@ -267,7 +267,7 @@ func DescribeToolsetEntry(
 			Urns:      resourceUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to list resources in toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to list resources in toolset").LogError(ctx, logger)
 		}
 
 		resources = make([]*types.ResourceEntry, 0, len(functionResourceEntries))
@@ -282,7 +282,7 @@ func DescribeToolsetEntry(
 
 			envVars, err := extractFunctionEnvVars(ctx, logger, resource.Variables, nil)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract function environment variables from resource").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract function environment variables from resource").LogError(ctx, logger)
 			}
 			functionEnvVars = append(functionEnvVars, envVars...)
 		}
@@ -293,7 +293,7 @@ func DescribeToolsetEntry(
 		ToolsetID: toolset.ID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get prompt templates for toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get prompt templates for toolset").LogError(ctx, logger)
 	}
 
 	promptTemplates := make([]*types.PromptTemplateEntry, 0, len(ptrows))
@@ -360,7 +360,7 @@ func DescribeToolset(
 		"project id is set", pid != uuid.Nil,
 		"toolset slug is set", toolsetSlug != "",
 	); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "not enough information to describe toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "not enough information to describe toolset").LogError(ctx, logger)
 	}
 
 	toolset, err := toolsetRepo.GetToolset(ctx, tsr.GetToolsetParams{
@@ -369,9 +369,9 @@ func DescribeToolset(
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset").LogError(ctx, logger)
 	}
 
 	// TODO: It would be better if every query below accepted a deployment ID as a parameter to guarantee cache consistency.
@@ -407,12 +407,12 @@ func DescribeToolset(
 
 	toolsetTools, err := readToolsetTools(ctx, logger, tx, pid, activeDeploymentID, toolset.ID, toolsetVersion, toolUrns, resourceUrns, toolsetCache, platformExtras...)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset tools").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset tools").LogError(ctx, logger)
 	}
 
 	err = ApplyVariations(ctx, logger, tx, pid, toolVariationsGroupID, toolsetTools.Tools)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to toolset").LogError(ctx, logger)
 	}
 
 	ptrows, err := toolsetRepo.GetPromptTemplatesForToolset(ctx, tsr.GetPromptTemplatesForToolsetParams{
@@ -420,7 +420,7 @@ func DescribeToolset(
 		ToolsetID: toolset.ID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get prompt templates for toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get prompt templates for toolset").LogError(ctx, logger)
 	}
 
 	promptTemplates := make([]*types.PromptTemplate, 0, len(ptrows))
@@ -461,12 +461,12 @@ func DescribeToolset(
 			ID:        toolset.ExternalOauthServerID.UUID,
 		})
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get external oauth server metadata").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get external oauth server metadata").LogError(ctx, logger)
 		}
 		if len(externalOauthMetadata.Metadata) > 0 {
 			var metadata any
 			if err := json.Unmarshal(externalOauthMetadata.Metadata, &metadata); err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal external oauth metadata").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal external oauth metadata").LogError(ctx, logger)
 			}
 
 			externalOAuthServer = &types.ExternalOAuthServer{
@@ -486,7 +486,7 @@ func DescribeToolset(
 			ID:        toolset.OauthProxyServerID.UUID,
 		})
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get oauth proxy server").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get oauth proxy server").LogError(ctx, logger)
 		}
 		if err == nil {
 			oauthProxyProviders, err := oauthRepo.ListOAuthProxyProvidersByServer(ctx, oauth.ListOAuthProxyProvidersByServerParams{
@@ -494,7 +494,7 @@ func DescribeToolset(
 				OauthProxyServerID: oauthProxyServerData.ID,
 			})
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to get oauth proxy providers").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to get oauth proxy providers").LogError(ctx, logger)
 			}
 
 			providers := make([]*types.OAuthProxyProvider, 0, len(oauthProxyProviders))
@@ -540,7 +540,7 @@ func DescribeToolset(
 
 	orgMetadata, err := orgRepo.GetOrganizationMetadata(ctx, toolset.OrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get organization metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get organization metadata").LogError(ctx, logger)
 	}
 
 	oauth2AuthCodeSecurityCount := 0
@@ -582,7 +582,7 @@ func DescribeToolset(
 		case errors.Is(err, pgx.ErrNoRows):
 			// FK is dangling — treat as unlinked rather than erroring.
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to load linked user session issuer").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to load linked user session issuer").LogError(ctx, logger)
 		default:
 			id := usi.ID.String()
 			slug := types.Slug(usi.Slug)
@@ -726,7 +726,7 @@ func GetToolsetsSummary(
 		return nil
 	})
 	if err := eg.Wait(); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "batch fetch tool entries").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "batch fetch tool entries").LogError(ctx, logger)
 	}
 
 	httpTools := <-httpToolsCh
@@ -928,7 +928,7 @@ func readToolsetTools(
 			Urns:      toolUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to list tools in toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to list tools in toolset").LogError(ctx, logger)
 		}
 
 		tools = make([]*types.Tool, 0, len(definitions))
@@ -1011,7 +1011,7 @@ func readToolsetTools(
 			Urns:      toolUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get prompt templates for toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get prompt templates for toolset").LogError(ctx, logger)
 		}
 
 		for _, pt := range promptTools {
@@ -1051,7 +1051,7 @@ func readToolsetTools(
 			Urns:      toolUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get function tools for toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get function tools for toolset").LogError(ctx, logger)
 		}
 
 		for _, def := range functionDefinitions {
@@ -1059,7 +1059,7 @@ func readToolsetTools(
 			if def.FunctionToolDefinition.Meta != nil {
 				err = json.Unmarshal(def.FunctionToolDefinition.Meta, &meta)
 				if err != nil {
-					return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal meta tags").Log(ctx, logger)
+					return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal meta tags").LogError(ctx, logger)
 				}
 			}
 			functionTool := &types.FunctionToolDefinition{
@@ -1098,7 +1098,7 @@ func readToolsetTools(
 
 			envVars, err := extractFunctionEnvVars(ctx, logger, def.FunctionToolDefinition.Variables, def.FunctionToolDefinition.AuthInput)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract function environment variables").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract function environment variables").LogError(ctx, logger)
 			}
 			functionEnvVars = append(functionEnvVars, envVars...)
 
@@ -1109,7 +1109,7 @@ func readToolsetTools(
 
 		securityVars, serverVars, err = environmentVariablesForTools(ctx, tx, toolsetID, envQueries)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment variables for toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment variables for toolset").LogError(ctx, logger)
 		}
 	}
 
@@ -1118,7 +1118,7 @@ func readToolsetTools(
 		externalmcpRepo := externalmcpR.New(tx)
 		externalMCPTools, err := externalmcpRepo.ListExternalMCPToolDefinitions(ctx, activeDeploymentID)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get external mcp tools for toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get external mcp tools for toolset").LogError(ctx, logger)
 		}
 
 		for _, def := range externalMCPTools {
@@ -1166,7 +1166,7 @@ func readToolsetTools(
 
 			headerDefs, err := extractExternalMCPHeaderDefinitions(ctx, logger, def.HeaderDefinitions, def.Slug)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract external mcp header definitions").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract external mcp header definitions").LogError(ctx, logger)
 			}
 			externalMCPHeaderDefinitions = append(externalMCPHeaderDefinitions, headerDefs...)
 
@@ -1182,7 +1182,7 @@ func readToolsetTools(
 			Urns:      resourceUrns,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get function resources for toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get function resources for toolset").LogError(ctx, logger)
 		}
 
 		for _, def := range functionResourceDefinitions {
@@ -1190,7 +1190,7 @@ func readToolsetTools(
 			if def.FunctionResourceDefinition.Meta != nil {
 				err = json.Unmarshal(def.FunctionResourceDefinition.Meta, &meta)
 				if err != nil {
-					return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal meta tags").Log(ctx, logger)
+					return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal meta tags").LogError(ctx, logger)
 				}
 			}
 			functionResource := &types.FunctionResourceDefinition{
@@ -1213,7 +1213,7 @@ func readToolsetTools(
 
 			envVars, err := extractFunctionEnvVars(ctx, logger, def.FunctionResourceDefinition.Variables, nil)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract function environment variables from resource").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to extract function environment variables from resource").LogError(ctx, logger)
 			}
 			functionEnvVars = append(functionEnvVars, envVars...)
 
@@ -1259,7 +1259,7 @@ func getToolsetOrigin(
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset origin").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset origin").LogError(ctx, logger)
 	}
 
 	return &types.ToolsetOrigin{
@@ -1299,7 +1299,7 @@ func ApplyVariations(ctx context.Context, logger *slog.Logger, tx DBTX, projectI
 		})
 	}
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to list tool variations").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to list tool variations").LogError(ctx, logger)
 	}
 
 	urnToVariation := make(map[string]types.ToolVariation, len(allVariations))

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -233,7 +233,7 @@ func (s *ExternalOAuthService) withAuth(h func(w http.ResponseWriter, r *http.Re
 
 		sessionToken, ok := contextvalues.GetSessionTokenFromContext(ctx)
 		if !ok {
-			return oops.E(oops.CodeUnauthorized, nil, "authentication required").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnauthorized, nil, "authentication required").LogError(ctx, s.logger)
 		}
 
 		// ctx, err = s.sessionManager.Authenticate(ctx, cookie.Value, false)
@@ -252,7 +252,7 @@ func (s *ExternalOAuthService) withAuth(h func(w http.ResponseWriter, r *http.Re
 		}
 
 		if projectSlug == "" {
-			return oops.E(oops.CodeBadRequest, nil, "project is required").Log(ctx, s.logger)
+			return oops.E(oops.CodeBadRequest, nil, "project is required").LogError(ctx, s.logger)
 		}
 
 		ctx, err = s.auth.Authorize(ctx, projectSlug, &security.APIKeyScheme{
@@ -274,18 +274,18 @@ func (s *ExternalOAuthService) handleExternalAuthorize(w http.ResponseWriter, r 
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		return oops.E(oops.CodeUnauthorized, nil, "authentication required").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, nil, "authentication required").LogError(ctx, s.logger)
 	}
 
 	// Parse query parameters
 	toolsetIDStr := r.URL.Query().Get("toolset_id")
 	if toolsetIDStr == "" {
-		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").LogError(ctx, s.logger)
 	}
 
 	redirectURI := r.URL.Query().Get("redirect_uri")
 	if redirectURI == "" {
-		return oops.E(oops.CodeBadRequest, nil, "redirect_uri is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "redirect_uri is required").LogError(ctx, s.logger)
 	}
 
 	externalMCPSlug := r.URL.Query().Get("external_mcp_slug")
@@ -293,15 +293,15 @@ func (s *ExternalOAuthService) handleExternalAuthorize(w http.ResponseWriter, r 
 	// Validate redirect_uri hostname is in the allowed list to prevent open redirects.
 	parsedRedirect, err := url.Parse(redirectURI)
 	if err != nil || parsedRedirect.Scheme == "" || parsedRedirect.Host == "" {
-		return oops.E(oops.CodeBadRequest, nil, "invalid redirect_uri").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "invalid redirect_uri").LogError(ctx, s.logger)
 	}
 	if !s.isAllowedRedirectHost(parsedRedirect.Hostname()) {
-		return oops.E(oops.CodeBadRequest, nil, "redirect_uri hostname not allowed").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "redirect_uri hostname not allowed").LogError(ctx, s.logger)
 	}
 
 	toolsetID, err := uuid.Parse(toolsetIDStr)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, s.logger)
 	}
 
 	// Load toolset and verify user has access
@@ -310,26 +310,26 @@ func (s *ExternalOAuthService) handleExternalAuthorize(w http.ResponseWriter, r 
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 	}
 
 	// Get external MCP OAuth configuration from toolset
 	oauthConfig, err := s.getExternalOAuthConfig(ctx, toolset, externalMCPSlug)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "toolset does not require OAuth or external MCP not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "toolset does not require OAuth or external MCP not found").LogError(ctx, s.logger)
 	}
 
 	// Standard DCR flow — register as client against the OAuth server (Gram proxy or external)
 	oauthClient, err := s.getOrRegisterClient(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, oauthConfig)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to register OAuth client").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to register OAuth client").LogError(ctx, s.logger)
 	}
 	oauthConfig.ClientID = oauthClient.ClientID
 
 	// Generate PKCE code_verifier (43-128 chars)
 	codeVerifier, err := generateCodeVerifier()
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to generate code verifier").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to generate code verifier").LogError(ctx, s.logger)
 	}
 
 	// Generate code_challenge using S256
@@ -338,13 +338,13 @@ func (s *ExternalOAuthService) handleExternalAuthorize(w http.ResponseWriter, r 
 	// Generate state ID for cache key
 	stateID, err := generateStateID()
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to generate state ID").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to generate state ID").LogError(ctx, s.logger)
 	}
 
 	// Build authorization URL
 	authURL, err := url.Parse(oauthConfig.AuthorizationEndpoint)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "invalid authorization endpoint").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "invalid authorization endpoint").LogError(ctx, s.logger)
 	}
 
 	// Create state object
@@ -367,7 +367,7 @@ func (s *ExternalOAuthService) handleExternalAuthorize(w http.ResponseWriter, r 
 
 	// Store state in cache
 	if err := s.stateStorage.Store(ctx, state); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to store OAuth state").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to store OAuth state").LogError(ctx, s.logger)
 	}
 
 	callbackURL := fmt.Sprintf("%s/oauth-external/callback", s.serverURL.String())
@@ -410,24 +410,24 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		return oops.E(oops.CodeUnauthorized, nil, "authentication required").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, nil, "authentication required").LogError(ctx, s.logger)
 	}
 
 	toolsetIDStr := r.URL.Query().Get("toolset_id")
 	if toolsetIDStr == "" {
-		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").LogError(ctx, s.logger)
 	}
 	redirectURI := r.URL.Query().Get("redirect_uri")
 	if redirectURI == "" {
-		return oops.E(oops.CodeBadRequest, nil, "redirect_uri is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "redirect_uri is required").LogError(ctx, s.logger)
 	}
 
 	parsedRedirect, err := url.Parse(redirectURI)
 	if err != nil || parsedRedirect.Scheme == "" || parsedRedirect.Host == "" {
-		return oops.E(oops.CodeBadRequest, nil, "invalid redirect_uri").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "invalid redirect_uri").LogError(ctx, s.logger)
 	}
 	if !s.isAllowedRedirectHost(parsedRedirect.Hostname()) {
-		return oops.E(oops.CodeBadRequest, nil, "redirect_uri hostname not allowed").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "redirect_uri hostname not allowed").LogError(ctx, s.logger)
 	}
 	redirectQuery := parsedRedirect.Query()
 	redirectQuery.Set("issuer_connected", "1")
@@ -435,7 +435,7 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 
 	toolsetID, err := uuid.Parse(toolsetIDStr)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, s.logger)
 	}
 
 	toolset, err := s.toolsetsRepo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
@@ -443,24 +443,24 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 	}
 
 	if !toolset.UserSessionIssuerID.Valid {
-		return oops.E(oops.CodeBadRequest, nil, "toolset is not issuer-gated").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "toolset is not issuer-gated").LogError(ctx, s.logger)
 	}
 
 	mcpSlug := toolset.McpSlug.String
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "toolset has no mcp slug").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "toolset has no mcp slug").LogError(ctx, s.logger)
 	}
 
 	clients, err := s.remoteChallengeMgr.ListClients(ctx, toolset.ProjectID, toolset.UserSessionIssuerID.UUID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "list remote session clients").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "list remote session clients").LogError(ctx, s.logger)
 	}
 	if len(clients) != 1 {
-		return oops.E(oops.CodeInvariantViolation, nil, "issuer-gated dashboard connect requires exactly one remote_session_client, found %d", len(clients)).Log(ctx, s.logger)
+		return oops.E(oops.CodeInvariantViolation, nil, "issuer-gated dashboard connect requires exactly one remote_session_client, found %d", len(clients)).LogError(ctx, s.logger)
 	}
 
 	subject := urn.NewUserSubject(authCtx.UserID)
@@ -475,7 +475,7 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 	}
 	authURL, err := s.remoteChallengeMgr.BuildAuthorizationUrl(ctx, parent, clients[0])
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build authorization URL").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "build authorization URL").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "redirecting to upstream issuer-gated OAuth provider",
@@ -505,21 +505,21 @@ func (s *ExternalOAuthService) handleExternalCallback(w http.ResponseWriter, r *
 	}
 
 	if code == "" {
-		return oops.E(oops.CodeBadRequest, nil, "code is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "code is required").LogError(ctx, s.logger)
 	}
 	if stateID == "" {
-		return oops.E(oops.CodeBadRequest, nil, "state is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "state is required").LogError(ctx, s.logger)
 	}
 
 	// Retrieve state from cache
 	state, err := s.stateStorage.Get(ctx, ExternalOAuthStateCacheKey(stateID))
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid or expired state").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid or expired state").LogError(ctx, s.logger)
 	}
 
 	// Check if state has expired
 	if time.Now().After(state.ExpiresAt) {
-		return oops.E(oops.CodeBadRequest, nil, "state has expired").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "state has expired").LogError(ctx, s.logger)
 	}
 
 	// Delete state from cache (one-time use)
@@ -533,18 +533,18 @@ func (s *ExternalOAuthService) handleExternalCallback(w http.ResponseWriter, r *
 		ProjectID: state.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 	}
 
 	oauthConfig, err := s.getExternalOAuthConfig(ctx, toolset, state.ExternalMCPSlug)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get OAuth config").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get OAuth config").LogError(ctx, s.logger)
 	}
 
 	// Standard DCR flow — retrieve or register client against the OAuth server
 	oauthClient, err := s.getOrRegisterClient(ctx, state.OrganizationID, state.ProjectID, oauthConfig)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get OAuth client credentials").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get OAuth client credentials").LogError(ctx, s.logger)
 	}
 	oauthConfig.ClientID = oauthClient.ClientID
 	oauthConfig.ClientSecret = oauthClient.ClientSecret
@@ -561,14 +561,14 @@ func (s *ExternalOAuthService) handleExternalCallback(w http.ResponseWriter, r *
 	// Encrypt tokens before storing
 	accessTokenEncrypted, err := s.enc.Encrypt([]byte(tokenResp.AccessToken))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to encrypt access token").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to encrypt access token").LogError(ctx, s.logger)
 	}
 
 	var refreshTokenEncrypted pgtype.Text
 	if tokenResp.RefreshToken != "" {
 		encrypted, err := s.enc.Encrypt([]byte(tokenResp.RefreshToken))
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to encrypt refresh token").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to encrypt refresh token").LogError(ctx, s.logger)
 		}
 		refreshTokenEncrypted = conv.ToPGText(encrypted)
 	}
@@ -595,7 +595,7 @@ func (s *ExternalOAuthService) handleExternalCallback(w http.ResponseWriter, r *
 		ProviderName:          conv.ToPGText(state.ProviderName),
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to store OAuth token").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to store OAuth token").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "external OAuth token stored successfully",
@@ -611,7 +611,7 @@ func (s *ExternalOAuthService) handleExternalCallback(w http.ResponseWriter, r *
 		StyleHash:    s.successStyleHash,
 	}
 	if err := s.successPageTmpl.Execute(w, data); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to render external OAuth success page").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to render external OAuth success page").LogError(ctx, s.logger)
 	}
 	return nil
 }
@@ -629,7 +629,7 @@ func (s *ExternalOAuthService) serveExternalSuccessScript(w http.ResponseWriter,
 	w.WriteHeader(http.StatusOK)
 
 	if _, err := w.Write(s.successScriptData); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write script response").Log(r.Context(), s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write script response").LogError(r.Context(), s.logger)
 	}
 	return nil
 }
@@ -647,7 +647,7 @@ func (s *ExternalOAuthService) serveExternalSuccessStyle(w http.ResponseWriter, 
 	w.WriteHeader(http.StatusOK)
 
 	if _, err := w.Write(s.successStyleData); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write style response").Log(r.Context(), s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write style response").LogError(r.Context(), s.logger)
 	}
 	return nil
 }
@@ -665,18 +665,18 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 	// Get user session - try context first, then Gram-Session header
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		return oops.E(oops.CodeUnauthorized, nil, "authentication required").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, nil, "authentication required").LogError(ctx, s.logger)
 	}
 
 	// Parse query parameters - issuer is required for status check
 	toolsetIDStr := r.URL.Query().Get("toolset_id")
 	if toolsetIDStr == "" {
-		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").LogError(ctx, s.logger)
 	}
 
 	toolsetID, err := uuid.Parse(toolsetIDStr)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, s.logger)
 	}
 
 	// Load toolset to verify user has access
@@ -685,7 +685,7 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 	}
 
 	// Issuer-gated toolsets store upstream tokens in remote_sessions keyed
@@ -765,7 +765,7 @@ func (s *ExternalOAuthService) writeIssuerGatedStatus(ctx context.Context, w htt
 	case errors.Is(err, remotesessions.ErrNoValidToken):
 		// fall through with status="needs_auth"
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "resolve remote session").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "resolve remote session").LogError(ctx, s.logger)
 	case token != "":
 		status = "authenticated"
 	}
@@ -788,17 +788,17 @@ func (s *ExternalOAuthService) handleExternalDisconnect(w http.ResponseWriter, r
 	// Get user session - try context first, then Gram-Session header
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		return oops.E(oops.CodeUnauthorized, nil, "authentication required").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, nil, "authentication required").LogError(ctx, s.logger)
 	}
 
 	toolsetIDStr := r.URL.Query().Get("toolset_id")
 	if toolsetIDStr == "" {
-		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").LogError(ctx, s.logger)
 	}
 
 	toolsetID, err := uuid.Parse(toolsetIDStr)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, s.logger)
 	}
 
 	// Verify toolset belongs to caller's project before deleting the token
@@ -806,7 +806,7 @@ func (s *ExternalOAuthService) handleExternalDisconnect(w http.ResponseWriter, r
 		ID:        toolsetID,
 		ProjectID: *authCtx.ProjectID,
 	}); err != nil {
-		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 	}
 
 	// Delete token
@@ -815,7 +815,7 @@ func (s *ExternalOAuthService) handleExternalDisconnect(w http.ResponseWriter, r
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ToolsetID:      toolsetID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to disconnect OAuth").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to disconnect OAuth").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "OAuth token disconnected",
@@ -1297,7 +1297,7 @@ func (s *ExternalOAuthService) redirectWithError(w http.ResponseWriter, r *http.
 
 	parsed, err := url.Parse(redirectURI)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "invalid redirect URI").Log(r.Context(), s.logger)
+		return oops.E(oops.CodeUnexpected, err, "invalid redirect URI").LogError(r.Context(), s.logger)
 	}
 
 	// Defense-in-depth: validate redirect URI hostname is in the allowed list.

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -259,7 +259,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	// Extract MCP slug from URL path
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 
 	// Load toolset from MCP slug
@@ -268,7 +268,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load authorization details for mcp server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load authorization details for mcp server").LogError(ctx, s.logger)
 	}
 
 	// Parse authorization request
@@ -309,7 +309,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 		ID:        toolset.OauthProxyServerID.UUID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "OAuth proxy server not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "OAuth proxy server not found").LogError(ctx, s.logger)
 	}
 
 	// Get OAuth proxy providers for this toolset
@@ -318,10 +318,10 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 		ProjectID:          toolset.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "OAuth providers not configured").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "OAuth providers not configured").LogError(ctx, s.logger)
 	}
 	if len(availableProviders) == 0 {
-		return oops.E(oops.CodeUnexpected, nil, "OAuth providers not configured").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, nil, "OAuth providers not configured").LogError(ctx, s.logger)
 	}
 
 	// TODO: Eventually support multiple providers
@@ -332,7 +332,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	if provider.ProviderType == string(OAuthProxyProviderTypeCustom) {
 		var secrets map[string]string
 		if err := json.Unmarshal(provider.Secrets, &secrets); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "OAuth provider secrets invalid").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "OAuth provider secrets invalid").LogError(ctx, s.logger)
 		}
 
 		clientID = secrets["client_id"]
@@ -341,7 +341,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 		if clientID == "" && secrets["environment_slug"] != "" {
 			envMap, err := s.environments.Load(ctx, toolset.ProjectID, toolconfig.Slug(secrets["environment_slug"]))
 			if err != nil {
-				return oops.E(oops.CodeUnexpected, err, "failed to load environment").Log(ctx, s.logger)
+				return oops.E(oops.CodeUnexpected, err, "failed to load environment").LogError(ctx, s.logger)
 			}
 
 			for k, v := range envMap {
@@ -352,7 +352,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 		}
 
 		if clientID == "" {
-			return oops.E(oops.CodeUnexpected, nil, "OAuth provider client_id not configured").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, nil, "OAuth provider client_id not configured").LogError(ctx, s.logger)
 		}
 	}
 
@@ -372,7 +372,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 
 	oauthReqInfoJSON, err := json.Marshal(oauthReqInfo)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to encode OAuth request info").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to encode OAuth request info").LogError(ctx, s.logger)
 	}
 
 	callbackURL := fmt.Sprintf("%s/oauth/callback", s.serverURL.String())
@@ -388,19 +388,19 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 			ScopesSupported: provider.ScopesSupported,
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to build gram OAuth URL").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to build gram OAuth URL").LogError(ctx, s.logger)
 		}
 	default:
 		// For custom providers, build the URL directly
 		authURL, err = url.Parse(provider.AuthorizationEndpoint.String)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to parse OAuth authorization URL").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to parse OAuth authorization URL").LogError(ctx, s.logger)
 		}
 
 		// Generate PKCE for the upstream provider
 		upstreamCodeVerifier, err := generateCodeVerifier()
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to generate PKCE verifier").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to generate PKCE verifier").LogError(ctx, s.logger)
 		}
 		upstreamCodeChallenge := generateCodeChallenge(upstreamCodeVerifier)
 
@@ -411,12 +411,12 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 			Nonce:    pkceNonce,
 			Verifier: upstreamCodeVerifier,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to store upstream PKCE verifier").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to store upstream PKCE verifier").LogError(ctx, s.logger)
 		}
 		oauthReqInfo["upstream_pkce_nonce"] = pkceNonce
 		oauthReqInfoJSON, err = json.Marshal(oauthReqInfo)
 		if err != nil {
-			return oops.E(oops.CodeBadRequest, err, "failed to encode OAuth request info").Log(ctx, s.logger)
+			return oops.E(oops.CodeBadRequest, err, "failed to encode OAuth request info").LogError(ctx, s.logger)
 		}
 
 		urlParams := url.Values{}
@@ -467,7 +467,7 @@ func (s *Service) handleToken(w http.ResponseWriter, r *http.Request) error {
 
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 
 	toolset, fullMCPURL, err := s.loadToolsetFromCurrentURLContext(ctx, mcpSlug)
@@ -475,17 +475,17 @@ func (s *Service) handleToken(w http.ResponseWriter, r *http.Request) error {
 	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load token exchange details for mcp server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load token exchange details for mcp server").LogError(ctx, s.logger)
 	}
 
 	if err := r.ParseForm(); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to parse form data").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to parse form data").LogError(ctx, s.logger)
 	}
 
 	// Extract client credentials based on authentication method
 	clientID, clientSecret, err := s.extractClientCredentials(r)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid client authentication").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid client authentication").LogError(ctx, s.logger)
 	}
 
 	req := &TokenRequest{
@@ -506,11 +506,11 @@ func (s *Service) handleToken(w http.ResponseWriter, r *http.Request) error {
 	case "refresh_token":
 		token, err = s.tokenService.ExchangeRefreshToken(ctx, req, fullMCPURL, toolset.ID)
 	default:
-		return oops.E(oops.CodeBadRequest, nil, "unsupported grant type: %s", req.GrantType).Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "unsupported grant type: %s", req.GrantType).LogError(ctx, s.logger)
 	}
 
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "token exchange failed").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "token exchange failed").LogError(ctx, s.logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -527,7 +527,7 @@ func (s *Service) handleClientRegistration(w http.ResponseWriter, r *http.Reques
 
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
 	}
 
 	_, fullMcpURL, err := s.loadToolsetFromCurrentURLContext(ctx, mcpSlug)
@@ -535,12 +535,12 @@ func (s *Service) handleClientRegistration(w http.ResponseWriter, r *http.Reques
 	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load client registration details for mcp server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load client registration details for mcp server").LogError(ctx, s.logger)
 	}
 
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, s.logger)
 	}
 	// Create a new reader for JSON decoding
 	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
@@ -548,13 +548,13 @@ func (s *Service) handleClientRegistration(w http.ResponseWriter, r *http.Reques
 	// Parse JSON request
 	var req ClientInfo
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid JSON in request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid JSON in request body").LogError(ctx, s.logger)
 	}
 
 	// Register client
 	client, err := s.clientRegistration.RegisterClient(ctx, &req, fullMcpURL)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "client registration failed").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "client registration failed").LogError(ctx, s.logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -571,12 +571,12 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 
 	stateParam := r.URL.Query().Get("state")
 	if stateParam == "" {
-		return oops.E(oops.CodeBadRequest, nil, "state is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "state is required").LogError(ctx, s.logger)
 	}
 
 	var oauthReqInfo map[string]string
 	if err := json.Unmarshal([]byte(stateParam), &oauthReqInfo); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to decode OAuth request info from state").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to decode OAuth request info from state").LogError(ctx, s.logger)
 	}
 
 	// Backwards-compat shim for remote_session_clients whose upstream
@@ -607,12 +607,12 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 	mcpSlug := oauthReqInfo["mcp_slug"]
 	projectIDStr := oauthReqInfo["project_id"]
 	if mcpSlug == "" || projectIDStr == "" {
-		return oops.E(oops.CodeBadRequest, nil, "mcp slug and project id is required in context").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "mcp slug and project id is required in context").LogError(ctx, s.logger)
 	}
 
 	projectID, err := uuid.Parse(projectIDStr)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid project id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 	}
 
 	toolset, fullMCPURL, err := s.loadToolsetForProjectAndMCPSlug(ctx, projectID, mcpSlug)
@@ -620,12 +620,12 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 	case errors.Is(err, errToolsetNotFound), errors.Is(err, errCustomDomainNotFound):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load authorization details for mcp server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load authorization details for mcp server").LogError(ctx, s.logger)
 	}
 
 	externalCode := r.URL.Query().Get("code")
 	if externalCode == "" {
-		return oops.E(oops.CodeBadRequest, nil, "code is required").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, nil, "code is required").LogError(ctx, s.logger)
 	}
 
 	// Get OAuth proxy providers for this toolset
@@ -634,10 +634,10 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 		ProjectID:          toolset.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "OAuth providers not configured").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "OAuth providers not configured").LogError(ctx, s.logger)
 	}
 	if len(availableProviders) == 0 {
-		return oops.E(oops.CodeUnexpected, nil, "OAuth providers not configured").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, nil, "OAuth providers not configured").LogError(ctx, s.logger)
 	}
 
 	// TODO: Eventually support multiple providers
@@ -662,7 +662,7 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 		pkceKey := UpstreamPKCEVerifier{Nonce: pkceNonce, Verifier: ""}.CacheKey()
 		stored, err := s.upstreamPKCEStorage.Get(ctx, pkceKey)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to retrieve upstream PKCE verifier").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to retrieve upstream PKCE verifier").LogError(ctx, s.logger)
 		}
 		upstreamCodeVerifier = stored.Verifier
 		// Clean up after use
@@ -694,7 +694,7 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 		)
 		if buildErr != nil {
 			s.logger.ErrorContext(ctx, "failed to build error response URL", attr.SlogError(buildErr))
-			return oops.E(oops.CodeUnexpected, buildErr, "failed to build error response").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, buildErr, "failed to build error response").LogError(ctx, s.logger)
 		}
 
 		// Add defensive check for empty error description
@@ -712,7 +712,7 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			if err := s.failurePageTmpl.Execute(w, data); err != nil {
-				return oops.E(oops.CodeUnexpected, err, "failed to render oauth failure page").Log(ctx, s.logger)
+				return oops.E(oops.CodeUnexpected, err, "failed to render oauth failure page").LogError(ctx, s.logger)
 			}
 		} else {
 			http.Redirect(w, r, errorURL, http.StatusFound)
@@ -753,7 +753,7 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 	// Build authorization response and redirect back to client
 	responseURL, err := s.grantManager.BuildAuthorizationResponse(ctx, grant, authReq.RedirectURI)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to build authorization response").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "failed to build authorization response").LogError(ctx, s.logger)
 	}
 
 	if provider.ProviderType == string(OAuthProxyProviderTypeGram) {
@@ -766,7 +766,7 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if err := s.successPageTmpl.Execute(w, data); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to render oauth success page").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to render oauth success page").LogError(ctx, s.logger)
 		}
 	} else {
 		http.Redirect(w, r, responseURL, http.StatusFound)
@@ -798,7 +798,7 @@ func (s *Service) serveSuccessScript(w http.ResponseWriter, r *http.Request) err
 
 	_, err := w.Write(s.oauthStatusPageScriptData)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write script response").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to write script response").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -924,22 +924,22 @@ func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) er
 		sessionToken = r.Header.Get(constants.SessionHeader)
 	}
 	if _, err := s.sessions.Authenticate(ctx, sessionToken); err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "authentication required").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, err, "authentication required").LogError(ctx, s.logger)
 	}
 
 	if s.guardianPolicy == nil {
-		return oops.E(oops.CodeUnexpected, nil, "proxy register handler is not configured").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, nil, "proxy register handler is not configured").LogError(ctx, s.logger)
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, requestMaxBodyBytes)
 	var req ProxyRegisterRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid JSON in request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid JSON in request body").LogError(ctx, s.logger)
 	}
 
 	endpoint, err := url.Parse(req.RegistrationEndpoint)
 	if err != nil || (endpoint.Scheme != "http" && endpoint.Scheme != "https") || endpoint.Host == "" {
-		return oops.E(oops.CodeBadRequest, err, "invalid registration_endpoint").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid registration_endpoint").LogError(ctx, s.logger)
 	}
 
 	serverURL := s.serverURL.String()
@@ -961,7 +961,7 @@ func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) er
 
 	body, err := json.Marshal(dcrReq)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to marshal DCR request").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal DCR request").LogError(ctx, s.logger)
 	}
 
 	upstreamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -969,14 +969,14 @@ func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) er
 
 	httpReq, err := http.NewRequestWithContext(upstreamCtx, http.MethodPost, endpoint.String(), bytes.NewReader(body))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to create DCR request").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to create DCR request").LogError(ctx, s.logger)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
 
 	resp, err := s.guardianPolicy.Client().Do(httpReq)
 	if err != nil {
-		return oops.E(oops.CodeGatewayError, err, "failed to reach registration endpoint").Log(ctx, s.logger)
+		return oops.E(oops.CodeGatewayError, err, "failed to reach registration endpoint").LogError(ctx, s.logger)
 	}
 	defer o11y.LogDefer(ctx, s.logger, func() error {
 		if closeErr := resp.Body.Close(); closeErr != nil {
@@ -987,22 +987,22 @@ func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) er
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, requestMaxBodyBytes))
 	if err != nil {
-		return oops.E(oops.CodeGatewayError, err, "failed to read DCR response").Log(ctx, s.logger)
+		return oops.E(oops.CodeGatewayError, err, "failed to read DCR response").LogError(ctx, s.logger)
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		s.logger.ErrorContext(ctx, "DCR failed",
 			attr.SlogHTTPResponseStatusCode(resp.StatusCode),
 			attr.SlogHTTPResponseBody(string(respBody)))
-		return oops.E(oops.CodeGatewayError, nil, "registration endpoint returned %d", resp.StatusCode).Log(ctx, s.logger)
+		return oops.E(oops.CodeGatewayError, nil, "registration endpoint returned %d", resp.StatusCode).LogError(ctx, s.logger)
 	}
 
 	var dcrResp DCRResponse
 	if err := json.Unmarshal(respBody, &dcrResp); err != nil {
-		return oops.E(oops.CodeGatewayError, err, "invalid DCR response").Log(ctx, s.logger)
+		return oops.E(oops.CodeGatewayError, err, "invalid DCR response").LogError(ctx, s.logger)
 	}
 	if dcrResp.ClientID == "" {
-		return oops.E(oops.CodeGatewayError, nil, "DCR response missing client_id").Log(ctx, s.logger)
+		return oops.E(oops.CodeGatewayError, nil, "DCR response missing client_id").LogError(ctx, s.logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -117,16 +117,16 @@ func ResolveOAuthServerMetadataFromToolset(
 			ProjectID:          toolset.ProjectID,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to list OAuth proxy providers").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to list OAuth proxy providers").LogError(ctx, logger)
 		}
 		if len(providers) == 0 {
-			return nil, oops.E(oops.CodeNotFound, nil, "no OAuth proxy providers configured for server").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, nil, "no OAuth proxy providers configured for server").LogError(ctx, logger)
 		}
 		if len(providers) > 1 {
 			logger.ErrorContext(ctx, "multiple OAuth proxy providers per server is not supported",
 				attr.SlogOAuthProxyServerID(toolset.OauthProxyServerID.UUID.String()),
 				attr.SlogOAuthProviderCount(len(providers)))
-			return nil, oops.E(oops.CodeUnexpected, nil, "multiple OAuth proxy providers per server is not supported").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, nil, "multiple OAuth proxy providers per server is not supported").LogError(ctx, logger)
 		}
 		provider := providers[0]
 

--- a/server/internal/oops/pp.go
+++ b/server/internal/oops/pp.go
@@ -138,7 +138,7 @@ func (e *ShareableError) effectiveCode(ctx context.Context) Code {
 	return e.Code
 }
 
-// Log logs the error using the provided logger and context. It also sets the
+// LogError logs the error using the provided logger and context. It also sets the
 // OpenTelemetry span status to error. Additional arguments can be provided to
 // include more context in the log entry.
 //
@@ -147,7 +147,7 @@ func (e *ShareableError) effectiveCode(ctx context.Context) Code {
 // not mark the span as errored or record an exception, to avoid drowning real
 // faults in disconnect noise. Server- and application-initiated cancellations,
 // where the request context is still live, keep full error severity.
-func (e *ShareableError) Log(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+func (e *ShareableError) LogError(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
 	canceled := e.effectiveCode(ctx) == CodeCanceled
 
 	span := trace.SpanFromContext(ctx)

--- a/server/internal/oops/pp_test.go
+++ b/server/internal/oops/pp_test.go
@@ -29,7 +29,7 @@ func TestShareableError_Log_LogsAtError(t *testing.T) {
 	logger, logBuf := captureLogger()
 	ctx, recorder := startRecordedSpan(t)
 
-	_ = E(CodeNotFound, nil, "resource not found").Log(ctx, logger)
+	_ = E(CodeNotFound, nil, "resource not found").LogError(ctx, logger)
 
 	entries := parseLogEntries(t, logBuf)
 	require.Len(t, entries, 1)
@@ -53,7 +53,7 @@ func TestShareableError_Log_ClientCanceledLogsAtInfo(t *testing.T) {
 
 	// Wrap context.Canceled to prove detection is by sentinel, not identity.
 	cause := fmt.Errorf("list tool variations: %w", context.Canceled)
-	_ = E(CodeUnexpected, cause, "failed to list tool variations").Log(ctx, logger)
+	_ = E(CodeUnexpected, cause, "failed to list tool variations").LogError(ctx, logger)
 
 	entries := parseLogEntries(t, logBuf)
 	require.Len(t, entries, 1)
@@ -76,7 +76,7 @@ func TestShareableError_Log_AppCanceledWithLiveContextLogsAtError(t *testing.T) 
 	ctx, recorder := startRecordedSpan(t)
 
 	cause := fmt.Errorf("errgroup sibling: %w", context.Canceled)
-	_ = E(CodeUnexpected, cause, "failed to fan out").Log(ctx, logger)
+	_ = E(CodeUnexpected, cause, "failed to fan out").LogError(ctx, logger)
 
 	entries := parseLogEntries(t, logBuf)
 	require.Len(t, entries, 1)
@@ -94,7 +94,7 @@ func TestShareableError_Log_DeadlineExceededLogsAtError(t *testing.T) {
 	ctx, recorder := startRecordedSpan(t)
 
 	cause := fmt.Errorf("query row: %w", context.DeadlineExceeded)
-	_ = E(CodeUnexpected, cause, "query failed").Log(ctx, logger)
+	_ = E(CodeUnexpected, cause, "query failed").LogError(ctx, logger)
 
 	entries := parseLogEntries(t, logBuf)
 	require.Len(t, entries, 1)

--- a/server/internal/openapi/extract_speakeasy.go
+++ b/server/internal/openapi/extract_speakeasy.go
@@ -135,7 +135,7 @@ func (p *ToolExtractor) doSpeakeasy(
 
 	doc, err := parseSpeakeasy(ctx, tracer, bytes.NewReader(data))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "error opening openapi document.\n%s", err.Error()).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "error opening openapi document.\n%s", err.Error()).LogError(ctx, logger)
 	}
 
 	upgradeStart := time.Now()
@@ -167,13 +167,13 @@ func (p *ToolExtractor) doSpeakeasy(
 
 	globalSecurity, err := serializeSecuritySpeakeasy(doc.GetSecurity())
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "error serializing global security").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "error serializing global security").LogError(ctx, logger)
 	}
 
 	securitySchemesParams, errs := extractSecuritySchemesSpeakeasy(ctx, logger, docInfo, doc, task)
 	if len(errs) > 0 {
 		for _, err := range errs {
-			_ = oops.E(oops.CodeUnexpected, err, "%s: error parsing security schemes: %s", docInfo.Name, err.Error()).Log(ctx, logger)
+			_ = oops.E(oops.CodeUnexpected, err, "%s: error parsing security schemes: %s", docInfo.Name, err.Error()).LogError(ctx, logger)
 		}
 	}
 
@@ -183,7 +183,7 @@ func (p *ToolExtractor) doSpeakeasy(
 	for key, scheme := range securitySchemesParams {
 		sec, err := tx.CreateHTTPSecurity(ctx, *scheme)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "%s: error writing security scheme: %s", docInfo.Name, err.Error()).Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "%s: error writing security scheme: %s", docInfo.Name, err.Error()).LogError(ctx, logger)
 		}
 
 		securitySchemes[key] = sec
@@ -384,7 +384,7 @@ func (p *ToolExtractor) doSpeakeasy(
 
 	if writeErrCount > 0 {
 		err := oops.Permanent(fmt.Errorf("%s: error writing tools definitions: %w", docInfo.Name, writeErr))
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save %d tool definitions", writeErrCount).Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save %d tool definitions", writeErrCount).LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, fmt.Sprintf("[%s] processed OpenAPI source: %d tools created, %d tools skipped", docInfo.Name, toolCount, toolSkippedCount))
@@ -546,7 +546,7 @@ func extractDefaultServerSpeakeasy(ctx context.Context, logger *slog.Logger, doc
 
 			u, err := url.Parse(server.URL)
 			if err != nil {
-				_ = oops.E(oops.CodeUnauthorized, err, "%s: %s: skipping server due to malformed url [%d:%d]: %s", docInfo.Name, server.URL, line, col, err.Error()).Log(ctx, logger)
+				_ = oops.E(oops.CodeUnauthorized, err, "%s: %s: skipping server due to malformed url [%d:%d]: %s", docInfo.Name, server.URL, line, col, err.Error()).LogError(ctx, logger)
 				continue
 			}
 
@@ -1020,7 +1020,7 @@ func mergeDefs(ctx context.Context, logger *slog.Logger, a, b Defs) Defs {
 			aHash := hashing.Hash(a.GetOrZero(key))
 			bHash := hashing.Hash(val)
 			if aHash != bHash {
-				_ = oops.E(oops.CodeUnexpected, oops.Permanent(fmt.Errorf("hash mismatch for defs schema %s", key)), "hash mismatch for defs schema %s", key).Log(ctx, logger)
+				_ = oops.E(oops.CodeUnexpected, oops.Permanent(fmt.Errorf("hash mismatch for defs schema %s", key)), "hash mismatch for defs schema %s", key).LogError(ctx, logger)
 				continue
 			}
 		} else {

--- a/server/internal/openapi/process.go
+++ b/server/internal/openapi/process.go
@@ -136,7 +136,7 @@ func (p *ToolExtractor) Do(
 		"openapi doc id set", openapiDocID != uuid.Nil,
 		"doc info set", docInfo != nil && docInfo.Name != "" && docInfo.Slug != "",
 	); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, oops.Permanent(err), "unable to process openapi document").Log(ctx, p.logger)
+		return nil, oops.E(oops.CodeInvariantViolation, oops.Permanent(err), "unable to process openapi document").LogError(ctx, p.logger)
 	}
 
 	doc, readErr := readDoc(ctx, readDocParams{
@@ -151,7 +151,7 @@ func (p *ToolExtractor) Do(
 
 	dbtx, err := p.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error opening database transaction").Log(ctx, p.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error opening database transaction").LogError(ctx, p.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -198,7 +198,7 @@ func (p *ToolExtractor) Do(
 		Openapiv3DocumentID: openapiDocID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error clearing deployment http tools").Log(ctx, p.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error clearing deployment http tools").LogError(ctx, p.logger)
 	}
 	if deletedTools > 0 {
 		logger.InfoContext(ctx, "cleared http tools from previous deployment attempt", attr.SlogDBDeletedRowsCount(deletedTools))
@@ -210,7 +210,7 @@ func (p *ToolExtractor) Do(
 		Openapiv3DocumentID: uuid.NullUUID{UUID: openapiDocID, Valid: openapiDocID != uuid.Nil},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error clearing deployment http tools").Log(ctx, p.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error clearing deployment http tools").LogError(ctx, p.logger)
 	}
 	if deletedSecurity > 0 {
 		logger.InfoContext(ctx, "cleared http security from previous deployment attempt", attr.SlogDBDeletedRowsCount(deletedSecurity))
@@ -227,7 +227,7 @@ func (p *ToolExtractor) Do(
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "error saving processed deployment").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "error saving processed deployment").LogError(ctx, logger)
 	}
 
 	return res, nil
@@ -410,7 +410,7 @@ func readDoc(ctx context.Context, params readDocParams) ([]byte, error) {
 			oops.CodeUnexpected,
 			err,
 			"error fetching openapi document",
-		).Log(ctx, params.logger)
+		).LogError(ctx, params.logger)
 	}
 
 	defer o11y.LogDefer(ctx, params.logger, func() error {
@@ -423,7 +423,7 @@ func readDoc(ctx context.Context, params readDocParams) ([]byte, error) {
 			oops.CodeUnexpected,
 			err,
 			"error reading openapi document",
-		).Log(ctx, params.logger)
+		).LogError(ctx, params.logger)
 	}
 
 	return doc, nil

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -171,7 +171,7 @@ func (s *Service) Get(ctx context.Context, _ *gen.GetPayload) (res *gen.Organiza
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").LogError(ctx, s.logger)
 	}
 
 	return &gen.Organization{
@@ -210,7 +210,7 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 
 	emailDomain, ok := inviteEmailDomain(normalizedEmail)
 	if !ok {
-		return nil, oops.E(oops.CodeBadRequest, nil, "email must be a valid email address").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "email must be a valid email address").LogError(ctx, logger)
 	}
 
 	_, err = userrepo.New(s.db).GetConnectedUserByEmail(ctx, userrepo.GetConnectedUserByEmailParams{
@@ -219,15 +219,15 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 	})
 	switch {
 	case err == nil:
-		return nil, oops.E(oops.CodeConflict, nil, "user is already a member of this organization").Log(ctx, logger)
+		return nil, oops.E(oops.CodeConflict, nil, "user is already a member of this organization").LogError(ctx, logger)
 	case errors.Is(err, pgx.ErrNoRows):
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "check organization membership").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "check organization membership").LogError(ctx, logger)
 	}
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "get organization metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get organization metadata").LogError(ctx, logger)
 	}
 	if workosOrgID := conv.FromPGTextOrEmpty[string](org.WorkosID); workosOrgID != "" {
 		if err := s.ensureInviteEmailDomainAllowed(ctx, logger, workosOrgID, emailDomain); err != nil {
@@ -237,7 +237,7 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 
 	rawToken, tokenHash, err := generateInviteToken()
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "generate invite token").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "generate invite token").LogError(ctx, logger)
 	}
 
 	roleSlug := pgtype.Text{String: "", Valid: false}
@@ -253,7 +253,7 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 	// a concurrent request cannot slip in between and claim the unique index.
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // rollback is no-op after commit
 
@@ -266,7 +266,7 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 		OrganizationID: ac.ActiveOrganizationID,
 		Email:          normalizedEmail,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "expire stale invitations").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "expire stale invitations").LogError(ctx, logger)
 	}
 
 	row, err := txRepo.CreateInvitation(ctx, orgrepo.CreateInvitationParams{
@@ -280,9 +280,9 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == "organization_invitations_org_email_pending_key" {
-			return nil, oops.E(oops.CodeConflict, nil, "an invitation is already pending for this email").Log(ctx, logger)
+			return nil, oops.E(oops.CodeConflict, nil, "an invitation is already pending for this email").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "create invitation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create invitation").LogError(ctx, logger)
 	}
 	span.SetAttributes(attr.OrganizationInviteID(row.ID.String()))
 	span.AddEvent("invite.created", trace.WithAttributes(
@@ -299,14 +299,14 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 		InviteeEmail:     row.Email,
 		RoleSlug:         conv.FromPGText[string](row.RoleSlug),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log organization invitation creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log organization invitation creation").LogError(ctx, logger)
 	}
 
 	inviteLink := ""
 	if s.email != nil {
 		inviteURL, err := url.Parse(s.serverURL + inviteCallbackPath)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "build invite link").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "build invite link").LogError(ctx, logger)
 		}
 		q := inviteURL.Query()
 		q.Set("invite_token", rawToken)
@@ -315,7 +315,7 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit invitation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit invitation").LogError(ctx, logger)
 	}
 
 	if s.email != nil {
@@ -347,7 +347,7 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 			// Revoke the invite so the user can retry — the invitee never
 			// received the invite link so the invite is useless.
 			_ = orgrepo.New(s.db).RevokeInvitation(ctx, row.ID)
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to send invite email").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to send invite email").LogError(ctx, logger)
 		}
 		span.AddEvent("invite.email_sent")
 	}
@@ -358,7 +358,7 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 func (s *Service) ensureInviteEmailDomainAllowed(ctx context.Context, logger *slog.Logger, workosOrgID string, emailDomain string) error {
 	policy, err := s.orgs.GetOrganizationDomainPolicy(ctx, workosOrgID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "get organization trusted domains").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "get organization trusted domains").LogError(ctx, logger)
 	}
 	if policy == nil {
 		return nil
@@ -381,12 +381,12 @@ func (s *Service) ensureInviteEmailDomainAllowed(ctx context.Context, logger *sl
 		return nil
 	}
 
-	return oops.E(oops.CodeBadRequest, nil, "invite email must use one of this organization's trusted domains: %s", strings.Join(trustedDomains, ", ")).Log(ctx, logger)
+	return oops.E(oops.CodeBadRequest, nil, "invite email must use one of this organization's trusted domains: %s", strings.Join(trustedDomains, ", ")).LogError(ctx, logger)
 }
 
 func (s *Service) resolveInviteRoleSlug(ctx context.Context, organizationID string, roleID string, logger *slog.Logger) (pgtype.Text, error) {
 	if strings.TrimSpace(roleID) == "" {
-		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role id is required").Log(ctx, logger)
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role id is required").LogError(ctx, logger)
 	}
 
 	// The dashboard sends a Gram local role UUID (as returned by
@@ -394,7 +394,7 @@ func (s *Service) resolveInviteRoleSlug(ctx context.Context, organizationID stri
 	// recover the WorkOS slug stored on the invite for acceptance time.
 	roleUUID, err := uuid.Parse(roleID)
 	if err != nil {
-		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role not found").Log(ctx, logger)
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role not found").LogError(ctx, logger)
 	}
 
 	role, err := accessrepo.New(s.db).GetOrganizationRoleByID(ctx, accessrepo.GetOrganizationRoleByIDParams{
@@ -403,9 +403,9 @@ func (s *Service) resolveInviteRoleSlug(ctx context.Context, organizationID stri
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role not found").Log(ctx, logger)
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role not found").LogError(ctx, logger)
 	case err != nil:
-		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeUnexpected, err, "get role for invite").Log(ctx, logger)
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeUnexpected, err, "get role for invite").LogError(ctx, logger)
 	}
 
 	return conv.ToPGText(role.WorkosSlug), nil
@@ -435,12 +435,12 @@ func (s *Service) RevokeInvite(ctx context.Context, payload *gen.RevokeInvitePay
 
 	inviteID, err := uuid.Parse(payload.InvitationID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid invitation id").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid invitation id").LogError(ctx, logger)
 	}
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -448,12 +448,12 @@ func (s *Service) RevokeInvite(ctx context.Context, payload *gen.RevokeInvitePay
 	invite, err := txRepo.GetInvitationByID(ctx, inviteID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return oops.C(oops.CodeNotFound).Log(ctx, logger)
+		return oops.C(oops.CodeNotFound).LogError(ctx, logger)
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "get invitation").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "get invitation").LogError(ctx, logger)
 	}
 	if invite.OrganizationID != ac.ActiveOrganizationID {
-		return oops.E(oops.CodeForbidden, nil, "invitation does not belong to this organization").Log(ctx, logger)
+		return oops.E(oops.CodeForbidden, nil, "invitation does not belong to this organization").LogError(ctx, logger)
 	}
 
 	span.SetAttributes(
@@ -470,7 +470,7 @@ func (s *Service) RevokeInvite(ctx context.Context, payload *gen.RevokeInvitePay
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "revoke invitation").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "revoke invitation").LogError(ctx, logger)
 	}
 
 	afterSnapshot := dbInvitationToGen(&row, conv.FromPGText[string](row.InviterUserID))
@@ -484,11 +484,11 @@ func (s *Service) RevokeInvite(ctx context.Context, payload *gen.RevokeInvitePay
 		InvitationSnapshotBefore: beforeSnapshot,
 		InvitationSnapshotAfter:  afterSnapshot,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log organization invitation revocation").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log organization invitation revocation").LogError(ctx, logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit invitation revocation").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit invitation revocation").LogError(ctx, logger)
 	}
 
 	span.AddEvent("invite.revoked")
@@ -521,25 +521,25 @@ func (s *Service) UpdateInviteRole(ctx context.Context, payload *gen.UpdateInvit
 
 	inviteID, err := uuid.Parse(payload.InvitationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid invitation id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid invitation id").LogError(ctx, logger)
 	}
 
 	repo := orgrepo.New(s.db)
 	invite, err := repo.GetInvitationByID(ctx, inviteID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.C(oops.CodeNotFound).Log(ctx, logger)
+		return nil, oops.C(oops.CodeNotFound).LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "get invitation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get invitation").LogError(ctx, logger)
 	}
 	if invite.OrganizationID != ac.ActiveOrganizationID {
-		return nil, oops.E(oops.CodeForbidden, nil, "invitation does not belong to this organization").Log(ctx, logger)
+		return nil, oops.E(oops.CodeForbidden, nil, "invitation does not belong to this organization").LogError(ctx, logger)
 	}
 	if invite.State != "pending" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "invitation is not pending").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "invitation is not pending").LogError(ctx, logger)
 	}
 	if invite.ExpiresAt.Valid && !invite.ExpiresAt.Time.After(time.Now()) {
-		return nil, oops.E(oops.CodeBadRequest, nil, "invitation is expired").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "invitation is expired").LogError(ctx, logger)
 	}
 
 	roleSlug, err := s.resolveInviteRoleSlug(ctx, ac.ActiveOrganizationID, payload.RoleID, logger)
@@ -549,7 +549,7 @@ func (s *Service) UpdateInviteRole(ctx context.Context, payload *gen.UpdateInvit
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -562,9 +562,9 @@ func (s *Service) UpdateInviteRole(ctx context.Context, payload *gen.UpdateInvit
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.C(oops.CodeNotFound).Log(ctx, logger)
+		return nil, oops.C(oops.CodeNotFound).LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "update invitation role").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update invitation role").LogError(ctx, logger)
 	}
 
 	afterSnapshot := dbInvitationToGen(&row, conv.FromPGText[string](row.InviterUserID))
@@ -578,11 +578,11 @@ func (s *Service) UpdateInviteRole(ctx context.Context, payload *gen.UpdateInvit
 		InvitationSnapshotBefore: beforeSnapshot,
 		InvitationSnapshotAfter:  afterSnapshot,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log organization invitation role update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log organization invitation role update").LogError(ctx, logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit invitation role update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit invitation role update").LogError(ctx, logger)
 	}
 
 	span.AddEvent("invite.role_updated", trace.WithAttributes(attr.OrganizationInviteRoleSlug(roleSlug.String)))
@@ -611,7 +611,7 @@ func (s *Service) ListInvites(ctx context.Context, _ *gen.ListInvitesPayload) (*
 
 	rows, err := orgrepo.New(s.db).ListPendingInvitations(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list invitations").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list invitations").LogError(ctx, logger)
 	}
 
 	out := make([]*gen.OrganizationInvitation, 0, len(rows))
@@ -642,7 +642,7 @@ func (s *Service) ListUsers(ctx context.Context, _ *gen.ListUsersPayload) (*gen.
 
 	rows, err := orgrepo.New(s.db).ListOrganizationUsers(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list organization users").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list organization users").LogError(ctx, s.logger)
 	}
 
 	out := make([]*gen.OrganizationUser, 0, len(rows))
@@ -667,7 +667,7 @@ func (s *Service) RemoveUser(ctx context.Context, payload *gen.RemoveUserPayload
 	}
 
 	if payload.UserID == ac.UserID {
-		return oops.E(oops.CodeBadRequest, nil, "cannot remove yourself from the organization").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "cannot remove yourself from the organization").LogError(ctx, logger)
 	}
 
 	trace.SpanFromContext(ctx).SetAttributes(
@@ -677,7 +677,7 @@ func (s *Service) RemoveUser(ctx context.Context, payload *gen.RemoveUserPayload
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -689,21 +689,21 @@ func (s *Service) RemoveUser(ctx context.Context, payload *gen.RemoveUserPayload
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return oops.E(oops.CodeNotFound, nil, "user is not a member of this organization").Log(ctx, logger)
+		return oops.E(oops.CodeNotFound, nil, "user is not a member of this organization").LogError(ctx, logger)
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "get organization user relationship").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "get organization user relationship").LogError(ctx, logger)
 	}
 
 	if err := qtx.DeleteOrganizationUserRelationship(ctx, orgrepo.DeleteOrganizationUserRelationshipParams{
 		OrganizationID: ac.ActiveOrganizationID,
 		UserID:         conv.ToPGText(payload.UserID),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete organization user relationship").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete organization user relationship").LogError(ctx, logger)
 	}
 
 	if rel.WorkosMembershipID.Valid && rel.WorkosMembershipID.String != "" {
 		if err := s.orgs.DeleteOrganizationMembership(ctx, rel.WorkosMembershipID.String); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "remove user").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "remove user").LogError(ctx, logger)
 		}
 	} else {
 		s.logger.DebugContext(ctx, "skipping WorkOS membership delete: no workos_membership_id on relationship",
@@ -714,7 +714,7 @@ func (s *Service) RemoveUser(ctx context.Context, payload *gen.RemoveUserPayload
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil
@@ -723,7 +723,7 @@ func (s *Service) RemoveUser(ctx context.Context, payload *gen.RemoveUserPayload
 func (s *Service) EnableWebhooks(ctx context.Context, payload *gen.EnableWebhooksPayload) (err error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -735,7 +735,7 @@ func (s *Service) EnableWebhooks(ctx context.Context, payload *gen.EnableWebhook
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to read organization details").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to read organization details").LogError(ctx, s.logger)
 	}
 
 	appID := conv.FromPGTextOrEmpty[string](org.SvixAppID)
@@ -749,20 +749,20 @@ func (s *Service) EnableWebhooks(ctx context.Context, payload *gen.EnableWebhook
 			ThrottleRate: nil,
 		}, nil)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to create or get webhook connection").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to create or get webhook connection").LogError(ctx, logger)
 		}
 		appID = app.Id
 	}
 
 	if appID == "" {
-		return oops.E(oops.CodeUnexpected, nil, "malformed webhook connection details").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, nil, "malformed webhook connection details").LogError(ctx, logger)
 	}
 
 	logger = logger.With(attr.SlogOrganizationID(orgID), attr.SlogSvixAppID(appID))
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to access organization details").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to access organization details").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -782,10 +782,10 @@ func (s *Service) EnableWebhooks(ctx context.Context, payload *gen.EnableWebhook
 	case errors.Is(err, pgx.ErrNoRows):
 		stored := conv.FromPGTextOrEmpty[string](row.SvixAppID)
 		if stored != appID {
-			return oops.E(oops.CodeUnexpected, nil, "failed to find organization details to update").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, nil, "failed to find organization details to update").LogError(ctx, logger)
 		}
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to store webhook connection details").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to store webhook connection details").LogError(ctx, logger)
 	}
 
 	if updated {
@@ -798,12 +798,12 @@ func (s *Service) EnableWebhooks(ctx context.Context, payload *gen.EnableWebhook
 			OrganizationSlug: org.Slug,
 			WebhooksEnabled:  row.WebhooksEnabled.Bool,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to log webhook toggle event").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to log webhook toggle event").LogError(ctx, logger)
 		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to save webhook connection details").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to save webhook connection details").LogError(ctx, logger)
 	}
 
 	return nil
@@ -812,7 +812,7 @@ func (s *Service) EnableWebhooks(ctx context.Context, payload *gen.EnableWebhook
 func (s *Service) DisableWebhooks(ctx context.Context, payload *gen.DisableWebhooksPayload) (err error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -824,13 +824,13 @@ func (s *Service) DisableWebhooks(ctx context.Context, payload *gen.DisableWebho
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to access organization details").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to access organization details").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to read organization details").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to read organization details").LogError(ctx, logger)
 	}
 
 	var updated bool
@@ -844,7 +844,7 @@ func (s *Service) DisableWebhooks(ctx context.Context, payload *gen.DisableWebho
 	case errors.Is(err, pgx.ErrNoRows):
 		// Org didn't have svix app id to begin with, effectively a noop
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to store webhook connection details").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to store webhook connection details").LogError(ctx, logger)
 	}
 
 	if updated {
@@ -857,12 +857,12 @@ func (s *Service) DisableWebhooks(ctx context.Context, payload *gen.DisableWebho
 			OrganizationSlug: org.Slug,
 			WebhooksEnabled:  row.WebhooksEnabled.Bool,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to log webhook toggle event").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to log webhook toggle event").LogError(ctx, logger)
 		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to save webhook connection details").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to save webhook connection details").LogError(ctx, logger)
 	}
 
 	return nil
@@ -871,7 +871,7 @@ func (s *Service) DisableWebhooks(ctx context.Context, payload *gen.DisableWebho
 func (s *Service) CreatePortalSession(ctx context.Context, payload *gen.CreatePortalSessionPayload) (res *gen.CreatePortalSessionResult, err error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	// See note below on why we use this pointer to a slice. It's also partly
@@ -892,7 +892,7 @@ func (s *Service) CreatePortalSession(ctx context.Context, payload *gen.CreatePo
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").LogError(ctx, logger)
 	}
 
 	appID := conv.FromPGTextOrEmpty[string](org.SvixAppID)
@@ -914,7 +914,7 @@ func (s *Service) CreatePortalSession(ctx context.Context, payload *gen.CreatePo
 		SessionId:    nil,
 	}, nil)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create webhook portal session").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create webhook portal session").LogError(ctx, logger)
 	}
 
 	return &gen.CreatePortalSessionResult{
@@ -926,7 +926,7 @@ func (s *Service) CreatePortalSession(ctx context.Context, payload *gen.CreatePo
 func (s *Service) GetOnboardingStatus(ctx context.Context, payload *gen.GetOnboardingStatusPayload) (*gen.OnboardingStatusResult, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -935,7 +935,7 @@ func (s *Service) GetOnboardingStatus(ctx context.Context, payload *gen.GetOnboa
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").LogError(ctx, s.logger)
 	}
 
 	workosOrgID := conv.FromPGTextOrEmpty[string](org.WorkosID)
@@ -945,12 +945,12 @@ func (s *Service) GetOnboardingStatus(ctx context.Context, payload *gen.GetOnboa
 
 	connections, err := s.orgs.ListConnections(ctx, workosOrgID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to check SSO connections").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to check SSO connections").LogError(ctx, s.logger)
 	}
 
 	directories, err := s.orgs.ListDirectories(ctx, workosOrgID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to check directory sync").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to check directory sync").LogError(ctx, s.logger)
 	}
 
 	return &gen.OnboardingStatusResult{
@@ -964,7 +964,7 @@ const verifyOnboardingHooksLimit = 50
 func (s *Service) VerifyOnboardingHooksSetup(ctx context.Context, payload *gen.VerifyOnboardingHooksSetupPayload) (*gen.VerifyOnboardingHooksSetupResult, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -981,7 +981,7 @@ func (s *Service) VerifyOnboardingHooksSetup(ctx context.Context, payload *gen.V
 	if payload.SinceUnixNano != nil && *payload.SinceUnixNano != "" {
 		parsed, parseErr := strconv.ParseInt(*payload.SinceUnixNano, 10, 64)
 		if parseErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid since_unix_nano cursor").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid since_unix_nano cursor").LogError(ctx, s.logger)
 		}
 		if parsed > 0 {
 			sinceUnixNano = parsed
@@ -990,7 +990,7 @@ func (s *Service) VerifyOnboardingHooksSetup(ctx context.Context, payload *gen.V
 
 	projects, err := projectsrepo.New(s.db).ListProjectsByOrganization(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list projects for organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list projects for organization").LogError(ctx, s.logger)
 	}
 
 	if len(projects) == 0 {
@@ -1011,12 +1011,12 @@ func (s *Service) VerifyOnboardingHooksSetup(ctx context.Context, payload *gen.V
 		Limit:         verifyOnboardingHooksLimit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to read recent hook events").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to read recent hook events").LogError(ctx, s.logger)
 	}
 
 	total, err := s.hooks.CountRecentHookEventsForOnboarding(ctx, projectIDs, sinceUnixNano)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to count recent hook events").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to count recent hook events").LogError(ctx, s.logger)
 	}
 
 	events := make([]*gen.OnboardingHookEvent, 0, len(rows))
@@ -1129,7 +1129,7 @@ func (s *Service) handleSetupCallback(w http.ResponseWriter, r *http.Request) {
 func (s *Service) SendEnterpriseAdminOnboardingEmail(ctx context.Context, payload *gen.SendEnterpriseAdminOnboardingEmailPayload) (*gen.SendEnterpriseAdminOnboardingEmailResult, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -1137,12 +1137,12 @@ func (s *Service) SendEnterpriseAdminOnboardingEmail(ctx context.Context, payloa
 	}
 
 	if s.email == nil {
-		return nil, oops.E(oops.CodeUnexpected, nil, "email service not configured").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, nil, "email service not configured").LogError(ctx, s.logger)
 	}
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").LogError(ctx, s.logger)
 	}
 
 	setupLink := fmt.Sprintf("%s/%s/setup", strings.TrimRight(s.siteURL, "/"), org.Slug)
@@ -1156,7 +1156,7 @@ func (s *Service) SendEnterpriseAdminOnboardingEmail(ctx context.Context, payloa
 			continue
 		}
 		if err := s.email.Send(ctx, recipient, tmpl); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to send onboarding email to %s", recipient).Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to send onboarding email to %s", recipient).LogError(ctx, s.logger)
 		}
 		sent++
 	}
@@ -1170,7 +1170,7 @@ func (s *Service) SendEnterpriseAdminOnboardingEmail(ctx context.Context, payloa
 func (s *Service) GenerateWorkOSAdminPortalLink(ctx context.Context, payload *gen.GenerateWorkOSAdminPortalLinkPayload) (res *gen.GenerateWorkOSAdminPortalLinkResult, err error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -1179,7 +1179,7 @@ func (s *Service) GenerateWorkOSAdminPortalLink(ctx context.Context, payload *ge
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").LogError(ctx, s.logger)
 	}
 
 	workosOrgID := conv.FromPGTextOrEmpty[string](org.WorkosID)
@@ -1216,7 +1216,7 @@ func (s *Service) GenerateWorkOSAdminPortalLink(ctx context.Context, payload *ge
 
 	link, err := s.orgs.GenerateAdminPortalLink(ctx, workosOrgID, workos.PortalIntent(payload.Intent), opts)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate WorkOS admin portal link").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate WorkOS admin portal link").LogError(ctx, s.logger)
 	}
 
 	return &gen.GenerateWorkOSAdminPortalLinkResult{
@@ -1227,7 +1227,7 @@ func (s *Service) GenerateWorkOSAdminPortalLink(ctx context.Context, payload *ge
 func (s *Service) authContext(ctx context.Context) (*contextvalues.AuthContext, error) {
 	ac, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || ac == nil {
-		return nil, oops.E(oops.CodeUnauthorized, errors.New("missing auth context"), "missing auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, errors.New("missing auth context"), "missing auth context").LogError(ctx, s.logger)
 	}
 
 	return ac, nil
@@ -1236,15 +1236,15 @@ func (s *Service) authContext(ctx context.Context) (*contextvalues.AuthContext, 
 func (s *Service) orgContext(ctx context.Context) (*contextvalues.AuthContext, string, error) {
 	ac, err := s.authContext(ctx)
 	if err != nil {
-		return nil, "", oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, "", oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
 
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, "", oops.E(oops.CodeUnexpected, err, "get organization metadata").Log(ctx, s.logger)
+		return nil, "", oops.E(oops.CodeUnexpected, err, "get organization metadata").LogError(ctx, s.logger)
 	}
 	if !org.WorkosID.Valid || org.WorkosID.String == "" {
-		return nil, "", oops.E(oops.CodeBadRequest, nil, "organization is not linked to WorkOS").Log(ctx, s.logger)
+		return nil, "", oops.E(oops.CodeBadRequest, nil, "organization is not linked to WorkOS").LogError(ctx, s.logger)
 	}
 	trace.SpanFromContext(ctx).SetAttributes(
 		attr.OrganizationID(ac.ActiveOrganizationID),

--- a/server/internal/otelforwarding/impl.go
+++ b/server/internal/otelforwarding/impl.go
@@ -124,7 +124,7 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -149,11 +149,11 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 		SnapshotBefore:   beforeSnap,
 		SnapshotAfter:    &afterSnap,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log otel forwarding upsert").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log otel forwarding upsert").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit otel forwarding upsert").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit otel forwarding upsert").LogError(ctx, logger)
 	}
 
 	s.client.RefreshCache(ctx, cfg)
@@ -182,7 +182,7 @@ func (s *Service) DeleteConfig(ctx context.Context, _ *gen.DeleteConfigPayload) 
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -197,11 +197,11 @@ func (s *Service) DeleteConfig(ctx context.Context, _ *gen.DeleteConfigPayload) 
 		ActorSlug:        nil,
 		ConfigURN:        urn.NewOtelForwardingConfig(row.ID),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log otel forwarding delete").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log otel forwarding delete").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit otel forwarding delete").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit otel forwarding delete").LogError(ctx, logger)
 	}
 
 	s.client.InvalidateCache(ctx, authCtx.ActiveOrganizationID)

--- a/server/internal/packages/impl.go
+++ b/server/internal/packages/impl.go
@@ -84,7 +84,7 @@ func (s *Service) ListPackages(ctx context.Context, form *gen.ListPackagesPayloa
 
 	packages, err := s.repo.ListPackages(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing packages").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing packages").LogError(ctx, logger)
 	}
 
 	result := &gen.ListPackagesResult{
@@ -138,7 +138,7 @@ func (s *Service) CreatePackage(ctx context.Context, form *gen.CreatePackagePayl
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing packages").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing packages").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -155,7 +155,7 @@ func (s *Service) CreatePackage(ctx context.Context, form *gen.CreatePackagePayl
 	if form.ImageAssetID != nil {
 		imgasset, err := uuid.Parse(*form.ImageAssetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeInvalid, err, "image id is not a valid uuid").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvalid, err, "image id is not a valid uuid").LogError(ctx, logger)
 		}
 
 		imageAssetID = uuid.NullUUID{UUID: imgasset, Valid: imgasset != uuid.Nil}
@@ -165,7 +165,7 @@ func (s *Service) CreatePackage(ctx context.Context, form *gen.CreatePackagePayl
 	if form.Description != nil {
 		html, err := conv.MarkdownToHTML([]byte(*form.Description))
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error converting markdown to html").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error converting markdown to html").LogError(ctx, logger)
 		}
 
 		descriptionHTML = new(string(html))
@@ -184,11 +184,11 @@ func (s *Service) CreatePackage(ctx context.Context, form *gen.CreatePackagePayl
 		ImageAssetID:    imageAssetID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error creating package").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating package").LogError(ctx, logger)
 	}
 
 	if packageID == uuid.Nil {
-		return nil, oops.E(oops.CodeInvariantViolation, nil, "error retrieving package id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, nil, "error retrieving package id").LogError(ctx, logger)
 	}
 
 	nullID := uuid.NullUUID{UUID: packageID, Valid: true}
@@ -198,7 +198,7 @@ func (s *Service) CreatePackage(ctx context.Context, form *gen.CreatePackagePayl
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving package").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving package").LogError(ctx, logger)
 	}
 
 	return &gen.CreatePackageResult{Package: pkg}, nil
@@ -218,14 +218,14 @@ func (s *Service) UpdatePackage(ctx context.Context, form *gen.UpdatePackagePayl
 
 	pkgID, err := uuid.Parse(form.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "error parsing package id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "error parsing package id").LogError(ctx, logger)
 	}
 
 	imageAssetID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
 	if form.ImageAssetID != nil {
 		imgasset, err := uuid.Parse(*form.ImageAssetID)
 		if err != nil {
-			return nil, oops.E(oops.CodeInvalid, err, "image id is not a valid uuid").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvalid, err, "image id is not a valid uuid").LogError(ctx, logger)
 		}
 
 		imageAssetID = uuid.NullUUID{UUID: imgasset, Valid: imgasset != uuid.Nil}
@@ -235,7 +235,7 @@ func (s *Service) UpdatePackage(ctx context.Context, form *gen.UpdatePackagePayl
 	if form.Description != nil {
 		html, err := conv.MarkdownToHTML([]byte(*form.Description))
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error converting markdown to html").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error converting markdown to html").LogError(ctx, logger)
 		}
 
 		descriptionHTML = new(string(html))
@@ -243,7 +243,7 @@ func (s *Service) UpdatePackage(ctx context.Context, form *gen.UpdatePackagePayl
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing packages").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing packages").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -265,11 +265,11 @@ func (s *Service) UpdatePackage(ctx context.Context, form *gen.UpdatePackagePayl
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "error updating package").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error updating package").LogError(ctx, logger)
 	}
 
 	if err := inv.Check("package update result", "id is set", id != uuid.Nil); err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "error updating package").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "error updating package").LogError(ctx, logger)
 	}
 
 	pkg, err := describePackage(ctx, logger, tx, ProjectID(*authCtx.ProjectID), NullablePackageID(uuid.NullUUID{UUID: id, Valid: true}), NullablePackageName(nil))
@@ -278,7 +278,7 @@ func (s *Service) UpdatePackage(ctx context.Context, form *gen.UpdatePackagePayl
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving package").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving package").LogError(ctx, logger)
 	}
 
 	return &gen.UpdatePackageResult{Package: pkg}, nil
@@ -298,7 +298,7 @@ func (s *Service) ListVersions(ctx context.Context, form *gen.ListVersionsPayloa
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing package versions").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing package versions").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -319,7 +319,7 @@ func (s *Service) ListVersions(ctx context.Context, form *gen.ListVersionsPayloa
 		ProjectID:   *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing versions").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing versions").LogError(ctx, logger)
 	}
 
 	versions := make([]*gen.PackageVersion, 0, len(versionRows))
@@ -363,12 +363,12 @@ func (s *Service) Publish(ctx context.Context, form *gen.PublishPayload) (res *g
 
 	semver, err := semver.ParseSemver(form.Version)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "error parsing version").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "error parsing version").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing packages").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing packages").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -378,7 +378,7 @@ func (s *Service) Publish(ctx context.Context, form *gen.PublishPayload) (res *g
 
 	depID, err := uuid.Parse(form.DeploymentID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "error parsing deployment id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "error parsing deployment id").LogError(ctx, logger)
 	}
 
 	pkgID, err := tx.PokePackageByName(ctx, repo.PokePackageByNameParams{
@@ -386,11 +386,11 @@ func (s *Service) Publish(ctx context.Context, form *gen.PublishPayload) (res *g
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error reading package data").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error reading package data").LogError(ctx, logger)
 	}
 
 	if pkgID == uuid.Nil {
-		return nil, oops.E(oops.CodeNotFound, nil, "package not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, nil, "package not found").LogError(ctx, logger)
 	}
 
 	row, err := tx.CreatePackageVersion(ctx, repo.CreatePackageVersionParams{
@@ -404,7 +404,7 @@ func (s *Service) Publish(ctx context.Context, form *gen.PublishPayload) (res *g
 		Visibility:   form.Visibility,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error creating package version").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating package version").LogError(ctx, logger)
 	}
 
 	pid := uuid.NullUUID{UUID: pkgID, Valid: true}
@@ -414,7 +414,7 @@ func (s *Service) Publish(ctx context.Context, form *gen.PublishPayload) (res *g
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving package version").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving package version").LogError(ctx, logger)
 	}
 
 	return &gen.PublishPackageResult{
@@ -448,7 +448,7 @@ func describePackage(
 		ProjectID:   uuid.UUID(projectID),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting package with latest version").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting package with latest version").LogError(ctx, logger)
 	}
 
 	var deletedAt *string

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -185,17 +185,17 @@ func (s *Service) ExecuteTool(ctx context.Context, plan *gateway.ToolCallPlan, e
 	}
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		return nil, oops.E(oops.CodeUnauthorized, nil, "platform tool requires project auth context").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnauthorized, nil, "platform tool requires project auth context").LogError(ctx, s.logger)
 	}
 	if authCtx.ProjectID.String() != plan.Descriptor.ProjectID {
-		return nil, oops.E(oops.CodeForbidden, nil, "platform tool auth context does not match project").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeForbidden, nil, "platform tool auth context does not match project").LogError(ctx, s.logger)
 	}
 
 	urnStr := plan.Descriptor.URN.String()
 
 	if feature, gated := s.featureGates[urnStr]; gated && s.featureChecker != nil {
 		if !s.featureChecker(ctx, authCtx.ActiveOrganizationID, feature) {
-			return nil, oops.E(oops.CodeNotFound, nil, "platform tool not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, nil, "platform tool not found").LogError(ctx, s.logger)
 		}
 	}
 
@@ -216,7 +216,7 @@ func (s *Service) ExecuteTool(ctx context.Context, plan *gateway.ToolCallPlan, e
 
 	executor, ok := s.executors[urnStr]
 	if !ok {
-		return nil, oops.E(oops.CodeNotFound, nil, "platform tool not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, nil, "platform tool not found").LogError(ctx, s.logger)
 	}
 
 	var out bytes.Buffer

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -220,7 +220,7 @@ func (s *Service) ListPlugins(ctx context.Context, payload *gen.ListPluginsPaylo
 		ProjectID:      *ac.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list plugins").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugins").LogError(ctx, s.logger)
 	}
 
 	plugins := make([]*gen.Plugin, 0, len(rows))
@@ -254,7 +254,7 @@ func (s *Service) GetPlugin(ctx context.Context, payload *gen.GetPluginPayload) 
 
 	pluginID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	plugin, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{
@@ -266,17 +266,17 @@ func (s *Service) GetPlugin(ctx context.Context, payload *gen.GetPluginPayload) 
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get plugin").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get plugin").LogError(ctx, s.logger)
 	}
 
 	servers, err := s.repo.ListPluginServers(ctx, pluginID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list plugin servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugin servers").LogError(ctx, s.logger)
 	}
 
 	assignments, err := s.repo.ListPluginAssignments(ctx, pluginID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list plugin assignments").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugin assignments").LogError(ctx, s.logger)
 	}
 
 	return pluginToGen(plugin, servers, assignments), nil
@@ -307,7 +307,7 @@ func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPay
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -323,7 +323,7 @@ func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPay
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 			return nil, oops.E(oops.CodeConflict, nil, "a plugin with this slug already exists")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "create plugin").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create plugin").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogPluginCreate(ctx, tx, audit.LogPluginCreateEvent{
@@ -336,11 +336,11 @@ func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPay
 		PluginName:       plugin.Name,
 		PluginSlug:       plugin.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin create").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin create").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
 	return pluginToGen(plugin, nil, nil), nil
@@ -358,7 +358,7 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 
 	pluginID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	slug := conv.ToSlug(payload.Slug)
@@ -368,7 +368,7 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -383,7 +383,7 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "load plugin").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load plugin").LogError(ctx, s.logger)
 	}
 
 	plugin, err := txRepo.UpdatePlugin(ctx, repo.UpdatePluginParams{
@@ -402,7 +402,7 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 			return nil, oops.E(oops.CodeConflict, nil, "a plugin with this slug already exists")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update plugin").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update plugin").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogPluginUpdate(ctx, tx, audit.LogPluginUpdateEvent{
@@ -425,21 +425,21 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 			Description: conv.FromPGText[string](plugin.Description),
 		},
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin update").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
 	servers, err := s.repo.ListPluginServers(ctx, pluginID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list plugin servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugin servers").LogError(ctx, s.logger)
 	}
 
 	assignments, err := s.repo.ListPluginAssignments(ctx, pluginID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list plugin assignments").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugin assignments").LogError(ctx, s.logger)
 	}
 
 	return pluginToGen(plugin, servers, assignments), nil
@@ -457,7 +457,7 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 
 	pluginID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid plugin id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	// Verify the plugin belongs to this project before mutating.
@@ -466,23 +466,23 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
-		return oops.E(oops.CodeUnexpected, err, "verify plugin ownership").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "verify plugin ownership").LogError(ctx, s.logger)
 	}
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	txRepo := s.repo.WithTx(tx)
 
 	if err := txRepo.SoftDeletePluginServers(ctx, pluginID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "soft-delete plugin servers").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "soft-delete plugin servers").LogError(ctx, s.logger)
 	}
 
 	if _, err := txRepo.RemoveAllPluginAssignments(ctx, pluginID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "remove plugin assignments").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "remove plugin assignments").LogError(ctx, s.logger)
 	}
 
 	if err := txRepo.DeletePlugin(ctx, repo.DeletePluginParams{
@@ -490,7 +490,7 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 		OrganizationID: ac.ActiveOrganizationID,
 		ProjectID:      *ac.ProjectID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete plugin").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "delete plugin").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogPluginDelete(ctx, tx, audit.LogPluginDeleteEvent{
@@ -503,11 +503,11 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 		PluginName:       plugin.Name,
 		PluginSlug:       plugin.Slug,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "audit log plugin delete").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "audit log plugin delete").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 	return nil
 }
@@ -526,7 +526,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 
 	pluginID, err := uuid.Parse(payload.PluginID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	backend, err := parseServerBackend(payload.ToolsetID, payload.McpServerID)
@@ -540,7 +540,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "verify plugin ownership").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "verify plugin ownership").LogError(ctx, s.logger)
 	}
 
 	displayName := ""
@@ -558,7 +558,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 			if errors.Is(mcpErr, pgx.ErrNoRows) {
 				return nil, oops.E(oops.CodeBadRequest, nil, "mcp server not found")
 			}
-			return nil, oops.E(oops.CodeUnexpected, mcpErr, "verify mcp server").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, mcpErr, "verify mcp server").LogError(ctx, s.logger)
 		}
 		if server.Visibility == mcpservers.VisibilityDisabled || !server.HasEndpoint {
 			return nil, oops.E(oops.CodeBadRequest, nil, "mcp server is disabled or has no published endpoint")
@@ -578,7 +578,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 			if errors.Is(tErr, pgx.ErrNoRows) {
 				return nil, oops.E(oops.CodeBadRequest, nil, "toolset not found")
 			}
-			return nil, oops.E(oops.CodeUnexpected, tErr, "verify toolset").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, tErr, "verify toolset").LogError(ctx, s.logger)
 		}
 		if !toolset.McpEnabled || !toolset.McpSlug.Valid || toolset.McpSlug.String == "" {
 			return nil, oops.E(oops.CodeBadRequest, nil, "toolset does not have MCP enabled")
@@ -592,7 +592,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -614,7 +614,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 				return nil, oops.E(oops.CodeConflict, nil, "a server with this display name already exists in the plugin")
 			}
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "add plugin server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "add plugin server").LogError(ctx, s.logger)
 	}
 
 	toolsetURN, mcpServerURN := backend.auditURNs()
@@ -634,11 +634,11 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 		ToolsetURN:        toolsetURN,
 		McpServerURN:      mcpServerURN,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin server add").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin server add").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
 	return pluginServerToGen(row), nil
@@ -713,11 +713,11 @@ func (s *Service) UpdatePluginServer(ctx context.Context, payload *gen.UpdatePlu
 
 	serverID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid server id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid server id").LogError(ctx, s.logger)
 	}
 	pluginID, err := uuid.Parse(payload.PluginID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	// Verify the plugin belongs to this project.
@@ -726,12 +726,12 @@ func (s *Service) UpdatePluginServer(ctx context.Context, payload *gen.UpdatePlu
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "verify plugin ownership").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "verify plugin ownership").LogError(ctx, s.logger)
 	}
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -746,7 +746,7 @@ func (s *Service) UpdatePluginServer(ctx context.Context, payload *gen.UpdatePlu
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update plugin server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update plugin server").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogPluginServerUpdate(ctx, tx, audit.LogPluginServerUpdateEvent{
@@ -763,11 +763,11 @@ func (s *Service) UpdatePluginServer(ctx context.Context, payload *gen.UpdatePlu
 		ServerPolicy:      row.Policy,
 		ServerSortOrder:   row.SortOrder,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin server update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin server update").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
 	return pluginServerToGen(row), nil
@@ -785,11 +785,11 @@ func (s *Service) RemovePluginServer(ctx context.Context, payload *gen.RemovePlu
 
 	serverID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid server id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid server id").LogError(ctx, s.logger)
 	}
 	pluginID, err := uuid.Parse(payload.PluginID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid plugin id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	// Verify the plugin belongs to this project.
@@ -798,12 +798,12 @@ func (s *Service) RemovePluginServer(ctx context.Context, payload *gen.RemovePlu
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
-		return oops.E(oops.CodeUnexpected, err, "verify plugin ownership").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "verify plugin ownership").LogError(ctx, s.logger)
 	}
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
@@ -815,7 +815,7 @@ func (s *Service) RemovePluginServer(ctx context.Context, payload *gen.RemovePlu
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
-		return oops.E(oops.CodeUnexpected, err, "remove plugin server").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "remove plugin server").LogError(ctx, s.logger)
 	}
 
 	toolsetURN, mcpServerURN := serverBackend{toolsetID: row.ToolsetID, mcpServerID: row.McpServerID}.auditURNs()
@@ -832,11 +832,11 @@ func (s *Service) RemovePluginServer(ctx context.Context, payload *gen.RemovePlu
 		ToolsetURN:       toolsetURN,
 		McpServerURN:     mcpServerURN,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "audit log plugin server remove").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "audit log plugin server remove").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 	return nil
 }
@@ -855,7 +855,7 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 
 	pluginID, err := uuid.Parse(payload.PluginID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	// Verify the plugin belongs to this project.
@@ -864,7 +864,7 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "verify plugin ownership").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "verify plugin ownership").LogError(ctx, s.logger)
 	}
 
 	// Normalize and validate every principal URN through urn.ParsePrincipal so
@@ -899,14 +899,14 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	txRepo := s.repo.WithTx(tx)
 
 	if _, err := txRepo.RemoveAllPluginAssignments(ctx, pluginID); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "remove existing assignments").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "remove existing assignments").LogError(ctx, s.logger)
 	}
 
 	assignments := make([]*gen.PluginAssignment, 0, len(urns))
@@ -917,7 +917,7 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 			PrincipalUrn:   u,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "add plugin assignment").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "add plugin assignment").LogError(ctx, s.logger)
 		}
 		assignments = append(assignments, pluginAssignmentToGen(row))
 	}
@@ -933,11 +933,11 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 		PluginSlug:       plugin.Slug,
 		PrincipalURNs:    urns,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin assignments set").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin assignments set").LogError(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
 	return &gen.SetPluginAssignmentsResult{Assignments: assignments}, nil
@@ -955,7 +955,7 @@ func (s *Service) DownloadPluginPackage(ctx context.Context, payload *gen.Downlo
 
 	pluginID, err := uuid.Parse(payload.PluginID)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	// Look up the plugin to get its slug.
@@ -968,7 +968,7 @@ func (s *Service) DownloadPluginPackage(ctx context.Context, payload *gen.Downlo
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil, oops.C(oops.CodeNotFound)
 		}
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "get plugin").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "get plugin").LogError(ctx, s.logger)
 	}
 
 	// Resolve all plugin infos and find the matching one.
@@ -1002,12 +1002,12 @@ func (s *Service) DownloadPluginPackage(ctx context.Context, payload *gen.Downlo
 
 	files, err := GenerateSinglePluginPackage(*pluginInfo, cfg, payload.Platform)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "generate plugin package").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "generate plugin package").LogError(ctx, s.logger)
 	}
 
 	var buf bytes.Buffer
 	if err := writePluginZip(&buf, files); err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "build plugin zip").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "build plugin zip").LogError(ctx, s.logger)
 	}
 
 	return &gen.DownloadPluginPackageResult{
@@ -1038,11 +1038,11 @@ func (s *Service) DownloadObservabilityPlugin(ctx context.Context, payload *gen.
 
 	candidate, err := s.buildPluginAPIKeyCandidate(auth.APIKeyScopeHooks, "hooks-download")
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "build hooks api key").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "build hooks api key").LogError(ctx, s.logger)
 	}
 
 	if err := s.persistDownloadAPIKey(ctx, ac, candidate); err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "persist hooks api key").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "persist hooks api key").LogError(ctx, s.logger)
 	}
 
 	cfg := s.generateConfig(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, *ac.ProjectSlug, *ac.ProjectID)
@@ -1050,12 +1050,12 @@ func (s *Service) DownloadObservabilityPlugin(ctx context.Context, payload *gen.
 
 	files, err := GenerateObservabilityPluginPackage(cfg, payload.Platform)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "generate observability plugin package").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "generate observability plugin package").LogError(ctx, s.logger)
 	}
 
 	var buf bytes.Buffer
 	if err := writePluginZip(&buf, files); err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "build plugin zip").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "build plugin zip").LogError(ctx, s.logger)
 	}
 
 	filename := "observability"
@@ -1100,7 +1100,7 @@ func (s *Service) DownloadCodexInstallScript(ctx context.Context, payload *gen.D
 
 	script, err := GenerateCodexInstallScript(marketplaceURL, cfg)
 	if err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "generate codex install script").Log(ctx, s.logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "generate codex install script").LogError(ctx, s.logger)
 	}
 
 	return &gen.DownloadCodexInstallScriptResult{
@@ -1211,7 +1211,7 @@ func (s *Service) GetPublishStatus(ctx context.Context, payload *gen.GetPublishS
 	if s.github != nil {
 		conn, err := s.repo.GetGitHubConnection(ctx, *ac.ProjectID)
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeUnexpected, err, "get github connection").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get github connection").LogError(ctx, s.logger)
 		}
 		if err == nil {
 			result.Connected = true
@@ -1373,7 +1373,7 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 	if projectName == "" {
 		project, err := projectsrepo.New(s.db).GetProjectByID(ctx, input.ProjectID)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "get project").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get project").LogError(ctx, s.logger)
 		}
 		projectName = project.Name
 	}
@@ -1385,7 +1385,7 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 	// GitHub) and persist it after a successful push.
 	fingerprint, err := PluginFingerprint(pluginInfos, cfg)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "compute plugin fingerprint").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "compute plugin fingerprint").LogError(ctx, s.logger)
 	}
 
 	// GitHub repo owner/name are case-insensitive. Normalize at the boundary
@@ -1401,7 +1401,7 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 		case errors.Is(err, pgx.ErrNoRows):
 			// Never published — fall through and publish for the first time.
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "get github connection").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get github connection").LogError(ctx, s.logger)
 		case conv.FromPGTextOrEmpty[string](existing.PublishedFingerprint) == fingerprint:
 			return &publishOutcome{RepoURL: repoURL, Skipped: true}, nil
 		}
@@ -1409,11 +1409,11 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 
 	mcpCandidate, err := s.buildPluginAPIKeyCandidate(auth.APIKeyScopeConsumer, "mcp")
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build plugin mcp api key").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build plugin mcp api key").LogError(ctx, s.logger)
 	}
 	hooksCandidate, err := s.buildPluginAPIKeyCandidate(auth.APIKeyScopeHooks, "hooks")
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build plugin hooks api key").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build plugin hooks api key").LogError(ctx, s.logger)
 	}
 
 	cfg.APIKey = mcpCandidate.fullKey
@@ -1421,11 +1421,11 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 
 	files, err := GeneratePluginPackages(pluginInfos, cfg)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "generate plugin packages").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "generate plugin packages").LogError(ctx, s.logger)
 	}
 
 	if err := s.github.Client.CreateRepo(ctx, s.github.InstallationID, repoOwner, repoName, true); err != nil {
-		return nil, oops.E(oops.CodeGatewayError, err, "create github repo").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeGatewayError, err, "create github repo").LogError(ctx, s.logger)
 	}
 
 	_, err = s.github.Client.PushFiles(
@@ -1438,7 +1438,7 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 		files,
 	)
 	if err != nil {
-		return nil, oops.E(oops.CodeGatewayError, err, "push plugin files to GitHub").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeGatewayError, err, "push plugin files to GitHub").LogError(ctx, s.logger)
 	}
 
 	for _, username := range input.GitHubUsernames {
@@ -1462,7 +1462,7 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 	// published repo contains key strings with no DB records — re-publish
 	// overwrites them with fresh valid keys.
 	if err := s.persistPluginAPIKeys(ctx, input, []pluginAPIKeyCandidate{mcpCandidate, hooksCandidate}, projectName, repoOwner, repoName, pluginSlugs, fingerprint); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "persist plugin api keys").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "persist plugin api keys").LogError(ctx, s.logger)
 	}
 
 	return &publishOutcome{RepoURL: repoURL, Skipped: false}, nil
@@ -1491,7 +1491,7 @@ func (s *Service) GetMarketplaceSettings(ctx context.Context, payload *gen.GetMa
 	case errors.Is(err, pgx.ErrNoRows):
 		// No row yet — leave override empty so the effective name is the default.
 	default:
-		return nil, oops.E(oops.CodeUnexpected, err, "get marketplace settings").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get marketplace settings").LogError(ctx, s.logger)
 	}
 
 	defaultName := s.resolveDefaultMarketplaceName(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, *ac.ProjectID)
@@ -1529,7 +1529,7 @@ func (s *Service) UpdateMarketplaceSettings(ctx context.Context, payload *gen.Up
 		ProjectID:       *ac.ProjectID,
 		MarketplaceName: conv.ToPGTextEmpty(override),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "upsert marketplace settings").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "upsert marketplace settings").LogError(ctx, s.logger)
 	}
 
 	// Republish only when GitHub is configured AND a connection already exists
@@ -1564,7 +1564,7 @@ func (s *Service) UpdateMarketplaceSettings(ctx context.Context, payload *gen.Up
 		case errors.Is(connErr, pgx.ErrNoRows):
 			// No published marketplace yet — settings saved, no republish.
 		default:
-			return nil, oops.E(oops.CodeUnexpected, connErr, "get github connection").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, connErr, "get github connection").LogError(ctx, s.logger)
 		}
 	}
 
@@ -1754,7 +1754,7 @@ func (s *Service) persistPluginAPIKeys(
 func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) ([]PluginInfo, error) {
 	rows, err := s.repo.ListPluginsWithServersForProject(ctx, projectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list plugins with servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugins with servers").LogError(ctx, s.logger)
 	}
 
 	// Remote MCP-backed (mcp_server) plugin servers are resolved by a separate
@@ -1762,7 +1762,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 	// until the AGE-1902 cutover.
 	mcpRows, err := s.repo.ListPluginsWithMcpServersForProject(ctx, projectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list plugins with mcp servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugins with mcp servers").LogError(ctx, s.logger)
 	}
 
 	// serverBuild carries the row's sort_order so the merged toolset- and
@@ -1822,11 +1822,11 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				case errors.Is(metaErr, pgx.ErrNoRows):
 					// No metadata configured → no env configs to surface.
 				case metaErr != nil:
-					return nil, oops.E(oops.CodeUnexpected, metaErr, "load mcp metadata for toolset").Log(ctx, s.logger)
+					return nil, oops.E(oops.CodeUnexpected, metaErr, "load mcp metadata for toolset").LogError(ctx, s.logger)
 				default:
 					envConfigs, envErr := mcpMeta.ListEnvironmentConfigs(ctx, metadata.ID)
 					if envErr != nil {
-						return nil, oops.E(oops.CodeUnexpected, envErr, "load environment configs for toolset").Log(ctx, s.logger)
+						return nil, oops.E(oops.CodeUnexpected, envErr, "load environment configs for toolset").LogError(ctx, s.logger)
 					}
 					for _, ec := range envConfigs {
 						if ec.ProvidedBy != "user" {

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -61,7 +61,7 @@ func (c *Client) IsFeatureEnabled(ctx context.Context, organizationID string, fe
 			err,
 			"failed to get organization feature flag %q",
 			string(feature),
-		).Log(ctx, c.logger, attr.SlogOrganizationID(organizationID))
+		).LogError(ctx, c.logger, attr.SlogOrganizationID(organizationID))
 	}
 
 	cacheEntry := FeatureCache{

--- a/server/internal/productfeatures/impl.go
+++ b/server/internal/productfeatures/impl.go
@@ -102,7 +102,7 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 			err,
 			"failed to set organization feature flag %q",
 			payload.FeatureName,
-		).Log(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		).LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	cacheEntry := FeatureCache{

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -101,7 +101,7 @@ func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting project by slug").Log(ctx, s.logger, attr.SlogProjectSlug(slug), attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting project by slug").LogError(ctx, s.logger, attr.SlogProjectSlug(slug), attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: proj.ID.String(), Dimensions: nil}); err != nil {
@@ -152,7 +152,7 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing projects").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing projects").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -170,9 +170,9 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 		if pgErr.Code == pgerrcode.UniqueViolation {
 			return nil, oops.E(oops.CodeConflict, err, "project slug already exists")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "database error creating project").Log(ctx, s.logger, attr.SlogOrganizationID(payload.OrganizationID), attr.SlogProjectName(payload.Name))
+		return nil, oops.E(oops.CodeUnexpected, err, "database error creating project").LogError(ctx, s.logger, attr.SlogOrganizationID(payload.OrganizationID), attr.SlogProjectName(payload.Name))
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "unexpected error creating project").Log(ctx, s.logger, attr.SlogOrganizationID(payload.OrganizationID), attr.SlogProjectName(payload.Name))
+		return nil, oops.E(oops.CodeUnexpected, err, "unexpected error creating project").LogError(ctx, s.logger, attr.SlogOrganizationID(payload.OrganizationID), attr.SlogProjectName(payload.Name))
 	}
 
 	_, err = er.CreateEnvironment(ctx, envrepo.CreateEnvironmentParams{
@@ -183,7 +183,7 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 		Description:    conv.ToPGText("Default project for organization"),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error creating default environment").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating default environment").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogProjectCreate(ctx, dbtx, audit.LogProjectCreateEvent{
@@ -197,11 +197,11 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 		ProjectName: prj.Name,
 		ProjectSlug: prj.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error creating project creation audit log").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating project creation audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving project creation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving project creation").LogError(ctx, s.logger)
 	}
 
 	project := &gen.CreateProjectResult{
@@ -298,12 +298,12 @@ func (s *Service) SetLogo(ctx context.Context, payload *gen.SetLogoPayload) (res
 
 	assetID, err := uuid.Parse(payload.AssetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "error parsing asset ID").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "error parsing asset ID").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing projects").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing projects").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -311,7 +311,7 @@ func (s *Service) SetLogo(ctx context.Context, payload *gen.SetLogoPayload) (res
 
 	existingRow, err := pr.GetProjectByID(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting project").Log(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
+		return nil, oops.E(oops.CodeUnexpected, err, "error getting project").LogError(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
 	}
 
 	existing := toProject(existingRow)
@@ -321,7 +321,7 @@ func (s *Service) SetLogo(ctx context.Context, payload *gen.SetLogoPayload) (res
 		LogoAssetID: uuid.NullUUID{UUID: assetID, Valid: true},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error updating project logo").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error updating project logo").LogError(ctx, s.logger)
 	}
 
 	projectResponse := toProject(updatedProject)
@@ -340,11 +340,11 @@ func (s *Service) SetLogo(ctx context.Context, payload *gen.SetLogoPayload) (res
 		ProjectSnapshotBefore: existing,
 		ProjectSnapshotAfter:  projectResponse,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error creating project update audit log").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating project update audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving project").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving project").LogError(ctx, s.logger)
 	}
 
 	return &gen.SetProjectLogoResult{
@@ -364,7 +364,7 @@ func (s *Service) ListAllowedOrigins(ctx context.Context, payload *gen.ListAllow
 
 	allowedOrigins, err := s.repo.ListAllowedOriginsByProjectID(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing allowed origins").Log(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing allowed origins").LogError(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
 	}
 
 	entries := make([]*gen.AllowedOrigin, 0, len(allowedOrigins))
@@ -406,7 +406,7 @@ func (s *Service) UpsertAllowedOrigin(ctx context.Context, payload *gen.UpsertAl
 		Status:    status,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error upserting allowed origin").Log(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
+		return nil, oops.E(oops.CodeUnexpected, err, "error upserting allowed origin").LogError(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()))
 	}
 
 	return &gen.UpsertAllowedOriginResult{
@@ -429,7 +429,7 @@ func (s *Service) DeleteProject(ctx context.Context, payload *gen.DeleteProjectP
 
 	projectID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeInvalid, err, "invalid project id").Log(ctx, s.logger)
+		return oops.E(oops.CodeInvalid, err, "invalid project id").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -446,7 +446,7 @@ func (s *Service) DeleteProject(ctx context.Context, payload *gen.DeleteProjectP
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "error retrieving project").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error retrieving project").LogError(ctx, s.logger)
 	}
 
 	// The first project (ordered by id ASC) is the default project
@@ -456,7 +456,7 @@ func (s *Service) DeleteProject(ctx context.Context, payload *gen.DeleteProjectP
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error accessing projects").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing projects").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -467,7 +467,7 @@ func (s *Service) DeleteProject(ctx context.Context, payload *gen.DeleteProjectP
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil // Return successfully even if the project was already deleted
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "error deleting project").Log(ctx, s.logger, attr.SlogProjectID(payload.ID))
+		return oops.E(oops.CodeUnexpected, err, "error deleting project").LogError(ctx, s.logger, attr.SlogProjectID(payload.ID))
 	}
 
 	if err := s.audit.LogProjectDelete(ctx, dbtx, audit.LogProjectDeleteEvent{
@@ -481,11 +481,11 @@ func (s *Service) DeleteProject(ctx context.Context, payload *gen.DeleteProjectP
 		ProjectName: project.Name,
 		ProjectSlug: project.Slug,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error creating project deletion audit log").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error creating project deletion audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error saving project deletion").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "error saving project deletion").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -500,7 +500,7 @@ func (s *Service) SetOrganizationWhitelist(ctx context.Context, payload *gen.Set
 	// Check that the API key is from the speakeasy-team organization
 	const speakeasyTeamOrgID = "5a25158b-24dc-4d49-b03d-e85acfbea59c"
 	if authCtx.ActiveOrganizationID != speakeasyTeamOrgID {
-		return oops.E(oops.CodeUnauthorized, nil, "only speakeasy-team can set organization whitelist status").Log(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeUnauthorized, nil, "only speakeasy-team can set organization whitelist status").LogError(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	err := s.repo.SetOrganizationWhitelist(ctx, repo.SetOrganizationWhitelistParams{
@@ -508,7 +508,7 @@ func (s *Service) SetOrganizationWhitelist(ctx context.Context, payload *gen.Set
 		Whitelisted:    payload.Whitelisted,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error setting organization whitelist status").Log(ctx, s.logger, attr.SlogOrganizationID(payload.OrganizationID))
+		return oops.E(oops.CodeUnexpected, err, "error setting organization whitelist status").LogError(ctx, s.logger, attr.SlogOrganizationID(payload.OrganizationID))
 	}
 
 	return nil

--- a/server/internal/remotemcp/discoverprotectedresource.go
+++ b/server/internal/remotemcp/discoverprotectedresource.go
@@ -38,7 +38,7 @@ func (s *Service) DiscoverProtectedResourceMetadata(ctx context.Context, payload
 
 	serverID, err := uuid.Parse(payload.RemoteMcpServerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote mcp server id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote mcp server id").LogError(ctx, logger)
 	}
 
 	server, err := repo.New(s.db).GetServerByID(ctx, repo.GetServerByIDParams{
@@ -47,9 +47,9 @@ func (s *Service) DiscoverProtectedResourceMetadata(ctx context.Context, payload
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get remote mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get remote mcp server").LogError(ctx, logger)
 	}
 
 	doc, warnings, probeErr := wellknown.DiscoverProtectedResourceMetadata(ctx, s.policy, server.Url)
@@ -68,7 +68,7 @@ func (s *Service) DiscoverProtectedResourceMetadata(ctx context.Context, payload
 		// The helper always wraps in *ProtectedResourceDiscoveryError; an
 		// untyped probe error is a programming bug, not a user-visible
 		// upstream failure.
-		return nil, oops.E(oops.CodeUnexpected, probeErr, "discover protected resource metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, probeErr, "discover protected resource metadata").LogError(ctx, logger)
 	}
 
 	return &gen.ProtectedResourceMetadataDiscovery{

--- a/server/internal/remotemcp/impl.go
+++ b/server/internal/remotemcp/impl.go
@@ -99,13 +99,13 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	if err := validateURL(ctx, s.policy, payload.URL); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid url").LogError(ctx, logger)
 	}
 
 	// Validate header inputs
 	for _, h := range payload.Headers {
 		if err := validateHeaderInput(h, false); err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid header").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid header").LogError(ctx, logger)
 		}
 	}
 
@@ -113,12 +113,12 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 	// the row can be inserted in a single statement (no insert-then-update).
 	serverID, err := uuid.NewV7()
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "generate server id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "generate server id").LogError(ctx, logger)
 	}
 
 	slug, err := computeServerSlug(payload.URL, serverID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "compute server slug").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "compute server slug").LogError(ctx, logger)
 	}
 
 	name := pgtype.Text{String: "", Valid: false}
@@ -130,7 +130,7 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -148,9 +148,9 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return nil, oops.E(oops.CodeConflict, err, "remote mcp server slug already in use").Log(ctx, logger)
+			return nil, oops.E(oops.CodeConflict, err, "remote mcp server slug already in use").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "create remote mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create remote mcp server").LogError(ctx, logger)
 	}
 
 	var headerRows []repo.RemoteMcpServerHeader
@@ -165,7 +165,7 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 			ValueFromRequestHeader: conv.PtrToPGTextEmpty(h.ValueFromRequestHeader),
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "create remote mcp server header").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "create remote mcp server header").LogError(ctx, logger)
 		}
 
 		headerRows = append(headerRows, row)
@@ -180,11 +180,11 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 		RemoteMcpServerID:  server.ID,
 		RemoteMcpServerURL: server.Url,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log remote mcp server creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log remote mcp server creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return mv.BuildRemoteMcpServerView(server, headerRows), nil
@@ -202,7 +202,7 @@ func (s *Service) ListServers(ctx context.Context, payload *gen.ListServersPaylo
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -211,7 +211,7 @@ func (s *Service) ListServers(ctx context.Context, payload *gen.ListServersPaylo
 
 	servers, err := txRepo.ListServersByProjectID(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list remote mcp servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list remote mcp servers").LogError(ctx, s.logger)
 	}
 
 	serverIDs := make([]uuid.UUID, len(servers))
@@ -221,7 +221,7 @@ func (s *Service) ListServers(ctx context.Context, payload *gen.ListServersPaylo
 
 	headersByServerID, err := headersRepo.ListHeadersByServerIDs(ctx, serverIDs, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list remote mcp server headers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list remote mcp server headers").LogError(ctx, s.logger)
 	}
 
 	result := make([]*types.RemoteMcpServer, 0, len(servers))
@@ -245,15 +245,15 @@ func (s *Service) GetServer(ctx context.Context, payload *gen.GetServerPayload) 
 	idProvided := payload.ID != nil && *payload.ID != ""
 	slugProvided := payload.Slug != nil && *payload.Slug != ""
 	if !idProvided && !slugProvided {
-		return nil, oops.E(oops.CodeBadRequest, nil, "id or slug is required").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "id or slug is required").LogError(ctx, s.logger)
 	}
 	if idProvided && slugProvided {
-		return nil, oops.E(oops.CodeBadRequest, nil, "id and slug are mutually exclusive").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "id and slug are mutually exclusive").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -264,7 +264,7 @@ func (s *Service) GetServer(ctx context.Context, payload *gen.GetServerPayload) 
 	if idProvided {
 		serverID, parseErr := uuid.Parse(*payload.ID)
 		if parseErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid server id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid server id").LogError(ctx, s.logger)
 		}
 		server, err = txRepo.GetServerByID(ctx, repo.GetServerByIDParams{
 			ID:        serverID,
@@ -278,15 +278,15 @@ func (s *Service) GetServer(ctx context.Context, payload *gen.GetServerPayload) 
 	}
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").LogError(ctx, s.logger)
 		}
 
-		return nil, oops.E(oops.CodeUnexpected, err, "get remote mcp server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get remote mcp server").LogError(ctx, s.logger)
 	}
 
 	headers, err := headersRepo.ListHeaders(ctx, server.ID, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list remote mcp server headers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list remote mcp server headers").LogError(ctx, s.logger)
 	}
 
 	return mv.BuildRemoteMcpServerView(server, headers), nil
@@ -306,25 +306,25 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 
 	serverID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid server id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid server id").LogError(ctx, logger)
 	}
 
 	if payload.URL != nil {
 		if err := validateURL(ctx, s.policy, *payload.URL); err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid url").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid url").LogError(ctx, logger)
 		}
 	}
 
 	// Validate header inputs (allow secret headers to omit value on updates to preserve existing)
 	for _, h := range payload.Headers {
 		if err := validateHeaderInput(h, true); err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid header").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid header").LogError(ctx, logger)
 		}
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -338,15 +338,15 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").LogError(ctx, logger)
 		}
 
-		return nil, oops.E(oops.CodeUnexpected, err, "get remote mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get remote mcp server").LogError(ctx, logger)
 	}
 
 	beforeHeaders, err := headersRepo.ListHeaders(ctx, existingServer.ID, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list headers for before snapshot").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list headers for before snapshot").LogError(ctx, logger)
 	}
 
 	beforeView := mv.BuildRemoteMcpServerView(existingServer, beforeHeaders)
@@ -363,7 +363,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 	finalURL := conv.PtrValOr(payload.URL, existingServer.Url)
 	slug, err := computeServerSlug(finalURL, existingServer.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "compute server slug").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "compute server slug").LogError(ctx, logger)
 	}
 
 	// Update server fields
@@ -378,9 +378,9 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return nil, oops.E(oops.CodeConflict, err, "remote mcp server slug already in use").Log(ctx, logger)
+			return nil, oops.E(oops.CodeConflict, err, "remote mcp server slug already in use").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update remote mcp server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update remote mcp server").LogError(ctx, logger)
 	}
 
 	// Reconcile headers: nil means leave unchanged, non-nil is the desired state.
@@ -388,7 +388,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 		// Fetch raw headers (with encrypted values intact) for secret value preservation
 		rawHeaders, err := txRepo.ListHeadersByServerID(ctx, serverID)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "list raw headers for preservation").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "list raw headers for preservation").LogError(ctx, logger)
 		}
 
 		rawByName := make(map[string]repo.RemoteMcpServerHeader, len(rawHeaders))
@@ -422,13 +422,13 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 						ValueFromRequestHeader: conv.PtrToPGTextEmpty(h.ValueFromRequestHeader),
 					})
 					if err != nil {
-						return nil, oops.E(oops.CodeUnexpected, err, "upsert remote mcp server header").Log(ctx, logger)
+						return nil, oops.E(oops.CodeUnexpected, err, "upsert remote mcp server header").LogError(ctx, logger)
 					}
 
 					continue
 				}
 
-				return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("header %q: new secret header must provide a value", h.Name), "invalid header").Log(ctx, logger)
+				return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("header %q: new secret header must provide a value", h.Name), "invalid header").LogError(ctx, logger)
 			}
 
 			_, err := headersRepo.UpsertHeader(ctx, repo.UpsertHeaderParams{
@@ -441,7 +441,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 				ValueFromRequestHeader: conv.PtrToPGTextEmpty(h.ValueFromRequestHeader),
 			})
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "upsert remote mcp server header").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "upsert remote mcp server header").LogError(ctx, logger)
 			}
 		}
 
@@ -449,7 +449,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 		for _, existing := range beforeHeaders {
 			if _, keep := desiredNames[existing.Name]; !keep {
 				if err := headersRepo.DeleteHeader(ctx, serverID, existing.Name); err != nil {
-					return nil, oops.E(oops.CodeUnexpected, err, "delete remote mcp server header").Log(ctx, logger)
+					return nil, oops.E(oops.CodeUnexpected, err, "delete remote mcp server header").LogError(ctx, logger)
 				}
 			}
 		}
@@ -458,7 +458,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 	// Fetch updated state for after-snapshot
 	afterHeaders, err := headersRepo.ListHeaders(ctx, updatedServer.ID, true)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list headers for after snapshot").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list headers for after snapshot").LogError(ctx, logger)
 	}
 
 	afterView := mv.BuildRemoteMcpServerView(updatedServer, afterHeaders)
@@ -474,11 +474,11 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 		SnapshotBefore:     beforeView,
 		SnapshotAfter:      afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log remote mcp server update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log remote mcp server update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return afterView, nil
@@ -497,7 +497,7 @@ func (s *Service) VerifyURL(ctx context.Context, payload *gen.VerifyURLPayload) 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	if err := validateURL(ctx, s.policy, payload.URL); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid url").LogError(ctx, logger)
 	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, verifyURLTimeout)
@@ -526,19 +526,19 @@ func (s *Service) DeleteServer(ctx context.Context, payload *gen.DeleteServerPay
 
 	serverID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid server id").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid server id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	txRepo := repo.New(dbtx)
 
 	if err := txRepo.DeleteHeadersByServerID(ctx, serverID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete remote mcp server headers").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete remote mcp server headers").LogError(ctx, logger)
 	}
 
 	deleted, err := txRepo.DeleteServer(ctx, repo.DeleteServerParams{
@@ -550,7 +550,7 @@ func (s *Service) DeleteServer(ctx context.Context, payload *gen.DeleteServerPay
 			return nil
 		}
 
-		return oops.E(oops.CodeUnexpected, err, "delete remote mcp server").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete remote mcp server").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogRemoteMcpServerDelete(ctx, dbtx, audit.LogRemoteMcpServerDeleteEvent{
@@ -562,11 +562,11 @@ func (s *Service) DeleteServer(ctx context.Context, payload *gen.DeleteServerPay
 		RemoteMcpServerID:  deleted.ID,
 		RemoteMcpServerURL: deleted.Url,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log remote mcp server deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log remote mcp server deletion").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/remotemcp/proxy/errors.go
+++ b/server/internal/remotemcp/proxy/errors.go
@@ -29,14 +29,14 @@ var ErrBatchRequest = errors.New("batch requests are not supported")
 func (p *Proxy) classifyForwardError(ctx context.Context, err error, timedOut bool) error {
 	switch {
 	case timedOut:
-		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").Log(ctx, p.Logger)
+		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").LogError(ctx, p.Logger)
 	case errors.Is(err, context.DeadlineExceeded):
 		// Backstop in case any transport-level deadline (e.g.
 		// TLSHandshakeTimeout) fires before our phase timer.
-		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").Log(ctx, p.Logger)
+		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").LogError(ctx, p.Logger)
 	case errors.Is(err, context.Canceled):
-		return oops.E(oops.CodeBadRequest, err, "client cancelled request").Log(ctx, p.Logger)
+		return oops.E(oops.CodeBadRequest, err, "client cancelled request").LogError(ctx, p.Logger)
 	default:
-		return oops.E(oops.CodeGatewayError, err, "remote mcp server unreachable").Log(ctx, p.Logger)
+		return oops.E(oops.CodeGatewayError, err, "remote mcp server unreachable").LogError(ctx, p.Logger)
 	}
 }

--- a/server/internal/remotemcp/proxy/headers.go
+++ b/server/internal/remotemcp/proxy/headers.go
@@ -106,7 +106,7 @@ func (p *Proxy) applyRequestHeaders(ctx context.Context, userReq *http.Request, 
 	for _, h := range p.Headers {
 		value, err := h.Resolve(userReq)
 		if err != nil {
-			return oops.E(oops.CodeBadRequest, err, "missing required header for remote mcp server").Log(ctx, p.Logger)
+			return oops.E(oops.CodeBadRequest, err, "missing required header for remote mcp server").LogError(ctx, p.Logger)
 		}
 		if value == "" {
 			remoteReq.Header.Del(h.Name)

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -357,7 +357,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 			})
 			return nil
 		}
-		return oops.E(oops.CodeBadRequest, parseErr, "invalid jsonrpc request").Log(ctx, p.Logger)
+		return oops.E(oops.CodeBadRequest, parseErr, "invalid jsonrpc request").LogError(ctx, p.Logger)
 	}
 
 	// Extract the originating request id once. Used as the correlation id
@@ -434,7 +434,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 	// into the cached body bytes so the forwarder sends the mutated payload
 	// upstream. A no-op when no interceptor mutated the request.
 	if mutated, err := userReq.refreshBody(); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "refresh mutated request body").Log(ctx, p.Logger)
+		return oops.E(oops.CodeUnexpected, err, "refresh mutated request body").LogError(ctx, p.Logger)
 	} else if mutated {
 		p.Logger.InfoContext(ctx, "forwarding mutated request body upstream",
 			attr.SlogComponent("remotemcp.proxy"),
@@ -469,7 +469,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 
 	bodyBytes, msg, err := readJSONRPCBody(upstreamResp.Body, p.MaxBufferedBodyBytes)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "invalid jsonrpc response from remote mcp server").Log(ctx, p.Logger)
+		return oops.E(oops.CodeUnexpected, err, "invalid jsonrpc response from remote mcp server").LogError(ctx, p.Logger)
 	}
 
 	// Empty bodies skip interceptor invocation but still relay through to
@@ -528,7 +528,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 		// the upstream's original payload. A no-op when no interceptor
 		// mutated the response.
 		if mutated, ok, err := remoteMsg.materializedBytes(); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "encode mutated response body").Log(ctx, p.Logger)
+			return oops.E(oops.CodeUnexpected, err, "encode mutated response body").LogError(ctx, p.Logger)
 		} else if ok {
 			bodyBytes = mutated
 			p.Logger.InfoContext(ctx, "relaying mutated response body to client",
@@ -580,7 +580,7 @@ func (p *Proxy) forwardRequest(ctx context.Context, r *http.Request, body io.Rea
 	if err != nil {
 		phaseTimer.Stop()
 		forwardCancel()
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "build upstream request").Log(ctx, p.Logger)
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "build upstream request").LogError(ctx, p.Logger)
 	}
 
 	if err := p.applyRequestHeaders(ctx, r, upstreamReq); err != nil {
@@ -1145,7 +1145,7 @@ func (p *Proxy) dispatchInterceptorError(
 ) error {
 	var mutErr *MutationError
 	if errors.As(err, &mutErr) {
-		return oops.E(oops.CodeUnexpected, err, "proxy interceptor mutation failure").Log(ctx, p.Logger)
+		return oops.E(oops.CodeUnexpected, err, "proxy interceptor mutation failure").LogError(ctx, p.Logger)
 	}
 	*responseBytes = p.writeRejection(ctx, w, span, id, err)
 	return nil

--- a/server/internal/remotemcp/resources_read_usage_limits_interceptor.go
+++ b/server/internal/remotemcp/resources_read_usage_limits_interceptor.go
@@ -85,7 +85,7 @@ func (i *ResourcesReadUsageLimitsInterceptor) InterceptResourcesReadRequest(ctx 
 	}
 
 	if periodUsage.ToolCalls >= hardToolCallsLimit {
-		return oops.E(oops.CodeForbidden, errors.New("tool usage limit reached"), "tool usage limit reached").Log(ctx, i.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeForbidden, errors.New("tool usage limit reached"), "tool usage limit reached").LogError(ctx, i.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	return nil

--- a/server/internal/remotemcp/tools_call_usage_limits_interceptor.go
+++ b/server/internal/remotemcp/tools_call_usage_limits_interceptor.go
@@ -84,7 +84,7 @@ func (i *ToolsCallUsageLimitsInterceptor) InterceptToolsCallRequest(ctx context.
 	}
 
 	if periodUsage.ToolCalls >= hardToolCallsLimit {
-		return oops.E(oops.CodeForbidden, errors.New("tool usage limit reached"), "tool usage limit reached").Log(ctx, i.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.E(oops.CodeForbidden, errors.New("tool usage limit reached"), "tool usage limit reached").LogError(ctx, i.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	return nil

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -375,11 +375,11 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	}
 	stateID := q.Get("state")
 	if stateID == "" {
-		return oops.E(oops.CodeBadRequest, nil, "state is required").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "state is required").LogError(ctx, logger)
 	}
 	code := q.Get("code")
 	if code == "" {
-		return oops.E(oops.CodeBadRequest, nil, "code is required").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "code is required").LogError(ctx, logger)
 	}
 
 	// Single-use state: GETDEL so a duplicate callback can't double-exchange
@@ -387,20 +387,20 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	// depth keeps the failure mode obvious.
 	state, err := m.cache.GetAndDelete(ctx, "remoteLogin:"+stateID)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "remote login state not found or expired").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "remote login state not found or expired").LogError(ctx, logger)
 	}
 	mcpSlug := state.McpSlug
 	if mcpSlug == "" {
 		mcpSlug = routeMcpSlug
 	}
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from remote login state").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from remote login state").LogError(ctx, logger)
 	}
 	if routeMcpSlug != "" && routeMcpSlug != mcpSlug {
-		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").LogError(ctx, logger)
 	}
 	if state.McpSlug != "" && state.McpSlug != mcpSlug {
-		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").LogError(ctx, logger)
 	}
 
 	logger = logger.With(
@@ -413,7 +413,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	// upstream authorization code on a request that can't produce a
 	// remote_sessions row anyway.
 	if state.Subject == nil || state.Subject.IsZero() {
-		return oops.E(oops.CodeUnauthorized, nil, "remote login requires a stamped subject on the parent challenge").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, nil, "remote login requires a stamped subject on the parent challenge").LogError(ctx, logger)
 	}
 
 	queries := remotesessions_repo.New(m.db)
@@ -422,14 +422,14 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		ProjectID: conv.ToNullUUID(state.ProjectID),
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "load remote session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "load remote session client").LogError(ctx, logger)
 	}
 
 	var clientSecret string
 	if clientRow.ClientSecretEncrypted.Valid {
 		decoded, derr := m.enc.Decrypt(clientRow.ClientSecretEncrypted.String)
 		if derr != nil {
-			return oops.E(oops.CodeUnexpected, derr, "decrypt client secret").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, derr, "decrypt client secret").LogError(ctx, logger)
 		}
 		clientSecret = decoded
 	}
@@ -438,18 +438,18 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	audience := conv.FromPGTextOrEmpty[string](clientRow.Audience)
 	tok, err := m.exchangeCode(ctx, state, clientRow.ClientID, clientSecret, authMethod, audience, code)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "upstream token exchange failed").Log(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "upstream token exchange failed").LogError(ctx, logger)
 	}
 
 	accessEnc, err := m.enc.Encrypt([]byte(tok.AccessToken))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "encrypt access token").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "encrypt access token").LogError(ctx, logger)
 	}
 	var refreshEnc *string
 	if tok.RefreshToken != "" {
 		v, eerr := m.enc.Encrypt([]byte(tok.RefreshToken))
 		if eerr != nil {
-			return oops.E(oops.CodeUnexpected, eerr, "encrypt refresh token").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, eerr, "encrypt refresh token").LogError(ctx, logger)
 		}
 		refreshEnc = &v
 	}
@@ -482,7 +482,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		RefreshExpiresAt:      conv.PtrToPGTimestamptz(refreshExpires),
 		Scopes:                scopes,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "store remote session").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "store remote session").LogError(ctx, logger)
 	}
 
 	routeBase := state.RouteBase

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -42,31 +42,31 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 
 	issuerID, err := uuid.Parse(payload.RemoteSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_issuer_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_issuer_id").LogError(ctx, logger)
 	}
 
 	userIssuerID, err := uuid.Parse(payload.UserSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").LogError(ctx, logger)
 	}
 
 	clientID := strings.TrimSpace(payload.ClientID)
 	if clientID == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "client_id is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "client_id is required").LogError(ctx, logger)
 	}
 
 	var secretCiphertext pgtype.Text
 	if payload.ClientSecret != nil && *payload.ClientSecret != "" {
 		encrypted, encErr := s.enc.Encrypt([]byte(*payload.ClientSecret))
 		if encErr != nil {
-			return nil, oops.E(oops.CodeUnexpected, encErr, "encrypt client secret").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, encErr, "encrypt client secret").LogError(ctx, logger)
 		}
 		secretCiphertext = conv.ToPGText(encrypted)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -82,9 +82,9 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 		OrganizationID: conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").LogError(ctx, logger)
 	}
 
 	// Reject the user session issuer if it belongs to a different project, so
@@ -94,9 +94,9 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 		ProjectID: *authCtx.ProjectID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, logger)
 	}
 
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
@@ -113,7 +113,7 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 		LegacyCallbackUrl:       false,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create remote session client").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create remote session client").LogError(ctx, logger)
 	}
 
 	if err = txRepo.AttachRemoteSessionClientToUserSessionIssuer(
@@ -127,7 +127,7 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 			oops.CodeUnexpected,
 			err,
 			"failed to attach remote session client to user session issuer",
-		).Log(ctx, logger)
+		).LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionClientCreate(ctx, dbtx, audit.LogRemoteSessionClientCreateEvent{
@@ -139,16 +139,16 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 		RemoteSessionClientURN: urn.NewRemoteSessionClient(created.ID),
 		ClientID:               created.ClientID,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log remote session client creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log remote session client creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	view, err := mv.BuildRemoteSessionClientView(created)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").LogError(ctx, logger)
 	}
 
 	return view, nil
@@ -176,7 +176,7 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	if !authCtx.IsAdmin {
-		return nil, oops.E(oops.CodeForbidden, nil, "platform admin required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeForbidden, nil, "platform admin required").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectWrite, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
@@ -185,22 +185,22 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 
 	proxyProviderID, err := uuid.Parse(payload.OauthProxyProviderID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid oauth_proxy_provider_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid oauth_proxy_provider_id").LogError(ctx, logger)
 	}
 
 	issuerID, err := uuid.Parse(payload.RemoteSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_issuer_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_issuer_id").LogError(ctx, logger)
 	}
 
 	userIssuerID, err := uuid.Parse(payload.UserSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -212,18 +212,18 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "oauth proxy provider not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "oauth proxy provider not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get oauth proxy provider").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get oauth proxy provider").LogError(ctx, logger)
 	}
 
 	if provider.ProviderType != "custom" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "only custom oauth_proxy_providers carry a clonable client; provider_type=%q", provider.ProviderType).Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "only custom oauth_proxy_providers carry a clonable client; provider_type=%q", provider.ProviderType).LogError(ctx, logger)
 	}
 
 	clientID, clientSecret, err := resolveProxyClientCredentials(ctx, s.environments, provider.ProjectID, provider.Secrets)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "oauth proxy provider client credentials unavailable for clone").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "oauth proxy provider client credentials unavailable for clone").LogError(ctx, logger)
 	}
 
 	// Confirm the issuer the caller named is reachable from the caller's
@@ -238,9 +238,9 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 		OrganizationID: conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").LogError(ctx, logger)
 	}
 
 	// Prevent binding in the event that the issuer does not belong to the
@@ -250,14 +250,14 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 		ProjectID: *authCtx.ProjectID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, logger)
 	}
 
 	encrypted, err := s.enc.Encrypt([]byte(clientSecret))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "encrypt client secret").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "encrypt client secret").LogError(ctx, logger)
 	}
 
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
@@ -278,7 +278,7 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 		LegacyCallbackUrl: true,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create remote session client").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create remote session client").LogError(ctx, logger)
 	}
 
 	if err := txRepo.AttachRemoteSessionClientToUserSessionIssuer(
@@ -288,7 +288,7 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 			UserSessionIssuerID:   userIssuerID,
 		},
 	); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to attach remote session client to user session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to attach remote session client to user session issuer").LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionClientCreate(ctx, dbtx, audit.LogRemoteSessionClientCreateEvent{
@@ -300,16 +300,16 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 		RemoteSessionClientURN: urn.NewRemoteSessionClient(created.ID),
 		ClientID:               created.ClientID,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log remote session client creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log remote session client creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	view, err := mv.BuildRemoteSessionClientView(created)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").LogError(ctx, logger)
 	}
 
 	return view, nil
@@ -378,17 +378,17 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 
 	clientID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_client id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_client id").LogError(ctx, logger)
 	}
 
 	userIssuerID, err := conv.PtrToNullUUID(payload.UserSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -400,14 +400,14 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote session client not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote session client not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get remote session client").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get remote session client").LogError(ctx, logger)
 	}
 
 	beforeView, err := mv.BuildRemoteSessionClientView(existing)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").LogError(ctx, logger)
 	}
 
 	if payload.UserSessionIssuerID != nil {
@@ -418,9 +418,9 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 			ProjectID: *authCtx.ProjectID,
 		}); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, logger)
+				return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, logger)
 		}
 	}
 
@@ -428,7 +428,7 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 	if payload.ClientSecret != nil && *payload.ClientSecret != "" {
 		encrypted, encErr := s.enc.Encrypt([]byte(*payload.ClientSecret))
 		if encErr != nil {
-			return nil, oops.E(oops.CodeUnexpected, encErr, "encrypt client secret").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, encErr, "encrypt client secret").LogError(ctx, logger)
 		}
 		secretCiphertext = conv.ToPGText(encrypted)
 	}
@@ -445,9 +445,9 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote session client not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote session client not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update remote session client").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update remote session client").LogError(ctx, logger)
 	}
 
 	shouldRemakeUserSessionIssuerAttachment := payload.UserSessionIssuerID != nil && userIssuerID.Valid && userIssuerID.UUID != existing.UserSessionIssuerID
@@ -467,7 +467,7 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 				err,
 				"failed to delete user session issuer attachments for remote session client %s",
 				updated.ID,
-			).Log(ctx, logger)
+			).LogError(ctx, logger)
 		}
 
 		if err = txRepo.AttachRemoteSessionClientToUserSessionIssuer(
@@ -481,13 +481,13 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 				oops.CodeUnexpected,
 				err,
 				"failed to attach remote session client to user session issuer",
-			).Log(ctx, logger)
+			).LogError(ctx, logger)
 		}
 	}
 
 	afterView, err := mv.BuildRemoteSessionClientView(updated)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionClientUpdate(ctx, dbtx, audit.LogRemoteSessionClientUpdateEvent{
@@ -501,11 +501,11 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 		SnapshotBefore:         beforeView,
 		SnapshotAfter:          afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log remote session client update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log remote session client update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return afterView, nil
@@ -525,33 +525,33 @@ func (s *Service) ListRemoteSessionClients(ctx context.Context, payload *gen.Lis
 
 	issuerFilter, err := conv.PtrToNullUUID(payload.RemoteSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_issuer_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_issuer_id").LogError(ctx, logger)
 	}
 
 	userIssuerFilter, err := conv.PtrToNullUUID(payload.UserSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").LogError(ctx, logger)
 	}
 
 	limit := pageLimit(payload.Limit)
 	cursor, err := parseCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, logger)
 	}
 
 	rows, err := s.listRemoteSessionClientsByProjectID(ctx, *authCtx.ProjectID, issuerFilter, userIssuerFilter, cursor, limit)
 	if err != nil {
 		if isRemoteSessionClientIssuerDrift(err) {
-			return nil, oops.E(oops.CodeInvariantViolation, err, "multiple remote session clients found for user session issuer").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvariantViolation, err, "multiple remote session clients found for user session issuer").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "list remote session clients").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list remote session clients").LogError(ctx, logger)
 	}
 
 	items := make([]*types.RemoteSessionClient, 0, len(rows))
 	for _, row := range rows {
 		item, err := mv.BuildRemoteSessionClientView(row)
 		if err != nil {
-			return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").LogError(ctx, logger)
 		}
 		items = append(items, item)
 	}
@@ -582,7 +582,7 @@ func (s *Service) GetRemoteSessionClient(ctx context.Context, payload *gen.GetRe
 
 	clientID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_client id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_client id").LogError(ctx, logger)
 	}
 
 	client, err := repo.New(s.db).GetRemoteSessionClientByID(ctx, repo.GetRemoteSessionClientByIDParams{
@@ -591,14 +591,14 @@ func (s *Service) GetRemoteSessionClient(ctx context.Context, payload *gen.GetRe
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote session client not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote session client not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get remote session client").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get remote session client").LogError(ctx, logger)
 	}
 
 	view, err := mv.BuildRemoteSessionClientView(client)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").LogError(ctx, logger)
 	}
 
 	return view, nil
@@ -622,12 +622,12 @@ func (s *Service) DeleteRemoteSessionClient(ctx context.Context, payload *gen.De
 
 	clientID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid remote_session_client id").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid remote_session_client id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -641,7 +641,7 @@ func (s *Service) DeleteRemoteSessionClient(ctx context.Context, payload *gen.De
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
-		return oops.E(oops.CodeUnexpected, err, "delete remote session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete remote session client").LogError(ctx, logger)
 	}
 
 	if err := txRepo.DeleteUserSessionIssuerAttachmentsForRemoteSessionClient(
@@ -656,11 +656,11 @@ func (s *Service) DeleteRemoteSessionClient(ctx context.Context, payload *gen.De
 			err,
 			"failed to delete user session issuer attachments for remote session client %s",
 			deleted.ID,
-		).Log(ctx, logger)
+		).LogError(ctx, logger)
 	}
 
 	if _, err := txRepo.SoftDeleteRemoteSessionsByClientID(ctx, deleted.ID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "soft-delete dependent remote sessions").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "soft-delete dependent remote sessions").LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionClientDelete(ctx, dbtx, audit.LogRemoteSessionClientDeleteEvent{
@@ -672,11 +672,11 @@ func (s *Service) DeleteRemoteSessionClient(ctx context.Context, payload *gen.De
 		RemoteSessionClientURN: urn.NewRemoteSessionClient(deleted.ID),
 		ClientID:               deleted.ClientID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log remote session client deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log remote session client deletion").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -66,20 +66,20 @@ func (s *Service) DiscoverRemoteSessionIssuer(ctx context.Context, payload *gen.
 
 	issuerURL := strings.TrimSpace(payload.Issuer)
 	if issuerURL == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "issuer is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "issuer is required").LogError(ctx, logger)
 	}
 
 	parsed, err := url.Parse(issuerURL)
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer url").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer url").LogError(ctx, logger)
 	}
 
 	doc, warnings, err := discoverIssuerMetadata(ctx, s.policy, issuerURL)
 	if err != nil {
 		if df, ok := errors.AsType[*discoveryError](err); ok {
-			return nil, oops.E(oops.CodeGatewayError, err, "%s", df.UserMessage()).Log(ctx, logger)
+			return nil, oops.E(oops.CodeGatewayError, err, "%s", df.UserMessage()).LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeGatewayError, err, "discover issuer metadata").Log(ctx, logger)
+		return nil, oops.E(oops.CodeGatewayError, err, "discover issuer metadata").LogError(ctx, logger)
 	}
 
 	draft := &types.RemoteSessionIssuerDraft{
@@ -115,20 +115,20 @@ func (s *Service) CreateRemoteSessionIssuer(ctx context.Context, payload *gen.Cr
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	if strings.TrimSpace(payload.Slug) == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "slug is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "slug is required").LogError(ctx, logger)
 	}
 	if strings.TrimSpace(payload.Issuer) == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "issuer is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "issuer is required").LogError(ctx, logger)
 	}
 
 	logoAssetID, err := conv.PtrToNullUUID(payload.LogoAssetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -153,7 +153,7 @@ func (s *Service) CreateRemoteSessionIssuer(ctx context.Context, payload *gen.Cr
 		Passthrough:                       conv.PtrValOr(payload.Passthrough, false),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create remote session issuer").LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionIssuerCreate(ctx, dbtx, audit.LogRemoteSessionIssuerCreateEvent{
@@ -167,11 +167,11 @@ func (s *Service) CreateRemoteSessionIssuer(ctx context.Context, payload *gen.Cr
 		IssuerURL:              issuer.Issuer,
 		Name:                   conv.FromPGText[string](issuer.Name),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log remote session issuer creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log remote session issuer creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return mv.BuildRemoteSessionIssuerView(issuer), nil
@@ -189,7 +189,7 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 
 	issuerID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, logger)
 	}
 
 	// slug and issuer are NOT NULL on the row. The SQL update treats an
@@ -198,10 +198,10 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 	// constraint, so reject empty here with an actionable error before the
 	// query runs.
 	if payload.Slug != nil && *payload.Slug == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "slug cannot be set to empty").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "slug cannot be set to empty").LogError(ctx, logger)
 	}
 	if payload.Issuer != nil && *payload.Issuer == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "issuer cannot be set to empty").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "issuer cannot be set to empty").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectWrite, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
@@ -210,12 +210,12 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 
 	logoAssetID, err := conv.PtrToNullUUID(payload.LogoAssetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -231,9 +231,9 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").LogError(ctx, logger)
 	}
 
 	beforeView := mv.BuildRemoteSessionIssuerView(existing)
@@ -258,9 +258,9 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update remote session issuer").LogError(ctx, logger)
 	}
 
 	afterView := mv.BuildRemoteSessionIssuerView(updated)
@@ -278,11 +278,11 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 		SnapshotBefore:         beforeView,
 		SnapshotAfter:          afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log remote session issuer update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log remote session issuer update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return afterView, nil
@@ -301,7 +301,7 @@ func (s *Service) ListRemoteSessionIssuers(ctx context.Context, payload *gen.Lis
 	limit := pageLimit(payload.Limit)
 	cursor, err := parseCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	rows, err := repo.New(s.db).ListRemoteSessionIssuersByProjectID(ctx, repo.ListRemoteSessionIssuersByProjectIDParams{
@@ -311,7 +311,7 @@ func (s *Service) ListRemoteSessionIssuers(ctx context.Context, payload *gen.Lis
 		LimitValue:     limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list remote session issuers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list remote session issuers").LogError(ctx, s.logger)
 	}
 
 	items := make([]*types.RemoteSessionIssuer, 0, len(rows))
@@ -344,7 +344,7 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 	hasID := payload.ID != nil && *payload.ID != ""
 	hasSlug := payload.Slug != nil && *payload.Slug != ""
 	if hasID == hasSlug {
-		return nil, oops.E(oops.CodeBadRequest, nil, "exactly one of id or slug is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "exactly one of id or slug is required").LogError(ctx, logger)
 	}
 
 	var issuer repo.RemoteSessionIssuer
@@ -352,7 +352,7 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 	case hasID:
 		issuerID, err := uuid.Parse(*payload.ID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, logger)
 		}
 		if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
 			return nil, err
@@ -364,9 +364,9 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").Log(ctx, logger)
+				return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").LogError(ctx, logger)
 		}
 	default: // hasSlug
 		if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
@@ -379,9 +379,9 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").Log(ctx, logger)
+				return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").LogError(ctx, logger)
 		}
 	}
 
@@ -400,7 +400,7 @@ func (s *Service) DeleteRemoteSessionIssuer(ctx context.Context, payload *gen.De
 
 	issuerID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectWrite, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
@@ -409,7 +409,7 @@ func (s *Service) DeleteRemoteSessionIssuer(ctx context.Context, payload *gen.De
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -417,10 +417,10 @@ func (s *Service) DeleteRemoteSessionIssuer(ctx context.Context, payload *gen.De
 
 	clientCount, err := txRepo.CountRemoteSessionClientsByIssuerID(ctx, issuerID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "count remote session clients").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "count remote session clients").LogError(ctx, logger)
 	}
 	if clientCount > 0 {
-		return oops.E(oops.CodeConflict, nil, "remote session issuer has active clients; delete the clients first").Log(ctx, logger)
+		return oops.E(oops.CodeConflict, nil, "remote session issuer has active clients; delete the clients first").LogError(ctx, logger)
 	}
 
 	deleted, err := txRepo.DeleteRemoteSessionIssuer(ctx, repo.DeleteRemoteSessionIssuerParams{
@@ -431,7 +431,7 @@ func (s *Service) DeleteRemoteSessionIssuer(ctx context.Context, payload *gen.De
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
-		return oops.E(oops.CodeUnexpected, err, "delete remote session issuer").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete remote session issuer").LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionIssuerDelete(ctx, dbtx, audit.LogRemoteSessionIssuerDeleteEvent{
@@ -445,11 +445,11 @@ func (s *Service) DeleteRemoteSessionIssuer(ctx context.Context, payload *gen.De
 		IssuerURL:              deleted.Issuer,
 		Name:                   conv.FromPGText[string](deleted.Name),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log remote session issuer deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log remote session issuer deletion").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/remotesessions/organizationissuerhandlers.go
+++ b/server/internal/remotesessions/organizationissuerhandlers.go
@@ -37,20 +37,20 @@ func (s *Service) CreateOrganizationRemoteSessionIssuer(ctx context.Context, pay
 	logger := s.logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 
 	if strings.TrimSpace(payload.Slug) == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "slug is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "slug is required").LogError(ctx, logger)
 	}
 	if strings.TrimSpace(payload.Issuer) == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "issuer is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "issuer is required").LogError(ctx, logger)
 	}
 
 	logoAssetID, err := conv.PtrToNullUUID(payload.LogoAssetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -75,7 +75,7 @@ func (s *Service) CreateOrganizationRemoteSessionIssuer(ctx context.Context, pay
 		Passthrough:                       conv.PtrValOr(payload.Passthrough, false),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create organization remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create organization remote session issuer").LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionIssuerCreate(ctx, dbtx, audit.LogRemoteSessionIssuerCreateEvent{
@@ -89,11 +89,11 @@ func (s *Service) CreateOrganizationRemoteSessionIssuer(ctx context.Context, pay
 		IssuerURL:              issuer.Issuer,
 		Name:                   conv.FromPGText[string](issuer.Name),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log organization remote session issuer creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log organization remote session issuer creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return mv.BuildRemoteSessionIssuerView(issuer), nil
@@ -111,17 +111,17 @@ func (s *Service) UpdateOrganizationRemoteSessionIssuer(ctx context.Context, pay
 
 	issuerID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, logger)
 	}
 
 	// slug and issuer are NOT NULL on the row; reject an explicit empty before
 	// the query runs (the SQL treats empty string as "clear to NULL" only for
 	// the nullable endpoint columns).
 	if payload.Slug != nil && *payload.Slug == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "slug cannot be set to empty").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "slug cannot be set to empty").LogError(ctx, logger)
 	}
 	if payload.Issuer != nil && *payload.Issuer == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "issuer cannot be set to empty").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "issuer cannot be set to empty").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -130,12 +130,12 @@ func (s *Service) UpdateOrganizationRemoteSessionIssuer(ctx context.Context, pay
 
 	logoAssetID, err := conv.PtrToNullUUID(payload.LogoAssetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid logo asset id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -147,9 +147,9 @@ func (s *Service) UpdateOrganizationRemoteSessionIssuer(ctx context.Context, pay
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "organization remote session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "organization remote session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get organization remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get organization remote session issuer").LogError(ctx, logger)
 	}
 
 	beforeView := mv.BuildRemoteSessionIssuerView(existing)
@@ -174,9 +174,9 @@ func (s *Service) UpdateOrganizationRemoteSessionIssuer(ctx context.Context, pay
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "organization remote session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "organization remote session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update organization remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update organization remote session issuer").LogError(ctx, logger)
 	}
 
 	afterView := mv.BuildRemoteSessionIssuerView(updated)
@@ -194,11 +194,11 @@ func (s *Service) UpdateOrganizationRemoteSessionIssuer(ctx context.Context, pay
 		SnapshotBefore:         beforeView,
 		SnapshotAfter:          afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log organization remote session issuer update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log organization remote session issuer update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return afterView, nil
@@ -217,7 +217,7 @@ func (s *Service) ListOrganizationRemoteSessionIssuers(ctx context.Context, payl
 	limit := pageLimit(payload.Limit)
 	cursor, err := parseCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	rows, err := repo.New(s.db).ListOrganizationRemoteSessionIssuers(ctx, repo.ListOrganizationRemoteSessionIssuersParams{
@@ -226,7 +226,7 @@ func (s *Service) ListOrganizationRemoteSessionIssuers(ctx context.Context, payl
 		LimitValue:     limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list organization remote session issuers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list organization remote session issuers").LogError(ctx, s.logger)
 	}
 
 	items := make([]*types.RemoteSessionIssuer, 0, len(rows))
@@ -258,7 +258,7 @@ func (s *Service) GetOrganizationRemoteSessionIssuer(ctx context.Context, payloa
 
 	issuerID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgRead, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -271,9 +271,9 @@ func (s *Service) GetOrganizationRemoteSessionIssuer(ctx context.Context, payloa
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "organization remote session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "organization remote session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get organization remote session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get organization remote session issuer").LogError(ctx, logger)
 	}
 
 	return mv.BuildRemoteSessionIssuerView(issuer), nil
@@ -291,7 +291,7 @@ func (s *Service) DeleteOrganizationRemoteSessionIssuer(ctx context.Context, pay
 
 	issuerID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
@@ -300,7 +300,7 @@ func (s *Service) DeleteOrganizationRemoteSessionIssuer(ctx context.Context, pay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -308,10 +308,10 @@ func (s *Service) DeleteOrganizationRemoteSessionIssuer(ctx context.Context, pay
 
 	clientCount, err := txRepo.CountRemoteSessionClientsByIssuerID(ctx, issuerID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "count remote session clients").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "count remote session clients").LogError(ctx, logger)
 	}
 	if clientCount > 0 {
-		return oops.E(oops.CodeConflict, nil, "remote session issuer has active clients; delete the clients first").Log(ctx, logger)
+		return oops.E(oops.CodeConflict, nil, "remote session issuer has active clients; delete the clients first").LogError(ctx, logger)
 	}
 
 	deleted, err := txRepo.DeleteOrganizationRemoteSessionIssuer(ctx, repo.DeleteOrganizationRemoteSessionIssuerParams{
@@ -322,7 +322,7 @@ func (s *Service) DeleteOrganizationRemoteSessionIssuer(ctx context.Context, pay
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
-		return oops.E(oops.CodeUnexpected, err, "delete organization remote session issuer").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete organization remote session issuer").LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionIssuerDelete(ctx, dbtx, audit.LogRemoteSessionIssuerDeleteEvent{
@@ -336,11 +336,11 @@ func (s *Service) DeleteOrganizationRemoteSessionIssuer(ctx context.Context, pay
 		IssuerURL:              deleted.Issuer,
 		Name:                   conv.FromPGText[string](deleted.Name),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log organization remote session issuer deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log organization remote session issuer deletion").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/remotesessions/sessionhandlers.go
+++ b/server/internal/remotesessions/sessionhandlers.go
@@ -36,13 +36,13 @@ func (s *Service) ListRemoteSessions(ctx context.Context, payload *gen.ListRemot
 	subjectFilter := conv.PtrToPGText(payload.SubjectUrn)
 	clientFilter, err := conv.PtrToNullUUID(payload.RemoteSessionClientID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_client_id").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid remote_session_client_id").LogError(ctx, logger)
 	}
 
 	limit := pageLimit(payload.Limit)
 	cursor, err := parseCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, logger)
 	}
 
 	rows, err := repo.New(s.db).ListRemoteSessionsByProjectID(ctx, repo.ListRemoteSessionsByProjectIDParams{
@@ -53,7 +53,7 @@ func (s *Service) ListRemoteSessions(ctx context.Context, payload *gen.ListRemot
 		LimitValue:            limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list remote sessions").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list remote sessions").LogError(ctx, logger)
 	}
 
 	items := make([]*types.RemoteSession, 0, len(rows))
@@ -87,12 +87,12 @@ func (s *Service) RevokeRemoteSession(ctx context.Context, payload *gen.RevokeRe
 
 	sessionID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid remote_session id").Log(ctx, logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid remote_session id").LogError(ctx, logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -106,7 +106,7 @@ func (s *Service) RevokeRemoteSession(ctx context.Context, payload *gen.RevokeRe
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
-		return oops.E(oops.CodeUnexpected, err, "revoke remote session").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "revoke remote session").LogError(ctx, logger)
 	}
 
 	if err := s.auditLogger.LogRemoteSessionDelete(ctx, dbtx, audit.LogRemoteSessionDeleteEvent{
@@ -118,11 +118,11 @@ func (s *Service) RevokeRemoteSession(ctx context.Context, payload *gen.RevokeRe
 		RemoteSessionURN: urn.NewRemoteSession(revoked.ID),
 		SubjectURN:       revoked.SubjectUrn,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log remote session revoke").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log remote session revoke").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/resources/impl.go
+++ b/server/internal/resources/impl.go
@@ -85,7 +85,7 @@ func (s *Service) ListResources(ctx context.Context, payload *gen.ListResourcesP
 	if payload.Cursor != nil {
 		cursorUUID, err := uuid.Parse(*payload.Cursor)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 		}
 		params.Cursor = uuid.NullUUID{UUID: cursorUUID, Valid: true}
 	}
@@ -93,14 +93,14 @@ func (s *Service) ListResources(ctx context.Context, payload *gen.ListResourcesP
 	if payload.DeploymentID != nil {
 		deploymentUUID, err := uuid.Parse(*payload.DeploymentID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid deployment ID").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid deployment ID").LogError(ctx, s.logger)
 		}
 		params.DeploymentID = uuid.NullUUID{UUID: deploymentUUID, Valid: true}
 	}
 
 	resources, err := s.repo.ListFunctionResources(ctx, params)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list resources").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list resources").LogError(ctx, s.logger)
 	}
 
 	result := &gen.ListResourcesResult{
@@ -113,7 +113,7 @@ func (s *Service) ListResources(ctx context.Context, payload *gen.ListResourcesP
 		if resource.Meta != nil {
 			err = json.Unmarshal(resource.Meta, &meta)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal meta").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal meta").LogError(ctx, s.logger)
 			}
 		}
 		result.Resources[i] = &types.Resource{

--- a/server/internal/risk/exclusion.go
+++ b/server/internal/risk/exclusion.go
@@ -151,7 +151,7 @@ func (s *Service) ListRiskExclusions(ctx context.Context, payload *gen.ListRiskE
 		RiskPolicyID: policyID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk exclusions").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk exclusions").LogError(ctx, s.logger)
 	}
 
 	exclusions := make([]*types.RiskExclusion, 0, len(rows))
@@ -182,7 +182,7 @@ func (s *Service) CreateRiskExclusion(ctx context.Context, payload *gen.CreateRi
 	// Confirm the parent policy exists in this project (policy-bound only).
 	if policyID.Valid {
 		if _, err := s.repo.GetRiskPolicy(ctx, repo.GetRiskPolicyParams{ID: policyID.UUID, ProjectID: *authCtx.ProjectID}); err != nil {
-			return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 		}
 	}
 
@@ -195,7 +195,7 @@ func (s *Service) CreateRiskExclusion(ctx context.Context, payload *gen.CreateRi
 			RiskPolicyID: policyID,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "count regex exclusions").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "count regex exclusions").LogError(ctx, s.logger)
 		}
 		if count >= exclusionMaxRegexPerScope {
 			return nil, oops.E(oops.CodeInvalid, nil, "too many regex exclusions in scope (max %d)", exclusionMaxRegexPerScope)
@@ -204,7 +204,7 @@ func (s *Service) CreateRiskExclusion(ctx context.Context, payload *gen.CreateRi
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -219,7 +219,7 @@ func (s *Service) CreateRiskExclusion(ctx context.Context, payload *gen.CreateRi
 		Enabled:        payload.Enabled,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create risk exclusion").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create risk exclusion").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogRiskExclusionCreate(ctx, dbtx, audit.LogRiskExclusionCreateEvent{
@@ -231,11 +231,11 @@ func (s *Service) CreateRiskExclusion(ctx context.Context, payload *gen.CreateRi
 		RiskExclusionID:  row.ID,
 		DisplayName:      exclusionDisplayName(row.MatchType, row.MatchValue),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk exclusion create").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk exclusion create").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk exclusion create").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk exclusion create").LogError(ctx, s.logger)
 	}
 
 	s.reconcileExclusion(ctx, row.ProjectID, row.ID)
@@ -265,13 +265,13 @@ func (s *Service) UpdateRiskExclusion(ctx context.Context, payload *gen.UpdateRi
 	}
 	if policyID.Valid {
 		if _, err := s.repo.GetRiskPolicy(ctx, repo.GetRiskPolicyParams{ID: policyID.UUID, ProjectID: *authCtx.ProjectID}); err != nil {
-			return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 		}
 	}
 
 	before, err := s.repo.GetRiskExclusion(ctx, repo.GetRiskExclusionParams{ID: id, ProjectID: *authCtx.ProjectID})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk exclusion not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk exclusion not found").LogError(ctx, s.logger)
 	}
 
 	// An omitted `enabled` leaves the current state untouched rather than
@@ -293,7 +293,7 @@ func (s *Service) UpdateRiskExclusion(ctx context.Context, payload *gen.UpdateRi
 				RiskPolicyID: policyID,
 			})
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "count regex exclusions").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "count regex exclusions").LogError(ctx, s.logger)
 			}
 			if count >= exclusionMaxRegexPerScope {
 				return nil, oops.E(oops.CodeInvalid, nil, "too many regex exclusions in scope (max %d)", exclusionMaxRegexPerScope)
@@ -303,7 +303,7 @@ func (s *Service) UpdateRiskExclusion(ctx context.Context, payload *gen.UpdateRi
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -318,7 +318,7 @@ func (s *Service) UpdateRiskExclusion(ctx context.Context, payload *gen.UpdateRi
 		Enabled:      enabled,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "update risk exclusion").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update risk exclusion").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogRiskExclusionUpdate(ctx, dbtx, audit.LogRiskExclusionUpdateEvent{
@@ -332,11 +332,11 @@ func (s *Service) UpdateRiskExclusion(ctx context.Context, payload *gen.UpdateRi
 		SnapshotBefore:   exclusionAuditSnapshot(before),
 		SnapshotAfter:    exclusionAuditSnapshot(row),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk exclusion update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk exclusion update").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk exclusion update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk exclusion update").LogError(ctx, s.logger)
 	}
 
 	s.reconcileExclusion(ctx, row.ProjectID, row.ID)
@@ -360,17 +360,17 @@ func (s *Service) DeleteRiskExclusion(ctx context.Context, payload *gen.DeleteRi
 
 	before, err := s.repo.GetRiskExclusion(ctx, repo.GetRiskExclusionParams{ID: id, ProjectID: *authCtx.ProjectID})
 	if err != nil {
-		return oops.E(oops.CodeNotFound, err, "risk exclusion not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, err, "risk exclusion not found").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	if err := repo.New(dbtx).DeleteRiskExclusion(ctx, repo.DeleteRiskExclusionParams{ID: id, ProjectID: *authCtx.ProjectID}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete risk exclusion").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "delete risk exclusion").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogRiskExclusionDelete(ctx, dbtx, audit.LogRiskExclusionDeleteEvent{
@@ -382,11 +382,11 @@ func (s *Service) DeleteRiskExclusion(ctx context.Context, payload *gen.DeleteRi
 		RiskExclusionID:  before.ID,
 		DisplayName:      exclusionDisplayName(before.MatchType, before.MatchValue),
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log risk exclusion delete").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "log risk exclusion delete").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit risk exclusion delete").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "commit risk exclusion delete").LogError(ctx, s.logger)
 	}
 
 	// Restore findings previously suppressed by this exclusion.

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -326,12 +326,12 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 
 	id, err := uuid.NewV7()
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "generate policy id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "generate policy id").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -355,7 +355,7 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		ModelConfig:          modelConfig,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create risk policy").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create risk policy").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogRiskPolicyCreate(ctx, dbtx, audit.LogRiskPolicyCreateEvent{
@@ -367,11 +367,11 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		RiskPolicyID:     row.ID,
 		RiskPolicyName:   row.Name,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy create").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy create").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy create").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy create").LogError(ctx, s.logger)
 	}
 
 	if s.shadowMCPClient != nil {
@@ -397,7 +397,7 @@ func (s *Service) ListRiskPolicies(ctx context.Context, payload *gen.ListRiskPol
 
 	rows, err := s.repo.ListRiskPolicies(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk policies").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk policies").LogError(ctx, s.logger)
 	}
 
 	policies := make([]*types.RiskPolicy, 0, len(rows))
@@ -432,7 +432,7 @@ func (s *Service) GetRiskPolicy(ctx context.Context, payload *gen.GetRiskPolicyP
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 	}
 
 	return s.policyToType(ctx, row)
@@ -463,7 +463,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 	}
 
 	// policy_type is immutable; gate edits to prompt_based policies behind the flag.
@@ -594,7 +594,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -616,7 +616,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		ModelConfig:          modelConfig,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "update risk policy").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update risk policy").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogRiskPolicyUpdate(ctx, dbtx, audit.LogRiskPolicyUpdateEvent{
@@ -630,11 +630,11 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		SnapshotBefore:   snapshotBefore,
 		SnapshotAfter:    policyRowSnapshot(row),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy update").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy update").LogError(ctx, s.logger)
 	}
 
 	if s.shadowMCPClient != nil {
@@ -667,12 +667,12 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -681,14 +681,14 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		ID:        id,
 		ProjectID: *authCtx.ProjectID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete risk policy").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "delete risk policy").LogError(ctx, s.logger)
 	}
 
 	if err := q.DeleteRiskPolicyBypassRequestsByPolicy(ctx, repo.DeleteRiskPolicyBypassRequestsByPolicyParams{
 		RiskPolicyID: id,
 		ProjectID:    *authCtx.ProjectID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete risk policy bypass requests").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "delete risk policy bypass requests").LogError(ctx, s.logger)
 	}
 
 	deletedExclusions, err := q.DeleteRiskExclusionsByPolicy(ctx, repo.DeleteRiskExclusionsByPolicyParams{
@@ -696,7 +696,7 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		ProjectID:    *authCtx.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete risk exclusions by policy").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "delete risk exclusions by policy").LogError(ctx, s.logger)
 	}
 	if deletedExclusions > 0 {
 		s.logger.InfoContext(ctx, "deleted risk exclusions for policy",
@@ -714,11 +714,11 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		RiskPolicyID:     id,
 		RiskPolicyName:   existing.Name,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log risk policy delete").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "log risk policy delete").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit risk policy delete").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "commit risk policy delete").LogError(ctx, s.logger)
 	}
 
 	if s.shadowMCPClient != nil {
@@ -809,7 +809,7 @@ func (s *Service) ListRiskResults(ctx context.Context, payload *gen.ListRiskResu
 
 	cursor, err := parseRiskResultsCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	pageSize := resolvePageSize(payload.Limit)
@@ -844,11 +844,11 @@ func (s *Service) ListRiskResults(ctx context.Context, payload *gen.ListRiskResu
 	}
 	fromTime, err := parseOptionalTimestamptz(payload.From)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid from").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid from").LogError(ctx, s.logger)
 	}
 	toTime, err := parseOptionalTimestamptz(payload.To)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid to").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid to").LogError(ctx, s.logger)
 	}
 	return s.listResultsByProject(ctx, *authCtx.ProjectID, cursor, pageSize, totalCount, category, ruleID, userID, uniqueMatch, fromTime, toTime)
 }
@@ -981,7 +981,7 @@ func (s *Service) ListRiskResultsByChat(ctx context.Context, payload *gen.ListRi
 
 	cursor, err := conv.PtrToNullUUID(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	pageSize := resolvePageSize(payload.Limit)
@@ -992,7 +992,7 @@ func (s *Service) ListRiskResultsByChat(ctx context.Context, payload *gen.ListRi
 		PageLimit: conv.SafeInt32(pageSize + 1),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk results by chat").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk results by chat").LogError(ctx, s.logger)
 	}
 
 	chats := make([]*types.RiskChatSummary, 0, len(rows))
@@ -1027,7 +1027,7 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 
 	from, to, err := resolveRiskOverviewWindow(payload.From, payload.To)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid overview window").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid overview window").LogError(ctx, s.logger)
 	}
 
 	window := riskOverviewWindowParams(from, to)
@@ -1037,7 +1037,7 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 		ToTime:    window.to,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "get risk overview counts").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get risk overview counts").LogError(ctx, s.logger)
 	}
 
 	userRows, err := s.repo.ListRiskOverviewTopUsers(ctx, repo.ListRiskOverviewTopUsersParams{
@@ -1050,7 +1050,7 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 		RowLimit: 200,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top users").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top users").LogError(ctx, s.logger)
 	}
 
 	timeSeriesRows, err := s.repo.ListRiskOverviewTimeSeriesFindings(ctx, repo.ListRiskOverviewTimeSeriesFindingsParams{
@@ -1059,7 +1059,7 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 		ToTime:    window.to,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview time series findings").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview time series findings").LogError(ctx, s.logger)
 	}
 
 	ruleRows, err := s.repo.ListRiskOverviewTopRules(ctx, repo.ListRiskOverviewTopRulesParams{
@@ -1072,7 +1072,7 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 		RowLimit: 200,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top rules").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top rules").LogError(ctx, s.logger)
 	}
 
 	topCategories := riskOverviewTopCategories(timeSeriesRows, 10)
@@ -1225,7 +1225,7 @@ func (s *Service) listResultsByChat(ctx context.Context, projectID uuid.UUID, ra
 		PageLimit:              conv.SafeInt32(pageSize + 1),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk results by chat").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk results by chat").LogError(ctx, s.logger)
 	}
 	results := make([]*types.RiskResult, 0, len(rows))
 	var nextCursor *riskResultsCursor
@@ -1253,7 +1253,7 @@ func (s *Service) listResultsByPolicy(ctx context.Context, projectID uuid.UUID, 
 		PageLimit:              conv.SafeInt32(pageSize + 1),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk results by policy").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk results by policy").LogError(ctx, s.logger)
 	}
 	results := make([]*types.RiskResult, 0, len(rows))
 	var nextCursor *riskResultsCursor
@@ -1282,7 +1282,7 @@ func (s *Service) listResultsByProject(ctx context.Context, projectID uuid.UUID,
 		PageLimit:              conv.SafeInt32(pageSize + 1),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk results").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk results").LogError(ctx, s.logger)
 	}
 	results := make([]*types.RiskResult, 0, len(rows))
 	var nextCursor *riskResultsCursor
@@ -1334,7 +1334,7 @@ func (s *Service) GetRiskUserBreakdown(ctx context.Context, payload *gen.GetRisk
 
 	from, to, err := resolveRiskOverviewWindow(payload.From, payload.To)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid window").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid window").LogError(ctx, s.logger)
 	}
 	window := riskOverviewWindowParams(from, to)
 
@@ -1345,7 +1345,7 @@ func (s *Service) GetRiskUserBreakdown(ctx context.Context, payload *gen.GetRisk
 		ExternalUserID: payload.ExternalUserID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list user category breakdown").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list user category breakdown").LogError(ctx, s.logger)
 	}
 
 	ruleRows, err := s.repo.ListRiskUserRuleBreakdown(ctx, repo.ListRiskUserRuleBreakdownParams{
@@ -1355,7 +1355,7 @@ func (s *Service) GetRiskUserBreakdown(ctx context.Context, payload *gen.GetRisk
 		ExternalUserID: payload.ExternalUserID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list user rule breakdown").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list user rule breakdown").LogError(ctx, s.logger)
 	}
 
 	categories := make([]*gen.RiskOverviewCategory, 0, len(categoryRows))
@@ -1399,7 +1399,7 @@ func (s *Service) GetRiskRuleBreakdown(ctx context.Context, payload *gen.GetRisk
 
 	from, to, err := resolveRiskOverviewWindow(payload.From, payload.To)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid window").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid window").LogError(ctx, s.logger)
 	}
 
 	window := riskOverviewWindowParams(from, to)
@@ -1410,7 +1410,7 @@ func (s *Service) GetRiskRuleBreakdown(ctx context.Context, payload *gen.GetRisk
 		Category:  payload.Category,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list rule breakdown").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list rule breakdown").LogError(ctx, s.logger)
 	}
 
 	rules := make([]*gen.RiskRuleBreakdownEntry, 0, len(rows))
@@ -1453,12 +1453,12 @@ func (s *Service) GetRiskPolicyStatus(ctx context.Context, payload *gen.GetRiskP
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 	}
 
 	totalMessages, err := s.repo.CountTotalMessages(ctx, uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "count total messages").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "count total messages").LogError(ctx, s.logger)
 	}
 
 	analyzedMessages, err := s.repo.CountAnalyzedMessages(ctx, repo.CountAnalyzedMessagesParams{
@@ -1467,7 +1467,7 @@ func (s *Service) GetRiskPolicyStatus(ctx context.Context, payload *gen.GetRiskP
 		RiskPolicyVersion: policy.Version,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "count analyzed messages").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "count analyzed messages").LogError(ctx, s.logger)
 	}
 
 	findingsCount, err := s.repo.CountFindingsByPolicy(ctx, repo.CountFindingsByPolicyParams{
@@ -1476,7 +1476,7 @@ func (s *Service) GetRiskPolicyStatus(ctx context.Context, payload *gen.GetRiskP
 		RiskPolicyVersion: policy.Version,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "count findings").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "count findings").LogError(ctx, s.logger)
 	}
 
 	pending := max(totalMessages-analyzedMessages, 0)
@@ -1531,7 +1531,7 @@ func (s *Service) CreateCustomDetectionRule(ctx context.Context, payload *gen.Cr
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -1549,11 +1549,11 @@ func (s *Service) CreateCustomDetectionRule(ctx context.Context, payload *gen.Cr
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 			return nil, oops.E(oops.CodeConflict, nil, "custom detection rule already exists")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "create custom detection rule").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create custom detection rule").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit custom detection rule create").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit custom detection rule create").LogError(ctx, s.logger)
 	}
 
 	return customDetectionRuleToType(row), nil
@@ -1571,7 +1571,7 @@ func (s *Service) ListCustomDetectionRules(ctx context.Context, payload *gen.Lis
 
 	rows, err := s.repo.ListCustomDetectionRules(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list custom detection rules").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list custom detection rules").LogError(ctx, s.logger)
 	}
 
 	rules := make([]*types.RiskCustomDetectionRule, 0, len(rows))
@@ -1602,7 +1602,7 @@ func (s *Service) GetCustomDetectionRule(ctx context.Context, payload *gen.GetCu
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "custom detection rule not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "custom detection rule not found").LogError(ctx, s.logger)
 	}
 
 	return customDetectionRuleToType(row), nil
@@ -1635,7 +1635,7 @@ func (s *Service) UpdateCustomDetectionRule(ctx context.Context, payload *gen.Up
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -1648,11 +1648,11 @@ func (s *Service) UpdateCustomDetectionRule(ctx context.Context, payload *gen.Up
 		Severity:    payload.Severity,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "custom detection rule not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "custom detection rule not found").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit custom detection rule update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit custom detection rule update").LogError(ctx, s.logger)
 	}
 
 	return customDetectionRuleToType(row), nil
@@ -1675,7 +1675,7 @@ func (s *Service) DeleteCustomDetectionRule(ctx context.Context, payload *gen.De
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -1683,11 +1683,11 @@ func (s *Service) DeleteCustomDetectionRule(ctx context.Context, payload *gen.De
 		ID:        id,
 		ProjectID: *authCtx.ProjectID,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete custom detection rule").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "delete custom detection rule").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit custom detection rule delete").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "commit custom detection rule delete").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -2000,7 +2000,7 @@ func (s *Service) TestDetectionRule(ctx context.Context, payload *gen.TestDetect
 func (s *Service) testGitleaksRule(ctx context.Context, ruleID, text string) (*gen.TestDetectionRuleResult, error) {
 	findings, err := ra.ScanWithGitleaks(text)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "run gitleaks").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "run gitleaks").LogError(ctx, s.logger)
 	}
 	matches := make([]*gen.TestDetectionRuleMatch, 0, len(findings))
 	for _, f := range findings {
@@ -2027,7 +2027,7 @@ func (s *Service) testPresidioRule(ctx context.Context, ruleID, text string) (*g
 	entity := strings.ToUpper(strings.TrimPrefix(ruleID, "pii."))
 	batches, err := s.piiScanner.AnalyzeBatch(ctx, []string{text}, []string{entity}, nil)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "run presidio").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "run presidio").LogError(ctx, s.logger)
 	}
 	matches := make([]*gen.TestDetectionRuleMatch, 0)
 	if len(batches) > 0 {
@@ -2058,7 +2058,7 @@ func (s *Service) testPromptInjectionRule(ctx context.Context, orgID, text strin
 	}
 	findings, err := s.piScanner.Scan(ctx, text, orgID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "run prompt-injection scanner").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "run prompt-injection scanner").LogError(ctx, s.logger)
 	}
 	matches := make([]*gen.TestDetectionRuleMatch, 0, len(findings))
 	for _, f := range findings {

--- a/server/internal/risk/policy_bypass.go
+++ b/server/internal/risk/policy_bypass.go
@@ -59,7 +59,7 @@ func (s *Service) ListRiskPolicyBypassRequests(ctx context.Context, payload *gen
 		Status:       conv.PtrToPGText(payload.Status),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk policy bypass requests").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk policy bypass requests").LogError(ctx, s.logger)
 	}
 
 	requests := make([]*gen.RiskPolicyBypassRequest, 0, len(rows))
@@ -80,7 +80,7 @@ func (s *Service) CreateRiskPolicyBypassRequest(ctx context.Context, payload *ge
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 	if strings.TrimSpace(s.jwtSecret) == "" {
-		return nil, oops.E(oops.CodeUnexpected, nil, "risk policy bypass request tokens are not configured").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, nil, "risk policy bypass request tokens are not configured").LogError(ctx, s.logger)
 	}
 
 	claims, err := parsePolicyBypassRequestToken(s.jwtSecret, payload.RequestToken)
@@ -109,7 +109,7 @@ func (s *Service) CreateRiskPolicyBypassRequest(ctx context.Context, payload *ge
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin risk policy bypass request").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin risk policy bypass request").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -117,7 +117,7 @@ func (s *Service) CreateRiskPolicyBypassRequest(ctx context.Context, payload *ge
 		ID:             projectID,
 		OrganizationID: claims.OrganizationID,
 	}); err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "project not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "project not found").LogError(ctx, s.logger)
 	}
 	q := repo.New(dbtx)
 	policy, err := q.GetRiskPolicyForUpdate(ctx, repo.GetRiskPolicyForUpdateParams{
@@ -125,7 +125,7 @@ func (s *Service) CreateRiskPolicyBypassRequest(ctx context.Context, payload *ge
 		ProjectID: projectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 	}
 
 	target, err := riskPolicyBypassTargetFromClaims(claims)
@@ -147,15 +147,15 @@ func (s *Service) CreateRiskPolicyBypassRequest(ctx context.Context, payload *ge
 		Status:           riskPolicyBypassRequestStatusRequested,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create risk policy bypass request").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create risk policy bypass request").LogError(ctx, s.logger)
 	}
 
 	if err := s.logRiskPolicyBypassRequestAudit(ctx, dbtx, audit.ActionRiskPolicyBypassRequestCreate, authCtx, policy.ID, policy.ProjectID, policy.Name, nil, &row); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy bypass request create").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy bypass request create").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy bypass request").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy bypass request").LogError(ctx, s.logger)
 	}
 
 	return riskPolicyBypassRequestView(row)
@@ -177,7 +177,7 @@ func (s *Service) ApproveRiskPolicyBypassRequest(ctx context.Context, payload *g
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin risk policy bypass approval").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin risk policy bypass approval").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -187,14 +187,14 @@ func (s *Service) ApproveRiskPolicyBypassRequest(ctx context.Context, payload *g
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy bypass request not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy bypass request not found").LogError(ctx, s.logger)
 	}
 	policy, err := q.GetRiskPolicy(ctx, repo.GetRiskPolicyParams{
 		ID:        current.RiskPolicyID,
 		ProjectID: current.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 	}
 	principals, principalURNs, err := riskPolicyBypassGrantPrincipals(current.RequesterUserID, payload.GrantedPrincipalUrns)
 	if err != nil {
@@ -205,7 +205,7 @@ func (s *Service) ApproveRiskPolicyBypassRequest(ctx context.Context, payload *g
 	}
 	selector, err := riskPolicyBypassGrantSelector(current)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build risk policy bypass selector").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build risk policy bypass selector").LogError(ctx, s.logger)
 	}
 	if current.Status == riskPolicyBypassRequestStatusApproved {
 		currentPrincipals, _, err := riskPolicyBypassGrantPrincipals(current.RequesterUserID, current.GrantedPrincipalUrns)
@@ -224,7 +224,7 @@ func (s *Service) ApproveRiskPolicyBypassRequest(ctx context.Context, payload *g
 				Principals: principalsToRevoke,
 				Selector:   selector,
 			}); err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "revoke replaced risk policy bypass grants").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "revoke replaced risk policy bypass grants").LogError(ctx, s.logger)
 			}
 		}
 	}
@@ -238,7 +238,7 @@ func (s *Service) ApproveRiskPolicyBypassRequest(ctx context.Context, payload *g
 		Principals: principals,
 		Selector:   selector,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "grant risk policy bypass").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "grant risk policy bypass").LogError(ctx, s.logger)
 	}
 
 	row, err := q.UpdateRiskPolicyBypassRequestStatus(ctx, repo.UpdateRiskPolicyBypassRequestStatusParams{
@@ -249,15 +249,15 @@ func (s *Service) ApproveRiskPolicyBypassRequest(ctx context.Context, payload *g
 		ProjectID:            *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "approve risk policy bypass request").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "approve risk policy bypass request").LogError(ctx, s.logger)
 	}
 
 	if err := s.logRiskPolicyBypassRequestAudit(ctx, dbtx, audit.ActionRiskPolicyBypassRequestApprove, authCtx, current.RiskPolicyID, current.ProjectID, policy.Name, &current, &row); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy bypass request approval").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy bypass request approval").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy bypass approval").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy bypass approval").LogError(ctx, s.logger)
 	}
 
 	return riskPolicyBypassRequestView(row)
@@ -279,7 +279,7 @@ func (s *Service) DenyRiskPolicyBypassRequest(ctx context.Context, payload *gen.
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin risk policy bypass denial").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin risk policy bypass denial").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -289,7 +289,7 @@ func (s *Service) DenyRiskPolicyBypassRequest(ctx context.Context, payload *gen.
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy bypass request not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy bypass request not found").LogError(ctx, s.logger)
 	}
 	if current.Status != riskPolicyBypassRequestStatusRequested {
 		return nil, oops.E(oops.CodeInvalid, nil, "risk policy bypass request must be pending")
@@ -299,7 +299,7 @@ func (s *Service) DenyRiskPolicyBypassRequest(ctx context.Context, payload *gen.
 		ProjectID: current.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 	}
 	row, err := q.UpdateRiskPolicyBypassRequestStatus(ctx, repo.UpdateRiskPolicyBypassRequestStatusParams{
 		Status:               riskPolicyBypassRequestStatusDenied,
@@ -309,15 +309,15 @@ func (s *Service) DenyRiskPolicyBypassRequest(ctx context.Context, payload *gen.
 		ProjectID:            *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy bypass request not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy bypass request not found").LogError(ctx, s.logger)
 	}
 
 	if err := s.logRiskPolicyBypassRequestAudit(ctx, dbtx, audit.ActionRiskPolicyBypassRequestDeny, authCtx, current.RiskPolicyID, current.ProjectID, policy.Name, &current, &row); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy bypass request denial").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy bypass request denial").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy bypass denial").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy bypass denial").LogError(ctx, s.logger)
 	}
 
 	return riskPolicyBypassRequestView(row)
@@ -339,7 +339,7 @@ func (s *Service) RevokeRiskPolicyBypassRequest(ctx context.Context, payload *ge
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin risk policy bypass revocation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin risk policy bypass revocation").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -349,14 +349,14 @@ func (s *Service) RevokeRiskPolicyBypassRequest(ctx context.Context, payload *ge
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy bypass request not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy bypass request not found").LogError(ctx, s.logger)
 	}
 	policy, err := q.GetRiskPolicy(ctx, repo.GetRiskPolicyParams{
 		ID:        current.RiskPolicyID,
 		ProjectID: current.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
 	}
 	principals, _, err := riskPolicyBypassGrantPrincipals(current.RequesterUserID, current.GrantedPrincipalUrns)
 	if err != nil {
@@ -364,7 +364,7 @@ func (s *Service) RevokeRiskPolicyBypassRequest(ctx context.Context, payload *ge
 	}
 	selector, err := riskPolicyBypassGrantSelector(current)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build risk policy bypass selector").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build risk policy bypass selector").LogError(ctx, s.logger)
 	}
 	if err := authz.RevokeResourceFromPrincipals(ctx, dbtx, authz.ResourceGrant{
 		Resource: authz.Resource{
@@ -376,7 +376,7 @@ func (s *Service) RevokeRiskPolicyBypassRequest(ctx context.Context, payload *ge
 		Principals: principals,
 		Selector:   selector,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "revoke risk policy bypass").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "revoke risk policy bypass").LogError(ctx, s.logger)
 	}
 
 	row, err := q.UpdateRiskPolicyBypassRequestStatus(ctx, repo.UpdateRiskPolicyBypassRequestStatusParams{
@@ -387,15 +387,15 @@ func (s *Service) RevokeRiskPolicyBypassRequest(ctx context.Context, payload *ge
 		ProjectID:            *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "revoke risk policy bypass request").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "revoke risk policy bypass request").LogError(ctx, s.logger)
 	}
 
 	if err := s.logRiskPolicyBypassRequestAudit(ctx, dbtx, audit.ActionRiskPolicyBypassRequestRevoke, authCtx, current.RiskPolicyID, current.ProjectID, policy.Name, &current, &row); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy bypass request revocation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy bypass request revocation").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy bypass revocation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy bypass revocation").LogError(ctx, s.logger)
 	}
 
 	return riskPolicyBypassRequestView(row)

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -1200,7 +1200,7 @@ func (s *Service) CaptureEvent(ctx context.Context, payload *telem_gen.CaptureEv
 	// Capture event in PostHog
 	if err := s.posthog.CaptureEvent(ctx, payload.Event, distinctID, properties); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to capture event").
-			Log(ctx, s.logger,
+			LogError(ctx, s.logger,
 				attr.SlogEvent(payload.Event),
 			)
 	}

--- a/server/internal/templates/impl.go
+++ b/server/internal/templates/impl.go
@@ -112,7 +112,7 @@ func (s *Service) CreateTemplate(ctx context.Context, payload *gen.CreateTemplat
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
 	}
 
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
@@ -126,17 +126,17 @@ func (s *Service) CreateTemplate(ctx context.Context, payload *gen.CreateTemplat
 		err = jsonschema.ValidateInputSchema(bytes.NewReader(args))
 		switch {
 		case errors.Is(err, jsonschema.ErrSchemaUnsupportedType) || errors.Is(err, jsonschema.ErrSchemaNotObject):
-			return nil, oops.E(oops.CodeInvalid, err, "invalid arguments schema").Log(ctx, logger)
+			return nil, oops.E(oops.CodeInvalid, err, "invalid arguments schema").LogError(ctx, logger)
 		case errors.Is(err, jsonschema.ErrSchemaHasNoProperties):
 			// This is allowed, it means the schema is empty, which is valid.
 		case err != nil:
-			return nil, oops.E(oops.CodeBadRequest, err, "failed to validate arguments schema").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "failed to validate arguments schema").LogError(ctx, logger)
 		}
 	}
 
 	toolURN := urn.NewTool(urn.ToolKindPrompt, payload.Kind, string(payload.Name))
 	if err := toolURN.Validate(); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid tool URN").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid tool URN").LogError(ctx, logger)
 	}
 
 	id, err := tr.CreateTemplate(ctx, repo.CreateTemplateParams{
@@ -157,9 +157,9 @@ func (s *Service) CreateTemplate(ctx context.Context, payload *gen.CreateTemplat
 		if pgErr.Code == pgerrcode.UniqueViolation {
 			return nil, oops.E(oops.CodeConflict, err, "template name already exists")
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "unexpected database error").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "unexpected database error").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create template").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogTemplateCreate(ctx, dbtx, audit.LogTemplateCreateEvent{
@@ -174,11 +174,11 @@ func (s *Service) CreateTemplate(ctx context.Context, payload *gen.CreateTemplat
 		TemplateURN:  toolURN,
 		TemplateName: string(payload.Name),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save template create audit log").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save template create audit log").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save template").LogError(ctx, logger)
 	}
 
 	pt, err := mv.DescribePromptTemplate(ctx, logger, s.db, mv.ProjectID(projectID), mv.PromptTemplateID(uuid.NullUUID{UUID: id, Valid: true}), mv.PromptTemplateName(nil))
@@ -205,7 +205,7 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin update operation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin update operation").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -222,9 +222,9 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "template not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "template not found").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").LogError(ctx, logger)
 	}
 
 	nextid := current.ID
@@ -236,21 +236,21 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 		err = jsonschema.ValidateInputSchema(bytes.NewReader(args))
 		switch {
 		case errors.Is(err, jsonschema.ErrSchemaUnsupportedType) || errors.Is(err, jsonschema.ErrSchemaNotObject):
-			return nil, oops.E(oops.CodeInvalid, err, "invalid arguments schema").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeInvalid, err, "invalid arguments schema").LogError(ctx, s.logger)
 		case errors.Is(err, jsonschema.ErrSchemaHasNoProperties):
 			// This is allowed, it means the schema is empty, which is valid.
 		case err != nil:
-			return nil, oops.E(oops.CodeBadRequest, err, "failed to validate arguments schema").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "failed to validate arguments schema").LogError(ctx, s.logger)
 		}
 	}
 
 	if payload.Kind != nil && *payload.Kind != current.Kind.String {
-		return nil, oops.E(oops.CodeBadRequest, nil, "kind cannot be changed").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "kind cannot be changed").LogError(ctx, logger)
 	}
 
 	toolURN := urn.NewTool(urn.ToolKindPrompt, current.Kind.String, current.Name)
 	if err := toolURN.Validate(); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid tool URN").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid tool URN").LogError(ctx, logger)
 	}
 
 	// We allow the editing of the name via variation
@@ -275,7 +275,7 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 			OpenWorldHint:    nil,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to update template").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to update template").LogError(ctx, logger)
 		}
 	}
 
@@ -299,7 +299,7 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 	case errors.Is(err, pgx.ErrNoRows):
 		// No change, so we can use the existing id
 	default:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to update template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to update template").LogError(ctx, logger)
 	}
 
 	if updated {
@@ -315,17 +315,17 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 			TemplateURN:  toolURN,
 			TemplateName: current.Name,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to save template update audit log").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to save template update audit log").LogError(ctx, logger)
 		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save updated template").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save updated template").LogError(ctx, s.logger)
 	}
 
 	// We need to invalidate the cache for any toolsets that contain this template as a tool
 	if err := s.toolsets.InvalidateCacheByTool(ctx, toolURN, projectID); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to invalidate toolset cache").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to invalidate toolset cache").LogError(ctx, s.logger)
 	}
 
 	pt, err := mv.DescribePromptTemplate(ctx, logger, s.db,
@@ -356,7 +356,7 @@ func (s *Service) DeleteTemplate(ctx context.Context, payload *gen.DeleteTemplat
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to access templates").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to access templates").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -390,7 +390,7 @@ func (s *Service) DeleteTemplate(ctx context.Context, payload *gen.DeleteTemplat
 		case errors.Is(err, pgx.ErrNoRows):
 			return nil
 		case err != nil:
-			return oops.E(oops.CodeUnexpected, err, "failed to delete template by id").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to delete template by id").LogError(ctx, logger)
 		}
 
 		auditEntry.id = deleted.ID
@@ -407,7 +407,7 @@ func (s *Service) DeleteTemplate(ctx context.Context, payload *gen.DeleteTemplat
 		case errors.Is(err, pgx.ErrNoRows):
 			return nil
 		case err != nil:
-			return oops.E(oops.CodeUnexpected, err, "failed to delete template by name").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to delete template by name").LogError(ctx, logger)
 		}
 
 		auditEntry.id = deleted.ID
@@ -430,18 +430,18 @@ func (s *Service) DeleteTemplate(ctx context.Context, payload *gen.DeleteTemplat
 			TemplateURN:  *auditEntry.toolURN,
 			TemplateName: auditEntry.name,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to save template delete audit log").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to save template delete audit log").LogError(ctx, logger)
 		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to save template deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to save template deletion").LogError(ctx, logger)
 	}
 
 	// Invalidate cache for any toolsets that contain this template as a tool
 	if auditEntry.id != uuid.Nil {
 		if err := s.toolsets.InvalidateCacheByTool(ctx, *auditEntry.toolURN, projectID); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to invalidate toolset cache").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to invalidate toolset cache").LogError(ctx, s.logger)
 		}
 	}
 
@@ -528,14 +528,14 @@ func (s *Service) RenderTemplateByID(ctx context.Context, payload *gen.RenderTem
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "template not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "template not found").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").LogError(ctx, logger)
 	}
 
 	data, err := RenderTemplate(ctx, logger, pt.Prompt, pt.Kind.String, pt.Engine.String, payload.Arguments)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "failed to render template").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "failed to render template").LogError(ctx, logger)
 	}
 
 	return &gen.RenderTemplateResult{Prompt: data}, nil
@@ -569,7 +569,7 @@ func RenderTemplate(ctx context.Context, logger *slog.Logger, template string, k
 	if kind == "higher_order_tool" {
 		renderedPrompt, err = RenderTemplateJSON(ctx, logger, template)
 		if err != nil {
-			return "", oops.E(oops.CodeBadRequest, err, "failed to render template").Log(ctx, logger)
+			return "", oops.E(oops.CodeBadRequest, err, "failed to render template").LogError(ctx, logger)
 		}
 	}
 
@@ -580,10 +580,10 @@ func RenderTemplate(ctx context.Context, logger *slog.Logger, template string, k
 	case "mustache":
 		data, err = mustache.Render(renderedPrompt, arguments)
 		if err != nil {
-			return "", oops.E(oops.CodeBadRequest, err, "failed to render template").Log(ctx, logger)
+			return "", oops.E(oops.CodeBadRequest, err, "failed to render template").LogError(ctx, logger)
 		}
 	default:
-		return "", oops.E(oops.CodeBadRequest, nil, "unsupported template engine").Log(ctx, logger)
+		return "", oops.E(oops.CodeBadRequest, nil, "unsupported template engine").LogError(ctx, logger)
 	}
 
 	return data, nil
@@ -613,7 +613,7 @@ type Step struct {
 func RenderTemplateJSON(ctx context.Context, logger *slog.Logger, promptJSON string) (string, error) {
 	var prompt CustomToolJSONV1
 	if err := json.Unmarshal([]byte(promptJSON), &prompt); err != nil {
-		return "", oops.E(oops.CodeBadRequest, err, "failed to unmarshal prompt").Log(ctx, logger)
+		return "", oops.E(oops.CodeBadRequest, err, "failed to unmarshal prompt").LogError(ctx, logger)
 	}
 
 	inputsPortion := ""

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -199,7 +199,7 @@ func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string) (string,
 	case errors.Is(err, pgx.ErrNoRows), key.Key == "":
 		org, err := o.orgRepo.GetOrganizationMetadata(ctx, orgID)
 		if err != nil {
-			return "", oops.E(oops.CodeUnexpected, err, "failed to get organization").Log(ctx, o.logger)
+			return "", oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 		}
 
 		creditAmount := o.getLimitForOrg(org)
@@ -216,19 +216,19 @@ func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string) (string,
 			MonthlyCredits: int64(creditAmount),
 		})
 		if err != nil {
-			return "", oops.E(oops.CodeUnexpected, err, "failed to store openrouter key data").Log(ctx, o.logger)
+			return "", oops.E(oops.CodeUnexpected, err, "failed to store openrouter key data").LogError(ctx, o.logger)
 		}
 
 		if o.refresher != nil {
 			if err := o.refresher.ScheduleOpenRouterKeyRefresh(ctx, orgID); err != nil {
-				return "", oops.E(oops.CodeUnexpected, err, "error scheduling open router key refresh").Log(ctx, o.logger)
+				return "", oops.E(oops.CodeUnexpected, err, "error scheduling open router key refresh").LogError(ctx, o.logger)
 			}
 		}
 
 		openrouterKey = *keyResponse.Key
 
 	case err != nil:
-		return "", oops.E(oops.CodeUnexpected, err, "error reading open router key data").Log(ctx, o.logger)
+		return "", oops.E(oops.CodeUnexpected, err, "error reading open router key data").LogError(ctx, o.logger)
 
 	default:
 		openrouterKey = key.Key
@@ -253,7 +253,7 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, limit
 
 	org, err := o.orgRepo.GetOrganizationMetadata(ctx, orgID)
 	if err != nil {
-		return 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").Log(ctx, o.logger)
+		return 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
 
 	var keyLimit int
@@ -275,7 +275,7 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, limit
 		Key:            key.Key,
 	})
 	if err != nil {
-		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").Log(ctx, o.logger)
+		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)
 	}
 
 	return keyLimit, nil
@@ -308,7 +308,7 @@ type generationResponse struct {
 func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string) (float64, int, error) {
 	org, err := o.orgRepo.GetOrganizationMetadata(ctx, orgID)
 	if err != nil {
-		return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").Log(ctx, o.logger)
+		return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
 	limit := o.getLimitForOrg(org)
 
@@ -530,7 +530,7 @@ func (o *OpenRouter) updateOpenRouterAPIKeyLimit(ctx context.Context, keyHash st
 func (o *OpenRouter) getGenerationDetails(ctx context.Context, generationID string, orgID string) (*generationResponse, int, error) {
 	key, err := o.repo.GetOpenRouterAPIKey(ctx, orgID)
 	if err != nil {
-		return nil, 0, oops.E(oops.CodeUnexpected, err, "failed to get openrouter API key").Log(ctx, o.logger)
+		return nil, 0, oops.E(oops.CodeUnexpected, err, "failed to get openrouter API key").LogError(ctx, o.logger)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", OpenRouterBaseURL+"/v1/generation", nil)

--- a/server/internal/tools/impl.go
+++ b/server/internal/tools/impl.go
@@ -139,7 +139,7 @@ func (s *Service) ListTools(ctx context.Context, payload *gen.ListToolsPayload) 
 			types.ToolType(urn.ToolKindPlatform):
 			toolKinds[urn.ToolKind(t)] = nil
 		default:
-			return nil, oops.E(oops.CodeBadRequest, nil, "invalid tool type: %s", t).Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "invalid tool type: %s", t).LogError(ctx, s.logger)
 		}
 	}
 
@@ -209,7 +209,7 @@ func (s *Service) ListTools(ctx context.Context, payload *gen.ListToolsPayload) 
 
 	err := mv.ApplyVariations(ctx, s.logger, s.db, *authCtx.ProjectID, nil, result.Tools)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to tools").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to apply variations to tools").LogError(ctx, s.logger)
 	}
 
 	return result, nil
@@ -243,7 +243,7 @@ func (s *Service) getHTTPTools(
 	if params.cursor != nil {
 		cursorUUID, err := uuid.Parse(*params.cursor)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 		}
 		toolParams.Cursor = uuid.NullUUID{UUID: cursorUUID, Valid: true}
 	}
@@ -251,14 +251,14 @@ func (s *Service) getHTTPTools(
 	if params.deploymentID != nil {
 		deploymentUUID, err := uuid.Parse(*params.deploymentID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid deployment ID").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid deployment ID").LogError(ctx, s.logger)
 		}
 		toolParams.DeploymentID = uuid.NullUUID{UUID: deploymentUUID, Valid: true}
 	}
 
 	tools, err := s.repo.ListHttpTools(ctx, toolParams)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list http tools").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list http tools").LogError(ctx, s.logger)
 	}
 	hasNextPage := len(tools) >= int(params.limit+1)
 	var nextCursor *string
@@ -357,7 +357,7 @@ func (s *Service) getFunctionTools(
 		Limit:        params.limit + 1,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list function tools").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list function tools").LogError(ctx, s.logger)
 	}
 
 	result := []*types.Tool{}
@@ -367,7 +367,7 @@ func (s *Service) getFunctionTools(
 		if tool.Meta != nil {
 			err = json.Unmarshal(tool.Meta, &meta)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal meta tags").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal meta tags").LogError(ctx, s.logger)
 			}
 		}
 		result = append(result, &types.Tool{
@@ -414,7 +414,7 @@ type getPromptTemplatesParams struct {
 func (s *Service) getPromptTemplates(ctx context.Context, params getPromptTemplatesParams) ([]*types.Tool, error) {
 	templates, err := s.templateRepo.ListTemplates(ctx, params.projectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list prompt templates").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list prompt templates").LogError(ctx, s.logger)
 	}
 
 	result := []*types.Tool{}
@@ -472,7 +472,7 @@ func (s *Service) getExternalMCPTools(
 	if params.deploymentID != nil {
 		deploymentUUID, err := uuid.Parse(*params.deploymentID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid deployment ID").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid deployment ID").LogError(ctx, s.logger)
 		}
 		queryParams.DeploymentID = uuid.NullUUID{UUID: deploymentUUID, Valid: true}
 	}
@@ -482,7 +482,7 @@ func (s *Service) getExternalMCPTools(
 		queryParams,
 	)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list external mcp tools").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list external mcp tools").LogError(ctx, s.logger)
 	}
 
 	result := []*types.Tool{}

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -131,7 +131,7 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 
 	slugSuffix, err := conv.GenerateRandomSlug(5)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate random slug").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate random slug").LogError(ctx, logger)
 	}
 
 	mcpSlug := authCtx.OrganizationSlug + "-" + slugSuffix
@@ -177,7 +177,7 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing toolsets").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing toolsets").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -190,7 +190,7 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 			return nil, oops.E(oops.CodeConflict, nil, "toolset slug already exists")
 		}
 
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create toolset").LogError(ctx, logger)
 	}
 
 	if payload.Origin != nil {
@@ -200,7 +200,7 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 			RegistrySpecifier: payload.Origin.RegistrySpecifier,
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to create toolset origin").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to create toolset origin").LogError(ctx, logger)
 		}
 	}
 
@@ -220,11 +220,11 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 		ToolsetName:      createdToolset.Name,
 		ToolsetSlug:      createdToolset.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving toolset").LogError(ctx, logger)
 	}
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(createdToolset.Slug), &s.toolsetCache, nil)
@@ -243,7 +243,7 @@ func (s *Service) ListToolsets(ctx context.Context, payload *gen.ListToolsetsPay
 
 	toolsets, err := s.repo.ListToolsetsByProject(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list toolsets").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list toolsets").LogError(ctx, s.logger)
 	}
 
 	toolsetIDs := make([]string, len(toolsets))
@@ -294,12 +294,12 @@ func (s *Service) ListToolsetsForOrg(ctx context.Context, payload *gen.ListTools
 
 	toolsets, err := s.repo.ListToolsetsWithVersionsByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list toolsets for organization").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list toolsets for organization").LogError(ctx, s.logger)
 	}
 
 	result, err := mv.GetToolsetsSummary(ctx, s.logger, s.db, toolsets)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset summaries").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset summaries").LogError(ctx, s.logger)
 	}
 
 	return &gen.ListToolsetSummariesResult{
@@ -317,7 +317,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing toolsets").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing toolsets").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -330,7 +330,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, existingToolset.ID.String(), authCtx.ProjectID.String())); err != nil {
@@ -338,7 +338,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 	}
 	existingView, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(existingToolset.Slug), new(s.toolsetCache.SkipCache()), nil)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe existing toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe existing toolset").LogError(ctx, logger)
 	}
 
 	// Convert update params
@@ -418,7 +418,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 			})
 
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "error clearing oauth configurations").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "error clearing oauth configurations").LogError(ctx, logger)
 			}
 
 			clearedOAuth = true
@@ -446,7 +446,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 
 	updatedToolset, err := tr.UpdateToolset(ctx, updateParams)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error updating toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error updating toolset").LogError(ctx, logger)
 	}
 
 	if payload.PromptTemplateNames != nil {
@@ -479,7 +479,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 			ExternalOAuthServerID:   new(existingToolset.ExternalOauthServerID.UUID.String()),
 			ExternalOAuthServerSlug: extoauthslug,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset detach external OAuth server audit event").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset detach external OAuth server audit event").LogError(ctx, logger)
 		}
 	}
 
@@ -501,7 +501,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 			OAuthProxyServerID:   new(existingToolset.OauthProxyServerID.UUID.String()),
 			OAuthProxyServerSlug: oauthProxySlug,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset detach OAuth proxy server audit event").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset detach OAuth proxy server audit event").LogError(ctx, logger)
 		}
 	}
 
@@ -518,11 +518,11 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		ToolsetSnapshotBefore: existingView,
 		ToolsetSnapshotAfter:  toolsetDetails,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving updated toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving updated toolset").LogError(ctx, logger)
 	}
 
 	return toolsetDetails, nil
@@ -538,7 +538,7 @@ func (s *Service) DeleteToolset(ctx context.Context, payload *gen.DeleteToolsetP
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error accessing toolsets").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "error accessing toolsets").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -552,7 +552,7 @@ func (s *Service) DeleteToolset(ctx context.Context, payload *gen.DeleteToolsetP
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to get toolset").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get toolset").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, toDelete.ID.String(), authCtx.ProjectID.String())); err != nil {
@@ -567,7 +567,7 @@ func (s *Service) DeleteToolset(ctx context.Context, payload *gen.DeleteToolsetP
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to delete toolset").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to delete toolset").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogToolsetDelete(ctx, dbtx, audit.LogToolsetDeleteEvent{
@@ -580,11 +580,11 @@ func (s *Service) DeleteToolset(ctx context.Context, payload *gen.DeleteToolsetP
 		ToolsetName:      deleted.Name,
 		ToolsetSlug:      deleted.Slug,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to log toolset delete").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to log toolset delete").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error saving toolset deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "error saving toolset deletion").LogError(ctx, logger)
 	}
 
 	return nil
@@ -620,9 +620,9 @@ func (s *Service) ListToolFilters(ctx context.Context, payload *gen.ListToolFilt
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "get toolset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get toolset").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPRead, toolset.ID.String(), authCtx.ProjectID.String())); err != nil {
@@ -665,7 +665,7 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -677,7 +677,7 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(
@@ -691,7 +691,7 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 	// Generate new slug with _copy suffix
 	slugSuffix, err := conv.GenerateRandomSlug(5)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate random slug").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate random slug").LogError(ctx, logger)
 	}
 
 	newName := originalToolset.Name + "_copy"
@@ -725,31 +725,31 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 
 		savepointName := fmt.Sprintf("clone_toolset_insert_%d", i)
 		if _, err := dbtx.Exec(ctx, "SAVEPOINT "+savepointName); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to clone toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to clone toolset").LogError(ctx, logger)
 		}
 
 		clonedToolset, err = tr.CreateToolset(ctx, baseParams)
 		if err == nil {
 			if _, releaseErr := dbtx.Exec(ctx, "RELEASE SAVEPOINT "+savepointName); releaseErr != nil {
-				return nil, oops.E(oops.CodeUnexpected, releaseErr, "failed to clone toolset").Log(ctx, logger)
+				return nil, oops.E(oops.CodeUnexpected, releaseErr, "failed to clone toolset").LogError(ctx, logger)
 			}
 			break
 		}
 
 		if _, rollbackErr := dbtx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+savepointName); rollbackErr != nil {
-			return nil, oops.E(oops.CodeUnexpected, rollbackErr, "failed to clone toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, rollbackErr, "failed to clone toolset").LogError(ctx, logger)
 		}
 		if _, releaseErr := dbtx.Exec(ctx, "RELEASE SAVEPOINT "+savepointName); releaseErr != nil {
-			return nil, oops.E(oops.CodeUnexpected, releaseErr, "failed to clone toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, releaseErr, "failed to clone toolset").LogError(ctx, logger)
 		}
 
 		var pgErr *pgconn.PgError
 		if !errors.As(err, &pgErr) || pgErr.Code != pgerrcode.UniqueViolation {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to clone toolset").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to clone toolset").LogError(ctx, logger)
 		}
 	}
 	if err != nil {
-		return nil, oops.E(oops.CodeConflict, nil, "could not create unique toolset name").Log(ctx, logger)
+		return nil, oops.E(oops.CodeConflict, nil, "could not create unique toolset name").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogToolsetCreate(ctx, dbtx, audit.LogToolsetCreateEvent{
@@ -762,7 +762,7 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 		ToolsetName:      clonedToolset.Name,
 		ToolsetSlug:      clonedToolset.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset create audit event").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset create audit event").LogError(ctx, logger)
 	}
 
 	// Clone the latest toolset version
@@ -814,16 +814,16 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 	toolsetDetails, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(clonedToolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to describe cloned toolset", attr.SlogError(err))
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe cloned toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to describe cloned toolset").LogError(ctx, logger)
 	}
 
 	if toolsetDetails == nil {
 		logger.ErrorContext(ctx, "toolsetDetails is nil after successful describe")
-		return nil, oops.E(oops.CodeUnexpected, nil, "toolset details is nil").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, nil, "toolset details is nil").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to save cloned toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to save cloned toolset").LogError(ctx, logger)
 	}
 
 	logger.InfoContext(ctx, "successfully cloned toolset",
@@ -845,12 +845,12 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 	}
 
 	if authCtx.AccountType == "free" {
-		return nil, oops.E(oops.CodeForbidden, nil, "free accounts cannot add external OAuth servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeForbidden, nil, "free accounts cannot add external OAuth servers").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing external oauth server configuration").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing external oauth server configuration").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -866,21 +866,21 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 	}
 
 	if existingToolset.McpIsPublic == nil || !*existingToolset.McpIsPublic {
-		return nil, oops.E(oops.CodeBadRequest, nil, "private MCP servers cannot have external OAuth servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "private MCP servers cannot have external OAuth servers").LogError(ctx, s.logger)
 	}
 
 	if existingToolset.ExternalOauthServer != nil || existingToolset.OauthProxyServer != nil {
-		return nil, oops.E(oops.CodeConflict, nil, "external OAuth server already exists").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeConflict, nil, "external OAuth server already exists").LogError(ctx, s.logger)
 	}
 
 	if existingToolset.OauthEnablementMetadata != nil && existingToolset.OauthEnablementMetadata.Oauth2SecurityCount > 1 {
-		return nil, oops.E(oops.CodeBadRequest, nil, "multiple OAuth2 security schemes detected").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "multiple OAuth2 security schemes detected").LogError(ctx, s.logger)
 	}
 
 	// Marshal metadata to JSON bytes
 	metadataBytes, err := json.Marshal(payload.ExternalOauthServer.Metadata)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid metadata format").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid metadata format").LogError(ctx, s.logger)
 	}
 
 	// Create the external OAuth server metadata entry
@@ -890,7 +890,7 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 		Metadata:  metadataBytes,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create external OAuth server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create external OAuth server").LogError(ctx, s.logger)
 	}
 
 	// Associate it with the toolset
@@ -901,9 +901,9 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to associate external OAuth server with toolset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to associate external OAuth server with toolset").LogError(ctx, s.logger)
 	}
 
 	updatedToolset, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
@@ -924,11 +924,11 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 		ExternalOAuthServerID:   externalOAuthServer.ID.String(),
 		ExternalOAuthServerSlug: externalOAuthServer.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error adding external OAuth server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error adding external OAuth server").LogError(ctx, s.logger)
 	}
 
 	return updatedToolset, nil
@@ -944,7 +944,7 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing oauth server configuration").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing oauth server configuration").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -957,9 +957,9 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset").LogError(ctx, logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, existingToolset.ID.String(), authCtx.ProjectID.String())); err != nil {
@@ -978,7 +978,7 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 			ID:        existingToolset.ExternalOauthServerID.UUID,
 		})
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to delete external OAuth server metadata").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to delete external OAuth server metadata").LogError(ctx, logger)
 		}
 
 		if row.Slug != "" {
@@ -997,7 +997,7 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 		})
 
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get OAuth proxy server metadata").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get OAuth proxy server metadata").LogError(ctx, logger)
 		}
 
 		if row.Slug != "" {
@@ -1012,9 +1012,9 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to remove OAuth server from toolset").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to remove OAuth server from toolset").LogError(ctx, logger)
 	}
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
@@ -1036,7 +1036,7 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 			ExternalOAuthServerID:   externalServerID,
 			ExternalOAuthServerSlug: externalServerSlug,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").LogError(ctx, logger)
 		}
 	}
 
@@ -1054,12 +1054,12 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 			OAuthProxyServerID:   oauthProxyID,
 			OAuthProxyServerSlug: oauthProxySlug,
 		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset detach OAuth proxy server audit event").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset detach OAuth proxy server audit event").LogError(ctx, logger)
 		}
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error removing OAuth server").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error removing OAuth server").LogError(ctx, logger)
 	}
 
 	return toolsetDetails, nil
@@ -1073,7 +1073,7 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OAuth proxy servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OAuth proxy servers").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -1088,11 +1088,11 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 
 	toolsetID, err := uuid.Parse(toolsetDetails.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").LogError(ctx, s.logger)
 	}
 
 	if toolsetDetails.OauthProxyServer != nil || toolsetDetails.ExternalOauthServer != nil {
-		return nil, oops.E(oops.CodeConflict, nil, "OAuth server already exists").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeConflict, nil, "OAuth server already exists").LogError(ctx, s.logger)
 	}
 
 	oauth2AuthCodeSecurityCount := 0
@@ -1105,44 +1105,44 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 	}
 
 	if oauth2AuthCodeSecurityCount > 1 {
-		return nil, oops.E(oops.CodeBadRequest, nil, "multiple OAuth2 security schemes detected").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "multiple OAuth2 security schemes detected").LogError(ctx, s.logger)
 	}
 
 	// Validate token_endpoint_auth_methods_supported
 	for _, method := range payload.OauthProxyServer.TokenEndpointAuthMethodsSupported {
 		if !validOAuthProxyAuthMethods[method] {
-			return nil, oops.E(oops.CodeBadRequest, nil, "invalid token_endpoint_auth_methods_supported value: %s (must be client_secret_basic or client_secret_post)", method).Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "invalid token_endpoint_auth_methods_supported value: %s (must be client_secret_basic or client_secret_post)", method).LogError(ctx, s.logger)
 		}
 	}
 
 	providerType := oauth.OAuthProxyProviderType(payload.OauthProxyServer.ProviderType)
 
 	if !providerType.IsValid() {
-		return nil, oops.E(oops.CodeBadRequest, nil, "invalid provider_type value: %s (must be 'custom' or 'gram')", payload.OauthProxyServer.ProviderType).Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "invalid provider_type value: %s (must be 'custom' or 'gram')", payload.OauthProxyServer.ProviderType).LogError(ctx, s.logger)
 	}
 
 	// Validate provider_type against public/private status
 	isPublic := toolsetDetails.McpIsPublic != nil && *toolsetDetails.McpIsPublic
 	if providerType == oauth.OAuthProxyProviderTypeGram && isPublic {
-		return nil, oops.E(oops.CodeBadRequest, nil, "gram provider type can only be used with private MCP servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "gram provider type can only be used with private MCP servers").LogError(ctx, s.logger)
 	}
 	if providerType == oauth.OAuthProxyProviderTypeCustom && !isPublic {
-		return nil, oops.E(oops.CodeBadRequest, nil, "custom provider type can only be used with public MCP servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "custom provider type can only be used with public MCP servers").LogError(ctx, s.logger)
 	}
 
 	// Validate required fields for custom provider type
 	if providerType == oauth.OAuthProxyProviderTypeCustom {
 		if payload.OauthProxyServer.EnvironmentSlug == nil || string(*payload.OauthProxyServer.EnvironmentSlug) == "" {
-			return nil, oops.E(oops.CodeBadRequest, nil, "environment_slug is required for custom provider type").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "environment_slug is required for custom provider type").LogError(ctx, s.logger)
 		}
 		if payload.OauthProxyServer.AuthorizationEndpoint == nil || *payload.OauthProxyServer.AuthorizationEndpoint == "" {
-			return nil, oops.E(oops.CodeBadRequest, nil, "authorization_endpoint is required for custom provider type").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "authorization_endpoint is required for custom provider type").LogError(ctx, s.logger)
 		}
 		if payload.OauthProxyServer.TokenEndpoint == nil || *payload.OauthProxyServer.TokenEndpoint == "" {
-			return nil, oops.E(oops.CodeBadRequest, nil, "token_endpoint is required for custom provider type").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "token_endpoint is required for custom provider type").LogError(ctx, s.logger)
 		}
 		if len(payload.OauthProxyServer.TokenEndpointAuthMethodsSupported) == 0 {
-			return nil, oops.E(oops.CodeBadRequest, nil, "token_endpoint_auth_methods_supported is required for custom provider type").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "token_endpoint_auth_methods_supported is required for custom provider type").LogError(ctx, s.logger)
 		}
 	}
 
@@ -1156,9 +1156,9 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "environment not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "environment not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment").LogError(ctx, s.logger)
 		}
 	}
 
@@ -1168,7 +1168,7 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 		Audience:  conv.PtrToPGText(payload.OauthProxyServer.Audience),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create OAuth proxy server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create OAuth proxy server").LogError(ctx, s.logger)
 	}
 
 	// Create the OAuth proxy provider with the secrets
@@ -1179,7 +1179,7 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 			"environment_slug": string(*payload.OauthProxyServer.EnvironmentSlug),
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal secrets").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal secrets").LogError(ctx, s.logger)
 		}
 	} else {
 		// Empty JSON object for gram provider (doesn't need environment)
@@ -1203,7 +1203,7 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 		Secrets:                           secretsJSON,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to create OAuth proxy provider").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create OAuth proxy provider").LogError(ctx, s.logger)
 	}
 
 	// Associate the OAuth proxy server with the toolset
@@ -1214,9 +1214,9 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to associate OAuth proxy server with toolset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to associate OAuth proxy server with toolset").LogError(ctx, s.logger)
 	}
 
 	toolsetDetails, err = mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
@@ -1237,11 +1237,11 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 		OAuthProxyServerID:   oauthProxyServer.ID.String(),
 		OAuthProxyServerSlug: oauthProxyServer.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error adding OAuth proxy server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error adding OAuth proxy server").LogError(ctx, s.logger)
 	}
 
 	return toolsetDetails, nil
@@ -1342,7 +1342,7 @@ func (s *Service) createToolsetVersion(ctx context.Context, toolUrnStrings []str
 		PredecessorID: predecessorID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to create toolset version").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to create toolset version").LogError(ctx, logger)
 	}
 
 	return nil
@@ -1358,7 +1358,7 @@ func (s *Service) updatePromptTemplates(ctx context.Context, dbtx pgx.Tx, projec
 		Names:     promptTemplateNames,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error validating prompt templates").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "error validating prompt templates").LogError(ctx, logger)
 	}
 
 	err = tr.ClearToolsetPromptTemplates(ctx, repo.ClearToolsetPromptTemplatesParams{
@@ -1366,7 +1366,7 @@ func (s *Service) updatePromptTemplates(ctx context.Context, dbtx pgx.Tx, projec
 		ToolsetID: toolsetID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error resetting prompt templates for toolset").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "error resetting prompt templates for toolset").LogError(ctx, logger)
 	}
 
 	additions := make([]repo.AddToolsetPromptTemplatesParams, 0, len(ptrows))
@@ -1382,7 +1382,7 @@ func (s *Service) updatePromptTemplates(ctx context.Context, dbtx pgx.Tx, projec
 
 	_, err = tr.AddToolsetPromptTemplates(ctx, additions)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error adding prompt templates to toolset").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "error adding prompt templates to toolset").LogError(ctx, logger)
 	}
 
 	return nil
@@ -1397,7 +1397,7 @@ func (s *Service) InvalidateCacheByTool(ctx context.Context, toolURN urn.Tool, p
 	// Get the latest deployment ID for this project
 	deploymentID, err := dr.GetActiveDeploymentID(ctx, projectID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get latest deployment").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get latest deployment").LogError(ctx, logger)
 	}
 
 	// Look up all toolsets that contain this tool in their latest version
@@ -1406,7 +1406,7 @@ func (s *Service) InvalidateCacheByTool(ctx context.Context, toolURN urn.Tool, p
 		ToolUrn:   toolURN.String(),
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get toolsets by tool URN").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get toolsets by tool URN").LogError(ctx, logger)
 	}
 
 	// For each toolset, invalidate its cache entry using the version from the query result

--- a/server/internal/toolsets/set_tool_variations_group.go
+++ b/server/internal/toolsets/set_tool_variations_group.go
@@ -44,14 +44,14 @@ func (s *Service) SetToolVariationsGroup(ctx context.Context, payload *gen.SetTo
 	if payload.ToolVariationsGroupID != nil {
 		parsed, parseErr := uuid.Parse(*payload.ToolVariationsGroupID)
 		if parseErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid tool_variations_group_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid tool_variations_group_id").LogError(ctx, s.logger)
 		}
 		groupID = uuid.NullUUID{UUID: parsed, Valid: true}
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -64,9 +64,9 @@ func (s *Service) SetToolVariationsGroup(ctx context.Context, payload *gen.SetTo
 			ProjectID: *authCtx.ProjectID,
 		}); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "tool variations group not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "tool variations group not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "load tool variations group").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "load tool variations group").LogError(ctx, s.logger)
 		}
 	}
 
@@ -76,9 +76,9 @@ func (s *Service) SetToolVariationsGroup(ctx context.Context, payload *gen.SetTo
 		ProjectID:             *authCtx.ProjectID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update toolset tool_variations_group").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update toolset tool_variations_group").LogError(ctx, s.logger)
 	}
 
 	afterView, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
@@ -88,7 +88,7 @@ func (s *Service) SetToolVariationsGroup(ctx context.Context, payload *gen.SetTo
 
 	toolsetUUID, err := uuid.Parse(afterView.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset id").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogToolsetUpdate(ctx, dbtx, audit.LogToolsetUpdateEvent{
@@ -104,11 +104,11 @@ func (s *Service) SetToolVariationsGroup(ctx context.Context, payload *gen.SetTo
 		ToolsetSnapshotBefore: beforeView,
 		ToolsetSnapshotAfter:  afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log toolset update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log toolset update").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
 	return afterView, nil

--- a/server/internal/toolsets/set_user_session_issuer.go
+++ b/server/internal/toolsets/set_user_session_issuer.go
@@ -44,14 +44,14 @@ func (s *Service) SetUserSessionIssuer(ctx context.Context, payload *gen.SetUser
 	if payload.UserSessionIssuerID != nil {
 		parsed, parseErr := uuid.Parse(*payload.UserSessionIssuerID)
 		if parseErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid user_session_issuer_id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, parseErr, "invalid user_session_issuer_id").LogError(ctx, s.logger)
 		}
 		usiID = uuid.NullUUID{UUID: parsed, Valid: true}
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -64,9 +64,9 @@ func (s *Service) SetUserSessionIssuer(ctx context.Context, payload *gen.SetUser
 			ProjectID: *authCtx.ProjectID,
 		}); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "load user session issuer").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "load user session issuer").LogError(ctx, s.logger)
 		}
 	}
 
@@ -76,9 +76,9 @@ func (s *Service) SetUserSessionIssuer(ctx context.Context, payload *gen.SetUser
 		ProjectID:           *authCtx.ProjectID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update toolset user_session_issuer").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update toolset user_session_issuer").LogError(ctx, s.logger)
 	}
 
 	afterView, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()), nil)
@@ -88,7 +88,7 @@ func (s *Service) SetUserSessionIssuer(ctx context.Context, payload *gen.SetUser
 
 	toolsetUUID, err := uuid.Parse(afterView.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset id").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogToolsetUpdate(ctx, dbtx, audit.LogToolsetUpdateEvent{
@@ -104,11 +104,11 @@ func (s *Service) SetUserSessionIssuer(ctx context.Context, payload *gen.SetUser
 		ToolsetSnapshotBefore: beforeView,
 		ToolsetSnapshotAfter:  afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log toolset update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log toolset update").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
 	return afterView, nil

--- a/server/internal/toolsets/updateoauthproxyserver.go
+++ b/server/internal/toolsets/updateoauthproxyserver.go
@@ -56,7 +56,7 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	if form.TokenEndpointAuthMethodsSupported != nil {
 		for _, method := range form.TokenEndpointAuthMethodsSupported {
 			if !validOAuthProxyAuthMethods[method] {
-				return nil, oops.E(oops.CodeBadRequest, nil, "invalid token_endpoint_auth_methods_supported value: %s (must be client_secret_basic, client_secret_post, or none)", method).Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeBadRequest, nil, "invalid token_endpoint_auth_methods_supported value: %s (must be client_secret_basic, client_secret_post, or none)", method).LogError(ctx, s.logger)
 			}
 		}
 	}
@@ -68,10 +68,10 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	// breaking OAuth for all users of the toolset. Mirrors AddOAuthProxyServer's
 	// validation at impl.go:1008-1012.
 	if form.AuthorizationEndpoint != nil && *form.AuthorizationEndpoint == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "authorization_endpoint cannot be empty").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "authorization_endpoint cannot be empty").LogError(ctx, s.logger)
 	}
 	if form.TokenEndpoint != nil && *form.TokenEndpoint == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "token_endpoint cannot be empty").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "token_endpoint cannot be empty").LogError(ctx, s.logger)
 	}
 
 	// Reject empty arrays for auth methods on update. The create path requires
@@ -79,12 +79,12 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	// produce a proxy that can't function. (scopes_supported is allowed to be
 	// empty — many MCP servers don't advertise scopes in their well-known doc.)
 	if form.TokenEndpointAuthMethodsSupported != nil && len(form.TokenEndpointAuthMethodsSupported) == 0 {
-		return nil, oops.E(oops.CodeBadRequest, nil, "token_endpoint_auth_methods_supported cannot be empty").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "token_endpoint_auth_methods_supported cannot be empty").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OAuth proxy servers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OAuth proxy servers").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -95,7 +95,7 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	}
 
 	if toolsetDetails.OauthProxyServer == nil {
-		return nil, oops.E(oops.CodeNotFound, nil, "no OAuth proxy server attached to this toolset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, nil, "no OAuth proxy server attached to this toolset").LogError(ctx, s.logger)
 	}
 
 	// Capture the pre-update state for the audit log. mv.DescribeToolset returns a fresh
@@ -104,12 +104,12 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 
 	toolsetID, err := uuid.Parse(toolsetDetails.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").LogError(ctx, s.logger)
 	}
 
 	serverID, err := uuid.Parse(toolsetDetails.OauthProxyServer.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "invalid OAuth proxy server ID").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "invalid OAuth proxy server ID").LogError(ctx, s.logger)
 	}
 
 	// Load the provider row so we can (a) check provider_type and (b) read existing
@@ -120,20 +120,20 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "OAuth proxy provider not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "OAuth proxy provider not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to load OAuth proxy provider").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to load OAuth proxy provider").LogError(ctx, s.logger)
 	}
 
 	// Gram-managed servers cannot be edited via this endpoint.
 	if oauth.OAuthProxyProviderType(provider.ProviderType) == oauth.OAuthProxyProviderTypeGram {
-		return nil, oops.E(oops.CodeBadRequest, nil, "gram-managed OAuth proxy servers cannot be edited via this endpoint").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "gram-managed OAuth proxy servers cannot be edited via this endpoint").LogError(ctx, s.logger)
 	}
 
 	// Validate environment_slug if provided.
 	if form.EnvironmentSlug != nil {
 		if string(*form.EnvironmentSlug) == "" {
-			return nil, oops.E(oops.CodeBadRequest, nil, "environment_slug cannot be empty").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "environment_slug cannot be empty").LogError(ctx, s.logger)
 		}
 		_, err = s.environmentRepo.WithTx(dbtx).GetEnvironmentBySlug(ctx, environmentsRepo.GetEnvironmentBySlugParams{
 			Slug:      string(*form.EnvironmentSlug),
@@ -141,9 +141,9 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "environment not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "environment not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment").LogError(ctx, s.logger)
 		}
 	}
 
@@ -156,9 +156,9 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "OAuth proxy server not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "OAuth proxy server not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to update OAuth proxy server audience").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to update OAuth proxy server audience").LogError(ctx, s.logger)
 		}
 	}
 
@@ -177,13 +177,13 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 			existingSecrets := map[string]string{}
 			if provider.Secrets != nil {
 				if err := json.Unmarshal(provider.Secrets, &existingSecrets); err != nil {
-					return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal provider secrets").Log(ctx, s.logger)
+					return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal provider secrets").LogError(ctx, s.logger)
 				}
 			}
 			existingSecrets["environment_slug"] = string(*form.EnvironmentSlug)
 			secretsBytes, err = json.Marshal(existingSecrets)
 			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal provider secrets").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal provider secrets").LogError(ctx, s.logger)
 			}
 		}
 		// secretsBytes == nil when environment_slug was not provided → COALESCE keeps existing value.
@@ -200,9 +200,9 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "OAuth proxy provider not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "OAuth proxy provider not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to update OAuth proxy provider fields").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to update OAuth proxy provider fields").LogError(ctx, s.logger)
 		}
 	}
 
@@ -230,11 +230,11 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 		ToolsetSnapshotBefore: toolsetSnapshotBefore,
 		ToolsetSnapshotAfter:  toolsetDetails,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset update").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error updating OAuth proxy server").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error updating OAuth proxy server").LogError(ctx, s.logger)
 	}
 
 	return toolsetDetails, nil

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -113,7 +113,7 @@ func (s *Service) ListTriggerInstances(ctx context.Context, _ *gen.ListTriggerIn
 		}
 		view, err := buildTriggerView(item, s.app.WebhookURL(item))
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").LogError(ctx, s.logger)
 		}
 		result = append(result, view)
 	}
@@ -129,7 +129,7 @@ func (s *Service) GetTriggerInstance(ctx context.Context, payload *gen.GetTrigge
 
 	triggerID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid trigger id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid trigger id").LogError(ctx, s.logger)
 	}
 
 	item, err := s.app.GetInstance(ctx, *authCtx.ProjectID, triggerID)
@@ -139,7 +139,7 @@ func (s *Service) GetTriggerInstance(ctx context.Context, payload *gen.GetTrigge
 
 	view, err := buildTriggerView(item, s.app.WebhookURL(item))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").LogError(ctx, s.logger)
 	}
 	return view, nil
 }
@@ -154,7 +154,7 @@ func (s *Service) CreateTriggerInstance(ctx context.Context, payload *gen.Create
 	if payload.EnvironmentID != nil {
 		parsed, err := uuid.Parse(*payload.EnvironmentID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid environment id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid environment id").LogError(ctx, s.logger)
 		}
 		envID = uuid.NullUUID{UUID: parsed, Valid: true}
 	}
@@ -188,7 +188,7 @@ func (s *Service) CreateTriggerInstance(ctx context.Context, payload *gen.Create
 
 	view, err := buildTriggerView(item, s.app.WebhookURL(item))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").LogError(ctx, s.logger)
 	}
 	return view, nil
 }
@@ -201,7 +201,7 @@ func (s *Service) UpdateTriggerInstance(ctx context.Context, payload *gen.Update
 
 	triggerID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid trigger id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid trigger id").LogError(ctx, s.logger)
 	}
 
 	existing, err := s.app.GetInstance(ctx, *authCtx.ProjectID, triggerID)
@@ -213,13 +213,13 @@ func (s *Service) UpdateTriggerInstance(ctx context.Context, payload *gen.Update
 	if payload.EnvironmentID != nil {
 		environmentID, err = uuid.Parse(*payload.EnvironmentID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid environment id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid environment id").LogError(ctx, s.logger)
 		}
 	}
 
 	configMap, err := configJSONToMap(existing.ConfigJson)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "decode trigger config").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "decode trigger config").LogError(ctx, s.logger)
 	}
 	if payload.Config != nil {
 		configMap = payload.Config
@@ -227,7 +227,7 @@ func (s *Service) UpdateTriggerInstance(ctx context.Context, payload *gen.Update
 
 	beforeView, err := buildTriggerView(existing, s.app.WebhookURL(existing))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").LogError(ctx, s.logger)
 	}
 
 	item, err := s.app.Update(ctx, bgtriggers.UpdateParams{
@@ -265,7 +265,7 @@ func (s *Service) UpdateTriggerInstance(ctx context.Context, payload *gen.Update
 
 	view, err := buildTriggerView(item, s.app.WebhookURL(item))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").LogError(ctx, s.logger)
 	}
 	return view, nil
 }
@@ -278,7 +278,7 @@ func (s *Service) DeleteTriggerInstance(ctx context.Context, payload *gen.Delete
 
 	triggerID, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid trigger id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid trigger id").LogError(ctx, s.logger)
 	}
 
 	if err := s.app.Delete(ctx, *authCtx.ProjectID, triggerID, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
@@ -342,7 +342,7 @@ func (s *Service) ResumeTriggerInstance(ctx context.Context, payload *gen.Resume
 func (s *Service) setTriggerStatus(ctx context.Context, authCtx *contextvalues.AuthContext, id string, status string, hooks ...bgtriggers.InstanceDBHook) (*types.TriggerInstance, error) {
 	triggerID, err := uuid.Parse(id)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid trigger id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid trigger id").LogError(ctx, s.logger)
 	}
 
 	item, err := s.app.SetStatus(ctx, *authCtx.ProjectID, triggerID, status, hooks...)
@@ -352,7 +352,7 @@ func (s *Service) setTriggerStatus(ctx context.Context, authCtx *contextvalues.A
 
 	view, err := buildTriggerView(item, s.app.WebhookURL(item))
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").LogError(ctx, s.logger)
 	}
 	return view, nil
 }
@@ -365,12 +365,12 @@ func (s *Service) HandleWebhook(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	triggerID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid trigger id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid trigger id").LogError(ctx, s.logger)
 	}
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "read request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "read request body").LogError(ctx, s.logger)
 	}
 
 	result, err := s.app.ProcessWebhook(ctx, triggerID, body, r.Header)
@@ -390,7 +390,7 @@ func (s *Service) HandleWebhook(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(statusCode)
 	if _, err := w.Write(responseBody); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "write webhook response").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "write webhook response").LogError(ctx, s.logger)
 	}
 
 	return nil
@@ -472,7 +472,7 @@ func toTriggerError(ctx context.Context, logger *slog.Logger, err error, message
 	case errors.Is(err, pgx.ErrNoRows):
 		code = oops.CodeNotFound
 	}
-	return oops.E(code, err, "%s", public).Log(ctx, logger)
+	return oops.E(code, err, "%s", public).LogError(ctx, logger)
 }
 
 func nullUUIDToUUID(value uuid.NullUUID) uuid.UUID {

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -105,7 +105,7 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to read request body").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to read request body").LogError(ctx, s.logger)
 	}
 	defer o11y.LogDefer(ctx, s.logger, func() error {
 		return r.Body.Close()
@@ -113,7 +113,7 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 
 	webhookPayload, err := s.billingRepo.ValidateAndParseWebhookEvent(ctx, body, r.Header)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to validate and parse webhook event").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to validate and parse webhook event").LogError(ctx, s.logger)
 	}
 
 	logger := s.logger.With(attr.SlogEvent(webhookPayload.Type))
@@ -138,20 +138,20 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 
 	existingOrgMetadata, err := s.orgRepo.GetOrganizationMetadata(ctx, webhookPayload.Data.Customer.ExternalID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get organization metadata").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get organization metadata").LogError(ctx, logger)
 	}
 
 	previousAccountType := existingOrgMetadata.GramAccountType
 
 	// we must invalidate the customer tier cache since customer tier may have changed witha subscription update
 	if err := s.billingRepo.InvalidateBillingCustomerCaches(ctx, webhookPayload.Data.Customer.ExternalID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to invalidate customer tier cache").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to invalidate customer tier cache").LogError(ctx, logger)
 	}
 
 	// we force a refresh of the state of the organization since customer tier may have changed witha subscription update
 	refreshedOrg, err := mv.DescribeOrganization(ctx, s.logger, s.orgRepo, s.billingRepo, webhookPayload.Data.Customer.ExternalID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to update organization metadata").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to update organization metadata").LogError(ctx, logger)
 	}
 	updatedAccountType := refreshedOrg.GramAccountType
 
@@ -163,19 +163,19 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 			ID:              refreshedOrg.ID,
 		})
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to set account type").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to set account type").LogError(ctx, logger)
 		}
 	}
 
 	if previousAccountType != updatedAccountType {
 		if _, err := s.openRouter.RefreshAPIKeyLimit(ctx, refreshedOrg.ID, nil); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to refresh openrouter key limit").Log(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "failed to refresh openrouter key limit").LogError(ctx, logger)
 		}
 	}
 
 	// we force a refresh of the period usage since usage may have changed with a subscription update
 	if _, err = s.billingRepo.GetPeriodUsage(ctx, webhookPayload.Data.Customer.ExternalID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get period usage").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get period usage").LogError(ctx, logger)
 	}
 
 	productName, productType := "", ""
@@ -203,10 +203,10 @@ func (s *Service) handleTopUpOrder(ctx context.Context, logger *slog.Logger, web
 	orgID := webhookPayload.Data.Customer.ExternalID
 
 	if err := s.billingRepo.InvalidateBillingCustomerCaches(ctx, orgID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to invalidate customer tier cache").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to invalidate customer tier cache").LogError(ctx, logger)
 	}
 	if _, err := s.billingRepo.GetPeriodUsage(ctx, orgID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to get period usage").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to get period usage").LogError(ctx, logger)
 	}
 
 	if err := s.posthogClient.CaptureEvent(ctx, "gram_topup_purchased", orgID, map[string]any{
@@ -240,14 +240,14 @@ func (s *Service) GetPeriodUsage(ctx context.Context, payload *gen.GetPeriodUsag
 		s.logger.InfoContext(ctx, "period usage cache miss, fetching from billing provider")
 		periodUsage, err = s.billingRepo.GetPeriodUsage(ctx, authCtx.ActiveOrganizationID)
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get period usage").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get period usage").LogError(ctx, s.logger)
 		}
 	}
 
 	// The actual number of enabled servers right this moment, which may not be updated in Polar yet.
 	actualEnabledServerCount, err := s.repo.GetEnabledServerCount(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "could not get public server count").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "could not get public server count").LogError(ctx, s.logger)
 	}
 
 	// We don't populate the maximums using GetUsageTiers because we want to reflect the actual granted credits, not the current product limits which may have changed.
@@ -266,7 +266,7 @@ func (s *Service) GetPeriodUsage(ctx context.Context, payload *gen.GetPeriodUsag
 func (s *Service) GetUsageTiers(ctx context.Context) (*gen.UsageTiers, error) {
 	tiers, err := s.billingRepo.GetUsageTiers(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get usage tiers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get usage tiers").LogError(ctx, s.logger)
 	}
 
 	return tiers, nil
@@ -285,7 +285,7 @@ func (s *Service) CreateCheckout(ctx context.Context, payload *gen.CreateCheckou
 
 	checkoutURL, err := s.billingRepo.CreateCheckout(ctx, authCtx.ActiveOrganizationID, s.serverURL.String(), successURL)
 	if err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "failed to create checkout").Log(ctx, s.logger)
+		return "", oops.E(oops.CodeUnexpected, err, "failed to create checkout").LogError(ctx, s.logger)
 	}
 	return checkoutURL, nil
 }
@@ -303,7 +303,7 @@ func (s *Service) CreateTopUpCheckout(ctx context.Context, payload *gen.CreateTo
 
 	checkoutURL, err := s.billingRepo.CreateTopUpCheckout(ctx, authCtx.ActiveOrganizationID, s.serverURL.String(), successURL)
 	if err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "failed to create top-up checkout").Log(ctx, s.logger)
+		return "", oops.E(oops.CodeUnexpected, err, "failed to create top-up checkout").LogError(ctx, s.logger)
 	}
 	return checkoutURL, nil
 }
@@ -319,7 +319,7 @@ func (s *Service) CreateCustomerSession(ctx context.Context, payload *gen.Create
 
 	sessionURL, err := s.billingRepo.CreateCustomerSession(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "failed to create customer session").Log(ctx, s.logger)
+		return "", oops.E(oops.CodeUnexpected, err, "failed to create customer session").LogError(ctx, s.logger)
 	}
 	return sessionURL, nil
 }

--- a/server/internal/usage/tum.go
+++ b/server/internal/usage/tum.go
@@ -31,7 +31,7 @@ func (s *Service) GetTokensUnderManagement(ctx context.Context, payload *gen.Get
 
 	meta, err := s.repo.GetBillingMetadata(ctx, authCtx.ActiveOrganizationID)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get billing metadata").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get billing metadata").LogError(ctx, s.logger)
 	}
 	// On pgx.ErrNoRows the zero-value row stands in for an unconfigured
 	// contract: no token limit, no alert email, and an anchor day that
@@ -46,7 +46,7 @@ func (s *Service) SetBillingMetadata(ctx context.Context, payload *gen.SetBillin
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 	if !authCtx.IsAdmin {
-		return nil, oops.E(oops.CodeForbidden, nil, "platform admin required").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeForbidden, nil, "platform admin required").LogError(ctx, s.logger)
 	}
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgRead, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (s *Service) SetBillingMetadata(ctx context.Context, payload *gen.SetBillin
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to update billing metadata").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to update billing metadata").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -71,7 +71,7 @@ func (s *Service) SetBillingMetadata(ctx context.Context, payload *gen.SetBillin
 	case err == nil:
 		snapshotBefore = billingMetadataSnapshot(before)
 	case !errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to get billing metadata").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to get billing metadata").LogError(ctx, s.logger)
 	}
 
 	row, err := qtx.UpsertBillingMetadata(ctx, repo.UpsertBillingMetadataParams{
@@ -81,7 +81,7 @@ func (s *Service) SetBillingMetadata(ctx context.Context, payload *gen.SetBillin
 		BillingCycleAnchorDay: conv.SafeInt32(payload.BillingCycleAnchorDay),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to upsert billing metadata").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to upsert billing metadata").LogError(ctx, s.logger)
 	}
 
 	if err := s.auditLogger.LogBillingMetadataUpdate(ctx, dbtx, audit.LogBillingMetadataUpdateEvent{
@@ -93,11 +93,11 @@ func (s *Service) SetBillingMetadata(ctx context.Context, payload *gen.SetBillin
 		BillingMetadataSnapshotBefore: snapshotBefore,
 		BillingMetadataSnapshotAfter:  billingMetadataSnapshot(row),
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to record billing metadata audit event").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to record billing metadata audit event").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to update billing metadata").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to update billing metadata").LogError(ctx, s.logger)
 	}
 
 	return s.buildTokensUnderManagement(ctx, authCtx, row)
@@ -116,7 +116,7 @@ func (s *Service) buildTokensUnderManagement(ctx context.Context, authCtx *conte
 
 	projectIDs, err := s.repo.ListProjectIDsByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list organization projects").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list organization projects").LogError(ctx, s.logger)
 	}
 
 	ids := make([]string, 0, len(projectIDs))
@@ -134,7 +134,7 @@ func (s *Service) buildTokensUnderManagement(ctx context.Context, authCtx *conte
 			EndUnixNano:   cycle.End.UnixNano(),
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to compute tokens under management").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to compute tokens under management").LogError(ctx, s.logger)
 		}
 
 		var cycleTokens int64

--- a/server/internal/usersessions/clienthandlers.go
+++ b/server/internal/usersessions/clienthandlers.go
@@ -36,12 +36,12 @@ func (s *Service) ListUserSessionClients(ctx context.Context, payload *gen.ListU
 	limit := pageLimit(payload.Limit)
 	cursor, err := parseCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	issuerFilter, err := conv.PtrToNullUUID(payload.UserSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").LogError(ctx, s.logger)
 	}
 
 	rows, err := repo.New(s.db).ListUserSessionClientsByProjectID(ctx, repo.ListUserSessionClientsByProjectIDParams{
@@ -51,7 +51,7 @@ func (s *Service) ListUserSessionClients(ctx context.Context, payload *gen.ListU
 		LimitValue:          limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list user session clients").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list user session clients").LogError(ctx, s.logger)
 	}
 
 	items := make([]*types.UserSessionClient, len(rows))
@@ -84,7 +84,7 @@ func (s *Service) GetUserSessionClient(ctx context.Context, payload *gen.GetUser
 
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid client id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid client id").LogError(ctx, s.logger)
 	}
 
 	row, err := repo.New(s.db).GetUserSessionClientByID(ctx, repo.GetUserSessionClientByIDParams{
@@ -93,9 +93,9 @@ func (s *Service) GetUserSessionClient(ctx context.Context, payload *gen.GetUser
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "user session client not found").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeNotFound, err, "user session client not found").LogError(ctx, s.logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get user session client").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get user session client").LogError(ctx, s.logger)
 	}
 
 	return mv.BuildUserSessionClientView(repo.UserSessionClient{
@@ -129,14 +129,14 @@ func (s *Service) RevokeUserSessionClient(ctx context.Context, payload *gen.Revo
 
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid client id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid client id").LogError(ctx, s.logger)
 	}
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -148,13 +148,13 @@ func (s *Service) RevokeUserSessionClient(ctx context.Context, payload *gen.Revo
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeNotFound, err, "user session client not found").Log(ctx, logger)
+			return oops.E(oops.CodeNotFound, err, "user session client not found").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "revoke user session client").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "revoke user session client").LogError(ctx, logger)
 	}
 
 	if _, err := txRepo.SoftDeleteUserSessionsByClientID(ctx, uuid.NullUUID{UUID: revoked.ID, Valid: true}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete child user sessions").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete child user sessions").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogUserSessionClientRevoke(ctx, dbtx, audit.LogUserSessionClientRevokeEvent{
@@ -167,11 +167,11 @@ func (s *Service) RevokeUserSessionClient(ctx context.Context, payload *gen.Revo
 		ClientID:             revoked.ClientID,
 		ClientName:           revoked.ClientName,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log user session client revocation").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log user session client revocation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/usersessions/consenthandlers.go
+++ b/server/internal/usersessions/consenthandlers.go
@@ -35,16 +35,16 @@ func (s *Service) ListUserSessionConsents(ctx context.Context, payload *gen.List
 	limit := pageLimit(payload.Limit)
 	cursor, err := parseCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	clientFilter, err := conv.PtrToNullUUID(payload.UserSessionClientID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_client_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_client_id").LogError(ctx, s.logger)
 	}
 	issuerFilter, err := conv.PtrToNullUUID(payload.UserSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").LogError(ctx, s.logger)
 	}
 
 	rows, err := repo.New(s.db).ListUserSessionConsentsByProjectID(ctx, repo.ListUserSessionConsentsByProjectIDParams{
@@ -56,7 +56,7 @@ func (s *Service) ListUserSessionConsents(ctx context.Context, payload *gen.List
 		LimitValue:          limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list user session consents").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list user session consents").LogError(ctx, s.logger)
 	}
 
 	items := make([]*types.UserSessionConsent, len(rows))
@@ -97,7 +97,7 @@ func (s *Service) RevokeUserSessionConsent(ctx context.Context, payload *gen.Rev
 
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid consent id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid consent id").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectWrite, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
@@ -108,7 +108,7 @@ func (s *Service) RevokeUserSessionConsent(ctx context.Context, payload *gen.Rev
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -120,9 +120,9 @@ func (s *Service) RevokeUserSessionConsent(ctx context.Context, payload *gen.Rev
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeNotFound, err, "user session consent not found").Log(ctx, logger)
+			return oops.E(oops.CodeNotFound, err, "user session consent not found").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "revoke user session consent").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "revoke user session consent").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogUserSessionConsentRevoke(ctx, dbtx, audit.LogUserSessionConsentRevokeEvent{
@@ -134,11 +134,11 @@ func (s *Service) RevokeUserSessionConsent(ctx context.Context, payload *gen.Rev
 		UserSessionConsentURN: urn.NewUserSessionConsent(revoked.ID),
 		Principal:             revoked.SubjectUrn,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log user session consent revocation").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log user session consent revocation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/usersessions/issuerhandlers.go
+++ b/server/internal/usersessions/issuerhandlers.go
@@ -40,16 +40,16 @@ func (s *Service) CreateUserSessionIssuer(ctx context.Context, payload *gen.Crea
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	if payload.Slug == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "slug is required").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "slug is required").LogError(ctx, logger)
 	}
 	if payload.SessionDurationHours <= 0 {
-		return nil, oops.E(oops.CodeBadRequest, nil, "session_duration_hours must be positive").Log(ctx, logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "session_duration_hours must be positive").LogError(ctx, logger)
 	}
 	dur := time.Duration(payload.SessionDurationHours) * time.Hour
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -60,7 +60,7 @@ func (s *Service) CreateUserSessionIssuer(ctx context.Context, payload *gen.Crea
 		SessionDuration:    pgtype.Interval{Microseconds: dur.Microseconds(), Days: 0, Months: 0, Valid: true},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create user session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "create user session issuer").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogUserSessionIssuerCreate(ctx, dbtx, audit.LogUserSessionIssuerCreateEvent{
@@ -72,11 +72,11 @@ func (s *Service) CreateUserSessionIssuer(ctx context.Context, payload *gen.Crea
 		UserSessionIssuerURN: urn.NewUserSessionIssuer(row.ID),
 		Slug:                 row.Slug,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log user session issuer creation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log user session issuer creation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return userSessionIssuerView(row), nil
@@ -95,7 +95,7 @@ func (s *Service) UpdateUserSessionIssuer(ctx context.Context, payload *gen.Upda
 
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, s.logger)
 	}
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
@@ -103,7 +103,7 @@ func (s *Service) UpdateUserSessionIssuer(ctx context.Context, payload *gen.Upda
 	var durPtr *time.Duration
 	if payload.SessionDurationHours != nil {
 		if *payload.SessionDurationHours <= 0 {
-			return nil, oops.E(oops.CodeBadRequest, nil, "session_duration_hours must be positive").Log(ctx, logger)
+			return nil, oops.E(oops.CodeBadRequest, nil, "session_duration_hours must be positive").LogError(ctx, logger)
 		}
 		parsed := time.Duration(*payload.SessionDurationHours) * time.Hour
 		durPtr = &parsed
@@ -111,7 +111,7 @@ func (s *Service) UpdateUserSessionIssuer(ctx context.Context, payload *gen.Upda
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -123,9 +123,9 @@ func (s *Service) UpdateUserSessionIssuer(ctx context.Context, payload *gen.Upda
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, logger)
 	}
 
 	beforeView := userSessionIssuerView(existing)
@@ -139,9 +139,9 @@ func (s *Service) UpdateUserSessionIssuer(ctx context.Context, payload *gen.Upda
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, logger)
+			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "update user session issuer").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "update user session issuer").LogError(ctx, logger)
 	}
 
 	afterView := userSessionIssuerView(updated)
@@ -157,11 +157,11 @@ func (s *Service) UpdateUserSessionIssuer(ctx context.Context, payload *gen.Upda
 		UserSessionIssuerSnapshotBefore: beforeView,
 		UserSessionIssuerSnapshotAfter:  afterView,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log user session issuer update").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "log user session issuer update").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return afterView, nil
@@ -181,7 +181,7 @@ func (s *Service) ListUserSessionIssuers(ctx context.Context, payload *gen.ListU
 	limit := pageLimit(payload.Limit)
 	cursor, err := parseCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	rows, err := repo.New(s.db).ListUserSessionIssuersByProjectID(ctx, repo.ListUserSessionIssuersByProjectIDParams{
@@ -190,7 +190,7 @@ func (s *Service) ListUserSessionIssuers(ctx context.Context, payload *gen.ListU
 		LimitValue: limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list user session issuers").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list user session issuers").LogError(ctx, s.logger)
 	}
 
 	items := make([]*types.UserSessionIssuer, len(rows))
@@ -224,14 +224,14 @@ func (s *Service) GetUserSessionIssuer(ctx context.Context, payload *gen.GetUser
 	hasID := payload.ID != nil && *payload.ID != ""
 	hasSlug := payload.Slug != nil && *payload.Slug != ""
 	if hasID == hasSlug {
-		return nil, oops.E(oops.CodeBadRequest, nil, "exactly one of id or slug must be provided").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "exactly one of id or slug must be provided").LogError(ctx, s.logger)
 	}
 
 	var row repo.UserSessionIssuer
 	if hasID {
 		id, err := uuid.Parse(*payload.ID)
 		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, s.logger)
 		}
 
 		row, err = repo.New(s.db).GetUserSessionIssuerByID(ctx, repo.GetUserSessionIssuerByIDParams{
@@ -240,9 +240,9 @@ func (s *Service) GetUserSessionIssuer(ctx context.Context, payload *gen.GetUser
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, s.logger)
 		}
 	} else {
 		var err error
@@ -252,9 +252,9 @@ func (s *Service) GetUserSessionIssuer(ctx context.Context, payload *gen.GetUser
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, s.logger)
+				return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, s.logger)
 			}
-			return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").Log(ctx, s.logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, s.logger)
 		}
 	}
 
@@ -275,14 +275,14 @@ func (s *Service) DeleteUserSessionIssuer(ctx context.Context, payload *gen.Dele
 
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid issuer id").LogError(ctx, s.logger)
 	}
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -294,9 +294,9 @@ func (s *Service) DeleteUserSessionIssuer(ctx context.Context, payload *gen.Dele
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeNotFound, err, "user session issuer not found").Log(ctx, logger)
+			return oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "delete user session issuer").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete user session issuer").LogError(ctx, logger)
 	}
 
 	if err = txRepo.DeleteRemoteSessionClientAttachmentsForUserSessionIssuer(
@@ -311,15 +311,15 @@ func (s *Service) DeleteUserSessionIssuer(ctx context.Context, payload *gen.Dele
 			err,
 			"failed to delete remote session client attachments for user session issuer %s",
 			deleted.ID,
-		).Log(ctx, logger)
+		).LogError(ctx, logger)
 	}
 
 	if _, err := txRepo.SoftDeleteUserSessionsByIssuerID(ctx, deleted.ID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete child user sessions").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete child user sessions").LogError(ctx, logger)
 	}
 
 	if _, err := txRepo.SoftDeleteUserSessionConsentsByIssuerID(ctx, deleted.ID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete child user session consents").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "delete child user session consents").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogUserSessionIssuerDelete(ctx, dbtx, audit.LogUserSessionIssuerDeleteEvent{
@@ -331,11 +331,11 @@ func (s *Service) DeleteUserSessionIssuer(ctx context.Context, payload *gen.Dele
 		UserSessionIssuerURN: urn.NewUserSessionIssuer(deleted.ID),
 		Slug:                 deleted.Slug,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log user session issuer deletion").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log user session issuer deletion").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/usersessions/minthandler.go
+++ b/server/internal/usersessions/minthandler.go
@@ -58,12 +58,12 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	}
 
 	if s.signer == nil || s.serverURL == "" {
-		return nil, oops.E(oops.CodeUnexpected, nil, "user-session signer not configured").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, nil, "user-session signer not configured").LogError(ctx, s.logger)
 	}
 
 	toolsetID, err := uuid.Parse(payload.ToolsetID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").LogError(ctx, s.logger)
 	}
 
 	toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{
@@ -72,9 +72,9 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").LogError(ctx, s.logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load toolset").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, toolset.ID.String(), toolset.ProjectID.String())); err != nil {
@@ -82,10 +82,10 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	}
 
 	if !toolset.UserSessionIssuerID.Valid {
-		return nil, oops.E(oops.CodeBadRequest, nil, "toolset is not issuer-gated; minting a user-session JWT is only meaningful for issuer-gated toolsets").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, nil, "toolset is not issuer-gated; minting a user-session JWT is only meaningful for issuer-gated toolsets").LogError(ctx, s.logger)
 	}
 	if toolset.McpSlug.String == "" {
-		return nil, oops.E(oops.CodeInvariantViolation, nil, "issuer-gated toolset has no mcp slug").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvariantViolation, nil, "issuer-gated toolset has no mcp slug").LogError(ctx, s.logger)
 	}
 
 	issuer, err := repo.New(s.db).GetUserSessionIssuerByID(ctx, repo.GetUserSessionIssuerByIDParams{
@@ -94,16 +94,16 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "user_session_issuer not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "user_session_issuer not found").LogError(ctx, s.logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "load user_session_issuer").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load user_session_issuer").LogError(ctx, s.logger)
 	}
 	if !issuer.SessionDuration.Valid || issuer.SessionDuration.Months != 0 || issuer.SessionDuration.Days != 0 {
-		return nil, oops.E(oops.CodeUnexpected, nil, "issuer session_duration is unset or carries Months/Days; only Microseconds intervals are supported").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, nil, "issuer session_duration is unset or carries Months/Days; only Microseconds intervals are supported").LogError(ctx, s.logger)
 	}
 	refreshLifetime := time.Duration(issuer.SessionDuration.Microseconds) * time.Microsecond
 	if refreshLifetime <= 0 {
-		return nil, oops.E(oops.CodeUnexpected, nil, "issuer session_duration is non-positive").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, nil, "issuer session_duration is non-positive").LogError(ctx, s.logger)
 	}
 
 	// Issuer URL matches what /token would emit: <serverURL>/mcp/<mcpSlug>.
@@ -112,7 +112,7 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	// indistinguishable from /token output in audit trails.
 	issuerURL, err := url.JoinPath(s.serverURL, "mcp", toolset.McpSlug.String)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "build issuer URL").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "build issuer URL").LogError(ctx, s.logger)
 	}
 
 	subject := urn.NewUserSubject(authCtx.UserID)
@@ -120,7 +120,7 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 
 	access, jti, err := s.signer.Mint(subject, audience, issuerURL, mintAccessTokenLifetime)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "mint session jwt").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "mint session jwt").LogError(ctx, s.logger)
 	}
 
 	now := time.Now()
@@ -138,7 +138,7 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 		ExpiresAt:        pgtype.Timestamptz{Time: now.Add(mintAccessTokenLifetime), InfinityModifier: 0, Valid: true},
 		RefreshExpiresAt: pgtype.Timestamptz{Time: now.Add(refreshLifetime), InfinityModifier: 0, Valid: true},
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "persist user session").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "persist user session").LogError(ctx, s.logger)
 	}
 
 	s.logger.InfoContext(ctx, "minted user session via dashboard",

--- a/server/internal/usersessions/sessionhandlers.go
+++ b/server/internal/usersessions/sessionhandlers.go
@@ -36,12 +36,12 @@ func (s *Service) ListUserSessions(ctx context.Context, payload *gen.ListUserSes
 	limit := pageLimit(payload.Limit)
 	cursor, err := parseCursor(payload.Cursor)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid cursor").LogError(ctx, s.logger)
 	}
 
 	issuerFilter, err := conv.PtrToNullUUID(payload.UserSessionIssuerID)
 	if err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeBadRequest, err, "invalid user_session_issuer_id").LogError(ctx, s.logger)
 	}
 
 	rows, err := repo.New(s.db).ListUserSessionsByProjectID(ctx, repo.ListUserSessionsByProjectIDParams{
@@ -52,7 +52,7 @@ func (s *Service) ListUserSessions(ctx context.Context, payload *gen.ListUserSes
 		LimitValue:          limit,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list user sessions").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list user sessions").LogError(ctx, s.logger)
 	}
 
 	items := make([]*types.UserSession, len(rows))
@@ -82,7 +82,7 @@ func (s *Service) RevokeUserSession(ctx context.Context, payload *gen.RevokeUser
 
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid session id").Log(ctx, s.logger)
+		return oops.E(oops.CodeBadRequest, err, "invalid session id").LogError(ctx, s.logger)
 	}
 
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectWrite, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
@@ -93,7 +93,7 @@ func (s *Service) RevokeUserSession(ctx context.Context, payload *gen.RevokeUser
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -105,9 +105,9 @@ func (s *Service) RevokeUserSession(ctx context.Context, payload *gen.RevokeUser
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return oops.E(oops.CodeNotFound, err, "user session not found").Log(ctx, logger)
+			return oops.E(oops.CodeNotFound, err, "user session not found").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "revoke user session").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "revoke user session").LogError(ctx, logger)
 	}
 
 	if err := s.audit.LogUserSessionRevoke(ctx, dbtx, audit.LogUserSessionRevokeEvent{
@@ -120,11 +120,11 @@ func (s *Service) RevokeUserSession(ctx context.Context, payload *gen.RevokeUser
 		Principal:        revoked.SubjectUrn,
 		Jti:              revoked.Jti,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log user session revocation").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "log user session revocation").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	// Push the jti into the revocation cache after the DB commit so a cached
@@ -132,7 +132,7 @@ func (s *Service) RevokeUserSession(ctx context.Context, payload *gen.RevokeUser
 	// surfaced as Unexpected — the row is gone but the access token would keep
 	// validating until expiry, which is the case the cache exists to prevent.
 	if err := s.chatSessions.RevokeToken(ctx, revoked.Jti); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "push jti into revocation cache").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "push jti into revocation cache").LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/variations/impl.go
+++ b/server/internal/variations/impl.go
@@ -91,7 +91,7 @@ func (s *Service) ListGlobal(ctx context.Context, payload *gen.ListGlobalPayload
 
 	rows, err := s.repo.ListGlobalToolVariations(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing global tool variations").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing global tool variations").LogError(ctx, s.logger)
 	}
 
 	variations := make([]*types.ToolVariation, 0, len(rows))
@@ -134,7 +134,7 @@ func (s *Service) ListGroups(ctx context.Context, payload *gen.ListGroupsPayload
 
 	rows, err := s.repo.ListToolVariationsGroups(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing tool variation groups").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing tool variation groups").LogError(ctx, s.logger)
 	}
 
 	groups := make([]*types.ToolVariationGroup, 0, len(rows))
@@ -181,10 +181,10 @@ func (s *Service) CreateGlobal(ctx context.Context, payload *gen.CreateGlobalPay
 			groupID, err = s.repo.PokeGlobalToolVariationsGroup(ctx, projectID)
 		}
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error initializing global tool variations group").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error initializing global tool variations group").LogError(ctx, logger)
 		}
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "error poking global tool variations group").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error poking global tool variations group").LogError(ctx, logger)
 	}
 
 	group, err := s.repo.GetToolVariationsGroupByID(ctx, repo.GetToolVariationsGroupByIDParams{
@@ -192,7 +192,7 @@ func (s *Service) CreateGlobal(ctx context.Context, payload *gen.CreateGlobalPay
 		ProjectID: projectID,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error loading tool variations group").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error loading tool variations group").LogError(ctx, logger)
 	}
 
 	return &gen.ToolVariationGroupResult{Group: toGroup(group)}, nil
@@ -213,7 +213,7 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error beginning transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error beginning transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error {
 		return dbtx.Rollback(ctx)
@@ -223,7 +223,7 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 
 	groupID, err := tx.PokeGlobalToolVariationsGroup(ctx, projectID)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return nil, oops.E(oops.CodeUnexpected, err, "error poking global tool variations group").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error poking global tool variations group").LogError(ctx, logger)
 	}
 
 	if errors.Is(err, pgx.ErrNoRows) || groupID == uuid.Nil {
@@ -233,13 +233,13 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 			Description: conv.ToPGTextEmpty(""),
 		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error initializing global tool variations group").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "error initializing global tool variations group").LogError(ctx, logger)
 		}
 	}
 
 	srcToolUrn, err := urn.ParseTool(payload.SrcToolUrn)
 	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid source tool urn").Log(ctx, logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid source tool urn").LogError(ctx, logger)
 	}
 
 	existingVariations, err := tx.FindGlobalVariationsByToolURNs(ctx, repo.FindGlobalVariationsByToolURNsParams{
@@ -247,7 +247,7 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 		ToolUrns:  []string{srcToolUrn.String()},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error finding existing global tool variations").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error finding existing global tool variations").LogError(ctx, logger)
 	}
 
 	var existing *types.ToolVariation
@@ -286,7 +286,7 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 		OpenWorldHint:   conv.PtrToPGBool(payload.OpenWorldHint),
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error upserting global tool variation").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error upserting global tool variation").LogError(ctx, logger)
 	}
 
 	result := toVariation(row)
@@ -302,11 +302,11 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 		VariationSnapshotBefore: existing,
 		VariationSnapshotAfter:  result,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error creating global tool variation audit log").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating global tool variation audit log").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error committing transaction").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error committing transaction").LogError(ctx, logger)
 	}
 
 	return &gen.UpsertGlobalToolVariationResult{Variation: result}, nil
@@ -324,12 +324,12 @@ func (s *Service) DeleteGlobal(ctx context.Context, payload *gen.DeleteGlobalPay
 
 	variationID, err := uuid.Parse(payload.VariationID)
 	if err != nil || variationID == uuid.Nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid variation ID").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeInvalid, err, "invalid variation ID").LogError(ctx, s.logger)
 	}
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing variations").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing variations").LogError(ctx, s.logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
@@ -341,9 +341,9 @@ func (s *Service) DeleteGlobal(ctx context.Context, payload *gen.DeleteGlobalPay
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeNotFound, err, "global tool variation not found").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeNotFound, err, "global tool variation not found").LogError(ctx, s.logger)
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "error deleting global tool variation").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error deleting global tool variation").LogError(ctx, s.logger)
 	}
 
 	if err := s.audit.LogVariationDeleteGlobal(ctx, dbtx, audit.LogVariationDeleteGlobalEvent{
@@ -355,11 +355,11 @@ func (s *Service) DeleteGlobal(ctx context.Context, payload *gen.DeleteGlobalPay
 		VariationURN:     urn.NewVariation(urn.VariationKindGlobal, row.ID),
 		SourceToolURN:    row.SrcToolUrn,
 	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error creating global tool variation deletion audit log").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating global tool variation deletion audit log").LogError(ctx, s.logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error saving variation deletion").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving variation deletion").LogError(ctx, s.logger)
 	}
 
 	return &gen.DeleteGlobalToolVariationResult{


### PR DESCRIPTION
In order to better enforce better log level handling at call sites, we are going to introduce varied log levels into `oops.ShareableError`. While the logging level could be passed in, it'll be less typing needed if the methods themselves handle the level rather than requiring a specific slog log level import and additional parameter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `(*oops.ShareableError).Log()` to `LogError()` and updated all usages, docs, tests, and lint config. This prepares `oops.ShareableError` for built-in log-level handling and simplifies call sites.

- **Refactors**
  - Replaced `.Log(ctx, logger, ...)` with `.LogError(ctx, logger, ...)` across services, jobs, handlers, and middleware.
  - Updated implementation in `server/internal/oops/pp.go` and tests in `pp_test.go`.
  - Fixed examples in `.agents/skills/golang/SKILL.md` and `REVIEW.md`.
  - Updated `server/.golangci.yaml` to match the `LogError` signature.

- **Migration**
  - Change all calls from `.Log(...)` to `.LogError(...)`.
  - No behavior changes expected.

<sup>Written for commit 19260dfbfea92ceeaf6a2bace8bfbdc7a18b4d27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

