### PR TITLE
feat(dashboard): add employee cost links

### DIFF
--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -13,7 +13,9 @@ import { ErrorAlert } from "@/components/ui/alert";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
+import { slugify } from "@/lib/constants";
 import { cn } from "@/lib/utils";
+import { useRoutes } from "@/routes";
 import { telemetryGetObservabilityOverview } from "@gram/client/funcs/telemetryGetObservabilityOverview";
 import { telemetryGetProjectMetricsSummary } from "@gram/client/funcs/telemetryGetProjectMetricsSummary";
 import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
@@ -46,12 +48,14 @@ import {
 import {
   Button,
   type Column,
+  Icon,
   type SortDescriptor,
   Table,
   sortTableData,
 } from "@speakeasy-api/moonshine";
 import { useMemo, useState } from "react";
 import { Bar, Chart } from "react-chartjs-2";
+import { Link } from "react-router";
 import { toast } from "sonner";
 
 ChartJS.register(
@@ -952,6 +956,16 @@ type EmployeeRow = UserSummary & {
   tokenShare: number;
 };
 
+function employeeDetailSegment(user: EmployeeRow): string {
+  if (user.email) {
+    return slugify(user.displayName);
+  }
+  if (user.userId.includes("@")) {
+    return encodeURIComponent(user.userId);
+  }
+  return slugify(user.userId);
+}
+
 function EmployeeCostTable({
   users,
   roleUsage,
@@ -970,6 +984,7 @@ function EmployeeCostTable({
   roleUsageLoading: boolean;
 }) {
   const PAGE_SIZE = 10;
+  const routes = useRoutes();
   const [page, setPage] = useState(0);
   const isCost = valueMode === "cost";
   const isRoleView = groupByDimension === "role";
@@ -1242,8 +1257,24 @@ function EmployeeCostTable({
           </div>
         ),
       },
+      {
+        key: "userId",
+        id: "employeeDetail",
+        header: "",
+        width: "0.6fr",
+        render: (user) => (
+          <Link
+            to={routes.employees.detail.href(employeeDetailSegment(user))}
+            className="flex items-center gap-1"
+            aria-label={`View ${user.displayName}`}
+          >
+            View
+            <Icon name="arrow-right" />
+          </Link>
+        ),
+      },
     ],
-    [clientFilter, isCost],
+    [clientFilter, isCost, routes.employees.detail],
   );
 
   const sortedUsers = useMemo(


### PR DESCRIPTION
## Summary
- link each employee cost row to the matching employee detail page

<img width="1488" height="408" alt="image" src="https://github.com/user-attachments/assets/428060b1-acb7-406a-95be-fad62931a564" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “View” link to each Employee Cost row that opens the employee detail page. This fulfills DNO-194 by linking list rows to profiles.

- **New Features**
  - Adds a final action column that routes to `routes.employees.detail.href(...)`.
  - Introduces `employeeDetailSegment` to build safe URL segments via `slugify` or `encodeURIComponent`.
  - Improves clarity and a11y with a “View” label and arrow icon; updates memo deps to include the route.

<sup>Written for commit 2bef11f995b597c26b705728182ef80a4a824df1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

