### PR TITLE
chore(pystreams): gate slow-task logging on threshold alone

### DIFF
--- a/pystreams/src/pystreams/deps/blocking.py
+++ b/pystreams/src/pystreams/deps/blocking.py
@@ -58,11 +58,16 @@ def activate_blocking_detection(
     logger = logger.bind(**{attr.COMPONENT: "aiocop"})
 
     def _on_slow_task(event: aiocop.SlowTaskEvent) -> None:
-        # aiocop's own stack capture incidentally trips low-severity audit events
-        # (e.g. linecache's os.stat), so it fires this callback for essentially
-        # every scheduled step. Only surface tasks that actually overran the
-        # threshold or carry non-trivial blocking IO — the rest is noise.
-        if not event.exceeded_threshold and event.severity_level == "low":
+        # aiocop's own stack capture (traceback.extract_stack -> linecache) trips
+        # dozens of os.stat/open audit events per scheduled step, inflating the
+        # severity score to medium/high even when the task never stalled the loop.
+        # Elapsed-vs-threshold is the honest signal: a task that ran under the
+        # threshold didn't block meaningfully regardless of severity label, so
+        # gate logging on that and let the severity descriptor only colour the
+        # entries that genuinely overran. Raising on real violations is handled
+        # separately inside aiocop (enable_raise_on_violations), so this only
+        # quiets the logs and never suppresses a genuine stall.
+        if not event.exceeded_threshold:
             return
         _violations_counter.add(1, {"severity": event.severity_level})
         logger.warning(


### PR DESCRIPTION
aiocop captures stacks via traceback.extract_stack, which trips dozens of os.stat/open audit events per scheduled step. Those incidental events inflate the severity score to medium/high even for tasks that never stalled the loop, so the previous "low severity and under threshold" gate still let plenty of noise through. Elapsed-vs-threshold is the honest signal for whether a task actually blocked, so gate logging on that alone and let severity only colour the entries that genuinely overran. Real violations still raise inside aiocop, so this only quiets the logs and never suppresses a genuine stall.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiet slow-task logs by gating on the elapsed-time threshold only in the `aiocop` handler. We now log only when `event.exceeded_threshold` is true; severity just labels real overruns.

- **Bug Fixes**
  - Removed the severity check to stop stack-capture audit noise (os.stat/open) from triggering logs.
  - Kept metrics via `_violations_counter` and warnings for true overruns; raising on violations stays in `aiocop`.

<sup>Written for commit c55cb76d2264f265c0e02958486be470fd7c0985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

