### PR TITLE
fix: move pijudge stage-1 model from Haiku 4.5 to Gemini 2.5 Flash

### DIFF
--- a/server/internal/pijudge/judge.go
+++ b/server/internal/pijudge/judge.go
@@ -45,12 +45,17 @@ const (
 	// on the realtime hook path, so this is also the worst-case added latency
 	// before a fail-open allow on a stuck model.
 	judgeTimeout = 10 * time.Second
-	// defaultModel is the stage-1 judge. Haiku 4.5 was the best balance in the
-	// POC-193 benchmark (0 false positives, AUC 0.982, cheap) — and 0 FP is the
-	// right bias for an engine that can block a legitimate tool call. The final
-	// model + the escalation target for the cascade remain open decisions
-	// (POC-193); this is a sensible, tunable default, not a closed choice.
-	defaultModel = "anthropic/claude-haiku-4.5"
+	// defaultModel is the stage-1 judge. Moved off Haiku 4.5 to Gemini 2.5 Flash
+	// after POC-193 follow-up: on real captured traffic Haiku flip-flopped on
+	// legitimate agent/MCP machinery (OAuth auth events, context notes) — ~80%
+	// false-block on some, non-deterministically — while Gemini 2.5 Flash judged
+	// the same events SAFE deterministically, and scored higher recall on the
+	// benchmark feed (87.8% vs 80%) at comparable FPR. (gemini-3.5-flash was
+	// rejected — it reintroduced the flip-flop; gemini-3.1-flash-lite, which
+	// riskjudge already uses, is an equivalent FP-clean alternative.) Parse-fail
+	// and every other error path fails open (SAFE), so this stays a tunable
+	// default, not a closed choice (POC-193).
+	defaultModel = "google/gemini-2.5-flash"
 	// defaultTemperature keeps verdicts deterministic.
 	defaultTemperature = 0.0
 	// concurrency bounds how many judge calls run in parallel for one batched


### PR DESCRIPTION
## What

Switches the stage-1 prompt-injection judge (`pijudge`) from `anthropic/claude-haiku-4.5` to `google/gemini-2.5-flash`.

## Why

POC-193 follow-up, driven by **real captured findings** (109 in a 39-min window, ~all false positives on the team's own agentic/MCP machinery). Benchmarking the production judge path against those bodies showed Haiku-4.5 **flip-flops** on legitimate machinery:

| input (real, `end_user` framing) | haiku-4.5 (current) | **gemini-2.5-flash** |
|---|---|---|
| OAuth `assistant_mcp_auth_required` event | flip-flop — 8/10 block (random) | **allow 0/10 ✓** |
| benign context-note dump | flip-flop | **allow ✓** |
| RFC prompt (must stay safe) | allow | allow ✓ |

Haiku sees the JWT/`client_secret` in an OAuth event and panics ("fabricated auth event… exfiltrate credentials"); Gemini correctly reads "legitimate MCP auth flow." Gemini-2.5-flash also has **higher recall** on the benchmark feed (87.8% vs Haiku's 80%) at comparable FPR.

## Model selection

- ❌ `gemini-3.5-flash` (newest) — **reintroduces the flip-flop** (3/8 on the OAuth event), so newer ≠ better here.
- ✅ `gemini-2.5-flash` — chosen: FP-clean + measured recall data.
- ◻️ `gemini-3.1-flash-lite` — equivalent FP-clean alternative, and it's already `riskjudge`'s default, so a reviewer who prefers cross-judge consistency can swap to it trivially. (Minor: in ad-hoc runs `gemini-2.5-flash` showed an occasional structured-output parse failure; `3.1-flash-lite` showed none. Both fail **open** → SAFE, surfaced by the existing judge error metric.)

## Scope / safety

One-line default change (`defaultModel`) + justification comment. `google/gemini-2.5-flash` is already in the OpenRouter allowlist. Every judge error path (parse-fail, timeout, rate-limit) already fails open, so a bad route degrades to L0 heuristics rather than dropping the scan.

This is one of several follow-ups; the **false positives on the agent's own machinery are not fully fixed by a model swap** — the `<invoke>` tool-call-XML class (61% of findings) is blocked by every model and needs the separate scan-path sanitizer.

## Verification
- `go build ./internal/pijudge/` — green
- `go test ./internal/pijudge/` — 9 passed
- `mise lint:server` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches stage‑1 `pijudge` from `anthropic/claude-haiku-4.5` to `google/gemini-2.5-flash` to cut false positives and stabilize verdicts on legitimate MCP events. Aligns with POC-193 findings.

- **Bug Fixes**
  - Removes flip‑flop blocks on OAuth auth-required events and benign context notes seen in real traffic.
  - Improves recall on the benchmark feed to 87.8% (vs 80%) at similar FPR.
  - Keeps fail‑open on errors; `gemini-3.5-flash` rejected for flip‑flops; `gemini-3.1-flash-lite` remains an FP‑clean alternative.

<sup>Written for commit 28d667c53c1a2f819962105746e38c2f9f7dc36e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

