### PR TITLE
fix: new cursor marketplace format

### DIFF
--- a/docs/plugins/package-format.md
+++ b/docs/plugins/package-format.md
@@ -30,20 +30,21 @@ When plugins are published, all platform configs land in a single repo. The root
 │       ├── hooks.json
 │       └── hook.sh
 │
-├── <org-slug>-observability-cursor/   # Cursor observability plugin
-│   ├── .cursor-plugin/plugin.json
-│   ├── mcp.json
-│   └── hooks/
-│       ├── hooks.json
-│       └── hook.sh
-│
 ├── <plugin-slug>/                     # Claude plugin (one per plugin)
 │   ├── .claude-plugin/plugin.json
 │   └── .mcp.json
 │
-├── <plugin-slug>-cursor/              # Cursor plugin (one per plugin)
-│   ├── .cursor-plugin/plugin.json
-│   └── mcp.json
+├── cursor-plugins/                    # All Cursor plugins (marketplace pluginRoot)
+│   ├── <org-slug>-observability-cursor/   # Cursor observability plugin
+│   │   ├── .cursor-plugin/plugin.json
+│   │   ├── mcp.json
+│   │   └── hooks/
+│   │       ├── hooks.json
+│   │       └── hook.sh
+│   │
+│   └── <plugin-slug>-cursor/              # Cursor plugin (one per plugin)
+│       ├── .cursor-plugin/plugin.json
+│       └── mcp.json
 │
 └── <plugin-slug>-codex/               # Codex plugin (one per plugin)
     ├── .codex-plugin/plugin.json
@@ -51,11 +52,15 @@ When plugins are published, all platform configs land in a single repo. The root
     └── plugin.json
 ```
 
+Cursor plugins are grouped under the `cursor-plugins/` subdirectory, declared via
+`metadata.pluginRoot` in the Cursor `marketplace.json`. Plugin `source` values are
+then resolved relative to that root (bare names, no `./` prefix).
+
 ## Marketplace manifests
 
 Each platform has a top-level `marketplace.json` that lists all plugins in the repo.
 
-**Claude / Cursor** (`marketplace.json`):
+**Claude** (`.claude-plugin/marketplace.json`):
 
 ```json
 {
@@ -65,6 +70,24 @@ Each platform has a top-level `marketplace.json` that lists all plugins in the r
     {
       "name": "<plugin-slug>",
       "source": "./<plugin-slug>",
+      "description": "Plugin description"
+    }
+  ]
+}
+```
+
+**Cursor** (`.cursor-plugin/marketplace.json`) — plugins live under `cursor-plugins/`,
+declared via `metadata.pluginRoot`; `source` values are bare names relative to that root:
+
+```json
+{
+  "name": "<org-slug>-gram",
+  "owner": { "name": "Org Name", "email": "" },
+  "metadata": { "pluginRoot": "cursor-plugins" },
+  "plugins": [
+    {
+      "name": "<plugin-slug>-cursor",
+      "source": "<plugin-slug>-cursor",
       "description": "Plugin description"
     }
   ]
@@ -154,7 +177,7 @@ For public servers, headers are omitted and an env var reference is used for aut
 
 ## Cursor plugin
 
-Directory: `<plugin-slug>-cursor/`
+Directory: `cursor-plugins/<plugin-slug>-cursor/`
 
 ### `.cursor-plugin/plugin.json`
 
@@ -273,7 +296,7 @@ curl -s -X POST \
 
 ### Cursor observability
 
-Directory: `<org-slug>-observability-cursor/`
+Directory: `cursor-plugins/<org-slug>-observability-cursor/`
 
 Cursor's hook events differ from Claude's — they use camelCase and Cursor-specific names:
 

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -215,6 +215,11 @@ var CursorObservabilityHookEvents = []string{
 	"afterMCPExecution",
 }
 
+// cursorPluginRoot is the subdirectory under which all Cursor plugins are
+// grouped in a published repo. Declared via marketplace.json's metadata.pluginRoot
+// so plugin sources can be referenced by bare name relative to this root.
+const cursorPluginRoot = "cursor-plugins"
+
 // GeneratePluginPackages produces the complete file map for a plugin distribution
 // repository containing Claude Code, Cursor, and Codex plugins. Used for GitHub push.
 func GeneratePluginPackages(plugins []PluginInfo, cfg GenerateConfig) (map[string][]byte, error) {
@@ -246,7 +251,7 @@ func GeneratePluginPackages(plugins []PluginInfo, cfg GenerateConfig) (map[strin
 		cursorObservability := CursorObservabilitySlug(cfg)
 		cursorPlugins = append(cursorPlugins, marketplaceEntry{
 			Name:        cursorObservability,
-			Source:      "./" + cursorObservability,
+			Source:      cursorObservability,
 			Description: "Required: Speakeasy observability hooks for " + cfg.OrgName + ".",
 		})
 		codexObservability := CodexObservabilitySlug(cfg)
@@ -280,7 +285,7 @@ func GeneratePluginPackages(plugins []PluginInfo, cfg GenerateConfig) (map[strin
 		})
 		cursorPlugins = append(cursorPlugins, marketplaceEntry{
 			Name:        p.Slug + "-cursor",
-			Source:      "./" + p.Slug + "-cursor",
+			Source:      p.Slug + "-cursor",
 			Description: p.Description,
 		})
 		codexPlugins = append(codexPlugins, codexMarketplaceEntry{
@@ -310,9 +315,10 @@ func GeneratePluginPackages(plugins []PluginInfo, cfg GenerateConfig) (map[strin
 	files[".claude-plugin/marketplace.json"] = claudeManifest
 
 	cursorManifest, err := marshalJSON(marketplaceManifest{
-		Name:    marketplaceName,
-		Owner:   owner,
-		Plugins: cursorPlugins,
+		Name:     marketplaceName,
+		Owner:    owner,
+		Metadata: &marketplaceMetadata{PluginRoot: cursorPluginRoot},
+		Plugins:  cursorPlugins,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal cursor marketplace.json: %w", err)
@@ -451,7 +457,8 @@ func generateClaudePlugin(files map[string][]byte, p PluginInfo, cfg GenerateCon
 }
 
 func generateCursorPlugin(files map[string][]byte, p PluginInfo, cfg GenerateConfig) error {
-	return generateCursorPluginInDir(files, p.Slug+"-cursor", p.Slug+"-cursor", p, cfg)
+	name := p.Slug + "-cursor"
+	return generateCursorPluginInDir(files, path.Join(cursorPluginRoot, name), name, p, cfg)
 }
 
 func generateCodexPlugin(files map[string][]byte, p PluginInfo, cfg GenerateConfig) error {
@@ -616,26 +623,23 @@ func generateClaudeObservabilityPluginInDir(files map[string][]byte, subdir stri
 // for Cursor. Same shape as the Claude variant but uses Cursor's hook event
 // names + script destination URL.
 func generateCursorObservabilityPlugin(files map[string][]byte, cfg GenerateConfig) error {
-	return generateCursorObservabilityPluginInDir(files, CursorObservabilitySlug(cfg), cfg)
+	name := CursorObservabilitySlug(cfg)
+	return generateCursorObservabilityPluginInDir(files, path.Join(cursorPluginRoot, name), name, cfg)
 }
 
 // generateCursorObservabilityPluginFlat emits the same files at the root
 // (no subdir) for direct ZIP installation.
 func generateCursorObservabilityPluginFlat(files map[string][]byte, cfg GenerateConfig) error {
-	return generateCursorObservabilityPluginInDir(files, "", cfg)
+	return generateCursorObservabilityPluginInDir(files, "", CursorObservabilitySlug(cfg), cfg)
 }
 
-func generateCursorObservabilityPluginInDir(files map[string][]byte, subdir string, cfg GenerateConfig) error {
-	name := subdir
-	if name == "" {
-		name = CursorObservabilitySlug(cfg)
-	}
+func generateCursorObservabilityPluginInDir(files map[string][]byte, subdir, name string, cfg GenerateConfig) error {
 	pluginJSON, err := marshalJSON(cursorPluginMeta{
 		Name:        name,
 		DisplayName: "Observability (Cursor)",
 		Description: "Speakeasy observability hooks for " + cfg.OrgName + ". Install this plugin to forward tool events to your team's Speakeasy dashboard.",
 		Version:     pluginManifestVersion(cfg),
-		Author:      pluginAuthor{Name: cfg.OrgName, URL: "https://getgram.ai"},
+		Author:      cursorAuthor{Name: cfg.OrgName},
 		Homepage:    "https://getgram.ai",
 	})
 	if err != nil {
@@ -1760,7 +1764,7 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 		DisplayName: displayName,
 		Description: p.Description,
 		Version:     pluginManifestVersion(cfg),
-		Author:      pluginAuthor{Name: cfg.OrgName, URL: "https://getgram.ai"},
+		Author:      cursorAuthor{Name: cfg.OrgName},
 		Homepage:    "https://getgram.ai",
 	})
 	if err != nil {
@@ -1802,9 +1806,17 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 // --- JSON types ---
 
 type marketplaceManifest struct {
-	Name    string             `json:"name"`
-	Owner   marketplaceOwner   `json:"owner"`
-	Plugins []marketplaceEntry `json:"plugins"`
+	Name     string               `json:"name"`
+	Owner    marketplaceOwner     `json:"owner"`
+	Metadata *marketplaceMetadata `json:"metadata,omitempty"`
+	Plugins  []marketplaceEntry   `json:"plugins"`
+}
+
+// marketplaceMetadata carries optional marketplace-level settings. Cursor uses
+// pluginRoot to declare the subdirectory that contains all plugins, letting
+// plugin sources be referenced by bare name relative to that root.
+type marketplaceMetadata struct {
+	PluginRoot string `json:"pluginRoot,omitempty"`
 }
 
 type marketplaceOwner struct {
@@ -1852,8 +1864,16 @@ type cursorPluginMeta struct {
 	DisplayName string       `json:"displayName"`
 	Description string       `json:"description"`
 	Version     string       `json:"version"`
-	Author      pluginAuthor `json:"author"`
+	Author      cursorAuthor `json:"author"`
 	Homepage    string       `json:"homepage"`
+}
+
+// cursorAuthor matches Cursor's documented plugin author schema (name + optional
+// email). Cursor does not recognize a url sub-field — the author URL belongs in
+// the top-level homepage/repository fields instead.
+type cursorAuthor struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
 }
 
 type cursorMCPConfig struct {

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -640,7 +640,7 @@ func generateCursorObservabilityPluginInDir(files map[string][]byte, subdir, nam
 		DisplayName: "Observability (Cursor)",
 		Description: "Speakeasy observability hooks for " + cfg.OrgName + ". Install this plugin to forward tool events to your team's Speakeasy dashboard.",
 		Version:     pluginManifestVersion(cfg),
-		Author:      cursorAuthor{Name: cfg.OrgName, Email: ""},
+		Author:      cursorAuthor{Name: cfg.OrgName, Email: cfg.OrgEmail},
 		Homepage:    "https://getgram.ai",
 	})
 	if err != nil {

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -305,9 +305,10 @@ func GeneratePluginPackages(plugins []PluginInfo, cfg GenerateConfig) (map[strin
 	marketplaceName := resolveMarketplaceName(cfg)
 
 	claudeManifest, err := marshalJSON(marketplaceManifest{
-		Name:    marketplaceName,
-		Owner:   owner,
-		Plugins: claudePlugins,
+		Name:     marketplaceName,
+		Owner:    owner,
+		Metadata: nil,
+		Plugins:  claudePlugins,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal claude marketplace.json: %w", err)
@@ -639,7 +640,7 @@ func generateCursorObservabilityPluginInDir(files map[string][]byte, subdir, nam
 		DisplayName: "Observability (Cursor)",
 		Description: "Speakeasy observability hooks for " + cfg.OrgName + ". Install this plugin to forward tool events to your team's Speakeasy dashboard.",
 		Version:     pluginManifestVersion(cfg),
-		Author:      cursorAuthor{Name: cfg.OrgName},
+		Author:      cursorAuthor{Name: cfg.OrgName, Email: ""},
 		Homepage:    "https://getgram.ai",
 	})
 	if err != nil {
@@ -1764,7 +1765,7 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 		DisplayName: displayName,
 		Description: p.Description,
 		Version:     pluginManifestVersion(cfg),
-		Author:      cursorAuthor{Name: cfg.OrgName},
+		Author:      cursorAuthor{Name: cfg.OrgName, Email: ""},
 		Homepage:    "https://getgram.ai",
 	})
 	if err != nil {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -84,8 +84,8 @@ func TestGeneratePluginPackagesProducesExpectedFiles(t *testing.T) {
 		".agents/plugins/marketplace.json",
 		"engineering-tools/.claude-plugin/plugin.json",
 		"engineering-tools/.mcp.json",
-		"engineering-tools-cursor/.cursor-plugin/plugin.json",
-		"engineering-tools-cursor/mcp.json",
+		"cursor-plugins/engineering-tools-cursor/.cursor-plugin/plugin.json",
+		"cursor-plugins/engineering-tools-cursor/mcp.json",
 		"engineering-tools-codex/.codex-plugin/plugin.json",
 		"engineering-tools-codex/.mcp.json",
 	}
@@ -144,7 +144,7 @@ func TestGenerateCursorMCPConfigUsesEnvSyntax(t *testing.T) {
 	require.NoError(t, err)
 
 	var mcpConfig cursorMCPConfig
-	err = json.Unmarshal(files["test-cursor/mcp.json"], &mcpConfig)
+	err = json.Unmarshal(files["cursor-plugins/test-cursor/mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
 	server := mcpConfig.MCPServers["gram-server"]
@@ -203,7 +203,7 @@ func TestGenerateCursorOAuthServerEmitsURLWithNoHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	var mcpConfig cursorMCPConfig
-	err = json.Unmarshal(files["test-cursor/mcp.json"], &mcpConfig)
+	err = json.Unmarshal(files["cursor-plugins/test-cursor/mcp.json"], &mcpConfig)
 	require.NoError(t, err)
 
 	server := mcpConfig.MCPServers["oauth-server"]
@@ -582,8 +582,10 @@ func TestGenerateMarketplaceManifest(t *testing.T) {
 
 	require.Equal(t, "acme-speakeasy", cursorManifest.Name)
 	require.Len(t, cursorManifest.Plugins, 2)
-	require.Equal(t, "./a-cursor", cursorManifest.Plugins[0].Source)
-	require.Equal(t, "./b-cursor", cursorManifest.Plugins[1].Source)
+	require.NotNil(t, cursorManifest.Metadata)
+	require.Equal(t, "cursor-plugins", cursorManifest.Metadata.PluginRoot)
+	require.Equal(t, "a-cursor", cursorManifest.Plugins[0].Source)
+	require.Equal(t, "b-cursor", cursorManifest.Plugins[1].Source)
 }
 
 func TestGenerateMarketplaceManifestUsesMarketplaceNameOverride(t *testing.T) {
@@ -820,7 +822,7 @@ func TestGenerateObservabilityPluginsIncludeIdentityHelper(t *testing.T) {
 
 	for _, path := range []string{
 		ClaudeObservabilitySlug(cfg) + "/hooks/identity.sh",
-		CursorObservabilitySlug(cfg) + "/hooks/identity.sh",
+		"cursor-plugins/" + CursorObservabilitySlug(cfg) + "/hooks/identity.sh",
 		CodexObservabilitySlug(cfg) + "/hooks/identity.sh",
 	} {
 		require.NotNil(t, files[path], "observability identity helper missing: %s", path)
@@ -1280,10 +1282,10 @@ func TestGeneratePluginPackagesStampsConfigVersionIntoEveryManifest(t *testing.T
 	// the supplied version.
 	manifestPaths := []string{
 		"engineering-tools/.claude-plugin/plugin.json",
-		"engineering-tools-cursor/.cursor-plugin/plugin.json",
+		"cursor-plugins/engineering-tools-cursor/.cursor-plugin/plugin.json",
 		"engineering-tools-codex/.codex-plugin/plugin.json",
 		"acme-observability/.claude-plugin/plugin.json",
-		"acme-observability-cursor/.cursor-plugin/plugin.json",
+		"cursor-plugins/acme-observability-cursor/.cursor-plugin/plugin.json",
 		"acme-observability-codex/.codex-plugin/plugin.json",
 	}
 	for _, p := range manifestPaths {

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -1018,7 +1018,7 @@ func TestPluginsService_PublishPlugins_PublicToolsetEnvConfigs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the Cursor config uses ${env:ANALYTICS_API_KEY} for the public server.
-	cursorMCP := mock.lastPushedFiles["public-test-cursor/mcp.json"]
+	cursorMCP := mock.lastPushedFiles["cursor-plugins/public-test-cursor/mcp.json"]
 	require.NotNil(t, cursorMCP)
 
 	var cursorConfig struct {
@@ -1107,7 +1107,7 @@ func TestPluginsService_PublishPlugins_SkipsUserEnvConfigsWithoutHeaderName(t *t
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.NoError(t, err)
 
-	cursorMCP := mock.lastPushedFiles["headerless-cursor/mcp.json"]
+	cursorMCP := mock.lastPushedFiles["cursor-plugins/headerless-cursor/mcp.json"]
 	require.NotNil(t, cursorMCP)
 
 	var cursorConfig struct {
@@ -1167,7 +1167,7 @@ func TestPluginsService_PublishPlugins_SkipsDisabledMCPToolsets(t *testing.T) {
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.NoError(t, err)
 
-	cursorMCP := mock.lastPushedFiles["mixed-cursor/mcp.json"]
+	cursorMCP := mock.lastPushedFiles["cursor-plugins/mixed-cursor/mcp.json"]
 	require.NotNil(t, cursorMCP)
 
 	var cursorConfig struct {
@@ -1246,9 +1246,9 @@ func TestPluginsService_PublishPlugins_EmitsObservabilityPlugin(t *testing.T) {
 	require.NotNil(t, mock.lastPushedFiles[claudeObservability+"/hooks/hooks.json"], "claude observability hooks/hooks.json missing")
 	require.NotNil(t, mock.lastPushedFiles[claudeObservability+"/hooks/hook.sh"], "claude observability hooks/hook.sh missing")
 
-	require.NotNil(t, mock.lastPushedFiles[cursorObservability+"/.cursor-plugin/plugin.json"], "cursor observability plugin.json missing")
-	require.NotNil(t, mock.lastPushedFiles[cursorObservability+"/hooks/hooks.json"], "cursor observability hooks/hooks.json missing")
-	require.NotNil(t, mock.lastPushedFiles[cursorObservability+"/hooks/hook.sh"], "cursor observability hooks/hook.sh missing")
+	require.NotNil(t, mock.lastPushedFiles["cursor-plugins/"+cursorObservability+"/.cursor-plugin/plugin.json"], "cursor observability plugin.json missing")
+	require.NotNil(t, mock.lastPushedFiles["cursor-plugins/"+cursorObservability+"/hooks/hooks.json"], "cursor observability hooks/hooks.json missing")
+	require.NotNil(t, mock.lastPushedFiles["cursor-plugins/"+cursorObservability+"/hooks/hook.sh"], "cursor observability hooks/hook.sh missing")
 }
 
 // PublishPlugins must succeed when the org has no custom plugins — the
@@ -1266,7 +1266,7 @@ func TestPluginsService_PublishPlugins_ObservabilityOnly(t *testing.T) {
 	claudeObservability, cursorObservability := orgObservabilitySlugs(t, ctx, ti)
 
 	require.NotNil(t, mock.lastPushedFiles[claudeObservability+"/hooks/hook.sh"], "claude observability hooks/hook.sh missing")
-	require.NotNil(t, mock.lastPushedFiles[cursorObservability+"/hooks/hook.sh"], "cursor observability hooks/hook.sh missing")
+	require.NotNil(t, mock.lastPushedFiles["cursor-plugins/"+cursorObservability+"/hooks/hook.sh"], "cursor observability hooks/hook.sh missing")
 
 	for _, p := range []struct {
 		path     string
@@ -1328,7 +1328,7 @@ func TestPluginsService_PublishPlugins_ObservabilityHookScriptContainsAPIKey(t *
 	claudeObservability, cursorObservability := orgObservabilitySlugs(t, ctx, ti)
 	// Both endpoints accept Gram-Key (Cursor requires it via Security; Claude
 	// accepts it as an optional header for plugin-driven attribution).
-	for _, path := range []string{claudeObservability + "/hooks/hook.sh", cursorObservability + "/hooks/hook.sh"} {
+	for _, path := range []string{claudeObservability + "/hooks/hook.sh", "cursor-plugins/" + cursorObservability + "/hooks/hook.sh"} {
 		script := string(mock.lastPushedFiles[path])
 		require.NotEmpty(t, script, path+" missing")
 		require.Contains(t, script, "Gram-Key: "+hooksKeyPrefix, "%s does not embed hooks key in Gram-Key", path)


### PR DESCRIPTION
Cursor changed their marketplace format at some point recently and our plugins weren't being detected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align plugin generation and docs with Cursor’s updated marketplace so our plugins are detected again. Cursor plugins now live under `cursor-plugins/` via `metadata.pluginRoot`, and `source` entries are bare names.

- **Bug Fixes**
  - Emit all Cursor plugin files under `cursor-plugins/<plugin-slug>-cursor/` (including observability).
  - Write `.cursor-plugin/marketplace.json` with `metadata.pluginRoot: "cursor-plugins"` and bare `source` values.
  - Use Cursor author schema `{ name, email? }` and keep URLs in `homepage`.
  - Update docs and tests for the new structure.

<sup>Written for commit 18343da3a444ef6a673d161d0222496ba74387d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

