### PR TITLE
chore: enable ruff lint for pystreams and enforce in hk

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -65,6 +65,9 @@ local linters = new Mapping<String, Step> {
   ["ruff-format"] = (Builtins.ruff_format) {
     exclude = List("**/vendor/**", "**/node_modules/**", "**/dist/**", "**/*_pb2.*")
   }
+  ["ruff"] = (Builtins.ruff) {
+    exclude = List("**/vendor/**", "**/node_modules/**", "**/dist/**", "**/*_pb2.*")
+  }
 }
 
 hooks {

--- a/pystreams/pyproject.toml
+++ b/pystreams/pyproject.toml
@@ -44,6 +44,9 @@ en-core-web-lg = { url = "https://github.com/explosion/spacy-models/releases/dow
 testpaths = ["tests"]
 asyncio_mode = "auto"
 
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "ASYNC", "RUF", "PT", "TID"]
+
 [tool.pyrefly]
 project-includes = ["**/*.py*", "**/*.ipynb"]
 

--- a/pystreams/src/pystreams/attr/__init__.py
+++ b/pystreams/src/pystreams/attr/__init__.py
@@ -1,6 +1,6 @@
 from typing import Final
 
-from opentelemetry.semconv.attributes import service_attributes, deployment_attributes
+from opentelemetry.semconv.attributes import deployment_attributes, service_attributes
 
 SERVICE_NAME = service_attributes.SERVICE_NAME
 SERVICE_VERSION = service_attributes.SERVICE_VERSION

--- a/pystreams/src/pystreams/cmd/flags_control.py
+++ b/pystreams/src/pystreams/cmd/flags_control.py
@@ -1,4 +1,5 @@
-from typing import Sequence
+from collections.abc import Sequence
+
 import click
 
 

--- a/pystreams/src/pystreams/cmd/flags_gcp.py
+++ b/pystreams/src/pystreams/cmd/flags_gcp.py
@@ -1,4 +1,5 @@
-from typing import Sequence
+from collections.abc import Sequence
+
 import click
 
 

--- a/pystreams/src/pystreams/cmd/flags_service.py
+++ b/pystreams/src/pystreams/cmd/flags_service.py
@@ -1,4 +1,5 @@
-from typing import Sequence
+from collections.abc import Sequence
+
 import click
 
 

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -3,13 +3,10 @@ import os
 import signal
 from functools import partial
 
-import click
-from pystreams.ping.handler import PingHandler
-from pystreams.risk.handler import PresidioHandler
-import structlog
 import anyio
+import click
+import structlog
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
-
 from gram.ping.v1 import ping_pb2, processor_pb2
 from gram.risk.v1 import presidio_request_pb2, presidio_scanner_pb2
 from gram_infra.pubsub import (
@@ -17,15 +14,16 @@ from gram_infra.pubsub import (
     PubSubBroker,
 )
 
-from .. import attr
-from ..deps import logging
-from ..deps.blocking import activate_blocking_detection
-from ..deps.loop_lag import monitor_event_loop_lag
-from ..health import HealthState, serve_control
+from pystreams import attr
+from pystreams.deps import logging
+from pystreams.deps.blocking import activate_blocking_detection
+from pystreams.deps.loop_lag import monitor_event_loop_lag
+from pystreams.health import HealthState, serve_control
+from pystreams.ping.handler import PingHandler
+from pystreams.risk.handler import PresidioHandler
+
+from . import flags_control, flags_gcp, flags_service
 from .receiver import ReceiverGroup
-from . import flags_service
-from . import flags_gcp
-from . import flags_control
 
 
 @click.command(

--- a/pystreams/src/pystreams/cmd/receiver.py
+++ b/pystreams/src/pystreams/cmd/receiver.py
@@ -15,11 +15,10 @@ from typing import TypeVar
 import anyio.abc
 import structlog
 from google.protobuf.message import Message
-
 from gram_infra.pubsub import SubscriberBroker, pubsub_subscriber_for_message
 from gram_infra.pubsub.subscriber import MessageCallback
 
-from ..deps.tracing import traced
+from pystreams.deps.tracing import traced
 
 M = TypeVar("M", bound=Message)
 

--- a/pystreams/src/pystreams/deps/blocking.py
+++ b/pystreams/src/pystreams/deps/blocking.py
@@ -22,7 +22,7 @@ import aiocop
 import structlog
 from opentelemetry import metrics
 
-from .. import attr
+from pystreams import attr
 
 # Tasks slower than this without yielding are treated as blocking the loop. The
 # trivial ping handler stays well under it, and the Presidio scan is offloaded to

--- a/pystreams/src/pystreams/deps/logging.py
+++ b/pystreams/src/pystreams/deps/logging.py
@@ -2,10 +2,11 @@ import logging
 import os
 from typing import Any
 
-from opentelemetry import trace
-from .. import attr
 import structlog
+from opentelemetry import trace
 from structlog.typing import EventDict, Processor, WrappedLogger
+
+from pystreams import attr
 
 
 def _add_open_telemetry_spans(_, __, event_dict):

--- a/pystreams/src/pystreams/deps/tracing.py
+++ b/pystreams/src/pystreams/deps/tracing.py
@@ -13,22 +13,17 @@ consumer that wires up handlers owns the span.
 
 from __future__ import annotations
 
-from typing import TypeVar
-
 from google.protobuf.message import Message
+from gram_infra.pubsub.subscriber import MessageCallback, MessageMetadata
 from opentelemetry import propagate, trace
 from opentelemetry.trace import StatusCode
 
-from gram_infra.pubsub.subscriber import MessageCallback, MessageMetadata
-
-from .. import attr
-
-M = TypeVar("M", bound=Message)
+from pystreams import attr
 
 _tracer = trace.get_tracer("github.com/speakeasy-api/gram/pystreams")
 
 
-def traced(
+def traced[M: Message](
     callback: MessageCallback[M],
     *,
     topic_proto_name: str,

--- a/pystreams/src/pystreams/health/__init__.py
+++ b/pystreams/src/pystreams/health/__init__.py
@@ -27,7 +27,7 @@ from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 
-__all__ = ["HealthState", "serve_control", "LIVENESS_PATH", "READINESS_PATH"]
+__all__ = ["LIVENESS_PATH", "READINESS_PATH", "HealthState", "serve_control"]
 
 LIVENESS_PATH = "/healthz"
 READINESS_PATH = "/readyz"
@@ -65,7 +65,7 @@ class _NoSignalServer(uvicorn.Server):
     with the worker's task group on shutdown.
     """
 
-    def install_signal_handlers(self) -> None:  # noqa: D102 - intentional no-op
+    def install_signal_handlers(self) -> None:
         return None
 
 
@@ -116,8 +116,10 @@ async def serve_control(
     async with anyio.create_task_group() as tg:
         tg.start_soon(server.serve)
 
-        # uvicorn flips ``started`` once the listening sockets are bound.
-        while not server.started:
+        # uvicorn flips ``started`` once the listening sockets are bound. It
+        # exposes only this polled boolean, not an awaitable event, so a poll
+        # loop is the available option here.
+        while not server.started:  # noqa: ASYNC110
             await anyio.sleep(0.02)
 
         bound_port = _bound_port(server, fallback=port)
@@ -131,6 +133,6 @@ def _bound_port(server: uvicorn.Server, *, fallback: int) -> int:
         for started_server in server.servers:
             for sock in started_server.sockets:
                 return sock.getsockname()[1]
-    except Exception:  # noqa: BLE001 - fall back to the requested port
+    except Exception:
         pass
     return fallback

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -2,11 +2,10 @@ from typing import Protocol
 
 import structlog
 from asyncer import asyncify
-from presidio_analyzer import AnalyzerEngine
-from presidio_analyzer.nlp_engine import NlpEngineProvider
-
 from gram.risk.v1 import presidio_request_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
+from presidio_analyzer import AnalyzerEngine
+from presidio_analyzer.nlp_engine import NlpEngineProvider
 
 # The spaCy model bundled into the image (pinned in pystreams/pyproject.toml).
 # Presidio's default AnalyzerEngine() would also load this model, but selecting
@@ -77,7 +76,7 @@ class PresidioHandler:
                 contents=list(message.contents),
                 entities=requested,
             )
-        except Exception as exc:  # noqa: BLE001 - keep shadow processing non-fatal
+        except Exception as exc:
             # This is best-effort shadow processing, and the PresidioScanner
             # subscription declares no dead-letter policy. Letting a scan failure
             # escape would nack the message, and any input that deterministically

--- a/pystreams/tests/conftest.py
+++ b/pystreams/tests/conftest.py
@@ -27,7 +27,7 @@ def _configure_aiocop():
     aiocop.patch_audit_functions()
     aiocop.start_blocking_io_detection()
     aiocop.detect_slow_tasks(threshold_ms=DEFAULT_THRESHOLD_MS)
-    yield
+    return
 
 
 @pytest.fixture(autouse=True)
@@ -41,4 +41,4 @@ async def _enforce_no_blocking(_configure_aiocop):
     """
     aiocop.activate()
     aiocop.enable_raise_on_violations()
-    yield
+    return

--- a/pystreams/tests/test_health.py
+++ b/pystreams/tests/test_health.py
@@ -15,9 +15,8 @@ async def _get(port: int, path: str) -> bytes:
     """
     stream = await anyio.connect_tcp("127.0.0.1", port)
     async with stream:
-        await stream.send(
-            f"GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".encode()
-        )
+        request = f"GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        await stream.send(request.encode())
         data = b""
         try:
             while True:

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -1,8 +1,8 @@
 import structlog
-from structlog.testing import capture_logs
-
 from gram.risk.v1 import presidio_request_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
+from structlog.testing import capture_logs
+
 from pystreams.risk.handler import PresidioHandler, Recognized
 
 

--- a/pystreams/tests/test_tracing.py
+++ b/pystreams/tests/test_tracing.py
@@ -1,4 +1,6 @@
 import pytest
+from gram.ping.v1 import ping_pb2, processor_pb2
+from gram_infra.pubsub.subscriber import MessageMetadata
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -7,8 +9,6 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 )
 from opentelemetry.trace import StatusCode
 
-from gram.ping.v1 import ping_pb2, processor_pb2
-from gram_infra.pubsub.subscriber import MessageMetadata
 from pystreams import attr
 from pystreams.deps import tracing
 
@@ -117,7 +117,7 @@ async def test_traced_marks_error_and_reraises(exporter: InMemorySpanExporter):
         handler, topic_proto_name=TOPIC, subscription_proto_name=SUBSCRIPTION
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="handler failed"):
         await wrapped(ping_pb2.Message(id="ping-1"), _meta())
 
     (span,) = exporter.get_finished_spans()


### PR DESCRIPTION
## What

Enable `ruff` linting for `pystreams/` and enforce it repo-wide via `hk`.

Previously `ruff` ran only as a **formatter** — there was no lint rule
selection anywhere and no `ruff check` step in any hook.

### Changes

- **`pystreams/pyproject.toml`** — add `[tool.ruff.lint]` selection:
  `E, F, W, I, UP, B, ASYNC, RUF, PT, TID`. `ASYNC` is the headline group
  for this async/anyio service — it flags event-loop-blocking patterns at
  review time, complementing the runtime `aiocop` guard.
- **`hk.pkl`** — add a `ruff` lint step (`Builtins.ruff`) alongside
  `ruff-format`, wired into the `pre-commit`, `fix`, and `check` hooks.
- **Lint fixes** — resolved all 34 findings the new selection surfaced:
  - Auto-fixed: import sorting, stale `# noqa`, deprecated imports,
    `__all__` ordering, relative→absolute imports (`TID`), and a PEP 695
    generic conversion (also removed the now-orphaned `TypeVar`).
  - By hand: `ASYNC110` (uvicorn exposes only a polled `started` bool, not
    an awaitable event — documented `# noqa`), one long line, and a broad
    `pytest.raises` now scoped with `match=`.

## Notes

- The lint step is repo-wide, but the rule selection lives in
  `pystreams/pyproject.toml`; other repo Python falls back to ruff
  defaults (`E4,E7,E9,F`). Can be promoted to a root config later if a
  consistent set is wanted.

## Testing

- `hk check` — `ruff` + `ruff-format` pass clean.
- Verified enforcement: a deliberate unused import made `hk check` fail
  with `F401`; reverted.
- `uv run pytest` — 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `ruff` linting for `pystreams/` and enforce it via `hk` so async and correctness issues are caught at review time. Adds an explicit rule set and fixes all violations; hooks and checks now fail on lint errors.

- **Refactors**
  - `pystreams/pyproject.toml`: add `[tool.ruff.lint]` selection `E,F,W,I,UP,B,ASYNC,RUF,PT,TID` (focus on `ASYNC` to flag event-loop blocking; complements `aiocop`).
  - `hk.pkl`: add `ruff` alongside `ruff-format`, wired into `pre-commit`, `fix`, and `check`.
  - Code cleanup: sort and de-duplicate imports, switch relative→absolute imports, convert TypeVar to PEP 695 generics, narrow `pytest.raises` with `match`, and document the `uvicorn` started poll with `# noqa: ASYNC110`.

<sup>Written for commit 3e209d74489adeb109d229cc3117fa1e5670cc5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

