### PR TITLE
fix: persist user info alongside otel logs

### DIFF
--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -228,7 +228,7 @@ func (s *Service) writeClaudeOTELLogsToClickHouse(ctx context.Context, payload *
 				params = append(params, telemetry.WithOTELMetadata(telemetry.LogParams{
 					Timestamp:  timestamp,
 					ToolInfo:   claudeOTELLogToolInfo(orgID, parsedProjectID.String()),
-					UserInfo:   telemetry.UserInfo{},
+					UserInfo:   telemetry.UserInfoByEmail(stringAttr(logAttrs, attr.UserEmailKey)),
 					Attributes: logAttrs,
 				}, observedTimestamp, resourceAttrs))
 			}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persist user info with OTEL logs by hydrating `telemetry.UserInfo` from the `attr.UserEmailKey` attribute when writing Claude OTEL logs to ClickHouse. Fixes missing user attribution in queries and improves auditability.

<sup>Written for commit cf92b90a7fde579d4d623d4ad0f9c973e44dd564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

