### PR TITLE
feat(assistants): GKE Agent Sandbox runtime backend alongside Fly

### DIFF
--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -39,10 +39,11 @@ enum Mode {
         #[arg(long, default_value = "0.0.0.0:8081", env = "GRAM_RUNNER_ADDR")]
         addr: SocketAddr,
 
-        /// The assistant id this VM serves. Stamped into /state for the
-        /// reaper's belt-and-suspenders identity check.
+        /// The assistant id this VM serves, stamped into /state. Optional: a
+        /// generic warm-pool sandbox boots without it and learns it from the
+        /// first turn instead (see ThreadTurnRequest.assistant_id).
         #[arg(long, env = "GRAM_ASSISTANT_ID")]
-        assistant_id: String,
+        assistant_id: Option<String>,
 
         /// Base URL of the management API the runner calls back into for
         /// bootstrap, completions, and MCP traffic.

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -1,6 +1,6 @@
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use agentkit_adapter_completions::CompletionsAdapter;
@@ -58,7 +58,11 @@ pub type AppState = Arc<RuntimeHost>;
 
 /// Singleton host shared by every per-thread task on the VM.
 pub struct RuntimeHost {
-    pub assistant_id: String,
+    /// The assistant this VM serves, surfaced in /state. Set from the
+    /// GRAM_ASSISTANT_ID boot env when present (Fly, GKE cold-start), or
+    /// stamped by the first turn that carries one (GKE warm-pool sandbox).
+    /// Set-once: boot env wins.
+    pub assistant_id: OnceLock<String>,
     pub started_at: Instant,
     /// Per-idempotency-key admission slot. The bool tracks whether the
     /// keyed turn has actually been enqueued: holding the mutex covers
@@ -118,7 +122,7 @@ impl ConfiguredThread {
 }
 
 pub async fn build_host(
-    assistant_id: String,
+    assistant_id: Option<String>,
     server_url: String,
     initial_token: String,
     thread_idle_ttl: Duration,
@@ -138,8 +142,12 @@ pub async fn build_host(
 
     let gram_client =
         GramBootstrapClient::new(server_url, build_bootstrap_client(http_client.clone()));
+    let assistant_id_cell = OnceLock::new();
+    if let Some(id) = assistant_id {
+        let _ = assistant_id_cell.set(id);
+    }
     let host = Arc::new(RuntimeHost {
-        assistant_id,
+        assistant_id: assistant_id_cell,
         started_at: Instant::now(),
         seen: DashMap::new(),
         threads: DashMap::new(),
@@ -752,8 +760,10 @@ mod tests {
             "http://localhost".to_string(),
             build_bootstrap_client(http_client.clone()),
         );
+        let assistant_id = OnceLock::new();
+        let _ = assistant_id.set("asst".to_string());
         Arc::new(RuntimeHost {
-            assistant_id: "asst".to_string(),
+            assistant_id,
             started_at: Instant::now(),
             seen: DashMap::new(),
             threads: DashMap::new(),

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -143,7 +143,9 @@ pub async fn build_host(
     let gram_client =
         GramBootstrapClient::new(server_url, build_bootstrap_client(http_client.clone()));
     let assistant_id_cell = OnceLock::new();
-    if let Some(id) = assistant_id {
+    // Ignore an empty/whitespace boot env so warm-pool pods stay unbound and
+    // can learn their assistant from the first turn.
+    if let Some(id) = assistant_id.filter(|id| !id.trim().is_empty()) {
         let _ = assistant_id_cell.set(id);
     }
     let host = Arc::new(RuntimeHost {

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -17,7 +17,7 @@ use crate::wire::{RunnerStateResponse, ThreadStateView, ThreadTurnRequest, Threa
 
 pub struct ServeConfig {
     pub addr: SocketAddr,
-    pub assistant_id: String,
+    pub assistant_id: Option<String>,
     pub server_url: String,
     pub initial_token: String,
 }
@@ -57,7 +57,7 @@ async fn healthz() -> &'static str {
 async fn state_handler(State(host): State<AppState>) -> Json<RunnerStateResponse> {
     let snapshot = snapshot_threads(&host);
     Json(RunnerStateResponse {
-        assistant_id: host.assistant_id.clone(),
+        assistant_id: host.assistant_id.get().cloned().unwrap_or_default(),
         uptime_seconds: host.started_at.elapsed().as_secs(),
         threads: snapshot
             .into_iter()
@@ -78,6 +78,12 @@ async fn thread_turn(
 ) -> Result<Json<ThreadTurnResponse>, (StatusCode, String)> {
     if thread_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "missing thread_id".to_string()));
+    }
+
+    // A warm-pool sandbox boots without GRAM_ASSISTANT_ID; the first turn that
+    // carries one stamps it for /state. Set-once, so a boot env value wins.
+    if let Some(assistant_id) = &request.assistant_id {
+        let _ = host.assistant_id.set(assistant_id.clone());
     }
 
     // Idempotency key is namespaced by thread so two threads sharing an

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -80,12 +80,6 @@ async fn thread_turn(
         return Err((StatusCode::BAD_REQUEST, "missing thread_id".to_string()));
     }
 
-    // A warm-pool sandbox boots without GRAM_ASSISTANT_ID; the first turn that
-    // carries one stamps it for /state. Set-once, so a boot env value wins.
-    if let Some(assistant_id) = &request.assistant_id {
-        let _ = host.assistant_id.set(assistant_id.clone());
-    }
-
     // Idempotency key is namespaced by thread so two threads sharing an
     // event_id namespace can't collide.
     let idempotency_key = headers
@@ -118,6 +112,19 @@ async fn thread_turn(
     let thread = ensure_thread(&host, &thread_id, request.auth_token)
         .await
         .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
+
+    // A warm-pool sandbox boots without GRAM_ASSISTANT_ID and learns its
+    // assistant from the first turn that carries one. Bind it only after
+    // bootstrap succeeds (so a failed turn can't poison the pod's identity) and
+    // never from an empty/whitespace id. Set-once: a boot env value wins.
+    if let Some(assistant_id) = request
+        .assistant_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        let _ = host.assistant_id.set(assistant_id.to_string());
+    }
 
     thread
         .enqueue(request.input)

--- a/agents/runner/src/wire.rs
+++ b/agents/runner/src/wire.rs
@@ -21,6 +21,11 @@ pub struct ThreadTurnRequest {
     pub input: String,
     #[serde(default)]
     pub auth_token: Option<String>,
+    /// Identity for a runner that booted without `GRAM_ASSISTANT_ID` — i.e. a
+    /// generic warm-pool sandbox that learns which assistant it serves from
+    /// the first turn. Ignored once the boot env has set it (env wins).
+    #[serde(default)]
+    pub assistant_id: Option<String>,
 }
 
 /// 202-style ack returned by `/threads/{thread_id}/turn`. The actual turn

--- a/agents/runtime-image/init.sh
+++ b/agents/runtime-image/init.sh
@@ -2,19 +2,27 @@
 
 set -euo pipefail
 
-workdir_mount=/var/lib/gram-assistant/work
+workdir=/var/lib/gram-assistant/work
 sandbox_src=/usr/share/gram/sandbox
-mkdir -p "$workdir_mount"
-mount -t tmpfs -o size=256m,mode=0755 tmpfs "$workdir_mount"
-for dep in browser.ts package.json node_modules; do
-  src="$sandbox_src/$dep"
-  dst="$workdir_mount/$dep"
-  [ -e "$src" ] || continue
-  # The bind target must exist inside the tmpfs first.
-  if [ -d "$src" ]; then mkdir -p "$dst"; else : >"$dst"; fi
-  mount --bind "$src" "$dst"
-  mount -o remount,bind,ro "$dst"
-done
+mkdir -p "$workdir"
+
+# Size-capped tmpfs + read-only bind-mounted deps where mount(2) is permitted;
+# symlink the deps where it is not (the platform supplies the writable workdir).
+if mount -t tmpfs -o size=256m,mode=0755 tmpfs "$workdir" 2>/dev/null; then
+  for dep in browser.ts package.json node_modules; do
+    src="$sandbox_src/$dep"
+    dst="$workdir/$dep"
+    [ -e "$src" ] || continue
+    if [ -d "$src" ]; then mkdir -p "$dst"; else : >"$dst"; fi
+    mount --bind "$src" "$dst"
+    mount -o remount,bind,ro "$dst"
+  done
+else
+  for dep in browser.ts package.json node_modules; do
+    [ -e "$sandbox_src/$dep" ] || continue
+    ln -sfn "$sandbox_src/$dep" "$workdir/$dep"
+  done
+fi
 
 /usr/local/bin/lightpanda-supervise &
 

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -281,6 +281,8 @@ linters:
         - '^k8s.io/apimachinery/pkg/apis/meta/v1\..+$'
         - '^k8s.io/api/networking/v1\..+$'
         - '^sigs.k8s.io/gateway-api/apis/v1\..+$'
+        - '^k8s.io/client-go/rest\.Config$'
+        - '^k8s.io/client-go/rest\.TLSClientConfig$'
         - '^github.com/posthog/posthog-go\..+$'
         - '^github\.com/speakeasy-api/openapi/.*'
         - '^github\.com/polarsource/polar-go/.*'

--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -121,12 +121,20 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 		gkeNamespace = "gram-" + c.String("environment")
 	}
 
+	// tokens.Parse returns a non-nil value even for an empty string, so guard on
+	// the raw flag: a GKE-only deployment leaves the Fly token unset and must not
+	// have the Fly backend (and its validation) forced on.
+	var flyTokens *tokens.Tokens
+	if raw := c.String("assistant-runtime-flyio-api-token"); raw != "" {
+		flyTokens = tokens.Parse(raw)
+	}
+
 	return assistants.RuntimeBackendConfig{
 		Provider: provider,
 		Fly: assistants.FlyRuntimeConfig{
 			ServiceName:        "gram",
 			ServiceVersion:     GitSHA,
-			FlyTokens:          tokens.Parse(c.String("assistant-runtime-flyio-api-token")),
+			FlyTokens:          flyTokens,
 			FlyAPIURL:          "",
 			FlyMachinesBaseURL: "",
 			DefaultFlyOrg:      c.String("assistant-runtime-flyio-org"),
@@ -172,10 +180,12 @@ func newAssistantRuntime(
 		return nil, err
 	}
 
-	// The GKE backend reaches Agent Sandbox through the in-cluster kubernetes
-	// API. InitializeK8sClient is a singleton and returns nil clients in local
-	// env, where GKE is unsupported — GKERuntimeConfig.Validate rejects that.
-	if cfg.Provider == assistants.RuntimeProviderGKE {
+	// Build the GKE backend whenever it is configured (a warm pool is set), not
+	// only when it is the target: a fly-target process must still reach Agent
+	// Sandbox to reap gke-backed runtime rows (and vice versa). InitializeK8sClient
+	// is a singleton that returns nil clients in local env, where GKE is
+	// unsupported — leaving Dynamic nil so the backend is skipped.
+	if cfg.GKE.WarmPool != "" {
 		k8sClients, err := k8s.InitializeK8sClient(ctx, logger, c.String("environment"), false)
 		if err != nil {
 			return nil, fmt.Errorf("initialize kubernetes client for gke assistant runtime: %w", err)

--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -2,6 +2,7 @@ package gram
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -37,9 +38,19 @@ var assistantRuntimeFlags = []cli.Flag{
 		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_NAMESPACE"},
 	},
 	&cli.StringFlag{
-		Name:    "assistant-runtime-gke-warm-pool",
-		Usage:   "SandboxWarmPool name that GKE assistant runtime claims check out from.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_WARM_POOL"},
+		Name:    "assistant-runtime-gke-sandbox-template",
+		Usage:   "SandboxTemplate name that GKE assistant runtime claims reference (a SandboxWarmPool on the same template pre-warms pods).",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_SANDBOX_TEMPLATE"},
+	},
+	&cli.StringFlag{
+		Name:    "assistant-runtime-gke-cluster-endpoint",
+		Usage:   "API endpoint (host or IP) of the assistant runtime cluster. Setting this enables the GKE backend.",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_CLUSTER_ENDPOINT"},
+	},
+	&cli.StringFlag{
+		Name:    "assistant-runtime-gke-cluster-ca",
+		Usage:   "Base64-encoded CA certificate of the assistant runtime cluster.",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_CLUSTER_CA"},
 	},
 	&cli.StringFlag{
 		Name:    "assistant-runtime-server-url",
@@ -148,19 +159,17 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 			OTLPHeaders:        c.String("assistant-runtime-otlp-headers"),
 			Environment:        c.String("environment"),
 		},
-		// Dynamic is injected in newAssistantRuntime from the in-cluster
-		// kubernetes client — it is not available from the CLI context alone.
-		// Dynamic is injected in newAssistantRuntime from the in-cluster
-		// kubernetes client; the egress-controlled HTTP client is built from
-		// the guardian policy in assistants.NewRuntimeBackend.
+		// Dynamic is injected in newAssistantRuntime from a remote client for the
+		// assistant cluster (k8s.NewRemoteDynamicClient); the egress-controlled
+		// HTTP client is built from the guardian policy in NewRuntimeBackend.
 		GKE: assistants.GKERuntimeConfig{
-			Dynamic:   nil,
-			Namespace: gkeNamespace,
-			WarmPool:  c.String("assistant-runtime-gke-warm-pool"),
-			GuestPort: 0,
-			OCIImage:  c.String("assistant-runtime-oci-image"),
-			ImageTag:  AssistantRuntimeImageHash,
-			ServerURL: resolvedServerURL,
+			Dynamic:         nil,
+			Namespace:       gkeNamespace,
+			SandboxTemplate: c.String("assistant-runtime-gke-sandbox-template"),
+			GuestPort:       0,
+			OCIImage:        c.String("assistant-runtime-oci-image"),
+			ImageTag:        AssistantRuntimeImageHash,
+			ServerURL:       resolvedServerURL,
 		},
 	}, nil
 }
@@ -180,17 +189,21 @@ func newAssistantRuntime(
 		return nil, err
 	}
 
-	// Build the GKE backend whenever it is configured (a warm pool is set), not
-	// only when it is the target: a fly-target process must still reach Agent
-	// Sandbox to reap gke-backed runtime rows (and vice versa). InitializeK8sClient
-	// is a singleton that returns nil clients in local env, where GKE is
-	// unsupported — leaving Dynamic nil so the backend is skipped.
-	if cfg.GKE.WarmPool != "" {
-		k8sClients, err := k8s.InitializeK8sClient(ctx, logger, c.String("environment"), false)
+	// Build the GKE backend whenever an assistant cluster is configured (its
+	// endpoint is set), not only when it is the target: a fly-target process must
+	// still reach the assistant cluster to reap gke-backed runtime rows (and vice
+	// versa). The client authenticates with the process's Google credentials
+	// (workload identity in-cluster, ADC locally) against the separate cluster.
+	if endpoint := c.String("assistant-runtime-gke-cluster-endpoint"); endpoint != "" {
+		caCert, err := base64.StdEncoding.DecodeString(c.String("assistant-runtime-gke-cluster-ca"))
 		if err != nil {
-			return nil, fmt.Errorf("initialize kubernetes client for gke assistant runtime: %w", err)
+			return nil, fmt.Errorf("decode --assistant-runtime-gke-cluster-ca: %w", err)
 		}
-		cfg.GKE.Dynamic = k8sClients.DynamicClient
+		dynamicClient, err := k8s.NewRemoteDynamicClient(ctx, endpoint, caCert)
+		if err != nil {
+			return nil, fmt.Errorf("build assistant cluster client: %w", err)
+		}
+		cfg.GKE.Dynamic = dynamicClient
 	}
 
 	// Fly and GKE call back to the server at the same URL; validate it once.

--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -52,6 +52,11 @@ var assistantRuntimeFlags = []cli.Flag{
 		Usage:   "Base64-encoded CA certificate of the assistant runtime cluster.",
 		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_CLUSTER_CA"},
 	},
+	&cli.StringSliceFlag{
+		Name:    "assistant-runtime-gke-runner-cidr",
+		Usage:   "Pod CIDR(s) the assistant runner pods are reachable on. The server dials runners by pod IP, so these are allowlisted past the guardian egress policy (which blocks RFC1918 by default).",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_RUNNER_CIDR"},
+	},
 	&cli.StringFlag{
 		Name:    "assistant-runtime-server-url",
 		Usage:   "Optional host-reachable server base URL for assistant runtimes. Defaults to --server-url.",
@@ -163,13 +168,14 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 		// assistant cluster (k8s.NewRemoteDynamicClient); the egress-controlled
 		// HTTP client is built from the guardian policy in NewRuntimeBackend.
 		GKE: assistants.GKERuntimeConfig{
-			Dynamic:         nil,
-			Namespace:       gkeNamespace,
-			SandboxTemplate: c.String("assistant-runtime-gke-sandbox-template"),
-			GuestPort:       0,
-			OCIImage:        c.String("assistant-runtime-oci-image"),
-			ImageTag:        AssistantRuntimeImageHash,
-			ServerURL:       resolvedServerURL,
+			Dynamic:          nil,
+			Namespace:        gkeNamespace,
+			SandboxTemplate:  c.String("assistant-runtime-gke-sandbox-template"),
+			GuestPort:        0,
+			OCIImage:         c.String("assistant-runtime-oci-image"),
+			ImageTag:         AssistantRuntimeImageHash,
+			ServerURL:        resolvedServerURL,
+			RunnerCIDRBlocks: c.StringSlice("assistant-runtime-gke-runner-cidr"),
 		},
 	}, nil
 }

--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -13,22 +13,33 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/assistants"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/k8s"
 )
 
 var assistantRuntimeFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "assistant-runtime-provider",
-		Usage:   "Assistant runtime provider. Allowed values: flyio.",
+		Usage:   "Assistant runtime provider. Allowed values: flyio, gke.",
 		Value:   assistants.RuntimeProviderFlyIO,
 		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_PROVIDER"},
 		Action: func(_ *cli.Context, val string) error {
 			switch val {
-			case "", assistants.RuntimeProviderFlyIO:
+			case "", assistants.RuntimeProviderFlyIO, assistants.RuntimeProviderGKE:
 				return nil
 			default:
 				return fmt.Errorf("invalid assistant runtime provider: %s", val)
 			}
 		},
+	},
+	&cli.StringFlag{
+		Name:    "assistant-runtime-gke-namespace",
+		Usage:   "Kubernetes namespace for GKE Agent Sandbox assistant runtimes. Defaults to gram-{environment}.",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_NAMESPACE"},
+	},
+	&cli.StringFlag{
+		Name:    "assistant-runtime-gke-warm-pool",
+		Usage:   "SandboxWarmPool name that GKE assistant runtime claims check out from.",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_WARM_POOL"},
 	},
 	&cli.StringFlag{
 		Name:    "assistant-runtime-server-url",
@@ -97,11 +108,17 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 	}
 
 	provider := c.String("assistant-runtime-provider")
-	if provider == "" {
+	switch provider {
+	case "", assistants.RuntimeProviderFlyIO:
 		provider = assistants.RuntimeProviderFlyIO
-	}
-	if provider != assistants.RuntimeProviderFlyIO {
+	case assistants.RuntimeProviderGKE:
+	default:
 		return assistants.RuntimeBackendConfig{}, fmt.Errorf("invalid assistant runtime provider: %s", provider)
+	}
+
+	gkeNamespace := c.String("assistant-runtime-gke-namespace")
+	if gkeNamespace == "" {
+		gkeNamespace = "gram-" + c.String("environment")
 	}
 
 	return assistants.RuntimeBackendConfig{
@@ -123,6 +140,20 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 			OTLPHeaders:        c.String("assistant-runtime-otlp-headers"),
 			Environment:        c.String("environment"),
 		},
+		// Dynamic is injected in newAssistantRuntime from the in-cluster
+		// kubernetes client — it is not available from the CLI context alone.
+		// Dynamic is injected in newAssistantRuntime from the in-cluster
+		// kubernetes client; the egress-controlled HTTP client is built from
+		// the guardian policy in assistants.NewRuntimeBackend.
+		GKE: assistants.GKERuntimeConfig{
+			Dynamic:   nil,
+			Namespace: gkeNamespace,
+			WarmPool:  c.String("assistant-runtime-gke-warm-pool"),
+			GuestPort: 0,
+			OCIImage:  c.String("assistant-runtime-oci-image"),
+			ImageTag:  AssistantRuntimeImageHash,
+			ServerURL: resolvedServerURL,
+		},
 	}, nil
 }
 
@@ -140,11 +171,26 @@ func newAssistantRuntime(
 	if err != nil {
 		return nil, err
 	}
-	if err := cfg.Fly.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid fly assistant runtime config: %w", err)
+
+	// The GKE backend reaches Agent Sandbox through the in-cluster kubernetes
+	// API. InitializeK8sClient is a singleton and returns nil clients in local
+	// env, where GKE is unsupported — GKERuntimeConfig.Validate rejects that.
+	if cfg.Provider == assistants.RuntimeProviderGKE {
+		k8sClients, err := k8s.InitializeK8sClient(ctx, logger, c.String("environment"), false)
+		if err != nil {
+			return nil, fmt.Errorf("initialize kubernetes client for gke assistant runtime: %w", err)
+		}
+		cfg.GKE.Dynamic = k8sClients.DynamicClient
 	}
+
+	// Fly and GKE call back to the server at the same URL; validate it once.
 	if err := guardianPolicy.ValidateHost(ctx, cfg.Fly.ServerURL.Hostname()); err != nil {
-		return nil, fmt.Errorf("assistant fly runtime requires a public --assistant-runtime-server-url or --server-url; got %q: %w", cfg.Fly.ServerURL.String(), err)
+		return nil, fmt.Errorf("assistant runtime requires a public --assistant-runtime-server-url or --server-url; got %q: %w", cfg.Fly.ServerURL.String(), err)
 	}
-	return assistants.NewRuntimeBackend(logger, tracerProvider, guardianPolicy, cfg), nil
+
+	backend, err := assistants.NewRuntimeBackend(logger, tracerProvider, guardianPolicy, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build assistant runtime backend: %w", err)
+	}
+	return backend, nil
 }

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -759,35 +759,49 @@ WHERE assistant_id = @assistant_id
   AND backend_metadata_json <> '{}'::jsonb;
 
 -- name: ListInactiveAssistantRuntimesForReap :many
--- Returns runtime rows that still carry backend metadata, are no longer
--- supposed to have a backend app, and whose owning assistant has had no
--- runtime activity since @inactive_before — orphans whose Stop/Reap never
--- completed. A row qualifies when it is finalized (soft-deleted or ended;
--- the state value is intentionally ignored since a tombstone can carry any
--- state, e.g. one stamped by a racing turn) or when its owning assistant is
--- soft-deleted (delete paths reap best-effort and rely on this janitor as
--- the safety net). A live row under a live assistant is never a candidate:
--- an idle runtime keeps its VM until the assistant is deleted.
+-- Returns runtime rows that still carry backend metadata and are safe to
+-- collect, in two cases:
+--   1. Orphans: finalized (soft-deleted or ended; the state value is ignored
+--      since a tombstone can carry any state, e.g. one stamped by a racing
+--      turn) or under a soft-deleted assistant, whose owning assistant has had
+--      no runtime activity since @inactive_before — i.e. Stop/Reap never
+--      completed. A live row under a live assistant is never an orphan: an
+--      idle runtime keeps its VM until the assistant is deleted.
+--   2. Superseded backend: a row on a backend the process no longer targets
+--      (backend <> @target_backend), parked at @stopped_state after its warm
+--      window. Collecting it frees the deprecated backend's resources so the
+--      next admit lands on the target backend. Active/starting/expiring rows
+--      are left to finish, so a live assistant is never disrupted mid-turn.
 SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
 FROM assistant_runtimes r
 WHERE r.backend_metadata_json <> '{}'::jsonb
   AND (
-    r.deleted IS TRUE
-    OR r.ended IS TRUE
-    OR EXISTS (
-      SELECT 1
-      FROM assistants a
-      WHERE a.id = r.assistant_id
-        AND a.project_id = r.project_id
-        AND a.deleted IS TRUE
+    (
+      (
+        r.deleted IS TRUE
+        OR r.ended IS TRUE
+        OR EXISTS (
+          SELECT 1
+          FROM assistants a
+          WHERE a.id = r.assistant_id
+            AND a.project_id = r.project_id
+            AND a.deleted IS TRUE
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM assistant_runtimes r2
+        WHERE r2.assistant_id = r.assistant_id
+          AND r2.updated_at >= @inactive_before
+          AND r2.backend_metadata_json <> '{}'::jsonb
+      )
     )
-  )
-  AND NOT EXISTS (
-    SELECT 1
-    FROM assistant_runtimes r2
-    WHERE r2.assistant_id = r.assistant_id
-      AND r2.updated_at >= @inactive_before
-      AND r2.backend_metadata_json <> '{}'::jsonb
+    OR (
+      r.backend <> @target_backend
+      AND r.deleted IS NOT TRUE
+      AND r.ended IS NOT TRUE
+      AND r.state = @stopped_state
+    )
   )
 ORDER BY r.updated_at ASC
 LIMIT @limit_count;

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1459,29 +1459,41 @@ SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.b
 FROM assistant_runtimes r
 WHERE r.backend_metadata_json <> '{}'::jsonb
   AND (
-    r.deleted IS TRUE
-    OR r.ended IS TRUE
-    OR EXISTS (
-      SELECT 1
-      FROM assistants a
-      WHERE a.id = r.assistant_id
-        AND a.project_id = r.project_id
-        AND a.deleted IS TRUE
+    (
+      (
+        r.deleted IS TRUE
+        OR r.ended IS TRUE
+        OR EXISTS (
+          SELECT 1
+          FROM assistants a
+          WHERE a.id = r.assistant_id
+            AND a.project_id = r.project_id
+            AND a.deleted IS TRUE
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM assistant_runtimes r2
+        WHERE r2.assistant_id = r.assistant_id
+          AND r2.updated_at >= $1
+          AND r2.backend_metadata_json <> '{}'::jsonb
+      )
+    )
+    OR (
+      r.backend <> $2
+      AND r.deleted IS NOT TRUE
+      AND r.ended IS NOT TRUE
+      AND r.state = $3
     )
   )
-  AND NOT EXISTS (
-    SELECT 1
-    FROM assistant_runtimes r2
-    WHERE r2.assistant_id = r.assistant_id
-      AND r2.updated_at >= $1
-      AND r2.backend_metadata_json <> '{}'::jsonb
-  )
 ORDER BY r.updated_at ASC
-LIMIT $2
+LIMIT $4
 `
 
 type ListInactiveAssistantRuntimesForReapParams struct {
 	InactiveBefore pgtype.Timestamptz
+	TargetBackend  string
+	StoppedState   string
 	LimitCount     int32
 }
 
@@ -1496,17 +1508,26 @@ type ListInactiveAssistantRuntimesForReapRow struct {
 	WarmUntil           pgtype.Timestamptz
 }
 
-// Returns runtime rows that still carry backend metadata, are no longer
-// supposed to have a backend app, and whose owning assistant has had no
-// runtime activity since @inactive_before — orphans whose Stop/Reap never
-// completed. A row qualifies when it is finalized (soft-deleted or ended;
-// the state value is intentionally ignored since a tombstone can carry any
-// state, e.g. one stamped by a racing turn) or when its owning assistant is
-// soft-deleted (delete paths reap best-effort and rely on this janitor as
-// the safety net). A live row under a live assistant is never a candidate:
-// an idle runtime keeps its VM until the assistant is deleted.
+// Returns runtime rows that still carry backend metadata and are safe to
+// collect, in two cases:
+//  1. Orphans: finalized (soft-deleted or ended; the state value is ignored
+//     since a tombstone can carry any state, e.g. one stamped by a racing
+//     turn) or under a soft-deleted assistant, whose owning assistant has had
+//     no runtime activity since @inactive_before — i.e. Stop/Reap never
+//     completed. A live row under a live assistant is never an orphan: an
+//     idle runtime keeps its VM until the assistant is deleted.
+//  2. Superseded backend: a row on a backend the process no longer targets
+//     (backend <> @target_backend), parked at @stopped_state after its warm
+//     window. Collecting it frees the deprecated backend's resources so the
+//     next admit lands on the target backend. Active/starting/expiring rows
+//     are left to finish, so a live assistant is never disrupted mid-turn.
 func (q *Queries) ListInactiveAssistantRuntimesForReap(ctx context.Context, arg ListInactiveAssistantRuntimesForReapParams) ([]ListInactiveAssistantRuntimesForReapRow, error) {
-	rows, err := q.db.Query(ctx, listInactiveAssistantRuntimesForReap, arg.InactiveBefore, arg.LimitCount)
+	rows, err := q.db.Query(ctx, listInactiveAssistantRuntimesForReap,
+		arg.InactiveBefore,
+		arg.TargetBackend,
+		arg.StoppedState,
+		arg.LimitCount,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -86,12 +86,11 @@ type runtimeToolCall struct {
 type runtimeTurnRequest struct {
 	Input     string `json:"input"`
 	AuthToken string `json:"auth_token,omitempty"`
-	// AssistantID and ProjectID let a runner that booted without
-	// GRAM_ASSISTANT_ID / GRAM_ASSISTANT_PROJECT_ID env (e.g. a generic
-	// warm-pool sandbox on GKE) learn its identity from the turn. Boot env
-	// wins when present, so these are harmless and unused on Fly.
+	// AssistantID lets a runner that booted without GRAM_ASSISTANT_ID env
+	// (e.g. a generic warm-pool sandbox on GKE) learn which assistant it serves
+	// from the turn. Boot env wins when present, so it is harmless and unused
+	// on Fly.
 	AssistantID string `json:"assistant_id,omitempty"`
-	ProjectID   string `json:"project_id,omitempty"`
 }
 
 type runtimeHTTPRequest struct {

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -4,11 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/chat"
 )
+
+// runtimeHTTPDoer is the HTTP surface both backends use to reach the in-pod
+// runner. Production builds it from the guardian egress policy; tests inject a
+// plain client.
+type runtimeHTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
 
 // defaultRuntimeGuestPort is the HTTP port the runner listens on inside a
 // guest VM. Backends use it when wiring service ports on freshly launched
@@ -78,6 +86,12 @@ type runtimeToolCall struct {
 type runtimeTurnRequest struct {
 	Input     string `json:"input"`
 	AuthToken string `json:"auth_token,omitempty"`
+	// AssistantID and ProjectID let a runner that booted without
+	// GRAM_ASSISTANT_ID / GRAM_ASSISTANT_PROJECT_ID env (e.g. a generic
+	// warm-pool sandbox on GKE) learn its identity from the turn. Boot env
+	// wins when present, so these are harmless and unused on Fly.
+	AssistantID string `json:"assistant_id,omitempty"`
+	ProjectID   string `json:"project_id,omitempty"`
 }
 
 type runtimeHTTPRequest struct {

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -25,6 +25,14 @@ type RuntimeBackend interface {
 	// machines with, in the "<repo>:<tag>" form. Stable for the lifetime
 	// of the process — the tag is stamped at build time.
 	ImageRef() string
+	// ReusesIdleRuntimes reports whether a stopped runtime's resources are
+	// kept for warm restart on the next admission (true) or torn down so the
+	// next admission always provisions a fresh one (false). It selects how a
+	// deploy rolls the fleet onto a new image: reusing backends (Fly) keep the
+	// machine and need an in-place RecycleImage; non-reusing backends (GKE)
+	// drop the idle runtime so re-admission adopts a fresh warm-pool pod
+	// already running the new image — no in-place swap exists or is needed.
+	ReusesIdleRuntimes() bool
 	Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error)
 	// RecycleImage rolls the runtime's existing machine onto the configured
 	// runtime image when it is running a stale one, without launching

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -848,7 +848,6 @@ func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 		Input:       prompt,
 		AuthToken:   authToken,
 		AssistantID: runtime.AssistantID.String(),
-		ProjectID:   runtime.ProjectID.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal assistant fly runtime turn request: %w", err)

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -122,10 +122,6 @@ type flyRuntimeFlapsFactory interface {
 	New(ctx context.Context) (flyRuntimeFlapsClient, error)
 }
 
-type flyRuntimeHTTPDoer interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
 type defaultFlyRuntimeFlapsFactory struct {
 	serviceName    string
 	serviceVersion string
@@ -156,7 +152,7 @@ type FlyRuntimeBackend struct {
 	config       FlyRuntimeConfig
 	client       flyRuntimeAPIClient
 	flapsFactory flyRuntimeFlapsFactory
-	httpClient   flyRuntimeHTTPDoer
+	httpClient   runtimeHTTPDoer
 }
 
 func NewFlyRuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider, httpPolicy *guardian.Policy, config FlyRuntimeConfig) *FlyRuntimeBackend {
@@ -843,8 +839,10 @@ func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 	}
 
 	reqBody, err := json.Marshal(runtimeTurnRequest{
-		Input:     prompt,
-		AuthToken: authToken,
+		Input:       prompt,
+		AuthToken:   authToken,
+		AssistantID: runtime.AssistantID.String(),
+		ProjectID:   runtime.ProjectID.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal assistant fly runtime turn request: %w", err)
@@ -1120,7 +1118,7 @@ func (f *FlyRuntimeBackend) runtimeState(ctx context.Context, target flyRuntimeT
 // clientForTarget is a hook point for per-target dialing. The runner is
 // reachable via the app's hostname today; a future dedicated-IP design can
 // swap this to pin a request to a specific IP without changing callers.
-func (f *FlyRuntimeBackend) clientForTarget(_ flyRuntimeTarget) flyRuntimeHTTPDoer {
+func (f *FlyRuntimeBackend) clientForTarget(_ flyRuntimeTarget) runtimeHTTPDoer {
 	return f.httpClient
 }
 

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -221,6 +221,12 @@ func (f *FlyRuntimeBackend) ImageRef() string {
 	return f.desiredImageRef()
 }
 
+// ReusesIdleRuntimes is true: Stop pauses the machine but keeps the app and
+// allocated IP, so a later admit resumes the same incarnation. Fly has no warm
+// pool, so a new image is rolled onto that preserved machine in place via
+// RecycleImage rather than by discarding it.
+func (f *FlyRuntimeBackend) ReusesIdleRuntimes() bool { return true }
+
 // Ensure does not auto-recreate the app on ensureExisting errors. Health and
 // configure timeouts must bubble so Temporal retries drive convergence.
 // Destructive app recreation churns Fly's allocated IPs and creates DNS-stale

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -28,12 +28,12 @@ const runtimeBackendGKE = "gke"
 
 const (
 	// gkeRuntimeReadyTimeout bounds the wait for a freshly claimed sandbox to be
-	// assigned a pod and report Ready. Cold-started claims (we inject per-thread
-	// env, which forces a cold start off the warm pool's template) pull the
-	// image before they become ready, so this is generous.
+	// assigned a pod and report Ready. A claim with no pre-warmed pod available
+	// cold-starts (the pod pulls the image before it becomes ready), so this is
+	// generous.
 	gkeRuntimeReadyTimeout = 3 * time.Minute
 	// gkeRuntimeHealthTimeout bounds the runner /healthz wait once the sandbox
-	// reports Ready and a routable serviceFQDN.
+	// reports Ready and its runner pod has a routable IP.
 	gkeRuntimeHealthTimeout = 60 * time.Second
 	gkeRuntimePollInterval  = time.Second
 	// gkeRuntimeReapCallTimeout caps a single delete during reap so one wedged
@@ -48,24 +48,35 @@ const (
 	gkeMetadataProjectID   = "gram.speakeasy.com/project-id"
 	gkeMetadataRole        = "gram.speakeasy.com/role"
 	gkeMetadataRoleValue   = "assistant_runtime"
+
+	// gkeClaimUIDLabel is injected by the SandboxClaim controller onto the pod,
+	// carrying the owning claim's UID. We resolve the runner pod (for its IP) by
+	// this label.
+	gkeClaimUIDLabel = "agents.x-k8s.io/claim-uid"
 )
 
 var (
-	gkeSandboxClaimGVR = schema.GroupVersionResource{Group: "extensions.agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxclaims"}
-	gkeSandboxGVR      = schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxes"}
+	// GKE's managed Agent Sandbox addon serves v1alpha1 (upstream main is on
+	// v1beta1, but the GKE-shipped feature is v1alpha1).
+	gkeSandboxClaimGVR = schema.GroupVersionResource{Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxclaims"}
+	gkeSandboxGVR      = schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxes"}
+	gkePodGVR          = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 )
 
-// GKERuntimeConfig configures the GKE Agent Sandbox runtime backend. The
-// dynamic client and namespace are resolved from the in-cluster k8s client
-// (see server/internal/k8s) at construction; the backend is only usable inside
-// a cluster, never in --dev-single-process.
+// GKERuntimeConfig configures the GKE Agent Sandbox runtime backend. The dynamic
+// client targets the (separate) assistant cluster and is built from its endpoint
+// + CA with the process's Google credentials — see k8s.NewRemoteDynamicClient.
+// The gram server reaches the cluster by endpoint, not in-cluster config, so it
+// runs from the gram cluster (or locally) against a different cluster.
 type GKERuntimeConfig struct {
 	Dynamic dynamic.Interface
 
-	// Namespace is where SandboxClaims are created and the warm pool lives.
+	// Namespace is where SandboxClaims, the SandboxTemplate, and the warm pool live.
 	Namespace string
-	// WarmPool is the SandboxWarmPool name a claim checks out from.
-	WarmPool string
+	// SandboxTemplate is the SandboxTemplate name a claim references. A
+	// SandboxWarmPool referencing the same template pre-warms pods, and the
+	// controller adopts a warm pod for the claim automatically.
+	SandboxTemplate string
 	// GuestPort is the runner HTTP port inside the sandbox pod.
 	GuestPort int
 
@@ -74,20 +85,19 @@ type GKERuntimeConfig struct {
 	// ServerURL is the management API base the server embeds in the runner
 	// bootstrap response (completions + MCP URLs). The runner's own
 	// GRAM_SERVER_URL (for the bootstrap call) and OTLP config are baked into
-	// the SandboxTemplate, not the claim — putting them in the claim would
-	// force a cold start.
+	// the SandboxTemplate, so the claim carries no env and adopts a warm pod.
 	ServerURL *url.URL
 }
 
 func (c GKERuntimeConfig) Validate() error {
 	if c.Dynamic == nil {
-		return fmt.Errorf("gke assistant runtime requires an in-cluster kubernetes client (not available in local env)")
+		return fmt.Errorf("gke assistant runtime requires a kubernetes client for the assistant cluster (set --assistant-runtime-gke-cluster-endpoint)")
 	}
 	if c.Namespace == "" {
 		return fmt.Errorf("--assistant-runtime-gke-namespace is required")
 	}
-	if c.WarmPool == "" {
-		return fmt.Errorf("--assistant-runtime-gke-warm-pool is required")
+	if c.SandboxTemplate == "" {
+		return fmt.Errorf("--assistant-runtime-gke-sandbox-template is required")
 	}
 	if c.OCIImage == "" {
 		return fmt.Errorf("--assistant-runtime-oci-image is required")
@@ -99,13 +109,14 @@ func (c GKERuntimeConfig) Validate() error {
 }
 
 // gkeRuntimeMetadata is persisted opaquely in assistant_runtimes.backend_metadata_json
-// for gke-backed rows. ServiceFQDN is the sandbox's headless Service DNS name;
-// the runner is reached at http://<ServiceFQDN>:<guest port>.
+// for gke-backed rows. PodIP is the runner pod's IP, routable from the gram
+// cluster across the shared VPC; the runner is reached at http://<PodIP>:<guest
+// port> (in-cluster Service DNS is not resolvable across clusters).
 type gkeRuntimeMetadata struct {
 	Namespace   string `json:"namespace"`
 	ClaimName   string `json:"claim_name"`
 	SandboxName string `json:"sandbox_name"`
-	ServiceFQDN string `json:"service_fqdn"`
+	PodIP       string `json:"pod_ip"`
 	Image       string `json:"image,omitempty"`
 }
 
@@ -207,21 +218,21 @@ func (g *GKERuntimeBackend) buildClaim(name string, runtime assistantRuntimeReco
 			"namespace": g.config.Namespace,
 			"labels":    labels,
 		},
-		// No spec.env: per the SandboxClaim API that would force a cold start
-		// off the warm pool's template. The runner boots generic from a
-		// pristine pooled pod and learns its assistant from the first /turn
-		// (env-or-request); shared config (GRAM_SERVER_URL, OTLP) lives in the
-		// SandboxTemplate. additionalPodMetadata propagates identity labels to
-		// the pod for log/trace correlation without forcing a cold start.
+		// The claim references the SandboxTemplate; a SandboxWarmPool on the same
+		// template pre-warms pods and the controller adopts one for the claim.
+		// No spec.env — the runner boots generic from a pooled pod and learns its
+		// assistant from the first /turn (env-or-request); shared config
+		// (GRAM_SERVER_URL, OTLP) lives in the SandboxTemplate. shutdownPolicy
+		// Delete cascades a claim delete to the Sandbox and its pod.
 		"spec": map[string]any{
-			"warmPoolRef":           map[string]any{"name": g.config.WarmPool},
-			"additionalPodMetadata": map[string]any{"labels": labels},
+			"sandboxTemplateRef": map[string]any{"name": g.config.SandboxTemplate},
+			"lifecycle":          map[string]any{"shutdownPolicy": "Delete"},
 		},
 	}}
 }
 
 // waitForSandbox polls the claim until it names an assigned Sandbox, then polls
-// that Sandbox until it reports Ready with a routable serviceFQDN.
+// that Sandbox until it reports Ready and its runner pod has an IP.
 func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string) (gkeRuntimeMetadata, error) {
 	deadline := time.Now().Add(gkeRuntimeReadyTimeout)
 	sandboxes := g.config.Dynamic.Resource(gkeSandboxGVR).Namespace(g.config.Namespace)
@@ -230,19 +241,23 @@ func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string
 		if err != nil {
 			return gkeRuntimeMetadata{}, fmt.Errorf("get sandbox claim %s: %w", claimName, err)
 		}
-		sandboxName, _, _ := unstructured.NestedString(claim.Object, "status", "sandbox", "name")
+		sandboxName, _, _ := unstructured.NestedString(claim.Object, "status", "sandbox", "Name")
 		if sandboxName != "" {
 			sandbox, err := sandboxes.Get(ctx, sandboxName, metav1.GetOptions{})
 			if err != nil && !k8serrors.IsNotFound(err) {
 				return gkeRuntimeMetadata{}, fmt.Errorf("get sandbox %s: %w", sandboxName, err)
 			}
-			if err == nil {
-				if fqdn, ready := sandboxReadyEndpoint(sandbox); ready && fqdn != "" {
+			if err == nil && sandboxReady(sandbox) {
+				podIP, err := g.resolvePodIP(ctx, string(claim.GetUID()))
+				if err != nil {
+					return gkeRuntimeMetadata{}, err
+				}
+				if podIP != "" {
 					return gkeRuntimeMetadata{
 						Namespace:   g.config.Namespace,
 						ClaimName:   claimName,
 						SandboxName: sandboxName,
-						ServiceFQDN: fqdn,
+						PodIP:       podIP,
 						Image:       "",
 					}, nil
 				}
@@ -259,9 +274,8 @@ func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string
 	}
 }
 
-// sandboxReadyEndpoint reads the Sandbox's Ready condition and serviceFQDN.
-func sandboxReadyEndpoint(sandbox *unstructured.Unstructured) (string, bool) {
-	fqdn, _, _ := unstructured.NestedString(sandbox.Object, "status", "serviceFQDN")
+// sandboxReady reports whether the Sandbox's Ready condition is true.
+func sandboxReady(sandbox *unstructured.Unstructured) bool {
 	conditions, _, _ := unstructured.NestedSlice(sandbox.Object, "status", "conditions")
 	for _, raw := range conditions {
 		cond, ok := raw.(map[string]any)
@@ -271,14 +285,34 @@ func sandboxReadyEndpoint(sandbox *unstructured.Unstructured) (string, bool) {
 		condType, _, _ := unstructured.NestedString(cond, "type")
 		condStatus, _, _ := unstructured.NestedString(cond, "status")
 		if condType == gkeSandboxReadyConditionType {
-			return fqdn, condStatus == string(metav1.ConditionTrue)
+			return condStatus == string(metav1.ConditionTrue)
 		}
 	}
-	return fqdn, false
+	return false
+}
+
+// resolvePodIP finds the runner pod for a claim (by the controller-injected
+// claim-uid label) and returns its IP once the pod is Running. An empty string
+// means the pod is not scheduled/running yet, so the caller keeps polling.
+func (g *GKERuntimeBackend) resolvePodIP(ctx context.Context, claimUID string) (string, error) {
+	pods, err := g.config.Dynamic.Resource(gkePodGVR).Namespace(g.config.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: gkeClaimUIDLabel + "=" + claimUID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("list runner pods for claim %s: %w", claimUID, err)
+	}
+	for i := range pods.Items {
+		phase, _, _ := unstructured.NestedString(pods.Items[i].Object, "status", "phase")
+		ip, _, _ := unstructured.NestedString(pods.Items[i].Object, "status", "podIP")
+		if phase == "Running" && ip != "" {
+			return ip, nil
+		}
+	}
+	return "", nil
 }
 
 func (g *GKERuntimeBackend) endpoint(metadata gkeRuntimeMetadata) string {
-	return fmt.Sprintf("http://%s:%d", metadata.ServiceFQDN, g.config.GuestPort)
+	return fmt.Sprintf("http://%s:%d", metadata.PodIP, g.config.GuestPort)
 }
 
 func (g *GKERuntimeBackend) waitForHealth(ctx context.Context, metadata gkeRuntimeMetadata) error {
@@ -306,8 +340,8 @@ func (g *GKERuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 	if err != nil {
 		return err
 	}
-	if metadata.ServiceFQDN == "" {
-		return fmt.Errorf("%w: gke runtime service fqdn is not available", ErrRuntimeUnhealthy)
+	if metadata.PodIP == "" {
+		return fmt.Errorf("%w: gke runtime pod ip is not available", ErrRuntimeUnhealthy)
 	}
 
 	reqBody, err := json.Marshal(runtimeTurnRequest{
@@ -333,8 +367,8 @@ func (g *GKERuntimeBackend) Status(ctx context.Context, runtime assistantRuntime
 	if err != nil {
 		return RuntimeBackendStatus{}, err
 	}
-	if metadata.ServiceFQDN == "" {
-		return RuntimeBackendStatus{}, fmt.Errorf("%w: gke runtime service fqdn is not available", ErrRuntimeUnhealthy)
+	if metadata.PodIP == "" {
+		return RuntimeBackendStatus{}, fmt.Errorf("%w: gke runtime pod ip is not available", ErrRuntimeUnhealthy)
 	}
 	body, err := g.doRequest(ctx, metadata, http.MethodGet, "/state", nil, "", "", 0)
 	if err != nil {
@@ -348,10 +382,9 @@ func (g *GKERuntimeBackend) Status(ctx context.Context, runtime assistantRuntime
 }
 
 // Stop deletes the SandboxClaim. GKE has no cheap pause: a fresh admit recreates
-// the claim (and, but for the per-thread env we inject, would reclaim a
-// pre-warmed pod). The runner holds no per-assistant state across restarts —
-// history is replayed from the server on the next /turn — so deleting on Stop
-// loses nothing.
+// the claim and adopts a pre-warmed pod from the pool. The runner holds no
+// per-assistant state across restarts — history is replayed from the server on
+// the next /turn — so deleting on Stop loses nothing.
 func (g *GKERuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
 	return g.deleteClaim(ctx, runtime)
 }

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -1,0 +1,448 @@
+package assistants
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const runtimeBackendGKE = "gke"
+
+const (
+	// gkeRuntimeReadyTimeout bounds the wait for a freshly claimed sandbox to be
+	// assigned a pod and report Ready. Cold-started claims (we inject per-thread
+	// env, which forces a cold start off the warm pool's template) pull the
+	// image before they become ready, so this is generous.
+	gkeRuntimeReadyTimeout = 3 * time.Minute
+	// gkeRuntimeHealthTimeout bounds the runner /healthz wait once the sandbox
+	// reports Ready and a routable serviceFQDN.
+	gkeRuntimeHealthTimeout = 60 * time.Second
+	gkeRuntimePollInterval  = time.Second
+	// gkeRuntimeReapCallTimeout caps a single delete during reap so one wedged
+	// row cannot consume the parent activity's deadline.
+	gkeRuntimeReapCallTimeout   = 30 * time.Second
+	gkeRuntimeDefaultReqTimeout = 2 * time.Minute
+	gkeRuntimeTurnTimeout       = 30 * time.Minute
+
+	gkeSandboxReadyConditionType = "Ready"
+
+	gkeMetadataAssistantID = "gram.speakeasy.com/assistant-id"
+	gkeMetadataProjectID   = "gram.speakeasy.com/project-id"
+	gkeMetadataRole        = "gram.speakeasy.com/role"
+	gkeMetadataRoleValue   = "assistant_runtime"
+)
+
+var (
+	gkeSandboxClaimGVR = schema.GroupVersionResource{Group: "extensions.agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxclaims"}
+	gkeSandboxGVR      = schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxes"}
+)
+
+// GKERuntimeConfig configures the GKE Agent Sandbox runtime backend. The
+// dynamic client and namespace are resolved from the in-cluster k8s client
+// (see server/internal/k8s) at construction; the backend is only usable inside
+// a cluster, never in --dev-single-process.
+type GKERuntimeConfig struct {
+	Dynamic dynamic.Interface
+
+	// Namespace is where SandboxClaims are created and the warm pool lives.
+	Namespace string
+	// WarmPool is the SandboxWarmPool name a claim checks out from.
+	WarmPool string
+	// GuestPort is the runner HTTP port inside the sandbox pod.
+	GuestPort int
+
+	OCIImage string
+	ImageTag string
+	// ServerURL is the management API base the server embeds in the runner
+	// bootstrap response (completions + MCP URLs). The runner's own
+	// GRAM_SERVER_URL (for the bootstrap call) and OTLP config are baked into
+	// the SandboxTemplate, not the claim — putting them in the claim would
+	// force a cold start.
+	ServerURL *url.URL
+}
+
+func (c GKERuntimeConfig) Validate() error {
+	if c.Dynamic == nil {
+		return fmt.Errorf("gke assistant runtime requires an in-cluster kubernetes client (not available in local env)")
+	}
+	if c.Namespace == "" {
+		return fmt.Errorf("--assistant-runtime-gke-namespace is required")
+	}
+	if c.WarmPool == "" {
+		return fmt.Errorf("--assistant-runtime-gke-warm-pool is required")
+	}
+	if c.OCIImage == "" {
+		return fmt.Errorf("--assistant-runtime-oci-image is required")
+	}
+	if c.ServerURL == nil || c.ServerURL.Hostname() == "" {
+		return fmt.Errorf("gke assistant runtime requires a public --assistant-runtime-server-url or --server-url")
+	}
+	return nil
+}
+
+// gkeRuntimeMetadata is persisted opaquely in assistant_runtimes.backend_metadata_json
+// for gke-backed rows. ServiceFQDN is the sandbox's headless Service DNS name;
+// the runner is reached at http://<ServiceFQDN>:<guest port>.
+type gkeRuntimeMetadata struct {
+	Namespace   string `json:"namespace"`
+	ClaimName   string `json:"claim_name"`
+	SandboxName string `json:"sandbox_name"`
+	ServiceFQDN string `json:"service_fqdn"`
+	Image       string `json:"image,omitempty"`
+}
+
+type GKERuntimeBackend struct {
+	logger     *slog.Logger
+	tracer     trace.Tracer
+	config     GKERuntimeConfig
+	httpClient runtimeHTTPDoer
+}
+
+func NewGKERuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider, httpClient runtimeHTTPDoer, config GKERuntimeConfig) *GKERuntimeBackend {
+	if config.GuestPort == 0 {
+		config.GuestPort = defaultRuntimeGuestPort
+	}
+	return &GKERuntimeBackend{
+		logger:     logger.With(attr.SlogComponent("assistants_gke")),
+		tracer:     tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/assistants"),
+		config:     config,
+		httpClient: httpClient,
+	}
+}
+
+func (g *GKERuntimeBackend) Backend() string { return runtimeBackendGKE }
+
+func (g *GKERuntimeBackend) SupportsBackend(backend string) bool { return backend == runtimeBackendGKE }
+
+func (g *GKERuntimeBackend) ServerURL() *url.URL { return g.config.ServerURL }
+
+func (g *GKERuntimeBackend) ImageRef() string { return g.desiredImageRef() }
+
+func (g *GKERuntimeBackend) desiredImageRef() string {
+	if g.config.ImageTag == "" {
+		return g.config.OCIImage
+	}
+	return g.config.OCIImage + ":" + g.config.ImageTag
+}
+
+func (g *GKERuntimeBackend) claimName(runtime assistantRuntimeRecord) string {
+	return "gram-asst-" + strings.ToLower(runtime.AssistantID.String())
+}
+
+func (g *GKERuntimeBackend) claims() dynamic.ResourceInterface {
+	return g.config.Dynamic.Resource(gkeSandboxClaimGVR).Namespace(g.config.Namespace)
+}
+
+func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntimeRecord) (result RuntimeBackendEnsureResult, err error) {
+	if err := validateRuntimeBackend(g, runtime.Backend); err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+
+	ctx, span := g.tracer.Start(ctx, "assistants.runtime.gke.ensure")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	name := g.claimName(runtime)
+	coldStart := false
+	if _, getErr := g.claims().Get(ctx, name, metav1.GetOptions{}); getErr != nil {
+		if !k8serrors.IsNotFound(getErr) {
+			return RuntimeBackendEnsureResult{}, fmt.Errorf("get sandbox claim %s: %w", name, getErr)
+		}
+		if _, createErr := g.claims().Create(ctx, g.buildClaim(name, runtime), metav1.CreateOptions{}); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
+			return RuntimeBackendEnsureResult{}, fmt.Errorf("create sandbox claim %s: %w", name, createErr)
+		}
+		coldStart = true
+	}
+
+	metadata, err := g.waitForSandbox(ctx, name)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+	metadata.Image = g.desiredImageRef()
+
+	if err := g.waitForHealth(ctx, metadata); err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+
+	payload, err := json.Marshal(metadata)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, fmt.Errorf("encode gke runtime metadata: %w", err)
+	}
+	return RuntimeBackendEnsureResult{ColdStart: coldStart, BackendMetadataJSON: payload}, nil
+}
+
+func (g *GKERuntimeBackend) buildClaim(name string, runtime assistantRuntimeRecord) *unstructured.Unstructured {
+	labels := map[string]any{
+		gkeMetadataAssistantID: strings.ToLower(runtime.AssistantID.String()),
+		gkeMetadataProjectID:   strings.ToLower(runtime.ProjectID.String()),
+		gkeMetadataRole:        gkeMetadataRoleValue,
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gkeSandboxClaimGVR.Group + "/" + gkeSandboxClaimGVR.Version,
+		"kind":       "SandboxClaim",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": g.config.Namespace,
+			"labels":    labels,
+		},
+		// No spec.env: per the SandboxClaim API that would force a cold start
+		// off the warm pool's template. The runner boots generic from a
+		// pristine pooled pod and learns its assistant from the first /turn
+		// (env-or-request); shared config (GRAM_SERVER_URL, OTLP) lives in the
+		// SandboxTemplate. additionalPodMetadata propagates identity labels to
+		// the pod for log/trace correlation without forcing a cold start.
+		"spec": map[string]any{
+			"warmPoolRef":           map[string]any{"name": g.config.WarmPool},
+			"additionalPodMetadata": map[string]any{"labels": labels},
+		},
+	}}
+}
+
+// waitForSandbox polls the claim until it names an assigned Sandbox, then polls
+// that Sandbox until it reports Ready with a routable serviceFQDN.
+func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string) (gkeRuntimeMetadata, error) {
+	deadline := time.Now().Add(gkeRuntimeReadyTimeout)
+	sandboxes := g.config.Dynamic.Resource(gkeSandboxGVR).Namespace(g.config.Namespace)
+	for {
+		claim, err := g.claims().Get(ctx, claimName, metav1.GetOptions{})
+		if err != nil {
+			return gkeRuntimeMetadata{}, fmt.Errorf("get sandbox claim %s: %w", claimName, err)
+		}
+		sandboxName, _, _ := unstructured.NestedString(claim.Object, "status", "sandbox", "name")
+		if sandboxName != "" {
+			sandbox, err := sandboxes.Get(ctx, sandboxName, metav1.GetOptions{})
+			if err != nil && !k8serrors.IsNotFound(err) {
+				return gkeRuntimeMetadata{}, fmt.Errorf("get sandbox %s: %w", sandboxName, err)
+			}
+			if err == nil {
+				if fqdn, ready := sandboxReadyEndpoint(sandbox); ready && fqdn != "" {
+					return gkeRuntimeMetadata{
+						Namespace:   g.config.Namespace,
+						ClaimName:   claimName,
+						SandboxName: sandboxName,
+						ServiceFQDN: fqdn,
+						Image:       "",
+					}, nil
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return gkeRuntimeMetadata{}, fmt.Errorf("%w: sandbox claim %s not ready within %s", ErrRuntimeUnhealthy, claimName, gkeRuntimeReadyTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return gkeRuntimeMetadata{}, fmt.Errorf("wait for sandbox %s: %w", claimName, ctx.Err())
+		case <-time.After(gkeRuntimePollInterval):
+		}
+	}
+}
+
+// sandboxReadyEndpoint reads the Sandbox's Ready condition and serviceFQDN.
+func sandboxReadyEndpoint(sandbox *unstructured.Unstructured) (string, bool) {
+	fqdn, _, _ := unstructured.NestedString(sandbox.Object, "status", "serviceFQDN")
+	conditions, _, _ := unstructured.NestedSlice(sandbox.Object, "status", "conditions")
+	for _, raw := range conditions {
+		cond, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		condType, _, _ := unstructured.NestedString(cond, "type")
+		condStatus, _, _ := unstructured.NestedString(cond, "status")
+		if condType == gkeSandboxReadyConditionType {
+			return fqdn, condStatus == string(metav1.ConditionTrue)
+		}
+	}
+	return fqdn, false
+}
+
+func (g *GKERuntimeBackend) endpoint(metadata gkeRuntimeMetadata) string {
+	return fmt.Sprintf("http://%s:%d", metadata.ServiceFQDN, g.config.GuestPort)
+}
+
+func (g *GKERuntimeBackend) waitForHealth(ctx context.Context, metadata gkeRuntimeMetadata) error {
+	deadline := time.Now().Add(gkeRuntimeHealthTimeout)
+	for {
+		if _, err := g.doRequest(ctx, metadata, http.MethodGet, "/healthz", nil, "", "", 0); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w: gke runtime health check timed out", ErrRuntimeUnhealthy)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for gke runtime health: %w", ctx.Err())
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func (g *GKERuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntimeRecord, threadID uuid.UUID, idempotencyKey string, authToken string, prompt string) error {
+	if err := validateRuntimeBackend(g, runtime.Backend); err != nil {
+		return err
+	}
+	metadata, err := decodeGKERuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return err
+	}
+	if metadata.ServiceFQDN == "" {
+		return fmt.Errorf("%w: gke runtime service fqdn is not available", ErrRuntimeUnhealthy)
+	}
+
+	reqBody, err := json.Marshal(runtimeTurnRequest{
+		Input:       prompt,
+		AuthToken:   authToken,
+		AssistantID: runtime.AssistantID.String(),
+		ProjectID:   runtime.ProjectID.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal gke runtime turn request: %w", err)
+	}
+	if _, err := g.doRequest(ctx, metadata, http.MethodPost, "/threads/"+threadID.String()+"/turn", reqBody, "application/json", idempotencyKey, gkeRuntimeTurnTimeout); err != nil {
+		return fmt.Errorf("%w: execute gke turn request: %w", classifyTurnError(err), err)
+	}
+	return nil
+}
+
+func (g *GKERuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
+	if err := validateRuntimeBackend(g, runtime.Backend); err != nil {
+		return RuntimeBackendStatus{}, err
+	}
+	metadata, err := decodeGKERuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return RuntimeBackendStatus{}, err
+	}
+	if metadata.ServiceFQDN == "" {
+		return RuntimeBackendStatus{}, fmt.Errorf("%w: gke runtime service fqdn is not available", ErrRuntimeUnhealthy)
+	}
+	body, err := g.doRequest(ctx, metadata, http.MethodGet, "/state", nil, "", "", 0)
+	if err != nil {
+		return RuntimeBackendStatus{}, fmt.Errorf("load gke runtime state: %w", err)
+	}
+	var state runnerStateResponse
+	if err := json.Unmarshal(body, &state); err != nil {
+		return RuntimeBackendStatus{}, fmt.Errorf("decode gke runtime state: %w", err)
+	}
+	return RuntimeBackendStatus{Configured: true, IdleSeconds: state.minThreadIdle()}, nil
+}
+
+// Stop deletes the SandboxClaim. GKE has no cheap pause: a fresh admit recreates
+// the claim (and, but for the per-thread env we inject, would reclaim a
+// pre-warmed pod). The runner holds no per-assistant state across restarts —
+// history is replayed from the server on the next /turn — so deleting on Stop
+// loses nothing.
+func (g *GKERuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
+	return g.deleteClaim(ctx, runtime)
+}
+
+// Reap permanently deletes the SandboxClaim, which cascades to the Sandbox and
+// pod. Idempotent: a missing claim is success.
+func (g *GKERuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRecord) error {
+	return g.deleteClaim(ctx, runtime)
+}
+
+func (g *GKERuntimeBackend) deleteClaim(ctx context.Context, runtime assistantRuntimeRecord) error {
+	if err := validateRuntimeBackend(g, runtime.Backend); err != nil {
+		return err
+	}
+	metadata, err := decodeGKERuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return err
+	}
+	name := metadata.ClaimName
+	if name == "" {
+		name = g.claimName(runtime)
+	}
+
+	deleteCtx, cancel := context.WithTimeout(ctx, gkeRuntimeReapCallTimeout)
+	defer cancel()
+	if err := g.claims().Delete(deleteCtx, name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("delete sandbox claim %s: %w", name, err)
+	}
+	return nil
+}
+
+// RecycleImage is a no-op on GKE. There is no in-place image swap: a claimed
+// sandbox's pod ownership has moved off the warm pool, so a SandboxTemplate /
+// warm-pool image bump never disturbs an in-flight turn — the running sandbox
+// finishes on its current image and new admissions draw new-image pods. Old
+// idle sandboxes roll over via warm-TTL expiry and the janitor.
+func (g *GKERuntimeBackend) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+	if err := validateRuntimeBackend(g, runtime.Backend); err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+	return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
+}
+
+func (g *GKERuntimeBackend) doRequest(ctx context.Context, metadata gkeRuntimeMetadata, method, path string, body []byte, contentType, idempotencyKey string, maxTimeout time.Duration) ([]byte, error) {
+	fallback := gkeRuntimeDefaultReqTimeout
+	if maxTimeout > 0 {
+		fallback = maxTimeout
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, fallback)
+	defer cancel()
+
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(reqCtx, method, g.endpoint(metadata)+path, reader)
+	if err != nil {
+		return nil, fmt.Errorf("build gke runtime request: %w", err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if idempotencyKey != "" {
+		req.Header.Set("X-Idempotency-Key", idempotencyKey)
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute gke runtime request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read gke runtime response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("gke runtime request %s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return respBody, nil
+}
+
+func decodeGKERuntimeMetadata(raw []byte) (gkeRuntimeMetadata, error) {
+	if len(raw) == 0 {
+		return gkeRuntimeMetadata{}, fmt.Errorf("gke runtime metadata is empty")
+	}
+	var metadata gkeRuntimeMetadata
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return gkeRuntimeMetadata{}, fmt.Errorf("decode gke runtime metadata: %w", err)
+	}
+	return metadata, nil
+}
+
+var _ RuntimeBackend = (*GKERuntimeBackend)(nil)

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -203,28 +203,35 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 		if !k8serrors.IsNotFound(getErr) {
 			return RuntimeBackendEnsureResult{}, fmt.Errorf("get sandbox claim %s: %w", name, getErr)
 		}
-		if _, createErr := g.claims().Create(ctx, g.buildClaim(name, runtime), metav1.CreateOptions{}); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
+		_, createErr := g.claims().Create(ctx, g.buildClaim(name, runtime), metav1.CreateOptions{})
+		switch {
+		case createErr == nil:
+			coldStart = true
+			// We created this claim. If readiness below fails, delete it so the
+			// next admission recreates a fresh claim rather than re-attaching to
+			// an unhealthy one with no persisted metadata. Only this branch owns
+			// the claim: a pre-existing claim, or one a racing Ensure created
+			// (AlreadyExists), is left alone — another turn may be using it. Use
+			// WithoutCancel so cleanup still runs when the failure was a timeout.
+			defer func() {
+				if err == nil {
+					return
+				}
+				delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gkeRuntimeReapCallTimeout)
+				defer cancel()
+				if delErr := g.claims().Delete(delCtx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
+					g.logger.WarnContext(ctx, "delete sandbox claim after failed ensure",
+						attr.SlogAssistantID(runtime.AssistantID.String()),
+						attr.SlogError(delErr),
+					)
+				}
+			}()
+		case k8serrors.IsAlreadyExists(createErr):
+			// A racing Ensure created the claim between our Get and Create. Attach
+			// to it like a pre-existing claim; the other turn owns its lifecycle.
+		default:
 			return RuntimeBackendEnsureResult{}, fmt.Errorf("create sandbox claim %s: %w", name, createErr)
 		}
-		coldStart = true
-		// We created this claim. If readiness below fails, delete it so the next
-		// admission recreates a fresh claim rather than re-attaching to an
-		// unhealthy one with no persisted metadata. A pre-existing claim is left
-		// alone — another turn may be using it. Use WithoutCancel so the cleanup
-		// still runs when the failure was a context timeout.
-		defer func() {
-			if err == nil {
-				return
-			}
-			delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gkeRuntimeReapCallTimeout)
-			defer cancel()
-			if delErr := g.claims().Delete(delCtx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
-				g.logger.WarnContext(ctx, "delete sandbox claim after failed ensure",
-					attr.SlogAssistantID(runtime.AssistantID.String()),
-					attr.SlogError(delErr),
-				)
-			}
-		}()
 	}
 
 	metadata, err := g.waitForSandbox(ctx, name)

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -87,6 +88,11 @@ type GKERuntimeConfig struct {
 	// GRAM_SERVER_URL (for the bootstrap call) and OTLP config are baked into
 	// the SandboxTemplate, so the claim carries no env and adopts a warm pod.
 	ServerURL *url.URL
+	// RunnerCIDRBlocks are the pod CIDR(s) runner pods draw IPs from. The server
+	// dials runners by pod IP (resolved from the Kubernetes API) — RFC1918
+	// addresses the guardian egress policy blocks by default — so these blocks
+	// are allowlisted for the runner HTTP client only.
+	RunnerCIDRBlocks []string
 }
 
 func (c GKERuntimeConfig) Validate() error {
@@ -104,6 +110,14 @@ func (c GKERuntimeConfig) Validate() error {
 	}
 	if c.ServerURL == nil || c.ServerURL.Hostname() == "" {
 		return fmt.Errorf("gke assistant runtime requires a public --assistant-runtime-server-url or --server-url")
+	}
+	if len(c.RunnerCIDRBlocks) == 0 {
+		return fmt.Errorf("--assistant-runtime-gke-runner-cidr is required: the server dials runner pod IPs, which the egress policy blocks unless their CIDR is allowlisted")
+	}
+	for _, cidr := range c.RunnerCIDRBlocks {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return fmt.Errorf("invalid --assistant-runtime-gke-runner-cidr %q: %w", cidr, err)
+		}
 	}
 	return nil
 }
@@ -193,6 +207,24 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 			return RuntimeBackendEnsureResult{}, fmt.Errorf("create sandbox claim %s: %w", name, createErr)
 		}
 		coldStart = true
+		// We created this claim. If readiness below fails, delete it so the next
+		// admission recreates a fresh claim rather than re-attaching to an
+		// unhealthy one with no persisted metadata. A pre-existing claim is left
+		// alone — another turn may be using it. Use WithoutCancel so the cleanup
+		// still runs when the failure was a context timeout.
+		defer func() {
+			if err == nil {
+				return
+			}
+			delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gkeRuntimeReapCallTimeout)
+			defer cancel()
+			if delErr := g.claims().Delete(delCtx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
+				g.logger.WarnContext(ctx, "delete sandbox claim after failed ensure",
+					attr.SlogAssistantID(runtime.AssistantID.String()),
+					attr.SlogError(delErr),
+				)
+			}
+		}()
 	}
 
 	metadata, err := g.waitForSandbox(ctx, name)
@@ -356,7 +388,6 @@ func (g *GKERuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 		Input:       prompt,
 		AuthToken:   authToken,
 		AssistantID: runtime.AssistantID.String(),
-		ProjectID:   runtime.ProjectID.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal gke runtime turn request: %w", err)

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -147,6 +147,14 @@ func (g *GKERuntimeBackend) ServerURL() *url.URL { return g.config.ServerURL }
 
 func (g *GKERuntimeBackend) ImageRef() string { return g.desiredImageRef() }
 
+// ReusesIdleRuntimes is false: Stop deletes the SandboxClaim, so the next
+// admission recreates the claim and adopts a fresh pre-warmed pod from the
+// pool — already running whatever image the SandboxTemplate now points at. A
+// new image therefore rolls in by terminating idle runtimes (the deploy sweep
+// and the warm-TTL expiry both do this) rather than the in-place RecycleImage
+// Fly relies on.
+func (g *GKERuntimeBackend) ReusesIdleRuntimes() bool { return false }
+
 func (g *GKERuntimeBackend) desiredImageRef() string {
 	if g.config.ImageTag == "" {
 		return g.config.OCIImage

--- a/server/internal/assistants/runtime_gke_test.go
+++ b/server/internal/assistants/runtime_gke_test.go
@@ -29,6 +29,7 @@ func newGKEFakeDynamic() *dynamicfake.FakeDynamicClient {
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
 		gkeSandboxClaimGVR: "SandboxClaimList",
 		gkeSandboxGVR:      "SandboxList",
+		gkePodGVR:          "PodList",
 	})
 }
 
@@ -46,13 +47,13 @@ func seedUnstructured(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersi
 func newTestGKEBackend(t *testing.T, dyn dynamic.Interface, doer runtimeHTTPDoer, port int) *GKERuntimeBackend {
 	t.Helper()
 	return NewGKERuntimeBackend(testenv.NewLogger(t), testenv.NewTracerProvider(t), doer, GKERuntimeConfig{
-		Dynamic:   dyn,
-		Namespace: "gram-test",
-		WarmPool:  "gram-asst-pool",
-		GuestPort: port,
-		OCIImage:  "registry.example.com/gram-assistant-runtime",
-		ImageTag:  "test",
-		ServerURL: &url.URL{Scheme: "https", Host: "gram.example.com"},
+		Dynamic:         dyn,
+		Namespace:       "gram-test",
+		SandboxTemplate: "gram-asst-pool",
+		GuestPort:       port,
+		OCIImage:        "registry.example.com/gram-assistant-runtime",
+		ImageTag:        "test",
+		ServerURL:       &url.URL{Scheme: "https", Host: "gram.example.com"},
 	})
 }
 
@@ -71,13 +72,13 @@ func testRunner(t *testing.T, handler http.HandlerFunc) (doer runtimeHTTPDoer, h
 	return srv.Client(), h, portNum
 }
 
-func gkeRecord(t *testing.T, backend *GKERuntimeBackend, assistantID uuid.UUID, fqdn string) assistantRuntimeRecord {
+func gkeRecord(t *testing.T, backend *GKERuntimeBackend, assistantID uuid.UUID, podIP string) assistantRuntimeRecord {
 	t.Helper()
 	meta := gkeRuntimeMetadata{
 		Namespace:   "gram-test",
 		ClaimName:   "gram-asst-" + assistantID.String(),
 		SandboxName: "sb-1",
-		ServiceFQDN: fqdn,
+		PodIP:       podIP,
 		Image:       backend.desiredImageRef(),
 	}
 	raw, err := json.Marshal(meta)
@@ -94,31 +95,25 @@ func gkeRecord(t *testing.T, backend *GKERuntimeBackend, assistantID uuid.UUID, 
 	}
 }
 
-func TestSandboxReadyEndpoint(t *testing.T) {
+func TestSandboxReady(t *testing.T) {
 	t.Parallel()
 
 	ready := &unstructured.Unstructured{Object: map[string]any{
 		"status": map[string]any{
-			"serviceFQDN": "sb-1.gram-test.svc.cluster.local",
 			"conditions": []any{
 				map[string]any{"type": "Suspended", "status": "False"},
 				map[string]any{"type": "Ready", "status": "True"},
 			},
 		},
 	}}
-	fqdn, ok := sandboxReadyEndpoint(ready)
-	require.True(t, ok)
-	require.Equal(t, "sb-1.gram-test.svc.cluster.local", fqdn)
+	require.True(t, sandboxReady(ready))
 
 	notReady := &unstructured.Unstructured{Object: map[string]any{
 		"status": map[string]any{
-			"serviceFQDN": "sb-1.gram-test.svc.cluster.local",
-			"conditions":  []any{map[string]any{"type": "Ready", "status": "False"}},
+			"conditions": []any{map[string]any{"type": "Ready", "status": "False"}},
 		},
 	}}
-	fqdn, ok = sandboxReadyEndpoint(notReady)
-	require.False(t, ok)
-	require.Equal(t, "sb-1.gram-test.svc.cluster.local", fqdn)
+	require.False(t, sandboxReady(notReady))
 }
 
 func TestGKERunTurnPostsToRunner(t *testing.T) {
@@ -176,22 +171,34 @@ func TestGKEEnsureWaitsForReadySandbox(t *testing.T) {
 	claim := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": gkeSandboxClaimGVR.Group + "/" + gkeSandboxClaimGVR.Version,
 		"kind":       "SandboxClaim",
-		"metadata":   map[string]any{"name": claimName, "namespace": "gram-test"},
-		"status":     map[string]any{"sandbox": map[string]any{"name": "sb-1"}},
+		"metadata":   map[string]any{"name": claimName, "namespace": "gram-test", "uid": "claim-uid-1"},
+		"status":     map[string]any{"sandbox": map[string]any{"Name": "sb-1"}},
 	}}
 	sandbox := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": gkeSandboxGVR.Group + "/" + gkeSandboxGVR.Version,
 		"kind":       "Sandbox",
 		"metadata":   map[string]any{"name": "sb-1", "namespace": "gram-test"},
 		"status": map[string]any{
-			"serviceFQDN": host,
-			"conditions":  []any{map[string]any{"type": "Ready", "status": "True"}},
+			"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
 		},
+	}}
+	// The controller injects the claim-uid label on the runner pod; the backend
+	// resolves the pod IP by it.
+	pod := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "sb-1-pod",
+			"namespace": "gram-test",
+			"labels":    map[string]any{gkeClaimUIDLabel: "claim-uid-1"},
+		},
+		"status": map[string]any{"phase": "Running", "podIP": host},
 	}}
 
 	dyn := newGKEFakeDynamic()
 	seedUnstructured(t, dyn, gkeSandboxClaimGVR, claim)
 	seedUnstructured(t, dyn, gkeSandboxGVR, sandbox)
+	seedUnstructured(t, dyn, gkePodGVR, pod)
 	backend := newTestGKEBackend(t, dyn, doer, port)
 	result, err := backend.Ensure(t.Context(), assistantRuntimeRecord{
 		ID:                  uuid.New(),
@@ -209,7 +216,7 @@ func TestGKEEnsureWaitsForReadySandbox(t *testing.T) {
 	require.NoError(t, json.Unmarshal(result.BackendMetadataJSON, &meta))
 	require.Equal(t, claimName, meta.ClaimName)
 	require.Equal(t, "sb-1", meta.SandboxName)
-	require.Equal(t, host, meta.ServiceFQDN)
+	require.Equal(t, host, meta.PodIP)
 }
 
 func TestGKEReapDeletesClaimIdempotently(t *testing.T) {

--- a/server/internal/assistants/runtime_gke_test.go
+++ b/server/internal/assistants/runtime_gke_test.go
@@ -47,13 +47,14 @@ func seedUnstructured(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersi
 func newTestGKEBackend(t *testing.T, dyn dynamic.Interface, doer runtimeHTTPDoer, port int) *GKERuntimeBackend {
 	t.Helper()
 	return NewGKERuntimeBackend(testenv.NewLogger(t), testenv.NewTracerProvider(t), doer, GKERuntimeConfig{
-		Dynamic:         dyn,
-		Namespace:       "gram-test",
-		SandboxTemplate: "gram-asst-pool",
-		GuestPort:       port,
-		OCIImage:        "registry.example.com/gram-assistant-runtime",
-		ImageTag:        "test",
-		ServerURL:       &url.URL{Scheme: "https", Host: "gram.example.com"},
+		Dynamic:          dyn,
+		Namespace:        "gram-test",
+		SandboxTemplate:  "gram-asst-pool",
+		GuestPort:        port,
+		OCIImage:         "registry.example.com/gram-assistant-runtime",
+		ImageTag:         "test",
+		ServerURL:        &url.URL{Scheme: "https", Host: "gram.example.com"},
+		RunnerCIDRBlocks: []string{"10.52.0.0/16"},
 	})
 }
 

--- a/server/internal/assistants/runtime_gke_test.go
+++ b/server/internal/assistants/runtime_gke_test.go
@@ -1,0 +1,237 @@
+package assistants
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func newGKEFakeDynamic() *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		gkeSandboxClaimGVR: "SandboxClaimList",
+		gkeSandboxGVR:      "SandboxList",
+	})
+}
+
+// seedUnstructured inserts an object under an explicit GVR. The fake's default
+// kind->resource guesser pluralizes "Sandbox" to "sandboxs" (not "sandboxes"),
+// so seeding via the constructor would file objects under the wrong resource;
+// creating through the typed GVR interface registers them where the backend
+// reads them.
+func seedUnstructured(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersionResource, obj *unstructured.Unstructured) {
+	t.Helper()
+	_, err := dyn.Resource(gvr).Namespace(obj.GetNamespace()).Create(t.Context(), obj, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func newTestGKEBackend(t *testing.T, dyn dynamic.Interface, doer runtimeHTTPDoer, port int) *GKERuntimeBackend {
+	t.Helper()
+	return NewGKERuntimeBackend(testenv.NewLogger(t), testenv.NewTracerProvider(t), doer, GKERuntimeConfig{
+		Dynamic:   dyn,
+		Namespace: "gram-test",
+		WarmPool:  "gram-asst-pool",
+		GuestPort: port,
+		OCIImage:  "registry.example.com/gram-assistant-runtime",
+		ImageTag:  "test",
+		ServerURL: &url.URL{Scheme: "https", Host: "gram.example.com"},
+	})
+}
+
+// testRunner spins up an httptest server impersonating the in-pod runner and
+// returns a doer wired to it plus the host/port the backend should dial.
+func testRunner(t *testing.T, handler http.HandlerFunc) (doer runtimeHTTPDoer, host string, port int) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	h, p, err := net.SplitHostPort(u.Host)
+	require.NoError(t, err)
+	portNum, err := strconv.Atoi(p)
+	require.NoError(t, err)
+	return srv.Client(), h, portNum
+}
+
+func gkeRecord(t *testing.T, backend *GKERuntimeBackend, assistantID uuid.UUID, fqdn string) assistantRuntimeRecord {
+	t.Helper()
+	meta := gkeRuntimeMetadata{
+		Namespace:   "gram-test",
+		ClaimName:   "gram-asst-" + assistantID.String(),
+		SandboxName: "sb-1",
+		ServiceFQDN: fqdn,
+		Image:       backend.desiredImageRef(),
+	}
+	raw, err := json.Marshal(meta)
+	require.NoError(t, err)
+	return assistantRuntimeRecord{
+		ID:                  uuid.New(),
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendGKE,
+		BackendMetadataJSON: raw,
+		State:               runtimeStateActive,
+		WarmUntil:           pgtype.Timestamptz{},
+	}
+}
+
+func TestSandboxReadyEndpoint(t *testing.T) {
+	t.Parallel()
+
+	ready := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{
+			"serviceFQDN": "sb-1.gram-test.svc.cluster.local",
+			"conditions": []any{
+				map[string]any{"type": "Suspended", "status": "False"},
+				map[string]any{"type": "Ready", "status": "True"},
+			},
+		},
+	}}
+	fqdn, ok := sandboxReadyEndpoint(ready)
+	require.True(t, ok)
+	require.Equal(t, "sb-1.gram-test.svc.cluster.local", fqdn)
+
+	notReady := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{
+			"serviceFQDN": "sb-1.gram-test.svc.cluster.local",
+			"conditions":  []any{map[string]any{"type": "Ready", "status": "False"}},
+		},
+	}}
+	fqdn, ok = sandboxReadyEndpoint(notReady)
+	require.False(t, ok)
+	require.Equal(t, "sb-1.gram-test.svc.cluster.local", fqdn)
+}
+
+func TestGKERunTurnPostsToRunner(t *testing.T) {
+	t.Parallel()
+
+	assistantID := uuid.New()
+	threadID := uuid.New()
+	var gotPath, gotIdem string
+	var gotBody runtimeTurnRequest
+	doer, host, port := testRunner(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotIdem = r.Header.Get("X-Idempotency-Key")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	backend := newTestGKEBackend(t, newGKEFakeDynamic(), doer, port)
+	err := backend.RunTurn(t.Context(), gkeRecord(t, backend, assistantID, host), threadID, "event-123", "jwt-token", "hello")
+	require.NoError(t, err)
+	require.Equal(t, "/threads/"+threadID.String()+"/turn", gotPath)
+	require.Equal(t, "event-123", gotIdem)
+	require.Equal(t, "hello", gotBody.Input)
+	require.Equal(t, "jwt-token", gotBody.AuthToken)
+}
+
+func TestGKEStatusReadsRunnerState(t *testing.T) {
+	t.Parallel()
+
+	doer, host, port := testRunner(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(runnerStateResponse{
+			AssistantID:   "a",
+			UptimeSeconds: 10,
+			Threads:       []runnerThreadState{{ThreadID: "t1", ChatID: "c1", IdleSeconds: 7}},
+		})
+	})
+
+	backend := newTestGKEBackend(t, newGKEFakeDynamic(), doer, port)
+	status, err := backend.Status(t.Context(), gkeRecord(t, backend, uuid.New(), host))
+	require.NoError(t, err)
+	require.True(t, status.Configured)
+	require.NotNil(t, status.IdleSeconds)
+	require.Equal(t, uint64(7), *status.IdleSeconds)
+}
+
+func TestGKEEnsureWaitsForReadySandbox(t *testing.T) {
+	t.Parallel()
+
+	assistantID := uuid.New()
+	doer, host, port := testRunner(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	claimName := "gram-asst-" + assistantID.String()
+	claim := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gkeSandboxClaimGVR.Group + "/" + gkeSandboxClaimGVR.Version,
+		"kind":       "SandboxClaim",
+		"metadata":   map[string]any{"name": claimName, "namespace": "gram-test"},
+		"status":     map[string]any{"sandbox": map[string]any{"name": "sb-1"}},
+	}}
+	sandbox := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gkeSandboxGVR.Group + "/" + gkeSandboxGVR.Version,
+		"kind":       "Sandbox",
+		"metadata":   map[string]any{"name": "sb-1", "namespace": "gram-test"},
+		"status": map[string]any{
+			"serviceFQDN": host,
+			"conditions":  []any{map[string]any{"type": "Ready", "status": "True"}},
+		},
+	}}
+
+	dyn := newGKEFakeDynamic()
+	seedUnstructured(t, dyn, gkeSandboxClaimGVR, claim)
+	seedUnstructured(t, dyn, gkeSandboxGVR, sandbox)
+	backend := newTestGKEBackend(t, dyn, doer, port)
+	result, err := backend.Ensure(t.Context(), assistantRuntimeRecord{
+		ID:                  uuid.New(),
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendGKE,
+		BackendMetadataJSON: nil,
+		State:               runtimeStateStarting,
+		WarmUntil:           pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+	require.False(t, result.ColdStart) // claim already existed
+	var meta gkeRuntimeMetadata
+	require.NoError(t, json.Unmarshal(result.BackendMetadataJSON, &meta))
+	require.Equal(t, claimName, meta.ClaimName)
+	require.Equal(t, "sb-1", meta.SandboxName)
+	require.Equal(t, host, meta.ServiceFQDN)
+}
+
+func TestGKEReapDeletesClaimIdempotently(t *testing.T) {
+	t.Parallel()
+
+	assistantID := uuid.New()
+	claimName := "gram-asst-" + assistantID.String()
+	claim := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gkeSandboxClaimGVR.Group + "/" + gkeSandboxClaimGVR.Version,
+		"kind":       "SandboxClaim",
+		"metadata":   map[string]any{"name": claimName, "namespace": "gram-test"},
+	}}
+	dyn := newGKEFakeDynamic()
+	seedUnstructured(t, dyn, gkeSandboxClaimGVR, claim)
+	// No runner doer: Reap only deletes the SandboxClaim, no HTTP to the pod.
+	backend := newTestGKEBackend(t, dyn, nil, 8081)
+	record := gkeRecord(t, backend, assistantID, "127.0.0.1")
+
+	require.NoError(t, backend.Reap(t.Context(), record))
+	_, err := dyn.Resource(gkeSandboxClaimGVR).Namespace("gram-test").Get(t.Context(), claimName, metav1.GetOptions{})
+	require.True(t, k8serrors.IsNotFound(err))
+
+	// Idempotent: reaping an already-gone claim succeeds.
+	require.NoError(t, backend.Reap(t.Context(), record))
+}

--- a/server/internal/assistants/runtime_provider.go
+++ b/server/internal/assistants/runtime_provider.go
@@ -94,9 +94,14 @@ func NewRuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider,
 			return nil, fmt.Errorf("invalid gke assistant runtime config: %w", err)
 		}
 		// Reach the in-pod runner through the guardian egress policy, matching
-		// the Fly backend. The policy must permit the in-cluster sandbox
-		// network for traffic to land.
-		backends[runtimeBackendGKE] = NewGKERuntimeBackend(logger, tracerProvider, httpPolicy.PooledClient(guardian.WithDefaultRetryConfig()), config.GKE)
+		// the Fly backend, but allowlist the runner pod CIDR: the server dials
+		// runners by their RFC1918 pod IP (resolved from the Kubernetes API),
+		// which the default policy would otherwise reject as SSRF.
+		gkeClient := httpPolicy.PooledClient(
+			guardian.WithDefaultRetryConfig(),
+			guardian.WithAllowedCIDRBlocks(config.GKE.RunnerCIDRBlocks...),
+		)
+		backends[runtimeBackendGKE] = NewGKERuntimeBackend(logger, tracerProvider, gkeClient, config.GKE)
 	}
 
 	router, err := newRuntimeRouter(config.Provider, backends)

--- a/server/internal/assistants/runtime_provider.go
+++ b/server/internal/assistants/runtime_provider.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	RuntimeProviderFlyIO = runtimeBackendFlyIO
+	RuntimeProviderGKE   = runtimeBackendGKE
 
 	defaultFlyRuntimeRegion = "us"
 	defaultFlyRuntimePrefix = "gram-asst"
@@ -21,6 +22,7 @@ const (
 type RuntimeBackendConfig struct {
 	Provider string
 	Fly      FlyRuntimeConfig
+	GKE      GKERuntimeConfig
 }
 
 type FlyRuntimeConfig struct {
@@ -71,11 +73,35 @@ func (c FlyRuntimeConfig) Validate() error {
 	return nil
 }
 
-func NewRuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider, httpPolicy *guardian.Policy, config RuntimeBackendConfig) RuntimeBackend {
-	switch config.Provider {
-	case RuntimeProviderFlyIO:
-		return NewFlyRuntimeBackend(logger, tracerProvider, httpPolicy, config.Fly)
-	default:
-		panic(fmt.Sprintf("assistants.NewRuntimeBackend: unsupported provider %q (CLI validation should have rejected this)", config.Provider))
+// NewRuntimeBackend assembles a runtimeRouter over every configured backend and
+// targets config.Provider for new admissions. A backend is constructed when its
+// config is present — Fly when an API token is set, GKE when an in-cluster
+// kubernetes client is injected — so the two can run side by side (e.g. target
+// GKE while still tearing down Fly-backed rows). The target backend must be
+// among those constructed.
+func NewRuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider, httpPolicy *guardian.Policy, config RuntimeBackendConfig) (RuntimeBackend, error) {
+	backends := map[string]RuntimeBackend{}
+
+	if config.Fly.FlyTokens != nil {
+		if err := config.Fly.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid fly assistant runtime config: %w", err)
+		}
+		backends[runtimeBackendFlyIO] = NewFlyRuntimeBackend(logger, tracerProvider, httpPolicy, config.Fly)
 	}
+
+	if config.GKE.Dynamic != nil {
+		if err := config.GKE.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid gke assistant runtime config: %w", err)
+		}
+		// Reach the in-pod runner through the guardian egress policy, matching
+		// the Fly backend. The policy must permit the in-cluster sandbox
+		// network for traffic to land.
+		backends[runtimeBackendGKE] = NewGKERuntimeBackend(logger, tracerProvider, httpPolicy.PooledClient(guardian.WithDefaultRetryConfig()), config.GKE)
+	}
+
+	router, err := newRuntimeRouter(config.Provider, backends)
+	if err != nil {
+		return nil, fmt.Errorf("assemble assistant runtime backends: %w", err)
+	}
+	return router, nil
 }

--- a/server/internal/assistants/runtime_router.go
+++ b/server/internal/assistants/runtime_router.go
@@ -1,0 +1,127 @@
+package assistants
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/google/uuid"
+)
+
+// runtimeRouter fans RuntimeBackend calls out to the backend named by each
+// runtime row's Backend column, while presenting the configured target backend
+// for everything that concerns a *new* runtime (Backend(), ServerURL(),
+// ImageRef()). This lets the server run Fly and GKE side by side: rows keep
+// reaching whichever backend created them, and freshly reserved rows are
+// stamped with — and admitted onto — the target.
+type runtimeRouter struct {
+	backends map[string]RuntimeBackend
+	target   string
+}
+
+func newRuntimeRouter(target string, backends map[string]RuntimeBackend) (*runtimeRouter, error) {
+	if len(backends) == 0 {
+		return nil, fmt.Errorf("assistant runtime router requires at least one backend")
+	}
+	if _, ok := backends[target]; !ok {
+		return nil, fmt.Errorf("assistant runtime target backend %q is not configured", target)
+	}
+	return &runtimeRouter{backends: backends, target: target}, nil
+}
+
+// route resolves the backend that owns a runtime row. A row referencing a
+// backend the process no longer runs (e.g. flyio rows after a deployment that
+// dropped Fly config) is a configuration error surfaced to the caller, not a
+// silent no-op — Stop/Reap of such a row would otherwise leak its resources.
+func (r *runtimeRouter) route(backend string) (RuntimeBackend, error) {
+	b, ok := r.backends[backend]
+	if !ok {
+		return nil, fmt.Errorf("assistant runtime backend %q is not configured", backend)
+	}
+	return b, nil
+}
+
+func (r *runtimeRouter) Backend() string { return r.target }
+
+func (r *runtimeRouter) SupportsBackend(backend string) bool {
+	_, ok := r.backends[backend]
+	return ok
+}
+
+// ServerURL and ImageRef describe where a new runtime launches, so they resolve
+// against the target backend. Both are stable for the process lifetime.
+func (r *runtimeRouter) ServerURL() *url.URL { return r.backends[r.target].ServerURL() }
+func (r *runtimeRouter) ImageRef() string    { return r.backends[r.target].ImageRef() }
+
+func (r *runtimeRouter) Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error) {
+	b, err := r.route(runtime.Backend)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+	result, err := b.Ensure(ctx, runtime)
+	if err != nil {
+		return result, fmt.Errorf("ensure %s runtime: %w", runtime.Backend, err)
+	}
+	return result, nil
+}
+
+func (r *runtimeRouter) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+	b, err := r.route(runtime.Backend)
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+	result, err := b.RecycleImage(ctx, runtime)
+	if err != nil {
+		return result, fmt.Errorf("recycle %s runtime image: %w", runtime.Backend, err)
+	}
+	return result, nil
+}
+
+func (r *runtimeRouter) RunTurn(ctx context.Context, runtime assistantRuntimeRecord, threadID uuid.UUID, idempotencyKey string, authToken string, prompt string) error {
+	b, err := r.route(runtime.Backend)
+	if err != nil {
+		return err
+	}
+	// Wrap with %w so the classifyTurnError sentinels the service matches on
+	// (ErrRuntimeUnhealthy, ErrCompletionFailed, ErrHistoryCorrupted) survive.
+	if err := b.RunTurn(ctx, runtime, threadID, idempotencyKey, authToken, prompt); err != nil {
+		return fmt.Errorf("run turn on %s runtime: %w", runtime.Backend, err)
+	}
+	return nil
+}
+
+func (r *runtimeRouter) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
+	b, err := r.route(runtime.Backend)
+	if err != nil {
+		return RuntimeBackendStatus{}, err
+	}
+	status, err := b.Status(ctx, runtime)
+	if err != nil {
+		return status, fmt.Errorf("status of %s runtime: %w", runtime.Backend, err)
+	}
+	return status, nil
+}
+
+func (r *runtimeRouter) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
+	b, err := r.route(runtime.Backend)
+	if err != nil {
+		return err
+	}
+	if err := b.Stop(ctx, runtime); err != nil {
+		return fmt.Errorf("stop %s runtime: %w", runtime.Backend, err)
+	}
+	return nil
+}
+
+func (r *runtimeRouter) Reap(ctx context.Context, runtime assistantRuntimeRecord) error {
+	b, err := r.route(runtime.Backend)
+	if err != nil {
+		return err
+	}
+	if err := b.Reap(ctx, runtime); err != nil {
+		return fmt.Errorf("reap %s runtime: %w", runtime.Backend, err)
+	}
+	return nil
+}
+
+var _ RuntimeBackend = (*runtimeRouter)(nil)

--- a/server/internal/assistants/runtime_router.go
+++ b/server/internal/assistants/runtime_router.go
@@ -53,6 +53,11 @@ func (r *runtimeRouter) SupportsBackend(backend string) bool {
 func (r *runtimeRouter) ServerURL() *url.URL { return r.backends[r.target].ServerURL() }
 func (r *runtimeRouter) ImageRef() string    { return r.backends[r.target].ImageRef() }
 
+// ReusesIdleRuntimes resolves against the target: it drives how a deploy rolls
+// new runtimes onto the configured image, which only concerns the backend that
+// admits them. The deploy sweep skips non-target rows for the same reason.
+func (r *runtimeRouter) ReusesIdleRuntimes() bool { return r.backends[r.target].ReusesIdleRuntimes() }
+
 func (r *runtimeRouter) Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error) {
 	b, err := r.route(runtime.Backend)
 	if err != nil {

--- a/server/internal/assistants/runtime_router_test.go
+++ b/server/internal/assistants/runtime_router_test.go
@@ -1,0 +1,131 @@
+package assistants
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+)
+
+func testRuntimeRecord(backend string) assistantRuntimeRecord {
+	return assistantRuntimeRecord{
+		ID:                  uuid.New(),
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             backend,
+		BackendMetadataJSON: nil,
+		State:               runtimeStateActive,
+		WarmUntil:           pgtype.Timestamptz{},
+	}
+}
+
+// stubRuntimeBackend records which calls land on it so router dispatch can be
+// asserted by backend identity.
+type stubRuntimeBackend struct {
+	name      string
+	serverURL *url.URL
+	imageRef  string
+
+	ensureRecords []assistantRuntimeRecord
+	runTurnCount  int
+	stopCount     int
+	reapCount     int
+}
+
+func (s *stubRuntimeBackend) Backend() string               { return s.name }
+func (s *stubRuntimeBackend) SupportsBackend(b string) bool { return b == s.name }
+func (s *stubRuntimeBackend) ServerURL() *url.URL           { return s.serverURL }
+func (s *stubRuntimeBackend) ImageRef() string              { return s.imageRef }
+
+func (s *stubRuntimeBackend) Ensure(_ context.Context, r assistantRuntimeRecord) (RuntimeBackendEnsureResult, error) {
+	s.ensureRecords = append(s.ensureRecords, r)
+	return RuntimeBackendEnsureResult{ColdStart: true, BackendMetadataJSON: []byte("{}")}, nil
+}
+
+func (s *stubRuntimeBackend) RecycleImage(_ context.Context, _ assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+	return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
+}
+
+func (s *stubRuntimeBackend) RunTurn(_ context.Context, _ assistantRuntimeRecord, _ uuid.UUID, _ string, _ string, _ string) error {
+	s.runTurnCount++
+	return nil
+}
+
+func (s *stubRuntimeBackend) Status(_ context.Context, _ assistantRuntimeRecord) (RuntimeBackendStatus, error) {
+	return RuntimeBackendStatus{Configured: true, IdleSeconds: nil}, nil
+}
+
+func (s *stubRuntimeBackend) Stop(_ context.Context, _ assistantRuntimeRecord) error {
+	s.stopCount++
+	return nil
+}
+
+func (s *stubRuntimeBackend) Reap(_ context.Context, _ assistantRuntimeRecord) error {
+	s.reapCount++
+	return nil
+}
+
+var _ RuntimeBackend = (*stubRuntimeBackend)(nil)
+
+func newTestRouter(t *testing.T, target string) (*runtimeRouter, *stubRuntimeBackend, *stubRuntimeBackend) {
+	t.Helper()
+	fly := &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: &url.URL{Scheme: "https", Host: "fly.example.com"}, imageRef: "fly:img", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
+	gke := &stubRuntimeBackend{name: runtimeBackendGKE, serverURL: &url.URL{Scheme: "https", Host: "gke.example.com"}, imageRef: "gke:img", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
+	router, err := newRuntimeRouter(target, map[string]RuntimeBackend{
+		runtimeBackendFlyIO: fly,
+		runtimeBackendGKE:   gke,
+	})
+	require.NoError(t, err)
+	return router, fly, gke
+}
+
+func TestRuntimeRouterDispatchesByRecordBackend(t *testing.T) {
+	t.Parallel()
+
+	router, fly, gke := newTestRouter(t, runtimeBackendGKE)
+
+	_, err := router.Ensure(t.Context(), testRuntimeRecord(runtimeBackendFlyIO))
+	require.NoError(t, err)
+	require.Len(t, fly.ensureRecords, 1)
+	require.Empty(t, gke.ensureRecords)
+
+	require.NoError(t, router.Reap(t.Context(), testRuntimeRecord(runtimeBackendGKE)))
+	require.Equal(t, 1, gke.reapCount)
+	require.Equal(t, 0, fly.reapCount)
+}
+
+func TestRuntimeRouterTargetSurface(t *testing.T) {
+	t.Parallel()
+
+	router, _, gke := newTestRouter(t, runtimeBackendGKE)
+	require.Equal(t, runtimeBackendGKE, router.Backend())
+	require.Equal(t, gke.serverURL, router.ServerURL())
+	require.Equal(t, gke.imageRef, router.ImageRef())
+	require.True(t, router.SupportsBackend(runtimeBackendFlyIO))
+	require.True(t, router.SupportsBackend(runtimeBackendGKE))
+	require.False(t, router.SupportsBackend("bogus"))
+}
+
+func TestRuntimeRouterUnknownBackendErrors(t *testing.T) {
+	t.Parallel()
+
+	router, _, _ := newTestRouter(t, runtimeBackendGKE)
+	err := router.Stop(t.Context(), testRuntimeRecord("bogus"))
+	require.ErrorContains(t, err, `backend "bogus" is not configured`)
+}
+
+func TestNewRuntimeRouterRequiresTargetConfigured(t *testing.T) {
+	t.Parallel()
+
+	_, err := newRuntimeRouter(runtimeBackendGKE, map[string]RuntimeBackend{
+		runtimeBackendFlyIO: &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: nil, imageRef: "", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0},
+	})
+	require.ErrorContains(t, err, `target backend "gke" is not configured`)
+
+	_, err = newRuntimeRouter(runtimeBackendFlyIO, map[string]RuntimeBackend{})
+	require.ErrorContains(t, err, "at least one backend")
+}

--- a/server/internal/assistants/runtime_router_test.go
+++ b/server/internal/assistants/runtime_router_test.go
@@ -26,9 +26,10 @@ func testRuntimeRecord(backend string) assistantRuntimeRecord {
 // stubRuntimeBackend records which calls land on it so router dispatch can be
 // asserted by backend identity.
 type stubRuntimeBackend struct {
-	name      string
-	serverURL *url.URL
-	imageRef  string
+	name       string
+	serverURL  *url.URL
+	imageRef   string
+	reusesIdle bool
 
 	ensureRecords []assistantRuntimeRecord
 	runTurnCount  int
@@ -40,6 +41,7 @@ func (s *stubRuntimeBackend) Backend() string               { return s.name }
 func (s *stubRuntimeBackend) SupportsBackend(b string) bool { return b == s.name }
 func (s *stubRuntimeBackend) ServerURL() *url.URL           { return s.serverURL }
 func (s *stubRuntimeBackend) ImageRef() string              { return s.imageRef }
+func (s *stubRuntimeBackend) ReusesIdleRuntimes() bool      { return s.reusesIdle }
 
 func (s *stubRuntimeBackend) Ensure(_ context.Context, r assistantRuntimeRecord) (RuntimeBackendEnsureResult, error) {
 	s.ensureRecords = append(s.ensureRecords, r)
@@ -73,8 +75,8 @@ var _ RuntimeBackend = (*stubRuntimeBackend)(nil)
 
 func newTestRouter(t *testing.T, target string) (*runtimeRouter, *stubRuntimeBackend, *stubRuntimeBackend) {
 	t.Helper()
-	fly := &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: &url.URL{Scheme: "https", Host: "fly.example.com"}, imageRef: "fly:img", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
-	gke := &stubRuntimeBackend{name: runtimeBackendGKE, serverURL: &url.URL{Scheme: "https", Host: "gke.example.com"}, imageRef: "gke:img", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
+	fly := &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: &url.URL{Scheme: "https", Host: "fly.example.com"}, imageRef: "fly:img", reusesIdle: true, ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
+	gke := &stubRuntimeBackend{name: runtimeBackendGKE, serverURL: &url.URL{Scheme: "https", Host: "gke.example.com"}, imageRef: "gke:img", reusesIdle: false, ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
 	router, err := newRuntimeRouter(target, map[string]RuntimeBackend{
 		runtimeBackendFlyIO: fly,
 		runtimeBackendGKE:   gke,
@@ -105,9 +107,13 @@ func TestRuntimeRouterTargetSurface(t *testing.T) {
 	require.Equal(t, runtimeBackendGKE, router.Backend())
 	require.Equal(t, gke.serverURL, router.ServerURL())
 	require.Equal(t, gke.imageRef, router.ImageRef())
+	require.False(t, router.ReusesIdleRuntimes(), "gke target resolves to the gke backend's non-reuse")
 	require.True(t, router.SupportsBackend(runtimeBackendFlyIO))
 	require.True(t, router.SupportsBackend(runtimeBackendGKE))
 	require.False(t, router.SupportsBackend("bogus"))
+
+	flyTarget, _, _ := newTestRouter(t, runtimeBackendFlyIO)
+	require.True(t, flyTarget.ReusesIdleRuntimes(), "fly target resolves to the fly backend's warm reuse")
 }
 
 func TestRuntimeRouterUnknownBackendErrors(t *testing.T) {
@@ -122,7 +128,7 @@ func TestNewRuntimeRouterRequiresTargetConfigured(t *testing.T) {
 	t.Parallel()
 
 	_, err := newRuntimeRouter(runtimeBackendGKE, map[string]RuntimeBackend{
-		runtimeBackendFlyIO: &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: nil, imageRef: "", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0},
+		runtimeBackendFlyIO: &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: nil, imageRef: "", reusesIdle: true, ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0},
 	})
 	require.ErrorContains(t, err, `target backend "gke" is not configured`)
 

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -117,6 +117,10 @@ func (t *telemetryRuntimeBackend) ImageRef() string {
 	return t.inner.ImageRef()
 }
 
+func (t *telemetryRuntimeBackend) ReusesIdleRuntimes() bool {
+	return t.inner.ReusesIdleRuntimes()
+}
+
 func (t *telemetryRuntimeBackend) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
 	result, err := t.inner.RecycleImage(ctx, runtime)
 	if err != nil {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1112,9 +1112,19 @@ type RecycleAssistantRuntimeImagesParams struct {
 // RecycleActiveRuntimeImages best-effort rolls every active v2 runtime onto
 // the currently configured runtime image, so deploys absorb the image-pull +
 // reboot cost while runtimes are idle instead of the next turn paying it.
-// Busy or failed rows are not chased — the per-admission recycle in Ensure
-// catches them lazily.
+// Busy or failed rows are not chased — the per-admission path catches them
+// lazily.
+//
+// This is the in-place roll for backends that reuse idle runtimes (Fly). A
+// non-reuse backend (GKE) has no in-place swap and rolls onto a new image by
+// terminating idle runtimes instead (the warm-TTL expiry stops them, which
+// deletes the claim, and the next /turn re-admits onto a fresh warm-pool pod
+// already running the new image), so this sweep is a no-op for it.
 func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params RecycleAssistantRuntimeImagesParams) (RecycleAssistantRuntimeImagesResult, error) {
+	if !s.runtime.ReusesIdleRuntimes() {
+		return RecycleAssistantRuntimeImagesResult{}, nil
+	}
+
 	queries := assistantrepo.New(s.db)
 	rows, err := queries.ListActiveAssistantRuntimesForImageRecycle(ctx, runtimeStateActive)
 	if err != nil {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1059,7 +1059,12 @@ func (s *ServiceCore) ReapInactiveAssistantRuntimes(ctx context.Context, params 
 
 	rows, err := assistantrepo.New(s.db).ListInactiveAssistantRuntimesForReap(ctx, assistantrepo.ListInactiveAssistantRuntimesForReapParams{
 		InactiveBefore: conv.ToPGTimestamptz(time.Now().UTC().Add(-params.InactivityThreshold)),
-		LimitCount:     params.BatchSize,
+		// Also collect runtimes parked on a backend we no longer target so a
+		// provider switch (e.g. flyio -> gke) drains the old backend lazily as
+		// assistants go idle, without an admission-path teardown.
+		TargetBackend: s.runtime.Backend(),
+		StoppedState:  runtimeStateStopped,
+		LimitCount:    params.BatchSize,
 	})
 	if err != nil {
 		return ReapAssistantRuntimesResult{}, fmt.Errorf("list inactive assistant runtimes for reap: %w", err)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1122,7 +1122,7 @@ type RecycleAssistantRuntimeImagesParams struct {
 // already running the new image), so this sweep is a no-op for it.
 func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params RecycleAssistantRuntimeImagesParams) (RecycleAssistantRuntimeImagesResult, error) {
 	if !s.runtime.ReusesIdleRuntimes() {
-		return RecycleAssistantRuntimeImagesResult{}, nil
+		return RecycleAssistantRuntimeImagesResult{Recycled: 0, Skipped: 0, Errors: 0}, nil
 	}
 
 	queries := assistantrepo.New(s.db)

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1309,6 +1309,7 @@ func insertActiveV2RuntimeRow(
 	t *testing.T,
 	conn *pgxpool.Pool,
 	projectID, assistantID, threadID uuid.UUID,
+	backend string,
 	state string,
 	metadata string,
 ) uuid.UUID {
@@ -1318,7 +1319,7 @@ func insertActiveV2RuntimeRow(
 		AssistantThreadID: threadID,
 		AssistantID:       assistantID,
 		ProjectID:         projectID,
-		Backend:           runtimeBackendFlyIO,
+		Backend:           backend,
 		State:             state,
 	}))
 	row, err := assistantsrepo.New(conn).GetAssistantRuntimeV2(t.Context(), assistantsrepo.GetAssistantRuntimeV2Params{
@@ -1343,7 +1344,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesRecyclesAndPersists(t *testing.T) 
 	// insertReapableProject seeds no thread events, so the runtime reads as
 	// fully idle to the sweep's in-flight guard.
 	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-persist")
-	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-stale","machine_id":"m-1"}`)
+	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeBackendFlyIO, runtimeStateActive, `{"app_name":"gram-asst-stale","machine_id":"m-1"}`)
 
 	recycledMetadata := `{"app_name":"gram-asst-stale","machine_id":"m-1","last_boot_id":"boot-2"}`
 	recycleCalls := &atomic.Int64{}
@@ -1378,12 +1379,12 @@ func TestServiceCoreRecycleActiveRuntimeImagesSweepsOnlyActiveV2Rows(t *testing.
 	// Candidate: active v2 row with metadata. The fake reports no recycle
 	// (image already current), so it must count as skipped.
 	activeProj, activeAssistant, activeThread := insertReapableProject(t, conn, "recycle-active")
-	insertActiveV2RuntimeRow(t, conn, activeProj, activeAssistant, activeThread, runtimeStateActive, `{"app_name":"gram-asst-current","machine_id":"m-1"}`)
+	insertActiveV2RuntimeRow(t, conn, activeProj, activeAssistant, activeThread, runtimeBackendFlyIO, runtimeStateActive, `{"app_name":"gram-asst-current","machine_id":"m-1"}`)
 
 	// Non-candidates: a starting v2 row (mid-boot, already on the new
 	// image) and a v1 row (per-thread runtimes recycle on admission).
 	startingProj, startingAssistant, startingThread := insertReapableProject(t, conn, "recycle-starting")
-	insertActiveV2RuntimeRow(t, conn, startingProj, startingAssistant, startingThread, runtimeStateStarting, `{"app_name":"gram-asst-booting","machine_id":"m-2"}`)
+	insertActiveV2RuntimeRow(t, conn, startingProj, startingAssistant, startingThread, runtimeBackendFlyIO, runtimeStateStarting, `{"app_name":"gram-asst-booting","machine_id":"m-2"}`)
 	v1Proj, v1Assistant, v1Thread := insertReapableProject(t, conn, "recycle-v1")
 	insertReapableRuntimeRow(t, conn, v1Proj, v1Assistant, v1Thread, runtimeStateActive, "gram-asst-v1", time.Now().UTC())
 
@@ -1412,7 +1413,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesSkipsAssistantsWithInFlightEvents(
 	// insertAssistantFixture seeds a pending thread event, which is exactly
 	// the in-flight signal the sweep must respect.
 	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
-	insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-busy","machine_id":"m-1"}`)
+	insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeBackendFlyIO, runtimeStateActive, `{"app_name":"gram-asst-busy","machine_id":"m-1"}`)
 
 	recycleCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{
@@ -1440,7 +1441,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesIgnoresDeletedAssistants(t *testin
 	// delete belongs to the janitor; recycling it would bump updated_at and
 	// postpone the inactivity-based collection.
 	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-deleted-assistant")
-	insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-orphan","machine_id":"m-1"}`)
+	insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeBackendFlyIO, runtimeStateActive, `{"app_name":"gram-asst-orphan","machine_id":"m-1"}`)
 	require.NoError(t, assistantsrepo.New(conn).DeleteAssistant(t.Context(), assistantsrepo.DeleteAssistantParams{
 		AssistantID: assistantID,
 		ProjectID:   projectID,
@@ -1470,7 +1471,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesUndoesRecycleWhenRowExpiresMidSwee
 
 	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-raced")
 	originalMetadata := `{"app_name":"gram-asst-raced","machine_id":"m-1"}`
-	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, originalMetadata)
+	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeBackendFlyIO, runtimeStateActive, originalMetadata)
 
 	// The fake recycles "successfully" but expires the row first, simulating
 	// the warm timer winning the race while the machine update was in flight.
@@ -1515,7 +1516,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesCountsBackendErrors(t *testing.T) 
 	require.NoError(t, err)
 
 	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-errors")
-	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, `{"app_name":"gram-asst-flaky","machine_id":"m-1"}`)
+	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeBackendFlyIO, runtimeStateActive, `{"app_name":"gram-asst-flaky","machine_id":"m-1"}`)
 
 	backend := testRuntimeBackend{
 		backend:    runtimeBackendFlyIO,
@@ -1532,6 +1533,41 @@ func TestServiceCoreRecycleActiveRuntimeImagesCountsBackendErrors(t *testing.T) 
 	runtime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: runtimeID, ProjectID: projectID})
 	require.NoError(t, err)
 	require.JSONEq(t, `{"app_name":"gram-asst-flaky","machine_id":"m-1"}`, string(runtime.BackendMetadataJson))
+}
+
+// A non-reuse backend (GKE) has no in-place image swap: it rolls onto a new
+// image by terminating idle runtimes (warm-TTL expiry), so the in-place recycle
+// sweep is a no-op for it — it touches no rows and tears nothing down.
+func TestServiceCoreRecycleActiveRuntimeImagesNoOpsForNonReuseBackend(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_gke_noop")
+	require.NoError(t, err)
+
+	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-gke-noop")
+	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeBackendGKE, runtimeStateActive, `{"claim_name":"gram-asst-idle"}`)
+
+	stopCalls := &atomic.Int64{}
+	recycleCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{
+		backend:      runtimeBackendGKE,
+		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: nil},
+		stopCalls:    stopCalls,
+		recycleCalls: recycleCalls,
+	}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+
+	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Recycled)
+	require.Equal(t, 0, result.Skipped)
+	require.Equal(t, 0, result.Errors)
+	require.EqualValues(t, 0, stopCalls.Load(), "the in-place sweep must not tear down GKE runtimes")
+	require.EqualValues(t, 0, recycleCalls.Load(), "GKE has no in-place recycle")
+
+	runtime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: runtimeID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateActive, runtime.State, "GKE rows roll via terminate-on-idle, not the sweep")
 }
 
 func TestServiceCoreReapInactiveAssistantRuntimesCollectsOnlyInactive(t *testing.T) {
@@ -1768,6 +1804,12 @@ func (t testRuntimeBackend) Ensure(context.Context, assistantRuntimeRecord) (Run
 
 func (t testRuntimeBackend) ImageRef() string {
 	return t.imageRef
+}
+
+func (t testRuntimeBackend) ReusesIdleRuntimes() bool {
+	// Mirror production: GKE tears idle runtimes down (no warm reuse), every
+	// other backend preserves them for warm restart.
+	return t.backend != runtimeBackendGKE
 }
 
 func (t testRuntimeBackend) RecycleImage(ctx context.Context, record assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -113,9 +113,10 @@ func DefaultRetryConfig() *RetryConfig {
 }
 
 type htttpClientOptions struct {
-	otelHTTPOptions []otelhttp.Option
-	retryConfig     *RetryConfig
-	resolver        *net.Resolver
+	otelHTTPOptions   []otelhttp.Option
+	retryConfig       *RetryConfig
+	resolver          *net.Resolver
+	allowedCIDRBlocks []*net.IPNet
 }
 
 // WithOTelHTTPOptions appends additional [otelhttp.Option] values to the
@@ -132,6 +133,26 @@ func WithOTelHTTPOptions(options ...otelhttp.Option) func(*htttpClientOptions) {
 func WithDefaultRetryConfig() func(*htttpClientOptions) {
 	return func(o *htttpClientOptions) {
 		o.retryConfig = DefaultRetryConfig()
+	}
+}
+
+// WithAllowedCIDRBlocks permits this client to dial IPs inside the given CIDR
+// blocks even when the policy's blocklist would otherwise reject them. Use it
+// only for clients whose destinations are trusted and not user-controlled —
+// e.g. the assistant runtime client dialing GKE runner pods by the (RFC1918)
+// pod IP it resolved from the Kubernetes API. The relaxation is scoped to this
+// client; the policy's global enforcement is unchanged. Invalid CIDRs are
+// ignored, so validate them at the configuration boundary.
+func WithAllowedCIDRBlocks(cidrs ...string) func(*htttpClientOptions) {
+	return func(o *htttpClientOptions) {
+		for _, cidr := range cidrs {
+			if cidr == "" {
+				continue
+			}
+			if block, err := parseCIDR(cidr); err == nil {
+				o.allowedCIDRBlocks = append(o.allowedCIDRBlocks, block)
+			}
+		}
 	}
 }
 
@@ -227,6 +248,9 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 	if opts.resolver != nil {
 		dialOpts = append(dialOpts, WithDialerResolver(opts.resolver))
 	}
+	if len(opts.allowedCIDRBlocks) > 0 {
+		dialOpts = append(dialOpts, WithDialerAllowedCIDRBlocks(opts.allowedCIDRBlocks))
+	}
 	transport.DialContext = p.Dialer(dialOpts...).DialContext
 
 	otelOpts := []otelhttp.Option{otelhttp.WithTracerProvider(p.tracerProvider)}
@@ -255,12 +279,22 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 }
 
 type dialerOptions struct {
-	resolver *net.Resolver
+	resolver          *net.Resolver
+	allowedCIDRBlocks []*net.IPNet
 }
 
 func WithDialerResolver(resolver *net.Resolver) func(*dialerOptions) {
 	return func(o *dialerOptions) {
 		o.resolver = resolver
+	}
+}
+
+// WithDialerAllowedCIDRBlocks permits the dialer to connect to IPs inside the
+// given blocks even when the policy blocklist covers them. See
+// [WithAllowedCIDRBlocks] for when this is appropriate.
+func WithDialerAllowedCIDRBlocks(blocks []*net.IPNet) func(*dialerOptions) {
+	return func(o *dialerOptions) {
+		o.allowedCIDRBlocks = blocks
 	}
 }
 
@@ -297,6 +331,14 @@ func (p *Policy) Dialer(options ...func(*dialerOptions)) *net.Dialer {
 			ip := net.ParseIP(host)
 			if ip == nil {
 				return fmt.Errorf("%s: %w: bad ip", address, ErrBadHost)
+			}
+
+			// A client-scoped allowlist overrides the blocklist for trusted,
+			// non-user-controlled destinations (e.g. GKE runner pod IPs).
+			for _, block := range opts.allowedCIDRBlocks {
+				if block.Contains(ip) {
+					return nil
+				}
 			}
 
 			return p.checkIP(ip)

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -146,6 +146,24 @@ func TestPolicy_DialerControlContext_CustomPolicy(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestPolicy_DialerAllowedCIDRBlocksOverridesBlock(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+
+	_, allowed, err := net.ParseCIDR("10.52.0.0/16")
+	require.NoError(t, err)
+	dialer := policy.Dialer(guardian.WithDialerAllowedCIDRBlocks([]*net.IPNet{allowed}))
+	ctx := t.Context()
+
+	// An IP inside the allowlisted block is permitted even though it is RFC1918
+	// (the GKE runner pod case).
+	require.NoError(t, dialer.ControlContext(ctx, "tcp", "10.52.1.2:8081", nil))
+
+	// A private IP outside the allowlist is still blocked — the relaxation is
+	// scoped to the configured blocks only.
+	require.ErrorIs(t, dialer.ControlContext(ctx, "tcp", "10.1.0.5:80", nil), guardian.ErrBlockedIP)
+}
+
 func TestPolicy_ClientWrapsTransportWithOtel(t *testing.T) {
 	t.Parallel()
 	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))

--- a/server/internal/k8s/remote.go
+++ b/server/internal/k8s/remote.go
@@ -1,0 +1,51 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// gkeAuthScope is the OAuth2 scope GKE accepts for authenticating a Google
+// access token against the cluster API (mapped to the caller's identity via the
+// cluster's RBAC).
+const gkeAuthScope = "https://www.googleapis.com/auth/cloud-platform"
+
+// NewRemoteDynamicClient builds a dynamic client for a remote GKE cluster (the
+// assistant runtime cluster) authenticated with the caller's Google credentials:
+// workload identity when running in a cluster, Application Default Credentials
+// locally. Unlike InitializeK8sClient it does not require running inside the
+// target cluster, so the gram server reaches a separate assistant cluster the
+// same way it reaches Fly — by endpoint and credentials, not in-cluster config.
+func NewRemoteDynamicClient(ctx context.Context, endpoint string, caCert []byte) (dynamic.Interface, error) {
+	if endpoint == "" {
+		return nil, fmt.Errorf("remote cluster endpoint is required")
+	}
+	if len(caCert) == 0 {
+		return nil, fmt.Errorf("remote cluster CA certificate is required")
+	}
+
+	tokenSource, err := google.DefaultTokenSource(ctx, gkeAuthScope)
+	if err != nil {
+		return nil, fmt.Errorf("resolve google token source for remote cluster: %w", err)
+	}
+
+	config := &rest.Config{
+		Host:            "https://" + endpoint,
+		TLSClientConfig: rest.TLSClientConfig{CAData: caCert},
+	}
+	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &oauth2.Transport{Source: tokenSource, Base: rt}
+	})
+
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create remote dynamic client: %w", err)
+	}
+	return client, nil
+}

--- a/server/internal/k8s/remote.go
+++ b/server/internal/k8s/remote.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -35,8 +36,16 @@ func NewRemoteDynamicClient(ctx context.Context, endpoint string, caCert []byte)
 		return nil, fmt.Errorf("resolve google token source for remote cluster: %w", err)
 	}
 
+	// Accept a bare host (the common case) or a full URL — prepend the scheme
+	// only when the caller didn't, so an endpoint that already carries one
+	// doesn't become "https://https://...".
+	host := endpoint
+	if !strings.Contains(host, "://") {
+		host = "https://" + host
+	}
+
 	config := &rest.Config{
-		Host:            "https://" + endpoint,
+		Host:            host,
 		TLSClientConfig: rest.TLSClientConfig{CAData: caCert},
 	}
 	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {


### PR DESCRIPTION
## What

Adds a second assistant-runtime backend on **GKE Agent Sandbox** (gVisor), selectable per-deployment via `--assistant-runtime-provider=gke`. Fly stays fully supported; `provider=fly` is unchanged.

- **`runtime_router.go`** — a `RuntimeBackend` that dispatches per `record.Backend`, so existing call sites are untouched. On admission it reaps the **non-target** backend's runtime.
- **`runtime_gke.go`** — the GKE backend: ensures a `SandboxClaim` against the configured warm pool, waits for the `Sandbox` to report a routable service FQDN, and drives turns over the shared runner HTTP client. `Stop`/`Reap` delete the claim; `RecycleImage` is a no-op.
- **`runtime.go` / `runtime_fly.go`** — share the runner HTTP doer; send `AssistantID`/`ProjectID` on `/turn` (harmless/unused on Fly, used for state on GKE).
- **`queries.sql`** — the periodic reaper drains the non-target backend's stopped runtimes.
- **`flags_assistants.go`** — GKE flags + in-cluster dynamic client wiring.
- **`agents/runner`** — learns its assistant identity from the first `/turn` when not supplied via env (env wins), so warm-pool pods need no per-claim env.
- **`agents/runtime-image/init.sh`** — capability-detect `mount`: symlink deps when `mount(2)` is unavailable (hardened Sandbox), keep tmpfs + RO binds on Fly.

## Safety

GKE is **dormant** until a deployment sets `provider=gke` (dev only, in the gram-infra helm PR). Prod values are unchanged → prod stays on Fly. On merge, the release pipeline publishes the runtime image (with this `init.sh`) to GCR — the bootable image the SandboxTemplate pulls.

## Merge order

PR **3 of 4**: gram-infra#1411 (pool, applied) → gram-infra#1413 (addon + RBAC, applied) → **this** → gram-infra#1412 (helm deploy). Merge before the helm PR so the runtime image exists and the server binary understands `provider=gke`.