### PR TITLE
chore: log destination URL and downstream body on forward failures

### DIFF
--- a/server/internal/otelforwarding/forwarder.go
+++ b/server/internal/otelforwarding/forwarder.go
@@ -123,6 +123,7 @@ func (f *Forwarder) Enqueue(ctx context.Context, job Job) {
 		f.dropped.Add(ctx, 1)
 		f.logger.WarnContext(ctx, "otel forward queue full, dropping job",
 			attr.SlogOrganizationID(job.OrgID),
+			attr.SlogURLFull(job.URL),
 		)
 	}
 }
@@ -155,12 +156,15 @@ func (f *Forwarder) send(ctx context.Context, job Job) {
 	sendCtx, span := f.tracer.Start(sendCtx, "otelforwarding.send")
 	defer span.End()
 
+	span.SetAttributes(attr.URLFull(job.URL))
+
 	req, err := http.NewRequestWithContext(sendCtx, http.MethodPost, job.URL, bytes.NewReader(job.Body))
 	if err != nil {
 		f.failed.Add(ctx, 1)
 		f.logger.WarnContext(sendCtx, "build otel forward request",
 			attr.SlogError(err),
 			attr.SlogOrganizationID(job.OrgID),
+			attr.SlogURLFull(job.URL),
 		)
 		return
 	}
@@ -177,17 +181,24 @@ func (f *Forwarder) send(ctx context.Context, job Job) {
 		f.logger.WarnContext(sendCtx, "otel forward request failed",
 			attr.SlogError(err),
 			attr.SlogOrganizationID(job.OrgID),
+			attr.SlogURLFull(job.URL),
 		)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
-		f.failed.Add(ctx, 1)
+		// Capture the truncated response prefix we already read so the
+		// downstream's rejection reason (e.g. an auth error message) is
+		// recoverable from logs instead of discarded.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		f.failed.Add(ctx, 1, metric.WithAttributes(attr.HTTPResponseStatusCode(resp.StatusCode)))
+		span.SetAttributes(attr.HTTPResponseStatusCode(resp.StatusCode))
 		f.logger.WarnContext(sendCtx, "otel forward returned error status",
 			attr.SlogHTTPResponseStatusCode(resp.StatusCode),
 			attr.SlogOrganizationID(job.OrgID),
+			attr.SlogURLFull(job.URL),
+			attr.SlogHTTPResponseBody(string(body)),
 		)
 		return
 	}

--- a/server/internal/otelforwarding/forwarder_test.go
+++ b/server/internal/otelforwarding/forwarder_test.go
@@ -1,0 +1,123 @@
+package otelforwarding
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// newCapturingForwarder builds a Forwarder whose logs are written as JSON to
+// buf so tests can assert on the emitted attributes. NewUnsafePolicy with no
+// disallowed blocks lets the pooled client reach the loopback httptest server.
+func newCapturingForwarder(t *testing.T, buf *bytes.Buffer) *Forwarder {
+	t.Helper()
+
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+
+	return NewForwarder(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), policy)
+}
+
+// findLog returns the first captured JSON log record with the given message.
+func findLog(t *testing.T, buf *bytes.Buffer, msg string) map[string]any {
+	t.Helper()
+
+	for line := range bytes.SplitSeq(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var record map[string]any
+		require.NoError(t, json.Unmarshal(line, &record))
+		if record["msg"] == msg {
+			return record
+		}
+	}
+
+	t.Fatalf("no log record with msg %q in: %s", msg, buf.String())
+	return nil
+}
+
+func TestForwarderSendErrorStatusLogsURLAndBody(t *testing.T) {
+	t.Parallel()
+
+	const downstreamMessage = "forbidden: token expired"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(downstreamMessage))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	f := newCapturingForwarder(t, &buf)
+
+	const secretHeaderValue = "Bearer super-secret-token"
+	const destURL = "/v1/traces"
+	f.send(t.Context(), Job{
+		OrgID:       "org-123",
+		URL:         server.URL + destURL,
+		ContentType: "application/x-protobuf",
+		Headers:     map[string]string{"Authorization": secretHeaderValue},
+		Body:        []byte("payload"),
+	})
+
+	record := findLog(t, &buf, "otel forward returned error status")
+	require.EqualValues(t, http.StatusForbidden, record["http.response.status_code"])
+	require.Equal(t, "org-123", record["gram.org.id"])
+	require.Equal(t, server.URL+destURL, record["url.full"], "destination URL should be logged")
+	require.Equal(t, downstreamMessage, record["http.response.body"], "downstream rejection reason should be captured")
+	require.NotContains(t, buf.String(), secretHeaderValue, "auth header value must never be logged")
+}
+
+func TestForwarderSendRequestFailedLogsURL(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	f := newCapturingForwarder(t, &buf)
+
+	// Closed listener: the request transport fails before any response.
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.Close()
+
+	f.send(t.Context(), Job{
+		OrgID:       "org-456",
+		URL:         server.URL + "/v1/metrics",
+		ContentType: "application/x-protobuf",
+		Headers:     nil,
+		Body:        []byte("payload"),
+	})
+
+	record := findLog(t, &buf, "otel forward request failed")
+	require.Equal(t, "org-456", record["gram.org.id"])
+	require.Equal(t, server.URL+"/v1/metrics", record["url.full"])
+}
+
+func TestForwarderSendSuccessNoWarning(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	f := newCapturingForwarder(t, &buf)
+
+	f.send(t.Context(), Job{
+		OrgID:       "org-789",
+		URL:         server.URL + "/v1/traces",
+		ContentType: "application/x-protobuf",
+		Headers:     nil,
+		Body:        []byte("payload"),
+	})
+
+	require.NotContains(t, buf.String(), "otel forward", "successful forward should not emit a warning")
+}

--- a/server/internal/otelforwarding/middleware.go
+++ b/server/internal/otelforwarding/middleware.go
@@ -143,6 +143,7 @@ func tryForward(ctx context.Context, logger *slog.Logger, client *Client, forwar
 		logger.WarnContext(ctx, "build otel forwarding target url",
 			attr.SlogError(err),
 			attr.SlogOrganizationID(orgID),
+			attr.SlogURLFull(cfg.URL),
 		)
 		return
 	}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/DNO-289/improve-otel-forwarding-failure-observability-for-platform-admin

Forwarding-failure warnings only carried the org ID. Add the destination URL to all forwarder warn paths, capture the truncated response body on the `>=400` path, set `url.full` and `http.response.status_code` as `otelforwarding.send` span attributes, and add a `status_code` dimension to the `otelforwarding.failed` metric.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve OTel forward failure observability by logging the destination `url.full`, capturing up to 4KB of downstream error body, and tagging spans/metrics with status codes. Aligns with Linear DNO-289 to help Platform Admins diagnose forwarding issues faster.

- **New Features**
  - Log `url.full` on all warn paths (queue full, request build/transport failures, middleware URL build errors).
  - On `>=400` responses: log truncated `http.response.body`; set `url.full` and `http.response.status_code` on `otelforwarding.send` span; add `status_code` to `otelforwarding.failed` metric.
  - Tests verify URL/body logging, no secret leakage, and no warnings on success.

<sup>Written for commit c9c7f53a17eaeece49f38ffa9d079fb66bfd4d9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

