### PR TITLE
chore(zero): use local:start task if defined

### DIFF
--- a/zero
+++ b/zero
@@ -147,14 +147,20 @@ interactive_only mise zero:summary
 
 echo -e "\n✅ All set up!"
 
+# Use local:start if it's defined, otherwise fall back to the default start task.
+start_task="start"
+if mise tasks info local:start &>/dev/null; then
+    start_task="local:start"
+fi
+
 if $auto_yes; then
-    exec mise run start
+    exec mise run "$start_task"
 elif ! $agent_mode; then
-    echo "Want me to start the server and dashboard (\`mise run start\`)?"
+    echo "Want me to start the server and dashboard (\`mise run $start_task\`)?"
     echo -n "[y/N] "
     read -r answer
     answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]')
     if [ "$answer" = "y" ]; then
-    exec mise run start
+    exec mise run "$start_task"
     fi
 fi


### PR DESCRIPTION
Test driving developer tooling like pitchfork (https://pitchfork.jdx.dev) for managing local service processes. Letting the zero bootstrap script prefer a `local:start` task when one is defined lets developers wire up an alternative startup path without changing the default `start` task that the wider team relies on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `zero` bootstrap script to prefer `local:start` when available, falling back to `start`. This lets developers use custom local setups without changing the shared `start` task.

<sup>Written for commit 1b5ac2364e3b72c7796dc87c8ab6145e92c00b3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

