### PR TITLE
fix: send temperature 0 to the LLM judge (drop omitempty)

### DIFF
--- a/server/internal/thirdparty/openrouter/types.go
+++ b/server/internal/thirdparty/openrouter/types.go
@@ -172,11 +172,16 @@ type TraceConfig struct {
 
 // OpenAIChatRequest represents the request structure for OpenAI chat completions
 type OpenAIChatRequest struct {
-	Model          string                             `json:"model"`
-	Messages       []or.ChatMessages                  `json:"messages"`
-	Stream         bool                               `json:"stream"`
-	Tools          []Tool                             `json:"tools,omitempty"`
-	Temperature    float32                            `json:"temperature,omitempty"`
+	Model    string            `json:"model"`
+	Messages []or.ChatMessages `json:"messages"`
+	Stream   bool              `json:"stream"`
+	Tools    []Tool            `json:"tools,omitempty"`
+	// No omitempty: temperature 0 is a meaningful value (deterministic
+	// sampling), not "unset". With omitempty a caller-requested 0 would be
+	// dropped from the wire and the provider would silently fall back to its
+	// non-zero default. initializeRequest always assigns a concrete value
+	// (defaulting to 1.0), so this field is always intentionally set.
+	Temperature    float32                            `json:"temperature"`
 	ResponseFormat *or.ResponseFormat                 `json:"response_format,omitempty"`
 	Reasoning      *Reasoning                         `json:"reasoning,omitempty"`
 	CacheControl   *or.AnthropicCacheControlDirective `json:"cache_control,omitempty"`

--- a/server/internal/thirdparty/openrouter/types_test.go
+++ b/server/internal/thirdparty/openrouter/types_test.go
@@ -1,0 +1,31 @@
+package openrouter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenAIChatRequestTemperatureZeroIsSent guards against re-introducing
+// `omitempty` on Temperature. A caller requesting temperature 0 (deterministic
+// sampling) must have it sent on the wire; with omitempty the zero value is
+// dropped and the provider silently falls back to its non-zero default, which
+// defeats callers like pijudge that rely on temperature 0 for stable verdicts.
+func TestOpenAIChatRequestTemperatureZeroIsSent(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(OpenAIChatRequest{Model: "anthropic/claude-haiku-4.5", Temperature: 0})
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"temperature":0`)
+}
+
+// TestOpenAIChatRequestTemperatureNonZeroIsSent confirms an explicit non-zero
+// temperature still serializes as-is.
+func TestOpenAIChatRequestTemperatureNonZeroIsSent(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(OpenAIChatRequest{Model: "anthropic/claude-haiku-4.5", Temperature: 0.7})
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"temperature":0.7`)
+}


### PR DESCRIPTION
## What

`OpenAIChatRequest.Temperature` was tagged `float32 \`json:"temperature,omitempty"\``. Because `0.0` is the zero value of `float32`, `omitempty` **dropped a caller-requested temperature of 0 from the request body entirely** — and the upstream provider then applied its own non-zero default (~1.0).

This silently defeated `pijudge` (the LLM prompt-injection judge), which sets `temperature: 0` precisely so verdicts are deterministic ("`defaultTemperature keeps verdicts deterministic`"). In practice the judge was running at the provider default, so a borderline input could **flip-flop between blocked and allowed across otherwise identical calls** — i.e. a legitimate prompt intermittently getting flagged as a prompt-injection block.

## Fix

Drop `omitempty` so a temperature of `0` is always serialized. `initializeRequest` already assigns a concrete value (defaulting to `1.0` when the caller passes none), so every request intentionally carries a temperature — there was no "let the provider pick" path that relied on omission.

- `server/internal/thirdparty/openrouter/types.go` — remove `omitempty` from `Temperature`, with a comment explaining why 0 must be sent.
- `server/internal/thirdparty/openrouter/types_test.go` — regression test asserting `"temperature":0` is on the wire (guards against re-adding `omitempty`).

## Verification

- `go test ./internal/thirdparty/openrouter/` — 72 passed (incl. the 2 new tests)
- `mise build:server` — green
- `mise lint:server` — clean

## Notes / follow-ups

This is the determinism half of the "why does this prompt randomly get flagged" investigation. Two things are intentionally **out of scope** here:

- **Provider routing.** The judge call pins no OpenRouter `provider`, so `claude-haiku-4.5` can still route to Anthropic / Bedrock / Vertex, which can disagree on borderline inputs — a separate, smaller nondeterminism source worth pinning for the judge.
- The specific prompt that triggered this investigation is robustly classified *safe* on its own; this fix removes a real latent flip source but the original report likely also involves a larger judged body. Tracked under POC-193.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure temperature 0 is sent in OpenRouter chat requests so `pijudge` verdicts stay deterministic and stop flipping between block/allow. Addresses the POC-193 determinism issue.

- **Bug Fixes**
  - Removed `omitempty` from `OpenAIChatRequest.Temperature` in `server/internal/thirdparty/openrouter/types.go` so `0` is always serialized; `initializeRequest` still defaults to `1.0` when unset.
  - Added regression tests in `server/internal/thirdparty/openrouter/types_test.go` to assert `"temperature":0` (and non-zero) are present on the wire.

<sup>Written for commit 6084e253ecacae66340d892475759caac4b3406d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

