### PR TITLE
fix(dashboard): apply filter sheet option clicks via modal popover

### DIFF
--- a/.changeset/filter-sheet-option-clicks.md
+++ b/.changeset/filter-sheet-option-clicks.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix filter sheet options not applying when clicked. The multiselect controls in the unified filter sheet opened their dropdown but never registered option clicks, so filters on the MCP & Tools and Insights pages did not respond.

--- a/client/dashboard/src/components/filters/FilterControl.tsx
+++ b/client/dashboard/src/components/filters/FilterControl.tsx
@@ -66,6 +66,13 @@ export function FilterControl({
           className={className}
           hideSelectAll
           singleLine
+          // This control only ever renders inside the FilterSheet, which is a
+          // non-modal Radix Dialog. A non-modal popover nested in a non-modal
+          // dialog doesn't reliably receive option clicks in the browser (the
+          // dialog's dismissable/focus layer swallows them), so the dropdown
+          // appears but selecting an option does nothing (AIS-168). Running the
+          // popover modal makes it the top interactive layer so clicks land.
+          modalPopover
         />
       );
     case "select":


### PR DESCRIPTION
Linear: [AIS-168](https://linear.app/speakeasy/issue/AIS-168/bug-dashboard-does-not-respond-when-mcp-tools-or-insights-filters-are)

The unified filter bar (#3489) renders every dimension's control through `FilterControl` inside `FilterSheet`, a non-modal Radix Dialog. The multiselect control opens its own non-modal Radix Popover, and a non-modal popover nested in a non-modal dialog does not reliably receive option clicks in the browser, so the dropdown opens but selecting an option never toggles the checkbox or applies the filter. This affected every page using the sheet, including MCP & Tools and Insights.

This runs the in-sheet `MultiSelect` popover modal so it becomes the top interactive layer and clicks land. `FilterControl` renders only inside `FilterSheet`, so the single prop covers all pages. The bug is browser-only (focus/pointer-events layering), which is why `happy-dom` unit tests could not catch it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dashboard filters not applying by making the in-sheet multiselect popover modal so option clicks register. Restores working filters on MCP & Tools and Insights pages (Linear: AIS-168).

- Bug Fixes
  - Set modal popover on the multiselect inside the filter sheet so clicks reach options instead of being swallowed by dialog layering.
  - Affects all pages using the unified filter bar; no test changes needed (browser-only issue).

<sup>Written for commit 644b28c6879e14a5b4e69375e80cc97a16b0f7e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

