### PR TITLE
chore(ci): disable VCS stamping for gen tasks

### DIFF
--- a/.mise-tasks/gen/devidp.sh
+++ b/.mise-tasks/gen/devidp.sh
@@ -5,10 +5,7 @@
 
 set -e
 
-# `go tool goa` builds the goa binary on demand and `goa gen` then `go run`s
-# its throwaway main; every one of those builds stamps VCS info, which has
-# crashed CI with `signal: bus error` while shelling out to git. Codegen
-# binaries are throwaway and never shipped, so the VCS stamp buys nothing.
+# Codegen binaries are throwaway; skip VCS stamping.
 export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
 
 # `goa gen` writes a throwaway `goa<random>/main.go` generator into its working

--- a/.mise-tasks/gen/devidp.sh
+++ b/.mise-tasks/gen/devidp.sh
@@ -5,6 +5,12 @@
 
 set -e
 
+# `go tool goa` builds the goa binary on demand and `goa gen` then `go run`s
+# its throwaway main; every one of those builds stamps VCS info, which has
+# crashed CI with `signal: bus error` while shelling out to git. Codegen
+# binaries are throwaway and never shipped, so the VCS stamp buys nothing.
+export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
+
 # `goa gen` writes a throwaway `goa<random>/main.go` generator into its working
 # directory. goa removes it on both success and failure, but on a hard interrupt
 # (Ctrl-C) or --debug it can linger. That main imports goa's codegen deps

--- a/.mise-tasks/gen/goa-server.sh
+++ b/.mise-tasks/gen/goa-server.sh
@@ -5,10 +5,7 @@
 
 set -e
 
-# `go tool goa` builds the goa binary on demand and `goa gen` then `go run`s
-# its throwaway main; every one of those builds stamps VCS info, which has
-# crashed CI with `signal: bus error` while shelling out to git. Codegen
-# binaries are throwaway and never shipped, so the VCS stamp buys nothing.
+# Codegen binaries are throwaway; skip VCS stamping.
 export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
 
 # `goa gen` writes a throwaway `goa<random>/main.go` generator into its working

--- a/.mise-tasks/gen/goa-server.sh
+++ b/.mise-tasks/gen/goa-server.sh
@@ -5,6 +5,12 @@
 
 set -e
 
+# `go tool goa` builds the goa binary on demand and `goa gen` then `go run`s
+# its throwaway main; every one of those builds stamps VCS info, which has
+# crashed CI with `signal: bus error` while shelling out to git. Codegen
+# binaries are throwaway and never shipped, so the VCS stamp buys nothing.
+export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
+
 # `goa gen` writes a throwaway `goa<random>/main.go` generator into its working
 # directory. goa removes it on both success and failure, but on a hard interrupt
 # (Ctrl-C) or --debug it can linger. That main imports goa's codegen deps

--- a/.mise-tasks/gen/infra.sh
+++ b/.mise-tasks/gen/infra.sh
@@ -5,9 +5,7 @@
 
 set -euo pipefail
 
-# `go run` builds a throwaway binary and stamps VCS info, which has crashed
-# CI with `signal: bus error` while shelling out to git. Codegen binaries
-# are never shipped, so the stamp buys nothing.
+# Codegen binaries are throwaway; skip VCS stamping.
 export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
 
 # Prune stale codegen for both languages before regenerating: buf has no clean

--- a/.mise-tasks/gen/infra.sh
+++ b/.mise-tasks/gen/infra.sh
@@ -5,6 +5,11 @@
 
 set -euo pipefail
 
+# `go run` builds a throwaway binary and stamps VCS info, which has crashed
+# CI with `signal: bus error` while shelling out to git. Codegen binaries
+# are never shipped, so the stamp buys nothing.
+export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
+
 # Prune stale codegen for both languages before regenerating: buf has no clean
 # option, so a deleted or renamed proto would otherwise leave orphaned modules
 # behind (committed, shipped in the Python wheel, and invisible to CI's

--- a/.mise-tasks/gen/webhooks-server.sh
+++ b/.mise-tasks/gen/webhooks-server.sh
@@ -7,9 +7,7 @@
 
 set -e
 
-# `go run` builds a throwaway binary and stamps VCS info, which has crashed
-# CI with `signal: bus error` while shelling out to git. Codegen binaries
-# are never shipped, so the stamp buys nothing.
+# Codegen binaries are throwaway; skip VCS stamping.
 export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
 
 args=()

--- a/.mise-tasks/gen/webhooks-server.sh
+++ b/.mise-tasks/gen/webhooks-server.sh
@@ -6,6 +6,12 @@
 #USAGE flag "-c --check" help="Verify catalog_gen.go and catalog_gen.yaml are up to date without writing"
 
 set -e
+
+# `go run` builds a throwaway binary and stamps VCS info, which has crashed
+# CI with `signal: bus error` while shelling out to git. Codegen binaries
+# are never shipped, so the stamp buys nothing.
+export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
+
 args=()
 if [[ "${usage_check:-}" == "true" ]]; then
     args=(--check)


### PR DESCRIPTION
## Summary

- All four `gen:*` mise tasks shell out to `go run` / `go tool goa gen`. Each builds a throwaway binary and the Go toolchain stamps VCS info via `git` during that build.
- Merge-queue run [27692555861](https://github.com/speakeasy-api/gram/actions/runs/27692555861/job/81911946849) failed `server-build-lint` with `error obtaining VCS status: signal: bus error (core dumped)` — a transient SIGBUS while VCS-stamping the goa tool binary. Go's own error message points at this exact mitigation: `Use -buildvcs=false to disable VCS stamping.`
- The stamped binary is discarded as soon as codegen finishes; the stamp had no value. Removing it removes the entire failure mode.

Adds `export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"` at the top of `gen/goa-server.sh`, `gen/devidp.sh`, `gen/infra.sh`, `gen/webhooks-server.sh`. Re-ran all four locally — output identical (no codegen drift).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Go VCS stamping in all codegen tasks to prevent flaky CI crashes. Sets `GOFLAGS="-buildvcs=false"` in four `gen:*` scripts; no codegen drift.

- **Bug Fixes**
  - Avoids SIGBUS from `git` during VCS stamping when `go run`/`go tool goa gen` builds throwaway binaries in CI.
  - Applied to `.mise-tasks/gen/goa-server.sh`, `devidp.sh`, `infra.sh`, and `webhooks-server.sh`.

- **Refactors**
  - Trimmed the VCS-stamping comment to one line in the updated scripts.

<sup>Written for commit 4c2d3b0f40a5ef5303f688bf6c338fac514e87fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

