### PR TITLE
chore(dashboard): remove gram-remote-mcp feature flag gating

### DIFF
--- a/client/dashboard/src/components/mcp/MCPServerCard.tsx
+++ b/client/dashboard/src/components/mcp/MCPServerCard.tsx
@@ -9,10 +9,10 @@ import { Badge } from "../ui/badge";
 import { MCPStatusIndicator } from "./MCPStatusIndicator";
 
 // MCPServerCard renders an mcp_servers row inside the /mcp listing grid.
-// Today only Remote-MCP-backed servers reach this component (gated upstream
-// by the gram-remote-mcp flag and the remoteMcpServerId filter); after the
-// AGE-1902/AGE-1880 cutover, toolset-backed mcp_servers will render through
-// the same card alongside Hosted MCPCard.
+// Today only Remote-MCP-backed servers reach this component (filtered upstream
+// by the remoteMcpServerId filter); after the AGE-1902/AGE-1880 cutover,
+// toolset-backed mcp_servers will render through the same card alongside Hosted
+// MCPCard.
 //
 // TODO(AGE-1902): collapse with MCPCard once Hosted (toolset-backed) cards
 // also source from mcp_servers and the per-card data shape no longer branches

--- a/client/dashboard/src/components/sources/Sources.tsx
+++ b/client/dashboard/src/components/sources/Sources.tsx
@@ -73,8 +73,6 @@ export default function Sources(): JSX.Element {
   const telemetry = useTelemetry();
   const isFunctionsEnabled =
     telemetry.isFeatureEnabled("gram-functions") ?? false;
-  const isRemoteMcpEnabled =
-    telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
 
   const {
     data: deploymentResult,
@@ -83,15 +81,12 @@ export default function Sources(): JSX.Element {
   } = useLatestDeployment();
   const { data: assets, refetch: refetchAssets } = useListAssets();
   const { data: remoteMcpServersResult, isLoading: isLoadingRemoteMcp } =
-    useRemoteMcpServers(undefined, undefined, {
-      enabled: isRemoteMcpEnabled,
-    });
+    useRemoteMcpServers();
   const catalogIconMap = useCatalogIconMap();
   const deployment = deploymentResult?.deployment;
   // Remote MCP sources aren't deployment-bound, so the page isn't ready until
   // both queries have resolved.
-  const isLoading =
-    isLoadingDeployment || (isRemoteMcpEnabled && isLoadingRemoteMcp);
+  const isLoading = isLoadingDeployment || isLoadingRemoteMcp;
 
   const [viewMode, setViewMode] = useViewMode();
   const toolCountsBySource = useToolCountsBySource();
@@ -336,24 +331,22 @@ export default function Sources(): JSX.Element {
                         </span>
                       </div>
                     </DropdownMenuItem>
-                    {isRemoteMcpEnabled && (
-                      <DropdownMenuItem
-                        onSelect={() => routes.sources.addRemoteMcp.goTo()}
-                        className="flex cursor-pointer items-start gap-3 rounded-md p-2"
-                      >
-                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
-                          <Network className="h-5 w-5 text-violet-600 dark:text-violet-400" />
-                        </div>
-                        <div className="flex flex-col gap-0.5">
-                          <span className="font-medium">
-                            Custom remote server
-                          </span>
-                          <span className="text-muted-foreground text-xs">
-                            Add existing remote servers by URL
-                          </span>
-                        </div>
-                      </DropdownMenuItem>
-                    )}
+                    <DropdownMenuItem
+                      onSelect={() => routes.sources.addRemoteMcp.goTo()}
+                      className="flex cursor-pointer items-start gap-3 rounded-md p-2"
+                    >
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
+                        <Network className="h-5 w-5 text-violet-600 dark:text-violet-400" />
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-medium">
+                          Custom remote server
+                        </span>
+                        <span className="text-muted-foreground text-xs">
+                          Add existing remote servers by URL
+                        </span>
+                      </div>
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 )}
               </DropdownMenu>

--- a/client/dashboard/src/components/sources/SourcesEmptyState.tsx
+++ b/client/dashboard/src/components/sources/SourcesEmptyState.tsx
@@ -25,8 +25,6 @@ export function SourcesEmptyState(): JSX.Element {
   const telemetry = useTelemetry();
   const isFunctionsEnabled =
     telemetry.isFeatureEnabled("gram-functions") ?? false;
-  const isRemoteMcpEnabled =
-    telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
 
   return (
     <Page.Section>
@@ -106,24 +104,22 @@ export function SourcesEmptyState(): JSX.Element {
                         </span>
                       </div>
                     </DropdownMenuItem>
-                    {isRemoteMcpEnabled && (
-                      <DropdownMenuItem
-                        onSelect={() => routes.sources.addRemoteMcp.goTo()}
-                        className="flex cursor-pointer items-start gap-3 rounded-md p-2"
-                      >
-                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
-                          <Network className="h-5 w-5 text-violet-600 dark:text-violet-400" />
-                        </div>
-                        <div className="flex flex-col gap-0.5">
-                          <span className="font-medium">
-                            Custom remote server
-                          </span>
-                          <span className="text-muted-foreground text-xs">
-                            Add existing remote servers by URL
-                          </span>
-                        </div>
-                      </DropdownMenuItem>
-                    )}
+                    <DropdownMenuItem
+                      onSelect={() => routes.sources.addRemoteMcp.goTo()}
+                      className="flex cursor-pointer items-start gap-3 rounded-md p-2"
+                    >
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
+                        <Network className="h-5 w-5 text-violet-600 dark:text-violet-400" />
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-medium">
+                          Custom remote server
+                        </span>
+                        <span className="text-muted-foreground text-xs">
+                          Add existing remote servers by URL
+                        </span>
+                      </div>
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 )}
               </DropdownMenu>

--- a/client/dashboard/src/pages/collections/CollectionDetail.tsx
+++ b/client/dashboard/src/pages/collections/CollectionDetail.tsx
@@ -7,7 +7,6 @@ import { Dialog } from "@/components/ui/dialog";
 import { Combobox } from "@/components/ui/combobox";
 import { Type } from "@/components/ui/type";
 import { useOrganization } from "@/contexts/Auth";
-import { useTelemetry } from "@/contexts/Telemetry";
 import {
   AlertTriangle,
   Calendar,
@@ -121,9 +120,6 @@ function CollectionDetailInner() {
   const [isSaving, setIsSaving] = useState(false);
 
   const client = useSdkClient();
-  const telemetry = useTelemetry();
-  const isRemoteMcpEnabled =
-    telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
   const attachServer = useAttachServer();
   const detachServer = useDetachServer();
 
@@ -145,12 +141,12 @@ function CollectionDetailInner() {
     })),
   });
 
-  // Remote MCP-backed mcp_servers per project, gated on the remote-mcp feature.
+  // Remote MCP-backed mcp_servers per project.
   const mcpServerQueries = useQueries({
     queries: projects.map((project) => ({
       queryKey: ["mcpServers", "list", project.slug],
       queryFn: () => client.mcpServers.list({ gramProject: project.slug }),
-      enabled: isRemoteMcpEnabled && !!project.slug,
+      enabled: !!project.slug,
     })),
   });
 

--- a/client/dashboard/src/pages/collections/CreateCollection.tsx
+++ b/client/dashboard/src/pages/collections/CreateCollection.tsx
@@ -6,7 +6,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Type } from "@/components/ui/type";
 import { useOrganization } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
-import { useTelemetry } from "@/contexts/Telemetry";
 import { cn } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
 import { Button, Input, Stack } from "@speakeasy-api/moonshine";
@@ -83,10 +82,6 @@ function CreateCollectionForm() {
   const [serverSearch, setServerSearch] = useState("");
   const createCollection = useCreateCollection();
 
-  const telemetry = useTelemetry();
-  const isRemoteMcpEnabled =
-    telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
-
   // Fetch toolsets from every project in the org
   const toolsetQueries = useQueries({
     queries: projects.map((project) => ({
@@ -96,14 +91,14 @@ function CreateCollectionForm() {
     })),
   });
 
-  // Fetch Remote MCP-backed mcp_servers from every project (gated on the
-  // remote-mcp feature). Toolset-backed mcp_servers don't exist yet
-  // (AGE-1902), so today this only surfaces remote-backed servers.
+  // Fetch Remote MCP-backed mcp_servers from every project. Toolset-backed
+  // mcp_servers don't exist yet (AGE-1902), so today this only surfaces
+  // remote-backed servers.
   const mcpServerQueries = useQueries({
     queries: projects.map((project) => ({
       queryKey: ["mcpServers", "list", project.slug],
       queryFn: () => client.mcpServers.list({ gramProject: project.slug }),
-      enabled: isRemoteMcpEnabled && !!project.slug,
+      enabled: !!project.slug,
     })),
   });
 

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -11,7 +11,6 @@ import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { useViewMode } from "@/components/ui/use-view-mode";
 import { useProjectSlugForRequests, useSdkClient } from "@/contexts/Sdk";
-import { useTelemetry } from "@/contexts/Telemetry";
 import { useRoutes } from "@/routes";
 import {
   useMcpEndpoints,
@@ -70,9 +69,6 @@ function MCPOverview() {
   const routes = useRoutes();
   const navigate = useNavigate();
   const client = useSdkClient();
-  const telemetry = useTelemetry();
-  const isRemoteMcpEnabled =
-    telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
 
   // TODO(AGE-1902): collapse this fetch with useToolsets() once Hosted
   // (toolset-backed) MCP servers also source from mcp_servers. Until then the
@@ -88,7 +84,6 @@ function MCPOverview() {
     isLoading: isLoadingMcpServers,
     isError: isMcpServersError,
   } = useMcpServers({ gramProject }, undefined, {
-    enabled: isRemoteMcpEnabled,
     throwOnError: false,
   });
   const {
@@ -96,7 +91,6 @@ function MCPOverview() {
     isLoading: isLoadingEndpoints,
     isError: isEndpointsError,
   } = useMcpEndpoints({ gramProject }, undefined, {
-    enabled: isRemoteMcpEnabled,
     throwOnError: false,
   });
   // Filter the listing to Remote-MCP-backed rows for now — the AGE-1902
@@ -121,8 +115,7 @@ function MCPOverview() {
   }, [endpointsResult]);
 
   const isLoading =
-    toolsets.isLoading ||
-    (isRemoteMcpEnabled && (isLoadingMcpServers || isLoadingEndpoints));
+    toolsets.isLoading || isLoadingMcpServers || isLoadingEndpoints;
 
   const hasRefreshError =
     toolsets.isError || isMcpServersError || isEndpointsError;

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -77,8 +77,6 @@ export default function MCPServerDetails(): JSX.Element {
   const navigate = useNavigate();
   const routes = useRoutes();
   const telemetry = useTelemetry();
-  const isRemoteMcpEnabled =
-    telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
   const isRbacEnabled = telemetry.isFeatureEnabled("gram-rbac") ?? false;
   const idOrSlug = mcpServerSlug ?? "";
   const activeTab = activeTabFromPath(location.pathname, idOrSlug);
@@ -104,20 +102,17 @@ export default function MCPServerDetails(): JSX.Element {
     isLoading,
     isError,
   } = useGetMcpServer(getMcpServerArgs(idOrSlug), undefined, {
-    enabled: isRemoteMcpEnabled && idOrSlug !== "",
+    enabled: idOrSlug !== "",
   });
 
   const mcpServerId = mcpServer?.id ?? "";
 
   const { data: endpointsResult, isLoading: isLoadingEndpoints } =
     useMcpEndpoints({ mcpServerId }, undefined, {
-      enabled: isRemoteMcpEnabled && mcpServerId !== "",
+      enabled: mcpServerId !== "",
     });
   const endpoints = endpointsResult?.mcpEndpoints ?? [];
 
-  if (!isRemoteMcpEnabled) {
-    return <Navigate to={routes.mcp.href()} replace />;
-  }
   if (!idOrSlug) {
     return <Navigate to={routes.mcp.href()} replace />;
   }

--- a/client/dashboard/src/pages/onboarding/Wizard.tsx
+++ b/client/dashboard/src/pages/onboarding/Wizard.tsx
@@ -393,9 +393,6 @@ export const InitialChoiceStep = ({
   const navigate = useNavigate();
   const telemetry = useTelemetry();
 
-  const isRemoteMcpEnabled =
-    telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
-
   const onChoiceSelected = (
     choice:
       | "connect_to_data"
@@ -453,17 +450,15 @@ export const InitialChoiceStep = ({
           title="Connect to Popular MCPs"
           description="Browse and connect to official and community-maintained MCP servers"
         />
-        {isRemoteMcpEnabled && (
-          <ChoiceCard
-            onClick={() => {
-              onChoiceSelected("connect_to_custom_remote_mcp");
-              routes.sources.addRemoteMcp.goTo();
-            }}
-            icon={Network}
-            title="Custom Remote MCP"
-            description="Connect to an existing MCP server by URL"
-          />
-        )}
+        <ChoiceCard
+          onClick={() => {
+            onChoiceSelected("connect_to_custom_remote_mcp");
+            routes.sources.addRemoteMcp.goTo();
+          }}
+          icon={Network}
+          title="Custom Remote MCP"
+          description="Connect to an existing MCP server by URL"
+        />
         <ChoiceCard
           onClick={handleConnectToData}
           icon={Database}

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -41,7 +41,6 @@ import type {
   ToolsetEntry,
 } from "@gram/client/models/components";
 import { useSdkClient } from "@/contexts/Sdk";
-import { useTelemetry } from "@/contexts/Telemetry";
 import { toast } from "sonner";
 
 // A selectable server for a plugin, sourced from either a toolset (Hosted) or
@@ -68,9 +67,6 @@ export default function PluginDetail(): JSX.Element | null {
   const { data: plugin } = usePluginSuspense({ id: pluginId! });
 
   const client = useSdkClient();
-  const telemetry = useTelemetry();
-  const isRemoteMcpEnabled =
-    telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
 
   const { data: toolsetsData, isLoading: isLoadingToolsets } =
     useListToolsets();
@@ -79,10 +75,10 @@ export default function PluginDetail(): JSX.Element | null {
     [toolsetsData?.toolsets],
   );
 
-  // Remote MCP-backed mcp_servers for this project, gated on the remote-mcp
-  // feature. Only remote-backed, non-disabled servers are publishable today.
+  // Remote MCP-backed mcp_servers for this project. Only remote-backed,
+  // non-disabled servers are publishable today.
   const { data: mcpServersData, isLoading: isLoadingMcpServers } =
-    useMcpServers({}, undefined, { enabled: isRemoteMcpEnabled });
+    useMcpServers({});
   const mcpServers = useMemo(
     () =>
       (mcpServersData?.mcpServers ?? []).filter(


### PR DESCRIPTION
Linear: https://linear.app/speakeasy/issue/AGE-2120/open-gram-remote-mcp-posthog-feature-flag-to-all-customers

Remove all dashboard references to the `gram-remote-mcp` PostHog flag, unconditionally rendering the Remote MCP UI and enabling its queries. The flag has been rolled out to 100% in PostHog; with the gate gone the feature ships to all customers.

Drops the `isRemoteMcpEnabled` gate across 8 components/pages (including the hard redirect in `MCPServerDetails`), removes now-unused `useTelemetry` imports, and updates stale comments referencing the flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `gram-remote-mcp` feature flag gating in the dashboard so the Remote MCP UI is always visible and its queries always run for all customers. Completes Linear AGE-2120 to open the feature to everyone.

- **Refactors**
  - Dropped `isRemoteMcpEnabled` checks and removed unused `useTelemetry` imports across 9 components/pages; updated comments.
  - Always show “Custom remote server” in Sources, Sources empty state, and the onboarding wizard.
  - Unconditionally enable Remote MCP queries (`useRemoteMcpServers`, `useMcpServers`, `useMcpEndpoints`, `useGetMcpServer`); simplified loading in Sources and MCP.
  - Removed the redirect guard in `MCPServerDetails`; details and endpoints load when an id/slug is present.
  - Collections and Plugin detail now fetch Remote MCP servers per project without gating.

<sup>Written for commit 704d12acf201cc3361e72d06458822ea6fe430c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

