### PR TITLE
fix(chat): show all Agent Sessions to org admins via org:admin RBAC scope

### DIFF
--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -55,6 +55,7 @@ var _ gen.Auther = (*Service)(nil)
 
 type Service struct {
 	auth             *auth.Auth
+	authz            *authz.Engine
 	db               *pgxpool.Pool
 	repo             *repo.Queries
 	tracer           trace.Tracer
@@ -91,6 +92,7 @@ func NewService(
 
 	return &Service{
 		auth:             auth.New(logger, db, sessions, authzEngine),
+		authz:            authzEngine,
 		db:               db,
 		sessions:         sessions,
 		chatSessions:     chatSessions,
@@ -199,19 +201,30 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	var userInfo *sessions.CachedUserInfo
-	if authCtx.SessionID != nil {
-		var err error
-		userInfo, _, err = s.sessions.GetUserInfo(ctx, authCtx.UserID)
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "error getting user info").LogError(ctx, s.logger)
-		}
-	}
-
 	// An assistant principal is set only on the assistant runtime path and
 	// only the managed-assistant platform toolset surfaces chat tools, so
 	// treat it as admin-equivalent for project-wide visibility.
 	_, isAssistantCall := contextvalues.GetAssistantPrincipal(ctx)
+
+	// Project-wide visibility is gated on the org:admin RBAC scope. When RBAC is
+	// not enforced for the org we must NOT fall through to "see all" — Require
+	// short-circuits to allow when enforcement is off, so check ShouldEnforce
+	// explicitly and treat the disabled case as a non-admin (own sessions only).
+	isOrgAdmin := false
+	if enforce, err := s.authz.ShouldEnforce(ctx); err != nil {
+		return nil, err
+	} else if enforce {
+		err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil})
+		var shareableErr *oops.ShareableError
+		switch {
+		case err == nil:
+			isOrgAdmin = true
+		case errors.As(err, &shareableErr) && shareableErr.Code == oops.CodeForbidden:
+			// Not an org admin — fall through to own-sessions-only below.
+		default:
+			return nil, err
+		}
+	}
 
 	var fromTime, toTime pgtype.Timestamptz
 	if payload.From != nil {
@@ -233,12 +246,12 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 	assistantID := conv.PtrValOr(payload.AssistantID, "")
 	hasRiskFilter := conv.PtrValOr(payload.HasRisk, "")
 
-	// Payload filters only apply for admin users and the managed-assistant runtime.
+	// Payload filters only apply for org admins and the managed-assistant runtime.
 	var externalUserID, userID string
 	switch {
 	case authCtx.ExternalUserID != "":
 		externalUserID = authCtx.ExternalUserID
-	case userInfo != nil && userInfo.Admin, isAssistantCall:
+	case isOrgAdmin, isAssistantCall:
 		externalUserID = conv.PtrValOr(payload.ExternalUserID, "")
 	default:
 		if authCtx.UserID == "" {

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -206,13 +206,17 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 	// treat it as admin-equivalent for project-wide visibility.
 	_, isAssistantCall := contextvalues.GetAssistantPrincipal(ctx)
 
-	// Project-wide visibility is gated on the org:admin RBAC scope. When RBAC is
-	// not enforced for the org we must NOT fall through to "see all" — Require
-	// short-circuits to allow when enforcement is off, so check ShouldEnforce
-	// explicitly and treat the disabled case as a non-admin (own sessions only).
+	// Whether the caller sees all project sessions or only their own is decided
+	// by the org:admin RBAC scope — this is a visibility choice, never a gate on
+	// the route, so a caller without org:admin (or when the check can't be made)
+	// still gets a successful response scoped to their own sessions.
+	//
+	// When RBAC is not enforced for the org we must NOT fall through to "see
+	// all" — Require short-circuits to allow when enforcement is off, so check
+	// ShouldEnforce explicitly and treat the disabled case as non-admin.
 	isOrgAdmin := false
 	if enforce, err := s.authz.ShouldEnforce(ctx); err != nil {
-		return nil, err
+		s.logger.WarnContext(ctx, "could not determine RBAC enforcement for chat visibility; showing own sessions", attr.SlogError(err))
 	} else if enforce {
 		err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil})
 		var shareableErr *oops.ShareableError
@@ -220,9 +224,11 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 		case err == nil:
 			isOrgAdmin = true
 		case errors.As(err, &shareableErr) && shareableErr.Code == oops.CodeForbidden:
-			// Not an org admin — fall through to own-sessions-only below.
+			// Forbidden simply means not an org admin — show own sessions.
 		default:
-			return nil, err
+			// Any other error is unexpected; log it but still serve own
+			// sessions rather than failing the listing.
+			s.logger.WarnContext(ctx, "org admin visibility check failed for chat listing; showing own sessions", attr.SlogError(err))
 		}
 	}
 

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
-	mockidp "github.com/speakeasy-api/gram/dev-idp/pkg/testidp"
 	gen "github.com/speakeasy-api/gram/server/gen/chat"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
-	userRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
 // defaultPayload returns a ListChatsPayload with required non-pointer fields
@@ -104,21 +104,15 @@ func initSessionCtx(t *testing.T, ti *chatTestInstance) context.Context {
 	return ctx
 }
 
-// makeAdmin upgrades the session user to admin and invalidates the sessions
-// cache so GetUserInfo returns Admin: true on the next call.
-func makeAdmin(t *testing.T, ctx context.Context, ti *chatTestInstance) {
+// grantOrgAdmin returns a context carrying an org:admin RBAC grant for the
+// caller's active organization, with RBAC enforcement active (enterprise).
+// This is what a real customer org admin has — distinct from the platform-staff
+// users.admin flag the visibility gate used to read.
+func grantOrgAdmin(t *testing.T, ctx context.Context) context.Context {
 	t.Helper()
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
-	_, err := userRepo.New(ti.conn).UpsertUser(ctx, userRepo.UpsertUserParams{
-		ID:          authCtx.UserID,
-		Email:       mockidp.MockUserEmail,
-		DisplayName: "Dev User",
-		PhotoUrl:    pgtype.Text{},
-		Admin:       true,
-	})
-	require.NoError(t, err)
-	require.NoError(t, ti.sessions.InvalidateUserInfoCache(ctx, authCtx.UserID))
+	return authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID))
 }
 
 // externalUserCtx builds a context carrying an external-user AuthContext
@@ -232,13 +226,13 @@ func TestListChats_RegularUser_SeesOnlyOwnChats(t *testing.T) {
 	require.Equal(t, authCtx.UserID, conv.PtrValOr(result.Chats[0].UserID, ""))
 }
 
-// TestListChats_AdminUser_SeesAllChats verifies that an admin user can see all chats in the project,
-// regardless of which user or external user owns them.
-func TestListChats_AdminUser_SeesAllChats(t *testing.T) {
+// TestListChats_OrgAdmin_SeesAllChats verifies that a customer org admin (holding
+// the org:admin RBAC scope, no platform-staff flag) can see all chats in the
+// project, regardless of which user or external user owns them.
+func TestListChats_OrgAdmin_SeesAllChats(t *testing.T) {
 	t.Parallel()
 	ti := newTestChatService(t)
-	ctx := initSessionCtx(t, ti)
-	makeAdmin(t, ctx, ti)
+	ctx := grantOrgAdmin(t, initSessionCtx(t, ti))
 
 	seedChat(t, ctx, ti, "", "ext-aaa", "chat A")
 	seedChat(t, ctx, ti, "user-bbb", "", "chat B")
@@ -247,6 +241,51 @@ func TestListChats_AdminUser_SeesAllChats(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, result.Total)
 	require.Len(t, result.Chats, 2)
+}
+
+// TestListChats_Member_SeesOnlyOwnChats verifies that a session user who holds
+// no org:admin grant (a regular member) is scoped to their own chats even when
+// RBAC is enforced for the org.
+func TestListChats_Member_SeesOnlyOwnChats(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	// WithExactGrants marks the context enterprise (RBAC active) but grants
+	// nothing, so the org:admin check is denied.
+	ctx := authztest.WithExactGrants(t, initSessionCtx(t, ti))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	seedChat(t, ctx, ti, authCtx.UserID, "", "own chat")
+	seedChat(t, ctx, ti, "other-user-id", "", "other users chat")
+
+	result, err := ti.service.ListChats(ctx, defaultPayload())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, authCtx.UserID, conv.PtrValOr(result.Chats[0].UserID, ""))
+}
+
+// TestListChats_RBACDisabled_SeesOnlyOwnChats is the regression guard for the
+// RBAC-disabled org: enforcement is off, so even a would-be admin must fall back
+// to own-sessions-only rather than seeing every chat (Require short-circuits to
+// allow when enforcement is off — the handler must not treat that as admin).
+func TestListChats_RBACDisabled_SeesOnlyOwnChats(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatServiceRBACDisabled(t)
+	// Mark the context enterprise + grant org:admin; with the org's RBAC
+	// feature flag off, ShouldEnforce still returns false and the grant is moot.
+	ctx := grantOrgAdmin(t, initSessionCtx(t, ti))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	seedChat(t, ctx, ti, authCtx.UserID, "", "own chat")
+	seedChat(t, ctx, ti, "other-user-id", "", "other users chat")
+
+	result, err := ti.service.ListChats(ctx, defaultPayload())
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, authCtx.UserID, conv.PtrValOr(result.Chats[0].UserID, ""))
 }
 
 // TestListChats_ManagedAssistant_SeesAllChats verifies that the managed
@@ -282,13 +321,12 @@ func TestLoadChat_ManagedAssistant_LoadsExternalUserChat(t *testing.T) {
 	require.Equal(t, chatID.String(), result.ID)
 }
 
-// TestListChats_AdminUser_FilterByExternalUserID verifies that an admin can narrow results to a
+// TestListChats_OrgAdmin_FilterByExternalUserID verifies that an org admin can narrow results to a
 // specific external user via the payload filter.
-func TestListChats_AdminUser_FilterByExternalUserID(t *testing.T) {
+func TestListChats_OrgAdmin_FilterByExternalUserID(t *testing.T) {
 	t.Parallel()
 	ti := newTestChatService(t)
-	ctx := initSessionCtx(t, ti)
-	makeAdmin(t, ctx, ti)
+	ctx := grantOrgAdmin(t, initSessionCtx(t, ti))
 
 	seedChat(t, ctx, ti, "", "ext-123", "chat for ext-123")
 	seedChat(t, ctx, ti, "", "ext-456", "chat for ext-456")

--- a/server/internal/chat/setup_test.go
+++ b/server/internal/chat/setup_test.go
@@ -13,20 +13,24 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
 var infra *testenv.Environment
 
 func TestMain(m *testing.M) {
 	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{
-		Postgres: true,
-		Redis:    true,
+		Postgres:   true,
+		Redis:      true,
+		ClickHouse: true,
 	})
 	if err != nil {
 		log.Fatalf("Failed to launch test infrastructure: %v", err)
@@ -51,7 +55,22 @@ type chatTestInstance struct {
 	orgID     string
 }
 
+// newTestChatService builds a chat service with RBAC enforcement enabled for
+// the org. Use authztest.WithExactGrants to grant org:admin in tests that need
+// project-wide visibility.
 func newTestChatService(t *testing.T) *chatTestInstance {
+	t.Helper()
+	return newTestChatServiceWithRBAC(t, authztest.RBACAlwaysEnabled)
+}
+
+// newTestChatServiceRBACDisabled builds a chat service whose org has the RBAC
+// feature flag off, so ShouldEnforce returns false even for enterprise callers.
+func newTestChatServiceRBACDisabled(t *testing.T) *chatTestInstance {
+	t.Helper()
+	return newTestChatServiceWithRBAC(t, authztest.RBACAlwaysDisabled)
+}
+
+func newTestChatServiceWithRBAC(t *testing.T, isRBACEnabled authz.IsRBACEnabled) *chatTestInstance {
 	t.Helper()
 
 	ctx := t.Context()
@@ -83,13 +102,17 @@ func newTestChatService(t *testing.T) *chatTestInstance {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
 	billingClient := billing.NewStubClient(logger, tp)
 	// Use a unique suffix per test to isolate Redis cache entries when tests
 	// run in parallel and all use the same mockidp.MockUserID.
 	suffix := cache.Suffix("gram-local-" + uuid.NewString()[:8])
 	mgr := testenv.NewTestManager(t, logger, tp, conn, redisClient, suffix, billingClient)
 
-	svc := chat.NewService(logger, tp, conn, mgr, nil, nil, nil, nil, nil, nil, nil, nil, nil, billingClient)
+	authzEngine := authz.NewEngine(logger, conn, chConn, isRBACEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
+	svc := chat.NewService(logger, tp, conn, mgr, nil, nil, nil, nil, nil, nil, nil, authzEngine, nil, billingClient)
 
 	return &chatTestInstance{
 		service:   svc,


### PR DESCRIPTION
## Summary

Fixes [DNO-212](https://linear.app/speakeasy/issue/DNO-212/bug-agents-tab-sometimes-only-shows-own-users-sessions) — the Agents tab sometimes only showed a user's own sessions.

`chat.ListChats` decided project-wide Agent Session visibility from `userInfo.Admin`, which is the `users.admin` column — the Gram **platform-staff** (Speakeasy employee) flag, not an org role. A real org admin has `Admin == false`, fell into the `default` branch, and was scoped to their own `userID` — so they only saw their own sessions. The "sometimes" was because it worked for platform admins and for whoever's own sessions were being viewed.

## Changes

This is a **visibility decision, not a route gate** — `ListChats` always returns a successful response; the only question is whether it returns all project sessions or only the caller's own.

- Decide visibility from the **`org:admin` RBAC scope** instead of the platform-staff flag. `ListChats` now:
  - Checks `s.authz.ShouldEnforce(ctx)` first. When RBAC is **not** enforced (disabled for the org, or non-enterprise), the caller sees **own sessions only** — `Require` short-circuits to "allow" when enforcement is off, so an explicit `ShouldEnforce` check is required to avoid flipping everyone to "see all".
  - Then calls `Require(ScopeOrgAdmin, ActiveOrganizationID)`. `nil` → org admin (all sessions, payload filters honored); `CodeForbidden` → not admin (own sessions); **any other error is logged and treated as not-admin (own sessions)** — the listing is never failed because the admin determination couldn't be made.
- **Removed the platform-staff path** and the now-dead `sessions.GetUserInfo` fetch (it was only read for `.Admin`). Staff impersonating a customer org keep seeing all sessions — their impersonation context carries `org:admin` via the admin-override grant.
- **Wired `*authz.Engine`** onto `chat.Service`.

## Tests

`server/internal/chat/list_chats_test.go` + `setup_test.go` build a real `authz.Engine` (parameterized on `IsRBACEnabled`) and grant `org:admin` via `authztest.WithExactGrants`:

- org admin **with** `org:admin` → sees all org-project chats
- member **without** `org:admin` → sees only own (successful response, not an error)
- RBAC **disabled** for org → sees only own (regression guard)
- assistant-call path still sees all (unchanged)

`mise run lint:server` passes; `mise run test:server ./internal/chat/...` → 55 tests pass.

## Risk

Medium — visibility change affecting which sessions are listed. Must not over-expose (members stay scoped to own) nor under-expose (org admins see all), and preserves behavior for RBAC-disabled orgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
