### PR TITLE
chore(auth): log forbidden access checks at warn level

### DIFF
--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -104,10 +104,8 @@ func (s *Auth) checkProjectAccess(ctx context.Context, logger *slog.Logger, proj
 		}
 	}
 
-	logger = logger.With(attr.SlogProjectSlug(projectSlug), attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
-
 	if !hasProjectAccess {
-		return ctx, oops.C(oops.CodeForbidden).LogError(ctx, logger)
+		return ctx, oops.C(oops.CodeForbidden)
 	}
 
 	ctx = contextvalues.SetAuthContext(ctx, authCtx)
@@ -126,7 +124,7 @@ func (s *Auth) CheckProjectAccess(ctx context.Context, logger *slog.Logger, proj
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return oops.C(oops.CodeForbidden).LogError(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return oops.C(oops.CodeForbidden).LogWarn(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "error checking project access").LogError(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
@@ -177,7 +175,7 @@ func (s *Auth) logAuthContext(ctx context.Context, err error, scheme string) {
 	}
 
 	if err != nil {
-		s.logger.ErrorContext(ctx, fmt.Sprintf("auth scheme check failed (%s)", scheme), attrs...)
+		s.logger.WarnContext(ctx, fmt.Sprintf("auth scheme check failed (%s)", scheme), attrs...)
 	} else {
 		s.logger.InfoContext(ctx, fmt.Sprintf("auth scheme check passed (%s)", scheme), attrs...)
 	}


### PR DESCRIPTION
A client hitting a project it cannot access is an expected, client-driven outcome rather than a server fault. Emitting these at error level inflated error metrics and triggered noisy alerts for what is normal authorization behavior, so forbidden checks now log at warn and the redundant log on the inner access check is dropped in favor of the single warn at the boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forbidden project access now logs at warn instead of error to cut noisy alerts. Only the boundary emits a warn, and auth scheme failures now warn too.

- **Refactors**
  - Emit warn (not error) for forbidden in `CheckProjectAccess` (e.g., `pgx.ErrNoRows`); unexpected errors still log as error.
  - Remove inner `checkProjectAccess` logging and logger scoping; return `oops.CodeForbidden` without logging.
  - Change `logAuthContext` failures from error to warn.

<sup>Written for commit 10c3e218b584d0a90301a60c2219ce706dae39b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

