### PR TITLE
fix(dashboard): adapt favicon via prefers-color-scheme

### DIFF
--- a/.changeset/favicon-prefers-color-scheme.md
+++ b/.changeset/favicon-prefers-color-scheme.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Adapt the favicon to the browser color scheme via prefers-color-scheme, so the transparent marketing logo stays visible on both light and dark tab bars

--- a/client/dashboard/index.html
+++ b/client/dashboard/index.html
@@ -2,8 +2,23 @@
 <html lang="en" class="dark:scheme-dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" id="favicon" href="/favicon.png" />
-    <link rel="alternate icon" id="favicon-alt" href="/favicon.ico" />
+    <!-- Favicon adapts to the browser/OS color scheme, matching the
+         Speakeasy marketing site. The PNGs are bare transparent logos, so
+         the visible variant must track the tab-bar background — which
+         follows prefers-color-scheme, not the in-app theme. -->
+    <link
+      rel="icon"
+      type="image/png"
+      href="/favicon.png"
+      media="(prefers-color-scheme: light)"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      href="/favicon-dark.png"
+      media="(prefers-color-scheme: dark)"
+    />
+    <link rel="alternate icon" href="/favicon.ico" />
 
     <!-- Apply the theme class before first paint to avoid a flash of the
          wrong theme on load. Mirrors App.tsx (key: "preferred-theme",
@@ -18,14 +33,6 @@
           var root = document.documentElement;
           root.classList.remove("light", "dark");
           root.classList.add(theme);
-          var favicon = document.getElementById("favicon");
-          var faviconAlt = document.getElementById("favicon-alt");
-          if (favicon)
-            favicon.href =
-              theme === "dark" ? "/favicon-dark.png" : "/favicon.png";
-          if (faviconAlt)
-            faviconAlt.href =
-              theme === "dark" ? "/favicon-dark.ico" : "/favicon.ico";
         } catch (e) {
           /* localStorage unavailable — fall back to CSS defaults */
         }

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -61,19 +61,8 @@ export default function App(): JSX.Element {
     root.classList.add(theme);
     root.classList.remove(theme === "dark" ? "light" : "dark");
 
-    // Update favicon based on theme
-    const favicon = document.getElementById("favicon") as HTMLLinkElement;
-    const faviconAlt = document.getElementById(
-      "favicon-alt",
-    ) as HTMLLinkElement;
-
-    if (favicon) {
-      favicon.href = theme === "dark" ? "/favicon-dark.png" : "/favicon.png";
-    }
-
-    if (faviconAlt) {
-      faviconAlt.href = theme === "dark" ? "/favicon-dark.ico" : "/favicon.ico";
-    }
+    // Favicon is driven by prefers-color-scheme in index.html (matching the
+    // marketing site), so it intentionally does not follow the in-app theme.
 
     localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, theme);
 


### PR DESCRIPTION
## Problem

[#3499](https://github.com/speakeasy-api/gram/pull/3499) switched the dashboard favicon to the marketing site logo, which is a **bare transparent** PNG (no background plate). The dashboard selected the light/dark variant from the **in-app theme** (`localStorage["preferred-theme"]`), but a browser **tab-bar's background follows the OS/browser color scheme** (`prefers-color-scheme`), which is independent of the in-app theme.

Result: with the browser in dark mode but the app defaulting to light, the light (black) logo rendered on a dark tab bar — effectively invisible (and vice versa). The old framed favicon hid this because it carried its own solid background.

## Fix

Select the favicon with `prefers-color-scheme` media queries in `index.html` — exactly how the marketing site does it — so the visible variant always matches the tab-bar background:

```html
<link rel="icon" type="image/png" href="/favicon.png"      media="(prefers-color-scheme: light)" />
<link rel="icon" type="image/png" href="/favicon-dark.png" media="(prefers-color-scheme: dark)" />
<link rel="alternate icon" href="/favicon.ico" />
```

Removes the now-redundant app-theme favicon swap from `index.html` and `App.tsx`. The before-paint theme-class logic (FOUC prevention) is unchanged.

## Notes

- Follow-up to the already-merged #3499 (which shipped the image assets).
- No asset changes here — purely the selection mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)