### PR TITLE
chore: structure org ID correctly

### DIFF
--- a/client/dashboard/src/lib/fermat.ts
+++ b/client/dashboard/src/lib/fermat.ts
@@ -17,7 +17,10 @@ type FermatCommand =
       config: {
         id: string;
         sourceType: string;
-        metadata?: { properties?: Record<string, unknown> };
+        metadata?: {
+          orgId: string;
+          properties?: Record<string, unknown>;
+        };
       };
     }
   | {
@@ -71,9 +74,9 @@ export function initializeFermat(): void {
       id: FERMAT_SOURCE_ID,
       sourceType: "external-b2b",
       metadata: {
+        orgId: FERMAT_ORG_ID,
         properties: {
           app_name: "Speakeasy",
-          orgId: FERMAT_ORG_ID,
         },
       },
     },


### PR DESCRIPTION
We errantly published org ID as part of the wrong fermat object

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly place the organization ID in Fermat source metadata by moving `orgId` from `metadata.properties` to `metadata.orgId`. Updates the type and `initializeFermat` payload so events match the expected Fermat schema and publish correctly.

<sup>Written for commit 27128789e757309b3f72c33f81ee55f86ce6e9b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

