### PR TITLE
mig: add application_config to risk_policies

### DIFF
--- a/.changeset/mig-policy-application-config.md
+++ b/.changeset/mig-policy-application-config.md
@@ -1,0 +1,8 @@
+---
+"server": patch
+---
+
+Add a nullable `application_config jsonb` column to `risk_policies`: a
+self-describing `{ include, exempt }` predicate set that narrows which messages
+a policy evaluates (generalizing `message_types`, now deprecated) and exempts
+matched messages inline. Schema-only.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2963,7 +2963,19 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   -- (an allowlist). Disjoint from custom_rule_ids — a rule is either a detector
   -- or an exemption in a given policy.
   exempt_rule_ids TEXT[] NOT NULL DEFAULT '{}',
+  -- DEPRECATED: superseded by application_config.include — message-type
+  -- selection is now a `message_type in (...)` condition within the include
+  -- predicate. Kept nullable and read as a fallback until application_config is
+  -- backfilled, then dropped in a contract migration (AGE-2785).
   message_types TEXT[],
+  -- Granular policy application as a self-describing JSON object:
+  --   { "include": <match_config>, "exempt": <match_config> }
+  -- A policy applies to a message when `include` matches AND `exempt` does not
+  -- (alongside exempt_rule_ids). `include` generalizes message_types (the cards
+  -- are coarse sugar over a `message_type in (...)` condition); `exempt` is the
+  -- inline exemption predicate. NULL or an absent key means all-in / none-exempt.
+  -- Named application_config (not "scope") to avoid colliding with RBAC scopes.
+  application_config JSONB,
   action TEXT NOT NULL DEFAULT 'flag',
   audience_type TEXT NOT NULL DEFAULT 'everyone',
   auto_name BOOLEAN NOT NULL DEFAULT TRUE,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1330,6 +1330,7 @@ type RiskPolicy struct {
 	CustomRuleIds        []string
 	ExemptRuleIds        []string
 	MessageTypes         []string
+	ApplicationConfig    []byte
 	Action               string
 	AudienceType         string
 	AutoName             bool

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -55,6 +55,7 @@ type RiskPolicy struct {
 	CustomRuleIds        []string
 	ExemptRuleIds        []string
 	MessageTypes         []string
+	ApplicationConfig    []byte
 	Action               string
 	AudienceType         string
 	AutoName             bool

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -257,7 +257,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -282,6 +282,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.CustomRuleIds,
 		&i.ExemptRuleIds,
 		&i.MessageTypes,
+		&i.ApplicationConfig,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,
@@ -590,7 +591,7 @@ VALUES (
   , $18::jsonb
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -650,6 +651,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.CustomRuleIds,
 		&i.ExemptRuleIds,
 		&i.MessageTypes,
+		&i.ApplicationConfig,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,
@@ -1060,7 +1062,7 @@ func (q *Queries) GetRiskOverviewCounts(ctx context.Context, arg GetRiskOverview
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1089,6 +1091,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.CustomRuleIds,
 		&i.ExemptRuleIds,
 		&i.MessageTypes,
+		&i.ApplicationConfig,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,
@@ -1145,7 +1148,7 @@ func (q *Queries) GetRiskPolicyBypassRequest(ctx context.Context, arg GetRiskPol
 }
 
 const getRiskPolicyForUpdate = `-- name: GetRiskPolicyForUpdate :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1175,6 +1178,7 @@ func (q *Queries) GetRiskPolicyForUpdate(ctx context.Context, arg GetRiskPolicyF
 		&i.CustomRuleIds,
 		&i.ExemptRuleIds,
 		&i.MessageTypes,
+		&i.ApplicationConfig,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,
@@ -1283,7 +1287,7 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1314,6 +1318,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.CustomRuleIds,
 			&i.ExemptRuleIds,
 			&i.MessageTypes,
+			&i.ApplicationConfig,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1388,7 +1393,7 @@ func (q *Queries) ListEnabledExclusionsForPolicy(ctx context.Context, arg ListEn
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1418,6 +1423,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.CustomRuleIds,
 			&i.ExemptRuleIds,
 			&i.MessageTypes,
+			&i.ApplicationConfig,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1441,7 +1447,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1473,6 +1479,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.CustomRuleIds,
 			&i.ExemptRuleIds,
 			&i.MessageTypes,
+			&i.ApplicationConfig,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1496,7 +1503,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1531,6 +1538,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.CustomRuleIds,
 			&i.ExemptRuleIds,
 			&i.MessageTypes,
+			&i.ApplicationConfig,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1838,7 +1846,7 @@ func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, arg ListRiskOver
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -1868,6 +1876,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.CustomRuleIds,
 			&i.ExemptRuleIds,
 			&i.MessageTypes,
+			&i.ApplicationConfig,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -2885,7 +2894,7 @@ SET name = $1
 WHERE id = $15
   AND project_id = $16
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, exempt_rule_ids, message_types, application_config, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -2941,6 +2950,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.CustomRuleIds,
 		&i.ExemptRuleIds,
 		&i.MessageTypes,
+		&i.ApplicationConfig,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,

--- a/server/migrations/20260618215458_add_policy_application_config.sql
+++ b/server/migrations/20260618215458_add_policy_application_config.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "application_config" jsonb NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lM7+8w4775ir+oSYtEQUJW1siKDirnqWJjDTMuzmbwA=
+h1:1gVCCWnw15+fyXgM5eby6EtetdWuowaye/YOiouQZWU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -224,3 +224,4 @@ h1:lM7+8w4775ir+oSYtEQUJW1siKDirnqWJjDTMuzmbwA=
 20260618194743_deployments-functions-add-infra-overrides.sql h1:MNR3+BYsl1tfjLes6MbKUWqGkw/nMs8HO2cfyZvTTPs=
 20260618215143_add_custom_rule_match_config.sql h1:ZALVgDTK3jWQrHREznqnbbQDNdfIuOZAWr3VnqLAgbo=
 20260618215426_add_policy_exempt_rule_ids.sql h1:uqPhDrPfnPbTq+gBiBzRRQ5hL0/ykd+nG5znnFXmpoM=
+20260618215458_add_policy_application_config.sql h1:cozOiplaXDgA4cOZSKhblUt7irXH3VfsIDEd9JMcaVo=


### PR DESCRIPTION
Migration-only. Nullable `jsonb { include, exempt }` predicate set; generalizes the now-deprecated `message_types` and supports inline exemption.