### PR TITLE
fix(assistants): harden turn-error classification to stop runtime teardown loop

### DIFF
--- a/.changeset/assistant-turn-error-teardown-cap.md
+++ b/.changeset/assistant-turn-error-teardown-cap.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix(assistants): stop a single bad assistant turn from tearing down and recreating its runtime forever. Errors returned by a live runtime are now treated as terminal (and capped) instead of being mistaken for a dead machine, and a hard ceiling fails an event after repeated teardowns so a stuck event can no longer churn machines indefinitely.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -857,7 +857,7 @@ func newStartCommand() *cli.Command {
 			)
 			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
 			chatService := chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo)
-			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger, contextWindowResolver)
+			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, meterProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger, contextWindowResolver)
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsCore.SetDashboardIngestor(triggerApp)
 			assistantsCore.SetChatMessageWriter(chatWriter)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -728,7 +728,7 @@ func newWorkerCommand() *cli.Command {
 				return err
 			}
 			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
-			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemetryLogger, contextWindowResolver)
+			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, meterProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemetryLogger, contextWindowResolver)
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsCore.SetDashboardIngestor(triggerApp)
 			assistantsCore.SetChatMessageWriter(chatWriter)

--- a/server/internal/assistants/classify_turn_error_test.go
+++ b/server/internal/assistants/classify_turn_error_test.go
@@ -61,6 +61,41 @@ func TestClassifyTurnError(t *testing.T) {
 				errors.New("execute fly turn request: status=422 body=provider error: "+corruptionMarker)),
 			want: ErrHistoryCorrupted,
 		},
+		{
+			name: "runner rejected truncated tool_call args (decode marker)",
+			err:  fmt.Errorf("execute fly turn request: %w", &runtimeResponseError{StatusCode: 503, Body: "decode tool_call arguments for id call_1: EOF while parsing a value"}),
+			want: ErrHistoryCorrupted,
+		},
+		{
+			name: "runner rejected history missing tool_call_id",
+			err:  &runtimeResponseError{StatusCode: 503, Body: "tool history message missing tool_call_id"},
+			want: ErrHistoryCorrupted,
+		},
+		{
+			name: "live runner deterministic 400 is terminal, not a teardown",
+			err:  fmt.Errorf("execute gke turn request: %w", &runtimeResponseError{StatusCode: 400, Body: "bad request"}),
+			want: ErrCompletionFailed,
+		},
+		{
+			name: "live runner 404 is terminal",
+			err:  &runtimeResponseError{StatusCode: 404, Body: "thread not found"},
+			want: ErrCompletionFailed,
+		},
+		{
+			name: "live runner 429 is transient — retry under teardown, not terminal",
+			err:  &runtimeResponseError{StatusCode: 429, Body: "rate limited"},
+			want: ErrRuntimeUnhealthy,
+		},
+		{
+			name: "live runner 408 is transient",
+			err:  &runtimeResponseError{StatusCode: 408, Body: "request timeout"},
+			want: ErrRuntimeUnhealthy,
+		},
+		{
+			name: "live runner 500 without a known marker stays unhealthy (bounded by C)",
+			err:  &runtimeResponseError{StatusCode: 500, Body: "internal error"},
+			want: ErrRuntimeUnhealthy,
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/internal/assistants/compaction_persist_test.go
+++ b/server/internal/assistants/compaction_persist_test.go
@@ -53,7 +53,7 @@ func TestRecordCompactedGenerationWritesNewGeneration(t *testing.T) {
 	}
 
 	logger := testenv.NewLogger(t)
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil)
 	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, assetstest.NewTestBlobStore(t))
 	t.Cleanup(func() { _ = chatWriterShutdown(ctx) })
 	core.SetChatMessageWriter(chatWriter)
@@ -93,7 +93,7 @@ func TestRecordCompactedGenerationRejectsForeignAssistant(t *testing.T) {
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil)
 	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, assetstest.NewTestBlobStore(t))
 	t.Cleanup(func() { _ = chatWriterShutdown(ctx) })
 	core.SetChatMessageWriter(chatWriter)
@@ -118,7 +118,7 @@ func recordCompactedGenerationMalformedFixture(t *testing.T, slug string) (*Serv
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil)
 	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, assetstest.NewTestBlobStore(t))
 	t.Cleanup(func() { _ = chatWriterShutdown(ctx) })
 	core.SetChatMessageWriter(chatWriter)
@@ -170,7 +170,7 @@ func TestRecordCompactedGenerationRejectsEmptyMessages(t *testing.T) {
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil)
 	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, assetstest.NewTestBlobStore(t))
 	t.Cleanup(func() { _ = chatWriterShutdown(ctx) })
 	core.SetChatMessageWriter(chatWriter)

--- a/server/internal/assistants/impl_test.go
+++ b/server/internal/assistants/impl_test.go
@@ -299,7 +299,7 @@ func newRBACServiceWithConn(t *testing.T, dbName string) (*Service, context.Cont
 		logger:   logger,
 		auth:     nil,
 		authz:    authzEngine,
-		core:     NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil),
+		core:     NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil),
 		signaler: &stubWorkflowSignaler{signalledThreads: nil},
 	}
 

--- a/server/internal/assistants/provisioning_test.go
+++ b/server/internal/assistants/provisioning_test.go
@@ -20,7 +20,7 @@ import (
 func newProvisioningCore(t *testing.T, conn *pgxpool.Pool) *ServiceCore {
 	t.Helper()
 	logger := testenv.NewLogger(t)
-	return NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil)
+	return NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(logger), nil)
 }
 
 func newProvisioningProject(t *testing.T, conn *pgxpool.Pool, slug string) uuid.UUID {

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -130,11 +131,46 @@ var ErrCompletionFailed = errors.New("assistant completion failed")
 // once per event before giving up.
 var ErrHistoryCorrupted = errors.New("assistant chat history corrupted")
 
-// classifyTurnError buckets a /turn error into runtime-unhealthy (tear
-// down), completion-failed (terminal), or history-corrupted (self-heal).
-// "provider error" is agentkit-provider-openrouter's prefix; "completion
-// failed" is Gram's gateway-stamped variant. chat.IsHistoryCorrupted
-// detects the Gram-owned marker stamped on upstream 400/422 responses.
+// runtimeResponseError is returned by a backend's HTTP layer when the runner
+// answered with a non-2xx status. Its presence in an error chain is proof the
+// VM is alive — the failure is the runner's response, not the transport — so
+// classifyTurnError never buckets it as runtime-unhealthy on its own.
+type runtimeResponseError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *runtimeResponseError) Error() string {
+	return fmt.Sprintf("status=%d body=%s", e.StatusCode, e.Body)
+}
+
+// deterministicClientError reports whether the status is a client error that
+// replaying would just reproduce. 408/429 are excluded — they are transient
+// and worth retrying.
+func (e *runtimeResponseError) deterministicClientError() bool {
+	if e.StatusCode < 400 || e.StatusCode >= 500 {
+		return false
+	}
+	return e.StatusCode != http.StatusRequestTimeout && e.StatusCode != http.StatusTooManyRequests
+}
+
+// runnerHistoryRejectMarkers are substrings the runner stamps when it refuses
+// to replay a malformed transcript (normalize_history). Routing these to
+// ErrHistoryCorrupted lets the self-heal trim the bad tail instead of tearing
+// the VM down and replaying the same poison forever.
+var runnerHistoryRejectMarkers = []string{
+	"decode tool_call arguments",
+	"missing tool_call_id",
+}
+
+// classifyTurnError buckets a /turn error into runtime-unhealthy (tear down),
+// completion-failed (terminal), or history-corrupted (self-heal). The guiding
+// rule is the failure *layer*: if the runner answered (a runtimeResponseError
+// is in the chain) the VM is alive and must not be torn down on its own; only
+// a transport failure — or a 5xx we cannot attribute to a deterministic cause —
+// is treated as unhealthy. "provider error" is agentkit-provider-openrouter's
+// prefix; "completion failed" is Gram's gateway-stamped variant;
+// chat.IsHistoryCorrupted detects the Gram marker stamped on upstream 400/422.
 func classifyTurnError(err error) error {
 	if err == nil {
 		return nil
@@ -143,8 +179,50 @@ func classifyTurnError(err error) error {
 		return ErrHistoryCorrupted
 	}
 	msg := err.Error()
+	for _, marker := range runnerHistoryRejectMarkers {
+		if strings.Contains(msg, marker) {
+			return ErrHistoryCorrupted
+		}
+	}
 	if strings.Contains(msg, "provider error") || strings.Contains(msg, "completion failed") {
 		return ErrCompletionFailed
 	}
+	// The runner answered with a deterministic client error (4xx, excluding
+	// transient 408/429): replaying repeats it, so fail terminally rather than
+	// churning the VM.
+	var respErr *runtimeResponseError
+	if errors.As(err, &respErr) && respErr.deterministicClientError() {
+		return ErrCompletionFailed
+	}
+	// Transport failure, or a 5xx we cannot attribute to a deterministic cause.
+	// Tear the runtime down and re-admit under a fresh VM — but bounded by
+	// maxRuntimeTeardowns so a misclassified deterministic error cannot loop.
 	return ErrRuntimeUnhealthy
+}
+
+// turnOutcome is a low-cardinality classifyTurnError bucket reported as a
+// metric dimension. The values are alert/dashboard contract — keep them stable.
+type turnOutcome string
+
+const (
+	turnOutcomeRuntimeUnhealthy          turnOutcome = "runtime_unhealthy"
+	turnOutcomeRuntimeUnhealthyExhausted turnOutcome = "runtime_unhealthy_exhausted"
+	turnOutcomeHistoryCorrupted          turnOutcome = "history_corrupted"
+	turnOutcomeCompletionFailed          turnOutcome = "completion_failed"
+	turnOutcomeTransient                 turnOutcome = "transient"
+)
+
+// turnErrorBucket names the classifyTurnError outcome for metrics. transient
+// covers anything that falls through to the capped inline-retry path.
+func turnErrorBucket(err error) turnOutcome {
+	switch {
+	case errors.Is(err, ErrRuntimeUnhealthy):
+		return turnOutcomeRuntimeUnhealthy
+	case errors.Is(err, ErrHistoryCorrupted):
+		return turnOutcomeHistoryCorrupted
+	case errors.Is(err, ErrCompletionFailed):
+		return turnOutcomeCompletionFailed
+	default:
+		return turnOutcomeTransient
+	}
 }

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -1164,7 +1164,7 @@ func (f *FlyRuntimeBackend) runtimeRequest(ctx context.Context, target flyRuntim
 		return nil, fmt.Errorf("read assistant fly runtime response: %w", err)
 	}
 	if resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, &runtimeResponseError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(body))}
 	}
 	return body, nil
 }

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -508,7 +508,7 @@ func (g *GKERuntimeBackend) doRequest(ctx context.Context, metadata gkeRuntimeMe
 		return nil, fmt.Errorf("read gke runtime response: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("gke runtime request %s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(respBody)))
+		return nil, &runtimeResponseError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(respBody))}
 	}
 	return respBody, nil
 }

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
@@ -67,6 +68,20 @@ const (
 	// a broken upstream (LLM 502, bad tool, etc.) from burning the retry
 	// loop forever.
 	maxEventAttempts = 5
+
+	// maxRuntimeTeardowns caps how many times one event may tear down and
+	// re-admit its runtime (the ErrRuntimeUnhealthy path) before it is failed
+	// terminally. Higher than maxEventAttempts because a genuine infra blip
+	// deserves generous retries — but a deterministic error misclassified as
+	// unhealthy must not keep killing fresh VMs forever (the DNO-290 hazard).
+	// event.Attempts advances on every claim, so it doubles as the teardown
+	// counter on this path.
+	maxRuntimeTeardowns = 10
+
+	// meterAssistantTurnClassified counts turn failures by classifyTurnError
+	// outcome so a runaway teardown loop is visible (the DNO-290 incident ran
+	// ~13h silent).
+	meterAssistantTurnClassified = "assistant.turn.classified"
 
 	runtimeStartupReapGrace = 2 * time.Minute
 	// runtimeExpiringReapGrace is the cushion the reaper waits before
@@ -322,11 +337,13 @@ type ServiceCore struct {
 	wakeCanceller     WakeCanceller
 	chatWriter        *chat.ChatMessageWriter
 	dashboardIngestor DashboardIngestor
+	turnClassified    metric.Int64Counter
 }
 
 func NewServiceCore(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
+	meterProvider metric.MeterProvider,
 	db *pgxpool.Pool,
 	guardianPolicy *guardian.Policy,
 	encryptionClient *encryption.Client,
@@ -337,6 +354,16 @@ func NewServiceCore(
 	telemetryLogger *telemetry.Logger,
 	contextWindow *openrouter.ContextWindowResolver,
 ) *ServiceCore {
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/assistants")
+	turnClassified, err := meter.Int64Counter(
+		meterAssistantTurnClassified,
+		metric.WithDescription("Assistant turn failures bucketed by classifyTurnError outcome"),
+		metric.WithUnit("{turn}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterAssistantTurnClassified), attr.SlogError(err))
+	}
+
 	return &ServiceCore{
 		logger:            logger,
 		tracer:            tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/assistants"),
@@ -352,6 +379,7 @@ func NewServiceCore(
 		wakeCanceller:     nil,
 		chatWriter:        nil,
 		dashboardIngestor: nil,
+		turnClassified:    turnClassified,
 	}
 }
 
@@ -1845,6 +1873,13 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			)
 			s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "turn_failed", "assistant turn failed", "ERROR", runErr)
 
+			teardownExhausted := errors.Is(runErr, ErrRuntimeUnhealthy) && event.Attempts >= maxRuntimeTeardowns
+			outcome := turnErrorBucket(runErr)
+			if teardownExhausted {
+				outcome = turnOutcomeRuntimeUnhealthyExhausted
+			}
+			s.recordTurnClassification(turnCtx, outcome)
+
 			// Runtime-level failure (dead VM, connection refused, missing
 			// state). Tear down the runtime row and leave the event in
 			// 'processing' — do NOT reset it to 'pending', or the outer
@@ -1852,6 +1887,27 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			// A reaper reclaims stuck 'processing' events after a grace
 			// window so they flow through cleanly under a fresh VM.
 			if errors.Is(runErr, ErrRuntimeUnhealthy) {
+				// An event that has torn down this many runtimes is almost
+				// certainly a deterministic failure misread as infra (the
+				// DNO-290 hazard), not a transient blip. Stop re-admitting it
+				// and fail it terminally instead of churning VMs forever.
+				if teardownExhausted {
+					s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_terminal", "assistant event exceeded runtime teardown limit", "ERROR", runErr)
+					_ = s.runtime.Stop(ctx, runtimeRecord)
+					_ = s.stopRuntimeRecord(ctx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
+					if err := s.failEvent(ctx, thread.ProjectID, event.ID, fmt.Errorf("exceeded %d runtime teardowns: %w", maxRuntimeTeardowns, runErr)); err != nil {
+						return ProcessThreadEventsResult{}, err
+					}
+					return ProcessThreadEventsResult{
+						AssistantID:         assistant.ID,
+						WarmUntil:           time.Time{},
+						WarmTTLSeconds:      assistant.WarmTTLSeconds,
+						RuntimeActive:       false,
+						RetryAdmission:      false,
+						ProcessedAnyEvent:   processedAny,
+						BootstrappedRuntime: bootstrappedRuntime,
+					}, nil
+				}
 				_ = s.runtime.Stop(ctx, runtimeRecord)
 				_ = s.stopRuntimeRecord(ctx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
 				return ProcessThreadEventsResult{
@@ -2683,6 +2739,15 @@ func (s *ServiceCore) completeEvent(ctx context.Context, projectID, eventID uuid
 		return fmt.Errorf("complete assistant thread event: %w", err)
 	}
 	return nil
+}
+
+// recordTurnClassification counts a failed turn by its classifyTurnError
+// bucket so teardown loops are alertable.
+func (s *ServiceCore) recordTurnClassification(ctx context.Context, outcome turnOutcome) {
+	if s.turnClassified == nil {
+		return
+	}
+	s.turnClassified.Add(ctx, 1, metric.WithAttributes(attr.AssistantTurnOutcome(string(outcome))))
 }
 
 func (s *ServiceCore) failEvent(ctx context.Context, projectID, eventID uuid.UUID, runErr error) error {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -77,6 +77,12 @@ const (
 	// advances on every claim, so it doubles as the teardown counter here.
 	maxRuntimeTeardowns = 10
 
+	// teardownCapCleanupTimeout bounds the detached cleanup (stop runtime,
+	// fail event) on the exhausted-teardown path. The turn that triggered it
+	// already failed — often because its context was canceled — so the cleanup
+	// runs on a fresh deadline rather than the dead request context.
+	teardownCapCleanupTimeout = 30 * time.Second
+
 	meterAssistantTurnClassified = "assistant.turn.classified"
 
 	runtimeStartupReapGrace = 2 * time.Minute
@@ -1891,9 +1897,12 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 				// the thread must get a fresh runtime rather than sit idle.
 				if teardownExhausted {
 					s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_terminal", "assistant event exceeded runtime teardown limit", "ERROR", runErr)
-					_ = s.runtime.Stop(ctx, runtimeRecord)
-					_ = s.stopRuntimeRecord(ctx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
-					if err := s.failEvent(ctx, thread.ProjectID, event.ID, fmt.Errorf("exceeded %d runtime teardowns: %w", maxRuntimeTeardowns, runErr)); err != nil {
+					cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
+					_ = s.runtime.Stop(cleanupCtx, runtimeRecord)
+					_ = s.stopRuntimeRecord(cleanupCtx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
+					err := s.failEvent(cleanupCtx, thread.ProjectID, event.ID, fmt.Errorf("exceeded %d runtime teardowns: %w", maxRuntimeTeardowns, runErr))
+					cancelCleanup()
+					if err != nil {
 						return ProcessThreadEventsResult{}, err
 					}
 					return ProcessThreadEventsResult{
@@ -1966,10 +1975,13 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			}
 
 			// Upstream completion provider rejected the request (Anthropic 400
-			// on a malformed message, OpenRouter rate limit, etc). The runtime
-			// is fine — replaying the same input would just produce the same
-			// failure, so terminally fail the event and keep the VM warm for
-			// subsequent ones rather than churning Fly on every retry.
+			// on a malformed message, OpenRouter rate limit, etc), or a live
+			// runtime returned a deterministic 4xx. The runtime is fine —
+			// replaying the same input would just reproduce it, so terminally
+			// fail the event and keep the VM warm. Request admission so any
+			// other pending event on the thread is drained on the warm runtime
+			// instead of waiting out the warm timer; the failed event is no
+			// longer claimable, so this cannot loop on it.
 			if errors.Is(runErr, ErrCompletionFailed) || errors.Is(runErr, ErrHistoryCorrupted) {
 				s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_terminal", "assistant event failed at completion provider", "ERROR", runErr)
 				if err := s.failEvent(ctx, thread.ProjectID, event.ID, runErr); err != nil {
@@ -1984,7 +1996,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 					WarmUntil:           warmUntil,
 					WarmTTLSeconds:      assistant.WarmTTLSeconds,
 					RuntimeActive:       true,
-					RetryAdmission:      false,
+					RetryAdmission:      true,
 					ProcessedAnyEvent:   processedAny,
 					BootstrappedRuntime: bootstrappedRuntime,
 				}, nil

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -72,15 +72,11 @@ const (
 	// maxRuntimeTeardowns caps how many times one event may tear down and
 	// re-admit its runtime (the ErrRuntimeUnhealthy path) before it is failed
 	// terminally. Higher than maxEventAttempts because a genuine infra blip
-	// deserves generous retries — but a deterministic error misclassified as
-	// unhealthy must not keep killing fresh VMs forever (the DNO-290 hazard).
-	// event.Attempts advances on every claim, so it doubles as the teardown
-	// counter on this path.
+	// deserves generous retries, while a deterministic error misclassified as
+	// unhealthy still cannot churn fresh runtimes without bound. event.Attempts
+	// advances on every claim, so it doubles as the teardown counter here.
 	maxRuntimeTeardowns = 10
 
-	// meterAssistantTurnClassified counts turn failures by classifyTurnError
-	// outcome so a runaway teardown loop is visible (the DNO-290 incident ran
-	// ~13h silent).
 	meterAssistantTurnClassified = "assistant.turn.classified"
 
 	runtimeStartupReapGrace = 2 * time.Minute
@@ -1878,7 +1874,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			if teardownExhausted {
 				outcome = turnOutcomeRuntimeUnhealthyExhausted
 			}
-			s.recordTurnClassification(turnCtx, outcome)
+			s.recordTurnClassification(turnCtx, assistant.ID, thread.ID, outcome)
 
 			// Runtime-level failure (dead VM, connection refused, missing
 			// state). Tear down the runtime row and leave the event in
@@ -1887,10 +1883,12 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			// A reaper reclaims stuck 'processing' events after a grace
 			// window so they flow through cleanly under a fresh VM.
 			if errors.Is(runErr, ErrRuntimeUnhealthy) {
-				// An event that has torn down this many runtimes is almost
-				// certainly a deterministic failure misread as infra (the
-				// DNO-290 hazard), not a transient blip. Stop re-admitting it
-				// and fail it terminally instead of churning VMs forever.
+				// An event that has torn down this many runtimes is far more
+				// likely a deterministic failure misread as infra than a
+				// transient blip, so fail it terminally instead of re-admitting
+				// it forever. Still request admission afterwards: the failed
+				// event is no longer claimable, but any other pending event on
+				// the thread must get a fresh runtime rather than sit idle.
 				if teardownExhausted {
 					s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_terminal", "assistant event exceeded runtime teardown limit", "ERROR", runErr)
 					_ = s.runtime.Stop(ctx, runtimeRecord)
@@ -1903,7 +1901,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 						WarmUntil:           time.Time{},
 						WarmTTLSeconds:      assistant.WarmTTLSeconds,
 						RuntimeActive:       false,
-						RetryAdmission:      false,
+						RetryAdmission:      true,
 						ProcessedAnyEvent:   processedAny,
 						BootstrappedRuntime: bootstrappedRuntime,
 					}, nil
@@ -2742,12 +2740,15 @@ func (s *ServiceCore) completeEvent(ctx context.Context, projectID, eventID uuid
 }
 
 // recordTurnClassification counts a failed turn by its classifyTurnError
-// bucket so teardown loops are alertable.
-func (s *ServiceCore) recordTurnClassification(ctx context.Context, outcome turnOutcome) {
-	if s.turnClassified == nil {
-		return
-	}
-	s.turnClassified.Add(ctx, 1, metric.WithAttributes(attr.AssistantTurnOutcome(string(outcome))))
+// bucket. The thread and assistant ids are attached explicitly — metric
+// instruments do not inherit them from the context — so a runaway teardown
+// loop can be grouped to a single thread.
+func (s *ServiceCore) recordTurnClassification(ctx context.Context, assistantID, threadID uuid.UUID, outcome turnOutcome) {
+	s.turnClassified.Add(ctx, 1, metric.WithAttributes(
+		attr.AssistantTurnOutcome(string(outcome)),
+		attr.AssistantID(assistantID.String()),
+		attr.AssistantThreadID(threadID.String()),
+	))
 }
 
 func (s *ServiceCore) failEvent(ctx context.Context, projectID, eventID uuid.UUID, runErr error) error {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1913,8 +1913,14 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 					_ = s.runtime.Stop(stopCtx, runtimeRecord)
 					cancelStop()
 					recordCtx, cancelRecord := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
-					_ = s.stopRuntimeRecord(recordCtx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
+					recordErr := s.stopRuntimeRecord(recordCtx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
 					cancelRecord()
+					if recordErr != nil {
+						// The slot is still held by an active row; re-admitting now
+						// would redispatch siblings onto the dead runtime. Surface the
+						// error so the workflow retries and frees the slot first.
+						return ProcessThreadEventsResult{}, fmt.Errorf("free runtime slot after teardown cap: %w", recordErr)
+					}
 					return ProcessThreadEventsResult{
 						AssistantID:         assistant.ID,
 						WarmUntil:           time.Time{},

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1897,19 +1897,24 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 				// the thread must get a fresh runtime rather than sit idle.
 				if teardownExhausted {
 					s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_terminal", "assistant event exceeded runtime teardown limit", "ERROR", runErr)
-					// Mark the event failed first, on its own budget: this is the
-					// step that actually stops the loop, so the best-effort runtime
-					// teardown below must not be able to starve it of time.
+					// Each step gets its own detached budget so a slow best-effort
+					// runtime Stop cannot starve the two writes that actually break
+					// the loop: failEvent makes the event terminal, and
+					// stopRuntimeRecord frees the per-thread runtime slot so the
+					// re-admission below reserves a fresh VM instead of redispatching
+					// onto this dead one.
 					failCtx, cancelFail := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
 					err := s.failEvent(failCtx, thread.ProjectID, event.ID, fmt.Errorf("exceeded %d runtime teardowns: %w", maxRuntimeTeardowns, runErr))
 					cancelFail()
 					if err != nil {
 						return ProcessThreadEventsResult{}, err
 					}
-					cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
-					_ = s.runtime.Stop(cleanupCtx, runtimeRecord)
-					_ = s.stopRuntimeRecord(cleanupCtx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
-					cancelCleanup()
+					stopCtx, cancelStop := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
+					_ = s.runtime.Stop(stopCtx, runtimeRecord)
+					cancelStop()
+					recordCtx, cancelRecord := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
+					_ = s.stopRuntimeRecord(recordCtx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
+					cancelRecord()
 					return ProcessThreadEventsResult{
 						AssistantID:         assistant.ID,
 						WarmUntil:           time.Time{},

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1897,14 +1897,19 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 				// the thread must get a fresh runtime rather than sit idle.
 				if teardownExhausted {
 					s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_terminal", "assistant event exceeded runtime teardown limit", "ERROR", runErr)
-					cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
-					_ = s.runtime.Stop(cleanupCtx, runtimeRecord)
-					_ = s.stopRuntimeRecord(cleanupCtx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
-					err := s.failEvent(cleanupCtx, thread.ProjectID, event.ID, fmt.Errorf("exceeded %d runtime teardowns: %w", maxRuntimeTeardowns, runErr))
-					cancelCleanup()
+					// Mark the event failed first, on its own budget: this is the
+					// step that actually stops the loop, so the best-effort runtime
+					// teardown below must not be able to starve it of time.
+					failCtx, cancelFail := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
+					err := s.failEvent(failCtx, thread.ProjectID, event.ID, fmt.Errorf("exceeded %d runtime teardowns: %w", maxRuntimeTeardowns, runErr))
+					cancelFail()
 					if err != nil {
 						return ProcessThreadEventsResult{}, err
 					}
+					cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), teardownCapCleanupTimeout)
+					_ = s.runtime.Stop(cleanupCtx, runtimeRecord)
+					_ = s.stopRuntimeRecord(cleanupCtx, thread.ProjectID, runtimeRecord.ID, runtimeStateFailed)
+					cancelCleanup()
 					return ProcessThreadEventsResult{
 						AssistantID:         assistant.ID,
 						WarmUntil:           time.Time{},

--- a/server/internal/assistants/service_self_heal_test.go
+++ b/server/internal/assistants/service_self_heal_test.go
@@ -179,13 +179,13 @@ func TestServiceCoreSkipsSelfHealAfterFirstRetry(t *testing.T) {
 
 	result, err := core.ProcessThreadEvents(ctx, projectID, threadID)
 	require.NoError(t, err)
-	require.False(t, result.RetryAdmission, "second corruption must NOT retry — self-heal already ran")
+	require.True(t, result.RetryAdmission, "thread is re-admitted so siblings drain on the warm runtime; the failed event is not re-run")
 	require.True(t, result.RuntimeActive, "completion-fail path keeps the runtime warm")
 	require.Equal(t, int64(0), stopCalls.Load(), "second corruption must not Stop the runtime")
 
 	event, err := q.GetLatestAssistantThreadEventByThreadID(ctx, assistantsrepo.GetLatestAssistantThreadEventByThreadIDParams{AssistantThreadID: threadID, ProjectID: projectID})
 	require.NoError(t, err)
-	require.Equal(t, eventStatusFailed, event.Status, "second corruption must terminally fail")
+	require.Equal(t, eventStatusFailed, event.Status, "second corruption must terminally fail and not be re-run")
 
 	// Only the seeded gen 0 should exist — no second self-heal generation was written.
 	gen, err := chatrepo.New(conn).GetMaxGenerationForChat(ctx, chatID)

--- a/server/internal/assistants/service_self_heal_test.go
+++ b/server/internal/assistants/service_self_heal_test.go
@@ -70,7 +70,7 @@ func TestServiceCoreSelfHealsHistoryCorruptionOnFirstAttempt(t *testing.T) {
 		runTurnErr: corruption,
 		stopCalls:  &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
 	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, assetstest.NewTestBlobStore(t))
 	t.Cleanup(func() { _ = chatWriterShutdown(ctx) })
 	core.SetChatMessageWriter(chatWriter)
@@ -168,7 +168,7 @@ func TestServiceCoreSkipsSelfHealAfterFirstRetry(t *testing.T) {
 		runTurnErr: corruption,
 		stopCalls:  &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
 	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, assetstest.NewTestBlobStore(t))
 	t.Cleanup(func() { _ = chatWriterShutdown(ctx) })
 	core.SetChatMessageWriter(chatWriter)

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -51,7 +51,7 @@ func TestServiceCoreAdmitPendingThreadsUsesFlyBackend(t *testing.T) {
 
 	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestServiceCoreAdmitPendingThreadsCapsFanOut(t *testing.T) {
 	assistantID, pending := seedAssistantWithPendingThreads(t, conn, "assistants-cap", 2, 3)
 	preActivateV2Runtime(t, conn, assistantID, pending[0])
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	admitted, err := core.AdmitPendingThreads(ctx, assistantID)
 	require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestServiceCoreAdmitPendingThreadsBlocksWhenActiveAtCap(t *testing.T) {
 	require.NotEmpty(t, pending)
 	preActivateV2Runtime(t, conn, assistantID, active[0])
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	admitted, err := core.AdmitPendingThreads(ctx, assistantID)
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestServiceCoreAdmitPendingThreadsReleasesPartialHeadroom(t *testing.T) {
 	assistantID, active, _ := seedAssistantWithActiveAndPending(t, conn, "assistants-partial", 2, 1, 2)
 	preActivateV2Runtime(t, conn, assistantID, active[0])
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	admitted, err := core.AdmitPendingThreads(ctx, assistantID)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestServiceCoreAdmitPendingThreadsBypassesCapForReservedStarter(t *testing.
 	assistantID, _, pending := seedAssistantWithActiveAndPending(t, conn, "assistants-cold-bypass", 1, 1, 1)
 	require.NotEmpty(t, pending)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	admitted, err := core.AdmitPendingThreads(ctx, assistantID)
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestServiceCoreEnsureWarmupThreadBootsRuntimeViaTurnMachinery(t *testing.T)
 	assistantID, projectID := seedAssistant(t, conn, "assistants-warmup", 2)
 
 	metadata := []byte(`{"app_name":"gram-asst-warm"}`)
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, ensureResult: RuntimeBackendEnsureResult{ColdStart: true, BackendMetadataJSON: metadata}}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, ensureResult: RuntimeBackendEnsureResult{ColdStart: true, BackendMetadataJSON: metadata}}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.EnsureWarmupThread(ctx, assistantID)
 	require.NoError(t, err)
@@ -190,7 +190,7 @@ func TestServiceCoreEnsureWarmupThreadIsIdempotent(t *testing.T) {
 	ctx := t.Context()
 	assistantID, projectID := seedAssistant(t, conn, "assistants-warmup-idem", 2)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	first, err := core.EnsureWarmupThread(ctx, assistantID)
 	require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestServiceCoreWarmupThreadDoesNotConsumeConcurrencySlot(t *testing.T) {
 	ctx := t.Context()
 	assistantID, projectID := seedAssistant(t, conn, "assistants-warmup-cap", 1)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	warmup, err := core.EnsureWarmupThread(ctx, assistantID)
 	require.NoError(t, err)
@@ -246,7 +246,7 @@ func TestServiceCoreEnsureWarmupThreadSkipsWhenTrafficOwnsRuntime(t *testing.T) 
 	assistantID, pending := seedAssistantWithPendingThreads(t, conn, "assistants-warmup-noop", 2, 1)
 	preActivateV2Runtime(t, conn, assistantID, pending[0])
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.EnsureWarmupThread(ctx, assistantID)
 	require.NoError(t, err)
@@ -273,7 +273,7 @@ func TestServiceCoreEnsureWarmupThreadSkipsInactiveAssistant(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.EnsureWarmupThread(ctx, assistantID)
 	require.NoError(t, err)
@@ -443,7 +443,7 @@ func TestServiceCoreExpireThreadRuntimeRevertsWhenTurnInFlight(t *testing.T) {
 		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: &busyIdle},
 		stopCalls:    &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(logger), nil)
 
 	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.NoError(t, err)
@@ -502,7 +502,7 @@ func TestServiceCoreExpireThreadRuntimeRetryAfterStopFailureIsIdempotent(t *test
 		stopErr:      errors.New("fly delete app blew up"),
 		stopCalls:    &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, failingBackend, nil, nil, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, failingBackend, nil, nil, nil, telemetry.NewStub(logger), nil)
 
 	_, err = core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.Error(t, err, "first attempt with failing Stop must surface the error so Temporal retries")
@@ -520,7 +520,7 @@ func TestServiceCoreExpireThreadRuntimeRetryAfterStopFailureIsIdempotent(t *test
 		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: new(uint64(DefaultWarmTTLSeconds + 60))},
 		stopCalls:    &stopCalls,
 	}
-	core = NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, healingBackend, nil, nil, nil, telemetry.NewStub(logger), nil)
+	core = NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, healingBackend, nil, nil, nil, telemetry.NewStub(logger), nil)
 
 	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.NoError(t, err, "retry must drive the existing expiring row to a terminal state")
@@ -568,7 +568,7 @@ func TestServiceCoreReapStuckRuntimesCleansUpStuckExpiring(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapStuckRuntimes(t.Context())
 	require.NoError(t, err)
@@ -613,7 +613,7 @@ func TestServiceCoreReapStuckRuntimesLeavesFreshExpiring(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapStuckRuntimes(t.Context())
 	require.NoError(t, err)
@@ -665,7 +665,7 @@ func TestServiceCoreReapStuckRuntimesSkipsLiveProcessingLease(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapStuckRuntimes(ctx)
 	require.NoError(t, err)
@@ -724,7 +724,7 @@ func TestServiceCoreReapStuckRuntimesLeavesIdleActiveRuntime(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapStuckRuntimes(ctx)
 	require.NoError(t, err)
@@ -850,7 +850,7 @@ func TestServiceCoreLoadChatHistoryReplaysToolTurns(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	history, err := core.loadChatHistory(t.Context(), chatID, projectID)
 	require.NoError(t, err)
@@ -932,7 +932,7 @@ func TestServiceCoreLoadChatHistoryReturnsOnlyLatestGeneration(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	history, err := core.loadChatHistory(t.Context(), chatID, projectID)
 	require.NoError(t, err)
@@ -977,7 +977,7 @@ func TestServiceCoreLoadChatHistoryFailsWhenToolRowMissingCallID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	_, err = core.loadChatHistory(ctx, chatID, projectID)
 	require.ErrorContains(t, err, "tool chat row missing tool_call_id")
@@ -993,7 +993,7 @@ func TestServiceCoreProcessThreadEventsCompletesEvent(t *testing.T) {
 
 	logger := testenv.NewLogger(t)
 	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, tokens, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, tokens, nil, telemetry.NewStub(logger), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -1026,7 +1026,7 @@ func TestServiceCoreProcessThreadEventsRequeuesOnTurnFailure(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: errors.New("runtime RunTurn blew up")}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, tokens, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, tokens, nil, telemetry.NewStub(logger), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -1062,7 +1062,7 @@ func TestServiceCoreProcessThreadEventsMarksRuntimeFailedOnUnhealthyTurn(t *test
 		runTurnErr: ErrRuntimeUnhealthy,
 		stopCalls:  &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -1083,6 +1083,66 @@ func TestServiceCoreProcessThreadEventsMarksRuntimeFailedOnUnhealthyTurn(t *test
 	event, err := assistantsrepo.New(conn).GetLatestAssistantThreadEventByThreadID(t.Context(), assistantsrepo.GetLatestAssistantThreadEventByThreadIDParams{AssistantThreadID: threadID, ProjectID: projectID})
 	require.NoError(t, err)
 	require.Equal(t, eventStatusProcessing, event.Status, "unhealthy turn leaves the event in processing for the reaper")
+}
+
+// An event that has already torn down its runtime maxRuntimeTeardowns times is
+// failed terminally instead of being re-admitted forever — the bound that stops
+// a deterministic error misclassified as unhealthy from looping (DNO-290).
+func TestServiceCoreProcessThreadEventsCapsRuntimeTeardowns(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_teardown_cap")
+	require.NoError(t, err)
+
+	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
+
+	var stopCalls atomic.Int64
+	logger := testenv.NewLogger(t)
+	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
+	backend := testRuntimeBackend{
+		backend:    runtimeBackendFlyIO,
+		runTurnErr: ErrRuntimeUnhealthy,
+		stopCalls:  &stopCalls,
+	}
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
+
+	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{threadID}, admitted.ThreadIDs)
+
+	// Drive attempts up to maxRuntimeTeardowns-1 the way the real teardown
+	// cycle does — claim (which increments attempts) then requeue back to
+	// pending — so the next claim inside ProcessThreadEvents lands on the
+	// ceiling.
+	repo := assistantsrepo.New(conn)
+	requeueBefore := pgtype.Timestamptz{Time: time.Now().UTC().Add(time.Hour), Valid: true}
+	for range maxRuntimeTeardowns - 1 {
+		_, err = repo.ClaimNextPendingEvent(t.Context(), assistantsrepo.ClaimNextPendingEventParams{
+			ProcessingStatus: eventStatusProcessing,
+			ProjectID:        projectID,
+			ThreadID:         threadID,
+			PendingStatus:    eventStatusPending,
+		})
+		require.NoError(t, err)
+		_, err = repo.RequeueStaleAssistantEvents(t.Context(), assistantsrepo.RequeueStaleAssistantEventsParams{
+			PendingStatus:    eventStatusPending,
+			ProcessingStatus: eventStatusProcessing,
+			UpdatedBefore:    requeueBefore,
+		})
+		require.NoError(t, err)
+	}
+
+	result, err := core.ProcessThreadEvents(t.Context(), projectID, threadID)
+	require.NoError(t, err)
+	require.False(t, result.RetryAdmission, "exhausted teardown budget must stop re-admitting the event")
+	require.False(t, result.RuntimeActive)
+	require.Equal(t, int64(1), stopCalls.Load(), "the runtime is still torn down on the final attempt")
+
+	event, err := assistantsrepo.New(conn).GetLatestAssistantThreadEventByThreadID(t.Context(), assistantsrepo.GetLatestAssistantThreadEventByThreadIDParams{AssistantThreadID: threadID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.Equal(t, eventStatusFailed, event.Status, "event is failed terminally, not left for the reaper to re-admit")
+	require.True(t, event.LastError.Valid)
+	require.Contains(t, event.LastError.String, "exceeded 10 runtime teardowns")
 }
 
 // insertReapableProject inserts an isolated project + assistant + thread so a
@@ -1189,7 +1249,7 @@ func TestServiceCoreDeleteAssistantReapsRuntimes(t *testing.T) {
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	require.NoError(t, core.DeleteAssistant(t.Context(), projectID, assistantID))
 	require.EqualValues(t, 1, reapCalls.Load())
@@ -1225,7 +1285,7 @@ func TestServiceCoreDeleteAssistantSucceedsEvenWhenReapErrors(t *testing.T) {
 		reapCalls: reapCalls,
 		reapErr:   errors.New("fly api 503"),
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	require.NoError(t, core.DeleteAssistant(t.Context(), projectID, assistantID))
 	require.EqualValues(t, 1, reapCalls.Load())
@@ -1251,7 +1311,7 @@ func TestServiceCoreReapAssistantRuntimesCallsBackendAndClearsMetadata(t *testin
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapAssistantRuntimes(t.Context(), projectID, assistantID)
 	require.NoError(t, err)
@@ -1294,7 +1354,7 @@ func TestServiceCoreReapAssistantRuntimesSkipsRowsWithoutMetadata(t *testing.T) 
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapAssistantRuntimes(t.Context(), projectID, assistantID)
 	require.NoError(t, err)
@@ -1356,7 +1416,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesRecyclesAndPersists(t *testing.T) 
 			BackendMetadataJSON: []byte(recycledMetadata),
 		},
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
 	require.NoError(t, err)
@@ -1394,7 +1454,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesSweepsOnlyActiveV2Rows(t *testing.
 		recycleCalls:  recycleCalls,
 		recycleResult: RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil},
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
 	require.NoError(t, err)
@@ -1421,7 +1481,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesSkipsAssistantsWithInFlightEvents(
 		recycleCalls:  recycleCalls,
 		recycleResult: RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: []byte(`{}`)},
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
 	require.NoError(t, err)
@@ -1453,7 +1513,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesIgnoresDeletedAssistants(t *testin
 		recycleCalls:  recycleCalls,
 		recycleResult: RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: []byte(`{}`)},
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
 	require.NoError(t, err)
@@ -1494,7 +1554,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesUndoesRecycleWhenRowExpiresMidSwee
 			}, nil
 		},
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
 	require.NoError(t, err)
@@ -1522,7 +1582,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesCountsBackendErrors(t *testing.T) 
 		backend:    runtimeBackendFlyIO,
 		recycleErr: errors.New("fly api 503"),
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
 	require.NoError(t, err)
@@ -1555,7 +1615,7 @@ func TestServiceCoreRecycleActiveRuntimeImagesNoOpsForNonReuseBackend(t *testing
 		stopCalls:    stopCalls,
 		recycleCalls: recycleCalls,
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
 	require.NoError(t, err)
@@ -1584,7 +1644,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesCollectsOnlyInactive(t *testing
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
@@ -1619,7 +1679,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsAssistantWithRecentActivit
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
@@ -1670,7 +1730,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesReapsSiblingsAcrossSweeps(t *te
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	first, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
@@ -1735,7 +1795,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsLiveRowsCollectsFinalized(
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	rowProcessed := &atomic.Int64{}
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
@@ -1865,7 +1925,7 @@ func TestServiceCoreEnqueueTriggerTaskSkipsMissingAssistant(t *testing.T) {
 
 	logger := testenv.NewLogger(t)
 	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, tokens, nil, telemetry.NewStub(logger), nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, tokens, nil, telemetry.NewStub(logger), nil)
 
 	missing := uuid.New()
 	result, err := core.EnqueueTriggerTask(t.Context(), bgtriggers.Task{

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1087,7 +1087,7 @@ func TestServiceCoreProcessThreadEventsMarksRuntimeFailedOnUnhealthyTurn(t *test
 
 // An event that has already torn down its runtime maxRuntimeTeardowns times is
 // failed terminally instead of being re-admitted forever — the bound that stops
-// a deterministic error misclassified as unhealthy from looping (DNO-290).
+// a deterministic error misclassified as unhealthy from looping.
 func TestServiceCoreProcessThreadEventsCapsRuntimeTeardowns(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1134,13 +1134,13 @@ func TestServiceCoreProcessThreadEventsCapsRuntimeTeardowns(t *testing.T) {
 
 	result, err := core.ProcessThreadEvents(t.Context(), projectID, threadID)
 	require.NoError(t, err)
-	require.False(t, result.RetryAdmission, "exhausted teardown budget must stop re-admitting the event")
+	require.True(t, result.RetryAdmission, "thread is re-admitted so any other pending events run on a fresh runtime")
 	require.False(t, result.RuntimeActive)
 	require.Equal(t, int64(1), stopCalls.Load(), "the runtime is still torn down on the final attempt")
 
 	event, err := assistantsrepo.New(conn).GetLatestAssistantThreadEventByThreadID(t.Context(), assistantsrepo.GetLatestAssistantThreadEventByThreadIDParams{AssistantThreadID: threadID, ProjectID: projectID})
 	require.NoError(t, err)
-	require.Equal(t, eventStatusFailed, event.Status, "event is failed terminally, not left for the reaper to re-admit")
+	require.Equal(t, eventStatusFailed, event.Status, "the poisoned event itself is failed terminally, not re-admitted")
 	require.True(t, event.LastError.Valid)
 	require.Contains(t, event.LastError.String, "exceeded 10 runtime teardowns")
 }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -153,6 +153,7 @@ const (
 	AssistantColdStartKey          = attribute.Key("gram.assistant.cold_start")
 	AssistantAppCreatedKey         = attribute.Key("gram.assistant.app_created")
 	AssistantSetupFailureClassKey  = attribute.Key("gram.assistant.setup_failure_class")
+	AssistantTurnOutcomeKey        = attribute.Key("gram.assistant.turn_outcome")
 	AssistantServerIPKey           = attribute.Key("gram.assistant.server_ip")
 	AssistantImageRecycleKey       = attribute.Key("gram.assistant.image_recycle")
 	AssistantImageDesiredKey       = attribute.Key("gram.assistant.image_desired")
@@ -1688,6 +1689,8 @@ func AssistantAppCreated(v bool) attribute.KeyValue { return AssistantAppCreated
 func AssistantSetupFailureClass(v string) attribute.KeyValue {
 	return AssistantSetupFailureClassKey.String(v)
 }
+
+func AssistantTurnOutcome(v string) attribute.KeyValue { return AssistantTurnOutcomeKey.String(v) }
 
 func AssistantImageRecycle(v bool) attribute.KeyValue { return AssistantImageRecycleKey.Bool(v) }
 


### PR DESCRIPTION
## Summary

`classifyTurnError` failed open: any unrecognized `/turn` error defaulted to `ErrRuntimeUnhealthy` — the one retry path with **no attempt ceiling**. A deterministic, per-input error from a *live* runner was misfiled as "the VM is dead," so the coordinator tore down and re-admitted the machine forever (the DNO-290 incident churned ~186 machines/day for ~13h before manual intervention).

This closes the latent hazard so any future source of such an error cannot loop.

- **Classify by failure layer, not body substring.** The Fly and GKE turn-request paths now return a typed `runtimeResponseError` carrying the HTTP status + body instead of a flattened `status=%d body=%s` string. A runner *response* (status present) means the VM is alive → `ErrCompletionFailed` (terminal/capped) or `ErrHistoryCorrupted` (self-heal); only a *transport* failure or an unattributable 5xx → `ErrRuntimeUnhealthy`. `408`/`429` stay transient. The classifier lives in `runtime.go` and is shared by both backends at the `RunTurn` boundary.
- **Ceiling on the unhealthy path.** A dedicated `maxRuntimeTeardowns = 10` (distinct from `maxEventAttempts = 5`) terminal-fails an event after it has torn down that many runtimes, reusing the existing `assistant_thread_events.attempts` counter — **no migration**. Genuine infra blips keep generous retry; deterministic poison still gets capped.
- **Observability.** A new OTel counter `assistant.turn.classified` is bucketed by outcome (`runtime_unhealthy`, `runtime_unhealthy_exhausted`, `history_corrupted`, `completion_failed`, `transient`). `MeterProvider` is wired through `NewServiceCore`.

## Datadog monitor (Scope D deliverable)

Monitors are managed in the Datadog SaaS platform, not as code in this repo. Create the following against the new counter so a runaway teardown loop is no longer silent:

- **Type:** Metric monitor (sum)
- **Query:** `sum(last_1h):sum:assistant.turn.classified{gram.assistant.turn_outcome IN (runtime_unhealthy, runtime_unhealthy_exhausted)}.as_count() by {gram.assistant.thread_id} > 20`
- **Warning:** `> 10`
- **Message:** Assistant runtime teardowns spiking on a single thread — likely a deterministic turn error misclassified as infra (see DNO-295/DNO-290). Check `assistant.turn.classified` by `gram.assistant.turn_outcome`.
- **Notify:** assistants on-call

Closes [DNO-295](https://linear.app/speakeasy/issue/DNO-295/fixassistants-harden-turn-error-classification-to-stop-unbounded)

✻ Clauded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the unbounded runtime teardown loop by classifying assistant turn errors by layer and capping unhealthy teardowns. Threads are re-admitted after terminal failures so siblings drain, and we emit an outcome metric. Addresses DNO-295.

- **Bug Fixes**
  - Classify by layer using typed `runtimeResponseError` from Fly and GKE: runner responses → `ErrCompletionFailed`/`ErrHistoryCorrupted` (includes history-reject markers); only transport or unattributable 5xx → `ErrRuntimeUnhealthy` (`408`/`429` stay transient).
  - Cap unhealthy teardowns at `maxRuntimeTeardowns = 10` using the existing attempts counter; on exhaust, fail the event first, then stop the runtime and free the runtime row, each with its own timeout; surface runtime-row cleanup errors so re-admission doesn’t reuse a dead runtime; re-admit the thread so siblings run on a fresh runtime. Also re-admit after terminal `ErrCompletionFailed`/`ErrHistoryCorrupted` so siblings drain on the warm runtime.

- **New Features**
  - Emit OTel counter `assistant.turn.classified` with outcomes (incl. `runtime_unhealthy_exhausted`), tagged with `gram.assistant.turn_outcome`, `assistant_id`, and `thread_id`; pass `MeterProvider` through `assistants.NewServiceCore`.

<sup>Written for commit ac0f001fc48fc66ad33e491c26f29a58f93247af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

