### PR TITLE
chore(lint): forbid logging calls that bypass structured logging (GG011/GG012)

### DIFF
--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -119,16 +119,24 @@ linters:
         linters:
           - glint
         text: enforceo11yconventions
+      # slog.go is the sanctioned logger: it constructs slog.NewJSONHandler(os.Stderr, ...)
+      # by design, which is the one place os.Stderr is allowed.
+      - path: internal/o11y/slog\.go
+        linters:
+          - forbidigo
+        text: GG012
       # Not interesting to enforce this in tests
       - path: _test\.go|internal/testenv/
         linters:
           - glint
         text: enforceo11yconventions
-      # Not interesting to enforce this in tests
+      # Not interesting to enforce this in tests. Tests and testenv legitimately
+      # use the stdlib log package (setup_test.go) and occasionally os.Std* for
+      # diagnostics, so they are also exempt from GG011/GG012.
       - path: _test\.go|internal/testenv/|internal/testinfra/
         linters:
           - forbidigo
-        text: GG001|GG002
+        text: GG001|GG002|GG011|GG012
       # The testenv package is the canonical provider of the helpers that
       # GG006/GG008/GG009 redirect tests to. It necessarily constructs the
       # underlying primitives directly.
@@ -221,6 +229,23 @@ linters:
           msg: "GG009: Use testenv.NewMeterProvider(t) in tests instead of constructing a noop meter provider inline."
         - pattern: '\.InsertAuditLog\('
           msg: "GG010: Call (*audit.Logger).log() instead of (*repo.Queries).InsertAuditLog directly."
+        - pattern: ^(print|println)$
+          msg: "GG011: The print/println builtins write to stderr and bypass structured logging (they surface as untagged status:error logs in production). Use a *slog.Logger instead."
+        - pattern: ^fmt\.Print(f|ln)?$
+          pkg: ^fmt$
+          msg: "GG011: fmt.Print/Printf/Println write to stdout and bypass structured logging. Use a *slog.Logger instead."
+        - pattern: ^log\.(Print(f|ln)?|Fatal(f|ln)?|Panic(f|ln)?|New|Default|SetOutput|SetFlags|SetPrefix)$
+          pkg: ^log$
+          msg: "GG011: The standard library log package bypasses structured logging. Use a *slog.Logger (log/slog) instead."
+        - pattern: ^debug\.PrintStack$
+          pkg: ^runtime/debug$
+          msg: "GG011: debug.PrintStack writes to stderr. Capture debug.Stack() and log it via a *slog.Logger instead."
+        - pattern: ^os\.Stdout$
+          pkg: ^os$
+          msg: "GG012: Writing to os.Stdout bypasses structured logging. Use a *slog.Logger instead."
+        - pattern: ^os\.Stderr$
+          pkg: ^os$
+          msg: "GG012: Writing to os.Stderr bypasses structured logging. Use a *slog.Logger instead. The sanctioned slog handler setup in internal/o11y/slog.go is exempt."
     sloglint:
       no-mixed-args: true
       attr-only: true
@@ -325,6 +350,15 @@ linters:
               desc: V3 is not ready yet use github.com/urfave/cli/v2
             - pkg: "github.com/pkg/errors"
               desc: Should be replaced by standard lib errors package
+            # GG011: debug value dumpers write to stdout/stderr and bypass
+            # structured logging. Forbidden at the import level (forbidigo only
+            # matches call sites). Use a *slog.Logger instead.
+            - pkg: "github.com/davecgh/go-spew/spew"
+              desc: "GG011: spew bypasses structured logging; use a *slog.Logger."
+            - pkg: "github.com/sanity-io/litter"
+              desc: "GG011: litter bypasses structured logging; use a *slog.Logger."
+            - pkg: "github.com/k0kubun/pp"
+              desc: "GG011: pp bypasses structured logging; use a *slog.Logger."
         # testenv exposes cross-cutting test primitives (loggers, OTel
         # providers, encryption clients, infra launchers). It must not import
         # domain packages, otherwise internal tests in those packages can no

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -1071,8 +1071,6 @@ func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByI
 		return make(map[string]ChatMetricsRow), nil
 	}
 
-	println("\n\n\n", strings.Join(arg.ChatIDs, ", "), "\n\n\n")
-
 	sb := sq.Select(
 		"gram_chat_id",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') as total_input_tokens",


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2811/lint-against-logging-calls-that-bypass-structured-logging-forbidigo

A stray debug `println` in the telemetry repo leaked chat UUIDs to stderr, which GKE/Datadog tagged `status:error` with no `error.message`/`trace_id`, producing thousands of bogus error logs. Add forbidigo rules to the server config to guard this class of mistake:

- GG011: `print`/`println`, `fmt.Print*`, the stdlib `log.*` set, and `debug.PrintStack`.
- GG012: `os.Stdout`/`os.Stderr`, which also covers `fmt.Fprint*` to the std streams and `.Write`/`.WriteString` on them.

Debug value dumpers (`spew`/`litter`/`pp`) are blocked at the import level via `depguard` rather than `forbidigo`, since they guard zero call sites today.

Scoped to the server (`cmd/`, generated code, and tests are exempt). The sanctioned `slog.NewJSONHandler(os.Stderr, ...)` in `internal/o11y/slog.go` is exempt from GG012, and the stray `println` is removed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces structured logging in the server by forbidding direct writes to stdout/stderr and stdlib logging; also removes a stray `println` that leaked chat IDs. Addresses AGE-2811.

- **New Features**
  - Added `forbidigo` GG011 to block `print`/`println`, `fmt.Print*`, `log.*`, and `runtime/debug.PrintStack`.
  - Added `forbidigo` GG012 to block `os.Stdout`/`os.Stderr` (also catches `fmt.Fprint*` and `.Write*` to these).
  - Blocked debug dumpers via `depguard`: `github.com/davecgh/go-spew/spew`, `github.com/sanity-io/litter`, `github.com/k0kubun/pp`.
  - Scoped to the server; `cmd/`, generated code, and tests are exempt. Allow `internal/o11y/slog.go` to build `slog.NewJSONHandler(os.Stderr, ...)`.

- **Bug Fixes**
  - Removed a stray `println` in `internal/telemetry/repo/queries.sql.go` that wrote chat UUIDs to stderr and produced noisy error logs.

<sup>Written for commit ae72007b153934682f9d01591b235a08b5627503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

