### PR TITLE
fix: tolerate non-critical fetch errors on the MCP servers screen

### DIFF
--- a/.changeset/mcp-screen-tolerate-fetch-errors.md
+++ b/.changeset/mcp-screen-tolerate-fetch-errors.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The MCP servers screen no longer crashes when a non-critical request fails to load. It now keeps showing the most recently loaded servers with a subtle "couldn't refresh" indicator instead of replacing the whole page with an error.

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -12,7 +12,7 @@ import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { ViewToggle } from "@/components/ui/view-toggle";
 import { useViewMode } from "@/components/ui/use-view-mode";
-import { useSdkClient } from "@/contexts/Sdk";
+import { useProjectSlugForRequests, useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useRoutes } from "@/routes";
 import {
@@ -70,12 +70,14 @@ function MCPOverview() {
   // mcp_servers (Remote-MCP-backed today) — in the same grid.
   // These listing fetches are non-critical: degrade to the last good (or empty)
   // data with an inline indicator instead of throwing to the page error
-  // boundary and replacing the whole screen.
+  // boundary and replacing the whole screen. Key them by project so a tolerated
+  // failure can't leave another project's rows on screen after a switch.
+  const gramProject = useProjectSlugForRequests();
   const {
     data: mcpServersResult,
     isLoading: isLoadingMcpServers,
     isError: isMcpServersError,
-  } = useMcpServers({}, undefined, {
+  } = useMcpServers({ gramProject }, undefined, {
     enabled: isRemoteMcpEnabled,
     throwOnError: false,
   });
@@ -83,7 +85,7 @@ function MCPOverview() {
     data: endpointsResult,
     isLoading: isLoadingEndpoints,
     isError: isEndpointsError,
-  } = useMcpEndpoints({}, undefined, {
+  } = useMcpEndpoints({ gramProject }, undefined, {
     enabled: isRemoteMcpEnabled,
     throwOnError: false,
   });

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -8,6 +8,7 @@ import { MCPTableRow, MCPTableRowSkeleton } from "@/components/mcp/MCPTableRow";
 import { Page } from "@/components/page-layout";
 import { DotTable } from "@/components/ui/dot-table";
 import { SearchBar } from "@/components/ui/search-bar";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { ViewToggle } from "@/components/ui/view-toggle";
 import { useViewMode } from "@/components/ui/use-view-mode";
@@ -18,7 +19,7 @@ import {
   useMcpEndpoints,
   useMcpServers,
 } from "@gram/client/react-query/index.js";
-import { Button } from "@speakeasy-api/moonshine";
+import { Badge, Button, Icon } from "@speakeasy-api/moonshine";
 import { Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Outlet, useNavigate } from "react-router";
@@ -67,10 +68,25 @@ function MCPOverview() {
   // (toolset-backed) MCP servers also source from mcp_servers. Until then the
   // listing merges two parallel collections — toolsets (Hosted) and
   // mcp_servers (Remote-MCP-backed today) — in the same grid.
-  const { data: mcpServersResult, isLoading: isLoadingMcpServers } =
-    useMcpServers({}, undefined, { enabled: isRemoteMcpEnabled });
-  const { data: endpointsResult, isLoading: isLoadingEndpoints } =
-    useMcpEndpoints({}, undefined, { enabled: isRemoteMcpEnabled });
+  // These listing fetches are non-critical: degrade to the last good (or empty)
+  // data with an inline indicator instead of throwing to the page error
+  // boundary and replacing the whole screen.
+  const {
+    data: mcpServersResult,
+    isLoading: isLoadingMcpServers,
+    isError: isMcpServersError,
+  } = useMcpServers({}, undefined, {
+    enabled: isRemoteMcpEnabled,
+    throwOnError: false,
+  });
+  const {
+    data: endpointsResult,
+    isLoading: isLoadingEndpoints,
+    isError: isEndpointsError,
+  } = useMcpEndpoints({}, undefined, {
+    enabled: isRemoteMcpEnabled,
+    throwOnError: false,
+  });
   // Filter the listing to Remote-MCP-backed rows for now — the AGE-1902
   // cutover will introduce toolset-backed rows that today still render
   // through the existing Hosted MCPCard path via useToolsets().
@@ -95,6 +111,9 @@ function MCPOverview() {
   const isLoading =
     toolsets.isLoading ||
     (isRemoteMcpEnabled && (isLoadingMcpServers || isLoadingEndpoints));
+
+  const hasRefreshError =
+    toolsets.isError || isMcpServersError || isEndpointsError;
 
   const [viewMode, setViewMode] = useViewMode();
   const [newMcpDialogOpen, setNewMcpDialogOpen] = useState(false);
@@ -157,6 +176,17 @@ function MCPOverview() {
     </RequireScope>
   );
 
+  const refreshErrorIndicator = (
+    <SimpleTooltip tooltip="We couldn't reach the server to refresh this list. Showing the most recently loaded data.">
+      <Badge variant="warning">
+        <Badge.LeftIcon>
+          <Icon name="triangle-alert" className="inline-block" />
+        </Badge.LeftIcon>
+        <Badge.Text>Couldn&apos;t refresh</Badge.Text>
+      </Badge>
+    </SimpleTooltip>
+  );
+
   const newMcpServerDialog = (
     <InputDialog
       open={newMcpDialogOpen}
@@ -200,7 +230,12 @@ function MCPOverview() {
     </Page.Section>
   );
 
-  if (!isLoading && toolsets.length === 0 && mcpServers.length === 0) {
+  if (
+    !isLoading &&
+    !hasRefreshError &&
+    toolsets.length === 0 &&
+    mcpServers.length === 0
+  ) {
     return (
       <>
         <MCPEmptyState cta={newMcpServerButton} />
@@ -214,6 +249,9 @@ function MCPOverview() {
     <>
       <Page.Section>
         <Page.Section.Title>Hosted MCP Servers</Page.Section.Title>
+        {hasRefreshError ? (
+          <Page.Section.CTA>{refreshErrorIndicator}</Page.Section.CTA>
+        ) : null}
         <Page.Section.CTA>
           <ViewToggle value={viewMode} onChange={setViewMode} />
         </Page.Section.CTA>

--- a/client/dashboard/src/pages/toolsets/useToolsets.ts
+++ b/client/dashboard/src/pages/toolsets/useToolsets.ts
@@ -5,7 +5,22 @@ export function useToolsets(): NonNullable<
 >["toolsets"] & {
   refetch: ReturnType<typeof useListToolsets>["refetch"];
   isLoading: ReturnType<typeof useListToolsets>["isLoading"];
+  isError: ReturnType<typeof useListToolsets>["isError"];
 } {
-  const { data: toolsets, refetch, isLoading } = useListToolsets();
-  return Object.assign(toolsets?.toolsets || [], { refetch, isLoading });
+  const {
+    data: toolsets,
+    refetch,
+    isLoading,
+    isError,
+  } = useListToolsets(undefined, undefined, {
+    // toolsets.list is non-critical for the MCP screens — degrade to the last
+    // good (or empty) list with an inline indicator instead of throwing to the
+    // page error boundary.
+    throwOnError: false,
+  });
+  return Object.assign(toolsets?.toolsets || [], {
+    refetch,
+    isLoading,
+    isError,
+  });
 }

--- a/client/dashboard/src/pages/toolsets/useToolsets.ts
+++ b/client/dashboard/src/pages/toolsets/useToolsets.ts
@@ -1,3 +1,4 @@
+import { useProjectSlugForRequests } from "@/contexts/Sdk";
 import { useListToolsets } from "@gram/client/react-query/index.js";
 
 export function useToolsets(): NonNullable<
@@ -7,15 +8,17 @@ export function useToolsets(): NonNullable<
   isLoading: ReturnType<typeof useListToolsets>["isLoading"];
   isError: ReturnType<typeof useListToolsets>["isError"];
 } {
+  const gramProject = useProjectSlugForRequests();
   const {
     data: toolsets,
     refetch,
     isLoading,
     isError,
-  } = useListToolsets(undefined, undefined, {
+  } = useListToolsets({ gramProject }, undefined, {
     // toolsets.list is non-critical for the MCP screens — degrade to the last
     // good (or empty) list with an inline indicator instead of throwing to the
-    // page error boundary.
+    // page error boundary. Key the query by project so a tolerated failure can
+    // never leave another project's cached toolsets on screen after a switch.
     throwOnError: false,
   });
   return Object.assign(toolsets?.toolsets || [], {


### PR DESCRIPTION
## Summary

- The MCP servers screen previously crashed to a full-page "Error loading Page" card whenever a non-critical fetch failed. The global QueryClient (`Sdk.tsx`) throws every non-403 error to the nearest `ContentErrorBoundary`, so a transient `toolsets.list` failure (e.g. connection-refused during a pod restart) replaced the entire screen.
- Make the screen's non-critical listing queries — `toolsets.list` (via the shared `useToolsets` hook) plus `useMcpServers`/`useMcpEndpoints` — pass `throwOnError: false` so they degrade instead of throwing. React Query already retains the last successful `data` across a failed background refetch, so stale servers stay on screen.
- Surface a subtle "Couldn't refresh" warning badge (with tooltip) in the section header when any of those fetches errored.
- Suppress the empty state when a fetch errored, so a load failure isn't mistaken for an empty project.

Closes [DNO-276](https://linear.app/speakeasy/issue/DNO-276)

✻ Clauded with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent full-page crashes on the MCP servers screen by degrading gracefully when non-critical fetches fail, keeping the last good data and showing a small warning. Also scope listing queries by project so a failure after switching projects never shows another project's rows. Satisfies Linear DNO-276 to tolerate `toolsets.list` and remote MCP listing failures.

- **Bug Fixes**
  - Set `throwOnError: false` for non-critical queries: `useToolsets` (`toolsets.list`), `useMcpServers`, `useMcpEndpoints`.
  - Key these queries by `gramProject` to isolate caches per project and prevent cross-project stale data after a switch.
  - Preserve stale data during failed background refetches and avoid the page error boundary.
  - Show a “Couldn't refresh” warning badge with tooltip; suppress the empty state when an error occurs.

<sup>Written for commit 9d1e74de7cc1f7f5ea867a5d1807465abdcac7ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

