### PR TITLE
feat(dashboard): query builder for custom detection rules

### DIFF
--- a/.changeset/query-builder-detection-rules.md
+++ b/.changeset/query-builder-detection-rules.md
@@ -1,0 +1,11 @@
+---
+"dashboard": minor
+---
+
+Author custom detection rules with a structured condition builder instead of a
+single regex field: add/remove condition rows, each a target (`tool_server`,
+`tool_args` JSON path, content, …) + operator (`equals`, `contains`,
+`starts_with`, `regex`, `exists`, `is any of` for a value set, …) + value,
+combined with AND/OR. `is any of` takes a comma-separated list (e.g. match tool
+calls across servers X and Y in one row). Regex conditions accept RE2 inline
+flags such as `(?i)`. Maps to the rule `match_config` API.

--- a/client/dashboard/src/pages/security/DetectionRules.tsx
+++ b/client/dashboard/src/pages/security/DetectionRules.tsx
@@ -12,6 +12,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { Dialog } from "@/components/ui/dialog";
 import { TextArea } from "@/components/ui/textarea";
 import { Type } from "@/components/ui/type";
 import { cn } from "@/lib/utils";
@@ -43,13 +44,25 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   BUILTIN_RULES_BY_CATEGORY,
   SEVERITY_LEVELS,
+  buildMatchConfig,
+  defaultCondition,
+  ruleCombine,
+  ruleConditions,
+  ruleSummary,
   useDetectionRulesStore,
+  validateConditions,
   validateCustomRuleId,
-  validateRegex,
   type BuiltinRule,
   type CustomDetectionRule,
+  type CustomRuleDraft,
+  type MatchCombine,
   type SeverityLevel,
 } from "./detection-rules-data";
+import { ConditionBuilder } from "./condition-builder";
+import type {
+  RiskMatchConfig,
+  RiskMatchCondition,
+} from "@gram/client/models/components";
 import { RULE_CATEGORY_META, type RuleCategory } from "./policy-data";
 
 /** Presidio-backed categories: kept in the same order the policy form uses
@@ -146,9 +159,8 @@ function DetectionRulesContent() {
       <Page.Section>
         <Page.Section.Title stage="beta">Detection Rules</Page.Section.Title>
         <Page.Section.Description>
-          Built-in detection rules grouped by category. Click a rule to view its
-          description and try it against pasted text, or add your own custom
-          regex rule.
+          Reusable built-in and custom rules your policies use to flag — or
+          exempt — messages.
         </Page.Section.Description>
         <Page.Section.CTA>
           <Button onClick={() => setCreateOpen(true)}>
@@ -241,7 +253,7 @@ function CustomRulesSection({
       <div className="border-border divide-border divide-y rounded-lg border">
         <CategoryHeader
           icon={meta.icon as IconName}
-          label="Custom Patterns"
+          label={meta.label}
           description={`${rules.length} organization-defined rule${rules.length === 1 ? "" : "s"}`}
           expanded={expanded}
           onClick={onToggle}
@@ -253,7 +265,7 @@ function CustomRulesSection({
               <RuleRow
                 key={rule.id}
                 title={rule.title || rule.id}
-                subtitle={rule.id}
+                subtitle={ruleSummary(rule)}
                 onClick={() => onSelect(rule)}
               />
             ))}
@@ -455,7 +467,7 @@ function BuiltinRuleDetail({ rule }: { rule: BuiltinRule }) {
           <p className="text-sm leading-relaxed">{rule.description}</p>
         </DetailField>
 
-        <RulePlayground ruleId={rule.id} regex={null} />
+        <RulePlayground ruleId={rule.id} matchConfig={null} />
       </div>
     </>
   );
@@ -467,29 +479,33 @@ function CustomRuleDetail({
   onDelete,
 }: {
   rule: CustomDetectionRule;
-  onUpdate: (
-    patch: Partial<Omit<CustomDetectionRule, "id" | "dbId" | "createdAt">>,
-  ) => Promise<void>;
+  onUpdate: (patch: Partial<Omit<CustomRuleDraft, "id">>) => Promise<void>;
   onDelete: () => void;
 }) {
   const [title, setTitle] = useState(rule.title);
   const [description, setDescription] = useState(rule.description);
-  const [regex, setRegex] = useState(rule.regex);
+  const [conditions, setConditions] = useState<RiskMatchCondition[]>(() =>
+    ruleConditions(rule),
+  );
+  const [combine, setCombine] = useState<MatchCombine>(() => ruleCombine(rule));
   const [saveState, setSaveState] = useState<
     "idle" | "saving" | "saved" | "error"
   >("idle");
   const savedTimerRef = useRef<number | undefined>(undefined);
-  const savedValuesRef = useRef({
+  const savedRef = useRef({
     title: rule.title,
     description: rule.description,
-    regex: rule.regex,
+    matcher: JSON.stringify({
+      conditions: ruleConditions(rule),
+      combine: ruleCombine(rule),
+    }),
   });
 
-  const regexError = useMemo(() => validateRegex(regex), [regex]);
+  const conditionsError = validateConditions(conditions);
   const dirty =
-    title !== savedValuesRef.current.title ||
-    description !== savedValuesRef.current.description ||
-    regex !== savedValuesRef.current.regex;
+    title !== savedRef.current.title ||
+    description !== savedRef.current.description ||
+    JSON.stringify({ conditions, combine }) !== savedRef.current.matcher;
 
   useEffect(() => {
     if (dirty && saveState === "error") {
@@ -507,10 +523,23 @@ function CustomRuleDetail({
   );
 
   const handleSave = async () => {
+    if (conditionsError) {
+      toast.error(conditionsError);
+      return;
+    }
     setSaveState("saving");
     try {
-      await onUpdate({ title, description, regex });
-      savedValuesRef.current = { title, description, regex };
+      await onUpdate({
+        title,
+        description,
+        conditions,
+        combine,
+      });
+      savedRef.current = {
+        title,
+        description,
+        matcher: JSON.stringify({ conditions, combine }),
+      };
       setSaveState("saved");
       if (savedTimerRef.current !== undefined) {
         window.clearTimeout(savedTimerRef.current);
@@ -555,19 +584,23 @@ function CustomRuleDetail({
         </div>
 
         <div className="space-y-2">
-          <Label className="text-sm font-medium">Regex</Label>
-          <TextArea
-            value={regex}
-            onChange={setRegex}
-            rows={3}
-            className="font-mono text-xs"
+          <Label className="text-sm font-medium">Match conditions</Label>
+          <ConditionBuilder
+            conditions={conditions}
+            combine={combine}
+            onChange={(c, cb) => {
+              setConditions(c);
+              setCombine(cb);
+            }}
           />
-          {regexError && (
-            <p className="text-destructive text-xs">{regexError}</p>
-          )}
         </div>
 
-        <RulePlayground ruleId={rule.id} regex={regex} />
+        <RulePlayground
+          ruleId={rule.id}
+          matchConfig={
+            conditionsError ? null : buildMatchConfig(conditions, combine)
+          }
+        />
       </div>
       <SheetFooter className="border-border flex-row items-center justify-between border-t px-6 py-4">
         <Button
@@ -585,7 +618,10 @@ function CustomRuleDetail({
           )}
           <Button
             disabled={
-              !dirty || !!regexError || !title.trim() || saveState === "saving"
+              !dirty ||
+              !!conditionsError ||
+              !title.trim() ||
+              saveState === "saving"
             }
             onClick={() => void handleSave()}
           >
@@ -607,10 +643,10 @@ function CustomRuleDetail({
 
 function RulePlayground({
   ruleId,
-  regex,
+  matchConfig,
 }: {
   ruleId: string;
-  regex: string | null;
+  matchConfig: RiskMatchConfig | null;
 }) {
   const [mode, setMode] = useState<"sample" | "chat">("sample");
 
@@ -642,9 +678,9 @@ function RulePlayground({
       </RadioGroup>
 
       {mode === "sample" ? (
-        <SamplePlayground ruleId={ruleId} regex={regex} />
+        <SamplePlayground ruleId={ruleId} matchConfig={matchConfig} />
       ) : (
-        <ChatPlayground ruleId={ruleId} regex={regex} />
+        <ChatPlayground ruleId={ruleId} matchConfig={matchConfig} />
       )}
     </DetailField>
   );
@@ -652,10 +688,10 @@ function RulePlayground({
 
 function SamplePlayground({
   ruleId,
-  regex,
+  matchConfig,
 }: {
   ruleId: string;
-  regex: string | null;
+  matchConfig: RiskMatchConfig | null;
 }) {
   const [sample, setSample] = useState("");
   const [matches, setMatches] = useState<TestDetectionRuleMatch[] | null>(null);
@@ -680,7 +716,7 @@ function SamplePlayground({
         testDetectionRuleRequestBody: {
           ruleId,
           text: sample,
-          ...(regex ? { regex } : {}),
+          ...(matchConfig ? { matchConfig } : {}),
         },
       },
     });
@@ -775,10 +811,10 @@ type ChatMessageResult = {
 
 function ChatPlayground({
   ruleId,
-  regex,
+  matchConfig,
 }: {
   ruleId: string;
-  regex: string | null;
+  matchConfig: RiskMatchConfig | null;
 }) {
   const client = useSdkClient();
   const chatsQuery = useListChats(undefined, undefined, {
@@ -874,7 +910,7 @@ function ChatPlayground({
             testDetectionRuleRequestBody: {
               ruleId,
               text: item.fullText,
-              ...(regex ? { regex } : {}),
+              ...(matchConfig ? { matchConfig } : {}),
             },
           });
           setResults((prev) =>
@@ -1175,20 +1211,17 @@ function CreateCustomRuleSheet({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   existingCustomIds: string[];
-  onCreate: (rule: {
-    id: string;
-    title: string;
-    description: string;
-    regex: string;
-    severity: SeverityLevel;
-  }) => void;
+  onCreate: (rule: CustomRuleDraft) => void;
 }) {
   const [step, setStep] = useState<CreateStep>("prompt");
   const [askPrompt, setAskPrompt] = useState("");
   const [idSuffix, setIdSuffix] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [regex, setRegex] = useState("");
+  const [conditions, setConditions] = useState<RiskMatchCondition[]>(() => [
+    defaultCondition(),
+  ]);
+  const [combine, setCombine] = useState<MatchCombine>("and");
   const [severity, setSeverity] = useState<SeverityLevel>("medium");
 
   const reset = () => {
@@ -1197,7 +1230,8 @@ function CreateCustomRuleSheet({
     setIdSuffix("");
     setTitle("");
     setDescription("");
-    setRegex("");
+    setConditions([defaultCondition()]);
+    setCombine("and");
     setSeverity("medium");
   };
 
@@ -1207,7 +1241,16 @@ function CreateCustomRuleSheet({
       setIdSuffix(customRuleIDSuffix(next.ruleId));
       setTitle(next.title);
       setDescription(next.description);
-      setRegex(next.regex);
+      // Prefer the suggested condition matcher (which can target tool calls,
+      // arguments, keywords, …); fall back to a content/regex clause for
+      // older/heuristic suggestions that only return a regex.
+      if (next.matchConfig && next.matchConfig.conditions.length > 0) {
+        setConditions(next.matchConfig.conditions);
+        setCombine(next.matchConfig.combine === "or" ? "or" : "and");
+      } else {
+        setConditions([{ target: "content", op: "regex", value: next.regex }]);
+        setCombine("and");
+      }
       setSeverity(
         (SEVERITY_LEVELS as readonly string[]).includes(next.severity)
           ? (next.severity as SeverityLevel)
@@ -1242,7 +1285,8 @@ function CreateCustomRuleSheet({
     setIdSuffix("");
     setTitle("");
     setDescription("");
-    setRegex("");
+    setConditions([defaultCondition()]);
+    setCombine("and");
     setSeverity("medium");
     setStep("review");
   };
@@ -1257,13 +1301,10 @@ function CreateCustomRuleSheet({
         : null,
     [idSuffix, existingCustomIds],
   );
-  const regexError = useMemo(
-    () => (regex ? validateRegex(regex) : null),
-    [regex],
-  );
+  const conditionsError = validateConditions(conditions);
 
   const canSubmit =
-    idSuffix.trim() && title.trim() && regex.trim() && !idError && !regexError;
+    idSuffix.trim() && title.trim() && !idError && !conditionsError;
 
   const handleSubmit = () => {
     const finalRuleId = customRuleIDFromSuffix(idSuffix);
@@ -1272,38 +1313,38 @@ function CreateCustomRuleSheet({
       toast.error(finalIdError);
       return;
     }
-    const finalRegexError = validateRegex(regex);
-    if (finalRegexError) {
-      toast.error(finalRegexError);
+    if (conditionsError) {
+      toast.error(conditionsError);
       return;
     }
     onCreate({
       id: finalRuleId,
       title: title.trim(),
       description: description.trim(),
-      regex: regex.trim(),
+      conditions,
+      combine,
       severity,
     });
     reset();
   };
 
   return (
-    <Sheet
+    <Dialog
       open={open}
       onOpenChange={(next) => {
         onOpenChange(next);
         if (!next) reset();
       }}
     >
-      <SheetContent className="flex flex-col overflow-y-auto sm:max-w-lg">
-        <SheetHeader className="px-6 pt-6">
-          <SheetTitle>New Custom Detection Rule</SheetTitle>
-          <SheetDescription>
+      <Dialog.Content className="flex max-h-[85vh] flex-col gap-0 overflow-y-auto p-0 sm:max-w-3xl">
+        <Dialog.Header className="px-6 pt-6">
+          <Dialog.Title>New Custom Detection Rule</Dialog.Title>
+          <Dialog.Description>
             {step === "prompt"
               ? "Describe what you want to detect. We'll suggest the rule ID, regex, and severity, you tweak before saving."
               : "Review the suggested rule. Adjust any field before saving."}
-          </SheetDescription>
-        </SheetHeader>
+          </Dialog.Description>
+        </Dialog.Header>
 
         {step === "prompt" ? (
           <>
@@ -1324,7 +1365,7 @@ function CreateCustomRuleSheet({
                 </p>
               </div>
             </div>
-            <SheetFooter className="border-border flex-row items-center justify-between border-t px-6 py-4">
+            <Dialog.Footer className="border-border flex-row items-center justify-between border-t px-6 py-4">
               <Button variant="ghost" size="sm" onClick={handleManual}>
                 Skip, fill manually
               </Button>
@@ -1341,7 +1382,7 @@ function CreateCustomRuleSheet({
                 )}
                 Suggest with AI
               </Button>
-            </SheetFooter>
+            </Dialog.Footer>
           </>
         ) : (
           <>
@@ -1389,25 +1430,18 @@ function CreateCustomRuleSheet({
               </div>
 
               <div className="space-y-2">
-                <Label className="text-sm font-medium">Regex</Label>
-                <TextArea
-                  value={regex}
-                  onChange={setRegex}
-                  rows={3}
-                  className="font-mono text-xs"
-                  placeholder="e.g. acme_[a-z0-9]{32}"
+                <Label className="text-sm font-medium">Match conditions</Label>
+                <ConditionBuilder
+                  conditions={conditions}
+                  combine={combine}
+                  onChange={(c, cb) => {
+                    setConditions(c);
+                    setCombine(cb);
+                  }}
                 />
-                {regexError ? (
-                  <p className="text-destructive text-xs">{regexError}</p>
-                ) : (
-                  <p className="text-muted-foreground text-xs">
-                    Anchors are not required, the pattern is matched against the
-                    full scanned payload.
-                  </p>
-                )}
               </div>
             </div>
-            <SheetFooter className="border-border flex-row items-center justify-between border-t px-6 py-4">
+            <Dialog.Footer className="border-border flex-row items-center justify-between border-t px-6 py-4">
               <Button
                 variant="ghost"
                 size="sm"
@@ -1419,10 +1453,10 @@ function CreateCustomRuleSheet({
               <Button disabled={!canSubmit} onClick={handleSubmit}>
                 Create rule
               </Button>
-            </SheetFooter>
+            </Dialog.Footer>
           </>
         )}
-      </SheetContent>
-    </Sheet>
+      </Dialog.Content>
+    </Dialog>
   );
 }

--- a/client/dashboard/src/pages/security/condition-builder.tsx
+++ b/client/dashboard/src/pages/security/condition-builder.tsx
@@ -1,0 +1,341 @@
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import type { RiskMatchCondition } from "@gram/client/models/components";
+import { Button } from "@speakeasy-api/moonshine";
+import { Plus, X } from "lucide-react";
+import type { JSX, ReactNode } from "react";
+import {
+  defaultCondition,
+  OP_LABELS,
+  TARGET_DESCRIPTIONS,
+  TARGET_LABELS,
+  validateCondition,
+  type MatchCombine,
+} from "./detection-rules-data";
+
+type MatchTarget = RiskMatchCondition["target"];
+type MatchOp = RiskMatchCondition["op"];
+
+// Field menu order: message/prompt text first, then tool facets. Each item
+// carries a one-line description so the close-but-distinct tool fields
+// (name vs server vs function vs args) are unambiguous.
+const BUILDER_TARGETS: MatchTarget[] = [
+  "content",
+  "user_prompt",
+  "assistant_text",
+  "tool_result",
+  "tool_name",
+  "tool_server",
+  "tool_function",
+  "tool_args",
+];
+
+// Operators the builder authors, in menu order. The legacy glob/keyword ops are
+// intentionally omitted — old rules using them still parse and render, they just
+// aren't offered as new choices.
+const BUILDER_OPS: MatchOp[] = [
+  "equals",
+  "not_equals",
+  "contains",
+  "not_contains",
+  "in",
+  "starts_with",
+  "ends_with",
+  "regex",
+  "exists",
+];
+
+// Operators that match on presence alone — the value input is hidden for these.
+const VALUELESS_OPS = new Set<MatchOp>(["exists"]);
+
+// Operators that take a list of values (rendered as a comma-separated input that
+// maps to the condition's `values` array) instead of a single `value`.
+const MULTI_VALUE_OPS = new Set<MatchOp>(["in"]);
+
+// Fixed-width leading column that holds the row connector ("Where" / "and" /
+// "or"), so the field selects line up regardless of the connector content. Wide
+// enough that the and/or dropdown isn't cramped.
+const CONNECTOR = "w-[72px] shrink-0";
+
+/** A structured, no-DSL editor for a single match_config: a list of
+ *  `target <op> value` rows joined by a sentence-style connector. The AND/OR is
+ *  the editable connector on the second row (it sets the whole group); there is
+ *  no separate combinator header. Fully controlled. */
+export function ConditionBuilder({
+  conditions,
+  combine,
+  onChange,
+}: {
+  conditions: RiskMatchCondition[];
+  combine: MatchCombine;
+  onChange: (conditions: RiskMatchCondition[], combine: MatchCombine) => void;
+}): JSX.Element {
+  // Always render at least one row. When `conditions` is empty we show a blank
+  // "ghost" row (not part of the data) so scope and exemptions both present a
+  // ready-to-fill row; editing it commits the first real condition, while an
+  // untouched ghost stays out of the data — so an unused group never blocks save
+  // or persists a spurious rule.
+  const rows = conditions.length > 0 ? conditions : [defaultCondition()];
+  const removable = conditions.length > 0;
+
+  const setTarget = (i: number, target: MatchTarget) =>
+    onChange(
+      rows.map((c, j) => {
+        if (j !== i) return c;
+        const next = { ...c, target };
+        // The JSON path only applies to tool_args; drop it when leaving.
+        if (target !== "tool_args") delete next.path;
+        return next;
+      }),
+      combine,
+    );
+
+  const setOp = (i: number, op: MatchOp) =>
+    onChange(
+      rows.map((c, j) => {
+        if (j !== i) return c;
+        const next = { ...c, op };
+        if (VALUELESS_OPS.has(op)) {
+          next.value = "";
+          delete next.values;
+        } else if (MULTI_VALUE_OPS.has(op)) {
+          // Switching into a list op: seed the list from the single value so the
+          // entered text isn't lost, then drop `value`.
+          if (!(next.values ?? []).length && (next.value ?? "").trim()) {
+            next.values = [next.value!.trim()];
+          }
+          next.value = "";
+        } else {
+          // Switching into a single-value op: collapse the list back to the
+          // first value so the input stays populated, then drop `values`.
+          if (!(next.value ?? "").trim() && (next.values ?? []).length) {
+            next.value = next.values!.join(", ");
+          }
+          delete next.values;
+        }
+        return next;
+      }),
+      combine,
+    );
+
+  const patch = (i: number, fields: Partial<RiskMatchCondition>) =>
+    onChange(
+      rows.map((c, j) => (j === i ? { ...c, ...fields } : c)),
+      combine,
+    );
+
+  const remove = (i: number) =>
+    onChange(
+      rows.filter((_, j) => j !== i),
+      combine,
+    );
+
+  const add = () => onChange([...conditions, defaultCondition()], combine);
+
+  // The connector for each row: "Where" leads; the first join is an editable
+  // and/or that flips the whole group; later joins mirror it as static text.
+  const connector = (i: number): ReactNode => {
+    if (i === 0) return <span className="text-muted-foreground">Where</span>;
+    if (i === 1)
+      return (
+        <Select
+          value={combine}
+          onValueChange={(v) => onChange(conditions, v as MatchCombine)}
+        >
+          <SelectTrigger className="h-8 w-full px-2 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="and">and</SelectItem>
+            <SelectItem value="or">or</SelectItem>
+          </SelectContent>
+        </Select>
+      );
+    return (
+      <span className="text-muted-foreground">
+        {combine === "or" ? "or" : "and"}
+      </span>
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      {rows.map((condition, i) => (
+        <ConditionRow
+          // Rows are positional and fully controlled by `condition`.
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          condition={condition}
+          connector={connector(i)}
+          removable={removable}
+          onTarget={(t) => setTarget(i, t)}
+          onOp={(op) => setOp(i, op)}
+          onPatch={(fields) => patch(i, fields)}
+          onRemove={() => remove(i)}
+        />
+      ))}
+
+      <div className="flex gap-2">
+        <div className={CONNECTOR} />
+        <Button variant="secondary" onClick={add}>
+          <Button.LeftIcon>
+            <Plus className="h-4 w-4" />
+          </Button.LeftIcon>
+          <Button.Text>Add condition</Button.Text>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ConditionRow({
+  condition,
+  connector,
+  removable,
+  onTarget,
+  onOp,
+  onPatch,
+  onRemove,
+}: {
+  condition: RiskMatchCondition;
+  connector: ReactNode;
+  removable: boolean;
+  onTarget: (t: MatchTarget) => void;
+  onOp: (op: MatchOp) => void;
+  onPatch: (fields: Partial<RiskMatchCondition>) => void;
+  onRemove: () => void;
+}): JSX.Element {
+  const showValue = !VALUELESS_OPS.has(condition.op);
+  const isMulti = MULTI_VALUE_OPS.has(condition.op);
+  const isRegex = condition.op === "regex";
+  const isToolArgs = condition.target === "tool_args";
+  // Only surface a row error for content that's present but invalid (e.g. a
+  // malformed regex). "Missing value" is left to the parent's save gate so a
+  // freshly-added row doesn't shout before it's been filled in.
+  const hasContent =
+    (condition.value ?? "").trim() !== "" ||
+    (condition.values ?? []).some((v) => v.trim() !== "");
+  const valueError = hasContent ? validateCondition(condition) : null;
+
+  return (
+    <div className="space-y-1">
+      {/* Wraps so the value field drops to its own full-width line when the row
+          is too tight to keep everything inline (e.g. the narrower rule sheet),
+          instead of squeezing the value to a sliver. */}
+      <div className="flex flex-wrap items-start gap-2">
+        <div className={cn("flex h-9 items-center text-sm", CONNECTOR)}>
+          {connector}
+        </div>
+
+        <Select
+          value={condition.target}
+          onValueChange={(v) => onTarget(v as MatchTarget)}
+        >
+          <SelectTrigger className="h-9 w-[190px] shrink-0">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="w-[340px]">
+            {BUILDER_TARGETS.map((t) => (
+              <SelectItem
+                key={t}
+                value={t}
+                description={TARGET_DESCRIPTIONS[t]}
+              >
+                {TARGET_LABELS[t]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={condition.op} onValueChange={(v) => onOp(v as MatchOp)}>
+          <SelectTrigger className="h-9 w-[176px] shrink-0">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {BUILDER_OPS.map((op) => (
+              <SelectItem key={op} value={op}>
+                {OP_LABELS[op]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="flex min-w-[220px] flex-1 items-start gap-2">
+          {!showValue ? (
+            <span className="text-muted-foreground flex h-9 flex-1 items-center text-xs">
+              (any value)
+            </span>
+          ) : isMulti ? (
+            <Input
+              // Comma-separated list bound to `values`. Segments are trimmed but
+              // empties are kept while typing so a trailing comma survives; the
+              // build step drops empties before persisting.
+              value={(condition.values ?? []).join(", ")}
+              onChange={(v) =>
+                onPatch({ values: v.split(",").map((s) => s.trim()) })
+              }
+              placeholder="value1, value2, …"
+              className="h-9 min-w-0 flex-1"
+            />
+          ) : (
+            <Input
+              value={condition.value ?? ""}
+              onChange={(v) => onPatch({ value: v })}
+              placeholder={isRegex ? "regular expression" : "value"}
+              className={cn(
+                "h-9 min-w-0 flex-1",
+                isRegex && "font-mono text-xs",
+              )}
+            />
+          )}
+
+          {removable ? (
+            <button
+              type="button"
+              onClick={onRemove}
+              aria-label="Remove condition"
+              className="text-muted-foreground hover:text-foreground mt-2.5 shrink-0"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          ) : (
+            // Keep the value field's width stable when the lone ghost row has no
+            // remove affordance.
+            <div className="mt-2.5 h-4 w-4 shrink-0" />
+          )}
+        </div>
+      </div>
+
+      {isToolArgs && (
+        <div className="flex gap-2">
+          <div className={CONNECTOR} />
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground shrink-0 text-xs">
+              argument path
+            </span>
+            <Input
+              value={condition.path ?? ""}
+              onChange={(v) => onPatch({ path: v })}
+              placeholder="$.command (optional — omit to match the whole payload)"
+              className="h-8 w-[360px] max-w-full font-mono text-xs"
+            />
+          </div>
+        </div>
+      )}
+
+      {valueError && (
+        <div className="flex gap-2">
+          <div className={CONNECTOR} />
+          <p className="text-destructive text-xs">{valueError}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/security/detection-rules-data.ts
+++ b/client/dashboard/src/pages/security/detection-rules-data.ts
@@ -1,4 +1,8 @@
 import {
+  type RiskMatchCondition,
+  type RiskMatchConfig,
+} from "@gram/client/models/components";
+import {
   invalidateAllRiskListCustomDetectionRules,
   useRiskCreateCustomDetectionRuleMutation,
   useRiskDeleteCustomDetectionRuleMutation,
@@ -6,7 +10,13 @@ import {
   useRiskUpdateCustomDetectionRuleMutation,
 } from "@gram/client/react-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { DETECTION_RULES, type RuleCategory } from "./policy-data";
+import {
+  DETECTION_RULES,
+  type PolicyMessageType,
+  type RuleCategory,
+} from "./policy-data";
+
+export type { RiskMatchCondition, RiskMatchConfig };
 
 /** Severity levels assigned to a detection rule. Drives how findings show
  *  up in dashboards and (eventually) which actions a policy is allowed to
@@ -151,15 +161,32 @@ const BUILTIN_RULE_IDS = new Set<string>([
   ...Object.values(DETECTION_RULES).flatMap((rules) => rules.map((r) => r.id)),
 ]);
 
+/** How a rule's conditions reduce to a verdict. The backend stores a single,
+ *  flat combine (no nested grouping). */
+export type MatchCombine = "and" | "or";
+
 export type CustomDetectionRule = {
   id: string;
   dbId: string;
   title: string;
   description: string;
+  /** Legacy single pattern. Surfaced as a content/regex condition by
+   *  ruleConditions when matchConfig is absent. */
   regex: string;
+  matchConfig: RiskMatchConfig | null;
   severity: SeverityLevel;
   createdAt: string;
   updatedAt: string;
+};
+
+/** Fields needed to create or fully edit a custom rule's matcher. */
+export type CustomRuleDraft = {
+  id: string;
+  title: string;
+  description: string;
+  conditions: RiskMatchCondition[];
+  combine: MatchCombine;
+  severity: SeverityLevel;
 };
 
 function mapCustomDetectionRule(rule: {
@@ -168,6 +195,7 @@ function mapCustomDetectionRule(rule: {
   title: string;
   description: string;
   regex: string;
+  matchConfig?: RiskMatchConfig | null;
   severity: string;
   createdAt: Date;
   updatedAt: Date;
@@ -178,6 +206,7 @@ function mapCustomDetectionRule(rule: {
     title: rule.title,
     description: rule.description,
     regex: rule.regex,
+    matchConfig: rule.matchConfig ?? null,
     severity: rule.severity as SeverityLevel,
     createdAt: rule.createdAt.toISOString(),
     updatedAt: rule.updatedAt.toISOString(),
@@ -209,28 +238,28 @@ function useDetectionRulesStoreImpl() {
     customRules,
     isLoading: rulesQuery.isLoading,
     error: rulesQuery.error,
-    addCustomRule: (
-      rule: Omit<CustomDetectionRule, "dbId" | "createdAt" | "updatedAt">,
-    ) =>
+    addCustomRule: (rule: CustomRuleDraft) =>
       createMutation.mutate({
         request: {
           createCustomDetectionRuleRequestBody: {
             ruleId: rule.id,
             title: rule.title,
             description: rule.description,
-            regex: rule.regex,
+            matchConfig: buildMatchConfig(rule.conditions, rule.combine),
             severity: rule.severity,
           },
         },
       }),
     updateCustomRule: (
       id: string,
-      patch: Partial<Omit<CustomDetectionRule, "id" | "dbId" | "createdAt">>,
+      patch: Partial<Omit<CustomRuleDraft, "id">>,
     ) => {
       const rule = customRules.find((r) => r.id === id);
       if (!rule) {
         return Promise.reject(new Error("Custom detection rule not found"));
       }
+      const conditions = patch.conditions ?? ruleConditions(rule);
+      const combine = patch.combine ?? ruleCombine(rule);
       return updateMutation
         .mutateAsync({
           request: {
@@ -238,7 +267,7 @@ function useDetectionRulesStoreImpl() {
               id: rule.dbId,
               title: patch.title ?? rule.title,
               description: patch.description ?? rule.description,
-              regex: patch.regex ?? rule.regex,
+              matchConfig: buildMatchConfig(conditions, combine),
               severity: patch.severity ?? rule.severity,
             },
           },
@@ -290,10 +319,250 @@ export function validateCustomRuleId(
 export function validateRegex(pattern: string): string | null {
   const trimmed = pattern.trim();
   if (!trimmed) return "Regex is required";
+  // The scanner compiles with Go's RE2, which accepts a leading inline-flag
+  // group like (?i) / (?is). JS RegExp rejects those ("Invalid group"), so lift
+  // a leading (?flags) into JS flags before validating the body. RE2-only flags
+  // JS lacks (e.g. U) are ignored — the server is the source of truth.
+  let body = trimmed;
+  let flags = "";
+  const inline = /^\(\?([a-z]+)\)/.exec(trimmed);
+  if (inline) {
+    const re2Flags = inline[1] ?? "";
+    if (re2Flags.includes("i")) flags += "i";
+    if (re2Flags.includes("m")) flags += "m";
+    if (re2Flags.includes("s")) flags += "s";
+    body = trimmed.slice(inline[0].length);
+  }
   try {
-    new RegExp(trimmed);
+    new RegExp(body, flags);
     return null;
   } catch (err) {
     return err instanceof Error ? err.message : "Invalid regex";
   }
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Condition (match_config) helpers — shared by the query-builder UI         */
+/* -------------------------------------------------------------------------- */
+
+type MatchTarget = RiskMatchCondition["target"];
+type MatchOp = RiskMatchCondition["op"];
+
+export const MATCH_TARGETS = [
+  "content",
+  "user_prompt",
+  "assistant_text",
+  "tool_result",
+  "tool_name",
+  "tool_server",
+  "tool_function",
+  "tool_args",
+] as const satisfies readonly MatchTarget[];
+
+export const MATCH_OPS = [
+  "regex",
+  "equals",
+  "not_equals",
+  "glob",
+  "keyword",
+  "exists",
+] as const satisfies readonly MatchOp[];
+
+export const TARGET_LABELS: Record<MatchTarget, string> = {
+  content: "Message content",
+  user_prompt: "User prompt",
+  assistant_text: "Assistant text",
+  tool_result: "Tool result",
+  tool_name: "Tool name",
+  tool_server: "Tool server",
+  tool_function: "Tool function",
+  tool_args: "Tool argument",
+};
+
+export const OP_LABELS: Record<MatchOp, string> = {
+  equals: "equals",
+  not_equals: "does not equal",
+  contains: "contains",
+  not_contains: "does not contain",
+  in: "is one of",
+  starts_with: "starts with",
+  ends_with: "ends with",
+  regex: "matches regex",
+  glob: "matches glob",
+  keyword: "contains keyword",
+  exists: "is present",
+};
+
+/** Affordance copy for each target, shown in the query-bar suggestions so the
+ *  distinctions (esp. tool_name vs tool_server vs tool_function) are clear. */
+export const TARGET_DESCRIPTIONS: Record<MatchTarget, string> = {
+  content: "Whole message text (any message type)",
+  user_prompt: "The user's prompt text",
+  assistant_text: "The assistant's reply text",
+  tool_result: "A tool call's result output",
+  tool_name: "Raw tool-call name, e.g. mcp__mise__run_task",
+  tool_server: "MCP server name; empty for native tools (Bash, Read, …)",
+  tool_function: "Bare function name, harness-agnostic, e.g. run_task",
+  tool_args: "A value inside the tool arguments (JSON path)",
+};
+
+export const OP_DESCRIPTIONS: Record<MatchOp, string> = {
+  equals: "exact value (empty matches native tools)",
+  not_equals: "any value except this",
+  contains: "substring; union: (a OR b) matches any",
+  not_contains: "matches none of the substrings",
+  in: "exactly one of (a OR b)",
+  starts_with: "value is a prefix",
+  ends_with: "value is a suffix",
+  regex: "/RE2 regular expression/",
+  glob: "wildcard pattern, e.g. *secret*",
+  keyword: "contains any of these comma-separated terms",
+  exists: "the field is present (no value)",
+};
+
+/** Message type each target is scoped to (a tool_server condition only matches
+ *  tool-request messages, etc). `null` means the target applies to any type.
+ *  Drives the PolicyCenter coverage warning. */
+export const TARGET_MESSAGE_TYPE: Record<
+  MatchTarget,
+  PolicyMessageType | null
+> = {
+  content: null,
+  user_prompt: "user_message",
+  assistant_text: "assistant_message",
+  tool_result: "tool_response",
+  tool_name: "tool_request",
+  tool_server: "tool_request",
+  tool_function: "tool_request",
+  tool_args: "tool_request",
+};
+
+export function defaultCondition(): RiskMatchCondition {
+  return { target: "content", op: "regex", value: "" };
+}
+
+export function buildMatchConfig(
+  conditions: RiskMatchCondition[],
+  combine: MatchCombine,
+): RiskMatchConfig {
+  // Drop empty entries from list-valued conditions (the comma input keeps
+  // empties while typing, e.g. a trailing comma) before persisting.
+  const cleaned = conditions.map((c) =>
+    c.values
+      ? { ...c, values: c.values.map((v) => v.trim()).filter(Boolean) }
+      : c,
+  );
+  return { combine, conditions: cleaned };
+}
+
+/** Effective conditions for a rule — its match_config, or the legacy regex
+ *  surfaced as a single content/regex condition. */
+export function ruleConditions(
+  rule: CustomDetectionRule,
+): RiskMatchCondition[] {
+  if (rule.matchConfig && rule.matchConfig.conditions.length > 0) {
+    return rule.matchConfig.conditions;
+  }
+  if (rule.regex) {
+    return [{ target: "content", op: "regex", value: rule.regex }];
+  }
+  return [];
+}
+
+export function ruleCombine(rule: CustomDetectionRule): MatchCombine {
+  return (rule.matchConfig?.combine as MatchCombine) ?? "and";
+}
+
+/** Message types a rule can ever match, inferred from its condition targets.
+ *  Empty means "any" (a content-only rule). */
+export function ruleRequiredMessageTypes(
+  conditions: RiskMatchCondition[],
+): PolicyMessageType[] {
+  const types = new Set<PolicyMessageType>();
+  for (const c of conditions) {
+    const t = TARGET_MESSAGE_TYPE[c.target];
+    if (t) types.add(t);
+  }
+  return [...types];
+}
+
+export function validateCondition(c: RiskMatchCondition): string | null {
+  const hasValue = (c.value ?? "").trim() !== "";
+  const hasValues = (c.values ?? []).some((v) => v.trim());
+  switch (c.op) {
+    case "regex":
+      return validateRegex(c.value ?? "");
+    case "glob":
+      return hasValue ? null : "Pattern is required";
+    case "keyword":
+    case "contains":
+    case "not_contains":
+    case "in":
+      return hasValue || hasValues ? null : "Add at least one value";
+    case "starts_with":
+    case "ends_with":
+      return hasValue ? null : "Value is required";
+    // equals / not_equals / exists — empty value is allowed.
+    case "equals":
+    case "not_equals":
+    case "exists":
+      return null;
+  }
+}
+
+export function validateConditions(
+  conditions: RiskMatchCondition[],
+): string | null {
+  if (conditions.length === 0) return "Add at least one condition";
+  for (const c of conditions) {
+    const err = validateCondition(c);
+    if (err) return err;
+  }
+  return null;
+}
+
+/** A compact value-syntax summary of a condition, matching the query bar. */
+function summarizeCondition(c: RiskMatchCondition): string {
+  const field =
+    c.target === "tool_args" && c.path ? `tool_args.${c.path}` : c.target;
+  const list = (c.values ?? []).filter((v) => v.trim());
+  const operands = list.length > 0 ? list : c.value ? [c.value] : [];
+  switch (c.op) {
+    case "exists":
+      return `${field}:*`;
+    case "regex":
+      return `${field}:/${c.value ?? ""}/`;
+    case "equals":
+      return `${field}:${c.value ?? ""}`;
+    case "not_equals":
+      return `-${field}:${c.value ?? ""}`;
+    case "starts_with":
+      return `${field}:${c.value ?? ""}*`;
+    case "ends_with":
+      return `${field}:*${c.value ?? ""}`;
+    case "contains":
+    case "not_contains":
+      return `${c.op === "not_contains" ? "-" : ""}${field}:*${operands[0] ?? ""}*`;
+    case "in":
+    case "keyword":
+      return `${field}:${operands.join(", ")}`;
+    case "glob":
+      return `${field}:${c.value ?? ""}`;
+  }
+}
+
+/** Human-readable one-liner summarizing a rule's conditions, for list rows. */
+export function summarizeConditions(
+  conditions: RiskMatchCondition[],
+  combine: MatchCombine = "and",
+): string {
+  if (conditions.length === 0) return "No matcher configured";
+  const joiner = combine === "or" ? " OR " : " AND ";
+  return conditions.map(summarizeCondition).join(joiner);
+}
+
+/** List-row summary of a rule's conditions. The allow/deny polarity is no
+ *  longer a rule property — it is configured per policy. */
+export function ruleSummary(rule: CustomDetectionRule): string {
+  return summarizeConditions(ruleConditions(rule), ruleCombine(rule));
 }


### PR DESCRIPTION
**AGE-2703 frontend.** Datadog-style Monaco query bar for authoring rule `match_config`.

**Review focus:** colon-query → `match_config` mapping; operator inference; flat AND/OR only (nested grouping deferred); autocomplete docs.