### PR TITLE
chore: fix workos onboarding

### DIFF
--- a/client/dashboard/src/pages/setup/components/steps/connect-idp-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/connect-idp-step.tsx
@@ -91,11 +91,12 @@ export function ConnectIdpStep({
             intent: "sso",
             successUrl: `${getServerURL()}/v1/setup/callback?intent=sso`,
             returnUrl: window.location.href,
-            intentOptions: {
-              sso: {
-                providerType: provider.providerType,
-              },
-            },
+            // NOTE: intent_options.sso.provider_type is intentionally omitted.
+            // WorkOS currently only accepts "GoogleSAML" here and 422s on every
+            // other provider, breaking non-Google onboarding. Omitting it lets
+            // WorkOS open its own provider picker so all providers work. Restore
+            // provider.providerType once WorkOS supports the full set:
+            // https://speakeasyapi.slack.com/archives/C079KDQDY9X/p1781722173272439
           },
         },
       },


### PR DESCRIPTION
This addresses an issue where onboarding fails to proceed due to a very silly workOS api.

While we track the resolution, we omit the parameter and accept a very slightly degraded experience

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes onboarding for non-Google SSO providers by omitting the WorkOS admin portal `intent_options.sso.provider_type`, which was causing 422s for non-Google providers. WorkOS now shows its own provider picker, so all providers can complete setup; minor UX tradeoff until WorkOS fixes this (AIS-164).

<sup>Written for commit e07b31f6c3bd7cdaedd5a4d1c56cfa58b90518da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

