### PR TITLE
feat: label deprecated Pub/Sub topics and subscriptions

### DIFF
--- a/infra/internal/gcp/cc_pubsub_test.go
+++ b/infra/internal/gcp/cc_pubsub_test.go
@@ -6,7 +6,12 @@ import (
 	"testing"
 	"time"
 
+	pubsubv1 "github.com/speakeasy-api/gram/infra/gen/gcp/pubsub/v1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func TestBuildPubSubValues_StableOrder(t *testing.T) {
@@ -149,6 +154,76 @@ func TestCCPubSub_WriteValues(t *testing.T) {
 	require.NotContains(t, content, "cnrm.cloud.google.com/project-id")
 	require.NotContains(t, content, "apiVersion")
 	require.NotContains(t, content, "PubSubTopic")
+}
+
+// TestDiscoverPubSub_DeprecatedOption verifies that a marker message carrying
+// the standard protobuf `option deprecated = true` produces a "deprecated"
+// label on the generated topic/subscription (and the synthesized DLQ), while a
+// non-deprecated message gets no such label.
+func TestDiscoverPubSub_DeprecatedOption(t *testing.T) {
+	t.Parallel()
+
+	const pkg = "test.deprecated.v1"
+
+	deprecatedTopicOpts := &descriptorpb.MessageOptions{Deprecated: new(true)}
+	proto.SetExtension(deprecatedTopicOpts, pubsubv1.E_Topic, pubsubv1.TopicOptions_builder{
+		RetentionHint: durationpb.New(24 * time.Hour),
+	}.Build())
+
+	activeTopicOpts := &descriptorpb.MessageOptions{}
+	proto.SetExtension(activeTopicOpts, pubsubv1.E_Topic, pubsubv1.TopicOptions_builder{}.Build())
+
+	deprecatedSubOpts := &descriptorpb.MessageOptions{Deprecated: new(true)}
+	proto.SetExtension(deprecatedSubOpts, pubsubv1.E_Subscription, pubsubv1.SubscriptionOptions_builder{
+		Topic: new(pkg + ".Event"),
+		DeadLetter: pubsubv1.DeadLetterPolicy_builder{
+			MaxDeliveryAttempts: new(int32(5)),
+		}.Build(),
+	}.Build())
+
+	fileProto := &descriptorpb.FileDescriptorProto{
+		Name:       new("test/deprecated/v1/test.proto"),
+		Package:    new(pkg),
+		Syntax:     new("proto3"),
+		Dependency: []string{"gcp/pubsub/v1/options.proto"},
+		MessageType: []*descriptorpb.DescriptorProto{
+			{Name: new("Event"), Options: deprecatedTopicOpts},
+			{Name: new("ActiveEvent"), Options: activeTopicOpts},
+			{Name: new("Processor"), Options: deprecatedSubOpts},
+		},
+	}
+
+	set := &descriptorpb.FileDescriptorSet{
+		File: []*descriptorpb.FileDescriptorProto{
+			protodesc.ToFileDescriptorProto(descriptorpb.File_google_protobuf_descriptor_proto),
+			protodesc.ToFileDescriptorProto(durationpb.File_google_protobuf_duration_proto),
+			protodesc.ToFileDescriptorProto(pubsubv1.File_gcp_pubsub_v1_options_proto),
+			fileProto,
+		},
+	}
+	raw, err := proto.Marshal(set)
+	require.NoError(t, err)
+
+	topics, subs, err := discoverPubSubFromDescriptor(raw)
+	require.NoError(t, err)
+
+	topicsByName := map[string]DesiredTopic{}
+	for _, topic := range topics {
+		topicsByName[topic.Name] = topic
+	}
+	subsByName := map[string]DesiredSubscription{}
+	for _, sub := range subs {
+		subsByName[sub.Name] = sub
+	}
+
+	// Deprecated topic carries the label; active topic does not.
+	require.Equal(t, deprecatedLabelValue, topicsByName["test-deprecated-v1-event"].Labels[deprecatedLabelKey])
+	require.NotContains(t, topicsByName["test-deprecated-v1-active-event"].Labels, deprecatedLabelKey)
+
+	// Deprecated subscription carries the label, and the label propagates to its
+	// synthesized dead-letter topic.
+	require.Equal(t, deprecatedLabelValue, subsByName["test-deprecated-v1-processor"].Labels[deprecatedLabelKey])
+	require.Equal(t, deprecatedLabelValue, topicsByName["test-deprecated-v1-processor-dlq"].Labels[deprecatedLabelKey])
 }
 
 func TestDurationToGCPString(t *testing.T) {

--- a/infra/internal/gcp/pubsub_discover.go
+++ b/infra/internal/gcp/pubsub_discover.go
@@ -21,6 +21,16 @@ const (
 	dlqSuffix      = "-dlq"
 	maxTopicIDLen  = 255
 
+	// deprecatedLabelKey is the metadata label key stamped on topics and
+	// subscriptions whose marker message carries the standard protobuf
+	// `option deprecated = true`. Its value is always "true".
+	deprecatedLabelKey = "deprecated"
+
+	// deprecatedLabelValue is the value stamped under deprecatedLabelKey. GCP
+	// label values must match [\p{Ll}\p{Lo}\p{N}_-]{0,63}, which "true"
+	// satisfies.
+	deprecatedLabelValue = "true"
+
 	// GCP requires a dead-letter policy's max delivery attempts to fall within
 	// this inclusive range; values outside it are rejected at reconcile time.
 	minDeliveryAttempts = 5
@@ -162,6 +172,16 @@ func SubscriptionOptionsFromMessage(message protoreflect.MessageDescriptor) (*pu
 	return subOptions, true
 }
 
+// messageDeprecated reports whether the marker message carries the standard
+// protobuf `option deprecated = true` message option.
+func messageDeprecated(message protoreflect.MessageDescriptor) bool {
+	options, ok := message.Options().(*descriptorpb.MessageOptions)
+	if !ok || options == nil {
+		return false
+	}
+	return options.GetDeprecated()
+}
+
 func ResolveSubscriptionName(message protoreflect.MessageDescriptor, opts *pubsubv1.SubscriptionOptions) string {
 	name := strings.TrimSpace(opts.GetName())
 	if name == "" {
@@ -196,6 +216,9 @@ func desiredTopicFromOptions(message protoreflect.MessageDescriptor, topicOption
 	labels := make(map[string]string, len(inlabels)+1)
 	maps.Copy(labels, inlabels)
 	labels["managed_by"] = managedByLabel
+	if messageDeprecated(message) {
+		labels[deprecatedLabelKey] = deprecatedLabelValue
+	}
 
 	return DesiredTopic{
 		Name:         ResolveTopicName(message, topicOptions),
@@ -210,6 +233,9 @@ func desiredSubscriptionFromOptions(message protoreflect.MessageDescriptor, subO
 	labels := make(map[string]string, len(inlabels)+1)
 	maps.Copy(labels, inlabels)
 	labels["managed_by"] = managedByLabel
+	if messageDeprecated(message) {
+		labels[deprecatedLabelKey] = deprecatedLabelValue
+	}
 
 	subName := ResolveSubscriptionName(message, subOptions)
 
@@ -365,13 +391,20 @@ func dedupeAndValidate(topics []DesiredTopic, subs []DesiredSubscription) ([]Des
 			)
 		}
 
+		dlqLabels := map[string]string{
+			"managed_by": managedByLabel,
+			"dlq_for":    sub.Name,
+		}
+		// A DLQ inherits its subscription's deprecation: marking the consumer
+		// deprecated should mark its dead-letter sink the same way.
+		if sub.Labels[deprecatedLabelKey] == deprecatedLabelValue {
+			dlqLabels[deprecatedLabelKey] = deprecatedLabelValue
+		}
+
 		dlqTopic := DesiredTopic{
-			Name:      sub.DeadLetterTopic,
-			Retention: 0,
-			Labels: map[string]string{
-				"managed_by": managedByLabel,
-				"dlq_for":    sub.Name,
-			},
+			Name:         sub.DeadLetterTopic,
+			Retention:    0,
+			Labels:       dlqLabels,
 			ProtoMessage: sub.ProtoMessage,
 		}
 		topicByName[dlqTopic.Name] = dlqTopic


### PR DESCRIPTION
## Summary

When a Pub/Sub marker message sets the standard protobuf `option deprecated = true`, the discovery pass now stamps a `deprecated: "true"` metadata label on the generated topic or subscription. The label also propagates to the DLQ topic synthesized for a deprecated subscription, so a deprecated consumer's dead-letter sink is marked the same way.

This gives us a consistent, queryable signal in GCP for Pub/Sub resources that are on their way out, without removing them.

## Changes

- `messageDeprecated` helper reads the `option deprecated` message option off a marker message.
- `desiredTopicFromOptions` / `desiredSubscriptionFromOptions` add `deprecated: "true"` when the marker is deprecated.
- DLQ topics inherit the `deprecated` label from their owning subscription.
- Test coverage verifying the label appears on deprecated topics/subscriptions/DLQs and is absent on active ones.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a `deprecated` label to discovered Pub/Sub topics and subscriptions when their marker protobuf message sets `option deprecated = true`. The label also propagates to synthesized DLQ topics.

- **New Features**
  - Stamp `deprecated: "true"` on topics and subscriptions generated from deprecated marker messages.
  - Propagate the `deprecated` label to DLQ topics created for deprecated subscriptions.
  - Add tests to verify labeling for deprecated and non-deprecated messages.

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
