### PR TITLE
mig: drop unused risk_results.llm_judge_reason column

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3073,11 +3073,6 @@ CREATE TABLE IF NOT EXISTS risk_results (
   confidence DOUBLE PRECISION,
   tags TEXT[],
 
-  -- The LLM judge's one-sentence explanation of why this finding fired. NULL for
-  -- L0 heuristic findings and any engine that emits no judge reason. Expand step
-  -- (nullable, populated going forward) so existing rows are unaffected.
-  llm_judge_reason TEXT,
-
   -- Populated on rows that represent a message the scanner could not analyze
   -- after exhausting its retry budget
   dead_letter_reason TEXT,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1381,7 +1381,6 @@ type RiskResult struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
-	LlmJudgeReason      pgtype.Text
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -1937,7 +1937,7 @@ func (q *Queries) ListRiskPolicyBypassRequests(ctx context.Context, arg ListRisk
 }
 
 const listRiskResultsByChatFound = `-- name: ListRiskResultsByChatFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.llm_judge_reason, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -1977,7 +1977,6 @@ type ListRiskResultsByChatFoundRow struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
-	LlmJudgeReason      pgtype.Text
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
@@ -2021,7 +2020,6 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
-			&i.LlmJudgeReason,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,
@@ -2044,7 +2042,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 }
 
 const listRiskResultsByProjectAndPolicy = `-- name: ListRiskResultsByProjectAndPolicy :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.llm_judge_reason, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -2084,7 +2082,6 @@ type ListRiskResultsByProjectAndPolicyRow struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
-	LlmJudgeReason      pgtype.Text
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
@@ -2128,7 +2125,6 @@ func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg Lis
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
-			&i.LlmJudgeReason,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,

--- a/server/internal/testenv/testrepo/models.go
+++ b/server/internal/testenv/testrepo/models.go
@@ -112,7 +112,6 @@ type RiskResult struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
-	LlmJudgeReason      pgtype.Text
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -350,7 +350,7 @@ func (q *Queries) ListDeploymentHTTPTools(ctx context.Context, deploymentID uuid
 }
 
 const listRiskResultsAll = `-- name: ListRiskResultsAll :many
-SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, llm_judge_reason, dead_letter_reason, excluded_at, excluded_exclusion_id, false_positive_at, false_positive_reason, created_at
+SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, dead_letter_reason, excluded_at, excluded_exclusion_id, false_positive_at, false_positive_reason, created_at
 FROM risk_results
 WHERE project_id = $1
   AND risk_policy_id = $2
@@ -390,7 +390,6 @@ func (q *Queries) ListRiskResultsAll(ctx context.Context, arg ListRiskResultsAll
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
-			&i.LlmJudgeReason,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,

--- a/server/migrations/20260618141330_risk-results-drop-llm-judge-reason.sql
+++ b/server/migrations/20260618141330_risk-results-drop-llm-judge-reason.sql
@@ -1,0 +1,9 @@
+-- atlas:txtar
+
+-- checks/destructive.sql --
+-- atlas:assert DS103
+SELECT NOT EXISTS (SELECT 1 FROM "risk_results" WHERE "llm_judge_reason" IS NOT NULL) AS "is_empty";
+
+-- migration.sql --
+-- Modify "risk_results" table
+ALTER TABLE "risk_results" DROP COLUMN "llm_judge_reason";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:QXs81a5lUbhfTZnqDnpz7Mx5wpeR1/2ruEVrTQjfOcI=
+h1:eEt5lYbX/2I82kk4/vjUXJoEIPd/vHQ4Gypn9tpEhyA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -219,3 +219,4 @@ h1:QXs81a5lUbhfTZnqDnpz7Mx5wpeR1/2ruEVrTQjfOcI=
 20260615104135_false_positive_sweep.sql h1:1jocVB88SQg/3BOArQIAbPECNrLXOIVDCI9VFpplmbY=
 20260615113504_workos-metadata-for-directory-attributes-sync.sql h1:sZiNf5tqa+2mqki7Xr4sUuF126gZBup1Kg92bX7AtkM=
 20260618115411_risk-results-add-llm-judge-reason.sql h1:aI+VA7W9POYKH1mpSAUDTa4sfmr7gXkdmkBtXVK1NLI=
+20260618141330_risk-results-drop-llm-judge-reason.sql h1:D1AdewSg0AisvTZYT5ta9zDyUH5sFMWvaew/BPmLDtI=


### PR DESCRIPTION
## What

Drops the unused `risk_results.llm_judge_reason` column.

```sql
ALTER TABLE "risk_results" DROP COLUMN "llm_judge_reason";
```

## Why

**Contract step** for the column added in #3505. The plumbing that would have populated it never shipped: #3506 instead surfaces the prompt-injection judge's reason through the existing `description` column (the dedicated column duplicated `description` and earned no separate surface). The column is empty and unreferenced by any code, so the drop is safe.

## Scope

Migration + the mechanical sqlc regen it forces (the column drops out of `models.go`, the `SELECT *` expansions, and the testenv repo). Verified: `mise build:server` green.

## Sequencing

Safe to merge independently — neither `main` nor #3506 reads or writes the column. Ideally lands alongside/after #3506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the unused `risk_results.llm_judge_reason` column via a migration (with an Atlas assertion to ensure it’s empty) and regenerates `sqlc` models/queries. No behavior or API changes; judge reasons continue to use `description`.

<sup>Written for commit 5e06ba353c20d01432d9bb6ca4c01de152fe3910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

