### PR TITLE
chore: lay foundation for event-loop lag metric in pystreams

### DIFF
--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -17,6 +17,7 @@ from gram_infra.pubsub import (
 
 from .. import attr
 from ..deps import logging
+from ..deps.loop_lag import monitor_event_loop_lag
 from ..health import HealthState, serve_control
 from .receiver import ReceiverGroup
 from . import flags_service
@@ -84,6 +85,7 @@ async def multi(
 
         async with anyio.create_task_group() as tg:
             tg.start_soon(_shutdown_on_signal, tg.cancel_scope, health_state, logger)
+            tg.start_soon(monitor_event_loop_lag)
             # Start the health server first (and wait until it is bound) so the
             # liveness probe answers as early as possible, then begin consuming
             # and only then report ready.

--- a/pystreams/src/pystreams/deps/loop_lag.py
+++ b/pystreams/src/pystreams/deps/loop_lag.py
@@ -1,0 +1,53 @@
+"""Event-loop lag sampling.
+
+An asyncio event loop runs cooperatively on a single thread, so any coroutine
+that fails to yield — CPU-bound work, a synchronous client call, an un-awaited
+blocking call — delays every other ready task until it returns. A liveness probe
+only catches the terminal case (a fully wedged loop), giving no early warning
+that the loop is starting to saturate.
+
+This samples the loop's scheduling delay so that pressure is observable before
+it becomes an outage. The sampler parks on ``anyio.sleep(interval)`` and compares
+the wall-clock elapsed against the interval it asked for: the excess is time the
+loop spent unable to run a ready timer — a direct proxy for loop saturation.
+
+Each sample is recorded into an OpenTelemetry histogram. Until a ``MeterProvider``
+is configured the instrument resolves to the API's implicit no-op, so recording
+is a cheap no-op; once a provider is installed the distribution (p50/p99/max)
+flows out wherever metrics are collected, with no change here.
+"""
+
+from __future__ import annotations
+
+import time
+
+import anyio
+from opentelemetry import metrics
+
+_meter = metrics.get_meter("github.com/speakeasy-api/gram/pystreams")
+
+# Distribution of event-loop scheduling delay, in seconds.
+_lag_histogram = _meter.create_histogram(
+    "pystreams.event_loop.lag",
+    unit="s",
+    description=(
+        "Delay between when a loop timer was scheduled to fire and when the "
+        "event loop actually ran it; a proxy for loop saturation."
+    ),
+)
+
+
+async def monitor_event_loop_lag(interval: float = 0.5) -> None:
+    """Sample event-loop lag until cancelled.
+
+    Launch with ``task_group.start_soon``; it is cancelled cleanly with the
+    surrounding task group on shutdown. ``interval`` is how often a sample is
+    taken — a short, cheap sleep whose overshoot is recorded as the lag.
+    """
+    while True:
+        start = time.perf_counter()
+        await anyio.sleep(interval)
+        # Overshoot beyond the requested interval is loop lag: the timer was due
+        # at ``start + interval`` but the loop only got back to it ``lag`` later.
+        lag = max(0.0, (time.perf_counter() - start) - interval)
+        _lag_histogram.record(lag)


### PR DESCRIPTION
Every co-resident subscriber in the pystreams process shares a single asyncio event loop, so one coroutine that fails to yield stalls all the others. The liveness probe only catches a fully-wedged loop, which is too late to act on — it gives no early signal that the loop is saturating and that a handler should be split into its own process.

This adds a sampler that measures the loop's scheduling delay and records it into an OpenTelemetry histogram, plus the call site that runs it. No MeterProvider is configured yet (the OTLP exporter is still blocked on a protobuf 7.x upstream fix), so the instrument resolves to the API's implicit no-op and recording is cheap. The foundation is in place now so that once a provider is wired the signal flows out with no code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an event-loop lag sampler to `pystreams` and run it in the multi-process command to give early signal of loop saturation before the liveness probe trips. Samples are recorded to an OpenTelemetry histogram; without a configured `opentelemetry` `MeterProvider`, this is a no-op with near-zero overhead.

- **New Features**
  - Added `monitor_event_loop_lag(interval=0.5)`, which measures scheduling delay via `anyio.sleep` overshoot and records to `pystreams.event_loop.lag` (seconds).
  - Started the sampler in `multi.py` alongside the health server so it runs for the process lifetime.
  - Safe to enable now; metrics emit once a `MeterProvider` is configured.

<sup>Written for commit 5dd9d825009bf32a7ce97a44be9f67a5c2536555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

