### PR TITLE
fix(dashboard): stop Project Assistant chat hanging after tool turns

### DIFF
--- a/.changeset/fix-assistant-chat-stuck-loading.md
+++ b/.changeset/fix-assistant-chat-stuck-loading.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the Project Assistant chat getting stuck "loading" after a tool-using turn, where the assistant had already replied but the composer stayed disabled.

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -247,93 +247,100 @@ async function pollForReplies(args: {
   // step writes below.
   let stepOpen = false;
 
-  for (;;) {
-    if (abortSignal?.aborted) {
-      throw new DOMException("Aborted", "AbortError");
-    }
-
-    const res = await chatLoad(
-      client,
-      { id: chatId, generation: pinnedGeneration },
-      undefined,
-      { fetchOptions: { signal: abortSignal } },
-    );
-    if (res.ok) {
-      consecutiveFailures = 0;
-      if (pinnedGeneration === undefined) {
-        pinnedGeneration = res.value.generation;
+  // The `finally` closes whatever step is still open however the loop exits —
+  // terminal return, timeout, poll failure, or abort — so the stream never ends
+  // mid-step.
+  try {
+    for (;;) {
+      if (abortSignal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
       }
-      // Only the *new* (post-baseline) assistant rows belong to this turn —
-      // prior-turn terminal rows would otherwise satisfy the terminal check on
-      // the first iteration and short-circuit the loop with empty replies.
-      let lastNewAssistant: {
-        finishReason?: string;
-        toolCalls?: string;
-      } | null = null;
-      for (const m of res.value.messages) {
-        if (m.role === "tool") {
-          if (m.toolCallId && pendingToolCalls.delete(m.toolCallId)) {
-            writer.write({
-              type: "tool-output-available",
-              toolCallId: m.toolCallId,
-              output: toolOutputValue(m.content),
+
+      const res = await chatLoad(
+        client,
+        { id: chatId, generation: pinnedGeneration },
+        undefined,
+        { fetchOptions: { signal: abortSignal } },
+      );
+      if (res.ok) {
+        consecutiveFailures = 0;
+        if (pinnedGeneration === undefined) {
+          pinnedGeneration = res.value.generation;
+        }
+        // Only the *new* (post-baseline) assistant rows belong to this turn —
+        // prior-turn terminal rows would otherwise satisfy the terminal check on
+        // the first iteration and short-circuit the loop with empty replies.
+        let lastNewAssistant: {
+          finishReason?: string;
+          toolCalls?: string;
+        } | null = null;
+        for (const m of res.value.messages) {
+          if (m.role === "tool") {
+            if (m.toolCallId && pendingToolCalls.delete(m.toolCallId)) {
+              writer.write({
+                type: "tool-output-available",
+                toolCallId: m.toolCallId,
+                output: toolOutputValue(m.content),
+              });
+            }
+            continue;
+          }
+          if (m.role !== "assistant") continue;
+          if (seen.has(m.id)) continue;
+          seen.add(m.id);
+          lastNewAssistant = m;
+          // Open a fresh step for each completion (closing the prior one).
+          // Without these boundaries the whole turn collapses into one step, and
+          // assistant-ui's resume check
+          // (`lastAssistantMessageIsCompleteWithToolCalls`, which inspects only
+          // the last step's tool parts) sees the turn's resolved tool calls and
+          // auto-resends a turn the server already finished. Per-step framing
+          // keeps the final text-only row in a step of its own, so that check
+          // finds no pending tool calls and stays put.
+          if (stepOpen) {
+            writer.write({ type: "finish-step" });
+          }
+          writer.write({ type: "start-step" });
+          stepOpen = true;
+          const text = contentText(m.content);
+          if (text) {
+            await writeStreamedText({
+              writer,
+              id: m.id,
+              text,
+              abortSignal,
             });
           }
-          continue;
+          for (const call of parseToolCalls(m.toolCalls)) {
+            writer.write({
+              type: "tool-input-available",
+              toolCallId: call.id,
+              toolName: call.name,
+              input: call.input,
+            });
+            pendingToolCalls.add(call.id);
+          }
         }
-        if (m.role !== "assistant") continue;
-        if (seen.has(m.id)) continue;
-        seen.add(m.id);
-        lastNewAssistant = m;
-        // Open a fresh step for each completion (closing the prior one). Without
-        // these boundaries the whole turn collapses into a single step, and
-        // assistant-ui's `lastAssistantMessageIsCompleteWithToolCalls` resume
-        // check — which inspects only the last step's tool parts — sees the
-        // turn's resolved tool calls and auto-resends a turn the server already
-        // finished. Per-step framing keeps the final text-only row in a step of
-        // its own, so that check finds no pending tool calls and stays put.
-        if (stepOpen) {
-          writer.write({ type: "finish-step" });
+        if (lastNewAssistant && isTurnTerminal(lastNewAssistant)) {
+          return;
         }
-        writer.write({ type: "start-step" });
-        stepOpen = true;
-        const text = contentText(m.content);
-        if (text) {
-          await writeStreamedText({
-            writer,
-            id: m.id,
-            text,
-            abortSignal,
-          });
-        }
-        for (const call of parseToolCalls(m.toolCalls)) {
-          writer.write({
-            type: "tool-input-available",
-            toolCallId: call.id,
-            toolName: call.name,
-            input: call.input,
-          });
-          pendingToolCalls.add(call.id);
+      } else {
+        consecutiveFailures++;
+        if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+          throw res.error;
         }
       }
-      if (lastNewAssistant && isTurnTerminal(lastNewAssistant)) {
-        if (stepOpen) {
-          writer.write({ type: "finish-step" });
-        }
-        return;
-      }
-    } else {
-      consecutiveFailures++;
-      if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
-        throw res.error;
-      }
-    }
 
-    if (Date.now() >= deadline) {
-      throw new Error("Timed out waiting for the assistant's reply.");
+      if (Date.now() >= deadline) {
+        throw new Error("Timed out waiting for the assistant's reply.");
+      }
+      await sleep(nextPollDelay(attempt, pollIntervalMs), abortSignal);
+      attempt++;
     }
-    await sleep(nextPollDelay(attempt, pollIntervalMs), abortSignal);
-    attempt++;
+  } finally {
+    if (stepOpen) {
+      writer.write({ type: "finish-step" });
+    }
   }
 }
 

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -123,6 +123,8 @@ export function createServerAssistantTransport(
             ? AbortSignal.any([abortSignal, poll.signal])
             : poll.signal;
 
+          writer.write({ type: "start" });
+
           let chatId = ctx.getChatId();
           // Bind the local thread identity at send-start so a server-minted
           // chat id is reconciled with THIS thread even if a parallel send on
@@ -168,19 +170,6 @@ export function createServerAssistantTransport(
             chatId = sent.value.chatId;
             adopt(chatId);
           }
-
-          // The runtime dedupes by idempotency key. assistant-ui auto-resends a
-          // turn whose last assistant message is "complete with tool calls", and
-          // a user can double-submit — both replay the same key, so the runtime
-          // enqueues nothing and returns `accepted: false`. No reply will ever
-          // land, so polling would spin until the timeout and leave the composer
-          // stuck "loading". End the turn now without opening an assistant
-          // message (`start` is written below only once a turn is in flight).
-          if (!sent.value.accepted) {
-            return;
-          }
-
-          writer.write({ type: "start" });
 
           await pollForReplies({
             deps,

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -123,8 +123,6 @@ export function createServerAssistantTransport(
             ? AbortSignal.any([abortSignal, poll.signal])
             : poll.signal;
 
-          writer.write({ type: "start" });
-
           let chatId = ctx.getChatId();
           // Bind the local thread identity at send-start so a server-minted
           // chat id is reconciled with THIS thread even if a parallel send on
@@ -170,6 +168,19 @@ export function createServerAssistantTransport(
             chatId = sent.value.chatId;
             adopt(chatId);
           }
+
+          // The runtime dedupes by idempotency key. assistant-ui auto-resends a
+          // turn whose last assistant message is "complete with tool calls", and
+          // a user can double-submit — both replay the same key, so the runtime
+          // enqueues nothing and returns `accepted: false`. No reply will ever
+          // land, so polling would spin until the timeout and leave the composer
+          // stuck "loading". End the turn now without opening an assistant
+          // message (`start` is written below only once a turn is in flight).
+          if (!sent.value.accepted) {
+            return;
+          }
+
+          writer.write({ type: "start" });
 
           await pollForReplies({
             deps,
@@ -230,6 +241,11 @@ async function pollForReplies(args: {
   const pendingToolCalls = new Set<string>();
   let consecutiveFailures = 0;
   let attempt = 0;
+  // Tracks whether a `start-step` is open and awaiting its `finish-step`. Each
+  // server completion (assistant row) is bracketed as its own step so the
+  // turn's final, text-only row lands in a step with no tool calls — see the
+  // step writes below.
+  let stepOpen = false;
 
   for (;;) {
     if (abortSignal?.aborted) {
@@ -269,6 +285,18 @@ async function pollForReplies(args: {
         if (seen.has(m.id)) continue;
         seen.add(m.id);
         lastNewAssistant = m;
+        // Open a fresh step for each completion (closing the prior one). Without
+        // these boundaries the whole turn collapses into a single step, and
+        // assistant-ui's `lastAssistantMessageIsCompleteWithToolCalls` resume
+        // check — which inspects only the last step's tool parts — sees the
+        // turn's resolved tool calls and auto-resends a turn the server already
+        // finished. Per-step framing keeps the final text-only row in a step of
+        // its own, so that check finds no pending tool calls and stays put.
+        if (stepOpen) {
+          writer.write({ type: "finish-step" });
+        }
+        writer.write({ type: "start-step" });
+        stepOpen = true;
         const text = contentText(m.content);
         if (text) {
           await writeStreamedText({
@@ -289,6 +317,9 @@ async function pollForReplies(args: {
         }
       }
       if (lastNewAssistant && isTurnTerminal(lastNewAssistant)) {
+        if (stepOpen) {
+          writer.write({ type: "finish-step" });
+        }
         return;
       }
     } else {


### PR DESCRIPTION
## Problem

Project Assistant chat (full-page `/chat` and the insights dock) gets stuck "loading" after a tool-using turn: the assistant has finished and the final message renders, but the loader stays and the composer submit button is disabled, so the user can't continue.

## Root cause

`ServerAssistantTransport` fake-streams a polled turn into a single assistant-ui message **without emitting `start-step`/`finish-step` boundaries**. The runtime uses `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls`; that helper inspects only the parts after the last `step-start`, filters to tool parts (ignoring text), and returns true if they're all resolved. With no step boundaries the whole turn is "one step" whose tool calls are all done → assistant-ui auto-resends the already-finished turn. The runtime dedupes the re-send (`accepted: false`), and the re-send's poll loop spins until the 10-minute timeout — loader stuck, composer disabled.

Verified on prod: RUM shows `chat.load?generation=0` polled every ~2s indefinitely, with a deduped `sendMessage` ~3s after each tool turn; DB shows a single generation whose last row is `assistant/stop`, written once at stream close. Not a generation/compaction issue, and `/chat/completions` writes the assistant row once (no save-then-update).

## Changes

`client/dashboard/src/lib/ServerAssistantTransport.ts`: bracket each server completion with `start-step`/`finish-step` in `pollForReplies` so the final, text-only row is its own step with no tool calls — assistant-ui's resume check then finds nothing pending and doesn't auto-resend. A `try/finally` closes the open step on every exit (terminal, timeout, poll failure, abort) so the stream stays balanced.

Closes [DNO-272](https://linear.app/speakeasy/issue/DNO-272/bug-assistant-never-finishes-streaming-in-composer)

✻ Clauded with [Claude Code](https://claude.com/claude-code)
