### PR TITLE
fix(server): increase graceful-shutdown drain window to 60s

### DIFF
--- a/.changeset/graceful-shutdown-drain-60s.md
+++ b/.changeset/graceful-shutdown-drain-60s.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+increase graceful-shutdown drain window to 60s

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -114,6 +114,16 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/xmcp"
 )
 
+// shutdownDrainTimeout is how long srv.Shutdown waits for in-flight requests
+// to complete on SIGTERM before the process exits. It must cover the slowest
+// outbound work any endpoint can do, including the MCP runtime path
+// (POST /mcp/{mcpSlug}).
+//
+// Note: the effective drain is also bounded by infrastructure settings such as
+// terminationGracePeriodSeconds in Kubernetes, which must be set above this
+// value for the full window to be honored.
+const shutdownDrainTimeout = 60 * time.Second
+
 func newStartCommand() *cli.Command {
 	var shutdownFuncs []func(context.Context) error
 
@@ -1183,7 +1193,7 @@ func newStartCommand() *cli.Command {
 
 				logger.InfoContext(ctx, "shutting down server")
 
-				graceCtx, graceCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+				graceCtx, graceCancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownDrainTimeout)
 				defer graceCancel()
 
 				if err := srv.Shutdown(graceCtx); err != nil {


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2802/gram-server-increase-graceful-shutdown-drain-window-from-10s-to-60s-to

On SIGTERM, `srv.Shutdown` was given only 10s to drain in-flight requests. The MCP runtime path (`POST /mcp/{mcpSlug}`) proxies tool calls to the Fly Functions runner with a 60s client timeout, so requests past ~p95 were cut mid-flight and surfaced as customer-visible `roundtrip: EOF` errors during rolling deploys and node evictions.

Extract the drain timeout into a documented `shutdownDrainTimeout` constant and raise it from 10s to 60s to align with the outbound client timeout.

Realizing the full window also requires raising the pod's `terminationGracePeriodSeconds` in gram-infra (AGE-2803).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the `gram-server` graceful-shutdown drain window from 10s to 60s by introducing `shutdownDrainTimeout` and using it with `srv.Shutdown`. This aligns with the 60s outbound Fly Functions client timeout and prevents cutting in-flight MCP tool calls, addressing AGE-2802 and reducing `roundtrip: EOF` errors during deploys and evictions.

- **Migration**
  - Set `terminationGracePeriodSeconds` > 60s for `gram-server` pods to realize the full window (tracked in AGE-2803).

<sup>Written for commit 6e1858afa9dd457403b6ebf543d977abde2b58a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

