### PR TITLE
feat(dashboard): update sidebar navigation groups

### DIFF
--- a/.changeset/sidebar-nav-groups.md
+++ b/.changeset/sidebar-nav-groups.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Rename and reorder project sidebar navigation groups.

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -123,14 +123,14 @@ export function AppSidebar({
   ].some((r) => r.active);
 
   let activeGroup: string | undefined;
-  if (connectActive) {
-    activeGroup = "Connect";
-  } else if (distributeActive) {
-    activeGroup = "Distribute";
-  } else if (observeActive) {
+  if (observeActive) {
     activeGroup = "Observe";
   } else if (securityActive) {
     activeGroup = "Secure";
+  } else if (connectActive) {
+    activeGroup = "Connect";
+  } else if (distributeActive) {
+    activeGroup = "Distribute";
   }
 
   // Find the specific active route title for the sliding highlight. Shared with
@@ -173,7 +173,7 @@ export function AppSidebar({
             activeGroup={activeGroup}
             defaultOpenGroups={
               !activeGroup
-                ? ["Connect", "Distribute", "Observe", "Secure"]
+                ? ["Observe", "Secure", "Connect", "Distribute"]
                 : undefined
             }
             activeItem={activeItem}
@@ -184,6 +184,63 @@ export function AppSidebar({
                 item={routes.home}
                 scope={scopeFor(routes.home)}
               />
+
+              {/* Observe group */}
+              <CollapsibleNavGroup
+                label="Observe"
+                Icon={(p) => <Icon {...p} name="eye" />}
+                defaultHref={routes.employees.href()}
+              >
+                <ScopeGatedNavItem
+                  item={routes.employees}
+                  scope={scopeFor(routes.employees)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.costs}
+                  scope={scopeFor(routes.costs)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.insights}
+                  scope={scopeFor(routes.insights)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.agentSessions}
+                  scope={scopeFor(routes.agentSessions)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.logs}
+                  scope={scopeFor(routes.logs)}
+                />
+              </CollapsibleNavGroup>
+
+              {/* Secure group */}
+              <CollapsibleNavGroup
+                label="Secure"
+                Icon={(p) => <Icon {...p} name="shield" />}
+                defaultHref={routes.riskOverview.href()}
+                stage="beta"
+              >
+                <ScopeGatedNavItem
+                  item={routes.riskOverview}
+                  scope={scopeFor(routes.riskOverview)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.policyCenter}
+                  scope={scopeFor(routes.policyCenter)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.riskEvents}
+                  scope={scopeFor(routes.riskEvents)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.approvalRequests}
+                  scope={scopeFor(routes.approvalRequests)}
+                />
+                <ScopeGatedNavItem
+                  item={routes.detectionRules}
+                  scope={scopeFor(routes.detectionRules)}
+                />
+              </CollapsibleNavGroup>
 
               {/* Connect group */}
               <CollapsibleNavGroup
@@ -238,63 +295,6 @@ export function AppSidebar({
                 <ScopeGatedNavItem
                   item={routes.environments}
                   scope={scopeFor(routes.environments)}
-                />
-              </CollapsibleNavGroup>
-
-              {/* Observe group */}
-              <CollapsibleNavGroup
-                label="Observe"
-                Icon={(p) => <Icon {...p} name="eye" />}
-                defaultHref={routes.employees.href()}
-              >
-                <ScopeGatedNavItem
-                  item={routes.employees}
-                  scope={scopeFor(routes.employees)}
-                />
-                <ScopeGatedNavItem
-                  item={routes.costs}
-                  scope={scopeFor(routes.costs)}
-                />
-                <ScopeGatedNavItem
-                  item={routes.insights}
-                  scope={scopeFor(routes.insights)}
-                />
-                <ScopeGatedNavItem
-                  item={routes.agentSessions}
-                  scope={scopeFor(routes.agentSessions)}
-                />
-                <ScopeGatedNavItem
-                  item={routes.logs}
-                  scope={scopeFor(routes.logs)}
-                />
-              </CollapsibleNavGroup>
-
-              {/* Security group */}
-              <CollapsibleNavGroup
-                label="Secure"
-                Icon={(p) => <Icon {...p} name="shield" />}
-                defaultHref={routes.riskOverview.href()}
-                stage="beta"
-              >
-                <ScopeGatedNavItem
-                  item={routes.riskOverview}
-                  scope={scopeFor(routes.riskOverview)}
-                />
-                <ScopeGatedNavItem
-                  item={routes.policyCenter}
-                  scope={scopeFor(routes.policyCenter)}
-                />
-                <ScopeGatedNavItem
-                  item={routes.riskEvents}
-                  scope={scopeFor(routes.riskEvents)}
-                />
-                <ScopeGatedNavItem
-                  item={routes.approvalRequests}
-                  scope={scopeFor(routes.approvalRequests)}
-                />
-                <ScopeGatedNavItem
-                  item={routes.detectionRules}
-                  scope={scopeFor(routes.detectionRules)}
                 />
               </CollapsibleNavGroup>
 

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -98,7 +98,7 @@ export function AppSidebar({
     ...(isDeploymentsPageEnabled ? [routes.deployments] : []),
   ].some((r) => r.active);
 
-  const buildActive = [
+  const distributeActive = [
     routes.mcp,
     routes.clis,
     routes.plugins,
@@ -125,8 +125,8 @@ export function AppSidebar({
   let activeGroup: string | undefined;
   if (connectActive) {
     activeGroup = "Connect";
-  } else if (buildActive) {
-    activeGroup = "Build";
+  } else if (distributeActive) {
+    activeGroup = "Distribute";
   } else if (observeActive) {
     activeGroup = "Observe";
   } else if (securityActive) {
@@ -173,7 +173,7 @@ export function AppSidebar({
             activeGroup={activeGroup}
             defaultOpenGroups={
               !activeGroup
-                ? ["Connect", "Build", "Observe", "Secure"]
+                ? ["Connect", "Distribute", "Observe", "Secure"]
                 : undefined
             }
             activeItem={activeItem}
@@ -211,9 +211,9 @@ export function AppSidebar({
                 )}
               </CollapsibleNavGroup>
 
-              {/* Build group */}
+              {/* Distribute group */}
               <CollapsibleNavGroup
-                label="Build"
+                label="Distribute"
                 Icon={(p) => <Icon {...p} name="hammer" />}
                 defaultHref={routes.mcp.href()}
               >


### PR DESCRIPTION
## Summary
- Rename the Build sidebar group to Distribute.
- Reorder project sidebar groups to Home, Observe, Secure, Connect, Distribute, Project settings.

<img width="1879" height="1405" alt="image" src="https://github.com/user-attachments/assets/7b1848a0-dbe6-46a8-adc7-7b754d73394d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Build sidebar group to Distribute and reordered project sidebar groups to: Home, Observe, Secure, Connect, Distribute, Project settings.
Updated active-group precedence (Observe > Secure > Connect > Distribute) and set default-open groups to Observe, Secure, Connect, Distribute; added a `dashboard` patch changeset for DNO-193.

<sup>Written for commit ebcdbb00f578dd838aa09d3254d58fb3c3dbb93d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



