### PR TITLE
chore(telemetry): record span errors with stack traces and log trace listing failures

### DIFF
--- a/server/internal/middleware/trace.go
+++ b/server/internal/middleware/trace.go
@@ -2,11 +2,14 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	goa "goa.design/goa/v3/pkg"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
 func TraceMethods(tracer trace.Tracer) func(goa.Endpoint) goa.Endpoint {
@@ -27,7 +30,12 @@ func TraceMethods(tracer trace.Tracer) func(goa.Endpoint) goa.Endpoint {
 
 			val, err := next(ctx, req)
 			if err != nil {
-				span.SetStatus(codes.Error, err.Error())
+				if se, ok := errors.AsType[*oops.ShareableError](err); ok {
+					span.SetStatus(codes.Error, se.String())
+				} else {
+					span.SetStatus(codes.Error, err.Error())
+				}
+				span.RecordError(err, trace.WithStackTrace(true))
 				return nil, err
 			}
 

--- a/server/internal/middleware/trace.go
+++ b/server/internal/middleware/trace.go
@@ -30,12 +30,20 @@ func TraceMethods(tracer trace.Tracer) func(goa.Endpoint) goa.Endpoint {
 
 			val, err := next(ctx, req)
 			if err != nil {
+				// A boundary logging helper (LogError/LogWarn/LogInfo) already
+				// applies span treatment, including deliberate cancellation- and
+				// client-fault-noise suppression. Re-recording here would duplicate
+				// the exception event and undo that suppression, so only act as a
+				// fallback for errors that never passed through such a helper.
 				if se, ok := errors.AsType[*oops.ShareableError](err); ok {
-					span.SetStatus(codes.Error, se.String())
+					if !se.SpanHandled() {
+						span.SetStatus(codes.Error, se.String())
+						span.RecordError(se, trace.WithStackTrace(true))
+					}
 				} else {
 					span.SetStatus(codes.Error, err.Error())
+					span.RecordError(err, trace.WithStackTrace(true))
 				}
-				span.RecordError(err, trace.WithStackTrace(true))
 				return nil, err
 			}
 

--- a/server/internal/oops/pp.go
+++ b/server/internal/oops/pp.go
@@ -29,11 +29,12 @@ func E(code Code, cause error, public string, args ...any) *ShareableError {
 	}
 
 	return &ShareableError{
-		Code:    code,
-		id:      goa.NewErrorID(),
-		cause:   cause,
-		private: "",
-		public:  msg,
+		spanHandled: false,
+		Code:        code,
+		id:          goa.NewErrorID(),
+		cause:       cause,
+		private:     "",
+		public:      msg,
 	}
 }
 
@@ -44,11 +45,12 @@ func E(code Code, cause error, public string, args ...any) *ShareableError {
 //go:noinline
 func C(code Code) *ShareableError {
 	return &ShareableError{
-		Code:    code,
-		id:      goa.NewErrorID(),
-		cause:   nil,
-		private: "",
-		public:  code.UserMessage(),
+		spanHandled: false,
+		Code:        code,
+		id:          goa.NewErrorID(),
+		cause:       nil,
+		private:     "",
+		public:      code.UserMessage(),
 	}
 }
 

--- a/server/internal/oops/pp.go
+++ b/server/internal/oops/pp.go
@@ -62,6 +62,19 @@ type ShareableError struct {
 	cause   error
 	public  string
 	private string
+	// spanHandled records that a boundary logging helper (LogError/LogWarn/
+	// LogInfo) has already applied this error's OpenTelemetry span treatment,
+	// including any deliberate suppression. Outer tracing middleware uses this to
+	// avoid recording the same error on the same span twice.
+	spanHandled bool
+}
+
+// SpanHandled reports whether a boundary logging helper has already decided this
+// error's span treatment. Tracing middleware should not record the error on the
+// span again when this is true, to avoid duplicate exception events and to
+// preserve the helpers' cancellation- and client-fault-noise suppression.
+func (e *ShareableError) SpanHandled() bool {
+	return e.spanHandled
 }
 
 // Error implements the error interface.
@@ -148,6 +161,7 @@ func (e *ShareableError) effectiveCode(ctx context.Context) Code {
 // faults in disconnect noise. Server- and application-initiated cancellations,
 // where the request context is still live, keep full error severity.
 func (e *ShareableError) LogError(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	e.spanHandled = true
 	canceled := e.effectiveCode(ctx) == CodeCanceled
 
 	span := trace.SpanFromContext(ctx)
@@ -186,6 +200,7 @@ func (e *ShareableError) LogError(ctx context.Context, logger *slog.Logger, args
 // request context) is demoted to info level, mirroring LogError's cancellation
 // handling.
 func (e *ShareableError) LogWarn(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	e.spanHandled = true
 	level := slog.LevelWarn
 	if e.effectiveCode(ctx) == CodeCanceled {
 		level = slog.LevelInfo
@@ -214,6 +229,7 @@ func (e *ShareableError) LogWarn(ctx context.Context, logger *slog.Logger, args 
 // already info and the span is never touched) but is kept for symmetry with
 // LogError and LogWarn.
 func (e *ShareableError) LogInfo(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
+	e.spanHandled = true
 	level := slog.LevelInfo
 	if e.effectiveCode(ctx) == CodeCanceled {
 		level = slog.LevelInfo

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -2300,6 +2300,8 @@ func (s *Service) ListToolUsageTraces(ctx context.Context, payload *telem_gen.Li
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	logger := s.logger
+
 	params, err := s.prepareTelemetrySearch(ctx, payload.Limit, payload.Sort, payload.Cursor, &payload.From, &payload.To)
 	if err != nil {
 		return nil, err
@@ -2332,7 +2334,7 @@ func (s *Service) ListToolUsageTraces(ctx context.Context, payload *telem_gen.Li
 
 	hostedMCPMatchers, err := s.toolUsageHostedMCPMatchers(ctx, *authCtx.ProjectID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing hosted MCP servers")
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing hosted MCP servers").LogError(ctx, logger)
 	}
 
 	rows, err := s.chRepo.ListToolUsageTraces(ctx, repo.ListToolUsageTracesParams{
@@ -2353,7 +2355,7 @@ func (s *Service) ListToolUsageTraces(ctx context.Context, payload *telem_gen.Li
 		Limit:              params.limit + 1,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error fetching tool usage traces")
+		return nil, oops.E(oops.CodeUnexpected, err, "error fetching tool usage traces").LogError(ctx, logger)
 	}
 
 	nextCursor := ""


### PR DESCRIPTION
Surface backend failures more clearly in traces and logs. The trace middleware now records the error on the span with a stack trace and uses the ShareableError representation for the span status when available, giving richer detail when investigating failed requests. The tool usage trace listing also logs its hosted-MCP and ClickHouse fetch errors so they're captured server-side rather than only returned to the caller.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve observability of backend failures in traces and logs. The trace middleware now records errors on spans with stack traces and sets span status from `oops.ShareableError`, skipping errors already handled by logging helpers to avoid duplicate exceptions and preserve cancellation/client‑fault suppression; tool‑usage trace listing now logs hosted‑MCP and ClickHouse fetch errors server‑side.

<sup>Written for commit 932220defaa5671a39ab41f787d39ecf2ef28b57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

