### PR TITLE
chore(gateway): tag proxy logs with per-caller components

### DIFF
--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -178,15 +178,15 @@ func (tp *ToolProxy) Do(
 	case "":
 		return oops.E(oops.CodeInvariantViolation, nil, "tool kind is not set").LogError(ctx, tp.logger)
 	case ToolKindFunction:
-		return tp.doFunction(ctx, logger, w, requestBody, env, plan.Descriptor, plan.Function, attrs)
+		return tp.doFunction(ctx, logger.With(attr.SlogComponent("gateway-function-caller")), w, requestBody, env, plan.Descriptor, plan.Function, attrs)
 	case ToolKindHTTP:
-		return tp.doHTTP(ctx, logger, w, requestBody, env, plan.Descriptor, plan.HTTP, attrs)
+		return tp.doHTTP(ctx, logger.With(attr.SlogComponent("gateway-http-caller")), w, requestBody, env, plan.Descriptor, plan.HTTP, attrs)
 	case ToolKindPrompt:
-		return tp.doPrompt(ctx, logger, w, requestBody, env, plan.Descriptor, plan.Prompt)
+		return tp.doPrompt(ctx, logger.With(attr.SlogComponent("gateway-prompt-caller")), w, requestBody, env, plan.Descriptor, plan.Prompt)
 	case ToolKindPlatform:
-		return tp.doPlatform(ctx, logger, w, requestBody, env, plan, attrs)
+		return tp.doPlatform(ctx, logger.With(attr.SlogComponent("gateway-platform-caller")), w, requestBody, env, plan, attrs)
 	case ToolKindExternalMCP:
-		return tp.doExternalMCP(ctx, logger, w, requestBody, env, plan.ExternalMCP)
+		return tp.doExternalMCP(ctx, logger.With(attr.SlogComponent("gateway-externalmcp-caller")), w, requestBody, env, plan.ExternalMCP)
 	default:
 		return fmt.Errorf("tool type not supported: %s", plan.Kind)
 	}


### PR DESCRIPTION
The ToolProxy.Do switch handed the same logger to every tool-kind handler, so log lines from function, HTTP, prompt, platform, and external MCP calls were indistinguishable from one another. Attaching a distinct slog component to each branch lets these code paths be filtered and correlated independently when triaging gateway issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-caller `slog` components to gateway proxy logging so function, HTTP, prompt, platform, and external MCP calls are easy to filter and correlate during triage.

- **Refactors**
  - In `ToolProxy.Do`, pass `logger.With(attr.SlogComponent(...))` to each handler instead of a shared logger.
  - Components: `gateway-function-caller`, `gateway-http-caller`, `gateway-prompt-caller`, `gateway-platform-caller`, `gateway-externalmcp-caller`.

<sup>Written for commit 5e724f936146d10579a10bc2b135d2e71beef22a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

