### PR TITLE
chore: enable ruff lint and event-loop blocking guard for infra

### DIFF
--- a/.mise-tasks/lint/infra.sh
+++ b/.mise-tasks/lint/infra.sh
@@ -12,4 +12,7 @@ against="${usage_against:?--against is required}"
 buf lint
 buf breaking --against "${against}"
 
+# ruff is provided by mise (see mise.toml), not the uv environment, so call it
+# directly. It picks up the lint selection from infra/pyproject.toml and skips
+# the buf-generated gen_py tree via that config's extend-exclude.
 ruff check infra

--- a/.mise-tasks/lint/infra.sh
+++ b/.mise-tasks/lint/infra.sh
@@ -9,10 +9,18 @@ set -eo pipefail
 
 against="${usage_against:?--against is required}"
 
+gum log --level info "Running buf lint"
 buf lint
+
+echo ""
+
+gum log --level info "Running buf breaking against ${against}"
 buf breaking --against "${against}"
+
+echo ""
 
 # ruff is provided by mise (see mise.toml), not the uv environment, so call it
 # directly. It picks up the lint selection from infra/pyproject.toml and skips
 # the buf-generated gen_py tree via that config's extend-exclude.
+gum log --level info "Running ruff linters against infra"
 ruff check infra

--- a/.mise-tasks/lint/infra.sh
+++ b/.mise-tasks/lint/infra.sh
@@ -11,3 +11,5 @@ against="${usage_against:?--against is required}"
 
 buf lint
 buf breaking --against "${against}"
+
+ruff check infra

--- a/infra/gram_infra/demos/_common.py
+++ b/infra/gram_infra/demos/_common.py
@@ -12,14 +12,14 @@ import logging
 import os
 import signal
 import uuid
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 import anyio
 import structlog
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from google.protobuf.timestamp_pb2 import Timestamp
-
 from gram.ping.v1 import ping_pb2
+
 from gram_infra.pubsub import EmulatedPubSubBroker
 from gram_infra.pubsub.publisher import Publisher
 

--- a/infra/gram_infra/demos/pubsub.py
+++ b/infra/gram_infra/demos/pubsub.py
@@ -19,8 +19,8 @@ from __future__ import annotations
 
 import anyio
 import structlog
-
 from gram.ping.v1 import ping_pb2, processor_pb2
+
 from gram_infra.pubsub import (
     pubsub_publisher_for_message,
     pubsub_subscriber_for_message,

--- a/infra/gram_infra/demos/pubsub_stream.py
+++ b/infra/gram_infra/demos/pubsub_stream.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 
 import anyio
 import structlog
-
 from gram.ping.v1 import ping_pb2, processor_pb2
+
 from gram_infra.pubsub import (
     Subscriber,
     pubsub_publisher_for_message,

--- a/infra/gram_infra/pubsub/__init__.py
+++ b/infra/gram_infra/pubsub/__init__.py
@@ -46,27 +46,23 @@ from .subscriber import (
 )
 
 __all__ = [
-    # brokers
-    "PubSubBroker",
     "EmulatedPubSubBroker",
-    "PublisherBroker",
-    "SubscriberBroker",
-    "PublisherHandle",
-    "SubscriberHandle",
-    # publisher
-    "Publisher",
-    "pubsub_publisher_for_message",
-    # subscriber
-    "Subscriber",
-    "MessageMetadata",
-    "ReceivedMessage",
     "MessageCallback",
+    "MessageMetadata",
+    "PubSubBroker",
+    "Publisher",
+    "PublisherBroker",
+    "PublisherHandle",
+    "ReceivedMessage",
+    "Subscriber",
+    "SubscriberBroker",
+    "SubscriberHandle",
+    "pubsub_publisher_for_message",
     "pubsub_subscriber_for_message",
-    # discovery / naming
-    "topic_options_from_message",
-    "subscription_options_from_message",
-    "resolve_topic_name",
-    "resolve_subscription_name",
     "resolve_dead_letter_topic_name",
+    "resolve_subscription_name",
+    "resolve_topic_name",
+    "subscription_options_from_message",
     "to_kebab",
+    "topic_options_from_message",
 ]

--- a/infra/gram_infra/pubsub/broker.py
+++ b/infra/gram_infra/pubsub/broker.py
@@ -33,12 +33,11 @@ from types import TracebackType
 from typing import Protocol, Self, runtime_checkable
 
 import structlog
+from gcp.pubsub.v1 import options_pb2
 from google.api_core.exceptions import AlreadyExists
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.message import Message
-
-from gcp.pubsub.v1 import options_pb2
 
 from .discover import (
     require_subscription_for_message,
@@ -49,12 +48,12 @@ from .discover import (
 )
 
 __all__ = [
-    "PublisherHandle",
-    "SubscriberHandle",
-    "PublisherBroker",
-    "SubscriberBroker",
-    "PubSubBroker",
     "EmulatedPubSubBroker",
+    "PubSubBroker",
+    "PublisherBroker",
+    "PublisherHandle",
+    "SubscriberBroker",
+    "SubscriberHandle",
 ]
 
 
@@ -105,7 +104,8 @@ class PublisherHandle:
 
 @dataclass(frozen=True)
 class SubscriberHandle:
-    """A subscriber client paired with the fully-qualified subscription path to receive from."""
+    """A subscriber client paired with the fully-qualified subscription path to
+    receive from."""
 
     client: SubscriberClient
     subscription_path: str
@@ -209,7 +209,7 @@ class PubSubBroker:
             self._closed = True
 
     def _drain_publisher(self) -> None:
-        """Flush batched publishes and wait for those commits before the transport closes.
+        """Flush batched publishes, awaiting their commits before transport close.
 
         ``PublisherClient`` inherits the generated client's ``__exit__``, which
         only calls ``transport.close()`` — it never stops the batching layer. So a

--- a/infra/gram_infra/pubsub/discover.py
+++ b/infra/gram_infra/pubsub/discover.py
@@ -13,15 +13,14 @@ The full topology validation / kcc.yaml generation stays in Go.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NamedTuple, Union, cast
-
-from google.protobuf.descriptor import Descriptor
-from google.protobuf.message import Message
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 # Importing the generated options module registers the ``topic`` and
 # ``subscription`` extensions in the default descriptor pool, which is what makes
 # them readable off a message's options below.
 from gcp.pubsub.v1 import options_pb2
+from google.protobuf.descriptor import Descriptor
+from google.protobuf.message import Message
 
 if TYPE_CHECKING:
     # types-protobuf types ``type[Message].DESCRIPTOR`` as a union of the upb (C)
@@ -29,22 +28,22 @@ if TYPE_CHECKING:
     # descriptor is passed in. Resolved only by the type checker.
     from google._upb._message import Descriptor as _CDescriptor
 
-    MessageDescriptor = Union[Descriptor, _CDescriptor]
+    MessageDescriptor = Descriptor | _CDescriptor
 else:
     MessageDescriptor = Descriptor
 
 __all__ = [
     "DLQ_SUFFIX",
-    "topic_options_from_message",
-    "subscription_options_from_message",
-    "require_topic_options",
-    "require_subscription_options",
-    "require_subscription_for_message",
     "SubscriptionBinding",
-    "resolve_topic_name",
-    "resolve_subscription_name",
+    "require_subscription_for_message",
+    "require_subscription_options",
+    "require_topic_options",
     "resolve_dead_letter_topic_name",
+    "resolve_subscription_name",
+    "resolve_topic_name",
+    "subscription_options_from_message",
     "to_kebab",
+    "topic_options_from_message",
 ]
 
 # Suffix appended to a subscription name to derive its dead-letter topic when no
@@ -70,7 +69,8 @@ def _message_options_extension(descriptor: MessageDescriptor, extension: Any):
 def topic_options_from_message(
     descriptor: MessageDescriptor,
 ) -> options_pb2.TopicOptions | None:
-    """Return the TopicOptions declared on a message, or None if it declares no topic."""
+    """Return the TopicOptions declared on a message, or None if it declares no
+    topic."""
     return cast(
         "options_pb2.TopicOptions | None",
         _message_options_extension(descriptor, options_pb2.topic),
@@ -80,7 +80,8 @@ def topic_options_from_message(
 def subscription_options_from_message(
     descriptor: MessageDescriptor,
 ) -> options_pb2.SubscriptionOptions | None:
-    """Return the SubscriptionOptions declared on a message, or None if it declares no subscription."""
+    """Return the SubscriptionOptions declared on a message, or None if it
+    declares no subscription."""
     return cast(
         "options_pb2.SubscriptionOptions | None",
         _message_options_extension(descriptor, options_pb2.subscription),
@@ -90,7 +91,8 @@ def subscription_options_from_message(
 def require_topic_options(
     message_type: type[Message],
 ) -> tuple[MessageDescriptor, options_pb2.TopicOptions]:
-    """Return ``(descriptor, TopicOptions)`` for a message type, raising if it declares no topic."""
+    """Return ``(descriptor, TopicOptions)`` for a message type, raising if it
+    declares no topic."""
     descriptor = message_type.DESCRIPTOR
     options = topic_options_from_message(descriptor)
     if options is None:
@@ -103,12 +105,14 @@ def require_topic_options(
 def require_subscription_options(
     subscription_type: type[Message],
 ) -> tuple[MessageDescriptor, options_pb2.SubscriptionOptions]:
-    """Return ``(descriptor, SubscriptionOptions)`` for a marker type, raising if it declares no subscription."""
+    """Return ``(descriptor, SubscriptionOptions)`` for a marker type, raising if
+    it declares no subscription."""
     descriptor = subscription_type.DESCRIPTOR
     options = subscription_options_from_message(descriptor)
     if options is None:
         raise ValueError(
-            f"proto message {descriptor.full_name} does not declare a pubsub subscription"
+            f"proto message {descriptor.full_name} does not declare a pubsub "
+            "subscription"
         )
     return descriptor, options
 
@@ -169,7 +173,8 @@ def _require_ascii(name: str, context: str) -> None:
 
 
 def _resolve_name(descriptor: MessageDescriptor, explicit: str) -> str:
-    """Resolve a resource ID: the explicit name when set, else the kebab-cased proto full name."""
+    """Resolve a resource ID: the explicit name when set, else the kebab-cased
+    proto full name."""
     name = (explicit or "").strip()
     if not name:
         name = descriptor.full_name
@@ -180,21 +185,24 @@ def _resolve_name(descriptor: MessageDescriptor, explicit: str) -> str:
 def resolve_topic_name(
     descriptor: MessageDescriptor, options: options_pb2.TopicOptions
 ) -> str:
-    """Resolve a topic ID: the explicit name when set, else the kebab-cased proto full name."""
+    """Resolve a topic ID: the explicit name when set, else the kebab-cased proto
+    full name."""
     return _resolve_name(descriptor, options.name)
 
 
 def resolve_subscription_name(
     descriptor: MessageDescriptor, options: options_pb2.SubscriptionOptions
 ) -> str:
-    """Resolve a subscription ID: the explicit name when set, else the kebab-cased proto full name."""
+    """Resolve a subscription ID: the explicit name when set, else the kebab-cased
+    proto full name."""
     return _resolve_name(descriptor, options.name)
 
 
 def resolve_dead_letter_topic_name(
     subscription_name: str, dead_letter: options_pb2.DeadLetterPolicy
 ) -> str:
-    """Resolve a DLQ topic ID: the kebab-cased explicit name when set, else ``<sub>-dlq``."""
+    """Resolve a DLQ topic ID: the kebab-cased explicit name when set, else
+    ``<sub>-dlq``."""
     explicit = (dead_letter.name or "").strip()
     if not explicit:
         return subscription_name + DLQ_SUFFIX

--- a/infra/gram_infra/pubsub/publisher.py
+++ b/infra/gram_infra/pubsub/publisher.py
@@ -9,19 +9,16 @@ name>`` — so messages are interoperable across languages.
 from __future__ import annotations
 
 import threading
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 import anyio
 import anyio.from_thread
-
 from google.protobuf.message import Message
 from opentelemetry import propagate
 
 from .broker import PublisherBroker, PublisherHandle
 
-__all__ = ["Publisher", "pubsub_publisher_for_message", "CONTENT_TYPE"]
-
-M = TypeVar("M", bound=Message)
+__all__ = ["CONTENT_TYPE", "Publisher", "pubsub_publisher_for_message"]
 
 # Attribute value mirrored from publisher.go; identifies the body encoding.
 CONTENT_TYPE = "application/x-protobuf"
@@ -42,7 +39,7 @@ def _message_attributes(schema: str) -> dict[str, str]:
     return attributes
 
 
-class Publisher(Generic[M]):
+class Publisher[M: Message]:
     """Publishes messages of a single proto type to a fixed topic."""
 
     def __init__(self, handle: PublisherHandle, schema: str) -> None:
@@ -98,7 +95,7 @@ class Publisher(Generic[M]):
                     # trip per completion, serializing batch-resolved publishes
                     # at loop latency apiece.
                     portal.start_task_soon(done.set)
-                except BaseException:  # noqa: BLE001 - never raise into the commit thread
+                except BaseException:
                     # The portal is gone: the publish was cancelled or the loop
                     # is tearing down, so no waiter remains. The send itself
                     # still proceeds on the commit thread.
@@ -111,7 +108,7 @@ class Publisher(Generic[M]):
         return future.result()
 
 
-def pubsub_publisher_for_message(
+def pubsub_publisher_for_message[M: Message](
     broker: PublisherBroker, message_type: type[M]
 ) -> Publisher[M]:
     """Return a publisher for the topic declared by ``message_type``'s topic option.

--- a/infra/gram_infra/pubsub/subscriber.py
+++ b/infra/gram_infra/pubsub/subscriber.py
@@ -29,17 +29,13 @@ from __future__ import annotations
 
 import queue as queue_module
 import threading
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from concurrent.futures import CancelledError as FutureCancelledError
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import (
     Any,
-    AsyncGenerator,
-    Awaitable,
-    Callable,
-    Generic,
     NoReturn,
-    Optional,
     TypeVar,
 )
 
@@ -53,12 +49,11 @@ from google.protobuf.message import Message
 
 from .broker import SubscriberBroker, SubscriberHandle
 
-
 __all__ = [
+    "MessageCallback",
     "MessageMetadata",
     "ReceivedMessage",
     "Subscriber",
-    "MessageCallback",
     "pubsub_subscriber_for_message",
 ]
 
@@ -100,7 +95,7 @@ class MessageMetadata:
     attributes: dict[str, str] = field(default_factory=dict)
     # Number of delivery attempts. Set (starting at 1) only when dead-lettering
     # is enabled for the subscription; otherwise None.
-    delivery_attempt: Optional[int] = None
+    delivery_attempt: int | None = None
 
 
 # A callback returns None to ack; raising any exception nacks the message.
@@ -108,7 +103,7 @@ MessageCallback = Callable[[M, MessageMetadata], Awaitable[None]]
 
 
 @dataclass
-class ReceivedMessage(Generic[M]):
+class ReceivedMessage[M: Message]:
     """A message delivered by :meth:`Subscriber.stream`, with explicit disposition.
 
     The callback form (:meth:`Subscriber.receive`) ties ack/nack to the callback's
@@ -207,7 +202,7 @@ class _PortalScheduler(Scheduler):
             return
         try:
             future = self._portal.start_task_soon(self._enqueue, message)
-        except BaseException:  # noqa: BLE001 - never raise back into the library thread
+        except BaseException:
             # The portal is already stopped (RuntimeError) or going away. Nack so
             # the broker redelivers; raising here would only crash the library's
             # background dispatch thread.
@@ -217,7 +212,7 @@ class _PortalScheduler(Scheduler):
         def _nack_on_failure(f) -> None:
             try:
                 failed = f.cancelled() or f.exception() is not None
-            except BaseException:  # noqa: BLE001 - runs on arbitrary threads
+            except BaseException:
                 failed = True
             if failed:
                 message.nack()
@@ -286,7 +281,7 @@ class _PortalScheduler(Scheduler):
         """
         try:
             self._portal.call(self.close)
-        except BaseException:  # noqa: BLE001 - never raise back into the library thread
+        except BaseException:
             # The portal (and with it the event loop side) is already gone: the
             # loop-side teardown in Subscriber._session closes and nacks on its
             # own task, so nothing is stranded. Report no dropped messages rather
@@ -297,7 +292,7 @@ class _PortalScheduler(Scheduler):
         return []
 
 
-class Subscriber(Generic[M]):
+class Subscriber[M: Message]:
     """Receives messages of a single proto type from a fixed subscription."""
 
     def __init__(
@@ -322,7 +317,7 @@ class Subscriber(Generic[M]):
     @asynccontextmanager
     async def _session(
         self,
-    ) -> AsyncGenerator[tuple[_PortalScheduler, Any, MemoryObjectReceiveStream], None]:
+    ) -> AsyncGenerator[tuple[_PortalScheduler, Any, MemoryObjectReceiveStream]]:
         """Portal + scheduler + streaming-pull plumbing shared by receive/stream.
 
         Teardown is fully synchronous (checkpoint-free), so it runs to completion
@@ -356,7 +351,10 @@ class Subscriber(Generic[M]):
         self,
         callback: MessageCallback[M],
         *,
-        timeout: float | None = None,
+        # A timeout is part of receive()'s public contract (bounded consumption
+        # for callers/tests); ASYNC109 prefers anyio.fail_after, but that would
+        # move the responsibility onto every caller and change the API.
+        timeout: float | None = None,  # noqa: ASYNC109
         max_concurrency: int | None = None,
     ) -> None:
         """Receive messages, blocking until cancelled or ``timeout`` elapses.
@@ -421,7 +419,7 @@ class Subscriber(Generic[M]):
             raise unwrapped from None
 
     @asynccontextmanager
-    async def stream(self) -> AsyncGenerator[_MessageIterator[M], None]:
+    async def stream(self) -> AsyncGenerator[_MessageIterator[M]]:
         """Receive messages as an async iterator instead of via a callback.
 
         Use as an async context manager wrapping an ``async for``::
@@ -533,7 +531,7 @@ class Subscriber(Generic[M]):
 
         try:
             await callback(instance, metadata)
-        except BaseException as exc:  # noqa: BLE001 - isolate one bad message
+        except BaseException as exc:
             # Cooperative cancellation must propagate: a cancelled handler is
             # neither acked nor nacked here. The library was started with
             # await_callbacks_on_shutdown=True, so on a *graceful* stop in-flight
@@ -562,7 +560,7 @@ class Subscriber(Generic[M]):
         message.ack()
 
 
-class _MessageIterator(Generic[M]):
+class _MessageIterator[M: Message]:
     """Async iterator yielded by ``Subscriber.stream``.
 
     Holds no scope of its own — the portal and streaming pull live in the
@@ -621,14 +619,14 @@ class _MessageIterator(Generic[M]):
         raise StopAsyncIteration
 
 
-def pubsub_subscriber_for_message(
+def pubsub_subscriber_for_message[M: Message](
     broker: SubscriberBroker,
     message_type: type[M],
     subscription_type: type[Message],
     *,
     logger: structlog.stdlib.BoundLogger | None = None,
 ) -> Subscriber[M]:
-    """Return a subscriber for ``subscription_type`` delivering ``message_type`` messages.
+    """Return a subscriber that delivers ``message_type`` for ``subscription_type``.
 
     Raises ValueError if the message declares no topic or the subscription marker
     declares no subscription.

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -25,6 +25,10 @@ pubsub-stream-demo = "gram_infra.demos.pubsub_stream:main"
 # work on a fresh checkout without an undocumented --extra flag.
 [dependency-groups]
 dev = [
+  # Runtime detection of code that blocks the asyncio event loop. Dev-only: the
+  # blocking guard is enforced across the test suite (see tests/conftest.py), but
+  # never shipped — runtime activation is the consuming app's job (e.g. pystreams).
+  "aiocop>=1.1.4",
   "pyrefly>=1.0.0",
   "pytest>=8.0.0",
   "pytest-asyncio>=0.24.0",
@@ -46,6 +50,19 @@ build-backend = "hatchling.build"
 # namespace packages, so the buf-generated tree is left untouched.
 [tool.hatch.build.targets.wheel]
 packages = ["gram_infra", "gen_py/gcp", "gen_py/gram"]
+
+[tool.ruff]
+# gen_py/{gcp,gram} are buf-generated protobuf modules; never lint them.
+extend-exclude = ["gen_py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "ASYNC", "RUF", "PT", "TID"]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests synchronize on bounded poll loops (wait for acks / scheduler readiness),
+# which is idiomatic for test orchestration and not a service hot path. ASYNC110
+# stays enabled for library code under gram_infra.
+"tests/**" = ["ASYNC110"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/infra/tests/conftest.py
+++ b/infra/tests/conftest.py
@@ -1,13 +1,57 @@
-"""Shared test fakes for the google-cloud-pubsub surfaces the library touches.
+"""Shared test fakes and the event-loop blocking guard for the test suite.
 
-These were previously duplicated (and had drifted) between test_backends.py and
-test_handle.py; keeping one copy here is what stops the next divergence.
+The fakes stand in for the google-cloud-pubsub surfaces the library touches; they
+were previously duplicated (and had drifted) between test_backends.py and
+test_handle.py, so keeping one copy here is what stops the next divergence.
+
+The aiocop fixtures fail any test whose async handler blocks the event loop —
+this library bridges blocking google-cloud-pubsub threads onto an anyio loop, so
+a stray synchronous call there would silently saturate it in production. aiocop
+patches the *running* asyncio loop, so it only applies to the ``async def`` tests
+(pytest-asyncio, asyncio backend); the trio coverage in test_backends.py runs as
+sync functions via ``anyio.run`` and is left untouched, which is correct since
+aiocop is asyncio-only.
 """
 
 from __future__ import annotations
 
 import threading
 from typing import Any
+
+import aiocop
+import pytest
+
+# Tasks that run this long without yielding are treated as blocking the loop.
+# Matches the threshold the consuming services use (see pystreams.deps.blocking).
+DEFAULT_THRESHOLD_MS = 50
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _configure_aiocop():
+    """Register the audit hook and slow-task detection once for the session.
+
+    These are loop-independent globals; ``detect_slow_tasks`` itself guards
+    against being configured more than once.
+    """
+    aiocop.patch_audit_functions()
+    aiocop.start_blocking_io_detection()
+    aiocop.detect_slow_tasks(threshold_ms=DEFAULT_THRESHOLD_MS)
+    return
+
+
+@pytest.fixture(autouse=True)
+async def _enforce_no_blocking(_configure_aiocop):
+    """Patch this test's running loop and raise on high-severity blocking IO.
+
+    ``activate()`` runs aiocop's on-activate hooks against the loop that is live
+    right now (idempotent per loop); ``enable_raise_on_violations`` arms the raise
+    for this test's context, so a high-severity blocking call surfaces as a
+    ``HighSeverityBlockingIoException`` that fails the test. Async-only: pytest
+    skips this fixture for the sync trio tests, which have no asyncio loop to patch.
+    """
+    aiocop.activate()
+    aiocop.enable_raise_on_violations()
+    return
 
 
 class FakeMessage:

--- a/infra/tests/test_backends.py
+++ b/infra/tests/test_backends.py
@@ -12,25 +12,23 @@ from __future__ import annotations
 
 import concurrent.futures as cf
 import threading
+from datetime import timedelta
 from typing import Any, cast
 
 import anyio
+import anyio.lowlevel
 import pytest
 import structlog
-
-from datetime import timedelta
-
-from google.protobuf.duration_pb2 import Duration
-
 from conftest import FakeMessage, FakeSubscriberClient
 from gcp.pubsub.v1 import options_pb2
-from gram.ping.v1 import processor_pb2
-from gram.ping.v1 import ping_pb2
+from google.protobuf.duration_pb2 import Duration
+from gram.ping.v1 import ping_pb2, processor_pb2
+
 from gram_infra.pubsub import (
     EmulatedPubSubBroker,
-    PubSubBroker,
     Publisher,
     PublisherHandle,
+    PubSubBroker,
     Subscriber,
     SubscriberHandle,
 )
@@ -329,7 +327,7 @@ def test_receive_acks_messages_on_backend(backend) -> None:
                 await done.wait()
                 # Let the in-flight handlers ack before we tear down.
                 while not all(message.acked for message in messages):
-                    await anyio.sleep(0)
+                    await anyio.lowlevel.checkpoint()
             tg.cancel_scope.cancel()
 
         return seen

--- a/infra/tests/test_binding.py
+++ b/infra/tests/test_binding.py
@@ -36,5 +36,5 @@ def test_mismatched_pair_raises(monkeypatch) -> None:
 
     monkeypatch.setattr(discover, "require_topic_options", fake_require_topic_options)
 
-    with pytest.raises(ValueError, match="declares topic 'gram.ping.v1.Message'"):
+    with pytest.raises(ValueError, match=r"declares topic 'gram\.ping\.v1\.Message'"):
         require_subscription_for_message(ping_pb2.Message, processor_pb2.Processor)

--- a/infra/tests/test_handle.py
+++ b/infra/tests/test_handle.py
@@ -18,11 +18,11 @@ import anyio
 import anyio.to_thread
 import pytest
 import structlog
+from conftest import FakeMessage, FakeSubscriberClient
 from google.api_core.exceptions import NotFound
+from gram.ping.v1 import ping_pb2
 from structlog.testing import capture_logs
 
-from conftest import FakeMessage, FakeSubscriberClient
-from gram.ping.v1 import ping_pb2
 from gram_infra.pubsub import MessageMetadata, Subscriber, SubscriberHandle
 from gram_infra.pubsub.subscriber import _PortalScheduler
 
@@ -226,7 +226,8 @@ async def test_handler_cancelled_while_queued_on_limiter_is_nacked() -> None:
 
     assert queued.nacked is True
     assert queued.acked is False
-    assert blocked.acked is False and blocked.nacked is False
+    assert blocked.acked is False
+    assert blocked.nacked is False
 
 
 async def test_scheduler_shutdown_waits_for_inflight_handlers() -> None:

--- a/infra/tests/test_integration.py
+++ b/infra/tests/test_integration.py
@@ -13,9 +13,10 @@ import os
 import socket
 import uuid
 
-from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 import pytest
+from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from gram.ping.v1 import ping_pb2, processor_pb2
+
 from gram_infra.pubsub import (
     EmulatedPubSubBroker,
     pubsub_publisher_for_message,
@@ -50,10 +51,16 @@ pytestmark = pytest.mark.skipif(
 
 
 async def test_publish_subscribe_roundtrip() -> None:
+    # Constructing the gRPC clients eagerly opens a channel — blocking import +
+    # file IO that would stall the event loop (the suite's aiocop guard fails on
+    # it), so build them off-loop in a worker thread.
+    publisher_client, subscriber_client = await asyncio.to_thread(
+        lambda: (PublisherClient(), SubscriberClient())
+    )
     broker = EmulatedPubSubBroker(
         "gram-infra-it",
-        publisher_client=PublisherClient(),
-        subscriber_client=SubscriberClient(),
+        publisher_client=publisher_client,
+        subscriber_client=subscriber_client,
     )
 
     publisher = pubsub_publisher_for_message(broker, ping_pb2.Message)

--- a/infra/tests/test_naming.py
+++ b/infra/tests/test_naming.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pytest
 from gcp.pubsub.v1 import options_pb2
 from gram.ping.v1 import ping_pb2, processor_pb2
+
 from gram_infra.pubsub import (
     resolve_dead_letter_topic_name,
     resolve_subscription_name,

--- a/infra/tests/test_options.py
+++ b/infra/tests/test_options.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from gram.ping.v1 import ping_pb2, processor_pb2
+
 from gram_infra.pubsub import (
     subscription_options_from_message,
     topic_options_from_message,

--- a/uv.lock
+++ b/uv.lock
@@ -407,6 +407,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiocop" },
     { name = "anyio", extra = ["trio"] },
     { name = "pyrefly" },
     { name = "pytest" },
@@ -426,6 +427,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiocop", specifier = ">=1.1.4" },
     { name = "anyio", extras = ["trio"], specifier = ">=4.13.0" },
     { name = "pyrefly", specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },


### PR DESCRIPTION
## What

Bring `infra/`'s Python (`gram-infra`) up to the same bar as `pystreams`:
a `ruff` lint rule selection, and a fail-fast event-loop blocking guard.

Previously `ruff` ran only as a **formatter** (no lint selection), and unlike
pystreams there was no guard against code that blocks the asyncio loop — a real
hazard here, since `gram_infra` bridges blocking google-cloud-pubsub threads
onto an anyio loop.

### Changes

- **`infra/pyproject.toml`**
  - `[tool.ruff.lint]` selection `E, F, W, I, UP, B, ASYNC, RUF, PT, TID`
    (mirrors pystreams); `extend-exclude = ["gen_py"]` for the buf-generated
    protobuf modules.
  - `per-file-ignores`: `tests/** → ASYNC110` (bounded poll-loops are idiomatic
    test synchronization; the rule stays on for library code).
  - `aiocop` added as a **dev** dependency.
- **`infra/tests/conftest.py`** — session + per-test fixtures that arm aiocop's
  blocking-IO detection and raise on high-severity violations. Async-only, so it
  applies to the asyncio `async def` tests and leaves the sync trio coverage in
  `test_backends.py` untouched (aiocop is asyncio-specific).
- **Lint fixes** — resolved all 55 findings: import sorting, PEP 695 generic
  conversions (`UP046/047`, plus removing an orphaned `TypeVar`), `Union` →
  `|`, deprecated imports, reflowed 12 over-length docstrings, escaped a
  `pytest.raises` pattern (`RUF043`), and a documented `# noqa: ASYNC109` on the
  subscriber's public `timeout=` param (converting it would break the API).
- **Real blocking bug caught by the guard** — `test_integration.py` constructed
  its gRPC `PublisherClient`/`SubscriberClient` on the event loop (blocking
  import + channel open). Now built off-loop via `asyncio.to_thread`.

## Notes

- aiocop is **dev-only**: `gram_infra` is a library, so runtime blocking
  detection stays the consuming app's responsibility (pystreams already wires it
  at its entrypoint). The test suite enforces no-blocking here.
- Repo-wide `ruff check` enforcement in `hk` lands in the pystreams PR (#3557);
  once both merge, infra is lint-enforced in pre-commit/CI. This PR's
  `[tool.ruff.lint]` config is what scopes the rules to infra.

## Testing

- `ruff check` + `ruff format --check` — clean.
- `uv run pyrefly check` — 0 errors (validates the PEP 695 conversions).
- `uv run pytest` — 79 passed, with aiocop active and the emulator integration
  test exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables `ruff` linting and an asyncio event-loop blocking guard for `infra` to match `pystreams`. Adds `ruff` to the `lint:infra` task and enforces no‑blocking in async tests; fixes a blocking gRPC client init in the integration test.

- **Refactors**
  - Configure `ruff` for `infra/` with E, F, W, I, UP, B, ASYNC, RUF, PT, TID; `extend-exclude = ["gen_py"]`; per-file ignore `tests/** → ASYNC110`.
  - Run `ruff check infra` in `.mise` so local lint catches Python issues.
  - Lint-driven updates: PEP 695 generics, `collections.abc` types, `|` unions, import/docstring tidy; keep public `timeout` param with `# noqa: ASYNC109`.
  - Add `aiocop` (dev) and test fixtures: register audit hooks, detect slow tasks (50ms), patch the running loop, and raise on high‑severity blocking IO in asyncio tests.

- **Bug Fixes**
  - Build gRPC `PublisherClient`/`SubscriberClient` off-loop via `asyncio.to_thread` in the integration test.

<sup>Written for commit 46a8ab85bd25a77495c1fa3ea8feccac25917c96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

