### PR TITLE
fix(hooks): simplify MCP verification deny message

### DIFF
--- a/.changeset/mcp-verification-error-copy.md
+++ b/.changeset/mcp-verification-error-copy.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix(hooks): clearer message when an MCP tool call can't be verified. The deny reason now tells you to restart Claude or run /reload-plugins instead of suggesting the session is still initializing.

--- a/.changeset/mcp-verification-error-copy.md
+++ b/.changeset/mcp-verification-error-copy.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-fix(hooks): clearer message when an MCP tool call can't be verified. The deny reason now tells you to restart Claude or run /reload-plugins instead of suggesting the session is still initializing.
+fix(hooks): clearer message when an MCP tool call can't be verified. The deny reason now tells you to restart Claude or run /reload-plugins instead of suggesting the session is still initializing, and includes an error code so you can tell why the call couldn't be verified.

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -38,6 +38,17 @@ const decodeBodySampleLimit = 1024
 
 const claudeShadowMCPMetadataUnavailableReason = "Speakeasy could not verify this MCP tool call. Try restarting Claude, or running /reload-plugins."
 
+// Diagnostic codes appended to claudeShadowMCPMetadataUnavailableReason. The
+// three fail-closed branches that can't verify an MCP call all surface the
+// same generic copy, so the code is the only thing that tells a user (or
+// support) which branch denied the call from the message alone. They mirror
+// the slog event suffixes on each branch.
+const (
+	denyCodeNoSession   = "NO_SESSION"
+	denyCodeNoMetadata  = "NO_METADATA"
+	denyCodeNoUserEmail = "NO_USER_EMAIL"
+)
+
 // decoderFunc adapts a plain function to the goahttp.Decoder interface so we
 // can capture per-request context (logger, raw body, headers) in a closure
 // instead of via struct fields. This keeps containedctx happy and keeps the
@@ -606,8 +617,8 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 	deny := "deny"
 	result := makeHookResult(payload.HookEventName)
 	output, _ := result.HookSpecificOutput.(*HookSpecificOutput)
-	denyUnverifiedMCP := func() (*gen.ClaudeHookResult, error) {
-		reason := claudeShadowMCPMetadataUnavailableReason
+	denyUnverifiedMCP := func(code string) (*gen.ClaudeHookResult, error) {
+		reason := fmt.Sprintf("%s (err code: %s)", claudeShadowMCPMetadataUnavailableReason, code)
 		result.SystemMessage = &reason
 		if output != nil {
 			output.PermissionDecision = &deny
@@ -644,7 +655,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 		s.logger.WarnContext(ctx, "claude PreToolUse fired without session id; denying MCP tool call",
 			attr.SlogEvent("claude_hook_pretooluse_no_session"),
 		)
-		return denyUnverifiedMCP()
+		return denyUnverifiedMCP(denyCodeNoSession)
 	}
 	// Plugin path: when the request authenticated via Gram-Key + Gram-Project,
 	// org/project come from the auth context — same pattern as recordHook.
@@ -666,7 +677,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 			attr.SlogToolName(rawToolName),
 			attr.SlogError(err),
 		)
-		return denyUnverifiedMCP()
+		return denyUnverifiedMCP(denyCodeNoMetadata)
 	}
 	if strings.TrimSpace(metadata.UserEmail) == "" {
 		s.logger.WarnContext(ctx, "claude PreToolUse metadata has no user email; denying MCP tool call",
@@ -676,7 +687,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 			attr.SlogGenAIConversationID(sessionID),
 			attr.SlogToolName(rawToolName),
 		)
-		return denyUnverifiedMCP()
+		return denyUnverifiedMCP(denyCodeNoUserEmail)
 	}
 
 	policy := s.lookupShadowMCPBlockingPolicy(ctx, metadata.GramOrgID, metadata.ProjectID, metadata.UserID)

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -36,7 +36,7 @@ import (
 // payload.
 const decodeBodySampleLimit = 1024
 
-const claudeShadowMCPMetadataUnavailableReason = "Speakeasy could not verify this MCP tool call because the Claude session metadata is not available yet. Try again after the session initializes."
+const claudeShadowMCPMetadataUnavailableReason = "Speakeasy could not verify this MCP tool call. Try restarting Claude, or running /reload-plugins."
 
 // decoderFunc adapts a plain function to the goahttp.Decoder interface so we
 // can capture per-request context (logger, raw body, headers) in a closure

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -692,6 +692,7 @@ func TestClaude_PreToolUse_DeniesMCPWhenNoAuthAndNoCachedMetadata(t *testing.T) 
 		"MCP tool calls without enforcement metadata must fail closed")
 	require.NotNil(t, output.PermissionDecisionReason)
 	assert.Contains(t, *output.PermissionDecisionReason, "could not verify this MCP tool call")
+	assert.Contains(t, *output.PermissionDecisionReason, "/reload-plugins")
 }
 
 func TestClaude_PreToolUse_DeniesMCPWhenResolvedMetadataHasNoUserEmail(t *testing.T) {

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -693,6 +693,7 @@ func TestClaude_PreToolUse_DeniesMCPWhenNoAuthAndNoCachedMetadata(t *testing.T) 
 	require.NotNil(t, output.PermissionDecisionReason)
 	assert.Contains(t, *output.PermissionDecisionReason, "could not verify this MCP tool call")
 	assert.Contains(t, *output.PermissionDecisionReason, "/reload-plugins")
+	assert.Contains(t, *output.PermissionDecisionReason, "(err code: "+denyCodeNoMetadata+")")
 }
 
 func TestClaude_PreToolUse_DeniesMCPWhenResolvedMetadataHasNoUserEmail(t *testing.T) {
@@ -733,6 +734,7 @@ func TestClaude_PreToolUse_DeniesMCPWhenResolvedMetadataHasNoUserEmail(t *testin
 	assert.Equal(t, "deny", *output.PermissionDecision)
 	require.NotNil(t, output.PermissionDecisionReason)
 	assert.Contains(t, *output.PermissionDecisionReason, "could not verify this MCP tool call")
+	assert.Contains(t, *output.PermissionDecisionReason, "(err code: "+denyCodeNoUserEmail+")")
 }
 
 // Claude Code's hook output schema only permits hookSpecificOutput for


### PR DESCRIPTION
## Summary

- Replaces the customer-facing reason returned when an MCP tool call can't be verified (the deny-on-missing-session-metadata path).
- Old copy: `Speakeasy could not verify this MCP tool call because the Claude session metadata is not available yet. Try again after the session initializes.`
- New copy: `Speakeasy could not verify this MCP tool call. Try restarting Claude, or running /reload-plugins.`
- The old wording was misleading: the metadata is missing due to a prior error, not because the session is still initializing, so "try again after the session initializes" pointed users at the wrong recovery. The new copy drops the implementation detail and gives two concrete, valid recovery actions (`/reload-plugins` is a real Claude Code plugin command).
- Pure copy swap, no behavior change. Tightened one existing hook test to also assert the new `/reload-plugins` guidance.

Closes [DNO-294](https://linear.app/speakeasy/issue/DNO-294/bug-simplify-customer-facing-mcp-verification-error-message)

✻ Clauded by daniel

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the MCP verification deny message per DNO-294 and added a diagnostic error code to clarify why the call was denied. The message now reads: "Speakeasy could not verify this MCP tool call. Try restarting Claude, or running /reload-plugins." and includes "(err code: CODE)".

- **New Features**
  - Append stable err codes to the deny reason: NO_SESSION, NO_METADATA, NO_USER_EMAIL.
  - Tightened hook tests to assert the new "/reload-plugins" guidance and the err code.

<sup>Written for commit 11378d646365422b047ad810f762d5ab1a7051e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

