### PR TITLE
fix: costs page follow-ups — logs overlay, unset drilldown, header tweaks

### DIFF
--- a/client/dashboard/src/pages/costs/CostTable.tsx
+++ b/client/dashboard/src/pages/costs/CostTable.tsx
@@ -106,8 +106,11 @@ function displayValue(groupValue: string): string {
   return groupValue === "" ? "(unset)" : groupValue;
 }
 
+// "" is the "(unset)" bucket — a real slice (everyone missing this attribute),
+// so it stays drillable. Only "Other" — the synthetic top-N overflow rollup of
+// many distinct values — can't map back to a single filter, so it's inert.
 function isDrillableValue(groupValue: string): boolean {
-  return groupValue !== "" && groupValue !== "Other";
+  return groupValue !== "Other";
 }
 
 // The provider logo for a model value (claude-* → Claude, gpt-* → OpenAI, …).
@@ -356,7 +359,7 @@ export function CostTable({
         </span>
         <span className="flex">
           <HeaderButton
-            label="Chats"
+            label="Sessions"
             sortKey="chats"
             sort={sort}
             onSort={onSort}

--- a/client/dashboard/src/pages/costs/CostWidgets.tsx
+++ b/client/dashboard/src/pages/costs/CostWidgets.tsx
@@ -452,7 +452,7 @@ export function CostWidgets({
       </div>
       <div className="grid grid-cols-3 gap-4">
         <KpiTile
-          label="Chat sessions"
+          label="Agent sessions"
           value={formatCompact(totals.sessions)}
           series={series.chats}
           delta={relDelta(totals.sessions, prevTotals.sessions)}

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -12,9 +12,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { TimeRangePicker } from "@/components/DashboardTimeRangePicker";
+import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { InsightsConfig } from "@/components/insights-dock";
+import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { useDateRangeFilter } from "@/components/observe/useDateRangeFilter";
 import { useSlugs } from "@/contexts/Sdk";
+import { useLogsEnabledErrorCheck } from "@/hooks/useLogsEnabled";
 import {
   type CostEntityLevel,
   costExplorerSuggestions,
@@ -153,6 +156,7 @@ export function CostsExplorer(): JSX.Element {
   // while loading/empty: availableDims is undefined and nothing gets hidden.
   const { data: attrKeysData } = useQuery({
     queryKey: ["costs-attr-keys", from.toISOString(), to.toISOString()],
+    throwOnError: false,
     queryFn: () =>
       unwrapAsync(
         telemetryListAttributeKeys(client, {
@@ -169,30 +173,39 @@ export function CostsExplorer(): JSX.Element {
     ? byParam
     : defaultGroupBy(path, availableDims);
 
-  const { data, isFetching, isError } = useQuery({
-    queryKey: [
-      "costs-explorer",
-      from.toISOString(),
-      to.toISOString(),
-      groupBy,
-      filters,
-    ],
-    queryFn: () =>
-      unwrapAsync(
-        telemetryQuery(client, {
-          queryPayload: {
-            from,
-            to,
-            groupBy: groupBy as GroupBy,
-            sortBy: "total_cost",
-            topN: 100,
-            // Daily buckets → ~30 points per group for the row trend sparklines.
-            granularitySeconds: 86400,
-            filters: filters.length ? filters : undefined,
-          },
-        }),
-      ),
-  });
+  // The primary query also doubles as the logs-enabled probe: telemetry.query
+  // returns 404 when logging is off for the org. Opt out of the app-wide
+  // throw-to-error-boundary policy (Sdk.tsx) so that 404 lands in `error`
+  // instead of crashing the page, then derive `isLogsDisabled` from it to show
+  // the shared EnableLoggingOverlay — same pattern as the Logs/Agents pages.
+  const { data, isFetching, isError, refetch, isLogsDisabled } =
+    useLogsEnabledErrorCheck(
+      useQuery({
+        queryKey: [
+          "costs-explorer",
+          from.toISOString(),
+          to.toISOString(),
+          groupBy,
+          filters,
+        ],
+        throwOnError: false,
+        queryFn: () =>
+          unwrapAsync(
+            telemetryQuery(client, {
+              queryPayload: {
+                from,
+                to,
+                groupBy: groupBy as GroupBy,
+                sortBy: "total_cost",
+                topN: 100,
+                // Daily buckets → ~30 points per group for the row trend sparklines.
+                granularitySeconds: 86400,
+                filters: filters.length ? filters : undefined,
+              },
+            }),
+          ),
+      }),
+    );
 
   // The current entity's own attributes: a no-group_by query over the same
   // filters returns a single aggregate row whose dimension_values are this
@@ -206,6 +219,7 @@ export function CostsExplorer(): JSX.Element {
       filters,
     ],
     enabled: path.length > 0,
+    throwOnError: false,
     queryFn: () =>
       unwrapAsync(
         telemetryQuery(client, {
@@ -234,6 +248,7 @@ export function CostsExplorer(): JSX.Element {
       groupBy,
       filters,
     ],
+    throwOnError: false,
     queryFn: () =>
       unwrapAsync(
         telemetryQuery(client, {
@@ -332,6 +347,7 @@ export function CostsExplorer(): JSX.Element {
       filters,
     ],
     enabled: !!mixDimA,
+    throwOnError: false,
     queryFn: () =>
       unwrapAsync(
         telemetryQuery(client, {
@@ -355,6 +371,7 @@ export function CostsExplorer(): JSX.Element {
       filters,
     ],
     enabled: !!mixDimB,
+    throwOnError: false,
     queryFn: () =>
       unwrapAsync(
         telemetryQuery(client, {
@@ -487,7 +504,9 @@ export function CostsExplorer(): JSX.Element {
     // drilling stays enabled and never blocks prematurely.)
     const next = nextAvailableDimension(dim, availableDims);
     if (next === null) return;
-    if (value === "" || value === "Other") return;
+    // "" (the "(unset)" bucket) is drillable — it filters to the entities
+    // missing this attribute. Only "Other" (the synthetic top-N rollup) isn't.
+    if (value === "Other") return;
     goToNode([...path, { dim, value }], next);
   };
 
@@ -577,7 +596,7 @@ export function CostsExplorer(): JSX.Element {
       onCustomRangeChange={setCustomRangeParam}
       onClearCustomRange={clearCustomRange}
       projectSlug={projectSlug}
-      className="py-1"
+      className="bg-background py-1"
     />
   );
 
@@ -592,6 +611,35 @@ export function CostsExplorer(): JSX.Element {
       loading={isFetching && !data}
     />
   );
+
+  // Logging off for the org → no cost data exists. Show the shared enable
+  // overlay over a skeleton instead of an empty/broken profile, and hide the
+  // assistant dock (its prompts assume populated numbers). Enabling refetches.
+  if (isLogsDisabled) {
+    return (
+      <>
+        <InsightsConfig hideTrigger />
+        <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto p-8 pb-24">
+          <div className="flex min-w-0 flex-col gap-1">
+            <h1 className="text-xl font-semibold">Costs</h1>
+            <p className="text-muted-foreground text-sm">
+              Break down AI spend across your organization by division,
+              department, user, agent, and model.
+            </p>
+          </div>
+          <div className="relative flex-1">
+            <div
+              className="pointer-events-none h-full select-none"
+              aria-hidden="true"
+            >
+              <ObservabilitySkeleton />
+            </div>
+            <EnableLoggingOverlay onEnabled={() => void refetch()} />
+          </div>
+        </div>
+      </>
+    );
+  }
 
   return (
     <>

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -67,7 +67,7 @@ function buildCostCsv(rows: QueryRow[], groupLabel: string): string {
     "Total Cost",
     "% Share",
     "Cost / Session",
-    "Chats",
+    "Sessions",
     "Tool Calls",
     "Tokens",
   ];
@@ -229,7 +229,7 @@ export type EntityProfileProps = {
   onDrill: (row: QueryRow) => void;
   // Per-group daily cost series for the row sparklines.
   seriesByGroup: Map<string, number[]>;
-  // The date-range picker control, rendered next to the row count.
+  // The date-range picker control, rendered in the header above the stats.
   rangePicker: ReactNode;
   // Human date-range label (e.g. "June 15–19") for the CSV export filename.
   rangeLabel: string;
@@ -334,6 +334,9 @@ export function EntityProfile({
               </span>
             </button>
           </div>
+          {/* Date-range picker pinned to the top-right of the header, in line
+              with the back controls on the left — it scopes every number below. */}
+          <div className="absolute top-5 right-8 z-10">{rangePicker}</div>
           <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex min-w-0 items-start gap-4">
               <div className="border-border bg-background flex size-16 shrink-0 items-center justify-center rounded-2xl border">
@@ -356,7 +359,7 @@ export function EntityProfile({
             <div className="flex shrink-0 gap-8">
               <HeaderStat label="Cost" value={formatCost(stats.cost)} />
               <HeaderStat
-                label="Chat sessions"
+                label="Agent sessions"
                 value={stats.sessions.toLocaleString()}
               />
               <HeaderStat
@@ -375,37 +378,34 @@ export function EntityProfile({
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-8 pt-2 pb-24">
         {widgets}
         <div className="flex flex-col gap-3">
-          <div className="mb-3 flex items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              <h2 className="flex items-center gap-2 text-sm font-semibold">
-                Breakdown by
-                <Select
-                  value={groupBy}
-                  onValueChange={(value) => onGroupByChange(value as Dimension)}
-                >
-                  <SelectTrigger className="border-border hover:bg-muted data-[state=open]:bg-muted !h-auto w-auto -my-1 cursor-pointer gap-1.5 rounded-md border bg-transparent py-1.5 pr-2.5 pl-3 text-sm font-semibold shadow-none transition-colors focus-visible:ring-0">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {pivotOptions.map((p) => (
-                      <SelectItem key={p.dim} value={p.dim}>
-                        {p.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </h2>
-              <button
-                type="button"
-                onClick={handleExportCsv}
-                disabled={rows.length === 0}
-                className="text-muted-foreground hover:text-foreground border-border hover:bg-muted inline-flex items-center gap-1.5 rounded-md border bg-transparent px-2.5 py-1.5 text-sm transition-colors disabled:pointer-events-none disabled:opacity-40"
+          <div className="mb-3 flex items-center gap-3">
+            <h2 className="flex items-center gap-2 text-sm font-semibold">
+              Breakdown by
+              <Select
+                value={groupBy}
+                onValueChange={(value) => onGroupByChange(value as Dimension)}
               >
-                <Download className="size-3.5 shrink-0" />
-                Export CSV
-              </button>
-            </div>
-            {rangePicker}
+                <SelectTrigger className="border-border hover:bg-muted data-[state=open]:bg-muted !h-auto w-auto -my-1 cursor-pointer gap-1.5 rounded-md border bg-transparent py-1.5 pr-2.5 pl-3 text-sm font-semibold shadow-none transition-colors focus-visible:ring-0">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {pivotOptions.map((p) => (
+                    <SelectItem key={p.dim} value={p.dim}>
+                      {p.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </h2>
+            <button
+              type="button"
+              onClick={handleExportCsv}
+              disabled={rows.length === 0}
+              className="text-muted-foreground hover:text-foreground border-border hover:bg-muted inline-flex items-center gap-1.5 rounded-md border bg-transparent px-2.5 py-1.5 text-sm transition-colors disabled:pointer-events-none disabled:opacity-40"
+            >
+              <Download className="size-3.5 shrink-0" />
+              Export CSV
+            </button>
           </div>
           {isError ? (
             <Type className="text-muted-foreground">

--- a/server/clickhouse/scripts/seed-costs.mjs
+++ b/server/clickhouse/scripts/seed-costs.mjs
@@ -1,0 +1,665 @@
+#!/usr/bin/env node
+// Local cost-dashboard seed (dev only — never run against dev/prod databases).
+//
+// Generates a coherent, plausible @speakeasy.com org tree and writes telemetry
+// rows into local ClickHouse `telemetry_logs`. The attribute_metrics_summaries
+// materialized view aggregates them, so the org-scoped telemetry.query endpoint
+// (and the cost dashboard) can group/filter by every existing dimension:
+//   division_name, department_name, job_title, employee_type, cost_center_name,
+//   email (user), model, hook_source (agent), role[], group[] (== team here).
+//
+// A deterministic slice of users are missing attributes, so every breakdown has
+// a populated, drillable "(unset)" bucket (scalar → '', array → []).
+//
+// Manager + team are NOT queryable dimensions yet (deferred), but we stamp
+//   user.attributes.manager_email / manager_name  and  user.groups = [team]
+// so the data is ready and "Team" works today via the existing `group` axis.
+//
+// Pure Node builtins + the `docker` CLI — no workspace deps.
+//   Run:  node server/clickhouse/scripts/seed-costs.mjs
+// Idempotent: deletes all @speakeasy.com rows from telemetry_logs AND
+// attribute_metrics_summaries first (the MV only appends, so we must clear the
+// aggregate too or re-runs double-count), then re-inserts.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import { execFileSync } from "node:child_process";
+
+// Resolve container names by substring — compose sometimes recreates them with
+// a hash prefix (e.g. 936ee56b0865_gram-clickhouse-1), so a hardcoded name rots.
+function resolveContainer(substr, fallback) {
+  try {
+    const out = execFileSync(
+      "docker",
+      ["ps", "--filter", `name=${substr}`, "--format", "{{.Names}}"],
+      { encoding: "utf8" },
+    )
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return out[0] || fallback;
+  } catch {
+    return fallback;
+  }
+}
+const CH_CONTAINER = resolveContainer("clickhouse", "gram-clickhouse-1");
+const PG_CONTAINER = resolveContainer("gram-gram-db", "gram-gram-db-1");
+const EMAIL_DOMAIN = "speakeasy.com";
+const DAYS_BACK = 28; // stay under the aggregate's 30-day TTL
+const NOW = Date.now();
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// ---- deterministic PRNG (mulberry32) so re-runs are identical -------------
+let _s = 0x9e3779b9;
+function rnd() {
+  _s |= 0;
+  _s = (_s + 0x6d2b79f5) | 0;
+  let t = Math.imul(_s ^ (_s >>> 15), 1 | _s);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+const randint = (lo, hi) => lo + Math.floor(rnd() * (hi - lo + 1));
+const pick = (arr) => arr[Math.floor(rnd() * arr.length)];
+function weightedPick(items, weights) {
+  const total = weights.reduce((a, b) => a + b, 0);
+  let r = rnd() * total;
+  for (let i = 0; i < items.length; i++) {
+    if ((r -= weights[i]) < 0) return items[i];
+  }
+  return items[items.length - 1];
+}
+
+// ---- name pools (no apostrophes — they'd break the SQL string literals) ----
+const FIRST = [
+  "Adam",
+  "Maya",
+  "Liam",
+  "Sofia",
+  "Noah",
+  "Priya",
+  "Ethan",
+  "Olivia",
+  "Lucas",
+  "Ava",
+  "Mateo",
+  "Zoe",
+  "Kai",
+  "Nina",
+  "Owen",
+  "Aisha",
+  "Leo",
+  "Ruby",
+  "Felix",
+  "Hana",
+  "Jonas",
+  "Elena",
+  "Theo",
+  "Iris",
+  "Diego",
+  "Clara",
+  "Sven",
+  "Mira",
+  "Arjun",
+  "Lena",
+  "Marcus",
+  "Yuki",
+  "Caleb",
+  "Freya",
+  "Omar",
+  "Isla",
+  "Victor",
+  "Anya",
+  "Dane",
+  "Nora",
+  "Pablo",
+  "Tara",
+  "Hugo",
+  "Esme",
+  "Rafa",
+  "Lia",
+  "Soren",
+  "Mae",
+  "Niko",
+  "Vera",
+];
+const LAST = [
+  "Reyes",
+  "Novak",
+  "Chen",
+  "Patel",
+  "Okafor",
+  "Vasquez",
+  "Lindqvist",
+  "Haddad",
+  "Suzuki",
+  "Moreau",
+  "Bauer",
+  "Costa",
+  "Ivanov",
+  "Nguyen",
+  "Schmidt",
+  "Rossi",
+  "Khan",
+  "Andersen",
+  "Silva",
+  "Kowalski",
+  "Mensah",
+  "Park",
+  "Dubois",
+  "Romano",
+  "Becker",
+  "Sato",
+  "Lopez",
+  "Fischer",
+  "Tanaka",
+  "Weber",
+  "Marsh",
+  "Cole",
+  "Frost",
+  "Vance",
+  "Holt",
+  "Quinn",
+  "Drake",
+  "Sloane",
+  "Beck",
+  "Wren",
+];
+
+// ---- org model: divisions -> departments -> teams --------------------------
+// Each department: division, cost center, IC titles, manager title, the agent
+// surfaces its people lean on (weighted, first = primary), role pool, and the
+// rough session intensity of its ICs (drives cost distribution + top_n).
+const DEPARTMENTS = [
+  {
+    name: "Engineering",
+    division: "R&D",
+    cc: "CC-ENG-1000",
+    teams: ["Platform", "SDK Generation", "Gram / MCP", "Infrastructure"],
+    icTitles: [
+      "Software Engineer",
+      "Senior Software Engineer",
+      "Staff Engineer",
+    ],
+    mgrTitle: "Engineering Manager",
+    agents: ["claude-code", "cursor", "codex"],
+    agentW: [60, 30, 10],
+    roles: ["developer"],
+    intensity: [25, 60],
+    tokenScale: 2.2,
+    icPerTeam: [7, 11],
+  },
+  {
+    name: "Product",
+    division: "R&D",
+    cc: "CC-PRD-1100",
+    teams: ["Core Product", "Growth"],
+    icTitles: ["Product Manager", "Senior Product Manager"],
+    mgrTitle: "Director of Product",
+    agents: ["claude-code", "cowork"],
+    agentW: [55, 45],
+    roles: ["analyst", "viewer"],
+    intensity: [12, 30],
+    tokenScale: 1.2,
+    icPerTeam: [4, 6],
+  },
+  {
+    name: "Design",
+    division: "R&D",
+    cc: "CC-DSN-1200",
+    teams: ["Product Design", "Brand"],
+    icTitles: ["Product Designer", "Brand Designer"],
+    mgrTitle: "Design Lead",
+    agents: ["cowork", "claude-code"],
+    agentW: [70, 30],
+    roles: ["viewer"],
+    intensity: [8, 22],
+    tokenScale: 1.0,
+    icPerTeam: [3, 5],
+  },
+  {
+    name: "Developer Relations",
+    division: "Go-To-Market",
+    cc: "CC-DRL-2000",
+    teams: ["DevRel", "Docs"],
+    icTitles: ["Developer Advocate", "Technical Writer"],
+    mgrTitle: "Head of DevRel",
+    agents: ["claude-code", "cowork"],
+    agentW: [55, 45],
+    roles: ["developer", "viewer"],
+    intensity: [20, 45],
+    tokenScale: 1.6,
+    icPerTeam: [3, 5],
+  },
+  {
+    name: "Sales",
+    division: "Go-To-Market",
+    cc: "CC-SAL-2100",
+    teams: ["Enterprise", "Mid-Market", "SDR"],
+    icTitles: ["Account Executive", "Sales Development Rep"],
+    mgrTitle: "Sales Manager",
+    agents: ["cowork", "cursor"],
+    agentW: [80, 20],
+    roles: ["viewer"],
+    intensity: [6, 20],
+    tokenScale: 0.8,
+    icPerTeam: [5, 8],
+  },
+  {
+    name: "Marketing",
+    division: "Go-To-Market",
+    cc: "CC-MKT-2200",
+    teams: ["Demand Gen", "Content"],
+    icTitles: ["Marketing Manager", "Content Strategist"],
+    mgrTitle: "Head of Marketing",
+    agents: ["cowork"],
+    agentW: [100],
+    roles: ["viewer", "analyst"],
+    intensity: [8, 24],
+    tokenScale: 1.0,
+    icPerTeam: [3, 5],
+  },
+  {
+    name: "Customer Success",
+    division: "Operations",
+    cc: "CC-CS-3000",
+    teams: ["Onboarding", "Support"],
+    icTitles: ["Customer Success Manager", "Support Engineer"],
+    mgrTitle: "CS Manager",
+    agents: ["claude-code", "cowork"],
+    agentW: [45, 55],
+    roles: ["viewer"],
+    intensity: [10, 28],
+    tokenScale: 1.1,
+    icPerTeam: [4, 7],
+  },
+  {
+    name: "Finance & Ops",
+    division: "Operations",
+    cc: "CC-FIN-3100",
+    teams: ["Finance", "RevOps"],
+    icTitles: ["Financial Analyst", "Operations Analyst"],
+    mgrTitle: "Finance Manager",
+    agents: ["cowork"],
+    agentW: [100],
+    roles: ["billing", "viewer"],
+    intensity: [6, 18],
+    tokenScale: 0.9,
+    icPerTeam: [3, 4],
+  },
+  {
+    name: "People",
+    division: "Operations",
+    cc: "CC-PPL-3200",
+    teams: ["Recruiting", "People Ops"],
+    icTitles: ["Recruiter", "People Partner"],
+    mgrTitle: "Head of People",
+    agents: ["cowork"],
+    agentW: [100],
+    roles: ["viewer"],
+    intensity: [5, 16],
+    tokenScale: 0.8,
+    icPerTeam: [2, 4],
+  },
+];
+
+const EMP_TYPES = ["full_time", "contractor", "part_time"];
+const EMP_WEIGHTS = [85, 11, 4];
+const MODELS = [
+  ["claude-sonnet-4-6", "anthropic"],
+  ["claude-haiku-4-5", "anthropic"],
+  ["claude-opus-4-8", "anthropic"],
+  ["gpt-4o", "openai"],
+  ["gpt-4o-mini", "openai"],
+];
+const MODEL_WEIGHTS = [40, 22, 8, 18, 12];
+const TOOLS = [
+  "tools:http:github:create_issue",
+  "tools:http:github:list_pull_requests",
+  "tools:http:slack:send_message",
+  "tools:http:linear:create_issue",
+  "tools:http:postgres:run_query",
+  "tools:http:stripe:create_charge",
+  "tools:functions:gram:generate_sdk",
+  "tools:http:notion:create_page",
+  "tools:http:datadog:search_logs",
+];
+
+// ---- build the people ------------------------------------------------------
+const usedEmails = new Set();
+function emailFor(first, last) {
+  let base = `${first}.${last}`.toLowerCase().replace(/[^a-z.]/g, "");
+  let e = `${base}@${EMAIL_DOMAIN}`;
+  let n = 1;
+  while (usedEmails.has(e)) e = `${base}${++n}@${EMAIL_DOMAIN}`;
+  usedEmails.add(e);
+  return e;
+}
+let nameCursor = 0;
+function nextName() {
+  const f = FIRST[nameCursor % FIRST.length];
+  const l =
+    LAST[
+      (Math.floor(nameCursor / FIRST.length) % LAST.length) + (nameCursor % 3)
+    ];
+  nameCursor++;
+  return [f, l];
+}
+
+const people = []; // {name,email,division,department,team,title,empType,roles,groups,agents,agentW,manager,intensity,tokenScale}
+let uid = 0;
+function addPerson(p) {
+  p.userId = `sk-user-${uid++}`;
+  people.push(p);
+  return p;
+}
+
+// CEO (the logged-in user) — top of the tree.
+const ceo = addPerson({
+  name: "Adam Bull",
+  email: `adam@${EMAIL_DOMAIN}`,
+  division: "Executive",
+  department: "Executive",
+  team: "Leadership",
+  title: "CEO / Co-Founder",
+  empType: "full_time",
+  roles: ["admin", "billing"],
+  groups: ["Leadership"],
+  agents: ["claude-code", "cursor"],
+  agentW: [70, 30],
+  managerEmail: "",
+  managerName: "",
+  intensity: [8, 18],
+  tokenScale: 1.5,
+});
+usedEmails.add(ceo.email);
+
+// One VP per division, reporting to the CEO. VP department = flagship dept.
+const DIVISIONS = ["R&D", "Go-To-Market", "Operations"];
+const flagshipDept = {
+  "R&D": "Engineering",
+  "Go-To-Market": "Sales",
+  Operations: "Finance & Ops",
+};
+const vpByDivision = {};
+for (const div of DIVISIONS) {
+  const [f, l] = nextName();
+  const dept = DEPARTMENTS.find((d) => d.name === flagshipDept[div]);
+  const vp = addPerson({
+    name: `${f} ${l}`,
+    email: emailFor(f, l),
+    division: div,
+    department: dept.name,
+    team: "Leadership",
+    title: `VP of ${div === "R&D" ? "Engineering" : div === "Go-To-Market" ? "Go-To-Market" : "Operations"}`,
+    empType: "full_time",
+    roles: ["admin"],
+    groups: ["Leadership"],
+    agents: dept.agents,
+    agentW: dept.agentW,
+    managerEmail: ceo.email,
+    managerName: ceo.name,
+    intensity: [6, 14],
+    tokenScale: 1.3,
+  });
+  vpByDivision[div] = vp;
+}
+
+// Team managers + ICs per department.
+for (const dept of DEPARTMENTS) {
+  const vp = vpByDivision[dept.division];
+  for (const team of dept.teams) {
+    const [mf, ml] = nextName();
+    const mgr = addPerson({
+      name: `${mf} ${ml}`,
+      email: emailFor(mf, ml),
+      division: dept.division,
+      department: dept.name,
+      team,
+      title: dept.mgrTitle,
+      empType: "full_time",
+      roles: [...new Set(["admin", ...dept.roles])],
+      groups: [team],
+      agents: dept.agents,
+      agentW: dept.agentW,
+      managerEmail: vp.email,
+      managerName: vp.name,
+      intensity: [8, 20],
+      tokenScale: dept.tokenScale * 0.9,
+    });
+    const icCount = randint(dept.icPerTeam[0], dept.icPerTeam[1]);
+    for (let i = 0; i < icCount; i++) {
+      const [f, l] = nextName();
+      const empType = weightedPick(EMP_TYPES, EMP_WEIGHTS);
+      const roles = [...new Set([...dept.roles, "viewer"])];
+      addPerson({
+        name: `${f} ${l}`,
+        email: emailFor(f, l),
+        division: dept.division,
+        department: dept.name,
+        team,
+        title: pick(dept.icTitles),
+        empType,
+        roles,
+        groups: [team],
+        agents: dept.agents,
+        agentW: dept.agentW,
+        managerEmail: mgr.email,
+        managerName: mgr.name,
+        intensity: dept.intensity,
+        tokenScale: dept.tokenScale,
+      });
+    }
+  }
+}
+
+// ---- generate telemetry rows ----------------------------------------------
+const projectIds = discoverProjectIds();
+const projectWeights = projectIds.map((_, i) =>
+  i === 0 ? 70 : 30 / (projectIds.length - 1 || 1),
+);
+
+function uuidv5(name) {
+  const h = crypto
+    .createHash("sha1")
+    .update("speakeasy-costs-ns")
+    .update(name)
+    .digest();
+  h[6] = (h[6] & 0x0f) | 0x50;
+  h[8] = (h[8] & 0x3f) | 0x80;
+  const x = h.toString("hex").slice(0, 32);
+  return `${x.slice(0, 8)}-${x.slice(8, 12)}-${x.slice(12, 16)}-${x.slice(16, 20)}-${x.slice(20, 32)}`;
+}
+const sql = (s) => String(s).replace(/'/g, "''");
+function attrJSON(obj) {
+  return sql(JSON.stringify(obj));
+}
+
+let chatSeq = 0;
+let totalChats = 0;
+const rows = [];
+
+for (const p of people) {
+  // Real directory syncs are incomplete: a slice of people are missing one or
+  // more attributes. Blanking them here populates the "(unset)" bucket in every
+  // breakdown (scalar → '', array → []) so the now-drillable "(unset)" rows have
+  // real cost behind them. Keep the CEO (the logged-in user) fully populated.
+  const full = p === ceo;
+  const orBlank = (prob, value) => (!full && rnd() < prob ? "" : value);
+  const orEmpty = (prob, value) => (!full && rnd() < prob ? [] : value);
+  const costCenter =
+    (DEPARTMENTS.find((d) => d.name === p.department) || {}).cc ||
+    "CC-EXEC-0000";
+
+  // Shared WorkOS-style attribute block for every row this user emits.
+  const ua = {
+    "user.email": p.email,
+    "user.id": p.userId,
+    "user.attributes.division_name": orBlank(0.06, p.division),
+    "user.attributes.department_name": orBlank(0.08, p.department),
+    "user.attributes.team_name": p.team, // not a dimension yet (deferred)
+    "user.attributes.job_title": orBlank(0.18, p.title),
+    "user.attributes.employee_type": orBlank(0.1, p.empType),
+    "user.attributes.cost_center_name": orBlank(0.1, costCenter),
+    "user.attributes.manager_email": p.managerEmail, // deferred dim, stamped for later
+    "user.attributes.manager_name": p.managerName,
+    "user.roles": orEmpty(0.12, p.roles), // [] → "(unset)" on the Role axis
+    "user.groups": orEmpty(0.15, p.groups), // == team; [] → "(unset)" Team
+  };
+
+  const sessions = randint(p.intensity[0], p.intensity[1]);
+  for (let s = 0; s < sessions; s++) {
+    totalChats++;
+    const chatId = uuidv5(`chat-${chatSeq++}`);
+    const projectId = weightedPick(projectIds, projectWeights);
+    const hookSource = weightedPick(p.agents, p.agentW);
+    const daysAgo = rnd() * DAYS_BACK;
+    const t = BigInt(Math.floor(NOW - daysAgo * MS_PER_DAY)) * 1000000n;
+    const traceId = crypto.randomBytes(16).toString("hex");
+    const baseAttrs = {
+      ...ua,
+      "gram.hook.source": hookSource,
+      "gram.project.id": projectId,
+    };
+
+    // 1) tool-call row(s) — drives total_tool_calls (urn must start "tools:")
+    const nTools = randint(1, 4);
+    for (let k = 0; k < nTools; k++) {
+      const toolUrn = pick(TOOLS);
+      const status = rnd() < 0.93 ? 200 : pick([400, 500, 502]);
+      const latency = (0.05 + rnd() * 2).toFixed(3);
+      const a = {
+        "http.response.status_code": status,
+        "http.server.request.duration": Number(latency),
+        "gram.tool.urn": toolUrn,
+        "gen_ai.conversation.id": chatId,
+        ...baseAttrs,
+      };
+      const tt = t + BigInt(k * 1000);
+      rows.push(
+        `(${tt}, ${tt}, 'INFO', 'Tool call: ${sql(toolUrn)}', '${traceId}', '${attrJSON(a)}', '{"gram.deployment.id": "deployment-1"}', '${projectId}', '${sql(toolUrn)}', 'gram-mcp-gateway', '${chatId}')`,
+      );
+    }
+
+    // 2) chat-completion row — drives cost + token measures + total_chats
+    const [model, provider] = weightedPick(MODELS, MODEL_WEIGHTS);
+    const scale = p.tokenScale;
+    const inputTokens = Math.floor((500 + rnd() * 7500) * scale);
+    const outputTokens = Math.floor((100 + rnd() * 2900) * scale);
+    const cacheRead = Math.floor(inputTokens * (rnd() * 0.5));
+    const cacheCreate = Math.floor(inputTokens * (rnd() * 0.15));
+    const cost = ((inputTokens * 3 + outputTokens * 15) / 1_000_000).toFixed(6);
+    const finish = rnd() < 0.7 ? "stop" : rnd() < 0.9 ? "length" : "error";
+    const duration = 30 + Math.floor(rnd() * 150);
+    const ct = t + 1000000n;
+    const ca = {
+      "gen_ai.response.finish_reasons": [finish],
+      "gen_ai.conversation.id": chatId,
+      "gen_ai.conversation.duration": duration,
+      "gen_ai.usage.input_tokens": inputTokens,
+      "gen_ai.usage.output_tokens": outputTokens,
+      "gen_ai.usage.total_tokens": inputTokens + outputTokens,
+      "gen_ai.usage.cache_read.input_tokens": cacheRead,
+      "gen_ai.usage.cache_creation.input_tokens": cacheCreate,
+      "gen_ai.usage.cost": Number(cost),
+      "gen_ai.response.model": model,
+      "gen_ai.provider.name": provider,
+      "gram.resource.urn": "agents:chat:completion",
+      "http.response.status_code": rnd() < 0.95 ? 200 : 500,
+      ...baseAttrs,
+    };
+    rows.push(
+      `(${ct}, ${ct}, 'INFO', 'Chat completion', '${traceId}', '${attrJSON(ca)}', '{"gram.deployment.id": "deployment-1"}', '${projectId}', 'agents:chat:completion', 'gram-mcp-gateway', '${chatId}')`,
+    );
+  }
+}
+
+// ---- flush to ClickHouse ---------------------------------------------------
+const CLEANUP = [
+  "SET mutations_sync = 1;",
+  `ALTER TABLE telemetry_logs DELETE WHERE user_email LIKE '%@${EMAIL_DOMAIN}';`,
+  `ALTER TABLE attribute_metrics_summaries DELETE WHERE user_email LIKE '%@${EMAIL_DOMAIN}';`,
+];
+const COLS =
+  "(time_unix_nano, observed_time_unix_nano, severity_text, body, trace_id, attributes, resource_attributes, gram_project_id, gram_urn, service_name, gram_chat_id)";
+
+const parts = [...CLEANUP];
+const CHUNK = 2000;
+for (let i = 0; i < rows.length; i += CHUNK) {
+  parts.push(
+    `INSERT INTO telemetry_logs ${COLS} VALUES\n${rows.slice(i, i + CHUNK).join(",\n")};`,
+  );
+}
+
+const tmp = `${os.tmpdir()}/seed_costs_${process.pid}.sql`;
+fs.writeFileSync(tmp, parts.join("\n"));
+console.log(
+  `Generated ${people.length} users across ${DEPARTMENTS.length} departments / ${DIVISIONS.length} divisions, ` +
+    `${totalChats} chat sessions → ${rows.length} telemetry rows.`,
+);
+console.log(`Target org projects: ${projectIds.join(", ")}`);
+
+try {
+  execFileSync("docker", ["cp", tmp, `${CH_CONTAINER}:/tmp/seed_costs.sql`], {
+    stdio: "inherit",
+  });
+  execFileSync(
+    "docker",
+    [
+      "exec",
+      CH_CONTAINER,
+      "clickhouse-client",
+      "--multiquery",
+      "--queries-file",
+      "/tmp/seed_costs.sql",
+    ],
+    { stdio: "inherit" },
+  );
+  fs.unlinkSync(tmp);
+  console.log("Inserted into ClickHouse. Verifying aggregate…");
+  verify();
+} catch (e) {
+  console.error("ClickHouse insert failed:", e.message);
+  console.error(`SQL kept at ${tmp} for inspection.`);
+  process.exit(1);
+}
+
+// ---- helpers that shell out ------------------------------------------------
+function discoverProjectIds() {
+  const q =
+    "SELECT id FROM projects WHERE organization_id = " +
+    "(SELECT organization_id FROM projects GROUP BY organization_id ORDER BY count(*) DESC LIMIT 1) ORDER BY id;";
+  const out = execFileSync(
+    "docker",
+    ["exec", PG_CONTAINER, "psql", "-U", "gram", "-d", "gram", "-tA", "-c", q],
+    {
+      encoding: "utf8",
+    },
+  );
+  const ids = out
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!ids.length) {
+    console.error(
+      "No projects found in local Postgres — run `mise run seed` first.",
+    );
+    process.exit(1);
+  }
+  return ids;
+}
+
+function verify() {
+  const q =
+    "SELECT division_name, department_name, uniqExact(user_email) AS users, " +
+    "round(sumIfMerge(total_cost), 2) AS cost " +
+    `FROM attribute_metrics_summaries WHERE user_email LIKE '%@${EMAIL_DOMAIN}' ` +
+    "GROUP BY division_name, department_name ORDER BY division_name, department_name " +
+    "FORMAT PrettyCompactMonoBlock;";
+  const out = execFileSync(
+    "docker",
+    ["exec", CH_CONTAINER, "clickhouse-client", "-q", q],
+    { encoding: "utf8" },
+  );
+  console.log(out);
+}

--- a/server/internal/telemetry/repo/attribute_metrics.go
+++ b/server/internal/telemetry/repo/attribute_metrics.go
@@ -229,6 +229,35 @@ func attributeDimensionValuesExpr(groupBy string) string {
 	return "map(" + strings.Join(parts, ", ") + ") AS dimension_values"
 }
 
+// arrayDimFilter builds the WHERE predicate for an Array(String) dimension.
+// An empty array is grouped under the "" ("(unset)") bucket — see the
+// empty→[”] mapping in attributeGroupValueExpr — so a requested "" value must
+// match array emptiness, not a literal "" element: hasAny never matches an
+// empty array. Non-empty requested values keep using hasAny; when both are
+// present they combine with OR so the "(unset)" row stays drillable for arrays.
+func arrayDimFilter(column string, values []string) squirrel.Sqlizer {
+	hasEmpty := false
+	nonEmpty := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			hasEmpty = true
+			continue
+		}
+		nonEmpty = append(nonEmpty, v)
+	}
+	emptyPred := squirrel.Expr("empty(" + column + ")")
+	if len(nonEmpty) == 0 {
+		// Only "(unset)" requested → match rows whose array is empty.
+		return emptyPred
+	}
+	// hasAny(col, [v1, v2, ...]); clickhouse-go binds the slice as an array arg.
+	hasAnyPred := squirrel.Expr("hasAny("+column+", ?)", nonEmpty)
+	if !hasEmpty {
+		return hasAnyPred
+	}
+	return squirrel.Or{hasAnyPred, emptyPred}
+}
+
 // applyAttributeFilters adds the WHERE predicates for the supplied filters.
 func applyAttributeFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter) (squirrel.SelectBuilder, error) {
 	for _, f := range filters {
@@ -241,8 +270,7 @@ func applyAttributeFilters(sb squirrel.SelectBuilder, filters []AttributeMetrics
 		}
 		switch dim.kind {
 		case attributeDimArray:
-			// hasAny(col, [v1, v2, ...]); clickhouse-go binds the slice as an array arg.
-			sb = sb.Where(squirrel.Expr("hasAny("+dim.column+", ?)", f.Values))
+			sb = sb.Where(arrayDimFilter(dim.column, f.Values))
 		case attributeDimScalar, attributeDimProject:
 			sb = sb.Where(squirrel.Eq{dim.column: f.Values})
 		default:

--- a/server/internal/telemetry/repo/queries_test.go
+++ b/server/internal/telemetry/repo/queries_test.go
@@ -40,3 +40,32 @@ func TestToolUsageTraceRowsCTE_UsesDeterministicStatusAggregation(t *testing.T) 
 	require.NotContains(t, strings.ToLower(sql), "any(hook_status)")
 	require.Contains(t, sql, "max(hook_status_rank)")
 }
+
+// Array dimensions group an empty array under the "" ("(unset)") bucket, so the
+// filter for "" must test array emptiness — hasAny never matches an empty array.
+func TestArrayDimFilter_UnsetMatchesEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	sql, args, err := arrayDimFilter("groups", []string{""}).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "empty(groups)", sql)
+	require.Empty(t, args)
+}
+
+func TestArrayDimFilter_NonEmptyUsesHasAny(t *testing.T) {
+	t.Parallel()
+
+	sql, args, err := arrayDimFilter("groups", []string{"eng", "design"}).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "hasAny(groups, ?)", sql)
+	require.Equal(t, []any{[]string{"eng", "design"}}, args)
+}
+
+func TestArrayDimFilter_MixedCombinesWithOr(t *testing.T) {
+	t.Parallel()
+
+	sql, args, err := arrayDimFilter("groups", []string{"eng", ""}).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "(hasAny(groups, ?) OR empty(groups))", sql)
+	require.Equal(t, []any{[]string{"eng"}}, args)
+}

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -60,7 +60,7 @@ func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFi
 		}
 		switch dim.kind {
 		case attributeDimArray:
-			sb = sb.Where(squirrel.Expr("hasAny("+dim.column+", ?)", f.Values))
+			sb = sb.Where(arrayDimFilter(dim.column, f.Values))
 		case attributeDimScalar, attributeDimProject:
 			sb = sb.Where(squirrel.Eq{dim.column: f.Values})
 		default:


### PR DESCRIPTION
## What

Follow-up fixes for the new cost-taxonomy dashboard (`gram-new-costs-page`).

### Fixes

- **No more crash when logging is off.** `telemetry.query` 404s when an org hasn't enabled logging. The costs queries inherited the app-wide throw-to-error-boundary policy, so the page crashed. They now opt out (`throwOnError: false`) and the page shows the shared `EnableLoggingOverlay` + skeleton, matching the Logs/Agents pages.
- **"(unset)" rows are now drillable.** Rows whose group value is empty (e.g. users with no job title) were inert. The UI now blocks only the synthetic `"Other"` rollup. The backend array-dimension filter (`group`, `role`) was also asymmetric: grouping buckets empty arrays under `''`, but the filter used `hasAny(col, [''])`, which never matches an empty array. New `arrayDimFilter` helper uses `empty(col)` for the unset case, so the drill returns real data for array dims too (scalar dims already worked). Unit tests added.

### Tweaks

- Time-range picker moved to the header top-right (in line with the back control), with a solid background so it reads over the hero gradient.
- "Chat sessions" widget/stat → "Agent sessions"; table "Chats" column → "Sessions" (labels only; underlying metric unchanged).

### Dev tooling

- Adds `server/clickhouse/scripts/seed-costs.mjs` — a local-only ClickHouse seed that builds a plausible org tree (incl. a deterministic slice of missing attributes, so every breakdown has a populated, drillable "(unset)" bucket).

## Testing

- `go build`, `go vet`, `go test ./server/internal/telemetry/...` — green (3 new `arrayDimFilter` tests).
- Dashboard `type-check` — clean.
- Seeded locally and verified "(unset)" division/department buckets carry real cost.

## Notes

- All UI is behind the `gram-new-costs-page` PostHog flag.
- No schema/migration changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes costs dashboard crashes when logging is disabled, makes “(unset)” rows drillable, and updates header/labels for clarity. Adds a local ClickHouse seed script and corrects array-dimension filtering with tests.

- **Bug Fixes**
  - Show `EnableLoggingOverlay` with a skeleton when `telemetry.query` returns 404; queries now set `throwOnError: false`.
  - Allow drilling into “(unset)” buckets; only “Other” is blocked. Backend adds `arrayDimFilter` to match empty arrays (`empty(col)`) and updates usage in sessions; unit tests included.

- **Tweaks**
  - Move the time-range picker to the header top-right with a solid background. Rename “Chat sessions” to “Agent sessions” and table “Chats” to “Sessions”.
  - Add `server/clickhouse/scripts/seed-costs.mjs` to seed local ClickHouse with realistic org data, including deterministic missing attributes so “(unset)” buckets have real cost.

<sup>Written for commit 8a22299d72f3c68e457f542879a92c9acdae9cbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

