### PR TITLE
feat(dashboard): add employee metric drilldowns

### DIFF
--- a/.changeset/employee-metric-drilldowns.md
+++ b/.changeset/employee-metric-drilldowns.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add employee detail metric drilldowns for tool logs, agent sessions, and risk events.

--- a/client/dashboard/src/components/chart/MetricCard.tsx
+++ b/client/dashboard/src/components/chart/MetricCard.tsx
@@ -19,6 +19,7 @@ export type MetricCardProps = {
   accentColor?: AccentColor;
   subtext?: string;
   tooltip?: string;
+  action?: React.ReactNode;
 };
 
 export function MetricCard(props: MetricCardProps): JSX.Element {
@@ -34,6 +35,7 @@ export function MetricCard(props: MetricCardProps): JSX.Element {
     comparisonLabel,
     subtext,
     tooltip,
+    action,
   } = props;
   const formatValue = (v: number) => {
     switch (format) {
@@ -93,36 +95,44 @@ export function MetricCard(props: MetricCardProps): JSX.Element {
           </div>
         )}
       </div>
-      <div className="flex items-end justify-between">
-        <span className={`text-3xl font-semibold tracking-tight ${valueColor}`}>
-          {displayValue ?? formatValue(value)}
-        </span>
-        {previousValue > 0 && delta !== 0 && (
-          <div className="flex flex-col items-end gap-0.5">
-            <div
-              className={`flex items-center gap-1 text-xs font-medium ${
-                isGood ? "text-emerald-600" : "text-red-500"
-              }`}
+      <div className="flex flex-nowrap items-end">
+        <div className="flex-1 flex flex-col gap-1">
+          <div className="flex items-end justify-between">
+            <span
+              className={`text-3xl font-semibold tracking-tight ${valueColor}`}
             >
-              <Icon
-                name={isPositive ? "trending-up" : "trending-down"}
-                className="size-3"
-              />
-              <span>{delta.toFixed(1)}%</span>
-            </div>
-            {comparisonLabel && (
-              <span className="text-muted-foreground text-[10px]">
-                {comparisonLabel}
-              </span>
+              {displayValue ?? formatValue(value)}
+            </span>
+            {previousValue > 0 && delta !== 0 && (
+              <div className="flex flex-col items-end gap-0.5">
+                <div
+                  className={`flex items-center gap-1 text-xs font-medium ${
+                    isGood ? "text-emerald-600" : "text-red-500"
+                  }`}
+                >
+                  <Icon
+                    name={isPositive ? "trending-up" : "trending-down"}
+                    className="size-3"
+                  />
+                  <span>{delta.toFixed(1)}%</span>
+                </div>
+                {comparisonLabel && (
+                  <span className="text-muted-foreground text-[10px]">
+                    {comparisonLabel}
+                  </span>
+                )}
+              </div>
             )}
           </div>
-        )}
+          {subtext && (
+            <span className="text-muted-foreground mt-1 block text-xs">
+              {subtext}
+            </span>
+          )}
+        </div>
+
+        {action && <div className="shrink">{action}</div>}
       </div>
-      {subtext && (
-        <span className="text-muted-foreground mt-1 block text-xs">
-          {subtext}
-        </span>
-      )}
     </div>
   );
 }

--- a/client/dashboard/src/components/chart/MetricCard.tsx
+++ b/client/dashboard/src/components/chart/MetricCard.tsx
@@ -2,6 +2,7 @@ import { Icon, type IconName } from "@speakeasy-api/moonshine";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { formatCompact } from "@/lib/format";
 import { getValueColor, ThresholdConfig } from "./chartUtils";
+import { Link } from "react-router";
 
 type AccentColor = "red" | "orange" | "yellow" | "green" | "blue" | "purple";
 
@@ -19,7 +20,8 @@ export type MetricCardProps = {
   accentColor?: AccentColor;
   subtext?: string;
   tooltip?: string;
-  action?: React.ReactNode;
+  link?: string;
+  linkText?: string;
 };
 
 export function MetricCard(props: MetricCardProps): JSX.Element {
@@ -35,7 +37,8 @@ export function MetricCard(props: MetricCardProps): JSX.Element {
     comparisonLabel,
     subtext,
     tooltip,
-    action,
+    link,
+    linkText = "View",
   } = props;
   const formatValue = (v: number) => {
     switch (format) {
@@ -131,7 +134,18 @@ export function MetricCard(props: MetricCardProps): JSX.Element {
           )}
         </div>
 
-        {action && <div className="shrink">{action}</div>}
+        {link && (
+          <div className="shrink">
+            <Link
+              to={link}
+              aria-label={`View ${title}`}
+              className="text-primary/70 hover:text-primary flex items-center gap-1 text-xs no-underline"
+            >
+              {linkText}
+              <Icon name="arrow-right" />
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -38,7 +38,11 @@ import type {
   TimeSeriesBucket,
   UserSummary,
 } from "@gram/client/models/components";
-import { useGramContext, useMembers } from "@gram/client/react-query";
+import {
+  useGramContext,
+  useListChats,
+  useMembers,
+} from "@gram/client/react-query";
 import { unwrapAsync } from "@gram/client/types/fp";
 import {
   TimeRangePicker,
@@ -202,6 +206,19 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
     routes.agentSessions,
     to,
   ]);
+  const agentSessionsQuery = useListChats(
+    {
+      search: employeeEmailFilter ?? undefined,
+      from,
+      to,
+      limit: 1,
+    },
+    undefined,
+    {
+      enabled: employeeEmailFilter != null,
+      throwOnError: false,
+    },
+  );
 
   const handlePresetChange = (preset: DateRangePreset) => {
     setDateRange(preset);
@@ -412,7 +429,12 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                 />
                 <MetricCard
                   title="Agent Sessions"
-                  value={summary?.totalChats ?? 0}
+                  value={agentSessionsQuery.data?.total ?? 0}
+                  displayValue={
+                    agentSessionsQuery.isLoading || agentSessionsQuery.isError
+                      ? "-"
+                      : undefined
+                  }
                   icon="message-square"
                   subtext={`Over ${rangeLabel}`}
                   action={

--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -43,6 +43,7 @@ import {
   useListChats,
   useMembers,
 } from "@gram/client/react-query";
+import { useRiskOverview } from "@gram/client/react-query/index.js";
 import { unwrapAsync } from "@gram/client/types/fp";
 import {
   TimeRangePicker,
@@ -219,6 +220,32 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
       throwOnError: false,
     },
   );
+  const riskEventsHref = useMemo(() => {
+    const params = new URLSearchParams();
+    if (employeeEmailFilter) {
+      params.set("user_id", employeeEmailFilter);
+    }
+    const query = params.toString();
+    return query
+      ? `${routes.riskEvents.href()}?${query}`
+      : routes.riskEvents.href();
+  }, [employeeEmailFilter, routes.riskEvents]);
+  const riskOverviewQuery = useRiskOverview({ from, to }, undefined, {
+    enabled: employeeEmailFilter != null,
+    throwOnError: false,
+  });
+  const riskEventsCount = useMemo(() => {
+    if (!employeeEmailFilter) return 0;
+    const normalizedEmail = employeeEmailFilter.toLowerCase();
+    return (
+      riskOverviewQuery.data?.topUsers.find((user) => {
+        return (
+          user.email.toLowerCase() === normalizedEmail ||
+          user.externalUserId.toLowerCase() === normalizedEmail
+        );
+      })?.findings ?? 0
+    );
+  }, [employeeEmailFilter, riskOverviewQuery.data?.topUsers]);
 
   const handlePresetChange = (preset: DateRangePreset) => {
     setDateRange(preset);
@@ -402,9 +429,6 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                     : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5",
                 )}
               >
-                <FirstActivityCard
-                  firstSeenUnixNano={summary?.firstSeenUnixNano}
-                />
                 <MetricCard
                   title="Total Tokens"
                   value={totalTokens}
@@ -453,6 +477,36 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                         View Agent Sessions for {member?.name ?? routeUser}
                       </TooltipContent>
                     </Tooltip>
+                  }
+                />
+                <MetricCard
+                  title="Risk Events"
+                  value={riskEventsCount}
+                  displayValue={
+                    riskOverviewQuery.isLoading || riskOverviewQuery.isError
+                      ? "-"
+                      : undefined
+                  }
+                  icon="flag"
+                  subtext={`Over ${rangeLabel}`}
+                  action={
+                    employeeEmailFilter ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Link
+                            to={riskEventsHref}
+                            aria-label="View Risk Events"
+                            className="text-primary/70 hover:text-primary flex items-center gap-1 text-xs no-underline"
+                          >
+                            View
+                            <Icon name="arrow-right" />
+                          </Link>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          View Risk Events for {member?.name ?? routeUser}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : null
                   }
                 />
               </section>
@@ -550,50 +604,6 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
       </div>
     </>
   );
-}
-
-function FirstActivityCard({
-  firstSeenUnixNano,
-}: {
-  firstSeenUnixNano?: string | null;
-}) {
-  const hasActivity =
-    firstSeenUnixNano != null &&
-    firstSeenUnixNano !== "" &&
-    firstSeenUnixNano !== "0";
-  const date = hasActivity ? unixNanoToDate(firstSeenUnixNano) : null;
-  const primary = date
-    ? date.toLocaleDateString([], {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })
-    : "No activity";
-  const subtext = date ? `${daysSince(date).toLocaleString()} days ago` : null;
-
-  return (
-    <div className="bg-card border-border rounded-lg border p-5">
-      <div className="mb-3 flex items-center justify-between">
-        <span className="text-sm font-semibold">First Activity</span>
-        <div className="bg-muted/50 rounded-lg p-2">
-          <Icon name="calendar" className="text-muted-foreground size-4" />
-        </div>
-      </div>
-      <span className="block text-3xl font-semibold tracking-tight">
-        {primary}
-      </span>
-      {subtext && (
-        <span className="text-muted-foreground mt-1 block text-xs">
-          {subtext}
-        </span>
-      )}
-    </div>
-  );
-}
-
-function daysSince(date: Date) {
-  const ms = Date.now() - date.getTime();
-  return Math.max(0, Math.floor(ms / 86_400_000));
 }
 
 function DetailLoadingState({ isInsightsOpen }: { isInsightsOpen: boolean }) {

--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -66,7 +66,7 @@ import {
 import { slugify } from "@/lib/constants";
 import { useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
-import { Link, useParams } from "react-router";
+import { useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import {
   Background,
@@ -463,25 +463,7 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                   value={summary?.totalToolCalls ?? 0}
                   icon="wrench"
                   subtext={`${(summary?.toolCallSuccess ?? 0).toLocaleString()} succeeded / ${(summary?.toolCallFailure ?? 0).toLocaleString()} failed`}
-                  action={
-                    employeeEmailFilter ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Link
-                            to={toolLogsHref}
-                            aria-label="View Tool Logs"
-                            className="text-primary/70 hover:text-primary flex items-center gap-1 text-xs no-underline"
-                          >
-                            View
-                            <Icon name="arrow-right" />
-                          </Link>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          View Tool Logs for {member?.name ?? routeUser}
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : null
-                  }
+                  link={toolLogsHref}
                 />
                 <MetricCard
                   title="Agent Sessions"
@@ -493,23 +475,7 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                   }
                   icon="message-square"
                   subtext={`Over ${rangeLabel}`}
-                  action={
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Link
-                          to={agentSessionsHref}
-                          aria-label="View Agent Sessions"
-                          className="text-primary/70 hover:text-primary flex items-center gap-1 text-xs no-underline"
-                        >
-                          View
-                          <Icon name="arrow-right" />
-                        </Link>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        View Agent Sessions for {member?.name ?? routeUser}
-                      </TooltipContent>
-                    </Tooltip>
-                  }
+                  link={agentSessionsHref}
                 />
                 <MetricCard
                   title="Risk Events"
@@ -521,25 +487,7 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                   }
                   icon="flag"
                   subtext={`Over ${rangeLabel}`}
-                  action={
-                    employeeEmailFilter ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Link
-                            to={riskEventsHref}
-                            aria-label="View Risk Events"
-                            className="text-primary/70 hover:text-primary flex items-center gap-1 text-xs no-underline"
-                          >
-                            View
-                            <Icon name="arrow-right" />
-                          </Link>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          View Risk Events for {member?.name ?? routeUser}
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : null
-                  }
+                  link={riskEventsHref}
                 />
               </section>
 

--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -207,6 +207,19 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
     routes.agentSessions,
     to,
   ]);
+  const toolLogsHref = useMemo(() => {
+    const params = new URLSearchParams();
+    if (employeeEmailFilter) {
+      params.set("user", employeeEmailFilter);
+    }
+    if (customRange) {
+      params.set("from", from.toISOString());
+      params.set("to", to.toISOString());
+    } else {
+      params.set("range", dateRange);
+    }
+    return `${routes.logs.href()}?${params.toString()}`;
+  }, [customRange, dateRange, employeeEmailFilter, from, routes.logs, to]);
   const agentSessionsQuery = useListChats(
     {
       search: employeeEmailFilter ?? undefined,
@@ -450,6 +463,25 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                   value={summary?.totalToolCalls ?? 0}
                   icon="wrench"
                   subtext={`${(summary?.toolCallSuccess ?? 0).toLocaleString()} succeeded / ${(summary?.toolCallFailure ?? 0).toLocaleString()} failed`}
+                  action={
+                    employeeEmailFilter ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Link
+                            to={toolLogsHref}
+                            aria-label="View Tool Logs"
+                            className="text-primary/70 hover:text-primary flex items-center gap-1 text-xs no-underline"
+                          >
+                            View
+                            <Icon name="arrow-right" />
+                          </Link>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          View Tool Logs for {member?.name ?? routeUser}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : null
+                  }
                 />
                 <MetricCard
                   title="Agent Sessions"

--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -17,7 +17,11 @@ import { ErrorAlert } from "@/components/ui/alert";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { SimpleTooltip } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { cn } from "@/lib/utils";
@@ -50,7 +54,7 @@ import {
   LinearScale,
   LineElement,
   PointElement,
-  Tooltip,
+  Tooltip as ChartTooltip,
   type ChartOptions,
 } from "chart.js";
 import { slugify } from "@/lib/constants";
@@ -81,7 +85,7 @@ ChartJS.register(
   PointElement,
   LineElement,
   Filler,
-  Tooltip,
+  ChartTooltip,
   Legend,
 );
 
@@ -819,14 +823,17 @@ function DataFlowMetricBadge({ metric }: { metric: DataFlowNodeMetric }) {
   const tooltip = `${metric.value.toLocaleString()} calls received (${metric.successValue.toLocaleString()} ok / ${metric.failureValue.toLocaleString()} blocked)`;
 
   return (
-    <SimpleTooltip tooltip={tooltip}>
-      <Badge variant="neutral" background>
-        <Badge.LeftIcon>
-          <ArrowRight className="h-3.5 w-3.5" />
-        </Badge.LeftIcon>
-        <Badge.Text>{metric.value.toLocaleString()}</Badge.Text>
-      </Badge>
-    </SimpleTooltip>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant="neutral" background>
+          <Badge.LeftIcon>
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Badge.LeftIcon>
+          <Badge.Text>{metric.value.toLocaleString()}</Badge.Text>
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -913,16 +920,19 @@ function ServerClassBadge({
       : meta.tooltip;
 
   return (
-    <SimpleTooltip tooltip={tooltip}>
-      <Badge variant={meta.variant} background aria-label={meta.tooltip}>
-        <Badge.LeftIcon>
-          <ClassIcon className="h-3.5 w-3.5" />
-        </Badge.LeftIcon>
-        {count !== undefined && (
-          <Badge.Text>{count.toLocaleString()}</Badge.Text>
-        )}
-      </Badge>
-    </SimpleTooltip>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant={meta.variant} background aria-label={meta.tooltip}>
+          <Badge.LeftIcon>
+            <ClassIcon className="h-3.5 w-3.5" />
+          </Badge.LeftIcon>
+          {count !== undefined && (
+            <Badge.Text>{count.toLocaleString()}</Badge.Text>
+          )}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -25,6 +25,7 @@ import {
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { cn } from "@/lib/utils";
+import { useRoutes } from "@/routes";
 import { telemetryGetEmployeeDataFlowGraph } from "@gram/client/funcs/telemetryGetEmployeeDataFlowGraph";
 import { telemetryGetObservabilityOverview } from "@gram/client/funcs/telemetryGetObservabilityOverview";
 import { telemetryGetUserMetricsSummary } from "@gram/client/funcs/telemetryGetUserMetricsSummary";
@@ -60,7 +61,7 @@ import {
 import { slugify } from "@/lib/constants";
 import { useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import {
   Background,
@@ -139,6 +140,7 @@ const DATA_FLOW_EDGE_TYPES = { dataFlow: DataFlowEdgeLine };
 export function InsightsEmployeeDetailContent(): JSX.Element {
   const { userSlug } = useParams<{ userSlug: string }>();
   const client = useGramContext();
+  const routes = useRoutes();
   const { isExpanded: isInsightsOpen } = useInsightsState();
   const mcpConfig = useObservabilityMcpConfig({
     toolsToInclude: ["gram_search_users", "gram_list_organization_users"],
@@ -178,6 +180,28 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
     if (customRange) return customRangeLabel ?? "the selected range";
     return formatDateRangeLabel(dateRange, null);
   }, [customRange, customRangeLabel, dateRange]);
+  const employeeEmailFilter =
+    member?.email ?? (routeUser.includes("@") ? routeUser : null);
+  const agentSessionsHref = useMemo(() => {
+    const params = new URLSearchParams();
+    if (customRange) {
+      params.set("from", from.toISOString());
+      params.set("to", to.toISOString());
+    } else {
+      params.set("range", dateRange);
+    }
+    if (employeeEmailFilter) {
+      params.set("search", employeeEmailFilter);
+    }
+    return `${routes.agentSessions.href()}?${params.toString()}`;
+  }, [
+    customRange,
+    dateRange,
+    employeeEmailFilter,
+    from,
+    routes.agentSessions,
+    to,
+  ]);
 
   const handlePresetChange = (preset: DateRangePreset) => {
     setDateRange(preset);
@@ -391,6 +415,23 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                   value={summary?.totalChats ?? 0}
                   icon="message-square"
                   subtext={`Over ${rangeLabel}`}
+                  action={
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Link
+                          to={agentSessionsHref}
+                          aria-label="View Agent Sessions"
+                          className="text-primary/70 hover:text-primary flex items-center gap-1 text-xs no-underline"
+                        >
+                          View
+                          <Icon name="arrow-right" />
+                        </Link>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        View Agent Sessions for {member?.name ?? routeUser}
+                      </TooltipContent>
+                    </Tooltip>
+                  }
                 />
               </section>
 

--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -354,7 +354,7 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                   "grid gap-4 transition-all duration-300",
                   isInsightsOpen
                     ? "grid-cols-1 md:grid-cols-2"
-                    : "grid-cols-1 md:grid-cols-2 lg:grid-cols-4",
+                    : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5",
                 )}
               >
                 <FirstActivityCard
@@ -381,6 +381,12 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                   value={summary?.totalToolCalls ?? 0}
                   icon="wrench"
                   subtext={`${(summary?.toolCallSuccess ?? 0).toLocaleString()} succeeded / ${(summary?.toolCallFailure ?? 0).toLocaleString()} failed`}
+                />
+                <MetricCard
+                  title="Agent Sessions"
+                  value={summary?.totalChats ?? 0}
+                  icon="message-square"
+                  subtext={`Over ${rangeLabel}`}
                 />
               </section>
 
@@ -531,10 +537,10 @@ function DetailLoadingState({ isInsightsOpen }: { isInsightsOpen: boolean }) {
           "grid gap-4 transition-all duration-300",
           isInsightsOpen
             ? "grid-cols-1 md:grid-cols-2"
-            : "grid-cols-1 md:grid-cols-2 lg:grid-cols-4",
+            : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5",
         )}
       >
-        {Array.from({ length: 4 }).map((_, index) => (
+        {Array.from({ length: 5 }).map((_, index) => (
           <div key={index} className="bg-card rounded-lg border p-5">
             <Skeleton className="mb-4 h-4 w-28" />
             <Skeleton className="h-9 w-20" />
@@ -697,7 +703,7 @@ function EmployeeDataFlowGraphCard({
                 pannable
                 zoomable
                 ariaLabel="Data flow minimap"
-                className="!bg-card !border-border rounded-md border"
+                className="bg-card! border-border! rounded-md border"
                 maskColor="hsl(0 0% 50% / 0.12)"
                 nodeColor={getDataFlowMiniMapColor}
                 nodeStrokeWidth={2}
@@ -765,7 +771,7 @@ function DataFlowNodeCard({ data }: NodeProps<DataFlowGraphNode>) {
       <Handle
         type="target"
         position={Position.Left}
-        className="!border-background !bg-muted-foreground"
+        className="border-background! bg-muted-foreground!"
       />
       <div className="mb-2 flex items-center gap-2">
         <DataFlowNodeVisual
@@ -803,7 +809,7 @@ function DataFlowNodeCard({ data }: NodeProps<DataFlowGraphNode>) {
       <Handle
         type="source"
         position={Position.Right}
-        className="!border-background !bg-muted-foreground"
+        className="border-background! bg-muted-foreground!"
       />
     </div>
   );

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -52,6 +52,7 @@ import { slugify } from "@/lib/constants";
 import {
   Badge,
   type Column,
+  Icon,
   type SortDescriptor,
   Table,
   sortTableData,
@@ -678,13 +679,13 @@ function EmployeeTable({
       },
       {
         key: "action",
-        header: <span className="block text-right">Action</span>,
+        header: "",
         width: "auto",
         render: (item) => (
           <div className="text-right">
             <button
               type="button"
-              className="text-primary hover:text-primary/80 text-sm font-medium underline underline-offset-4"
+              className="flex items-center gap-1"
               aria-label={`View ${item.name}`}
               onClick={(event) => {
                 event.stopPropagation();
@@ -692,6 +693,7 @@ function EmployeeTable({
               }}
             >
               View
+              <Icon name="arrow-right" />
             </button>
           </div>
         ),


### PR DESCRIPTION
## Summary
- Add employee detail metric drilldown links for tool logs, agent sessions, and risk events
- Update MetricCard to allow for link props for consistent inline metric actions

<img width="2295" height="1439" alt="Screenshot 2026-06-16 at 6 22 54 PM" src="https://github.com/user-attachments/assets/a9314a3e-3089-4386-b342-a6f55fe86958" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds drilldown links from employee profile metrics to filtered Agent Sessions, Tool Logs, and Risk Events, preserving the selected date range and user filter. Satisfies Linear DNO-195 by linking to pre-filtered `agentSessions` from the employee profile.

- **New Features**
  - `Agent Sessions` metric shows count over the selected range and links to `agentSessions` with the employee email and date range.
  - `Tool Calls` metric links to `logs` with user and date range filters.
  - New `Risk Events` metric with count and link to `riskEvents` filtered to the employee.
  - `MetricCard` now supports `link` and `linkText` props and renders an inline “View” action with an arrow icon.

- **Refactors**
  - Switched to `ui/tooltip` components.
  - Removed “First Activity” card and updated the grid layout.
  - Employee table action updated to “View” with an arrow icon.
  - Added a changeset entry for the dashboard patch.

<sup>Written for commit 86e5c046a1489ac11aeae9be30b4f14f5a7cbaed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



