### PR TITLE
mig: relax remote session client issuer binding to many-to-many

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -907,7 +907,7 @@ CREATE TABLE IF NOT EXISTS remote_session_clients (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid,
   remote_session_issuer_id uuid NOT NULL,
-  user_session_issuer_id uuid NOT NULL,
+  user_session_issuer_id uuid,
 
   client_id TEXT NOT NULL,
   client_secret_encrypted TEXT,
@@ -950,9 +950,6 @@ CREATE TABLE IF NOT EXISTS remote_session_client_user_session_issuers (
 
 CREATE INDEX IF NOT EXISTS remote_session_client_user_session_issuers_issuer_idx
 ON remote_session_client_user_session_issuers (user_session_issuer_id, remote_session_client_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS remote_session_client_user_session_issuers_one_per_issuer
-ON remote_session_client_user_session_issuers (user_session_issuer_id);
 
 -- Remote sessions represent credentials for an external resource that have
 -- been granted to a single Gram subject

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1237,7 +1237,7 @@ type RemoteSessionClient struct {
 	ID                      uuid.UUID
 	ProjectID               uuid.NullUUID
 	RemoteSessionIssuerID   uuid.UUID
-	UserSessionIssuerID     uuid.UUID
+	UserSessionIssuerID     uuid.NullUUID
 	ClientID                string
 	ClientSecretEncrypted   pgtype.Text
 	ClientIDIssuedAt        pgtype.Timestamptz

--- a/server/internal/mcp/remotesession_resolver_integration_test.go
+++ b/server/internal/mcp/remotesession_resolver_integration_test.go
@@ -235,7 +235,7 @@ func createIssuerGatedExternalMCPFixture(
 	remoteClient, err := remoteRepo.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
 		ProjectID:             conv.ToNullUUID(toolset.ProjectID),
 		RemoteSessionIssuerID: remoteIssuer.ID,
-		UserSessionIssuerID:   userIssuer.ID,
+		UserSessionIssuerID:   conv.ToNullUUID(userIssuer.ID),
 		ClientID:              "resolver-extmcp-client-" + suffix,
 		ClientSecretEncrypted: pgtype.Text{},
 		ClientIDIssuedAt:      pgtype.Timestamptz{Time: time.Now(), Valid: true},

--- a/server/internal/mcp/remotesession_resolver_test.go
+++ b/server/internal/mcp/remotesession_resolver_test.go
@@ -188,7 +188,7 @@ func createRemoteSessionResolverFixture(
 	remoteClient, err := remoteRepo.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
 		ProjectID:             conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID: remoteIssuer.ID,
-		UserSessionIssuerID:   userIssuer.ID,
+		UserSessionIssuerID:   conv.ToNullUUID(userIssuer.ID),
 		ClientID:              "resolver-client-" + suffix,
 		ClientSecretEncrypted: pgtype.Text{String: "", Valid: false},
 		ClientIDIssuedAt:      pgtype.Timestamptz{Time: time.Now(), Valid: true},

--- a/server/internal/mv/remotesessionclient.go
+++ b/server/internal/mv/remotesessionclient.go
@@ -23,11 +23,15 @@ func BuildRemoteSessionClientView(row repo.RemoteSessionClient) (*types.RemoteSe
 		s := row.ClientSecretExpiresAt.Time.Format(time.RFC3339)
 		expiresAt = &s
 	}
+	var userSessionIssuerID string
+	if row.UserSessionIssuerID.Valid {
+		userSessionIssuerID = row.UserSessionIssuerID.UUID.String()
+	}
 	return &types.RemoteSessionClient{
 		ID:                      row.ID.String(),
 		ProjectID:               row.ProjectID.UUID.String(),
 		RemoteSessionIssuerID:   row.RemoteSessionIssuerID.String(),
-		UserSessionIssuerID:     row.UserSessionIssuerID.String(),
+		UserSessionIssuerID:     userSessionIssuerID,
 		ClientID:                row.ClientID,
 		ClientIDIssuedAt:        issuedAt,
 		ClientSecretExpiresAt:   expiresAt,

--- a/server/internal/oauthtest/issuergated.go
+++ b/server/internal/oauthtest/issuergated.go
@@ -141,7 +141,7 @@ func CreateIssuerGatedToolset(
 	rsc, err := remoteRepo.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
 		ProjectID:             conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID: rsi.ID,
-		UserSessionIssuerID:   usi.ID,
+		UserSessionIssuerID:   conv.ToNullUUID(usi.ID),
 		ClientID:              clientID,
 		ClientSecretEncrypted: conv.ToPGText(encSecret),
 		ClientIDIssuedAt:      pgtype.Timestamptz{Time: time.Now(), Valid: true},

--- a/server/internal/remotesessions/challenge_audience_e2e_test.go
+++ b/server/internal/remotesessions/challenge_audience_e2e_test.go
@@ -95,7 +95,7 @@ func TestBuildAuthorizationUrl_AudienceResolution(t *testing.T) {
 			client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 				ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 				RemoteSessionIssuerID:   issuer.ID,
-				UserSessionIssuerID:     userIssuer,
+				UserSessionIssuerID:     conv.ToNullUUID(userIssuer),
 				ClientID:                "aud-cid",
 				ClientSecretEncrypted:   pgtype.Text{String: "", Valid: false},
 				ClientIDIssuedAt:        pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},

--- a/server/internal/remotesessions/challenge_scope_e2e_test.go
+++ b/server/internal/remotesessions/challenge_scope_e2e_test.go
@@ -96,7 +96,7 @@ func TestBuildAuthorizationUrl_ScopeResolution(t *testing.T) {
 			client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 				ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 				RemoteSessionIssuerID:   issuer.ID,
-				UserSessionIssuerID:     userIssuer,
+				UserSessionIssuerID:     conv.ToNullUUID(userIssuer),
 				ClientID:                "scope-cid",
 				ClientSecretEncrypted:   pgtype.Text{String: "", Valid: false},
 				ClientIDIssuedAt:        pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -150,7 +150,7 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuerID,
-		UserSessionIssuerID:     userIssuerID,
+		UserSessionIssuerID:     conv.ToNullUUID(userIssuerID),
 		ClientID:                clientID,
 		ClientSecretEncrypted:   secretCiphertext,
 		ClientIDIssuedAt:        conv.ToPGTimestamptz(time.Now().UTC()),
@@ -315,7 +315,7 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuerID,
-		UserSessionIssuerID:     userIssuerID,
+		UserSessionIssuerID:     conv.ToNullUUID(userIssuerID),
 		ClientID:                clientID,
 		ClientSecretEncrypted:   conv.ToPGText(encrypted),
 		ClientIDIssuedAt:        conv.ToPGTimestamptz(time.Now().UTC()),
@@ -517,13 +517,13 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 		return nil, oops.E(oops.CodeUnexpected, err, "update remote session client").LogError(ctx, logger)
 	}
 
-	shouldRemakeUserSessionIssuerAttachment := payload.UserSessionIssuerID != nil && userIssuerID.Valid && userIssuerID.UUID != existing.UserSessionIssuerID
+	shouldRemakeUserSessionIssuerAttachment := payload.UserSessionIssuerID != nil && userIssuerID.Valid && userIssuerID.UUID != existing.UserSessionIssuerID.UUID
 
 	if shouldRemakeUserSessionIssuerAttachment {
 		// The new user_session_issuer must not already bind a different client
 		// for this client's remote_session_issuer. Exclude this client so a
 		// no-op re-bind passes.
-		if err = s.guardSingleClientPerRemoteIssuer(ctx, logger, txRepo, *authCtx.ProjectID, updated.UserSessionIssuerID, existing.RemoteSessionIssuerID, updated.ID); err != nil {
+		if err = s.guardSingleClientPerRemoteIssuer(ctx, logger, txRepo, *authCtx.ProjectID, updated.UserSessionIssuerID.UUID, existing.RemoteSessionIssuerID, updated.ID); err != nil {
 			return nil, err
 		}
 
@@ -550,7 +550,7 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 			ctx,
 			repo.AttachRemoteSessionClientToUserSessionIssuerParams{
 				RemoteSessionClientID: updated.ID,
-				UserSessionIssuerID:   updated.UserSessionIssuerID,
+				UserSessionIssuerID:   updated.UserSessionIssuerID.UUID,
 			},
 		); err != nil {
 			return nil, oops.E(

--- a/server/internal/remotesessions/clienthandlers_test.go
+++ b/server/internal/remotesessions/clienthandlers_test.go
@@ -456,7 +456,7 @@ func TestListRemoteSessionClients_ColumnOnlyClientNotVisible(t *testing.T) {
 	columnOnlyClient, err := repo.New(ti.conn).CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuerUUID,
-		UserSessionIssuerID:     userIssuerID,
+		UserSessionIssuerID:     conv.ToNullUUID(userIssuerID),
 		ClientID:                "column-only-client",
 		ClientSecretEncrypted:   pgtype.Text{},
 		ClientIDIssuedAt:        conv.ToPGTimestamptz(time.Now().UTC()),

--- a/server/internal/remotesessions/repo/models.go
+++ b/server/internal/remotesessions/repo/models.go
@@ -30,7 +30,7 @@ type RemoteSessionClient struct {
 	ID                      uuid.UUID
 	ProjectID               uuid.NullUUID
 	RemoteSessionIssuerID   uuid.UUID
-	UserSessionIssuerID     uuid.UUID
+	UserSessionIssuerID     uuid.NullUUID
 	ClientID                string
 	ClientSecretEncrypted   pgtype.Text
 	ClientIDIssuedAt        pgtype.Timestamptz

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -112,7 +112,7 @@ RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, clie
 type CreateRemoteSessionClientParams struct {
 	ProjectID               uuid.NullUUID
 	RemoteSessionIssuerID   uuid.UUID
-	UserSessionIssuerID     uuid.UUID
+	UserSessionIssuerID     uuid.NullUUID
 	ClientID                string
 	ClientSecretEncrypted   pgtype.Text
 	ClientIDIssuedAt        pgtype.Timestamptz
@@ -753,7 +753,7 @@ type GetRemoteSessionClientWithIssuerByIDRow struct {
 	ClientAudience          pgtype.Text
 	LegacyCallbackUrl       bool
 	RemoteSessionIssuerID   uuid.UUID
-	UserSessionIssuerID     uuid.UUID
+	UserSessionIssuerID     uuid.NullUUID
 	IssuerSlug              string
 	IssuerUrl               string
 	AuthorizationEndpoint   pgtype.Text
@@ -1520,7 +1520,7 @@ type ListRemoteSessionClientsForUserSessionIssuerRow struct {
 	ClientAudience          pgtype.Text
 	LegacyCallbackUrl       bool
 	RemoteSessionIssuerID   uuid.UUID
-	UserSessionIssuerID     uuid.UUID
+	UserSessionIssuerID     uuid.NullUUID
 	IssuerSlug              string
 	IssuerUrl               string
 	AuthorizationEndpoint   pgtype.Text

--- a/server/internal/remotesessions/tokenservice_audience_test.go
+++ b/server/internal/remotesessions/tokenservice_audience_test.go
@@ -100,7 +100,7 @@ func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *up
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuer.ID,
-		UserSessionIssuerID:     userIssuer,
+		UserSessionIssuerID:     conv.ToNullUUID(userIssuer),
 		ClientID:                "aud-cid",
 		ClientSecretEncrypted:   conv.ToPGText(secretCiphertext),
 		ClientIDIssuedAt:        conv.ToPGTimestamptz(time.Now()),

--- a/server/internal/remotesessions/tokenservice_authmethod_test.go
+++ b/server/internal/remotesessions/tokenservice_authmethod_test.go
@@ -122,7 +122,7 @@ func setupRefreshFixture(t *testing.T, authMethod string, spy *upstreamSpy) (con
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuer.ID,
-		UserSessionIssuerID:     userIssuer,
+		UserSessionIssuerID:     conv.ToNullUUID(userIssuer),
 		ClientID:                externalCID,
 		ClientSecretEncrypted:   conv.ToPGText(secretCiphertext),
 		ClientIDIssuedAt:        conv.ToPGTimestamptz(time.Now()),

--- a/server/internal/remotesessions/tokenservice_resolve_test.go
+++ b/server/internal/remotesessions/tokenservice_resolve_test.go
@@ -76,7 +76,7 @@ func seedActiveClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, pro
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(projectID),
 		RemoteSessionIssuerID:   issuer.ID,
-		UserSessionIssuerID:     userIssuerID,
+		UserSessionIssuerID:     conv.ToNullUUID(userIssuerID),
 		ClientID:                "cid-" + slug,
 		ClientSecretEncrypted:   pgtype.Text{String: "", Valid: false},
 		ClientIDIssuedAt:        conv.ToPGTimestamptz(time.Now()),

--- a/server/migrations/20260618145406_remotesession-clients-relax-issuer-binding.sql
+++ b/server/migrations/20260618145406_remotesession-clients-relax-issuer-binding.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Drop index "remote_session_client_user_session_issuers_one_per_issuer" from table: "remote_session_client_user_session_issuers"
+DROP INDEX CONCURRENTLY "remote_session_client_user_session_issuers_one_per_issuer";
+-- Modify "remote_session_clients" table
+ALTER TABLE "remote_session_clients" ALTER COLUMN "user_session_issuer_id" DROP NOT NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:eEt5lYbX/2I82kk4/vjUXJoEIPd/vHQ4Gypn9tpEhyA=
+h1:bgD7d/dmkHnbN0wsVnH7ncqAZx7bfmpZcDFzH+NHPUc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -220,3 +220,4 @@ h1:eEt5lYbX/2I82kk4/vjUXJoEIPd/vHQ4Gypn9tpEhyA=
 20260615113504_workos-metadata-for-directory-attributes-sync.sql h1:sZiNf5tqa+2mqki7Xr4sUuF126gZBup1Kg92bX7AtkM=
 20260618115411_risk-results-add-llm-judge-reason.sql h1:aI+VA7W9POYKH1mpSAUDTa4sfmr7gXkdmkBtXVK1NLI=
 20260618141330_risk-results-drop-llm-judge-reason.sql h1:D1AdewSg0AisvTZYT5ta9zDyUH5sFMWvaew/BPmLDtI=
+20260618145406_remotesession-clients-relax-issuer-binding.sql h1:Ilx2asUwFZi73cQMVj5yrXGc5aq6QihR2Sd4uaC4h6o=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-137/migration-drop-one-per-issuer-index-and-make-user-session-issuer-id

Drop the `one_per_issuer` unique index on the `remote_session_client_user_session_issuers` join table and relax `remote_session_clients.user_session_issuer_id` to nullable, preparing for column removal. The column and its FK stay until the AIS-138 cutover. Regenerating SQLc flips the column to `uuid.NullUUID`, so minimal `conv.ToNullUUID` / `.UUID` shims accompany it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed remote session client binding to support many-to-many with user session issuers by dropping the join-table unique index and making `remote_session_clients.user_session_issuer_id` nullable. Aligns with AIS-137 expand-contract and prepares for AIS-138 column removal.

- **Migration**
  - Drops `remote_session_client_user_session_issuers_one_per_issuer` concurrently and makes `remote_session_clients.user_session_issuer_id` nullable (schema, new Atlas migration, `atlas.sum`).
  - Apply only after AIS-136 runtime multi-client routing is deployed.

- **Refactors**
  - Regenerated `sqlc`: `UserSessionIssuerID` is now `uuid.NullUUID`; updated service logic to use `conv.ToNullUUID`, compare nullable IDs, and pass `.UUID` where required; tests updated.
  - Client view treats `UserSessionIssuerID` as optional and omits it when null.

<sup>Written for commit 9064d01ec2613ecf045c9e5d6b73e8bf63093cb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

