### PR TITLE
feat(assistants): upgrade default model to Opus 4.7

### DIFF
--- a/.changeset/default-assistant-model-opus-47.md
+++ b/.changeset/default-assistant-model-opus-47.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Upgrade the default assistant model to Claude Opus 4.7. The platform-managed Project Assistant, the assistant onboarding flow, and the onboarding system prompt's default recommendation now use `anthropic/claude-opus-4.7` instead of `anthropic/claude-sonnet-4.6`. Existing assistants are unaffected; only newly created assistants pick up the new default.

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -225,7 +225,7 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
           systemPrompt,
           mcps,
           model: {
-            defaultModel: "anthropic/claude-sonnet-4.6" as Model,
+            defaultModel: "anthropic/claude-opus-4.7" as Model,
             showModelPicker: false,
           },
           welcome,

--- a/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
@@ -44,18 +44,18 @@ Pass section bodies WITHOUT a leading heading — the tool adds it. Inside a sec
 - Integration — packaged toolset from the catalog. \`list_integrations\`.
 
 # Models (pass full id to \`update_assistant\`)
-- Anthropic: \`anthropic/claude-opus-4.8\`, \`anthropic/claude-opus-4.7\`, \`anthropic/claude-sonnet-4.6\` (default), \`anthropic/claude-haiku-4.5\`, \`anthropic/claude-sonnet-4.5\`, \`anthropic/claude-opus-4.6\`, \`anthropic/claude-opus-4.5\`, \`anthropic/claude-sonnet-4\`
+- Anthropic: \`anthropic/claude-opus-4.8\`, \`anthropic/claude-opus-4.7\` (default), \`anthropic/claude-sonnet-4.6\`, \`anthropic/claude-haiku-4.5\`, \`anthropic/claude-sonnet-4.5\`, \`anthropic/claude-opus-4.6\`, \`anthropic/claude-opus-4.5\`, \`anthropic/claude-sonnet-4\`
 - OpenAI: \`openai/gpt-5.5\`, \`openai/gpt-5.5-pro\`, \`openai/gpt-5.4\`, \`openai/gpt-5.4-mini\`, \`openai/gpt-5.4-nano\`, \`openai/gpt-5.3-codex\`, \`openai/gpt-5.1\`, \`openai/gpt-5\`, \`openai/gpt-4.1\`, \`openai/o4-mini\`, \`openai/o3\`
 - Google: \`google/gemini-3.5-flash\`, \`google/gemini-3.1-pro-preview\`, \`google/gemini-3.1-flash-lite\`, \`google/gemini-2.5-pro\`, \`google/gemini-2.5-flash\`
 - Others: \`deepseek/deepseek-v4-pro\`, \`deepseek/deepseek-v4-flash\`, \`deepseek/deepseek-v3.2\`, \`deepseek/deepseek-r1\`, \`meta-llama/llama-4-maverick\`, \`x-ai/grok-4.3\`, \`x-ai/grok-4.20\`, \`qwen/qwen3.7-max\`, \`qwen/qwen3-coder\`, \`moonshotai/kimi-k2.6\`, \`moonshotai/kimi-k2.5\`, \`mistralai/mistral-medium-3-5\`, \`mistralai/codestral-2508\`, \`mistralai/devstral-2512\`, \`mistralai/mistral-medium-3.1\`
 
 Recommend:
-- Agentic / tool-heavy → \`anthropic/claude-sonnet-4.6\` (default) or \`anthropic/claude-opus-4.8\` (hardest reasoning, pricier).
+- Agentic / tool-heavy → \`anthropic/claude-opus-4.7\` (default) or \`anthropic/claude-opus-4.8\` (hardest reasoning, pricier).
 - Cheap / fast / high-volume → \`anthropic/claude-haiku-4.5\` or \`openai/gpt-5.4-mini\`.
 - Coding → \`openai/gpt-5.3-codex\`, \`qwen/qwen3-coder\`, \`mistralai/codestral-2508\`.
 - Deep reasoning / math → \`openai/o3\` or \`openai/o4-mini\`.
 - Fast Google → \`google/gemini-2.5-flash\`.
-- Unsure → \`anthropic/claude-sonnet-4.6\`.
+- Unsure → \`anthropic/claude-opus-4.7\`.
 
 # "How do I connect X?" decision tree
 1. \`list_docs\` — if X has a doc (currently: \`slack\`, \`cron\`), follow it. Slack: route through \`propose_slack_setup\` (the user picks capabilities + events; the tool creates a per-assistant Slack toolset and slack trigger — never reuse a catalog toolset). Then \`add_environment_keys\` → \`show_slack_app_guide\` with the returned webhook_url (skip if SLACK_BOT_TOKEN is already populated; check via \`list_environments\` → \`populated_entry_names\`) → \`request_environment_secrets\`.

--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -226,7 +226,7 @@ async function ensureAssistant(
     createAssistantForm: {
       name: payload.name ?? "Untitled assistant",
       instructions: payload.instructions ?? "You are a helpful assistant.",
-      model: payload.model ?? "anthropic/claude-sonnet-4.6",
+      model: payload.model ?? "anthropic/claude-opus-4.7",
       status: payload.status,
       toolsets: [],
       ...(payload.warm_ttl_seconds !== undefined

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -30,8 +30,9 @@ import (
 var managedAssistantInstructions string
 
 const (
-	// managedAssistantModel mirrors the model the sidebar used client-side.
-	managedAssistantModel = "anthropic/claude-sonnet-4.6"
+	// managedAssistantModel is the default model for the platform-managed
+	// assistant. Upgraded to Opus 4.7 for the Assistants beta (DNO-264).
+	managedAssistantModel = "anthropic/claude-opus-4.7"
 
 	// Schema defaults for the assistants table, applied explicitly so the
 	// managed assistant's intent is visible at the call site.


### PR DESCRIPTION
## What

Upgrades the **default model for assistants** from `anthropic/claude-sonnet-4.6` to `anthropic/claude-opus-4.7`.

Closes DNO-264.

## Changes

- **`server/internal/assistants/provisioning.go`** — `managedAssistantModel` constant (the platform-managed Project Assistant) now defaults to Opus 4.7.
- **`AssistantOnboarding.tsx`** — onboarding chat `defaultModel` → Opus 4.7.
- **`useOnboardingTools.tsx`** — create-assistant fallback model → Opus 4.7.
- **`systemPrompt.ts`** — moved the `(default)` marker to Opus 4.7 and updated the "agentic / tool-heavy" and "unsure" recommendations.

## Notes

- Opus 4.7 was already in the `openrouter.go` allowlist and the `contextCompaction` limits map, so this is purely a default flip — **no security-gate or context-limit changes**.
- The `openrouter.go` allowlist is untouched: Sonnet 4.6 stays an _allowed_ selectable model, just no longer the default.
- **No migration / data change.** Existing assistants store their model per-row and are unaffected; only newly created assistants (and the auto-provisioned managed assistant) pick up Opus 4.7.
- Provisioning tests assert against the `managedAssistantModel` constant, so they track the new value automatically — no test edits needed.

## Verification

- `go build ./internal/assistants/...` passes.
- `anthropic/claude-opus-4.7` is a valid member of every model list used by the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `anthropic/claude-opus-4.7` as the default assistant model across provisioning and onboarding, replacing `anthropic/claude-sonnet-4.6` (DNO-264). New assistants, including the platform-managed assistant, use Opus 4.7; existing assistants are unchanged, and there are no allowlist or context-limit changes.

<sup>Written for commit 8e9cda6ae6d4267b3a3bcab4f29e8438a23f45c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

