### PR TITLE
chore(streams): exit the streams process when the ping publisher fails

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -892,7 +892,7 @@ type pubSubBroker interface {
 func newPubSubClient(ctx context.Context, c *cli.Context, logger *slog.Logger) (*pubsub.Client, pubSubBroker, func(ctx context.Context) error, error) {
 	var emulated bool
 	var projectID string
-	opts := []option.ClientOption{option.WithLogger(logger)}
+	opts := []option.ClientOption{option.WithLogger(logger.With(attr.SlogComponent("gcp-pubsub-client")))}
 	switch {
 	case c.String("pubsub-emulator-host") != "":
 		emulated = true
@@ -917,9 +917,9 @@ func newPubSubClient(ctx context.Context, c *cli.Context, logger *slog.Logger) (
 
 	var broker pubSubBroker
 	if emulated {
-		broker = gcp.NewEmulatedPubSub(logger, projectID, client, gen.Descriptors)
+		broker = gcp.NewEmulatedPubSub(logger.With(attr.SlogComponent("gcp-emulated-pubsub-broker")), projectID, client, gen.Descriptors)
 	} else {
-		broker = gcp.NewPubSubBroker(logger, client, gen.Descriptors)
+		broker = gcp.NewPubSubBroker(logger.With(attr.SlogComponent("gcp-pubsub-broker")), client, gen.Descriptors)
 	}
 
 	return client, broker, func(context.Context) error { return client.Close() }, nil

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -190,7 +190,7 @@ func newStreamsCommand() *cli.Command {
 			}
 
 			// Use errgroup.WithContext (not a bare errgroup.Group) so the first
-			// receiver or publisher to exit cancels gctx and unwinds the rest.
+			// receiver or publisher to return a non-nil error cancels gctx and unwinds the rest.
 			// A plain group's Wait blocks until *every* goroutine returns, and
 			// the heartbeat publisher loops until its context is cancelled — so
 			// a subscriber whose Receive returns (e.g. its subscription vanished

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -189,10 +189,20 @@ func newStreamsCommand() *cli.Command {
 				shutdownFuncs = append(shutdownFuncs, shutdown)
 			}
 
-			group := new(errgroup.Group)
+			// Use errgroup.WithContext (not a bare errgroup.Group) so the first
+			// receiver or publisher to exit cancels gctx and unwinds the rest.
+			// A plain group's Wait blocks until *every* goroutine returns, and
+			// the heartbeat publisher loops until its context is cancelled — so
+			// a subscriber whose Receive returns (e.g. its subscription vanished
+			// after the emulator restarted) would be recorded as failed but the
+			// process would keep running on the eternal publisher, leaving the
+			// dead subscriber silently un-restarted. Cancelling on first exit
+			// lets Wait return, the process exit, and the supervisor restart us
+			// so subscriptions get reconciled afresh.
+			group, gctx := errgroup.WithContext(ctx)
 			rg := receiverGroup{
 				group:      group,
-				getContext: func() context.Context { return ctx },
+				getContext: func() context.Context { return gctx },
 				tracer:     tracerProvider.Tracer("github.com/speakeasy-api/gram/server/cmd/gram/streams"),
 				logger:     logger,
 				broker:     psbroker,
@@ -209,7 +219,7 @@ func newStreamsCommand() *cli.Command {
 			// subscriber flow is working by driving a simple message through
 			// the system every N seconds and logging it in the subscriber.
 			group.Go(func() error {
-				if err := ping.StartPublisher(ctx, logger, psbroker); err != nil {
+				if err := ping.StartPublisher(gctx, logger, psbroker); err != nil {
 					return fmt.Errorf("publish pings: %w", err)
 				}
 				return nil

--- a/server/internal/ping/publisher.go
+++ b/server/internal/ping/publisher.go
@@ -45,7 +45,7 @@ func StartPublisher(ctx context.Context, logger *slog.Logger, broker gcp.Publish
 		case errors.Is(err, context.Canceled):
 			return nil
 		case err != nil:
-			return errors.Join(err, fmt.Errorf("publish ping message: %w", err))
+			return fmt.Errorf("publish ping message: %w", err)
 		}
 	}
 }

--- a/server/internal/ping/publisher.go
+++ b/server/internal/ping/publisher.go
@@ -45,8 +45,7 @@ func StartPublisher(ctx context.Context, logger *slog.Logger, broker gcp.Publish
 		case errors.Is(err, context.Canceled):
 			return nil
 		case err != nil:
-			logger.ErrorContext(ctx, "publish failed", attr.SlogError(err))
-			continue
+			return errors.Join(err, fmt.Errorf("publish ping message: %w", err))
 		}
 	}
 }


### PR DESCRIPTION
The ping publisher used to log and continue on a failed publish, so a topic-not-found error (e.g. after the emulator restarted and dropped the ping topic) was swallowed and the publisher looped forever on a broken broker. Worse, the streams command ran its receivers and the publisher under a bare errgroup whose Wait only returns once *every* goroutine exits — and the publisher never exits on its own. A receiver that died (its subscription vanished) would be recorded as failed, but the eternal publisher kept the process alive, leaving the dead subscriber silently un-restarted.

Switch to errgroup.WithContext so the first goroutine to return cancels the shared context and unwinds the rest, and make the publisher return the publish error instead of looping. Now any fatal publish or receive failure brings the process down, letting the supervisor restart it and reconcile subscriptions afresh. Logger components are also tagged so the pub/sub client, broker, and emulator are distinguishable in logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exit the streams process when the ping publisher fails instead of looping forever. This lets the supervisor restart the service and re-create missing subscriptions.

- **Bug Fixes**
  - Use `errgroup.WithContext` and pass its context to receivers and the publisher so the first goroutine that returns a non‑nil error cancels the rest and unblocks `Wait`.
  - Make the `ping` publisher return publish errors (e.g., topic not found) instead of logging and continuing.
  - Tag Pub/Sub loggers with components: `gcp-pubsub-client`, `gcp-pubsub-broker`, `gcp-emulated-pubsub-broker`.

<sup>Written for commit 07d9d15e8c9b4acf6c60b40e0018c15a024c0bf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

