### PR TITLE
feat(dashboard): add Beta badges to Project Assistant, promote Assistants to Beta

### DIFF
--- a/.changeset/assistant-beta-badge.md
+++ b/.changeset/assistant-beta-badge.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add Beta badges to the Project Assistant (sidebar nav item, footer resume button, and `/chat` landing page) and promote the Assistants surface from Preview to Beta. Both use the shared `ReleaseStageBadge` so the label stays consistent across every surface.

--- a/client/dashboard/src/components/insights-dock-resume-button.tsx
+++ b/client/dashboard/src/components/insights-dock-resume-button.tsx
@@ -4,6 +4,7 @@ import {
   useInsightsDockCta,
 } from "@/hooks/useInsightsDockCta";
 import { Sparkles } from "lucide-react";
+import { ReleaseStageBadge } from "./release-stage-badge";
 import { SidebarFooterAction } from "./sidebar-footer-action";
 
 /**
@@ -25,6 +26,12 @@ export function InsightsDockResumeButton(): JSX.Element | null {
       label="Project Assistant"
       className={INSIGHTS_DOCK_VT_CLASS}
       contentClassName={INSIGHTS_DOCK_CONTENT_VT_CLASS}
+      trailing={
+        <ReleaseStageBadge
+          stage="beta"
+          className="group-data-[collapsible=icon]:hidden"
+        />
+      }
     />
   );
 }

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -104,7 +104,7 @@ export default function AssistantsIndex(): JSX.Element {
       />
     ) : (
       <Page.Section>
-        <Page.Section.Title stage="preview">Assistants</Page.Section.Title>
+        <Page.Section.Title stage="beta">Assistants</Page.Section.Title>
         <Page.Section.Description className="max-w-xl">
           Openclaw-inspired secure Assistants. Every assistant connects through
           the MCPs and Skills your org already uses, with identity, guardrails,

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -36,6 +36,7 @@ import {
   type InsightsSuggestion,
 } from "@/lib/insights-suggestions";
 import { cn } from "@/lib/utils";
+import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { useRoutes } from "@/routes";
 
 // Shared pill-style icon button used by the page chrome (back affordances).
@@ -236,9 +237,12 @@ export function ChatLanding({
   return (
     <div className="flex w-full flex-col gap-6">
       <div className="flex flex-col gap-4">
-        <h1 className="text-foreground text-3xl font-semibold tracking-tight">
-          {greeting}
-        </h1>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <h1 className="text-foreground text-3xl font-semibold tracking-tight">
+            {greeting}
+          </h1>
+          <ReleaseStageBadge stage="beta" />
+        </div>
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -190,6 +190,7 @@ const ROUTE_STRUCTURE = {
     title: "Project Assistant",
     url: "chat",
     icon: "message-circle",
+    stage: "beta",
     // Layout route: renders the index (ChatHome) or a conversation subpage.
     component: ChatRoot,
     indexComponent: ChatHome,
@@ -311,7 +312,7 @@ const ROUTE_STRUCTURE = {
     title: "Assistants",
     url: "assistants",
     icon: "bot",
-    stage: "preview",
+    stage: "beta",
     component: AssistantsRoot,
     indexComponent: AssistantsIndex,
     subPages: {


### PR DESCRIPTION
## What

Adds a **Beta** release-stage badge to the **Project Assistant** feature and promotes the **Assistants** management surface from **Preview** to **Beta**.

All badges use the shared `ReleaseStageBadge` component (`beta` → Moonshine `information` / Speakeasy brand-blue, with a tooltip), so the label stays consistent across every surface and is trivial to remove when the feature ships GA.

<img width="1714" height="392" alt="CleanShot 2026-06-17 at 12 13 03@2x" src="https://github.com/user-attachments/assets/1dd029f5-6523-4cb6-9499-eef11618820f" />

<img width="520" height="432" alt="CleanShot 2026-06-17 at 12 12 56@2x" src="https://github.com/user-attachments/assets/e20f87e4-8d38-40d3-81bc-bdb7ec8d17c8" />

## Changes

**Project Assistant** (`/chat`):

- `routes.chat` now sets `stage: "beta"` — the sidebar nav item renders the badge automatically via `NavButton` (no manual JSX).
- The "Project Assistant" sidebar **footer resume button** gets the badge through `SidebarFooterAction`'s `trailing` slot, hidden in collapsed-icon mode to match the label.
- The `/chat` landing greeting (`ChatLanding`) is wrapped with the badge. This component is shared with the project home-page embed, so the badge appears on both surfaces — intentional, per the frontend skill's "badge every surface where the user encounters the feature's name" guidance.

**Assistants** (management route):

- `routes.assistants` promoted `preview` → `beta`.
- `Assistants.tsx` page title promoted `preview` → `beta`.

## Notes

- The dock's expanded chat panel header is intentionally **not** badged — it's a Granola-style header with no title bar to anchor a feature badge. The canonical `/chat` page (opened via the dock's expand-to-page button) carries the page badge instead.

## Verification

- `pnpm -F dashboard type-check` — 0 errors
- `pnpm -F dashboard lint` — format, no-barrels, oxlint, type-check all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Beta badges to Project Assistant and promotes the Assistants management surface from Preview to Beta. Uses the shared `ReleaseStageBadge` for consistent labeling across surfaces.

- **New Features**
  - Project Assistant surfaces badged: sidebar nav (`stage: "beta"` in routes), footer resume button, and `/chat` landing (shared with project home embed).
  - Assistants management updated to Beta: route and page title.
  - All badges use `ReleaseStageBadge`, with the footer badge hidden in collapsed-icon mode.

<sup>Written for commit 0b6b72cf342f3dbd1c63a180fbefa79d62a71df9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

