### PR TITLE
chore(pystreams): rename log event field to message in JSON output

### DIFF
--- a/pystreams/src/pystreams/deps/logging.py
+++ b/pystreams/src/pystreams/deps/logging.py
@@ -27,6 +27,18 @@ def _add_open_telemetry_spans(_, __, event_dict):
     return event_dict
 
 
+def _rename_event_to_message(_, __, event_dict):
+    """Rename the ``event`` key to ``message``, when present.
+
+    Unlike ``structlog.processors.EventRenamer``, this guards on the key being
+    present so log calls without an event (e.g. ``log.info(None, foo="bar")``)
+    don't raise a ``KeyError``.
+    """
+    if "event" in event_dict:
+        event_dict["message"] = event_dict.pop("event")
+    return event_dict
+
+
 def _add_base_attrs(base_attrs: dict[str, Any]):
     """Build a processor that merges fixed base attributes into every event."""
 
@@ -71,6 +83,7 @@ def configure_logging(
         renderer = structlog.dev.ConsoleRenderer()
     else:
         shared_processors.append(structlog.processors.format_exc_info)
+        shared_processors.append(_rename_event_to_message)
         renderer = structlog.processors.JSONRenderer()
 
     structlog.configure(


### PR DESCRIPTION
JSON log aggregators key off a "message" field for the primary log text, but structlog emits it under "event" by default. Renaming the field on the JSON renderer path makes pystreams logs align with the rest of the platform's logging conventions so the main log line is parsed and displayed correctly. The pretty console path is left untouched for local readability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update JSON logging to emit the primary log text under "message" instead of "event" so aggregators parse and display logs correctly. Implemented with a guarded custom processor on the JSON renderer path to avoid KeyErrors when no "event" is present; pretty console output is unchanged.

<sup>Written for commit b9a212bb25407d41282394c12154af0e2d70d464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

