### PR TITLE
fix: always evaluate policy if audience is everyone

### DIFF
--- a/server/internal/risk/policy_audience_test.go
+++ b/server/internal/risk/policy_audience_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/message"
 	"github.com/speakeasy-api/gram/server/internal/risk"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -243,6 +244,83 @@ func TestScanner_ScanForEnforcement_EveryoneAudienceAppliesWithoutResolvedUser(t
 	require.Equal(t, "Everyone Runtime", memberResult.PolicyName)
 }
 
+func TestScanner_ScanForEnforcement_EveryoneAudienceAppliesWithoutEvaluateGrant(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	policyID := uuid.New()
+	_, err := riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:               policyID,
+		ProjectID:        *authCtx.ProjectID,
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Name:             "Migrated Everyone Runtime",
+		Sources:          []string{"presidio"},
+		PresidioEntities: []string{"EMAIL_ADDRESS"},
+		Enabled:          true,
+		Action:           "block",
+		AudienceType:     "everyone",
+		AutoName:         false,
+	})
+	require.NoError(t, err)
+	requirePolicyAudience(t, ctx, ti, authCtx.ActiveOrganizationID, policyID.String(), nil)
+
+	pii := &instrumentedPIIScanner{findOnEntity: "EMAIL_ADDRESS"}
+	scanner, err := risk.NewScanner(
+		testenv.NewLogger(t),
+		ti.conn,
+		pii,
+		nil,
+		nil,
+		nil,
+		testenv.NewMeterProvider(t),
+	)
+	require.NoError(t, err)
+
+	result, err := scanner.ScanForEnforcement(ctx, "", *authCtx.ProjectID, "", "irrelevant text", message.User, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "Migrated Everyone Runtime", result.PolicyName)
+}
+
+func TestScanner_ScanForEnforcement_TargetedAudienceRequiresEvaluateGrant(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	policyID := uuid.New()
+	_, err := riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:               policyID,
+		ProjectID:        *authCtx.ProjectID,
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Name:             "Migrated Targeted Runtime",
+		Sources:          []string{"presidio"},
+		PresidioEntities: []string{"EMAIL_ADDRESS"},
+		Enabled:          true,
+		Action:           "block",
+		AudienceType:     "targeted",
+		AutoName:         false,
+	})
+	require.NoError(t, err)
+	requirePolicyAudience(t, ctx, ti, authCtx.ActiveOrganizationID, policyID.String(), nil)
+
+	pii := &instrumentedPIIScanner{findOnEntity: "EMAIL_ADDRESS"}
+	scanner, err := risk.NewScanner(
+		testenv.NewLogger(t),
+		ti.conn,
+		pii,
+		nil,
+		nil,
+		nil,
+		testenv.NewMeterProvider(t),
+	)
+	require.NoError(t, err)
+
+	result, err := scanner.ScanForEnforcement(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "irrelevant text", message.User, "")
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
 func TestScanner_LookupShadowMCPBlockingPolicy_EveryoneAudienceAppliesWithoutResolvedUser(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestRiskService(t)
@@ -282,6 +360,43 @@ func TestScanner_LookupShadowMCPBlockingPolicy_EveryoneAudienceAppliesWithoutRes
 	require.NoError(t, err)
 	require.NotNil(t, unknownUserPolicy)
 	require.Equal(t, "Everyone Shadow MCP", unknownUserPolicy.Name)
+}
+
+func TestScanner_LookupShadowMCPBlockingPolicy_EveryoneAudienceAppliesWithoutEvaluateGrant(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	policyID := uuid.New()
+	_, err := riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:             policyID,
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Name:           "Migrated Everyone Shadow MCP",
+		Sources:        []string{"shadow_mcp"},
+		Enabled:        true,
+		Action:         "block",
+		AudienceType:   "everyone",
+		AutoName:       false,
+	})
+	require.NoError(t, err)
+	requirePolicyAudience(t, ctx, ti, authCtx.ActiveOrganizationID, policyID.String(), nil)
+
+	scanner, err := risk.NewScanner(
+		testenv.NewLogger(t),
+		ti.conn,
+		nil,
+		nil,
+		nil,
+		nil,
+		testenv.NewMeterProvider(t),
+	)
+	require.NoError(t, err)
+
+	policy, err := scanner.LookupShadowMCPBlockingPolicy(ctx, "", *authCtx.ProjectID, "")
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	require.Equal(t, "Migrated Everyone Shadow MCP", policy.Name)
 }
 
 func grantKey(effect authz.PolicyEffect, principalURN string) string {

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -175,11 +175,13 @@ func (s *Scanner) ScanForEnforcement(ctx context.Context, organizationID string,
 		s.recordScan(ctx, projectID.String(), "skipped", time.Since(start))
 		return nil, nil
 	}
-
-	grants, err := s.riskPolicyGrants(ctx, organizationID, userID)
-	if err != nil {
-		s.recordScan(ctx, projectID.String(), o11y.OutcomeFailure, time.Since(start))
-		return nil, err
+	var grants []authz.Grant
+	if riskPoliciesNeedGrants(policies) {
+		grants, err = s.riskPolicyGrants(ctx, organizationID, userID)
+		if err != nil {
+			s.recordScan(ctx, projectID.String(), o11y.OutcomeFailure, time.Since(start))
+			return nil, err
+		}
 	}
 
 	// Resolve the prompt-policy flag once per scan (on the parent ctx, before
@@ -208,12 +210,12 @@ func (s *Scanner) ScanForEnforcement(ctx context.Context, organizationID string,
 	)
 	g, gctx := errgroup.WithContext(ctx)
 	for _, p := range policies {
-		policyApplication, err := authz.RiskPolicyApplies(p.ID.String(), authz.RiskPolicyDimensions{ServerURL: "", ServerIdentity: ""}).Evaluate(grants)
+		applies, err := riskPolicyApplies(p, grants)
 		if err != nil {
 			s.recordScan(ctx, projectID.String(), o11y.OutcomeFailure, time.Since(start))
 			return nil, fmt.Errorf("evaluate risk policy application: %w", err)
 		}
-		if !policyApplication.Satisfied {
+		if !applies {
 			continue
 		}
 		if len(p.MessageTypes) > 0 && !slices.Contains(p.MessageTypes, messageType) {
@@ -255,21 +257,23 @@ func (s *Scanner) ScanForEnforcement(ctx context.Context, organizationID string,
 // for the project whose action is "block". Flag-action policies surface as
 // findings via the batch scanner instead of denying at the hook layer.
 func (s *Scanner) LookupShadowMCPBlockingPolicy(ctx context.Context, organizationID string, projectID uuid.UUID, userID string) (*ShadowMCPPolicy, error) {
-	grants, err := s.riskPolicyGrants(ctx, organizationID, userID)
-	if err != nil {
-		return nil, err
-	}
-
 	policies, err := s.repo.ListEnabledShadowMCPPoliciesByProject(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("list shadow_mcp policies: %w", err)
 	}
+	var grants []authz.Grant
+	if riskPoliciesNeedGrants(policies) {
+		grants, err = s.riskPolicyGrants(ctx, organizationID, userID)
+		if err != nil {
+			return nil, err
+		}
+	}
 	for _, p := range policies {
-		policyApplication, err := authz.RiskPolicyApplies(p.ID.String(), authz.RiskPolicyDimensions{ServerURL: "", ServerIdentity: ""}).Evaluate(grants)
+		applies, err := riskPolicyApplies(p, grants)
 		if err != nil {
 			return nil, fmt.Errorf("evaluate risk policy application: %w", err)
 		}
-		if !policyApplication.Satisfied {
+		if !applies {
 			continue
 		}
 		if p.Action == "block" {
@@ -282,6 +286,28 @@ func (s *Scanner) LookupShadowMCPBlockingPolicy(ctx context.Context, organizatio
 		}
 	}
 	return nil, nil
+}
+
+func riskPoliciesNeedGrants(policies []repo.RiskPolicy) bool {
+	return slices.ContainsFunc(policies, func(policy repo.RiskPolicy) bool {
+		return policy.AudienceType == riskPolicyAudienceTargeted
+	})
+}
+
+func riskPolicyApplies(policy repo.RiskPolicy, grants []authz.Grant) (bool, error) {
+	switch policy.AudienceType {
+	case riskPolicyAudienceEveryone:
+		return true, nil
+	case riskPolicyAudienceTargeted:
+	default:
+		return false, fmt.Errorf("invalid risk policy audience type %q", policy.AudienceType)
+	}
+
+	policyApplication, err := authz.RiskPolicyApplies(policy.ID.String(), authz.RiskPolicyDimensions{ServerURL: "", ServerIdentity: ""}).Evaluate(grants)
+	if err != nil {
+		return false, fmt.Errorf("evaluate risk policy grants: %w", err)
+	}
+	return policyApplication.Satisfied, nil
 }
 
 func (s *Scanner) riskPolicyGrants(ctx context.Context, organizationID string, userID string) ([]authz.Grant, error) {


### PR DESCRIPTION
## Summary
- Apply risk policies with audience_type=everyone without requiring risk_policy:evaluate grants.
- Keep grant evaluation for audience_type=targeted policies.
- Add regression coverage for migrated everyone policies without evaluate grants, including shadow-MCP lookup.

## Regression
The audience migration defaulted existing risk_policies rows to audience_type=everyone, but the runtime scanner still required a risk_policy:evaluate grant for every policy. Existing migrated policies did not necessarily have the new user:all evaluate grant row, so they could stop applying until edited/backfilled. This PR makes the runtime behavior match the persisted audience type: everyone policies apply regardless of grants, while targeted policies remain grant-gated.

## Validation
- rtk go test ./server/internal/risk -run 'TestScanner_(ScanForEnforcement|LookupShadowMCPBlockingPolicy).*Audience|TestScanner_ScanForEnforcement_TargetedAudienceRequiresEvaluateGrant'
- rtk go test ./server/internal/risk

Note: rtk mise lint:server is currently blocked by the unrelated untracked server/internal/authz/expressions_bench_test.go referencing the old GrantDifference.Exclusion field.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes enforcement so "everyone" risk policies apply without `risk_policy:evaluate` grants, while "targeted" policies still require grants. Resolves the audience migration regression and covers Shadow MCP lookups.

- **Bug Fixes**
  - Apply `audience_type=everyone` policies without grants in `ScanForEnforcement` and `LookupShadowMCPBlockingPolicy`; only fetch/evaluate grants for `audience_type=targeted`.
  - Add tests for migrated everyone policies (runtime and Shadow MCP) and for targeted policies still requiring `risk_policy:evaluate`.

<sup>Written for commit 3776a76441f555baf36aedeaeb8e384bb02ce7b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

