### PR TITLE
chore(telemetry): base64 encode prompts for comparison

### DIFF
--- a/server/internal/telemetry/claude_prompt_correlation_test.go
+++ b/server/internal/telemetry/claude_prompt_correlation_test.go
@@ -80,7 +80,7 @@ func TestListClaudeUserPromptCandidatesForCorrelationBindsLargePrompt(t *testing
 		GramProjectID:          uuid.NewString(),
 		GramChatID:             uuid.NewString(),
 		SessionID:              uuid.NewString(),
-		MessagePrompt:          strings.Repeat("Here is a production example for serviceMainCategories ", 10_000),
+		MessagePrompt:          strings.Repeat("Here is a production example for serviceMainCategories.\nKeep tabs\tand literal JSON escapes like \\n intact. ", 10_000),
 		MessageTimeUnixNano:    time.Now().UTC().UnixNano(),
 		AfterEventSequence:     0,
 		AfterEventTimeUnixNano: 0,
@@ -89,6 +89,47 @@ func TestListClaudeUserPromptCandidatesForCorrelationBindsLargePrompt(t *testing
 	})
 	require.NoError(t, err)
 	require.Empty(t, candidates)
+}
+
+func TestListClaudeUserPromptCandidatesForCorrelationMatchesEscapedPrompt(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	projectID := uuid.New().String()
+	chatID := uuid.New().String()
+	sessionID := uuid.New().String()
+	now := time.Now().UTC()
+	prompt := `Review this output with \"quotes\", backslashes \\\\, tabs\tand\nnewlines. Keep literal JSON escapes like \\n intact.`
+
+	insertClaudeUserPromptEvent(t, ctx, ti.chClient, claudeUserPromptEventFixture{
+		projectID:     projectID,
+		chatID:        chatID,
+		sessionID:     sessionID,
+		promptID:      "prompt-escaped",
+		prompt:        prompt,
+		eventSequence: 1,
+		timestamp:     now,
+	})
+
+	var candidates []telemetryRepo.ClaudeUserPromptCandidate
+	require.Eventually(t, func() bool {
+		var err error
+		candidates, err = ti.chClient.ListClaudeUserPromptCandidatesForCorrelation(ctx, telemetryRepo.ListClaudeUserPromptCandidatesForCorrelationParams{
+			GramProjectID:          projectID,
+			GramChatID:             chatID,
+			SessionID:              sessionID,
+			MessagePrompt:          prompt,
+			MessageTimeUnixNano:    now.UnixNano(),
+			AfterEventSequence:     0,
+			AfterEventTimeUnixNano: 0,
+			MinFuzzyLength:         40,
+			MaxTimeDeltaNanos:      (10 * time.Minute).Nanoseconds(),
+		})
+		return err == nil && len(candidates) == 1 && candidates[0].PromptID == "prompt-escaped"
+	}, 2*time.Second, 50*time.Millisecond)
+
+	require.GreaterOrEqual(t, candidates[0].Similarity, 0.95)
 }
 
 type claudeUserPromptEventFixture struct {

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -4282,7 +4283,7 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 		"gram_project_id":               arg.GramProjectID,
 		"gram_chat_id":                  arg.GramChatID,
 		"session_id":                    arg.SessionID,
-		"message_prompt":                arg.MessagePrompt,
+		"message_prompt_b64":            base64.StdEncoding.EncodeToString([]byte(arg.MessagePrompt)),
 		"message_time_unix_nano":        strconv.FormatInt(arg.MessageTimeUnixNano, 10),
 		"after_event_sequence":          strconv.FormatInt(arg.AfterEventSequence, 10),
 		"after_event_time_unix_nano":    strconv.FormatInt(arg.AfterEventTimeUnixNano, 10),
@@ -4341,7 +4342,7 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 		"is_exact",
 	).
 		Prefix(`WITH
-			{message_prompt:String} AS message_prompt,
+			replaceRegexpAll(trimBoth(base64Decode({message_prompt_b64:String})), '\\s+', ' ') AS message_prompt,
 			lengthUTF8(message_prompt) AS message_len,
 			{message_time_unix_nano:Int64} AS message_time_unix_nano,
 			{max_time_delta_nanos:Int64} AS max_time_delta_nanos`).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Base64-encode prompts before ClickHouse comparison to fix parameter escaping and ensure accurate Claude prompt correlation for inputs with quotes, backslashes, tabs, and newlines.

- **Bug Fixes**
  - Encode `message_prompt` in Go with `encoding/base64` and pass as `message_prompt_b64`; decode in SQL and normalize whitespace to avoid false mismatches.
  - Updated query to compare against the decoded, trimmed prompt string.
  - Added a test for escaped prompts and expanded the large-prompt test to include tabs, newlines, and JSON escape sequences.

<sup>Written for commit bc1ec4e86cf9bd34cfc4cba25c774f95a6e846bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

