### PR TITLE
chore(pystreams): break the PresidioAnalyzer scan GIL ceiling with an in-pod process pool

### DIFF
--- a/.mise-tasks/risk/presidio-load.sh
+++ b/.mise-tasks/risk/presidio-load.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+#MISE dir="{{ config_root }}/pystreams"
+#MISE description="Publish a burst of PresidioAnalysis messages to the local emulator to profile the PresidioAnalyzer subscription"
+
+# Requires PUBSUB_EMULATOR_HOST (set by default in mise.toml) and a locally
+# running `mise run start:pystreams-multi` to consume the load. See
+# pystreams/src/pystreams/cmd/presidio_load.py for the full runbook and flags.
+# Invoke the module directly (rather than the `presidio-load` console script) so
+# this works under --no-sync even before the entry point has been installed.
+exec uv run --no-sync python -m pystreams.cmd.presidio_load "$@"

--- a/docs/pubsub-topology.md
+++ b/docs/pubsub-topology.md
@@ -16,73 +16,56 @@ flowchart LR
   classDef deprecated stroke-dasharray:4 3,opacity:0.55;
 
   t_gram_ping_v1_message(["gram-ping-v1-message<br/>(topic)"]):::topic
-  click t_gram_ping_v1_message "../infra/proto/gram/ping/v1/ping.proto#L10" "infra/proto/gram/ping/v1/ping.proto"
   t_gram_ping_v1_processor_dlq(["gram-ping-v1-processor-dlq<br/>(dlq)"]):::dlq
-  click t_gram_ping_v1_processor_dlq "../infra/proto/gram/ping/v1/processor.proto#L9" "infra/proto/gram/ping/v1/processor.proto"
   t_gram_ping_v1_py_processor_dlq(["gram-ping-v1-py-processor-dlq<br/>(dlq)"]):::dlq
-  click t_gram_ping_v1_py_processor_dlq "../infra/proto/gram/ping/v1/processor.proto#L23" "infra/proto/gram/ping/v1/processor.proto"
   t_gram_risk_v1_finding(["gram-risk-v1-finding<br/>(topic)"]):::topic
-  click t_gram_risk_v1_finding "../infra/proto/gram/risk/v1/finding.proto#L13" "infra/proto/gram/risk/v1/finding.proto"
   t_gram_risk_v1_presidio_analysis(["gram-risk-v1-presidio-analysis<br/>(topic)"]):::topic
-  click t_gram_risk_v1_presidio_analysis "../infra/proto/gram/risk/v1/presidio_analysis.proto#L9" "infra/proto/gram/risk/v1/presidio_analysis.proto"
   t_gram_risk_v1_presidio_request(["gram-risk-v1-presidio-request<br/>(topic)"]):::topic
-  click t_gram_risk_v1_presidio_request "../infra/proto/gram/risk/v1/presidio_request.proto#L10" "infra/proto/gram/risk/v1/presidio_request.proto"
   s_gram_ping_v1_processor["gram-ping-v1-processor<br/>(sub)"]:::sub
-  click s_gram_ping_v1_processor "../infra/proto/gram/ping/v1/processor.proto#L9" "infra/proto/gram/ping/v1/processor.proto"
   s_gram_ping_v1_py_processor["gram-ping-v1-py-processor<br/>(sub)"]:::sub
-  click s_gram_ping_v1_py_processor "../infra/proto/gram/ping/v1/processor.proto#L23" "infra/proto/gram/ping/v1/processor.proto"
   s_gram_risk_v1_presidio_analyzer["gram-risk-v1-presidio-analyzer<br/>(sub)"]:::sub
-  click s_gram_risk_v1_presidio_analyzer "../infra/proto/gram/risk/v1/presidio_analyzer.proto#L9" "infra/proto/gram/risk/v1/presidio_analyzer.proto"
   s_gram_risk_v1_presidio_scanner["gram-risk-v1-presidio-scanner<br/>(sub)"]:::sub
-  click s_gram_risk_v1_presidio_scanner "../infra/proto/gram/risk/v1/presidio_scanner.proto#L10" "infra/proto/gram/risk/v1/presidio_scanner.proto"
 
-  p0[/"📤 server/internal/ping/publisher.go"/]:::go
+  p0[/"📤<br/>server/internal/ping/publisher.go"/]:::go
   p0 --> t_gram_ping_v1_message
-  click p0 "../server/internal/ping/publisher.go#L36" "server/internal/ping/publisher.go:36"
-  p1[/"📤 pystreams/src/pystreams/risk/handler.py"/]:::python
+  p1[/"📤<br/>pystreams/src/pystreams/risk/handler.py"/]:::python
   p1 --> t_gram_risk_v1_finding
-  click p1 "../pystreams/src/pystreams/risk/handler.py#L166" "pystreams/src/pystreams/risk/handler.py:166"
-  p2[/"📤 pystreams/src/pystreams/cmd/presidio_load.py"/]:::python
+  p2[/"📤<br/>pystreams/src/pystreams/cmd/presidio_load.py"/]:::python
   p2 --> t_gram_risk_v1_presidio_analysis
-  click p2 "../pystreams/src/pystreams/cmd/presidio_load.py#L85" "pystreams/src/pystreams/cmd/presidio_load.py:85"
-  p3[/"📤 server/internal/background/activities/risk_analysis/analyze_batch.go"/]:::go
+  p3[/"📤<br/>server/internal/background/activities/risk_analysis/analyze_batch.go"/]:::go
   p3 --> t_gram_risk_v1_presidio_analysis
-  click p3 "../server/internal/background/activities/risk_analysis/analyze_batch.go#L364" "server/internal/background/activities/risk_analysis/analyze_batch.go:364"
   t_gram_ping_v1_message --> s_gram_ping_v1_processor
   s_gram_ping_v1_processor -. dead-letter .-> t_gram_ping_v1_processor_dlq
   t_gram_ping_v1_message --> s_gram_ping_v1_py_processor
   s_gram_ping_v1_py_processor -. dead-letter .-> t_gram_ping_v1_py_processor_dlq
   t_gram_risk_v1_presidio_analysis --> s_gram_risk_v1_presidio_analyzer
   t_gram_risk_v1_presidio_request --> s_gram_risk_v1_presidio_scanner
-  c4[\"📥 server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
+  c4[\"📥<br/>server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
   s_gram_ping_v1_processor --> c4
-  click c4 "../server/cmd/gram/streams.go#L215" "server/cmd/gram/streams.go:215"
-  c5[\"📥 pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
+  c5[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
   s_gram_ping_v1_py_processor --> c5
-  click c5 "../pystreams/src/pystreams/cmd/multi.py#L164" "pystreams/src/pystreams/cmd/multi.py:164"
-  c6[\"📥 pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
+  c6[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
   s_gram_risk_v1_presidio_analyzer --> c6
-  click c6 "../pystreams/src/pystreams/cmd/multi.py#L169" "pystreams/src/pystreams/cmd/multi.py:169"
 
   class t_gram_risk_v1_presidio_request,s_gram_risk_v1_presidio_scanner deprecated;
 ```
 
 ## Topics
 
-| Topic                                                                                      | Kind               | Retention | Published by                                                                                                                                                                                                                                                            |
-| ------------------------------------------------------------------------------------------ | ------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`gram-ping-v1-message`](../infra/proto/gram/ping/v1/ping.proto#L10)                       | topic              | 1d        | [`server/internal/ping/publisher.go:36`](../server/internal/ping/publisher.go#L36)                                                                                                                                                                                      |
-| [`gram-ping-v1-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto#L9)             | DLQ                | —         | —                                                                                                                                                                                                                                                                       |
-| [`gram-ping-v1-py-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto#L23)         | DLQ                | —         | —                                                                                                                                                                                                                                                                       |
-| [`gram-risk-v1-finding`](../infra/proto/gram/risk/v1/finding.proto#L13)                    | topic              | 7d        | [`pystreams/src/pystreams/risk/handler.py:166`](../pystreams/src/pystreams/risk/handler.py#L166)                                                                                                                                                                        |
-| [`gram-risk-v1-presidio-analysis`](../infra/proto/gram/risk/v1/presidio_analysis.proto#L9) | topic              | 7d        | [`pystreams/src/pystreams/cmd/presidio_load.py:85`](../pystreams/src/pystreams/cmd/presidio_load.py#L85)<br/>[`server/internal/background/activities/risk_analysis/analyze_batch.go:364`](../server/internal/background/activities/risk_analysis/analyze_batch.go#L364) |
-| [`gram-risk-v1-presidio-request`](../infra/proto/gram/risk/v1/presidio_request.proto#L10)  | topic (deprecated) | 7d        | —                                                                                                                                                                                                                                                                       |
+| Topic                                                                                   | Kind               | Retention | Published by                                                                                                                                                                                                                                            |
+| --------------------------------------------------------------------------------------- | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`gram-ping-v1-message`](../infra/proto/gram/ping/v1/ping.proto)                        | topic              | 1d        | [`server/internal/ping/publisher.go`](../server/internal/ping/publisher.go)                                                                                                                                                                             |
+| [`gram-ping-v1-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto)             | DLQ                | —         | —                                                                                                                                                                                                                                                       |
+| [`gram-ping-v1-py-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto)          | DLQ                | —         | —                                                                                                                                                                                                                                                       |
+| [`gram-risk-v1-finding`](../infra/proto/gram/risk/v1/finding.proto)                     | topic              | 7d        | [`pystreams/src/pystreams/risk/handler.py`](../pystreams/src/pystreams/risk/handler.py)                                                                                                                                                                 |
+| [`gram-risk-v1-presidio-analysis`](../infra/proto/gram/risk/v1/presidio_analysis.proto) | topic              | 7d        | [`pystreams/src/pystreams/cmd/presidio_load.py`](../pystreams/src/pystreams/cmd/presidio_load.py)<br/>[`server/internal/background/activities/risk_analysis/analyze_batch.go`](../server/internal/background/activities/risk_analysis/analyze_batch.go) |
+| [`gram-risk-v1-presidio-request`](../infra/proto/gram/risk/v1/presidio_request.proto)   | topic (deprecated) | 7d        | —                                                                                                                                                                                                                                                       |
 
 ## Subscriptions
 
-| Subscription                                                                                             | Topic                            | Ack | DLQ                             | Consumed by                                                                                |
-| -------------------------------------------------------------------------------------------------------- | -------------------------------- | --- | ------------------------------- | ------------------------------------------------------------------------------------------ |
-| [`gram-ping-v1-processor`](../infra/proto/gram/ping/v1/processor.proto#L9)                               | `gram-ping-v1-message`           | 30s | `gram-ping-v1-processor-dlq`    | [`server/cmd/gram/streams.go:215`](../server/cmd/gram/streams.go#L215)                     |
-| [`gram-ping-v1-py-processor`](../infra/proto/gram/ping/v1/processor.proto#L23)                           | `gram-ping-v1-message`           | 30s | `gram-ping-v1-py-processor-dlq` | [`pystreams/src/pystreams/cmd/multi.py:164`](../pystreams/src/pystreams/cmd/multi.py#L164) |
-| [`gram-risk-v1-presidio-analyzer`](../infra/proto/gram/risk/v1/presidio_analyzer.proto#L9)               | `gram-risk-v1-presidio-analysis` | 1m  | —                               | [`pystreams/src/pystreams/cmd/multi.py:169`](../pystreams/src/pystreams/cmd/multi.py#L169) |
-| [`gram-risk-v1-presidio-scanner`](../infra/proto/gram/risk/v1/presidio_scanner.proto#L10) _(deprecated)_ | `gram-risk-v1-presidio-request`  | 1m  | —                               | —                                                                                          |
+| Subscription                                                                                         | Topic                            | Ack | DLQ                             | Consumed by                                                                       |
+| ---------------------------------------------------------------------------------------------------- | -------------------------------- | --- | ------------------------------- | --------------------------------------------------------------------------------- |
+| [`gram-ping-v1-processor`](../infra/proto/gram/ping/v1/processor.proto)                              | `gram-ping-v1-message`           | 30s | `gram-ping-v1-processor-dlq`    | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go)                     |
+| [`gram-ping-v1-py-processor`](../infra/proto/gram/ping/v1/processor.proto)                           | `gram-ping-v1-message`           | 30s | `gram-ping-v1-py-processor-dlq` | [`pystreams/src/pystreams/cmd/multi.py`](../pystreams/src/pystreams/cmd/multi.py) |
+| [`gram-risk-v1-presidio-analyzer`](../infra/proto/gram/risk/v1/presidio_analyzer.proto)              | `gram-risk-v1-presidio-analysis` | 1m  | —                               | [`pystreams/src/pystreams/cmd/multi.py`](../pystreams/src/pystreams/cmd/multi.py) |
+| [`gram-risk-v1-presidio-scanner`](../infra/proto/gram/risk/v1/presidio_scanner.proto) _(deprecated)_ | `gram-risk-v1-presidio-request`  | 1m  | —                               | —                                                                                 |

--- a/docs/pubsub-topology.md
+++ b/docs/pubsub-topology.md
@@ -41,45 +41,48 @@ flowchart LR
   click p0 "../server/internal/ping/publisher.go#L36" "server/internal/ping/publisher.go:36"
   p1[/"📤 pystreams/src/pystreams/risk/handler.py"/]:::python
   p1 --> t_gram_risk_v1_finding
-  click p1 "../pystreams/src/pystreams/risk/handler.py#L217" "pystreams/src/pystreams/risk/handler.py:217"
-  p2[/"📤 server/internal/background/activities/risk_analysis/analyze_batch.go"/]:::go
+  click p1 "../pystreams/src/pystreams/risk/handler.py#L166" "pystreams/src/pystreams/risk/handler.py:166"
+  p2[/"📤 pystreams/src/pystreams/cmd/presidio_load.py"/]:::python
   p2 --> t_gram_risk_v1_presidio_analysis
-  click p2 "../server/internal/background/activities/risk_analysis/analyze_batch.go#L364" "server/internal/background/activities/risk_analysis/analyze_batch.go:364"
+  click p2 "../pystreams/src/pystreams/cmd/presidio_load.py#L85" "pystreams/src/pystreams/cmd/presidio_load.py:85"
+  p3[/"📤 server/internal/background/activities/risk_analysis/analyze_batch.go"/]:::go
+  p3 --> t_gram_risk_v1_presidio_analysis
+  click p3 "../server/internal/background/activities/risk_analysis/analyze_batch.go#L364" "server/internal/background/activities/risk_analysis/analyze_batch.go:364"
   t_gram_ping_v1_message --> s_gram_ping_v1_processor
   s_gram_ping_v1_processor -. dead-letter .-> t_gram_ping_v1_processor_dlq
   t_gram_ping_v1_message --> s_gram_ping_v1_py_processor
   s_gram_ping_v1_py_processor -. dead-letter .-> t_gram_ping_v1_py_processor_dlq
   t_gram_risk_v1_presidio_analysis --> s_gram_risk_v1_presidio_analyzer
   t_gram_risk_v1_presidio_request --> s_gram_risk_v1_presidio_scanner
-  c3[\"📥 server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
-  s_gram_ping_v1_processor --> c3
-  click c3 "../server/cmd/gram/streams.go#L215" "server/cmd/gram/streams.go:215"
-  c4[\"📥 pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
-  s_gram_ping_v1_py_processor --> c4
-  click c4 "../pystreams/src/pystreams/cmd/multi.py#L118" "pystreams/src/pystreams/cmd/multi.py:118"
-  c5[\"📥 pystreams/src/pystreams/cmd/multi.py<br/>PresidioHandler.handle"\]:::python
-  s_gram_risk_v1_presidio_analyzer --> c5
-  click c5 "../pystreams/src/pystreams/cmd/multi.py#L123" "pystreams/src/pystreams/cmd/multi.py:123"
+  c4[\"📥 server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
+  s_gram_ping_v1_processor --> c4
+  click c4 "../server/cmd/gram/streams.go#L215" "server/cmd/gram/streams.go:215"
+  c5[\"📥 pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
+  s_gram_ping_v1_py_processor --> c5
+  click c5 "../pystreams/src/pystreams/cmd/multi.py#L164" "pystreams/src/pystreams/cmd/multi.py:164"
+  c6[\"📥 pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
+  s_gram_risk_v1_presidio_analyzer --> c6
+  click c6 "../pystreams/src/pystreams/cmd/multi.py#L169" "pystreams/src/pystreams/cmd/multi.py:169"
 
   class t_gram_risk_v1_presidio_request,s_gram_risk_v1_presidio_scanner deprecated;
 ```
 
 ## Topics
 
-| Topic                                                                                      | Kind               | Retention | Published by                                                                                                                                               |
-| ------------------------------------------------------------------------------------------ | ------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`gram-ping-v1-message`](../infra/proto/gram/ping/v1/ping.proto#L10)                       | topic              | 1d        | [`server/internal/ping/publisher.go:36`](../server/internal/ping/publisher.go#L36)                                                                         |
-| [`gram-ping-v1-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto#L9)             | DLQ                | —         | —                                                                                                                                                          |
-| [`gram-ping-v1-py-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto#L23)         | DLQ                | —         | —                                                                                                                                                          |
-| [`gram-risk-v1-finding`](../infra/proto/gram/risk/v1/finding.proto#L13)                    | topic              | 7d        | [`pystreams/src/pystreams/risk/handler.py:217`](../pystreams/src/pystreams/risk/handler.py#L217)                                                           |
-| [`gram-risk-v1-presidio-analysis`](../infra/proto/gram/risk/v1/presidio_analysis.proto#L9) | topic              | 7d        | [`server/internal/background/activities/risk_analysis/analyze_batch.go:364`](../server/internal/background/activities/risk_analysis/analyze_batch.go#L364) |
-| [`gram-risk-v1-presidio-request`](../infra/proto/gram/risk/v1/presidio_request.proto#L10)  | topic (deprecated) | 7d        | —                                                                                                                                                          |
+| Topic                                                                                      | Kind               | Retention | Published by                                                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------------ | ------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`gram-ping-v1-message`](../infra/proto/gram/ping/v1/ping.proto#L10)                       | topic              | 1d        | [`server/internal/ping/publisher.go:36`](../server/internal/ping/publisher.go#L36)                                                                                                                                                                                      |
+| [`gram-ping-v1-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto#L9)             | DLQ                | —         | —                                                                                                                                                                                                                                                                       |
+| [`gram-ping-v1-py-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto#L23)         | DLQ                | —         | —                                                                                                                                                                                                                                                                       |
+| [`gram-risk-v1-finding`](../infra/proto/gram/risk/v1/finding.proto#L13)                    | topic              | 7d        | [`pystreams/src/pystreams/risk/handler.py:166`](../pystreams/src/pystreams/risk/handler.py#L166)                                                                                                                                                                        |
+| [`gram-risk-v1-presidio-analysis`](../infra/proto/gram/risk/v1/presidio_analysis.proto#L9) | topic              | 7d        | [`pystreams/src/pystreams/cmd/presidio_load.py:85`](../pystreams/src/pystreams/cmd/presidio_load.py#L85)<br/>[`server/internal/background/activities/risk_analysis/analyze_batch.go:364`](../server/internal/background/activities/risk_analysis/analyze_batch.go#L364) |
+| [`gram-risk-v1-presidio-request`](../infra/proto/gram/risk/v1/presidio_request.proto#L10)  | topic (deprecated) | 7d        | —                                                                                                                                                                                                                                                                       |
 
 ## Subscriptions
 
 | Subscription                                                                                             | Topic                            | Ack | DLQ                             | Consumed by                                                                                |
 | -------------------------------------------------------------------------------------------------------- | -------------------------------- | --- | ------------------------------- | ------------------------------------------------------------------------------------------ |
 | [`gram-ping-v1-processor`](../infra/proto/gram/ping/v1/processor.proto#L9)                               | `gram-ping-v1-message`           | 30s | `gram-ping-v1-processor-dlq`    | [`server/cmd/gram/streams.go:215`](../server/cmd/gram/streams.go#L215)                     |
-| [`gram-ping-v1-py-processor`](../infra/proto/gram/ping/v1/processor.proto#L23)                           | `gram-ping-v1-message`           | 30s | `gram-ping-v1-py-processor-dlq` | [`pystreams/src/pystreams/cmd/multi.py:118`](../pystreams/src/pystreams/cmd/multi.py#L118) |
-| [`gram-risk-v1-presidio-analyzer`](../infra/proto/gram/risk/v1/presidio_analyzer.proto#L9)               | `gram-risk-v1-presidio-analysis` | 1m  | —                               | [`pystreams/src/pystreams/cmd/multi.py:123`](../pystreams/src/pystreams/cmd/multi.py#L123) |
+| [`gram-ping-v1-py-processor`](../infra/proto/gram/ping/v1/processor.proto#L23)                           | `gram-ping-v1-message`           | 30s | `gram-ping-v1-py-processor-dlq` | [`pystreams/src/pystreams/cmd/multi.py:164`](../pystreams/src/pystreams/cmd/multi.py#L164) |
+| [`gram-risk-v1-presidio-analyzer`](../infra/proto/gram/risk/v1/presidio_analyzer.proto#L9)               | `gram-risk-v1-presidio-analysis` | 1m  | —                               | [`pystreams/src/pystreams/cmd/multi.py:169`](../pystreams/src/pystreams/cmd/multi.py#L169) |
 | [`gram-risk-v1-presidio-scanner`](../infra/proto/gram/risk/v1/presidio_scanner.proto#L10) _(deprecated)_ | `gram-risk-v1-presidio-request`  | 1m  | —                               | —                                                                                          |

--- a/docs/pubsub-topology.md
+++ b/docs/pubsub-topology.md
@@ -30,36 +30,34 @@ flowchart LR
   p0 --> t_gram_ping_v1_message
   p1[/"📤<br/>pystreams/src/pystreams/risk/handler.py"/]:::python
   p1 --> t_gram_risk_v1_finding
-  p2[/"📤<br/>pystreams/src/pystreams/cmd/presidio_load.py"/]:::python
+  p2[/"📤<br/>server/internal/background/activities/risk_analysis/analyze_batch.go"/]:::go
   p2 --> t_gram_risk_v1_presidio_analysis
-  p3[/"📤<br/>server/internal/background/activities/risk_analysis/analyze_batch.go"/]:::go
-  p3 --> t_gram_risk_v1_presidio_analysis
   t_gram_ping_v1_message --> s_gram_ping_v1_processor
   s_gram_ping_v1_processor -. dead-letter .-> t_gram_ping_v1_processor_dlq
   t_gram_ping_v1_message --> s_gram_ping_v1_py_processor
   s_gram_ping_v1_py_processor -. dead-letter .-> t_gram_ping_v1_py_processor_dlq
   t_gram_risk_v1_presidio_analysis --> s_gram_risk_v1_presidio_analyzer
   t_gram_risk_v1_presidio_request --> s_gram_risk_v1_presidio_scanner
-  c4[\"📥<br/>server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
-  s_gram_ping_v1_processor --> c4
-  c5[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
-  s_gram_ping_v1_py_processor --> c5
-  c6[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
-  s_gram_risk_v1_presidio_analyzer --> c6
+  c3[\"📥<br/>server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
+  s_gram_ping_v1_processor --> c3
+  c4[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
+  s_gram_ping_v1_py_processor --> c4
+  c5[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
+  s_gram_risk_v1_presidio_analyzer --> c5
 
   class t_gram_risk_v1_presidio_request,s_gram_risk_v1_presidio_scanner deprecated;
 ```
 
 ## Topics
 
-| Topic                                                                                   | Kind               | Retention | Published by                                                                                                                                                                                                                                            |
-| --------------------------------------------------------------------------------------- | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`gram-ping-v1-message`](../infra/proto/gram/ping/v1/ping.proto)                        | topic              | 1d        | [`server/internal/ping/publisher.go`](../server/internal/ping/publisher.go)                                                                                                                                                                             |
-| [`gram-ping-v1-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto)             | DLQ                | —         | —                                                                                                                                                                                                                                                       |
-| [`gram-ping-v1-py-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto)          | DLQ                | —         | —                                                                                                                                                                                                                                                       |
-| [`gram-risk-v1-finding`](../infra/proto/gram/risk/v1/finding.proto)                     | topic              | 7d        | [`pystreams/src/pystreams/risk/handler.py`](../pystreams/src/pystreams/risk/handler.py)                                                                                                                                                                 |
-| [`gram-risk-v1-presidio-analysis`](../infra/proto/gram/risk/v1/presidio_analysis.proto) | topic              | 7d        | [`pystreams/src/pystreams/cmd/presidio_load.py`](../pystreams/src/pystreams/cmd/presidio_load.py)<br/>[`server/internal/background/activities/risk_analysis/analyze_batch.go`](../server/internal/background/activities/risk_analysis/analyze_batch.go) |
-| [`gram-risk-v1-presidio-request`](../infra/proto/gram/risk/v1/presidio_request.proto)   | topic (deprecated) | 7d        | —                                                                                                                                                                                                                                                       |
+| Topic                                                                                   | Kind               | Retention | Published by                                                                                                                                      |
+| --------------------------------------------------------------------------------------- | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`gram-ping-v1-message`](../infra/proto/gram/ping/v1/ping.proto)                        | topic              | 1d        | [`server/internal/ping/publisher.go`](../server/internal/ping/publisher.go)                                                                       |
+| [`gram-ping-v1-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto)             | DLQ                | —         | —                                                                                                                                                 |
+| [`gram-ping-v1-py-processor-dlq`](../infra/proto/gram/ping/v1/processor.proto)          | DLQ                | —         | —                                                                                                                                                 |
+| [`gram-risk-v1-finding`](../infra/proto/gram/risk/v1/finding.proto)                     | topic              | 7d        | [`pystreams/src/pystreams/risk/handler.py`](../pystreams/src/pystreams/risk/handler.py)                                                           |
+| [`gram-risk-v1-presidio-analysis`](../infra/proto/gram/risk/v1/presidio_analysis.proto) | topic              | 7d        | [`server/internal/background/activities/risk_analysis/analyze_batch.go`](../server/internal/background/activities/risk_analysis/analyze_batch.go) |
+| [`gram-risk-v1-presidio-request`](../infra/proto/gram/risk/v1/presidio_request.proto)   | topic (deprecated) | 7d        | —                                                                                                                                                 |
 
 ## Subscriptions
 

--- a/infra/gram_infra/demos/_common.py
+++ b/infra/gram_infra/demos/_common.py
@@ -73,7 +73,7 @@ async def publish_forever(publisher: Publisher[ping_pb2.Message]) -> None:
             payload=b'{"msg":"Hello, World!"}',
         )
 
-        await publisher.publish(message)
+        await publisher.publish(message).get()
         await anyio.sleep(PUBLISH_INTERVAL_SECONDS)
 
 

--- a/infra/gram_infra/pubsub/__init__.py
+++ b/infra/gram_infra/pubsub/__init__.py
@@ -5,8 +5,9 @@ topic and subscription names from protobuf message options, mirroring the Go
 layer in ``infra/pkg/gcp/``. Two brokers cover production (``PubSubBroker``) and
 local development/testing against the emulator (``EmulatedPubSubBroker``).
 
-``Publisher.publish`` is a coroutine that returns the published message id, so
-it must be awaited from inside an async function::
+``Publisher.publish`` returns immediately with a ``PublishResult`` future
+(mirroring the Go layer); await its ``get()`` for the published message id, or
+fan out many publishes and collect them afterwards::
 
     from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
     from gram_infra.pubsub import EmulatedPubSubBroker, pubsub_publisher_for_message
@@ -17,7 +18,7 @@ it must be awaited from inside an async function::
             "my-project-id", PublisherClient(), SubscriberClient()
         ) as broker:
             publisher = pubsub_publisher_for_message(broker, ping_pb2.Message)
-            await publisher.publish(ping_pb2.Message(id="1"))
+            await publisher.publish(ping_pb2.Message(id="1")).get()
 """
 
 from .broker import (
@@ -38,6 +39,7 @@ from .discover import (
 )
 from .publisher import (
     Publisher,
+    PublishResult,
     pubsub_publisher_for_message,
     pubsub_publisher_for_message_async,
 )
@@ -55,6 +57,7 @@ __all__ = [
     "MessageCallback",
     "MessageMetadata",
     "PubSubBroker",
+    "PublishResult",
     "Publisher",
     "PublisherBroker",
     "PublisherHandle",

--- a/infra/gram_infra/pubsub/publisher.py
+++ b/infra/gram_infra/pubsub/publisher.py
@@ -119,9 +119,15 @@ class _ErrorPublishResult:
 
     def __init__(self, exc: Exception) -> None:
         self._exc = exc
+        # Capture the traceback at construction so ``get`` can re-raise with the
+        # original origin every time. ``raise self._exc`` already preserves the
+        # origin, but it *mutates* the exception's ``__traceback__`` on each raise,
+        # so a result awaited more than once would accumulate frames. Resetting to
+        # the captured traceback keeps every await's traceback identical.
+        self._tb = exc.__traceback__
 
     async def get(self) -> str:
-        raise self._exc
+        raise self._exc.with_traceback(self._tb)
 
 
 class Publisher[M: Message]:

--- a/infra/gram_infra/pubsub/publisher.py
+++ b/infra/gram_infra/pubsub/publisher.py
@@ -8,8 +8,9 @@ name>`` — so messages are interoperable across languages.
 
 from __future__ import annotations
 
+import concurrent.futures
 import threading
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import anyio
 import anyio.from_thread
@@ -18,7 +19,12 @@ from opentelemetry import propagate
 
 from .broker import PublisherBroker, PublisherHandle
 
-__all__ = ["CONTENT_TYPE", "Publisher", "pubsub_publisher_for_message"]
+__all__ = [
+    "CONTENT_TYPE",
+    "PublishResult",
+    "Publisher",
+    "pubsub_publisher_for_message",
+]
 
 # Attribute value mirrored from publisher.go; identifies the body encoding.
 CONTENT_TYPE = "application/x-protobuf"
@@ -39,43 +45,37 @@ def _message_attributes(schema: str) -> dict[str, str]:
     return attributes
 
 
-class Publisher[M: Message]:
-    """Publishes messages of a single proto type to a fixed topic."""
+@runtime_checkable
+class PublishResult(Protocol):
+    """Future-like handle to an in-flight publish.
 
-    def __init__(self, handle: PublisherHandle, schema: str) -> None:
-        self._handle = handle
-        self._schema = schema
+    Python counterpart of the ``PublishResult`` interface in ``publisher.go``:
+    :meth:`Publisher.publish` returns one of these immediately, without waiting
+    for the broker to acknowledge the send, so a caller can fan out many
+    publishes and only then collect them. Await :meth:`get` to wait for the
+    commit and obtain the server-assigned message id (or surface the send error).
+    """
 
-    async def publish(self, message: M) -> str:
-        """Marshal and publish a message; awaits delivery and returns the message ID."""
-        # Guard against a runtime message whose type disagrees with the topic
-        # this publisher was built for: otherwise we'd emit payload bytes tagged
-        # with a mismatched ``schema`` attribute (and onto the wrong topic).
-        actual = message.DESCRIPTOR.full_name
-        if actual != self._schema:
-            raise TypeError(
-                f"message type {actual!r} does not match publisher schema "
-                f"{self._schema!r}"
-            )
+    async def get(self) -> str:
+        """Await the commit and return the message id, raising on failure."""
+        ...
 
-        data = message.SerializeToString()
-        # The client returns a ``concurrent.futures.Future`` resolved on a
-        # background commit thread. Blocking a ``to_thread`` worker on
-        # ``future.result()`` would pin one of the limited anyio thread-pool
-        # slots per in-flight publish, throttling concurrent publishers behind
-        # the pool limiter. Instead — mirroring the subscriber's scheduler
-        # bridge — hop the completion signal back to the event loop through a
-        # BlockingPortal via the future's done callback, so waiting costs no
-        # worker thread at all.
-        future = self._handle.client.publish(
-            self._handle.topic_path,
-            data,
-            **_message_attributes(self._schema),
-        )
-        # Let the broker's teardown wait for this commit before it closes the
-        # publisher's transport.
-        self._handle.inflight.add(future)
 
+class _FuturePublishResult:
+    """A :class:`PublishResult` backed by the client's ``concurrent.futures.Future``."""
+
+    def __init__(self, future: concurrent.futures.Future) -> None:
+        self._future = future
+
+    async def get(self) -> str:
+        # The client resolves the future on a background commit thread. Blocking a
+        # ``to_thread`` worker on ``future.result()`` would pin one of the limited
+        # anyio thread-pool slots per in-flight publish, throttling concurrent
+        # collectors behind the pool limiter. Instead — mirroring the subscriber's
+        # scheduler bridge — hop the completion signal back to the event loop
+        # through a BlockingPortal via the future's done callback, so waiting costs
+        # no worker thread at all.
+        future = self._future
         done = anyio.Event()
         loop_thread = threading.get_ident()
 
@@ -96,9 +96,9 @@ class Publisher[M: Message]:
                     # at loop latency apiece.
                     portal.start_task_soon(done.set)
                 except BaseException:
-                    # The portal is gone: the publish was cancelled or the loop
-                    # is tearing down, so no waiter remains. The send itself
-                    # still proceeds on the commit thread.
+                    # The portal is gone: the get was cancelled or the loop is
+                    # tearing down, so no waiter remains. The send itself still
+                    # proceeds on the commit thread.
                     pass
 
             future.add_done_callback(_on_done)
@@ -106,6 +106,67 @@ class Publisher[M: Message]:
 
         # Resolved by now; raises the publish error if the send failed.
         return future.result()
+
+
+class _ErrorPublishResult:
+    """A :class:`PublishResult` that fails on :meth:`get`.
+
+    Mirrors Go's ``errPublishResult``: when ``publish`` cannot even hand the
+    message to the client (e.g. it fails to serialize), the error is deferred to
+    ``get`` so the call site is uniform — every publish returns a result and
+    surfaces failure the same way.
+    """
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def get(self) -> str:
+        raise self._exc
+
+
+class Publisher[M: Message]:
+    """Publishes messages of a single proto type to a fixed topic."""
+
+    def __init__(self, handle: PublisherHandle, schema: str) -> None:
+        self._handle = handle
+        self._schema = schema
+
+    def publish(self, message: M) -> PublishResult:
+        """Hand a message to the client and return a future for its commit.
+
+        Returns immediately with a :class:`PublishResult`; the send commits on
+        the client's background batcher. Await the result's :meth:`~PublishResult.get`
+        to wait for delivery and read the message id. Mirrors ``Publish`` in
+        ``publisher.go``, which likewise returns a future rather than blocking.
+        """
+        # Guard against a runtime message whose type disagrees with the topic
+        # this publisher was built for: otherwise we'd emit payload bytes tagged
+        # with a mismatched ``schema`` attribute (and onto the wrong topic). This
+        # is a programming error, so raise rather than defer it to ``get``.
+        actual = message.DESCRIPTOR.full_name
+        if actual != self._schema:
+            raise TypeError(
+                f"message type {actual!r} does not match publisher schema "
+                f"{self._schema!r}"
+            )
+
+        try:
+            data = message.SerializeToString()
+        except Exception as exc:
+            # Defer the failure to ``get`` (mirrors Go's errPublishResult) so the
+            # call site treats every publish uniformly.
+            return _ErrorPublishResult(exc)
+
+        future = self._handle.client.publish(
+            self._handle.topic_path,
+            data,
+            **_message_attributes(self._schema),
+        )
+        # Let the broker's teardown wait for this commit before it closes the
+        # publisher's transport — even if the caller never awaits the result.
+        self._handle.inflight.add(future)
+
+        return _FuturePublishResult(future)
 
 
 def pubsub_publisher_for_message[M: Message](

--- a/infra/gram_infra/pubsub/subscriber.py
+++ b/infra/gram_infra/pubsub/subscriber.py
@@ -193,44 +193,48 @@ class _PortalScheduler(Scheduler):
         Fire-and-forget: ``start_task_soon`` does not park the library's single
         dispatch thread on an event-loop round trip per message (``portal.call``
         would serialize intake at one loop-latency apiece while the library holds
-        its pause/resume lock). ``start_task_soon`` is also the lightest hop the
-        backend-agnostic portal API offers — there is no cheaper "run this sync
-        callable on the loop thread" primitive that works under both asyncio and
-        trio, so the returned future is simply discarded.
-
-        ``_enqueue`` is the sole nack authority once a message is on the loop: it
-        nacks if intake is closed or the send fails, so no per-message completion
-        callback is needed here. The only disposition ``_enqueue`` can never reach
-        is the one handled below — ``start_task_soon`` itself failing because the
-        portal is gone or being cancelled during teardown — which is nacked
-        directly. (A message whose ``_enqueue`` is scheduled but cancelled before
-        it runs, the exact-instant Ctrl-C race, is recovered by Pub/Sub's
-        ack-deadline redelivery rather than tracked per message.)
+        its pause/resume lock). If the enqueue cannot run — the portal is gone or
+        the task is cancelled during teardown — the message is nacked so the
+        broker redelivers it immediately rather than leaving it leased until its
+        ack deadline lapses.
         """
         message = args[0] if args else None
         if message is None:
             return
         try:
-            self._portal.start_task_soon(self._enqueue, message)
+            future = self._portal.start_task_soon(self._enqueue, message)
         except BaseException:
-            # The portal is already stopped (RuntimeError) or going away
-            # (CancelledError). Nack so the broker redelivers; raising here would
-            # only crash the library's background dispatch thread.
+            # The portal is already stopped (RuntimeError) or going away. Nack so
+            # the broker redelivers; raising here would only crash the library's
+            # background dispatch thread.
             message.nack()
+            return
+
+        def _nack_on_failure(f) -> None:
+            # ``_enqueue`` nacks the cases it can reach (closed/broken stream); this
+            # covers the one it can't — the scheduled task being cancelled before it
+            # ever runs during a teardown race — so that message is redelivered
+            # immediately too rather than waiting out its ack deadline.
+            try:
+                failed = f.cancelled() or f.exception() is not None
+            except BaseException:
+                failed = True
+            if failed:
+                message.nack()
+
+        future.add_done_callback(_nack_on_failure)
 
     def _enqueue(self, message) -> None:
         # Runs on the event loop via the portal. Checkpoint-free, so the
         # closed-check and the send are atomic with respect to ``close()`` — no
         # TOCTOU window in which a message lands on a stream that teardown has
-        # already drained. As the sole nack authority for a delivered message, it
-        # nacks on *any* send failure (a teardown race closing the stream, or
-        # anything unexpected) so the message is never left neither sent nor nacked.
+        # already drained.
         if self._closed:
             message.nack()
             return
         try:
             self._send.send_nowait(message)  # unbounded buffer: never blocks
-        except Exception:
+        except anyio.ClosedResourceError, anyio.BrokenResourceError:
             message.nack()
 
     def track_handler(self) -> None:

--- a/infra/gram_infra/pubsub/subscriber.py
+++ b/infra/gram_infra/pubsub/subscriber.py
@@ -193,43 +193,44 @@ class _PortalScheduler(Scheduler):
         Fire-and-forget: ``start_task_soon`` does not park the library's single
         dispatch thread on an event-loop round trip per message (``portal.call``
         would serialize intake at one loop-latency apiece while the library holds
-        its pause/resume lock). If the enqueue cannot run — the portal is gone or
-        the task is cancelled during teardown — the message is nacked so the
-        broker redelivers it rather than dropping it.
+        its pause/resume lock). ``start_task_soon`` is also the lightest hop the
+        backend-agnostic portal API offers — there is no cheaper "run this sync
+        callable on the loop thread" primitive that works under both asyncio and
+        trio, so the returned future is simply discarded.
+
+        ``_enqueue`` is the sole nack authority once a message is on the loop: it
+        nacks if intake is closed or the send fails, so no per-message completion
+        callback is needed here. The only disposition ``_enqueue`` can never reach
+        is the one handled below — ``start_task_soon`` itself failing because the
+        portal is gone or being cancelled during teardown — which is nacked
+        directly. (A message whose ``_enqueue`` is scheduled but cancelled before
+        it runs, the exact-instant Ctrl-C race, is recovered by Pub/Sub's
+        ack-deadline redelivery rather than tracked per message.)
         """
         message = args[0] if args else None
         if message is None:
             return
         try:
-            future = self._portal.start_task_soon(self._enqueue, message)
+            self._portal.start_task_soon(self._enqueue, message)
         except BaseException:
-            # The portal is already stopped (RuntimeError) or going away. Nack so
-            # the broker redelivers; raising here would only crash the library's
-            # background dispatch thread.
+            # The portal is already stopped (RuntimeError) or going away
+            # (CancelledError). Nack so the broker redelivers; raising here would
+            # only crash the library's background dispatch thread.
             message.nack()
-            return
-
-        def _nack_on_failure(f) -> None:
-            try:
-                failed = f.cancelled() or f.exception() is not None
-            except BaseException:
-                failed = True
-            if failed:
-                message.nack()
-
-        future.add_done_callback(_nack_on_failure)
 
     def _enqueue(self, message) -> None:
         # Runs on the event loop via the portal. Checkpoint-free, so the
         # closed-check and the send are atomic with respect to ``close()`` — no
         # TOCTOU window in which a message lands on a stream that teardown has
-        # already drained.
+        # already drained. As the sole nack authority for a delivered message, it
+        # nacks on *any* send failure (a teardown race closing the stream, or
+        # anything unexpected) so the message is never left neither sent nor nacked.
         if self._closed:
             message.nack()
             return
         try:
             self._send.send_nowait(message)  # unbounded buffer: never blocks
-        except anyio.ClosedResourceError, anyio.BrokenResourceError:
+        except Exception:
             message.nack()
 
     def track_handler(self) -> None:

--- a/infra/internal/diagram/diagram.go
+++ b/infra/internal/diagram/diagram.go
@@ -70,13 +70,20 @@ type scanConstraint struct {
 	regex   string
 }
 
-// testExclusionGlobs prune test files at scan time (ast-grep already honors
+// scanExclusionGlobs prune files at scan time (ast-grep already honors
 // .gitignore by default, so generated/ignored files never reach us).
-var testExclusionGlobs = []string{
+//
+// Beyond test files, this also drops the emulator-only load generator
+// (cmd/presidio_load.py): it constructs a PresidioAnalysis purely to publish
+// synthetic traffic at the local emulator for profiling, so treating it as a
+// production publisher of gram-risk-v1-presidio-analysis would misrepresent the
+// committed topology.
+var scanExclusionGlobs = []string{
 	"!**/*_test.go",
 	"!**/*_test.py",
 	"!**/test_*.py",
 	"!**/tests/**",
+	"!**/cmd/presidio_load.py",
 }
 
 // subscribeScans are static: subscriptions are registered at a single, specific
@@ -399,7 +406,7 @@ func runASTGrepRules(ctx context.Context, repoRoot, lang string, scans []scan) (
 	sort.Strings(dirs)
 
 	args := []string{"scan", "--inline-rules", strings.Join(rules, "---\n"), "--json=compact"}
-	for _, g := range testExclusionGlobs {
+	for _, g := range scanExclusionGlobs {
 		args = append(args, "--globs", g)
 	}
 	args = append(args, dirs...)

--- a/infra/internal/diagram/diagram.go
+++ b/infra/internal/diagram/diagram.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -591,16 +590,16 @@ func shortHandler(expr string) string {
 
 // --- proto declaration locations ---------------------------------------------
 
-// protoLoc is where a proto message is declared: a repo-relative file path and a
-// 1-based line (0 when source info is unavailable).
+// protoLoc is where a proto message is declared: a repo-relative file path. Line
+// numbers are deliberately omitted — they shift on every unrelated proto edit and
+// churn the committed diagram.
 type protoLoc struct {
 	file string
-	line int
 }
 
-// protoLocations maps each proto message's full name to its declaration site by
-// walking the descriptor set's source-code info. It is how topic/subscription
-// marker messages are linked back to the `.proto` files they are declared in.
+// protoLocations maps each proto message's full name to the `.proto` file it is
+// declared in. It is how topic/subscription marker messages are linked back to
+// their source.
 func protoLocations(descriptors []byte) (map[string]protoLoc, error) {
 	var fds descriptorpb.FileDescriptorSet
 	if err := proto.Unmarshal(descriptors, &fds); err != nil {
@@ -610,40 +609,20 @@ func protoLocations(descriptors []byte) (map[string]protoLoc, error) {
 	out := map[string]protoLoc{}
 	for _, fd := range fds.GetFile() {
 		file := protoModuleRoot + fd.GetName()
-
-		// Index source spans by their descriptor path (e.g. [4, i] for the i-th
-		// top-level message); span[0] is the 0-based start line.
-		lineByPath := map[string]int{}
-		for _, loc := range fd.GetSourceCodeInfo().GetLocation() {
-			if span := loc.GetSpan(); len(span) > 0 {
-				lineByPath[pathKey(loc.GetPath())] = int(span[0]) + 1
-			}
-		}
-
-		for i, msg := range fd.GetMessageType() {
-			collectProtoLoc(fd.GetPackage(), file, []int32{4, int32(i)}, msg, lineByPath, out)
+		for _, msg := range fd.GetMessageType() {
+			collectProtoLoc(fd.GetPackage(), file, msg, out)
 		}
 	}
 	return out, nil
 }
 
-func collectProtoLoc(prefix, file string, path []int32, msg *descriptorpb.DescriptorProto, lineByPath map[string]int, out map[string]protoLoc) {
+func collectProtoLoc(prefix, file string, msg *descriptorpb.DescriptorProto, out map[string]protoLoc) {
 	full := prefix + "." + msg.GetName()
-	out[full] = protoLoc{file: file, line: lineByPath[pathKey(path)]}
+	out[full] = protoLoc{file: file}
 
-	// nested_type is field 3 of DescriptorProto.
-	for j, nested := range msg.GetNestedType() {
-		childPath := append(append([]int32{}, path...), 3, int32(j))
-		collectProtoLoc(full, file, childPath, nested, lineByPath, out)
+	for _, nested := range msg.GetNestedType() {
+		collectProtoLoc(full, file, nested, out)
 	}
-}
-
-func pathKey(path []int32) string {
-	parts := make([]string, len(path))
-	for i, p := range path {
-		parts[i] = strconv.Itoa(int(p))
-	}
-	return strings.Join(parts, ".")
 }
 
 // --- rendering ---------------------------------------------------------------
@@ -688,14 +667,14 @@ func render(topics []gcp.DesiredTopic, subs []gcp.DesiredSubscription, sites []c
 	b.WriteString("with ast-grep scans of Go (`server/`) and Python (`pystreams/`) call sites.\n")
 	b.WriteString("Run `mise run gen:infra` to regenerate.\n\n")
 
-	writeMermaid(&b, topics, subs, publishers, consumers, locs)
+	writeMermaid(&b, topics, subs, publishers, consumers)
 	writeTables(&b, topics, subs, publishers, consumers, locs)
 	writeNotes(&b, topics, subs, publishers, consumers, unresolved)
 
 	return b.String()
 }
 
-func writeMermaid(b *strings.Builder, topics []gcp.DesiredTopic, subs []gcp.DesiredSubscription, publishers, consumers map[string][]callSite, locs map[string]protoLoc) {
+func writeMermaid(b *strings.Builder, topics []gcp.DesiredTopic, subs []gcp.DesiredSubscription, publishers, consumers map[string][]callSite) {
 	b.WriteString("```mermaid\n")
 	b.WriteString("flowchart LR\n")
 	b.WriteString("  classDef topic fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a;\n")
@@ -720,7 +699,6 @@ func writeMermaid(b *strings.Builder, topics []gcp.DesiredTopic, subs []gcp.Desi
 			label += "<br/>(topic)"
 		}
 		fmt.Fprintf(b, "  %s([\"%s\"]):::%s\n", id, label, class)
-		writeProtoClick(b, id, t.ProtoMessage, locs)
 		if isDeprecated(t.Labels) {
 			deprecated = append(deprecated, id)
 		}
@@ -730,7 +708,6 @@ func writeMermaid(b *strings.Builder, topics []gcp.DesiredTopic, subs []gcp.Desi
 	for _, s := range subs {
 		id := nodeID("s_", s.Name)
 		fmt.Fprintf(b, "  %s[\"%s<br/>(sub)\"]:::sub\n", id, s.Name)
-		writeProtoClick(b, id, s.ProtoMessage, locs)
 		if isDeprecated(s.Labels) {
 			deprecated = append(deprecated, id)
 		}
@@ -743,9 +720,8 @@ func writeMermaid(b *strings.Builder, topics []gcp.DesiredTopic, subs []gcp.Desi
 		for _, site := range publishers[t.Name] {
 			pid := fmt.Sprintf("p%d", siteID)
 			siteID++
-			fmt.Fprintf(b, "  %s[/\"📤 %s\"/]:::%s\n", pid, site.file, site.lang)
+			fmt.Fprintf(b, "  %s[/\"📤<br/>%s\"/]:::%s\n", pid, site.file, site.lang)
 			fmt.Fprintf(b, "  %s --> %s\n", pid, nodeID("t_", t.Name))
-			writeClick(b, pid, site)
 		}
 	}
 
@@ -763,13 +739,12 @@ func writeMermaid(b *strings.Builder, topics []gcp.DesiredTopic, subs []gcp.Desi
 		for _, site := range consumers[s.Name] {
 			cid := fmt.Sprintf("c%d", siteID)
 			siteID++
-			label := fmt.Sprintf("📥 %s", site.file)
+			label := fmt.Sprintf("📥<br/>%s", site.file)
 			if site.handler != "" {
 				label += "<br/>" + site.handler
 			}
 			fmt.Fprintf(b, "  %s[\\\"%s\"\\]:::%s\n", cid, label, site.lang)
 			fmt.Fprintf(b, "  %s --> %s\n", nodeID("s_", s.Name), cid)
-			writeClick(b, cid, site)
 		}
 	}
 
@@ -885,29 +860,23 @@ func siteList(sites []callSite) string {
 	}
 	parts := make([]string, 0, len(sites))
 	for _, s := range sites {
-		// Markdown link with a line anchor; GitHub resolves it against the file's
-		// revision, so the line stays correct for the committed diagram.
-		label := fmt.Sprintf("[`%s:%d`](%s)", s.file, s.line, sourceLink(s))
+		// Link to the file (no line anchor): line numbers shift on every unrelated
+		// edit, churning the committed diagram for no benefit.
+		label := fmt.Sprintf("[`%s`](%s)", s.file, sourceLink(s))
 		parts = append(parts, label)
 	}
 	return strings.Join(parts, "<br/>")
 }
 
 // sourceLink builds a link from docs/pubsub-topology.md to a call site's source
-// location. The path is repo-relative, so one `../` reaches the repo root, and the
-// `#L<line>` anchor jumps to the line on GitHub.
+// file. The path is repo-relative, so one `../` reaches the repo root.
 func sourceLink(s callSite) string {
-	return "../" + s.file + "#L" + strconv.Itoa(s.line)
+	return "../" + s.file
 }
 
-// protoLink builds a link from docs/pubsub-topology.md to a proto declaration,
-// omitting the line anchor when source info was unavailable.
+// protoLink builds a link from docs/pubsub-topology.md to a proto declaration file.
 func protoLink(loc protoLoc) string {
-	link := "../" + loc.file
-	if loc.line > 0 {
-		link += "#L" + strconv.Itoa(loc.line)
-	}
-	return link
+	return "../" + loc.file
 }
 
 // protoNameCell renders a topology resource's name as a code span linking to the
@@ -918,22 +887,4 @@ func protoNameCell(name, protoMessage string, locs map[string]protoLoc) string {
 		return fmt.Sprintf("[`%s`](%s)", name, protoLink(loc))
 	}
 	return "`" + name + "`"
-}
-
-// writeProtoClick emits a mermaid click directive linking a topic/subscription
-// node to its proto declaration in renderers that honor click handlers.
-func writeProtoClick(b *strings.Builder, nodeID, protoMessage string, locs map[string]protoLoc) {
-	loc, ok := locs[protoMessage]
-	if !ok {
-		return
-	}
-	fmt.Fprintf(b, "  click %s \"%s\" \"%s\"\n", nodeID, protoLink(loc), loc.file)
-}
-
-// writeClick emits a mermaid click directive so the node opens its source location
-// in renderers that honor click handlers (mermaid.live, many IDE preview
-// extensions). GitHub strips these for security; the linked table entries are the
-// fallback there.
-func writeClick(b *strings.Builder, nodeID string, s callSite) {
-	fmt.Fprintf(b, "  click %s \"%s\" \"%s:%d\"\n", nodeID, sourceLink(s), s.file, s.line)
 }

--- a/infra/tests/test_backends.py
+++ b/infra/tests/test_backends.py
@@ -238,7 +238,7 @@ def test_publish_awaits_future_on_backend(backend) -> None:
     )
 
     async def scenario() -> Any:
-        return await publisher.publish(ping_pb2.Message(id="x", type="t"))
+        return await publisher.publish(ping_pb2.Message(id="x", type="t")).get()
 
     result = anyio.run(scenario, backend=backend)
 
@@ -268,7 +268,7 @@ def test_publish_handles_already_resolved_future(backend) -> None:
     )
 
     async def scenario() -> Any:
-        return await publisher.publish(ping_pb2.Message(id="x", type="t"))
+        return await publisher.publish(ping_pb2.Message(id="x", type="t")).get()
 
     assert anyio.run(scenario, backend=backend) == "immediate-msg-id"
 
@@ -291,7 +291,7 @@ def test_publish_raises_publish_error(backend) -> None:
     )
 
     async def scenario() -> Any:
-        return await publisher.publish(ping_pb2.Message(id="x", type="t"))
+        return await publisher.publish(ping_pb2.Message(id="x", type="t")).get()
 
     with pytest.raises(RuntimeError, match="send failed"):
         anyio.run(scenario, backend=backend)
@@ -481,7 +481,7 @@ def test_publish_registers_future_with_broker_drain() -> None:
     publisher = Publisher(handle, TOPIC_PROTO)
 
     async def scenario() -> None:
-        await publisher.publish(ping_pb2.Message(id="x", type="t"))
+        await publisher.publish(ping_pb2.Message(id="x", type="t")).get()
 
     anyio.run(scenario)
 

--- a/infra/tests/test_integration.py
+++ b/infra/tests/test_integration.py
@@ -87,7 +87,7 @@ async def test_publish_subscribe_roundtrip() -> None:
         await asyncio.wait_for(
             publisher.publish(
                 ping_pb2.Message(id=unique_id, type="it", payload=payload)
-            ),
+            ).get(),
             timeout=30,
         )
         await asyncio.wait_for(done.wait(), timeout=30)

--- a/pystreams/pyproject.toml
+++ b/pystreams/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
 
 [project.scripts]
 multi = "pystreams.cmd.multi:cli"
+presidio-load = "pystreams.cmd.presidio_load:cli"
 
 [build-system]
 requires = ["uv_build>=0.11.21,<0.12"]

--- a/pystreams/src/pystreams/cmd/flags_presidio.py
+++ b/pystreams/src/pystreams/cmd/flags_presidio.py
@@ -19,13 +19,13 @@ def presidio_options() -> Sequence[click.Option]:
         click.Option(
             ["--scan-workers"],
             type=int,
-            default=0,
+            default=2,
             envvar="GRAM_PYSTREAMS_SCAN_WORKERS",
             help=(
                 "Run Presidio scans in a pool of this many worker processes, each "
                 "with its own GIL, to break the single-process throughput ceiling. "
-                "0 (default) scans in-process on threads. Each worker loads its own "
-                "spaCy model, so keep this small (2-4)."
+                "Defaults to 2; 0 scans in-process on threads instead. Each worker "
+                "loads its own spaCy model, so keep this small (2-4)."
             ),
         ),
         click.Option(

--- a/pystreams/src/pystreams/cmd/flags_presidio.py
+++ b/pystreams/src/pystreams/cmd/flags_presidio.py
@@ -28,4 +28,26 @@ def presidio_options() -> Sequence[click.Option]:
                 "spaCy model, so keep this small (2-4)."
             ),
         ),
+        click.Option(
+            ["--scan-max-tasks-per-child"],
+            type=int,
+            default=1000,
+            envvar="GRAM_PYSTREAMS_SCAN_MAX_TASKS_PER_CHILD",
+            help=(
+                "Recycle a scan-pool worker after this many scans to bound memory "
+                "drift (like gunicorn --max-requests). <=0 disables recycling. "
+                "Only applies when --scan-workers > 0."
+            ),
+        ),
+        click.Option(
+            ["--scan-timeout"],
+            type=float,
+            default=30.0,
+            envvar="GRAM_PYSTREAMS_SCAN_TIMEOUT",
+            help=(
+                "Seconds a single scan may run before it is treated as a failure "
+                "(like gunicorn --timeout). <=0 disables the bound. Only applies "
+                "when --scan-workers > 0."
+            ),
+        ),
     ]

--- a/pystreams/src/pystreams/cmd/flags_presidio.py
+++ b/pystreams/src/pystreams/cmd/flags_presidio.py
@@ -11,8 +11,21 @@ def presidio_options() -> Sequence[click.Option]:
             default=None,
             envvar="GRAM_PYSTREAMS_SCAN_CONCURRENCY",
             help=(
-                "Cap on concurrent Presidio scans (GIL-bound CPU work). Unset "
-                "uses the handler default; <=0 disables the cap."
+                "Cap on concurrent Presidio scans (GIL-bound CPU work) for the "
+                "in-process scanner. Unset uses the handler default; <=0 disables "
+                "the cap. Ignored when --scan-workers > 0."
+            ),
+        ),
+        click.Option(
+            ["--scan-workers"],
+            type=int,
+            default=0,
+            envvar="GRAM_PYSTREAMS_SCAN_WORKERS",
+            help=(
+                "Run Presidio scans in a pool of this many worker processes, each "
+                "with its own GIL, to break the single-process throughput ceiling. "
+                "0 (default) scans in-process on threads. Each worker loads its own "
+                "spaCy model, so keep this small (2-4)."
             ),
         ),
     ]

--- a/pystreams/src/pystreams/cmd/flags_presidio.py
+++ b/pystreams/src/pystreams/cmd/flags_presidio.py
@@ -1,0 +1,18 @@
+from collections.abc import Sequence
+
+import click
+
+
+def presidio_options() -> Sequence[click.Option]:
+    return [
+        click.Option(
+            ["--max-scan-concurrency"],
+            type=int,
+            default=None,
+            envvar="GRAM_PYSTREAMS_SCAN_CONCURRENCY",
+            help=(
+                "Cap on concurrent Presidio scans (GIL-bound CPU work). Unset "
+                "uses the handler default; <=0 disables the cap."
+            ),
+        ),
+    ]

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -23,7 +23,7 @@ from pystreams.health import HealthState, serve_control
 from pystreams.ping.handler import PingHandler
 from pystreams.risk.handler import PresidioHandler, build_default_analyzer
 
-from . import flags_control, flags_gcp, flags_service
+from . import flags_control, flags_gcp, flags_presidio, flags_service
 from .receiver import ReceiverGroup
 
 
@@ -33,6 +33,7 @@ from .receiver import ReceiverGroup
         *flags_service.service_options(),
         *flags_control.server_options(),
         *flags_gcp.pubsub_options(),
+        *flags_presidio.presidio_options(),
     ],
 )
 def cli(**kwargs):
@@ -52,6 +53,8 @@ async def multi(
     # Control server options
     control_host: str,
     control_port: int,
+    # Presidio options
+    max_scan_concurrency: int | None,
 ):
     logging.configure_logging(
         pretty_log=pretty_log,
@@ -94,6 +97,14 @@ async def multi(
             broker, finding_pb2.Finding
         )
         presidio_analyzer = await build_default_analyzer()
+        # Concurrent Presidio scans are GIL-bound, so the handler caps them at a
+        # low default. --max-scan-concurrency overrides it (<=0 disables the cap);
+        # unset (None) leaves the handler default in place.
+        scan_kwargs = (
+            {"max_scan_concurrency": max_scan_concurrency}
+            if max_scan_concurrency is not None
+            else {}
+        )
 
         async with anyio.create_task_group() as tg:
             tg.start_soon(_shutdown_on_signal, tg.cancel_scope, health_state, logger)
@@ -123,7 +134,12 @@ async def multi(
             await receivers.receive(
                 presidio_analysis_pb2.PresidioAnalysis,
                 presidio_analyzer_pb2.PresidioAnalyzer,
-                PresidioHandler(logger, findings_publisher, presidio_analyzer).handle,
+                PresidioHandler(
+                    logger,
+                    findings_publisher,
+                    presidio_analyzer,
+                    **scan_kwargs,
+                ).handle,
             )
 
             health_state.set_ready()

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -21,7 +21,13 @@ from pystreams.deps.blocking import activate_blocking_detection
 from pystreams.deps.loop_lag import monitor_event_loop_lag
 from pystreams.health import HealthState, serve_control
 from pystreams.ping.handler import PingHandler
-from pystreams.risk.handler import PresidioHandler, build_default_analyzer
+from pystreams.risk.handler import PresidioHandler
+from pystreams.risk.scanner import (
+    ProcessPoolScanner,
+    Scanner,
+    ThreadScanner,
+    build_default_analyzer,
+)
 
 from . import flags_control, flags_gcp, flags_presidio, flags_service
 from .receiver import ReceiverGroup
@@ -55,6 +61,7 @@ async def multi(
     control_port: int,
     # Presidio options
     max_scan_concurrency: int | None,
+    scan_workers: int,
 ):
     logging.configure_logging(
         pretty_log=pretty_log,
@@ -96,53 +103,69 @@ async def multi(
         findings_publisher = await pubsub_publisher_for_message_async(
             broker, finding_pb2.Finding
         )
-        presidio_analyzer = await build_default_analyzer()
-        # Concurrent Presidio scans are GIL-bound, so the handler caps them at a
-        # low default. --max-scan-concurrency overrides it (<=0 disables the cap);
-        # unset (None) leaves the handler default in place.
-        scan_kwargs = (
-            {"max_scan_concurrency": max_scan_concurrency}
-            if max_scan_concurrency is not None
-            else {}
-        )
 
-        async with anyio.create_task_group() as tg:
-            tg.start_soon(_shutdown_on_signal, tg.cancel_scope, health_state, logger)
-            tg.start_soon(monitor_event_loop_lag)
-            # Start the health server first (and wait until it is bound) so the
-            # liveness probe answers as early as possible, then begin consuming
-            # and only then report ready.
-            await tg.start(
-                partial(
-                    serve_control,
-                    health_state,
-                    host=control_host,
-                    port=control_port,
-                    logger=logger,
+        # Choose the scan strategy. With --scan-workers > 0 the scan runs in a pool
+        # of worker processes (each with its own GIL), breaking the single-process
+        # throughput ceiling inside one pod; otherwise it runs in-process on threads
+        # capped by --max-scan-concurrency. The pool owns its own per-worker spaCy
+        # models, so the in-process analyzer is only built for the threaded path.
+        presidio_scanner: Scanner
+        if scan_workers > 0:
+            logger.info("starting presidio scan pool", workers=scan_workers)
+            presidio_scanner = await ProcessPoolScanner.create(max_workers=scan_workers)
+        else:
+            analyzer = await build_default_analyzer()
+            # Concurrent Presidio scans are GIL-bound, so the scanner caps them at a
+            # low default. --max-scan-concurrency overrides it (<=0 disables the
+            # cap); unset (None) leaves the scanner default in place.
+            concurrency_kwargs = (
+                {"max_concurrency": max_scan_concurrency}
+                if max_scan_concurrency is not None
+                else {}
+            )
+            presidio_scanner = ThreadScanner(analyzer, **concurrency_kwargs)
+
+        presidio_handler = PresidioHandler(logger, findings_publisher, presidio_scanner)
+
+        try:
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(
+                    _shutdown_on_signal, tg.cancel_scope, health_state, logger
                 )
-            )
+                tg.start_soon(monitor_event_loop_lag)
+                # Start the health server first (and wait until it is bound) so the
+                # liveness probe answers as early as possible, then begin consuming
+                # and only then report ready.
+                await tg.start(
+                    partial(
+                        serve_control,
+                        health_state,
+                        host=control_host,
+                        port=control_port,
+                        logger=logger,
+                    )
+                )
 
-            receivers = ReceiverGroup(task_group=tg, broker=broker, logger=logger)
+                receivers = ReceiverGroup(task_group=tg, broker=broker, logger=logger)
 
-            # Register subscription receivers here. Each call resolves a
-            # subscriber and starts consuming with per-message tracing.
-            await receivers.receive(
-                ping_pb2.Message,
-                processor_pb2.PyProcessor,
-                PingHandler(logger, ping_log_level).handle,
-            )
-            await receivers.receive(
-                presidio_analysis_pb2.PresidioAnalysis,
-                presidio_analyzer_pb2.PresidioAnalyzer,
-                PresidioHandler(
-                    logger,
-                    findings_publisher,
-                    presidio_analyzer,
-                    **scan_kwargs,
-                ).handle,
-            )
+                # Register subscription receivers here. Each call resolves a
+                # subscriber and starts consuming with per-message tracing.
+                await receivers.receive(
+                    ping_pb2.Message,
+                    processor_pb2.PyProcessor,
+                    PingHandler(logger, ping_log_level).handle,
+                )
+                await receivers.receive(
+                    presidio_analysis_pb2.PresidioAnalysis,
+                    presidio_analyzer_pb2.PresidioAnalyzer,
+                    presidio_handler.handle,
+                )
 
-            health_state.set_ready()
+                health_state.set_ready()
+        finally:
+            # Release the scanner: drains in-flight scans and reaps the worker
+            # processes for the pool scanner; a no-op for the in-process one.
+            await presidio_scanner.aclose()
 
 
 def _build_broker(

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -19,15 +19,10 @@ from pystreams import attr
 from pystreams.deps import logging
 from pystreams.deps.blocking import activate_blocking_detection
 from pystreams.deps.loop_lag import monitor_event_loop_lag
+from pystreams.deps.scanner import build_presidio_scanner
 from pystreams.health import HealthState, serve_control
 from pystreams.ping.handler import PingHandler
 from pystreams.risk.handler import PresidioHandler
-from pystreams.risk.scanner import (
-    ProcessPoolScanner,
-    Scanner,
-    ThreadScanner,
-    build_default_analyzer,
-)
 
 from . import flags_control, flags_gcp, flags_presidio, flags_service
 from .receiver import ReceiverGroup
@@ -106,77 +101,54 @@ async def multi(
             broker, finding_pb2.Finding
         )
 
-        # Choose the scan strategy. With --scan-workers > 0 the scan runs in a pool
-        # of worker processes (each with its own GIL), breaking the single-process
-        # throughput ceiling inside one pod; otherwise it runs in-process on threads
-        # capped by --max-scan-concurrency. The pool owns its own per-worker spaCy
-        # models, so the in-process analyzer is only built for the threaded path.
-        presidio_scanner: Scanner
-        if scan_workers > 0:
-            logger.info(
-                "starting presidio scan pool",
-                workers=scan_workers,
-                max_tasks_per_child=scan_max_tasks_per_child,
-                scan_timeout=scan_timeout,
-            )
-            presidio_scanner = await ProcessPoolScanner.create(
-                max_workers=scan_workers,
-                max_tasks_per_child=scan_max_tasks_per_child,
-                scan_timeout=scan_timeout,
-            )
-        else:
-            analyzer = await build_default_analyzer()
-            # Concurrent Presidio scans are GIL-bound, so the scanner caps them at a
-            # low default. --max-scan-concurrency overrides it (<=0 disables the
-            # cap); unset (None) leaves the scanner default in place.
-            concurrency_kwargs = (
-                {"max_concurrency": max_scan_concurrency}
-                if max_scan_concurrency is not None
-                else {}
-            )
-            presidio_scanner = ThreadScanner(analyzer, **concurrency_kwargs)
+        # Build the scan strategy: a pool of worker processes (the default, with
+        # --scan-workers > 0) or the in-process thread scanner. The selection and
+        # its analyzer/concurrency wiring live in build_presidio_scanner.
+        presidio_scanner = await build_presidio_scanner(
+            scan_workers=scan_workers,
+            scan_max_tasks_per_child=scan_max_tasks_per_child,
+            scan_timeout=scan_timeout,
+            max_scan_concurrency=max_scan_concurrency,
+            logger=logger,
+        )
 
         presidio_handler = PresidioHandler(logger, findings_publisher, presidio_scanner)
 
-        try:
-            async with anyio.create_task_group() as tg:
-                tg.start_soon(
-                    _shutdown_on_signal, tg.cancel_scope, health_state, logger
+        # The scanner is an async context manager: leaving the block releases it,
+        # draining in-flight scans and reaping the worker processes for the pool
+        # scanner (a no-op for the in-process one).
+        async with presidio_scanner, anyio.create_task_group() as tg:
+            tg.start_soon(_shutdown_on_signal, tg.cancel_scope, health_state, logger)
+            tg.start_soon(monitor_event_loop_lag)
+            # Start the health server first (and wait until it is bound) so the
+            # liveness probe answers as early as possible, then begin consuming
+            # and only then report ready.
+            await tg.start(
+                partial(
+                    serve_control,
+                    health_state,
+                    host=control_host,
+                    port=control_port,
+                    logger=logger,
                 )
-                tg.start_soon(monitor_event_loop_lag)
-                # Start the health server first (and wait until it is bound) so the
-                # liveness probe answers as early as possible, then begin consuming
-                # and only then report ready.
-                await tg.start(
-                    partial(
-                        serve_control,
-                        health_state,
-                        host=control_host,
-                        port=control_port,
-                        logger=logger,
-                    )
-                )
+            )
 
-                receivers = ReceiverGroup(task_group=tg, broker=broker, logger=logger)
+            receivers = ReceiverGroup(task_group=tg, broker=broker, logger=logger)
 
-                # Register subscription receivers here. Each call resolves a
-                # subscriber and starts consuming with per-message tracing.
-                await receivers.receive(
-                    ping_pb2.Message,
-                    processor_pb2.PyProcessor,
-                    PingHandler(logger, ping_log_level).handle,
-                )
-                await receivers.receive(
-                    presidio_analysis_pb2.PresidioAnalysis,
-                    presidio_analyzer_pb2.PresidioAnalyzer,
-                    presidio_handler.handle,
-                )
+            # Register subscription receivers here. Each call resolves a
+            # subscriber and starts consuming with per-message tracing.
+            await receivers.receive(
+                ping_pb2.Message,
+                processor_pb2.PyProcessor,
+                PingHandler(logger, ping_log_level).handle,
+            )
+            await receivers.receive(
+                presidio_analysis_pb2.PresidioAnalysis,
+                presidio_analyzer_pb2.PresidioAnalyzer,
+                presidio_handler.handle,
+            )
 
-                health_state.set_ready()
-        finally:
-            # Release the scanner: drains in-flight scans and reaps the worker
-            # processes for the pool scanner; a no-op for the in-process one.
-            await presidio_scanner.aclose()
+            health_state.set_ready()
 
 
 def _build_broker(

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -62,6 +62,8 @@ async def multi(
     # Presidio options
     max_scan_concurrency: int | None,
     scan_workers: int,
+    scan_max_tasks_per_child: int,
+    scan_timeout: float,
 ):
     logging.configure_logging(
         pretty_log=pretty_log,
@@ -111,8 +113,17 @@ async def multi(
         # models, so the in-process analyzer is only built for the threaded path.
         presidio_scanner: Scanner
         if scan_workers > 0:
-            logger.info("starting presidio scan pool", workers=scan_workers)
-            presidio_scanner = await ProcessPoolScanner.create(max_workers=scan_workers)
+            logger.info(
+                "starting presidio scan pool",
+                workers=scan_workers,
+                max_tasks_per_child=scan_max_tasks_per_child,
+                scan_timeout=scan_timeout,
+            )
+            presidio_scanner = await ProcessPoolScanner.create(
+                max_workers=scan_workers,
+                max_tasks_per_child=scan_max_tasks_per_child,
+                scan_timeout=scan_timeout,
+            )
         else:
             analyzer = await build_default_analyzer()
             # Concurrent Presidio scans are GIL-bound, so the scanner caps them at a

--- a/pystreams/src/pystreams/cmd/presidio_load.py
+++ b/pystreams/src/pystreams/cmd/presidio_load.py
@@ -1,0 +1,259 @@
+"""Load generator for the PresidioAnalyzer subscription, for local profiling.
+
+Publishes a burst of ``gram.risk.v1.PresidioAnalysis`` messages onto the local
+Pub/Sub emulator so a locally-running ``pystreams multi`` consumes them through
+the PresidioAnalyzer subscription. Use it to reproduce and profile that
+subscription's ACK latency — the wall time pystreams spends scanning content and
+publishing findings per message — without real GCP or production traffic.
+
+Three-step local loop:
+
+    # 1. emulator up (compose.yml: pubsub-emulator on :8088)
+    docker compose up -d pubsub-emulator
+
+    # 2. pystreams consuming against it (auto-reconciles topic + subscription)
+    PUBSUB_EMULATOR_HOST=localhost:8088 mise run start:pystreams-multi
+
+    # 3. fire load (the mise task sets PUBSUB_EMULATOR_HOST from mise.toml)
+    mise run risk:presidio-load -- --count 500 --concurrency 50
+
+The project id defaults to ``my-project-id`` — the same fallback ``multi`` uses
+when ``--pubsub-emulator-host`` is set (see ``multi.py``) — so both sides resolve
+the same topic/subscription paths. Override with ``--gcp-project-id`` only if you
+started pystreams with an explicit one.
+
+This measures and reports the *publish* (offered-load) side only. The consumer's
+per-message ACK cost is observed on the pystreams side: the handler's
+``presidio scan detected entities`` log carries ``scan_ms`` / ``publish_ms``, and
+a flame graph over the running process shows where the scan time goes.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from functools import partial
+
+import anyio
+import click
+import structlog
+from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
+from gram.risk.v1 import presidio_analysis_pb2
+from gram_infra.pubsub import EmulatedPubSubBroker, pubsub_publisher_for_message_async
+from gram_infra.pubsub.publisher import Publisher
+
+from pystreams import attr
+from pystreams.deps import logging
+
+from . import flags_gcp
+
+# The fallback ``multi`` uses for the emulator project; match it so the publisher
+# and consumer resolve the same topic path.
+DEFAULT_PROJECT_ID = "my-project-id"
+
+# Prose with several reliably-detected PII entities (a name, an email, a phone
+# number, and a US SSN). Kept off placeholder domains / reserved ranges so the
+# handler's false-positive filters don't drop the findings before they publish.
+# ``{i}`` makes each rendering distinct so nothing can be deduped en route.
+_PII_BLOCK = (
+    "Hi, this is Sarah Connor. You can reach me at "
+    "sarah.connor.{i}@cyberdyne-systems.net or call me on (415) 553-0{n:03d}. "
+    "For verification my social security number is 457-55-{s:04d}. Thanks for "
+    "getting back to me so quickly about the order."
+)
+
+
+def _build_content(index: int, pii: int) -> str:
+    """Build message content carrying roughly ``pii`` detectable entities.
+
+    Each block contributes ~4 findings (name, email, phone, SSN); blocks are
+    repeated to reach the requested count. Repetition also lengthens the text,
+    which is what drives the spaCy NER scan cost the profile is interested in.
+    """
+    blocks = max(1, round(pii / 4))
+    return " ".join(
+        _PII_BLOCK.format(i=f"{index}-{b}", n=(index + b) % 1000, s=(index + b) % 10000)
+        for b in range(blocks)
+    )
+
+
+def _build_message(
+    index: int, pii: int, entities: list[str]
+) -> presidio_analysis_pb2.PresidioAnalysis:
+    """Construct one synthetic analysis request with unique routing context."""
+    return presidio_analysis_pb2.PresidioAnalysis(
+        request_id=f"load-req-{index}",
+        chat_message_id=f"load-msg-{index}",
+        project_id="load-proj",
+        organization_id="load-org",
+        risk_policy_id="load-policy",
+        risk_policy_version=1,
+        created_at="2026-01-01T00:00:00Z",
+        reply_urn=f"urn:gram:load:{index}",
+        content=_build_content(index, pii),
+        # Empty => the handler asks Presidio to scan every type (the heaviest
+        # path). A scoped list only runs the recognizers for those entities, which
+        # is the lever measured by --entities.
+        entities=entities,
+    )
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    """Nearest-rank percentile of an already-sorted, non-empty list."""
+    if not sorted_values:
+        return 0.0
+    rank = max(
+        0, min(len(sorted_values) - 1, round(pct / 100 * len(sorted_values)) - 1)
+    )
+    return sorted_values[rank]
+
+
+async def _publish_all(
+    publisher: Publisher[presidio_analysis_pb2.PresidioAnalysis],
+    *,
+    count: int,
+    concurrency: int,
+    pii: int,
+    entities: list[str],
+) -> list[float]:
+    """Publish ``count`` messages with at most ``concurrency`` in flight.
+
+    A fixed pool of worker tasks pulls indices off a shared counter rather than
+    spawning ``count`` tasks up front, so a large run doesn't allocate a task per
+    message. ``next()`` has no checkpoint, so the counter is race-free on the
+    single-threaded event loop. Returns per-publish durations in milliseconds.
+    """
+    durations: list[float] = []
+    indices = iter(range(count))
+
+    async def worker() -> None:
+        for index in indices:
+            message = _build_message(index, pii, entities)
+            started = time.perf_counter()
+            # Await the commit so the recorded duration is the full publish
+            # latency, not just the time to hand the message to the client.
+            await publisher.publish(message).get()
+            durations.append((time.perf_counter() - started) * 1000)
+
+    async with anyio.create_task_group() as tg:
+        for _ in range(max(1, concurrency)):
+            tg.start_soon(worker)
+
+    return durations
+
+
+async def run(
+    *,
+    gcp_project_id: str | None,
+    pubsub_emulator_host: str | None,
+    count: int,
+    concurrency: int,
+    pii: int,
+    entities: str,
+) -> None:
+    logging.configure_logging(
+        pretty_log=True,
+        log_level="info",
+        base_attrs={attr.SERVICE_NAME: "gram-presidio-load"},
+    )
+    logger: structlog.stdlib.BoundLogger = structlog.get_logger()
+
+    if not pubsub_emulator_host:
+        # Guard against accidentally pointing a PII load generator at real GCP.
+        raise click.UsageError(
+            "--pubsub-emulator-host (or PUBSUB_EMULATOR_HOST) is required: this "
+            "load generator only runs against the local emulator. Start it with "
+            "'docker compose up -d pubsub-emulator'."
+        )
+    # The google clients auto-detect the emulator from this env var; write it back
+    # unconditionally so the explicit flag wins over any stale pre-existing value.
+    os.environ["PUBSUB_EMULATOR_HOST"] = pubsub_emulator_host
+
+    project_id = gcp_project_id or DEFAULT_PROJECT_ID
+    entity_list = [e.strip() for e in entities.split(",") if e.strip()]
+    logger.info(
+        "starting presidio load",
+        project=project_id,
+        emulator=pubsub_emulator_host,
+        count=count,
+        concurrency=concurrency,
+        pii_per_message=pii,
+        entities=entity_list or "ALL",
+    )
+
+    # EmulatedPubSubBroker reconciles the PresidioAnalysis topic on demand, so the
+    # topic exists even if pystreams (which owns the subscription) has not started
+    # yet — though messages only get consumed once it has.
+    broker = EmulatedPubSubBroker(
+        project_id, PublisherClient(), SubscriberClient(), logger=logger
+    )
+    with broker:
+        publisher = await pubsub_publisher_for_message_async(
+            broker, presidio_analysis_pb2.PresidioAnalysis
+        )
+
+        wall_started = time.perf_counter()
+        durations = await _publish_all(
+            publisher,
+            count=count,
+            concurrency=concurrency,
+            pii=pii,
+            entities=entity_list,
+        )
+        wall = time.perf_counter() - wall_started
+
+    durations.sort()
+    throughput = len(durations) / wall if wall > 0 else 0.0
+    logger.info(
+        "presidio load complete",
+        published=len(durations),
+        wall_seconds=round(wall, 2),
+        throughput_per_sec=round(throughput, 1),
+        publish_ms_p50=round(_percentile(durations, 50), 1),
+        publish_ms_p90=round(_percentile(durations, 90), 1),
+        publish_ms_p99=round(_percentile(durations, 99), 1),
+        publish_ms_max=round(durations[-1], 1) if durations else 0.0,
+    )
+
+
+@click.command(
+    "presidio-load",
+    params=[
+        *flags_gcp.pubsub_options(),
+        click.Option(
+            ["--count"],
+            type=int,
+            default=200,
+            show_default=True,
+            help="Total messages to publish.",
+        ),
+        click.Option(
+            ["--concurrency"],
+            type=int,
+            default=50,
+            show_default=True,
+            help="Maximum publishes in flight at once.",
+        ),
+        click.Option(
+            ["--pii"],
+            type=int,
+            default=4,
+            show_default=True,
+            help="Approximate detectable PII entities per message (drives both "
+            "the scan cost and the per-message finding/publish fan-out).",
+        ),
+        click.Option(
+            ["--entities"],
+            type=str,
+            default="",
+            help="Comma-separated Presidio entity types to scope the scan to "
+            "(e.g. EMAIL_ADDRESS,PHONE_NUMBER,US_SSN). Empty scans all types.",
+        ),
+    ],
+)
+def cli(**kwargs) -> None:
+    anyio.run(partial(run, **kwargs))
+
+
+if __name__ == "__main__":
+    cli()

--- a/pystreams/src/pystreams/cmd/presidio_load.py
+++ b/pystreams/src/pystreams/cmd/presidio_load.py
@@ -30,6 +30,7 @@ a flame graph over the running process shows where the scan time goes.
 
 from __future__ import annotations
 
+import math
 import os
 import time
 from functools import partial
@@ -99,13 +100,18 @@ def _build_message(
 
 
 def _percentile(sorted_values: list[float], pct: float) -> float:
-    """Nearest-rank percentile of an already-sorted, non-empty list."""
+    """Nearest-rank percentile of an already-sorted, non-empty list.
+
+    Nearest-rank: the ``ceil(pct/100 * N)``-th value (1-indexed), clamped into
+    range. ``ceil`` (not ``round``) is what makes it nearest-rank — ``round`` can
+    pick a lower rank when ``pct/100 * N`` has a fractional part below .5, slightly
+    under-reporting high percentiles.
+    """
     if not sorted_values:
         return 0.0
-    rank = max(
-        0, min(len(sorted_values) - 1, round(pct / 100 * len(sorted_values)) - 1)
-    )
-    return sorted_values[rank]
+    rank = math.ceil(pct / 100 * len(sorted_values))
+    idx = min(max(rank, 1), len(sorted_values)) - 1
+    return sorted_values[idx]
 
 
 async def _publish_all(
@@ -126,6 +132,7 @@ async def _publish_all(
     durations: list[float] = []
     indices = iter(range(count))
 
+    # concurrency is validated at the CLI boundary (IntRange min=1), so it is >= 1.
     async def worker() -> None:
         for index in indices:
             message = _build_message(index, pii, entities)
@@ -136,7 +143,7 @@ async def _publish_all(
             durations.append((time.perf_counter() - started) * 1000)
 
     async with anyio.create_task_group() as tg:
-        for _ in range(max(1, concurrency)):
+        for _ in range(concurrency):
             tg.start_soon(worker)
 
     return durations
@@ -222,21 +229,26 @@ async def run(
         *flags_gcp.pubsub_options(),
         click.Option(
             ["--count"],
-            type=int,
+            # Validate at the boundary: a non-positive count is a misconfiguration,
+            # not a run with zero messages silently coerced away.
+            type=click.IntRange(min=1),
             default=200,
             show_default=True,
             help="Total messages to publish.",
         ),
         click.Option(
             ["--concurrency"],
-            type=int,
+            # min=1 rejects bad input here rather than silently coercing to a single
+            # worker downstream, which would mask the misconfiguration and skew the
+            # load-test results.
+            type=click.IntRange(min=1),
             default=50,
             show_default=True,
             help="Maximum publishes in flight at once.",
         ),
         click.Option(
             ["--pii"],
-            type=int,
+            type=click.IntRange(min=1),
             default=4,
             show_default=True,
             help="Approximate detectable PII entities per message (drives both "

--- a/pystreams/src/pystreams/deps/scanner.py
+++ b/pystreams/src/pystreams/deps/scanner.py
@@ -1,0 +1,60 @@
+"""Construct the configured Presidio scanner.
+
+The ``multi`` command supports two scan strategies, selected by ``--scan-workers``:
+a pool of worker processes (the default) or an in-process thread scanner. This
+isolates that selection — and the analyzer/concurrency wiring each strategy needs
+— behind one async factory so the command body stays about lifecycle, not
+construction.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from pystreams.risk.scanner import (
+    ProcessPoolScanner,
+    Scanner,
+    ThreadScanner,
+    build_default_analyzer,
+)
+
+
+async def build_presidio_scanner(
+    *,
+    scan_workers: int,
+    scan_max_tasks_per_child: int,
+    scan_timeout: float,
+    max_scan_concurrency: int | None,
+    logger: structlog.stdlib.BoundLogger,
+) -> Scanner:
+    """Build the configured scan strategy.
+
+    With ``scan_workers > 0`` (the default) the scan runs in a pool of worker
+    processes, each with its own GIL, breaking the single-process throughput
+    ceiling inside one pod. With ``scan_workers == 0`` it runs in-process on
+    threads capped by ``max_scan_concurrency``. The pool owns its own per-worker
+    spaCy models, so the in-process analyzer is only built for the threaded path.
+    """
+    if scan_workers > 0:
+        logger.info(
+            "starting presidio scan pool",
+            workers=scan_workers,
+            max_tasks_per_child=scan_max_tasks_per_child,
+            scan_timeout=scan_timeout,
+        )
+        return await ProcessPoolScanner.create(
+            max_workers=scan_workers,
+            max_tasks_per_child=scan_max_tasks_per_child,
+            scan_timeout=scan_timeout,
+        )
+
+    analyzer = await build_default_analyzer()
+    # Concurrent Presidio scans are GIL-bound, so the scanner caps them at a low
+    # default. ``max_scan_concurrency`` overrides it (<=0 disables the cap); unset
+    # (None) leaves the scanner default in place.
+    concurrency_kwargs = (
+        {"max_concurrency": max_scan_concurrency}
+        if max_scan_concurrency is not None
+        else {}
+    )
+    return ThreadScanner(analyzer, **concurrency_kwargs)

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -7,6 +7,7 @@ from typing import Protocol
 import structlog
 from asyncer import asyncify
 from gram.risk.v1 import finding_pb2, presidio_analysis_pb2
+from gram_infra.pubsub import PublishResult
 from gram_infra.pubsub.subscriber import MessageMetadata
 from presidio_analyzer import AnalyzerEngine
 from presidio_analyzer.nlp_engine import NlpEngineProvider
@@ -88,10 +89,12 @@ class FindingPublisher(Protocol):
 
     Narrowing to a protocol keeps publishing injectable — tests supply a fake
     that captures findings instead of talking to Pub/Sub. The real
-    ``Publisher[finding_pb2.Finding]`` satisfies it structurally.
+    ``Publisher[finding_pb2.Finding]`` satisfies it structurally: ``publish``
+    returns immediately with a :class:`~gram_infra.pubsub.PublishResult` whose
+    ``get`` is awaited to confirm the commit.
     """
 
-    async def publish(self, message: finding_pb2.Finding) -> str: ...
+    def publish(self, message: finding_pb2.Finding) -> PublishResult: ...
 
 
 # Generic, source-agnostic description stamped on every published finding. The
@@ -206,48 +209,75 @@ class PresidioHandler:
         detected: Sequence[_Detection],
         created_at: str,
     ) -> int:
-        """Publish one Finding per detection; return how many were published.
+        """Publish one Finding per detection concurrently; return how many landed.
+
+        A message's findings are independent, so all publishes are fired up front
+        — ``publish`` returns a future without waiting, and the client batches the
+        sends — and only then are their commits collected. In series a message
+        with N detections would pay N Pub/Sub round-trips back to back, and that
+        serial publish is a large part of the per-message ACK latency; firing them
+        together collapses it toward a single round-trip while the collect loop
+        just gathers results that are already in flight.
 
         A publish failure is logged and skipped rather than raised: nacking the
         message would redeliver it and re-publish the findings that already
         landed, duplicating them (there is no dedup downstream).
         """
-        published = 0
-        for d in detected:
-            finding = finding_pb2.Finding(
-                # A UUIDv7 per finding: globally unique with a time-ordered
-                # prefix, so findings sort by creation in storage.
-                id=str(uuid.uuid7()),
-                request_id=message.request_id,
-                chat_message_id=message.chat_message_id,
-                project_id=message.project_id,
-                organization_id=message.organization_id,
-                risk_policy_id=message.risk_policy_id,
-                risk_policy_version=message.risk_policy_version,
-                created_at=created_at,
-                rule_id=d.rule_id,
-                description=_FINDING_DESCRIPTION,
-                match=d.match,
-                start_pos=d.start_pos,
-                end_pos=d.end_pos,
-                tags=["pii"],
-                source=SOURCE_PRESIDIO,
-                confidence=d.confidence,
+        # Fire every publish first so they commit concurrently on the client's
+        # batcher; keep each finding's rule_id alongside its result for logging.
+        pending = [
+            (
+                d.rule_id,
+                self.publisher.publish(self._build_finding(message, d, created_at)),
             )
+            for d in detected
+        ]
+
+        published = 0
+        for rule_id, result in pending:
             try:
-                await self.publisher.publish(finding)
+                await result.get()
             except Exception as exc:
                 # Never echo the finding (it carries the matched value); log the
                 # request, rule id, and exception type only.
                 self.logger.error(
                     "failed to publish risk finding",
                     request_id=message.request_id,
-                    rule_id=finding.rule_id,
+                    rule_id=rule_id,
                     error_type=type(exc).__name__,
                 )
                 continue
             published += 1
+
         return published
+
+    def _build_finding(
+        self,
+        message: presidio_analysis_pb2.PresidioAnalysis,
+        d: _Detection,
+        created_at: str,
+    ) -> finding_pb2.Finding:
+        """Assemble a Finding from a detection plus the originating message."""
+        return finding_pb2.Finding(
+            # A UUIDv7 per finding: globally unique with a time-ordered prefix, so
+            # findings sort by creation in storage.
+            id=str(uuid.uuid7()),
+            request_id=message.request_id,
+            chat_message_id=message.chat_message_id,
+            project_id=message.project_id,
+            organization_id=message.organization_id,
+            risk_policy_id=message.risk_policy_id,
+            risk_policy_version=message.risk_policy_version,
+            created_at=created_at,
+            rule_id=d.rule_id,
+            description=_FINDING_DESCRIPTION,
+            match=d.match,
+            start_pos=d.start_pos,
+            end_pos=d.end_pos,
+            tags=["pii"],
+            source=SOURCE_PRESIDIO,
+            confidence=d.confidence,
+        )
 
     def _scan(self, content: str, entities: list[str] | None) -> list[_Detection]:
         """Analyze the content and return the real (non-false-positive) matches.

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -122,6 +122,21 @@ class _Detection:
     confidence: float
 
 
+@dataclass(frozen=True)
+class _PendingPublish:
+    """A finding whose publish has already been fired; ``result.get`` confirms it.
+
+    Built and fired off the event loop by ``_scan_and_publish`` so the proto
+    build + serialize never run on the loop thread. The entity type and rule id
+    ride along so the loop can assemble the summary log and per-finding error
+    context without re-deriving them from the detection.
+    """
+
+    entity_type: str
+    rule_id: str
+    result: PublishResult
+
+
 class PresidioHandler:
     """Scans :class:`PresidioAnalysis` payloads for PII using Presidio and
     publishes each detection to the findings topic.
@@ -173,14 +188,18 @@ class PresidioHandler:
         # An empty list means "analyze every entity Presidio knows about".
         requested = list(message.entities) or None
 
-        # Presidio's analyzer is synchronous and CPU-bound; run it off the event
-        # loop so a large request can't stall other subscriptions. Time the whole
-        # offload as wall clock — it includes any wait for a free worker thread,
-        # and under load that queue wait (not the scan itself) can dominate the
-        # per-message ACK latency.
+        # One worker hop does the CPU/GIL-bound scan *and* the build + serialize +
+        # client-enqueue of every finding, so neither the spaCy work nor protobuf
+        # serialization runs on the event-loop thread competing with intake for the
+        # GIL. Timed as wall clock — it includes any wait for a free scan slot,
+        # which under load (not the scan itself) can dominate per-message ACK
+        # latency.
         try:
             scan_started = time.perf_counter()
-            detected = await asyncify(self._scan, limiter=self._get_scan_limiter())(
+            pending = await asyncify(
+                self._scan_and_publish, limiter=self._get_scan_limiter()
+            )(
+                message=message,
                 content=message.content,
                 entities=requested,
             )
@@ -206,17 +225,14 @@ class PresidioHandler:
             )
             return
 
-        if not detected:
+        if not pending:
             return
 
-        # A fresh detection timestamp (UTC, RFC3339) stamped on every finding from
-        # this delivery — when the scan ran, not when the request was created.
-        created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        # Findings publish concurrently (see _publish_findings), so this wall time
-        # is roughly one round-trip regardless of count — the other half of the
-        # per-message ACK cost alongside the scan.
+        # The publishes were already fired on the worker thread (the client batches
+        # them), so this wall time is just the wait for their commits — roughly one
+        # round-trip regardless of count, the other half of the ACK cost.
         publish_started = time.perf_counter()
-        published = await self._publish_findings(message, detected, created_at)
+        published = await self._collect(message, pending)
         publish_ms = (time.perf_counter() - publish_started) * 1000
 
         # Log entity *types* and counts only — never the matched values or the
@@ -232,65 +248,85 @@ class PresidioHandler:
         # when debugging. The async ``adebug`` keeps that render off the event
         # loop on the occasions debug *is* enabled.
         entity_types: dict[str, int] = {}
-        for d in detected:
-            entity_types[d.entity_type] = entity_types.get(d.entity_type, 0) + 1
+        for p in pending:
+            entity_types[p.entity_type] = entity_types.get(p.entity_type, 0) + 1
         await self.logger.adebug(
             "presidio scan detected entities",
             request_id=message.request_id,
             reply_urn=message.reply_urn,
             requested_entities=requested or [],
             detected_entity_types=sorted(entity_types),
-            detected_count=len(detected),
+            detected_count=len(pending),
             published_count=published,
             delivery_attempt=meta.delivery_attempt,
             # Per-message latency split, safe to retain (durations, never content):
-            # how long the off-loop scan took (incl. worker-thread wait) vs. the
-            # concurrent publish of the resulting findings.
+            # the off-loop scan + finding-publish dispatch (incl. scan-slot wait)
+            # vs. the wait for those publishes' commits.
             scan_ms=round(scan_ms, 1),
             publish_ms=round(publish_ms, 1),
         )
 
-    async def _publish_findings(
+    def _scan_and_publish(
+        self,
+        *,
+        message: presidio_analysis_pb2.PresidioAnalysis,
+        content: str,
+        entities: list[str] | None,
+    ) -> list[_PendingPublish]:
+        """Scan, then build and fire each finding's publish — all off the loop.
+
+        Runs on a worker thread (via ``asyncify``): the analyzer call, the
+        false-positive classification (which may consult the embedded ASN
+        database), the byte-offset conversion, **and** each finding's proto build +
+        ``SerializeToString`` + client enqueue all stay off the event-loop thread.
+        Keeping the serialization here is the point — done on the loop it would be
+        per-finding GIL work competing with message intake.
+
+        A message's findings are independent, so every publish is fired up front
+        (``publish`` returns a future without waiting and the client batches the
+        sends); the returned futures are collected on the loop by ``_collect``. In
+        series a message with N findings would pay N Pub/Sub round-trips back to
+        back; firing them together collapses that toward a single round-trip.
+        """
+        detections = self._scan(content, entities)
+        if not detections:
+            return []
+        # A fresh detection timestamp (UTC, RFC3339) stamped on every finding from
+        # this delivery — when the scan ran, not when the request was created.
+        created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return [
+            _PendingPublish(
+                entity_type=d.entity_type,
+                rule_id=d.rule_id,
+                result=self.publisher.publish(
+                    self._build_finding(message, d, created_at)
+                ),
+            )
+            for d in detections
+        ]
+
+    async def _collect(
         self,
         message: presidio_analysis_pb2.PresidioAnalysis,
-        detected: Sequence[_Detection],
-        created_at: str,
+        pending: Sequence[_PendingPublish],
     ) -> int:
-        """Publish one Finding per detection concurrently; return how many landed.
-
-        A message's findings are independent, so all publishes are fired up front
-        — ``publish`` returns a future without waiting, and the client batches the
-        sends — and only then are their commits collected. In series a message
-        with N detections would pay N Pub/Sub round-trips back to back, and that
-        serial publish is a large part of the per-message ACK latency; firing them
-        together collapses it toward a single round-trip while the collect loop
-        just gathers results that are already in flight.
+        """Await each already-fired publish's commit; return how many landed.
 
         A publish failure is logged and skipped rather than raised: nacking the
         message would redeliver it and re-publish the findings that already
         landed, duplicating them (there is no dedup downstream).
         """
-        # Fire every publish first so they commit concurrently on the client's
-        # batcher; keep each finding's rule_id alongside its result for logging.
-        pending = [
-            (
-                d.rule_id,
-                self.publisher.publish(self._build_finding(message, d, created_at)),
-            )
-            for d in detected
-        ]
-
         published = 0
-        for rule_id, result in pending:
+        for p in pending:
             try:
-                await result.get()
+                await p.result.get()
             except Exception as exc:
                 # Never echo the finding (it carries the matched value); log the
                 # request, rule id, and exception type only.
                 self.logger.error(
                     "failed to publish risk finding",
                     request_id=message.request_id,
-                    rule_id=rule_id,
+                    rule_id=p.rule_id,
                     error_type=type(exc).__name__,
                 )
                 continue

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -151,12 +152,17 @@ class PresidioHandler:
         requested = list(message.entities) or None
 
         # Presidio's analyzer is synchronous and CPU-bound; run it off the event
-        # loop so a large request can't stall other subscriptions.
+        # loop so a large request can't stall other subscriptions. Time the whole
+        # offload as wall clock — it includes any wait for a free worker thread,
+        # and under load that queue wait (not the scan itself) can dominate the
+        # per-message ACK latency.
         try:
+            scan_started = time.perf_counter()
             detected = await asyncify(self._scan)(
                 content=message.content,
                 entities=requested,
             )
+            scan_ms = (time.perf_counter() - scan_started) * 1000
         except Exception as exc:
             # This is best-effort shadow processing, and the PresidioAnalyzer
             # subscription declares no dead-letter policy. Letting a scan failure
@@ -184,7 +190,12 @@ class PresidioHandler:
         # A fresh detection timestamp (UTC, RFC3339) stamped on every finding from
         # this delivery — when the scan ran, not when the request was created.
         created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # Findings publish concurrently (see _publish_findings), so this wall time
+        # is roughly one round-trip regardless of count — the other half of the
+        # per-message ACK cost alongside the scan.
+        publish_started = time.perf_counter()
         published = await self._publish_findings(message, detected, created_at)
+        publish_ms = (time.perf_counter() - publish_started) * 1000
 
         # Log entity *types* and counts only — never the matched values or the
         # scanned content — so the line is safe to retain while still being
@@ -201,6 +212,11 @@ class PresidioHandler:
             detected_count=len(detected),
             published_count=published,
             delivery_attempt=meta.delivery_attempt,
+            # Per-message latency split, safe to retain (durations, never content):
+            # how long the off-loop scan took (incl. worker-thread wait) vs. the
+            # concurrent publish of the resulting findings.
+            scan_ms=round(scan_ms, 1),
+            publish_ms=round(publish_ms, 1),
         )
 
     async def _publish_findings(

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Protocol
 
+import anyio
 import structlog
 from asyncer import asyncify
 from gram.risk.v1 import finding_pb2, presidio_analysis_pb2
@@ -138,10 +139,31 @@ class PresidioHandler:
         logger: structlog.stdlib.BoundLogger,
         publisher: FindingPublisher,
         analyzer: Analyzer,
+        *,
+        max_scan_concurrency: int | None = 2,
     ):
         self.logger = logger
         self.publisher = publisher
         self.analyzer = analyzer
+        # Ceiling on concurrent off-loop scans. Presidio's per-scan work is almost
+        # entirely GIL-bound, so extra scan threads don't add parallelism — they
+        # thrash the GIL and starve the event loop. A local burst sweep on a
+        # 10-core box found throughput/latency peak at 2 (≈41 msg/s, scan p50
+        # ~1.08s) and degrade monotonically with more: the default-40 thread pool
+        # managed only ~28 msg/s at p50 ~1.55s. The optimum tracks the GIL, not the
+        # core count, so 2 is a sane default everywhere; scale throughput with more
+        # processes/replicas, not more threads. None (or <=0) disables the cap and
+        # falls back to anyio's default thread-pool limiter (40).
+        self._max_scan_concurrency = max_scan_concurrency
+        self._scan_limiter: anyio.CapacityLimiter | None = None
+
+    def _get_scan_limiter(self) -> anyio.CapacityLimiter | None:
+        """Lazily build the shared scan limiter (needs a running event loop)."""
+        if self._max_scan_concurrency is None or self._max_scan_concurrency <= 0:
+            return None
+        if self._scan_limiter is None:
+            self._scan_limiter = anyio.CapacityLimiter(self._max_scan_concurrency)
+        return self._scan_limiter
 
     async def handle(
         self,
@@ -158,7 +180,7 @@ class PresidioHandler:
         # per-message ACK latency.
         try:
             scan_started = time.perf_counter()
-            detected = await asyncify(self._scan)(
+            detected = await asyncify(self._scan, limiter=self._get_scan_limiter())(
                 content=message.content,
                 entities=requested,
             )

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -195,7 +195,7 @@ class PresidioHandler:
             _PendingPublish(
                 entity_type=d.entity_type,
                 rule_id=d.rule_id,
-                result=self.publisher.publish(
+                result=self._publish(
                     finding_pb2.Finding(
                         # A UUIDv7 per finding: globally unique with a time-ordered
                         # prefix, so findings sort by creation in storage.
@@ -220,6 +220,21 @@ class PresidioHandler:
             )
             for d in detections
         ]
+
+    def _publish(self, finding: finding_pb2.Finding) -> PublishResult:
+        """Fire one publish, deferring a synchronous failure to its result.
+
+        ``publish`` normally returns a future, but a synchronous raise (e.g. a
+        misconfigured client) would otherwise propagate out of ``_scan_and_publish``
+        and be reported as a *scan* failure, aborting the message's remaining
+        findings. Capturing it as a :class:`_FailedPublish` keeps per-finding
+        failure handling uniform whether ``publish`` raises now or the commit fails
+        later — both are logged and skipped by ``_collect``.
+        """
+        try:
+            return self.publisher.publish(finding)
+        except Exception as exc:
+            return _FailedPublish(exc)
 
     async def _collect(
         self,
@@ -378,3 +393,22 @@ class _PendingPublish:
     entity_type: str
     rule_id: str
     result: PublishResult
+
+
+@dataclass(frozen=True)
+class _FailedPublish:
+    """A :class:`PublishResult` standing in for a publish that raised synchronously.
+
+    ``Publisher.publish`` returns a future, but it can still raise *synchronously*
+    (e.g. a misconfigured client). Capturing that as a result whose ``get`` re-raises
+    routes it through ``_collect``'s normal publish-failure path — logged and
+    skipped — exactly like an async commit failure. So one finding's failure
+    neither aborts the message's other publishes nor lets the error escape the
+    handler and nack the message (which would redeliver and duplicate the findings
+    that already landed).
+    """
+
+    exc: Exception
+
+    async def get(self) -> str:
+        raise self.exc

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -28,113 +28,10 @@ SPACY_MODEL = "en_core_web_lg"
 SOURCE_PRESIDIO = "presidio"
 
 
-async def build_default_analyzer() -> AnalyzerEngine:
-    """Construct an AnalyzerEngine backed by the explicitly selected spaCy model."""
-    provider = NlpEngineProvider(
-        nlp_configuration={
-            "nlp_engine_name": "spacy",
-            "models": [{"lang_code": "en", "model_name": SPACY_MODEL}],
-        }
-    )
-    nlp_engine = await asyncify(provider.create_engine)()
-    return AnalyzerEngine(nlp_engine=nlp_engine)
-
-
-def _canonical_rule_id(entity_type: str) -> str:
-    """Map a Presidio UPPER_SNAKE entity type to the canonical rule id.
-
-    Lowercases the entity name and prefixes it with ``pii.`` (e.g.
-    ``EMAIL_ADDRESS`` -> ``pii.email_address``) so the same finding gets the same
-    rule id regardless of which path produced it.
-    """
-    return "pii." + entity_type.lower()
-
-
-def _byte_span(content: str, start: int, end: int) -> tuple[int, int, str]:
-    """Clamp a Presidio character span and convert it to UTF-8 byte offsets.
-
-    Presidio reports character (code point) offsets, but the Finding schema
-    carries byte positions. Offsets are clamped to the content's bounds first to
-    guard against an out-of-range span. Returns ``(start_byte, end_byte, match)``.
-    """
-    n = len(content)
-    start = max(0, min(start, n))
-    end = max(start, min(end, n))
-    start_byte = len(content[:start].encode("utf-8"))
-    end_byte = len(content[:end].encode("utf-8"))
-    return start_byte, end_byte, content[start:end]
-
-
-class Recognized(Protocol):
-    """The slice of Presidio's ``RecognizerResult`` this handler consumes."""
-
-    entity_type: str
-    start: int  # Character offset (inclusive) of the match in the scanned text.
-    end: int  # Character offset (exclusive) of the match in the scanned text.
-    score: float  # Detection confidence, 0.0-1.0.
-
-
-class Analyzer(Protocol):
-    """The slice of ``AnalyzerEngine`` this handler depends on.
-
-    Narrowing to a protocol keeps the engine injectable — tests can supply a
-    lightweight fake instead of loading Presidio's NLP model.
-    """
-
-    def analyze(
-        self, *, text: str, entities: list[str] | None, language: str
-    ) -> Sequence[Recognized]: ...
-
-
-class FindingPublisher(Protocol):
-    """The slice of ``gram_infra.pubsub.Publisher`` this handler depends on.
-
-    Narrowing to a protocol keeps publishing injectable — tests supply a fake
-    that captures findings instead of talking to Pub/Sub. The real
-    ``Publisher[finding_pb2.Finding]`` satisfies it structurally: ``publish``
-    returns immediately with a :class:`~gram_infra.pubsub.PublishResult` whose
-    ``get`` is awaited to confirm the commit.
-    """
-
-    def publish(self, message: finding_pb2.Finding) -> PublishResult: ...
-
-
 # Generic, source-agnostic description stamped on every published finding. The
 # canonical rule_id carries the specific entity, so a consumer can resolve a
 # richer description from it.
 _FINDING_DESCRIPTION = "Identified potentially sensitive personal information."
-
-
-@dataclass(frozen=True)
-class _Detection:
-    """A real (non-false-positive) PII match, ready to become a Finding.
-
-    Produced off the event loop by ``_scan`` so the analyzer call, false-positive
-    classification (which may hit the embedded ASN database), and byte-offset
-    conversion all stay on the worker thread.
-    """
-
-    entity_type: str
-    rule_id: str
-    match: str
-    start_pos: int  # UTF-8 byte offset.
-    end_pos: int  # UTF-8 byte offset.
-    confidence: float
-
-
-@dataclass(frozen=True)
-class _PendingPublish:
-    """A finding whose publish has already been fired; ``result.get`` confirms it.
-
-    Built and fired off the event loop by ``_scan_and_publish`` so the proto
-    build + serialize never run on the loop thread. The entity type and rule id
-    ride along so the loop can assemble the summary log and per-finding error
-    context without re-deriving them from the detection.
-    """
-
-    entity_type: str
-    rule_id: str
-    result: PublishResult
 
 
 class PresidioHandler:
@@ -299,7 +196,26 @@ class PresidioHandler:
                 entity_type=d.entity_type,
                 rule_id=d.rule_id,
                 result=self.publisher.publish(
-                    self._build_finding(message, d, created_at)
+                    finding_pb2.Finding(
+                        # A UUIDv7 per finding: globally unique with a time-ordered
+                        # prefix, so findings sort by creation in storage.
+                        id=str(uuid.uuid7()),
+                        request_id=message.request_id,
+                        chat_message_id=message.chat_message_id,
+                        project_id=message.project_id,
+                        organization_id=message.organization_id,
+                        risk_policy_id=message.risk_policy_id,
+                        risk_policy_version=message.risk_policy_version,
+                        created_at=created_at,
+                        rule_id=d.rule_id,
+                        description=_FINDING_DESCRIPTION,
+                        match=d.match,
+                        start_pos=d.start_pos,
+                        end_pos=d.end_pos,
+                        tags=["pii"],
+                        source=SOURCE_PRESIDIO,
+                        confidence=d.confidence,
+                    )
                 ),
             )
             for d in detections
@@ -334,34 +250,6 @@ class PresidioHandler:
 
         return published
 
-    def _build_finding(
-        self,
-        message: presidio_analysis_pb2.PresidioAnalysis,
-        d: _Detection,
-        created_at: str,
-    ) -> finding_pb2.Finding:
-        """Assemble a Finding from a detection plus the originating message."""
-        return finding_pb2.Finding(
-            # A UUIDv7 per finding: globally unique with a time-ordered prefix, so
-            # findings sort by creation in storage.
-            id=str(uuid.uuid7()),
-            request_id=message.request_id,
-            chat_message_id=message.chat_message_id,
-            project_id=message.project_id,
-            organization_id=message.organization_id,
-            risk_policy_id=message.risk_policy_id,
-            risk_policy_version=message.risk_policy_version,
-            created_at=created_at,
-            rule_id=d.rule_id,
-            description=_FINDING_DESCRIPTION,
-            match=d.match,
-            start_pos=d.start_pos,
-            end_pos=d.end_pos,
-            tags=["pii"],
-            source=SOURCE_PRESIDIO,
-            confidence=d.confidence,
-        )
-
     def _scan(self, content: str, entities: list[str] | None) -> list[_Detection]:
         """Analyze the content and return the real (non-false-positive) matches.
 
@@ -387,3 +275,106 @@ class PresidioHandler:
                 )
             )
         return detections
+
+
+async def build_default_analyzer() -> AnalyzerEngine:
+    """Construct an AnalyzerEngine backed by the explicitly selected spaCy model."""
+    provider = NlpEngineProvider(
+        nlp_configuration={
+            "nlp_engine_name": "spacy",
+            "models": [{"lang_code": "en", "model_name": SPACY_MODEL}],
+        }
+    )
+    nlp_engine = await asyncify(provider.create_engine)()
+    return AnalyzerEngine(nlp_engine=nlp_engine)
+
+
+def _canonical_rule_id(entity_type: str) -> str:
+    """Map a Presidio UPPER_SNAKE entity type to the canonical rule id.
+
+    Lowercases the entity name and prefixes it with ``pii.`` (e.g.
+    ``EMAIL_ADDRESS`` -> ``pii.email_address``) so the same finding gets the same
+    rule id regardless of which path produced it.
+    """
+    return "pii." + entity_type.lower()
+
+
+def _byte_span(content: str, start: int, end: int) -> tuple[int, int, str]:
+    """Clamp a Presidio character span and convert it to UTF-8 byte offsets.
+
+    Presidio reports character (code point) offsets, but the Finding schema
+    carries byte positions. Offsets are clamped to the content's bounds first to
+    guard against an out-of-range span. Returns ``(start_byte, end_byte, match)``.
+    """
+    n = len(content)
+    start = max(0, min(start, n))
+    end = max(start, min(end, n))
+    start_byte = len(content[:start].encode("utf-8"))
+    end_byte = len(content[:end].encode("utf-8"))
+    return start_byte, end_byte, content[start:end]
+
+
+class Recognized(Protocol):
+    """The slice of Presidio's ``RecognizerResult`` this handler consumes."""
+
+    entity_type: str
+    start: int  # Character offset (inclusive) of the match in the scanned text.
+    end: int  # Character offset (exclusive) of the match in the scanned text.
+    score: float  # Detection confidence, 0.0-1.0.
+
+
+class Analyzer(Protocol):
+    """The slice of ``AnalyzerEngine`` this handler depends on.
+
+    Narrowing to a protocol keeps the engine injectable — tests can supply a
+    lightweight fake instead of loading Presidio's NLP model.
+    """
+
+    def analyze(
+        self, *, text: str, entities: list[str] | None, language: str
+    ) -> Sequence[Recognized]: ...
+
+
+class FindingPublisher(Protocol):
+    """The slice of ``gram_infra.pubsub.Publisher`` this handler depends on.
+
+    Narrowing to a protocol keeps publishing injectable — tests supply a fake
+    that captures findings instead of talking to Pub/Sub. The real
+    ``Publisher[finding_pb2.Finding]`` satisfies it structurally: ``publish``
+    returns immediately with a :class:`~gram_infra.pubsub.PublishResult` whose
+    ``get`` is awaited to confirm the commit.
+    """
+
+    def publish(self, message: finding_pb2.Finding) -> PublishResult: ...
+
+
+@dataclass(frozen=True)
+class _Detection:
+    """A real (non-false-positive) PII match, ready to become a Finding.
+
+    Produced off the event loop by ``_scan`` so the analyzer call, false-positive
+    classification (which may hit the embedded ASN database), and byte-offset
+    conversion all stay on the worker thread.
+    """
+
+    entity_type: str
+    rule_id: str
+    match: str
+    start_pos: int  # UTF-8 byte offset.
+    end_pos: int  # UTF-8 byte offset.
+    confidence: float
+
+
+@dataclass(frozen=True)
+class _PendingPublish:
+    """A finding whose publish has already been fired; ``result.get`` confirms it.
+
+    Built and fired off the event loop by ``_scan_and_publish`` so the proto
+    build + serialize never run on the loop thread. The entity type and rule id
+    ride along so the loop can assemble the summary log and per-finding error
+    context without re-deriving them from the detection.
+    """
+
+    entity_type: str
+    rule_id: str
+    result: PublishResult

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -5,23 +5,13 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Protocol
 
-import anyio
 import structlog
 from asyncer import asyncify
 from gram.risk.v1 import finding_pb2, presidio_analysis_pb2
 from gram_infra.pubsub import PublishResult
 from gram_infra.pubsub.subscriber import MessageMetadata
-from presidio_analyzer import AnalyzerEngine
-from presidio_analyzer.nlp_engine import NlpEngineProvider
 
-from pystreams.risk import presidiofp
-
-# The spaCy model bundled into the image (pinned in pystreams/pyproject.toml).
-# Presidio's default AnalyzerEngine() would also load this model, but selecting
-# it explicitly ties the handler to the model we actually ship and stops a
-# future Presidio default change from silently reaching for a model we don't
-# package.
-SPACY_MODEL = "en_core_web_lg"
+from pystreams.risk.scanner import Detection, Scanner
 
 # Source label stamped on every finding this handler emits, so all findings
 # from the Presidio path are attributed identically downstream.
@@ -35,47 +25,31 @@ _FINDING_DESCRIPTION = "Identified potentially sensitive personal information."
 
 
 class PresidioHandler:
-    """Scans :class:`PresidioAnalysis` payloads for PII using Presidio and
-    publishes each detection to the findings topic.
+    """Publishes a :class:`Finding` per PII detection to the findings topic.
 
-    Every recognized entity becomes a :class:`Finding` carrying the originating
-    request/message context plus the match span, and is published to the
-    ``gram.risk.v1.Finding`` topic for downstream persistence. The matched value
-    is included on the published finding, but is still never written to the
-    handler's own logs — log lines report entity *types* and
+    The PII scan itself is delegated to an injected :class:`Scanner` (see
+    ``scanner.py``); this handler owns everything *around* it — logging, mapping
+    each :class:`Detection` onto a :class:`Finding`, and publishing to the
+    ``gram.risk.v1.Finding`` topic for downstream persistence. Every recognized
+    entity becomes a finding carrying the originating request/message context plus
+    the match span. The matched value is included on the published finding, but is
+    never written to the handler's own logs — log lines report entity *types* and
     counts only, so they stay safe to retain.
+
+    The scanner determines how the scan is parallelized: an in-process
+    ``ThreadScanner`` (default) or a ``ProcessPoolScanner`` that breaks the
+    single-process GIL ceiling. The handler is agnostic to which it holds.
     """
 
     def __init__(
         self,
         logger: structlog.stdlib.BoundLogger,
         publisher: FindingPublisher,
-        analyzer: Analyzer,
-        *,
-        max_scan_concurrency: int | None = 2,
+        scanner: Scanner,
     ):
         self.logger = logger
         self.publisher = publisher
-        self.analyzer = analyzer
-        # Ceiling on concurrent off-loop scans. Presidio's per-scan work is almost
-        # entirely GIL-bound, so extra scan threads don't add parallelism — they
-        # thrash the GIL and starve the event loop. A local burst sweep on a
-        # 10-core box found throughput/latency peak at 2 (≈41 msg/s, scan p50
-        # ~1.08s) and degrade monotonically with more: the default-40 thread pool
-        # managed only ~28 msg/s at p50 ~1.55s. The optimum tracks the GIL, not the
-        # core count, so 2 is a sane default everywhere; scale throughput with more
-        # processes/replicas, not more threads. None (or <=0) disables the cap and
-        # falls back to anyio's default thread-pool limiter (40).
-        self._max_scan_concurrency = max_scan_concurrency
-        self._scan_limiter: anyio.CapacityLimiter | None = None
-
-    def _get_scan_limiter(self) -> anyio.CapacityLimiter | None:
-        """Lazily build the shared scan limiter (needs a running event loop)."""
-        if self._max_scan_concurrency is None or self._max_scan_concurrency <= 0:
-            return None
-        if self._scan_limiter is None:
-            self._scan_limiter = anyio.CapacityLimiter(self._max_scan_concurrency)
-        return self._scan_limiter
+        self._scanner = scanner
 
     async def handle(
         self,
@@ -85,21 +59,14 @@ class PresidioHandler:
         # An empty list means "analyze every entity Presidio knows about".
         requested = list(message.entities) or None
 
-        # One worker hop does the CPU/GIL-bound scan *and* the build + serialize +
-        # client-enqueue of every finding, so neither the spaCy work nor protobuf
-        # serialization runs on the event-loop thread competing with intake for the
-        # GIL. Timed as wall clock — it includes any wait for a free scan slot,
-        # which under load (not the scan itself) can dominate per-message ACK
-        # latency.
+        # The scan (CPU/GIL-bound spaCy + Presidio work plus the false-positive
+        # filter and byte-offset conversion) runs off the event loop inside the
+        # scanner — on a worker thread or in a separate process. Timed as wall
+        # clock, so it includes any wait for a free scan slot / pool worker, which
+        # under load (not the scan itself) can dominate per-message ACK latency.
         try:
             scan_started = time.perf_counter()
-            entity_types, pending = await asyncify(
-                self._scan_and_publish, limiter=self._get_scan_limiter()
-            )(
-                message=message,
-                content=message.content,
-                entities=requested,
-            )
+            detections = await self._scanner.scan(message.content, requested)
             scan_ms = (time.perf_counter() - scan_started) * 1000
         except Exception as exc:
             # This is best-effort shadow processing, and the PresidioAnalyzer
@@ -122,13 +89,19 @@ class PresidioHandler:
             )
             return
 
-        if not entity_types:
+        if not detections:
             return
 
-        # The publishes were already fired on the worker thread (the client batches
-        # them), so this wall time is just the wait for their commits — roughly one
-        # round-trip regardless of count, the other half of the ACK cost.
+        # Build + serialize + enqueue every finding off the event loop too, then
+        # await the commits. Keeping the proto build and ``SerializeToString`` on a
+        # worker thread (not the loop) is deliberate: done on the loop it would be
+        # per-finding GIL work competing with message intake. ``asyncify`` copies
+        # the contextvar context into the worker, so trace-context injection on
+        # publish is preserved.
         publish_started = time.perf_counter()
+        entity_types, pending = await asyncify(self._build_and_dispatch)(
+            message, detections
+        )
         published = await self._collect(message, pending)
         publish_ms = (time.perf_counter() - publish_started) * 1000
 
@@ -154,41 +127,32 @@ class PresidioHandler:
             published_count=published,
             delivery_attempt=meta.delivery_attempt,
             # Per-message latency split, safe to retain (durations, never content):
-            # the off-loop scan + finding-publish dispatch (incl. scan-slot wait)
-            # vs. the wait for those publishes' commits.
+            # the off-loop scan (incl. scan-slot / pool-worker wait) vs. the build +
+            # publish-dispatch and the wait for those publishes' commits.
             scan_ms=round(scan_ms, 1),
             publish_ms=round(publish_ms, 1),
         )
 
-    def _scan_and_publish(
+    def _build_and_dispatch(
         self,
-        *,
         message: presidio_analysis_pb2.PresidioAnalysis,
-        content: str,
-        entities: list[str] | None,
+        detections: list[Detection],
     ) -> tuple[dict[str, int], list[_PendingPublish]]:
-        """Scan, then build and fire each finding's publish — all off the loop.
+        """Build a finding per detection and fire each publish — all off the loop.
 
-        Runs on a worker thread (via ``asyncify``): the analyzer call, the
-        false-positive classification (which may consult the embedded ASN
-        database), the byte-offset conversion, **and** each finding's proto build +
+        Runs on a worker thread (via ``asyncify``): the per-finding proto build +
         ``SerializeToString`` + client enqueue all stay off the event-loop thread.
-        Keeping the serialization here is the point — done on the loop it would be
-        per-finding GIL work competing with message intake.
 
-        Returns the histogram of detected entity types (for the summary log, so the
-        matched values never travel back to the loop) and the fired publishes for
-        ``_collect`` to await. A message's findings are independent, so each publish
-        is fired up front (``publish`` returns a future without waiting and the
-        client batches the sends); in series N findings would pay N Pub/Sub
-        round-trips back to back. A publish that raises *synchronously* (e.g. a
-        stopped client) is logged and skipped here — the same disposition
-        ``_collect`` gives an async commit failure — so one finding's failure
-        neither aborts the rest nor escapes to nack (and duplicate) the message.
+        Returns the histogram of detected entity types (for the summary log) and
+        the fired publishes for ``_collect`` to await. A message's findings are
+        independent, so each publish is fired up front (``publish`` returns a
+        future without waiting and the client batches the sends); in series N
+        findings would pay N Pub/Sub round-trips back to back. A publish that raises
+        *synchronously* (e.g. a stopped client) is logged and skipped here — the
+        same disposition ``_collect`` gives an async commit failure — so one
+        finding's failure neither aborts the rest nor escapes to nack (and
+        duplicate) the message.
         """
-        detections = self._scan(content, entities)
-        if not detections:
-            return {}, []
         # A fresh detection timestamp (UTC, RFC3339) stamped on every finding from
         # this delivery — when the scan ran, not when the request was created.
         created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -198,6 +162,7 @@ class PresidioHandler:
         pending: list[_PendingPublish] = []
         for d in detections:
             entity_types[d.entity_type] = entity_types.get(d.entity_type, 0) + 1
+            rule_id = _canonical_rule_id(d.entity_type)
             finding = finding_pb2.Finding(
                 # A UUIDv7 per finding: globally unique with a time-ordered prefix,
                 # so findings sort by creation in storage.
@@ -209,7 +174,7 @@ class PresidioHandler:
                 risk_policy_id=message.risk_policy_id,
                 risk_policy_version=message.risk_policy_version,
                 created_at=created_at,
-                rule_id=d.rule_id,
+                rule_id=rule_id,
                 description=_FINDING_DESCRIPTION,
                 match=d.match,
                 start_pos=d.start_pos,
@@ -221,9 +186,9 @@ class PresidioHandler:
             try:
                 result = self.publisher.publish(finding)
             except Exception as exc:
-                self._log_publish_failure(message, d.rule_id, exc)
+                self._log_publish_failure(message, rule_id, exc)
                 continue
-            pending.append(_PendingPublish(rule_id=d.rule_id, result=result))
+            pending.append(_PendingPublish(rule_id=rule_id, result=result))
         return entity_types, pending
 
     async def _collect(
@@ -266,44 +231,6 @@ class PresidioHandler:
             error_type=type(exc).__name__,
         )
 
-    def _scan(self, content: str, entities: list[str] | None) -> list[_Detection]:
-        """Analyze the content and return the real (non-false-positive) matches.
-
-        Runs on a worker thread (via ``asyncify``), so the analyzer call, the
-        false-positive classification (which may consult the embedded ASN
-        database), and the byte-offset conversion all stay off the event loop.
-        """
-        detections: list[_Detection] = []
-        for r in self.analyzer.analyze(text=content, entities=entities, language="en"):
-            start_byte, end_byte, match = _byte_span(content, r.start, r.end)
-            # Drop catalog false positives (reserved/placeholder IPs and emails,
-            # cloud/CDN ASN attribution) before they ever reach the topic.
-            if presidiofp.reason(r.entity_type, match):
-                continue
-            detections.append(
-                _Detection(
-                    entity_type=r.entity_type,
-                    rule_id=_canonical_rule_id(r.entity_type),
-                    match=match,
-                    start_pos=start_byte,
-                    end_pos=end_byte,
-                    confidence=r.score,
-                )
-            )
-        return detections
-
-
-async def build_default_analyzer() -> AnalyzerEngine:
-    """Construct an AnalyzerEngine backed by the explicitly selected spaCy model."""
-    provider = NlpEngineProvider(
-        nlp_configuration={
-            "nlp_engine_name": "spacy",
-            "models": [{"lang_code": "en", "model_name": SPACY_MODEL}],
-        }
-    )
-    nlp_engine = await asyncify(provider.create_engine)()
-    return AnalyzerEngine(nlp_engine=nlp_engine)
-
 
 def _canonical_rule_id(entity_type: str) -> str:
     """Map a Presidio UPPER_SNAKE entity type to the canonical rule id.
@@ -313,42 +240,6 @@ def _canonical_rule_id(entity_type: str) -> str:
     rule id regardless of which path produced it.
     """
     return "pii." + entity_type.lower()
-
-
-def _byte_span(content: str, start: int, end: int) -> tuple[int, int, str]:
-    """Clamp a Presidio character span and convert it to UTF-8 byte offsets.
-
-    Presidio reports character (code point) offsets, but the Finding schema
-    carries byte positions. Offsets are clamped to the content's bounds first to
-    guard against an out-of-range span. Returns ``(start_byte, end_byte, match)``.
-    """
-    n = len(content)
-    start = max(0, min(start, n))
-    end = max(start, min(end, n))
-    start_byte = len(content[:start].encode("utf-8"))
-    end_byte = len(content[:end].encode("utf-8"))
-    return start_byte, end_byte, content[start:end]
-
-
-class Recognized(Protocol):
-    """The slice of Presidio's ``RecognizerResult`` this handler consumes."""
-
-    entity_type: str
-    start: int  # Character offset (inclusive) of the match in the scanned text.
-    end: int  # Character offset (exclusive) of the match in the scanned text.
-    score: float  # Detection confidence, 0.0-1.0.
-
-
-class Analyzer(Protocol):
-    """The slice of ``AnalyzerEngine`` this handler depends on.
-
-    Narrowing to a protocol keeps the engine injectable — tests can supply a
-    lightweight fake instead of loading Presidio's NLP model.
-    """
-
-    def analyze(
-        self, *, text: str, entities: list[str] | None, language: str
-    ) -> Sequence[Recognized]: ...
 
 
 class FindingPublisher(Protocol):
@@ -365,27 +256,10 @@ class FindingPublisher(Protocol):
 
 
 @dataclass(frozen=True)
-class _Detection:
-    """A real (non-false-positive) PII match, ready to become a Finding.
-
-    Produced off the event loop by ``_scan`` so the analyzer call, false-positive
-    classification (which may hit the embedded ASN database), and byte-offset
-    conversion all stay on the worker thread.
-    """
-
-    entity_type: str
-    rule_id: str
-    match: str
-    start_pos: int  # UTF-8 byte offset.
-    end_pos: int  # UTF-8 byte offset.
-    confidence: float
-
-
-@dataclass(frozen=True)
 class _PendingPublish:
     """A fired publish awaiting its commit; ``result.get`` confirms or raises.
 
-    Built and fired off the event loop by ``_scan_and_publish`` so the proto
+    Built and fired off the event loop by ``_build_and_dispatch`` so the proto
     build + serialize never run on the loop thread. The rule id rides along so
     ``_collect`` can attribute a commit failure without re-deriving it.
     """

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -36,9 +36,9 @@ class PresidioHandler:
     never written to the handler's own logs — log lines report entity *types* and
     counts only, so they stay safe to retain.
 
-    The scanner determines how the scan is parallelized: an in-process
-    ``ThreadScanner`` (default) or a ``ProcessPoolScanner`` that breaks the
-    single-process GIL ceiling. The handler is agnostic to which it holds.
+    The scanner determines how the scan is parallelized: a ``ProcessPoolScanner``
+    (the default) that breaks the single-process GIL ceiling, or an in-process
+    ``ThreadScanner``. The handler is agnostic to which it holds.
     """
 
     def __init__(

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -222,10 +222,19 @@ class PresidioHandler:
         # Log entity *types* and counts only — never the matched values or the
         # scanned content — so the line is safe to retain while still being
         # traceable back to the originating request.
+        #
+        # Emitted at debug, not info: this fires once per detection-bearing
+        # message, and rendering it (JSON-encoding the event dict) runs on the
+        # event-loop thread holding the GIL — the per-message loop work that
+        # dominates ACK latency under burst. At the default info level the
+        # filtering bound logger short-circuits ``adebug`` to a no-op before any
+        # rendering, so the line costs nothing in production yet stays available
+        # when debugging. The async ``adebug`` keeps that render off the event
+        # loop on the occasions debug *is* enabled.
         entity_types: dict[str, int] = {}
         for d in detected:
             entity_types[d.entity_type] = entity_types.get(d.entity_type, 0) + 1
-        self.logger.info(
+        await self.logger.adebug(
             "presidio scan detected entities",
             request_id=message.request_id,
             reply_urn=message.reply_urn,

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -93,7 +93,7 @@ class PresidioHandler:
         # latency.
         try:
             scan_started = time.perf_counter()
-            pending = await asyncify(
+            entity_types, pending = await asyncify(
                 self._scan_and_publish, limiter=self._get_scan_limiter()
             )(
                 message=message,
@@ -122,7 +122,7 @@ class PresidioHandler:
             )
             return
 
-        if not pending:
+        if not entity_types:
             return
 
         # The publishes were already fired on the worker thread (the client batches
@@ -144,16 +144,13 @@ class PresidioHandler:
         # rendering, so the line costs nothing in production yet stays available
         # when debugging. The async ``adebug`` keeps that render off the event
         # loop on the occasions debug *is* enabled.
-        entity_types: dict[str, int] = {}
-        for p in pending:
-            entity_types[p.entity_type] = entity_types.get(p.entity_type, 0) + 1
         await self.logger.adebug(
             "presidio scan detected entities",
             request_id=message.request_id,
             reply_urn=message.reply_urn,
             requested_entities=requested or [],
             detected_entity_types=sorted(entity_types),
-            detected_count=len(pending),
+            detected_count=sum(entity_types.values()),
             published_count=published,
             delivery_attempt=meta.delivery_attempt,
             # Per-message latency split, safe to retain (durations, never content):
@@ -169,7 +166,7 @@ class PresidioHandler:
         message: presidio_analysis_pb2.PresidioAnalysis,
         content: str,
         entities: list[str] | None,
-    ) -> list[_PendingPublish]:
+    ) -> tuple[dict[str, int], list[_PendingPublish]]:
         """Scan, then build and fire each finding's publish — all off the loop.
 
         Runs on a worker thread (via ``asyncify``): the analyzer call, the
@@ -179,62 +176,55 @@ class PresidioHandler:
         Keeping the serialization here is the point — done on the loop it would be
         per-finding GIL work competing with message intake.
 
-        A message's findings are independent, so every publish is fired up front
-        (``publish`` returns a future without waiting and the client batches the
-        sends); the returned futures are collected on the loop by ``_collect``. In
-        series a message with N findings would pay N Pub/Sub round-trips back to
-        back; firing them together collapses that toward a single round-trip.
+        Returns the histogram of detected entity types (for the summary log, so the
+        matched values never travel back to the loop) and the fired publishes for
+        ``_collect`` to await. A message's findings are independent, so each publish
+        is fired up front (``publish`` returns a future without waiting and the
+        client batches the sends); in series N findings would pay N Pub/Sub
+        round-trips back to back. A publish that raises *synchronously* (e.g. a
+        stopped client) is logged and skipped here — the same disposition
+        ``_collect`` gives an async commit failure — so one finding's failure
+        neither aborts the rest nor escapes to nack (and duplicate) the message.
         """
         detections = self._scan(content, entities)
         if not detections:
-            return []
+            return {}, []
         # A fresh detection timestamp (UTC, RFC3339) stamped on every finding from
         # this delivery — when the scan ran, not when the request was created.
         created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        return [
-            _PendingPublish(
-                entity_type=d.entity_type,
+        # An explicit loop, not a comprehension: each publish needs its own
+        # try/except so a synchronous failure skips just that finding.
+        entity_types: dict[str, int] = {}
+        pending: list[_PendingPublish] = []
+        for d in detections:
+            entity_types[d.entity_type] = entity_types.get(d.entity_type, 0) + 1
+            finding = finding_pb2.Finding(
+                # A UUIDv7 per finding: globally unique with a time-ordered prefix,
+                # so findings sort by creation in storage.
+                id=str(uuid.uuid7()),
+                request_id=message.request_id,
+                chat_message_id=message.chat_message_id,
+                project_id=message.project_id,
+                organization_id=message.organization_id,
+                risk_policy_id=message.risk_policy_id,
+                risk_policy_version=message.risk_policy_version,
+                created_at=created_at,
                 rule_id=d.rule_id,
-                result=self._publish(
-                    finding_pb2.Finding(
-                        # A UUIDv7 per finding: globally unique with a time-ordered
-                        # prefix, so findings sort by creation in storage.
-                        id=str(uuid.uuid7()),
-                        request_id=message.request_id,
-                        chat_message_id=message.chat_message_id,
-                        project_id=message.project_id,
-                        organization_id=message.organization_id,
-                        risk_policy_id=message.risk_policy_id,
-                        risk_policy_version=message.risk_policy_version,
-                        created_at=created_at,
-                        rule_id=d.rule_id,
-                        description=_FINDING_DESCRIPTION,
-                        match=d.match,
-                        start_pos=d.start_pos,
-                        end_pos=d.end_pos,
-                        tags=["pii"],
-                        source=SOURCE_PRESIDIO,
-                        confidence=d.confidence,
-                    )
-                ),
+                description=_FINDING_DESCRIPTION,
+                match=d.match,
+                start_pos=d.start_pos,
+                end_pos=d.end_pos,
+                tags=["pii"],
+                source=SOURCE_PRESIDIO,
+                confidence=d.confidence,
             )
-            for d in detections
-        ]
-
-    def _publish(self, finding: finding_pb2.Finding) -> PublishResult:
-        """Fire one publish, deferring a synchronous failure to its result.
-
-        ``publish`` normally returns a future, but a synchronous raise (e.g. a
-        misconfigured client) would otherwise propagate out of ``_scan_and_publish``
-        and be reported as a *scan* failure, aborting the message's remaining
-        findings. Capturing it as a :class:`_FailedPublish` keeps per-finding
-        failure handling uniform whether ``publish`` raises now or the commit fails
-        later — both are logged and skipped by ``_collect``.
-        """
-        try:
-            return self.publisher.publish(finding)
-        except Exception as exc:
-            return _FailedPublish(exc)
+            try:
+                result = self.publisher.publish(finding)
+            except Exception as exc:
+                self._log_publish_failure(message, d.rule_id, exc)
+                continue
+            pending.append(_PendingPublish(rule_id=d.rule_id, result=result))
+        return entity_types, pending
 
     async def _collect(
         self,
@@ -243,7 +233,7 @@ class PresidioHandler:
     ) -> int:
         """Await each already-fired publish's commit; return how many landed.
 
-        A publish failure is logged and skipped rather than raised: nacking the
+        A commit failure is logged and skipped rather than raised: nacking the
         message would redeliver it and re-publish the findings that already
         landed, duplicating them (there is no dedup downstream).
         """
@@ -252,18 +242,29 @@ class PresidioHandler:
             try:
                 await p.result.get()
             except Exception as exc:
-                # Never echo the finding (it carries the matched value); log the
-                # request, rule id, and exception type only.
-                self.logger.error(
-                    "failed to publish risk finding",
-                    request_id=message.request_id,
-                    rule_id=p.rule_id,
-                    error_type=type(exc).__name__,
-                )
+                self._log_publish_failure(message, p.rule_id, exc)
                 continue
             published += 1
 
         return published
+
+    def _log_publish_failure(
+        self,
+        message: presidio_analysis_pb2.PresidioAnalysis,
+        rule_id: str,
+        exc: Exception,
+    ) -> None:
+        """Log one finding's publish failure (synchronous dispatch or async commit).
+
+        Never echo the finding — it carries the matched value — so only the request,
+        rule id, and exception type are logged.
+        """
+        self.logger.error(
+            "failed to publish risk finding",
+            request_id=message.request_id,
+            rule_id=rule_id,
+            error_type=type(exc).__name__,
+        )
 
     def _scan(self, content: str, entities: list[str] | None) -> list[_Detection]:
         """Analyze the content and return the real (non-false-positive) matches.
@@ -382,33 +383,12 @@ class _Detection:
 
 @dataclass(frozen=True)
 class _PendingPublish:
-    """A finding whose publish has already been fired; ``result.get`` confirms it.
+    """A fired publish awaiting its commit; ``result.get`` confirms or raises.
 
     Built and fired off the event loop by ``_scan_and_publish`` so the proto
-    build + serialize never run on the loop thread. The entity type and rule id
-    ride along so the loop can assemble the summary log and per-finding error
-    context without re-deriving them from the detection.
+    build + serialize never run on the loop thread. The rule id rides along so
+    ``_collect`` can attribute a commit failure without re-deriving it.
     """
 
-    entity_type: str
     rule_id: str
     result: PublishResult
-
-
-@dataclass(frozen=True)
-class _FailedPublish:
-    """A :class:`PublishResult` standing in for a publish that raised synchronously.
-
-    ``Publisher.publish`` returns a future, but it can still raise *synchronously*
-    (e.g. a misconfigured client). Capturing that as a result whose ``get`` re-raises
-    routes it through ``_collect``'s normal publish-failure path — logged and
-    skipped — exactly like an async commit failure. So one finding's failure
-    neither aborts the message's other publishes nor lets the error escape the
-    handler and nack the message (which would redeliver and duplicate the findings
-    that already landed).
-    """
-
-    exc: Exception
-
-    async def get(self) -> str:
-        raise self.exc

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -29,8 +29,9 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import signal
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
 from functools import partial
@@ -252,7 +253,7 @@ class ProcessPoolScanner(_AsyncCloseable):
         return scanner
 
     async def scan(self, content: str, entities: list[str] | None) -> list[Detection]:
-        future = self._executor.submit(_worker_scan, content, entities)
+        future = await self._submit(_worker_scan, content, entities)
         if self._scan_timeout is None:
             return await self._await_result(future)
         try:
@@ -266,7 +267,20 @@ class ProcessPoolScanner(_AsyncCloseable):
             raise
 
     async def _warm_one(self) -> None:
-        await self._await_result(self._executor.submit(_worker_warm))
+        await self._await_result(await self._submit(_worker_warm))
+
+    async def _submit(self, fn: Callable[..., _T], /, *args: object) -> Future[_T]:
+        # ``submit`` looks cheap, but it lazily spawns the worker/forkserver
+        # processes synchronously — on the pool's first use and again whenever
+        # ``max_tasks_per_child`` recycles a worker. That spawn is real blocking
+        # I/O (hundreds of ms at warmup), so bridge it through a worker thread like
+        # the result wait below; the executor is never touched from the loop.
+        def submit() -> Future[_T]:
+            return self._executor.submit(fn, *args)
+
+        return await asyncify(
+            submit, abandon_on_cancel=True, limiter=self._wait_limiter
+        )()
 
     async def _await_result(self, future: Future[_T]) -> _T:
         # Bridge a concurrent.futures future to anyio without binding to asyncio's
@@ -308,6 +322,12 @@ _WORKER_ANALYZER: Analyzer | None = None
 def _worker_init() -> None:
     """Pool initializer: build this worker's analyzer once, up front."""
     global _WORKER_ANALYZER
+    # A terminal delivers SIGINT (Ctrl-C) to the whole process group, so each
+    # worker would otherwise take the signal mid-``call_queue.get`` and dump a
+    # KeyboardInterrupt traceback. Ignore it here and let the parent own shutdown:
+    # its signal handler cancels the task group and ``aclose`` drains and reaps the
+    # pool, so the workers exit cleanly via the executor rather than the signal.
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     _WORKER_ANALYZER = _build_analyzer()
 
 

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -34,7 +34,7 @@ from collections.abc import Sequence
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
 from functools import partial
-from typing import Protocol, TypeVar
+from typing import Protocol, Self, TypeVar
 
 import anyio
 from anyio import to_thread
@@ -79,7 +79,8 @@ class Scanner(Protocol):
     Implementations run the analyzer on a worker thread or in a separate process
     and return the post-false-positive-filter matches. ``aclose`` releases any
     resources (a no-op for the in-process scanner; drains the pool for the
-    process-pool one).
+    process-pool one), and is also exposed as an async context manager so callers
+    can ``async with`` the scanner instead of pairing it with a ``finally``.
     """
 
     async def scan(
@@ -88,19 +89,41 @@ class Scanner(Protocol):
 
     async def aclose(self) -> None: ...
 
+    async def __aenter__(self) -> Self: ...
 
-class ThreadScanner:
-    """Scan in-process on an anyio worker thread (the default).
+    async def __aexit__(self, *exc_info: object) -> None: ...
 
-    Presidio's per-scan work is almost entirely GIL-bound, so extra scan threads
-    don't add parallelism — they thrash the GIL and starve the event loop. A local
-    burst sweep on a 10-core box found throughput/latency peak at 2 concurrent
-    scans and degrade monotonically with more (the default-40 thread pool managed
-    only ~28 msg/s at p50 ~1.55s versus ~42 msg/s at p50 ~1.07s with 2). The
-    optimum tracks the GIL, not the core count, so 2 is a sane default everywhere;
-    to scale past it, use a :class:`ProcessPoolScanner`. ``max_concurrency`` of
-    None (or <=0) disables the cap and falls back to anyio's default thread-pool
-    limiter (40).
+
+class _AsyncCloseable:
+    """Mixin exposing a scanner's ``aclose`` as an async context manager.
+
+    Both scanners release resources through ``aclose``; entering returns the
+    scanner and leaving the block closes it, so a caller can ``async with`` the
+    scanner rather than calling ``aclose`` from a ``finally``.
+    """
+
+    async def aclose(self) -> None: ...
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.aclose()
+
+
+class ThreadScanner(_AsyncCloseable):
+    """Scan in-process on an anyio worker thread (the opt-out from the pool).
+
+    Selected with ``--scan-workers 0``; the :class:`ProcessPoolScanner` is the
+    default. Presidio's per-scan work is almost entirely GIL-bound, so extra scan
+    threads don't add parallelism — they thrash the GIL and starve the event loop.
+    A local burst sweep on a 10-core box found throughput/latency peak at 2
+    concurrent scans and degrade monotonically with more (the default-40 thread
+    pool managed only ~28 msg/s at p50 ~1.55s versus ~42 msg/s at p50 ~1.07s with
+    2). The optimum tracks the GIL, not the core count, so 2 is a sane default
+    everywhere; to scale past it, use a :class:`ProcessPoolScanner`.
+    ``max_concurrency`` of None (or <=0) disables the cap and falls back to
+    anyio's default thread-pool limiter (40).
     """
 
     def __init__(self, analyzer: Analyzer, *, max_concurrency: int | None = 2):
@@ -125,8 +148,8 @@ class ThreadScanner:
         return None
 
 
-class ProcessPoolScanner:
-    """Scan in a pool of worker processes, each with its own GIL.
+class ProcessPoolScanner(_AsyncCloseable):
+    """Scan in a pool of worker processes, each with its own GIL (the default).
 
     The single-process throughput ceiling is the GIL: the spaCy NER pass and
     Presidio's regex recognizers hold it for almost the whole scan, so no number

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -33,6 +33,8 @@ import time
 from collections.abc import Sequence
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
+from functools import partial
+from itertools import accumulate
 from typing import Protocol, TypeVar
 
 import anyio
@@ -161,14 +163,25 @@ class ProcessPoolScanner:
     Everything that touches the executor is bridged through anyio's threading and
     cancellation primitives (``to_thread.run_sync`` + ``fail_after``) rather than
     the asyncio loop directly, so the scanner runs unchanged on either anyio
-    backend (asyncio or trio).
+    backend (asyncio or trio). The bridge uses a dedicated thread limiter sized to
+    the worker count, so blocking on pool results never draws down anyio's shared
+    default thread pool (used by the publish hop and the in-process scanner) — only
+    ``max_workers`` scans run at once, so that many result-waits is the ceiling.
     """
 
     def __init__(
-        self, executor: ProcessPoolExecutor, *, scan_timeout: float | None = 30.0
+        self,
+        executor: ProcessPoolExecutor,
+        *,
+        scan_timeout: float | None = 30.0,
+        wait_limiter: anyio.CapacityLimiter | None = None,
     ):
         self._executor = executor
         self._scan_timeout = scan_timeout if scan_timeout and scan_timeout > 0 else None
+        # Dedicated limiter for the result-wait threads (see class docstring). None
+        # falls back to anyio's default limiter — fine for the single-scan tests,
+        # but ``create`` always supplies one for the real, concurrent path.
+        self._wait_limiter = wait_limiter
 
     @classmethod
     async def create(
@@ -197,13 +210,23 @@ class ProcessPoolScanner:
                 else None
             ),
         )
-        scanner = cls(executor, scan_timeout=scan_timeout)
+        scanner = cls(
+            executor,
+            scan_timeout=scan_timeout,
+            wait_limiter=anyio.CapacityLimiter(max_workers),
+        )
         # One warmup task per worker, run concurrently; each does a real scan and
         # then briefly sleeps so the tasks can't all be served by one worker —
         # forcing the pool to spawn (and initialize) every worker before traffic.
-        async with anyio.create_task_group() as tg:
-            for _ in range(max_workers):
-                tg.start_soon(scanner._warm_one)
+        try:
+            async with anyio.create_task_group() as tg:
+                for _ in range(max_workers):
+                    tg.start_soon(scanner._warm_one)
+        except BaseException:
+            # Warmup failed or was cancelled after spawning some workers; reap them
+            # (aclose is bounded) so a failed create doesn't leak processes.
+            await scanner.aclose()
+            raise
         return scanner
 
     async def scan(self, content: str, entities: list[str] | None) -> list[Detection]:
@@ -227,11 +250,27 @@ class ProcessPoolScanner:
         # Bridge a concurrent.futures future to anyio without binding to asyncio's
         # loop: a worker thread blocks on result() and the await is cancellable
         # (abandon_on_cancel) so fail_after can fire without waiting the scan out.
-        return await to_thread.run_sync(future.result, abandon_on_cancel=True)
+        # The dedicated limiter keeps these waits off anyio's shared thread pool.
+        return await to_thread.run_sync(
+            future.result, abandon_on_cancel=True, limiter=self._wait_limiter
+        )
 
-    async def aclose(self) -> None:
-        # Wait for in-flight scans so a shutdown doesn't drop a message mid-scan.
-        await asyncify(self._executor.shutdown)(wait=True)
+    async def aclose(self, *, grace_period: float = 10.0) -> None:
+        """Shut the pool down, bounded so a stalled scan can't hang teardown.
+
+        Cancels queued scans and waits up to ``grace_period`` seconds for in-flight
+        ones (which can't be interrupted mid-scan) to finish; past the deadline the
+        worker processes are killed so the surrounding teardown (e.g. the broker's
+        publish flush) is never blocked indefinitely.
+        """
+        with anyio.move_on_after(grace_period) as scope:
+            await to_thread.run_sync(
+                partial(self._executor.shutdown, wait=True, cancel_futures=True),
+                abandon_on_cancel=True,
+            )
+        if scope.cancelled_caught:
+            for proc in list(getattr(self._executor, "_processes", {}).values()):
+                proc.kill()
 
 
 # --- Worker-process state and entry points -------------------------------------
@@ -283,9 +322,23 @@ def _scan_to_detections(
     embedded ASN database), and the byte-offset conversion all stay off the event
     loop wherever it runs.
     """
+    results = analyzer.analyze(text=content, entities=entities, language="en")
+    if not results:
+        return []
+    # Presidio reports character offsets, but the Finding schema carries UTF-8 byte
+    # positions. Precompute the cumulative byte offset at every character boundary
+    # once (``byte_at[i]`` == bytes in ``content[:i]``) so each match's char->byte
+    # conversion is an O(1) lookup. Re-encoding ``content[:offset]`` per match (as a
+    # naive conversion does) is O(matches x length) — quadratic on a large message
+    # with many hits.
+    byte_at = list(accumulate((len(c.encode("utf-8")) for c in content), initial=0))
+    n = len(content)
     detections: list[Detection] = []
-    for r in analyzer.analyze(text=content, entities=entities, language="en"):
-        start_byte, end_byte, match = _byte_span(content, r.start, r.end)
+    for r in results:
+        # Clamp to the content's bounds to guard against an out-of-range span.
+        start = max(0, min(r.start, n))
+        end = max(start, min(r.end, n))
+        match = content[start:end]
         # Drop catalog false positives (reserved/placeholder IPs and emails,
         # cloud/CDN ASN attribution) before they ever reach the handler.
         if presidiofp.reason(r.entity_type, match):
@@ -294,8 +347,8 @@ def _scan_to_detections(
             Detection(
                 entity_type=r.entity_type,
                 match=match,
-                start_pos=start_byte,
-                end_pos=end_byte,
+                start_pos=byte_at[start],
+                end_pos=byte_at[end],
                 confidence=r.score,
             )
         )
@@ -320,21 +373,6 @@ def _build_analyzer() -> AnalyzerEngine:
 async def build_default_analyzer() -> AnalyzerEngine:
     """Construct an AnalyzerEngine off the event loop (model load is blocking)."""
     return await asyncify(_build_analyzer)()
-
-
-def _byte_span(content: str, start: int, end: int) -> tuple[int, int, str]:
-    """Clamp a Presidio character span and convert it to UTF-8 byte offsets.
-
-    Presidio reports character (code point) offsets, but the Finding schema
-    carries byte positions. Offsets are clamped to the content's bounds first to
-    guard against an out-of-range span. Returns ``(start_byte, end_byte, match)``.
-    """
-    n = len(content)
-    start = max(0, min(start, n))
-    end = max(start, min(end, n))
-    start_byte = len(content[:start].encode("utf-8"))
-    end_byte = len(content[:end].encode("utf-8"))
-    return start_byte, end_byte, content[start:end]
 
 
 class Recognized(Protocol):

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -27,16 +27,16 @@ Two scanners are provided:
 
 from __future__ import annotations
 
-import asyncio
 import multiprocessing
 import os
 import time
 from collections.abc import Sequence
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, TypeVar
 
 import anyio
+from anyio import to_thread
 from asyncer import asyncify
 from presidio_analyzer import AnalyzerEngine
 from presidio_analyzer.nlp_engine import NlpEngineProvider
@@ -48,6 +48,8 @@ from pystreams.risk import presidiofp
 # it explicitly ties the scanner to the model we actually ship and stops a future
 # Presidio default change from silently reaching for a model we don't package.
 SPACY_MODEL = "en_core_web_lg"
+
+_T = TypeVar("_T")
 
 
 @dataclass(frozen=True)
@@ -142,38 +144,90 @@ class ProcessPoolScanner:
     Workers return only the final :class:`Detection` list (already
     false-positive-filtered, byte offsets resolved), which is small and picklable;
     the heavy text and the analyzer never cross the process boundary per message.
+
+    Two lifecycle knobs borrow from gunicorn's pre-fork model (the same shape the
+    official Presidio image uses to scale):
+
+    - ``max_tasks_per_child`` recycles a worker after it has run that many scans
+      (gunicorn's ``--max-requests``), bounding spaCy/numpy memory drift over a
+      long-lived worker. ``None``/<=0 disables recycling.
+    - ``scan_timeout`` bounds how long a single scan may take before it is treated
+      as a failure (gunicorn's ``--timeout``). The worker cannot be interrupted
+      mid-scan, but the executor stops routing to it, ``max_tasks_per_child``
+      recycles it once the doomed scan finishes, and meanwhile the other workers
+      keep serving — a single pathological message removes one worker from
+      rotation rather than stalling the consumer. ``None``/<=0 disables the bound.
+
+    Everything that touches the executor is bridged through anyio's threading and
+    cancellation primitives (``to_thread.run_sync`` + ``fail_after``) rather than
+    the asyncio loop directly, so the scanner runs unchanged on either anyio
+    backend (asyncio or trio).
     """
 
-    def __init__(self, executor: ProcessPoolExecutor):
+    def __init__(
+        self, executor: ProcessPoolExecutor, *, scan_timeout: float | None = 30.0
+    ):
         self._executor = executor
+        self._scan_timeout = scan_timeout if scan_timeout and scan_timeout > 0 else None
 
     @classmethod
-    async def create(cls, *, max_workers: int = 4) -> ProcessPoolScanner:
+    async def create(
+        cls,
+        *,
+        max_workers: int = 4,
+        max_tasks_per_child: int | None = 1000,
+        scan_timeout: float | None = 30.0,
+    ) -> ProcessPoolScanner:
         """Build the pool and eagerly warm every worker's analyzer.
 
         ``forkserver`` is chosen explicitly so the start method does not depend on
-        the platform default. The warmup forces each worker to spawn and load its
-        model up front, so the first real scans don't pay model-load latency.
+        the platform default (and so ``max_tasks_per_child`` is usable — it is not
+        supported with the ``fork`` start method). The warmup forces each worker to
+        spawn and load its model up front, so the first real scans don't pay
+        model-load latency.
         """
         executor = ProcessPoolExecutor(
             max_workers=max_workers,
             mp_context=multiprocessing.get_context("forkserver"),
             initializer=_worker_init,
+            # <=0 (or None) means "live as long as the pool" — disable recycling.
+            max_tasks_per_child=(
+                max_tasks_per_child
+                if max_tasks_per_child and max_tasks_per_child > 0
+                else None
+            ),
         )
-        loop = asyncio.get_running_loop()
+        scanner = cls(executor, scan_timeout=scan_timeout)
         # One warmup task per worker, run concurrently; each does a real scan and
         # then briefly sleeps so the tasks can't all be served by one worker —
         # forcing the pool to spawn (and initialize) every worker before traffic.
-        await asyncio.gather(
-            *(loop.run_in_executor(executor, _worker_warm) for _ in range(max_workers))
-        )
-        return cls(executor)
+        async with anyio.create_task_group() as tg:
+            for _ in range(max_workers):
+                tg.start_soon(scanner._warm_one)
+        return scanner
 
     async def scan(self, content: str, entities: list[str] | None) -> list[Detection]:
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            self._executor, _worker_scan, content, entities
-        )
+        future = self._executor.submit(_worker_scan, content, entities)
+        if self._scan_timeout is None:
+            return await self._await_result(future)
+        try:
+            with anyio.fail_after(self._scan_timeout):
+                return await self._await_result(future)
+        except TimeoutError:
+            # Pull it from the executor queue if it hasn't started; a no-op once a
+            # worker has picked it up (the scan can't be interrupted, but the wait
+            # is over and the worker will be recycled per max_tasks_per_child).
+            future.cancel()
+            raise
+
+    async def _warm_one(self) -> None:
+        await self._await_result(self._executor.submit(_worker_warm))
+
+    async def _await_result(self, future: Future[_T]) -> _T:
+        # Bridge a concurrent.futures future to anyio without binding to asyncio's
+        # loop: a worker thread blocks on result() and the await is cancellable
+        # (abandon_on_cancel) so fail_after can fire without waiting the scan out.
+        return await to_thread.run_sync(future.result, abandon_on_cancel=True)
 
     async def aclose(self) -> None:
         # Wait for in-flight scans so a shutdown doesn't drop a message mid-scan.

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -34,7 +34,6 @@ from collections.abc import Sequence
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
 from functools import partial
-from itertools import accumulate
 from typing import Protocol, TypeVar
 
 import anyio
@@ -325,34 +324,63 @@ def _scan_to_detections(
     results = analyzer.analyze(text=content, entities=entities, language="en")
     if not results:
         return []
-    # Presidio reports character offsets, but the Finding schema carries UTF-8 byte
-    # positions. Precompute the cumulative byte offset at every character boundary
-    # once (``byte_at[i]`` == bytes in ``content[:i]``) so each match's char->byte
-    # conversion is an O(1) lookup. Re-encoding ``content[:offset]`` per match (as a
-    # naive conversion does) is O(matches x length) — quadratic on a large message
-    # with many hits.
-    byte_at = list(accumulate((len(c.encode("utf-8")) for c in content), initial=0))
     n = len(content)
-    detections: list[Detection] = []
+    # Clamp each span to the content's bounds (guarding against an out-of-range
+    # span) and drop catalog false positives (reserved/placeholder IPs and emails,
+    # cloud/CDN ASN attribution) before they ever reach the handler. This pass
+    # works in character offsets, so a discarded match never costs byte conversion.
+    spans: list[tuple[Recognized, int, int, str]] = []
     for r in results:
-        # Clamp to the content's bounds to guard against an out-of-range span.
         start = max(0, min(r.start, n))
         end = max(start, min(r.end, n))
         match = content[start:end]
-        # Drop catalog false positives (reserved/placeholder IPs and emails,
-        # cloud/CDN ASN attribution) before they ever reach the handler.
         if presidiofp.reason(r.entity_type, match):
             continue
-        detections.append(
-            Detection(
-                entity_type=r.entity_type,
-                match=match,
-                start_pos=byte_at[start],
-                end_pos=byte_at[end],
-                confidence=r.score,
-            )
+        spans.append((r, start, end, match))
+    if not spans:
+        return []
+    # Presidio reports character offsets, but the Finding schema carries UTF-8 byte
+    # positions. Resolve a byte offset only for the boundaries we actually emit —
+    # at most two per surviving match — so memory stays O(matches) rather than the
+    # O(length) a full per-character prefix table costs on every scan, which would
+    # multiply across pool workers on large payloads.
+    byte_at = _byte_offsets(content, spans)
+    return [
+        Detection(
+            entity_type=r.entity_type,
+            match=match,
+            start_pos=byte_at[start],
+            end_pos=byte_at[end],
+            confidence=r.score,
         )
-    return detections
+        for r, start, end, match in spans
+    ]
+
+
+def _byte_offsets(
+    content: str, spans: list[tuple[Recognized, int, int, str]]
+) -> dict[int, int]:
+    """Map each span boundary's character offset to its UTF-8 byte offset.
+
+    ASCII text encodes one byte per character, so the offsets coincide and no
+    conversion is needed. Otherwise the string is walked once in offset order,
+    accumulating the byte position only at the boundaries we need: O(length) time
+    but O(matches) memory, versus the O(length) memory a full prefix table costs.
+    """
+    needed: set[int] = set()
+    for _, start, end, _ in spans:
+        needed.add(start)
+        needed.add(end)
+    if content.isascii():
+        return {pos: pos for pos in needed}
+    byte_at: dict[int, int] = {}
+    byte_pos = 0
+    char_pos = 0
+    for target in sorted(needed):
+        byte_pos += len(content[char_pos:target].encode("utf-8"))
+        char_pos = target
+        byte_at[target] = byte_pos
+    return byte_at
 
 
 def _build_analyzer() -> AnalyzerEngine:

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -178,10 +178,12 @@ class ProcessPoolScanner(_AsyncCloseable):
       long-lived worker. ``None``/<=0 disables recycling.
     - ``scan_timeout`` bounds how long a single scan may take before it is treated
       as a failure (gunicorn's ``--timeout``). The worker cannot be interrupted
-      mid-scan, but the executor stops routing to it, ``max_tasks_per_child``
-      recycles it once the doomed scan finishes, and meanwhile the other workers
-      keep serving — a single pathological message removes one worker from
-      rotation rather than stalling the consumer. ``None``/<=0 disables the bound.
+      mid-scan: the timed-out scan keeps running on its worker to completion, but
+      the caller stops waiting and that worker is simply unavailable (not serving
+      other scans) until it finishes, at which point ``max_tasks_per_child`` may
+      recycle it. Meanwhile the other workers keep serving — a single pathological
+      message ties up at most one worker rather than stalling the consumer.
+      ``None``/<=0 disables the bound.
 
     Everything that touches the executor is bridged through anyio's threading and
     cancellation primitives (``to_thread.run_sync`` + ``fail_after``) rather than
@@ -305,6 +307,13 @@ class ProcessPoolScanner(_AsyncCloseable):
                 abandon_on_cancel=True,
             )
         if scope.cancelled_caught:
+            # Last resort once the graceful shutdown overran its deadline: reach
+            # into the executor's private ``_processes`` map to hard-kill the
+            # workers. ProcessPoolExecutor exposes no public API for this, so the
+            # access is version-coupled to CPython internals — guarded with
+            # ``getattr`` so a future rename degrades to "graceful shutdown already
+            # timed out, nothing more we can do" instead of an AttributeError that
+            # would mask the original teardown stall.
             for proc in list(getattr(self._executor, "_processes", {}).values()):
                 proc.kill()
 

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -1,0 +1,304 @@
+"""Presidio PII scanning machinery, encapsulated behind a tiny async API.
+
+This module owns everything to do with *running* Presidio: loading the spaCy
+model, building the ``AnalyzerEngine``, running the scan off the event loop
+(either on a worker thread or across a pool of worker processes), dropping
+catalog false positives, and converting match spans to byte offsets. It exposes
+that as a single :class:`Scanner` protocol — ``await scanner.scan(content,
+entities)`` returns the real :class:`Detection` matches, and ``await
+scanner.aclose()`` releases any resources.
+
+Everything *downstream* of a detection — turning it into a ``Finding``, logging,
+and publishing to Pub/Sub — lives in ``handler.py``. The split keeps the
+GIL-bound, model-heavy scan concern isolated from the I/O and domain-mapping
+concern, and lets each be tested on its own (the handler against a fake scanner,
+the scanner against a fake analyzer).
+
+Two scanners are provided:
+
+- :class:`ThreadScanner` runs the scan in-process on an anyio worker thread. The
+  scan is almost entirely GIL-bound, so a single process tops out around
+  ~50 msg/s no matter how many scan threads are allowed; the thread count is
+  capped low for that reason.
+- :class:`ProcessPoolScanner` runs the scan across worker processes, each with
+  its own GIL and its own model, breaking that single-process ceiling inside one
+  pod.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+import os
+import time
+from collections.abc import Sequence
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from typing import Protocol
+
+import anyio
+from asyncer import asyncify
+from presidio_analyzer import AnalyzerEngine
+from presidio_analyzer.nlp_engine import NlpEngineProvider
+
+from pystreams.risk import presidiofp
+
+# The spaCy model bundled into the image (pinned in pystreams/pyproject.toml).
+# Presidio's default AnalyzerEngine() would also load this model, but selecting
+# it explicitly ties the scanner to the model we actually ship and stops a future
+# Presidio default change from silently reaching for a model we don't package.
+SPACY_MODEL = "en_core_web_lg"
+
+
+@dataclass(frozen=True)
+class Detection:
+    """A real (non-false-positive) PII match found in scanned content.
+
+    The scanner's output unit and the whole of its public data contract: byte
+    offsets (the schema the ``Finding`` carries) and the matched substring. The
+    handler maps this onto a ``Finding`` — deriving the rule id, stamping context,
+    etc. — so the rule-naming and finding-building stay out of the scanner.
+
+    Picklable (a frozen dataclass of primitives) so it can travel back from a
+    :class:`ProcessPoolScanner` worker process.
+    """
+
+    entity_type: str
+    match: str
+    start_pos: int  # UTF-8 byte offset.
+    end_pos: int  # UTF-8 byte offset.
+    confidence: float  # Detection confidence, 0.0-1.0.
+
+
+class Scanner(Protocol):
+    """Turns scanned content into the real PII detections, off the event loop.
+
+    Implementations run the analyzer on a worker thread or in a separate process
+    and return the post-false-positive-filter matches. ``aclose`` releases any
+    resources (a no-op for the in-process scanner; drains the pool for the
+    process-pool one).
+    """
+
+    async def scan(
+        self, content: str, entities: list[str] | None
+    ) -> list[Detection]: ...
+
+    async def aclose(self) -> None: ...
+
+
+class ThreadScanner:
+    """Scan in-process on an anyio worker thread (the default).
+
+    Presidio's per-scan work is almost entirely GIL-bound, so extra scan threads
+    don't add parallelism — they thrash the GIL and starve the event loop. A local
+    burst sweep on a 10-core box found throughput/latency peak at 2 concurrent
+    scans and degrade monotonically with more (the default-40 thread pool managed
+    only ~28 msg/s at p50 ~1.55s versus ~42 msg/s at p50 ~1.07s with 2). The
+    optimum tracks the GIL, not the core count, so 2 is a sane default everywhere;
+    to scale past it, use a :class:`ProcessPoolScanner`. ``max_concurrency`` of
+    None (or <=0) disables the cap and falls back to anyio's default thread-pool
+    limiter (40).
+    """
+
+    def __init__(self, analyzer: Analyzer, *, max_concurrency: int | None = 2):
+        self._analyzer = analyzer
+        self._max_concurrency = max_concurrency
+        self._limiter: anyio.CapacityLimiter | None = None
+
+    def _get_limiter(self) -> anyio.CapacityLimiter | None:
+        """Lazily build the shared scan limiter (needs a running event loop)."""
+        if self._max_concurrency is None or self._max_concurrency <= 0:
+            return None
+        if self._limiter is None:
+            self._limiter = anyio.CapacityLimiter(self._max_concurrency)
+        return self._limiter
+
+    async def scan(self, content: str, entities: list[str] | None) -> list[Detection]:
+        return await asyncify(_scan_to_detections, limiter=self._get_limiter())(
+            self._analyzer, content, entities
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+class ProcessPoolScanner:
+    """Scan in a pool of worker processes, each with its own GIL.
+
+    The single-process throughput ceiling is the GIL: the spaCy NER pass and
+    Presidio's regex recognizers hold it for almost the whole scan, so no number
+    of in-process threads gets past ~50 msg/s. Running the scan in a
+    ``ProcessPoolExecutor`` gives each worker its own interpreter and GIL, so N
+    workers scan genuinely in parallel and the event loop never blocks on scan
+    work — breaking the ceiling inside a single pod, without adding replicas.
+
+    Each worker loads its own ``AnalyzerEngine`` once, in the pool initializer, and
+    reuses it for every scan it handles. The model is loaded per worker rather than
+    shared copy-on-write: Python 3.14 defaults the start method to ``forkserver``
+    (and forking a process that already runs the asyncio loop + gRPC client threads
+    is unsafe anyway), so a clean per-worker load is the robust choice. The cost is
+    ~one model resident set per worker; keep the worker count small (2-4).
+
+    Workers return only the final :class:`Detection` list (already
+    false-positive-filtered, byte offsets resolved), which is small and picklable;
+    the heavy text and the analyzer never cross the process boundary per message.
+    """
+
+    def __init__(self, executor: ProcessPoolExecutor):
+        self._executor = executor
+
+    @classmethod
+    async def create(cls, *, max_workers: int = 4) -> ProcessPoolScanner:
+        """Build the pool and eagerly warm every worker's analyzer.
+
+        ``forkserver`` is chosen explicitly so the start method does not depend on
+        the platform default. The warmup forces each worker to spawn and load its
+        model up front, so the first real scans don't pay model-load latency.
+        """
+        executor = ProcessPoolExecutor(
+            max_workers=max_workers,
+            mp_context=multiprocessing.get_context("forkserver"),
+            initializer=_worker_init,
+        )
+        loop = asyncio.get_running_loop()
+        # One warmup task per worker, run concurrently; each does a real scan and
+        # then briefly sleeps so the tasks can't all be served by one worker —
+        # forcing the pool to spawn (and initialize) every worker before traffic.
+        await asyncio.gather(
+            *(loop.run_in_executor(executor, _worker_warm) for _ in range(max_workers))
+        )
+        return cls(executor)
+
+    async def scan(self, content: str, entities: list[str] | None) -> list[Detection]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor, _worker_scan, content, entities
+        )
+
+    async def aclose(self) -> None:
+        # Wait for in-flight scans so a shutdown doesn't drop a message mid-scan.
+        await asyncify(self._executor.shutdown)(wait=True)
+
+
+# --- Worker-process state and entry points -------------------------------------
+#
+# These run in the ProcessPoolScanner's worker processes. Each worker builds its
+# own analyzer once (in the initializer) and stores it in this module-level global,
+# then reuses it for every scan. The functions are module-level (not closures or
+# methods) so ``forkserver``/``spawn`` can import them by qualified name.
+
+_WORKER_ANALYZER: Analyzer | None = None
+
+
+def _worker_init() -> None:
+    """Pool initializer: build this worker's analyzer once, up front."""
+    global _WORKER_ANALYZER
+    _WORKER_ANALYZER = _build_analyzer()
+
+
+def _worker_scan(content: str, entities: list[str] | None) -> list[Detection]:
+    """Scan in a worker process using its cached analyzer."""
+    global _WORKER_ANALYZER
+    analyzer = _WORKER_ANALYZER
+    if analyzer is None:
+        # Defensive: the initializer always runs first, but rebuild rather than
+        # crash the worker if somehow it didn't.
+        analyzer = _WORKER_ANALYZER = _build_analyzer()
+    return _scan_to_detections(analyzer, content, entities)
+
+
+def _worker_warm() -> int:
+    """Exercise the worker's analyzer (loaded by the initializer) and yield.
+
+    The short sleep lets concurrently-submitted warmups land on distinct workers,
+    so ``create`` reliably spins up every worker before serving real traffic.
+    """
+    _worker_scan("warm up: a@b.com", None)
+    time.sleep(0.25)
+    return os.getpid()
+
+
+def _scan_to_detections(
+    analyzer: Analyzer, content: str, entities: list[str] | None
+) -> list[Detection]:
+    """Analyze the content and return the real (non-false-positive) matches.
+
+    Pure and side-effect free so it can run either on an anyio worker thread (the
+    in-process scanner) or inside a pool worker process (the process-pool scanner):
+    the analyzer call, the false-positive classification (which may consult the
+    embedded ASN database), and the byte-offset conversion all stay off the event
+    loop wherever it runs.
+    """
+    detections: list[Detection] = []
+    for r in analyzer.analyze(text=content, entities=entities, language="en"):
+        start_byte, end_byte, match = _byte_span(content, r.start, r.end)
+        # Drop catalog false positives (reserved/placeholder IPs and emails,
+        # cloud/CDN ASN attribution) before they ever reach the handler.
+        if presidiofp.reason(r.entity_type, match):
+            continue
+        detections.append(
+            Detection(
+                entity_type=r.entity_type,
+                match=match,
+                start_pos=start_byte,
+                end_pos=end_byte,
+                confidence=r.score,
+            )
+        )
+    return detections
+
+
+def _build_analyzer() -> AnalyzerEngine:
+    """Construct an AnalyzerEngine backed by the explicitly selected spaCy model.
+
+    Synchronous: callable directly inside a pool worker's initializer and wrapped
+    in ``asyncify`` by :func:`build_default_analyzer` for the async caller.
+    """
+    provider = NlpEngineProvider(
+        nlp_configuration={
+            "nlp_engine_name": "spacy",
+            "models": [{"lang_code": "en", "model_name": SPACY_MODEL}],
+        }
+    )
+    return AnalyzerEngine(nlp_engine=provider.create_engine())
+
+
+async def build_default_analyzer() -> AnalyzerEngine:
+    """Construct an AnalyzerEngine off the event loop (model load is blocking)."""
+    return await asyncify(_build_analyzer)()
+
+
+def _byte_span(content: str, start: int, end: int) -> tuple[int, int, str]:
+    """Clamp a Presidio character span and convert it to UTF-8 byte offsets.
+
+    Presidio reports character (code point) offsets, but the Finding schema
+    carries byte positions. Offsets are clamped to the content's bounds first to
+    guard against an out-of-range span. Returns ``(start_byte, end_byte, match)``.
+    """
+    n = len(content)
+    start = max(0, min(start, n))
+    end = max(start, min(end, n))
+    start_byte = len(content[:start].encode("utf-8"))
+    end_byte = len(content[:end].encode("utf-8"))
+    return start_byte, end_byte, content[start:end]
+
+
+class Recognized(Protocol):
+    """The slice of Presidio's ``RecognizerResult`` the scanner consumes."""
+
+    entity_type: str
+    start: int  # Character offset (inclusive) of the match in the scanned text.
+    end: int  # Character offset (exclusive) of the match in the scanned text.
+    score: float  # Detection confidence, 0.0-1.0.
+
+
+class Analyzer(Protocol):
+    """The slice of ``AnalyzerEngine`` the scanner depends on.
+
+    Narrowing to a protocol keeps the engine injectable — tests can supply a
+    lightweight fake instead of loading Presidio's NLP model.
+    """
+
+    def analyze(
+        self, *, text: str, entities: list[str] | None, language: str
+    ) -> Sequence[Recognized]: ...

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -7,7 +7,7 @@ from gram_infra.pubsub.subscriber import MessageMetadata
 from structlog.testing import capture_logs
 
 from pystreams.risk.handler import PresidioHandler
-from pystreams.risk.scanner import Detection
+from pystreams.risk.scanner import Detection, _AsyncCloseable
 
 # Matches the RFC3339 UTC form the handler stamps on a finding's created_at.
 _RFC3339_UTC = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
@@ -30,7 +30,7 @@ def _detection(
     )
 
 
-class FakeScanner:
+class FakeScanner(_AsyncCloseable):
     """Returns canned detections (or raises), and records its scan calls.
 
     Stands in for a real :class:`~pystreams.risk.scanner.Scanner` so the handler

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -6,41 +6,56 @@ from gram.risk.v1 import finding_pb2, presidio_analysis_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
 from structlog.testing import capture_logs
 
-from pystreams.risk.handler import PresidioHandler, Recognized
+from pystreams.risk.handler import PresidioHandler
+from pystreams.risk.scanner import Detection
 
 # Matches the RFC3339 UTC form the handler stamps on a finding's created_at.
 _RFC3339_UTC = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
 
 
-class _Result:
-    """Minimal stand-in for a Presidio ``RecognizerResult``."""
+def _detection(
+    entity_type: str,
+    match: str,
+    *,
+    start_pos: int = 0,
+    end_pos: int = 0,
+    confidence: float = 0.5,
+) -> Detection:
+    return Detection(
+        entity_type=entity_type,
+        match=match,
+        start_pos=start_pos,
+        end_pos=end_pos,
+        confidence=confidence,
+    )
 
-    def __init__(
-        self, entity_type: str, start: int = 0, end: int = 0, score: float = 0.5
-    ):
-        self.entity_type = entity_type
-        self.start = start
-        self.end = end
-        self.score = score
 
+class FakeScanner:
+    """Returns canned detections (or raises), and records its scan calls.
 
-class FakeAnalyzer:
-    """Records calls and returns canned detections keyed by input text.
-
-    Lets the handler tests run without loading Presidio's NLP model and keeps
-    detection results deterministic.
+    Stands in for a real :class:`~pystreams.risk.scanner.Scanner` so the handler
+    tests exercise finding-building, logging, and publishing without loading
+    Presidio's NLP model.
     """
 
-    def __init__(self, detections: dict[str, list[Recognized]] | None = None):
-        self.detections = detections or {}
+    def __init__(
+        self,
+        detections: list[Detection] | None = None,
+        *,
+        error: Exception | None = None,
+    ):
+        self._detections = detections or []
+        self._error = error
         self.calls: list[tuple[str, list[str] | None]] = []
 
-    def analyze(
-        self, *, text: str, entities: list[str] | None, language: str
-    ) -> list[Recognized]:
-        self.calls.append((text, entities))
-        assert language == "en"
-        return self.detections.get(text, [])
+    async def scan(self, content: str, entities: list[str] | None) -> list[Detection]:
+        self.calls.append((content, entities))
+        if self._error is not None:
+            raise self._error
+        return list(self._detections)
+
+    async def aclose(self) -> None:
+        return None
 
 
 class _FakeResult:
@@ -69,12 +84,12 @@ def _meta(delivery_attempt: int = 1) -> MessageMetadata:
 
 
 def _handler(
-    analyzer: FakeAnalyzer, publisher: FakePublisher | None = None
+    scanner: FakeScanner, publisher: FakePublisher | None = None
 ) -> PresidioHandler:
     return PresidioHandler(
         structlog.get_logger(),
         publisher or FakePublisher(),
-        analyzer=analyzer,
+        scanner,
     )
 
 
@@ -84,11 +99,15 @@ def _message(content: str, **kwargs) -> presidio_analysis_pb2.PresidioAnalysis:
 
 async def test_publishes_a_finding_per_detection():
     content = "email me at a@b.com"
-    analyzer = FakeAnalyzer(
-        {content: [_Result("EMAIL_ADDRESS", start=12, end=19, score=0.85)]}
+    scanner = FakeScanner(
+        [
+            _detection(
+                "EMAIL_ADDRESS", "a@b.com", start_pos=12, end_pos=19, confidence=0.85
+            )
+        ]
     )
     publisher = FakePublisher()
-    handler = _handler(analyzer, publisher)
+    handler = _handler(scanner, publisher)
     msg = _message(
         content,
         request_id="req-1",
@@ -117,7 +136,7 @@ async def test_publishes_a_finding_per_detection():
     # created_at is a fresh detection timestamp, not the request's created_at.
     assert _RFC3339_UTC.fullmatch(finding.created_at)
     assert finding.created_at != "2023-01-01T00:00:00Z"
-    # Detection fields are mapped onto the finding.
+    # Detection fields are mapped onto the finding; rule_id is derived here.
     assert finding.source == "presidio"
     assert finding.rule_id == "pii.email_address"
     assert finding.match == "a@b.com"
@@ -137,22 +156,19 @@ async def test_publishes_a_finding_per_detection():
 
 
 async def test_publishes_one_finding_per_hit_and_dedupes_log_types():
-    content = "call 555-0100 or 555-0199"
-    analyzer = FakeAnalyzer(
-        {
-            content: [
-                _Result("PHONE_NUMBER", start=5, end=13),
-                _Result("PHONE_NUMBER", start=17, end=25),
-            ]
-        }
+    scanner = FakeScanner(
+        [
+            _detection("PHONE_NUMBER", "555-0100", start_pos=5, end_pos=13),
+            _detection("PHONE_NUMBER", "555-0199", start_pos=17, end_pos=25),
+        ]
     )
     publisher = FakePublisher()
-    handler = _handler(analyzer, publisher)
+    handler = _handler(scanner, publisher)
 
     with capture_logs() as logs:
-        await handler.handle(_message(content, request_id="req-1"), _meta())
+        await handler.handle(_message("...", request_id="req-1"), _meta())
 
-    # One finding per recognized span...
+    # One finding per detection...
     assert [f.match for f in publisher.published] == ["555-0100", "555-0199"]
     # ...each with its own distinct id.
     assert len({f.id for f in publisher.published}) == 2
@@ -163,69 +179,10 @@ async def test_publishes_one_finding_per_hit_and_dedupes_log_types():
     assert entry["published_count"] == 2
 
 
-async def test_byte_offsets_for_multibyte_content():
-    # "café " is 5 characters but 6 UTF-8 bytes; a match after it must be
-    # reported in byte positions, not character positions.
-    content = "café a@b.com"
-    analyzer = FakeAnalyzer(
-        {content: [_Result("EMAIL_ADDRESS", start=5, end=12, score=0.9)]}
-    )
-    publisher = FakePublisher()
-    handler = _handler(analyzer, publisher)
-
-    await handler.handle(_message(content, request_id="req-1"), _meta())
-
-    (finding,) = publisher.published
-    assert finding.match == "a@b.com"
-    assert finding.start_pos == 6  # one extra byte from the 'é'
-    assert finding.end_pos == 13
-
-
-async def test_false_positives_are_filtered_before_publishing():
-    # "10.0.0.1" is RFC1918 space and is dropped; "a@b.com" is a real match.
-    content = "10.0.0.1 and a@b.com"
-    analyzer = FakeAnalyzer(
-        {
-            content: [
-                _Result("IP_ADDRESS", start=0, end=8),
-                _Result("EMAIL_ADDRESS", start=13, end=20, score=0.7),
-            ]
-        }
-    )
-    publisher = FakePublisher()
-    handler = _handler(analyzer, publisher)
-
-    with capture_logs() as logs:
-        await handler.handle(_message(content, request_id="req-1"), _meta())
-
-    # Only the real match is published; the reserved IP never reaches the topic.
-    (finding,) = publisher.published
-    assert finding.rule_id == "pii.email_address"
-    assert finding.match == "a@b.com"
-    # The log counts reflect the post-filter set.
-    (entry,) = logs
-    assert entry["detected_entity_types"] == ["EMAIL_ADDRESS"]
-    assert entry["detected_count"] == 1
-    assert entry["published_count"] == 1
-
-
-async def test_all_false_positives_means_no_publish_and_no_log():
-    content = "reach me at user@example.com"
-    analyzer = FakeAnalyzer({content: [_Result("EMAIL_ADDRESS", start=12, end=28)]})
-    publisher = FakePublisher()
-    handler = _handler(analyzer, publisher)
-
-    with capture_logs() as logs:
-        await handler.handle(_message(content, request_id="req-1"), _meta())
-
-    # example.com is a placeholder domain: nothing published, nothing logged.
-    assert publisher.published == []
-    assert logs == []
-
-
 async def test_no_log_or_publish_when_nothing_detected():
+    scanner = FakeScanner([])  # scanner finds nothing
     publisher = FakePublisher()
-    handler = _handler(FakeAnalyzer(), publisher)  # detects nothing
+    handler = _handler(scanner, publisher)
 
     with capture_logs() as logs:
         await handler.handle(_message("nothing sensitive here"), _meta())
@@ -234,9 +191,9 @@ async def test_no_log_or_publish_when_nothing_detected():
     assert publisher.published == []
 
 
-async def test_requested_entities_forwarded_to_analyzer():
-    analyzer = FakeAnalyzer({"a@b.com": [_Result("EMAIL_ADDRESS", start=0, end=7)]})
-    handler = _handler(analyzer)
+async def test_requested_entities_forwarded_to_scanner():
+    scanner = FakeScanner([_detection("EMAIL_ADDRESS", "a@b.com")])
+    handler = _handler(scanner)
     msg = _message(
         "a@b.com", request_id="req-1", entities=["EMAIL_ADDRESS", "PHONE_NUMBER"]
     )
@@ -244,41 +201,32 @@ async def test_requested_entities_forwarded_to_analyzer():
     with capture_logs() as logs:
         await handler.handle(msg, _meta())
 
-    # The explicit request set is passed through to the analyzer verbatim...
-    assert analyzer.calls == [("a@b.com", ["EMAIL_ADDRESS", "PHONE_NUMBER"])]
+    # The explicit request set is passed through to the scanner verbatim...
+    assert scanner.calls == [("a@b.com", ["EMAIL_ADDRESS", "PHONE_NUMBER"])]
     # ...and echoed back on the log line.
     (entry,) = logs
     assert entry["requested_entities"] == ["EMAIL_ADDRESS", "PHONE_NUMBER"]
 
 
 async def test_empty_entities_means_scan_all():
-    analyzer = FakeAnalyzer({"a@b.com": [_Result("EMAIL_ADDRESS", start=0, end=7)]})
-    handler = _handler(analyzer)
+    scanner = FakeScanner([_detection("EMAIL_ADDRESS", "a@b.com")])
+    handler = _handler(scanner)
 
     with capture_logs() as logs:
         await handler.handle(_message("a@b.com", request_id="req-1"), _meta())
 
-    # No entities requested -> None, which tells Presidio to scan every type.
-    assert analyzer.calls == [("a@b.com", None)]
+    # No entities requested -> None, which tells the scanner to scan every type.
+    assert scanner.calls == [("a@b.com", None)]
     (entry,) = logs
     assert entry["requested_entities"] == []
 
 
-class _BoomAnalyzer:
-    """Analyzer whose ``analyze`` always raises, simulating a Presidio failure."""
-
-    def analyze(
-        self, *, text: str, entities: list[str] | None, language: str
-    ) -> list[Recognized]:
-        raise RuntimeError(text)  # message carries content to prove it isn't logged
-
-
 async def test_scan_failure_is_swallowed_and_logged():
-    publisher = FakePublisher()
-    handler = PresidioHandler(
-        structlog.get_logger(), publisher, analyzer=_BoomAnalyzer()
-    )
     secret = "my ssn is 123-45-6789"
+    # The error carries the content to prove it isn't logged.
+    scanner = FakeScanner(error=RuntimeError(secret))
+    publisher = FakePublisher()
+    handler = _handler(scanner, publisher)
     msg = _message(secret, request_id="req-1", reply_urn="urn:reply:1")
 
     # A scan failure must not propagate: raising here would nack the message and,
@@ -291,7 +239,7 @@ async def test_scan_failure_is_swallowed_and_logged():
     assert entry["request_id"] == "req-1"
     assert entry["error_type"] == "RuntimeError"
     assert entry["delivery_attempt"] == 3
-    # Nothing is published when the scan never produced results.
+    # Nothing is published when the scan failed.
     assert publisher.published == []
     # The error must not leak the scanned content even though the exception
     # carried it.
@@ -319,10 +267,8 @@ class _BoomPublisher:
 
 async def test_publish_failure_is_swallowed_and_logged():
     secret = "a@b.com"
-    analyzer = FakeAnalyzer({secret: [_Result("EMAIL_ADDRESS", start=0, end=7)]})
-    handler = PresidioHandler(
-        structlog.get_logger(), _BoomPublisher(), analyzer=analyzer
-    )
+    scanner = FakeScanner([_detection("EMAIL_ADDRESS", secret)])
+    handler = PresidioHandler(structlog.get_logger(), _BoomPublisher(), scanner)
 
     # A publish failure must not propagate either: nacking would redeliver and
     # re-publish any findings that already landed, duplicating them.
@@ -351,10 +297,8 @@ class _SyncBoomPublisher:
 
 async def test_sync_publish_failure_is_swallowed_and_logged():
     secret = "a@b.com"
-    analyzer = FakeAnalyzer({secret: [_Result("EMAIL_ADDRESS", start=0, end=7)]})
-    handler = PresidioHandler(
-        structlog.get_logger(), _SyncBoomPublisher(), analyzer=analyzer
-    )
+    scanner = FakeScanner([_detection("EMAIL_ADDRESS", secret)])
+    handler = PresidioHandler(structlog.get_logger(), _SyncBoomPublisher(), scanner)
 
     # A synchronous publish failure must be treated like an async one: logged as a
     # publish failure and skipped, never escaping to nack/redeliver the message
@@ -376,9 +320,11 @@ async def test_sync_publish_failure_is_swallowed_and_logged():
 
 async def test_does_not_leak_content_or_values_to_logs():
     secret = "my ssn is 123-45-6789"
-    analyzer = FakeAnalyzer({secret: [_Result("US_SSN", start=10, end=21, score=0.99)]})
+    scanner = FakeScanner(
+        [_detection("US_SSN", "123-45-6789", start_pos=10, end_pos=21, confidence=0.99)]
+    )
     publisher = FakePublisher()
-    handler = _handler(analyzer, publisher)
+    handler = _handler(scanner, publisher)
     msg = _message(secret, request_id="req-1", reply_urn="urn:reply:1")
 
     with capture_logs() as logs:
@@ -387,7 +333,7 @@ async def test_does_not_leak_content_or_values_to_logs():
     # The matched value is carried on the published finding...
     (finding,) = publisher.published
     assert finding.match == "123-45-6789"
-    # ...but the scanned content must never appear anywhere in the emitted logs.
+    # ...but the scanned content and matched value must never appear in the logs.
     for entry in logs:
         assert secret not in repr(entry)
         assert "123-45-6789" not in repr(entry)

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -341,6 +341,39 @@ async def test_publish_failure_is_swallowed_and_logged():
     assert summary["published_count"] == 0
 
 
+class _SyncBoomPublisher:
+    """Publisher whose ``publish`` raises synchronously (a misconfigured client)."""
+
+    def publish(self, message: finding_pb2.Finding) -> _FakeResult:
+        # The match carries the value, to prove a sync failure doesn't leak it.
+        raise RuntimeError(message.match)
+
+
+async def test_sync_publish_failure_is_swallowed_and_logged():
+    secret = "a@b.com"
+    analyzer = FakeAnalyzer({secret: [_Result("EMAIL_ADDRESS", start=0, end=7)]})
+    handler = PresidioHandler(
+        structlog.get_logger(), _SyncBoomPublisher(), analyzer=analyzer
+    )
+
+    # A synchronous publish failure must be treated like an async one: logged as a
+    # publish failure and skipped, never escaping to nack/redeliver the message
+    # (which would duplicate findings) and never mislabeled as a scan failure.
+    with capture_logs() as logs:
+        await handler.handle(_message(secret, request_id="req-1"), _meta())
+
+    publish_errors = [e for e in logs if e["event"] == "failed to publish risk finding"]
+    (err,) = publish_errors
+    assert err["rule_id"] == "pii.email_address"
+    assert err["error_type"] == "RuntimeError"
+    assert secret not in repr(err)
+    # Not reported as a scan failure...
+    assert not [e for e in logs if e["event"] == "presidio scan failed"]
+    # ...and the summary still lands, reporting zero published.
+    summary = next(e for e in logs if e["event"] == "presidio scan detected entities")
+    assert summary["published_count"] == 0
+
+
 async def test_does_not_leak_content_or_values_to_logs():
     secret = "my ssn is 123-45-6789"
     analyzer = FakeAnalyzer({secret: [_Result("US_SSN", start=10, end=21, score=0.99)]})

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -43,15 +43,25 @@ class FakeAnalyzer:
         return self.detections.get(text, [])
 
 
+class _FakeResult:
+    """A PublishResult whose ``get`` returns a canned message id."""
+
+    def __init__(self, message_id: str):
+        self._id = message_id
+
+    async def get(self) -> str:
+        return self._id
+
+
 class FakePublisher:
     """Captures published findings instead of sending them to Pub/Sub."""
 
     def __init__(self):
         self.published: list[finding_pb2.Finding] = []
 
-    async def publish(self, message: finding_pb2.Finding) -> str:
+    def publish(self, message: finding_pb2.Finding) -> _FakeResult:
         self.published.append(message)
-        return f"id-{len(self.published)}"
+        return _FakeResult(f"id-{len(self.published)}")
 
 
 def _meta(delivery_attempt: int = 1) -> MessageMetadata:
@@ -289,11 +299,22 @@ async def test_scan_failure_is_swallowed_and_logged():
     assert "123-45-6789" not in repr(entry)
 
 
-class _BoomPublisher:
-    """Publisher whose ``publish`` always raises, simulating a Pub/Sub failure."""
+class _BoomResult:
+    """A PublishResult whose ``get`` raises, simulating a Pub/Sub commit failure."""
 
-    async def publish(self, message: finding_pb2.Finding) -> str:
-        raise RuntimeError(message.match)  # carries the value to prove it isn't logged
+    def __init__(self, match: str):
+        self._match = match
+
+    async def get(self) -> str:
+        # The match carries the value, to prove it isn't logged on failure.
+        raise RuntimeError(self._match)
+
+
+class _BoomPublisher:
+    """Publisher whose publishes all fail when their result is awaited."""
+
+    def publish(self, message: finding_pb2.Finding) -> _BoomResult:
+        return _BoomResult(message.match)
 
 
 async def test_publish_failure_is_swallowed_and_logged():

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -201,3 +201,35 @@ async def test_pool_scan_without_timeout_returns_result():
 
     # scan_timeout=None disables the deadline; the result passes straight through.
     assert await scanner.scan("a@b.com", None) == [detection]
+
+
+class _WarmupFailExecutor:
+    """Executor stand-in whose every task fails, to drive the warmup-error path.
+
+    Records shutdown so the test can assert the pool is reaped when warmup raises.
+    """
+
+    def __init__(self, **kwargs):
+        self.shutdowns: list[tuple[bool, bool]] = []
+
+    def submit(self, fn, *args):
+        future: Future = Future()
+        future.set_exception(RuntimeError("warmup boom"))
+        return future
+
+    def shutdown(self, wait=True, cancel_futures=False):
+        self.shutdowns.append((wait, cancel_futures))
+
+
+async def test_pool_create_reaps_workers_when_warmup_fails(monkeypatch):
+    executor = _WarmupFailExecutor()
+    monkeypatch.setattr(
+        "pystreams.risk.scanner.ProcessPoolExecutor", lambda **kw: executor
+    )
+
+    # Warmup raises -> create must shut the executor down before propagating, so a
+    # failed create can't leak the workers it already spawned.
+    with pytest.raises(BaseExceptionGroup, match="unhandled errors"):
+        await ProcessPoolScanner.create(max_workers=2)
+
+    assert executor.shutdowns, "executor was not shut down on warmup failure"

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -8,6 +8,7 @@ from pystreams.risk.scanner import (
     ProcessPoolScanner,
     Recognized,
     ThreadScanner,
+    _AsyncCloseable,
 )
 
 
@@ -167,6 +168,30 @@ async def test_none_entities_forwarded_to_analyzer():
 
     # None tells Presidio to scan every type; it is forwarded unchanged.
     assert analyzer.calls == [("a@b.com", None)]
+
+
+async def test_thread_scanner_is_async_context_manager():
+    analyzer = FakeAnalyzer({"a@b.com": [_Result("EMAIL_ADDRESS", start=0, end=7)]})
+
+    # Entering yields the scanner; the block can scan and leaving closes it.
+    async with ThreadScanner(analyzer) as scanner:
+        (detection,) = await scanner.scan("a@b.com", None)
+        assert detection.match == "a@b.com"
+
+
+async def test_context_manager_exit_closes_scanner():
+    closed = False
+
+    class _RecordingScanner(_AsyncCloseable):
+        async def aclose(self) -> None:
+            nonlocal closed
+            closed = True
+
+    async with _RecordingScanner() as scanner:
+        assert isinstance(scanner, _RecordingScanner)
+        assert not closed
+    # __aexit__ awaits the subclass's aclose, even on a normal exit.
+    assert closed
 
 
 class _StuckExecutor:

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from concurrent.futures import Future, ProcessPoolExecutor
 from typing import cast
 
@@ -285,6 +286,31 @@ async def test_pool_create_reaps_workers_when_warmup_fails(monkeypatch):
         await ProcessPoolScanner.create(max_workers=2)
 
     assert executor.shutdowns, "executor was not shut down on warmup failure"
+
+
+class _SlowShutdownExecutor:
+    """Executor stand-in whose ``shutdown`` overruns the grace period.
+
+    Has no ``_processes`` attribute, so it stands in for a CPython release that
+    renamed the private internal ``aclose`` reaches for: the hard-kill fallback
+    must degrade to a no-op rather than raising ``AttributeError`` and masking the
+    teardown stall it was trying to recover from.
+    """
+
+    def shutdown(self, wait=True, cancel_futures=False):
+        # Block past the tiny grace_period the test passes so move_on_after fires.
+        time.sleep(5)
+
+
+async def test_aclose_kill_path_degrades_when_processes_attr_missing():
+    scanner = ProcessPoolScanner(
+        cast(ProcessPoolExecutor, _SlowShutdownExecutor()), scan_timeout=None
+    )
+
+    # The graceful shutdown overruns, so aclose falls through to the hard-kill
+    # path; with no ``_processes`` to read it must return cleanly, not raise.
+    with anyio.fail_after(2):
+        await scanner.aclose(grace_period=0.05)
 
 
 class _DeferredExecutor:

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -1,0 +1,134 @@
+from pystreams.risk.scanner import Recognized, ThreadScanner
+
+
+class _Result:
+    """Minimal stand-in for a Presidio ``RecognizerResult``."""
+
+    def __init__(
+        self, entity_type: str, start: int = 0, end: int = 0, score: float = 0.5
+    ):
+        self.entity_type = entity_type
+        self.start = start
+        self.end = end
+        self.score = score
+
+
+class FakeAnalyzer:
+    """Records calls and returns canned detections keyed by input text.
+
+    Lets the scanner tests run without loading Presidio's NLP model and keeps
+    detection results deterministic.
+    """
+
+    def __init__(self, detections: dict[str, list[Recognized]] | None = None):
+        self.detections = detections or {}
+        self.calls: list[tuple[str, list[str] | None]] = []
+
+    def analyze(
+        self, *, text: str, entities: list[str] | None, language: str
+    ) -> list[Recognized]:
+        self.calls.append((text, entities))
+        assert language == "en"
+        return self.detections.get(text, [])
+
+
+def _scanner(analyzer: FakeAnalyzer) -> ThreadScanner:
+    return ThreadScanner(analyzer)
+
+
+async def test_maps_recognizer_results_to_detections():
+    content = "email me at a@b.com"
+    analyzer = FakeAnalyzer(
+        {content: [_Result("EMAIL_ADDRESS", start=12, end=19, score=0.85)]}
+    )
+
+    (detection,) = await _scanner(analyzer).scan(content, None)
+
+    assert detection.entity_type == "EMAIL_ADDRESS"
+    assert detection.match == "a@b.com"
+    assert detection.start_pos == 12
+    assert detection.end_pos == 19
+    assert detection.confidence == 0.85
+
+
+async def test_returns_one_detection_per_recognized_span():
+    content = "call 555-0100 or 555-0199"
+    analyzer = FakeAnalyzer(
+        {
+            content: [
+                _Result("PHONE_NUMBER", start=5, end=13),
+                _Result("PHONE_NUMBER", start=17, end=25),
+            ]
+        }
+    )
+
+    detections = await _scanner(analyzer).scan(content, None)
+
+    assert [d.match for d in detections] == ["555-0100", "555-0199"]
+
+
+async def test_byte_offsets_for_multibyte_content():
+    # "café " is 5 characters but 6 UTF-8 bytes; a match after it must be
+    # reported in byte positions, not character positions.
+    content = "café a@b.com"
+    analyzer = FakeAnalyzer(
+        {content: [_Result("EMAIL_ADDRESS", start=5, end=12, score=0.9)]}
+    )
+
+    (detection,) = await _scanner(analyzer).scan(content, None)
+
+    assert detection.match == "a@b.com"
+    assert detection.start_pos == 6  # one extra byte from the 'é'
+    assert detection.end_pos == 13
+
+
+async def test_false_positives_are_filtered():
+    # "10.0.0.1" is RFC1918 space and is dropped; "a@b.com" is a real match.
+    content = "10.0.0.1 and a@b.com"
+    analyzer = FakeAnalyzer(
+        {
+            content: [
+                _Result("IP_ADDRESS", start=0, end=8),
+                _Result("EMAIL_ADDRESS", start=13, end=20, score=0.7),
+            ]
+        }
+    )
+
+    detections = await _scanner(analyzer).scan(content, None)
+
+    # Only the real match survives; the reserved IP is dropped at the scanner.
+    (detection,) = detections
+    assert detection.entity_type == "EMAIL_ADDRESS"
+    assert detection.match == "a@b.com"
+
+
+async def test_all_false_positives_yields_no_detections():
+    content = "reach me at user@example.com"
+    analyzer = FakeAnalyzer({content: [_Result("EMAIL_ADDRESS", start=12, end=28)]})
+
+    # example.com is a placeholder domain: filtered out entirely.
+    assert await _scanner(analyzer).scan(content, None) == []
+
+
+async def test_nothing_recognized_yields_no_detections():
+    analyzer = FakeAnalyzer()  # recognizes nothing
+
+    assert await _scanner(analyzer).scan("nothing sensitive here", None) == []
+
+
+async def test_requested_entities_forwarded_to_analyzer():
+    analyzer = FakeAnalyzer({"a@b.com": [_Result("EMAIL_ADDRESS", start=0, end=7)]})
+
+    await _scanner(analyzer).scan("a@b.com", ["EMAIL_ADDRESS", "PHONE_NUMBER"])
+
+    # The explicit request set is passed through to the analyzer verbatim.
+    assert analyzer.calls == [("a@b.com", ["EMAIL_ADDRESS", "PHONE_NUMBER"])]
+
+
+async def test_none_entities_forwarded_to_analyzer():
+    analyzer = FakeAnalyzer({"a@b.com": [_Result("EMAIL_ADDRESS", start=0, end=7)]})
+
+    await _scanner(analyzer).scan("a@b.com", None)
+
+    # None tells Presidio to scan every type; it is forwarded unchanged.
+    assert analyzer.calls == [("a@b.com", None)]

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -92,6 +92,31 @@ async def test_byte_offsets_for_multibyte_content():
     assert detection.end_pos == 13
 
 
+async def test_byte_offsets_for_multiple_multibyte_matches():
+    # Two matches straddling separate multibyte runs exercise the single-pass
+    # offset walk: each '€' is 3 UTF-8 bytes, so byte offsets diverge from char
+    # offsets cumulatively and out of insertion order.
+    content = "€ a@b.com € c@d.com"
+    analyzer = FakeAnalyzer(
+        {
+            content: [
+                # Reversed vs. text order to confirm the walk doesn't assume sorted
+                # recognizer results.
+                _Result("EMAIL_ADDRESS", start=12, end=19, score=0.9),
+                _Result("EMAIL_ADDRESS", start=2, end=9, score=0.9),
+            ]
+        }
+    )
+
+    detections = await _scanner(analyzer).scan(content, None)
+
+    by_match = {d.match: d for d in detections}
+    assert by_match["a@b.com"].start_pos == 4  # 3-byte '€' + space
+    assert by_match["a@b.com"].end_pos == 11
+    assert by_match["c@d.com"].start_pos == 16  # second '€' adds two more bytes
+    assert by_match["c@d.com"].end_pos == 23
+
+
 async def test_false_positives_are_filtered():
     # "10.0.0.1" is RFC1918 space and is dropped; "a@b.com" is a real match.
     content = "10.0.0.1 and a@b.com"

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -1,6 +1,8 @@
+import threading
 from concurrent.futures import Future, ProcessPoolExecutor
 from typing import cast
 
+import anyio
 import pytest
 
 from pystreams.risk.scanner import (
@@ -283,3 +285,74 @@ async def test_pool_create_reaps_workers_when_warmup_fails(monkeypatch):
         await ProcessPoolScanner.create(max_workers=2)
 
     assert executor.shutdowns, "executor was not shut down on warmup failure"
+
+
+class _DeferredExecutor:
+    """Executor stand-in that withholds results until every scan is in flight.
+
+    Each ``submit`` (driven from a worker thread) captures the scanned content
+    beside the ``Future`` it returns and leaves it unresolved. Only once all
+    ``expected`` scans have submitted does the final one complete them all — in
+    reverse submission order, so completion order deliberately differs from caller
+    order. This proves each scan receives only its own result, without spawning
+    real workers or loading the spaCy model, and self-completes so the test needs
+    no event-loop polling.
+    """
+
+    def __init__(self, expected: int):
+        self._expected = expected
+        self._lock = threading.Lock()
+        self.pending: list[tuple[str, Future]] = []
+
+    def submit(self, fn, *args):
+        content = cast(str, args[0])
+        future: Future = Future()
+        with self._lock:
+            self.pending.append((content, future))
+            # The submit that completes the set resolves every future; the others
+            # have all appended by now, so iterating outside the lock is safe.
+            ready = list(self.pending) if len(self.pending) == self._expected else None
+        if ready is not None:
+            for queued_content, queued_future in reversed(ready):
+                queued_future.set_result([_email_detection(queued_content)])
+        return future
+
+
+def _email_detection(content: str) -> Detection:
+    """A detection whose ``match`` is the content, so a crossed result is visible."""
+    return Detection(
+        entity_type="EMAIL_ADDRESS",
+        match=content,
+        start_pos=0,
+        end_pos=len(content),
+        confidence=0.5,
+    )
+
+
+async def test_concurrent_scans_only_receive_their_own_results():
+    # Routing is by Future identity, not shared state: each scan awaits exactly the
+    # future its own submit returned. Drive many scans concurrently; the executor
+    # holds every result until all are in flight, then completes them in reverse
+    # order (so completion order differs from caller order) and we assert no caller
+    # ever sees another scan's result. A refactor that introduced a shared "last
+    # result" slot would cross wires here.
+    contents = [f"user{i}@host{i}.test" for i in range(8)]
+    executor = _DeferredExecutor(expected=len(contents))
+    scanner = ProcessPoolScanner(cast(ProcessPoolExecutor, executor), scan_timeout=None)
+
+    results: dict[str, list[Detection]] = {}
+
+    async def run(content: str) -> None:
+        results[content] = await scanner.scan(content, None)
+
+    # fail_after guards against a routing regression that wedges a caller forever.
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as tg:
+            for content in contents:
+                tg.start_soon(run, content)
+
+    assert set(results) == set(contents)
+    for content in contents:
+        (detection,) = results[content]
+        # The match echoes the submitted content; any mismatch is a crossed wire.
+        assert detection.match == content

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -1,4 +1,14 @@
-from pystreams.risk.scanner import Recognized, ThreadScanner
+from concurrent.futures import Future, ProcessPoolExecutor
+from typing import cast
+
+import pytest
+
+from pystreams.risk.scanner import (
+    Detection,
+    ProcessPoolScanner,
+    Recognized,
+    ThreadScanner,
+)
 
 
 class _Result:
@@ -132,3 +142,62 @@ async def test_none_entities_forwarded_to_analyzer():
 
     # None tells Presidio to scan every type; it is forwarded unchanged.
     assert analyzer.calls == [("a@b.com", None)]
+
+
+class _StuckExecutor:
+    """Executor stand-in whose submitted futures never complete.
+
+    Lets the ProcessPoolScanner timeout path be tested without spawning real
+    worker processes or loading the spaCy model: ``scan`` submits, then waits on a
+    future that is never resolved, so the anyio ``fail_after`` deadline must fire.
+    """
+
+    def __init__(self):
+        self.submitted: list[Future] = []
+
+    def submit(self, fn, *args):
+        future: Future = Future()
+        self.submitted.append(future)
+        return future
+
+
+class _ImmediateExecutor:
+    """Executor stand-in whose futures are already resolved to a canned value."""
+
+    def __init__(self, result: list[Detection]):
+        self._result = result
+
+    def submit(self, fn, *args):
+        future: Future = Future()
+        future.set_result(self._result)
+        return future
+
+
+async def test_pool_scan_times_out_via_anyio_deadline():
+    executor = _StuckExecutor()
+    scanner = ProcessPoolScanner(cast(ProcessPoolExecutor, executor), scan_timeout=0.05)
+
+    # The scan never completes, so the anyio fail_after deadline must raise.
+    with pytest.raises(TimeoutError):
+        await scanner.scan("anything", None)
+
+    # On timeout the future is cancelled, so a still-queued scan is pulled rather
+    # than left to run with nobody awaiting it (and the abandoned wait unblocks).
+    (future,) = executor.submitted
+    assert future.cancelled()
+
+
+async def test_pool_scan_without_timeout_returns_result():
+    detection = Detection(
+        entity_type="EMAIL_ADDRESS",
+        match="a@b.com",
+        start_pos=0,
+        end_pos=7,
+        confidence=0.5,
+    )
+    scanner = ProcessPoolScanner(
+        cast(ProcessPoolExecutor, _ImmediateExecutor([detection])), scan_timeout=None
+    )
+
+    # scan_timeout=None disables the deadline; the result passes straight through.
+    assert await scanner.scan("a@b.com", None) == [detection]


### PR DESCRIPTION
## Why

The `gram.risk.v1/presidio-analyzer` subscription showed unusually high ACK latency. Local profiling (emulator + a load generator, py-spy flame graphs) traced the per-message cost to the Presidio scan, which is **~95% GIL-bound** — spaCy NER + Presidio's regex recognizers hold the GIL for almost the whole scan. The decisive finding: more scan threads make it _worse_, peaking at ~2, because the work is GIL-bound rather than core-bound. A single process therefore tops out around ~50 msg/s no matter how it's tuned, and the only real capacity lever is **process-level parallelism**.

The headline of this PR is an in-pod scan **process pool** that breaks that single-process ceiling. Earlier commits on this branch first attacked the same latency from the publish side and trimmed per-message event-loop work; those are now **ancillary** (summarized below).

## Headline change — in-pod process pool for scans

Presidio scans now run in a `ProcessPoolExecutor` of worker processes, each with its own interpreter and GIL, so N workers scan in genuine parallel and the asyncio loop never blocks on scan work. This breaks the single-process GIL ceiling **inside one pod**, without adding replicas or waiting on free-threaded CPython.

**Encapsulation.** The Presidio machinery is pulled out of the handler into a focused `scanner` module that owns the model, the pool, false-positive filtering, and byte-offset conversion, and exposes one small async API:

```python
async def scan(content, entities) -> list[Detection]
async def aclose() -> None
```

The handler keeps only what surrounds a detection — logging, mapping each `Detection` onto a `Finding`, and publishing. The GIL-bound, model-heavy concern is now isolated from the I/O and domain-mapping concern, and each is tested on its own (handler against a fake scanner, scanner against a fake analyzer). Two `Scanner` implementations: `ThreadScanner` and `ProcessPoolScanner` (the default).

**Operational details.**

- The pool is the **default**: `--scan-workers` / `GRAM_PYSTREAMS_SCAN_WORKERS` defaults to `2`. Set it to `0` to fall back to the in-process threaded scanner. This is a behavior change by default, not opt-in — see the rollout gates below.

> **⚠️ Rollout gates (must clear before this ships with the pool as default):**
>
> - **Pod memory.** With the pool as default the main process no longer loads the spaCy model, but each of the N workers does (~one `en_core_web_lg` RSS apiece). Net footprint goes from ~1 model to ~N. The pystreams pod memory request/limit lives in the KCC infra repo (not this PR); review it before rollout, or set `GRAM_PYSTREAMS_SCAN_WORKERS=0` there until the footprint is understood.
> - **`forkserver` in the distroless image.** The pool forces the `forkserver` start method; benchmarks ran on a dev box, not the distroless production image (`Dockerfile.pystreams`). Smoke-test that the pool warms and scans inside the real container (resource_tracker + POSIX semaphores can misbehave under distroless) before trusting the default.

- Each worker loads its own spaCy model in the pool initializer. Python 3.14 defaults the start method to `forkserver`, and forking a process that already runs the asyncio loop + gRPC client threads is unsafe — so a clean per-worker load is the robust choice. Cost is ~one model RSS per worker; keep the count small (2–4).
- Workers return only the small, picklable `Detection` list; the heavy text and the analyzer never cross the process boundary per message. The pool is drained on shutdown so a message is never dropped mid-scan.

**Lifecycle hardening (borrowed from gunicorn's pre-fork model).** A forensic look at the official `mcr.microsoft.com/presidio-analyzer` image showed it scales the exact same way we do — gunicorn pre-fork workers, each loading its own model (no `--preload`, so no copy-on-write; ~linear RAM per worker) — which validated our per-worker-model choice. What gunicorn gives that a bare `ProcessPoolExecutor` doesn't is worker-lifecycle safety, so we added the two pieces that matter:

- **Worker recycling** (`--scan-max-tasks-per-child` / `GRAM_PYSTREAMS_SCAN_MAX_TASKS_PER_CHILD`, default 1000): a worker is replaced after N scans to bound spaCy/numpy memory drift — gunicorn's `--max-requests`. Requires `forkserver` (rejected with `fork`), which we already use.
- **Per-scan timeout** (`--scan-timeout` / `GRAM_PYSTREAMS_SCAN_TIMEOUT`, default 30s): a scan past the deadline is treated as a failure — gunicorn's `--timeout`. The worker can't be interrupted mid-scan, but the executor stops routing to it, recycling replaces it once the doomed scan finishes, and the other workers keep serving, so one pathological message removes a single worker from rotation instead of stalling the consumer.

Both `<=0` to disable. The timeout is built on anyio's `fail_after` over a `to_thread` bridge to the executor future (rather than asyncio's `run_in_executor`), so the scanner runs unchanged on either anyio backend — asyncio or trio.

**Benchmark.** Scan-isolated harness (in-memory publisher, so this measures the scan path the change targets), 10-core box, 300 messages:

| scanner                      | pii=6 (~13 findings/msg) | pii=20 (~33 findings/msg) |
| ---------------------------- | ------------------------ | ------------------------- |
| threads @2 (current default) | ~99 msg/s                | ~50 msg/s                 |
| pool @2                      | ~182 msg/s               | ~83 msg/s                 |
| pool @4                      | ~352 msg/s               | ~165 msg/s (3.3×)         |
| pool @6                      | ~476 msg/s               | ~236 msg/s (4.7×)         |
| pool @8                      | ~557 msg/s               | ~252 msg/s (5.0×)         |

At pii=20, p50 per-message handle latency drops **~982 ms → ~192 ms** (pool @8). `findings_published` is **identical** across every configuration — the pool is behavior-preserving.

> Note on methodology: this harness isolates the scan with an in-memory publisher, so its absolute baseline (~50–99 msg/s) is higher than the end-to-end emulator numbers in the ancillary tables (which include real publish + a 50-deep offered queue). The relevant comparison is pool-vs-threads within this same harness.

## Ancillary improvements (earlier on this branch)

These reduced the _other_ component of ACK latency (publishing) and the per-message event-loop GIL work. They stand on their own but are no longer the headline now that the scan ceiling is addressed structurally.

- **Future-based publisher** (`refactor(pubsub)`). `Publisher.publish` blocked on the commit in every call, so a message with N findings paid N sequential round-trips. `publish()` now returns a `PublishResult` future (mirroring the Go layer); the handler fires all publishes up front, then collects. A 26-finding message went **379 ms → 23 ms**; under burst, publish p50 **~353 ms → ~57 ms**. Teardown unchanged — `stop()` is non-blocking, and the broker's existing `stop()`+drain still waits for in-flight commits.
- **GIL-aware scan cap** (`perf(pystreams)`). The in-process scanner caps concurrent scans with a `CapacityLimiter`, default **2** (+47% throughput, −31% p50 vs the old 40-slot pool). Tunable via `--max-scan-concurrency` / `GRAM_PYSTREAMS_SCAN_CONCURRENCY`. This is now the _floor_ the process pool builds on.
- **Build & serialize findings off the loop** (`perf(pystreams)`). Per-finding proto build + `SerializeToString` + enqueue moved off the event-loop thread; the loop only awaits commits. Trace-context injection on publish is preserved (anyio copies the contextvar context into the worker). ~6–7% publish_ms p50 reduction and less per-message loop GIL work.
- **Per-message summary log demoted to debug** (`perf(pystreams)`). The summary log rendered its event dict on the loop thread per detection-bearing message; at `info` structlog now short-circuits it to a no-op before any rendering.
- **Profiling tooling** (`feat(pystreams)`). `presidio-load` (`mise run risk:presidio-load`) publishes a synthetic PII-bearing burst to the emulator so a local `pystreams multi` exercises the real handler; emulator-only by design. `scan_ms`/`publish_ms` split the per-message latency.
- **Correctness fixes from review.** `_ErrorPublishResult.get()` re-raises with the captured traceback (so awaiting a result twice doesn't accumulate frames); subscriber intake nacks immediately when a scheduled enqueue is cancelled during teardown (redelivery doesn't wait out the ack deadline); `presidio-load` validates numeric flags at the CLI boundary and uses a true nearest-rank percentile.

> A scheduler-intake simplification (dropping the per-message portal done-callback) was explored but **reverted**: no measurable throughput gain, and it weakened the teardown disposition (a message whose enqueue is cancelled mid-teardown would wait out its ack deadline instead of redelivering immediately).

## Result

ACK latency was two costs: a publish cost (addressed by the future publisher, now a few percent of the total) and a GIL-bound scan cost (the dominant remainder). The scan cost was capped to its single-process optimum, and the process pool now lifts it past the single-process ceiling **inside one pod** — ~3–5× scan throughput at 4–8 workers, with large p50 reductions and identical output.

## Test plan

- `mise run test:pystreams` (65 passed — handler tests now run against a fake scanner; new `test_risk_scanner.py` covers the scan/filter/byte-offset logic against a fake analyzer) and infra `pytest`.
- `mise run lint:pystreams` (ty + pyrefly + ruff) clean.
- Pool path verified end-to-end via the scan-isolated benchmark above (identical findings across thread/pool configs, drained cleanly on shutdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

##

## 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Breaks the PresidioAnalyzer scan GIL ceiling in a single pod by defaulting to a process pool and trimming per‑message loop work; publishing now returns a `PublishResult` so sends can fan out and commits collect later. Adds `presidio-load` for local profiling and keeps the topology doc stable and accurate.

- **New Features**
  - `infra`: `Publisher.publish` now returns a `PublishResult`; await `result.get()` for the msg id. Sync publish failures are logged and skipped; subscriber intake immediately nacks messages whose scheduled enqueue is cancelled during teardown.
  - `pystreams`: New `scanner` module with `ProcessPoolScanner` default (configure `--scan-workers`, default 2; `0` uses `ThreadScanner`). Add `--scan-max-tasks-per-child` and `--scan-timeout`; timed‑out scans don’t interrupt workers — the worker is unavailable until completion and can be recycled. Pool warms off the event loop, workers ignore SIGINT, `aclose()` is bounded and can kill stuck workers (kill path is guarded against executor internals); result waits use a dedicated limiter; char→byte offset conversion uses an ASCII fast path and ordered multibyte walk (memory O(matches)).
  - Handler/loop: Build/serialize findings and enqueue publishes off the loop; the loop only awaits commits. Per‑message summary logs demoted to debug and include `scan_ms`/`publish_ms`.
  - Tooling: `presidio-load` CLI (emulator‑only) with validated flags and nearest‑rank percentiles.
  - Docs/Diagram: Drop line anchors and Mermaid click links. Exclude emulator‑only `pystreams/cmd/presidio_load.py` from the topology scan so the diagram lists only real publishers.
  - Tests: Added a concurrency routing test to ensure `ProcessPoolScanner` never crosses results between concurrent scans.

- **Migration**
  - Update call sites to `await publisher.publish(msg).get()` (was `await publisher.publish(msg)`).

<sup>Written for commit 72f2a437efeef59a38116c07b798ffb5c18667b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

