### PR TITLE
fix(hooks): preserve OTEL session email across batched log records

### DIFF
--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -139,10 +139,18 @@ func extractSessionMetadata(payload *gen.LogsPayload) claudeLogMetadata {
 					continue
 				}
 
-				// Store session metadata in Redis
+				// Store session metadata in Redis. Claude Code batches many log
+				// records per session, but user.email / organization.id only ride
+				// on some event types (e.g. api_request, not tool events). Assign
+				// only non-empty values so a later emailless record in the batch
+				// does not clobber an email already extracted from an earlier one.
 				metadata.SessionID = data.SessionID
-				metadata.UserEmail = data.UserEmail
-				metadata.ClaudeOrgID = data.ClaudeOrgID
+				if data.UserEmail != "" {
+					metadata.UserEmail = data.UserEmail
+				}
+				if data.ClaudeOrgID != "" {
+					metadata.ClaudeOrgID = data.ClaudeOrgID
+				}
 			}
 		}
 	}

--- a/server/internal/hooks/otel_test.go
+++ b/server/internal/hooks/otel_test.go
@@ -202,6 +202,41 @@ func TestExtractSessionMetadataSkipsNilOTELAttributeElements(t *testing.T) {
 	}, "session.id"))
 }
 
+func TestExtractSessionMetadataKeepsEmailFromEarlierRecordInBatch(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "claude-session-batch"
+
+	// Claude Code batches many log records per session, but user.email and
+	// organization.id only ride on some event types. The trailing record here
+	// carries the session id but no email/org, which must not wipe the values
+	// extracted from the earlier api_request record.
+	payload := claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		&gen.OTELScope{Name: new("claude-code"), Version: new("1.0.0")},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", sessionID),
+				strAttr("user.email", "dev@example.com"),
+				strAttr("organization.id", "claude-org-1"),
+			},
+		},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("tool event")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", sessionID),
+				strAttr("event.name", "tool_call"),
+			},
+		},
+	)
+
+	metadata := extractSessionMetadata(payload)
+	require.Equal(t, sessionID, metadata.SessionID)
+	require.Equal(t, "dev@example.com", metadata.UserEmail)
+	require.Equal(t, "claude-org-1", metadata.ClaudeOrgID)
+}
+
 func enableHookTelemetryLogger(t *testing.T, ctx context.Context, ti *testInstance) *telemetryrepo.Queries {
 	t.Helper()
 


### PR DESCRIPTION
## Why

Hooks started failing en masse with:

> Speakeasy could not verify this MCP tool call because the Claude session metadata is not available yet. Try again after the session initializes.

The error is misleading — the session metadata *is* available; the **email** is missing from it.

## Root cause

Claude Code exports OTEL logs in **batches of multiple records per session**, but `user.email` / `organization.id` only ride on *some* event types (e.g. the `api request` record, not `tool event` records). `extractSessionMetadata` (`server/internal/hooks/otel.go`) assigned both fields **unconditionally** on every record, so a trailing emailless record clobbered the email extracted from an earlier one:

```go
metadata.SessionID  = data.SessionID
metadata.UserEmail  = data.UserEmail    // record 2 (no email) overwrites record 1's email with ""
metadata.ClaudeOrgID = data.ClaudeOrgID
```

The session metadata was then cached with an empty email.

This clobber has existed since hooks v2 but was **harmless** — the PreToolUse guard fell back to `authCtx.UserID`. PR #3492 (`fix: resolve hook actors from payload email`) made a non-empty `user_email` a hard requirement, so a cached empty email now makes the Claude PreToolUse guard fail closed and deny MCP tool calls at the start of essentially every session.

## Fix

Assign `user.email` / `organization.id` only when the current record actually carries them, so the value survives regardless of batch ordering. Email extraction from the OTEL payload now works reliably, as it did before.

## Test

Added `TestExtractSessionMetadataKeepsEmailFromEarlierRecordInBatch` — feeds a two-record batch (email on the first, none on the trailing record) and asserts the extracted email/org survive. Fails on the old unconditional-overwrite code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)