### PR TITLE
mig: add infrastructure override columns to deployments_functions

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -413,6 +413,12 @@ CREATE TABLE IF NOT EXISTS deployments_functions (
   memory_mib INT,
   scale INT,
 
+  -- Durable operator overrides for Fly infrastructure settings. When set, these
+  -- take precedence over the customer-supplied memory_mib/scale (sourced from
+  -- gram.config.ts) and survive later customer deploys.
+  memory_mib_override INT,
+  scale_override INT,
+
   CONSTRAINT deployments_functions_pkey PRIMARY KEY (id),
   CONSTRAINT deployments_functions_deployment_id_fkey FOREIGN KEY (deployment_id) REFERENCES deployments (id) ON DELETE CASCADE,
   CONSTRAINT deployments_functions_asset_id_fkey FOREIGN KEY (asset_id) REFERENCES assets (id) ON DELETE CASCADE

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -405,15 +405,17 @@ type DeploymentTagHistory struct {
 }
 
 type DeploymentsFunction struct {
-	ID            uuid.UUID
-	DeploymentID  uuid.UUID
-	AssetID       uuid.UUID
-	Name          string
-	Slug          string
-	Runtime       string
-	RunnerVersion pgtype.Text
-	MemoryMib     pgtype.Int4
-	Scale         pgtype.Int4
+	ID                uuid.UUID
+	DeploymentID      uuid.UUID
+	AssetID           uuid.UUID
+	Name              string
+	Slug              string
+	Runtime           string
+	RunnerVersion     pgtype.Text
+	MemoryMib         pgtype.Int4
+	Scale             pgtype.Int4
+	MemoryMibOverride pgtype.Int4
+	ScaleOverride     pgtype.Int4
 }
 
 type DeploymentsOpenapiv3Asset struct {

--- a/server/internal/deployments/repo/models.go
+++ b/server/internal/deployments/repo/models.go
@@ -29,15 +29,17 @@ type Deployment struct {
 }
 
 type DeploymentsFunction struct {
-	ID            uuid.UUID
-	DeploymentID  uuid.UUID
-	AssetID       uuid.UUID
-	Name          string
-	Slug          string
-	Runtime       string
-	RunnerVersion pgtype.Text
-	MemoryMib     pgtype.Int4
-	Scale         pgtype.Int4
+	ID                uuid.UUID
+	DeploymentID      uuid.UUID
+	AssetID           uuid.UUID
+	Name              string
+	Slug              string
+	Runtime           string
+	RunnerVersion     pgtype.Text
+	MemoryMib         pgtype.Int4
+	Scale             pgtype.Int4
+	MemoryMibOverride pgtype.Int4
+	ScaleOverride     pgtype.Int4
 }
 
 type DeploymentsOpenapiv3Asset struct {

--- a/server/internal/deployments/repo/queries.sql.go
+++ b/server/internal/deployments/repo/queries.sql.go
@@ -1122,7 +1122,7 @@ func (q *Queries) GetDeploymentByIdempotencyKey(ctx context.Context, arg GetDepl
 }
 
 const getDeploymentFunctions = `-- name: GetDeploymentFunctions :many
-SELECT df.id, df.deployment_id, df.asset_id, df.name, df.slug, df.runtime, df.runner_version, df.memory_mib, df.scale
+SELECT df.id, df.deployment_id, df.asset_id, df.name, df.slug, df.runtime, df.runner_version, df.memory_mib, df.scale, df.memory_mib_override, df.scale_override
 FROM deployments_functions df
 INNER JOIN deployments d ON df.deployment_id = d.id
 WHERE 
@@ -1154,6 +1154,8 @@ func (q *Queries) GetDeploymentFunctions(ctx context.Context, arg GetDeploymentF
 			&i.RunnerVersion,
 			&i.MemoryMib,
 			&i.Scale,
+			&i.MemoryMibOverride,
+			&i.ScaleOverride,
 		); err != nil {
 			return nil, err
 		}

--- a/server/migrations/20260618194743_deployments-functions-add-infra-overrides.sql
+++ b/server/migrations/20260618194743_deployments-functions-add-infra-overrides.sql
@@ -1,0 +1,2 @@
+-- Modify "deployments_functions" table
+ALTER TABLE "deployments_functions" ADD COLUMN "memory_mib_override" integer NULL, ADD COLUMN "scale_override" integer NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:bgD7d/dmkHnbN0wsVnH7ncqAZx7bfmpZcDFzH+NHPUc=
+h1:bNFqsxeRpc08rZtEE2tT5QGnTx+OofgQKEOW8vjoKtU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -221,3 +221,4 @@ h1:bgD7d/dmkHnbN0wsVnH7ncqAZx7bfmpZcDFzH+NHPUc=
 20260618115411_risk-results-add-llm-judge-reason.sql h1:aI+VA7W9POYKH1mpSAUDTa4sfmr7gXkdmkBtXVK1NLI=
 20260618141330_risk-results-drop-llm-judge-reason.sql h1:D1AdewSg0AisvTZYT5ta9zDyUH5sFMWvaew/BPmLDtI=
 20260618145406_remotesession-clients-relax-issuer-binding.sql h1:Ilx2asUwFZi73cQMVj5yrXGc5aq6QihR2Sd4uaC4h6o=
+20260618194743_deployments-functions-add-infra-overrides.sql h1:MNR3+BYsl1tfjLes6MbKUWqGkw/nMs8HO2cfyZvTTPs=


### PR DESCRIPTION
Adds nullable `memory_mib_override` and `scale_override` columns to the `deployments_functions` table so Fly memory and scale settings can be overridden durably in the database. Migration only; the deployment code that prefers these columns over `gram.config.ts` values lands in AGE-2810.

Linear: https://linear.app/speakeasy/issue/AGE-2809/feat-database-migration-for-deployment-function-infrastructure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nullable `memory_mib_override` and `scale_override` columns to `deployments_functions`, and expose them in repo/database models and queries to enable durable Fly memory/scale overrides. Addresses AGE-2809; no behavior change yet—deployment code will read these in AGE-2810.

<sup>Written for commit 6842432cb810f380a7c49df3dc3b7d923932f101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

