### PR TITLE
fix: filter bar default chips show no remove button + drawer prefills date range

### DIFF
--- a/client/dashboard/src/components/filters/FilterChip.tsx
+++ b/client/dashboard/src/components/filters/FilterChip.tsx
@@ -27,6 +27,10 @@ const OP_OPTIONS: { value: Operator; label: string }[] = [
  * A solid grey filter pill: `value ✕`. The body opens the editor (the filter
  * sheet); the × clears the filter. Matches the Untitled UI reference where every
  * applied filter reads as a uniform pill.
+ *
+ * `onRemove` is optional: a pinned dimension sitting at its default value (e.g.
+ * "All servers" or a daterange on its default preset) has nothing to clear, so
+ * the caller omits it and the × is hidden rather than rendered as a no-op.
  */
 export function FilterChip({
   label,
@@ -35,10 +39,14 @@ export function FilterChip({
 }: {
   label: string;
   onClick?: () => void;
-  onRemove: () => void;
+  onRemove?: () => void;
 }): JSX.Element {
   return (
-    <span className="border-border bg-card hover:bg-muted/50 inline-flex h-10 shrink-0 items-center gap-2 rounded-md border pr-2 pl-3 text-sm font-medium transition-colors">
+    <span
+      className={`border-border bg-card hover:bg-muted/50 inline-flex h-10 shrink-0 items-center gap-2 rounded-md border pl-3 text-sm font-medium transition-colors ${
+        onRemove ? "pr-2" : "pr-3"
+      }`}
+    >
       <button
         type="button"
         onClick={onClick}
@@ -46,14 +54,16 @@ export function FilterChip({
       >
         {label}
       </button>
-      <button
-        type="button"
-        onClick={onRemove}
-        aria-label={`Remove ${label} filter`}
-        className="text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <X className="size-4" />
-      </button>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${label} filter`}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <X className="size-4" />
+        </button>
+      )}
     </span>
   );
 }

--- a/client/dashboard/src/components/filters/FilterSheet.tsx
+++ b/client/dashboard/src/components/filters/FilterSheet.tsx
@@ -82,6 +82,12 @@ export function FilterSheet({
         className="bg-card w-full overflow-y-auto sm:max-w-md"
         onInteractOutside={keepOpenOnPopoverInteraction}
         onPointerDownOutside={keepOpenOnPopoverInteraction}
+        // Radix auto-focuses the first focusable control on open. When that's a
+        // daterange dimension (e.g. the Sessions sheet, where `date` is first),
+        // focusing the TimeRangePicker's input flips it into edit mode and blanks
+        // the displayed value — the picker looks un-prefilled. Suppress the
+        // open-autofocus so every control keeps showing its current value.
+        onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <SheetHeader>
           <SheetTitle>Filters</SheetTitle>

--- a/client/dashboard/src/components/filters/filter-schema.ts
+++ b/client/dashboard/src/components/filters/filter-schema.ts
@@ -170,6 +170,24 @@ export function isDimensionActive(
   }
 }
 
+/**
+ * Whether a dimension's value equals its default ("empty") value. Drives whether
+ * a chip shows a clear (×) button: clearing an at-default chip is a no-op, so we
+ * hide the × for default pinned chips (e.g. "All servers" or a daterange already
+ * on its `defaultPreset`). Differs from `!isDimensionActive` only for daterange,
+ * whose default may be a non-null preset.
+ */
+export function isDimensionAtDefault(
+  dim: FilterDimension,
+  value: FilterValueByKind[FilterKind],
+): boolean {
+  if (dim.kind === "daterange") {
+    const v = value as DateRangeValue;
+    return v.customRange === null && v.preset === (dim.defaultPreset ?? null);
+  }
+  return !isDimensionActive(dim, value);
+}
+
 /** Resolve a raw value to its option label, falling back to the raw value. */
 function optionLabel(
   value: string,

--- a/client/dashboard/src/components/ui/toolbar.tsx
+++ b/client/dashboard/src/components/ui/toolbar.tsx
@@ -26,6 +26,7 @@ import { FilterSheet } from "@/components/filters/FilterSheet";
 import {
   chipLabel,
   isDimensionActive,
+  isDimensionAtDefault,
   type FilterDimension,
   type FilterValue,
   type OptionsById,
@@ -229,7 +230,13 @@ function ToolbarFilters({
           key={dim.id}
           label={chipLabel(dim, values[dim.id]!, optionsById[dim.id])}
           onClick={() => setSheetOpen(true)}
-          onRemove={() => onClear(dim.id)}
+          // A default pinned chip ("All …", default daterange) has nothing to
+          // clear — omit onRemove so the × is hidden instead of a no-op.
+          onRemove={
+            isDimensionAtDefault(dim, values[dim.id]!)
+              ? undefined
+              : () => onClear(dim.id)
+          }
         />
       ))}
 


### PR DESCRIPTION
## What

Two fixes to the unified `Page.Toolbar` filter bar.

### 1. Default filter chips no longer show a dead × button

Pinned dimensions always render a chip — even at their default value (`"All policies"`, a daterange on its `defaultPreset`). The chip still rendered an × that called `onClear`, which "reset" to the value already shown — a visible no-op. The × now only renders when clearing would actually change something.

- New `isDimensionAtDefault(dim, value)` helper. For every kind except `daterange` this is just `!isDimensionActive`; for `daterange` it compares against the default preset.
- `FilterChip.onRemove` is now optional; the × is hidden when omitted (padding adjusts so a label-only chip stays symmetric).
- The toolbar passes `onRemove` only for chips not at their default.

"Reset to default" still clears everything; active filters keep their ×.

### 2. Drawer time-range filter prefills with the current value

Radix auto-focuses the first focusable control when the filter sheet opens. On date-first sheets (e.g. Sessions, where `date` is the first dimension), that focus flipped the `TimeRangePicker` into edit mode and blanked its displayed value — so it looked un-prefilled. Suppressing the sheet's open-autofocus keeps every control showing its current value.

## Why

Both are confusing UX on the new filter bar: an × that does nothing, and a date picker that appears empty despite an active range.

## Scope

Dashboard-only, no API/schema changes. Fix lives in the shared filter components, so every page using `Page.Toolbar.Filters` benefits (Catalog, MCP, Sessions, Risk Events, Insights, Observe).

## Test plan

- `pnpm -F dashboard type-check` passes.
- Default pinned chips render without an ×; active filters keep theirs.
- Open the Sessions filter drawer — the time range shows the active preset instead of a blank input.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two UX issues in the dashboard filter bar: default pinned chips no longer show a no-op remove button, and the filter drawer now keeps the time range prefilled on open.

- **Bug Fixes**
  - Hide the × on pinned chips when at their default value. Adds `isDimensionAtDefault`, makes `FilterChip.onRemove` optional, and only passes it when clearing would change the value.
  - Prevent the filter sheet from auto-focusing on open so `TimeRangePicker` keeps showing the current preset/value (no more blank field).

<sup>Written for commit 725aae04bbb1fedb8658e3dda50edf4e874c485e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

