### PR TITLE
feat: prefer deployment function infrastructure override columns

### DIFF
--- a/.changeset/prefer-infra-override-columns.md
+++ b/.changeset/prefer-infra-override-columns.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Function deployments now prefer the operator-set `memory_mib_override` / `scale_override` columns over the config-driven memory and scale, and carry those overrides forward across redeploys so they are not reset by a later customer deploy.

--- a/server/internal/background/activities/deploy_function_runners.go
+++ b/server/internal/background/activities/deploy_function_runners.go
@@ -222,12 +222,20 @@ func (d *DeployFunctionRunners) preflightFunction(
 		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has empty asset integrity hash").LogError(ctx, logger)
 	}
 
+	// Operator-set infrastructure overrides win over the customer-supplied
+	// (gram.config.ts-driven) values when present.
 	mem := int(fnc.MemoryMib.Int32)
+	if fnc.MemoryMibOverride.Valid {
+		mem = int(fnc.MemoryMibOverride.Int32)
+	}
 	if mem < 0 || mem > constants.MaxFunctionMemoryMiB {
 		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has invalid memory configuration").LogError(ctx, logger)
 	}
 
 	scale := int(fnc.Scale.Int32)
+	if fnc.ScaleOverride.Valid {
+		scale = int(fnc.ScaleOverride.Int32)
+	}
 	if scale < 0 || scale > constants.MaxFunctionScale {
 		return empty, oops.E(oops.CodeInvariantViolation, nil, "function has invalid scale configuration").LogError(ctx, logger)
 	}

--- a/server/internal/deployments/queries.sql
+++ b/server/internal/deployments/queries.sql
@@ -318,8 +318,10 @@ INSERT INTO deployments_functions (
   , runtime
   , memory_mib
   , scale
+  , memory_mib_override
+  , scale_override
 )
-SELECT 
+SELECT
   @clone_deployment_id
   , current.asset_id
   , current.name
@@ -327,6 +329,10 @@ SELECT
   , current.runtime
   , COALESCE(current.memory_mib, @default_memory_mib::int)
   , COALESCE(current.scale, @default_scale::int)
+  -- Operator overrides are carried forward as-is (NULL or value) so they
+  -- survive a later customer deploy instead of being reset.
+  , current.memory_mib_override
+  , current.scale_override
 FROM deployments_functions as current
 WHERE current.deployment_id = @original_deployment_id
   AND current.asset_id <> ALL (@excluded_ids::uuid[])

--- a/server/internal/deployments/redeploy_test.go
+++ b/server/internal/deployments/redeploy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
@@ -657,6 +658,84 @@ func TestDeploymentsService_Redeploy_ClonesMemoryAndScale(t *testing.T) {
 	require.Equal(t, int32(2048), *redeployed.Deployment.FunctionsAssets[0].MemoryMib)
 	require.NotNil(t, redeployed.Deployment.FunctionsAssets[0].Scale)
 	require.Equal(t, int32(3), *redeployed.Deployment.FunctionsAssets[0].Scale)
+}
+
+func TestDeploymentsService_Redeploy_CarriesInfraOverridesForward(t *testing.T) {
+	t.Parallel()
+
+	assetStorage := assetstest.NewTestBlobStore(t)
+	ctx, ti := newTestDeploymentService(t, assetStorage)
+
+	fres := uploadFunctionsWithManifest(t, ctx, ti.assets, "fixtures/manifest-todo.json", "nodejs:24")
+
+	// Create initial deployment with config-driven memory and scale.
+	initial, err := ti.service.CreateDeployment(ctx, &gen.CreateDeploymentPayload{
+		IdempotencyKey:  "test-redeploy-infra-overrides",
+		Openapiv3Assets: []*gen.AddOpenAPIv3DeploymentAssetForm{},
+		Functions: []*gen.AddFunctionsForm{
+			{
+				AssetID:   fres.Asset.ID,
+				Name:      "my-functions",
+				Slug:      "my-functions",
+				Runtime:   "nodejs:24",
+				MemoryMib: new(uint(2048)),
+				Scale:     new(uint(3)),
+			},
+		},
+		Packages:         []*gen.AddDeploymentPackageForm{},
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		GithubRepo:       nil,
+		GithubPr:         nil,
+		GithubSha:        nil,
+		ExternalID:       nil,
+		ExternalURL:      nil,
+	})
+	require.NoError(t, err, "create initial deployment")
+	require.Equal(t, "completed", initial.Deployment.Status)
+
+	initialDeploymentID, err := uuid.Parse(initial.Deployment.ID)
+	require.NoError(t, err, "parse initial deployment id")
+
+	// Simulate an operator setting durable Fly infrastructure overrides directly
+	// in the database.
+	err = testrepo.New(ti.conn).SetDeploymentFunctionInfraOverrides(ctx, testrepo.SetDeploymentFunctionInfraOverridesParams{
+		DeploymentID:      initialDeploymentID,
+		MemoryMibOverride: pgtype.Int4{Int32: 4096, Valid: true},
+		ScaleOverride:     pgtype.Int4{Int32: 5, Valid: true},
+	})
+	require.NoError(t, err, "set infrastructure overrides")
+
+	// Redeploy — a fresh customer deploy must not clear operator overrides.
+	redeployed, err := ti.service.Redeploy(ctx, &gen.RedeployPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		DeploymentID:     initial.Deployment.ID,
+	})
+	require.NoError(t, err, "redeploy deployment")
+	require.Equal(t, "completed", redeployed.Deployment.Status)
+	require.NotEqual(t, initial.Deployment.ID, redeployed.Deployment.ID)
+
+	// The config-driven memory/scale are still cloned as before.
+	require.Len(t, redeployed.Deployment.FunctionsAssets, 1)
+	require.NotNil(t, redeployed.Deployment.FunctionsAssets[0].MemoryMib)
+	require.Equal(t, int32(2048), *redeployed.Deployment.FunctionsAssets[0].MemoryMib)
+	require.NotNil(t, redeployed.Deployment.FunctionsAssets[0].Scale)
+	require.Equal(t, int32(3), *redeployed.Deployment.FunctionsAssets[0].Scale)
+
+	// The operator overrides survived the clone unchanged.
+	redeployedID, err := uuid.Parse(redeployed.Deployment.ID)
+	require.NoError(t, err, "parse redeployed deployment id")
+
+	overrides, err := testrepo.New(ti.conn).GetDeploymentFunctionInfraOverrides(ctx, redeployedID)
+	require.NoError(t, err, "read cloned infrastructure overrides")
+	require.Len(t, overrides, 1)
+	require.True(t, overrides[0].MemoryMibOverride.Valid)
+	require.Equal(t, int32(4096), overrides[0].MemoryMibOverride.Int32)
+	require.True(t, overrides[0].ScaleOverride.Valid)
+	require.Equal(t, int32(5), overrides[0].ScaleOverride.Int32)
 }
 
 func TestDeploymentsService_Redeploy_DefaultsNullMemoryAndScale(t *testing.T) {

--- a/server/internal/deployments/repo/queries.sql.go
+++ b/server/internal/deployments/repo/queries.sql.go
@@ -138,8 +138,10 @@ INSERT INTO deployments_functions (
   , runtime
   , memory_mib
   , scale
+  , memory_mib_override
+  , scale_override
 )
-SELECT 
+SELECT
   $1
   , current.asset_id
   , current.name
@@ -147,6 +149,10 @@ SELECT
   , current.runtime
   , COALESCE(current.memory_mib, $2::int)
   , COALESCE(current.scale, $3::int)
+  -- Operator overrides are carried forward as-is (NULL or value) so they
+  -- survive a later customer deploy instead of being reset.
+  , current.memory_mib_override
+  , current.scale_override
 FROM deployments_functions as current
 WHERE current.deployment_id = $4
   AND current.asset_id <> ALL ($5::uuid[])

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -38,6 +38,12 @@ WHERE deployment_id = @deployment_id;
 -- name: ScrubDeploymentFunctionMachineSpecs :exec
 -- Simulates a legacy deployment by NULLing out memory_mib and scale, as if the row was inserted before these columns existed.
 UPDATE deployments_functions SET memory_mib = NULL, scale = NULL WHERE deployment_id = @deployment_id;
+
+-- name: SetDeploymentFunctionInfraOverrides :exec
+UPDATE deployments_functions SET memory_mib_override = @memory_mib_override, scale_override = @scale_override WHERE deployment_id = @deployment_id;
+
+-- name: GetDeploymentFunctionInfraOverrides :many
+SELECT memory_mib_override, scale_override FROM deployments_functions WHERE deployment_id = @deployment_id;
 -- name: CountOutboxEntriesByEventType :one
 SELECT COUNT(*)
 FROM outbox

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -116,6 +116,35 @@ func (q *Queries) CreateOrganizationUserRelationshipFixture(ctx context.Context,
 	return err
 }
 
+const getDeploymentFunctionInfraOverrides = `-- name: GetDeploymentFunctionInfraOverrides :many
+SELECT memory_mib_override, scale_override FROM deployments_functions WHERE deployment_id = $1
+`
+
+type GetDeploymentFunctionInfraOverridesRow struct {
+	MemoryMibOverride pgtype.Int4
+	ScaleOverride     pgtype.Int4
+}
+
+func (q *Queries) GetDeploymentFunctionInfraOverrides(ctx context.Context, deploymentID uuid.UUID) ([]GetDeploymentFunctionInfraOverridesRow, error) {
+	rows, err := q.db.Query(ctx, getDeploymentFunctionInfraOverrides, deploymentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetDeploymentFunctionInfraOverridesRow
+	for rows.Next() {
+		var i GetDeploymentFunctionInfraOverridesRow
+		if err := rows.Scan(&i.MemoryMibOverride, &i.ScaleOverride); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getOutboxEntry = `-- name: GetOutboxEntry :one
 SELECT id FROM outbox WHERE id = $1
 `
@@ -414,6 +443,21 @@ UPDATE deployments_functions SET memory_mib = NULL, scale = NULL WHERE deploymen
 // Simulates a legacy deployment by NULLing out memory_mib and scale, as if the row was inserted before these columns existed.
 func (q *Queries) ScrubDeploymentFunctionMachineSpecs(ctx context.Context, deploymentID uuid.UUID) error {
 	_, err := q.db.Exec(ctx, scrubDeploymentFunctionMachineSpecs, deploymentID)
+	return err
+}
+
+const setDeploymentFunctionInfraOverrides = `-- name: SetDeploymentFunctionInfraOverrides :exec
+UPDATE deployments_functions SET memory_mib_override = $1, scale_override = $2 WHERE deployment_id = $3
+`
+
+type SetDeploymentFunctionInfraOverridesParams struct {
+	MemoryMibOverride pgtype.Int4
+	ScaleOverride     pgtype.Int4
+	DeploymentID      uuid.UUID
+}
+
+func (q *Queries) SetDeploymentFunctionInfraOverrides(ctx context.Context, arg SetDeploymentFunctionInfraOverridesParams) error {
+	_, err := q.db.Exec(ctx, setDeploymentFunctionInfraOverrides, arg.MemoryMibOverride, arg.ScaleOverride, arg.DeploymentID)
 	return err
 }
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2810/feat-deployment-code-should-prefer-infrastructure-override-columns

Prefer the nullable `memory_mib_override` / `scale_override` columns on `deployments_functions` over the config-driven `memory_mib` / `scale` when building the Fly runner deploy request, and carry the overrides forward unconditionally on redeploy clone so an operator override survives a later customer deploy.

Resolved values still flow through the existing range validation, so an out-of-range override fails the deploy loudly rather than being clamped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer operator-set overrides for function memory and scale, and keep them across redeploys so customer deploys don’t reset them. Implements Linear AGE-2810; out-of-range overrides still fail validation.

- **New Features**
  - Use `memory_mib_override` / `scale_override` from `deployments_functions` when set; otherwise use config values, then defaults.
  - Clone `memory_mib_override` / `scale_override` unchanged during redeploys.

<sup>Written for commit 1f33e6e15faf8084cf21267a9af0dc9f64134f27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

