### PR TITLE
fix(assistants): drop truncated tool_call generations at chat capture

### DIFF
--- a/.changeset/drop-truncated-tool-call-generations.md
+++ b/.changeset/drop-truncated-tool-call-generations.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix(assistants): stop assistant threads from getting stuck when a model response is cut off mid-tool-call. A truncated generation used to be saved with malformed tool-call arguments, which made the thread fail and retry forever (silent assistants, wedged cron digests). Such generations are now dropped at capture while the preceding messages are kept, so the thread stays usable.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -722,7 +722,7 @@ func newStartCommand() *cli.Command {
 			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db, assetStorage)
 			shutdownFuncs = append(shutdownFuncs, chatWriterShutdown)
 
-			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, db, chatWriter)
+			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, meterProvider, db, chatWriter)
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -564,7 +564,7 @@ func newWorkerCommand() *cli.Command {
 			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db, assetStorage)
 			shutdownFuncs = append(shutdownFuncs, chatWriterShutdown)
 
-			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, db, chatWriter)
+			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, meterProvider, db, chatWriter)
 
 			riskSignaler := background.NewThrottledSignaler(
 				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger},

--- a/server/internal/chat/hash.go
+++ b/server/internal/chat/hash.go
@@ -106,12 +106,27 @@ func toolCallIDsFromStoredJSON(toolCallsJSON []byte) []string {
 // tool_call IDs only, so capture and replay do not need byte-identical
 // JSON serialization.
 func assistantToolCallsJSON(msg or.ChatMessages) ([]byte, error) {
-	if msg.Type != or.ChatMessagesTypeAssistant {
+	out := assistantToolCalls(msg)
+	if len(out) == 0 {
 		return nil, nil
+	}
+	bs, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("marshal assistant tool calls: %w", err)
+	}
+	return bs, nil
+}
+
+// assistantToolCalls extracts an incoming assistant message's tool_calls in the
+// openrouter shape. Returns nil for non-assistant messages or assistants
+// without tool_calls.
+func assistantToolCalls(msg or.ChatMessages) []openrouter.ToolCall {
+	if msg.Type != or.ChatMessagesTypeAssistant {
+		return nil
 	}
 	calls := msg.ChatAssistantMessage.GetToolCalls()
 	if len(calls) == 0 {
-		return nil, nil
+		return nil
 	}
 	out := make([]openrouter.ToolCall, len(calls))
 	for i, c := range calls {
@@ -125,9 +140,5 @@ func assistantToolCallsJSON(msg or.ChatMessages) ([]byte, error) {
 			},
 		}
 	}
-	bs, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("marshal assistant tool calls: %w", err)
-	}
-	return bs, nil
+	return out
 }

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -25,18 +25,14 @@ import (
 // chat is treated as deliberately titled and never retitled.
 const DefaultChatTitle = "New Chat"
 
-// meterChatDroppedGenerations counts assistant generations dropped at capture
-// because the model produced malformed tool_call arguments.
-const meterChatDroppedGenerations = "chat.capture.dropped_generations"
-
 // ChatMessageCaptureStrategy captures completion messages to the database.
 // It implements the MessageCaptureStrategy interface.
 type ChatMessageCaptureStrategy struct {
-	logger             *slog.Logger
-	db                 *pgxpool.Pool
-	repo               *repo.Queries
-	writer             *ChatMessageWriter
-	droppedGenerations metric.Int64Counter
+	logger  *slog.Logger
+	db      *pgxpool.Pool
+	repo    *repo.Queries
+	writer  *ChatMessageWriter
+	metrics *captureMetrics
 }
 
 var _ openrouter.MessageCaptureStrategy = (*ChatMessageCaptureStrategy)(nil)
@@ -59,22 +55,12 @@ func NewChatMessageCaptureStrategy(
 	db *pgxpool.Pool,
 	writer *ChatMessageWriter,
 ) *ChatMessageCaptureStrategy {
-	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/chat")
-	droppedGenerations, err := meter.Int64Counter(
-		meterChatDroppedGenerations,
-		metric.WithDescription("Assistant generations dropped at capture because the model produced malformed tool_call arguments"),
-		metric.WithUnit("{generation}"),
-	)
-	if err != nil {
-		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterChatDroppedGenerations), attr.SlogError(err))
-	}
-
 	return &ChatMessageCaptureStrategy{
-		logger:             logger,
-		db:                 db,
-		repo:               repo.New(db),
-		writer:             writer,
-		droppedGenerations: droppedGenerations,
+		logger:  logger,
+		db:      db,
+		repo:    repo.New(db),
+		writer:  writer,
+		metrics: newCaptureMetrics(meterProvider, logger),
 	}
 }
 
@@ -448,12 +434,7 @@ func (s *ChatMessageCaptureStrategy) recordDroppedGeneration(ctx context.Context
 		attr.SlogProjectID(projectID.String()),
 		attr.SlogToolName(toolName),
 	)
-	if s.droppedGenerations != nil {
-		s.droppedGenerations.Add(ctx, 1, metric.WithAttributes(
-			attr.ProjectID(projectID.String()),
-			attr.ToolName(toolName),
-		))
-	}
+	s.metrics.RecordDroppedGeneration(ctx, projectID, toolName)
 }
 
 // dropPoisonedAssistantMessages removes incoming assistant messages whose

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -120,7 +120,11 @@ func (s *ChatMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, requ
 		matchedPrefix = 0
 	}
 
-	newMessages := request.Messages[matchedPrefix:]
+	// A client can replay a previous turn's aborted assistant message, whose
+	// tool_call arguments are malformed JSON. Drop it here for the same reason
+	// CaptureMessage drops the response: neither ingress may persist a row the
+	// runner can't replay.
+	newMessages := s.dropPoisonedAssistantMessages(ctx, request, projectID, request.Messages[matchedPrefix:])
 	if len(newMessages) == 0 {
 		return &chatCaptureSession{
 			generation:  generation,
@@ -331,18 +335,7 @@ func (s *ChatMessageCaptureStrategy) CaptureMessage(
 	// must never enter the transcript. Drop the assistant row but still flush
 	// the preceding user/tool input, keeping the transcript tail drivable.
 	if toolName, ok := firstInvalidToolCall(response.ToolCalls); ok {
-		s.logger.WarnContext(ctx, "dropping assistant generation with malformed tool_call arguments",
-			attr.SlogChatID(request.ChatID.String()),
-			attr.SlogProjectID(projectID.String()),
-			attr.SlogToolName(toolName),
-			attr.SlogChatModel(response.Model),
-		)
-		if s.droppedGenerations != nil {
-			s.droppedGenerations.Add(ctx, 1, metric.WithAttributes(
-				attr.ProjectID(projectID.String()),
-				attr.ToolName(toolName),
-			))
-		}
+		s.recordDroppedGeneration(ctx, request.ChatID, projectID, toolName, "dropping assistant generation with malformed tool_call arguments")
 		if len(session.pendingRows) > 0 {
 			if err := s.writer.WriteWithAssets(ctx, projectID, session.pendingRows); err != nil {
 				s.logger.ErrorContext(ctx, "failed to store chat input messages after dropping assistant generation", attr.SlogError(err))
@@ -445,6 +438,70 @@ func firstInvalidToolCall(toolCalls []openrouter.ToolCall) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// recordDroppedGeneration logs and counts a generation dropped at capture
+// because the model produced malformed tool_call arguments.
+func (s *ChatMessageCaptureStrategy) recordDroppedGeneration(ctx context.Context, chatID, projectID uuid.UUID, toolName, msg string) {
+	s.logger.WarnContext(ctx, msg,
+		attr.SlogChatID(chatID.String()),
+		attr.SlogProjectID(projectID.String()),
+		attr.SlogToolName(toolName),
+	)
+	if s.droppedGenerations != nil {
+		s.droppedGenerations.Add(ctx, 1, metric.WithAttributes(
+			attr.ProjectID(projectID.String()),
+			attr.ToolName(toolName),
+		))
+	}
+}
+
+// dropPoisonedAssistantMessages removes incoming assistant messages whose
+// tool_call arguments are malformed JSON, along with any tool results that pair
+// with the dropped calls — keeping a tool_result without its tool_use orphans
+// it and the model rejects the replay. This is the input-side counterpart to
+// the drop in CaptureMessage.
+func (s *ChatMessageCaptureStrategy) dropPoisonedAssistantMessages(ctx context.Context, request openrouter.CompletionRequest, projectID uuid.UUID, msgs []or.ChatMessages) []or.ChatMessages {
+	droppedCallIDs := make(map[string]struct{})
+	for _, msg := range msgs {
+		calls := assistantToolCalls(msg)
+		toolName, ok := firstInvalidToolCall(calls)
+		if !ok {
+			continue
+		}
+		for _, c := range calls {
+			droppedCallIDs[c.ID] = struct{}{}
+		}
+		s.recordDroppedGeneration(ctx, request.ChatID, projectID, toolName, "dropping replayed assistant message with malformed tool_call arguments")
+	}
+	if len(droppedCallIDs) == 0 {
+		return msgs
+	}
+
+	kept := make([]or.ChatMessages, 0, len(msgs))
+	for _, msg := range msgs {
+		if pairsWithDroppedCall(msg, droppedCallIDs) {
+			continue
+		}
+		kept = append(kept, msg)
+	}
+	return kept
+}
+
+// pairsWithDroppedCall reports whether msg is a dropped assistant message (one
+// of its tool_calls is in the set) or a tool result for one of those calls.
+func pairsWithDroppedCall(msg or.ChatMessages, droppedCallIDs map[string]struct{}) bool {
+	for _, c := range assistantToolCalls(msg) {
+		if _, ok := droppedCallIDs[c.ID]; ok {
+			return true
+		}
+	}
+	if tcID := openrouter.GetToolCallID(msg); tcID != nil {
+		if _, ok := droppedCallIDs[*tcID]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveSession returns the session produced by StartOrResumeChat. If the

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -10,6 +10,8 @@ import (
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -23,13 +25,18 @@ import (
 // chat is treated as deliberately titled and never retitled.
 const DefaultChatTitle = "New Chat"
 
+// meterChatDroppedGenerations counts assistant generations dropped at capture
+// because the model produced malformed tool_call arguments.
+const meterChatDroppedGenerations = "chat.capture.dropped_generations"
+
 // ChatMessageCaptureStrategy captures completion messages to the database.
 // It implements the MessageCaptureStrategy interface.
 type ChatMessageCaptureStrategy struct {
-	logger *slog.Logger
-	db     *pgxpool.Pool
-	repo   *repo.Queries
-	writer *ChatMessageWriter
+	logger             *slog.Logger
+	db                 *pgxpool.Pool
+	repo               *repo.Queries
+	writer             *ChatMessageWriter
+	droppedGenerations metric.Int64Counter
 }
 
 var _ openrouter.MessageCaptureStrategy = (*ChatMessageCaptureStrategy)(nil)
@@ -48,14 +55,26 @@ type chatCaptureSession struct {
 // NewChatMessageCaptureStrategy creates a new ChatMessageCaptureStrategy.
 func NewChatMessageCaptureStrategy(
 	logger *slog.Logger,
+	meterProvider metric.MeterProvider,
 	db *pgxpool.Pool,
 	writer *ChatMessageWriter,
 ) *ChatMessageCaptureStrategy {
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/chat")
+	droppedGenerations, err := meter.Int64Counter(
+		meterChatDroppedGenerations,
+		metric.WithDescription("Assistant generations dropped at capture because the model produced malformed tool_call arguments"),
+		metric.WithUnit("{generation}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterChatDroppedGenerations), attr.SlogError(err))
+	}
+
 	return &ChatMessageCaptureStrategy{
-		logger: logger,
-		db:     db,
-		repo:   repo.New(db),
-		writer: writer,
+		logger:             logger,
+		db:                 db,
+		repo:               repo.New(db),
+		writer:             writer,
+		droppedGenerations: droppedGenerations,
 	}
 }
 
@@ -306,6 +325,33 @@ func (s *ChatMessageCaptureStrategy) CaptureMessage(
 		return err
 	}
 
+	// A truncated/aborted completion stream can leave a tool_call with
+	// unterminated JSON arguments. The runner's normalize_history rejects such
+	// a row on replay and the turn then retries without a cap, so the poison
+	// must never enter the transcript. Drop the assistant row but still flush
+	// the preceding user/tool input, keeping the transcript tail drivable.
+	if toolName, ok := firstInvalidToolCall(response.ToolCalls); ok {
+		s.logger.WarnContext(ctx, "dropping assistant generation with malformed tool_call arguments",
+			attr.SlogChatID(request.ChatID.String()),
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogToolName(toolName),
+			attr.SlogChatModel(response.Model),
+		)
+		if s.droppedGenerations != nil {
+			s.droppedGenerations.Add(ctx, 1, metric.WithAttributes(
+				attr.ProjectID(projectID.String()),
+				attr.ToolName(toolName),
+			))
+		}
+		if len(session.pendingRows) > 0 {
+			if err := s.writer.WriteWithAssets(ctx, projectID, session.pendingRows); err != nil {
+				s.logger.ErrorContext(ctx, "failed to store chat input messages after dropping assistant generation", attr.SlogError(err))
+				return fmt.Errorf("store chat input messages: %w", err)
+			}
+		}
+		return nil
+	}
+
 	assistantRows := buildAssistantRows(request, response, projectID, toolCallsJSON, origin, userAgent, ipAddress, session.generation)
 
 	if len(session.pendingRows) == 0 {
@@ -383,6 +429,22 @@ func buildAssistantRows(
 	only.TotalTokens = totalTokens
 
 	return []repo.CreateChatMessageParams{only}
+}
+
+// firstInvalidToolCall mirrors the runner's normalize_history validation:
+// empty arguments are treated as an empty object; anything else must be valid
+// JSON. A truncated/aborted completion stream leaves unterminated JSON here.
+func firstInvalidToolCall(toolCalls []openrouter.ToolCall) (string, bool) {
+	for _, tc := range toolCalls {
+		args := tc.Function.Arguments
+		if args == "" {
+			continue
+		}
+		if !json.Valid([]byte(args)) {
+			return tc.Function.Name, true
+		}
+	}
+	return "", false
 }
 
 // resolveSession returns the session produced by StartOrResumeChat. If the

--- a/server/internal/chat/message_capture_strategy_test.go
+++ b/server/internal/chat/message_capture_strategy_test.go
@@ -24,6 +24,7 @@ func newCaptureStrategy(t *testing.T, conn *pgxpool.Pool) *chat.ChatMessageCaptu
 	t.Cleanup(func() { _ = writerShutdown(t.Context()) })
 	return chat.NewChatMessageCaptureStrategy(
 		testenv.NewLogger(t),
+		testenv.NewMeterProvider(t),
 		conn,
 		writer,
 	)
@@ -663,6 +664,71 @@ func TestCaptureMessage_StoresAssistantResponseWithBothTextAndToolCallsInSingleR
 	require.Equal(t, int64(10), assistant.PromptTokens)
 	require.Equal(t, int64(5), assistant.CompletionTokens)
 	require.Equal(t, int64(15), assistant.TotalTokens)
+}
+
+// A truncated/aborted generation persists a tool_call with unterminated JSON
+// arguments. The runner rejects such a row on replay and the turn retries
+// without a cap, so capture must drop the assistant row while keeping the
+// preceding user input — the transcript tail stays drivable. Valid (or empty)
+// arguments are unaffected.
+func TestCaptureMessage_DropsGenerationWithMalformedToolCallArgs(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name      string
+		arguments []string // one entry per tool call in the response
+		dropped   bool
+	}{
+		{name: "valid object args", arguments: []string{`{"city":"SF"}`}, dropped: false},
+		{name: "empty args treated as object", arguments: []string{``}, dropped: false},
+		{name: "truncated object", arguments: []string{`{"city":"SF`}, dropped: true},
+		{name: "truncated array", arguments: []string{`[{"a":1}`}, dropped: true},
+		{name: "not json", arguments: []string{`not json at all`}, dropped: true},
+		{name: "second call truncated", arguments: []string{`{"ok":true}`, `{"half":`}, dropped: true},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ti := newTestChatService(t)
+			ctx, conn, projectID, orgID := t.Context(), ti.conn, ti.projectID, ti.orgID
+			s := newCaptureStrategy(t, conn)
+			chatID := uuid.New()
+
+			toolCalls := make([]openrouter.ToolCall, len(tc.arguments))
+			for i, args := range tc.arguments {
+				toolCalls[i] = openrouter.ToolCall{
+					Index: i,
+					ID:    "call_" + string(rune('a'+i)),
+					Type:  "function",
+					Function: openrouter.ToolCallFunction{
+						Name:      "send_message",
+						Arguments: args,
+					},
+				}
+			}
+
+			runTurn(t, ctx, s,
+				makeRequest(chatID, projectID, orgID, openrouter.CreateMessageUser("do it")),
+				openrouter.CompletionResponse{
+					Content:   "",
+					Model:     "test-model",
+					MessageID: "msg-toolcall",
+					ToolCalls: toolCalls,
+				},
+			)
+
+			rows := listAllMessages(t, ctx, conn, chatID, projectID)
+			if tc.dropped {
+				require.Equal(t, []string{"user"}, roles(rows),
+					"malformed generation dropped; user input retained and tail stays drivable")
+			} else {
+				require.Equal(t, []string{"user", "assistant"}, roles(rows),
+					"well-formed generation persists normally")
+			}
+		})
+	}
 }
 
 // Whitespace-only assistant response content is treated as no text so storage

--- a/server/internal/chat/message_capture_strategy_test.go
+++ b/server/internal/chat/message_capture_strategy_test.go
@@ -731,6 +731,81 @@ func TestCaptureMessage_DropsGenerationWithMalformedToolCallArgs(t *testing.T) {
 	}
 }
 
+// A client can replay a previous turn's aborted assistant message — malformed
+// tool_call arguments and all. StartOrResumeChat must drop that message (and
+// any tool result that pairs with it, else the tool_result is orphaned) before
+// persisting, while keeping the surrounding user input.
+func TestStartOrResumeChat_DropsReplayedAssistantWithMalformedToolCallArgs(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestChatService(t)
+	ctx, conn, projectID, orgID := t.Context(), ti.conn, ti.projectID, ti.orgID
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("do it"),
+			makeAssistantToolOnly(or.ChatToolCall{
+				ID:   "call_bad",
+				Type: or.ChatToolCallTypeFunction,
+				Function: or.ChatToolCallFunction{
+					Name:      "send_message",
+					Arguments: `{"text":"hi`,
+				},
+			}),
+			or.CreateChatMessagesTool(or.ChatToolMessage{
+				Role:       or.ChatToolMessageRoleTool,
+				Content:    or.CreateChatToolMessageContentStr(`{"ok":true}`),
+				ToolCallID: "call_bad",
+			}),
+			openrouter.CreateMessageUser("still there?"),
+		),
+		makeResponse("yes"),
+	)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	require.Equal(t, []string{"user", "user", "assistant"}, roles(rows),
+		"poisoned assistant + its tool result dropped; user input and fresh response kept")
+	require.Equal(t, "yes", rows[2].Content)
+}
+
+// A valid replayed assistant tool_call must NOT be dropped — only malformed
+// arguments are poison.
+func TestStartOrResumeChat_KeepsReplayedAssistantWithValidToolCallArgs(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestChatService(t)
+	ctx, conn, projectID, orgID := t.Context(), ti.conn, ti.projectID, ti.orgID
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("do it"),
+			makeAssistantToolOnly(or.ChatToolCall{
+				ID:   "call_ok",
+				Type: or.ChatToolCallTypeFunction,
+				Function: or.ChatToolCallFunction{
+					Name:      "send_message",
+					Arguments: `{"text":"hi"}`,
+				},
+			}),
+			or.CreateChatMessagesTool(or.ChatToolMessage{
+				Role:       or.ChatToolMessageRoleTool,
+				Content:    or.CreateChatToolMessageContentStr(`{"ok":true}`),
+				ToolCallID: "call_ok",
+			}),
+			openrouter.CreateMessageUser("next"),
+		),
+		makeResponse("done"),
+	)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	require.Equal(t, []string{"user", "assistant", "tool", "user", "assistant"}, roles(rows),
+		"well-formed replayed tool call and its result persist intact")
+}
+
 // Whitespace-only assistant response content is treated as no text so storage
 // does not preserve invisible narrative around tool calls.
 func TestCaptureMessage_WhitespaceOnlyContentWithToolCallsStoresSingleRow(t *testing.T) {

--- a/server/internal/chat/metrics.go
+++ b/server/internal/chat/metrics.go
@@ -1,0 +1,49 @@
+package chat
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const meterChatDroppedGenerations = "chat.capture.dropped_generations"
+
+// captureMetrics holds the instruments recorded while capturing chat
+// completions to the database.
+type captureMetrics struct {
+	droppedGenerations metric.Int64Counter
+}
+
+func newCaptureMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *captureMetrics {
+	ctx := context.Background()
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/chat")
+
+	droppedGenerations, err := meter.Int64Counter(
+		meterChatDroppedGenerations,
+		metric.WithDescription("Assistant generations dropped at capture because the model produced malformed tool_call arguments"),
+		metric.WithUnit("{generation}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "create metric", attr.SlogMetricName(meterChatDroppedGenerations), attr.SlogError(err))
+	}
+
+	return &captureMetrics{
+		droppedGenerations: droppedGenerations,
+	}
+}
+
+// RecordDroppedGeneration counts an assistant generation dropped at capture
+// because the model produced malformed tool_call arguments.
+func (m *captureMetrics) RecordDroppedGeneration(ctx context.Context, projectID uuid.UUID, toolName string) {
+	if m.droppedGenerations == nil {
+		return
+	}
+	m.droppedGenerations.Add(ctx, 1, metric.WithAttributes(
+		attr.ProjectID(projectID.String()),
+		attr.ToolName(toolName),
+	))
+}

--- a/server/internal/chat/storage_dedup_test.go
+++ b/server/internal/chat/storage_dedup_test.go
@@ -96,7 +96,7 @@ func TestStoreMessages_DeduplicatesContentAddressableWrites(t *testing.T) {
 	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, counting)
 	t.Cleanup(func() { _ = shutdown(t.Context()) })
 
-	s := chat.NewChatMessageCaptureStrategy(testenv.NewLogger(t), conn, writer)
+	s := chat.NewChatMessageCaptureStrategy(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn, writer)
 	chatID := uuid.New()
 
 	// Two user messages with identical content + one distinct system message.


### PR DESCRIPTION
## Summary

- A truncated/aborted model completion could persist an assistant row whose `tool_call` arguments are unterminated JSON. On the next turn the runner's `normalize_history` rejects it, and that error path retries with **no attempt cap** — so the thread wedges forever (silent assistants, stuck cron digests). Diagnosed on the Data Sniffer health-digest assistant: its Morning Digest cron wedged ~13h (198 retries, ~186 dead Fly machines/day).
- `CaptureMessage` now validates `tool_call` arguments with the **same predicate the runner enforces** (`firstInvalidToolCall`: empty args are an empty object, anything non-empty must be valid JSON). When a generation is malformed it drops the assistant row but still flushes the preceding user/tool input, so the transcript tail stays drivable.
- Emits a `WarnContext` log + `chat.capture.dropped_generations` counter so dropped generations are visible.
- The runner's `normalize_history` stays **strict** — capture and runtime now agree on what is "usable".

## Changes

- `server/internal/chat/message_capture_strategy.go`: validate tool_call args in `CaptureMessage`; drop the unusable assistant row; flush input rows; warn log + metric. New `firstInvalidToolCall` helper; constructor takes a `MeterProvider`.
- `server/cmd/gram/{start,worker}.go`: pass `meterProvider` into the capture strategy.
- `server/internal/chat/message_capture_strategy_test.go`: table-driven test — truncated/garbage args drop the assistant row and retain user input; valid/empty args persist normally.

## Follow-up (separate, not this PR)

`classifyTurnError` + the `ErrRuntimeUnhealthy` branch bypass the `maxEventAttempts` cap. This PR removes the only known source of a malformed persisted row; an attempt-cap backstop on that path is tracked for later.

Closes [DNO-290](https://linear.app/speakeasy/issue/DNO-290)

✻ Clauded with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop assistant generations and replayed assistant messages with malformed `tool_call` arguments during chat capture to stop poisoned transcripts and infinite retry loops. Keeps valid input and, when needed, drops paired tool results to avoid orphans. Addresses DNO-290.

- **Bug Fixes**
  - Validate `tool_call.function.arguments` in both `CaptureMessage` and `StartOrResumeChat` (non-empty must be valid JSON); if invalid, skip the assistant row.
  - On input, also drop any tool results paired with a dropped assistant call; still persist preceding user/tool messages so the tail stays drivable.
  - Add warn log and `chat.capture.dropped_generations` counter; `NewChatMessageCaptureStrategy` now takes a `meterProvider`.
  - Keep runner `normalize_history` strict; tests cover malformed-args drops and valid/empty-args paths, including replayed assistants.

- **Refactors**
  - Moved capture metrics into a dedicated `metrics.go` wrapper; no behavior change.

<sup>Written for commit 5f18afc041a08112c89a6040b665674052fa52a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

