### PR TITLE
feat(assistants): gate onboarding by read perm, not write

### DIFF
--- a/client/dashboard/src/pages/assistants/onboarding/AssistantDraftContext.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantDraftContext.tsx
@@ -21,6 +21,7 @@ import {
 import {
   AssistantDraftCtx,
   AssistantEnv,
+  AssistantStatus,
   DraftContextValue,
   PendingResolver,
 } from "./useAssistantDraft";
@@ -43,16 +44,27 @@ export function AssistantDraftProvider({
   );
   const pendingRef = useRef(new Map<string, PendingResolver>());
 
-  const { data: assistant, refetch } = useAssistantsGet(
-    { id: assistantId ?? "" },
-    undefined,
-    {
-      enabled: !!assistantId,
-      retry: false,
-      throwOnError: false,
-      refetchOnWindowFocus: false,
-    },
-  );
+  const {
+    data: assistant,
+    refetch,
+    isFetching: isFetchingAssistant,
+    isError: assistantFetchErrored,
+  } = useAssistantsGet({ id: assistantId ?? "" }, undefined, {
+    enabled: !!assistantId,
+    retry: false,
+    throwOnError: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const assistantStatus: AssistantStatus = !assistantId
+    ? "missing"
+    : assistant
+      ? "ready"
+      : assistantFetchErrored
+        ? "missing"
+        : isFetchingAssistant
+          ? "loading"
+          : "missing";
 
   const setAssistantId = useCallback(
     (id: string) => {
@@ -122,6 +134,7 @@ export function AssistantDraftProvider({
       setAssistantId,
       setAssistant,
       assistant,
+      assistantStatus,
       refetchAssistant: refetch,
       invalidateAll,
       registerPending,
@@ -134,6 +147,7 @@ export function AssistantDraftProvider({
       setAssistantId,
       setAssistant,
       assistant,
+      assistantStatus,
       refetch,
       invalidateAll,
       registerPending,

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -1,6 +1,8 @@
 import { Page } from "@/components/page-layout";
 import { useHideInsightsDock } from "@/components/insights-context";
+import { Type } from "@/components/ui/type";
 import { useProject, useSession } from "@/contexts/Auth";
+import { useRBAC } from "@/hooks/useRBAC";
 import { internalMcpUrl } from "@/hooks/useToolsetUrl";
 import { getServerURL } from "@/lib/utils";
 import {
@@ -11,9 +13,13 @@ import {
 } from "@gram-ai/elements";
 import { useListToolsets } from "@gram/client/react-query";
 import { useChatSessionsCreateMutation } from "@gram/client/react-query/chatSessionsCreate.js";
-import { ResizablePanel, useMoonshineConfig } from "@speakeasy-api/moonshine";
+import {
+  Icon,
+  ResizablePanel,
+  useMoonshineConfig,
+} from "@speakeasy-api/moonshine";
 import { Loader2 } from "lucide-react";
-import { useCallback, useMemo, useRef } from "react";
+import { ReactNode, useCallback, useMemo, useRef } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { AssistantDraftProvider } from "./AssistantDraftContext";
@@ -83,19 +89,58 @@ function OnboardingShell() {
         <Page.Header.Breadcrumbs fullWidth substitutions={substitutions} />
       </Page.Header>
       <Page.Body fullWidth fullHeight className="p-0">
-        <ResizablePanel
-          direction="horizontal"
-          className="[&>[role='separator']]:bg-neutral-softest [&>[role='separator']]:hover:bg-primary h-full [&>[role='separator']]:relative [&>[role='separator']]:w-px [&>[role='separator']]:border-0 [&>[role='separator']]:before:absolute [&>[role='separator']]:before:inset-y-0 [&>[role='separator']]:before:-right-1 [&>[role='separator']]:before:-left-1 [&>[role='separator']]:before:cursor-col-resize"
-        >
-          <ResizablePanel.Pane minSize={35}>
-            <ChatPane mode={mode} />
-          </ResizablePanel.Pane>
-          <ResizablePanel.Pane minSize={24} defaultSize={36}>
-            <AssistantDraftPanel />
-          </ResizablePanel.Pane>
-        </ResizablePanel>
+        <OnboardingEntryGate>
+          <ResizablePanel
+            direction="horizontal"
+            className="[&>[role='separator']]:bg-neutral-softest [&>[role='separator']]:hover:bg-primary h-full [&>[role='separator']]:relative [&>[role='separator']]:w-px [&>[role='separator']]:border-0 [&>[role='separator']]:before:absolute [&>[role='separator']]:before:inset-y-0 [&>[role='separator']]:before:-right-1 [&>[role='separator']]:before:-left-1 [&>[role='separator']]:before:cursor-col-resize"
+          >
+            <ResizablePanel.Pane minSize={35}>
+              <ChatPane mode={mode} />
+            </ResizablePanel.Pane>
+            <ResizablePanel.Pane minSize={24} defaultSize={36}>
+              <AssistantDraftPanel />
+            </ResizablePanel.Pane>
+          </ResizablePanel>
+        </OnboardingEntryGate>
       </Page.Body>
     </Page>
+  );
+}
+
+function OnboardingEntryGate({ children }: { children: ReactNode }) {
+  const draft = useAssistantDraft();
+  const { hasAllScopes, isLoading: rbacLoading } = useRBAC();
+
+  if (draft.assistantStatus === "ready") return <>{children}</>;
+
+  if (draft.assistantStatus === "loading" || rbacLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  const canCreate = hasAllScopes(["project:write", "mcp:write"]);
+  if (!canCreate) return <AssistantUnavailableNotice />;
+
+  return <>{children}</>;
+}
+
+function AssistantUnavailableNotice() {
+  return (
+    <div className="flex h-full min-h-[400px] w-full items-center justify-center">
+      <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+        <div className="bg-muted flex h-12 w-12 items-center justify-center rounded-full">
+          <Icon name="bot" className="text-muted-foreground h-5 w-5" />
+        </div>
+        <Type variant="subheading">No assistant yet</Type>
+        <Type small muted>
+          Ask an admin to set up an assistant for this project before you can
+          chat with it.
+        </Type>
+      </div>
+    </div>
   );
 }
 

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -108,6 +108,7 @@ function OnboardingShell() {
 }
 
 function OnboardingEntryGate({ children }: { children: ReactNode }) {
+  const project = useProject();
   const draft = useAssistantDraft();
   const { hasAllScopes, isLoading: rbacLoading } = useRBAC();
 
@@ -121,7 +122,7 @@ function OnboardingEntryGate({ children }: { children: ReactNode }) {
     );
   }
 
-  const canCreate = hasAllScopes(["project:write", "mcp:write"]);
+  const canCreate = hasAllScopes(["project:read", "project:write"], project.id);
   if (!canCreate) return <AssistantUnavailableNotice />;
 
   return <>{children}</>;

--- a/client/dashboard/src/pages/assistants/onboarding/useAssistantDraft.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/useAssistantDraft.ts
@@ -5,11 +5,14 @@ type PendingResolver = (result: unknown) => void;
 
 export type AssistantEnv = { id: string; slug: string };
 
+export type AssistantStatus = "loading" | "ready" | "missing";
+
 export type DraftContextValue = {
   assistantId: string | null;
   setAssistantId: (id: string) => void;
   setAssistant: (assistant: Assistant) => void;
   assistant: Assistant | undefined;
+  assistantStatus: AssistantStatus;
   refetchAssistant: () => Promise<unknown>;
   invalidateAll: () => void;
   registerPending: (toolCallId: string, resolver: PendingResolver) => void;


### PR DESCRIPTION
## Summary

Decouple the "open this assistant" path from the "create one" path in the dashboard onboarding flow. The chat shell — and the `sendMessage` path underneath it — only needs `project:read`. The first LLM tool call (`ensureAssistant`) needed `project:write`, so viewers were dropped into a chat that 403'd before they could send a message.

## What changed

- `AssistantDraftProvider` now exposes `assistantStatus: "loading" | "ready" | "missing"` derived from the existing `useAssistantsGet` (`isFetching`, `isError`, `assistantId`, `data`).
- A new `OnboardingEntryGate` wraps the chat + draft panes inside `OnboardingShell` and branches on status:
  - `ready` → render chat for anyone with `project:read`.
  - `loading` → spinner.
  - `missing` + has `project:write` + `mcp:write` → render chat (LLM tools keep lazily creating on first name pick — no eager orphan drafts).
  - `missing` + no write → render an "Ask an admin to set up an assistant" notice.
- No changes to the LLM tools, the chat session API, or the assistant runtime.

## Why this shape

The simpler "decouple" option from the design discussion. Polymorphic error mapping in `ensureAssistant` would still need a read-then-write internally to distinguish "missing + can't write" from "exists + write race", and would shift UX classification into server error responses. The page-level gate keeps the role check local + cheap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the assistants onboarding chat by read permission so viewers with `project:read` can open and chat without 403s. Assistant creation stays write-gated and scoped to the current project; viewers see a clear notice if none exists.

- **Bug Fixes**
  - `AssistantDraftProvider` now exposes `assistantStatus` (`loading` | `ready` | `missing`) and `OnboardingEntryGate` branches: ready → chat for `project:read`; loading/RBAC-loading → spinner; missing → chat only if the user has `project:read` + `project:write` on the current project (lazy create), else an admin notice.
  - Scope checks use `hasAllScopes([...], project.id)` to avoid cross-project grants; dropped `mcp:write` from the creation gate. No changes to LLM tools, chat session API, or the assistant runtime.

<sup>Written for commit ed5113cd3309e525819c15efba1df47c46bc4bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

