### PR TITLE
fix: resolve hook actors from payload email

### DIFF
--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -475,22 +475,12 @@ func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 	// carry user_email from the device agent; use it immediately when present
 	// so Claude can attribute hooks before OTEL logs arrive. Older hooks still
 	// fall back to buffering.
+	authMetadata, hasAuthMetadata := s.claudeAuthContextMetadata(ctx, sessionID, payloadUserEmail)
+
 	metadata, err := s.getSessionMetadata(ctx, sessionID)
 	if err == nil {
-		if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ProjectID != nil {
-			authMetadata := SessionMetadata{
-				SessionID:   sessionID,
-				ServiceName: "",
-				UserEmail:   payloadUserEmail,
-				UserID:      authCtx.UserID,
-				ClaudeOrgID: "",
-				GramOrgID:   authCtx.ActiveOrganizationID,
-				ProjectID:   authCtx.ProjectID.String(),
-			}
-			if authMetadata.UserID == "" && authMetadata.UserEmail != "" {
-				authMetadata.UserID = s.resolveUserByEmail(ctx, authMetadata.UserEmail, authMetadata.GramOrgID)
-			}
-			metadata = mergeClaudeAuthContextMetadata(authMetadata, metadata)
+		if hasAuthMetadata {
+			metadata = s.mergeClaudeAuthContextMetadata(ctx, authMetadata, metadata)
 		}
 		// Persistence does DB writes plus a Temporal workflow start, which
 		// can take longer than Claude Code is willing to wait for a hook
@@ -498,33 +488,74 @@ func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 		// immediately on the response). Run it detached so the response
 		// returns promptly and the work completes in the background.
 		go s.persistHook(ctx, payload, &metadata)
-	} else {
-		if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ProjectID != nil && payloadUserEmail != "" {
-			metadata := SessionMetadata{
-				SessionID:   sessionID,
-				ServiceName: "",
-				UserEmail:   payloadUserEmail,
-				UserID:      authCtx.UserID,
-				ClaudeOrgID: "",
-				GramOrgID:   authCtx.ActiveOrganizationID,
-				ProjectID:   authCtx.ProjectID.String(),
-			}
-			if metadata.UserID == "" && metadata.UserEmail != "" {
-				metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
-			}
-			go s.persistHook(ctx, payload, &metadata)
-			return
-		}
-		if err := s.bufferHook(ctx, sessionID, payload); err != nil {
-			logger.ErrorContext(ctx, "Failed to buffer hook",
-				attr.SlogEvent("claude_hook_buffer_failed"),
-				attr.SlogError(err),
-			)
-		}
+		return
+	}
+
+	if hasAuthMetadata && payloadUserEmail != "" {
+		go s.persistHook(ctx, payload, &authMetadata)
+		return
+	}
+
+	if err := s.bufferHook(ctx, sessionID, payload); err != nil {
+		logger.ErrorContext(ctx, "Failed to buffer hook",
+			attr.SlogEvent("claude_hook_buffer_failed"),
+			attr.SlogError(err),
+		)
 	}
 }
 
+func (s *Service) claudeAuthContextMetadata(ctx context.Context, sessionID, userEmail string) (SessionMetadata, bool) {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		return SessionMetadata{
+			SessionID:   "",
+			ServiceName: "",
+			UserEmail:   "",
+			UserID:      "",
+			ClaudeOrgID: "",
+			GramOrgID:   "",
+			ProjectID:   "",
+		}, false
+	}
+
+	metadata := SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "",
+		UserEmail:   userEmail,
+		UserID:      "",
+		ClaudeOrgID: "",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}
+	if metadata.UserEmail != "" {
+		metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
+	}
+
+	return metadata, true
+}
+
+func (s *Service) resolveClaudeSessionMetadata(ctx context.Context, sessionID, userEmail string) (SessionMetadata, error) {
+	authMetadata, hasAuthMetadata := s.claudeAuthContextMetadata(ctx, sessionID, strings.TrimSpace(userEmail))
+
+	metadata, err := s.getSessionMetadata(ctx, sessionID)
+	if err == nil {
+		if hasAuthMetadata {
+			metadata = s.mergeClaudeAuthContextMetadata(ctx, authMetadata, metadata)
+		} else {
+			metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
+		}
+		return metadata, nil
+	}
+
+	if hasAuthMetadata {
+		return authMetadata, nil
+	}
+	return SessionMetadata{}, err
+}
+
 func (s *Service) persistHook(ctx context.Context, payload *gen.ClaudePayload, metadata *SessionMetadata) {
+	metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
+
 	if isConversationEvent(payload.HookEventName) {
 		if err := s.persistConversationEvent(ctx, payload, metadata); err != nil {
 			s.logger.ErrorContext(ctx, "Failed to persist conversation event", attr.SlogError(err))
@@ -610,43 +641,21 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 	// session, before OTEL Logs has had a chance to seed Redis. Redis is still
 	// consulted to enrich UserEmail / ServiceName / ClaudeOrgID for the
 	// downstream ClickHouse row, but absence of cached fields is non-fatal.
-	var metadata SessionMetadata
-	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ProjectID != nil {
-		metadata = SessionMetadata{
-			SessionID:   sessionID,
-			ServiceName: "",
-			UserEmail:   strings.TrimSpace(conv.PtrValOr(payload.UserEmail, "")),
-			UserID:      authCtx.UserID,
-			ClaudeOrgID: "",
-			GramOrgID:   authCtx.ActiveOrganizationID,
-			ProjectID:   authCtx.ProjectID.String(),
-		}
-		if metadata.UserID == "" && metadata.UserEmail != "" {
-			metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
-		}
-		if cached, err := s.getSessionMetadata(ctx, sessionID); err == nil {
-			metadata = mergeClaudeAuthContextMetadata(metadata, cached)
-		}
-	} else {
-		var err error
-		metadata, err = s.getSessionMetadata(ctx, sessionID)
-		if err != nil {
-			// OTEL path with no cached metadata yet. Native tools are already
-			// skipped above; MCP calls must fail closed because buffered
-			// telemetry cannot undo an already-allowed tool call.
-			s.logger.WarnContext(ctx, "claude PreToolUse fired before session metadata available; denying MCP tool call",
-				attr.SlogEvent("claude_hook_pretooluse_no_metadata"),
-				attr.SlogHookSource("claude"),
-				attr.SlogHookEvent(payload.HookEventName),
-				attr.SlogGenAIConversationID(sessionID),
-				attr.SlogToolName(rawToolName),
-				attr.SlogError(err),
-			)
-			return denyUnverifiedMCP()
-		}
-		if metadata.UserID == "" {
-			metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
-		}
+	payloadUserEmail := strings.TrimSpace(conv.PtrValOr(payload.UserEmail, ""))
+	metadata, err := s.resolveClaudeSessionMetadata(ctx, sessionID, payloadUserEmail)
+	if err != nil {
+		// OTEL path with no cached metadata yet. Native tools are already
+		// skipped above; MCP calls must fail closed because buffered telemetry
+		// cannot undo an already-allowed tool call.
+		s.logger.WarnContext(ctx, "claude PreToolUse fired before session metadata available; denying MCP tool call",
+			attr.SlogEvent("claude_hook_pretooluse_no_metadata"),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent(payload.HookEventName),
+			attr.SlogGenAIConversationID(sessionID),
+			attr.SlogToolName(rawToolName),
+			attr.SlogError(err),
+		)
+		return denyUnverifiedMCP()
 	}
 
 	policy := s.lookupShadowMCPBlockingPolicy(ctx, metadata.GramOrgID, metadata.ProjectID, metadata.UserID)
@@ -793,14 +802,12 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 	return constructBlockResponse(payload.HookEventName, userReason), nil
 }
 
-func mergeClaudeAuthContextMetadata(metadata SessionMetadata, cached SessionMetadata) SessionMetadata {
+func (s *Service) mergeClaudeAuthContextMetadata(ctx context.Context, metadata SessionMetadata, cached SessionMetadata) SessionMetadata {
 	metadata.ServiceName = cached.ServiceName
 	if cached.UserEmail != "" {
 		metadata.UserEmail = cached.UserEmail
 	}
-	if metadata.UserID == "" && cached.UserID != "" {
-		metadata.UserID = cached.UserID
-	}
+	metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
 	metadata.ClaudeOrgID = cached.ClaudeOrgID
 	return metadata
 }

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -554,6 +554,17 @@ func (s *Service) resolveClaudeSessionMetadata(ctx context.Context, sessionID, u
 }
 
 func (s *Service) persistHook(ctx context.Context, payload *gen.ClaudePayload, metadata *SessionMetadata) {
+	metadata.UserEmail = strings.TrimSpace(metadata.UserEmail)
+	if metadata.UserEmail == "" {
+		s.logger.WarnContext(ctx, "skipping claude hook persistence without user email",
+			attr.SlogEvent("claude_hook_persist_no_user_email"),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent(payload.HookEventName),
+			attr.SlogGenAIConversationID(conv.PtrValOr(payload.SessionID, "")),
+		)
+		return
+	}
+
 	metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
 
 	if isConversationEvent(payload.HookEventName) {
@@ -654,6 +665,16 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 			attr.SlogGenAIConversationID(sessionID),
 			attr.SlogToolName(rawToolName),
 			attr.SlogError(err),
+		)
+		return denyUnverifiedMCP()
+	}
+	if strings.TrimSpace(metadata.UserEmail) == "" {
+		s.logger.WarnContext(ctx, "claude PreToolUse metadata has no user email; denying MCP tool call",
+			attr.SlogEvent("claude_hook_pretooluse_no_user_email"),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent(payload.HookEventName),
+			attr.SlogGenAIConversationID(sessionID),
+			attr.SlogToolName(rawToolName),
 		)
 		return denyUnverifiedMCP()
 	}

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -33,7 +33,26 @@ func (stubBlockingShadowMCPScanner) HasEnabledShadowMCPPolicy(_ context.Context,
 	return true, nil
 }
 
-func TestResolveClaudeScanContext_PrefersAuthContextOverCachedMetadata(t *testing.T) {
+type userScopedShadowMCPScanner struct {
+	userID string
+}
+
+func (s userScopedShadowMCPScanner) ScanForEnforcement(_ context.Context, _ string, _ uuid.UUID, _ string, _ string, _ string, _ string) (*risk.ScanResult, error) {
+	return nil, nil
+}
+
+func (s userScopedShadowMCPScanner) LookupShadowMCPBlockingPolicy(_ context.Context, _ string, _ uuid.UUID, userID string) (*risk.ShadowMCPPolicy, error) {
+	if userID != s.userID {
+		return nil, nil
+	}
+	return &risk.ShadowMCPPolicy{ID: "00000000-0000-0000-0000-000000000001", Name: "shadow-mcp-block"}, nil
+}
+
+func (s userScopedShadowMCPScanner) HasEnabledShadowMCPPolicy(_ context.Context, _ uuid.UUID) (bool, error) {
+	return true, nil
+}
+
+func TestResolveClaudeScanContext_PrefersAuthContextProjectOverCachedMetadata(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestHooksService(t)
@@ -54,7 +73,30 @@ func TestResolveClaudeScanContext_PrefersAuthContextOverCachedMetadata(t *testin
 	require.True(t, ok)
 	assert.Equal(t, authCtx.ActiveOrganizationID, got.organizationID)
 	assert.Equal(t, *authCtx.ProjectID, got.projectID)
-	assert.Equal(t, authCtx.UserID, got.userID)
+	assert.Empty(t, got.userID)
+}
+
+func TestResolveClaudeScanContext_ResolvesPayloadEmailBeforeAuthUserID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	userID := "user_payload_email_scan"
+	userEmail := "payload-email-scan@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, userID, userEmail)
+
+	sessionID := uuid.NewString()
+	got, ok := ti.service.resolveClaudeScanContext(ctx, &gen.ClaudePayload{
+		SessionID: &sessionID,
+		UserEmail: &userEmail,
+	})
+	require.True(t, ok)
+	assert.Equal(t, authCtx.ActiveOrganizationID, got.organizationID)
+	assert.Equal(t, *authCtx.ProjectID, got.projectID)
+	assert.Equal(t, userID, got.userID)
 }
 
 func TestResolveClaudeScanContext_ResolvesAuthContextActorFromCachedEmail(t *testing.T) {
@@ -241,6 +283,46 @@ func TestClaude_PreToolUse_DeniesLocalStdioServer(t *testing.T) {
 	assert.Equal(t, "deny", *output.PermissionDecision)
 }
 
+func TestClaude_PreToolUse_TargetedShadowMCPPolicyUsesResolvedHookUser(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	hookUserID := "claude-hook-user"
+	hookUserEmail := "claude-hook-user@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, hookUserID, hookUserEmail)
+	ti.service.riskScanner = userScopedShadowMCPScanner{userID: hookUserID}
+
+	sessionID := uuid.NewString()
+	toolName := "mcp__mise__install_tool"
+	toolUseID := "toolu_claude_specific_user_policy"
+
+	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID),
+		[]MCPServerEntry{{Source: "local", Name: "mise", Command: "mise mcp", Transport: "STDIO"}},
+		sessionMCPListTTL,
+	))
+
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &hookUserEmail,
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		ToolInput:     map[string]any{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
+	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
+	require.NotNil(t, output.PermissionDecision)
+	assert.Equal(t, "deny", *output.PermissionDecision)
+}
+
 func TestClaude_PreToolUse_DeniesLocalStdioServerWithLegacyIdentityRule(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
@@ -348,33 +430,29 @@ func TestClaude_PreToolUse_AllowsGramHostedServer(t *testing.T) {
 	assert.Equal(t, "allow", *output.PermissionDecision)
 }
 
-func TestMergeClaudeAuthContextMetadata_PreservesAuthUserIDWhenCacheIsEmpty(t *testing.T) {
+func TestMergeClaudeAuthContextMetadata_DoesNotSelectUserID(t *testing.T) {
 	t.Parallel()
 
-	metadata := mergeClaudeAuthContextMetadata(
-		SessionMetadata{
-			SessionID:   "session_test",
-			ServiceName: "",
-			UserEmail:   "",
-			UserID:      "user_from_auth",
-			ClaudeOrgID: "",
-			GramOrgID:   "org_from_auth",
-			ProjectID:   "project_from_auth",
-		},
-		SessionMetadata{
-			SessionID:   "session_test",
-			ServiceName: "claude-code",
-			UserEmail:   "local-hook-testing@example.com",
-			UserID:      "",
-			ClaudeOrgID: "claude_org",
-			GramOrgID:   "org_from_cache",
-			ProjectID:   "project_from_cache",
-		},
-	)
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
 
-	assert.Equal(t, "user_from_auth", metadata.UserID)
-	assert.Equal(t, "org_from_auth", metadata.GramOrgID)
-	assert.Equal(t, "project_from_auth", metadata.ProjectID)
+	authMetadata, ok := ti.service.claudeAuthContextMetadata(ctx, "session_test", "")
+	require.True(t, ok)
+	metadata := ti.service.mergeClaudeAuthContextMetadata(ctx, authMetadata, SessionMetadata{
+		SessionID:   "session_test",
+		ServiceName: "claude-code",
+		UserEmail:   "local-hook-testing@example.com",
+		UserID:      "",
+		ClaudeOrgID: "claude_org",
+		GramOrgID:   "org_from_cache",
+		ProjectID:   "project_from_cache",
+	})
+
+	assert.Empty(t, metadata.UserID)
+	assert.Equal(t, authCtx.ActiveOrganizationID, metadata.GramOrgID)
+	assert.Equal(t, authCtx.ProjectID.String(), metadata.ProjectID)
 	assert.Equal(t, "claude-code", metadata.ServiceName)
 	assert.Equal(t, "local-hook-testing@example.com", metadata.UserEmail)
 	assert.Equal(t, "claude_org", metadata.ClaudeOrgID)
@@ -448,7 +526,7 @@ func TestClaude_RecordHook_BuffersAuthContextCacheMissWithoutPayloadEmail(t *tes
 	assert.Equal(t, "UserPromptSubmit", buffered[0].HookEventName)
 }
 
-func TestClaude_RecordHook_UsesAuthContextUserIDOnCacheMissWithPayloadEmail(t *testing.T) {
+func TestClaude_RecordHook_DoesNotUseAuthUserIDWhenPayloadEmailDoesNotResolve(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
 	ti.service.productFeatures = alwaysEnabledFeatures{}
@@ -481,37 +559,33 @@ func TestClaude_RecordHook_UsesAuthContextUserIDOnCacheMissWithPayloadEmail(t *t
 		return err == nil && len(msgs) == 1
 	}, 2*time.Second, 25*time.Millisecond)
 
-	assert.Equal(t, authCtx.UserID, msgs[0].UserID.String)
+	assert.Empty(t, msgs[0].UserID.String)
 	assert.Equal(t, payloadEmail, msgs[0].ExternalUserID.String)
 }
 
-func TestMergeClaudeAuthContextMetadata_PrefersAuthUserIDOverCache(t *testing.T) {
+func TestMergeClaudeAuthContextMetadata_DropsCachedUserID(t *testing.T) {
 	t.Parallel()
 
-	metadata := mergeClaudeAuthContextMetadata(
-		SessionMetadata{
-			SessionID:   "session_test",
-			ServiceName: "",
-			UserEmail:   "",
-			UserID:      "user_from_auth",
-			ClaudeOrgID: "",
-			GramOrgID:   "org_from_auth",
-			ProjectID:   "project_from_auth",
-		},
-		SessionMetadata{
-			SessionID:   "session_test",
-			ServiceName: "claude-code",
-			UserEmail:   "local-hook-testing@example.com",
-			UserID:      "user_from_cache",
-			ClaudeOrgID: "claude_org",
-			GramOrgID:   "org_from_cache",
-			ProjectID:   "project_from_cache",
-		},
-	)
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
 
-	assert.Equal(t, "user_from_auth", metadata.UserID)
-	assert.Equal(t, "org_from_auth", metadata.GramOrgID)
-	assert.Equal(t, "project_from_auth", metadata.ProjectID)
+	authMetadata, ok := ti.service.claudeAuthContextMetadata(ctx, "session_test", "")
+	require.True(t, ok)
+	metadata := ti.service.mergeClaudeAuthContextMetadata(ctx, authMetadata, SessionMetadata{
+		SessionID:   "session_test",
+		ServiceName: "claude-code",
+		UserEmail:   "local-hook-testing@example.com",
+		UserID:      "user_from_cache",
+		ClaudeOrgID: "claude_org",
+		GramOrgID:   "org_from_cache",
+		ProjectID:   "project_from_cache",
+	})
+
+	assert.Empty(t, metadata.UserID)
+	assert.Equal(t, authCtx.ActiveOrganizationID, metadata.GramOrgID)
+	assert.Equal(t, authCtx.ProjectID.String(), metadata.ProjectID)
 	assert.Equal(t, "claude-code", metadata.ServiceName)
 	assert.Equal(t, "local-hook-testing@example.com", metadata.UserEmail)
 	assert.Equal(t, "claude_org", metadata.ClaudeOrgID)

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -65,14 +65,36 @@ func TestResolveClaudeScanContext_PrefersAuthContextProjectOverCachedMetadata(t 
 	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
 		SessionID: sessionID,
 		ProjectID: cachedProjectID.String(),
+		UserEmail: "cached-scan@example.com",
 	}, 0))
 
-	got, ok := ti.service.resolveClaudeScanContext(ctx, &gen.ClaudePayload{
+	got, err := ti.service.resolveClaudeScanContext(ctx, &gen.ClaudePayload{
 		SessionID: &sessionID,
 	})
-	require.True(t, ok)
+	require.NoError(t, err)
 	assert.Equal(t, authCtx.ActiveOrganizationID, got.organizationID)
 	assert.Equal(t, *authCtx.ProjectID, got.projectID)
+	assert.Empty(t, got.userID)
+}
+
+func TestResolveClaudeScanContext_RejectsMetadataWithoutUserEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+
+	sessionID := uuid.NewString()
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID: sessionID,
+		ProjectID: uuid.NewString(),
+		UserEmail: "",
+	}, 0))
+
+	got, err := ti.service.resolveClaudeScanContext(ctx, &gen.ClaudePayload{
+		SessionID: &sessionID,
+	})
+	require.ErrorContains(t, err, "claude session metadata missing user email")
+	assert.Empty(t, got.organizationID)
+	assert.Equal(t, uuid.Nil, got.projectID)
 	assert.Empty(t, got.userID)
 }
 
@@ -89,11 +111,11 @@ func TestResolveClaudeScanContext_ResolvesPayloadEmailBeforeAuthUserID(t *testin
 	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, userID, userEmail)
 
 	sessionID := uuid.NewString()
-	got, ok := ti.service.resolveClaudeScanContext(ctx, &gen.ClaudePayload{
+	got, err := ti.service.resolveClaudeScanContext(ctx, &gen.ClaudePayload{
 		SessionID: &sessionID,
 		UserEmail: &userEmail,
 	})
-	require.True(t, ok)
+	require.NoError(t, err)
 	assert.Equal(t, authCtx.ActiveOrganizationID, got.organizationID)
 	assert.Equal(t, *authCtx.ProjectID, got.projectID)
 	assert.Equal(t, userID, got.userID)
@@ -125,10 +147,10 @@ func TestResolveClaudeScanContext_ResolvesAuthContextActorFromCachedEmail(t *tes
 		ProjectID:   uuid.NewString(),
 	}, 0))
 
-	got, ok := ti.service.resolveClaudeScanContext(ctx, &gen.ClaudePayload{
+	got, err := ti.service.resolveClaudeScanContext(ctx, &gen.ClaudePayload{
 		SessionID: &sessionID,
 	})
-	require.True(t, ok)
+	require.NoError(t, err)
 	assert.Equal(t, authCtx.ActiveOrganizationID, got.organizationID)
 	assert.Equal(t, *authCtx.ProjectID, got.projectID)
 	assert.Equal(t, userID, got.userID)
@@ -156,6 +178,7 @@ func TestClaude_PreToolUse_UsesAuthContextWhenNoCachedMetadata(t *testing.T) {
 	sessionID := uuid.NewString()
 	toolName := "mcp__gram__do_thing"
 	toolUseID := "toolu_pretooluse_authctx"
+	userEmail := "claude-authctx@example.com"
 
 	// No MCP list snapshot is cached for this session, so the guard must
 	// deny with the retry/restart message. Reaching that check at all proves
@@ -164,6 +187,7 @@ func TestClaude_PreToolUse_UsesAuthContextWhenNoCachedMetadata(t *testing.T) {
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
 		ToolInput:     map[string]any{"foo": "bar"},
@@ -191,10 +215,12 @@ func TestClaude_PreToolUse_DeniesWhenMCPListNotCached(t *testing.T) {
 	sessionID := uuid.NewString()
 	toolName := "mcp__gram__do_thing"
 	toolUseID := "toolu_no_mcp_list"
+	userEmail := "claude-no-mcp-list@example.com"
 
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
 		ToolInput:     map[string]any{},
@@ -223,6 +249,7 @@ func TestClaude_PreToolUse_DeniesWhenMatchedServerNotGramHosted(t *testing.T) {
 	sessionID := uuid.NewString()
 	toolName := "mcp__plugin_slack_slack__send_message"
 	toolUseID := "toolu_non_gram_hosted"
+	userEmail := "claude-non-gram@example.com"
 
 	// Seed the cache with an entry that resolves the tool's server prefix
 	// but points at a non-Gram host.
@@ -234,6 +261,7 @@ func TestClaude_PreToolUse_DeniesWhenMatchedServerNotGramHosted(t *testing.T) {
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
 		ToolInput:     map[string]any{},
@@ -261,6 +289,7 @@ func TestClaude_PreToolUse_DeniesLocalStdioServer(t *testing.T) {
 	sessionID := uuid.NewString()
 	toolName := "mcp__mise__install_tool"
 	toolUseID := "toolu_local_stdio"
+	userEmail := "claude-local-stdio@example.com"
 
 	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID),
 		[]MCPServerEntry{{Source: "local", Name: "mise", Command: "mise mcp", Transport: "STDIO"}},
@@ -270,6 +299,7 @@ func TestClaude_PreToolUse_DeniesLocalStdioServer(t *testing.T) {
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
 		ToolInput:     map[string]any{},
@@ -336,6 +366,7 @@ func TestClaude_PreToolUse_DeniesLocalStdioServerWithLegacyIdentityRule(t *testi
 	sessionID := uuid.NewString()
 	toolName := "mcp__mise__install_tool"
 	toolUseID := "toolu_local_stdio_approved"
+	userEmail := "claude-legacy-identity@example.com"
 
 	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID),
 		[]MCPServerEntry{{Source: "local", Name: "mise", Command: "mise mcp", Transport: "STDIO"}},
@@ -346,6 +377,7 @@ func TestClaude_PreToolUse_DeniesLocalStdioServerWithLegacyIdentityRule(t *testi
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
 		ToolInput:     map[string]any{},
@@ -372,6 +404,7 @@ func TestClaude_PreToolUse_DoesNotAllowUnconfiguredServerByIdentityRule(t *testi
 	sessionID := uuid.NewString()
 	toolName := "mcp__github__search"
 	toolUseID := "toolu_unconfigured_identity"
+	userEmail := "claude-unconfigured@example.com"
 
 	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID),
 		[]MCPServerEntry{{Source: "local", Name: "linear", Command: "linear mcp", Transport: "STDIO"}},
@@ -382,6 +415,7 @@ func TestClaude_PreToolUse_DoesNotAllowUnconfiguredServerByIdentityRule(t *testi
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
 		ToolInput:     map[string]any{},
@@ -408,6 +442,7 @@ func TestClaude_PreToolUse_AllowsGramHostedServer(t *testing.T) {
 	sessionID := uuid.NewString()
 	toolName := "mcp__gram__do_thing"
 	toolUseID := "toolu_gram_hosted_ok"
+	userEmail := "claude-gram-hosted@example.com"
 
 	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID),
 		[]MCPServerEntry{{Source: "local", Name: "gram", URL: "https://app.getgram.ai/mcp/team-foo"}},
@@ -417,6 +452,7 @@ func TestClaude_PreToolUse_AllowsGramHostedServer(t *testing.T) {
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
 		ToolInput:     map[string]any{},
@@ -654,6 +690,46 @@ func TestClaude_PreToolUse_DeniesMCPWhenNoAuthAndNoCachedMetadata(t *testing.T) 
 	require.NotNil(t, output.PermissionDecision)
 	assert.Equal(t, "deny", *output.PermissionDecision,
 		"MCP tool calls without enforcement metadata must fail closed")
+	require.NotNil(t, output.PermissionDecisionReason)
+	assert.Contains(t, *output.PermissionDecisionReason, "could not verify this MCP tool call")
+}
+
+func TestClaude_PreToolUse_DeniesMCPWhenResolvedMetadataHasNoUserEmail(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := uuid.NewString()
+	toolName := "mcp__gram__do_thing"
+	toolUseID := "toolu_pretooluse_no_email"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "claude-code",
+		UserEmail:   "",
+		UserID:      "",
+		ClaudeOrgID: "claude_org",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}, 0))
+
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		ToolInput:     map[string]any{"foo": "bar"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
+	require.True(t, ok)
+	require.NotNil(t, output.PermissionDecision)
+	assert.Equal(t, "deny", *output.PermissionDecision)
 	require.NotNil(t, output.PermissionDecisionReason)
 	assert.Contains(t, *output.PermissionDecisionReason, "could not verify this MCP tool call")
 }

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -40,7 +40,7 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
-	metadata := s.codexSessionMetadata(ctx, payload, orgID, projectID, authCtx.UserID)
+	metadata := s.codexSessionMetadata(ctx, payload, orgID, projectID)
 	logger = logger.With(
 		attr.SlogOrganizationID(orgID),
 		attr.SlogProjectID(projectID),
@@ -149,12 +149,12 @@ func (s *Service) recordCodexHook(ctx context.Context, payload *gen.CodexPayload
 	}
 }
 
-func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPayload, orgID, projectID, authenticatedUserID string) *SessionMetadata {
+func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPayload, orgID, projectID string) *SessionMetadata {
 	metadata := &SessionMetadata{
 		SessionID:   conv.PtrValOr(payload.SessionID, ""),
 		ServiceName: "Codex",
 		UserEmail:   strings.TrimSpace(conv.PtrValOr(payload.UserEmail, "")),
-		UserID:      authenticatedUserID,
+		UserID:      "",
 		ClaudeOrgID: "",
 		GramOrgID:   orgID,
 		ProjectID:   projectID,
@@ -166,14 +166,13 @@ func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPa
 			if metadata.UserEmail == "" {
 				metadata.UserEmail = cached.UserEmail
 			}
-			if metadata.UserID == "" {
-				metadata.UserID = cached.UserID
-			}
 		}
 	}
 
-	if metadata.UserID == "" {
+	if metadata.UserEmail != "" {
 		metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, orgID)
+	} else {
+		metadata.UserID = ""
 	}
 
 	return metadata

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcpname"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
@@ -41,6 +42,9 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
 	metadata := s.codexSessionMetadata(ctx, payload, orgID, projectID)
+	if metadata.UserEmail == "" {
+		return nil, oops.E(oops.CodeInvalid, nil, "codex hook payload missing user_email")
+	}
 	logger = logger.With(
 		attr.SlogOrganizationID(orgID),
 		attr.SlogProjectID(projectID),

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -34,6 +34,34 @@ func TestCodex_PreToolUse_ShadowMCPBlockWithIdentityEvidenceIncludesRequestLink(
 	require.Contains(t, *result.Reason, shadowMCPApprovalRequestPrompt)
 }
 
+func TestCodex_PreToolUse_TargetedShadowMCPPolicyUsesResolvedHookUser(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	hookUserID := "codex-hook-user"
+	hookUserEmail := "codex-hook-user@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, hookUserID, hookUserEmail)
+	ti.service.riskScanner = userScopedShadowMCPScanner{userID: hookUserID}
+
+	sessionID := "codex-session-specific-user-policy"
+	toolName := "mcp__gram__do_thing"
+	result, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &hookUserEmail,
+		ToolName:      &toolName,
+		ToolInput:     map[string]any{"foo": "bar"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Decision)
+	require.Equal(t, "deny", *result.Decision)
+}
+
 func TestBuildCodexTelemetryAttributes_UsesPayloadUserEmail(t *testing.T) {
 	t.Parallel()
 	_, ti := newTestHooksService(t)
@@ -76,12 +104,12 @@ func TestCodexSessionMetadata_CachesSessionStartEmail(t *testing.T) {
 	metadata := ti.service.codexSessionMetadata(ctx, &gen.CodexPayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
-	}, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), authCtx.UserID)
+	}, authCtx.ActiveOrganizationID, authCtx.ProjectID.String())
 	require.Equal(t, email, metadata.UserEmail)
 	require.Equal(t, authCtx.UserID, metadata.UserID)
 }
 
-func TestCodexSessionMetadata_PrefersAuthenticatedUserIDOverCachedMetadata(t *testing.T) {
+func TestCodexSessionMetadata_IgnoresCachedUserIDWhenEmailDoesNotResolve(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
 
@@ -104,8 +132,8 @@ func TestCodexSessionMetadata_PrefersAuthenticatedUserIDOverCachedMetadata(t *te
 	metadata := ti.service.codexSessionMetadata(ctx, &gen.CodexPayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
-	}, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), authCtx.UserID)
+	}, authCtx.ActiveOrganizationID, authCtx.ProjectID.String())
 
 	require.Equal(t, email, metadata.UserEmail)
-	require.Equal(t, authCtx.UserID, metadata.UserID)
+	require.Empty(t, metadata.UserID)
 }

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -17,10 +17,12 @@ func TestCodex_PreToolUse_ShadowMCPBlockWithIdentityEvidenceIncludesRequestLink(
 
 	sessionID := "codex-session-blocked"
 	toolName := "mcp__gram__do_thing"
+	userEmail := "anonymous-codex@example.com"
 
 	result, err := ti.service.Codex(ctx, &gen.CodexPayload{
 		HookEventName: "PreToolUse",
 		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
 		ToolName:      &toolName,
 		ToolInput:     map[string]any{"foo": "bar"},
 	})
@@ -60,6 +62,23 @@ func TestCodex_PreToolUse_TargetedShadowMCPPolicyUsesResolvedHookUser(t *testing
 	require.NotNil(t, result)
 	require.NotNil(t, result.Decision)
 	require.Equal(t, "deny", *result.Decision)
+}
+
+func TestCodex_RequiresUserEmail(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	sessionID := "codex-session-missing-email"
+	toolName := "mcp__gram__do_thing"
+	result, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &toolName,
+		ToolInput:     map[string]any{"foo": "bar"},
+	})
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "codex hook payload missing user_email")
 }
 
 func TestBuildCodexTelemetryAttributes_UsesPayloadUserEmail(t *testing.T) {

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -53,10 +53,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
-	actorUserID := authCtx.UserID
-	if actorUserID == "" {
-		actorUserID = s.resolveUserByEmail(ctx, conv.PtrValOr(payload.UserEmail, ""), orgID)
-	}
+	actorUserID := s.resolveUserByEmail(ctx, conv.PtrValOr(payload.UserEmail, ""), orgID)
 	logger = logger.With(
 		attr.SlogOrganizationID(orgID),
 		attr.SlogProjectID(projectID),

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcpname"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
@@ -53,7 +54,11 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
-	actorUserID := s.resolveUserByEmail(ctx, conv.PtrValOr(payload.UserEmail, ""), orgID)
+	userEmail := strings.TrimSpace(conv.PtrValOr(payload.UserEmail, ""))
+	if userEmail == "" {
+		return nil, oops.E(oops.CodeInvalid, nil, "cursor hook payload missing user_email")
+	}
+	actorUserID := s.resolveUserByEmail(ctx, userEmail, orgID)
 	logger = logger.With(
 		attr.SlogOrganizationID(orgID),
 		attr.SlogProjectID(projectID),

--- a/server/internal/hooks/cursor_test.go
+++ b/server/internal/hooks/cursor_test.go
@@ -203,6 +203,38 @@ func TestCursor_BeforeMCPExecution_ShadowMCPBlockIncludesRequestLink(t *testing.
 	assert.Equal(t, *result.UserMessage, *result.AgentMessage)
 }
 
+func TestCursor_BeforeMCPExecution_TargetedShadowMCPPolicyUsesResolvedHookUser(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	hookUserID := "cursor-hook-user"
+	hookUserEmail := "cursor-hook-user@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, hookUserID, hookUserEmail)
+	ti.service.riskScanner = userScopedShadowMCPScanner{userID: hookUserID}
+
+	toolName := "list_issues"
+	toolUseID := "toolu_mcp_specific_user_policy"
+	conversationID := "conv-mcp-specific-user-policy"
+	serverURL := "https://mcp.linear.app/sse"
+	result, err := ti.service.Cursor(ctx, &hooks.CursorPayload{
+		HookEventName:  "beforeMCPExecution",
+		ToolName:       &toolName,
+		ToolUseID:      &toolUseID,
+		UserEmail:      &hookUserEmail,
+		ConversationID: &conversationID,
+		URL:            &serverURL,
+		ToolInput:      map[string]any{"foo": "bar"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Permission)
+	assert.Equal(t, "deny", *result.Permission)
+}
+
 func TestBuildCursorTelemetryAttributes_BeforeMCPExecution_ToolSourceFromURL(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)

--- a/server/internal/hooks/cursor_test.go
+++ b/server/internal/hooks/cursor_test.go
@@ -40,11 +40,13 @@ func TestCursor_PostToolUse_ReturnsEmpty(t *testing.T) {
 
 	toolName := "Read"
 	toolUseID := "toolu_cursor_456"
+	userEmail := "dev@example.com"
 
 	result, err := ti.service.Cursor(ctx, &hooks.CursorPayload{
 		HookEventName: "postToolUse",
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
+		UserEmail:     &userEmail,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -57,12 +59,14 @@ func TestCursor_PostToolUseFailure_ReturnsEmpty(t *testing.T) {
 
 	toolName := "Bash"
 	toolUseID := "toolu_cursor_789"
+	userEmail := "dev@example.com"
 	isInterrupt := true
 
 	result, err := ti.service.Cursor(ctx, &hooks.CursorPayload{
 		HookEventName: "postToolUseFailure",
 		ToolName:      &toolName,
 		ToolUseID:     &toolUseID,
+		UserEmail:     &userEmail,
 		IsInterrupt:   &isInterrupt,
 		Error:         "command timed out",
 	})
@@ -74,9 +78,11 @@ func TestCursor_PostToolUseFailure_ReturnsEmpty(t *testing.T) {
 func TestCursor_UnknownEvent_ReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
+	userEmail := "dev@example.com"
 
 	result, err := ti.service.Cursor(ctx, &hooks.CursorPayload{
 		HookEventName: "someNewEvent",
+		UserEmail:     &userEmail,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -100,6 +106,24 @@ func TestCursor_RequiresAuth(t *testing.T) {
 	assert.Equal(t, "deny", *result.Permission)
 	require.NotNil(t, result.UserMessage)
 	assert.Contains(t, *result.UserMessage, "unauthorized")
+}
+
+func TestCursor_RequiresUserEmail(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	toolName := "Edit"
+	toolUseID := "toolu_cursor_missing_email"
+	conversationID := "conv-missing-email"
+	result, err := ti.service.Cursor(ctx, &hooks.CursorPayload{
+		HookEventName:  "preToolUse",
+		ToolName:       &toolName,
+		ToolUseID:      &toolUseID,
+		ConversationID: &conversationID,
+	})
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "cursor hook payload missing user_email")
 }
 
 func TestBuildCursorTelemetryAttributes_BasicFields(t *testing.T) {
@@ -159,11 +183,13 @@ func TestCursor_BeforeMCPExecution_ReturnsAllow(t *testing.T) {
 	toolUseID := "toolu_mcp_123"
 	conversationID := "conv-mcp-abc"
 	serverURL := "https://mcp.linear.app/sse"
+	userEmail := "anonymous-cursor@example.com"
 
 	result, err := ti.service.Cursor(ctx, &hooks.CursorPayload{
 		HookEventName:  "beforeMCPExecution",
 		ToolName:       &toolName,
 		ToolUseID:      &toolUseID,
+		UserEmail:      &userEmail,
 		ConversationID: &conversationID,
 		URL:            &serverURL,
 	})
@@ -182,11 +208,13 @@ func TestCursor_BeforeMCPExecution_ShadowMCPBlockIncludesRequestLink(t *testing.
 	toolUseID := "toolu_mcp_blocked"
 	conversationID := "conv-mcp-blocked"
 	serverURL := "https://mcp.linear.app/sse"
+	userEmail := "anonymous-cursor@example.com"
 
 	result, err := ti.service.Cursor(ctx, &hooks.CursorPayload{
 		HookEventName:  "beforeMCPExecution",
 		ToolName:       &toolName,
 		ToolUseID:      &toolUseID,
+		UserEmail:      &userEmail,
 		ConversationID: &conversationID,
 		URL:            &serverURL,
 		ToolInput:      map[string]any{"foo": "bar"},

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -134,8 +134,7 @@ func (s *Service) buildTelemetryAttributesWithMetadata(ctx context.Context, payl
 		attr.OrganizationIDKey: metadata.GramOrgID,
 		attr.HookSourceKey:     hookSource,
 	}
-	metadata.UserID = ""
-	if metadata.UserEmail != "" {
+	if metadata.UserID == "" && metadata.UserEmail != "" {
 		metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
 	}
 	if metadata.UserID != "" {

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -134,7 +134,8 @@ func (s *Service) buildTelemetryAttributesWithMetadata(ctx context.Context, payl
 		attr.OrganizationIDKey: metadata.GramOrgID,
 		attr.HookSourceKey:     hookSource,
 	}
-	if metadata.UserID == "" {
+	metadata.UserID = ""
+	if metadata.UserEmail != "" {
 		metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
 	}
 	if metadata.UserID != "" {

--- a/server/internal/hooks/risk_scan.go
+++ b/server/internal/hooks/risk_scan.go
@@ -8,7 +8,6 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/message"
 	"github.com/speakeasy-api/gram/server/internal/risk"
@@ -82,52 +81,23 @@ func (s *Service) resolveClaudeScanContext(ctx context.Context, payload *gen.Cla
 		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, false
 	}
 	sessionID := *payload.SessionID
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	if ok && authCtx != nil && authCtx.ProjectID != nil {
-		metadata := SessionMetadata{
-			SessionID:   sessionID,
-			ServiceName: "",
-			UserEmail:   conv.PtrValOr(payload.UserEmail, ""),
-			UserID:      authCtx.UserID,
-			ClaudeOrgID: "",
-			GramOrgID:   authCtx.ActiveOrganizationID,
-			ProjectID:   authCtx.ProjectID.String(),
-		}
-		if metadata.UserID == "" && metadata.UserEmail != "" {
-			metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
-		}
-		if cached, err := s.getSessionMetadata(ctx, sessionID); err == nil {
-			metadata = mergeClaudeAuthContextMetadata(metadata, cached)
-		}
-		if metadata.UserID == "" && metadata.UserEmail != "" {
-			metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
-		}
-		return claudeScanContext{
-			organizationID: metadata.GramOrgID,
-			projectID:      *authCtx.ProjectID,
-			userID:         metadata.UserID,
-		}, true
+	payloadUserEmail := ""
+	if payload.UserEmail != nil {
+		payloadUserEmail = *payload.UserEmail
 	}
-
-	metadata, err := s.getSessionMetadata(ctx, sessionID)
+	metadata, err := s.resolveClaudeSessionMetadata(ctx, sessionID, payloadUserEmail)
 	if err != nil {
 		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, false
 	}
-
 	projectID, err := uuid.Parse(metadata.ProjectID)
 	if err != nil {
 		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, false
 	}
 
-	userID := metadata.UserID
-	if userID == "" {
-		userID = s.resolveUserByEmail(ctx, metadata.UserEmail, metadata.GramOrgID)
-	}
-
 	return claudeScanContext{
 		organizationID: metadata.GramOrgID,
 		projectID:      projectID,
-		userID:         userID,
+		userID:         metadata.UserID,
 	}, true
 }
 

--- a/server/internal/hooks/risk_scan.go
+++ b/server/internal/hooks/risk_scan.go
@@ -3,6 +3,9 @@ package hooks
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -44,8 +47,12 @@ func (s *Service) scanClaudeForEnforcement(ctx context.Context, payload *gen.Cla
 		return nil
 	}
 
-	scanContext, ok := s.resolveClaudeScanContext(ctx, payload)
-	if !ok {
+	scanContext, err := s.resolveClaudeScanContext(ctx, payload)
+	if err != nil {
+		s.logger.WarnContext(ctx, "could not resolve Claude risk scan context",
+			attr.SlogError(err),
+			attr.SlogEvent("risk_scan_context_error"),
+		)
 		return nil
 	}
 
@@ -76,9 +83,12 @@ type claudeScanContext struct {
 // hook risk scan. The plugin-auth context populated by Gram-Key + Gram-Project
 // wins when present. Session metadata cached by the OTEL Logs endpoint remains
 // the fallback for legacy hooks without plugin auth.
-func (s *Service) resolveClaudeScanContext(ctx context.Context, payload *gen.ClaudePayload) (claudeScanContext, bool) {
-	if payload == nil || payload.SessionID == nil {
-		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, false
+func (s *Service) resolveClaudeScanContext(ctx context.Context, payload *gen.ClaudePayload) (claudeScanContext, error) {
+	if payload == nil {
+		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, errors.New("claude payload is nil")
+	}
+	if payload.SessionID == nil || *payload.SessionID == "" {
+		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, errors.New("claude payload missing session id")
 	}
 	sessionID := *payload.SessionID
 	payloadUserEmail := ""
@@ -87,18 +97,21 @@ func (s *Service) resolveClaudeScanContext(ctx context.Context, payload *gen.Cla
 	}
 	metadata, err := s.resolveClaudeSessionMetadata(ctx, sessionID, payloadUserEmail)
 	if err != nil {
-		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, false
+		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, fmt.Errorf("resolve claude session metadata: %w", err)
+	}
+	if strings.TrimSpace(metadata.UserEmail) == "" {
+		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, errors.New("claude session metadata missing user email")
 	}
 	projectID, err := uuid.Parse(metadata.ProjectID)
 	if err != nil {
-		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, false
+		return claudeScanContext{organizationID: "", projectID: uuid.Nil, userID: ""}, fmt.Errorf("parse claude project id: %w", err)
 	}
 
 	return claudeScanContext{
 		organizationID: metadata.GramOrgID,
 		projectID:      projectID,
 		userID:         metadata.UserID,
-	}, true
+	}, nil
 }
 
 // scanCursorForEnforcement runs the risk scanner for a Cursor hook payload.


### PR DESCRIPTION
Shadow MCP policy enforcement was using the authenticated API key owner as the hook actor in several paths. That meant a policy targeted at the person actually running Claude, Cursor, or Codex could be skipped whenever the API key belonged to a different user. It also allowed cached user IDs to be trusted even when the hook email was the only reliable principal signal.

This change makes hook attribution resolve the Gram user from the hook payload email for Claude, Cursor, and Codex. Auth context still supplies org/project context, but it no longer supplies the actor user ID for enforcement or telemetry attribution. Claude metadata merging now recomputes the user from the final email, persisted hook metadata re-resolves before writing, and risk scanning uses the same resolution path.

The added coverage exercises targeted Shadow MCP policies for Claude, Cursor, and Codex so a policy scoped to the resolved hook user is the one enforced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hook actor attribution by resolving from the payload email and requiring a non-empty user_email for Claude, Cursor, and Codex. Ensures Shadow MCP policies and telemetry target the actual user and avoids stale/cached IDs.

- **Bug Fixes**
  - Claude: centralized session/auth merge; always compute user from email; PreToolUse/risk-scan deny when user_email is missing; recordHook skips persistence without email; avoids duplicate email lookups.
  - Codex: require user_email; ignore authenticated/cached user IDs; resolve user from email; return invalid when user_email is missing.
  - Cursor: require user_email; resolve actor from email; return invalid when user_email is missing.
  - Telemetry: only resolve user ID from email and only when email is present; added tests validating user-scoped Shadow MCP policies enforce against the resolved hook user.

- **Migration**
  - Clients must include user_email in all Claude, Cursor, and Codex hook payloads; missing emails will cause denials or errors.

<sup>Written for commit 2a1a29ba572be5eb5e74a7f4b19f147137d8966d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

