### PR TITLE
chore(skills): add pentest-discover-routes skill

### DIFF
--- a/.agents/skills/pentest-discover-routes/SKILL.md
+++ b/.agents/skills/pentest-discover-routes/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: pentest-discover-routes
+description: Produce a complete inventory of HTTP routes/endpoints in the Gram codebase (dashboard React-Router routes, Goa-designed management API routes, and hand-attached net/http handlers) as CSV plus a security-scheme reference, for penetration-test prep and attack-surface review. Activate whenever the task is to enumerate routes, endpoints, or the attack surface — phrasings like "list all routes for a pentest", "what endpoints does the server expose", "produce a route inventory", "map the attack surface", or "find all the dashboard pages/API endpoints" — even when "pentest" isn't said explicitly. Note: it enumerates the existing surface, so it does not apply to adding, modifying, debugging, or rate-limiting a single route.
+metadata:
+  relevant_files:
+    - "client/dashboard/src/routes.tsx"
+    - "client/dashboard/src/App.tsx"
+    - "server/design/**/*.go"
+    - "server/internal/**/*.go"
+---
+
+# Discovering Gram's HTTP Routes for a Pentest
+
+Gram exposes HTTP routes from three independent surfaces. A route inventory is only trustworthy for security review if **all three** are covered — each lives in a different place and is declared a different way, and the hand-attached handlers in particular are invisible to the generated OpenAPI spec, so they're the easiest to miss and often the most interesting.
+
+| Surface                          | Where declared                                                    | How                                              |
+| -------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------ |
+| Dashboard (frontend)             | `client/dashboard/src/routes.tsx`, `client/dashboard/src/App.tsx` | React-Router v7, declarative route tables        |
+| Management API (backend)         | `server/design/**/*.go`                                           | Goa DSL — `Service`/`Method`/`HTTP` blocks       |
+| Hand-attached handlers (backend) | `server/internal/**/*.go`                                         | `o11y.AttachHandler(mux, method, path, handler)` |
+
+Produce one CSV per surface (frontend and backend are shaped differently enough that forcing them into one schema loses information), plus a `security-schemes.md` documenting the auth schemes referenced by the backend rows. The two backend extractors share a schema and concatenate.
+
+## Output schema
+
+Backend CSV columns (both Goa and net/http rows):
+
+```
+framework,http_method,route_path,service,method,authenticated,security_scheme,route_declared_in
+```
+
+Frontend CSV columns:
+
+```
+framework,http_method,route_path,title,scope,authenticated,layout,component,route_declared_in,component_file
+```
+
+`route_declared_in` and `component_file` are paths relative to the repo root — the pentester needs to jump to the source fast. `http_method` is `GET` for all frontend rows (page loads). Conventions worth keeping consistent because they were chosen deliberately:
+
+- `framework` values: `vite + react`, `golang (goa)`, `golang (net/http)`.
+- `security_scheme`: human-readable scheme names, multiple alternatives joined with `OR` (a route accepting either a session or an API key is `Session OR APIKey`). `ByKey` is renamed to `APIKey`. `ProjectSlug` is a request-scoping header, not caller authentication, so it is excluded from this column.
+
+## Backend routes — use the bundled scripts
+
+The Goa and `o11y.AttachHandler` extractions are deterministic, so they're scripted. Run both from the repo root; the second appends to the first:
+
+```bash
+python3 .agents/skills/pentest-discover-routes/scripts/extract_goa_routes.py --root . --out server-design-routes.csv
+python3 .agents/skills/pentest-discover-routes/scripts/extract_attach_handler_routes.py --root . --out server-design-routes.csv --append
+```
+
+What each does and the subtleties it already handles (don't re-derive these by hand — they were bugs found the hard way):
+
+- **`extract_goa_routes.py`** walks `server/design/`, and for every `Method` in every `Service` emits one row per HTTP verb (so a method declaring two routes yields two rows). It **strips comments first** (design files contain prose mentioning `Method("...")`/`Security(...)` that otherwise corrupts attribution), **splits files on `Service` boundaries** (some files declare two services), and resolves effective auth as method-level `Security()`/`NoSecurity()` falling back to the service level.
+- **`extract_attach_handler_routes.py`** greps `o11y.AttachHandler` across `server/internal/`, skips commented-out calls, resolves `http.MethodX` constants and path constants (including `const + "/suffix"` concatenations) by scanning the repo for their definitions, and records the handler function name (or `(inline)`). These rows are marked `authenticated=unknown`, `security_scheme=(manual handler)` because auth is enforced inside each handler, not declaratively — flag them for manual review.
+
+After running, sanity-check the counts the scripts print to stderr against a raw grep, e.g. `grep -rhoE '\b(GET|POST|PUT|DELETE)\(' server/design --include='*.go' | wc -l` should equal the Goa row count. If a script prints `UNPARSED:` lines, a new call shape appeared — inspect and extend the script rather than dropping the route.
+
+## Frontend routes — reconstruct from the route tables
+
+This is interpretive rather than scripted: the routes live in a nested TypeScript object whose shape and wrapping layout may change, so read the files and rebuild paths rather than trusting a brittle regex.
+
+1. Read `client/dashboard/src/routes.tsx`. It defines two tables:
+   - `ROUTE_STRUCTURE` — **project** routes, mounted under `/:orgSlug/projects/:projectSlug`.
+   - `ORG_ROUTE_STRUCTURE` — **org** routes, mounted under `/:orgSlug`.
+     Each entry has `url`, `title`, `component`, optional `indexComponent`, and nested `subPages`. Concatenate parent `url`s to get the full path; a child `url: ":id"` under `sources` (`url: "sources"`) becomes `/:orgSlug/projects/:projectSlug/sources/:id`. An empty `url: ""` is the index route at the parent path. Map each `component`/`indexComponent` identifier back to its `import` to fill `component_file`.
+2. Read `client/dashboard/src/App.tsx` for routes declared directly in JSX `<Route>`s (outside the tables) — e.g. `/login`, `/register`, `/switch-org`, `/shadow-mcp/request`, `/risk-policy-bypass/request`, and the `/` CLI-callback flow. The `<Routes>` tree there also encodes which layout wraps each group (`AppLayout`, `OrgLayout`, `LoginCheck`, or none) and which routes are `outsideMainLayout`/`unauthenticated` — capture that in the `layout`/`authenticated` columns.
+3. For `authenticated`: routes under the `<Route path="/" element={<LoginCheck />}>` subtree require login; siblings registered outside it (and the `from_cli` `/` flow) do not. The per-page RBAC scope only gates nav/command-palette visibility, **not** route reachability — note this so the pentest targets server-side authz, not the client guard.
+
+## Security schemes reference
+
+Generate `security-schemes.md` listing each distinct value appearing in the backend CSV's `security_scheme` column as a `##` heading with a one-paragraph description. Source the definitions from `server/design/security/*.go` (each scheme's `Description(...)` and whether it's `APIKeySecurity` vs `JWTSecurity`) and the actual header/credential names from `server/internal/constants/auth.go` (e.g. `Gram-Key`, `Gram-Session`, `Gram-Chat-Session`). Include the synthetic values too: `none` (no declarative scheme — public/webhook/optional-credential) and `(manual handler)` (the `o11y.AttachHandler` rows). Keep each description to one paragraph; the point is orientation, not exhaustive docs.
+
+## Deliverables checklist
+
+- `dashboard-routes.csv` — frontend routes
+- `server-design-routes.csv` — Goa + net/http backend routes
+- `security-schemes.md` — auth scheme reference
+- A short summary highlighting the security-relevant rows: anything `authenticated` is `no`/`unknown`, the `(manual handler)` routes, inbound webhooks, and OAuth/MCP flows with path params.

--- a/.agents/skills/pentest-discover-routes/scripts/extract_attach_handler_routes.py
+++ b/.agents/skills/pentest-discover-routes/scripts/extract_attach_handler_routes.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Extract routes registered directly on the HTTP mux via `o11y.AttachHandler`.
+
+These bypass Goa entirely — they're hand-attached `net/http` handlers, so they
+do NOT appear in the OpenAPI spec and each enforces (or skips) auth in its own
+code. That makes them a high-value, easy-to-overlook part of the attack surface.
+
+Call shape: o11y.AttachHandler(mux, <method>, <path>, <handler>)
+  * <method> is a literal ("POST") or an http.MethodX constant.
+  * <path> is a literal, a named const (e.g. PlatformToolsetRoute), or a
+    `const + "/suffix"` concatenation (e.g. wellknown.OAuthProtectedResourcePath
+    + "/mcp/{mcpSlug}"). Constants are resolved by scanning the server tree for
+    their `= "..."` definitions, so new routes resolve without editing this script.
+  * Commented-out calls (line starts with //) are skipped.
+
+Output columns match the Goa extractor so the two CSVs concatenate cleanly:
+  framework,http_method,route_path,service,method,authenticated,security_scheme,route_declared_in
+"""
+
+import os, re, csv, sys, argparse
+
+CALL_RE = re.compile(
+    r"o11y\.AttachHandler\(\s*mux\s*,\s*([^,]+?)\s*,\s*(.+?)\s*,\s*(.*)$"
+)
+CONST_DEF_RE = re.compile(r'\b([A-Za-z_]\w*)\s*=\s*"([^"]*)"')
+METHOD = {
+    "http.MethodGet": "GET",
+    "http.MethodPost": "POST",
+    "http.MethodDelete": "DELETE",
+    "http.MethodPut": "PUT",
+    "http.MethodPatch": "PATCH",
+    "http.MethodHead": "HEAD",
+    "http.MethodOptions": "OPTIONS",
+}
+
+
+def build_const_map(root: str) -> dict:
+    """Map string-constant identifiers -> their literal value, scanned across
+    server/. Keyed by the bare identifier (last segment of any qualified name)."""
+    cmap = {}
+    server = os.path.join(root, "server")
+    for dirpath, _, files in os.walk(server):
+        for fn in files:
+            if not fn.endswith(".go"):
+                continue
+            for m in CONST_DEF_RE.finditer(open(os.path.join(dirpath, fn)).read()):
+                cmap.setdefault(m.group(1), m.group(2))
+    return cmap
+
+
+def resolve_method(tok: str) -> str:
+    tok = tok.strip()
+    return METHOD.get(tok, tok.strip('"'))
+
+
+def resolve_path(expr: str, cmap: dict) -> str:
+    expr = expr.strip()
+    m = re.match(r'([A-Za-z_][\w.]*)\s*\+\s*"([^"]*)"', expr)  # const + "suffix"
+    if m:
+        base = cmap.get(m.group(1).split(".")[-1], m.group(1))
+        return base + m.group(2)
+    if expr.startswith('"'):
+        return expr.split('"')[1]
+    return cmap.get(expr.split(".")[-1], expr)  # bare const
+
+
+def resolve_handler(rest: str) -> str:
+    rest = rest.strip()
+    if rest.startswith("func("):
+        return "(inline)"
+    m = re.search(
+        r"(?:oops\.\w+Handle\([^,]+,\s*)?([A-Za-z_][\w.]*)\)\.ServeHTTP", rest
+    )
+    if m:
+        return m.group(1).split(".")[-1]
+    m = re.match(r"([A-Za-z_]\w*)\)", rest)  # bare handler variable
+    if m:
+        return m.group(1)
+    return "(inline)" if "func(" in rest else rest[:40]
+
+
+def extract(root: str):
+    cmap = build_const_map(root)
+    rows = []
+    server = os.path.join(root, "server")
+    for dirpath, _, files in os.walk(server):
+        for fn in files:
+            if not fn.endswith(".go"):
+                continue
+            path = os.path.join(dirpath, fn)
+            for line in open(path):
+                if "o11y.AttachHandler" not in line or line.lstrip().startswith("//"):
+                    continue
+                m = CALL_RE.search(line)
+                if not m:
+                    print(f"UNPARSED: {path}: {line.strip()}", file=sys.stderr)
+                    continue
+                method = resolve_method(m.group(1))
+                pathval = resolve_path(m.group(2), cmap)
+                handler = resolve_handler(m.group(3))
+                pm = re.search(r"server/internal/([^/]+)/", path.replace(os.sep, "/"))
+                service = pm.group(1) if pm else os.path.relpath(path, root)
+                rows.append(
+                    (
+                        "golang (net/http)",
+                        method,
+                        pathval,
+                        service,
+                        handler,
+                        "unknown",
+                        "(manual handler)",
+                        os.path.relpath(path, root),
+                    )
+                )
+    rows.sort(key=lambda r: (r[7], r[2], r[1]))
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".", help="repo root (default: cwd)")
+    ap.add_argument("--out", default="attach-handler-routes.csv")
+    ap.add_argument(
+        "--append",
+        action="store_true",
+        help="append rows only (no header) — for adding to the Goa CSV",
+    )
+    args = ap.parse_args()
+    rows = extract(args.root)
+    mode = "a" if args.append else "w"
+    with open(args.out, mode, newline="") as f:
+        w = csv.writer(f)
+        if not args.append:
+            w.writerow(
+                [
+                    "framework",
+                    "http_method",
+                    "route_path",
+                    "service",
+                    "method",
+                    "authenticated",
+                    "security_scheme",
+                    "route_declared_in",
+                ]
+            )
+        w.writerows(rows)
+    verb = "appended" if args.append else "wrote"
+    print(
+        f"{verb} {len(rows)} o11y.AttachHandler routes -> {args.out}", file=sys.stderr
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/pentest-discover-routes/scripts/extract_goa_routes.py
+++ b/.agents/skills/pentest-discover-routes/scripts/extract_goa_routes.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Extract every HTTP route declared in the Goa design (server/design/**/*.go).
+
+Goa services are defined with `Service("name", func() { ... })` containing
+`Method("name", func() { ... HTTP(func() { GET("/path") ... }) })`. A single
+method may declare more than one verb/path — each becomes its own row.
+
+Why the parsing is shaped this way:
+  * Comments are stripped first because design files contain prose like
+    `// ... the same Security() block as Method("cursor")` that would otherwise
+    be mistaken for real DSL and corrupt method attribution.
+  * Files can declare more than one Service (e.g. hooks/design.go), so we split
+    on Service boundaries rather than assuming one service per file.
+  * Effective auth = the method's own Security()/NoSecurity() if present, else
+    the enclosing service's — mirroring Goa's resolution order.
+
+Output columns:
+  framework,http_method,route_path,service,method,authenticated,security_scheme,route_declared_in
+"""
+
+import os, re, csv, sys, argparse
+from collections import Counter
+
+VERB_RE = re.compile(r'\b(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\(\s*"([^"]*)"')
+SVC_RE = re.compile(r'\bService\(\s*"([^"]+)"')
+METHOD_RE = re.compile(r'\bMethod\(\s*"([^"]+)"')
+SEC_RE = re.compile(r"\bSecurity\(([a-zA-Z][a-zA-Z0-9_.]*)")
+NOSEC_RE = re.compile(r"\bNoSecurity\(\)")
+
+# Schemes that express request *scoping* rather than caller authentication.
+# Excluded from the auth scheme list (a pentest cares "who proved identity",
+# and ProjectSlug is just a header naming the target project).
+SCOPING_SCHEMES = {"ProjectSlug"}
+# Normalize design identifiers to the names used in security-schemes.md.
+RENAME = {"ByKey": "APIKey"}
+
+
+def strip_comments(src: str) -> str:
+    """Remove // and /* */ comments while preserving string/raw/rune literals
+    (so a URL like "https://x" inside a string is never truncated)."""
+    out, i, n = [], 0, len(src)
+    while i < n:
+        c = src[i]
+        if c in "\"'`":
+            q = c
+            out.append(c)
+            i += 1
+            while i < n:
+                out.append(src[i])
+                if src[i] == "\\" and q != "`":
+                    i += 1
+                    if i < n:
+                        out.append(src[i])
+                        i += 1
+                    continue
+                if src[i] == q:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            while i < n and src[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and src[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (src[i] == "*" and src[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def scheme_name(token: str) -> str:
+    name = re.sub(r"SecuritySchema$|SecurityScheme$", "", token.split(".")[-1])
+    return RENAME.get(name, name)
+
+
+def resolve_auth(scheme_tokens, nosec):
+    if nosec:
+        return "no", "none"
+    schemes = [
+        s for s in (scheme_name(t) for t in scheme_tokens) if s not in SCOPING_SCHEMES
+    ]
+    schemes = list(dict.fromkeys(schemes))  # dedupe, keep order
+    if schemes:
+        return "yes", " OR ".join(schemes)
+    return None, None  # signal: fall back to outer scope
+
+
+def extract(root: str):
+    design_dir = os.path.join(root, "server", "design")
+    rows = []
+    for dirpath, _, files in os.walk(design_dir):
+        for fn in sorted(files):
+            if not fn.endswith(".go"):
+                continue
+            path = os.path.join(dirpath, fn)
+            text = strip_comments(open(path).read())
+            svcs = list(SVC_RE.finditer(text))
+            for si, sm in enumerate(svcs):
+                service = sm.group(1)
+                span_end = svcs[si + 1].start() if si + 1 < len(svcs) else len(text)
+                body = text[sm.end() : span_end]
+                starts = [(m.start(), m.group(1)) for m in METHOD_RE.finditer(body)]
+                preamble = body[: starts[0][0]] if starts else body
+                svc_auth = resolve_auth(
+                    SEC_RE.findall(preamble), bool(NOSEC_RE.search(preamble))
+                )
+                for i, (pos, mname) in enumerate(starts):
+                    end = starts[i + 1][0] if i + 1 < len(starts) else len(body)
+                    chunk = body[pos:end]
+                    auth = resolve_auth(
+                        SEC_RE.findall(chunk), bool(NOSEC_RE.search(chunk))
+                    )
+                    if auth == (None, None):
+                        auth = (
+                            svc_auth
+                            if svc_auth != (None, None)
+                            else ("unknown", "none")
+                        )
+                    rel = os.path.relpath(path, root)
+                    for vm in VERB_RE.finditer(chunk):
+                        rows.append(
+                            (
+                                "golang (goa)",
+                                vm.group(1),
+                                vm.group(2),
+                                service,
+                                mname,
+                                auth[0],
+                                auth[1],
+                                rel,
+                            )
+                        )
+    rows.sort(key=lambda r: (r[7], r[3], r[2]))
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".", help="repo root (default: cwd)")
+    ap.add_argument("--out", default="server-design-routes.csv")
+    args = ap.parse_args()
+    rows = extract(args.root)
+    with open(args.out, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(
+            [
+                "framework",
+                "http_method",
+                "route_path",
+                "service",
+                "method",
+                "authenticated",
+                "security_scheme",
+                "route_declared_in",
+            ]
+        )
+        w.writerows(rows)
+    print(
+        f"wrote {len(rows)} Goa routes across {len(set(r[3] for r in rows))} services -> {args.out}",
+        file=sys.stderr,
+    )
+    multi = [k for k, v in Counter((r[3], r[4]) for r in rows).items() if v > 1]
+    if multi:
+        print(f"methods declaring multiple routes: {multi}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Gram exposes three HTTP surfaces — dashboard React-Router routes, Goa-designed management API routes, and hand-attached net/http handlers — each declared in a different place. Assembling a single route inventory for pentest prep means knowing where each surface lives and how to read it. This skill packages that knowledge with extractor scripts so the list can be produced quickly and consistently on demand.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `pentest-discover-routes` skill to generate a complete inventory of Gram’s HTTP routes (dashboard, Goa API, and hand-attached `net/http`) for pentest prep. Includes extractor scripts that produce CSVs and a security-scheme reference for fast, repeatable audits.

- **New Features**
  - `SKILL.md` outlining scope, output schemas, and a compact workflow to capture frontend routes and backend auth schemes.
  - `scripts/extract_goa_routes.py` parses `server/design/**/*.go`, strips comments, handles multiple services per file, resolves `Security`/`NoSecurity`, and emits one row per verb/path.
  - `scripts/extract_attach_handler_routes.py` finds `o11y.AttachHandler` in `server/internal/**/*.go`, resolves `http.Method*` and path constants (including concatenations), records handler names, and marks auth as `unknown` with `security_scheme=(manual handler)`; supports appending to the Goa CSV.
  - Outputs: a combined backend CSV (Goa + hand-attached), guidance to compile `dashboard-routes.csv`, and a short `security-schemes.md` for penetration testing.

<sup>Written for commit 66ece4557d8b54ca59e57491d882bee3e531f099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

