### PR TITLE
fix(hooks): preserve OTEL session email across batched log records

### DIFF
--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -139,10 +139,18 @@ func extractSessionMetadata(payload *gen.LogsPayload) claudeLogMetadata {
 					continue
 				}
 
-				// Store session metadata in Redis
+				// Store session metadata in Redis. Claude Code batches many log
+				// records per session, but user.email / organization.id only ride
+				// on some event types (e.g. api_request, not tool events). Assign
+				// only non-empty values so a later emailless record in the batch
+				// does not clobber an email already extracted from an earlier one.
 				metadata.SessionID = data.SessionID
-				metadata.UserEmail = data.UserEmail
-				metadata.ClaudeOrgID = data.ClaudeOrgID
+				if data.UserEmail != "" {
+					metadata.UserEmail = data.UserEmail
+				}
+				if data.ClaudeOrgID != "" {
+					metadata.ClaudeOrgID = data.ClaudeOrgID
+				}
 			}
 		}
 	}

--- a/server/internal/hooks/otel_test.go
+++ b/server/internal/hooks/otel_test.go
@@ -202,6 +202,41 @@ func TestExtractSessionMetadataSkipsNilOTELAttributeElements(t *testing.T) {
 	}, "session.id"))
 }
 
+func TestExtractSessionMetadataKeepsEmailFromEarlierRecordInBatch(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "claude-session-batch"
+
+	// Claude Code batches many log records per session, but user.email and
+	// organization.id only ride on some event types. The trailing record here
+	// carries the session id but no email/org, which must not wipe the values
+	// extracted from the earlier api_request record.
+	payload := claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		&gen.OTELScope{Name: new("claude-code"), Version: new("1.0.0")},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", sessionID),
+				strAttr("user.email", "dev@example.com"),
+				strAttr("organization.id", "claude-org-1"),
+			},
+		},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("tool event")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", sessionID),
+				strAttr("event.name", "tool_call"),
+			},
+		},
+	)
+
+	metadata := extractSessionMetadata(payload)
+	require.Equal(t, sessionID, metadata.SessionID)
+	require.Equal(t, "dev@example.com", metadata.UserEmail)
+	require.Equal(t, "claude-org-1", metadata.ClaudeOrgID)
+}
+
 func enableHookTelemetryLogger(t *testing.T, ctx context.Context, ti *testInstance) *telemetryrepo.Queries {
 	t.Helper()
 


### PR DESCRIPTION
Claude Code exports OTEL logs in batches of multiple records per session, but user.email and organization.id only ride on some event types (e.g. api_request, not tool events). extractSessionMetadata assigned both unconditionally on every record, so a trailing emailless record clobbered the email extracted from an earlier one. The session metadata was then cached with an empty email.

This was harmless until #3492 made hook attribution require a non-empty user_email: a cached empty email now makes the Claude PreToolUse guard fail closed with "session metadata is not available yet", denying MCP tool calls at the start of essentially every session.

Assign user.email / organization.id only when the current record actually carries them, so the value survives regardless of batch ordering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OTEL session metadata clobbering in batched logs by only setting `user.email` and `organization.id` when present on the current record. Prevents cached empty emails that caused the Claude PreToolUse guard to deny early MCP tool calls.

- **Bug Fixes**
  - Update `extractSessionMetadata` to conditionally assign `UserEmail` and `ClaudeOrgID` so later emailless records don’t overwrite earlier values.
  - Add test to ensure email/org persist across mixed-record batches.

<sup>Written for commit 2314a065b98df88a361d2ac9f93bf5cfd6d92ce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

