### PR TITLE
fix(hooks): isolate identity per session in multi-session OTEL log batches

### DIFF
--- a/.changeset/age-2812-multi-session-otel-identity.md
+++ b/.changeset/age-2812-multi-session-otel-identity.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Isolate Claude Code session identity per `session.id` when an OpenTelemetry Collector or gateway re-batches multiple sessions into one OTLP logs export, so a session is never cached or authorized with another session's `user.email` / `organization.id`.

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
@@ -20,14 +21,9 @@ const claudeOTELLogsURN = "claude-code:otel:logs"
 
 // Logs handles authenticated OTEL logs data from Claude Code.
 func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
-	claudeMetadata := extractSessionMetadata(payload)
-
 	logger := s.logger.With(
 		attr.SlogHookSource("claude"),
 		attr.SlogHookEvent("Logs"),
-		attr.SlogServiceName(claudeMetadata.ServiceName),
-		attr.SlogGenAIConversationID(claudeMetadata.SessionID),
-		attr.SlogAuthUserEmail(claudeMetadata.UserEmail),
 	)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -58,37 +54,64 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 
 	s.writeClaudeOTELLogsToClickHouse(ctx, payload, orgID, projectID)
 
-	if claudeMetadata.SessionID == "" {
+	sessions := extractSessionMetadata(payload)
+	if len(sessions) == 0 {
 		logger.WarnContext(ctx, "claude OTEL logs payload contained no session ID",
 			attr.SlogEvent("claude_logs_no_session"),
 		)
 		return nil
 	}
 
-	userID := s.resolveUserByEmail(ctx, claudeMetadata.UserEmail, orgID)
+	// Resolve each distinct user once per payload. A re-batching collector can
+	// repeat the same identity across sessions, so memoize on the normalized
+	// email (the same key resolveUserByEmail queries with) to issue the minimal
+	// set of database lookups.
+	userIDByEmail := make(map[string]string)
+	for i := range sessions {
+		session := sessions[i]
 
-	completeMetadata := SessionMetadata{
-		SessionID:   claudeMetadata.SessionID,
-		ServiceName: claudeMetadata.ServiceName,
-		UserEmail:   claudeMetadata.UserEmail,
-		UserID:      userID,
-		ClaudeOrgID: claudeMetadata.ClaudeOrgID,
-		GramOrgID:   orgID,
-		ProjectID:   projectID,
-	}
+		userID := ""
+		if session.UserEmail != "" {
+			lookup := conv.NormalizeEmail(session.UserEmail)
+			id, ok := userIDByEmail[lookup]
+			if !ok {
+				id = s.resolveUserByEmail(ctx, session.UserEmail, orgID)
+				userIDByEmail[lookup] = id
+			}
+			userID = id
+		}
 
-	if err := s.cache.Set(ctx, sessionCacheKey(completeMetadata.SessionID), completeMetadata, 24*time.Hour); err != nil {
-		logger.ErrorContext(ctx, "Failed to store session metadata",
-			attr.SlogEvent("claude_logs_cache_set_failed"),
-			attr.SlogError(err),
+		completeMetadata := SessionMetadata{
+			SessionID:   session.SessionID,
+			ServiceName: session.ServiceName,
+			UserEmail:   session.UserEmail,
+			UserID:      userID,
+			ClaudeOrgID: session.ClaudeOrgID,
+			GramOrgID:   orgID,
+			ProjectID:   projectID,
+		}
+
+		sessionLogger := logger.With(
+			attr.SlogServiceName(session.ServiceName),
+			attr.SlogGenAIConversationID(session.SessionID),
+			attr.SlogAuthUserEmail(session.UserEmail),
+		)
+
+		// Process each session independently so a single cache failure does not
+		// abort flushing the remaining sessions in the batch.
+		if err := s.cache.Set(ctx, sessionCacheKey(completeMetadata.SessionID), completeMetadata, 24*time.Hour); err != nil {
+			sessionLogger.ErrorContext(ctx, "Failed to store session metadata",
+				attr.SlogEvent("claude_logs_cache_set_failed"),
+				attr.SlogError(err),
+			)
+		}
+
+		s.flushPendingHooks(ctx, completeMetadata.SessionID, &completeMetadata)
+
+		sessionLogger.InfoContext(ctx, "Stored session metadata",
+			attr.SlogEvent("session_validated"),
 		)
 	}
-
-	s.flushPendingHooks(ctx, completeMetadata.SessionID, &completeMetadata)
-
-	logger.InfoContext(ctx, "Stored session metadata",
-		attr.SlogEvent("session_validated"),
-	)
 
 	return nil
 }
@@ -100,62 +123,77 @@ type claudeLogMetadata struct {
 	ClaudeOrgID string
 }
 
-func extractSessionMetadata(payload *gen.LogsPayload) claudeLogMetadata {
-	metadata := claudeLogMetadata{
-		SessionID:   "",
-		ServiceName: "",
-		UserEmail:   "",
-		ClaudeOrgID: "",
-	}
+// extractSessionMetadata partitions an OTLP logs payload into one metadata
+// entry per distinct session.id, in first-seen order. A single Claude Code CLI
+// process emits one session per payload, but an OpenTelemetry Collector or
+// gateway can re-batch records from many sessions into one export. Keying by
+// session keeps each session's identity isolated so the caller never seeds one
+// session with another session's user.email / organization.id.
+func extractSessionMetadata(payload *gen.LogsPayload) []claudeLogMetadata {
 	if payload == nil {
-		return metadata
+		return nil
 	}
 
-	// Iterate through all resource logs
+	ordered := make([]claudeLogMetadata, 0)
+	indexBySession := make(map[string]int)
+
 	for _, resourceLog := range payload.ResourceLogs {
 		if resourceLog == nil {
 			continue
 		}
 
-		// Extract service name from resource attributes
-		metadata.ServiceName = extractResourceAttribute(resourceLog.Resource, "service.name")
+		serviceName := extractResourceAttribute(resourceLog.Resource, "service.name")
 
-		// Iterate through all scope logs
 		for _, scopeLog := range resourceLog.ScopeLogs {
 			if scopeLog == nil {
 				continue
 			}
 
-			// Iterate through all log records
 			for _, logRecord := range scopeLog.LogRecords {
 				if logRecord == nil {
 					continue
 				}
 
-				// Extract session data
 				data := extractLogData(logRecord)
-
 				if data.SessionID == "" {
 					continue
 				}
 
-				// Store session metadata in Redis. Claude Code batches many log
-				// records per session, but user.email / organization.id only ride
-				// on some event types (e.g. api_request, not tool events). Assign
-				// only non-empty values so a later emailless record in the batch
-				// does not clobber an email already extracted from an earlier one.
-				metadata.SessionID = data.SessionID
+				idx, ok := indexBySession[data.SessionID]
+				if !ok {
+					ordered = append(ordered, claudeLogMetadata{
+						SessionID:   data.SessionID,
+						ServiceName: serviceName,
+						UserEmail:   "",
+						ClaudeOrgID: "",
+					})
+					indexBySession[data.SessionID] = len(ordered) - 1
+					idx = len(ordered) - 1
+				}
+
+				// Claude Code batches many log records per session, but
+				// user.email / organization.id only ride on some event types
+				// (e.g. api_request, not tool events). Assign only non-empty
+				// values so a later emailless record in the batch does not
+				// clobber a value already extracted from an earlier record for
+				// the same session. ServiceName uses first-non-empty wins in
+				// case a re-batched session spans resources with differing
+				// service.name values.
+				meta := &ordered[idx]
 				if data.UserEmail != "" {
-					metadata.UserEmail = data.UserEmail
+					meta.UserEmail = data.UserEmail
 				}
 				if data.ClaudeOrgID != "" {
-					metadata.ClaudeOrgID = data.ClaudeOrgID
+					meta.ClaudeOrgID = data.ClaudeOrgID
+				}
+				if meta.ServiceName == "" && serviceName != "" {
+					meta.ServiceName = serviceName
 				}
 			}
 		}
 	}
 
-	return metadata
+	return ordered
 }
 
 func (s *Service) writeClaudeOTELLogsToClickHouse(ctx context.Context, payload *gen.LogsPayload, orgID string, projectID string) {

--- a/server/internal/hooks/otel_test.go
+++ b/server/internal/hooks/otel_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -146,6 +147,55 @@ func TestLogs_CodexPayloadContinuesThroughUsagePath(t *testing.T) {
 	}, 300*time.Millisecond, 50*time.Millisecond)
 }
 
+func TestLogs_CachesMultiSessionBatchPerSessionWithoutLeakingIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	userID := uuid.NewString()
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, userID, "a@example.com")
+
+	// One export carrying two sessions: A carries an email/org, B (later in the
+	// batch) carries neither. B must be cached with an empty identity rather
+	// than inheriting A's, and each session must land under its own cache key.
+	err := ti.service.Logs(ctx, claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		&gen.OTELScope{Name: new("claude-code"), Version: new("1.0.0")},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("session a api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", "claude-session-a"),
+				strAttr("user.email", "a@example.com"),
+				strAttr("organization.id", "claude-org-a"),
+			},
+		},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("session b tool event")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", "claude-session-b"),
+				strAttr("event.name", "tool_call"),
+			},
+		},
+	))
+	require.NoError(t, err)
+
+	var sessionA SessionMetadata
+	require.NoError(t, ti.service.cache.Get(ctx, sessionCacheKey("claude-session-a"), &sessionA))
+	require.Equal(t, "claude-session-a", sessionA.SessionID)
+	require.Equal(t, "a@example.com", sessionA.UserEmail)
+	require.Equal(t, "claude-org-a", sessionA.ClaudeOrgID)
+	require.Equal(t, userID, sessionA.UserID)
+
+	var sessionB SessionMetadata
+	require.NoError(t, ti.service.cache.Get(ctx, sessionCacheKey("claude-session-b"), &sessionB))
+	require.Equal(t, "claude-session-b", sessionB.SessionID)
+	require.Empty(t, sessionB.UserEmail)
+	require.Empty(t, sessionB.ClaudeOrgID)
+	require.Empty(t, sessionB.UserID)
+}
+
 func TestShouldTriggerClaudePromptCorrelation(t *testing.T) {
 	t.Parallel()
 
@@ -185,14 +235,15 @@ func TestExtractSessionMetadataSkipsNilOTELAttributeElements(t *testing.T) {
 		},
 	)
 
-	var metadata claudeLogMetadata
+	var sessions []claudeLogMetadata
 	require.NotPanics(t, func() {
-		metadata = extractSessionMetadata(payload)
+		sessions = extractSessionMetadata(payload)
 	})
-	require.Equal(t, "claude-code", metadata.ServiceName)
-	require.Equal(t, "claude-session-1", metadata.SessionID)
-	require.Equal(t, "dev@example.com", metadata.UserEmail)
-	require.Equal(t, "claude-org-1", metadata.ClaudeOrgID)
+	require.Len(t, sessions, 1)
+	require.Equal(t, "claude-code", sessions[0].ServiceName)
+	require.Equal(t, "claude-session-1", sessions[0].SessionID)
+	require.Equal(t, "dev@example.com", sessions[0].UserEmail)
+	require.Equal(t, "claude-org-1", sessions[0].ClaudeOrgID)
 
 	require.Empty(t, extractLogData(&gen.OTELLogRecord{Attributes: []*gen.OTELAttribute{nil}}).SessionID)
 	require.Empty(t, extractAttributeString([]*gen.OTELAttribute{nil}, "session.id"))
@@ -231,10 +282,51 @@ func TestExtractSessionMetadataKeepsEmailFromEarlierRecordInBatch(t *testing.T) 
 		},
 	)
 
-	metadata := extractSessionMetadata(payload)
-	require.Equal(t, sessionID, metadata.SessionID)
-	require.Equal(t, "dev@example.com", metadata.UserEmail)
-	require.Equal(t, "claude-org-1", metadata.ClaudeOrgID)
+	sessions := extractSessionMetadata(payload)
+	require.Len(t, sessions, 1)
+	require.Equal(t, sessionID, sessions[0].SessionID)
+	require.Equal(t, "dev@example.com", sessions[0].UserEmail)
+	require.Equal(t, "claude-org-1", sessions[0].ClaudeOrgID)
+}
+
+func TestExtractSessionMetadataIsolatesIdentityAcrossSessionsInBatch(t *testing.T) {
+	t.Parallel()
+
+	// A re-batching OpenTelemetry Collector can place records from multiple
+	// sessions in one export. Session A carries an email; session B (emitted
+	// later in the batch) carries none. B must keep an empty email rather than
+	// inheriting A's identity, and each session must be returned under its own
+	// session id.
+	payload := claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		&gen.OTELScope{Name: new("claude-code"), Version: new("1.0.0")},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("session a api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", "claude-session-a"),
+				strAttr("user.email", "a@example.com"),
+				strAttr("organization.id", "claude-org-a"),
+			},
+		},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("session b tool event")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", "claude-session-b"),
+				strAttr("event.name", "tool_call"),
+			},
+		},
+	)
+
+	sessions := extractSessionMetadata(payload)
+	require.Len(t, sessions, 2)
+
+	require.Equal(t, "claude-session-a", sessions[0].SessionID)
+	require.Equal(t, "a@example.com", sessions[0].UserEmail)
+	require.Equal(t, "claude-org-a", sessions[0].ClaudeOrgID)
+
+	require.Equal(t, "claude-session-b", sessions[1].SessionID)
+	require.Empty(t, sessions[1].UserEmail)
+	require.Empty(t, sessions[1].ClaudeOrgID)
 }
 
 func enableHookTelemetryLogger(t *testing.T, ctx context.Context, ti *testInstance) *telemetryrepo.Queries {


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2812/extractsessionmetadata-collapses-multi-session-otel-batches-into-one

`extractSessionMetadata` collapsed an entire OTLP logs payload into one `claudeLogMetadata`, so a re-batched export carrying multiple sessions (as an OpenTelemetry Collector or gateway produces) cached the surviving session with another session's `user.email` / `organization.id` and dropped the rest. #3519 made that surviving-session outcome worse: wrong-identity authorized rather than empty/fail-closed.

Partition records into one entry per distinct `session.id` (first-seen order), and cache + flush pending hooks per session independently so a session is never seeded with another session's identity. Per-session user lookups are memoized on the normalized email to issue the minimal set of database queries, and a single cache failure no longer aborts the rest of the batch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes identity leakage in multi-session OTEL log batches by isolating metadata per `session.id` and handling each session independently. Prevents wrong-user authorization and ensures correct caching and hook flushing. Addresses AGE-2812.

- **Bug Fixes**
  - Partition each OTLP logs payload into one entry per `session.id` (first-seen order); cache and flush hooks per session.
  - Memoize user lookups by normalized email to reduce DB queries.
  - Continue processing other sessions if one cache write fails.

<sup>Written for commit e4b93bca266dde894c09f60a73a4b6fad29f2581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

