### PR TITLE
chore(cost): remove the full prompt text from the clickhouse sql

### DIFF
--- a/server/internal/telemetry/claude_prompt_correlation_test.go
+++ b/server/internal/telemetry/claude_prompt_correlation_test.go
@@ -80,7 +80,7 @@ func TestListClaudeUserPromptCandidatesForCorrelationBindsLargePrompt(t *testing
 		GramProjectID:          uuid.NewString(),
 		GramChatID:             uuid.NewString(),
 		SessionID:              uuid.NewString(),
-		MessagePrompt:          strings.Repeat("Вот тебе пример с прода для serviceMainCategories ", 10_000),
+		MessagePrompt:          strings.Repeat("Here is a production example for serviceMainCategories ", 10_000),
 		MessageTimeUnixNano:    time.Now().UTC().UnixNano(),
 		AfterEventSequence:     0,
 		AfterEventTimeUnixNano: 0,

--- a/server/internal/telemetry/claude_prompt_correlation_test.go
+++ b/server/internal/telemetry/claude_prompt_correlation_test.go
@@ -3,6 +3,7 @@ package telemetry_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +40,15 @@ func TestListClaudeUserPromptCandidatesForCorrelationRanksFuzzyMatch(t *testing.
 		eventSequence: 2,
 		timestamp:     now.Add(time.Second),
 	})
+	insertClaudeUserPromptEvent(t, ctx, ti.chClient, claudeUserPromptEventFixture{
+		projectID:     projectID,
+		chatID:        chatID,
+		sessionID:     sessionID,
+		promptID:      "prompt-outside-window",
+		prompt:        "please summarize the repository changes and include only important implementation details",
+		eventSequence: 3,
+		timestamp:     now.Add(20 * time.Minute),
+	})
 
 	var candidates []telemetryRepo.ClaudeUserPromptCandidate
 	require.Eventually(t, func() bool {
@@ -59,6 +69,26 @@ func TestListClaudeUserPromptCandidatesForCorrelationRanksFuzzyMatch(t *testing.
 
 	require.False(t, candidates[0].IsExact)
 	require.Greater(t, candidates[0].Similarity, candidates[1].Similarity)
+}
+
+func TestListClaudeUserPromptCandidatesForCorrelationBindsLargePrompt(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	candidates, err := ti.chClient.ListClaudeUserPromptCandidatesForCorrelation(ctx, telemetryRepo.ListClaudeUserPromptCandidatesForCorrelationParams{
+		GramProjectID:          uuid.NewString(),
+		GramChatID:             uuid.NewString(),
+		SessionID:              uuid.NewString(),
+		MessagePrompt:          strings.Repeat("Вот тебе пример с прода для serviceMainCategories ", 10_000),
+		MessageTimeUnixNano:    time.Now().UTC().UnixNano(),
+		AfterEventSequence:     0,
+		AfterEventTimeUnixNano: 0,
+		MinFuzzyLength:         40,
+		MaxTimeDeltaNanos:      (10 * time.Minute).Nanoseconds(),
+	})
+	require.NoError(t, err)
+	require.Empty(t, candidates)
 }
 
 type claudeUserPromptEventFixture struct {

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -4277,6 +4278,19 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 		return nil, nil
 	}
 
+	ctx = clickhouse.Context(ctx, clickhouse.WithParameters(clickhouse.Parameters{
+		"gram_project_id":               arg.GramProjectID,
+		"gram_chat_id":                  arg.GramChatID,
+		"session_id":                    arg.SessionID,
+		"message_prompt":                arg.MessagePrompt,
+		"message_time_unix_nano":        strconv.FormatInt(arg.MessageTimeUnixNano, 10),
+		"after_event_sequence":          strconv.FormatInt(arg.AfterEventSequence, 10),
+		"after_event_time_unix_nano":    strconv.FormatInt(arg.AfterEventTimeUnixNano, 10),
+		"min_fuzzy_length":              strconv.Itoa(arg.MinFuzzyLength),
+		"max_time_delta_nanos":          strconv.FormatInt(arg.MaxTimeDeltaNanos, 10),
+		"negative_max_time_delta_nanos": strconv.FormatInt(-arg.MaxTimeDeltaNanos, 10),
+	}))
+
 	rawEvents := sq.Select(
 		"toString(attributes.prompt.id) AS prompt_id",
 		"replaceRegexpAll(trimBoth(toString(attributes.prompt)), '\\\\s+', ' ') AS prompt",
@@ -4284,16 +4298,21 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 		"time_unix_nano",
 	).
 		From("telemetry_logs").
-		Where("gram_project_id = ?", arg.GramProjectID).
-		Where("gram_chat_id = ?", arg.GramChatID).
-		Where("toString(attributes.session.id) = ?", arg.SessionID).
+		Where("gram_project_id = {gram_project_id:String}").
+		Where("gram_chat_id = {gram_chat_id:String}").
+		Where("toString(attributes.session.id) = {session_id:String}").
 		Where("toString(attributes.event.name) = 'user_prompt'").
 		Where("toString(attributes.prompt.id) != ''").
 		Where("toString(attributes.prompt) != ''").
 		Where(squirrel.Or{
-			squirrel.Expr("event_sequence > ?", arg.AfterEventSequence),
-			squirrel.Expr("(event_sequence = ? AND time_unix_nano > ?)", arg.AfterEventSequence, arg.AfterEventTimeUnixNano),
-		})
+			squirrel.Expr("event_sequence > {after_event_sequence:Int64}"),
+			squirrel.Expr(`(
+				event_sequence = {after_event_sequence:Int64}
+				AND time_unix_nano > {after_event_time_unix_nano:Int64}
+			)`),
+		}).
+		Where(`time_unix_nano BETWEEN message_time_unix_nano + {negative_max_time_delta_nanos:Int64}
+			AND message_time_unix_nano + max_time_delta_nanos`)
 
 	scoredCandidates := sq.Select(
 		"prompt_id",
@@ -4308,8 +4327,8 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 				toFloat64(editDistanceUTF8(prompt, message_prompt))
 				/ toFloat64(greatest(lengthUTF8(prompt), message_len, 1))
 			)
-		) AS similarity`,
-		"abs(time_unix_nano - message_time_unix_nano) AS time_delta",
+		) AS similarity,
+		abs(time_unix_nano - message_time_unix_nano) AS time_delta`,
 	).
 		FromSelect(rawEvents, "raw_events")
 
@@ -4321,18 +4340,18 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 		"similarity",
 		"is_exact",
 	).
-		Prefix(
-			"WITH ? AS message_prompt, lengthUTF8(message_prompt) AS message_len, toInt64(?) AS message_time_unix_nano",
-			arg.MessagePrompt,
-			arg.MessageTimeUnixNano,
-		).
+		Prefix(`WITH
+			{message_prompt:String} AS message_prompt,
+			lengthUTF8(message_prompt) AS message_len,
+			{message_time_unix_nano:Int64} AS message_time_unix_nano,
+			{max_time_delta_nanos:Int64} AS max_time_delta_nanos`).
 		FromSelect(scoredCandidates, "scored_candidates").
 		Where(squirrel.Or{
 			squirrel.Expr("is_exact"),
 			squirrel.And{
-				squirrel.Expr("message_len >= ?", arg.MinFuzzyLength),
-				squirrel.Expr("lengthUTF8(prompt) >= ?", arg.MinFuzzyLength),
-				squirrel.Expr("time_delta <= ?", arg.MaxTimeDeltaNanos),
+				squirrel.Expr("message_len >= {min_fuzzy_length:UInt64}"),
+				squirrel.Expr("lengthUTF8(prompt) >= {min_fuzzy_length:UInt64}"),
+				squirrel.Expr("time_delta <= max_time_delta_nanos"),
 			},
 		}).
 		OrderBy("is_exact DESC", "similarity DESC", "time_delta ASC", "event_sequence ASC", "time_unix_nano ASC").
@@ -4342,8 +4361,11 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 	if err != nil {
 		return nil, fmt.Errorf("building list Claude user prompt candidates query: %w", err)
 	}
+	if len(args) > 0 {
+		return nil, fmt.Errorf("building list Claude user prompt candidates query: unexpected positional arguments")
+	}
 
-	rows, err := q.conn.Query(ctx, query, args...)
+	rows, err := q.conn.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Resolves DNO-281

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the prompt-correlation query to ClickHouse named parameters so the full `message_prompt` no longer appears in generated SQL, reducing logging/storage cost and protecting user data. Adds a strict time window filter and tests for large prompts.

- **Refactors**
  - Use ClickHouse named parameters via `clickhouse.Context`/`WithParameters`; remove positional args and error if any are passed.
  - Bind `message_prompt`, timestamps, and limits through `{param}` and a WITH clause instead of interpolating values.
  - Add time window filter using `message_time_unix_nano ± max_time_delta_nanos`.
  - Tests: add large-prompt binding test; ensure prompts outside the window are ignored.

<sup>Written for commit 653618f5c1bc3ab085c8c9b7ffa0e44d2c8a8691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

