### PR TITLE
fix(telemetry): align PostHog group memberships with configured group types

### DIFF
--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -169,7 +169,6 @@ export function useRegisterChatTelemetry({
     if (!chatId) return;
     if (!chatUrl) return;
 
-    telemetry.group("chat_id", chatId, {});
     telemetry.register({
       chat_id: chatId,
       chat_url: chatUrl,
@@ -201,7 +200,6 @@ export function useRegisterToolsetTelemetry({
 
   useEffect(() => {
     if (!toolsetSlug) return;
-    telemetry.group("toolset_slug", toolsetSlug, {});
     telemetry.register({
       toolset_slug: toolsetSlug,
     });
@@ -224,10 +222,11 @@ export function useRegisterProjectForTelemetry({
     if (!projectSlug) return;
     if (!organizationSlug) return;
 
-    // Register the super properties for this workspace to be sent with every event
-    telemetry.group("project_id", projectId, {});
-    telemetry.group("project_slug", projectSlug, {});
-    telemetry.group("organization_slug", organizationSlug, {});
+    // PostHog caps a project at 5 group types; "organization" and "slug" are the
+    // only org/project slots that exist, so we register just those two. Other
+    // group types (project_id, project_slug, chat_id, toolset_slug, …) are
+    // dropped at ingestion; their values still ship as register() properties.
+    telemetry.group("organization", organizationSlug, {});
     telemetry.group("slug", `${organizationSlug}/${projectSlug}`, {});
 
     telemetry.register({

--- a/server/internal/feature/provider.go
+++ b/server/internal/feature/provider.go
@@ -39,17 +39,20 @@ func (imp *InMemory) SetFlag(flag Flag, distinctID string, enabled bool) {
 }
 
 // OrgProjectGroups returns the PostHog group memberships used to evaluate
-// org/project-scoped flags, mirroring the groups the dashboard registers (see
-// client/dashboard/src/contexts/Telemetry.tsx): "organization_slug" keyed by
-// the org slug and "slug" keyed by "<orgSlug>/<projectSlug>". Empty slug
-// components are omitted so a release targeting either group matches the same
-// way it does for the frontend. Returns nil when no group can be built.
+// org/project-scoped flags. It keys the "organization" group by the org slug
+// and the "slug" group by "<orgSlug>/<projectSlug>" — the same group types the
+// dashboard (client/dashboard/src/contexts/Telemetry.tsx) and backend event
+// capture (server/internal/thirdparty/posthog) register. PostHog caps a project
+// at 5 group types and these are the only org/project ones that exist; any
+// other group type is silently dropped at ingestion, so a flag release targeting
+// it could never match. Empty slug components are omitted. Returns nil when no
+// group can be built.
 func OrgProjectGroups(orgSlug, projectSlug string) map[string]string {
 	if orgSlug == "" {
 		return nil
 	}
 
-	groups := map[string]string{"organization_slug": orgSlug}
+	groups := map[string]string{"organization": orgSlug}
 	if projectSlug != "" {
 		groups["slug"] = orgSlug + "/" + projectSlug
 	}

--- a/server/internal/feature/provider_test.go
+++ b/server/internal/feature/provider_test.go
@@ -13,8 +13,8 @@ func TestOrgProjectGroups_OrgAndProject(t *testing.T) {
 
 	got := feature.OrgProjectGroups("speakeasy-team", "default")
 	require.Equal(t, map[string]string{
-		"organization_slug": "speakeasy-team",
-		"slug":              "speakeasy-team/default",
+		"organization": "speakeasy-team",
+		"slug":         "speakeasy-team/default",
 	}, got)
 }
 
@@ -22,7 +22,7 @@ func TestOrgProjectGroups_OrgOnly(t *testing.T) {
 	t.Parallel()
 
 	got := feature.OrgProjectGroups("speakeasy-team", "")
-	require.Equal(t, map[string]string{"organization_slug": "speakeasy-team"}, got)
+	require.Equal(t, map[string]string{"organization": "speakeasy-team"}, got)
 }
 
 func TestOrgProjectGroups_NoOrgReturnsNil(t *testing.T) {


### PR DESCRIPTION
## What

PostHog allows a **maximum of 5 group types per project**, created on first use; beyond that, new group types are not created and the association is dropped at ingestion. The shared "Speakeasy" project's 5 slots are: `workspace`, `organization`, `slug`, `workspace_id`, `internal`.

An audit of every group-attribute call site found that most of Gram's were targeting group types that don't exist in that set:

| Group type sent | By | Configured slot? | Result |
|---|---|---|---|
| `slug` | FE `group()`, BE capture, BE flag-eval | ✅ | works |
| `organization` | BE event capture | ✅ | works |
| `organization_slug` | FE `group()`, BE flag-eval | ❌ | silently dropped |
| `project_id`, `project_slug`, `chat_id`, `toolset_slug` | FE `group()` | ❌ | silently dropped |

## Changes

- **`client/dashboard/src/contexts/Telemetry.tsx`** — remove the dead `group()` no-ops (`chat_id`, `toolset_slug`, `project_id`, `project_slug`) and rename `group("organization_slug")` → `group("organization")` so the dashboard feeds the same group type the backend already populates. **All `register()` super-properties are unchanged**, so these values still flow as event properties for filtering/breakdowns — they were just never usable as group analytics.
- **`server/internal/feature/provider.go`** — `OrgProjectGroups` now keys the org membership `"organization"` instead of the nonexistent `"organization_slug"`, so group-targeted feature-flag releases (`prompt-injection-use-classifier`, `gram-prompt-policies`) can actually match. Docstring corrected.
- **`provider_test.go`** — assertions updated.

## Why it's safe

`register()` (FE) / the `properties` map (BE) set **event properties** (uncapped); `group()` / the `groups` map set **group-type memberships** (capped at 5). This PR only touches the group-type surface — no event property is removed or renamed.

## Verification

- `go test ./server/internal/feature/...` → 3/3 pass; `gofmt`/`oxfmt` clean (pre-commit hooks pass).
- Dashboard `Telemetry.tsx` type-clean (edit is type-identical: string args + comments).

## Follow-up (not in this PR)

Confirm via PostHog whether the two gated flags are group-aggregated on `organization_slug` (would make the backend rename a live flag-eval fix vs. dead config). The 3 non-Gram slots (`workspace`/`workspace_id`/`internal`) are shared with the main Speakeasy platform — reclaiming a slot for project-level grouping needs cross-team coordination (and `slug` already identifies a project uniquely).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align PostHog group memberships with the project’s configured group types so group-targeted flags match; remove dead `group()` calls while keeping event super-properties unchanged.

- **Bug Fixes**
  - Dashboard: drop `group()` for `chat_id`, `toolset_slug`, `project_id`, `project_slug`; use `group("organization", orgSlug)` and `group("slug", "<org>/<project>")` instead of `"organization_slug"`.
  - Backend: `OrgProjectGroups` now keys org membership as `"organization"` (was `"organization_slug"`); tests updated.

<sup>Written for commit 5e5a2855a5ff4a13678dcbc103437549184e4347. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

