### PR TITLE
chore(risk): rename mcpname package to toolref

### DIFF
--- a/.changeset/toolref-rename.md
+++ b/.changeset/toolref-rename.md
@@ -1,0 +1,7 @@
+---
+"server": patch
+---
+
+Rename the internal `mcpname` package to `toolref` and route the Codex hook's
+MCP tool-name attribution through `toolref.AttributeTool` instead of a
+hand-rolled `mcp__<server>__<tool>` split. No behavior change.

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -25,13 +25,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/feature"
-	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/message"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/outbox"
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
 // DescribeShadowMCP returns the canonical (rule_id, description) for an
@@ -706,7 +706,7 @@ func (a *AnalyzeBatch) scanMessageToolCalls(ctx context.Context, orgID string, r
 		}
 		// Native (non-MCP) tools don't carry the x-gram-toolset-id property
 		// and are out of scope for shadow-MCP enforcement.
-		if !mcpname.IsMCPToolName(toolName) {
+		if !toolref.IsMCPToolName(toolName) {
 			continue
 		}
 		var toolInput any
@@ -716,7 +716,7 @@ func (a *AnalyzeBatch) scanMessageToolCalls(ctx context.Context, orgID string, r
 				toolInput = nil
 			}
 		}
-		bareName := mcpname.MCPFunctionOf(toolName)
+		bareName := toolref.MCPFunctionOf(toolName)
 		if a.shadowMCPClient == nil {
 			continue
 		}
@@ -730,7 +730,7 @@ func (a *AnalyzeBatch) scanMessageToolCalls(ctx context.Context, orgID string, r
 		// attribute the hook recorded on the corresponding ClickHouse log,
 		// when one exists. The fallback keeps findings useful even if the
 		// CH lookup misses (no hook log yet, ClickHouse outage, ...).
-		match := mcpname.MCPServerOf(toolName)
+		match := toolref.MCPServerOf(toolName)
 		if match == "" {
 			match = toolName
 		}
@@ -777,7 +777,7 @@ func (a *AnalyzeBatch) scanMessageDestructiveToolCalls(ctx context.Context, orgI
 	var findings []Finding
 	for _, call := range calls {
 		toolName := call.Function.Name
-		if toolName == "" || !mcpname.IsMCPToolName(toolName) {
+		if toolName == "" || !toolref.IsMCPToolName(toolName) {
 			continue
 		}
 
@@ -788,7 +788,7 @@ func (a *AnalyzeBatch) scanMessageDestructiveToolCalls(ctx context.Context, orgI
 			}
 		}
 
-		bareName := mcpname.MCPFunctionOf(toolName)
+		bareName := toolref.MCPFunctionOf(toolName)
 		resolved, ok := a.shadowMCPClient.ResolveToolsetCall(ctx, toolInput, bareName, orgID)
 		if !ok || resolved.Tool.Annotations == nil || resolved.Tool.Annotations.DestructiveHint == nil || !*resolved.Tool.Annotations.DestructiveHint {
 			continue

--- a/server/internal/background/activities/risk_analysis/llm_judge.go
+++ b/server/internal/background/activities/risk_analysis/llm_judge.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/message"
+	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
 const (
@@ -74,7 +74,7 @@ type JudgeToolCall struct {
 // so an MCP server/function is surfaced separately — a no-op for native tools
 // and non-tool messages, where toolName is "".
 func NewJudgeMessage(messageType message.Type, toolName, body string) JudgeMessage {
-	server, fn, _ := mcpname.AttributeTool(toolName)
+	server, fn, _ := toolref.AttributeTool(toolName)
 	return JudgeMessage{
 		Type:        messageType,
 		Body:        body,
@@ -102,7 +102,7 @@ func (m JudgeMessage) HasContent() bool {
 // NewJudgeToolCall destructures a tool name into its MCP components and pairs it
 // with the call's raw arguments, for one entry of a multi-call message.
 func NewJudgeToolCall(toolName, arguments string) JudgeToolCall {
-	server, fn, _ := mcpname.AttributeTool(toolName)
+	server, fn, _ := toolref.AttributeTool(toolName)
 	return JudgeToolCall{
 		ToolName:    toolName,
 		MCPServer:   server,

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
 func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.CodexHookResult, error) {
@@ -307,28 +308,28 @@ func (s *Service) buildCodexTelemetryAttributes(ctx context.Context, payload *ge
 	}
 
 	// Parse MCP tool names using the mcp__<server>__<tool> convention.
-	if strings.HasPrefix(toolName, "mcp__") {
-		parts := strings.SplitN(toolName, "__", 3)
-		if len(parts) == 3 {
-			attrs[attr.ToolCallSourceKey] = parts[1]
-			attrs[attr.ToolNameKey] = parts[2]
-			if metadata.SessionID != "" {
-				if entries, err := s.getCachedMCPList(ctx, metadata.SessionID); err == nil {
-					matched := matchCodexCachedMCPEntry(entries, toolName)
-					if matched != nil && matched.ToolPrefix != "" {
-						// Sanitized prefixes can contain "__", in which case
-						// the naive split misattributes part of the server
-						// name to the tool — recompute from the full prefix.
-						if rest, ok := strings.CutPrefix(toolName, "mcp__"+matched.ToolPrefix+"__"); ok {
-							attrs[attr.ToolCallSourceKey] = matched.ToolPrefix
-							attrs[attr.ToolNameKey] = rest
-						}
+	if server, fn, ok := toolref.AttributeTool(toolName); ok {
+		attrs[attr.ToolCallSourceKey] = server
+		attrs[attr.ToolNameKey] = fn
+		// Enrich with the cached MCP inventory: recover the true server/tool
+		// split for sanitized prefixes (which can themselves contain "__"),
+		// the resolved match key, and inventory attributes.
+		if metadata.SessionID != "" {
+			if entries, err := s.getCachedMCPList(ctx, metadata.SessionID); err == nil {
+				matched := matchCodexCachedMCPEntry(entries, toolName)
+				if matched != nil && matched.ToolPrefix != "" {
+					// Sanitized prefixes can contain "__", in which case
+					// the naive split misattributes part of the server
+					// name to the tool — recompute from the full prefix.
+					if rest, ok := strings.CutPrefix(toolName, "mcp__"+matched.ToolPrefix+"__"); ok {
+						attrs[attr.ToolCallSourceKey] = matched.ToolPrefix
+						attrs[attr.ToolNameKey] = rest
 					}
-					if v := resolvedMCPMatch(matched, parts[1]); v != "" {
-						attrs[attr.MCPMatchKey] = v
-					}
-					applyMCPInventoryAttrs(attrs, matched)
 				}
+				if v := resolvedMCPMatch(matched, server); v != "" {
+					attrs[attr.MCPMatchKey] = v
+				}
+				applyMCPInventoryAttrs(attrs, matched)
 			}
 		}
 	}

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -18,9 +18,9 @@ import (
 	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
 // Cursor is the endpoint for Cursor hook events
@@ -414,7 +414,7 @@ func (s *Service) buildCursorTelemetryAttributes(ctx context.Context, payload *g
 	// "MCP:" prefix (which AttributeTool also recognizes) is handled separately
 	// below, so guard on the mcp__ prefix to keep that split exclusive.
 	if strings.HasPrefix(toolName, "mcp__") {
-		if server, fn, ok := mcpname.AttributeTool(toolName); ok {
+		if server, fn, ok := toolref.AttributeTool(toolName); ok {
 			attrs[attr.ToolCallSourceKey] = server
 			attrs[attr.ToolNameKey] = fn
 		}

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/customdomains/repo"
-	"github.com/speakeasy-api/gram/server/internal/mcpname"
+	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
 // gramHostedMCPHost is the canonical host for Gram-managed MCP servers.
@@ -39,7 +39,7 @@ func parseClaudeToolName(rawName string) parsedClaudeToolName {
 	if !strings.HasPrefix(rawName, "mcp__") {
 		return parsedClaudeToolName{Server: "", Tool: "", IsMCP: false}
 	}
-	server, tool, isMCP := mcpname.AttributeTool(rawName)
+	server, tool, isMCP := toolref.AttributeTool(rawName)
 	if !isMCP {
 		return parsedClaudeToolName{Server: "", Tool: "", IsMCP: false}
 	}

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -13,8 +13,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/toolref"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
@@ -148,7 +148,7 @@ func (s *Service) buildTelemetryAttributesWithMetadata(ctx context.Context, payl
 	}
 
 	// Parse MCP tool names
-	if server, fn, ok := mcpname.AttributeTool(toolName); ok {
+	if server, fn, ok := toolref.AttributeTool(toolName); ok {
 		attrs[attr.ToolCallSourceKey] = server
 		attrs[attr.ToolNameKey] = fn
 	}

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -7,9 +7,9 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/mcpname"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
 func (s *Service) enforceShadowMCPToolAccess(
@@ -147,5 +147,5 @@ func claudeShadowMCPEvidence(rawToolName string) shadowmcp.AccessEvidence {
 // or Claude tool name. Both hosts emit the "mcp__<server>__<tool>" form, so the
 // shared parser's Cursor "MCP:" branch never fires here.
 func mcpServerIdentityFromToolName(rawName string) string {
-	return mcpname.MCPServerOf(rawName)
+	return toolref.MCPServerOf(rawName)
 }

--- a/server/internal/toolref/toolref.go
+++ b/server/internal/toolref/toolref.go
@@ -1,11 +1,13 @@
-// Package mcpname parses the namespaced tool-call names that agent hosts emit.
+// Package toolref parses and attributes the namespaced tool-call names that
+// agent hosts emit.
 //
 // MCP-routed tools use either the "mcp__<server>__<function>" convention
 // (Claude Code) or a "MCP:" prefix (Cursor); native tools are bare (e.g.
 // "bash"). These helpers are the single source of truth for that parsing,
 // shared by the hooks package (shadow_mcp matching, telemetry attribution) and
-// the risk_analysis package (batch analyzer + realtime judge attribution).
-package mcpname
+// the risk_analysis package (batch analyzer, realtime judge, and custom-rule
+// engine attribution).
+package toolref
 
 import "strings"
 

--- a/server/internal/toolref/toolref_test.go
+++ b/server/internal/toolref/toolref_test.go
@@ -1,11 +1,11 @@
-package mcpname_test
+package toolref_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/speakeasy-api/gram/server/internal/mcpname"
+	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
 func TestAttributeTool(t *testing.T) {
@@ -28,7 +28,7 @@ func TestAttributeTool(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			server, function, isMCP := mcpname.AttributeTool(tc.in)
+			server, function, isMCP := toolref.AttributeTool(tc.in)
 			require.Equal(t, tc.isMCP, isMCP)
 			require.Equal(t, tc.server, server)
 			require.Equal(t, tc.function, function)
@@ -57,7 +57,7 @@ func TestMCPServerOf(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tc.want, mcpname.MCPServerOf(tc.in))
+			require.Equal(t, tc.want, toolref.MCPServerOf(tc.in))
 		})
 	}
 }


### PR DESCRIPTION
Mechanical package rename + route the Codex hook's tool-name attribution through `toolref.AttributeTool`.

**Review focus:** confirm `codex_hooks.go` `AttributeTool` adoption is behavior-preserving vs the old `strings.SplitN("__")` (surrounding MCP-inventory enrichment is unchanged).

Part of the AGE-2703 / AGE-2756 / AGE-2783 policy-creation redesign.