### PR TITLE
feat: add agentkit compose tool and emit MCP structuredContent

### DIFF
--- a/.changeset/mcp-structured-content.md
+++ b/.changeset/mcp-structured-content.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+MCP tool calls that return a JSON object now also include `structuredContent`, so clients can consume a parsed object instead of re-parsing the text result.

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "agentkit-adapter-completions"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccf868fe81fc9cce7b9886e382104f8be17f7ae2c557432282256b27f01d2af"
+checksum = "b7a07def866615c3fb73d97cf3357922c8d714f40875fc3e26c921475d9a2795"
 dependencies = [
  "agentkit-core",
  "agentkit-http",
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-capabilities"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0668d77c0594ca03b33e1f8e45d8266959ff08bb6b437b9a1cadfb3010361"
+checksum = "d7c1b861d5cc04ae1fd33a1482783db68d39c4e7acda7347049e9cc286f92ae5"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-compaction"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9506ff89d2a68604f5813aede539a8ad743c7cfa54fce0d0bcc127949b04f3c"
+checksum = "9d43403488636da1089fdb200b52f0e9dddfb7fd18ae524e1f9ae2ebed7319af"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-core"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f183e70bd23e6662e4c6ebe6b0775c76a024c223153af188934e17c3b1401ca7"
+checksum = "3eb0a7694e4698536d8aad30edf8117d793a93dff2875281b5746aa750c56425"
 dependencies = [
  "futures-timer",
  "serde",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-http"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49de3d89a2b44934aae701ab40af56357f99b6ff9b9cb5a865b215e0c2c390e0"
+checksum = "78c65878055669670d83fd0c1a1ec88f1f1b028d7bcb1a0187a486cd91959957"
 dependencies = [
  "async-trait",
  "bytes",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-loop"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1d2ecf08e0703cf87a54e1395152038db28bf911dc72c3512a3004626b35fa"
+checksum = "44fd76bf5983235780daa53c1b323154d62021fb922422d394dbee5b4ed748d7"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-mcp"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d859a60b07c66618cb284aa833e3261fd05a8999596e01f393a8b653ee00e87"
+checksum = "09f2a99ba77d4331a0068deaaf6f3fbe9036bf916b9972824891422ca623ab28"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-provider-openrouter"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d3c3422c7f36360e2932e6f938df36a8f028767d8fc15c79ca5dd833b6e6a1"
+checksum = "9812b289175d71d2f831d11a5ac4d11560543c7d8eb67d4f49efc93a7a91e498"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-reporting"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088fcebbb834b5aced2f96b082eedacc80f765c1a73d523e25c37b37db68b992"
+checksum = "c358950c347607374646ef6f079abe78173d2a08aad5cc5594658ec39b02aca0"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-task-manager"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2b8ebcc040a673abfd4e45a0fae91827e8d69a955b6ad849bcdf73154a3dee"
+checksum = "88efafbc717584b5a16c34863699864dfb5ebfe16bc827835f1336841ed40b9a"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -160,10 +160,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "agentkit-tool-fs"
-version = "0.8.1"
+name = "agentkit-tool-compose"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03443829a26c566be19076346a22e50d2dd73125a7a11897c761468c227299b9"
+checksum = "b1c50df12dbf49ed582a0c4a755bc66e00766c6c36ec264e88a9e72f7f8a28a4"
+dependencies = [
+ "agentkit-core",
+ "agentkit-tools-core",
+ "async-trait",
+ "mlua",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "agentkit-tool-fs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8e81a14414966e7cac68884b79cb319670e1301ab8c2a26d7b8c11493a2afd"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -177,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-core"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6bdbaed6a65d856f76bd36418ea6124031b09c3aecf82600a19d69530a0264"
+checksum = "ec9ba7275160551a95411eed65fca851d0e9d00bafeb7fef86bac2e874fc71ac"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -193,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-derive"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de650ca60c7e911840515cdf424ed1741ffef3457a6a83ab8423e84a71c2d2b7"
+checksum = "5fdb08b8c13c74240722dbcdcc2a9e04934892d04e92b8532a97b549df5cb742"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -445,6 +460,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -703,6 +728,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +977,7 @@ dependencies = [
  "agentkit-mcp",
  "agentkit-provider-openrouter",
  "agentkit-reporting",
+ "agentkit-tool-compose",
  "agentkit-tool-fs",
  "agentkit-tools-core",
  "agentkit-tools-derive",
@@ -1440,6 +1477,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lua-src"
+version = "550.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.6.6+707c12b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1531,40 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlua"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
+dependencies = [
+ "bstr",
+ "either",
+ "erased-serde",
+ "futures-util",
+ "libc",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1624,6 +1714,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1799,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -2329,6 +2434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,6 +2999,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,6 +3266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -9,17 +9,18 @@ name = "gram-assistant-runner"
 path = "src/main.rs"
 
 [dependencies]
-agentkit-adapter-completions = "0.8.1"
-agentkit-compaction = "0.8.1"
-agentkit-core = "0.8.1"
-agentkit-http = { version = "0.8.1", features = ["reqwest-middleware-client"] }
-agentkit-loop = "0.8.1"
-agentkit-mcp = "0.8.1"
-agentkit-provider-openrouter = "0.8.1"
-agentkit-reporting = { version = "0.8.1", features = ["tracing"] }
-agentkit-tool-fs = "0.8.1"
-agentkit-tools-core = { version = "0.8.1", features = ["schemars"] }
-agentkit-tools-derive = "0.8.1"
+agentkit-adapter-completions = "0.9.1"
+agentkit-compaction = "0.9.1"
+agentkit-core = "0.9.1"
+agentkit-http = { version = "0.9.1", features = ["reqwest-middleware-client"] }
+agentkit-loop = "0.9.1"
+agentkit-mcp = "0.9.1"
+agentkit-provider-openrouter = "0.9.1"
+agentkit-reporting = { version = "0.9.1", features = ["tracing"] }
+agentkit-tool-compose = "0.9.1"
+agentkit-tool-fs = "0.9.1"
+agentkit-tools-core = { version = "0.9.1", features = ["schemars"] }
+agentkit-tools-derive = "0.9.1"
 opentelemetry = "0.32"
 opentelemetry-otlp = { version = "0.32", default-features = false, features = [
   "grpc-tonic",

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -385,11 +385,12 @@ async fn spawn_thread(
     );
 
     let mcp_source = ClippedToolSource::new(mcp_catalog, host.spill_root.clone());
+    let compose_source = agentkit_tool_compose::ComposeTool::wrap(mcp_source)
+        .with_source(native_tools.merge(agentkit_tool_fs::registry()));
+
     let mut builder = Agent::builder()
         .model(adapter)
-        .add_tool_source(native_tools)
-        .add_tool_source(agentkit_tool_fs::registry())
-        .add_tool_source(mcp_source)
+        .add_tool_source(compose_source)
         .permissions(permissions)
         .resources(fs_resources)
         .observer(TracingReporter::new())

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -384,13 +384,13 @@ async fn spawn_thread(
         tools::mcp_force_reconnect::McpForceReconnectTool::new(Arc::clone(host), mcp_server_ids),
     );
 
-    let mcp_source = ClippedToolSource::new(mcp_catalog, host.spill_root.clone());
-    let compose_source = agentkit_tool_compose::ComposeTool::wrap(mcp_source)
+    let compose_source = agentkit_tool_compose::ComposeTool::wrap(mcp_catalog)
         .with_source(native_tools.merge(agentkit_tool_fs::registry()));
+    let clipped_source = ClippedToolSource::new(compose_source, host.spill_root.clone());
 
     let mut builder = Agent::builder()
         .model(adapter)
-        .add_tool_source(compose_source)
+        .add_tool_source(clipped_source)
         .permissions(permissions)
         .resources(fs_resources)
         .observer(TracingReporter::new())

--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -253,7 +253,7 @@ func handleSearchToolsCall(
 		ID: reqID,
 		Result: toolCallResult{
 			Content:           []json.RawMessage{chunk},
-			StructuredContent: nil,
+			StructuredContent: json.RawMessage(payload),
 			IsError:           false,
 		},
 	})
@@ -368,7 +368,7 @@ func handleDescribeToolsCall(
 		ID: reqID,
 		Result: toolCallResult{
 			Content:           []json.RawMessage{chunk},
-			StructuredContent: nil,
+			StructuredContent: json.RawMessage(payload),
 			IsError:           false,
 		},
 	})

--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -252,8 +252,9 @@ func handleSearchToolsCall(
 	response, err := json.Marshal(result[toolCallResult]{
 		ID: reqID,
 		Result: toolCallResult{
-			Content: []json.RawMessage{chunk},
-			IsError: false,
+			Content:           []json.RawMessage{chunk},
+			StructuredContent: nil,
+			IsError:           false,
 		},
 	})
 	if err != nil {
@@ -366,8 +367,9 @@ func handleDescribeToolsCall(
 	response, err := json.Marshal(result[toolCallResult]{
 		ID: reqID,
 		Result: toolCallResult{
-			Content: []json.RawMessage{chunk},
-			IsError: false,
+			Content:           []json.RawMessage{chunk},
+			StructuredContent: nil,
+			IsError:           false,
 		},
 	})
 	if err != nil {

--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -201,7 +201,7 @@ func handleSearchToolsCall(
 	}
 
 	// construct full tool entries with similarity scores
-	var results []*toolListEntry
+	results := make([]*toolListEntry, 0, len(searchResults))
 	for _, searchResult := range searchResults {
 		tool, exists := toolsByName[searchResult.ToolName]
 		if !exists {

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -418,7 +418,7 @@ func handleToolsCall(
 		return bs, nil
 	}
 
-	chunk, err := formatResult(*rw, plan.Kind)
+	chunk, structured, err := formatResult(*rw, plan.Kind)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed format tool call result").LogError(ctx, logger)
 	}
@@ -426,8 +426,9 @@ func handleToolsCall(
 	bs, err := json.Marshal(result[toolCallResult]{
 		ID: req.ID,
 		Result: toolCallResult{
-			Content: []json.RawMessage{chunk},
-			IsError: rw.statusCode < 200 || rw.statusCode >= 300,
+			Content:           []json.RawMessage{chunk},
+			StructuredContent: structured,
+			IsError:           rw.statusCode < 200 || rw.statusCode >= 300,
 		},
 	})
 	if err != nil {
@@ -598,16 +599,22 @@ func (w *toolCallResponseWriter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-func formatResult(rw toolCallResponseWriter, toolKind gateway.ToolKind) (json.RawMessage, error) {
+// formatResult turns a tool's raw HTTP response body into an MCP content
+// chunk. When the body is a JSON object it also returns it verbatim as
+// structuredContent so spec-compliant clients (MCP 2025-06-18) receive a
+// parsed object instead of having to re-parse the stringified text block.
+// structured is nil for non-JSON bodies and for JSON that is not an object
+// (arrays/scalars), which the spec reserves the field for.
+func formatResult(rw toolCallResponseWriter, toolKind gateway.ToolKind) (chunk json.RawMessage, structured json.RawMessage, err error) {
 	body := rw.body.Bytes()
 	if len(body) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	ct := rw.headers.Get("content-type")
 	mt, _, err := mime.ParseMediaType(ct)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse content type %q: %w", ct, err)
+		return nil, nil, fmt.Errorf("failed to parse content type %q: %w", ct, err)
 	}
 
 	switch {
@@ -622,10 +629,16 @@ func formatResult(rw toolCallResponseWriter, toolKind gateway.ToolKind) (json.Ra
 			},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("serialize text content: %w", err)
+			return nil, nil, fmt.Errorf("serialize text content: %w", err)
 		}
 
-		return bs, nil
+		if contenttypes.IsJSON(mt) {
+			if trimmed := bytes.TrimSpace(body); len(trimmed) > 0 && trimmed[0] == '{' && json.Valid(trimmed) {
+				structured = json.RawMessage(trimmed)
+			}
+		}
+
+		return bs, structured, nil
 	case strings.HasPrefix(mt, "image/"):
 		encoded := base64.StdEncoding.EncodeToString(body)
 		bs, err := json.Marshal(contentChunk[json.RawMessage, string]{
@@ -636,10 +649,10 @@ func formatResult(rw toolCallResponseWriter, toolKind gateway.ToolKind) (json.Ra
 			Meta:     nil,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("serialize image content: %w", err)
+			return nil, nil, fmt.Errorf("serialize image content: %w", err)
 		}
 
-		return bs, nil
+		return bs, nil, nil
 	case strings.HasPrefix(mt, "audio/"):
 		encoded := base64.StdEncoding.EncodeToString(body)
 		bs, err := json.Marshal(contentChunk[json.RawMessage, string]{
@@ -650,12 +663,12 @@ func formatResult(rw toolCallResponseWriter, toolKind gateway.ToolKind) (json.Ra
 			Meta:     nil,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("serialize audio content: %w", err)
+			return nil, nil, fmt.Errorf("serialize audio content: %w", err)
 		}
 
-		return bs, nil
+		return bs, nil, nil
 	default:
-		return nil, fmt.Errorf("unsupported content type %q", ct)
+		return nil, nil, fmt.Errorf("unsupported content type %q", ct)
 	}
 }
 
@@ -668,8 +681,9 @@ type contentChunk[T any, D any] struct {
 }
 
 type toolCallResult struct {
-	Content []json.RawMessage `json:"content"`
-	IsError bool              `json:"isError,omitzero"`
+	Content           []json.RawMessage `json:"content"`
+	StructuredContent json.RawMessage   `json:"structuredContent,omitempty"`
+	IsError           bool              `json:"isError,omitzero"`
 }
 
 // filterOmittedEnvVars filters environment variables based on MCP metadata configuration.

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -409,7 +409,7 @@ func (s *Service) callPlatformToolsetTool(
 	}
 	outputBytes = int64(rw.body.Len())
 
-	chunk, err := formatResult(*rw, plan.Kind)
+	chunk, structured, err := formatResult(*rw, plan.Kind)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to format platform tool call result").LogError(ctx, logger)
 	}
@@ -417,8 +417,9 @@ func (s *Service) callPlatformToolsetTool(
 	bs, err := json.Marshal(result[toolCallResult]{
 		ID: req.ID,
 		Result: toolCallResult{
-			Content: []json.RawMessage{chunk},
-			IsError: rw.statusCode < 200 || rw.statusCode >= 300,
+			Content:           []json.RawMessage{chunk},
+			StructuredContent: structured,
+			IsError:           rw.statusCode < 200 || rw.statusCode >= 300,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## What

Two coordinated changes to the assistant runtime and MCP server:

- **Assistant runner**: bump `agentkit` `0.8.1 → 0.9.1` and add `agentkit-tool-compose`. The MCP tool source is now wrapped in a `ComposeTool`, which exposes a sandboxed-Lua `compose` meta-tool. The agent can chain many tool calls (iterate, paginate, filter, fan-out reads into writes) in a single round-trip so intermediate results never enter the conversation, while every underlying tool stays individually callable.
- **MCP server**: `formatResult` now also returns `structuredContent` for tool responses whose body is a JSON object, alongside the existing text content block. Applied to both the toolset (`handleToolsCall`) and platform (`callPlatformToolsetTool`) call paths.

## Why

- `compose` collapses multi-step tool workflows into one round-trip, cutting latency and context usage for the assistant.
- Returning `structuredContent` (MCP `2025-06-18`) lets spec-compliant clients consume a parsed object instead of re-parsing the stringified text block. The text block is preserved for backwards compatibility, so clients that don't understand `structuredContent` are unaffected.

## Notes

- `compose` wrapping keeps native, filesystem, and MCP tools advertised and directly callable; nested calls inside a compose script still flow through the agent's permission/approval pipeline.
- `structuredContent` is emitted only for JSON **objects** (not arrays/scalars/non-JSON), matching the spec's object-typed field. Non-JSON responses keep the previous wire shape (`omitempty`).
- New transitive dependency: `mlua` (embedded Lua VM) via the compose crate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `compose` meta-tool to chain multiple tool calls in one round-trip and emits MCP `structuredContent` for JSON-object results so clients can consume parsed data. Upgrades `agentkit` to `0.9.1` and caps compose aggregate output.

- **New Features**
  - Runner: add `agentkit-tool-compose`; wraps MCP tools and merges native/`fs`; clipping happens at the compose layer; underlying tools stay directly callable and approvals still apply.
  - Server: add `structuredContent` to tool results (toolset, platform, `search_tools`, `describe_tools`) when the body is a JSON object; text blocks are preserved.

- **Bug Fixes**
  - `search_tools` now returns an empty tools array when there are no matches.

<sup>Written for commit daebe97b537cb07aec4bd809ba6694e36e66a5cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

