### PR TITLE
feat(dashboard): bulk revoke, search, and brand badges on MCP Connections

### DIFF
--- a/.changeset/mcp-connections-bulk-revoke-search.md
+++ b/.changeset/mcp-connections-bulk-revoke-search.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Enhance the org-level MCP Connections page: multi-select with select-all to revoke sessions in bulk, a search box in the filter bar, brand status badges, and a status filter (removed the OAuth Client filter).

--- a/client/dashboard/src/components/sessions/RevokeSessionsDialog.tsx
+++ b/client/dashboard/src/components/sessions/RevokeSessionsDialog.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { useRevokeUserSessionMutation } from "@gram/client/react-query";
+
+export function RevokeSessionsDialog({
+  sessionIds,
+  open,
+  onOpenChange,
+  onRevoked,
+}: {
+  sessionIds: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRevoked: () => void;
+}): JSX.Element {
+  const revoke = useRevokeUserSessionMutation();
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  const count = sessionIds.length;
+
+  const handleRevoke = async () => {
+    setIsError(false);
+    setIsRevoking(true);
+    try {
+      // Fire all revocations concurrently; surface a single failure rather than
+      // leaving the caller guessing which of the batch went through.
+      await Promise.all(
+        sessionIds.map((id) => revoke.mutateAsync({ request: { id } })),
+      );
+      onOpenChange(false);
+      onRevoked();
+    } catch {
+      setIsError(true);
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>
+            Revoke {count} session{count === 1 ? "" : "s"}?
+          </Dialog.Title>
+          <Dialog.Description>
+            This immediately invalidates{" "}
+            {count === 1 ? "this session" : "these sessions"}. The affected
+            clients will need to re-authenticate.
+          </Dialog.Description>
+        </Dialog.Header>
+        {isError && (
+          <p className="text-destructive text-sm">
+            Some sessions couldn&apos;t be revoked. Please try again.
+          </p>
+        )}
+        <Dialog.Footer>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={isRevoking || count === 0}
+            onClick={() => void handleRevoke()}
+          >
+            {isRevoking ? "Revoking…" : `Revoke ${count}`}
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/client/dashboard/src/components/sessions/RevokeSessionsDialog.tsx
+++ b/client/dashboard/src/components/sessions/RevokeSessionsDialog.tsx
@@ -36,12 +36,14 @@ export function RevokeSessionsDialog({
     },
   });
 
-  const { reset } = bulkRevoke;
+  const { reset, isPending } = bulkRevoke;
   // Clear any prior result when the dialog closes so stale failure messaging
-  // doesn't linger across reopens.
+  // doesn't linger across reopens — but not while a batch is still in flight,
+  // or the Revoke button could re-enable and allow a duplicate submission.
+  // isPending is a dep so the reset still runs once the in-flight batch settles.
   useEffect(() => {
-    if (!open) reset();
-  }, [open, reset]);
+    if (!open && !isPending) reset();
+  }, [open, isPending, reset]);
 
   const count = sessionIds.length;
   const failedCount = bulkRevoke.data?.failedCount ?? 0;
@@ -80,10 +82,10 @@ export function RevokeSessionsDialog({
           </Button>
           <Button
             variant="destructive"
-            disabled={bulkRevoke.isPending || count === 0}
+            disabled={isPending || count === 0}
             onClick={handleRevoke}
           >
-            {bulkRevoke.isPending ? "Revoking…" : `Revoke ${count}`}
+            {isPending ? "Revoking…" : `Revoke ${count}`}
           </Button>
         </Dialog.Footer>
       </Dialog.Content>

--- a/client/dashboard/src/components/sessions/RevokeSessionsDialog.tsx
+++ b/client/dashboard/src/components/sessions/RevokeSessionsDialog.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect } from "react";
+import { useMutation } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
@@ -13,30 +14,45 @@ export function RevokeSessionsDialog({
   sessionIds: string[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onRevoked: () => void;
+  /** Reports the ids that were successfully revoked so the caller can clear them. */
+  onRevoked: (succeededIds: string[]) => void;
 }): JSX.Element {
   const revoke = useRevokeUserSessionMutation();
-  const [isRevoking, setIsRevoking] = useState(false);
-  const [isError, setIsError] = useState(false);
+
+  // Revoke each session concurrently. allSettled (not all) means a single
+  // failure doesn't discard the sessions that did revoke — we report the
+  // successes so the caller clears/refetches them, and keep the failures so the
+  // user can retry. react-query owns the pending/result state (no hand-rolled
+  // async flags).
+  const bulkRevoke = useMutation({
+    mutationFn: async (ids: string[]) => {
+      const results = await Promise.allSettled(
+        ids.map((id) => revoke.mutateAsync({ request: { id } })),
+      );
+      const succeededIds = ids.filter(
+        (_, i) => results[i]?.status === "fulfilled",
+      );
+      return { succeededIds, failedCount: ids.length - succeededIds.length };
+    },
+  });
+
+  const { reset } = bulkRevoke;
+  // Clear any prior result when the dialog closes so stale failure messaging
+  // doesn't linger across reopens.
+  useEffect(() => {
+    if (!open) reset();
+  }, [open, reset]);
 
   const count = sessionIds.length;
+  const failedCount = bulkRevoke.data?.failedCount ?? 0;
 
-  const handleRevoke = async () => {
-    setIsError(false);
-    setIsRevoking(true);
-    try {
-      // Fire all revocations concurrently; surface a single failure rather than
-      // leaving the caller guessing which of the batch went through.
-      await Promise.all(
-        sessionIds.map((id) => revoke.mutateAsync({ request: { id } })),
-      );
-      onOpenChange(false);
-      onRevoked();
-    } catch {
-      setIsError(true);
-    } finally {
-      setIsRevoking(false);
-    }
+  const handleRevoke = () => {
+    bulkRevoke.mutate(sessionIds, {
+      onSuccess: (result) => {
+        onRevoked(result.succeededIds);
+        if (result.failedCount === 0) onOpenChange(false);
+      },
+    });
   };
 
   return (
@@ -52,9 +68,10 @@ export function RevokeSessionsDialog({
             clients will need to re-authenticate.
           </Dialog.Description>
         </Dialog.Header>
-        {isError && (
+        {failedCount > 0 && (
           <p className="text-destructive text-sm">
-            Some sessions couldn&apos;t be revoked. Please try again.
+            {failedCount} session{failedCount === 1 ? "" : "s"} couldn&apos;t be
+            revoked. Please try again.
           </p>
         )}
         <Dialog.Footer>
@@ -63,10 +80,10 @@ export function RevokeSessionsDialog({
           </Button>
           <Button
             variant="destructive"
-            disabled={isRevoking || count === 0}
-            onClick={() => void handleRevoke()}
+            disabled={bulkRevoke.isPending || count === 0}
+            onClick={handleRevoke}
           >
-            {isRevoking ? "Revoking…" : `Revoke ${count}`}
+            {bulkRevoke.isPending ? "Revoking…" : `Revoke ${count}`}
           </Button>
         </Dialog.Footer>
       </Dialog.Content>

--- a/client/dashboard/src/components/sessions/SessionStatusBadge.tsx
+++ b/client/dashboard/src/components/sessions/SessionStatusBadge.tsx
@@ -1,6 +1,6 @@
+import { Badge } from "@speakeasy-api/moonshine";
 import type { UserSession } from "@gram/client/models/components";
 
-import { Badge } from "@/components/ui/badge";
 import { sessionStatus, STATUS_PRESENTATION } from "@/lib/user-session-status";
 
 export function SessionStatusBadge({
@@ -9,5 +9,9 @@ export function SessionStatusBadge({
   session: UserSession;
 }): JSX.Element {
   const p = STATUS_PRESENTATION[sessionStatus(session)];
-  return <Badge variant={p.badgeVariant}>{p.label}</Badge>;
+  return (
+    <Badge size="sm" variant={p.badgeVariant} background>
+      <Badge.Text>{p.label}</Badge.Text>
+    </Badge>
+  );
 }

--- a/client/dashboard/src/components/sessions/SessionTableRow.tsx
+++ b/client/dashboard/src/components/sessions/SessionTableRow.tsx
@@ -11,7 +11,6 @@ import {
 import { DotRow } from "@/components/ui/dot-row";
 import { MoreActions } from "@/components/ui/more-actions";
 import { Type } from "@/components/ui/type";
-import { useRBAC } from "@/hooks/useRBAC";
 import {
   sessionStatus,
   sessionTimeLabel,
@@ -23,23 +22,28 @@ import { RevokeSessionDialog } from "./RevokeSessionDialog";
 export function SessionTableRow({
   session,
   onRevoked,
+  canRevokeInProject = false,
   selectable = false,
   selected = false,
   onSelectedChange,
 }: {
   session: UserSession;
   onRevoked: () => void;
+  /**
+   * Whether the user holds project:write on this row's project (project-scoped,
+   * resolved by the parent). Combined with the row's status below.
+   */
+  canRevokeInProject?: boolean;
   /** Render the leading selection cell so columns align with the table header. */
   selectable?: boolean;
   selected?: boolean;
   onSelectedChange?: (checked: boolean) => void;
 }): JSX.Element {
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const { hasScope } = useRBAC();
   const status = sessionStatus(session);
-  // Revoke is a write mutation (backend requires project:write); hide the
-  // affordance for read-only users instead of letting them hit a 403.
-  const canRevoke = status === "active" && hasScope("project:write");
+  // Only active sessions can be revoked, and only when the user can write to
+  // this project (hide the affordance rather than 403 later).
+  const canRevoke = status === "active" && canRevokeInProject;
 
   const row = (
     <DotRow>

--- a/client/dashboard/src/components/sessions/SessionTableRow.tsx
+++ b/client/dashboard/src/components/sessions/SessionTableRow.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { UserSession } from "@gram/client/models/components";
 
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -22,9 +23,16 @@ import { RevokeSessionDialog } from "./RevokeSessionDialog";
 export function SessionTableRow({
   session,
   onRevoked,
+  selectable = false,
+  selected = false,
+  onSelectedChange,
 }: {
   session: UserSession;
   onRevoked: () => void;
+  /** Render the leading selection cell so columns align with the table header. */
+  selectable?: boolean;
+  selected?: boolean;
+  onSelectedChange?: (checked: boolean) => void;
 }): JSX.Element {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const { hasScope } = useRBAC();
@@ -35,6 +43,20 @@ export function SessionTableRow({
 
   const row = (
     <DotRow>
+      {selectable && (
+        <td className="w-10 px-3 py-3">
+          {canRevoke && (
+            <div className="flex" onClick={(e) => e.stopPropagation()}>
+              <Checkbox
+                checked={selected}
+                onCheckedChange={(c) => onSelectedChange?.(c === true)}
+                aria-label={`Select session for ${subjectLabel(session)}`}
+              />
+            </div>
+          )}
+        </td>
+      )}
+
       {/* Subject */}
       <td className="px-3 py-3">
         <Type

--- a/client/dashboard/src/components/ui/dot-table.tsx
+++ b/client/dashboard/src/components/ui/dot-table.tsx
@@ -8,10 +8,17 @@ export function DotTable({
   headers,
   children,
   className,
+  selectionHeader,
 }: {
   headers: { label: string; className?: string }[];
   children: React.ReactNode;
   className?: string;
+  /**
+   * When provided, renders a leading selection column (after the dot column)
+   * with this node as its header — typically a select-all checkbox. Rows must
+   * render a matching leading cell so columns stay aligned.
+   */
+  selectionHeader?: React.ReactNode;
 }): JSX.Element {
   return (
     <div
@@ -25,6 +32,9 @@ export function DotTable({
           <tr className="bg-muted/30 border-b">
             {/* Empty header for the dot-pattern column */}
             <th className="w-17" />
+            {selectionHeader !== undefined && (
+              <th className="w-10 px-3 py-2.5">{selectionHeader}</th>
+            )}
             {headers.map((header, index) => (
               <th
                 key={header.label || `header-${index}`}

--- a/client/dashboard/src/lib/user-session-status.ts
+++ b/client/dashboard/src/lib/user-session-status.ts
@@ -1,12 +1,17 @@
-import type { ComponentProps } from "react";
 import { format, formatDistanceToNow } from "date-fns";
 
-import type { Badge } from "@/components/ui/badge";
 import type { UserSession } from "@gram/client/models/components";
 
 export type SessionStatus = "active" | "expired" | "revoked";
 
-type BadgeVariant = ComponentProps<typeof Badge>["variant"];
+// Moonshine Badge semantic variants ("our brand badges"). The names are hooks
+// onto the brand palette, not literal alert semantics.
+type BadgeVariant =
+  | "neutral"
+  | "success"
+  | "information"
+  | "warning"
+  | "destructive";
 
 export function sessionStatus(session: UserSession): SessionStatus {
   if (session.revokedAt) return "revoked";
@@ -20,12 +25,12 @@ export const STATUS_PRESENTATION: Record<
 > = {
   active: {
     label: "Active",
-    badgeVariant: "default",
+    badgeVariant: "success",
     dotClass: "bg-emerald-500",
   },
   expired: {
     label: "Expired",
-    badgeVariant: "secondary",
+    badgeVariant: "neutral",
     dotClass: "bg-muted-foreground",
   },
   revoked: {

--- a/client/dashboard/src/pages/org/UserSessions.tsx
+++ b/client/dashboard/src/pages/org/UserSessions.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 import { Navigate } from "react-router";
 import {
   defineFilters,
@@ -10,8 +10,10 @@ import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useOrgRoutes } from "@/routes";
+import { RevokeSessionsDialog } from "@/components/sessions/RevokeSessionsDialog";
 import { SessionTableRow } from "@/components/sessions/SessionTableRow";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { DotTable } from "@/components/ui/dot-table";
 import {
   Select,
@@ -23,6 +25,8 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import { useOrganization, useProject } from "@/contexts/Auth";
+import { useRBAC } from "@/hooks/useRBAC";
+import { sessionStatus, subjectLabel } from "@/lib/user-session-status";
 import {
   useUserSessionFacets,
   useUserSessionsInfinite,
@@ -32,7 +36,6 @@ import type { ListUserSessionsQueryParamStatus } from "@gram/client/models/opera
 const USER_SESSION_FILTERS = defineFilters([
   { id: "status", label: "Status", kind: "select", pinned: true },
   { id: "issuerId", label: "MCP server", kind: "select", pinned: true },
-  { id: "clientId", label: "OAuth Client", kind: "select", pinned: true },
   { id: "subjectUrn", label: "User", kind: "select", pinned: true },
 ]);
 
@@ -41,6 +44,16 @@ const STATUS_TOOLBAR_OPTIONS = [
   { value: "expired", label: "Expired" },
   { value: "revoked", label: "Revoked" },
 ];
+
+// Tri-state for the select-all header checkbox.
+function selectAllState(
+  selectedCount: number,
+  totalCount: number,
+): boolean | "indeterminate" {
+  if (selectedCount === 0) return false;
+  if (selectedCount === totalCount) return true;
+  return "indeterminate";
+}
 
 export default function UserSessions(): JSX.Element {
   const telemetry = useTelemetry();
@@ -77,14 +90,24 @@ function UserSessionsInner(): JSX.Element {
     [organization.projects],
   );
 
+  const { hasScope } = useRBAC();
+  // Revoke is a write mutation (backend requires project:write); only expose the
+  // bulk-selection affordance to users who can actually act on it.
+  const canRevoke = hasScope("project:write");
+
   const [projectSlug, setProjectSlug] = useState<string>(project.slug);
   const filters = useFilterState(USER_SESSION_FILTERS);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
 
-  // Reset facet filters when switching projects so a stale selection from one
-  // project isn't submitted to another.
+  // Reset facet filters and selection when switching projects so a stale
+  // selection from one project isn't submitted to another.
   const handleProjectChange = (slug: string) => {
     setProjectSlug(slug);
     filters.clearAll();
+    setSearchQuery("");
+    setSelected(new Set());
   };
 
   const { data: facets } = useUserSessionFacets({ gramProject: projectSlug });
@@ -95,10 +118,6 @@ function UserSessionsInner(): JSX.Element {
       issuerId: (facets?.servers ?? []).map((s) => ({
         value: s.value,
         label: s.displayName,
-      })),
-      clientId: (facets?.clients ?? []).map((c) => ({
-        value: c.value,
-        label: c.displayName,
       })),
       subjectUrn: (facets?.users ?? []).map((u) => ({
         value: u.value,
@@ -121,11 +140,116 @@ function UserSessionsInner(): JSX.Element {
     status: (filters.values.status ?? undefined) as
       | ListUserSessionsQueryParamStatus
       | undefined,
-    clientId: filters.values.clientId ?? undefined,
     subjectUrn: filters.values.subjectUrn ?? undefined,
     userSessionIssuerId: filters.values.issuerId ?? undefined,
   });
-  const sessions = data?.pages.flatMap((p) => p.result.items) ?? [];
+  const sessions = useMemo(
+    () => data?.pages.flatMap((p) => p.result.items) ?? [],
+    [data],
+  );
+
+  // Search filters the loaded rows client-side (subject / client / server),
+  // matching the loaded-count semantics shown in the toolbar. Deferred so the
+  // input stays responsive while the list re-filters.
+  const deferredSearch = useDeferredValue(searchQuery);
+  const filteredSessions = useMemo(() => {
+    const q = deferredSearch.trim().toLowerCase();
+    if (!q) return sessions;
+    return sessions.filter(
+      (s) =>
+        subjectLabel(s).toLowerCase().includes(q) ||
+        (s.clientName ?? "").toLowerCase().includes(q) ||
+        s.issuerSlug.toLowerCase().includes(q),
+    );
+  }, [sessions, deferredSearch]);
+
+  // Only active sessions can be revoked, so selection (and select-all) operates
+  // over the active rows currently in view.
+  const activeIds = useMemo(
+    () =>
+      filteredSessions
+        .filter((s) => sessionStatus(s) === "active")
+        .map((s) => s.id),
+    [filteredSessions],
+  );
+  const selectedIds = activeIds.filter((id) => selected.has(id));
+  const selectionEnabled = canRevoke && activeIds.length > 0;
+
+  const toggleOne = (id: string, checked: boolean) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  };
+
+  const toggleAll = (checked: boolean) => {
+    setSelected(checked ? new Set(activeIds) : new Set());
+  };
+
+  let listBody: JSX.Element;
+  if (isPending) {
+    listBody = (
+      <div className="space-y-2">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    );
+  } else if (isError && sessions.length === 0) {
+    listBody = (
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-destructive text-sm">Couldn&apos;t load sessions.</p>
+        <Button variant="ghost" size="sm" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  } else if (sessions.length === 0) {
+    listBody = (
+      <p className="text-muted-foreground text-sm">No sessions found</p>
+    );
+  } else if (filteredSessions.length === 0) {
+    listBody = (
+      <p className="text-muted-foreground text-sm">
+        No sessions match your search
+      </p>
+    );
+  } else {
+    listBody = (
+      <DotTable
+        selectionHeader={
+          selectionEnabled ? (
+            <Checkbox
+              checked={selectAllState(selectedIds.length, activeIds.length)}
+              onCheckedChange={(c) => toggleAll(c === true)}
+              aria-label="Select all active sessions"
+            />
+          ) : undefined
+        }
+        headers={[
+          { label: "Subject" },
+          { label: "OAuth Client" },
+          { label: "MCP server" },
+          { label: "Status" },
+          { label: "Expires" },
+          { label: "", className: "w-10" },
+        ]}
+      >
+        {filteredSessions.map((s) => (
+          <SessionTableRow
+            key={s.id}
+            session={s}
+            onRevoked={() => void refetch()}
+            selectable={selectionEnabled}
+            selected={selected.has(s.id)}
+            onSelectedChange={(checked) => toggleOne(s.id, checked)}
+          />
+        ))}
+      </DotTable>
+    );
+  }
 
   return (
     <Page.Section>
@@ -155,6 +279,12 @@ function UserSessionsInner(): JSX.Element {
           </div>
 
           <Page.Toolbar>
+            <Page.Toolbar.Search
+              value={searchQuery}
+              onChange={setSearchQuery}
+              debounceMs={150}
+              placeholder="Search sessions"
+            />
             <Page.Toolbar.Filters
               schema={USER_SESSION_FILTERS}
               values={filters.values}
@@ -166,47 +296,34 @@ function UserSessionsInner(): JSX.Element {
               onClearAll={filters.clearAll}
             />
             <Page.Toolbar.Count>
-              {sessions.length} session{sessions.length === 1 ? "" : "s"}
+              {filteredSessions.length} session
+              {filteredSessions.length === 1 ? "" : "s"}
             </Page.Toolbar.Count>
           </Page.Toolbar>
 
-          {isPending ? (
-            <div className="space-y-2">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <Skeleton key={i} className="h-12 w-full" />
-              ))}
+          {selectionEnabled && selectedIds.length > 0 && (
+            <div className="border-border bg-muted/30 flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+              <Type small>{selectedIds.length} selected</Type>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSelected(new Set())}
+                >
+                  Clear
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setBulkConfirmOpen(true)}
+                >
+                  Revoke {selectedIds.length}
+                </Button>
+              </div>
             </div>
-          ) : isError && sessions.length === 0 ? (
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-destructive text-sm">
-                Couldn&apos;t load sessions.
-              </p>
-              <Button variant="ghost" size="sm" onClick={() => void refetch()}>
-                Retry
-              </Button>
-            </div>
-          ) : sessions.length === 0 ? (
-            <p className="text-muted-foreground text-sm">No sessions found</p>
-          ) : (
-            <DotTable
-              headers={[
-                { label: "Subject" },
-                { label: "OAuth Client" },
-                { label: "MCP server" },
-                { label: "Status" },
-                { label: "Expires" },
-                { label: "", className: "w-10" },
-              ]}
-            >
-              {sessions.map((s) => (
-                <SessionTableRow
-                  key={s.id}
-                  session={s}
-                  onRevoked={() => void refetch()}
-                />
-              ))}
-            </DotTable>
           )}
+
+          {listBody}
 
           {hasNextPage && (
             <div className="flex justify-center">
@@ -221,6 +338,16 @@ function UserSessionsInner(): JSX.Element {
             </div>
           )}
         </div>
+
+        <RevokeSessionsDialog
+          sessionIds={selectedIds}
+          open={bulkConfirmOpen}
+          onOpenChange={setBulkConfirmOpen}
+          onRevoked={() => {
+            setSelected(new Set());
+            void refetch();
+          }}
+        />
       </Page.Section.Body>
     </Page.Section>
   );

--- a/client/dashboard/src/pages/org/UserSessions.tsx
+++ b/client/dashboard/src/pages/org/UserSessions.tsx
@@ -255,8 +255,9 @@ function UserSessionsInner(): JSX.Element {
     <Page.Section>
       <Page.Section.Title>MCP Connections</Page.Section.Title>
       <Page.Section.Description>
-        Sessions clients hold into this project&apos;s MCP servers, established
-        via OAuth. Revoke a session to immediately cut off access.
+        View and manage active connections agents have established with your MCP
+        servers, established via OAuth. Revoke a connection to immediately cut
+        off access.
       </Page.Section.Description>
       <Page.Section.Body>
         <div className="space-y-4">

--- a/client/dashboard/src/pages/org/UserSessions.tsx
+++ b/client/dashboard/src/pages/org/UserSessions.tsx
@@ -91,12 +91,17 @@ function UserSessionsInner(): JSX.Element {
   );
 
   const { hasScope } = useRBAC();
-  // Revoke is a write mutation (backend requires project:write); only expose the
-  // bulk-selection affordance to users who can actually act on it.
-  const canRevoke = hasScope("project:write");
 
   const [projectSlug, setProjectSlug] = useState<string>(project.slug);
   const filters = useFilterState(USER_SESSION_FILTERS);
+
+  // Revoke is a write mutation (backend requires project:write). Scope the check
+  // to the *selected* project — a user with project:write on one project must
+  // not see revoke affordances after switching to another (they'd only fail at
+  // mutation time). Drives both the bulk selection and the per-row affordances.
+  const selectedProjectId = projects.find((p) => p.slug === projectSlug)?.id;
+  const canRevoke =
+    !!selectedProjectId && hasScope("project:write", selectedProjectId);
   const [searchQuery, setSearchQuery] = useState("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
@@ -241,6 +246,7 @@ function UserSessionsInner(): JSX.Element {
           <SessionTableRow
             key={s.id}
             session={s}
+            canRevokeInProject={canRevoke}
             onRevoked={() => void refetch()}
             selectable={selectionEnabled}
             selected={selected.has(s.id)}
@@ -344,8 +350,14 @@ function UserSessionsInner(): JSX.Element {
           sessionIds={selectedIds}
           open={bulkConfirmOpen}
           onOpenChange={setBulkConfirmOpen}
-          onRevoked={() => {
-            setSelected(new Set());
+          onRevoked={(succeededIds) => {
+            // Clear only the sessions that actually revoked; keep any failures
+            // selected so the user can retry them.
+            setSelected((prev) => {
+              const next = new Set(prev);
+              for (const id of succeededIds) next.delete(id);
+              return next;
+            });
             void refetch();
           }}
         />


### PR DESCRIPTION
## What

Follow-up UX optimizations to the org-level **MCP Connections** page (`/user-sessions`), shipped in #3524. All changes are dashboard-only and sit behind the existing `user-sessions-dashboard` PostHog flag.

## Changes

- **Bulk revoke** — per-row checkboxes on active (revokable) rows plus a tri-state select-all header checkbox. A bulk-action bar (`N selected` → Clear / Revoke N) opens a confirmation dialog that revokes the selected sessions concurrently, then refetches. Gated on `project:write`.
- **Search** — added the standard `Page.Toolbar.Search` (150ms debounce) to the filter bar. Filters loaded rows client-side by subject / client / MCP server, wrapped in `useDeferredValue` so typing stays responsive. The count reflects the filtered set.
- **Brand status badges** — `SessionStatusBadge` now uses Moonshine's `<Badge background>` (the same brand primitive as `ReleaseStageBadge`): active → `success`, expired → `neutral`, revoked → `destructive`.
- **Filters** — removed the **OAuth Client** filter dimension; status filtering retained. (The OAuth Client *column* is kept.)

## Notes

- `DotTable` gained an optional `selectionHeader` prop so the selection column is reusable; `SessionTableRow` renders a matching leading cell.
- Search + select-all operate over **loaded** rows only (the list is server-paginated via infinite query) — the toolbar count, search, and select-all all derive from the same memoized set so they never disagree.

## Verification

- `tsc -b --noEmit --force`, `oxlint --type-aware`, `oxfmt --check`, `knip` — all clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bulk revoke, search, and brand status badges to the org-level MCP Connections page to speed up session management. All actions require `project:write` on the selected project and the `user-sessions-dashboard` flag.

- **New Features**
  - Bulk revoke: checkboxes on active rows, tri-state select-all, confirm dialog; revokes concurrently and refetches; selection applies to loaded active rows.
  - Search: toolbar search (150ms debounce) filters by subject, OAuth client, and MCP server; count reflects the filtered set.
  - Brand badges: use `@speakeasy-api/moonshine` Badge with background (active→success, expired→neutral, revoked→destructive).
  - Filters: removed the OAuth Client filter; column remains; status filtering kept.

- **Bug Fixes**
  - Bulk revoke uses `useMutation` with `Promise.allSettled` to handle partial failures; successes clear/refetch, failures stay selected for retry; mutation state resets on close but is guarded while in flight to prevent duplicate submissions.
  - Scope the `project:write` check to the selected project so revoke affordances don’t appear after switching to a project without write access.

<sup>Written for commit 9fe63e6dc4f1cd7d7fbd7a05d9d27e0c7855e1a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

