### PR TITLE
fix(assistants): gate sendMessage on project:read

### DIFF
--- a/server/internal/assistants/impl.go
+++ b/server/internal/assistants/impl.go
@@ -223,7 +223,9 @@ func (s *Service) SendMessage(ctx context.Context, payload *gen.SendMessagePaylo
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectWrite, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
+	// Sending a message is gated on project:read: it does not mutate project
+	// configuration, and viewers must be able to talk to a project's assistants.
+	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
 		return nil, err
 	}
 	// Messages are sent as the calling user, so a user identity is required.

--- a/server/internal/assistants/send_message_test.go
+++ b/server/internal/assistants/send_message_test.go
@@ -21,6 +21,10 @@ func projectWriteGrant(projectID uuid.UUID) authz.Grant {
 	return authz.Grant{Scope: authz.ScopeProjectWrite, Selector: authz.NewSelector(authz.ScopeProjectWrite, projectID.String())}
 }
 
+func projectReadGrant(projectID uuid.UUID) authz.Grant {
+	return authz.Grant{Scope: authz.ScopeProjectRead, Selector: authz.NewSelector(authz.ScopeProjectRead, projectID.String())}
+}
+
 // fakeDashboardIngestor stands in for the triggers App: it records the call and
 // reproduces IngestDirect's observable effect by enqueuing the dashboard turn
 // through the same EnqueueTriggerTask path the real dispatcher uses, so the
@@ -85,6 +89,26 @@ func TestSendMessageEnqueues(t *testing.T) {
 	// user's message.
 	require.NotEqual(t, uuid.Nil, ingestor.lastInstance)
 	require.Contains(t, string(ingestor.lastPayload), "what are my top errors?")
+}
+
+// project:read alone is sufficient to send a message: a viewer of a project
+// must be able to talk to its assistants even without project:write.
+func TestSendMessageAllowedWithProjectReadOnly(t *testing.T) {
+	t.Parallel()
+
+	svc, ctx, projectID, _ := newRBACServiceWithConn(t, "assistants_send_message_read_only")
+	ctx = authztest.WithExactGrants(t, ctx, projectReadGrant(projectID))
+
+	managed, err := svc.core.EnableManagedAssistant(ctx, "org-test", projectID, "user-test")
+	require.NoError(t, err)
+	svc.core.SetDashboardIngestor(&fakeDashboardIngestor{core: svc.core, assistantID: managed.ID})
+
+	res, err := svc.SendMessage(ctx, &gen.SendMessagePayload{
+		AssistantID: managed.ID.String(),
+		Message:     "hello",
+	})
+	require.NoError(t, err)
+	require.True(t, res.Accepted)
 }
 
 // Each send without a chat id starts a fresh conversation with its own


### PR DESCRIPTION
## What

Gate `assistants.sendMessage` on `project:read` instead of `project:write`. `assistants.ensureManagedAssistant` stays on `project:write`.

## Why

`sendMessage` required `project:write`. That blocked any principal who holds only `project:read` — or who carries an explicit `project:write` **deny** on a project — from talking to the dashboard assistant, surfacing as `403 forbidden / "permission denied"` from `/rpc/assistants.sendMessage`.

Sending a message enqueues a conversation turn; it changes no project configuration, so `project:read` is the honest gate.

`ensureManagedAssistant` is left on `project:write`: provisioning the managed assistant is the consequential create. Config mutations (`create` / `update` / `delete` assistant) also stay on `project:write`.

## Tests

- `TestSendMessageAllowedWithProjectReadOnly` — new: a read-only grant can send.
- `TestSendMessageRequiresProjectGrant` — unchanged: zero grants still `forbidden`, so auth is not bypassed.

All assistants package tests pass.
