### PR TITLE
feat(assistants): add search box to the Assistants list

### DIFF
--- a/.changeset/assistants-search-box.md
+++ b/.changeset/assistants-search-box.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+feat(assistants): add a search box to the Assistants list, mirroring the MCP page. The shared `SearchBar` appears once a project has more than 6 assistants and filters the grid by name and model (case-insensitive), with a "no matches" message when a query returns nothing.

--- a/.changeset/assistants-search-box.md
+++ b/.changeset/assistants-search-box.md
@@ -2,4 +2,4 @@
 "dashboard": minor
 ---
 
-feat(assistants): add a search box to the Assistants list, mirroring the MCP page. The shared `SearchBar` appears once a project has more than 6 assistants and filters the grid by name and model (case-insensitive), with a "no matches" message when a query returns nothing.
+feat(assistants): add a search box to the Assistants list. The shared `SearchBar` is always shown above the list and filters the grid by name and model (case-insensitive), with a "no matches" message when a query returns nothing.

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -8,6 +8,7 @@ import { CardContextMenu } from "@/components/card-context-menu";
 import { Badge } from "@/components/ui/badge";
 import { DotCard } from "@/components/ui/dot-card";
 import { Action, MoreActions } from "@/components/ui/more-actions";
+import { SearchBar } from "@/components/ui/search-bar";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   PageTabsTrigger,
@@ -31,7 +32,7 @@ import { Button, Icon, Stack } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Bot, Boxes, Cpu, Info, Plus } from "lucide-react";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
-import { MouseEvent } from "react";
+import { MouseEvent, useMemo, useState } from "react";
 import { Outlet } from "react-router";
 
 import { AssistantsAuditLog } from "./AssistantAuditLog";
@@ -97,6 +98,23 @@ export default function AssistantsIndex(): JSX.Element {
 
   const assistants = data?.assistants ?? [];
 
+  const [search, setSearch] = useState("");
+
+  const filteredAssistants = useMemo(() => {
+    const query = search.toLowerCase();
+    return assistants.filter((assistant) => {
+      if (!query) return true;
+      return (
+        assistant.name.toLowerCase().includes(query) ||
+        assistant.model.toLowerCase().includes(query)
+      );
+    });
+  }, [assistants, search]);
+
+  const showSearch = !isLoading && assistants.length > 6;
+  const showNoMatches =
+    !isLoading && search !== "" && filteredAssistants.length === 0;
+
   const content =
     !isLoading && assistants.length === 0 ? (
       <AssistantsEmptyState
@@ -126,20 +144,20 @@ export default function AssistantsIndex(): JSX.Element {
           </RequireScope>
         </Page.Section.CTA>
         <Page.Section.Body>
-          {isLoading ? (
-            <Stack align="center" justify="center" className="py-16">
-              <Icon
-                name="loader-circle"
-                className="text-muted-foreground h-6 w-6 animate-spin"
-              />
-            </Stack>
-          ) : (
-            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-              {assistants.map((assistant) => (
-                <AssistantCard key={assistant.id} assistant={assistant} />
-              ))}
-            </div>
+          {showSearch && (
+            <SearchBar
+              value={search}
+              onChange={setSearch}
+              placeholder="Search assistants..."
+              className="mb-4"
+            />
           )}
+          <AssistantsBody
+            isLoading={isLoading}
+            showNoMatches={showNoMatches}
+            search={search}
+            assistants={filteredAssistants}
+          />
         </Page.Section.Body>
       </Page.Section>
     );
@@ -180,6 +198,45 @@ export default function AssistantsIndex(): JSX.Element {
         </Tabs>
       </Page.Body>
     </Page>
+  );
+}
+
+function AssistantsBody({
+  isLoading,
+  showNoMatches,
+  search,
+  assistants,
+}: {
+  isLoading: boolean;
+  showNoMatches: boolean;
+  search: string;
+  assistants: Assistant[];
+}): JSX.Element {
+  if (isLoading) {
+    return (
+      <Stack align="center" justify="center" className="py-16">
+        <Icon
+          name="loader-circle"
+          className="text-muted-foreground h-6 w-6 animate-spin"
+        />
+      </Stack>
+    );
+  }
+
+  if (showNoMatches) {
+    return (
+      <Type muted className="py-8 text-center">
+        No assistants matching &ldquo;{search}&rdquo;
+      </Type>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+      {assistants.map((assistant) => (
+        <AssistantCard key={assistant.id} assistant={assistant} />
+      ))}
+    </div>
   );
 }
 

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -111,7 +111,7 @@ export default function AssistantsIndex(): JSX.Element {
     });
   }, [assistants, search]);
 
-  const showSearch = !isLoading && (assistants.length > 6 || search !== "");
+  const showSearch = !isLoading;
   const showNoMatches =
     !isLoading && search !== "" && filteredAssistants.length === 0;
 

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -96,7 +96,7 @@ export default function AssistantsIndex(): JSX.Element {
     throwOnError: false,
   });
 
-  const assistants = data?.assistants ?? [];
+  const assistants = useMemo(() => data?.assistants ?? [], [data]);
 
   const [search, setSearch] = useState("");
 
@@ -111,7 +111,7 @@ export default function AssistantsIndex(): JSX.Element {
     });
   }, [assistants, search]);
 
-  const showSearch = !isLoading && assistants.length > 6;
+  const showSearch = !isLoading && (assistants.length > 6 || search !== "");
   const showNoMatches =
     !isLoading && search !== "" && filteredAssistants.length === 0;
 


### PR DESCRIPTION
## What
Adds a search box to the Assistants list page, matching the search experience on the MCP page.

## Details
- Reuses the shared `SearchBar` component (`@/components/ui/search-bar`) — same component the MCP page uses, so the two stay visually and behaviorally identical.
- The bar is **always visible** above the list. (Assistants lists are typically short, so the MCP page's `> 6`-item gate would hide it for most projects — it's dropped here.)
- Filters the grid by assistant **name** and **model**, case-insensitive (assistants have no slug, unlike MCP servers).
- Adds a "No assistants matching …" empty state when a query returns nothing.
- The loading / no-match / grid render branches were extracted into an `AssistantsBody` helper component instead of a nested multi-line ternary, per the frontend skill.
- `assistants` is memoized so the `filteredAssistants` `useMemo` dependency is stable (satisfies the dashboard's `oxlint --type-aware` hook rule).

## Testing
- `pnpm -F dashboard type-check` and the CI lint (`oxlint --type-aware`) pass with no errors in `Assistants.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
