### PR TITLE
feat(dashboard): per-rule risk counts in chat trace filter bar

### DIFF
--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -49,6 +49,7 @@ import {
   type TraceEntryType,
   getEntryTypeCounts,
   getRiskEntryCount,
+  getRuleCounts,
   getTraceEntryType,
   getVisibleMessages,
   parseToolCalls,
@@ -1094,6 +1095,7 @@ function ChatDetailPanel({
     riskResultsByMessage,
   }).length;
   const riskEntryCount = getRiskEntryCount(chatMessages, riskResultsByMessage);
+  const ruleCounts = getRuleCounts(riskResults);
 
   return (
     <div className="bg-background flex h-full flex-col">
@@ -1320,6 +1322,7 @@ function ChatDetailPanel({
             onChange={setEnabledEntryTypes}
             riskOnly={riskOnly}
             riskCount={riskEntryCount}
+            ruleCounts={ruleCounts}
             onRiskOnlyChange={setRiskOnly}
           />
 

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -5,6 +5,7 @@ import {
   ENTRY_TYPE_META,
   FILTERABLE_ENTRY_TYPES,
   type FilterableTraceEntryType,
+  type RuleCount,
 } from "./traceEntries";
 import { TraceEntryIcon } from "./TraceEntryIcon";
 
@@ -22,6 +23,7 @@ export function EntryTypeFilterBar({
   onChange,
   riskOnly = false,
   riskCount = 0,
+  ruleCounts = [],
   onRiskOnlyChange,
   title = "Entries Filter",
 }: {
@@ -32,6 +34,7 @@ export function EntryTypeFilterBar({
   onChange: (value: FilterableTraceEntryType[]) => void;
   riskOnly?: boolean;
   riskCount?: number;
+  ruleCounts?: ReadonlyArray<RuleCount>;
   onRiskOnlyChange?: (value: boolean) => void;
   title?: string;
 }) {
@@ -39,7 +42,7 @@ export function EntryTypeFilterBar({
 
   return (
     <div>
-      <div className="flex items-center justify-between gap-3 px-6 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 px-6 py-3">
         <div className="flex shrink-0 items-baseline gap-4">
           <div className="text-sm font-medium">{title}</div>
           <div className="text-muted-foreground text-xs">
@@ -50,14 +53,29 @@ export function EntryTypeFilterBar({
         {onRiskOnlyChange && (
           <div
             className={cn(
-              "inline-flex h-8 items-center gap-2 text-xs",
+              "inline-flex min-h-8 flex-wrap items-center justify-end gap-2 text-xs",
               riskOnlyDisabled && "opacity-50",
             )}
           >
+            {ruleCounts.length > 0 ? (
+              ruleCounts.map(({ ruleId, count }) => (
+                <span
+                  key={ruleId}
+                  className="bg-muted/40 text-muted-foreground inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 font-mono text-[10px] leading-none"
+                  title={`${count} ${ruleId}`}
+                >
+                  <span className="text-foreground">
+                    {count.toLocaleString()}
+                  </span>
+                  <span>{ruleId}</span>
+                </span>
+              ))
+            ) : (
+              <span className="font-mono text-[10px] leading-none">
+                {riskCount.toLocaleString()}
+              </span>
+            )}
             <span>Risk only</span>
-            <span className="font-mono text-[10px] leading-none">
-              {riskCount.toLocaleString()}
-            </span>
             <Switch
               checked={riskOnly}
               disabled={riskOnlyDisabled}

--- a/client/dashboard/src/pages/chatLogs/traceEntries.ts
+++ b/client/dashboard/src/pages/chatLogs/traceEntries.ts
@@ -176,3 +176,18 @@ export function getRiskEntryCount(
     messageHasRiskResults(message, riskResultsByMessage),
   ).length;
 }
+
+export type RuleCount = { ruleId: string; count: number };
+
+export function getRuleCounts(
+  riskResults: ReadonlyArray<{ ruleId?: string | null; source?: string }>,
+): RuleCount[] {
+  const counts = new Map<string, number>();
+  for (const r of riskResults) {
+    const key = r.ruleId?.trim() || r.source || "unknown";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return Array.from(counts, ([ruleId, count]) => ({ ruleId, count })).sort(
+    (a, b) => b.count - a.count || a.ruleId.localeCompare(b.ruleId),
+  );
+}

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -956,8 +956,15 @@ function PolicySheetBody({
                           Coming Soon
                         </Badge>
                       )}
-                      {isExpandable && categorySelected && (
-                        <Badge variant="outline" className="text-[10px]">
+                      {isExpandable && (
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "text-[10px]",
+                            !categorySelected && "invisible",
+                          )}
+                          aria-hidden={!categorySelected}
+                        >
                           {enabledRuleCount}/{rules.length} on
                         </Badge>
                       )}


### PR DESCRIPTION
## Why

When triaging a chat in the chat logs view, the filter bar only tells you how many messages have *any* risk finding. That hides which rules are actually firing, so you have to scroll the trace to figure out whether the noise is one chatty rule or many. Surfacing per-rule counts at the top makes it obvious where to focus, and trims a round-trip when verifying false-positive fixes.

Also fixes a small layout jitter in the policy sheet: toggling a category on/off shifted neighboring rows because the "N/M on" badge appeared and disappeared.

## What changed

- New `getRuleCounts` helper in `traceEntries.ts` that aggregates `riskResults` by `ruleId` (falling back to `source`), sorted by count desc then rule id.
- `ChatDetailPanel` computes `ruleCounts` from `riskResults` and passes it to the filter bar.
- `EntryTypeFilterBar` renders a per-rule chip list when counts are present, falls back to the old single count otherwise. Row now wraps so long rule lists don't overflow.
- `PolicyCenter` keeps the "N/M on" badge in the DOM with `invisible` + `aria-hidden` when the category is unselected, so the row width is stable.

### Before

- Filter bar shows a single ` Risk only  N ` count, with no breakdown by rule.
- In the policy sheet, the "N/M on" badge mounts/unmounts as you toggle a category, causing the rule label and switch to jump horizontally.

### After

- Filter bar shows one chip per rule (` 12 pii.email_address `, ` 3 pii.us_ssn `, ...), ordered by frequency.
- Policy sheet badge slot is always reserved, so toggling a category no longer shifts neighbors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show per-rule risk counts in the chat trace filter bar to speed up triage, and prevent layout shifts in the Policy Center when toggling categories.

- **New Features**
  - Added `getRuleCounts` to aggregate `riskResults` by `ruleId` (fallback to `source`), sorted by count.
  - `ChatDetailPanel` passes `ruleCounts` to `EntryTypeFilterBar`, which renders chips like `12 pii.email_address`; wraps on long lists and falls back to a single count if needed.

- **Bug Fixes**
  - In `PolicyCenter`, keep the "N/M on" badge mounted with `invisible` and `aria-hidden` when off to stop row jitter.

<sup>Written for commit 8515974069f5ed49fd7c655ac52ec896c519535d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

