### PR TITLE
mig: add match_config to risk_custom_detection_rules

### DIFF
--- a/.changeset/mig-custom-rule-match-config.md
+++ b/.changeset/mig-custom-rule-match-config.md
@@ -1,0 +1,8 @@
+---
+"server": patch
+---
+
+Add a nullable `match_config` JSONB column to `risk_custom_detection_rules`.
+Detection rules will evaluate this structured condition config instead of the
+single `regex` pattern; `regex` is retained (nullable) as a fallback until a
+later backfill+contract migration. Schema-only.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2998,7 +2998,15 @@ CREATE TABLE IF NOT EXISTS risk_custom_detection_rules (
   rule_id TEXT NOT NULL,
   title TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
+  -- Legacy single-pattern matcher. Superseded by match_config; retained
+  -- (nullable) so existing rules keep evaluating until a later ticket
+  -- backfills them into match_config and contracts this column away.
   regex TEXT,
+  -- Sparse, self-describing matcher config: an ANDed/ORed list of
+  -- {target, op, value, path?} conditions over message targets (content,
+  -- user_prompt, tool_server, tool_function, tool_args, ...). When NULL the
+  -- rule falls back to the regex column. See rule_engine.go for the shape.
+  match_config JSONB,
   severity TEXT NOT NULL DEFAULT 'medium',
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1292,6 +1292,7 @@ type RiskCustomDetectionRule struct {
 	Title          string
 	Description    string
 	Regex          pgtype.Text
+	MatchConfig    []byte
 	Severity       string
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -17,6 +17,7 @@ type RiskCustomDetectionRule struct {
 	Title          string
 	Description    string
 	Regex          pgtype.Text
+	MatchConfig    []byte
 	Severity       string
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -431,7 +431,7 @@ VALUES (
   , $6
   , $7
 )
-RETURNING id, project_id, organization_id, rule_id, title, description, regex, severity, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, rule_id, title, description, regex, match_config, severity, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateCustomDetectionRuleParams struct {
@@ -463,6 +463,7 @@ func (q *Queries) CreateCustomDetectionRule(ctx context.Context, arg CreateCusto
 		&i.Title,
 		&i.Description,
 		&i.Regex,
+		&i.MatchConfig,
 		&i.Severity,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -832,7 +833,7 @@ func (q *Queries) FetchUnanalyzedMessageIDs(ctx context.Context, arg FetchUnanal
 }
 
 const getCustomDetectionRule = `-- name: GetCustomDetectionRule :one
-SELECT id, project_id, organization_id, rule_id, title, description, regex, severity, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, rule_id, title, description, regex, match_config, severity, created_at, updated_at, deleted_at, deleted
 FROM risk_custom_detection_rules
 WHERE id = $1
   AND project_id = $2
@@ -855,6 +856,7 @@ func (q *Queries) GetCustomDetectionRule(ctx context.Context, arg GetCustomDetec
 		&i.Title,
 		&i.Description,
 		&i.Regex,
+		&i.MatchConfig,
 		&i.Severity,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -1231,7 +1233,7 @@ type InsertRiskResultsParams struct {
 }
 
 const listCustomDetectionRules = `-- name: ListCustomDetectionRules :many
-SELECT id, project_id, organization_id, rule_id, title, description, regex, severity, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, rule_id, title, description, regex, match_config, severity, created_at, updated_at, deleted_at, deleted
 FROM risk_custom_detection_rules
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -1255,6 +1257,7 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 			&i.Title,
 			&i.Description,
 			&i.Regex,
+			&i.MatchConfig,
 			&i.Severity,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -2735,7 +2738,7 @@ SET title = $1
 WHERE id = $5
   AND project_id = $6
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, rule_id, title, description, regex, severity, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, rule_id, title, description, regex, match_config, severity, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDetectionRuleParams struct {
@@ -2765,6 +2768,7 @@ func (q *Queries) UpdateCustomDetectionRule(ctx context.Context, arg UpdateCusto
 		&i.Title,
 		&i.Description,
 		&i.Regex,
+		&i.MatchConfig,
 		&i.Severity,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/migrations/20260618215143_add_custom_rule_match_config.sql
+++ b/server/migrations/20260618215143_add_custom_rule_match_config.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_custom_detection_rules" table
+ALTER TABLE "risk_custom_detection_rules" ADD COLUMN "match_config" jsonb NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:bNFqsxeRpc08rZtEE2tT5QGnTx+OofgQKEOW8vjoKtU=
+h1:8VrvJeWY1+wSE3tEAHVMJXnwraXipg1jBByQ84rciXw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -222,3 +222,4 @@ h1:bNFqsxeRpc08rZtEE2tT5QGnTx+OofgQKEOW8vjoKtU=
 20260618141330_risk-results-drop-llm-judge-reason.sql h1:D1AdewSg0AisvTZYT5ta9zDyUH5sFMWvaew/BPmLDtI=
 20260618145406_remotesession-clients-relax-issuer-binding.sql h1:Ilx2asUwFZi73cQMVj5yrXGc5aq6QihR2Sd4uaC4h6o=
 20260618194743_deployments-functions-add-infra-overrides.sql h1:MNR3+BYsl1tfjLes6MbKUWqGkw/nMs8HO2cfyZvTTPs=
+20260618215143_add_custom_rule_match_config.sql h1:ZALVgDTK3jWQrHREznqnbbQDNdfIuOZAWr3VnqLAgbo=


### PR DESCRIPTION
Migration-only. Nullable `match_config` JSONB column; `regex` retained as a fallback.

**Review focus:** additive column only; no app code (the engine that reads it ships separately).