### PR TITLE
mig: add policy scope + rule expression columns

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3004,19 +3004,18 @@ CREATE TABLE IF NOT EXISTS risk_custom_detection_rules (
   rule_id TEXT NOT NULL,
   title TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
-  -- Legacy single-pattern matcher. Superseded by match_config; retained
-  -- (nullable) so existing rules keep evaluating until a later ticket
-  -- backfills them into match_config and contracts this column away.
+  -- Legacy single-pattern matcher. Superseded by detection_expr; retained
+  -- (nullable) so existing rules keep evaluating until a later contract
+  -- migration drops it (after its readers are gone).
   regex TEXT,
-  -- Sparse, self-describing matcher config: an ANDed/ORed list of
-  -- {target, op, value, path?} conditions over message targets (content,
-  -- user_prompt, tool_server, tool_function, tool_args, ...). When NULL the
-  -- rule falls back to the regex column. See rule_engine.go for the shape.
+  -- Legacy structured matcher: an ANDed/ORed list of {target, op, value,
+  -- path?} conditions over message targets (content, user_prompt, tool_server,
+  -- tool_function, tool_args, ...). Also superseded by detection_expr and
+  -- retained until that same contract migration; new rules leave this NULL.
   match_config JSONB,
   -- CEL detection predicate, evaluated by internal/risk/celenv. A true verdict
-  -- produces a finding. NULL means no matcher configured (falls back to regex).
-  -- Supersedes match_config, which is retained until a later contract migration
-  -- drops it (after its readers are gone).
+  -- produces a finding. NULL means no CEL matcher is configured, in which case
+  -- the rule falls back to its legacy match_config / regex columns.
   detection_expr TEXT,
   severity TEXT NOT NULL DEFAULT 'medium',
 

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2958,6 +2958,12 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   disabled_rules TEXT[],
   custom_rule_ids TEXT[] NOT NULL DEFAULT '{}',
   message_types TEXT[],
+  -- Fine-grained applicability as CEL boolean expressions over message fields
+  -- (see internal/risk/celenv). A policy applies when scope_include is true (or
+  -- NULL = all) AND scope_exempt is not true. scope_include generalizes
+  -- message_types; NULL falls back to those cards.
+  scope_include TEXT,
+  scope_exempt TEXT,
   action TEXT NOT NULL DEFAULT 'flag',
   audience_type TEXT NOT NULL DEFAULT 'everyone',
   auto_name BOOLEAN NOT NULL DEFAULT TRUE,
@@ -3007,6 +3013,11 @@ CREATE TABLE IF NOT EXISTS risk_custom_detection_rules (
   -- user_prompt, tool_server, tool_function, tool_args, ...). When NULL the
   -- rule falls back to the regex column. See rule_engine.go for the shape.
   match_config JSONB,
+  -- CEL detection predicate, evaluated by internal/risk/celenv. A true verdict
+  -- produces a finding. NULL means no matcher configured (falls back to regex).
+  -- Supersedes match_config, which is retained until a later contract migration
+  -- drops it (after its readers are gone).
+  detection_expr TEXT,
   severity TEXT NOT NULL DEFAULT 'medium',
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -3083,6 +3094,11 @@ CREATE TABLE IF NOT EXISTS risk_results (
   end_pos INT,
   confidence DOUBLE PRECISION,
   tags TEXT[],
+
+  -- All matched spans attributed to this one finding, as a JSON array of
+  -- {match,field,path,start_pos,end_pos}. match/start_pos/end_pos above mirror
+  -- the primary (first) span; spans is the full set. NULL for legacy/empty rows.
+  spans jsonb,
 
   -- Populated on rows that represent a message the scanner could not analyze
   -- after exhausting its retry budget

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1293,6 +1293,7 @@ type RiskCustomDetectionRule struct {
 	Description    string
 	Regex          pgtype.Text
 	MatchConfig    []byte
+	DetectionExpr  pgtype.Text
 	Severity       string
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz
@@ -1329,6 +1330,8 @@ type RiskPolicy struct {
 	DisabledRules        []string
 	CustomRuleIds        []string
 	MessageTypes         []string
+	ScopeInclude         pgtype.Text
+	ScopeExempt          pgtype.Text
 	Action               string
 	AudienceType         string
 	AutoName             bool
@@ -1384,6 +1387,7 @@ type RiskResult struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
+	Spans               []byte
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -18,6 +18,7 @@ type RiskCustomDetectionRule struct {
 	Description    string
 	Regex          pgtype.Text
 	MatchConfig    []byte
+	DetectionExpr  pgtype.Text
 	Severity       string
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz
@@ -54,6 +55,8 @@ type RiskPolicy struct {
 	DisabledRules        []string
 	CustomRuleIds        []string
 	MessageTypes         []string
+	ScopeInclude         pgtype.Text
+	ScopeExempt          pgtype.Text
 	Action               string
 	AudienceType         string
 	AutoName             bool

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -257,7 +257,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -281,6 +281,8 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.DisabledRules,
 		&i.CustomRuleIds,
 		&i.MessageTypes,
+		&i.ScopeInclude,
+		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,
@@ -431,7 +433,7 @@ VALUES (
   , $6
   , $7
 )
-RETURNING id, project_id, organization_id, rule_id, title, description, regex, match_config, severity, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, rule_id, title, description, regex, match_config, detection_expr, severity, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateCustomDetectionRuleParams struct {
@@ -464,6 +466,7 @@ func (q *Queries) CreateCustomDetectionRule(ctx context.Context, arg CreateCusto
 		&i.Description,
 		&i.Regex,
 		&i.MatchConfig,
+		&i.DetectionExpr,
 		&i.Severity,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -585,7 +588,7 @@ VALUES (
   , $18::jsonb
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -644,6 +647,8 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.DisabledRules,
 		&i.CustomRuleIds,
 		&i.MessageTypes,
+		&i.ScopeInclude,
+		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,
@@ -833,7 +838,7 @@ func (q *Queries) FetchUnanalyzedMessageIDs(ctx context.Context, arg FetchUnanal
 }
 
 const getCustomDetectionRule = `-- name: GetCustomDetectionRule :one
-SELECT id, project_id, organization_id, rule_id, title, description, regex, match_config, severity, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, rule_id, title, description, regex, match_config, detection_expr, severity, created_at, updated_at, deleted_at, deleted
 FROM risk_custom_detection_rules
 WHERE id = $1
   AND project_id = $2
@@ -857,6 +862,7 @@ func (q *Queries) GetCustomDetectionRule(ctx context.Context, arg GetCustomDetec
 		&i.Description,
 		&i.Regex,
 		&i.MatchConfig,
+		&i.DetectionExpr,
 		&i.Severity,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -1054,7 +1060,7 @@ func (q *Queries) GetRiskOverviewCounts(ctx context.Context, arg GetRiskOverview
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1082,6 +1088,8 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.DisabledRules,
 		&i.CustomRuleIds,
 		&i.MessageTypes,
+		&i.ScopeInclude,
+		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,
@@ -1138,7 +1146,7 @@ func (q *Queries) GetRiskPolicyBypassRequest(ctx context.Context, arg GetRiskPol
 }
 
 const getRiskPolicyForUpdate = `-- name: GetRiskPolicyForUpdate :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1167,6 +1175,8 @@ func (q *Queries) GetRiskPolicyForUpdate(ctx context.Context, arg GetRiskPolicyF
 		&i.DisabledRules,
 		&i.CustomRuleIds,
 		&i.MessageTypes,
+		&i.ScopeInclude,
+		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,
@@ -1233,7 +1243,7 @@ type InsertRiskResultsParams struct {
 }
 
 const listCustomDetectionRules = `-- name: ListCustomDetectionRules :many
-SELECT id, project_id, organization_id, rule_id, title, description, regex, match_config, severity, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, rule_id, title, description, regex, match_config, detection_expr, severity, created_at, updated_at, deleted_at, deleted
 FROM risk_custom_detection_rules
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -1258,6 +1268,7 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 			&i.Description,
 			&i.Regex,
 			&i.MatchConfig,
+			&i.DetectionExpr,
 			&i.Severity,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -1275,7 +1286,7 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1305,6 +1316,8 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.DisabledRules,
 			&i.CustomRuleIds,
 			&i.MessageTypes,
+			&i.ScopeInclude,
+			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1379,7 +1392,7 @@ func (q *Queries) ListEnabledExclusionsForPolicy(ctx context.Context, arg ListEn
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1408,6 +1421,8 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.DisabledRules,
 			&i.CustomRuleIds,
 			&i.MessageTypes,
+			&i.ScopeInclude,
+			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1431,7 +1446,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1462,6 +1477,8 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.DisabledRules,
 			&i.CustomRuleIds,
 			&i.MessageTypes,
+			&i.ScopeInclude,
+			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1485,7 +1502,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1519,6 +1536,8 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.DisabledRules,
 			&i.CustomRuleIds,
 			&i.MessageTypes,
+			&i.ScopeInclude,
+			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1826,7 +1845,7 @@ func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, arg ListRiskOver
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -1855,6 +1874,8 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.DisabledRules,
 			&i.CustomRuleIds,
 			&i.MessageTypes,
+			&i.ScopeInclude,
+			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
 			&i.AutoName,
@@ -1940,7 +1961,7 @@ func (q *Queries) ListRiskPolicyBypassRequests(ctx context.Context, arg ListRisk
 }
 
 const listRiskResultsByChatFound = `-- name: ListRiskResultsByChatFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -1980,6 +2001,7 @@ type ListRiskResultsByChatFoundRow struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
+	Spans               []byte
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
@@ -2023,6 +2045,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.Spans,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,
@@ -2045,7 +2068,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 }
 
 const listRiskResultsByProjectAndPolicy = `-- name: ListRiskResultsByProjectAndPolicy :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -2085,6 +2108,7 @@ type ListRiskResultsByProjectAndPolicyRow struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
+	Spans               []byte
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID
@@ -2128,6 +2152,7 @@ func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg Lis
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.Spans,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,
@@ -2738,7 +2763,7 @@ SET title = $1
 WHERE id = $5
   AND project_id = $6
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, rule_id, title, description, regex, match_config, severity, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, rule_id, title, description, regex, match_config, detection_expr, severity, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDetectionRuleParams struct {
@@ -2769,6 +2794,7 @@ func (q *Queries) UpdateCustomDetectionRule(ctx context.Context, arg UpdateCusto
 		&i.Description,
 		&i.Regex,
 		&i.MatchConfig,
+		&i.DetectionExpr,
 		&i.Severity,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -2869,7 +2895,7 @@ SET name = $1
 WHERE id = $15
   AND project_id = $16
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -2924,6 +2950,8 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.DisabledRules,
 		&i.CustomRuleIds,
 		&i.MessageTypes,
+		&i.ScopeInclude,
+		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
 		&i.AutoName,

--- a/server/internal/testenv/testrepo/models.go
+++ b/server/internal/testenv/testrepo/models.go
@@ -112,6 +112,7 @@ type RiskResult struct {
 	EndPos              pgtype.Int4
 	Confidence          pgtype.Float8
 	Tags                []string
+	Spans               []byte
 	DeadLetterReason    pgtype.Text
 	ExcludedAt          pgtype.Timestamptz
 	ExcludedExclusionID uuid.NullUUID

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -379,7 +379,7 @@ func (q *Queries) ListDeploymentHTTPTools(ctx context.Context, deploymentID uuid
 }
 
 const listRiskResultsAll = `-- name: ListRiskResultsAll :many
-SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, dead_letter_reason, excluded_at, excluded_exclusion_id, false_positive_at, false_positive_reason, created_at
+SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, description, match, start_pos, end_pos, confidence, tags, spans, dead_letter_reason, excluded_at, excluded_exclusion_id, false_positive_at, false_positive_reason, created_at
 FROM risk_results
 WHERE project_id = $1
   AND risk_policy_id = $2
@@ -419,6 +419,7 @@ func (q *Queries) ListRiskResultsAll(ctx context.Context, arg ListRiskResultsAll
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.Spans,
 			&i.DeadLetterReason,
 			&i.ExcludedAt,
 			&i.ExcludedExclusionID,

--- a/server/migrations/20260620160523_policy-scope-columns.sql
+++ b/server/migrations/20260620160523_policy-scope-columns.sql
@@ -1,0 +1,6 @@
+-- Modify "risk_custom_detection_rules" table
+ALTER TABLE "risk_custom_detection_rules" ADD COLUMN "detection_expr" text NULL;
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "scope_include" text NULL, ADD COLUMN "scope_exempt" text NULL;
+-- Modify "risk_results" table
+ALTER TABLE "risk_results" ADD COLUMN "spans" jsonb NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8VrvJeWY1+wSE3tEAHVMJXnwraXipg1jBByQ84rciXw=
+h1:/3CGXu85i6RRt6AI67G9nJU0pKqU8NzynaBGHUp39bw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -223,3 +223,4 @@ h1:8VrvJeWY1+wSE3tEAHVMJXnwraXipg1jBByQ84rciXw=
 20260618145406_remotesession-clients-relax-issuer-binding.sql h1:Ilx2asUwFZi73cQMVj5yrXGc5aq6QihR2Sd4uaC4h6o=
 20260618194743_deployments-functions-add-infra-overrides.sql h1:MNR3+BYsl1tfjLes6MbKUWqGkw/nMs8HO2cfyZvTTPs=
 20260618215143_add_custom_rule_match_config.sql h1:ZALVgDTK3jWQrHREznqnbbQDNdfIuOZAWr3VnqLAgbo=
+20260620160523_policy-scope-columns.sql h1:Nd+/ilugIcMRbweLykPze7LzXxiEmd51qsfla1gj3Ig=


### PR DESCRIPTION
Expand the risk schema for the CEL-based policy redesign (first of a stacked series). Additive, nullable columns; the CEL acronym stays inside the engine.

- `risk_custom_detection_rules`: add `detection_expr`
- `risk_policies`: add `scope_include` / `scope_exempt`
- `risk_results`: add `spans` (a finding's correlated matched spans, JSON)

`match_config` is retained for now. Its contract (drop) lands in a later migration, once the structured-engine readers are gone (#3569) and the expand has baked. Migration plus regenerated sqlc only; the engine/API that uses these columns follows in the stacked PRs.