### PR TITLE
chore(pubsub): async broker paths and emulator retention clamping

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -109,7 +109,7 @@ services:
         hard: 262144
 
   pubsub-emulator:
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:570.0.0-emulators@sha256:55ff6adfca42dae15d8d58034167e87e822e1a9816780820ed60d8b3ec343b11
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:573.0.0-emulators@sha256:1b083a6a9647024a98d4f38c2b51906a0f61ca36adcba11672b8933544962efe
     restart: unless-stopped
     ports:
       - "${PUBSUB_EMULATOR_PORT}:8085"

--- a/infra/gram_infra/pubsub/__init__.py
+++ b/infra/gram_infra/pubsub/__init__.py
@@ -36,13 +36,18 @@ from .discover import (
     to_kebab,
     topic_options_from_message,
 )
-from .publisher import Publisher, pubsub_publisher_for_message
+from .publisher import (
+    Publisher,
+    pubsub_publisher_for_message,
+    pubsub_publisher_for_message_async,
+)
 from .subscriber import (
     MessageCallback,
     MessageMetadata,
     ReceivedMessage,
     Subscriber,
     pubsub_subscriber_for_message,
+    pubsub_subscriber_for_message_async,
 )
 
 __all__ = [
@@ -58,7 +63,9 @@ __all__ = [
     "SubscriberBroker",
     "SubscriberHandle",
     "pubsub_publisher_for_message",
+    "pubsub_publisher_for_message_async",
     "pubsub_subscriber_for_message",
+    "pubsub_subscriber_for_message_async",
     "resolve_dead_letter_topic_name",
     "resolve_subscription_name",
     "resolve_topic_name",

--- a/infra/gram_infra/pubsub/broker.py
+++ b/infra/gram_infra/pubsub/broker.py
@@ -32,6 +32,7 @@ from datetime import timedelta
 from types import TracebackType
 from typing import Protocol, Self, runtime_checkable
 
+import asyncer
 import structlog
 from gcp.pubsub.v1 import options_pb2
 from google.api_core.exceptions import AlreadyExists
@@ -115,10 +116,18 @@ class SubscriberHandle:
 class PublisherBroker(Protocol):
     def publisher_for_message(self, message_type: type[Message]) -> PublisherHandle: ...
 
+    async def publisher_for_message_async(
+        self, message_type: type[Message]
+    ) -> PublisherHandle: ...
+
 
 @runtime_checkable
 class SubscriberBroker(Protocol):
     def subscriber_for_message(
+        self, message_type: type[Message], subscription_type: type[Message]
+    ) -> SubscriberHandle: ...
+
+    async def subscriber_for_message_async(
         self, message_type: type[Message], subscription_type: type[Message]
     ) -> SubscriberHandle: ...
 
@@ -258,10 +267,38 @@ class PubSubBroker:
         created the resource.
         """
 
+    async def _reconcile_publisher_async(self, topic_id, options) -> None:
+        """Async counterpart of :meth:`_reconcile_publisher`.
+
+        No-op here too: production reconcile does nothing, so there is nothing to
+        keep off the event loop. The emulator broker overrides this to run its
+        blocking provisioning RPCs on a worker thread.
+        """
+
+    async def _reconcile_subscriber_async(self, sub_id, topic_id, binding) -> None:
+        """Async counterpart of :meth:`_reconcile_subscriber`. See above."""
+
     def publisher_for_message(self, message_type: type[Message]) -> PublisherHandle:
         descriptor, options = require_topic_options(message_type)
         topic_id = resolve_topic_name(descriptor, options)
         self._reconcile_publisher(topic_id, options)
+        return PublisherHandle(
+            self._publisher, self._topic_path(topic_id), self._inflight
+        )
+
+    async def publisher_for_message_async(
+        self, message_type: type[Message]
+    ) -> PublisherHandle:
+        """Async :meth:`publisher_for_message` that keeps reconcile off the loop.
+
+        Resolution is pure in-memory work; only the reconcile hook may block, so
+        that is the part the emulator broker offloads to a worker thread. Call
+        this from async wiring (e.g. ``pystreams``) so a one-time provisioning RPC
+        against the local emulator does not stall the event loop at startup.
+        """
+        descriptor, options = require_topic_options(message_type)
+        topic_id = resolve_topic_name(descriptor, options)
+        await self._reconcile_publisher_async(topic_id, options)
         return PublisherHandle(
             self._publisher, self._topic_path(topic_id), self._inflight
         )
@@ -276,6 +313,30 @@ class PubSubBroker:
         topic_id = resolve_topic_name(binding.message_descriptor, binding.topic_options)
         self._reconcile_subscriber(sub_id, topic_id, binding)
         return SubscriberHandle(self._subscriber, self._sub_path(sub_id))
+
+    async def subscriber_for_message_async(
+        self, message_type: type[Message], subscription_type: type[Message]
+    ) -> SubscriberHandle:
+        """Async :meth:`subscriber_for_message` that keeps reconcile off the loop."""
+        binding = require_subscription_for_message(message_type, subscription_type)
+        sub_id = resolve_subscription_name(
+            binding.subscription_descriptor, binding.subscription_options
+        )
+        topic_id = resolve_topic_name(binding.message_descriptor, binding.topic_options)
+        await self._reconcile_subscriber_async(sub_id, topic_id, binding)
+        return SubscriberHandle(self._subscriber, self._sub_path(sub_id))
+
+
+# The local emulator, unlike real Pub/Sub, does not support high message
+# retention periods and rejects anything beyond a few days with
+# "message_retention_duration out of bounds". Clamp the configured retention
+# down to this value for the emulator only — production resources go through
+# Config Connector, not this code path.
+_EMULATOR_MAX_RETENTION = timedelta(hours=72)
+
+
+def _clamp_emulator_retention(value: timedelta) -> timedelta:
+    return min(value, _EMULATOR_MAX_RETENTION)
 
 
 class EmulatedPubSubBroker(PubSubBroker):
@@ -315,6 +376,15 @@ class EmulatedPubSubBroker(PubSubBroker):
         self._reconcile_topic(topic_id, binding.topic_options)
         self._reconcile_subscription(sub_id, topic_id, binding.subscription_options)
 
+    async def _reconcile_publisher_async(self, topic_id, options) -> None:
+        # Reconcile issues synchronous gRPC create RPCs against the emulator;
+        # run them on a worker thread so the create round-trip does not block the
+        # event loop (the event-loop blocking monitor flags it otherwise).
+        await asyncer.asyncify(self._reconcile_publisher)(topic_id, options)
+
+    async def _reconcile_subscriber_async(self, sub_id, topic_id, binding) -> None:
+        await asyncer.asyncify(self._reconcile_subscriber)(sub_id, topic_id, binding)
+
     def _reconcile_topic(self, topic_id: str, options=None) -> None:
         if topic_id in self._reconciled_topics:
             return
@@ -333,7 +403,7 @@ class EmulatedPubSubBroker(PubSubBroker):
                 and options.retention_hint.ToNanoseconds() != 0
             ):
                 _validate_retention(options.retention_hint, topic_id)
-                request["message_retention_duration"] = (
+                request["message_retention_duration"] = _clamp_emulator_retention(
                     options.retention_hint.ToTimedelta()
                 )
 
@@ -362,7 +432,9 @@ class EmulatedPubSubBroker(PubSubBroker):
         # which the Go generation path accepts; negative values must validate.
         if options.HasField("retention") and options.retention.ToNanoseconds() != 0:
             _validate_retention(options.retention, sub_id)
-            request["message_retention_duration"] = options.retention.ToTimedelta()
+            request["message_retention_duration"] = _clamp_emulator_retention(
+                options.retention.ToTimedelta()
+            )
         labels = dict(options.labels)
         if labels:
             request["labels"] = labels

--- a/infra/gram_infra/pubsub/publisher.py
+++ b/infra/gram_infra/pubsub/publisher.py
@@ -121,3 +121,18 @@ def pubsub_publisher_for_message[M: Message](
 
     handle = broker.publisher_for_message(message_type)
     return Publisher(handle, message_type.DESCRIPTOR.full_name)
+
+
+async def pubsub_publisher_for_message_async[M: Message](
+    broker: PublisherBroker, message_type: type[M]
+) -> Publisher[M]:
+    """Async :func:`pubsub_publisher_for_message`.
+
+    Resolves the handle via the broker's async path so an emulator topic
+    reconcile runs off the event loop. Prefer this from async wiring.
+    """
+    if message_type is None:
+        raise ValueError("message type must not be None")
+
+    handle = await broker.publisher_for_message_async(message_type)
+    return Publisher(handle, message_type.DESCRIPTOR.full_name)

--- a/infra/gram_infra/pubsub/subscriber.py
+++ b/infra/gram_infra/pubsub/subscriber.py
@@ -644,3 +644,30 @@ def pubsub_subscriber_for_message[M: Message](
         topic_proto_name=message_type.DESCRIPTOR.full_name,
         subscription_proto_name=subscription_type.DESCRIPTOR.full_name,
     )
+
+
+async def pubsub_subscriber_for_message_async[M: Message](
+    broker: SubscriberBroker,
+    message_type: type[M],
+    subscription_type: type[Message],
+    *,
+    logger: structlog.stdlib.BoundLogger | None = None,
+) -> Subscriber[M]:
+    """Async :func:`pubsub_subscriber_for_message`.
+
+    Resolves the handle via the broker's async path so an emulator topic/
+    subscription reconcile runs off the event loop. Prefer this from async wiring.
+    """
+    if message_type is None:
+        raise ValueError("message type must not be None")
+    if subscription_type is None:
+        raise ValueError("subscription marker message type must not be None")
+
+    handle = await broker.subscriber_for_message_async(message_type, subscription_type)
+    return Subscriber(
+        handle,
+        message_type,
+        logger=logger or structlog.get_logger(__name__),
+        topic_proto_name=message_type.DESCRIPTOR.full_name,
+        subscription_proto_name=subscription_type.DESCRIPTOR.full_name,
+    )

--- a/infra/pkg/gcp/pubsub_local.go
+++ b/infra/pkg/gcp/pubsub_local.go
@@ -18,6 +18,11 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+// emulatorMaxRetention caps how long the local emulator retains messages.
+// Unlike real Pub/Sub, the emulator does not yet support high message
+// retention periods, so we clamp the configured retention down to this value.
+const emulatorMaxRetention = 72 * time.Hour
+
 type EmulatedPubSubBroker struct {
 	logger      *slog.Logger
 	projectID   string
@@ -74,6 +79,9 @@ func (e *EmulatedPubSubBroker) reconcileTopic(ctx context.Context, topicName str
 	var retention time.Duration
 	if options.GetRetentionHint() != nil {
 		retention = options.GetRetentionHint().AsDuration()
+	}
+	if retention > emulatorMaxRetention {
+		retention = emulatorMaxRetention
 	}
 	if retention > 0 {
 		topic.MessageRetentionDuration = durationpb.New(retention)
@@ -150,6 +158,11 @@ func (e *EmulatedPubSubBroker) reconcileSubscriptions(ctx context.Context, subNa
 		}
 	}
 
+	retention := options.GetRetention()
+	if retention != nil && retention.AsDuration() > emulatorMaxRetention {
+		retention = durationpb.New(emulatorMaxRetention)
+	}
+
 	var deadLetterPolicy *pubsubpb.DeadLetterPolicy
 	if dl := options.GetDeadLetter(); dl != nil {
 		dlqName := gcp.ResolveDeadLetterTopicName(subName, dl)
@@ -172,7 +185,7 @@ func (e *EmulatedPubSubBroker) reconcileSubscriptions(ctx context.Context, subNa
 		Topic:                         topicName,
 		AckDeadlineSeconds:            durationToSeconds(ackDeadline),
 		RetainAckedMessages:           options.GetRetainAckedMessages(),
-		MessageRetentionDuration:      options.GetRetention(),
+		MessageRetentionDuration:      retention,
 		Labels:                        options.GetLabels(),
 		ExpirationPolicy:              expPolicy,
 		Filter:                        options.GetFilter(),

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "protobuf>=7.35.0,<8",
   "google-cloud-pubsub>=2.31.0",
   "anyio>=4.13.0",
+  "asyncer>=0.0.17",
   "structlog>=26.1.0",
   "opentelemetry-api>=1.42.1",
 ]

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -110,12 +110,12 @@ async def multi(
 
             # Register subscription receivers here. Each call resolves a
             # subscriber and starts consuming with per-message tracing.
-            receivers.receive(
+            await receivers.receive(
                 ping_pb2.Message,
                 processor_pb2.PyProcessor,
                 PingHandler(logger, ping_log_level).handle,
             )
-            receivers.receive(
+            await receivers.receive(
                 presidio_request_pb2.PresidioRequest,
                 presidio_scanner_pb2.PresidioScanner,
                 PresidioHandler(logger).handle,

--- a/pystreams/src/pystreams/cmd/receiver.py
+++ b/pystreams/src/pystreams/cmd/receiver.py
@@ -15,7 +15,7 @@ from typing import TypeVar
 import anyio.abc
 import structlog
 from google.protobuf.message import Message
-from gram_infra.pubsub import SubscriberBroker, pubsub_subscriber_for_message
+from gram_infra.pubsub import SubscriberBroker, pubsub_subscriber_for_message_async
 from gram_infra.pubsub.subscriber import MessageCallback
 
 from pystreams.deps.tracing import traced
@@ -31,7 +31,7 @@ class ReceiverGroup:
     broker: SubscriberBroker
     logger: structlog.stdlib.BoundLogger
 
-    def receive(
+    async def receive(
         self,
         message_type: type[M],
         subscription_type: type[Message],
@@ -41,9 +41,11 @@ class ReceiverGroup:
 
         The handler is wrapped so every delivered message runs inside a
         ``stream.handleMessage`` span tagged with the topic and subscription
-        proto names.
+        proto names. Async because resolving the subscriber may reconcile the
+        topic/subscription against the local emulator, which is offloaded off the
+        event loop rather than blocking it.
         """
-        subscriber = pubsub_subscriber_for_message(
+        subscriber = await pubsub_subscriber_for_message_async(
             self.broker,
             message_type,
             subscription_type,

--- a/uv.lock
+++ b/uv.lock
@@ -399,6 +399,7 @@ version = "0.1.0"
 source = { editable = "infra" }
 dependencies = [
     { name = "anyio" },
+    { name = "asyncer" },
     { name = "google-cloud-pubsub" },
     { name = "opentelemetry-api" },
     { name = "protobuf" },
@@ -419,6 +420,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.13.0" },
+    { name = "asyncer", specifier = ">=0.0.17" },
     { name = "google-cloud-pubsub", specifier = ">=2.31.0" },
     { name = "opentelemetry-api", specifier = ">=1.42.1" },
     { name = "protobuf", specifier = ">=7.35.0,<8" },


### PR DESCRIPTION
The local Pub/Sub emulator reconciles topics and subscriptions on demand via synchronous gRPC create RPCs. When wired from async code like pystreams, that create round-trip ran on the event loop at startup and tripped the event-loop blocking monitor. Add async publisher/subscriber resolution that offloads only the emulator reconcile to a worker thread, leaving production (where reconcile is a no-op) unchanged.

The emulator also rejects retention durations beyond a few days, so clamp the configured retention to 72h for the emulator path only. Production resources are provisioned through Config Connector, not this code, so they keep their real retention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add async publisher/subscriber resolution so Pub/Sub emulator reconcile runs off the event loop. Clamp emulator message retention to 72h; production behavior is unchanged.

- **New Features**
  - Added async broker APIs: publisher_for_message_async/subscriber_for_message_async and helpers `pubsub_publisher_for_message_async`/`pubsub_subscriber_for_message_async`.
  - Emulator reconcile is offloaded via `asyncer.asyncify`; `pystreams` receivers now await async setup.

- **Bug Fixes**
  - Clamp message retention to 72h in the emulator (Python and Go paths) to avoid “retention out of bounds” errors.

<sup>Written for commit b22e635f7ae9019cc5ad301efd42c2ff279ef6ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

