### PR TITLE
fix(functions): stop leaking stack traces and fix dev-mode error handling

### DIFF
--- a/.changeset/functions-error-no-stack-trace.md
+++ b/.changeset/functions-error-no-stack-trace.md
@@ -1,0 +1,7 @@
+---
+"@gram-ai/functions": patch
+---
+
+fix: stop leaking stack traces in `ctx.fail()` errors and intercept errors in dev mode
+
+`ctx.fail()` no longer includes a stack trace in the user-facing error body — only the supplied message is returned. The dev-mode MCP server now intercepts thrown failures (and unexpected JavaScript errors) and surfaces them as normal `isError` tool results instead of an opaque "Internal Error" in clients like the MCP Inspector.

--- a/ts-framework/functions/src/framework.test.ts
+++ b/ts-framework/functions/src/framework.test.ts
@@ -456,6 +456,7 @@ test("appends one Gram to another", () => {
 });
 
 test("assert throws response with custom status", async () => {
+  expect.hasAssertions();
   try {
     assert(false, { error: "Bad request" }, { status: 400 });
   } catch (err) {
@@ -465,8 +466,33 @@ test("assert throws response with custom status", async () => {
     expect(response.headers.get("Content-Type")).toBe("application/json");
 
     const data = await response.json();
-    expect(data).toMatchObject({ error: "Bad request" });
-    expect(data).toHaveProperty("stack");
+    // The response body must contain only the caller-supplied data — no stack
+    // trace is leaked into the user-facing error message (AGE-2779).
+    expect(data).toEqual({ error: "Bad request" });
+    expect(data).not.toHaveProperty("stack");
+  }
+});
+
+test("ctx.fail() body omits any stack trace", async () => {
+  expect.hasAssertions();
+  const g = new Gram().tool({
+    name: "boom",
+    description: "Always fails",
+    inputSchema: {},
+    async execute(ctx) {
+      return ctx.fail({ error: "nope" }, { status: 422 });
+    },
+  });
+
+  try {
+    await g.handleToolCall({ name: "boom", input: {} });
+  } catch (err) {
+    expect(err).toBeInstanceOf(Response);
+    const response = err as Response;
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data).toEqual({ error: "nope" });
+    expect(data).not.toHaveProperty("stack");
   }
 });
 

--- a/ts-framework/functions/src/framework.ts
+++ b/ts-framework/functions/src/framework.ts
@@ -138,15 +138,15 @@ export function assert<V extends { error: string; stack?: never }>(
   options?: { status?: number },
 ): asserts cond {
   if (!cond) {
-    throw new Response(
-      JSON.stringify({ ...data, stack: new ResponseError().stack }),
-      {
-        status: options?.status || 500,
-        headers: {
-          "Content-Type": "application/json",
-        },
+    // Only the caller-supplied data is serialized into the response body. The
+    // body is surfaced verbatim to the MCP client, so we must never include a
+    // stack trace in a user-facing error message (AGE-2779).
+    throw new Response(JSON.stringify(data), {
+      status: options?.status || 500,
+      headers: {
+        "Content-Type": "application/json",
       },
-    );
+    });
   }
 }
 

--- a/ts-framework/functions/src/mcp.test.ts
+++ b/ts-framework/functions/src/mcp.test.ts
@@ -218,4 +218,69 @@ describe("fromGram", () => {
       ]);
     });
   });
+
+  // Regression coverage for AGE-2779: errors raised while handling a tool call
+  // must be intercepted and surfaced as normal `isError` results rather than
+  // bubbling up as an opaque MCP "Internal Error".
+  describe("error interception", () => {
+    test("ctx.fail() yields an isError result with only the message", async () => {
+      const g = new Gram().tool({
+        name: "fail",
+        description: "Fails via ctx.fail",
+        inputSchema: {},
+        async execute(ctx) {
+          return ctx.fail({ error: "something broke" }, { status: 500 });
+        },
+      });
+
+      const client = await setup(g);
+      // Must resolve (not reject): the thrown Response is intercepted.
+      const result = await client.callTool({ name: "fail", arguments: {} });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: '{"error":"something broke"}' },
+      ]);
+      // No stack trace leaks into the user-facing message.
+      expect(JSON.stringify(result.content)).not.toContain("stack");
+    });
+
+    test("a thrown JavaScript error is reported with its message", async () => {
+      const g = new Gram().tool({
+        name: "throws",
+        description: "Throws a raw error",
+        inputSchema: {},
+        async execute() {
+          throw new Error("kaboom");
+        },
+      });
+
+      const client = await setup(g);
+      const result = await client.callTool({ name: "throws", arguments: {} });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "kaboom" }]);
+    });
+
+    test("an input validation failure yields an isError result", async () => {
+      const g = new Gram().tool({
+        name: "needsName",
+        description: "Requires a name",
+        inputSchema: { name: z.string() },
+        async execute(ctx, input) {
+          return ctx.text(`Hello ${input.name}`);
+        },
+      });
+
+      const client = await setup(g);
+      // Missing required `name` triggers validation failure (ctx.fail, status 400).
+      const result = await client.callTool({
+        name: "needsName",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).not.toContain("stack");
+    });
+  });
 });

--- a/ts-framework/functions/src/mcp.ts
+++ b/ts-framework/functions/src/mcp.ts
@@ -244,62 +244,94 @@ export function fromGram(
     },
   );
 
+  // Converts a tool's `Response` into an MCP `CallToolResult`. Shared between
+  // the normal return path and the error path so that failures surfaced via
+  // `ctx.fail()` (which reject with a `Response`) render identically.
+  async function responseToCallToolResult(
+    resp: Response,
+  ): Promise<CallToolResult> {
+    let ctype = resp.headers.get("Content-Type") || "";
+    ctype = ctype.split(";")[0]?.trim() || "";
+
+    switch (true) {
+      case textLike.test(ctype) || structuredLike.test(ctype): {
+        const text = await resp.text();
+        return {
+          content: [{ type: "text", text }],
+          isError: !resp.ok,
+        };
+      }
+      case imageLike.test(ctype): {
+        return {
+          content: [
+            {
+              type: "image",
+              mimeType: ctype,
+              data: await responseToBase64(resp),
+            },
+          ],
+          isError: !resp.ok,
+        };
+      }
+      case audioLike.test(ctype): {
+        return {
+          content: [
+            {
+              type: "audio",
+              mimeType: ctype,
+              data: await responseToBase64(resp),
+            },
+          ],
+          isError: !resp.ok,
+        };
+      }
+      default: {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Unhandled content type: ${ctype}. Create a handler for this type in the MCP server.`,
+            },
+          ],
+        };
+      }
+    }
+  }
+
   server.setRequestHandler(
     CallToolRequestSchema,
     async (req, extra): Promise<CallToolResult> => {
       const { name, arguments: args } = req.params;
 
-      const resp = (await g.handleToolCall({ name, input: args } as any, {
-        signal: extra.signal,
-      })) as Response;
-
-      let ctype = resp.headers.get("Content-Type") || "";
-      ctype = ctype.split(";")[0]?.trim() || "";
-
-      switch (true) {
-        case textLike.test(ctype) || structuredLike.test(ctype): {
-          const text = await resp.text();
-          return {
-            content: [{ type: "text", text }],
-            isError: !resp.ok,
-          };
+      let resp: Response;
+      try {
+        resp = (await g.handleToolCall({ name, input: args } as any, {
+          signal: extra.signal,
+        })) as Response;
+      } catch (err) {
+        // `ctx.fail()` and input validation failures reject with a `Response`
+        // rather than returning one. Render it like any other tool response so
+        // the failure surfaces as a normal `isError` result instead of an
+        // opaque MCP "Internal Error" in clients like the Inspector (AGE-2779).
+        if (err instanceof Response) {
+          return responseToCallToolResult(err);
         }
-        case imageLike.test(ctype): {
-          return {
-            content: [
-              {
-                type: "image",
-                mimeType: ctype,
-                data: await responseToBase64(resp),
-              },
-            ],
-            isError: !resp.ok,
-          };
-        }
-        case audioLike.test(ctype): {
-          return {
-            content: [
-              {
-                type: "audio",
-                mimeType: ctype,
-                data: await responseToBase64(resp),
-              },
-            ],
-            isError: !resp.ok,
-          };
-        }
-        default: {
-          return {
-            isError: true,
-            content: [
-              {
-                type: "text",
-                text: `Unhandled content type: ${ctype}. Create a handler for this type in the MCP server.`,
-              },
-            ],
-          };
-        }
+        // Any other thrown value is an unexpected error in user code. Report
+        // its message to the client instead of letting the transport surface a
+        // generic internal error.
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: err instanceof Error ? err.message : String(err),
+            },
+          ],
+        };
       }
+
+      return responseToCallToolResult(resp);
     },
   );
 


### PR DESCRIPTION
## What & why

Fixes [AGE-2779](https://linear.app/speakeasy/issue/AGE-2779). A customer reported two related error-handling problems in Gram Functions:

1. **Stack traces leak to users.** When a function calls `ctx.fail()`, the MCP server returned a user-facing error whose body included a full JavaScript stack trace.
2. **Dev mode shows "Internal Error".** When testing locally with the MCP Inspector, a failing tool call surfaced as an opaque `Internal Error` instead of the real message.

Both stem from one design fact: `ctx.fail()` **throws** a `Response` instead of returning one. The production runner already tolerated the throw (so prod only had the cosmetic stack leak), but the dev MCP handler had no `try/catch`, so the throw escaped to the MCP SDK and became JSON-RPC `-32603` ("Internal error").

## Changes

- **`framework.ts`** — `assert()` (used by `ctx.fail()`) no longer injects `stack: new ResponseError().stack` into the response body. Only the caller-supplied data is serialized, so the user-facing message contains just the intended error.
- **`mcp.ts`** — `fromGram()`'s tool handler now wraps `g.handleToolCall()` in `try/catch`. A thrown `Response` (from `ctx.fail()` or input validation) is rendered through the same `responseToCallToolResult()` helper as a normal result; any other thrown error becomes an `isError` result carrying its message. This is the exact handler used by the stdio dev server, so the Inspector now sees real errors.

## Testing

- `pnpm -F @gram-ai/functions test` — green.
- `pnpm -F @gram-ai/functions build` (tsc) — clean.
- Red-green verified: reverting only the source fixes makes the new tests fail, including a direct reproduction of the customer's `MCP error -32603` ("Internal Error").

New regression coverage:

- `ctx.fail()` / `assert()` body contains no `stack`.
- Dev MCP: `ctx.fail()` resolves to an `isError` result with only the message (not a thrown `McpError`).
- Dev MCP: a thrown JS `Error` is reported with its message.
- Dev MCP: input validation failure yields an `isError` result.

A `@gram-ai/functions: patch` changeset is included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes leaked stack traces from `ctx.fail()` errors and fixes dev-mode MCP error handling so the Inspector shows real messages instead of “Internal Error”. Fixes AGE-2779.

- **Bug Fixes**
  - `assert()` now serializes only caller data; no stack traces in response bodies.
  - Dev MCP: `fromGram()` wraps `g.handleToolCall()` in `try/catch` and reports thrown `Response` or `Error` as `isError` using a shared `responseToCallToolResult` helper.
  - Added regression tests and a patch release for `@gram-ai/functions`.

<sup>Written for commit fe6a6b50c2fca01339c7da02ee00d58bca41652b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

