### PR TITLE
chore: i'm sick and tired of this toolbar position

### DIFF
--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -447,7 +447,7 @@ function RBACDevToolbarInner({ onHide }: { onHide: () => void }) {
     <div
       ref={rootRef}
       className="pointer-events-auto fixed z-[99999] select-none"
-      style={pos ? { left: pos.x, top: pos.y } : { left: 16, bottom: 16 }}
+      style={pos ? { left: pos.x, top: pos.y } : { right: 16, bottom: 16 }}
     >
       <div className={`
           w-80 rounded-xl border shadow-2xl backdrop-blur-md transition-all


### PR DESCRIPTION
Moves the developer toolkit so it doesn't hover a bunch of important stuff by default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the developer toolbar default from bottom-left to bottom-right so it doesn’t cover important UI. Custom/dragged positions still take precedence when set.

<sup>Written for commit dc53747a16c6b55dda5da53a0789e619274a438f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

