### PR TITLE
fix(dashboard): pin assistant shortcut hint to nav bar right edge and show it in the dock

### DIFF
--- a/.changeset/pin-assistant-shortcut-hint.md
+++ b/.changeset/pin-assistant-shortcut-hint.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Pin the assistant ⌘/ shortcut hint to the nav bar's right edge on wide screens, and show it in the assistant dock.

--- a/client/dashboard/src/components/insights-dock-shortcut-hint.tsx
+++ b/client/dashboard/src/components/insights-dock-shortcut-hint.tsx
@@ -9,6 +9,38 @@ const INSIGHTS_SHORTCUT_LABEL_MAC = ["⌘", "/"];
 const INSIGHTS_SHORTCUT_LABEL_PC = ["Ctrl", "/"];
 
 /**
+ * The platform-correct shortcut rendered as kbd pills (⌘ / on Mac, Ctrl / on
+ * PC). Decorative: marked aria-hidden because the real shortcut is conveyed via
+ * aria-keyshortcuts on the composer input. Shared so the page-header hint and
+ * the dock pill render identical keys from one definition.
+ */
+export function InsightsShortcutKeys({
+  className,
+}: {
+  className?: string;
+}): ReactElement {
+  const keys = isMacPlatform()
+    ? INSIGHTS_SHORTCUT_LABEL_MAC
+    : INSIGHTS_SHORTCUT_LABEL_PC;
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("flex shrink-0 items-center gap-1 select-none", className)}
+    >
+      {keys.map((key) => (
+        <kbd
+          key={key}
+          className="border-border bg-muted text-muted-foreground pointer-events-none inline-flex h-6 min-w-6 items-center justify-center rounded border px-1.5 font-mono text-sm leading-none font-medium select-none"
+        >
+          {key}
+        </kbd>
+      ))}
+    </span>
+  );
+}
+
+/**
  * Keyboard hint for the docked Project Assistant composer, shown on the
  * right-hand side of the page-header breadcrumbs. Renders nothing when no
  * InsightsProvider is mounted, the page hides the dock, or the dock is
@@ -27,10 +59,6 @@ export function InsightsDockShortcutHint({
   const { dismissed } = useInsightsDockCta();
   if (!available || dismissed) return null;
 
-  const keys = isMacPlatform()
-    ? INSIGHTS_SHORTCUT_LABEL_MAC
-    : INSIGHTS_SHORTCUT_LABEL_PC;
-
   return (
     <span
       className={cn(
@@ -38,14 +66,7 @@ export function InsightsDockShortcutHint({
         className,
       )}
     >
-      {keys.map((key) => (
-        <kbd
-          key={key}
-          className="border-border bg-muted text-muted-foreground pointer-events-none inline-flex h-6 min-w-6 items-center justify-center rounded border px-1.5 font-mono text-sm leading-none font-medium select-none"
-        >
-          {key}
-        </kbd>
-      ))}
+      <InsightsShortcutKeys />
       <span className="text-muted-foreground ml-1 text-xs font-normal">
         to launch assistant
       </span>

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -44,6 +44,7 @@ import {
 } from "react";
 import type { InsightsConfigOptions } from "./insights-context";
 import { InsightsContext, useInsightsState } from "./insights-context";
+import { InsightsShortcutKeys } from "./insights-dock-shortcut-hint";
 import { useAskAiListener } from "./command-palette/askAiBridge";
 
 // Types-only re-export (erased at compile time, won't break Fast Refresh)
@@ -512,6 +513,11 @@ function InsightsDock({
                     >
                       <HistoryIcon className="size-3.5" />
                     </button>
+                  )}
+                  {/* Greyed shortcut hint on the resting pill; hidden once the
+                      composer is engaged (focused or typing). */}
+                  {!composerExpanded && (
+                    <InsightsShortcutKeys className="opacity-60" />
                   )}
                   <button
                     type="button"

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -56,7 +56,7 @@ function PageHeaderTitle({
     // 1270 carefully chosen to make the header line up with the max width of the page content
     <Heading
       variant="h4"
-      className={cn("mx-auto ml-1 w-full max-w-[1270px]", className)}
+      className={cn("ml-1 w-full max-w-[1270px]", className)}
     >
       {children}
     </Heading>
@@ -195,37 +195,43 @@ function PageHeaderBreadcrumbs({
   visibleElements.push(...pageElements);
 
   return (
-    <PageHeader.Title className={cn(fullWidth ? "max-w-full" : "", className)}>
-      <div className="ml-auto flex items-center gap-2 normal-case">
-        {visibleElements.map((elem, index) => (
-          <React.Fragment key={`${elem.url}-${index}`}>
-            {elem.isCurrentPage || elem.disableLink ? (
-              <span
-                className={
-                  elem.isCurrentPage ? undefined : "text-muted-foreground"
-                }
-              >
-                {elem.display}
-              </span>
-            ) : (
-              <Link
-                to={elem.url}
-                className="text-muted-foreground hover:text-foreground trans"
-              >
-                {elem.display}
-              </Link>
-            )}
-            {index < visibleElements.length - 1 && (
-              <span className="text-muted-foreground"> / </span>
-            )}
-          </React.Fragment>
-        ))}
-        {stage && <ReleaseStageBadge stage={stage} />}
-        {/* Cmd+/ hint for the docked Project Assistant composer — lives here
-            (rather than inside the dock's input) so the pill stays clean. */}
-        <InsightsDockShortcutHint className="ml-auto" />
-      </div>
-    </PageHeader.Title>
+    // The shortcut hint is a sibling of the breadcrumb band — not nested inside
+    // it — so it pins to the true right edge of the nav bar. Nested, it would
+    // stop at the right edge of the centered max-w-[1270px] band, landing
+    // mid-bar on wide screens. Breadcrumbs are unchanged; only the hint moves.
+    <>
+      <PageHeader.Title
+        className={cn(fullWidth ? "max-w-full" : "", className)}
+      >
+        <div className="ml-auto flex items-center gap-2 normal-case">
+          {visibleElements.map((elem, index) => (
+            <React.Fragment key={`${elem.url}-${index}`}>
+              {elem.isCurrentPage || elem.disableLink ? (
+                <span
+                  className={
+                    elem.isCurrentPage ? undefined : "text-muted-foreground"
+                  }
+                >
+                  {elem.display}
+                </span>
+              ) : (
+                <Link
+                  to={elem.url}
+                  className="text-muted-foreground hover:text-foreground trans"
+                >
+                  {elem.display}
+                </Link>
+              )}
+              {index < visibleElements.length - 1 && (
+                <span className="text-muted-foreground"> / </span>
+              )}
+            </React.Fragment>
+          ))}
+          {stage && <ReleaseStageBadge stage={stage} />}
+        </div>
+      </PageHeader.Title>
+      <InsightsDockShortcutHint className="ml-auto shrink-0" />
+    </>
   );
 }
 


### PR DESCRIPTION
## What

Two cosmetic changes to the Project Assistant ⌘/ keyboard-shortcut hint:

1. **Nav bar:** Moves the shortcut hint out of the centered `max-w-[1270px]` breadcrumb band so it pins to the true right edge of the page-header nav bar. The hint is now a sibling of the breadcrumb `PageHeader.Title` rather than nested inside it.
2. **Dock:** Shows the same kbd pills as a greyed (`opacity-60`) hint on the right side of the floating assistant dock's resting pill. The hint hides once the composer is engaged (focused or typing).

The kbd-pill rendering is now a shared, exported `InsightsShortcutKeys` component used by both the nav hint and the dock, so they render identical keys from one definition.

<img width="1570" height="548" alt="CleanShot 2026-06-15 at 15 19 05@2x" src="https://github.com/user-attachments/assets/af90e153-631f-4907-97eb-688b9ada798b" />

## Why

On wide screens the hint previously drifted to mid-bar because the centered breadcrumb band capped its right edge. Pinning it to the real right edge reads as a stable affordance. Echoing the shortcut on the dock pill makes the keyboard entry point discoverable at the point of use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned the Project Assistant ⌘/ (Ctrl+/ on Windows) shortcut hint to the nav bar’s true right edge and mirrored the same kbd pills on the assistant dock pill. The dock hint shows in the resting state and hides when the composer is focused or typing.

- **Refactors**
  - Extracted `InsightsShortcutKeys` for consistent kbd-pill rendering in both header and dock.
  - Marked pills aria-hidden; the actual shortcut is exposed via aria-keyshortcuts on the composer input.

<sup>Written for commit b16f2cd91612ade77ad577087bd2f4dde1b81c6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

