### PR TITLE
feat(remotesessions): runtime multi-client routing + attach-time guard

### DIFF
--- a/.changeset/ais-136-runtime-multi-client-routing.md
+++ b/.changeset/ais-136-runtime-multi-client-routing.md
@@ -1,0 +1,11 @@
+---
+"server": patch
+---
+
+Resolve multiple remote-session authorizations per user session issuer at the
+MCP runtime, keyed by remote session issuer, and enforce at most one client per
+(user session issuer, remote session issuer) at attach time. The runtime
+resolves a per-issuer token map and re-auths when any attached remote session
+is missing or invalid; an application-level attach guard plus a runtime
+invariant replace the database one_per_issuer index. Issuer-gated dispatch
+fails closed when it cannot route among multiple upstream tokens.

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -269,19 +269,21 @@ func (s *Service) BaseURLForRequest(r *http.Request) string {
 // the toolset-keyed (/mcp) and mcp_server-keyed (/x/mcp) MCP runtime
 // paths. It validates the bearer token as a user-session JWT, falls back
 // to an assistant-runtime JWT scoped to the endpoint's project, and on
-// success resolves the upstream remote-session access token configured
+// success resolves the upstream remote-session access tokens configured
 // for the issuer.
 //
 // On success: returns the request context stamped with the resolved
-// principal plus the upstream access token. The token is "" when the
-// issuer has no remote_session_clients bound; today the inv.Check in
-// remotesessions.ResolveOneAccessToken caps the upstream to exactly 0 or
-// 1, so the return type is a single string rather than a slice. Callers
-// wrap the non-empty value into an oauthTokenInputs as needed for
-// downstream tool-dispatch chains.
+// principal plus a remote_session_issuer_id -> upstream access token map.
+// The map is nil/empty when the issuer has no remote_session_clients
+// bound; otherwise it holds one token per remote_session_issuer the
+// subject has linked. Callers wrap each entry into an oauthTokenInputs,
+// tagged with its remote_session_issuer_id, for downstream tool-dispatch
+// chains.
 //
 // On failure: writes a 401 + WWW-Authenticate to w and returns the
-// CodeUnauthorized error from WriteAuthenticateChallenge. The
+// CodeUnauthorized error from WriteAuthenticateChallenge. A re-auth
+// challenge is issued when any attached remote session is missing or
+// invalid (ResolveAccessTokens returns ErrNoValidToken). The
 // resource_metadata URL is built from baseURL + endpoint.RouteBase +
 // endpoint.Slug so a /x/mcp request gets pointed at /x/mcp's
 // protected-resource metadata, not /mcp's.
@@ -294,10 +296,10 @@ func (s *Service) ApplyIssuerGate(
 	w http.ResponseWriter,
 	authToken, baseURL string,
 	endpoint *ResolvedMcpEndpoint,
-) (context.Context, string, error) {
+) (context.Context, map[uuid.UUID]string, error) {
 	protectedResourceURL, err := endpoint.ProtectedResourceURL(baseURL)
 	if err != nil {
-		return ctx, "", oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, s.logger)
+		return ctx, nil, oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, s.logger)
 	}
 
 	newCtx, subject, ok := s.validateUserSessionToken(ctx, authToken, endpoint)
@@ -312,28 +314,29 @@ func (s *Service) ApplyIssuerGate(
 		}
 	}
 	if !ok {
-		return ctx, "", WriteAuthenticateChallenge(w, protectedResourceURL, "expired or invalid access token")
+		return ctx, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "expired or invalid access token")
 	}
 
-	// Resolve the upstream remote_session for this subject before
+	// Resolve the upstream remote_sessions for this subject before
 	// running the legacy auth chain. The resolver short-circuits to
 	// no-op when the issuer has no remote_session_clients bound;
-	// otherwise it either supplies the upstream access token (fed
-	// into tokenInputs so it satisfies the endpoint's oauth2 scheme
-	// downstream) or fails with ErrNoValidToken — which the user
-	// resolves by re-linking via {routeBase}/{slug}/connect.
-	var upstreamToken string
+	// otherwise it supplies one upstream access token per linked
+	// remote_session_issuer (fed into tokenInputs so they satisfy the
+	// endpoint's oauth2 schemes downstream) or fails with ErrNoValidToken
+	// when any attached remote session is missing or invalid — which the
+	// user resolves by re-linking via {routeBase}/{slug}/connect.
+	var upstreamTokens map[uuid.UUID]string
 	if subject != nil {
-		upstream, rerr := s.remoteChallengeMgr.ResolveOneAccessToken(newCtx, endpoint.ProjectID, endpoint.UserSessionIssuerID, *subject)
+		tokens, rerr := s.remoteChallengeMgr.ResolveAccessTokens(newCtx, endpoint.ProjectID, endpoint.UserSessionIssuerID, *subject)
 		switch {
 		case errors.Is(rerr, remotesessions.ErrNoValidToken):
-			return ctx, "", WriteAuthenticateChallenge(w, protectedResourceURL, "")
+			return ctx, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "")
 		case rerr != nil:
-			return ctx, "", oops.E(oops.CodeUnexpected, rerr, "resolve remote session").LogError(newCtx, s.logger)
+			return ctx, nil, oops.E(oops.CodeUnexpected, rerr, "resolve remote session").LogError(newCtx, s.logger)
 		}
-		upstreamToken = upstream
+		upstreamTokens = tokens
 	}
-	return newCtx, upstreamToken, nil
+	return newCtx, upstreamTokens, nil
 }
 
 var errToolsetEndpointMismatch = errors.New("authn challenge endpoint does not match toolset")

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -136,9 +136,65 @@ type Service struct {
 	remoteProxyManager *remotemcp.ProxyManager
 }
 
+// oauthTokenInputs is one upstream OAuth access token collected during MCP
+// request setup, paired with the tool security schemes it may satisfy.
+// ServeToolsetResolved gathers these from the request's auth sources and tool
+// dispatch (rpc_tools_call.go / rpc_tools_list.go) injects each token into the
+// tools whose oauth2 / openIdConnect security scheme it covers.
 type oauthTokenInputs struct {
-	securityKeys []string // can be empty if a single token applies to the whole server
-	Token        string
+	// remoteSessionIssuerID identifies the remote_session_issuer whose
+	// upstream this token authorizes, when the token came from the
+	// issuer-gated remote-session resolver. Invalid for tokens that aren't
+	// remote-session-backed. Dispatch selects a token by securityKeys; the
+	// issuer id is carried for per-tool routing (AIS-152), which will
+	// populate securityKeys from it.
+	remoteSessionIssuerID uuid.NullUUID
+
+	// securityKeys lists the tool security-scheme keys this token satisfies.
+	// Empty means the token applies to every matching oauth2 / openIdConnect
+	// tool on the server (one token covering the whole server); when
+	// populated, dispatch injects the token only into tools whose security
+	// scheme key is in the list.
+	securityKeys []string
+
+	// Token is the upstream bearer access token value. Dispatch writes it into
+	// the matching tool's *_ACCESS_TOKEN env var, which the gateway forwards
+	// as the Authorization header on the outgoing upstream request.
+	Token string
+}
+
+// appendRemoteSessionTokenInputs converts a remote_session_issuer_id -> token
+// map (resolved by ApplyIssuerGate / ResolveAccessTokens) into oauthTokenInputs
+// entries, tagging each with its remote_session_issuer_id. securityKeys is
+// left empty, so dispatch injects a remote-session token into every matching
+// oauth2 tool — correct only when a single remote issuer is bound.
+//
+// Fails closed when more than one token resolves: without per-tool routing
+// (AIS-152) we cannot tell which tool needs which issuer's token, and
+// injecting all of them with empty securityKeys could forward the wrong
+// bearer upstream. This mirrors singleUpstreamToken's fail-closed posture for
+// the remote-MCP backend. The state is unreachable while the
+// remote_session_client_user_session_issuers one_per_issuer index caps a
+// user_session_issuer at one client; it becomes reachable once AIS-137 drops
+// that index, at which point AIS-152 must land to route per tool.
+func appendRemoteSessionTokenInputs(dst []oauthTokenInputs, tokens map[uuid.UUID]string) ([]oauthTokenInputs, error) {
+	if len(tokens) > 1 {
+		return nil, fmt.Errorf("issuer-gated endpoint resolved %d remote-session upstream tokens; per-tool routing required to dispatch (AIS-152)", len(tokens))
+	}
+	for issuerID, token := range tokens {
+		// Defensive: ResolveAccessTokens never maps an issuer to an empty
+		// token (it returns ErrNoValidToken instead), so this skip should not
+		// fire; it guards against a caller passing an empty-valued entry.
+		if token == "" {
+			continue
+		}
+		dst = append(dst, oauthTokenInputs{
+			securityKeys:          nil,
+			remoteSessionIssuerID: uuid.NullUUID{UUID: issuerID, Valid: true},
+			Token:                 token,
+		})
+	}
+	return dst, nil
 }
 
 type mcpInputs struct {
@@ -447,7 +503,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	// Legacy toolset-by-slug path has no mcp_server, so there is no
 	// server-level variation group override; ServeToolsetResolved falls back to
 	// the toolset's own column.
-	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, "", nil)
+	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, nil, nil)
 }
 
 // ServeToolsetResolved serves an MCP runtime request after the slug has
@@ -465,11 +521,12 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 // gate keyed on mcp_servers.user_session_issuer_id, so the same request
 // isn't gated twice. /mcp callers always pass false.
 //
-// extraUpstreamToken is the upstream remote-session access token collected
-// by a caller-side issuer gate (today: /x/mcp's pre-dispatch ApplyIssuerGate
-// run). When non-empty it satisfies the toolset's oauth2 security scheme so
-// the downstream tool dispatch doesn't 401 when the in-toolset gate is
-// skipped. /mcp callers pass "".
+// extraUpstreamTokens are the upstream remote-session access tokens
+// collected by a caller-side issuer gate (today: /x/mcp's pre-dispatch
+// ApplyIssuerGate run), keyed by remote_session_issuer_id. When non-empty
+// they satisfy the toolset's oauth2 security schemes so the downstream tool
+// dispatch doesn't 401 when the in-toolset gate is skipped. /mcp callers
+// pass nil.
 //
 // mcpServerVariationsGroupID is the variation group resolved from the
 // mcp_servers row, when this request arrived via an mcp_endpoint that maps to
@@ -479,7 +536,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 // mcp_server and passes nil.
 //
 // The caller is responsible for closing r.Body.
-func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamToken string, mcpServerVariationsGroupID *uuid.UUID) error {
+func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]string, mcpServerVariationsGroupID *uuid.UUID) error {
 	ctx := r.Context()
 	var err error
 
@@ -519,11 +576,9 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	authToken := AuthorizationBearerToken(r)
 
 	var tokenInputs []oauthTokenInputs
-	if extraUpstreamToken != "" {
-		tokenInputs = append(tokenInputs, oauthTokenInputs{
-			securityKeys: []string{},
-			Token:        extraUpstreamToken,
-		})
+	tokenInputs, err = appendRemoteSessionTokenInputs(tokenInputs, extraUpstreamTokens)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "resolve upstream tokens for issuer-gated toolset").LogError(ctx, s.logger)
 	}
 
 	var oAuthProxyProvider *oauth_repo.OauthProxyProvider
@@ -576,16 +631,14 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		// all need to match the caller's surface, not the toolset's
 		// canonical /mcp surface.
 		endpoint := newResolvedMcpEndpointFromToolset(toolset, mcpRouteBase)
-		newCtx, gateToken, err := s.ApplyIssuerGate(ctx, w, authToken, baseURL, endpoint)
+		newCtx, gateTokens, err := s.ApplyIssuerGate(ctx, w, authToken, baseURL, endpoint)
 		if err != nil {
 			return err
 		}
 		ctx = newCtx
-		if gateToken != "" {
-			tokenInputs = append(tokenInputs, oauthTokenInputs{
-				securityKeys: []string{},
-				Token:        gateToken,
-			})
+		tokenInputs, err = appendRemoteSessionTokenInputs(tokenInputs, gateTokens)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "resolve upstream tokens for issuer-gated toolset").LogError(ctx, s.logger)
 		}
 	}
 
@@ -600,8 +653,9 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			// External OAuth server flow — collect token if present
 			if authToken != "" {
 				tokenInputs = append(tokenInputs, oauthTokenInputs{
-					securityKeys: []string{},
-					Token:        authToken,
+					securityKeys:          []string{},
+					remoteSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+					Token:                 authToken,
 				})
 			}
 		case toolset.McpIsPublic && oAuthProxyProvider != nil && oAuthProxyProvider.ProviderType == "custom":
@@ -632,8 +686,9 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 				if oauthToken != nil && !errors.Is(err, oauth.ErrExpiredAccessToken) {
 					for _, externalSecret := range oauthToken.ExternalSecrets {
 						tokenInputs = append(tokenInputs, oauthTokenInputs{
-							securityKeys: externalSecret.SecurityKeys,
-							Token:        externalSecret.Token,
+							securityKeys:          externalSecret.SecurityKeys,
+							remoteSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+							Token:                 externalSecret.Token,
 						})
 					}
 				}

--- a/server/internal/mcp/impl_internal_test.go
+++ b/server/internal/mcp/impl_internal_test.go
@@ -1,0 +1,45 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// appendRemoteSessionTokenInputs must fail closed when more than one
+// remote-session token resolves: without per-tool routing (AIS-152) it cannot
+// tell which tool needs which issuer's token, and injecting all with empty
+// securityKeys could forward the wrong bearer upstream.
+
+func TestAppendRemoteSessionTokenInputs_EmptyMapAddsNothing(t *testing.T) {
+	t.Parallel()
+
+	got, err := appendRemoteSessionTokenInputs(nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestAppendRemoteSessionTokenInputs_SingleTokenTaggedWithIssuer(t *testing.T) {
+	t.Parallel()
+
+	issuerID := uuid.New()
+	got, err := appendRemoteSessionTokenInputs(nil, map[uuid.UUID]string{issuerID: "upstream-token"})
+	require.NoError(t, err)
+	require.Equal(t, []oauthTokenInputs{{
+		securityKeys:          nil,
+		remoteSessionIssuerID: uuid.NullUUID{UUID: issuerID, Valid: true},
+		Token:                 "upstream-token",
+	}}, got)
+}
+
+func TestAppendRemoteSessionTokenInputs_MultipleTokensFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	got, err := appendRemoteSessionTokenInputs(nil, map[uuid.UUID]string{
+		uuid.New(): "token-a",
+		uuid.New(): "token-b",
+	})
+	require.Error(t, err)
+	require.Nil(t, got)
+}

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -120,23 +120,27 @@ func (s *Service) serveResolvedMCPEndpoint(
 	// gate (skipIssuerGate=true) so the same request isn't gated twice;
 	// remote-backed proxying forwards the upstream remote-session token
 	// via AuthorizationOverride.
-	var upstreamToken string
+	var upstreamTokens map[uuid.UUID]string
 	if issuerGated {
 		resolvedEndpoint, err := s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, mcpRouteBase)
 		if err != nil {
 			return err
 		}
-		newCtx, token, err := s.ApplyIssuerGate(ctx, w, AuthorizationBearerToken(r), s.BaseURLForRequest(r), resolvedEndpoint)
+		newCtx, tokens, err := s.ApplyIssuerGate(ctx, w, AuthorizationBearerToken(r), s.BaseURLForRequest(r), resolvedEndpoint)
 		if err != nil {
 			return fmt.Errorf("apply issuer gate: %w", err)
 		}
 		ctx = newCtx
 		r = r.WithContext(ctx)
-		upstreamToken = token
+		upstreamTokens = tokens
 	}
 
 	switch {
 	case mcpServer.RemoteMcpServerID.Valid:
+		upstreamToken, err := singleUpstreamToken(upstreamTokens)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "resolve upstream token for remote MCP backend").LogError(ctx, logger)
+		}
 		return s.serveRemoteBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken)
 	case mcpServer.ToolsetID.Valid:
 		// AGE-1902: toolset-backed branch still reads runtime config from the
@@ -165,7 +169,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 			mcpServerVariationsGroupID = &id
 		}
 
-		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamToken, mcpServerVariationsGroupID); err != nil {
+		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamTokens, mcpServerVariationsGroupID); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil
@@ -174,6 +178,27 @@ func (s *Service) serveResolvedMCPEndpoint(
 		// exactly one backend is set; this is defensive.
 		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").LogError(ctx, logger)
 	}
+}
+
+// singleUpstreamToken collapses the per-remote-issuer token map from
+// ApplyIssuerGate to the one Authorization value a remote MCP backend
+// forwards upstream. A remote-backed mcp_server proxies to exactly one
+// upstream, so at most one remote_session token is meaningful: the
+// remote_session_client_user_session_issuers one_per_issuer index binds a
+// user_session_issuer to a single remote issuer, so the map holds 0 or 1
+// entries. More than one token means the runtime cannot tell which upstream
+// credential the backend needs, so it fails closed rather than forwarding an
+// arbitrary (possibly mismatched) token; resolving the right token per
+// upstream is tracked in AIS-152.
+func singleUpstreamToken(tokens map[uuid.UUID]string) (string, error) {
+	if len(tokens) > 1 {
+		return "", fmt.Errorf("remote MCP backend bound to %d remote_session_issuers; cannot determine which upstream token to forward", len(tokens))
+	}
+	// len <= 1 here, so this returns the sole entry (or "" for an empty map).
+	for _, token := range tokens {
+		return token, nil
+	}
+	return "", nil
 }
 
 // ResolveMCPEndpointAndServer walks the runtime addressing chain shared by

--- a/server/internal/mcp/serveendpoint_internal_test.go
+++ b/server/internal/mcp/serveendpoint_internal_test.go
@@ -1,0 +1,40 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// singleUpstreamToken collapses the per-remote-issuer token map for the
+// single-Authorization remote-MCP backend. These cover the branches that the
+// DB-backed resolver tests cannot reach while the one_per_issuer index still
+// caps a user_session_issuer at one remote client.
+
+func TestSingleUpstreamToken_EmptyMapReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	token, err := singleUpstreamToken(nil)
+	require.NoError(t, err)
+	require.Empty(t, token)
+}
+
+func TestSingleUpstreamToken_SingleEntryReturnsToken(t *testing.T) {
+	t.Parallel()
+
+	token, err := singleUpstreamToken(map[uuid.UUID]string{uuid.New(): "upstream-token"})
+	require.NoError(t, err)
+	require.Equal(t, "upstream-token", token)
+}
+
+func TestSingleUpstreamToken_MultipleEntriesFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	token, err := singleUpstreamToken(map[uuid.UUID]string{
+		uuid.New(): "token-a",
+		uuid.New(): "token-b",
+	})
+	require.Error(t, err)
+	require.Empty(t, token)
+}

--- a/server/internal/mcp/types.go
+++ b/server/internal/mcp/types.go
@@ -76,8 +76,9 @@ func (m *McpInputs) toInternal() *mcpInputs {
 	oauthInputs := make([]oauthTokenInputs, len(m.OauthTokenInputs))
 	for i, ot := range m.OauthTokenInputs {
 		oauthInputs[i] = oauthTokenInputs{
-			securityKeys: ot.SecurityKeys,
-			Token:        ot.Token,
+			securityKeys:          ot.SecurityKeys,
+			remoteSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+			Token:                 ot.Token,
 		}
 	}
 

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -402,9 +402,11 @@ func (s *ExternalOAuthService) handleExternalAuthorize(w http.ResponseWriter, r 
 // (validated against the allowed-host list), and the user authenticating
 // against the dashboard already authorises the link.
 //
-// Requires the toolset's user_session_issuer to have exactly one bound
-// remote_session_client — the same invariant the runtime resolver enforces
-// at ResolveOneAccessToken time.
+// The toolset's user_session_issuer may bind multiple remote_session_clients
+// (one per remote_session_issuer). The optional remote_session_client_id
+// query param selects which upstream to connect; it may be omitted only when
+// exactly one client is bound. Each connect drives a single upstream OAuth
+// flow, so a multi-client issuer requires the caller to disambiguate.
 func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
@@ -459,8 +461,23 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "list remote session clients").LogError(ctx, s.logger)
 	}
-	if len(clients) != 1 {
-		return oops.E(oops.CodeInvariantViolation, nil, "issuer-gated dashboard connect requires exactly one remote_session_client, found %d", len(clients)).LogError(ctx, s.logger)
+	if len(clients) == 0 {
+		return oops.E(oops.CodeBadRequest, nil, "issuer-gated dashboard connect requires a remote_session_client, found none").LogError(ctx, s.logger)
+	}
+
+	selected := clients[0]
+	if clientIDParam := r.URL.Query().Get("remote_session_client_id"); clientIDParam != "" {
+		parsedClientID, perr := uuid.Parse(clientIDParam)
+		if perr != nil {
+			return oops.E(oops.CodeBadRequest, perr, "invalid remote_session_client_id").LogError(ctx, s.logger)
+		}
+		idx := slices.IndexFunc(clients, func(c remotesessions.Client) bool { return c.ID == parsedClientID })
+		if idx < 0 {
+			return oops.E(oops.CodeNotFound, nil, "remote_session_client not found for user session issuer").LogError(ctx, s.logger)
+		}
+		selected = clients[idx]
+	} else if len(clients) > 1 {
+		return oops.E(oops.CodeBadRequest, nil, "multiple remote_session_clients bound to user session issuer; specify remote_session_client_id").LogError(ctx, s.logger)
 	}
 
 	subject := urn.NewUserSubject(authCtx.UserID)
@@ -473,7 +490,7 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 		McpSlug:             mcpSlug,
 		FinalRedirectURI:    parsedRedirect.String(),
 	}
-	authURL, err := s.remoteChallengeMgr.BuildAuthorizationUrl(ctx, parent, clients[0])
+	authURL, err := s.remoteChallengeMgr.BuildAuthorizationUrl(ctx, parent, selected)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build authorization URL").LogError(ctx, s.logger)
 	}
@@ -750,15 +767,16 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 	return nil
 }
 
-// writeIssuerGatedStatus reports whether the dashboard user has a USABLE
-// remote_sessions row under the toolset's user_session_issuer. Mirrors the
-// runtime's ResolveOneAccessToken view: a row whose access token expired
-// without a workable refresh path resolves to "needs_auth", not
-// "authenticated" — otherwise the dashboard badge lies about a connection
-// that the next /mcp/{slug} call will 401 on.
+// writeIssuerGatedStatus reports whether the dashboard user has USABLE
+// remote_sessions under the toolset's user_session_issuer. Mirrors the
+// runtime's ResolveAccessTokens view: the badge reads "authenticated" only
+// when every bound remote_session_client resolves to a usable token. If any
+// attached session expired without a workable refresh path the resolver
+// returns ErrNoValidToken and the badge reads "needs_auth" — otherwise it
+// would lie about a connection that the next /mcp/{slug} call will 401 on.
 func (s *ExternalOAuthService) writeIssuerGatedStatus(ctx context.Context, w http.ResponseWriter, userID string, projectID, issuerID uuid.UUID) error {
 	subject := urn.NewUserSubject(userID)
-	token, err := s.remoteChallengeMgr.ResolveOneAccessToken(ctx, projectID, issuerID, subject)
+	tokens, err := s.remoteChallengeMgr.ResolveAccessTokens(ctx, projectID, issuerID, subject)
 
 	status := "needs_auth"
 	switch {
@@ -766,7 +784,7 @@ func (s *ExternalOAuthService) writeIssuerGatedStatus(ctx context.Context, w htt
 		// fall through with status="needs_auth"
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "resolve remote session").LogError(ctx, s.logger)
-	case token != "":
+	case len(tokens) > 0:
 		status = "authenticated"
 	}
 

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -27,6 +28,49 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
+
+// guardSingleClientPerRemoteIssuer enforces, at attach time, that at most one
+// active remote_session_client is bound to a given (user_session_issuer,
+// remote_session_issuer) pair through the join table. It scopes the
+// constraint per remote_session_issuer, so a user_session_issuer can bind
+// distinct clients across distinct remote issuers; the
+// remote_session_client_user_session_issuers one_per_issuer index applies a
+// stricter cap (one client per user_session_issuer regardless of remote
+// issuer) until AIS-137 removes it, after which this guard is the sole
+// attach-time enforcement.
+//
+// excludeClientID skips a row so an update of the same client passes; pass
+// uuid.Nil to exclude nothing (the create paths). Must run inside the attach
+// transaction. No database constraint enforces the per-pair uniqueness, so a
+// narrow window remains between concurrent attaches; the runtime resolver's
+// invariant (ResolveAccessTokens) is the backstop that surfaces any drift at
+// serve time.
+func (s *Service) guardSingleClientPerRemoteIssuer(
+	ctx context.Context,
+	logger *slog.Logger,
+	txRepo *repo.Queries,
+	projectID, userSessionIssuerID, remoteSessionIssuerID, excludeClientID uuid.UUID,
+) error {
+	// Two rows are enough to detect a conflict: at most one row can be
+	// excludeClientID, so a second row guarantees another client is already
+	// bound to the pair.
+	bound, err := txRepo.ListRemoteSessionClientsByProjectIDForUserSessionIssuer(ctx, repo.ListRemoteSessionClientsByProjectIDForUserSessionIssuerParams{
+		UserSessionIssuerID:   userSessionIssuerID,
+		ProjectID:             projectID,
+		RemoteSessionIssuerID: uuid.NullUUID{UUID: remoteSessionIssuerID, Valid: true},
+		Cursor:                uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		LimitValue:            2,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list remote session clients for user/remote issuer").LogError(ctx, logger)
+	}
+	for _, c := range bound {
+		if c.ID != excludeClientID {
+			return oops.E(oops.CodeConflict, nil, "a remote session client is already bound to this user session issuer for the same remote session issuer").LogError(ctx, logger)
+		}
+	}
+	return nil
+}
 
 func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.CreateRemoteSessionClientPayload) (*types.RemoteSessionClient, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -97,6 +141,10 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, logger)
+	}
+
+	if err = s.guardSingleClientPerRemoteIssuer(ctx, logger, txRepo, *authCtx.ProjectID, userIssuerID, issuerID, uuid.Nil); err != nil {
+		return nil, err
 	}
 
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
@@ -253,6 +301,10 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 			return nil, oops.E(oops.CodeNotFound, err, "user session issuer not found").LogError(ctx, logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get user session issuer").LogError(ctx, logger)
+	}
+
+	if err := s.guardSingleClientPerRemoteIssuer(ctx, logger, txRepo, *authCtx.ProjectID, userIssuerID, issuerID, uuid.Nil); err != nil {
+		return nil, err
 	}
 
 	encrypted, err := s.enc.Encrypt([]byte(clientSecret))
@@ -453,8 +505,17 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 	shouldRemakeUserSessionIssuerAttachment := payload.UserSessionIssuerID != nil && userIssuerID.Valid && userIssuerID.UUID != existing.UserSessionIssuerID
 
 	if shouldRemakeUserSessionIssuerAttachment {
-		// Deleting all attachments is a temporary measure to maintain
-		// 1:1 relationship functionality while in this opportunistic backfill phase.
+		// The new user_session_issuer must not already bind a different client
+		// for this client's remote_session_issuer. Exclude this client so a
+		// no-op re-bind passes.
+		if err = s.guardSingleClientPerRemoteIssuer(ctx, logger, txRepo, *authCtx.ProjectID, updated.UserSessionIssuerID, existing.RemoteSessionIssuerID, updated.ID); err != nil {
+			return nil, err
+		}
+
+		// Re-point the client at its new user_session_issuer by clearing its
+		// existing attachments and re-attaching, keeping a single attachment
+		// per client. AIS-138 moves the API and join-table usage to
+		// many-to-many.
 		if err = txRepo.DeleteUserSessionIssuerAttachmentsForRemoteSessionClient(
 			ctx,
 			repo.DeleteUserSessionIssuerAttachmentsForRemoteSessionClientParams{

--- a/server/internal/remotesessions/clienthandlers_test.go
+++ b/server/internal/remotesessions/clienthandlers_test.go
@@ -64,6 +64,31 @@ func TestCreateRemoteSessionClient_Manual(t *testing.T) {
 	require.Equal(t, beforeCount+1, afterCount)
 }
 
+func TestCreateRemoteSessionClient_RejectsDuplicateRemoteIssuerBinding(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	issuerID := createRemoteIssuer(t, ctx, ti, "rsc-dup", "")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-dup").String()
+
+	// First client binds (user_session_issuer, remote_session_issuer).
+	createRemoteClient(t, ctx, ti, issuerID, userIssuerID, "dup-client-1")
+
+	// Second client for the same pair must be rejected by the attach-time
+	// guard with a conflict, not a raw constraint error.
+	_, err := ti.service.CreateRemoteSessionClient(ctx, &clientsgen.CreateRemoteSessionClientPayload{
+		RemoteSessionIssuerID: issuerID,
+		UserSessionIssuerID:   userIssuerID,
+		ClientID:              "dup-client-2",
+		ClientSecret:          nil,
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+	})
+	requireOopsCode(t, err, oops.CodeConflict)
+}
+
 func TestCreateRemoteSessionClient_Manual_WithAuthMethodPost(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -10,10 +10,10 @@
 //     remote_session_client id and a subject, returns the stored
 //     upstream access token (refreshing if necessary) or empty string
 //     if no usable token exists.
-//   - ResolveOneAccessToken: the variant the MCP serving path calls.
-//     Wraps ResolveAccessToken with an inv.Check that the
-//     user_session_issuer has exactly one remote_session_client bound,
-//     and errors if not.
+//   - ResolveAccessTokens: the variant the MCP serving path calls.
+//     Resolves one upstream token per remote_session_issuer the subject
+//     has linked under the user_session_issuer, returning them as a
+//     remote_session_issuer_id -> token map.
 //
 // Refresh is invoked only when the stored access_expires_at is in the
 // past. A still-valid access token short-circuits: no upstream token
@@ -105,49 +105,78 @@ func (m *ChallengeManager) ResolveAccessToken(
 	return tok, nil
 }
 
-// ResolveOneAccessToken is the variant the MCP serving path calls.
-// It asserts via inv.Check that the user_session_issuer has exactly
-// one remote_session_client bound, and errors if not — this guards
-// against the case where someone has wired multiple clients to a
-// single issuer, which today's product config explicitly forbids and
-// which would otherwise force the resolver to arbitrarily pick a
-// binding.
+// ResolveAccessTokens is the variant the MCP serving path calls. It
+// resolves one upstream access token per remote_session_issuer the
+// subject has linked under the user_session_issuer, keyed by
+// remote_session_issuer_id, so downstream tool dispatch can forward the
+// right token per upstream.
 //
-//   - Issuer has no remote_session_clients: returns ("", nil). The
+//   - Issuer has no bound remote_session_clients: returns (nil, nil). The
 //     toolset has no remote-session requirement to satisfy.
-//   - Issuer has exactly one bound client and a usable token exists:
-//     returns the access token.
-//   - Issuer has exactly one bound client but no usable token:
-//     returns ("", ErrNoValidToken).
-//   - Issuer has more than one bound client: returns an
-//     inv.InvariantError. The MCP runtime treats this as an internal
-//     error, not a re-auth path.
-func (m *ChallengeManager) ResolveOneAccessToken(
+//   - Every bound client has a usable token: returns the
+//     remote_session_issuer_id -> token map.
+//   - Any bound client lacks a usable token: returns ErrNoValidToken. The
+//     MCP runtime surfaces this as a re-auth challenge so the user can
+//     re-link the missing upstream via {routeBase}/{slug}/connect — the
+//     "any attached remote session missing or invalid" rule from AIS-136.
+//
+// Current intent (all-or-nothing): resolution fails if ANY attached upstream
+// is missing or invalid, even when the tool the caller is about to invoke
+// only needs a different upstream. This is the safe default — the runtime
+// never dispatches a half-authorized request — and matches AIS-136's wording.
+// The cost is that one expired upstream blocks every tool on the issuer until
+// it is re-linked.
+//
+// Future intent (AIS-152): once dispatch knows which remote_session_issuer a
+// given tool requires, this can soften to challenging only when the upstream a
+// tool actually needs is missing, so an expired Slack link doesn't 401 a
+// Google-only tool call. Changing that behavior here without the per-tool
+// linkage in place would let requests through unauthorized, so it is
+// deliberately deferred to AIS-152.
+//
+// A runtime invariant asserts that no two bound clients target the same
+// remote_session_issuer. This is the application-level counterpart to the
+// attach-time guard in clienthandlers.go and keeps the map keys unambiguous.
+func (m *ChallengeManager) ResolveAccessTokens(
 	ctx context.Context,
 	projectID, userSessionIssuerID uuid.UUID,
 	subject urn.SessionSubject,
-) (string, error) {
+) (map[uuid.UUID]string, error) {
 	clients, err := m.listRemoteSessionClientRowsForUserSessionIssuer(ctx, projectID, userSessionIssuerID)
 	if err != nil {
-		return "", fmt.Errorf("list remote_session_clients: %w", err)
+		return nil, fmt.Errorf("list remote_session_clients: %w", err)
 	}
 	if len(clients) == 0 {
-		return "", nil
-	}
-	if err := inv.Check("remotesessions.ResolveOneAccessToken",
-		"single remote_session_client per user_session_issuer", len(clients) == 1,
-	); err != nil {
-		return "", fmt.Errorf("invariant: %w", err)
+		return nil, nil
 	}
 
-	tok, err := m.ResolveAccessToken(ctx, clients[0].ClientID, subject)
-	if err != nil {
-		return "", err
+	// Assert the per-(user_session_issuer, remote_session_issuer) uniqueness
+	// invariant up front, before resolving any tokens. Folding this into the
+	// token loop would let an unusable first client short-circuit with
+	// ErrNoValidToken and hide a duplicate that comes later — masking the very
+	// drift this backstop exists to surface.
+	seen := make(map[uuid.UUID]bool, len(clients))
+	for _, c := range clients {
+		if err := inv.Check("remotesessions.ResolveAccessTokens",
+			"at most one remote_session_client per (user_session_issuer, remote_session_issuer)", !seen[c.RemoteSessionIssuerID],
+		); err != nil {
+			return nil, fmt.Errorf("invariant: %w", err)
+		}
+		seen[c.RemoteSessionIssuerID] = true
 	}
-	if tok == "" {
-		return "", ErrNoValidToken
+
+	tokens := make(map[uuid.UUID]string, len(clients))
+	for _, c := range clients {
+		tok, err := m.ResolveAccessToken(ctx, c.ClientID, subject)
+		if err != nil {
+			return nil, fmt.Errorf("resolve access token: %w", err)
+		}
+		if tok == "" {
+			return nil, ErrNoValidToken
+		}
+		tokens[c.RemoteSessionIssuerID] = tok
 	}
-	return tok, nil
+	return tokens, nil
 }
 
 // validateAndRefresh returns the upstream access token for sess,

--- a/server/internal/remotesessions/tokenservice_resolve_test.go
+++ b/server/internal/remotesessions/tokenservice_resolve_test.go
@@ -1,0 +1,166 @@
+// tokenservice_resolve_test.go covers ResolveAccessTokens, the multi-client
+// MCP-runtime resolver that returns one upstream token per
+// remote_session_issuer linked to a user_session_issuer (keyed by
+// remote_session_issuer_id), and its "any attached session missing/invalid →
+// ErrNoValidToken" rule.
+//
+// The single-client happy path is the only multiplicity reachable today: the
+// remote_session_client_user_session_issuers one_per_issuer unique index still
+// caps a user_session_issuer at one client. The map-with-many-entries and the
+// per-issuer uniqueness invariant become exercisable once AIS-137 drops that
+// index.
+
+package remotesessions_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func newResolveManager(t *testing.T, conn *pgxpool.Pool, enc *encryption.Client) *remotesessions.ChallengeManager {
+	t.Helper()
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	return remotesessions.NewChallengeManager(
+		testenv.NewLogger(t),
+		conn,
+		enc,
+		policy,
+		cache.NoopCache,
+		mustURL(t, "http://localhost"),
+	)
+}
+
+// seedActiveClient creates a remote_session_issuer + remote_session_client
+// (attached to userIssuerID through the join table) and returns the client id
+// and its remote_session_issuer id.
+func seedActiveClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, userIssuerID uuid.UUID, slug string) (clientID, remoteIssuerID uuid.UUID) {
+	t.Helper()
+
+	q := repo.New(conn)
+	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         uuid.NullUUID{UUID: projectID, Valid: true},
+		Slug:                              slug,
+		Issuer:                            "https://issuer.example.com/" + slug,
+		AuthorizationEndpoint:             conv.ToPGText("https://issuer.example.com/authorize"),
+		TokenEndpoint:                     conv.ToPGText("https://issuer.example.com/token"),
+		RegistrationEndpoint:              pgtype.Text{String: "", Valid: false},
+		JwksUri:                           pgtype.Text{String: "", Valid: false},
+		ScopesSupported:                   []string{"openid"},
+		GrantTypesSupported:               []string{"authorization_code"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_post"},
+		Oidc:                              false,
+		Passthrough:                       false,
+	})
+	require.NoError(t, err)
+
+	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
+		ProjectID:               conv.ToNullUUID(projectID),
+		RemoteSessionIssuerID:   issuer.ID,
+		UserSessionIssuerID:     userIssuerID,
+		ClientID:                "cid-" + slug,
+		ClientSecretEncrypted:   pgtype.Text{String: "", Valid: false},
+		ClientIDIssuedAt:        conv.ToPGTimestamptz(time.Now()),
+		ClientSecretExpiresAt:   pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},
+		TokenEndpointAuthMethod: conv.ToPGText("client_secret_post"),
+		Scope:                   nil,
+		Audience:                pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	err = q.AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: client.ID,
+		UserSessionIssuerID:   userIssuerID,
+	})
+	require.NoError(t, err)
+
+	return client.ID, issuer.ID
+}
+
+func TestResolveAccessTokens_SingleClientHappyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	enc := testenv.NewEncryptionClient(t)
+	mgr := newResolveManager(t, ti.conn, enc)
+
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-resolve-happy")
+	clientID, remoteIssuerID := seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, "rsi-resolve-happy")
+
+	subject := urn.NewUserSubject("resolve-happy-subject")
+	accessEnc, err := enc.Encrypt([]byte("upstream-access-token"))
+	require.NoError(t, err)
+	_, err = repo.New(ti.conn).InsertRemoteSession(ctx, repo.InsertRemoteSessionParams{
+		SubjectUrn:            subject,
+		UserSessionIssuerID:   userIssuerID,
+		RemoteSessionClientID: clientID,
+		AccessTokenEncrypted:  accessEnc,
+		AccessExpiresAt:       pgtype.Timestamptz{Time: time.Now().Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, userIssuerID, subject)
+	require.NoError(t, err)
+	require.Equal(t, map[uuid.UUID]string{remoteIssuerID: "upstream-access-token"}, tokens)
+}
+
+func TestResolveAccessTokens_NoClientsReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mgr := newResolveManager(t, ti.conn, testenv.NewEncryptionClient(t))
+
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-resolve-empty")
+	subject := urn.NewUserSubject("resolve-empty-subject")
+
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, userIssuerID, subject)
+	require.NoError(t, err)
+	require.Nil(t, tokens)
+}
+
+func TestResolveAccessTokens_MissingSessionReturnsErrNoValidToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mgr := newResolveManager(t, ti.conn, testenv.NewEncryptionClient(t))
+
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-resolve-missing")
+	// Client bound, but the subject has never linked an upstream session.
+	seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, "rsi-resolve-missing")
+
+	subject := urn.NewUserSubject("resolve-missing-subject")
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, userIssuerID, subject)
+	require.ErrorIs(t, err, remotesessions.ErrNoValidToken)
+	require.Nil(t, tokens)
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-136/runtime-multi-client-routing-attach-time-guard-remove-drift-detection

Replace `ResolveOneAccessToken` (and its `len==1` invariant) with `ResolveAccessTokens`, which returns a `remote_session_issuer_id -> token` map for the subject and re-auths when any attached remote session is missing or invalid. `ApplyIssuerGate` returns the map; tool dispatch threads each token's `remote_session_issuer_id` (per-tool routing deferred to AIS-152). The remote-MCP backend fails closed when more than one upstream token resolves.

Enforce at most one client per `(user_session_issuer, remote_session_issuer)` at attach time via an application-level guard plus a runtime invariant, replacing the database `one_per_issuer` index that AIS-137 will drop. Update the dashboard issuer-connect and status handlers for multiple clients.

Application code only; safe to deploy before AIS-137 drops the index.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime multi-client routing by resolving one upstream token per remote issuer and tagging tokens with their `remote_session_issuer_id` for future per-tool selection. Enforces a single client per (user_session_issuer, remote_session_issuer) at attach time and issues an all-or-nothing re-auth when any attached session is missing or invalid, aligning with AIS-136.

- **New Features**
  - Replaced the single-token resolver with a per-issuer token map; `ApplyIssuerGate` returns tokens keyed by `remote_session_issuer_id` and challenges re-auth when any attached session is missing or invalid.
  - Added an attach-time guard and a runtime invariant to allow many clients across different remote issuers but at most one per (user_session_issuer, remote_session_issuer).
  - Remote MCP backend collapses to one Authorization token and fails closed if multiple tokens resolve; issuer-gated toolset dispatch also fails closed until per-tool routing lands (AIS-152).
  - Tool dispatch tags tokens with `remote_session_issuer_id` for future per-tool routing (AIS-152).
  - Dashboard `issuer-connect` accepts `remote_session_client_id` to select which upstream to link when multiple clients exist; `status` reports authenticated only when all attached sessions are usable.

- **Migration**
  - Safe to deploy before AIS-137 drops the `one_per_issuer` index; no DB migration needed.
  - When multiple clients are bound, callers must include `remote_session_client_id` on issuer-gated connect URLs.

<sup>Written for commit 8ebafffa6f43948b2fd4a759e4302405f23c8fdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

