### PR TITLE
feat: surface the LLM judge's reason on prompt-injection findings

### DIFF
--- a/server/internal/background/activities/risk_analysis/pi_scanner.go
+++ b/server/internal/background/activities/risk_analysis/pi_scanner.go
@@ -33,10 +33,13 @@ type PromptInjectionRequest struct {
 }
 
 // PromptInjectionResult is one prediction. Label decides whether to emit an L1 finding
-// (LabelInjection => emit); Score is retained as confidence metadata.
+// (LabelInjection => emit); Score is retained as confidence metadata; Rationale is the
+// judge's one-sentence explanation (empty for engines that emit none), used as the
+// finding description so a flagged event is explainable for triage.
 type PromptInjectionResult struct {
-	Label string
-	Score float64
+	Label     string
+	Score     float64
+	Rationale string
 }
 
 // PromptInjectionEngine is the L1 prompt-injection engine: it scores each message in the
@@ -168,6 +171,11 @@ func (s *PromptInjectionScanner) findingFromResult(text string, r PromptInjectio
 		return nil
 	}
 	ruleID, description := DescribePromptInjection()
+	// Prefer the judge's specific rationale as the description when present; fall
+	// back to the canonical label for L0 heuristic findings (which emit none).
+	if r.Rationale != "" {
+		description = r.Rationale
+	}
 	return &Finding{
 		RuleID:           ruleID,
 		Description:      description,

--- a/server/internal/pijudge/judge.go
+++ b/server/internal/pijudge/judge.go
@@ -128,7 +128,7 @@ var _ ra.PromptInjectionEngine = (*Engine)(nil).Classify
 // safeResult is the not-an-attack verdict. It is returned for empty messages and
 // for every fail-open path (canceled context, rate limit, judge error) so a
 // judge outage degrades to the L0 heuristics rather than dropping the scan.
-var safeResult = ra.PromptInjectionResult{Label: ra.LabelSafe, Score: 0}
+var safeResult = ra.PromptInjectionResult{Label: ra.LabelSafe, Score: 0, Rationale: ""}
 
 // New constructs an Engine. The composition root constructs the completions
 // client unconditionally, so it is always non-nil here.
@@ -213,7 +213,7 @@ func (c *Engine) classifyOne(ctx context.Context, req ra.PromptInjectionRequest,
 	}
 
 	start := time.Now()
-	isAttack, confidence, err := c.call(ctx, req, msg)
+	isAttack, confidence, rationale, err := c.call(ctx, req, msg)
 	c.metrics.RecordClassification(ctx, req.OrgID, labelFor(isAttack, err), o11y.OutcomeFromError(err), time.Since(start))
 	if err != nil {
 		c.logger.WarnContext(ctx, "pi judge call failed; failing open",
@@ -232,7 +232,7 @@ func (c *Engine) classifyOne(ctx context.Context, req ra.PromptInjectionRequest,
 	c.logger.InfoContext(ctx, "pi judge flagged prompt injection",
 		attr.SlogOrganizationID(req.OrgID),
 	)
-	return ra.PromptInjectionResult{Label: ra.LabelInjection, Score: confidence}
+	return ra.PromptInjectionResult{Label: ra.LabelInjection, Score: confidence, Rationale: rationale}
 }
 
 // judgePayload is the user turn: the captured event rendered as a structured
@@ -244,7 +244,7 @@ type judgePayload struct {
 	Message riskjudge.MessagePayload `json:"message"`
 }
 
-func (c *Engine) call(ctx context.Context, req ra.PromptInjectionRequest, msg ra.JudgeMessage) (isAttack bool, confidence float64, err error) {
+func (c *Engine) call(ctx context.Context, req ra.PromptInjectionRequest, msg ra.JudgeMessage) (isAttack bool, confidence float64, rationale string, err error) {
 	payload, err := json.Marshal(judgePayload{Message: riskjudge.RenderMessage(msg)})
 	if err != nil {
 		// Unreachable: the payload is strings, bools, and slices. Fall back to the
@@ -269,27 +269,30 @@ func (c *Engine) call(ctx context.Context, req ra.PromptInjectionRequest, msg ra
 		JSONSchema:     &c.schema,
 	})
 	if err != nil {
-		return false, 0, fmt.Errorf("openrouter object completion: %w", err)
+		return false, 0, "", fmt.Errorf("openrouter object completion: %w", err)
 	}
 	if response == nil || response.Message == nil {
-		return false, 0, fmt.Errorf("empty completion response")
+		return false, 0, "", fmt.Errorf("empty completion response")
 	}
 	raw := strings.TrimSpace(openrouter.GetText(*response.Message))
 	if raw == "" {
-		return false, 0, fmt.Errorf("empty completion content")
+		return false, 0, "", fmt.Errorf("empty completion content")
 	}
 
-	// The schema also requires a "rationale" (it makes the model articulate its
-	// call), but we deliberately do not read it back — it could echo payload
-	// content, and findings carry the canonical prompt-injection description.
+	// The schema also requires a "rationale" (the model's one-sentence
+	// explanation). We read it back and surface it as the finding description so a
+	// flagged event is explainable for triage. The system prompt instructs the
+	// judge not to echo secrets or raw payloads in it, and it is stored in the
+	// same privacy tier as the match text the finding already records.
 	var verdict struct {
 		IsAttack   bool    `json:"is_attack"`
 		Confidence float64 `json:"confidence"`
+		Rationale  string  `json:"rationale"`
 	}
 	if err := json.Unmarshal([]byte(raw), &verdict); err != nil {
-		return false, 0, fmt.Errorf("parse judge response: %w", err)
+		return false, 0, "", fmt.Errorf("parse judge response: %w", err)
 	}
-	return verdict.IsAttack, max(0, min(1, verdict.Confidence)), nil
+	return verdict.IsAttack, max(0, min(1, verdict.Confidence)), verdict.Rationale, nil
 }
 
 // VerdictSchema is the judge's structured-output JSON schema. Deliberately no

--- a/server/internal/pijudge/judge.go
+++ b/server/internal/pijudge/judge.go
@@ -213,8 +213,8 @@ func (c *Engine) classifyOne(ctx context.Context, req ra.PromptInjectionRequest,
 	}
 
 	start := time.Now()
-	isAttack, confidence, rationale, err := c.call(ctx, req, msg)
-	c.metrics.RecordClassification(ctx, req.OrgID, labelFor(isAttack, err), o11y.OutcomeFromError(err), time.Since(start))
+	verdict, err := c.call(ctx, req, msg)
+	c.metrics.RecordClassification(ctx, req.OrgID, labelFor(verdict.IsAttack, err), o11y.OutcomeFromError(err), time.Since(start))
 	if err != nil {
 		c.logger.WarnContext(ctx, "pi judge call failed; failing open",
 			attr.SlogError(err),
@@ -222,17 +222,17 @@ func (c *Engine) classifyOne(ctx context.Context, req ra.PromptInjectionRequest,
 		)
 		return safeResult
 	}
-	if !isAttack {
+	if !verdict.IsAttack {
 		return safeResult
 	}
-	c.metrics.RecordConfidence(ctx, req.OrgID, confidence)
+	c.metrics.RecordConfidence(ctx, req.OrgID, verdict.Confidence)
 	// Structured finding signal without raw payload (privacy): the dashboard
 	// surfaces findings and the judge_confidence metric carries the score; this
 	// log is for fleet-level visibility.
 	c.logger.InfoContext(ctx, "pi judge flagged prompt injection",
 		attr.SlogOrganizationID(req.OrgID),
 	)
-	return ra.PromptInjectionResult{Label: ra.LabelInjection, Score: confidence, Rationale: rationale}
+	return ra.PromptInjectionResult{Label: ra.LabelInjection, Score: verdict.Confidence, Rationale: verdict.Rationale}
 }
 
 // judgePayload is the user turn: the captured event rendered as a structured
@@ -244,7 +244,15 @@ type judgePayload struct {
 	Message riskjudge.MessagePayload `json:"message"`
 }
 
-func (c *Engine) call(ctx context.Context, req ra.PromptInjectionRequest, msg ra.JudgeMessage) (isAttack bool, confidence float64, rationale string, err error) {
+// judgeVerdict is the judge's structured-output response: the model's call plus
+// the one-sentence rationale that explains it.
+type judgeVerdict struct {
+	IsAttack   bool    `json:"is_attack"`
+	Confidence float64 `json:"confidence"`
+	Rationale  string  `json:"rationale"`
+}
+
+func (c *Engine) call(ctx context.Context, req ra.PromptInjectionRequest, msg ra.JudgeMessage) (judgeVerdict, error) {
 	payload, err := json.Marshal(judgePayload{Message: riskjudge.RenderMessage(msg)})
 	if err != nil {
 		// Unreachable: the payload is strings, bools, and slices. Fall back to the
@@ -269,14 +277,14 @@ func (c *Engine) call(ctx context.Context, req ra.PromptInjectionRequest, msg ra
 		JSONSchema:     &c.schema,
 	})
 	if err != nil {
-		return false, 0, "", fmt.Errorf("openrouter object completion: %w", err)
+		return judgeVerdict{}, fmt.Errorf("openrouter object completion: %w", err)
 	}
 	if response == nil || response.Message == nil {
-		return false, 0, "", fmt.Errorf("empty completion response")
+		return judgeVerdict{}, fmt.Errorf("empty completion response")
 	}
 	raw := strings.TrimSpace(openrouter.GetText(*response.Message))
 	if raw == "" {
-		return false, 0, "", fmt.Errorf("empty completion content")
+		return judgeVerdict{}, fmt.Errorf("empty completion content")
 	}
 
 	// The schema also requires a "rationale" (the model's one-sentence
@@ -284,15 +292,12 @@ func (c *Engine) call(ctx context.Context, req ra.PromptInjectionRequest, msg ra
 	// flagged event is explainable for triage. The system prompt instructs the
 	// judge not to echo secrets or raw payloads in it, and it is stored in the
 	// same privacy tier as the match text the finding already records.
-	var verdict struct {
-		IsAttack   bool    `json:"is_attack"`
-		Confidence float64 `json:"confidence"`
-		Rationale  string  `json:"rationale"`
-	}
+	var verdict judgeVerdict
 	if err := json.Unmarshal([]byte(raw), &verdict); err != nil {
-		return false, 0, "", fmt.Errorf("parse judge response: %w", err)
+		return judgeVerdict{}, fmt.Errorf("parse judge response: %w", err)
 	}
-	return verdict.IsAttack, max(0, min(1, verdict.Confidence)), verdict.Rationale, nil
+	verdict.Confidence = max(0, min(1, verdict.Confidence))
+	return verdict, nil
 }
 
 // VerdictSchema is the judge's structured-output JSON schema. Deliberately no


### PR DESCRIPTION
## What

Surfaces the prompt-injection judge's one-sentence reason on PI findings by using it as the finding **description**. No new column or API field.

## Why

`pijudge` already generates a rationale on every verdict (the structured-output schema requires it) but `call()` discarded it, so PI findings only ever showed the canonical `"Detected a prompt injection attempt."` label — opaque for triage (POC-193). The prompt-policy judge (`JudgeFinding`) already routes its rationale into the description; this brings the PI path in line.

## Changes

- `pijudge/judge.go`: read `rationale` back from the verdict and thread it through `call()` → `classifyOne()` → `PromptInjectionResult.Rationale`.
- `pi_scanner.go`: `findingFromResult` uses the rationale as the description when present, falling back to the canonical label for L0 heuristic findings (which emit none).

It flows through the existing `risk_results.description` column, management API, and dashboard popover — no schema / API / SDK change.

> **Supersedes** the earlier approach that added a dedicated `llm_judge_reason` column + API/SDK field. That duplicated `description` (identical value on the policy-judge path, double-rendered in the popover) and got the same redaction treatment, so it didn't earn its own surface. The now-unused `risk_results.llm_judge_reason` column (merged in #3505) is removed by a follow-up contract migration.

## Privacy

The judge's system prompt instructs it not to echo secrets or raw payloads; the reason rides the same privacy tier as the `match` text the finding already records.

## Verification
- `mise build:server` ✓
- `go test ./internal/{pijudge,background/activities/risk_analysis}` — 205 passed
- `mise lint:server` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
