### PR TITLE
feat(dashboard): add chart zoom controls

### DIFF
--- a/.changeset/chart-zoom-controls.md
+++ b/.changeset/chart-zoom-controls.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add drag-to-zoom time window controls to dashboard charts.

--- a/client/dashboard/package.json
+++ b/client/dashboard/package.json
@@ -60,6 +60,7 @@
     "@xyflow/react": "^12.8.6",
     "ai": "catalog:",
     "chart.js": "^4.5.1",
+    "chartjs-plugin-zoom": "^2.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/client/dashboard/src/components/chart/ChartButton.tsx
+++ b/client/dashboard/src/components/chart/ChartButton.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@speakeasy-api/moonshine";
+import { ReactNode } from "react";
+
+export type ChartButtonProps = {
+  onClick: () => void;
+  children: ReactNode;
+  ariaLabel: string;
+  className?: string;
+};
+
+export function ChartButton({
+  onClick,
+  children,
+  className,
+  ariaLabel,
+}: ChartButtonProps): ReactNode {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "text-muted-foreground hover:text-foreground hover:bg-accent/75 shrink-0 rounded-md p-1.5 flex transition-colors min-w-6 h-6 items-center justify-center text-xs gap-1",
+        className,
+      )}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  );
+}

--- a/client/dashboard/src/components/chart/ChartCard.test.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.test.tsx
@@ -62,6 +62,42 @@ describe("ChartCard", () => {
     expect(onExpand).toHaveBeenCalledWith(null);
   });
 
+  it("calls onResetZoom when the reset zoom button is clicked", () => {
+    const onResetZoom = vi.fn();
+    render(
+      <ChartCard
+        {...defaultProps}
+        isZoomed
+        onResetZoom={() => {
+          onResetZoom();
+        }}
+      >
+        -
+      </ChartCard>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset zoom" }));
+
+    expect(onResetZoom).toHaveBeenCalledOnce();
+  });
+
+  it("does not show the reset zoom button when the chart is not zoomed", () => {
+    const onResetZoom = vi.fn();
+    render(
+      <ChartCard
+        {...defaultProps}
+        isZoomed={false}
+        onResetZoom={() => {
+          onResetZoom();
+        }}
+      >
+        -
+      </ChartCard>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Reset zoom" })).toBeNull();
+  });
+
   it("hides the expand button when hasData is false", () => {
     render(
       <ChartCard {...defaultProps} hasData={false}>

--- a/client/dashboard/src/components/chart/ChartCard.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.tsx
@@ -1,24 +1,30 @@
-import { cn } from "@/lib/utils";
-import { Maximize2, Minimize2 } from "lucide-react";
+import { cn, Icon } from "@speakeasy-api/moonshine";
 import type { ReactNode } from "react";
+import { ChartButton } from "./ChartButton";
+
+export type ChartCardProps = {
+  title: string;
+  chartId: string;
+  hasData?: boolean;
+  expandable?: boolean;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
+  isZoomed?: boolean;
+  onResetZoom?: () => void;
+  children: ReactNode;
+};
 
 export function ChartCard({
   title,
   chartId,
-  expandedChart,
-  onExpand,
   hasData = true,
   expandable = true,
+  expandedChart,
+  onExpand,
+  isZoomed,
+  onResetZoom,
   children,
-}: {
-  title: string;
-  chartId: string;
-  expandedChart: string | null;
-  onExpand: (id: string | null) => void;
-  hasData?: boolean;
-  expandable?: boolean;
-  children: ReactNode;
-}): JSX.Element {
+}: ChartCardProps): ReactNode {
   const isExpanded = expandedChart === chartId;
   const showExpandButton = expandable && (hasData || isExpanded);
   return (
@@ -30,20 +36,26 @@ export function ChartCard({
     >
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text font-semibold">{title}</h3>
-        {showExpandButton && (
-          <button
-            type="button"
-            onClick={() => onExpand(isExpanded ? null : chartId)}
-            className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors"
-            aria-label={isExpanded ? "Minimize chart" : "Expand chart"}
-          >
-            {isExpanded ? (
-              <Minimize2 className="size-4" />
-            ) : (
-              <Maximize2 className="size-4" />
-            )}
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          {isZoomed && onResetZoom && (
+            <ChartButton onClick={onResetZoom} ariaLabel="Reset zoom">
+              <Icon name="rotate-ccw" />
+              Reset zoom
+            </ChartButton>
+          )}
+          {showExpandButton && (
+            <ChartButton
+              onClick={() => onExpand(isExpanded ? null : chartId)}
+              ariaLabel={isExpanded ? "Minimize chart" : "Expand chart"}
+            >
+              {isExpanded ? (
+                <Icon name="minimize-2" />
+              ) : (
+                <Icon name="maximize-2" />
+              )}
+            </ChartButton>
+          )}
+        </div>
       </div>
       {children}
     </div>

--- a/client/dashboard/src/components/chart/chartUtils.ts
+++ b/client/dashboard/src/components/chart/chartUtils.ts
@@ -57,6 +57,17 @@ export function formatChartLabel(date: Date, timeRangeMs: number): string {
   }
 }
 
+export function formatChartZoomRangeLabel(from: Date, to: Date): string {
+  const fmt = (date: Date) =>
+    date.toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  return `${fmt(from)} – ${fmt(to)}`;
+}
+
 export type ThresholdConfig = {
   red: number;
   amber: number;

--- a/client/dashboard/src/components/chart/useChartZoom.test.ts
+++ b/client/dashboard/src/components/chart/useChartZoom.test.ts
@@ -1,0 +1,150 @@
+import { act, renderHook } from "@testing-library/react";
+import type { Chart } from "chart.js";
+import type { ZoomPluginOptions } from "chartjs-plugin-zoom/types/options";
+import { describe, expect, it, vi } from "vitest";
+import { useChartZoom } from "./useChartZoom";
+
+function fireZoomComplete(
+  zoomPluginOptions: ZoomPluginOptions,
+  min: number,
+  max: number,
+) {
+  const onZoomComplete = zoomPluginOptions.zoom?.onZoomComplete;
+  if (!onZoomComplete) {
+    throw new Error("Expected zoom complete callback to be configured");
+  }
+
+  onZoomComplete({
+    chart: {
+      scales: {
+        x: { min, max },
+      },
+    } as unknown as Chart,
+  });
+}
+
+describe("useChartZoom", () => {
+  it("maps the selected x-axis range to dates", () => {
+    const onRangeSelect = vi.fn();
+    const { result } = renderHook(() =>
+      useChartZoom({
+        onRangeSelect: (from, to) => {
+          onRangeSelect(from, to);
+        },
+      }),
+    );
+    const from = Date.UTC(2026, 0, 1, 12, 0);
+    const to = Date.UTC(2026, 0, 2, 12, 0);
+
+    act(() => {
+      fireZoomComplete(result.current.zoomPluginOptions, from, to);
+    });
+
+    expect(onRangeSelect).toHaveBeenCalledWith(new Date(from), new Date(to));
+  });
+
+  it("does not configure in-progress range updates", () => {
+    const onRangeSelect = vi.fn();
+    const { result } = renderHook(() =>
+      useChartZoom({
+        onRangeSelect: (from, to) => {
+          onRangeSelect(from, to);
+        },
+      }),
+    );
+
+    expect(result.current.zoomPluginOptions.zoom?.onZoom).toBeUndefined();
+    expect(onRangeSelect).not.toHaveBeenCalled();
+  });
+
+  it("ignores zoom completion events caused by resetZoom", () => {
+    const onRangeSelect = vi.fn();
+    const { result } = renderHook(() =>
+      useChartZoom({
+        onRangeSelect: (from, to) => {
+          onRangeSelect(from, to);
+        },
+      }),
+    );
+    const chart = {
+      scales: {
+        x: {
+          min: Date.UTC(2026, 0, 1, 12, 0),
+          max: Date.UTC(2026, 0, 2, 12, 0),
+        },
+      },
+      resetZoom: vi.fn(() => {
+        result.current.zoomPluginOptions.zoom?.onZoomComplete?.({
+          chart: chart as unknown as Chart,
+        });
+      }),
+    };
+    (result.current.chartRef as unknown as { current: Chart | null }).current =
+      chart as unknown as Chart;
+
+    act(() => {
+      result.current.resetZoom();
+    });
+
+    expect(chart.resetZoom).toHaveBeenCalled();
+    expect(onRangeSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not configure drag selection when no range callback is provided", () => {
+    const { result } = renderHook(() => useChartZoom({}));
+
+    expect(result.current.zoomPluginOptions.zoom?.drag?.enabled).toBe(false);
+  });
+
+  it("ignores non-numeric chart scale ranges", () => {
+    const onRangeSelect = vi.fn();
+    const { result } = renderHook(() =>
+      useChartZoom({
+        onRangeSelect: (from, to) => {
+          onRangeSelect(from, to);
+        },
+      }),
+    );
+    const onZoomComplete =
+      result.current.zoomPluginOptions.zoom?.onZoomComplete;
+    if (!onZoomComplete) {
+      throw new Error("Expected zoom complete callback to be configured");
+    }
+
+    act(() => {
+      onZoomComplete({
+        chart: {
+          scales: {
+            x: { min: "start", max: Date.UTC(2026, 0, 2) },
+          },
+        } as unknown as Chart,
+      });
+    });
+
+    expect(onRangeSelect).not.toHaveBeenCalled();
+  });
+
+  it("uses a custom resolver for non-date scale ranges", () => {
+    const onRangeSelect = vi.fn();
+    const first = new Date(Date.UTC(2026, 0, 1, 12, 0));
+    const second = new Date(Date.UTC(2026, 0, 1, 13, 0));
+    const { result } = renderHook(() =>
+      useChartZoom({
+        onRangeSelect: (from, to) => {
+          onRangeSelect(from, to);
+        },
+        resolveRange: (min, max) => {
+          expect(min).toBe(0);
+          expect(max).toBe(1);
+          return { from: first, to: second };
+        },
+      }),
+    );
+
+    act(() => {
+      fireZoomComplete(result.current.zoomPluginOptions, 0, 1);
+    });
+
+    expect(onRangeSelect).toHaveBeenCalledWith(first, second);
+  });
+});

--- a/client/dashboard/src/components/chart/useChartZoom.ts
+++ b/client/dashboard/src/components/chart/useChartZoom.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo, useRef, type RefObject } from "react";
+import type { Chart as ChartJS, ChartType, DefaultDataPoint } from "chart.js";
+import type { ZoomPluginOptions } from "chartjs-plugin-zoom/types/options";
+
+type UseChartZoomResult<TType extends ChartType, TData, TLabel> = {
+  chartRef: RefObject<ChartJS<TType, TData, TLabel> | null>;
+  zoomPluginOptions: ZoomPluginOptions;
+  resetZoom: () => void;
+};
+
+export function useChartZoom<
+  TType extends ChartType = "line",
+  TData = DefaultDataPoint<TType>,
+  TLabel = unknown,
+>({
+  onRangeSelect,
+  resolveRange,
+}: {
+  onRangeSelect?: (from: Date, to: Date) => void;
+  resolveRange?: (min: number, max: number) => { from: Date; to: Date } | null;
+}): UseChartZoomResult<TType, TData, TLabel> {
+  const chartRef = useRef<ChartJS<TType, TData, TLabel>>(null);
+  const isResettingRef = useRef(false);
+
+  const resetZoom = useCallback(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+
+    isResettingRef.current = true;
+    chart.resetZoom();
+    queueMicrotask(() => {
+      isResettingRef.current = false;
+    });
+  }, []);
+
+  const zoomPluginOptions = useMemo<ZoomPluginOptions>(
+    () => ({
+      zoom: {
+        drag: {
+          enabled: !!onRangeSelect,
+          backgroundColor: "rgba(59, 130, 246, 0.15)",
+          borderColor: "rgba(59, 130, 246, 0.4)",
+          borderWidth: 1,
+        },
+        mode: "x",
+        onZoomComplete({ chart }) {
+          if (isResettingRef.current) return;
+          if (!onRangeSelect || !chart.scales.x) return;
+          const { min, max } = chart.scales.x;
+          if (typeof min !== "number" || typeof max !== "number") return;
+          const range = resolveRange
+            ? resolveRange(min, max)
+            : {
+                from: new Date(min),
+                to: new Date(max),
+              };
+          if (!range) return;
+          onRangeSelect(range.from, range.to);
+        },
+      },
+    }),
+    [onRangeSelect, resolveRange],
+  );
+
+  return { chartRef, zoomPluginOptions, resetZoom };
+}

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -1,6 +1,8 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ChartCard } from "@/components/chart/ChartCard";
-import { formatChartLabel, smoothData } from "@/components/chart/chartUtils";
+import { formatChartZoomRangeLabel } from "@/components/chart/chartUtils";
+import { useChartZoom } from "@/components/chart/useChartZoom";
+import { buildAgentTokenTimeSeriesChartData } from "@/components/observe/agentTokenTimeSeriesChartData";
 import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { formatCompact } from "@/lib/format";
 import { MetricCard } from "@/components/chart/MetricCard";
@@ -49,9 +51,9 @@ import {
   LinearScale,
   PointElement,
   Tooltip,
-  type ChartDataset,
   type ChartOptions,
 } from "chart.js";
+import ZoomPlugin from "chartjs-plugin-zoom";
 import {
   Button,
   type Column,
@@ -60,7 +62,7 @@ import {
   Table,
   sortTableData,
 } from "@speakeasy-api/moonshine";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Bar, Chart } from "react-chartjs-2";
 import { Link } from "react-router";
 import { toast } from "sonner";
@@ -74,6 +76,7 @@ ChartJS.register(
   Filler,
   Tooltip,
   Legend,
+  ZoomPlugin,
 );
 
 type ValueMode = "tokens" | "cost";
@@ -128,12 +131,6 @@ function initials(name: string): string {
   if (parts.length >= 2)
     return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
   return (name[0] ?? "?").toUpperCase();
-}
-
-function unixNanoToDate(value: string): Date {
-  const nanos = BigInt(value);
-  const millis = Number(nanos / 1_000_000n);
-  return new Date(millis);
 }
 
 function ValueModeToggle({
@@ -458,6 +455,20 @@ export function InsightsAgentsContent(): JSX.Element {
     membersLoading || usersQuery.isLoading || projectQuery.isLoading;
   const error = membersError ?? usersQuery.error ?? projectQuery.error;
 
+  const handleClearCustomRange = useCallback(() => {
+    costFilters.clearValue("date");
+  }, [costFilters]);
+  const handleChartRangeSelect = useCallback(
+    (rangeFrom: Date, rangeTo: Date) => {
+      costFilters.setValue("date", {
+        preset: null,
+        customRange: { from: rangeFrom, to: rangeTo },
+        customLabel: formatChartZoomRangeLabel(rangeFrom, rangeTo),
+      });
+    },
+    [costFilters],
+  );
+
   return (
     <>
       <InsightsConfig
@@ -572,6 +583,9 @@ export function InsightsAgentsContent(): JSX.Element {
                   valueMode={valueMode}
                   expandedChart={expandedChart}
                   onExpand={setExpandedChart}
+                  onRangeSelect={handleChartRangeSelect}
+                  isZoomed={customRange !== null}
+                  onResetZoom={handleClearCustomRange}
                 />
                 <ClientBreakdownChart
                   title="Usage by Client"
@@ -620,6 +634,9 @@ function TokenTimeSeriesChart({
   valueMode,
   expandedChart,
   onExpand,
+  onRangeSelect,
+  isZoomed,
+  onResetZoom,
 }: {
   title: string;
   subtitle?: string;
@@ -629,6 +646,9 @@ function TokenTimeSeriesChart({
   valueMode: ValueMode;
   expandedChart: string | null;
   onExpand: (id: string | null) => void;
+  onRangeSelect?: (from: Date, to: Date) => void;
+  isZoomed?: boolean;
+  onResetZoom?: () => void;
 }) {
   const isExpanded = expandedChart === chartId;
   const height = isExpanded ? 420 : 260;
@@ -639,82 +659,35 @@ function TokenTimeSeriesChart({
         : b.totalInputTokens + b.totalOutputTokens) > 0,
   );
 
-  // Mixed bar+line chart. Each dataset can override its `type` (chart.js
-  // supports per-dataset type overrides on a bar chart), so the dataset
-  // array is a union of bar and line dataset shapes.
-  const chartData = useMemo<{
-    labels: string[];
-    datasets: Array<
-      ChartDataset<"bar", number[]> | ChartDataset<"line", number[]>
-    >;
-  }>(() => {
-    const labels = timeSeries.map((b) =>
-      formatChartLabel(unixNanoToDate(b.bucketTimeUnixNano), timeRangeMs),
-    );
+  const { timestamps, chartData } = useMemo(
+    () =>
+      buildAgentTokenTimeSeriesChartData(timeSeries, timeRangeMs, valueMode),
+    [timeSeries, timeRangeMs, valueMode],
+  );
+  const resolveZoomRange = useCallback(
+    (min: number, max: number) => {
+      if (timestamps.length === 0) return null;
+      const fromIndex = Math.max(0, Math.floor(min));
+      const toIndex = Math.min(timestamps.length - 1, Math.ceil(max));
+      const from = timestamps[fromIndex];
+      const to = timestamps[toIndex];
+      if (from == null || to == null) return null;
+      return { from: new Date(from), to: new Date(to) };
+    },
+    [timestamps],
+  );
+  const { chartRef, zoomPluginOptions, resetZoom } = useChartZoom<
+    "bar" | "line",
+    number[],
+    string
+  >({
+    onRangeSelect,
+    resolveRange: resolveZoomRange,
+  });
 
-    // Raw bar datasets
-    const barDatasets =
-      valueMode === "cost"
-        ? [
-            {
-              label: "Cost",
-              data: timeSeries.map((b) => b.totalCost),
-              backgroundColor: "rgba(96, 165, 250, 0.35)",
-              stack: "stack",
-              order: 2,
-            },
-          ]
-        : [
-            {
-              label: "Input Tokens",
-              data: timeSeries.map((b) => b.totalInputTokens),
-              backgroundColor: "rgba(96, 165, 250, 0.35)",
-              stack: "stack",
-              order: 2,
-            },
-            {
-              label: "Output Tokens",
-              data: timeSeries.map((b) => b.totalOutputTokens),
-              backgroundColor: "rgba(52, 211, 153, 0.35)",
-              stack: "stack",
-              order: 2,
-            },
-            {
-              label: "Cache Read",
-              data: timeSeries.map((b) => b.cacheReadInputTokens),
-              backgroundColor: "rgba(167, 139, 250, 0.35)",
-              stack: "stack",
-              order: 2,
-            },
-          ];
-
-    // Smoothed trend line (total across all stacked values)
-    const rawTotal = timeSeries.map((b) =>
-      valueMode === "cost"
-        ? b.totalCost
-        : b.totalInputTokens + b.totalOutputTokens + b.cacheReadInputTokens,
-    );
-    const trendData = smoothData(rawTotal);
-
-    const trendDataset: ChartDataset<"line", number[]> = {
-      label: valueMode === "cost" ? "Cost Trend" : "Token Trend",
-      data: trendData,
-      type: "line",
-      borderColor: valueMode === "cost" ? "#818cf8" : "#3b82f6",
-      backgroundColor: "transparent",
-      pointRadius: 0,
-      pointHoverRadius: 4,
-      borderWidth: 2,
-      tension: 0.4,
-      fill: false,
-      order: 1,
-    };
-
-    return {
-      labels,
-      datasets: [...barDatasets, trendDataset],
-    };
-  }, [timeSeries, timeRangeMs, valueMode]);
+  useEffect(() => {
+    resetZoom();
+  }, [chartData, resetZoom]);
 
   const options = useMemo<ChartOptions<"bar">>(
     () => ({
@@ -747,6 +720,7 @@ function TokenTimeSeriesChart({
             },
           },
         },
+        zoom: zoomPluginOptions,
       },
       scales: {
         x: {
@@ -764,7 +738,7 @@ function TokenTimeSeriesChart({
         },
       },
     }),
-    [valueMode],
+    [valueMode, zoomPluginOptions],
   );
 
   return (
@@ -774,6 +748,8 @@ function TokenTimeSeriesChart({
       expandedChart={expandedChart}
       onExpand={onExpand}
       hasData={hasData}
+      isZoomed={isZoomed}
+      onResetZoom={onResetZoom}
     >
       {subtitle && (
         <p className="text-muted-foreground -mt-3 mb-2 text-xs">{subtitle}</p>
@@ -790,6 +766,7 @@ function TokenTimeSeriesChart({
               `"bar" | "line"` generic explicitly widens `<Chart>` to accept
               the union dataset shape. */}
           <Chart<"bar" | "line", number[], string>
+            ref={chartRef}
             type="bar"
             data={chartData}
             options={options}

--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -53,7 +53,6 @@ import {
 import { useSlugs } from "@/contexts/Sdk";
 import { formatDateRangeLabel } from "@/components/observe/useDateRangeFilter";
 import {
-  CategoryScale,
   Chart as ChartJS,
   Filler,
   Legend,
@@ -63,8 +62,10 @@ import {
   Tooltip as ChartTooltip,
   type ChartOptions,
 } from "chart.js";
+import ZoomPlugin from "chartjs-plugin-zoom";
+import { useChartZoom } from "@/components/chart/useChartZoom";
 import { slugify } from "@/lib/constants";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Line } from "react-chartjs-2";
 import { useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
@@ -86,13 +87,13 @@ import {
 import "@xyflow/react/dist/style.css";
 
 ChartJS.register(
-  CategoryScale,
   LinearScale,
   PointElement,
   LineElement,
   Filler,
   ChartTooltip,
   Legend,
+  ZoomPlugin,
 );
 
 const CHART_COLOR = "#60a5fa";
@@ -277,6 +278,20 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
     setCustomRange(null);
     setCustomRangeLabel(null);
   };
+  const handleChartRangeSelect = useCallback(
+    (from: Date, to: Date) => {
+      const fmt = (d: Date) =>
+        d.toLocaleString([], {
+          month: "short",
+          day: "numeric",
+          hour: "numeric",
+          minute: "2-digit",
+        });
+      setCustomRange({ from, to });
+      setCustomRangeLabel(`${fmt(from)} – ${fmt(to)}`);
+    },
+    [setCustomRange, setCustomRangeLabel],
+  );
 
   const fallbackUserQuery = useQuery({
     queryKey: [
@@ -576,6 +591,9 @@ export function InsightsEmployeeDetailContent(): JSX.Element {
                   )}
                   expandedChart={expandedChart}
                   onExpand={setExpandedChart}
+                  onRangeSelect={handleChartRangeSelect}
+                  isZoomed={customRange !== null}
+                  onResetZoom={handleClearCustomRange}
                 />
               )}
             </>
@@ -1443,6 +1461,9 @@ function TokenTimeSeriesChart({
   hasData,
   expandedChart,
   onExpand,
+  onRangeSelect,
+  isZoomed,
+  onResetZoom,
 }: {
   title: string;
   chartId: string;
@@ -1451,31 +1472,29 @@ function TokenTimeSeriesChart({
   hasData: boolean;
   expandedChart: string | null;
   onExpand: (id: string | null) => void;
+  onRangeSelect?: (from: Date, to: Date) => void;
+  isZoomed?: boolean;
+  onResetZoom?: () => void;
 }) {
   const isExpanded = expandedChart === chartId;
   const height = isExpanded ? 420 : 220;
 
-  const chartData = useMemo(() => {
-    const points = timeSeries.map((point) => {
-      const date = unixNanoToDate(point.bucketTimeUnixNano);
-      return {
-        label: formatChartLabel(date, timeRangeMs),
-        tooltipLabel: date.toLocaleString([], {
-          month: "short",
-          day: "numeric",
-          hour: "numeric",
-          minute: "2-digit",
-        }),
-        value: getTotalTokens(point),
-      };
-    });
+  const chartData = useMemo(
+    () =>
+      timeSeries.map((point) => ({
+        x: unixNanoToDate(point.bucketTimeUnixNano).getTime(),
+        y: getTotalTokens(point),
+      })),
+    [timeSeries],
+  );
 
-    return {
-      labels: points.map((p) => p.label),
-      tooltipLabels: points.map((p) => p.tooltipLabel),
-      values: points.map((p) => p.value),
-    };
-  }, [timeSeries, timeRangeMs]);
+  const { chartRef, zoomPluginOptions, resetZoom } = useChartZoom({
+    onRangeSelect,
+  });
+
+  useEffect(() => {
+    resetZoom();
+  }, [timeSeries, resetZoom]);
 
   const options = useMemo<ChartOptions<"line">>(
     () => ({
@@ -1486,17 +1505,31 @@ function TokenTimeSeriesChart({
         legend: { display: false },
         tooltip: {
           callbacks: {
-            title: (items) =>
-              chartData.tooltipLabels[items[0]?.dataIndex ?? 0] ?? "",
+            title: (items) => {
+              const x = items[0]?.parsed.x;
+              if (x == null) return "";
+              return new Date(x).toLocaleString([], {
+                month: "short",
+                day: "numeric",
+                hour: "numeric",
+                minute: "2-digit",
+              });
+            },
             label: (item) =>
               `Tokens: ${Number(item.parsed.y ?? 0).toLocaleString()}`,
           },
         },
+        zoom: zoomPluginOptions,
       },
       scales: {
         x: {
+          type: "linear",
           grid: { display: true, color: "rgba(128, 128, 128, 0.1)" },
-          ticks: { maxTicksLimit: 8 },
+          ticks: {
+            maxTicksLimit: 8,
+            callback: (value) =>
+              formatChartLabel(new Date(value as number), timeRangeMs),
+          },
         },
         y: {
           beginAtZero: true,
@@ -1505,7 +1538,7 @@ function TokenTimeSeriesChart({
         },
       },
     }),
-    [chartData.tooltipLabels],
+    [zoomPluginOptions, timeRangeMs],
   );
 
   return (
@@ -1515,6 +1548,8 @@ function TokenTimeSeriesChart({
       expandedChart={expandedChart}
       onExpand={onExpand}
       hasData={hasData}
+      isZoomed={isZoomed}
+      onResetZoom={onResetZoom}
     >
       {!hasData ? (
         <div className="text-muted-foreground flex h-[220px] items-center justify-center text-sm">
@@ -1523,12 +1558,12 @@ function TokenTimeSeriesChart({
       ) : (
         <div style={{ height }}>
           <Line
+            ref={chartRef}
             data={{
-              labels: chartData.labels,
               datasets: [
                 {
                   label: "Tokens",
-                  data: chartData.values,
+                  data: chartData,
                   borderColor: CHART_COLOR,
                   backgroundColor: `${CHART_COLOR}1a`,
                   pointBackgroundColor: CHART_COLOR,

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -46,7 +46,8 @@ import { unwrapAsync } from "@gram/client/types/fp";
 import { Badge, Icon } from "@speakeasy-api/moonshine";
 import { ChartCard } from "@/components/chart/ChartCard";
 import { MetricCard } from "@/components/chart/MetricCard";
-import { formatChartLabel } from "@/components/chart/chartUtils";
+import { formatChartZoomRangeLabel } from "@/components/chart/chartUtils";
+import { useChartZoom } from "@/components/chart/useChartZoom";
 import { useExpandedChart } from "@/hooks/useExpandedChart";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -64,6 +65,7 @@ import {
   type ChartOptions,
   type Scale,
 } from "chart.js";
+import ZoomPlugin from "chartjs-plugin-zoom";
 import { Bar, Line } from "react-chartjs-2";
 import { Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo } from "react";
@@ -72,6 +74,11 @@ import { useObserveFilters } from "@/components/observe/useObserveFilters";
 import { HooksEmptyState } from "@/pages/hooks/HooksEmptyState";
 import { HooksSetupButton } from "@/pages/hooks/HooksSetupDialog";
 import type { MultiSelectGroup } from "@/components/ui/multi-select";
+import {
+  bucketStartNsToMs,
+  buildToolUsageTimeSeries,
+  type TimeSeriesDataset,
+} from "./toolUsageTimeSeriesChartData";
 
 ChartJS.register(
   CategoryScale,
@@ -83,6 +90,7 @@ ChartJS.register(
   Filler,
   Tooltip,
   Legend,
+  ZoomPlugin,
 );
 
 const CHART_COLORS = {
@@ -484,6 +492,12 @@ function HooksInnerContent({
   useEffect(() => {
     if (summaryPending) setExpandedChart(null);
   }, [summaryPending, setExpandedChart]);
+  const handleChartRangeSelect = useCallback(
+    (from: Date, to: Date) => {
+      onCustomRangeChange(from, to, formatChartZoomRangeLabel(from, to));
+    },
+    [onCustomRangeChange],
+  );
   const hasSummaryData = (summaryData?.totals.eventCount ?? 0) > 0;
 
   return (
@@ -585,6 +599,9 @@ function HooksInnerContent({
                 summaryIsError={summaryIsError}
                 expandedChart={expandedChart}
                 onExpandedChartChange={setExpandedChart}
+                onRangeSelect={handleChartRangeSelect}
+                isZoomed={customRange !== null}
+                onResetZoom={onClearCustomRange}
               />
             )}
           </div>
@@ -1052,82 +1069,6 @@ function ServerErrorRateChart({
   );
 }
 
-type TimeSeriesDataset = {
-  label: string;
-  data: number[];
-  borderColor: string;
-  backgroundColor: string;
-  pointBackgroundColor: string;
-  fill: boolean;
-  tension: number;
-  borderWidth: number;
-  pointRadius: number;
-  pointHoverRadius: number;
-};
-
-function buildTimeSeriesFromSummary<
-  T extends { bucketStartNs: string; eventCount: number },
->(
-  timeSeries: T[],
-  keyFn: (p: T) => string,
-  timeRangeMs: number,
-  valueFn: (p: T) => number = (p) => p.eventCount,
-) {
-  if (timeSeries.length === 0)
-    return { labels: [], tooltipLabels: [], datasets: [] };
-
-  const seriesMap = new Map<string, Map<number, number>>();
-
-  for (const pt of timeSeries) {
-    const key = keyFn(pt);
-    if (!key) continue;
-    const ms = Number(BigInt(pt.bucketStartNs) / BigInt(1_000_000));
-    const series = seriesMap.get(key) ?? new Map<number, number>();
-    series.set(ms, (series.get(ms) ?? 0) + valueFn(pt));
-    seriesMap.set(key, series);
-  }
-
-  if (seriesMap.size === 0)
-    return { labels: [], tooltipLabels: [], datasets: [] };
-
-  const allTimestamps = new Set<number>();
-  for (const series of seriesMap.values()) {
-    for (const ts of series.keys()) allTimestamps.add(ts);
-  }
-  const sortedTs = Array.from(allTimestamps).sort((a, b) => a - b);
-  const labels = sortedTs.map((ts) =>
-    formatChartLabel(new Date(ts), timeRangeMs),
-  );
-  const tooltipLabels = sortedTs.map((ts) =>
-    new Date(ts).toLocaleString([], {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    }),
-  );
-
-  const datasets: TimeSeriesDataset[] = Array.from(seriesMap.entries()).map(
-    ([key, series], i) => {
-      const color = USER_SOURCE_COLORS[i % USER_SOURCE_COLORS.length]!;
-      return {
-        label: key,
-        data: sortedTs.map((ts) => series.get(ts) ?? 0),
-        borderColor: color,
-        backgroundColor: color + "1a",
-        pointBackgroundColor: color,
-        fill: false,
-        tension: 0.45,
-        borderWidth: 1.5,
-        pointRadius: 0,
-        pointHoverRadius: 4,
-      };
-    },
-  );
-
-  return { labels, tooltipLabels, datasets };
-}
-
 function ChartNoData({
   message = "No data in this period",
 }: {
@@ -1147,17 +1088,38 @@ function ChartNoData({
 
 function MultiLineChart({
   labels,
+  timestamps,
   tooltipLabels,
   datasets,
   tooltipAfterBody,
+  onRangeSelect,
   height = 200,
 }: {
   labels: string[];
+  timestamps: number[];
   tooltipLabels: string[];
   datasets: TimeSeriesDataset[];
   tooltipAfterBody?: (dataIndex: number) => string[];
+  onRangeSelect?: (from: Date, to: Date) => void;
   height?: number;
 }) {
+  const { chartRef, zoomPluginOptions, resetZoom } = useChartZoom({
+    onRangeSelect,
+    resolveRange: (min, max) => {
+      if (timestamps.length === 0) return null;
+      const fromIndex = Math.max(0, Math.floor(min));
+      const toIndex = Math.min(timestamps.length - 1, Math.ceil(max));
+      const from = timestamps[fromIndex];
+      const to = timestamps[toIndex];
+      if (from == null || to == null) return null;
+      return { from: new Date(from), to: new Date(to) };
+    },
+  });
+
+  useEffect(() => {
+    resetZoom();
+  }, [datasets, resetZoom]);
+
   if (labels.length === 0) {
     return <ChartNoData />;
   }
@@ -1186,6 +1148,7 @@ function MultiLineChart({
             : {}),
         },
       },
+      zoom: zoomPluginOptions,
     },
     scales: {
       x: {
@@ -1210,7 +1173,7 @@ function MultiLineChart({
       className="relative transition-all duration-200 ease-in-out"
       style={{ height }}
     >
-      <Line data={{ labels, datasets }} options={options} />
+      <Line ref={chartRef} data={{ labels, datasets }} options={options} />
     </div>
   );
 }
@@ -1222,6 +1185,9 @@ function ServerUsageTimeSeries({
   serverNameMappings,
   expandedChart,
   onExpand,
+  onRangeSelect,
+  isZoomed,
+  onResetZoom,
 }: {
   timeSeries: ToolUsageTargetTimeSeriesPoint[];
   from: Date;
@@ -1229,17 +1195,22 @@ function ServerUsageTimeSeries({
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
   expandedChart: string | null;
   onExpand: (id: string | null) => void;
+  onRangeSelect?: (from: Date, to: Date) => void;
+  isZoomed?: boolean;
+  onResetZoom?: () => void;
 }) {
   const chartId = "server-usage";
   const expanded = expandedChart === chartId;
   const timeRangeMs = to.getTime() - from.getTime();
-  const { labels, tooltipLabels, datasets } = useMemo(
+  const { labels, timestamps, tooltipLabels, datasets } = useMemo(
     () =>
-      buildTimeSeriesFromSummary(
+      buildToolUsageTimeSeries(
         timeSeries,
         (pt) =>
           displayTargetLabel(pt.targetLabel, pt.targetType, serverNameMappings),
         timeRangeMs,
+        undefined,
+        USER_SOURCE_COLORS,
       ),
     [timeSeries, timeRangeMs, serverNameMappings],
   );
@@ -1250,11 +1221,15 @@ function ServerUsageTimeSeries({
       expandedChart={expandedChart}
       onExpand={onExpand}
       hasData={labels.length > 0}
+      isZoomed={isZoomed}
+      onResetZoom={onResetZoom}
     >
       <MultiLineChart
         labels={labels}
+        timestamps={timestamps}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
+        onRangeSelect={onRangeSelect}
         height={
           expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
         }
@@ -1269,19 +1244,31 @@ function UserUsageTimeSeries({
   to,
   expandedChart,
   onExpand,
+  onRangeSelect,
+  isZoomed,
+  onResetZoom,
 }: {
   timeSeries: ToolUsageUserTimeSeriesPoint[];
   from: Date;
   to: Date;
   expandedChart: string | null;
   onExpand: (id: string | null) => void;
+  onRangeSelect?: (from: Date, to: Date) => void;
+  isZoomed?: boolean;
+  onResetZoom?: () => void;
 }) {
   const chartId = "user-usage";
   const expanded = expandedChart === chartId;
   const timeRangeMs = to.getTime() - from.getTime();
-  const { labels, tooltipLabels, datasets } = useMemo(
+  const { labels, timestamps, tooltipLabels, datasets } = useMemo(
     () =>
-      buildTimeSeriesFromSummary(timeSeries, (pt) => pt.userLabel, timeRangeMs),
+      buildToolUsageTimeSeries(
+        timeSeries,
+        (pt) => pt.userLabel,
+        timeRangeMs,
+        undefined,
+        USER_SOURCE_COLORS,
+      ),
     [timeSeries, timeRangeMs],
   );
   return (
@@ -1291,11 +1278,15 @@ function UserUsageTimeSeries({
       expandedChart={expandedChart}
       onExpand={onExpand}
       hasData={labels.length > 0}
+      isZoomed={isZoomed}
+      onResetZoom={onResetZoom}
     >
       <MultiLineChart
         labels={labels}
+        timestamps={timestamps}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
+        onRangeSelect={onRangeSelect}
         height={
           expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
         }
@@ -1310,22 +1301,30 @@ function SkillUsageTimeSeries({
   to,
   expandedChart,
   onExpand,
+  onRangeSelect,
+  isZoomed,
+  onResetZoom,
 }: {
   skillTimeSeries: ToolUsageTargetTimeSeriesPoint[];
   from: Date;
   to: Date;
   expandedChart: string | null;
   onExpand: (id: string | null) => void;
+  onRangeSelect?: (from: Date, to: Date) => void;
+  isZoomed?: boolean;
+  onResetZoom?: () => void;
 }) {
   const chartId = "skill-usage";
   const expanded = expandedChart === chartId;
   const timeRangeMs = to.getTime() - from.getTime();
-  const { labels, tooltipLabels, datasets } = useMemo(
+  const { labels, timestamps, tooltipLabels, datasets } = useMemo(
     () =>
-      buildTimeSeriesFromSummary(
+      buildToolUsageTimeSeries(
         skillTimeSeries,
         (pt) => pt.targetLabel,
         timeRangeMs,
+        undefined,
+        USER_SOURCE_COLORS,
       ),
     [skillTimeSeries, timeRangeMs],
   );
@@ -1336,11 +1335,15 @@ function SkillUsageTimeSeries({
       expandedChart={expandedChart}
       onExpand={onExpand}
       hasData={labels.length > 0}
+      isZoomed={isZoomed}
+      onResetZoom={onResetZoom}
     >
       <MultiLineChart
         labels={labels}
+        timestamps={timestamps}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
+        onRangeSelect={onRangeSelect}
         height={
           expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
         }
@@ -1435,6 +1438,9 @@ function ErrorsOverTimeChart({
   serverNameMappings,
   expandedChart,
   onExpand,
+  onRangeSelect,
+  isZoomed,
+  onResetZoom,
 }: {
   timeSeries: ToolUsageTargetTimeSeriesPoint[];
   from: Date;
@@ -1442,72 +1448,78 @@ function ErrorsOverTimeChart({
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
   expandedChart: string | null;
   onExpand: (id: string | null) => void;
+  onRangeSelect?: (from: Date, to: Date) => void;
+  isZoomed?: boolean;
+  onResetZoom?: () => void;
 }) {
   const timeRangeMs = to.getTime() - from.getTime();
-  const { labels, tooltipLabels, datasets, hasErrors, perServerByIndex } =
-    useMemo(() => {
-      const built = buildTimeSeriesFromSummary(
-        timeSeries,
-        () => "errors",
-        timeRangeMs,
-        (pt) => pt.failureCount,
+  const {
+    labels,
+    timestamps,
+    tooltipLabels,
+    datasets,
+    hasErrors,
+    perServerByIndex,
+  } = useMemo(() => {
+    const built = buildToolUsageTimeSeries(
+      timeSeries,
+      () => "errors",
+      timeRangeMs,
+      (pt) => pt.failureCount,
+      ["#ef4444"],
+    );
+    const errorColor = "#ef4444";
+    const recoloredDatasets = built.datasets.map((ds) => ({
+      ...ds,
+      label: "Errors",
+      borderColor: errorColor,
+      backgroundColor: errorColor + "1a",
+      pointBackgroundColor: errorColor,
+    }));
+    const tsIndex = new Map<number, number>(
+      built.timestamps.map((ts, i): [number, number] => [ts, i]),
+    );
+    const total = built.datasets[0]?.data.reduce((s, p) => s + p, 0) ?? 0;
+
+    const accumulator = new Map<number, Map<string, number>>(
+      built.timestamps.map((_, i): [number, Map<string, number>] => [
+        i,
+        new Map<string, number>(),
+      ]),
+    );
+
+    for (const pt of timeSeries) {
+      if (pt.failureCount === 0) continue;
+      const ms = bucketStartNsToMs(pt.bucketStartNs);
+      if (ms == null) continue;
+      const idx = tsIndex.get(ms);
+      if (idx === undefined) continue;
+      const displayName = displayTargetLabel(
+        pt.targetLabel,
+        pt.targetType,
+        serverNameMappings,
       );
-      const errorColor = "#ef4444";
-      const recoloredDatasets = built.datasets.map((ds) => ({
-        ...ds,
-        label: "Errors",
-        borderColor: errorColor,
-        backgroundColor: errorColor + "1a",
-        pointBackgroundColor: errorColor,
-      }));
-      const total = built.datasets[0]?.data.reduce((s, n) => s + n, 0) ?? 0;
+      const map = accumulator.get(idx)!;
+      map.set(displayName, (map.get(displayName) ?? 0) + pt.failureCount);
+    }
 
-      const allTimestamps = new Set<number>();
-      for (const pt of timeSeries) {
-        allTimestamps.add(Number(BigInt(pt.bucketStartNs) / BigInt(1_000_000)));
-      }
-      const sortedTs = Array.from(allTimestamps).sort((a, b) => a - b);
-      const tsIndex = new Map<number, number>(
-        sortedTs.map((ts, i): [number, number] => [ts, i]),
-      );
+    const perServerByIndex: { name: string; count: number }[][] = [];
+    for (const [i, map] of accumulator) {
+      perServerByIndex[i] = Array.from(map.entries())
+        .filter(([, count]) => count > 0)
+        .map(([name, count]) => ({ name, count }))
+        .sort((a, b) => b.count - a.count);
+    }
 
-      const accumulator = new Map<number, Map<string, number>>(
-        sortedTs.map((_, i): [number, Map<string, number>] => [
-          i,
-          new Map<string, number>(),
-        ]),
-      );
-
-      for (const pt of timeSeries) {
-        if (pt.failureCount === 0) continue;
-        const ms = Number(BigInt(pt.bucketStartNs) / BigInt(1_000_000));
-        const idx = tsIndex.get(ms);
-        if (idx === undefined) continue;
-        const displayName = displayTargetLabel(
-          pt.targetLabel,
-          pt.targetType,
-          serverNameMappings,
-        );
-        const map = accumulator.get(idx)!;
-        map.set(displayName, (map.get(displayName) ?? 0) + pt.failureCount);
-      }
-
-      const perServerByIndex: { name: string; count: number }[][] = [];
-      for (const [i, map] of accumulator) {
-        perServerByIndex[i] = Array.from(map.entries())
-          .filter(([, count]) => count > 0)
-          .map(([name, count]) => ({ name, count }))
-          .sort((a, b) => b.count - a.count);
-      }
-
-      return {
-        labels: built.labels,
-        tooltipLabels: built.tooltipLabels,
-        datasets: recoloredDatasets,
-        hasErrors: total > 0,
-        perServerByIndex,
-      };
-    }, [timeSeries, timeRangeMs, serverNameMappings]);
+    return {
+      labels: built.labels,
+      timestamps: built.timestamps,
+      tooltipLabels: built.tooltipLabels,
+      datasets: recoloredDatasets,
+      hasErrors: total > 0,
+      perServerByIndex,
+    };
+  }, [timeSeries, timeRangeMs, serverNameMappings]);
 
   const chartId = "errors-over-time";
   const expanded = expandedChart === chartId;
@@ -1519,14 +1531,18 @@ function ErrorsOverTimeChart({
       expandedChart={expandedChart}
       onExpand={onExpand}
       hasData={hasErrors}
+      isZoomed={isZoomed}
+      onResetZoom={onResetZoom}
     >
       {!hasErrors ? (
         <ChartNoData message="No errors in this period" />
       ) : (
         <MultiLineChart
           labels={labels}
+          timestamps={timestamps}
           tooltipLabels={tooltipLabels}
           datasets={datasets}
+          onRangeSelect={onRangeSelect}
           height={
             expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
           }
@@ -1553,6 +1569,9 @@ function HooksAnalytics({
   summaryIsError,
   expandedChart,
   onExpandedChartChange: setExpandedChart,
+  onRangeSelect,
+  isZoomed,
+  onResetZoom,
 }: {
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
   from: Date;
@@ -1565,6 +1584,9 @@ function HooksAnalytics({
   summaryIsError: boolean;
   expandedChart: string | null;
   onExpandedChartChange: (id: string | null) => void;
+  onRangeSelect?: (from: Date, to: Date) => void;
+  isZoomed?: boolean;
+  onResetZoom?: () => void;
 }) {
   const targets = summaryData?.targets;
   const users = summaryData?.users ?? [];
@@ -1753,6 +1775,9 @@ function HooksAnalytics({
           serverNameMappings={serverNameMappings}
           expandedChart={expandedChart}
           onExpand={setExpandedChart}
+          onRangeSelect={onRangeSelect}
+          isZoomed={isZoomed}
+          onResetZoom={onResetZoom}
         />
 
         <UsersPerServerChart
@@ -1773,6 +1798,9 @@ function HooksAnalytics({
           to={to}
           expandedChart={expandedChart}
           onExpand={setExpandedChart}
+          onRangeSelect={onRangeSelect}
+          isZoomed={isZoomed}
+          onResetZoom={onResetZoom}
         />
 
         <UserEventCountsChart
@@ -1789,6 +1817,9 @@ function HooksAnalytics({
           to={to}
           expandedChart={expandedChart}
           onExpand={setExpandedChart}
+          onRangeSelect={onRangeSelect}
+          isZoomed={isZoomed}
+          onResetZoom={onResetZoom}
         />
 
         <UsersPerSkillChart
@@ -1805,6 +1836,9 @@ function HooksAnalytics({
           serverNameMappings={serverNameMappings}
           expandedChart={expandedChart}
           onExpand={setExpandedChart}
+          onRangeSelect={onRangeSelect}
+          isZoomed={isZoomed}
+          onResetZoom={onResetZoom}
         />
 
         <ServerErrorRateChart

--- a/client/dashboard/src/components/observe/InsightsToolsTimeSeries.test.ts
+++ b/client/dashboard/src/components/observe/InsightsToolsTimeSeries.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { buildToolUsageTimeSeries } from "./toolUsageTimeSeriesChartData";
+
+describe("buildToolUsageTimeSeries", () => {
+  it("preserves bucketed chart data and returns timestamps for zoom", () => {
+    const first = Date.UTC(2026, 0, 1, 12, 0);
+    const second = Date.UTC(2026, 0, 1, 13, 0);
+
+    const result = buildToolUsageTimeSeries(
+      [
+        {
+          bucketStartNs: `${BigInt(first) * BigInt(1_000_000)}`,
+          eventCount: 3,
+          targetLabel: "Server A",
+        },
+        {
+          bucketStartNs: `${BigInt(second) * BigInt(1_000_000)}`,
+          eventCount: 5,
+          targetLabel: "Server A",
+        },
+      ],
+      (point) => point.targetLabel,
+      second - first,
+    );
+
+    expect(result.timestamps).toEqual([first, second]);
+    expect(result.datasets[0]?.data).toEqual([3, 5]);
+  });
+
+  it("skips malformed bucket timestamps instead of throwing", () => {
+    const valid = Date.UTC(2026, 0, 1, 12, 0);
+
+    const result = buildToolUsageTimeSeries(
+      [
+        {
+          bucketStartNs: "not-a-nanosecond-timestamp",
+          eventCount: 3,
+          targetLabel: "Server A",
+        },
+        {
+          bucketStartNs: `${BigInt(valid) * BigInt(1_000_000)}`,
+          eventCount: 5,
+          targetLabel: "Server A",
+        },
+      ],
+      (point) => point.targetLabel,
+      60 * 60 * 1000,
+    );
+
+    expect(result.timestamps).toEqual([valid]);
+    expect(result.datasets[0]?.data).toEqual([5]);
+  });
+});
+
+describe("InsightsTools chart zoom wiring", () => {
+  it("passes range-selection controls to the Skill Usage chart", () => {
+    const source = readFileSync(
+      "src/components/observe/InsightsTools.tsx",
+      "utf8",
+    );
+
+    const callsite = source.match(/<SkillUsageTimeSeries\b[\s\S]*?\/>/)?.[0];
+
+    expect(callsite).toContain("onRangeSelect={onRangeSelect}");
+    expect(callsite).toContain("isZoomed={isZoomed}");
+    expect(callsite).toContain("onResetZoom={onResetZoom}");
+  });
+});

--- a/client/dashboard/src/components/observe/agentTokenTimeSeriesChartData.test.ts
+++ b/client/dashboard/src/components/observe/agentTokenTimeSeriesChartData.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentTokenTimeSeriesChartData } from "./agentTokenTimeSeriesChartData";
+
+describe("buildAgentTokenTimeSeriesChartData", () => {
+  it("preserves category chart data and returns timestamps for zoom", () => {
+    const first = Date.UTC(2026, 0, 1, 12, 0);
+    const second = Date.UTC(2026, 0, 1, 13, 0);
+
+    const result = buildAgentTokenTimeSeriesChartData(
+      [
+        {
+          bucketTimeUnixNano: `${BigInt(first) * BigInt(1_000_000)}`,
+          totalInputTokens: 10,
+          totalOutputTokens: 20,
+          cacheReadInputTokens: 5,
+          totalCost: 0.1,
+        },
+        {
+          bucketTimeUnixNano: `${BigInt(second) * BigInt(1_000_000)}`,
+          totalInputTokens: 30,
+          totalOutputTokens: 40,
+          cacheReadInputTokens: 15,
+          totalCost: 0.2,
+        },
+      ],
+      second - first,
+      "tokens",
+    );
+
+    expect(result.timestamps).toEqual([first, second]);
+    expect(result.chartData.labels).toHaveLength(2);
+    expect(result.chartData.datasets[0]?.data).toEqual([10, 30]);
+    expect(result.chartData.datasets[1]?.data).toEqual([20, 40]);
+    expect(result.chartData.datasets[2]?.data).toEqual([5, 15]);
+    expect(result.chartData.datasets[3]?.data).toEqual([35, 85]);
+  });
+
+  it("builds cost data without changing the category chart shape", () => {
+    const first = Date.UTC(2026, 0, 1, 12, 0);
+
+    const result = buildAgentTokenTimeSeriesChartData(
+      [
+        {
+          bucketTimeUnixNano: `${BigInt(first) * BigInt(1_000_000)}`,
+          totalInputTokens: 10,
+          totalOutputTokens: 20,
+          cacheReadInputTokens: 5,
+          totalCost: 0.123,
+        },
+      ],
+      60 * 60 * 1000,
+      "cost",
+    );
+
+    expect(result.timestamps).toEqual([first]);
+    expect(result.chartData.datasets).toHaveLength(2);
+    expect(result.chartData.datasets[0]?.data).toEqual([0.123]);
+    expect(result.chartData.datasets[1]?.data).toEqual([0.123]);
+  });
+});

--- a/client/dashboard/src/components/observe/agentTokenTimeSeriesChartData.ts
+++ b/client/dashboard/src/components/observe/agentTokenTimeSeriesChartData.ts
@@ -1,0 +1,106 @@
+import { formatChartLabel, smoothData } from "@/components/chart/chartUtils";
+import type { TimeSeriesBucket } from "@gram/client/models/components";
+import type { ChartDataset } from "chart.js";
+
+export type AgentTokenValueMode = "tokens" | "cost";
+
+type AgentTokenTimeSeriesBucket = Pick<
+  TimeSeriesBucket,
+  | "bucketTimeUnixNano"
+  | "totalCost"
+  | "totalInputTokens"
+  | "totalOutputTokens"
+  | "cacheReadInputTokens"
+>;
+
+export type AgentTokenTimeSeriesChartData = {
+  labels: string[];
+  datasets: Array<
+    ChartDataset<"bar", number[]> | ChartDataset<"line", number[]>
+  >;
+};
+
+function unixNanoToMillis(value: string): number {
+  return Number(BigInt(value) / 1_000_000n);
+}
+
+export function buildAgentTokenTimeSeriesChartData(
+  timeSeries: AgentTokenTimeSeriesBucket[],
+  timeRangeMs: number,
+  valueMode: AgentTokenValueMode,
+): {
+  timestamps: number[];
+  chartData: AgentTokenTimeSeriesChartData;
+} {
+  const timestamps = timeSeries.map((bucket) =>
+    unixNanoToMillis(bucket.bucketTimeUnixNano),
+  );
+  const labels = timestamps.map((timestamp) =>
+    formatChartLabel(new Date(timestamp), timeRangeMs),
+  );
+
+  const barDatasets =
+    valueMode === "cost"
+      ? [
+          {
+            label: "Cost",
+            data: timeSeries.map((bucket) => bucket.totalCost),
+            backgroundColor: "rgba(96, 165, 250, 0.35)",
+            stack: "stack",
+            order: 2,
+          },
+        ]
+      : [
+          {
+            label: "Input Tokens",
+            data: timeSeries.map((bucket) => bucket.totalInputTokens),
+            backgroundColor: "rgba(96, 165, 250, 0.35)",
+            stack: "stack",
+            order: 2,
+          },
+          {
+            label: "Output Tokens",
+            data: timeSeries.map((bucket) => bucket.totalOutputTokens),
+            backgroundColor: "rgba(52, 211, 153, 0.35)",
+            stack: "stack",
+            order: 2,
+          },
+          {
+            label: "Cache Read",
+            data: timeSeries.map((bucket) => bucket.cacheReadInputTokens),
+            backgroundColor: "rgba(167, 139, 250, 0.35)",
+            stack: "stack",
+            order: 2,
+          },
+        ];
+
+  const rawTotal = timeSeries.map((bucket) =>
+    valueMode === "cost"
+      ? bucket.totalCost
+      : bucket.totalInputTokens +
+        bucket.totalOutputTokens +
+        bucket.cacheReadInputTokens,
+  );
+
+  const trendDataset: ChartDataset<"line", number[]> = {
+    label: valueMode === "cost" ? "Cost Trend" : "Token Trend",
+    data: smoothData(rawTotal),
+    type: "line",
+    borderColor: valueMode === "cost" ? "#818cf8" : "#3b82f6",
+    backgroundColor: "transparent",
+    pointRadius: 0,
+    pointHoverRadius: 4,
+    borderWidth: 2,
+    tension: 0.4,
+    fill: false,
+    order: 1,
+  };
+
+  return {
+    timestamps,
+    chartData: {
+      labels,
+      datasets: [...barDatasets, trendDataset],
+    },
+  };
+}

--- a/client/dashboard/src/components/observe/toolUsageTimeSeriesChartData.ts
+++ b/client/dashboard/src/components/observe/toolUsageTimeSeriesChartData.ts
@@ -1,0 +1,97 @@
+import { formatChartLabel } from "@/components/chart/chartUtils";
+import type { ChartDataset } from "chart.js";
+
+const DEFAULT_TIME_SERIES_COLORS = [
+  "#60a5fa",
+  "#fb923c",
+  "#34d399",
+  "#f87171",
+  "#a78bfa",
+  "#facc15",
+  "#22d3ee",
+  "#f472b6",
+  "#a3e635",
+];
+
+export type TimeSeriesDataset = ChartDataset<"line", number[]>;
+
+export function bucketStartNsToMs(bucketStartNs: string): number | null {
+  try {
+    const ms = Number(BigInt(bucketStartNs) / 1_000_000n);
+    return Number.isFinite(ms) ? ms : null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildToolUsageTimeSeries<
+  T extends { bucketStartNs: string; eventCount: number },
+>(
+  timeSeries: T[],
+  keyFn: (p: T) => string,
+  timeRangeMs: number,
+  valueFn: (p: T) => number = (p) => p.eventCount,
+  colors: readonly string[] = DEFAULT_TIME_SERIES_COLORS,
+): {
+  timestamps: number[];
+  labels: string[];
+  tooltipLabels: string[];
+  datasets: TimeSeriesDataset[];
+} {
+  if (timeSeries.length === 0) {
+    return { timestamps: [], labels: [], tooltipLabels: [], datasets: [] };
+  }
+
+  const seriesMap = new Map<string, Map<number, number>>();
+
+  for (const pt of timeSeries) {
+    const key = keyFn(pt);
+    if (!key) continue;
+    const ms = bucketStartNsToMs(pt.bucketStartNs);
+    if (ms == null) continue;
+    const series = seriesMap.get(key) ?? new Map<number, number>();
+    series.set(ms, (series.get(ms) ?? 0) + valueFn(pt));
+    seriesMap.set(key, series);
+  }
+
+  if (seriesMap.size === 0) {
+    return { timestamps: [], labels: [], tooltipLabels: [], datasets: [] };
+  }
+
+  const allTimestamps = new Set<number>();
+  for (const series of seriesMap.values()) {
+    for (const ts of series.keys()) allTimestamps.add(ts);
+  }
+  const timestamps = Array.from(allTimestamps).sort((a, b) => a - b);
+  const labels = timestamps.map((ts) =>
+    formatChartLabel(new Date(ts), timeRangeMs),
+  );
+  const tooltipLabels = timestamps.map((ts) =>
+    new Date(ts).toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }),
+  );
+
+  const datasets: TimeSeriesDataset[] = Array.from(seriesMap.entries()).map(
+    ([key, series], i) => {
+      const color = colors[i % colors.length] ?? DEFAULT_TIME_SERIES_COLORS[0]!;
+      return {
+        label: key,
+        data: timestamps.map((ts) => series.get(ts) ?? 0),
+        borderColor: color,
+        backgroundColor: color + "1a",
+        pointBackgroundColor: color,
+        fill: false,
+        tension: 0.45,
+        borderWidth: 1.5,
+        pointRadius: 0,
+        pointHoverRadius: 4,
+      };
+    },
+  );
+
+  return { timestamps, labels, tooltipLabels, datasets };
+}

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -1,6 +1,10 @@
 import { MetricCard } from "@/components/chart/MetricCard";
 import { ChartCard } from "@/components/chart/ChartCard";
-import { formatChartLabel } from "@/components/chart/chartUtils";
+import {
+  formatChartLabel,
+  formatChartZoomRangeLabel,
+} from "@/components/chart/chartUtils";
+import { useChartZoom } from "@/components/chart/useChartZoom";
 import { InsightsConfig } from "@/components/insights-dock";
 import { INSIGHTS_SUGGESTIONS } from "@/lib/insights-suggestions";
 import { Page } from "@/components/page-layout";
@@ -13,7 +17,7 @@ import { TimeRangePicker } from "@/components/DashboardTimeRangePicker";
 import { useRiskOverview } from "@gram/client/react-query/index.js";
 import { keepPreviousData } from "@tanstack/react-query";
 import { Shield } from "lucide-react";
-import { useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { Link, Outlet, useLocation } from "react-router";
 import { useRoutes } from "@/routes";
 import {
@@ -33,8 +37,10 @@ import {
   Tooltip,
   type ChartOptions,
 } from "chart.js";
+import ZoomPlugin from "chartjs-plugin-zoom";
 import { Line } from "react-chartjs-2";
 import { Type } from "@/components/ui/type";
+import { buildRiskTrendChartData, type TrendPoint } from "./riskTrendChartData";
 
 ChartJS.register(
   CategoryScale,
@@ -44,6 +50,7 @@ ChartJS.register(
   Filler,
   Tooltip,
   Legend,
+  ZoomPlugin,
 );
 
 const RISK_TREND_CHART_ID = "risk-events-trend";
@@ -68,40 +75,11 @@ const CHART_COLORS = {
   tooltipBorder: "#262626",
 } as const;
 
-const RISK_CATEGORY_CHART_COLORS = [
-  { category: "secrets", color: "#60a5fa" },
-  { category: "financial", color: "#34d399" },
-  { category: "pii", color: "#f87171" },
-  { category: "government_ids", color: "#a78bfa" },
-  { category: "healthcare", color: "#facc15" },
-  { category: "prompt_policy", color: "#38bdf8" },
-  { category: "prompt_injection", color: "#22d3ee" },
-  { category: "off_policy", color: "#f472b6" },
-  { category: "shadow_mcp", color: "#a3e635" },
-  { category: "destructive_tool", color: "#818cf8" },
-  { category: "cli_destructive", color: "#fb7185" },
-  { category: "custom", color: "#94a3b8" },
-] satisfies ReadonlyArray<{ category: RuleCategory; color: string }>;
-
-const RISK_CATEGORY_CHART_COLOR_BY_CATEGORY = new Map<RuleCategory, string>(
-  RISK_CATEGORY_CHART_COLORS.map(({ category, color }) => [category, color]),
-);
-
-const RISK_CATEGORY_CHART_ORDER = new Map<RuleCategory, number>(
-  RISK_CATEGORY_CHART_COLORS.map(({ category }, index) => [category, index]),
-);
-
 type BarDatum = {
   key: string;
   label: string;
   value: number;
   href?: string;
-};
-
-type TrendPoint = {
-  category: string;
-  bucketStart: Date;
-  findings: number;
 };
 
 export default function SecurityOverview(): JSX.Element {
@@ -208,6 +186,12 @@ function SecurityOverviewContent() {
   });
   const overview = overviewQuery.data;
   const isOverviewLoading = overviewQuery.isLoading;
+  const handleChartRangeSelect = useCallback(
+    (from: Date, to: Date) => {
+      setCustomRangeParam(from, to, formatChartZoomRangeLabel(from, to));
+    },
+    [setCustomRangeParam],
+  );
 
   const categoriesIndexHref = useMemo(() => {
     const r = (
@@ -487,12 +471,15 @@ function SecurityOverviewContent() {
               hasFindings &&
               overview.timeSeriesFindings.some((point) => point.findings > 0)
             }
+            isZoomed={customRange !== null}
+            onResetZoom={clearCustomRange}
           >
             <RiskTrendChart
               points={overview.timeSeriesFindings}
               from={overview.from}
               to={overview.to}
               height={250}
+              onRangeSelect={handleChartRangeSelect}
             />
           </ChartCard>
         )}
@@ -654,16 +641,26 @@ function RiskTrendChart({
   from,
   to,
   height,
+  onRangeSelect,
 }: {
   points: TrendPoint[];
   from: Date;
   to: Date;
   height: number;
+  onRangeSelect?: (from: Date, to: Date) => void;
 }) {
   const chartData = useMemo(
     () => buildRiskTrendChartData(points, from, to),
     [points, from, to],
   );
+  const timeRangeMs = to.getTime() - from.getTime();
+  const { chartRef, zoomPluginOptions, resetZoom } = useChartZoom({
+    onRangeSelect,
+  });
+
+  useEffect(() => {
+    resetZoom();
+  }, [points, resetZoom]);
 
   if (chartData.labels.length === 0) {
     return <ChartEmptyState />;
@@ -684,8 +681,17 @@ function RiskTrendChart({
         padding: 12,
         boxPadding: 4,
         callbacks: {
-          title: (items) =>
-            chartData.tooltipLabels[items[0]?.dataIndex ?? 0] ?? "",
+          title: (items) => {
+            const x = items[0]?.parsed.x;
+            if (x == null)
+              return chartData.tooltipLabels[items[0]?.dataIndex ?? 0] ?? "";
+            return new Date(x).toLocaleString([], {
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit",
+            });
+          },
           label: (item) => {
             if ((item.parsed.y ?? 0) === 0) return undefined;
             return item.formattedValue
@@ -694,15 +700,21 @@ function RiskTrendChart({
           },
         },
       },
+      zoom: zoomPluginOptions,
     },
     scales: {
       x: {
+        type: "linear",
         grid: {
           display: true,
           color: CHART_COLORS.gridLineFaint,
           lineWidth: 1,
         },
-        ticks: { maxTicksLimit: 8 },
+        ticks: {
+          maxTicksLimit: 8,
+          callback: (value) =>
+            formatChartLabel(new Date(value as number), timeRangeMs),
+        },
       },
       y: {
         beginAtZero: true,
@@ -720,79 +732,11 @@ function RiskTrendChart({
       className="relative transition-all duration-200 ease-in-out"
       style={{ height }}
     >
-      <Line data={chartData} options={options} />
+      <Line
+        ref={chartRef}
+        data={{ datasets: chartData.datasets }}
+        options={options}
+      />
     </div>
   );
-}
-
-function getRiskCategoryChartColor(category: string) {
-  return RISK_CATEGORY_CHART_COLOR_BY_CATEGORY.get(category as RuleCategory);
-}
-
-function buildRiskTrendChartData(points: TrendPoint[], from: Date, to: Date) {
-  if (points.length === 0) {
-    return { labels: [], tooltipLabels: [], datasets: [] };
-  }
-
-  const timeRangeMs = to.getTime() - from.getTime();
-  const dateMap = new Map<number, Date>();
-  const seriesMap = new Map<string, Map<number, number>>();
-
-  for (const point of points) {
-    const timestamp = point.bucketStart.getTime();
-    dateMap.set(timestamp, point.bucketStart);
-    const series = seriesMap.get(point.category) ?? new Map<number, number>();
-    series.set(timestamp, point.findings);
-    seriesMap.set(point.category, series);
-  }
-
-  const timestamps = Array.from(dateMap.keys()).sort((a, b) => a - b);
-  const labels = timestamps.map((timestamp) =>
-    formatChartLabel(dateMap.get(timestamp)!, timeRangeMs),
-  );
-  const tooltipLabels = timestamps.map((timestamp) =>
-    dateMap.get(timestamp)!.toLocaleString([], {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    }),
-  );
-
-  const datasets = Array.from(seriesMap.entries())
-    .sort(([left], [right]) => {
-      const leftOrder =
-        RISK_CATEGORY_CHART_ORDER.get(left as RuleCategory) ??
-        Number.MAX_SAFE_INTEGER;
-      const rightOrder =
-        RISK_CATEGORY_CHART_ORDER.get(right as RuleCategory) ??
-        Number.MAX_SAFE_INTEGER;
-
-      return leftOrder - rightOrder || left.localeCompare(right);
-    })
-    .map(([category, series], index) => {
-      const color =
-        getRiskCategoryChartColor(category) ??
-        RISK_CATEGORY_CHART_COLORS[index % RISK_CATEGORY_CHART_COLORS.length]!
-          .color;
-      const meta = RULE_CATEGORY_META[category as RuleCategory];
-      return {
-        label: meta?.label ?? category,
-        data: timestamps.map((timestamp) => series.get(timestamp) ?? 0),
-        borderColor: color,
-        backgroundColor: `${color}1a`,
-        pointBackgroundColor: color,
-        fill: false,
-        tension: 0.45,
-        borderWidth: 1.5,
-        pointRadius: 0,
-        pointHoverRadius: 4,
-      };
-    });
-
-  return {
-    labels,
-    tooltipLabels,
-    datasets,
-  };
 }

--- a/client/dashboard/src/pages/security/SecurityOverviewTimeSeries.test.ts
+++ b/client/dashboard/src/pages/security/SecurityOverviewTimeSeries.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildRiskTrendChartData } from "./riskTrendChartData";
+
+describe("buildRiskTrendChartData", () => {
+  it("returns timestamped line data for chart zoom", () => {
+    const first = new Date(Date.UTC(2026, 0, 1, 12, 0));
+    const second = new Date(Date.UTC(2026, 0, 1, 13, 0));
+
+    const result = buildRiskTrendChartData(
+      [
+        { category: "secrets", bucketStart: first, findings: 2 },
+        { category: "secrets", bucketStart: second, findings: 4 },
+      ],
+      first,
+      second,
+    );
+
+    expect(result.timestamps).toEqual([first.getTime(), second.getTime()]);
+    expect(result.datasets[0]?.data).toEqual([
+      { x: first.getTime(), y: 2 },
+      { x: second.getTime(), y: 4 },
+    ]);
+  });
+});

--- a/client/dashboard/src/pages/security/riskTrendChartData.ts
+++ b/client/dashboard/src/pages/security/riskTrendChartData.ts
@@ -1,0 +1,122 @@
+import { formatChartLabel } from "@/components/chart/chartUtils";
+import type { ChartDataset } from "chart.js";
+import { RULE_CATEGORY_META, type RuleCategory } from "./policy-data";
+
+type TimestampedLineDataset = ChartDataset<
+  "line",
+  Array<{ x: number; y: number }>
+>;
+
+const RISK_CATEGORY_CHART_COLORS = [
+  { category: "secrets", color: "#60a5fa" },
+  { category: "financial", color: "#34d399" },
+  { category: "pii", color: "#f87171" },
+  { category: "government_ids", color: "#a78bfa" },
+  { category: "healthcare", color: "#facc15" },
+  { category: "prompt_policy", color: "#38bdf8" },
+  { category: "prompt_injection", color: "#22d3ee" },
+  { category: "off_policy", color: "#f472b6" },
+  { category: "shadow_mcp", color: "#a3e635" },
+  { category: "destructive_tool", color: "#818cf8" },
+  { category: "cli_destructive", color: "#fb7185" },
+  { category: "custom", color: "#94a3b8" },
+] satisfies ReadonlyArray<{ category: RuleCategory; color: string }>;
+
+const RISK_CATEGORY_CHART_COLOR_BY_CATEGORY = new Map<RuleCategory, string>(
+  RISK_CATEGORY_CHART_COLORS.map(({ category, color }) => [category, color]),
+);
+
+const RISK_CATEGORY_CHART_ORDER = new Map<RuleCategory, number>(
+  RISK_CATEGORY_CHART_COLORS.map(({ category }, index) => [category, index]),
+);
+
+export type TrendPoint = {
+  category: string;
+  bucketStart: Date;
+  findings: number;
+};
+
+function getRiskCategoryChartColor(category: string) {
+  return RISK_CATEGORY_CHART_COLOR_BY_CATEGORY.get(category as RuleCategory);
+}
+
+export function buildRiskTrendChartData(
+  points: TrendPoint[],
+  from: Date,
+  to: Date,
+): {
+  timestamps: number[];
+  labels: string[];
+  tooltipLabels: string[];
+  datasets: TimestampedLineDataset[];
+} {
+  if (points.length === 0) {
+    return { timestamps: [], labels: [], tooltipLabels: [], datasets: [] };
+  }
+
+  const timeRangeMs = to.getTime() - from.getTime();
+  const dateMap = new Map<number, Date>();
+  const seriesMap = new Map<string, Map<number, number>>();
+
+  for (const point of points) {
+    const timestamp = point.bucketStart.getTime();
+    dateMap.set(timestamp, point.bucketStart);
+    const series = seriesMap.get(point.category) ?? new Map<number, number>();
+    series.set(timestamp, point.findings);
+    seriesMap.set(point.category, series);
+  }
+
+  const timestamps = Array.from(dateMap.keys()).sort((a, b) => a - b);
+  const labels = timestamps.map((timestamp) =>
+    formatChartLabel(dateMap.get(timestamp)!, timeRangeMs),
+  );
+  const tooltipLabels = timestamps.map((timestamp) =>
+    dateMap.get(timestamp)!.toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }),
+  );
+
+  const datasets = Array.from(seriesMap.entries())
+    .sort(([left], [right]) => {
+      const leftOrder =
+        RISK_CATEGORY_CHART_ORDER.get(left as RuleCategory) ??
+        Number.MAX_SAFE_INTEGER;
+      const rightOrder =
+        RISK_CATEGORY_CHART_ORDER.get(right as RuleCategory) ??
+        Number.MAX_SAFE_INTEGER;
+
+      return leftOrder - rightOrder || left.localeCompare(right);
+    })
+    .map(([category, series], index): TimestampedLineDataset => {
+      const color =
+        getRiskCategoryChartColor(category) ??
+        RISK_CATEGORY_CHART_COLORS[index % RISK_CATEGORY_CHART_COLORS.length]!
+          .color;
+      const meta = RULE_CATEGORY_META[category as RuleCategory];
+      return {
+        label: meta?.label ?? category,
+        data: timestamps.map((timestamp) => ({
+          x: timestamp,
+          y: series.get(timestamp) ?? 0,
+        })),
+        borderColor: color,
+        backgroundColor: `${color}1a`,
+        pointBackgroundColor: color,
+        fill: false,
+        tension: 0.45,
+        borderWidth: 1.5,
+        pointRadius: 0,
+        pointHoverRadius: 4,
+      };
+    });
+
+  return {
+    timestamps,
+    labels,
+    tooltipLabels,
+    datasets,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
+      chartjs-plugin-zoom:
+        specifier: ^2.2.0
+        version: 2.2.0(chart.js@4.5.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5471,6 +5474,9 @@ packages:
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
+  '@types/hammerjs@2.0.46':
+    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -6158,6 +6164,11 @@ packages:
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
+
+  chartjs-plugin-zoom@2.2.0:
+    resolution: {integrity: sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==}
+    peerDependencies:
+      chart.js: '>=3.2.0'
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -7322,6 +7333,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  hammerjs@2.0.8:
+    resolution: {integrity: sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==}
+    engines: {node: '>=0.8.0'}
 
   happy-dom@20.5.5:
     resolution: {integrity: sha512-7Rc6hQXgkdiuh9uyVIlkiprIiR3TObmWUhsfs1H7sLQZZGebKX+ZT+hgGrMBPuf8I8xwT8k28GD2zDgVG65FyQ==}
@@ -15150,6 +15165,8 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/hammerjs@2.0.46': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -15966,6 +15983,12 @@ snapshots:
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
+
+  chartjs-plugin-zoom@2.2.0(chart.js@4.5.1):
+    dependencies:
+      '@types/hammerjs': 2.0.46
+      chart.js: 4.5.1
+      hammerjs: 2.0.8
 
   check-error@2.1.1: {}
 
@@ -17247,6 +17270,8 @@ snapshots:
       srvx: 0.11.16
 
   hachure-fill@0.5.2: {}
+
+  hammerjs@2.0.8: {}
 
   happy-dom@20.5.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Add reusable Chart.js drag-to-zoom support via `chartjs-plugin-zoom`, `useChartZoom`, and shared `ChartCard` reset controls.
- Enable zoom-driven time window selection on employee token usage, Security risk trends, MCP usage time-series charts, and InsightsAgents Tokens/Cost Over Time.
- Preserve existing category-axis rendering for MCP and InsightsAgents charts while using timestamp side-channel data for zoom range resolution.
- Add focused tests for shared zoom behavior and chart data builders to guard against chart-shape regressions.

## Visual


https://github.com/user-attachments/assets/4c1f95ef-1139-4573-8b98-10aeaef5d7b0


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added drag-to-zoom time selection to dashboard charts and synced it with the time range picker for fast drill-downs into spikes. Implements DNO-254.

- **New Features**
  - Drag-select on charts sets a custom from/to range and updates the picker label (e.g., “Jan 5, 2:10 PM – Jan 5, 2:40 PM”).
  - Supported charts: Agents tokens/cost over time, Employee detail tokens, Hooks usage (server/user/skill) and errors over time, and Security risk events trend.
  - Added reset zoom control in chart headers.
  - Introduced `useChartZoom` and new chart data builders (`agentTokenTimeSeriesChartData`, `toolUsageTimeSeriesChartData`, `riskTrendChartData`) to map zoom ranges to dates across bar/line and category/timestamp scales.

- **Dependencies**
  - Added `chartjs-plugin-zoom`.

<sup>Written for commit 48866eb8f78f317d84ff6c503d4b6eab5deffc5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



