### PR TITLE
mig: add llm_judge_reason column to risk_results

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3073,6 +3073,11 @@ CREATE TABLE IF NOT EXISTS risk_results (
   confidence DOUBLE PRECISION,
   tags TEXT[],
 
+  -- The LLM judge's one-sentence explanation of why this finding fired. NULL for
+  -- L0 heuristic findings and any engine that emits no judge reason. Expand step
+  -- (nullable, populated going forward) so existing rows are unaffected.
+  llm_judge_reason TEXT,
+
   -- Populated on rows that represent a message the scanner could not analyze
   -- after exhausting its retry budget
   dead_letter_reason TEXT,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1381,6 +1381,7 @@ type RiskResult struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
+	LlmJudgeReason      pgtype.Text
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -1937,7 +1937,7 @@ func (q *Queries) ListRiskPolicyBypassRequests(ctx context.Context, arg ListRisk
 }
 
 const listRiskResultsByChatFound = `-- name: ListRiskResultsByChatFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.llm_judge_reason, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -1977,6 +1977,7 @@ type ListRiskResultsByChatFoundRow struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
+	LlmJudgeReason      pgtype.Text
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
@@ -2020,6 +2021,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.LlmJudgeReason,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,
@@ -2042,7 +2044,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 }
 
 const listRiskResultsByProjectAndPolicy = `-- name: ListRiskResultsByProjectAndPolicy :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.llm_judge_reason, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -2082,6 +2084,7 @@ type ListRiskResultsByProjectAndPolicyRow struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
+	LlmJudgeReason      pgtype.Text
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
@@ -2125,6 +2128,7 @@ func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg Lis
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.LlmJudgeReason,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,

--- a/server/internal/testenv/testrepo/models.go
+++ b/server/internal/testenv/testrepo/models.go
@@ -112,6 +112,7 @@ type RiskResult struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
+	LlmJudgeReason      pgtype.Text
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -350,7 +350,7 @@ func (q *Queries) ListDeploymentHTTPTools(ctx context.Context, deploymentID uuid
 }
 
 const listRiskResultsAll = `-- name: ListRiskResultsAll :many
-SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, dead_letter_reason, excluded_at, excluded_exclusion_id, false_positive_at, false_positive_reason, created_at
+SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, llm_judge_reason, dead_letter_reason, excluded_at, excluded_exclusion_id, false_positive_at, false_positive_reason, created_at
 FROM risk_results
 WHERE project_id = $1
   AND risk_policy_id = $2
@@ -390,6 +390,7 @@ func (q *Queries) ListRiskResultsAll(ctx context.Context, arg ListRiskResultsAll
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.LlmJudgeReason,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,

--- a/server/migrations/20260618115411_risk-results-add-llm-judge-reason.sql
+++ b/server/migrations/20260618115411_risk-results-add-llm-judge-reason.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_results" table
+ALTER TABLE "risk_results" ADD COLUMN "llm_judge_reason" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:HIriReMwNodAl5jTUyK3TfQdwN3T7ITKREaxyM616O0=
+h1:QXs81a5lUbhfTZnqDnpz7Mx5wpeR1/2ruEVrTQjfOcI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -218,3 +218,4 @@ h1:HIriReMwNodAl5jTUyK3TfQdwN3T7ITKREaxyM616O0=
 20260610231620_add-billing-metadata-table.sql h1:QtN9rqkm2eke8pugS7NNmlndanZj2mJ3axc5gqrY7/A=
 20260615104135_false_positive_sweep.sql h1:1jocVB88SQg/3BOArQIAbPECNrLXOIVDCI9VFpplmbY=
 20260615113504_workos-metadata-for-directory-attributes-sync.sql h1:sZiNf5tqa+2mqki7Xr4sUuF126gZBup1Kg92bX7AtkM=
+20260618115411_risk-results-add-llm-judge-reason.sql h1:aI+VA7W9POYKH1mpSAUDTa4sfmr7gXkdmkBtXVK1NLI=


### PR DESCRIPTION
## What

Adds a nullable `llm_judge_reason TEXT` column to `risk_results`.

```sql
ALTER TABLE "risk_results" ADD COLUMN "llm_judge_reason" text NULL;
```

## Why

The LLM judge already *generates* a one-sentence reason on every verdict (the structured-output schema requires it), but it's currently discarded — `risk_results` has nowhere to store it, so findings are opaque. Capturing it makes findings **explainable and triageable** (e.g. distinguishing "legitimate OAuth flow" from "credential harvesting" at a glance), which directly addresses the recent wave of false positives on agent/MCP machinery (POC-193).

## Scope

The **expand** step of expand-contract: the column is nullable and existing rows are unaffected. The plumbing that populates it (judge → finding → insert → API → dashboard) ships in a separate PR.

- `server/database/schema.sql` + Atlas-generated migration + `atlas.sum`.
- Regenerated sqlc artifacts: adding the column to `schema.sql` expands the `SELECT *` queries on `risk_results`, so `internal/database/models.go`, `internal/risk/repo/queries.sql.go`, and the testenv repo are regenerated alongside it. This is mechanical and required for the build's dirty-file check to pass.
- Verified: `mise db:migrate` applies cleanly; `mise build:server` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a nullable llm_judge_reason TEXT column to risk_results to store the LLM judge’s one‑sentence reason for each finding. Makes results explainable and easier to triage (supports POC‑193); includes migration plus generated model/query updates, expand-only with no impact to existing rows.

<sup>Written for commit e079dd9e9d2b7ec7671ebcab84fdb5be00b4aaa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
