### PR TITLE
chore: detect blocking code on the pystreams event loop with aiocop

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -162,6 +162,9 @@ GRAM_SSL_KEY_FILE = "{{config_root}}/local/ssl/keys/local-key.pem"
 # GRAM_PLUGINS_GITHUB_INSTALLATION_ID = ""
 GRAM_PYSTREAMS_CONTROL_PORT = "8089"
 GRAM_PYSTREAMS_CONTROL_HOST = "127.0.0.1"
+## Raise on blocking code detected on the pystreams event loop (aiocop). On by
+## default locally; unset in production. Set to "" in mise.local.toml to disable.
+GRAM_PYSTREAMS_DETECT_BLOCKING = "1"
 
 ##########################
 ## Observability config ##

--- a/pystreams/pyproject.toml
+++ b/pystreams/pyproject.toml
@@ -5,6 +5,7 @@ description = "Python Pub/Sub subscribers for Gram streams"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+  "aiocop>=1.1.4",
   "anyio>=4.13.0",
   "asyncer>=0.0.17",
   "click>=8.4.1",

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -19,6 +19,7 @@ from gram_infra.pubsub import (
 
 from .. import attr
 from ..deps import logging
+from ..deps.blocking import activate_blocking_detection
 from ..deps.loop_lag import monitor_event_loop_lag
 from ..health import HealthState, serve_control
 from .receiver import ReceiverGroup
@@ -63,6 +64,12 @@ async def multi(
         },
     )
     logger: structlog.stdlib.BoundLogger = structlog.get_logger()
+
+    # Opt-in (defaulted on for local dev via mise.toml): actively watch the loop
+    # for blocking calls and raise on a high-severity violation. The production
+    # container leaves the env var unset, so this is a no-op there.
+    if os.environ.get("GRAM_PYSTREAMS_DETECT_BLOCKING"):
+        activate_blocking_detection(logger=logger)
 
     # The emulator's project ID is arbitrary; against real GCP a project is
     # required to resolve the subscription path.

--- a/pystreams/src/pystreams/deps/blocking.py
+++ b/pystreams/src/pystreams/deps/blocking.py
@@ -1,0 +1,88 @@
+"""Fail-fast detection of blocking code on the event loop.
+
+An asyncio event loop runs cooperatively on a single thread, so any coroutine
+that fails to yield — CPU-bound work, a synchronous client call, an un-awaited
+blocking call — stalls every other ready task until it returns. ``loop_lag.py``
+records that pressure passively into a histogram; this module is the active
+counterpart: it installs `aiocop <https://github.com/Feverup/aiocop>`_, a runtime
+monitor that hooks ``sys.audit`` and the running loop to spot blocking calls as
+they happen, logs the offending task, and — when ``raise_on_violations`` is set —
+turns a high-severity violation into a ``HighSeverityBlockingIoException`` so the
+problem fails loudly in local development and tests instead of silently degrading
+throughput in production.
+
+It only sees blocking code while async code actually executes, so activation
+lives at the app entrypoint (gated by ``GRAM_PYSTREAMS_DETECT_BLOCKING``) and in
+the pytest suite, never in a static lint step.
+"""
+
+from __future__ import annotations
+
+import aiocop
+import structlog
+from opentelemetry import metrics
+
+from .. import attr
+
+# Tasks slower than this without yielding are treated as blocking the loop. The
+# trivial ping handler stays well under it, and the Presidio scan is offloaded to
+# a worker thread (so it never counts), leaving real blocking calls to stand out.
+DEFAULT_THRESHOLD_MS = 50
+
+_meter = metrics.get_meter("github.com/speakeasy-api/gram/pystreams")
+
+# Count of detected blocking-IO violations, broken down by severity. Until a
+# MeterProvider is configured the instrument is the API's implicit no-op, so
+# incrementing is cheap; once a provider is installed the count flows out wherever
+# metrics are collected.
+_violations_counter = _meter.create_counter(
+    "pystreams.event_loop.blocking_violations",
+    unit="{violation}",
+    description="Blocking-IO violations detected on the event loop, by severity.",
+)
+
+
+def activate_blocking_detection(
+    *,
+    logger: structlog.stdlib.BoundLogger,
+    threshold_ms: int = DEFAULT_THRESHOLD_MS,
+    raise_on_violations: bool = True,
+) -> None:
+    """Install and activate aiocop's blocking-IO monitor.
+
+    Wires the aiocop setup sequence and registers a structlog callback for every
+    detected slow task. When ``raise_on_violations`` is true a high-severity
+    violation also raises ``aiocop.HighSeverityBlockingIoException`` from within
+    the offending task. Call once, early, while the event loop is running.
+    """
+    logger = logger.bind(**{attr.COMPONENT: "aiocop"})
+
+    def _on_slow_task(event: aiocop.SlowTaskEvent) -> None:
+        # aiocop's own stack capture incidentally trips low-severity audit events
+        # (e.g. linecache's os.stat), so it fires this callback for essentially
+        # every scheduled step. Only surface tasks that actually overran the
+        # threshold or carry non-trivial blocking IO — the rest is noise.
+        if not event.exceeded_threshold and event.severity_level == "low":
+            return
+        _violations_counter.add(1, {"severity": event.severity_level})
+        logger.warning(
+            "blocking code detected on the event loop",
+            severity=event.severity_level,
+            elapsed_ms=round(event.elapsed_ms, 1),
+            threshold_ms=round(event.threshold_ms, 1),
+            reason=event.reason,
+            blocking_events=[str(e) for e in event.blocking_events],
+        )
+
+    aiocop.patch_audit_functions()
+    aiocop.start_blocking_io_detection()
+    aiocop.detect_slow_tasks(threshold_ms=threshold_ms, on_slow_task=_on_slow_task)
+    aiocop.activate()
+    if raise_on_violations:
+        aiocop.enable_raise_on_violations()
+
+    logger.info(
+        "event-loop blocking detection enabled",
+        threshold_ms=threshold_ms,
+        raise_on_violations=raise_on_violations,
+    )

--- a/pystreams/tests/conftest.py
+++ b/pystreams/tests/conftest.py
@@ -1,0 +1,44 @@
+"""Enforce event-loop blocking detection across the whole test suite.
+
+Mirrors the runtime guard wired into ``cmd/multi.py`` (see
+``pystreams.deps.blocking``) so blocking code in an async handler fails a test
+instead of silently saturating the loop in production. Always fatal — there is no
+warn-only mode here; CI and local behave identically.
+
+aiocop works by patching the *running* event loop's scheduling methods, and
+pytest-asyncio creates a fresh loop per test. So the global audit/slow-task setup
+runs once per session, but the loop patch + raise-on-violations must be armed from
+inside each test's own loop — hence the function-scoped async fixture.
+"""
+
+import aiocop
+import pytest
+
+from pystreams.deps.blocking import DEFAULT_THRESHOLD_MS
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _configure_aiocop():
+    """Register the audit hook and slow-task detection once for the session.
+
+    These are loop-independent globals; ``detect_slow_tasks`` itself guards
+    against being configured more than once.
+    """
+    aiocop.patch_audit_functions()
+    aiocop.start_blocking_io_detection()
+    aiocop.detect_slow_tasks(threshold_ms=DEFAULT_THRESHOLD_MS)
+    yield
+
+
+@pytest.fixture(autouse=True)
+async def _enforce_no_blocking(_configure_aiocop):
+    """Patch this test's running loop and raise on high-severity blocking IO.
+
+    ``activate()`` runs aiocop's on-activate hooks against the loop that is live
+    right now (idempotent per loop); ``enable_raise_on_violations`` arms the
+    raise for this test's context. A high-severity blocking call then surfaces as
+    a ``HighSeverityBlockingIoException`` that fails the test.
+    """
+    aiocop.activate()
+    aiocop.enable_raise_on_violations()
+    yield

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,15 @@ members = [
 ]
 
 [[package]]
+name = "aiocop"
+version = "1.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/3d/73386449323002edc3d88bc14cb72b59545fd6397f1610516685c042e82b/aiocop-1.1.4.tar.gz", hash = "sha256:2059a9837440dcd7122a16f5803f6c7a76e8bef99dea6f9af9d70d937debf6f0", size = 1391465, upload-time = "2026-02-26T10:50:41.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/b3/84769a0bcf73a548c095494b5cf1e1feba5ed685c91232029ffff7859062/aiocop-1.1.4-py3-none-any.whl", hash = "sha256:7263a4bc0c58023767729477590b20ce0dd9e5f51116cbba9a8ad1ec7e9ac51c", size = 21188, upload-time = "2026-02-26T10:50:42.609Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -911,6 +920,7 @@ name = "pystreams"
 version = "0.1.0"
 source = { editable = "pystreams" }
 dependencies = [
+    { name = "aiocop" },
     { name = "anyio" },
     { name = "asyncer" },
     { name = "click" },
@@ -936,6 +946,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiocop", specifier = ">=1.1.4" },
     { name = "anyio", specifier = ">=4.13.0" },
     { name = "asyncer", specifier = ">=0.0.17" },
     { name = "click", specifier = ">=8.4.1" },


### PR DESCRIPTION
## What

Add [`aiocop`](https://github.com/Feverup/aiocop) blocking-code detection to the `pystreams` async worker, so synchronous calls inside `async` handlers are caught instead of silently stalling every other subscription on the loop.

- **Local dev** — env-gated activation in `cmd/multi.py` (`GRAM_PYSTREAMS_DETECT_BLOCKING`, defaulted on in `mise.toml`). A high-severity blocking call raises `HighSeverityBlockingIoException` and takes the worker down loudly. Production leaves the var unset → no-op.
- **CI** — `tests/conftest.py` arms detection for the whole suite; blocking code in an async handler fails `mise run test:pystreams`, already a gate in the `pystreams-build-lint` job. No workflow YAML change needed.

This is the active counterpart to the existing passive `deps/loop_lag.py` histogram.

## Why aiocop isn't in the lint task

`aiocop` is a **runtime** event-loop monitor (patches `sys.audit` + the running loop); it has no CLI and does no static analysis. It can only flag blocking code *while async code executes*, so `.mise-tasks/lint/pystreams.sh` (which runs `ty`/`pyrefly` against source with nothing executing) is left unchanged. Detection lives in the app entrypoint and the test suite instead.

## Implementation notes

- New `deps/blocking.py` wraps aiocop's setup sequence with a noise-filtered structlog callback (aiocop's own stack capture trips incidental low-severity `os.stat` events; those are dropped).
- aiocop patches the **currently running** loop, and pytest-asyncio creates a fresh loop per test — so the conftest configures globals once per session but patches the loop + arms raising from a **function-scoped async fixture** running inside each test's loop.

## Verification

- ✅ aiocop installs and imports on Python 3.14; full API present
- ✅ 12 existing tests pass with detection armed — no false positives (incl. `test_health` async sockets and the `asyncify`-offloaded Presidio scan)
- ✅ A throwaway `time.sleep(0.2)` test failed with `HighSeverityBlockingIoException`, then removed
- ✅ Runtime helper smoke-tested in an anyio loop
- ✅ `mise run lint:pystreams` clean (`ty` + `pyrefly`)

To silence locally: set `GRAM_PYSTREAMS_DETECT_BLOCKING = ""` in `mise.local.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add runtime detection of blocking code on the `pystreams` event loop using `aiocop`, so blocking sync calls in async handlers fail fast instead of stalling other subscriptions. Enabled locally by default; production remains disabled.

- **New Features**
  - Added `deps/blocking.py` to wire `aiocop` with a 50ms slow-task threshold, log violations, export an OTel counter by severity, and raise `HighSeverityBlockingIoException` on high severity.
  - `cmd/multi.py` activates when `GRAM_PYSTREAMS_DETECT_BLOCKING` is set; default on locally via `mise.toml`.
  - `tests/conftest.py` patches each test loop and enables raise-on-violations so blocking code fails `mise run test:pystreams`; no lint or workflow changes.

- **Dependencies**
  - Added `aiocop>=1.1.4`.

<sup>Written for commit 0d308072619c84363ee30d45eda8ec9d280a5645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

