### PR TITLE
feat(remotemcp): record mcp_server_id across /mcp runtime telemetry

### DIFF
--- a/.changeset/record-mcp-server-id-runtime-telemetry.md
+++ b/.changeset/record-mcp-server-id-runtime-telemetry.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Record `mcp_server_id` across `/mcp` runtime telemetry so MCP server activity can be sliced from either the remote or the fronting-server perspective.

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -213,6 +213,10 @@ type mcpInputs struct {
 	// toolVariationsGroupID is the effective variation group resolved per
 	// request (mcp_servers, then toolsets, then nil for the project default).
 	toolVariationsGroupID *uuid.UUID
+	// mcpServerID is the fronting mcp_servers row id when the request arrived
+	// via an mcp_endpoint. Nil on the legacy toolset-by-slug path and for
+	// internal (agent-workflow) callers, which have no fronting server.
+	mcpServerID *uuid.UUID
 	// tags is the parsed ?tags= filter. When non-empty, tools/list and
 	// tools/call expose only tools whose variation row carries one of these
 	// tags. Empty means no filtering.
@@ -501,9 +505,9 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// Legacy toolset-by-slug path has no mcp_server, so there is no
-	// server-level variation group override; ServeToolsetResolved falls back to
-	// the toolset's own column.
-	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, nil, nil)
+	// server-level variation group override (ServeToolsetResolved falls back to
+	// the toolset's own column) and no fronting mcp_servers id to record.
+	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, nil, nil, nil)
 }
 
 // ServeToolsetResolved serves an MCP runtime request after the slug has
@@ -535,8 +539,14 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 // project-default group applies. /mcp's legacy toolset-by-slug path has no
 // mcp_server and passes nil.
 //
+// mcpServerID is the fronting mcp_servers row id when this request arrived via
+// an mcp_endpoint, recorded on the tools/call telemetry row so toolset-backed
+// activity can be sliced from the fronting-server perspective. /mcp's legacy
+// toolset-by-slug path has no mcp_server and passes nil, leaving the attribute
+// off the row.
+//
 // The caller is responsible for closing r.Body.
-func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]string, mcpServerVariationsGroupID *uuid.UUID) error {
+func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]string, mcpServerVariationsGroupID *uuid.UUID, mcpServerID *uuid.UUID) error {
 	ctx := r.Context()
 	var err error
 
@@ -813,6 +823,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		externalUserID:        externalUserID,
 		apiKeyID:              apiKeyID,
 		toolVariationsGroupID: toolVariationsGroupID,
+		mcpServerID:           mcpServerID,
 		tags:                  tags,
 	}
 

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -352,6 +352,9 @@ func handleToolsCall(
 			logAttrs[attr.APIKeyIDKey] = payload.apiKeyID
 		}
 		logAttrs.RecordToolsetSlug(payload.toolset)
+		if payload.mcpServerID != nil {
+			logAttrs[attr.McpServerIDKey] = payload.mcpServerID.String()
+		}
 		logAttrs.RecordMCPURL(mcpURL)
 		params := tm.LogParams{
 			Timestamp: time.Now(),

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -113,6 +113,9 @@ func (s *Service) serveResolvedMCPEndpoint(
 	slug, mcpRouteBase string,
 ) error {
 	ctx := r.Context()
+
+	logger = logger.With(attr.SlogMcpServerID(mcpServer.ID.String()))
+
 	issuerGated := mcpServer.UserSessionIssuerID.Valid
 
 	// Issuer-gated mcp_servers run the JWT-validation branch here, before
@@ -169,7 +172,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 			mcpServerVariationsGroupID = &id
 		}
 
-		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamTokens, mcpServerVariationsGroupID); err != nil {
+		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamTokens, mcpServerVariationsGroupID, &mcpServer.ID); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil

--- a/server/internal/mcp/types.go
+++ b/server/internal/mcp/types.go
@@ -96,8 +96,10 @@ func (m *McpInputs) toInternal() *mcpInputs {
 		externalUserID:   m.ExternalUserID,
 		apiKeyID:         m.APIKeyID,
 		// Internal clients (agent workflows) always use the project-default
-		// variation group and never filter by tag.
+		// variation group, never filter by tag, and have no fronting
+		// mcp_servers row to record.
 		toolVariationsGroupID: nil,
+		mcpServerID:           nil,
 		tags:                  nil,
 	}
 }

--- a/server/internal/remotemcp/initialize_posthog_event_interceptor.go
+++ b/server/internal/remotemcp/initialize_posthog_event_interceptor.go
@@ -23,18 +23,22 @@ const eventMCPInitialized = "mcp_initialized"
 // requests to it, so the interceptor never has to dispatch on method.
 // Analytics emission is best-effort and never rejects.
 type InitializePostHogEventInterceptor struct {
-	posthog *posthog.Posthog
-	logger  *slog.Logger
+	posthog  *posthog.Posthog
+	identity proxy.ServerIdentity
+	logger   *slog.Logger
 }
 
 var _ proxy.InitializeRequestInterceptor = (*InitializePostHogEventInterceptor)(nil)
 
 // NewInitializePostHogEventInterceptor constructs an interceptor bound to the
-// given PostHog client. The same instance can be reused across requests.
-func NewInitializePostHogEventInterceptor(posthogClient *posthog.Posthog, logger *slog.Logger) *InitializePostHogEventInterceptor {
+// given PostHog client and server correlation ids. Build a fresh instance per
+// request so the `remote_mcp_server_id` and `mcp_server_id` properties are
+// captured for the server the initialize landed on.
+func NewInitializePostHogEventInterceptor(posthogClient *posthog.Posthog, identity proxy.ServerIdentity, logger *slog.Logger) *InitializePostHogEventInterceptor {
 	return &InitializePostHogEventInterceptor{
-		posthog: posthogClient,
-		logger:  logger,
+		posthog:  posthogClient,
+		identity: identity,
+		logger:   logger,
 	}
 }
 
@@ -78,6 +82,8 @@ func (i *InitializePostHogEventInterceptor) InterceptInitializeRequest(ctx conte
 	if err := i.posthog.CaptureEvent(ctx, eventMCPInitialized, sessionID, map[string]any{
 		"project_id":           projectID,
 		"authenticated":        authenticated,
+		"remote_mcp_server_id": i.identity.RemoteMCPServerID,
+		"mcp_server_id":        i.identity.McpServerID,
 		"mcp_domain":           requestContext.Host,
 		"mcp_url":              requestContext.Host + requestContext.ReqURL,
 		"disable_notification": true,

--- a/server/internal/remotemcp/initialize_posthog_event_interceptor_test.go
+++ b/server/internal/remotemcp/initialize_posthog_event_interceptor_test.go
@@ -52,14 +52,14 @@ func newInitializeRequest(t *testing.T, sessionID string) *proxy.InitializeReque
 func TestInitializePostHogEventInterceptor_Name(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testenv.NewLogger(t))
+	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 	require.Equal(t, "initialize-posthog-event", interceptor.Name())
 }
 
 func TestInitializePostHogEventInterceptor_MissingRequestContextPassesThrough(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testenv.NewLogger(t))
+	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 
 	require.NoError(t, interceptor.InterceptInitializeRequest(t.Context(), newInitializeRequest(t, "session-1")))
 }
@@ -67,7 +67,7 @@ func TestInitializePostHogEventInterceptor_MissingRequestContextPassesThrough(t 
 func TestInitializePostHogEventInterceptor_PassesThrough(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testenv.NewLogger(t))
+	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 
 	projectID := uuid.New()
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
@@ -85,7 +85,7 @@ func TestInitializePostHogEventInterceptor_PassesThrough(t *testing.T) {
 func TestInitializePostHogEventInterceptor_MissingSessionIDPassesThrough(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testenv.NewLogger(t))
+	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 
 	// When Mcp-Session-Id is absent on the inbound request — common for the
 	// initial initialize handshake — the interceptor synthesizes a UUID for
@@ -101,7 +101,7 @@ func TestInitializePostHogEventInterceptor_MissingSessionIDPassesThrough(t *test
 func TestInitializePostHogEventInterceptor_UnauthenticatedPassesThrough(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testenv.NewLogger(t))
+	interceptor := remotemcp.NewInitializePostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 
 	// No auth context — the interceptor still emits with authenticated=false
 	// and an empty project_id rather than rejecting.

--- a/server/internal/remotemcp/proxy/metrics.go
+++ b/server/internal/remotemcp/proxy/metrics.go
@@ -88,7 +88,7 @@ func NewMetrics(meter metric.Meter, logger *slog.Logger) *Metrics {
 // because the metric measures upstream health. User-facing outcomes are
 // available via span status (set to error on rejection) and the
 // gram.remote_mcp.proxy.requests counter dimensioned by error class.
-func (m *Metrics) Record(ctx context.Context, serverID string, method string, upstreamStatus int, responseBytes int64, duration time.Duration) {
+func (m *Metrics) Record(ctx context.Context, identity ServerIdentity, method string, upstreamStatus int, responseBytes int64, duration time.Duration) {
 	if m == nil {
 		return
 	}
@@ -97,8 +97,11 @@ func (m *Metrics) Record(ctx context.Context, serverID string, method string, up
 		attr.HTTPRequestMethod(method),
 		attr.RemoteMCPProxyRemoteStatusClass(statusClass(upstreamStatus)),
 	}
-	if serverID != "" {
-		labels = append(labels, attr.RemoteMCPServerID(serverID))
+	if identity.RemoteMCPServerID != "" {
+		labels = append(labels, attr.RemoteMCPServerID(identity.RemoteMCPServerID))
+	}
+	if identity.McpServerID != "" {
+		labels = append(labels, attr.McpServerID(identity.McpServerID))
 	}
 
 	attrsOpt := metric.WithAttributes(labels...)

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -72,6 +72,18 @@ const (
 	DefaultMaxBufferedBodyBytes int64 = 50 * 1024 * 1024
 )
 
+// ServerIdentity bundles the two correlation ids the proxy stamps onto its
+// telemetry: RemoteMCPServerID is the remote_mcp_servers row id (the upstream
+// the proxy forwards to) and McpServerID is the fronting mcp_servers row id
+// (the server users manage). Bundling them keeps the pair from being
+// transposed across the constructors and record calls that thread them, and
+// both are omitted from emitted telemetry when empty rather than recorded as
+// empty-string labels.
+type ServerIdentity struct {
+	RemoteMCPServerID string
+	McpServerID       string
+}
+
 // Proxy is a one-request handler that forwards inbound MCP client requests
 // to a configured Remote MCP Server. A fresh value is expected per inbound
 // request so the SessionID and interceptor state stay tied to a single
@@ -107,6 +119,7 @@ type Proxy struct {
 	// disables metrics recording; tests that do not care about metrics pass
 	// nil here.
 	Metrics *Metrics
+
 	// MaxBufferedBodyBytes bounds the size of any JSON body that is fully
 	// read into memory before parsing — applied to both the inbound user
 	// request and the upstream response. Streamed responses are not subject
@@ -115,12 +128,15 @@ type Proxy struct {
 	// for the package default.
 	MaxBufferedBodyBytes int64
 
-	// ServerID is the Remote MCP Server UUID. When set, it is attached to
-	// every span emitted by the proxy so traces can be correlated across the
-	// HTTP lifecycle and the proxy forward.
-	ServerID string
+	// Identity carries the two correlation ids attached to every span, log
+	// line, and metric the proxy emits: the remote_mcp_servers row id and
+	// the fronting mcp_servers row id. Both are optional and omitted when
+	// empty rather than emitted as empty-string labels.
+	Identity ServerIdentity
+
 	// RemoteURL is the upstream endpoint all requests are forwarded to.
 	RemoteURL string
+
 	// Headers are applied on top of any forwarded client headers when
 	// constructing the upstream request.
 	Headers []ConfiguredHeader
@@ -232,7 +248,7 @@ func (p *Proxy) Delete(w http.ResponseWriter, r *http.Request) (err error) {
 		responseBytes  int64
 	)
 	defer func() {
-		p.Metrics.Record(ctx, p.ServerID, http.MethodDelete, upstreamStatus, responseBytes, time.Since(start))
+		p.Metrics.Record(ctx, p.Identity, http.MethodDelete, upstreamStatus, responseBytes, time.Since(start))
 	}()
 
 	//nolint:bodyclose // Body is closed via the defer below; linter can't trace the close across the forwardRequest helper.
@@ -282,7 +298,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 		responseBytes  int64
 	)
 	defer func() {
-		p.Metrics.Record(ctx, p.ServerID, http.MethodGet, upstreamStatus, responseBytes, time.Since(start))
+		p.Metrics.Record(ctx, p.Identity, http.MethodGet, upstreamStatus, responseBytes, time.Since(start))
 	}()
 
 	//nolint:bodyclose // Body is closed via the defer below; linter can't trace the close across the forwardRequest helper.
@@ -339,7 +355,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 		responseBytes  int64
 	)
 	defer func() {
-		p.Metrics.Record(ctx, p.ServerID, http.MethodPost, upstreamStatus, responseBytes, time.Since(start))
+		p.Metrics.Record(ctx, p.Identity, http.MethodPost, upstreamStatus, responseBytes, time.Since(start))
 	}()
 
 	userReq := &UserRequest{UserHTTPRequest: r, JSONRPCMessages: nil, body: nil, dirty: false}
@@ -438,7 +454,8 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 	} else if mutated {
 		p.Logger.InfoContext(ctx, "forwarding mutated request body upstream",
 			attr.SlogComponent("remotemcp.proxy"),
-			attr.SlogRemoteMCPServerID(p.ServerID))
+			attr.SlogRemoteMCPServerID(p.Identity.RemoteMCPServerID),
+			attr.SlogMcpServerID(p.Identity.McpServerID))
 	}
 
 	//nolint:bodyclose // Body is closed via the defer below; linter can't trace the close across the forwardRequest helper.
@@ -533,7 +550,8 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 			bodyBytes = mutated
 			p.Logger.InfoContext(ctx, "relaying mutated response body to client",
 				attr.SlogComponent("remotemcp.proxy"),
-				attr.SlogRemoteMCPServerID(p.ServerID))
+				attr.SlogRemoteMCPServerID(p.Identity.RemoteMCPServerID),
+				attr.SlogMcpServerID(p.Identity.McpServerID))
 		}
 	}
 
@@ -814,7 +832,8 @@ func (p *Proxy) relaySSEStream(
 				emit = formatSSEEventWithData(nonData, mutated)
 				p.Logger.InfoContext(ctx, "relaying mutated SSE event to client",
 					attr.SlogComponent("remotemcp.proxy"),
-					attr.SlogRemoteMCPServerID(p.ServerID))
+					attr.SlogRemoteMCPServerID(p.Identity.RemoteMCPServerID),
+					attr.SlogMcpServerID(p.Identity.McpServerID))
 			}
 		}
 		if _, writeErr := w.Write(emit); writeErr != nil {
@@ -835,15 +854,18 @@ func (p *Proxy) relaySSEStream(
 }
 
 // requestSpanAttributes returns the attribute set applied to every span the proxy
-// emits for an inbound request. ServerID is optional on Proxy and is omitted
-// when empty rather than emitted as an empty-string label.
+// emits for an inbound request. Both correlation ids are optional on Proxy and
+// are omitted when empty rather than emitted as empty-string labels.
 func (p *Proxy) requestSpanAttributes(method string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attr.HTTPRequestMethod(method),
 		attr.RemoteMCPServerURL(p.RemoteURL),
 	}
-	if p.ServerID != "" {
-		attrs = append(attrs, attr.RemoteMCPServerID(p.ServerID))
+	if p.Identity.RemoteMCPServerID != "" {
+		attrs = append(attrs, attr.RemoteMCPServerID(p.Identity.RemoteMCPServerID))
+	}
+	if p.Identity.McpServerID != "" {
+		attrs = append(attrs, attr.McpServerID(p.Identity.McpServerID))
 	}
 	return attrs
 }

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -876,7 +876,7 @@ func TestProxy_Post_RecordsMetrics(t *testing.T) {
 
 	p := newProxyForTest(t, upstream.URL)
 	p.Metrics = metrics
-	p.ServerID = "srv-abc"
+	p.Identity = proxy.ServerIdentity{RemoteMCPServerID: "srv-abc", McpServerID: "mcp-abc"}
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
 	req.Header.Set("Content-Type", "application/json")
@@ -899,6 +899,7 @@ func TestProxy_Post_RecordsMetrics(t *testing.T) {
 		attr.HTTPRequestMethod(http.MethodPost),
 		attr.RemoteMCPProxyRemoteStatusClass("2xx"),
 		attr.RemoteMCPServerID("srv-abc"),
+		attr.McpServerID("mcp-abc"),
 	)
 
 	duration, ok := byName[proxy.MeterRequestDuration]

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -24,10 +24,10 @@ import (
 // PostHog event capture.
 //
 // One factory is constructed at server startup and reused across requests.
-// The interceptors that hold no per-request state (usage limits/tracking,
-// PostHog initialize emitter) are constructed once on the factory; the
-// rest are instantiated per-call in [ProxyManager.Build] so the closure
-// over the remote-server id stays request-scoped.
+// The interceptors that hold no per-request state (usage limits/tracking)
+// are constructed once on the factory; the rest are instantiated per-call in
+// [ProxyManager.Build] so the closure over the per-server correlation ids
+// stays request-scoped.
 type ProxyManager struct {
 	logger          *slog.Logger
 	tracer          trace.Tracer
@@ -44,7 +44,6 @@ type ProxyManager struct {
 	toolsCallUsageTrackingInterceptor     *ToolsCallUsageTrackingInterceptor
 	resourcesReadUsageLimitsInterceptor   *ResourcesReadUsageLimitsInterceptor
 	resourcesReadUsageTrackingInterceptor *ResourcesReadUsageTrackingInterceptor
-	initializePostHogEventInterceptor     *InitializePostHogEventInterceptor
 }
 
 // NewProxyManager wires the MCP-aware proxy stack with its dependencies.
@@ -80,7 +79,6 @@ func NewProxyManager(
 		toolsCallUsageTrackingInterceptor:     NewToolsCallUsageTrackingInterceptor(billingTracker, logger),
 		resourcesReadUsageLimitsInterceptor:   NewResourcesReadUsageLimitsInterceptor(billingRepo, logger),
 		resourcesReadUsageTrackingInterceptor: NewResourcesReadUsageTrackingInterceptor(billingTracker, logger),
-		initializePostHogEventInterceptor:     NewInitializePostHogEventInterceptor(posthogClient, logger),
 	}
 }
 
@@ -126,12 +124,19 @@ func (f *ProxyManager) Build(
 
 	serverID := server.ID.String()
 
+	// Telemetry interceptors are keyed by both correlation ids: the
+	// remote_mcp_servers id (the upstream) and the fronting mcp_servers id
+	// (the server users manage). server.ID still drives the synthetic tool
+	// URN and the remote-server slog/metric dimension; mcpServerID lets the
+	// same activity be sliced from the fronting-server perspective.
+	identity := proxy.ServerIdentity{RemoteMCPServerID: serverID, McpServerID: mcpServerID}
+
 	// Per-request instance: the interceptor holds a single nilable start
 	// timestamp set by the request side and consumed by the response side.
 	// A fresh instance per Build makes that field's lifetime match the
 	// proxy's, so a stale timestamp from a failure path (request fires,
 	// response doesn't) is reclaimed when the proxy is dropped.
-	clickHouseLogInterceptor := NewToolsCallClickHouseLogInterceptor(f.telemLogger, serverID, logger)
+	clickHouseLogInterceptor := NewToolsCallClickHouseLogInterceptor(f.telemLogger, identity, logger)
 
 	// Counter records every attempted tools/call, including those later
 	// rejected by limits or per-tool authz. This mirrors /mcp, where
@@ -156,7 +161,7 @@ func (f *ProxyManager) Build(
 	// is Redis-cached (15-minute TTL) so the hot-path cost when the
 	// policy is disabled is a single cache GET.
 	toolsCallReqInterceptors := []proxy.ToolsCallRequestInterceptor{
-		NewToolsCallOTELCounterInterceptor(f.mcpMetrics, serverID, logger),
+		NewToolsCallOTELCounterInterceptor(f.mcpMetrics, identity, logger),
 		f.toolsCallUsageLimitsInterceptor,
 		NewToolsCallShadowMCPValidateAndStripInterceptor(f.shadowmcpClient, serverID, projectID, logger),
 		clickHouseLogInterceptor,
@@ -195,13 +200,13 @@ func (f *ProxyManager) Build(
 		StreamingTimeout:        proxy.DefaultStreamingTimeout,
 		Metrics:                 f.proxyMetrics,
 		MaxBufferedBodyBytes:    proxy.DefaultMaxBufferedBodyBytes,
-		ServerID:                serverID,
+		Identity:                identity,
 		RemoteURL:               server.Url,
 		Headers:                 configured,
 		AuthorizationOverride:   upstreamAuth,
 		UserRequestInterceptors: nil,
 		InitializeRequestInterceptors: []proxy.InitializeRequestInterceptor{
-			f.initializePostHogEventInterceptor,
+			NewInitializePostHogEventInterceptor(f.posthog, identity, logger),
 		},
 		RemoteMessageInterceptors:    nil,
 		ToolsCallRequestInterceptors: toolsCallReqInterceptors,
@@ -210,7 +215,7 @@ func (f *ProxyManager) Build(
 			clickHouseLogInterceptor,
 		},
 		ToolsListRequestInterceptors: []proxy.ToolsListRequestInterceptor{
-			NewToolsListPostHogEventInterceptor(f.posthog, serverID, logger),
+			NewToolsListPostHogEventInterceptor(f.posthog, identity, logger),
 		},
 		ToolsListResponseInterceptors: toolsListRespInterceptors,
 		ResourcesReadRequestInterceptors: []proxy.ResourcesReadRequestInterceptor{

--- a/server/internal/remotemcp/proxymetrics.go
+++ b/server/internal/remotemcp/proxymetrics.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"log/slog"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 )
 
 // instrumentMCPToolCall is the OTel instrument name for the per-tool MCP
@@ -56,15 +58,20 @@ func NewProxyMetrics(meter metric.Meter, logger *slog.Logger) *ProxyMetrics {
 // `outcome` attribute today; consumers that need to distinguish accepted
 // from rejected attempts should aggregate this counter alongside the
 // proxy-level request status histogram in [proxy.Metrics].
-func (m *ProxyMetrics) RecordMCPToolCall(ctx context.Context, orgID string, mcpURL string, remoteMCPServerID string, toolName string) {
+func (m *ProxyMetrics) RecordMCPToolCall(ctx context.Context, orgID string, mcpURL string, identity proxy.ServerIdentity, toolName string) {
 	if m.mcpToolCallCounter == nil {
 		return
 	}
 
-	m.mcpToolCallCounter.Add(ctx, 1, metric.WithAttributes(
+	labels := []attribute.KeyValue{
 		attr.OrganizationID(orgID),
 		attr.McpURL(mcpURL),
-		attr.RemoteMCPServerID(remoteMCPServerID),
+		attr.RemoteMCPServerID(identity.RemoteMCPServerID),
 		attr.ToolName(toolName),
-	))
+	}
+	if identity.McpServerID != "" {
+		labels = append(labels, attr.McpServerID(identity.McpServerID))
+	}
+
+	m.mcpToolCallCounter.Add(ctx, 1, metric.WithAttributes(labels...))
 }

--- a/server/internal/remotemcp/proxymetrics_test.go
+++ b/server/internal/remotemcp/proxymetrics_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -27,7 +28,7 @@ func TestProxyMetrics_RecordMCPToolCall_RecordsWithValidCounter(t *testing.T) {
 	m := NewProxyMetrics(meter, logger)
 
 	// Should not panic.
-	m.RecordMCPToolCall(t.Context(), "org-123", "https://x.example.com/x/mcp/server", "srv-abc", "search_tickets")
+	m.RecordMCPToolCall(t.Context(), "org-123", "https://x.example.com/x/mcp/server", proxy.ServerIdentity{RemoteMCPServerID: "srv-abc", McpServerID: "mcp-abc"}, "search_tickets")
 }
 
 func TestProxyMetrics_RecordMCPToolCall_NilCounterIsSafe(t *testing.T) {
@@ -35,5 +36,5 @@ func TestProxyMetrics_RecordMCPToolCall_NilCounterIsSafe(t *testing.T) {
 
 	m := &ProxyMetrics{mcpToolCallCounter: nil}
 	// Should not panic when counter is nil.
-	m.RecordMCPToolCall(t.Context(), "org-123", "https://x.example.com/x/mcp/server", "srv-abc", "search_tickets")
+	m.RecordMCPToolCall(t.Context(), "org-123", "https://x.example.com/x/mcp/server", proxy.ServerIdentity{RemoteMCPServerID: "srv-abc", McpServerID: "mcp-abc"}, "search_tickets")
 }

--- a/server/internal/remotemcp/tools_call_authz_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor_test.go
@@ -17,9 +17,15 @@ import (
 )
 
 const (
-	testServerID  = "11111111-1111-1111-1111-111111111111"
-	testProjectID = "22222222-2222-2222-2222-222222222222"
+	testServerID    = "11111111-1111-1111-1111-111111111111"
+	testMcpServerID = "33333333-3333-3333-3333-333333333333"
+	testProjectID   = "22222222-2222-2222-2222-222222222222"
 )
+
+// testServerIdentity pairs the remote_mcp_servers id with a distinct fronting
+// mcp_servers id for the telemetry interceptor tests, so assertions can tell
+// the two correlation dimensions apart.
+var testServerIdentity = proxy.ServerIdentity{RemoteMCPServerID: testServerID, McpServerID: testMcpServerID}
 
 func newAuthzEngineForTest(t *testing.T) *authz.Engine {
 	t.Helper()

--- a/server/internal/remotemcp/tools_call_clickhouse_log_interceptor.go
+++ b/server/internal/remotemcp/tools_call_clickhouse_log_interceptor.go
@@ -42,7 +42,7 @@ var DurationMissingKey = attribute.Key("gram.telemetry.duration_missing")
 // tool-call tail latency.
 type ToolsCallClickHouseLogInterceptor struct {
 	telemLogger *tm.Logger
-	serverID    string
+	identity    proxy.ServerIdentity
 	logger      *slog.Logger
 
 	// start is set by the request interceptor and consumed by the
@@ -57,13 +57,13 @@ var (
 )
 
 // NewToolsCallClickHouseLogInterceptor constructs an interceptor bound to the
-// given telemetry logger and Remote MCP Server id. Construct one per request
-// (or per buildProxy call) so the server-id attribute is closed over without
-// re-deriving it per emission.
-func NewToolsCallClickHouseLogInterceptor(telemLogger *tm.Logger, serverID string, logger *slog.Logger) *ToolsCallClickHouseLogInterceptor {
+// given telemetry logger and server correlation ids. Construct one per request
+// (or per buildProxy call) so the id attributes are closed over without
+// re-deriving them per emission.
+func NewToolsCallClickHouseLogInterceptor(telemLogger *tm.Logger, identity proxy.ServerIdentity, logger *slog.Logger) *ToolsCallClickHouseLogInterceptor {
 	return &ToolsCallClickHouseLogInterceptor{
 		telemLogger: telemLogger,
-		serverID:    serverID,
+		identity:    identity,
 		logger:      logger,
 		start:       nil,
 	}
@@ -125,11 +125,14 @@ func (i *ToolsCallClickHouseLogInterceptor) InterceptToolsCallResponse(ctx conte
 	// column may be empty for those tool names — acceptable; gram_urn
 	// (used for grouping) and tool_name (separate materialized column from
 	// gram.tool.name attribute) are still populated correctly.
-	toolURN := "tools:externalmcp:" + i.serverID + ":" + toolName
+	toolURN := "tools:externalmcp:" + i.identity.RemoteMCPServerID + ":" + toolName
 
 	logAttrs := tm.HTTPLogAttributes{
 		attr.EventSourceKey:       string(tm.EventSourceToolCall),
-		attr.RemoteMCPServerIDKey: i.serverID,
+		attr.RemoteMCPServerIDKey: i.identity.RemoteMCPServerID,
+	}
+	if i.identity.McpServerID != "" {
+		logAttrs[attr.McpServerIDKey] = i.identity.McpServerID
 	}
 	logAttrs.RecordDuration(durationSec)
 	logAttrs.RecordStatusCode(statusCode)

--- a/server/internal/remotemcp/tools_call_clickhouse_log_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_clickhouse_log_interceptor_test.go
@@ -21,7 +21,7 @@ import (
 func TestToolsCallClickHouseLogInterceptor_Name(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemetry.NewStub(testenv.NewLogger(t)), "server-id", testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemetry.NewStub(testenv.NewLogger(t)), proxy.ServerIdentity{RemoteMCPServerID: "server-id", McpServerID: "mcp-server-id"}, testenv.NewLogger(t))
 	require.Equal(t, "tools-call-clickhouse-log", interceptor.Name())
 }
 
@@ -38,6 +38,7 @@ func TestToolsCallClickHouseLogInterceptor_EmitsRow(t *testing.T) {
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()
+	mcpServerID := uuid.New().String()
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-test",
 		UserID:               "user-123",
@@ -45,7 +46,7 @@ func TestToolsCallClickHouseLogInterceptor_EmitsRow(t *testing.T) {
 		ProjectID:            &projectID,
 	})
 
-	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, serverID, logger)
+	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, proxy.ServerIdentity{RemoteMCPServerID: serverID, McpServerID: mcpServerID}, logger)
 
 	req := &proxy.ToolsCallRequest{
 		UserRequest: nil,
@@ -80,6 +81,12 @@ func TestToolsCallClickHouseLogInterceptor_EmitsRow(t *testing.T) {
 
 	require.NoError(t, interceptor.InterceptToolsCallResponse(ctx, resp))
 
+	// The two correlation ids are distinct, so a row matching both columns
+	// proves the interceptor records the fronting mcp_servers id alongside
+	// the remote_mcp_servers id rather than reusing one for both. A single
+	// shared id is what masked the PR #3405 RBAC bug.
+	require.NotEqual(t, serverID, mcpServerID)
+
 	// Emission is fire-and-forget; poll the read side until the row appears.
 	expectedURN := "tools:externalmcp:" + serverID + ":list_things"
 	require.Eventually(t, func() bool {
@@ -89,10 +96,11 @@ func TestToolsCallClickHouseLogInterceptor_EmitsRow(t *testing.T) {
 			 WHERE gram_project_id = ?
 			   AND gram_urn = ?
 			   AND remote_mcp_server_id = ?
+			   AND mcp_server_id = ?
 			   AND tool_name = ?
 			   AND event_source = ?
 			   AND toInt32OrZero(toString(attributes.http.response.status_code)) = 200`,
-			projectID.String(), expectedURN, serverID, "list_things", "tool_call")
+			projectID.String(), expectedURN, serverID, mcpServerID, "list_things", "tool_call")
 		if err := row.Scan(&count); err != nil {
 			return false
 		}
@@ -113,12 +121,13 @@ func TestToolsCallClickHouseLogInterceptor_DurationMissingSentinel(t *testing.T)
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()
+	mcpServerID := uuid.New().String()
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-test",
 		ProjectID:            &projectID,
 	})
 
-	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, serverID, logger)
+	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, proxy.ServerIdentity{RemoteMCPServerID: serverID, McpServerID: mcpServerID}, logger)
 
 	// Skip the request side so the response has no stashed start time.
 	req := &proxy.ToolsCallRequest{
@@ -179,7 +188,8 @@ func TestToolsCallClickHouseLogInterceptor_NoAuthContextSkips(t *testing.T) {
 	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled, nil)
 
 	serverID := uuid.New().String()
-	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, serverID, logger)
+	mcpServerID := uuid.New().String()
+	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, proxy.ServerIdentity{RemoteMCPServerID: serverID, McpServerID: mcpServerID}, logger)
 
 	// Deliberately call without an auth context on ctx — the response side
 	// must short-circuit and emit nothing.
@@ -312,12 +322,13 @@ func runStatusCodeMappingCase(t *testing.T, tc statusCodeCase) int32 {
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()
+	mcpServerID := uuid.New().String()
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-test",
 		ProjectID:            &projectID,
 	})
 
-	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, serverID, logger)
+	interceptor := remotemcp.NewToolsCallClickHouseLogInterceptor(telemLogger, proxy.ServerIdentity{RemoteMCPServerID: serverID, McpServerID: mcpServerID}, logger)
 
 	req := &proxy.ToolsCallRequest{
 		UserRequest: nil,

--- a/server/internal/remotemcp/tools_call_otel_counter_interceptor.go
+++ b/server/internal/remotemcp/tools_call_otel_counter_interceptor.go
@@ -15,20 +15,21 @@ import (
 // the same metric tracks attempted calls regardless of upstream success.
 type ToolsCallOTELCounterInterceptor struct {
 	metrics  *ProxyMetrics
-	serverID string
+	identity proxy.ServerIdentity
 	logger   *slog.Logger
 }
 
 var _ proxy.ToolsCallRequestInterceptor = (*ToolsCallOTELCounterInterceptor)(nil)
 
 // NewToolsCallOTELCounterInterceptor constructs an interceptor bound to the
-// given metrics object and Remote MCP Server id. Construct one per request
-// so the counter's `gram.remote_mcp_server.id` label is closed over without
-// re-deriving it from the URL path on every call.
-func NewToolsCallOTELCounterInterceptor(m *ProxyMetrics, serverID string, logger *slog.Logger) *ToolsCallOTELCounterInterceptor {
+// given metrics object and server correlation ids. Construct one per request
+// so the counter's `gram.remote_mcp_server.id` and `gram.mcp_server.id`
+// labels are closed over without re-deriving them from the URL path on every
+// call.
+func NewToolsCallOTELCounterInterceptor(m *ProxyMetrics, identity proxy.ServerIdentity, logger *slog.Logger) *ToolsCallOTELCounterInterceptor {
 	return &ToolsCallOTELCounterInterceptor{
 		metrics:  m,
-		serverID: serverID,
+		identity: identity,
 		logger:   logger,
 	}
 }
@@ -56,6 +57,6 @@ func (i *ToolsCallOTELCounterInterceptor) InterceptToolsCallRequest(ctx context.
 		mcpURL = requestContext.Host + requestContext.ReqURL
 	}
 
-	i.metrics.RecordMCPToolCall(ctx, authCtx.ActiveOrganizationID, mcpURL, i.serverID, call.Params.Name)
+	i.metrics.RecordMCPToolCall(ctx, authCtx.ActiveOrganizationID, mcpURL, i.identity, call.Params.Name)
 	return nil
 }

--- a/server/internal/remotemcp/tools_call_otel_counter_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_otel_counter_interceptor_test.go
@@ -21,7 +21,7 @@ import (
 func newCounterInterceptorForTest(t *testing.T) *ToolsCallOTELCounterInterceptor {
 	t.Helper()
 	logger := testenv.NewLogger(t)
-	return NewToolsCallOTELCounterInterceptor(NewProxyMetrics(testenv.NewMeterProvider(t).Meter("test"), logger), "srv-test", logger)
+	return NewToolsCallOTELCounterInterceptor(NewProxyMetrics(testenv.NewMeterProvider(t).Meter("test"), logger), proxy.ServerIdentity{RemoteMCPServerID: "srv-test", McpServerID: "mcp-test"}, logger)
 }
 
 func newToolsCallRequestForCounter(t *testing.T, toolName string) *proxy.ToolsCallRequest {

--- a/server/internal/remotemcp/tools_list_posthog_event_interceptor.go
+++ b/server/internal/remotemcp/tools_list_posthog_event_interceptor.go
@@ -32,7 +32,7 @@ const eventMCPServerToolsList = "mcp_server_tools_list"
 // tracks unifying the two runtimes onto this single event name.
 type ToolsListPostHogEventInterceptor struct {
 	posthog  *posthog.Posthog
-	serverID string
+	identity proxy.ServerIdentity
 	logger   *slog.Logger
 }
 
@@ -40,12 +40,12 @@ var _ proxy.ToolsListRequestInterceptor = (*ToolsListPostHogEventInterceptor)(ni
 
 // NewToolsListPostHogEventInterceptor constructs an interceptor scoped to a
 // single Remote MCP Server. Callers build a fresh instance per request so the
-// `remote_mcp_server_id` property is captured without re-parsing routing
-// state.
-func NewToolsListPostHogEventInterceptor(posthogClient *posthog.Posthog, serverID string, logger *slog.Logger) *ToolsListPostHogEventInterceptor {
+// `remote_mcp_server_id` and `mcp_server_id` properties are captured without
+// re-parsing routing state.
+func NewToolsListPostHogEventInterceptor(posthogClient *posthog.Posthog, identity proxy.ServerIdentity, logger *slog.Logger) *ToolsListPostHogEventInterceptor {
 	return &ToolsListPostHogEventInterceptor{
 		posthog:  posthogClient,
-		serverID: serverID,
+		identity: identity,
 		logger:   logger,
 	}
 }
@@ -87,7 +87,8 @@ func (i *ToolsListPostHogEventInterceptor) InterceptToolsListRequest(ctx context
 	if err := i.posthog.CaptureEvent(ctx, eventMCPServerToolsList, sessionID, map[string]any{
 		"project_id":           projectID,
 		"authenticated":        authenticated,
-		"remote_mcp_server_id": i.serverID,
+		"remote_mcp_server_id": i.identity.RemoteMCPServerID,
+		"mcp_server_id":        i.identity.McpServerID,
 		"mcp_domain":           requestContext.Host,
 		"mcp_url":              requestContext.Host + requestContext.ReqURL,
 		"disable_notification": true,

--- a/server/internal/remotemcp/tools_list_posthog_event_interceptor_test.go
+++ b/server/internal/remotemcp/tools_list_posthog_event_interceptor_test.go
@@ -34,14 +34,14 @@ func newToolsListRequest(t *testing.T, sessionID string) *proxy.ToolsListRequest
 func TestToolsListPostHogEventInterceptor_Name(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewToolsListPostHogEventInterceptor(newPosthogForTest(t), testServerID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListPostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 	require.Equal(t, "tools-list-posthog-event", interceptor.Name())
 }
 
 func TestToolsListPostHogEventInterceptor_MissingRequestContextPassesThrough(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewToolsListPostHogEventInterceptor(newPosthogForTest(t), testServerID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListPostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 
 	require.NoError(t, interceptor.InterceptToolsListRequest(t.Context(), newToolsListRequest(t, "session-1")))
 }
@@ -49,7 +49,7 @@ func TestToolsListPostHogEventInterceptor_MissingRequestContextPassesThrough(t *
 func TestToolsListPostHogEventInterceptor_PassesThrough(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewToolsListPostHogEventInterceptor(newPosthogForTest(t), testServerID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListPostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 
 	projectID := uuid.New()
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
@@ -67,7 +67,7 @@ func TestToolsListPostHogEventInterceptor_PassesThrough(t *testing.T) {
 func TestToolsListPostHogEventInterceptor_MissingSessionIDPassesThrough(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewToolsListPostHogEventInterceptor(newPosthogForTest(t), testServerID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListPostHogEventInterceptor(newPosthogForTest(t), testServerIdentity, testenv.NewLogger(t))
 
 	ctx := contextvalues.SetRequestContext(t.Context(), &contextvalues.RequestContext{
 		Host:   "x.example.com",


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2759/record-mcp-server-id-across-mcp-runtime-telemetry-for-fronting-server

Runtime telemetry for `/mcp` keyed remote-backed activity by `remote_mcp_server_id` and toolset-backed activity by `toolset_slug`, with no single dimension for the fronting `mcp_servers` row users actually manage. Attach `gram.mcp_server.id` across the runtime emitters so activity can be sliced from either the remote or the fronting-server perspective.

Introduce `proxy.ServerIdentity` to bundle the `remote_mcp_servers` and `mcp_servers` ids as one value, and stamp the pair onto the proxy transport metrics, span and slog lines, the OTel `mcp.tool.call` counter, the ClickHouse `telemetry_logs` row, and the PostHog `tools/list` and `initialize` events on the remote path, plus the `tools/call` ClickHouse row on the toolset path.

This change records the identifier only. Reading it back through the telemetry query filters and the observability overview is tracked separately in AGE-2789.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record the fronting `mcp_server_id` across `/mcp` runtime telemetry so activity can be sliced by either the remote server or the fronting server. Aligns with Linear AGE-2759; this records the ID only (query filters/UI follow in AGE-2789).

- **New Features**
  - Introduced `proxy.ServerIdentity` to carry both `remote_mcp_server_id` and `mcp_server_id`; applied to proxy metrics, span attributes, and slog lines.
  - Added `mcp_server_id` to the OTel `mcp.tool.call` counter.
  - Logged `mcp_server_id` to ClickHouse `telemetry_logs` for `tools/call` on both remote and toolset paths.
  - Emitted `mcp_server_id` in PostHog `initialize` and `tools/list` events.
  - Stamped the `/mcp` entrypoint request logger with `mcp_server_id`; plumbed through `ServeToolsetResolved` for toolset-backed calls.

<sup>Written for commit a05ffbba02319524e59446918ee2837af1811e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

