### PR TITLE
feat(dashboard): route identity SSO/SCIM setup buttons to setup wizard

### DIFF
--- a/.changeset/identity-setup-links.md
+++ b/.changeset/identity-setup-links.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Link the SSO and Directory Sync (SCIM) "Configure" buttons on the org Identity page to the in-product setup wizard (`/setup?step=connect-idp` and `/setup?step=directory-sync`) when no connection has been set up yet, instead of bouncing admins straight to the WorkOS admin portal. Once a connection exists, the buttons continue to open the WorkOS portal to manage it.

--- a/.changeset/identity-setup-links.md
+++ b/.changeset/identity-setup-links.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Link the SSO and Directory Sync (SCIM) "Configure" buttons on the org Identity page to the in-product setup wizard (`/setup?step=connect-idp` and `/setup?step=directory-sync`) when no connection has been set up yet, instead of bouncing admins straight to the WorkOS admin portal. Once a connection exists, the buttons continue to open the WorkOS portal to manage it.
+Link the SSO and Directory Sync (SCIM) "Configure" buttons on the org Identity page to the in-product setup wizard (`/setup?step=connect-idp` and `/setup?step=directory-sync`) when no connection has been set up yet, instead of bouncing admins straight to the WorkOS admin portal. Once a connection exists, the buttons continue to open the WorkOS portal to manage it. The entitled-org configure buttons no longer emit `identity_provider_interest` PostHog tracking events; the non-entitled upsell button still does (it backs the "our team has been contacted" notification).

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -1,18 +1,17 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
-import { Dialog } from "@/components/ui/dialog";
 import { Heading } from "@/components/ui/heading";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { useOrganization, useSessionData } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
+import { useOrgRoutes } from "@/routes";
 import {
   useGenerateWorkOSAdminPortalLinkMutation,
   useProductFeatures,
 } from "@gram/client/react-query";
 import { Badge, Button } from "@speakeasy-api/moonshine";
 import { FolderSync, Loader2, Lock } from "lucide-react";
-import { useState } from "react";
 import { toast } from "sonner";
 
 const UPSELL_COPY = "Contact our team to setup SSO and Directory Sync";
@@ -86,8 +85,34 @@ function useDirectorySyncPortalTelemetry() {
   };
 }
 
-function SSOConfigureButton({ skipModal }: { skipModal?: boolean }) {
-  const [open, setOpen] = useState(false);
+/**
+ * Routes an admin into Gram's guided setup wizard at the relevant step instead
+ * of bouncing them straight to the WorkOS admin portal. Used when SSO / Directory
+ * Sync has not been configured yet so first-run setup happens in-product.
+ */
+function SetupStepButton({
+  step,
+  sectionId,
+}: {
+  step: "connect-idp" | "directory-sync";
+  sectionId: IdentitySectionId;
+}) {
+  const orgRoutes = useOrgRoutes();
+  const captureInterest = useIdentityInterestCapture(sectionId);
+
+  return (
+    <RequireScope scope="org:admin" level="component">
+      <orgRoutes.setup.Link queryParams={{ step }}>
+        <Button variant="secondary" size="sm" onClick={captureInterest}>
+          Configure
+        </Button>
+      </orgRoutes.setup.Link>
+    </RequireScope>
+  );
+}
+
+/** Launches the WorkOS admin portal to manage an existing SSO connection. */
+function SSOConfigureButton() {
   const captureInterest = useIdentityInterestCapture("sso");
 
   const generatePortalLink = useGenerateWorkOSAdminPortalLinkMutation({
@@ -112,7 +137,6 @@ function SSOConfigureButton({ skipModal }: { skipModal?: boolean }) {
           captureInterest();
           window.open(data.url, "_blank", "noopener,noreferrer");
           toast.info("Continue setup in the WorkOS portal");
-          setOpen(false);
         },
       },
     );
@@ -123,7 +147,7 @@ function SSOConfigureButton({ skipModal }: { skipModal?: boolean }) {
       <Button
         variant="secondary"
         size="sm"
-        onClick={() => (skipModal ? launchPortal() : setOpen(true))}
+        onClick={launchPortal}
         disabled={generatePortalLink.isPending}
       >
         {generatePortalLink.isPending && (
@@ -133,59 +157,12 @@ function SSOConfigureButton({ skipModal }: { skipModal?: boolean }) {
         )}
         Configure
       </Button>
-      {!skipModal && (
-        <Dialog
-          open={open}
-          onOpenChange={(next) => {
-            if (!generatePortalLink.isPending) {
-              setOpen(next);
-            }
-          }}
-        >
-          <Dialog.Content className="sm:max-w-lg">
-            <Dialog.Header>
-              <Dialog.Title>Set up Single Sign-On</Dialog.Title>
-              <Dialog.Description>
-                Connecting SSO lets your team sign in to Speakeasy using your
-                identity provider. Once configured, members will authenticate
-                through your IdP instead of using email and password.
-              </Dialog.Description>
-            </Dialog.Header>
-            <div className="space-y-3 pt-2">
-              <Type muted small>
-                You&apos;ll be redirected to configure your identity provider
-                connection.
-              </Type>
-            </div>
-            <div className="flex justify-end gap-2 pt-4">
-              <Button
-                variant="secondary"
-                onClick={() => setOpen(false)}
-                disabled={generatePortalLink.isPending}
-              >
-                Cancel
-              </Button>
-              <Button
-                onClick={launchPortal}
-                disabled={generatePortalLink.isPending}
-              >
-                {generatePortalLink.isPending && (
-                  <Button.LeftIcon>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  </Button.LeftIcon>
-                )}
-                <Button.Text>Continue to setup</Button.Text>
-              </Button>
-            </div>
-          </Dialog.Content>
-        </Dialog>
-      )}
     </RequireScope>
   );
 }
 
-function DirectorySyncConfigureButton({ skipModal }: { skipModal?: boolean }) {
-  const [open, setOpen] = useState(false);
+/** Launches the WorkOS admin portal to manage an existing Directory Sync link. */
+function DirectorySyncConfigureButton() {
   const captureOpened = useDirectorySyncPortalTelemetry();
 
   const generatePortalLink = useGenerateWorkOSAdminPortalLinkMutation({
@@ -212,7 +189,6 @@ function DirectorySyncConfigureButton({ skipModal }: { skipModal?: boolean }) {
           captureOpened();
           window.open(data.url, "_blank", "noopener,noreferrer");
           toast.info("Continue setup in the WorkOS portal");
-          setOpen(false);
         },
       },
     );
@@ -223,7 +199,7 @@ function DirectorySyncConfigureButton({ skipModal }: { skipModal?: boolean }) {
       <Button
         variant="secondary"
         size="sm"
-        onClick={() => (skipModal ? launchPortal() : setOpen(true))}
+        onClick={launchPortal}
         disabled={generatePortalLink.isPending}
       >
         {generatePortalLink.isPending && (
@@ -233,61 +209,41 @@ function DirectorySyncConfigureButton({ skipModal }: { skipModal?: boolean }) {
         )}
         Configure
       </Button>
-      {!skipModal && (
-        <Dialog
-          open={open}
-          onOpenChange={(next) => {
-            if (!generatePortalLink.isPending) {
-              setOpen(next);
-            }
-          }}
-        >
-          <Dialog.Content className="sm:max-w-lg">
-            <Dialog.Header>
-              <Dialog.Title>Set up Directory Sync</Dialog.Title>
-              <Dialog.Description>
-                Connecting Directory Sync lets your identity provider manage who
-                belongs to this workspace and which role each directory user
-                has. You&apos;ll still create roles and grants in Speakeasy, but
-                role assignments for synced users will be controlled by your
-                identity provider&apos;s groups.
-              </Dialog.Description>
-            </Dialog.Header>
-            <div className="space-y-3 pt-2">
-              <Type muted small>
-                Members you invite outside of your directory will continue to be
-                managed here.
-              </Type>
-              <Type muted small>
-                You&apos;ll be redirected to your identity provider to complete
-                setup.
-              </Type>
-            </div>
-            <div className="flex justify-end gap-2 pt-4">
-              <Button
-                variant="secondary"
-                onClick={() => setOpen(false)}
-                disabled={generatePortalLink.isPending}
-              >
-                Cancel
-              </Button>
-              <Button
-                onClick={launchPortal}
-                disabled={generatePortalLink.isPending}
-              >
-                {generatePortalLink.isPending && (
-                  <Button.LeftIcon>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  </Button.LeftIcon>
-                )}
-                <Button.Text>Continue to setup</Button.Text>
-              </Button>
-            </div>
-          </Dialog.Content>
-        </Dialog>
-      )}
     </RequireScope>
   );
+}
+
+/**
+ * Picks the SSO configure control: upsell when the feature is not entitled, the
+ * WorkOS portal launcher once a connection exists, otherwise the in-product
+ * setup wizard for first-run configuration.
+ */
+function SSOConfigureControl({
+  featureEnabled,
+  active,
+}: {
+  featureEnabled: boolean;
+  active: boolean;
+}) {
+  if (!featureEnabled) return <ConfigureButton sectionId="sso" />;
+  if (active) return <SSOConfigureButton />;
+  return <SetupStepButton step="connect-idp" sectionId="sso" />;
+}
+
+/**
+ * Picks the Directory Sync configure control, mirroring {@link SSOConfigureControl}:
+ * upsell, WorkOS portal launcher, or the in-product setup wizard.
+ */
+function DirectorySyncConfigureControl({
+  featureEnabled,
+  active,
+}: {
+  featureEnabled: boolean;
+  active: boolean;
+}) {
+  if (!featureEnabled) return <ConfigureButton sectionId="directory_sync" />;
+  if (active) return <DirectorySyncConfigureButton />;
+  return <SetupStepButton step="directory-sync" sectionId="directory_sync" />;
 }
 
 function IdentitySection({
@@ -390,11 +346,10 @@ function OrgIdentityInner() {
           learnMoreHref="https://www.speakeasy.com/docs"
           active={ssoActive}
           configureButton={
-            ssoFeatureEnabled ? (
-              <SSOConfigureButton skipModal={ssoActive} />
-            ) : (
-              <ConfigureButton sectionId="sso" />
-            )
+            <SSOConfigureControl
+              featureEnabled={ssoFeatureEnabled}
+              active={ssoActive}
+            />
           }
         />
 
@@ -415,11 +370,10 @@ function OrgIdentityInner() {
           learnMoreHref="https://www.speakeasy.com/docs"
           active={scimActive}
           configureButton={
-            scimFeatureEnabled ? (
-              <DirectorySyncConfigureButton skipModal={scimActive} />
-            ) : (
-              <ConfigureButton sectionId="directory_sync" />
-            )
+            <DirectorySyncConfigureControl
+              featureEnabled={scimFeatureEnabled}
+              active={scimActive}
+            />
           }
         />
       </div>

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -32,7 +32,12 @@ type IdentityCardProps = {
   children?: React.ReactNode;
 };
 
-function useIdentityInterestCapture(sectionId: IdentitySectionId) {
+/**
+ * Notifies our team that a non-entitled org wants SSO / Directory Sync. This
+ * capture backs the "our team has been contacted" upsell toast, so it stays even
+ * though the entitled-org configure buttons no longer emit tracking events.
+ */
+function useUpsellInterestCapture(sectionId: IdentitySectionId) {
   const telemetry = useTelemetry();
   const { session } = useSessionData();
 
@@ -49,7 +54,7 @@ function useIdentityInterestCapture(sectionId: IdentitySectionId) {
 }
 
 function ConfigureButton({ sectionId }: { sectionId: IdentitySectionId }) {
-  const captureInterest = useIdentityInterestCapture(sectionId);
+  const captureInterest = useUpsellInterestCapture(sectionId);
 
   return (
     <SimpleTooltip tooltip={UPSELL_COPY}>
@@ -69,41 +74,18 @@ function ConfigureButton({ sectionId }: { sectionId: IdentitySectionId }) {
   );
 }
 
-function useDirectorySyncPortalTelemetry() {
-  const telemetry = useTelemetry();
-  const { session } = useSessionData();
-
-  return () => {
-    telemetry.capture("identity_provider_interest", {
-      section: "directory_sync",
-      action: "dsync_portal_opened",
-      email: session?.user.email ?? "",
-      organization_id: session?.organization?.id ?? "",
-      organization_name: session?.organization?.name ?? "",
-      organization_slug: session?.organization?.slug ?? "",
-    });
-  };
-}
-
 /**
  * Routes an admin into Gram's guided setup wizard at the relevant step instead
  * of bouncing them straight to the WorkOS admin portal. Used when SSO / Directory
  * Sync has not been configured yet so first-run setup happens in-product.
  */
-function SetupStepButton({
-  step,
-  sectionId,
-}: {
-  step: "connect-idp" | "directory-sync";
-  sectionId: IdentitySectionId;
-}) {
+function SetupStepButton({ step }: { step: "connect-idp" | "directory-sync" }) {
   const orgRoutes = useOrgRoutes();
-  const captureInterest = useIdentityInterestCapture(sectionId);
 
   return (
     <RequireScope scope="org:admin" level="component">
       <orgRoutes.setup.Link queryParams={{ step }}>
-        <Button variant="secondary" size="sm" onClick={captureInterest}>
+        <Button variant="secondary" size="sm">
           Configure
         </Button>
       </orgRoutes.setup.Link>
@@ -113,8 +95,6 @@ function SetupStepButton({
 
 /** Launches the WorkOS admin portal to manage an existing SSO connection. */
 function SSOConfigureButton() {
-  const captureInterest = useIdentityInterestCapture("sso");
-
   const generatePortalLink = useGenerateWorkOSAdminPortalLinkMutation({
     onError: (error) => {
       toast.error(
@@ -134,7 +114,6 @@ function SSOConfigureButton() {
       },
       {
         onSuccess: (data) => {
-          captureInterest();
           window.open(data.url, "_blank", "noopener,noreferrer");
           toast.info("Continue setup in the WorkOS portal");
         },
@@ -163,8 +142,6 @@ function SSOConfigureButton() {
 
 /** Launches the WorkOS admin portal to manage an existing Directory Sync link. */
 function DirectorySyncConfigureButton() {
-  const captureOpened = useDirectorySyncPortalTelemetry();
-
   const generatePortalLink = useGenerateWorkOSAdminPortalLinkMutation({
     onError: (error) => {
       toast.error(
@@ -186,7 +163,6 @@ function DirectorySyncConfigureButton() {
       },
       {
         onSuccess: (data) => {
-          captureOpened();
           window.open(data.url, "_blank", "noopener,noreferrer");
           toast.info("Continue setup in the WorkOS portal");
         },
@@ -227,7 +203,7 @@ function SSOConfigureControl({
 }) {
   if (!featureEnabled) return <ConfigureButton sectionId="sso" />;
   if (active) return <SSOConfigureButton />;
-  return <SetupStepButton step="connect-idp" sectionId="sso" />;
+  return <SetupStepButton step="connect-idp" />;
 }
 
 /**
@@ -243,7 +219,7 @@ function DirectorySyncConfigureControl({
 }) {
   if (!featureEnabled) return <ConfigureButton sectionId="directory_sync" />;
   if (active) return <DirectorySyncConfigureButton />;
-  return <SetupStepButton step="directory-sync" sectionId="directory_sync" />;
+  return <SetupStepButton step="directory-sync" />;
 }
 
 function IdentitySection({


### PR DESCRIPTION
## What

On the org **Identity** page, the **SSO** and **Directory Sync (SCIM)** "Configure" buttons now behave differently depending on whether a connection has been set up:

- **Not configured yet** → link into Gram's guided **setup wizard** at the relevant step:
  - SSO → `/setup?step=connect-idp`
  - SCIM → `/setup?step=directory-sync`
- **Already connected** → unchanged; still opens the WorkOS admin portal to manage the existing connection.
- **Not entitled** (feature flag off) → unchanged upsell button.

## Why

Dropping admins who haven't set anything up straight into the raw WorkOS admin portal is a rough first-run experience. Routing them through the in-product setup wizard gives a guided flow instead.

## How

- Replaced the old "open confirmation modal → launch WorkOS portal" path (used only in the not-configured state) with a `SetupStepButton` that navigates via the type-safe route helper `useOrgRoutes().setup.Link` with `queryParams={{ step }}` — no hardcoded org slug, works for every tenant.
- Extracted the three-way decision (upsell / manage / first-run setup) into small per-provider control components (`SSOConfigureControl`, `DirectorySyncConfigureControl`) to keep the JSX flat (no nested ternaries).
- The now-unused confirmation `Dialog` and `useState` were removed.

## Testing

- `tsc -b --noEmit --force` (dashboard) ✓
- `oxfmt --check` ✓
- `oxlint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the Identity page SSO and Directory Sync (SCIM) “Configure” buttons to the setup wizard when no connection exists (SSO → `/setup?step=connect-idp`, SCIM → `/setup?step=directory-sync`). Existing connections still open the WorkOS admin portal; the upsell stays the same and is the only path that still tracks interest.

- **Refactors**
  - Added `SetupStepButton` using `useOrgRoutes().setup.Link` for first-run setup.
  - Introduced `SSOConfigureControl` and `DirectorySyncConfigureControl` to choose upsell vs manage vs setup.
  - Removed the confirmation `Dialog` and local state; dropped PostHog `identity_provider_interest` from entitled configure buttons (upsell retains capture via `useUpsellInterestCapture`).

<sup>Written for commit de6d2800473cb8f715a7c0b7c5862b31db30f1bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

