### PR TITLE
feat(oops): add LogWarn and LogInfo methods to ShareableError

### DIFF
--- a/glint/no_client_error_log_error.go
+++ b/glint/no_client_error_log_error.go
@@ -1,0 +1,219 @@
+package glint
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"slices"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const (
+	noClientErrorLogErrorAnalyzer       = "noclienterrorlogerror"
+	noClientErrorLogErrorDefaultMessage = "client-fault (4xx) oops error %q is logged at error level via .LogError; chain .LogWarn or .LogInfo instead so the OpenTelemetry span is not marked errored"
+
+	oopsPkgPath            = "github.com/speakeasy-api/gram/server/internal/oops"
+	oopsShareableErrorName = "ShareableError"
+	oopsLogErrorName       = "LogError"
+)
+
+// clientErrorCodes is the set of oops.Code constant names this analyzer treats
+// as client faults (4xx) eligible for opt-in enforcement. It is keyed by the Go
+// constant identifier (e.g. CodeUnauthorized) to match how call sites and the
+// Codes setting reference codes, and is the authoritative universe the Codes
+// setting is validated against.
+//
+// It deliberately excludes codes that map to a 4xx status but are not client
+// faults: CodeInvariantViolation (422, but flagged as a server fault) stays at
+// error level, and CodeCanceled (499) is never authored directly (LogError's
+// own cancellation handling already demotes it). Server-fault codes
+// (CodeUnexpected, CodeGatewayError, CodeNotImplemented) are 5xx and out of
+// scope.
+var clientErrorCodes = map[string]struct{}{
+	"CodeBadRequest":          {}, // 400
+	"CodeUnauthorized":        {}, // 401
+	"CodeInsufficientCredits": {}, // 402
+	"CodeForbidden":           {}, // 403
+	"CodeNotFound":            {}, // 404
+	"CodeMethodNotAllowed":    {}, // 405
+	"CodeConflict":            {}, // 409
+	"CodeRequestTooLarge":     {}, // 413
+	"CodeUnsupportedMedia":    {}, // 415
+	"CodeInvalid":             {}, // 422 (validation, not a server fault)
+	"CodeRateLimitExceeded":   {}, // 429
+}
+
+type noClientErrorLogErrorSettings struct {
+	Disabled bool `json:"disabled"`
+
+	// Codes is the opt-in allowlist of oops.Code constant names to enforce (e.g.
+	// "CodeUnauthorized", "CodeForbidden"). An empty list reports nothing, which
+	// lets the rule be wired in with no effect until codes are opted in one at a
+	// time. This list setting is a deliberate exception to the package's
+	// Disabled-only convention, motivated by the phased rollout across the
+	// existing call sites.
+	Codes []string `json:"codes"`
+}
+
+func newNoClientErrorLogErrorAnalyzer(rule noClientErrorLogErrorSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: noClientErrorLogErrorAnalyzer,
+		// Doc intentionally omits the %q placeholder used in per-site diagnostics.
+		Doc:      "flag opt-in client-fault (4xx) oops codes logged at error level via .LogError; only direct oops.E/oops.C chains with constant code args are analyzed",
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Run: func(pass *analysis.Pass) (any, error) {
+			// Validate the opt-in list against the known client-fault codes so a
+			// typo or a non-4xx code surfaces as a configuration error rather than
+			// silently enforcing nothing.
+			enabled, err := clientErrorCodeSet(rule.Codes)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", noClientErrorLogErrorAnalyzer, err)
+			}
+
+			if len(enabled) == 0 {
+				return nil, nil
+			}
+
+			ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+			ins.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(node ast.Node) {
+				logCall := node.(*ast.CallExpr)
+
+				// Match a `.LogError(...)` method call whose receiver type is
+				// *oops.ShareableError. The receiver type is the load-bearing
+				// guard, so an unrelated LogError method elsewhere is not matched.
+				sel, ok := logCall.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != oopsLogErrorName {
+					return
+				}
+				if !isShareableErrorMethod(pass.TypesInfo.Uses[sel.Sel], oopsLogErrorName) {
+					return
+				}
+
+				// The receiver expression must be a direct oops.E(...) / oops.C(...)
+				// call so the authored code constant is visible. Errors stored in a
+				// variable before logging are out of scope (accepted false
+				// negatives) since the code cannot be resolved here.
+				codeArg, ok := oopsConstructorCodeArg(pass, sel.X)
+				if !ok {
+					return
+				}
+
+				// Resolve the code argument to an oops.Code constant name (e.g.
+				// "CodeUnauthorized"). A non-constant code (a variable holding the
+				// code) yields no name and is skipped.
+				code, ok := oopsCodeConstName(pass, codeArg)
+				if !ok {
+					return
+				}
+
+				if _, ok := enabled[code]; !ok {
+					return
+				}
+
+				pass.ReportRangef(sel.Sel, noClientErrorLogErrorDefaultMessage, code)
+			})
+
+			return nil, nil
+		},
+	}
+}
+
+// clientErrorCodeSet validates the opt-in codes against the known client-fault
+// codes and returns them as a set. An unknown or non-client-fault code is a
+// configuration error.
+func clientErrorCodeSet(codes []string) (map[string]struct{}, error) {
+	enabled := make(map[string]struct{}, len(codes))
+	for _, code := range codes {
+		if _, ok := clientErrorCodes[code]; !ok {
+			return nil, fmt.Errorf("unknown or non-client-fault oops code %q in codes setting", code)
+		}
+		enabled[code] = struct{}{}
+	}
+	return enabled, nil
+}
+
+// isShareableErrorMethod reports whether obj is the named method on
+// *oops.ShareableError, resolved via type information so it is robust against
+// import aliases.
+func isShareableErrorMethod(obj types.Object, name string) bool {
+	fn, ok := obj.(*types.Func)
+	if !ok || fn.Name() != name {
+		return false
+	}
+
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return false
+	}
+
+	recv := sig.Recv().Type()
+	if ptr, ok := recv.(*types.Pointer); ok {
+		recv = ptr.Elem()
+	}
+
+	named, ok := recv.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	return named.Obj().Name() == oopsShareableErrorName &&
+		named.Obj().Pkg() != nil &&
+		named.Obj().Pkg().Path() == oopsPkgPath
+}
+
+// oopsConstructorCodeArg reports the code argument of a direct oops.E(...) or
+// oops.C(...) call expression. Both constructors take the oops.Code as their
+// first argument.
+func oopsConstructorCodeArg(pass *analysis.Pass, expr ast.Expr) (ast.Expr, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) == 0 {
+		return nil, false
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil, false
+	}
+
+	fn, ok := pass.TypesInfo.Uses[sel.Sel].(*types.Func)
+	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != oopsPkgPath {
+		return nil, false
+	}
+	if fn.Signature().Recv() != nil {
+		return nil, false
+	}
+	if !slices.Contains([]string{"E", "C"}, fn.Name()) {
+		return nil, false
+	}
+
+	return call.Args[0], true
+}
+
+// oopsCodeConstName returns the identifier name of an oops.Code constant
+// referenced by expr (e.g. "CodeUnauthorized" for oops.CodeUnauthorized),
+// resolved via type information so it is robust against import aliases. It
+// reports false for anything that is not a direct reference to an exported
+// constant declared in the oops package, including a variable holding a code or
+// a constant from another package.
+func oopsCodeConstName(pass *analysis.Pass, expr ast.Expr) (string, bool) {
+	var ident *ast.Ident
+	switch e := expr.(type) {
+	case *ast.Ident:
+		ident = e
+	case *ast.SelectorExpr:
+		ident = e.Sel
+	default:
+		return "", false
+	}
+
+	c, ok := pass.TypesInfo.Uses[ident].(*types.Const)
+	if !ok || c.Pkg() == nil || c.Pkg().Path() != oopsPkgPath {
+		return "", false
+	}
+
+	return c.Name(), true
+}

--- a/glint/no_client_error_log_error_test.go
+++ b/glint/no_client_error_log_error_test.go
@@ -1,0 +1,56 @@
+package glint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestNoClientErrorLogError(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analyzer := newNoClientErrorLogErrorAnalyzer(noClientErrorLogErrorSettings{
+		Codes: []string{"CodeUnauthorized", "CodeNotFound"},
+	})
+	analysistest.Run(t, testdata, analyzer, "github.com/speakeasy-api/gram/server/internal/noclienterrorlogerror")
+}
+
+func TestNoClientErrorLogErrorAllowsKnownCodes(t *testing.T) {
+	t.Parallel()
+
+	enabled, err := clientErrorCodeSet([]string{"CodeUnauthorized", "CodeNotFound", "CodeBadRequest"})
+	require.NoError(t, err)
+	require.Len(t, enabled, 3)
+}
+
+func TestNoClientErrorLogErrorRejectsUnknownCode(t *testing.T) {
+	t.Parallel()
+
+	_, err := clientErrorCodeSet([]string{"CodeUnauthorized", "CodeNonsense"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CodeNonsense")
+}
+
+func TestNoClientErrorLogErrorRejectsNonClientFaultCode(t *testing.T) {
+	t.Parallel()
+
+	// A 5xx / server-fault code must not be accepted: it is not eligible for
+	// demotion off error level.
+	_, err := clientErrorCodeSet([]string{"CodeUnexpected"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CodeUnexpected")
+}
+
+func TestBuildAnalyzersSkipsDisabledNoClientErrorLogError(t *testing.T) {
+	t.Parallel()
+
+	p := disabledAllRulesPlugin()
+	p.settings.Rules.NoClientErrorLogError.Disabled = false
+
+	analyzers, err := p.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Len(t, analyzers, 1)
+	require.Equal(t, noClientErrorLogErrorAnalyzer, analyzers[0].Name)
+}

--- a/glint/plugin.go
+++ b/glint/plugin.go
@@ -33,6 +33,7 @@ type ruleSettings struct {
 	NoDirectChatMessageInsert  noDirectChatMessageInsertSettings  `json:"no-direct-chat-message-insert"`
 	NoSqlErrNoRows             noSqlErrNoRowsSettings             `json:"no-sql-err-no-rows"`
 	NoTestingRawSql            noTestingRawSqlSettings            `json:"no-testing-raw-sql"`
+	NoClientErrorLogError      noClientErrorLogErrorSettings      `json:"no-client-error-log-error"`
 }
 
 type plugin struct {
@@ -88,6 +89,9 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	}
 	if !p.settings.Rules.NoTestingRawSql.Disabled {
 		analyzers = append(analyzers, newNoTestingRawSqlAnalyzer(p.settings.Rules.NoTestingRawSql))
+	}
+	if !p.settings.Rules.NoClientErrorLogError.Disabled {
+		analyzers = append(analyzers, newNoClientErrorLogErrorAnalyzer(p.settings.Rules.NoClientErrorLogError))
 	}
 
 	return analyzers, nil

--- a/glint/plugin_test.go
+++ b/glint/plugin_test.go
@@ -25,6 +25,7 @@ func disabledAllRulesPlugin() *plugin {
 				NoDirectChatMessageInsert:  noDirectChatMessageInsertSettings{Disabled: true},
 				NoSqlErrNoRows:             noSqlErrNoRowsSettings{Disabled: true},
 				NoTestingRawSql:            noTestingRawSqlSettings{Disabled: true},
+				NoClientErrorLogError:      noClientErrorLogErrorSettings{Disabled: true},
 			},
 		},
 	}
@@ -45,5 +46,5 @@ func TestBuildAnalyzersAllEnabled(t *testing.T) {
 	p := &plugin{}
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)
-	require.Len(t, analyzers, 13)
+	require.Len(t, analyzers, 14)
 }

--- a/glint/testdata/src/github.com/speakeasy-api/gram/server/internal/noclienterrorlogerror/impl.go
+++ b/glint/testdata/src/github.com/speakeasy-api/gram/server/internal/noclienterrorlogerror/impl.go
@@ -1,0 +1,35 @@
+package noclienterrorlogerror
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// The analyzer under test is configured with the "CodeUnauthorized" and
+// "CodeNotFound" codes opted in.
+func examples(ctx context.Context, logger *slog.Logger) {
+	// Opted-in client-fault codes logged at error level are flagged.
+	_ = oops.E(oops.CodeUnauthorized, nil, "x").LogError(ctx, logger) // want `oops error "CodeUnauthorized" is logged at error level`
+	_ = oops.E(oops.CodeNotFound, nil, "y").LogError(ctx, logger)     // want `oops error "CodeNotFound" is logged at error level`
+	_ = oops.C(oops.CodeUnauthorized).LogError(ctx, logger)           // want `oops error "CodeUnauthorized" is logged at error level`
+
+	// Client-fault code that is not opted in: no diagnostic.
+	_ = oops.E(oops.CodeForbidden, nil, "z").LogError(ctx, logger)
+
+	// Already demoted off LogError: no diagnostic.
+	_ = oops.E(oops.CodeUnauthorized, nil, "x").LogWarn(ctx, logger)
+	_ = oops.E(oops.CodeNotFound, nil, "y").LogInfo(ctx, logger)
+
+	// Server-fault / 5xx code: out of scope.
+	_ = oops.E(oops.CodeUnexpected, nil, "boom").LogError(ctx, logger)
+
+	// Non-constant code cannot be resolved here, so it is skipped.
+	code := oops.CodeUnauthorized
+	_ = oops.E(code, nil, "x").LogError(ctx, logger)
+
+	// Error stored before logging: the receiver is not a direct constructor call.
+	e := oops.E(oops.CodeUnauthorized, nil, "x")
+	_ = e.LogError(ctx, logger)
+}

--- a/glint/testdata/src/github.com/speakeasy-api/gram/server/internal/oops/oops.go
+++ b/glint/testdata/src/github.com/speakeasy-api/gram/server/internal/oops/oops.go
@@ -1,0 +1,45 @@
+// Package oops is a minimal stub of the real
+// github.com/speakeasy-api/gram/server/internal/oops package, used so the
+// no-client-error-log-error analyzer fixtures resolve oops.E/oops.C and the
+// ShareableError log methods by type.
+package oops
+
+import (
+	"context"
+	"log/slog"
+)
+
+type Code string
+
+const (
+	CodeUnauthorized       Code = "unauthorized"
+	CodeForbidden          Code = "forbidden"
+	CodeBadRequest         Code = "bad_request"
+	CodeNotFound           Code = "not_found"
+	CodeConflict           Code = "conflict"
+	CodeInvalid            Code = "invalid"
+	CodeUnexpected         Code = "unexpected"
+	CodeInvariantViolation Code = "invariant_violation"
+)
+
+func E(code Code, cause error, public string, args ...any) *ShareableError {
+	return &ShareableError{}
+}
+
+func C(code Code) *ShareableError {
+	return &ShareableError{}
+}
+
+type ShareableError struct{}
+
+func (e *ShareableError) LogError(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	return e
+}
+
+func (e *ShareableError) LogWarn(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	return e
+}
+
+func (e *ShareableError) LogInfo(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	return e
+}

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -171,6 +171,12 @@ linters:
               disabled: false
             audit-action-naming:
               disabled: true
+            no-client-error-log-error:
+              disabled: false
+              # Opt in one oops.Code at a time as its 4xx `.LogError` call sites
+              # are migrated to `.LogWarn` / `.LogInfo`. An empty list reports
+              # nothing, so the rule stays silent until a code is enabled here.
+              codes: []
     gosec:
       excludes:
         # Temporarily ignore this lint rule because it needs to be a separate

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -191,10 +192,7 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		// Auth middleware should have rejected this already; log here so a
 		// stray unauthenticated request is still visible per source/event
 		// when filtering hook traffic in Datadog.
-		logger.WarnContext(ctx, "rejected unauthorized claude OTEL logs request",
-			attr.SlogEvent("claude_logs_unauthorized"),
-		)
-		return oops.E(oops.CodeUnauthorized, nil, "unauthorized")
+		return oops.E(oops.CodeUnauthorized, errors.New("rejected unauthorized claude OTEL logs request"), "unauthorized").LogWarn(ctx, logger, attr.SlogEvent("claude_logs_unauthorized"))
 	}
 
 	orgID := authCtx.ActiveOrganizationID
@@ -256,10 +254,7 @@ func (s *Service) Metrics(ctx context.Context, payload *gen.MetricsPayload) erro
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		logger.WarnContext(ctx, "rejected unauthorized claude OTEL metrics request",
-			attr.SlogEvent("claude_metrics_unauthorized"),
-		)
-		return oops.E(oops.CodeUnauthorized, nil, "unauthorized")
+		return oops.E(oops.CodeUnauthorized, errors.New("rejected unauthorized claude OTEL metrics request"), "unauthorized").LogWarn(ctx, logger, attr.SlogEvent("claude_metrics_unauthorized"))
 	}
 
 	orgID := authCtx.ActiveOrganizationID

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1210,8 +1210,7 @@ func (s *Service) authenticateToken(ctx context.Context, token string, oauthReso
 		return ctx, nil
 	}
 
-	s.logger.WarnContext(ctx, "failed to authorize token using any strategy", attr.SlogToolsetID(oauthResourceID.String()))
-	return ctx, oops.E(oops.CodeUnauthorized, nil, "failed to authorize")
+	return ctx, oops.E(oops.CodeUnauthorized, errors.New("failed to authorize token using any strategy"), "failed to authorize").LogWarn(ctx, s.logger, attr.SlogToolsetID(oauthResourceID.String()))
 }
 
 //nolint:unused // kept for follow-up: restore stored-credential resolution for session-authenticated users

--- a/server/internal/oops/pp.go
+++ b/server/internal/oops/pp.go
@@ -175,6 +175,64 @@ func (e *ShareableError) LogError(ctx context.Context, logger *slog.Logger, args
 	return e
 }
 
+// LogWarn logs the error using the provided logger and context at warn level.
+// Unlike LogError, it never sets the OpenTelemetry span status to error or
+// records the error on the span. It is intended for client-fault boundary errors
+// (e.g. 400/401/403/404) that should be visible in logs but must not pollute the
+// errored-span population that error-rate monitors and SLOs are keyed on.
+// Additional arguments can be provided to include more context in the log entry.
+//
+// A client-initiated cancellation (context.Canceled cause with a canceled
+// request context) is demoted to info level, mirroring LogError's cancellation
+// handling.
+func (e *ShareableError) LogWarn(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	level := slog.LevelWarn
+	if e.effectiveCode(ctx) == CodeCanceled {
+		level = slog.LevelInfo
+	}
+
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, LogWarn]
+	r := slog.NewRecord(time.Now(), level, e.public, pcs[0])
+
+	if len(args) > 0 {
+		r.AddAttrs(append(args, attr.SlogErrorID(e.id), attr.SlogErrorMessage(e.String()))...)
+	} else {
+		r.AddAttrs(attr.SlogErrorID(e.id), attr.SlogErrorMessage(e.String()))
+	}
+
+	_ = logger.Handler().Handle(ctx, r)
+	return e
+}
+
+// LogInfo logs the error using the provided logger and context at info level.
+// Like LogWarn, it never sets the OpenTelemetry span status to error or records
+// the error on the span. Additional arguments can be provided to include more
+// context in the log entry.
+//
+// The client-initiated cancellation check is a no-op at info level (the level is
+// already info and the span is never touched) but is kept for symmetry with
+// LogError and LogWarn.
+func (e *ShareableError) LogInfo(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	level := slog.LevelInfo
+	if e.effectiveCode(ctx) == CodeCanceled {
+		level = slog.LevelInfo
+	}
+
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, LogInfo]
+	r := slog.NewRecord(time.Now(), level, e.public, pcs[0])
+
+	if len(args) > 0 {
+		r.AddAttrs(append(args, attr.SlogErrorID(e.id), attr.SlogErrorMessage(e.String()))...)
+	} else {
+		r.AddAttrs(attr.SlogErrorID(e.id), attr.SlogErrorMessage(e.String()))
+	}
+
+	_ = logger.Handler().Handle(ctx, r)
+	return e
+}
+
 func (e *ShareableError) IsTemporary(ctx context.Context) bool {
 	return !errors.Is(e.cause, ErrPermanent) && e.effectiveCode(ctx).IsTemporary()
 }

--- a/server/internal/oops/pp_test.go
+++ b/server/internal/oops/pp_test.go
@@ -106,6 +106,105 @@ func TestShareableError_Log_DeadlineExceededLogsAtError(t *testing.T) {
 	require.Len(t, spans[0].Events(), 1)
 }
 
+func TestShareableError_LogWarn_LogsAtWarn(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+
+	_ = E(CodeUnauthorized, errors.New("bad signature"), "unauthorized").LogWarn(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "WARN", entries[0].Level)
+	require.Equal(t, "unauthorized", entries[0].Msg)
+	require.NotEmpty(t, entries[0].ErrorID)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code, "LogWarn must not mark the span as errored")
+	require.Empty(t, spans[0].Events(), "LogWarn must not record an exception event")
+}
+
+func TestShareableError_LogWarn_ClientCanceledLogsAtInfo(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	// A client disconnect cancels the request context itself.
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	cause := fmt.Errorf("authorize token: %w", context.Canceled)
+	_ = E(CodeUnauthorized, cause, "unauthorized").LogWarn(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "INFO", entries[0].Level, "client cancellation must demote LogWarn to info")
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code, "LogWarn must not mark the span as errored")
+	require.Empty(t, spans[0].Events())
+}
+
+func TestShareableError_LogWarn_AppCanceledWithLiveContextLogsAtWarn(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	// The request context is still live: a context.Canceled cause that did not
+	// originate from a client disconnect must not be demoted.
+	ctx, recorder := startRecordedSpan(t)
+
+	cause := fmt.Errorf("errgroup sibling: %w", context.Canceled)
+	_ = E(CodeUnauthorized, cause, "unauthorized").LogWarn(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "WARN", entries[0].Level, "a live request context must keep LogWarn at warn level")
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code, "LogWarn must never mark the span as errored")
+	require.Empty(t, spans[0].Events())
+}
+
+func TestShareableError_LogInfo_LogsAtInfo(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+
+	_ = E(CodeNotFound, nil, "resource not found").LogInfo(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "INFO", entries[0].Level)
+	require.Equal(t, "resource not found", entries[0].Msg)
+	require.NotEmpty(t, entries[0].ErrorID)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code, "LogInfo must not mark the span as errored")
+	require.Empty(t, spans[0].Events(), "LogInfo must not record an exception event")
+}
+
+func TestShareableError_LogInfo_ClientCanceledLogsAtInfo(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	cause := fmt.Errorf("authorize token: %w", context.Canceled)
+	_ = E(CodeUnauthorized, cause, "unauthorized").LogInfo(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "INFO", entries[0].Level, "LogInfo stays at info under client cancellation")
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code, "LogInfo must not mark the span as errored")
+	require.Empty(t, spans[0].Events())
+}
+
 func TestShareableError_HTTPStatus_Canceled(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -367,11 +367,10 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 
 	q := r.URL.Query()
 	if errCode := q.Get("error"); errCode != "" {
-		logger.WarnContext(ctx, "remote authn challenge returned error",
+		return oops.E(oops.CodeUnauthorized, nil, "remote authn challenge denied: %s", errCode).LogWarn(ctx, logger,
 			attr.SlogOAuthError(errCode),
 			attr.SlogOAuthErrorDescription(q.Get("error_description")),
 		)
-		return oops.E(oops.CodeUnauthorized, nil, "remote authn challenge denied: %s", errCode)
 	}
 	stateID := q.Get("state")
 	if stateID == "" {

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -467,8 +467,7 @@ func toTriggerError(ctx context.Context, logger *slog.Logger, err error, message
 		// Webhook signature failures are client faults: a 401 on a public
 		// endpoint, commonly a single trigger with a stale or wrong signing
 		// secret whose sender keeps retrying.
-		logger.WarnContext(ctx, "trigger webhook authentication failed", attr.SlogError(err))
-		return oops.E(oops.CodeUnauthorized, err, "%s", public)
+		return oops.E(oops.CodeUnauthorized, fmt.Errorf("trigger webhook authentication failed: %w", err), "%s", public).LogWarn(ctx, logger)
 	case errors.Is(err, pgx.ErrNoRows):
 		code = oops.CodeNotFound
 	}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2773/add-logwarn-and-loginfo-methods-to-oopsshareableerror

`LogWarn` and `LogInfo` mirror `LogError` (error id + error message attrs, client-cancellation demotion, per-method `runtime.Callers` for correct source lines) but never set the span status to error or record the error, so client-fault (4xx) boundary errors can be logged without polluting the errored-span population.

Convert the five hand-rolled `WarnContext`-then-`oops.E` boundary sites to chain `LogWarn`, folding each call's descriptive context into the `oops.E` cause so it still surfaces in `error.message`.

Add the `no-client-error-log-error` glint analyzer, which flags 4xx `oops` codes chained with `.LogError`. It is opt-in per `oops.Code` constant (empty list reports nothing) so the ~750 existing sites can be migrated incrementally rather than all at once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `LogWarn` and `LogInfo` to `oops.ShareableError` to log 4xx boundary errors at warn/info without marking spans errored, and introduces a `glint` rule to guide migration away from `.LogError`. Implements AGE-2773.

- **New Features**
  - `oops.ShareableError.LogWarn`/`.LogInfo`: include error id/message; never set span status or record exceptions; demote client cancellations to info; correct source lines via per-method `runtime.Callers`.
  - Converted five boundary sites to `.LogWarn`, folding prior context into the `oops.E` cause so it appears in `error.message`.
  - New `glint` rule `no-client-error-log-error`: flags opted-in 4xx `oops.Code` with `.LogError`; added to the analyzer plugin and `server/.golangci.yaml` (empty `codes` list by default); unit tests added.

- **Migration**
  - Use `.LogWarn` or `.LogInfo` for 4xx boundary errors; keep `.LogError` for server faults and unexpected errors.
  - Opt in `oops.Code` constants under `no-client-error-log-error.codes` in `server/.golangci.yaml` as sites are migrated.

<sup>Written for commit 4b20063b69ac02b434b6c9324bce239551b8f8b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

