### PR TITLE
feat(plugins): optimistic blocking with circuit-breaker recovery

### DIFF
--- a/.changeset/hooks-circuit-breaker.md
+++ b/.changeset/hooks-circuit-breaker.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix(hooks): keep Claude coding sessions usable when Gram is unreachable. When Observability Mode is off, generated Claude hook scripts now run optimistically — the server stays the sole authority on allow/block while reachable (2xx allows, 4xx blocks), but connection failures and 5xx responses fail open with degradation context instead of wedging the tool call. A new filesystem-backed circuit breaker (`hooks/breaker.sh`) counts outages within an error window, opens after a threshold to skip further calls, and periodically probes for recovery via a half-open lock. Bumps the plugin generator version to 5.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1043,7 +1043,7 @@ func renderBreakerScript(pluginName string) []byte {
 #   GRAM_BREAKER_THRESHOLD: Gram outage failures required within the error
 #     window before opening the circuit. Default: 5.
 #   GRAM_BREAKER_ERROR_WINDOW: seconds over which failures are counted.
-#     Default: 30.
+#     Default: 60.
 #   GRAM_BREAKER_COOLDOWN: seconds to wait before allowing a half-open recovery
 #     probe. Default: 60.
 #   GRAM_BREAKER_LOCK_STALE_AFTER: maximum trusted age, in seconds, for lock and
@@ -1056,7 +1056,7 @@ func renderBreakerScript(pluginName string) []byte {
 GRAM_BREAKER_OPEN_EXIT_CODE="${GRAM_BREAKER_OPEN_EXIT_CODE:-75}"
 GRAM_BREAKER_NAME="${GRAM_BREAKER_NAME:-__GRAM_BREAKER_DEFAULT_NAME__}"
 GRAM_BREAKER_THRESHOLD="${GRAM_BREAKER_THRESHOLD:-5}"
-GRAM_BREAKER_ERROR_WINDOW="${GRAM_BREAKER_ERROR_WINDOW:-30}"
+GRAM_BREAKER_ERROR_WINDOW="${GRAM_BREAKER_ERROR_WINDOW:-60}"
 GRAM_BREAKER_COOLDOWN="${GRAM_BREAKER_COOLDOWN:-60}"
 GRAM_BREAKER_LOCK_STALE_AFTER="${GRAM_BREAKER_LOCK_STALE_AFTER:-12}"
 GRAM_BREAKER_LOCK_WAIT="${GRAM_BREAKER_LOCK_WAIT:-0.005}"

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1046,6 +1046,8 @@ func renderBreakerScript(pluginName string) []byte {
 #     probe. Default: 60.
 #   GRAM_BREAKER_LOCK_STALE_AFTER: maximum trusted age, in seconds, for lock and
 #     half-open ownership. Default: 12 (the hook HTTP timeout plus 2 seconds).
+#   GRAM_BREAKER_LOCK_WAIT: seconds to wait between lock acquisition attempts.
+#     Default: 0.005.
 #   GRAM_BREAKER_DIR: directory for breaker state and lock directories. Default:
 #     ${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers.
 
@@ -1054,6 +1056,7 @@ GRAM_BREAKER_NAME="${GRAM_BREAKER_NAME:-__GRAM_BREAKER_DEFAULT_NAME__}"
 GRAM_BREAKER_THRESHOLD="${GRAM_BREAKER_THRESHOLD:-5}"
 GRAM_BREAKER_COOLDOWN="${GRAM_BREAKER_COOLDOWN:-60}"
 GRAM_BREAKER_LOCK_STALE_AFTER="${GRAM_BREAKER_LOCK_STALE_AFTER:-12}"
+GRAM_BREAKER_LOCK_WAIT="${GRAM_BREAKER_LOCK_WAIT:-0.005}"
 GRAM_BREAKER_DIR="${GRAM_BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"
 
 _gram_breaker_is_int() {
@@ -1087,7 +1090,7 @@ _gram_breaker_lock() {
   while ! mkdir "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null; do
     mtime="$(stat -f %m "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null ||
       stat -c %Y "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null)" || {
-      sleep 0.005
+      sleep "$GRAM_BREAKER_LOCK_WAIT"
       continue
     }
     if _gram_breaker_is_int "$mtime"; then
@@ -1095,7 +1098,7 @@ _gram_breaker_lock() {
       if [ $((now - mtime)) -ge "$GRAM_BREAKER_LOCK_STALE_AFTER" ]; then
         rm -f "$GRAM_BREAKER_LOCK_OWNER_FILE" 2>/dev/null || true
         rmdir "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null || true
-        sleep 0.005
+        sleep "$GRAM_BREAKER_LOCK_WAIT"
         continue
       fi
     fi
@@ -1104,7 +1107,7 @@ _gram_breaker_lock() {
     if [ -r "$GRAM_BREAKER_LOCK_OWNER_FILE" ]; then
       read -r owner_pid <"$GRAM_BREAKER_LOCK_OWNER_FILE" || true
       if _gram_breaker_pid_running "$owner_pid"; then
-        sleep 0.005
+        sleep "$GRAM_BREAKER_LOCK_WAIT"
         continue
       fi
       if _gram_breaker_is_int "$owner_pid" && [ "$owner_pid" -gt 0 ]; then
@@ -1112,7 +1115,7 @@ _gram_breaker_lock() {
         rmdir "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null || true
       fi
     fi
-    sleep 0.005
+    sleep "$GRAM_BREAKER_LOCK_WAIT"
   done
 
   if ! printf '%s\n' "$$" >"$GRAM_BREAKER_LOCK_OWNER_FILE"; then

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1040,8 +1040,10 @@ func renderBreakerScript(pluginName string) []byte {
 #     the circuit is open. Default: 75.
 #   GRAM_BREAKER_NAME: breaker identity used to derive state and lock filenames.
 #     Default: __GRAM_BREAKER_DEFAULT_NAME__.
-#   GRAM_BREAKER_THRESHOLD: consecutive Gram outage failures before opening the
-#     circuit. Default: 5.
+#   GRAM_BREAKER_THRESHOLD: Gram outage failures required within the error
+#     window before opening the circuit. Default: 5.
+#   GRAM_BREAKER_ERROR_WINDOW: seconds over which failures are counted.
+#     Default: 30.
 #   GRAM_BREAKER_COOLDOWN: seconds to wait before allowing a half-open recovery
 #     probe. Default: 60.
 #   GRAM_BREAKER_LOCK_STALE_AFTER: maximum trusted age, in seconds, for lock and
@@ -1054,6 +1056,7 @@ func renderBreakerScript(pluginName string) []byte {
 GRAM_BREAKER_OPEN_EXIT_CODE="${GRAM_BREAKER_OPEN_EXIT_CODE:-75}"
 GRAM_BREAKER_NAME="${GRAM_BREAKER_NAME:-__GRAM_BREAKER_DEFAULT_NAME__}"
 GRAM_BREAKER_THRESHOLD="${GRAM_BREAKER_THRESHOLD:-5}"
+GRAM_BREAKER_ERROR_WINDOW="${GRAM_BREAKER_ERROR_WINDOW:-30}"
 GRAM_BREAKER_COOLDOWN="${GRAM_BREAKER_COOLDOWN:-60}"
 GRAM_BREAKER_LOCK_STALE_AFTER="${GRAM_BREAKER_LOCK_STALE_AFTER:-12}"
 GRAM_BREAKER_LOCK_WAIT="${GRAM_BREAKER_LOCK_WAIT:-0.005}"
@@ -1126,13 +1129,31 @@ _gram_breaker_lock() {
 }
 
 _gram_breaker_read_state() {
+  local state_file_line
+
   GRAM_BREAKER_STATE="closed"
   GRAM_BREAKER_FAILURES=0
+  GRAM_BREAKER_WINDOW_STARTED_AT=0
   GRAM_BREAKER_OPENED_AT=0
   GRAM_BREAKER_OWNER_PID=0
 
   if [ -r "$GRAM_BREAKER_STATE_FILE" ]; then
-    read -r GRAM_BREAKER_STATE GRAM_BREAKER_FAILURES GRAM_BREAKER_OPENED_AT GRAM_BREAKER_OWNER_PID <"$GRAM_BREAKER_STATE_FILE" || true
+    read -r state_file_line <"$GRAM_BREAKER_STATE_FILE" || true
+    set -- $state_file_line
+    if [ "$#" -eq 4 ]; then
+      # Older generated breakers wrote: state failures opened_at owner_pid.
+      GRAM_BREAKER_STATE="$1"
+      GRAM_BREAKER_FAILURES="$2"
+      GRAM_BREAKER_WINDOW_STARTED_AT=0
+      GRAM_BREAKER_OPENED_AT="$3"
+      GRAM_BREAKER_OWNER_PID="$4"
+    elif [ "$#" -ge 5 ]; then
+      GRAM_BREAKER_STATE="$1"
+      GRAM_BREAKER_FAILURES="$2"
+      GRAM_BREAKER_WINDOW_STARTED_AT="$3"
+      GRAM_BREAKER_OPENED_AT="$4"
+      GRAM_BREAKER_OWNER_PID="$5"
+    fi
   fi
 
   case "$GRAM_BREAKER_STATE" in
@@ -1141,6 +1162,9 @@ _gram_breaker_read_state() {
   esac
   if ! _gram_breaker_is_int "$GRAM_BREAKER_FAILURES"; then
     GRAM_BREAKER_FAILURES=0
+  fi
+  if ! _gram_breaker_is_int "$GRAM_BREAKER_WINDOW_STARTED_AT"; then
+    GRAM_BREAKER_WINDOW_STARTED_AT=0
   fi
   if ! _gram_breaker_is_int "$GRAM_BREAKER_OPENED_AT"; then
     GRAM_BREAKER_OPENED_AT=0
@@ -1153,16 +1177,20 @@ _gram_breaker_read_state() {
 _gram_breaker_write_state() {
   local state="$1"
   local failures="$2"
-  local opened_at="$3"
-  local owner_pid="${4:-0}"
+  local window_started_at="$3"
+  local opened_at="$4"
+  local owner_pid="${5:-0}"
   local tmp
 
+  if ! _gram_breaker_is_int "$window_started_at"; then
+    window_started_at=0
+  fi
   if ! _gram_breaker_is_int "$owner_pid"; then
     owner_pid=0
   fi
 
   tmp="$(mktemp "${GRAM_BREAKER_DIR}/.${GRAM_BREAKER_SAFE_NAME}.XXXXXX")" || return 1
-  if printf '%s %s %s %s\n' "$state" "$failures" "$opened_at" "$owner_pid" >"$tmp"; then
+  if printf '%s %s %s %s %s\n' "$state" "$failures" "$window_started_at" "$opened_at" "$owner_pid" >"$tmp"; then
     mv "$tmp" "$GRAM_BREAKER_STATE_FILE"
     return $?
   fi
@@ -1205,7 +1233,7 @@ gram_breaker_before() {
       if [ "$elapsed" -ge "$GRAM_BREAKER_COOLDOWN" ]; then
         GRAM_BREAKER_RUN_MODE="half_open"
         GRAM_BREAKER_RUN_PID="$$"
-        _gram_breaker_write_state "half_open" "$GRAM_BREAKER_FAILURES" "$now" "$GRAM_BREAKER_RUN_PID" || {
+        _gram_breaker_write_state "half_open" "$GRAM_BREAKER_FAILURES" "$GRAM_BREAKER_WINDOW_STARTED_AT" "$now" "$GRAM_BREAKER_RUN_PID" || {
           _gram_breaker_unlock
           return 1
         }
@@ -1221,7 +1249,7 @@ gram_breaker_before() {
       if [ "$elapsed" -ge "$GRAM_BREAKER_LOCK_STALE_AFTER" ] || ! _gram_breaker_pid_running "$GRAM_BREAKER_OWNER_PID"; then
         GRAM_BREAKER_RUN_MODE="half_open"
         GRAM_BREAKER_RUN_PID="$$"
-        _gram_breaker_write_state "half_open" "$GRAM_BREAKER_FAILURES" "$now" "$GRAM_BREAKER_RUN_PID" || {
+        _gram_breaker_write_state "half_open" "$GRAM_BREAKER_FAILURES" "$GRAM_BREAKER_WINDOW_STARTED_AT" "$now" "$GRAM_BREAKER_RUN_PID" || {
           _gram_breaker_unlock
           return 1
         }
@@ -1241,6 +1269,9 @@ gram_breaker_after() {
   local command_status="$1"
   local now failures
 
+  GRAM_BREAKER_AFTER_DECISION="unchanged"
+  GRAM_BREAKER_AFTER_REASON=""
+
   _gram_breaker_prepare || return 2
   _gram_breaker_lock || return 1
   _gram_breaker_read_state
@@ -1248,30 +1279,69 @@ gram_breaker_after() {
   case "${GRAM_BREAKER_RUN_MODE:-}" in
     half_open)
       if [ "$GRAM_BREAKER_STATE" != "half_open" ] || [ "$GRAM_BREAKER_OWNER_PID" != "${GRAM_BREAKER_RUN_PID:-$$}" ]; then
+        GRAM_BREAKER_AFTER_DECISION="allow"
+        GRAM_BREAKER_AFTER_REASON="state_changed"
         _gram_breaker_unlock
         return 0
       fi
       if [ "$command_status" -eq 0 ]; then
-        _gram_breaker_write_state "closed" 0 0 0
+        _gram_breaker_write_state "closed" 0 0 0 0 || {
+          _gram_breaker_unlock
+          return 1
+        }
+        GRAM_BREAKER_AFTER_DECISION="allow"
+        GRAM_BREAKER_AFTER_REASON="success_closed"
       else
         now="$(date +%s)"
-        _gram_breaker_write_state "open" "$GRAM_BREAKER_THRESHOLD" "$now" 0
+        _gram_breaker_write_state "open" "$GRAM_BREAKER_THRESHOLD" 0 "$now" 0 || {
+          _gram_breaker_unlock
+          return 1
+        }
+        GRAM_BREAKER_AFTER_DECISION="allow"
+        GRAM_BREAKER_AFTER_REASON="half_open_failed"
       fi
       ;;
     closed)
       if [ "$GRAM_BREAKER_STATE" != "closed" ]; then
+        case "$GRAM_BREAKER_STATE" in
+          open | half_open)
+            GRAM_BREAKER_AFTER_DECISION="allow"
+            GRAM_BREAKER_AFTER_REASON="state_changed"
+            ;;
+        esac
         _gram_breaker_unlock
         return 0
       fi
       if [ "$command_status" -eq 0 ]; then
-        _gram_breaker_write_state "closed" 0 0 0
+        _gram_breaker_write_state "closed" 0 0 0 0 || {
+          _gram_breaker_unlock
+          return 1
+        }
+        GRAM_BREAKER_AFTER_DECISION="allow"
+        GRAM_BREAKER_AFTER_REASON="success_reset"
       else
-        failures=$((GRAM_BREAKER_FAILURES + 1))
-        if [ "$failures" -ge "$GRAM_BREAKER_THRESHOLD" ]; then
-          now="$(date +%s)"
-          _gram_breaker_write_state "open" "$failures" "$now" 0
+        now="$(date +%s)"
+        if [ "$GRAM_BREAKER_WINDOW_STARTED_AT" -le 0 ] ||
+          [ $((now - GRAM_BREAKER_WINDOW_STARTED_AT)) -gt "$GRAM_BREAKER_ERROR_WINDOW" ]; then
+          failures=1
+          GRAM_BREAKER_WINDOW_STARTED_AT="$now"
         else
-          _gram_breaker_write_state "closed" "$failures" "$GRAM_BREAKER_OPENED_AT" 0
+          failures=$((GRAM_BREAKER_FAILURES + 1))
+        fi
+        if [ "$failures" -ge "$GRAM_BREAKER_THRESHOLD" ]; then
+          _gram_breaker_write_state "open" "$failures" "$GRAM_BREAKER_WINDOW_STARTED_AT" "$now" 0 || {
+            _gram_breaker_unlock
+            return 1
+          }
+          GRAM_BREAKER_AFTER_DECISION="allow"
+          GRAM_BREAKER_AFTER_REASON="threshold_opened"
+        else
+          _gram_breaker_write_state "closed" "$failures" "$GRAM_BREAKER_WINDOW_STARTED_AT" "$GRAM_BREAKER_OPENED_AT" 0 || {
+            _gram_breaker_unlock
+            return 1
+          }
+          GRAM_BREAKER_AFTER_DECISION="block"
+          GRAM_BREAKER_AFTER_REASON="failure_recorded"
         fi
       fi
       ;;
@@ -1403,11 +1473,24 @@ body="$GRAM_HTTP_BODY"
 # curl returns 000 on connection failure. Treat 000/5xx as a Gram outage:
 # allow the request and let the circuit breaker decide when to probe again.
 if [ "$http_code" = "000" ] || [ "$http_code" -ge 500 ] 2>/dev/null; then
-  gram_breaker_after 1 || true
+  if ! gram_breaker_after 1; then
+    gram_emit_error_message \
+      "Speakeasy hook returned HTTP ${http_code}" \
+      "Speakeasy hook returned HTTP ${http_code}"
+    exit 2
+  fi
+  case "$GRAM_BREAKER_AFTER_DECISION" in
+    allow)
+      gram_emit_error_message \
+        "Gram hook degraded" \
+        "Gram hook degraded. Gram is temporarily unavailable, so this hook is allowing the request without policy evaluation. Continue normally."
+      exit 0
+      ;;
+  esac
   gram_emit_error_message \
-    "Gram hook degraded" \
-    "Gram hook degraded. Gram is temporarily unavailable, so this hook is allowing the request without policy evaluation. Continue normally."
-  exit 0
+    "Speakeasy hook returned HTTP ${http_code}" \
+    "Speakeasy hook returned HTTP ${http_code}"
+  exit 2
 fi
 
 gram_breaker_after 0 || true

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -118,7 +118,7 @@ func pluginManifestVersion(cfg GenerateConfig) string {
 // for generator changes that alter behaviour in ways the placeholder
 // fingerprint pass can't observe. The Plugin Generate Check CI workflow
 // requires this to change whenever generate.go does.
-const pluginGeneratorVersion = "4"
+const pluginGeneratorVersion = "5"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits
@@ -618,8 +618,9 @@ func generateClaudeObservabilityPluginInDir(files map[string][]byte, subdir stri
 		if event == "SessionStart" || event == "ConfigChange" {
 			script = "mcp_inventory.sh"
 		}
+		command := `bash "$CLAUDE_PLUGIN_ROOT/hooks/` + script + `"`
 		hookEvents[event] = []claudeHookMatcher{
-			{Matcher: "", Hooks: []claudeHookCommand{{Type: "command", Command: `bash "$CLAUDE_PLUGIN_ROOT/hooks/` + script + `"`, Async: claudeHookAsyncFlag(event, cfg.ObservabilityMode)}}},
+			{Matcher: "", Hooks: []claudeHookCommand{{Type: "command", Command: command, Async: claudeHookAsyncFlag(event, cfg.ObservabilityMode)}}},
 		}
 	}
 	hooksJSON, err := marshalJSON(claudeHooksConfig{Hooks: hookEvents})
@@ -631,6 +632,9 @@ func generateClaudeObservabilityPluginInDir(files map[string][]byte, subdir stri
 	files[path.Join(subdir, "hooks/identity.sh")] = renderDeviceAgentIdentityScript()
 	files[path.Join(subdir, "hooks/http.sh")] = renderSharedHTTPScript()
 	files[path.Join(subdir, "hooks/hook.sh")] = renderHookScript(cfg, "claude")
+	if !cfg.ObservabilityMode {
+		files[path.Join(subdir, "hooks/breaker.sh")] = renderBreakerScript()
+	}
 	files[path.Join(subdir, "hooks/mcp_inventory.sh")] = renderClaudeMCPInventoryScript(cfg)
 
 	return nil
@@ -1017,6 +1021,281 @@ gram_http_post() {
 `)
 }
 
+func renderBreakerScript() []byte {
+	return []byte(`#!/usr/bin/env bash
+# Filesystem-backed circuit breaker for Gram hook senders.
+#
+# Sourced (not executed) by generated Claude hook.sh when Observability Mode is
+# off. The breaker tracks repeated Gram outages and lets the hook fail open
+# while periodically probing for recovery.
+#
+# Usage:
+#   . "$script_dir/breaker.sh"
+#   gram_breaker_before || exit $?
+#   command args...
+#   gram_breaker_after $?
+#
+# Configuration:
+#   GRAM_BREAKER_OPEN_EXIT_CODE: exit code returned by gram_breaker_before while
+#     the circuit is open. Default: 75.
+#   BREAKER_NAME: breaker identity used to derive state and lock filenames.
+#     Default: gram-observability-claude-hooks.
+#   BREAKER_THRESHOLD: consecutive Gram outage failures before opening the
+#     circuit. Default: 5.
+#   BREAKER_COOLDOWN: seconds to wait before allowing a half-open recovery
+#     probe. Default: 60.
+#   BREAKER_LOCK_STALE_AFTER: maximum trusted age, in seconds, for lock and
+#     half-open ownership. Default: 12 (the hook HTTP timeout plus 2 seconds).
+#   BREAKER_DIR: directory for breaker state and lock directories. Default:
+#     ${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers.
+
+GRAM_BREAKER_OPEN_EXIT_CODE="${GRAM_BREAKER_OPEN_EXIT_CODE:-75}"
+BREAKER_NAME="${BREAKER_NAME:-gram-observability-claude-hooks}"
+BREAKER_THRESHOLD="${BREAKER_THRESHOLD:-5}"
+BREAKER_COOLDOWN="${BREAKER_COOLDOWN:-60}"
+BREAKER_LOCK_STALE_AFTER="${BREAKER_LOCK_STALE_AFTER:-12}"
+BREAKER_DIR="${BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"
+
+_gram_breaker_is_int() {
+  case "${1:-}" in
+    '' | *[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+_gram_breaker_pid_running() {
+  local pid="$1"
+  _gram_breaker_is_int "$pid" || return 1
+  [ "$pid" -gt 0 ] || return 1
+  kill -0 "$pid" >/dev/null 2>&1
+}
+
+_gram_breaker_unlock() {
+  local owner_pid=""
+  if [ -r "$GRAM_BREAKER_LOCK_OWNER_FILE" ]; then
+    read -r owner_pid <"$GRAM_BREAKER_LOCK_OWNER_FILE" || true
+  fi
+  if [ "$owner_pid" = "$$" ]; then
+    rm -f "$GRAM_BREAKER_LOCK_OWNER_FILE" 2>/dev/null || true
+    rmdir "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null || true
+  fi
+}
+
+_gram_breaker_lock() {
+  local owner_pid now mtime
+
+  while ! mkdir "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null; do
+    mtime="$(stat -f %m "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null ||
+      stat -c %Y "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null)" || {
+      sleep 0.005
+      continue
+    }
+    if _gram_breaker_is_int "$mtime"; then
+      now="$(date +%s)"
+      if [ $((now - mtime)) -ge "$GRAM_BREAKER_LOCK_STALE_AFTER" ]; then
+        rm -f "$GRAM_BREAKER_LOCK_OWNER_FILE" 2>/dev/null || true
+        rmdir "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null || true
+        sleep 0.005
+        continue
+      fi
+    fi
+
+    owner_pid=""
+    if [ -r "$GRAM_BREAKER_LOCK_OWNER_FILE" ]; then
+      read -r owner_pid <"$GRAM_BREAKER_LOCK_OWNER_FILE" || true
+      if _gram_breaker_pid_running "$owner_pid"; then
+        sleep 0.005
+        continue
+      fi
+      if _gram_breaker_is_int "$owner_pid" && [ "$owner_pid" -gt 0 ]; then
+        rm -f "$GRAM_BREAKER_LOCK_OWNER_FILE" 2>/dev/null || true
+        rmdir "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null || true
+      fi
+    fi
+    sleep 0.005
+  done
+
+  if ! printf '%s\n' "$$" >"$GRAM_BREAKER_LOCK_OWNER_FILE"; then
+    rm -f "$GRAM_BREAKER_LOCK_OWNER_FILE" 2>/dev/null || true
+    rmdir "$GRAM_BREAKER_LOCK_DIR" 2>/dev/null || true
+    return 1
+  fi
+}
+
+_gram_breaker_read_state() {
+  GRAM_BREAKER_STATE="closed"
+  GRAM_BREAKER_FAILURES=0
+  GRAM_BREAKER_OPENED_AT=0
+  GRAM_BREAKER_OWNER_PID=0
+
+  if [ -r "$GRAM_BREAKER_STATE_FILE" ]; then
+    read -r GRAM_BREAKER_STATE GRAM_BREAKER_FAILURES GRAM_BREAKER_OPENED_AT GRAM_BREAKER_OWNER_PID <"$GRAM_BREAKER_STATE_FILE" || true
+  fi
+
+  case "$GRAM_BREAKER_STATE" in
+    closed | open | half_open) ;;
+    *) GRAM_BREAKER_STATE="closed" ;;
+  esac
+  if ! _gram_breaker_is_int "$GRAM_BREAKER_FAILURES"; then
+    GRAM_BREAKER_FAILURES=0
+  fi
+  if ! _gram_breaker_is_int "$GRAM_BREAKER_OPENED_AT"; then
+    GRAM_BREAKER_OPENED_AT=0
+  fi
+  if ! _gram_breaker_is_int "$GRAM_BREAKER_OWNER_PID"; then
+    GRAM_BREAKER_OWNER_PID=0
+  fi
+}
+
+_gram_breaker_write_state() {
+  local state="$1"
+  local failures="$2"
+  local opened_at="$3"
+  local owner_pid="${4:-0}"
+  local tmp
+
+  if ! _gram_breaker_is_int "$owner_pid"; then
+    owner_pid=0
+  fi
+
+  tmp="$(mktemp "${GRAM_BREAKER_DIR}/.${GRAM_BREAKER_SAFE_NAME}.XXXXXX")" || return 1
+  if printf '%s %s %s %s\n' "$state" "$failures" "$opened_at" "$owner_pid" >"$tmp"; then
+    mv "$tmp" "$GRAM_BREAKER_STATE_FILE"
+    return $?
+  fi
+  rm -f "$tmp"
+  return 1
+}
+
+_gram_breaker_prepare() {
+  GRAM_BREAKER_NAME="$BREAKER_NAME"
+  GRAM_BREAKER_THRESHOLD="$BREAKER_THRESHOLD"
+  GRAM_BREAKER_COOLDOWN="$BREAKER_COOLDOWN"
+  GRAM_BREAKER_LOCK_STALE_AFTER="$BREAKER_LOCK_STALE_AFTER"
+  GRAM_BREAKER_DIR="$BREAKER_DIR"
+
+  if ! _gram_breaker_is_int "$GRAM_BREAKER_THRESHOLD" || [ "$GRAM_BREAKER_THRESHOLD" -lt 1 ]; then
+    GRAM_BREAKER_THRESHOLD=5
+  fi
+  if ! _gram_breaker_is_int "$GRAM_BREAKER_COOLDOWN"; then
+    GRAM_BREAKER_COOLDOWN=60
+  fi
+  if ! _gram_breaker_is_int "$GRAM_BREAKER_LOCK_STALE_AFTER" || [ "$GRAM_BREAKER_LOCK_STALE_AFTER" -lt 1 ]; then
+    GRAM_BREAKER_LOCK_STALE_AFTER=12
+  fi
+
+  GRAM_BREAKER_SAFE_NAME="${GRAM_BREAKER_NAME//[!A-Za-z0-9_.-]/_}"
+  if [ -z "$GRAM_BREAKER_SAFE_NAME" ]; then
+    GRAM_BREAKER_SAFE_NAME="default"
+  fi
+
+  mkdir -p "$GRAM_BREAKER_DIR" 2>/dev/null || return 1
+  [ -d "$GRAM_BREAKER_DIR" ] && [ -w "$GRAM_BREAKER_DIR" ] || return 1
+  GRAM_BREAKER_STATE_FILE="${GRAM_BREAKER_DIR}/${GRAM_BREAKER_SAFE_NAME}.state"
+  GRAM_BREAKER_LOCK_DIR="${GRAM_BREAKER_DIR}/${GRAM_BREAKER_SAFE_NAME}.lockdir"
+  GRAM_BREAKER_LOCK_OWNER_FILE="${GRAM_BREAKER_LOCK_DIR}/owner.pid"
+}
+
+gram_breaker_before() {
+  _gram_breaker_prepare || return 2
+
+  local now elapsed
+
+  GRAM_BREAKER_RUN_MODE=""
+  GRAM_BREAKER_RUN_PID=""
+  _gram_breaker_lock || return 1
+  _gram_breaker_read_state
+
+  case "$GRAM_BREAKER_STATE" in
+    closed)
+      GRAM_BREAKER_RUN_MODE="closed"
+      _gram_breaker_unlock
+      return 0
+      ;;
+    open)
+      now="$(date +%s)"
+      elapsed=$((now - GRAM_BREAKER_OPENED_AT))
+      if [ "$elapsed" -ge "$GRAM_BREAKER_COOLDOWN" ]; then
+        GRAM_BREAKER_RUN_MODE="half_open"
+        GRAM_BREAKER_RUN_PID="$$"
+        _gram_breaker_write_state "half_open" "$GRAM_BREAKER_FAILURES" "$now" "$GRAM_BREAKER_RUN_PID" || {
+          _gram_breaker_unlock
+          return 1
+        }
+        _gram_breaker_unlock
+        return 0
+      fi
+      _gram_breaker_unlock
+      return "$GRAM_BREAKER_OPEN_EXIT_CODE"
+      ;;
+    half_open)
+      now="$(date +%s)"
+      elapsed=$((now - GRAM_BREAKER_OPENED_AT))
+      if [ "$elapsed" -ge "$GRAM_BREAKER_LOCK_STALE_AFTER" ] || ! _gram_breaker_pid_running "$GRAM_BREAKER_OWNER_PID"; then
+        GRAM_BREAKER_RUN_MODE="half_open"
+        GRAM_BREAKER_RUN_PID="$$"
+        _gram_breaker_write_state "half_open" "$GRAM_BREAKER_FAILURES" "$now" "$GRAM_BREAKER_RUN_PID" || {
+          _gram_breaker_unlock
+          return 1
+        }
+        _gram_breaker_unlock
+        return 0
+      fi
+      _gram_breaker_unlock
+      return "$GRAM_BREAKER_OPEN_EXIT_CODE"
+      ;;
+  esac
+
+  _gram_breaker_unlock
+  return 1
+}
+
+gram_breaker_after() {
+  local command_status="$1"
+  local now failures
+
+  _gram_breaker_prepare || return 2
+  _gram_breaker_lock || return 1
+  _gram_breaker_read_state
+
+  case "${GRAM_BREAKER_RUN_MODE:-}" in
+    half_open)
+      if [ "$GRAM_BREAKER_STATE" != "half_open" ] || [ "$GRAM_BREAKER_OWNER_PID" != "${GRAM_BREAKER_RUN_PID:-$$}" ]; then
+        _gram_breaker_unlock
+        return 0
+      fi
+      if [ "$command_status" -eq 0 ]; then
+        _gram_breaker_write_state "closed" 0 0 0
+      else
+        now="$(date +%s)"
+        _gram_breaker_write_state "open" "$GRAM_BREAKER_THRESHOLD" "$now" 0
+      fi
+      ;;
+    closed)
+      if [ "$GRAM_BREAKER_STATE" != "closed" ]; then
+        _gram_breaker_unlock
+        return 0
+      fi
+      if [ "$command_status" -eq 0 ]; then
+        _gram_breaker_write_state "closed" 0 0 0
+      else
+        failures=$((GRAM_BREAKER_FAILURES + 1))
+        if [ "$failures" -ge "$GRAM_BREAKER_THRESHOLD" ]; then
+          now="$(date +%s)"
+          _gram_breaker_write_state "open" "$failures" "$now" 0
+        else
+          _gram_breaker_write_state "closed" "$failures" "$GRAM_BREAKER_OPENED_AT" 0
+        fi
+      fi
+      ;;
+  esac
+
+  _gram_breaker_unlock
+  return 0
+}
+`)
+}
+
 func renderCurlAuthConfigSnippet(cfg GenerateConfig, failureExit int) string {
 	var config strings.Builder
 	fmt.Fprintf(&config, "header = \"Gram-Key: %s\"\n", curlConfigQuote(cfg.HooksAPIKey))
@@ -1042,6 +1321,111 @@ auth_config_arg=(--config "$auth_config")
 
 func curlConfigQuote(value string) string {
 	return strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(value)
+}
+
+func renderOptimisticClaudeHookScript(cfg GenerateConfig, keyPrefix, authConfigSnippet string) []byte {
+	script := `#!/usr/bin/env bash
+# Generated by Speakeasy. Do not edit - overwritten on every publish.
+# Key prefix: __KEY_PREFIX__ (correlate with the dashboard's API Keys page).
+#
+# Send a Claude hook event to Speakeasy. When reachable, the server is the sole
+# authority on whether to block:
+#   HTTP 2xx -> allow (exit 0). Body forwarded to stdout.
+#   HTTP 4xx -> block (exit 2). Server message relayed to stderr.
+#   HTTP 000/5xx -> allow with degradation context; counted by the breaker.
+# If Speakeasy is unreachable or repeatedly returns 5xx, fail open with context
+# so Claude can continue while the circuit breaker probes for recovery.
+
+set -u
+
+server_url="${GRAM_HOOKS_SERVER_URL:-__SERVER_URL__}"
+
+__AUTH_CONFIG_SNIPPET__
+__IDENTITY_SOURCE_SNIPPET__# shellcheck source=/dev/null
+. "$script_dir/breaker.sh"
+
+payload=$(cat)
+if type gram_enrich_identity_payload >/dev/null 2>&1; then
+  payload=$(gram_enrich_identity_payload "$payload")
+fi
+
+hook_hostname=$(hostname 2>/dev/null || true)
+hook_hostname_header=()
+if [ -n "$hook_hostname" ]; then
+  hook_hostname_header=(-H "X-Gram-Hook-Hostname: ${hook_hostname}")
+fi
+
+gram_json_escape() {
+  local s="${1:-}"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
+gram_emit_fail_open_response() {
+  local message
+  local escaped_message
+
+  message="Gram hook degraded. Gram is temporarily unavailable, so this hook is allowing the request without policy evaluation. Continue normally."
+
+  escaped_message="$(gram_json_escape "$message")"
+  printf '{"systemMessage":"%s"}\n' "$escaped_message"
+}
+
+GRAM_HTTP_CODE="000"
+GRAM_HTTP_BODY="{}"
+gram_breaker_before
+breaker_status=$?
+if [ "$breaker_status" -eq "$GRAM_BREAKER_OPEN_EXIT_CODE" ]; then
+  gram_emit_fail_open_response
+  exit 0
+fi
+if [ "$breaker_status" -ne 0 ]; then
+  gram_emit_fail_open_response
+  exit 0
+fi
+
+# gram_http_post (http.sh) retries transient resets so a single reset no
+# longer blocks the tool call; the server still decides allow/block.
+gram_http_post "${server_url}/rpc/hooks.claude" "$payload" 10 \
+  ${auth_config_arg[@]+"${auth_config_arg[@]}"} \
+  ${hook_hostname_header[@]+"${hook_hostname_header[@]}"}
+
+http_code="$GRAM_HTTP_CODE"
+body="$GRAM_HTTP_BODY"
+
+# curl returns 000 on connection failure. Treat 000/5xx as a Gram outage:
+# allow the request and let the circuit breaker decide when to probe again.
+if [ "$http_code" = "000" ] || [ "$http_code" -ge 500 ] 2>/dev/null; then
+  gram_breaker_after 1 || true
+  gram_emit_fail_open_response
+  exit 0
+fi
+
+gram_breaker_after 0 || true
+
+if [ "$http_code" -ge 200 ] 2>/dev/null && [ "$http_code" -lt 400 ] 2>/dev/null; then
+  echo "$body"
+  exit 0
+fi
+
+echo "$body"
+echo "Speakeasy hook returned HTTP ${http_code}" >&2
+exit 2
+`
+	replacements := map[string]string{
+		"__KEY_PREFIX__":              keyPrefix,
+		"__SERVER_URL__":              cfg.ServerURL,
+		"__AUTH_CONFIG_SNIPPET__":     authConfigSnippet,
+		"__IDENTITY_SOURCE_SNIPPET__": renderIdentitySourceSnippet(),
+	}
+	for old, new := range replacements {
+		script = strings.ReplaceAll(script, old, new)
+	}
+	return []byte(script)
 }
 
 // renderHookScript produces the bash wrapper that forwards hook event JSON
@@ -1073,6 +1457,10 @@ func renderHookScript(cfg GenerateConfig, platform string) []byte {
 	// Codex treats any stdout as a structured response and rejects unknown JSON,
 	// so for codex we suppress stdout on 2xx (empty stdout = allow).
 	// Both platforms treat exit 2 as a block; the reason goes to stderr.
+	if platform == "claude" && !cfg.ObservabilityMode {
+		return renderOptimisticClaudeHookScript(cfg, keyPrefix, authConfigSnippet)
+	}
+
 	if platform == "codex" {
 		return fmt.Appendf(nil, `#!/usr/bin/env bash
 # Generated by Speakeasy. Do not edit — overwritten on every publish.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -633,7 +633,7 @@ func generateClaudeObservabilityPluginInDir(files map[string][]byte, subdir stri
 	files[path.Join(subdir, "hooks/http.sh")] = renderSharedHTTPScript()
 	files[path.Join(subdir, "hooks/hook.sh")] = renderHookScript(cfg, "claude")
 	if !cfg.ObservabilityMode {
-		files[path.Join(subdir, "hooks/breaker.sh")] = renderBreakerScript()
+		files[path.Join(subdir, "hooks/breaker.sh")] = renderBreakerScript(name)
 	}
 	files[path.Join(subdir, "hooks/mcp_inventory.sh")] = renderClaudeMCPInventoryScript(cfg)
 
@@ -1021,8 +1021,8 @@ gram_http_post() {
 `)
 }
 
-func renderBreakerScript() []byte {
-	return []byte(`#!/usr/bin/env bash
+func renderBreakerScript(pluginName string) []byte {
+	script := `#!/usr/bin/env bash
 # Filesystem-backed circuit breaker for Gram hook senders.
 #
 # Sourced (not executed) by generated Claude hook.sh when Observability Mode is
@@ -1038,23 +1038,23 @@ func renderBreakerScript() []byte {
 # Configuration:
 #   GRAM_BREAKER_OPEN_EXIT_CODE: exit code returned by gram_breaker_before while
 #     the circuit is open. Default: 75.
-#   BREAKER_NAME: breaker identity used to derive state and lock filenames.
-#     Default: gram-observability-claude-hooks.
-#   BREAKER_THRESHOLD: consecutive Gram outage failures before opening the
+#   GRAM_BREAKER_NAME: breaker identity used to derive state and lock filenames.
+#     Default: __GRAM_BREAKER_DEFAULT_NAME__.
+#   GRAM_BREAKER_THRESHOLD: consecutive Gram outage failures before opening the
 #     circuit. Default: 5.
-#   BREAKER_COOLDOWN: seconds to wait before allowing a half-open recovery
+#   GRAM_BREAKER_COOLDOWN: seconds to wait before allowing a half-open recovery
 #     probe. Default: 60.
-#   BREAKER_LOCK_STALE_AFTER: maximum trusted age, in seconds, for lock and
+#   GRAM_BREAKER_LOCK_STALE_AFTER: maximum trusted age, in seconds, for lock and
 #     half-open ownership. Default: 12 (the hook HTTP timeout plus 2 seconds).
-#   BREAKER_DIR: directory for breaker state and lock directories. Default:
+#   GRAM_BREAKER_DIR: directory for breaker state and lock directories. Default:
 #     ${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers.
 
 GRAM_BREAKER_OPEN_EXIT_CODE="${GRAM_BREAKER_OPEN_EXIT_CODE:-75}"
-BREAKER_NAME="${BREAKER_NAME:-gram-observability-claude-hooks}"
-BREAKER_THRESHOLD="${BREAKER_THRESHOLD:-5}"
-BREAKER_COOLDOWN="${BREAKER_COOLDOWN:-60}"
-BREAKER_LOCK_STALE_AFTER="${BREAKER_LOCK_STALE_AFTER:-12}"
-BREAKER_DIR="${BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"
+GRAM_BREAKER_NAME="${GRAM_BREAKER_NAME:-__GRAM_BREAKER_DEFAULT_NAME__}"
+GRAM_BREAKER_THRESHOLD="${GRAM_BREAKER_THRESHOLD:-5}"
+GRAM_BREAKER_COOLDOWN="${GRAM_BREAKER_COOLDOWN:-60}"
+GRAM_BREAKER_LOCK_STALE_AFTER="${GRAM_BREAKER_LOCK_STALE_AFTER:-12}"
+GRAM_BREAKER_DIR="${GRAM_BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"
 
 _gram_breaker_is_int() {
   case "${1:-}" in
@@ -1168,22 +1168,6 @@ _gram_breaker_write_state() {
 }
 
 _gram_breaker_prepare() {
-  GRAM_BREAKER_NAME="$BREAKER_NAME"
-  GRAM_BREAKER_THRESHOLD="$BREAKER_THRESHOLD"
-  GRAM_BREAKER_COOLDOWN="$BREAKER_COOLDOWN"
-  GRAM_BREAKER_LOCK_STALE_AFTER="$BREAKER_LOCK_STALE_AFTER"
-  GRAM_BREAKER_DIR="$BREAKER_DIR"
-
-  if ! _gram_breaker_is_int "$GRAM_BREAKER_THRESHOLD" || [ "$GRAM_BREAKER_THRESHOLD" -lt 1 ]; then
-    GRAM_BREAKER_THRESHOLD=5
-  fi
-  if ! _gram_breaker_is_int "$GRAM_BREAKER_COOLDOWN"; then
-    GRAM_BREAKER_COOLDOWN=60
-  fi
-  if ! _gram_breaker_is_int "$GRAM_BREAKER_LOCK_STALE_AFTER" || [ "$GRAM_BREAKER_LOCK_STALE_AFTER" -lt 1 ]; then
-    GRAM_BREAKER_LOCK_STALE_AFTER=12
-  fi
-
   GRAM_BREAKER_SAFE_NAME="${GRAM_BREAKER_NAME//[!A-Za-z0-9_.-]/_}"
   if [ -z "$GRAM_BREAKER_SAFE_NAME" ]; then
     GRAM_BREAKER_SAFE_NAME="default"
@@ -1293,7 +1277,8 @@ gram_breaker_after() {
   _gram_breaker_unlock
   return 0
 }
-`)
+`
+	return []byte(strings.ReplaceAll(script, "__GRAM_BREAKER_DEFAULT_NAME__", shellDoubleQuoteValue(pluginName)))
 }
 
 func renderCurlAuthConfigSnippet(cfg GenerateConfig, failureExit int) string {
@@ -1321,6 +1306,10 @@ auth_config_arg=(--config "$auth_config")
 
 func curlConfigQuote(value string) string {
 	return strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(value)
+}
+
+func shellDoubleQuoteValue(value string) string {
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`, "$", `\$`, "`", "\\`").Replace(value)
 }
 
 func renderOptimisticClaudeHookScript(cfg GenerateConfig, keyPrefix, authConfigSnippet string) []byte {
@@ -1365,14 +1354,21 @@ gram_json_escape() {
   printf '%s' "$s"
 }
 
-gram_emit_fail_open_response() {
-  local message
+gram_emit_error_message() {
+  local reason="${1:-}"
+  local system_message="${2:-}"
   local escaped_message
 
-  message="Gram hook degraded. Gram is temporarily unavailable, so this hook is allowing the request without policy evaluation. Continue normally."
+  if [ -z "$reason" ]; then
+    reason="${system_message:-Speakeasy hook returned an error}"
+  fi
+  if [ -z "$system_message" ]; then
+    system_message="$reason"
+  fi
 
-  escaped_message="$(gram_json_escape "$message")"
+  escaped_message="$(gram_json_escape "$system_message")"
   printf '{"systemMessage":"%s"}\n' "$escaped_message"
+  printf '%s\n' "$reason" >&2
 }
 
 GRAM_HTTP_CODE="000"
@@ -1380,11 +1376,15 @@ GRAM_HTTP_BODY="{}"
 gram_breaker_before
 breaker_status=$?
 if [ "$breaker_status" -eq "$GRAM_BREAKER_OPEN_EXIT_CODE" ]; then
-  gram_emit_fail_open_response
+  gram_emit_error_message \
+    "Gram hook degraded" \
+    "Gram hook degraded. Gram is temporarily unavailable, so this hook is allowing the request without policy evaluation. Continue normally."
   exit 0
 fi
 if [ "$breaker_status" -ne 0 ]; then
-  gram_emit_fail_open_response
+  gram_emit_error_message \
+    "Gram hook degraded" \
+    "Gram hook degraded. Gram is temporarily unavailable, so this hook is allowing the request without policy evaluation. Continue normally."
   exit 0
 fi
 
@@ -1401,7 +1401,9 @@ body="$GRAM_HTTP_BODY"
 # allow the request and let the circuit breaker decide when to probe again.
 if [ "$http_code" = "000" ] || [ "$http_code" -ge 500 ] 2>/dev/null; then
   gram_breaker_after 1 || true
-  gram_emit_fail_open_response
+  gram_emit_error_message \
+    "Gram hook degraded" \
+    "Gram hook degraded. Gram is temporarily unavailable, so this hook is allowing the request without policy evaluation. Continue normally."
   exit 0
 fi
 
@@ -1412,8 +1414,9 @@ if [ "$http_code" -ge 200 ] 2>/dev/null && [ "$http_code" -lt 400 ] 2>/dev/null;
   exit 0
 fi
 
-echo "$body"
-echo "Speakeasy hook returned HTTP ${http_code}" >&2
+gram_emit_error_message \
+  "Speakeasy hook returned HTTP ${http_code}" \
+  "Speakeasy hook returned HTTP ${http_code}"
 exit 2
 `
 	replacements := map[string]string{

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -994,10 +994,14 @@ func TestGenerateClaudeObservabilityOptimisticBlockingFilesAndCommands(t *testin
 	require.Contains(t, breaker, "GRAM_BREAKER_THRESHOLD: consecutive Gram outage failures")
 	require.Contains(t, breaker, "GRAM_BREAKER_COOLDOWN: seconds to wait")
 	require.Contains(t, breaker, "GRAM_BREAKER_LOCK_STALE_AFTER: maximum trusted age")
+	require.Contains(t, breaker, "GRAM_BREAKER_LOCK_WAIT: seconds to wait")
 	require.Contains(t, breaker, `GRAM_BREAKER_DIR: directory for breaker state`)
 	require.Contains(t, breaker, `GRAM_BREAKER_NAME="${GRAM_BREAKER_NAME:-acme-observability}"`)
 	require.Contains(t, breaker, `GRAM_BREAKER_DIR="${GRAM_BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"`)
 	require.Contains(t, breaker, `GRAM_BREAKER_LOCK_STALE_AFTER="${GRAM_BREAKER_LOCK_STALE_AFTER:-12}"`)
+	require.Contains(t, breaker, `GRAM_BREAKER_LOCK_WAIT="${GRAM_BREAKER_LOCK_WAIT:-0.005}"`)
+	require.NotContains(t, breaker, "sleep 0.005")
+	require.Contains(t, breaker, `sleep "$GRAM_BREAKER_LOCK_WAIT"`)
 	require.Less(t, strings.Index(breaker, "# Configuration:"), strings.Index(breaker, "_gram_breaker_is_int()"))
 
 	var parsed claudeHooksConfig

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -967,6 +967,8 @@ func TestGenerateClaudeObservabilityOptimisticBlockingFilesAndCommands(t *testin
 	require.Contains(t, hook, "gram_breaker_before")
 	require.Contains(t, hook, "gram_breaker_after 1")
 	require.Contains(t, hook, "gram_breaker_after 0")
+	require.Contains(t, hook, "gram_emit_error_message")
+	require.NotContains(t, hook, "gram_emit_fail_open_response")
 	require.Contains(t, hook, "systemMessage")
 	require.NotContains(t, hook, "additionalContext")
 	require.NotContains(t, hook, "permissionDecision")
@@ -987,13 +989,15 @@ func TestGenerateClaudeObservabilityOptimisticBlockingFilesAndCommands(t *testin
 
 	require.Contains(t, breaker, "# Configuration:")
 	require.Contains(t, breaker, "GRAM_BREAKER_OPEN_EXIT_CODE: exit code returned")
-	require.Contains(t, breaker, "BREAKER_NAME: breaker identity")
-	require.Contains(t, breaker, "BREAKER_THRESHOLD: consecutive Gram outage failures")
-	require.Contains(t, breaker, "BREAKER_COOLDOWN: seconds to wait")
-	require.Contains(t, breaker, "BREAKER_LOCK_STALE_AFTER: maximum trusted age")
-	require.Contains(t, breaker, `BREAKER_DIR: directory for breaker state`)
-	require.Contains(t, breaker, `BREAKER_DIR="${BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"`)
-	require.Contains(t, breaker, `BREAKER_LOCK_STALE_AFTER="${BREAKER_LOCK_STALE_AFTER:-12}"`)
+	require.Contains(t, breaker, "GRAM_BREAKER_NAME: breaker identity")
+	require.Contains(t, breaker, "Default: acme-observability.")
+	require.Contains(t, breaker, "GRAM_BREAKER_THRESHOLD: consecutive Gram outage failures")
+	require.Contains(t, breaker, "GRAM_BREAKER_COOLDOWN: seconds to wait")
+	require.Contains(t, breaker, "GRAM_BREAKER_LOCK_STALE_AFTER: maximum trusted age")
+	require.Contains(t, breaker, `GRAM_BREAKER_DIR: directory for breaker state`)
+	require.Contains(t, breaker, `GRAM_BREAKER_NAME="${GRAM_BREAKER_NAME:-acme-observability}"`)
+	require.Contains(t, breaker, `GRAM_BREAKER_DIR="${GRAM_BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"`)
+	require.Contains(t, breaker, `GRAM_BREAKER_LOCK_STALE_AFTER="${GRAM_BREAKER_LOCK_STALE_AFTER:-12}"`)
 	require.Less(t, strings.Index(breaker, "# Configuration:"), strings.Index(breaker, "_gram_breaker_is_int()"))
 
 	var parsed claudeHooksConfig
@@ -1070,7 +1074,7 @@ printf '{"message":"down"}\n500'
 		cmd.Env = append(os.Environ(),
 			"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
 			"GRAM_CURL_COUNT="+curlCountPath,
-			"BREAKER_DIR="+filepath.Join(dir, "state"),
+			"GRAM_BREAKER_DIR="+filepath.Join(dir, "state"),
 			"GRAM_HTTP_MAX_ATTEMPTS=1",
 			"GRAM_DEVICE_AGENT_COMMANDS=missing-gram-agent",
 		)
@@ -1093,7 +1097,11 @@ printf '{"message":"down"}\n500'
 	require.Equal(t, countAfterFailures, countAfterOpen, "open circuit must skip the HTTP call")
 
 	var response map[string]any
-	require.NoError(t, json.Unmarshal(output, &response))
+	stdout := string(output)
+	if idx := strings.Index(stdout, "\nGram hook degraded\n"); idx >= 0 {
+		stdout = stdout[:idx+1]
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &response))
 	systemMessage, ok := response["systemMessage"].(string)
 	require.True(t, ok)
 	require.Contains(t, systemMessage, "Gram hook degraded")
@@ -1108,15 +1116,15 @@ func TestGeneratedBreakerReclaimsAgeBoundedOwnersEvenWhenPIDLooksAlive(t *testin
 	t.Parallel()
 
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "breaker.sh"), renderBreakerScript(), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "breaker.sh"), renderBreakerScript("gram-observability-claude-hooks"), 0o755))
 	cmd := exec.Command("bash", "-c", `
 set -u
 . ./breaker.sh
-BREAKER_DIR="$PWD/state"
-BREAKER_LOCK_STALE_AFTER=1
-mkdir -p "$BREAKER_DIR"
+GRAM_BREAKER_DIR="$PWD/state"
+GRAM_BREAKER_LOCK_STALE_AFTER=1
+mkdir -p "$GRAM_BREAKER_DIR"
 
-lock_dir="$BREAKER_DIR/gram-observability-claude-hooks.lockdir"
+lock_dir="$GRAM_BREAKER_DIR/gram-observability-claude-hooks.lockdir"
 mkdir "$lock_dir"
 printf '1\n' > "$lock_dir/owner.pid"
 sleep 2
@@ -1127,7 +1135,7 @@ if [ "$status" -ne 0 ]; then
 fi
 
 old=$(( $(date +%s) - 20 ))
-state_file="$BREAKER_DIR/gram-observability-claude-hooks.state"
+state_file="$GRAM_BREAKER_DIR/gram-observability-claude-hooks.state"
 printf 'half_open 5 %s 1\n' "$old" > "$state_file"
 gram_breaker_before
 status=$?

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -947,6 +947,67 @@ func TestGenerateClaudeObservabilityBlockingEventsDefaultToSync(t *testing.T) {
 	}
 }
 
+func TestGenerateClaudeObservabilityOptimisticBlockingFilesAndCommands(t *testing.T) {
+	t.Parallel()
+	cfg := GenerateConfig{
+		OrgName:     "Acme",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_local_secret_xyz",
+		ProjectSlug: "acme-prod",
+	}
+	files, err := GeneratePluginPackages(nil, cfg)
+	require.NoError(t, err)
+
+	slug := ClaudeObservabilitySlug(cfg)
+	hook := string(files[slug+"/hooks/hook.sh"])
+	breaker := string(files[slug+"/hooks/breaker.sh"])
+	require.NotEmpty(t, breaker, "optimistic blocking mode must generate hooks/breaker.sh")
+
+	require.Contains(t, hook, `. "$script_dir/breaker.sh"`)
+	require.Contains(t, hook, "gram_breaker_before")
+	require.Contains(t, hook, "gram_breaker_after 1")
+	require.Contains(t, hook, "gram_breaker_after 0")
+	require.Contains(t, hook, "systemMessage")
+	require.NotContains(t, hook, "additionalContext")
+	require.NotContains(t, hook, "permissionDecision")
+	require.NotContains(t, hook, "hookSpecificOutput")
+	require.NotContains(t, hook, "event_name")
+	require.NotContains(t, hook, "hook cwd:")
+	require.NotContains(t, hook, "state file:")
+	require.NotContains(t, hook, "Gram hook returned HTTP")
+	require.NotContains(t, hook, "circuit open")
+	require.NotContains(t, hook, "python3", "optimistic blocking hook.sh must stay shell-only")
+
+	for _, generated := range []string{hook, breaker} {
+		require.NotContains(t, generated, "gram_cb_")
+		require.NotContains(t, generated, "GRAM_CB_")
+		require.NotContains(t, generated, "CB_")
+		require.NotContains(t, generated, "gram_cb_run")
+	}
+
+	require.Contains(t, breaker, "# Configuration:")
+	require.Contains(t, breaker, "GRAM_BREAKER_OPEN_EXIT_CODE: exit code returned")
+	require.Contains(t, breaker, "BREAKER_NAME: breaker identity")
+	require.Contains(t, breaker, "BREAKER_THRESHOLD: consecutive Gram outage failures")
+	require.Contains(t, breaker, "BREAKER_COOLDOWN: seconds to wait")
+	require.Contains(t, breaker, "BREAKER_LOCK_STALE_AFTER: maximum trusted age")
+	require.Contains(t, breaker, `BREAKER_DIR: directory for breaker state`)
+	require.Contains(t, breaker, `BREAKER_DIR="${BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"`)
+	require.Contains(t, breaker, `BREAKER_LOCK_STALE_AFTER="${BREAKER_LOCK_STALE_AFTER:-12}"`)
+	require.Less(t, strings.Index(breaker, "# Configuration:"), strings.Index(breaker, "_gram_breaker_is_int()"))
+
+	var parsed claudeHooksConfig
+	require.NoError(t, json.Unmarshal(files[slug+"/hooks/hooks.json"], &parsed))
+	for _, event := range ClaudeObservabilityHookEvents {
+		command := parsed.Hooks[event][0].Hooks[0].Command
+		if event == "SessionStart" || event == "ConfigChange" {
+			require.Contains(t, command, "hooks/mcp_inventory.sh")
+			continue
+		}
+		require.Equal(t, `bash "$CLAUDE_PLUGIN_ROOT/hooks/hook.sh"`, command)
+	}
+}
+
 // With observability mode on, every hook event is emitted async so the plugin
 // can only observe and report — no hook can deny or delay a tool call.
 func TestGenerateClaudeObservabilityModeForcesAsyncForAllEvents(t *testing.T) {
@@ -961,6 +1022,8 @@ func TestGenerateClaudeObservabilityModeForcesAsyncForAllEvents(t *testing.T) {
 	files, err := GeneratePluginPackages(nil, cfg)
 	require.NoError(t, err)
 
+	require.Nil(t, files[ClaudeObservabilitySlug(cfg)+"/hooks/breaker.sh"], "full observability mode is already async/non-blocking and must not ship breaker.sh")
+
 	var parsed claudeHooksConfig
 	require.NoError(t, json.Unmarshal(files[ClaudeObservabilitySlug(cfg)+"/hooks/hooks.json"], &parsed))
 
@@ -969,6 +1032,117 @@ func TestGenerateClaudeObservabilityModeForcesAsyncForAllEvents(t *testing.T) {
 		require.NotNil(t, matchers[0].Hooks[0].Async, "event %q must carry an async flag", event)
 		require.True(t, *matchers[0].Hooks[0].Async, "event %q must be async in observability mode", event)
 	}
+}
+
+func TestGeneratedClaudeOptimisticHookFailsOpenAndSkipsHTTPWhenCircuitOpen(t *testing.T) {
+	t.Parallel()
+	cfg := GenerateConfig{
+		OrgName:     "Acme",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_local_secret_xyz",
+		ProjectSlug: "acme-prod",
+	}
+	files, err := GenerateObservabilityPluginPackage(cfg, "claude")
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	for _, file := range []string{"hooks/hook.sh", "hooks/http.sh", "hooks/identity.sh", "hooks/breaker.sh"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, filepath.Base(file)), files[file], 0o755))
+	}
+
+	curlCountPath := filepath.Join(dir, "curl-count")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "curl"), []byte(`#!/usr/bin/env bash
+count=0
+if [ -r "$GRAM_CURL_COUNT" ]; then
+  read -r count < "$GRAM_CURL_COUNT" || count=0
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$GRAM_CURL_COUNT"
+cat >/dev/null
+printf '{"message":"down"}\n500'
+`), 0o755))
+
+	runHook := func() []byte {
+		t.Helper()
+		cmd := exec.Command("bash", filepath.Join(dir, "hook.sh"))
+		cmd.Dir = dir
+		cmd.Stdin = strings.NewReader(`{"hook_event_name":"PreToolUse"}`)
+		cmd.Env = append(os.Environ(),
+			"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"GRAM_CURL_COUNT="+curlCountPath,
+			"BREAKER_DIR="+filepath.Join(dir, "state"),
+			"GRAM_HTTP_MAX_ATTEMPTS=1",
+			"GRAM_DEVICE_AGENT_COMMANDS=missing-gram-agent",
+		)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(output))
+		return output
+	}
+
+	for range 5 {
+		output := runHook()
+		require.Contains(t, string(output), "Gram hook degraded")
+	}
+
+	countAfterFailures := strings.TrimSpace(string(requireFileBytes(t, curlCountPath)))
+	require.Equal(t, "5", countAfterFailures)
+
+	output := runHook()
+	require.Contains(t, string(output), "Gram hook degraded")
+	countAfterOpen := strings.TrimSpace(string(requireFileBytes(t, curlCountPath)))
+	require.Equal(t, countAfterFailures, countAfterOpen, "open circuit must skip the HTTP call")
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(output, &response))
+	systemMessage, ok := response["systemMessage"].(string)
+	require.True(t, ok)
+	require.Contains(t, systemMessage, "Gram hook degraded")
+	require.NotContains(t, systemMessage, "hook cwd:")
+	require.NotContains(t, systemMessage, "state file:")
+	require.NotContains(t, systemMessage, "HTTP 500")
+	require.NotContains(t, systemMessage, "circuit open")
+	require.NotContains(t, response, "hookSpecificOutput")
+}
+
+func TestGeneratedBreakerReclaimsAgeBoundedOwnersEvenWhenPIDLooksAlive(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "breaker.sh"), renderBreakerScript(), 0o755))
+	cmd := exec.Command("bash", "-c", `
+set -u
+. ./breaker.sh
+BREAKER_DIR="$PWD/state"
+BREAKER_LOCK_STALE_AFTER=1
+mkdir -p "$BREAKER_DIR"
+
+lock_dir="$BREAKER_DIR/gram-observability-claude-hooks.lockdir"
+mkdir "$lock_dir"
+printf '1\n' > "$lock_dir/owner.pid"
+sleep 2
+gram_breaker_before
+status=$?
+if [ "$status" -ne 0 ]; then
+  exit "$status"
+fi
+
+old=$(( $(date +%s) - 20 ))
+state_file="$BREAKER_DIR/gram-observability-claude-hooks.state"
+printf 'half_open 5 %s 1\n' "$old" > "$state_file"
+gram_breaker_before
+status=$?
+if [ "$status" -ne 0 ]; then
+  exit "$status"
+fi
+read -r state failures opened_at owner_pid < "$state_file"
+if [ "$state" != "half_open" ] || [ "$owner_pid" != "$$" ]; then
+  printf 'unexpected state: %s %s %s %s\n' "$state" "$failures" "$opened_at" "$owner_pid" >&2
+  exit 1
+fi
+`)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
 }
 
 // mcp_inventory.sh enriches the payload with MCP inventory and posts to the

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -967,6 +967,7 @@ func TestGenerateClaudeObservabilityOptimisticBlockingFilesAndCommands(t *testin
 	require.Contains(t, hook, "gram_breaker_before")
 	require.Contains(t, hook, "gram_breaker_after 1")
 	require.Contains(t, hook, "gram_breaker_after 0")
+	require.Contains(t, hook, "GRAM_BREAKER_AFTER_DECISION")
 	require.Contains(t, hook, "gram_emit_error_message")
 	require.NotContains(t, hook, "gram_emit_fail_open_response")
 	require.Contains(t, hook, "systemMessage")
@@ -988,16 +989,20 @@ func TestGenerateClaudeObservabilityOptimisticBlockingFilesAndCommands(t *testin
 	}
 
 	require.Contains(t, breaker, "# Configuration:")
+	require.Contains(t, breaker, "GRAM_BREAKER_AFTER_DECISION")
+	require.Contains(t, breaker, "GRAM_BREAKER_AFTER_REASON")
 	require.Contains(t, breaker, "GRAM_BREAKER_OPEN_EXIT_CODE: exit code returned")
 	require.Contains(t, breaker, "GRAM_BREAKER_NAME: breaker identity")
 	require.Contains(t, breaker, "Default: acme-observability.")
-	require.Contains(t, breaker, "GRAM_BREAKER_THRESHOLD: consecutive Gram outage failures")
+	require.Contains(t, breaker, "GRAM_BREAKER_THRESHOLD: Gram outage failures required within the error")
+	require.Contains(t, breaker, "GRAM_BREAKER_ERROR_WINDOW: seconds over which failures are counted")
 	require.Contains(t, breaker, "GRAM_BREAKER_COOLDOWN: seconds to wait")
 	require.Contains(t, breaker, "GRAM_BREAKER_LOCK_STALE_AFTER: maximum trusted age")
 	require.Contains(t, breaker, "GRAM_BREAKER_LOCK_WAIT: seconds to wait")
 	require.Contains(t, breaker, `GRAM_BREAKER_DIR: directory for breaker state`)
 	require.Contains(t, breaker, `GRAM_BREAKER_NAME="${GRAM_BREAKER_NAME:-acme-observability}"`)
 	require.Contains(t, breaker, `GRAM_BREAKER_DIR="${GRAM_BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"`)
+	require.Contains(t, breaker, `GRAM_BREAKER_ERROR_WINDOW="${GRAM_BREAKER_ERROR_WINDOW:-30}"`)
 	require.Contains(t, breaker, `GRAM_BREAKER_LOCK_STALE_AFTER="${GRAM_BREAKER_LOCK_STALE_AFTER:-12}"`)
 	require.Contains(t, breaker, `GRAM_BREAKER_LOCK_WAIT="${GRAM_BREAKER_LOCK_WAIT:-0.005}"`)
 	require.NotContains(t, breaker, "sleep 0.005")
@@ -1070,7 +1075,7 @@ cat >/dev/null
 printf '{"message":"down"}\n500'
 `), 0o755))
 
-	runHook := func() []byte {
+	runHook := func() ([]byte, int) {
 		t.Helper()
 		cmd := exec.Command("bash", filepath.Join(dir, "hook.sh"))
 		cmd.Dir = dir
@@ -1083,19 +1088,33 @@ printf '{"message":"down"}\n500'
 			"GRAM_DEVICE_AGENT_COMMANDS=missing-gram-agent",
 		)
 		output, err := cmd.CombinedOutput()
-		require.NoError(t, err, string(output))
-		return output
+		if err == nil {
+			return output, 0
+		}
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr, string(output))
+		return output, exitErr.ExitCode()
 	}
 
-	for range 5 {
-		output := runHook()
-		require.Contains(t, string(output), "Gram hook degraded")
+	for range 4 {
+		output, code := runHook()
+		require.Equal(t, 2, code, string(output))
+		require.Contains(t, string(output), "Speakeasy hook returned HTTP 500")
+		require.NotContains(t, string(output), "Gram hook degraded")
 	}
+
+	countBeforeThreshold := strings.TrimSpace(string(requireFileBytes(t, curlCountPath)))
+	require.Equal(t, "4", countBeforeThreshold)
+
+	output, code := runHook()
+	require.Equal(t, 0, code, string(output))
+	require.Contains(t, string(output), "Gram hook degraded")
 
 	countAfterFailures := strings.TrimSpace(string(requireFileBytes(t, curlCountPath)))
 	require.Equal(t, "5", countAfterFailures)
 
-	output := runHook()
+	output, code = runHook()
+	require.Equal(t, 0, code, string(output))
 	require.Contains(t, string(output), "Gram hook degraded")
 	countAfterOpen := strings.TrimSpace(string(requireFileBytes(t, curlCountPath)))
 	require.Equal(t, countAfterFailures, countAfterOpen, "open circuit must skip the HTTP call")
@@ -1114,6 +1133,112 @@ printf '{"message":"down"}\n500'
 	require.NotContains(t, systemMessage, "HTTP 500")
 	require.NotContains(t, systemMessage, "circuit open")
 	require.NotContains(t, response, "hookSpecificOutput")
+}
+
+func TestGeneratedBreakerAfterDecisionBlocksUntilThreshold(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "breaker.sh"), renderBreakerScript("threshold-test"), 0o755))
+	cmd := exec.Command("bash", "-c", `
+set -u
+. ./breaker.sh
+GRAM_BREAKER_DIR="$PWD/state"
+GRAM_BREAKER_THRESHOLD=3
+mkdir -p "$GRAM_BREAKER_DIR"
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+`)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Equal(t, []string{
+		"block failure_recorded",
+		"block failure_recorded",
+		"allow threshold_opened",
+	}, strings.Split(strings.TrimSpace(string(output)), "\n"))
+}
+
+func TestGeneratedBreakerAfterDecisionAllowsHalfOpenFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "breaker.sh"), renderBreakerScript("half-open-test"), 0o755))
+	cmd := exec.Command("bash", "-c", `
+set -u
+. ./breaker.sh
+GRAM_BREAKER_DIR="$PWD/state"
+GRAM_BREAKER_THRESHOLD=1
+GRAM_BREAKER_COOLDOWN=0
+mkdir -p "$GRAM_BREAKER_DIR"
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+`)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Equal(t, []string{
+		"allow threshold_opened",
+		"allow half_open_failed",
+	}, strings.Split(strings.TrimSpace(string(output)), "\n"))
+}
+
+func TestGeneratedBreakerErrorWindowResetsOldFailures(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "breaker.sh"), renderBreakerScript("window-test"), 0o755))
+	cmd := exec.Command("bash", "-c", `
+set -u
+. ./breaker.sh
+GRAM_BREAKER_DIR="$PWD/state"
+GRAM_BREAKER_THRESHOLD=3
+GRAM_BREAKER_ERROR_WINDOW=1
+mkdir -p "$GRAM_BREAKER_DIR"
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+
+sleep 2
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+
+gram_breaker_before
+gram_breaker_after 1
+printf '%s %s\n' "$GRAM_BREAKER_AFTER_DECISION" "$GRAM_BREAKER_AFTER_REASON"
+`)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Equal(t, []string{
+		"block failure_recorded",
+		"block failure_recorded",
+		"block failure_recorded",
+		"allow threshold_opened",
+	}, strings.Split(strings.TrimSpace(string(output)), "\n"))
 }
 
 func TestGeneratedBreakerReclaimsAgeBoundedOwnersEvenWhenPIDLooksAlive(t *testing.T) {
@@ -1140,15 +1265,105 @@ fi
 
 old=$(( $(date +%s) - 20 ))
 state_file="$GRAM_BREAKER_DIR/gram-observability-claude-hooks.state"
-printf 'half_open 5 %s 1\n' "$old" > "$state_file"
+printf 'half_open 5 0 %s 1\n' "$old" > "$state_file"
 gram_breaker_before
 status=$?
 if [ "$status" -ne 0 ]; then
   exit "$status"
 fi
-read -r state failures opened_at owner_pid < "$state_file"
+read -r state failures window_started_at opened_at owner_pid < "$state_file"
 if [ "$state" != "half_open" ] || [ "$owner_pid" != "$$" ]; then
-  printf 'unexpected state: %s %s %s %s\n' "$state" "$failures" "$opened_at" "$owner_pid" >&2
+  printf 'unexpected state: %s %s %s %s %s\n' "$state" "$failures" "$window_started_at" "$opened_at" "$owner_pid" >&2
+  exit 1
+fi
+`)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+func TestGeneratedBreakerLockStressAllowsOnlyOneOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "breaker.sh"), renderBreakerScript("stress-test"), 0o755))
+
+	cmd := exec.Command("bash", "-c", `
+set -u
+cat > worker.sh <<'WORKER'
+#!/usr/bin/env bash
+set -u
+. ./breaker.sh
+
+i=0
+while [ "$i" -lt "${ITERS:-20}" ]; do
+  _gram_breaker_prepare || {
+    echo "prepare failed" >> "$VIOLATIONS"
+    exit 1
+  }
+  _gram_breaker_lock || {
+    echo "lock failed" >> "$VIOLATIONS"
+    exit 1
+  }
+
+  active=0
+  if mkdir "$ACTIVE_DIR" 2>/dev/null; then
+    active=1
+    printf '%s\n' "$$" > "$ACTIVE_DIR/pid" 2>/dev/null || true
+  else
+    echo "concurrent critical section" >> "$VIOLATIONS"
+  fi
+
+  sleep 0.001
+
+  if [ "$active" -eq 1 ]; then
+    rm -f "$ACTIVE_DIR/pid" 2>/dev/null || true
+    rmdir "$ACTIVE_DIR" 2>/dev/null || echo "active cleanup failed" >> "$VIOLATIONS"
+  fi
+  _gram_breaker_unlock || true
+  i=$((i + 1))
+done
+WORKER
+chmod +x worker.sh
+
+export GRAM_BREAKER_DIR="$PWD/state"
+export GRAM_BREAKER_NAME="stress-test"
+export GRAM_BREAKER_LOCK_WAIT=0.001
+export GRAM_BREAKER_LOCK_STALE_AFTER=2
+export ACTIVE_DIR="$PWD/active-owner"
+export VIOLATIONS="$PWD/violations"
+export ITERS=20
+
+mkdir -p "$GRAM_BREAKER_DIR"
+: > "$VIOLATIONS"
+
+pids=""
+n=0
+while [ "$n" -lt 25 ]; do
+  bash ./worker.sh &
+  pids="$pids $!"
+  n=$((n + 1))
+done
+
+failed=0
+for pid in $pids; do
+  if ! wait "$pid"; then
+    failed=1
+  fi
+done
+if [ "$failed" -ne 0 ]; then
+  echo "worker failed" >> "$VIOLATIONS"
+fi
+
+if [ -s "$VIOLATIONS" ]; then
+  cat "$VIOLATIONS" >&2
+  exit 1
+fi
+
+. ./breaker.sh
+_gram_breaker_prepare
+if [ -d "$GRAM_BREAKER_LOCK_DIR" ]; then
+  echo "lockdir leaked: $GRAM_BREAKER_LOCK_DIR" >&2
   exit 1
 fi
 `)

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1002,7 +1002,7 @@ func TestGenerateClaudeObservabilityOptimisticBlockingFilesAndCommands(t *testin
 	require.Contains(t, breaker, `GRAM_BREAKER_DIR: directory for breaker state`)
 	require.Contains(t, breaker, `GRAM_BREAKER_NAME="${GRAM_BREAKER_NAME:-acme-observability}"`)
 	require.Contains(t, breaker, `GRAM_BREAKER_DIR="${GRAM_BREAKER_DIR:-${CLAUDE_PLUGIN_DATA:-/tmp}/circuit-breakers}"`)
-	require.Contains(t, breaker, `GRAM_BREAKER_ERROR_WINDOW="${GRAM_BREAKER_ERROR_WINDOW:-30}"`)
+	require.Contains(t, breaker, `GRAM_BREAKER_ERROR_WINDOW="${GRAM_BREAKER_ERROR_WINDOW:-60}"`)
 	require.Contains(t, breaker, `GRAM_BREAKER_LOCK_STALE_AFTER="${GRAM_BREAKER_LOCK_STALE_AFTER:-12}"`)
 	require.Contains(t, breaker, `GRAM_BREAKER_LOCK_WAIT="${GRAM_BREAKER_LOCK_WAIT:-0.005}"`)
 	require.NotContains(t, breaker, "sleep 0.005")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add optimistic blocking for Claude hooks with a shell-based circuit breaker. On 5xx/connection failures, hooks block until a threshold, then fail open with a “Gram hook degraded” systemMessage and skip HTTP while probing for recovery.

- **New Features**
  - Generate `hooks/breaker.sh` and source it from Claude `hook.sh` when Observability Mode is off; Observability Mode stays fully async and ships no breaker.
  - Filesystem circuit breaker: failure threshold, 60s error window, 60s cooldown, half-open probes, and PID/lock handling; configurable via `GRAM_BREAKER_*` env vars.
  - New Claude `hook.sh`: 2xx allow (body to stdout), 4xx block; 5xx/000 counted as outages. When open, it returns a degraded `systemMessage` and bypasses HTTP until cooldown.
  - `hooks.json` commands now use `bash "$CLAUDE_PLUGIN_ROOT/hooks/<script>"`; `mcp_inventory.sh` still handles SessionStart/ConfigChange. Bump plugin generator version to `5`.

<sup>Written for commit 07a49aa1c12ab86b94b30b7b724ad7ddcfe51865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

