### PR TITLE
chore(ci): gate merges on format-check and reformat infra for py314

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1851,6 +1851,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - format-check
       - server-build-lint
       - server-test
       - docker-build-server

--- a/infra/gram_infra/pubsub/subscriber.py
+++ b/infra/gram_infra/pubsub/subscriber.py
@@ -234,7 +234,7 @@ class _PortalScheduler(Scheduler):
             return
         try:
             self._send.send_nowait(message)  # unbounded buffer: never blocks
-        except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+        except anyio.ClosedResourceError, anyio.BrokenResourceError:
             message.nack()
 
     def track_handler(self) -> None:
@@ -265,7 +265,7 @@ class _PortalScheduler(Scheduler):
         while True:
             try:
                 message = self._receive.receive_nowait()
-            except (anyio.EndOfStream, anyio.WouldBlock, anyio.ClosedResourceError):
+            except anyio.EndOfStream, anyio.WouldBlock, anyio.ClosedResourceError:
                 break
             message.nack()
 

--- a/infra/tests/test_integration.py
+++ b/infra/tests/test_integration.py
@@ -39,7 +39,7 @@ def _emulator_reachable() -> bool:
     try:
         with socket.create_connection((hostname or "localhost", int(port)), timeout=1):
             return True
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
 
 


### PR DESCRIPTION
## What

Two CI fixes, both stemming from the same incident — #3508 merged into `main` with a failing `format-check`:

1. **Add `format-check` to `ci-gate`'s `needs`.** `ci-gate` is the single required status check that aggregates every job's result. `format-check` was missing from its `needs` list, so a formatting failure reported a status that nothing required — the gate went green regardless and the PR merged. This is the actual reason the broken formatting reached `main`.

2. **Reformat the infra Python files for the py314 target.** #3508 bumped `infra/pyproject.toml` to `requires-python = ">=3.14"` (and the runtime to `python:3.14-slim`) but didn't rerun the formatter. ruff derives its format target from `requires-python`; at 3.14 it applies [PEP 758](https://peps.python.org/pep-0758/) and drops the parentheses from exception groups (`except (A, B):` → `except A, B:`). The existing parenthesized lines no longer matched, so `ruff format` now rewrites them.

## Why it passed locally but failed in CI

`hk fix --all` only looked clean on checkouts that predated the 3.14 bump (and the offending file). Same ruff version (`0.15.16`) on both sides — the difference was the inferred Python target, driven entirely by `requires-python`.

## Testing

- `hk check --all` passes clean locally.
- `ci-gate` now depends on `format-check`, so an equivalent regression would block merge instead of slipping through.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI so formatting failures block merges, and reformat infra code for Python 3.14 to align with `ruff`’s PEP 758 rules.

- **Bug Fixes**
  - Add `format-check` to `ci-gate` `needs` so a failing formatter blocks merges.
  - Reformat infra Python files for `requires-python >= 3.14` (PEP 758: unparenthesized except groups).

<sup>Written for commit 2e8b94d675b50858c001f7194e97cd9017d92e3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

