### PR TITLE
chore(streams): propagate trace context across the pub/sub boundary

### DIFF
--- a/infra/gram_infra/pubsub/publisher.py
+++ b/infra/gram_infra/pubsub/publisher.py
@@ -15,6 +15,7 @@ import anyio
 import anyio.from_thread
 
 from google.protobuf.message import Message
+from opentelemetry import propagate
 
 from .broker import PublisherBroker, PublisherHandle
 
@@ -24,6 +25,21 @@ M = TypeVar("M", bound=Message)
 
 # Attribute value mirrored from publisher.go; identifies the body encoding.
 CONTENT_TYPE = "application/x-protobuf"
+
+
+def _message_attributes(schema: str) -> dict[str, str]:
+    """Build the attribute set carried with an outgoing message.
+
+    Mirrors ``messageAttributes`` in ``publisher.go``: the ``content-type`` and
+    ``schema`` markers the subscriber uses to decode the payload, plus any trace
+    context injected from the active span so the subscriber can continue the
+    producer's trace. Injection uses the globally configured propagator (W3C
+    tracecontext + baggage by default, the same one the receiver extracts with);
+    with no active span it is a no-op and no propagation attributes are added.
+    """
+    attributes = {"content-type": CONTENT_TYPE, "schema": schema}
+    propagate.inject(attributes)
+    return attributes
 
 
 class Publisher(Generic[M]):
@@ -57,7 +73,7 @@ class Publisher(Generic[M]):
         future = self._handle.client.publish(
             self._handle.topic_path,
             data,
-            **{"content-type": CONTENT_TYPE, "schema": self._schema},
+            **_message_attributes(self._schema),
         )
         # Let the broker's teardown wait for this commit before it closes the
         # publisher's transport.

--- a/infra/pkg/gcp/publisher.go
+++ b/infra/pkg/gcp/publisher.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/pubsub/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -44,7 +46,14 @@ type Publisher[M any] interface {
 }
 
 type psPublisherOptions struct {
+	propagation     propagation.TextMapPropagator
 	publishSettings *pubsub.PublishSettings
+}
+
+func WithPropagator(prop propagation.TextMapPropagator) func(*psPublisherOptions) {
+	return func(o *psPublisherOptions) {
+		o.propagation = prop
+	}
 }
 
 func WithPubSubPublishSettings(settings *pubsub.PublishSettings) func(*psPublisherOptions) {
@@ -56,7 +65,8 @@ func WithPubSubPublishSettings(settings *pubsub.PublishSettings) func(*psPublish
 }
 
 type psPublisher[M proto.Message] struct {
-	pub *pubsub.Publisher
+	pub  *pubsub.Publisher
+	prop propagation.TextMapPropagator
 }
 
 // PubSubPublisherForMessage returns a publisher for the topic declared by a
@@ -73,6 +83,7 @@ func PubSubPublisherForMessage[M proto.Message](ctx context.Context, broker Publ
 	}
 
 	var o psPublisherOptions
+	o.propagation = otel.GetTextMapPropagator()
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -80,7 +91,24 @@ func PubSubPublisherForMessage[M proto.Message](ctx context.Context, broker Publ
 		publisher.PublishSettings = *o.publishSettings
 	}
 
-	return &psPublisher[M]{pub: publisher}, nil
+	return &psPublisher[M]{pub: publisher, prop: o.propagation}, nil
+}
+
+// messageAttributes builds the attribute set carried with an outgoing message:
+// the content-type and schema markers the subscriber uses to decode the
+// payload, plus any trace context propagated from ctx so the subscriber can
+// continue the producer's trace. The propagator is passed in so the behaviour
+// is testable without mutating global state; when ctx carries no active span
+// injection is a no-op and no propagation attributes are added.
+func messageAttributes(ctx context.Context, prop propagation.TextMapPropagator, msg proto.Message) map[string]string {
+	attributes := map[string]string{
+		"content-type": "application/x-protobuf",
+		"schema":       string(proto.MessageName(msg)),
+	}
+	if prop != nil {
+		prop.Inject(ctx, propagation.MapCarrier(attributes))
+	}
+	return attributes
 }
 
 func (p *psPublisher[M]) Publish(ctx context.Context, msg M) PublishResult {
@@ -90,11 +118,8 @@ func (p *psPublisher[M]) Publish(ctx context.Context, msg M) PublishResult {
 	}
 
 	res := p.pub.Publish(ctx, &pubsub.Message{
-		Data: bs,
-		Attributes: map[string]string{
-			"content-type": "application/x-protobuf",
-			"schema":       string(proto.MessageName(msg)),
-		},
+		Data:       bs,
+		Attributes: messageAttributes(ctx, p.prop, msg),
 	})
 
 	return res

--- a/infra/pkg/gcp/publisher_test.go
+++ b/infra/pkg/gcp/publisher_test.go
@@ -1,0 +1,71 @@
+package gcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// testPropagator is the W3C composite the server installs globally, passed
+// explicitly so these tests neither depend on nor mutate global propagator
+// state and can run in parallel.
+func testPropagator() propagation.TextMapPropagator {
+	return propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	)
+}
+
+func TestMessageAttributes_AlwaysCarriesContentTypeAndSchema(t *testing.T) {
+	t.Parallel()
+
+	attrs := messageAttributes(t.Context(), testPropagator(), &emptypb.Empty{})
+
+	require.Equal(t, "application/x-protobuf", attrs["content-type"])
+	require.Equal(t, "google.protobuf.Empty", attrs["schema"])
+}
+
+func TestMessageAttributes_NoTraceContextWithoutActiveSpan(t *testing.T) {
+	t.Parallel()
+
+	attrs := messageAttributes(t.Context(), testPropagator(), &emptypb.Empty{})
+
+	// With no span in ctx the propagator injects nothing, so unpropagated
+	// messages still let the subscriber start a fresh trace.
+	require.NotContains(t, attrs, "traceparent")
+}
+
+func TestMessageAttributes_RoundTripsTraceContextToSubscriber(t *testing.T) {
+	t.Parallel()
+
+	prop := testPropagator()
+
+	// A known remote span context, as if some upstream request started the trace.
+	traceID, err := trace.TraceIDFromHex("0af7651916cd43dd8448eb211c80319c")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("b7ad6b7169203331")
+	require.NoError(t, err)
+	parentSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	publishCtx := trace.ContextWithSpanContext(context.Background(), parentSC)
+
+	// Publisher side: messageAttributes injects the active trace context.
+	attrs := messageAttributes(publishCtx, prop, &emptypb.Empty{})
+	require.Contains(t, attrs, "traceparent", "an active span should be propagated")
+
+	// Subscriber side (mirrors streams.go): extract from the message attributes.
+	extracted := prop.Extract(context.Background(), propagation.MapCarrier(attrs))
+	gotSC := trace.SpanContextFromContext(extracted)
+
+	require.Equal(t, parentSC.TraceID(), gotSC.TraceID(), "subscriber should continue the producer's trace")
+	require.Equal(t, parentSC.SpanID(), gotSC.SpanID(), "subscriber's parent should be the publishing span")
+	require.True(t, gotSC.IsSampled())
+}

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "google-cloud-pubsub>=2.31.0",
   "anyio>=4.13.0",
   "structlog>=26.1.0",
+  "opentelemetry-api>=1.42.1",
 ]
 
 [project.scripts]

--- a/infra/tests/test_publisher.py
+++ b/infra/tests/test_publisher.py
@@ -1,0 +1,64 @@
+"""Publisher attribute-building tests (no live broker).
+
+Covers the outgoing attribute set built by ``_message_attributes``: the
+content-type/schema markers and the trace-context injection that lets a
+subscriber continue the producer's trace. The injection mirrors
+``messageAttributes`` in ``infra/pkg/gcp/publisher.go``; the round-trip uses the
+same global propagator the receiver extracts with (``deps/tracing.py``).
+"""
+
+from __future__ import annotations
+
+from opentelemetry import context, propagate, trace
+
+from gram_infra.pubsub.publisher import CONTENT_TYPE, _message_attributes
+
+SCHEMA = "gram.ping.v1.Message"
+
+
+def test_message_attributes_always_carries_content_type_and_schema() -> None:
+    attrs = _message_attributes(SCHEMA)
+
+    assert attrs["content-type"] == CONTENT_TYPE
+    assert attrs["schema"] == SCHEMA
+
+
+def test_message_attributes_omits_trace_context_without_active_span() -> None:
+    attrs = _message_attributes(SCHEMA)
+
+    # No span in context: the propagator injects nothing, so unpropagated
+    # messages still let the subscriber start a fresh trace.
+    assert "traceparent" not in attrs
+
+
+def test_message_attributes_round_trips_trace_context_to_subscriber() -> None:
+    # A known span context, as if some upstream request started the trace.
+    parent_ctx = trace.set_span_in_context(
+        trace.NonRecordingSpan(
+            trace.SpanContext(
+                trace_id=0x0AF7651916CD43DD8448EB211C80319C,
+                span_id=0xB7AD6B7169203331,
+                is_remote=True,
+                trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+            )
+        )
+    )
+
+    # Publisher side: inject the active trace context into the attributes. The
+    # global propagate.inject reads the current context, so attach the parent
+    # for the duration of the call.
+    token = context.attach(parent_ctx)
+    try:
+        attrs = _message_attributes(SCHEMA)
+    finally:
+        context.detach(token)
+
+    assert "traceparent" in attrs, "an active span should be propagated"
+
+    # Subscriber side (mirrors deps/tracing.py): extract from the attributes.
+    extracted = propagate.extract(attrs)
+    got = trace.get_current_span(extracted).get_span_context()
+
+    assert got.trace_id == 0x0AF7651916CD43DD8448EB211C80319C
+    assert got.span_id == 0xB7AD6B7169203331
+    assert got.trace_flags.sampled

--- a/pystreams/src/pystreams/deps/tracing.py
+++ b/pystreams/src/pystreams/deps/tracing.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from typing import TypeVar
 
 from google.protobuf.message import Message
-from opentelemetry import trace
+from opentelemetry import propagate, trace
 from opentelemetry.trace import StatusCode
 
 from gram_infra.pubsub.subscriber import MessageCallback, MessageMetadata
@@ -42,11 +42,20 @@ def traced(
     """
 
     async def wrapper(message: M, meta: MessageMetadata) -> None:
+        # Continue the producer's trace: extract any W3C trace context the
+        # publisher propagated through the message attributes, so this span is a
+        # child of the publishing span instead of the root of a fresh trace. The
+        # message attributes act as the textmap carrier; ``extract`` uses the
+        # globally configured propagator (W3C tracecontext + baggage by default)
+        # and quietly yields an empty context when no trace headers are present,
+        # so unpropagated messages still start a new trace.
+        parent = propagate.extract(meta.attributes)
         # Disable the context manager's automatic exception handling and do it
         # explicitly so the span's status description carries the error message,
         # matching the Go receiver's ``span.SetStatus(codes.Error, err.Error())``.
         with _tracer.start_as_current_span(
             "stream.handleMessage",
+            context=parent,
             attributes={
                 attr.TOPIC_PROTO_NAME: topic_proto_name,
                 attr.SUBSCRIPTION_PROTO_NAME: subscription_proto_name,

--- a/pystreams/tests/test_tracing.py
+++ b/pystreams/tests/test_tracing.py
@@ -58,6 +58,55 @@ async def test_traced_records_ok_span(exporter: InMemorySpanExporter):
     assert span.status.status_code == StatusCode.UNSET
 
 
+async def test_traced_continues_trace_from_attributes(
+    exporter: InMemorySpanExporter,
+):
+    # A W3C traceparent the publisher would have stamped onto the message
+    # attributes: version-00, the trace id, the parent span id, sampled flag.
+    trace_id = "0af7651916cd43dd8448eb211c80319c"
+    parent_span_id = "b7ad6b7169203331"
+    attributes = {
+        "traceparent": f"00-{trace_id}-{parent_span_id}-01",
+    }
+
+    async def handler(message: ping_pb2.Message, meta: MessageMetadata) -> None:
+        pass
+
+    wrapped = tracing.traced(
+        handler, topic_proto_name=TOPIC, subscription_proto_name=SUBSCRIPTION
+    )
+
+    await wrapped(
+        ping_pb2.Message(id="ping-1"),
+        MessageMetadata(id="m-1", attributes=attributes, delivery_attempt=1),
+    )
+
+    (span,) = exporter.get_finished_spans()
+    ctx = span.get_span_context()
+    assert ctx is not None
+    # Same trace as the producer, and parented to the propagated span.
+    assert format(ctx.trace_id, "032x") == trace_id
+    assert span.parent is not None
+    assert format(span.parent.span_id, "016x") == parent_span_id
+
+
+async def test_traced_starts_new_trace_without_attributes(
+    exporter: InMemorySpanExporter,
+):
+    async def handler(message: ping_pb2.Message, meta: MessageMetadata) -> None:
+        pass
+
+    wrapped = tracing.traced(
+        handler, topic_proto_name=TOPIC, subscription_proto_name=SUBSCRIPTION
+    )
+
+    # No traceparent on the message: the span roots its own trace.
+    await wrapped(ping_pb2.Message(id="ping-1"), _meta())
+
+    (span,) = exporter.get_finished_spans()
+    assert span.parent is None
+
+
 async def test_traced_marks_error_and_reraises(exporter: InMemorySpanExporter):
     boom = ValueError("handler failed")
 

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -12,6 +12,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/sdk/client"
 	"golang.org/x/sync/errgroup"
@@ -269,6 +270,15 @@ func receive[M proto.Message](
 
 	g.group.Go(func() error {
 		if err := sub.Receive(ctx, func(ctx context.Context, m M, meta gcp.MessageMetadata) (err error) {
+			// Continue the producer's trace: extract any trace context the
+			// publisher propagated through the message attributes so this span
+			// is a child of the publishing span instead of the root of a fresh
+			// trace. Extract uses the globally configured propagator (W3C
+			// tracecontext + baggage) and leaves ctx unchanged when no trace
+			// headers are present, so unpropagated messages still start a new
+			// trace.
+			ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(meta.Attributes))
+
 			ctx, span := g.tracer.Start(ctx, "stream.handleMessage", trace.WithAttributes(
 				attr.TopicProtoName(msgName),
 				attr.SubscriptionProtoName(subName),

--- a/uv.lock
+++ b/uv.lock
@@ -335,6 +335,7 @@ source = { editable = "infra" }
 dependencies = [
     { name = "anyio" },
     { name = "google-cloud-pubsub" },
+    { name = "opentelemetry-api" },
     { name = "protobuf" },
     { name = "structlog" },
 ]
@@ -353,6 +354,7 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.13.0" },
     { name = "google-cloud-pubsub", specifier = ">=2.31.0" },
+    { name = "opentelemetry-api", specifier = ">=1.42.1" },
     { name = "protobuf", specifier = ">=7.35.0,<8" },
     { name = "structlog", specifier = ">=26.1.0" },
 ]


### PR DESCRIPTION
Subscriber spans were rooting fresh traces, so a message's processing could not be tied back to the request that published it. Inject W3C trace context into message attributes on publish (Go and Python publishers) to match the extract-on-receive side already in place, so a subscriber span continues the producer's trace rather than starting a new one. With no active span, injection is a no-op and unpropagated messages still begin their own trace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates W3C trace context in Pub/Sub messages so subscriber spans continue the publisher’s trace. Injection happens on publish (Go and Python) and extraction on receive; if no active span, messages start a new trace.

- **New Features**
  - Go publisher: injects trace context into message attributes via a configurable `propagation.TextMapPropagator` (defaults to `otel.GetTextMapPropagator()`); attributes still include `content-type` and `schema`.
  - Python publisher: injects the current context into attributes with `opentelemetry.propagate.inject`.
  - Receivers (`server` and `pystreams`): extract from message attributes and parent `stream.handleMessage` spans; start a new trace when no headers are present.

- **Dependencies**
  - Added `opentelemetry-api>=1.42.1` to `infra`.

<sup>Written for commit 1117266c7d84f7a19a063982ca275838d4b31ba5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

