### PR TITLE
fix(dashboard): correct Cmd+K result focus and recents ranking

### DIFF
--- a/.changeset/cmdk-focus-and-ranking.md
+++ b/.changeset/cmdk-focus-and-ranking.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix two Cmd+K command palette glitches. Recently Visited is now only shown when the search box is empty, so a closer text match always ranks ahead of a recently visited page (AGE-2808). The "Ask AI" row drops below the results while searching, so the closest match keeps the auto-selected highlight instead of requiring an extra ↓ keypress to reach it (AGE-2807).

--- a/client/dashboard/src/components/command-palette/CommandPalette.tsx
+++ b/client/dashboard/src/components/command-palette/CommandPalette.tsx
@@ -96,6 +96,10 @@ export function CommandPalette(): JSX.Element {
   };
 
   const trimmedQuery = query.trim();
+  // Recently Visited is a zero-state convenience and the Project Assistant row
+  // moves to the bottom once the user starts typing (see below), so both branch
+  // on whether there's an active query.
+  const hasQuery = trimmedQuery.length > 0;
   const askAiLabel = trimmedQuery
     ? `Ask AI: "${trimmedQuery}"`
     : "Ask the Project Assistant…";
@@ -104,6 +108,28 @@ export function CommandPalette(): JSX.Element {
     requestAskAi(trimmedQuery);
     closeAndReset();
   };
+
+  // Free-form AI escape hatch — always offered regardless of the filter
+  // (forceMount) so the typed query can always be sent to the assistant.
+  // Project Assistant is project-scoped, so only at the project level. Rendered
+  // near the top when the palette is idle (discoverable) but pushed below the
+  // results while searching: cmdk auto-selects the first item in DOM order after
+  // filtering, so keeping this forceMounted row above the matches would steal
+  // the highlight from the closest result and force an extra ↓ keypress to reach
+  // it (AGE-2807).
+  const askAiGroup = inProject ? (
+    <CommandGroup heading="Assistant">
+      <CommandItem
+        forceMount
+        value="__ask_ai__"
+        onSelect={handleAskAi}
+        className="flex items-center gap-2"
+      >
+        <Icon name="sparkles" className="text-primary size-4 shrink-0" />
+        <span className="truncate">{askAiLabel}</span>
+      </CommandItem>
+    </CommandGroup>
+  ) : null;
 
   return (
     <CommandDialog
@@ -144,8 +170,11 @@ export function CommandPalette(): JSX.Element {
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
 
-        {/* Recently visited pages (most-recent first), client-side localStorage. */}
-        {recents.length > 0 && (
+        {/* Recently visited pages (most-recent first), client-side localStorage.
+            Only a zero-state affordance: once the user types, hide it so search
+            results rank on their own merits instead of recents jumping ahead of
+            a closer text match (AGE-2808). */}
+        {!hasQuery && recents.length > 0 && (
           <CommandGroup heading="Recently Visited">
             {recents.map((recent) => (
               <CommandItem
@@ -163,22 +192,8 @@ export function CommandPalette(): JSX.Element {
           </CommandGroup>
         )}
 
-        {/* Free-form AI escape hatch — always offered regardless of the filter
-            (forceMount) so the typed query can always be sent to the assistant.
-            Project Assistant is project-scoped, so only at the project level. */}
-        {inProject && (
-          <CommandGroup heading="Assistant">
-            <CommandItem
-              forceMount
-              value="__ask_ai__"
-              onSelect={handleAskAi}
-              className="flex items-center gap-2"
-            >
-              <Icon name="sparkles" className="text-primary size-4 shrink-0" />
-              <span className="truncate">{askAiLabel}</span>
-            </CommandItem>
-          </CommandGroup>
-        )}
+        {/* Idle: Ask AI sits up top for discoverability. */}
+        {!hasQuery && askAiGroup}
 
         {sortedGroups.map(([groupName, groupActions]) => (
           <CommandGroup key={groupName} heading={groupName}>
@@ -212,6 +227,11 @@ export function CommandPalette(): JSX.Element {
         {isOpen && inProject && (
           <ResourceResults onNavigate={closeAndReset} query={trimmedQuery} />
         )}
+
+        {/* Searching: Ask AI drops below the results so the closest match keeps
+            the auto-selected highlight, while the "Ask AI: …" fallback stays
+            available at the bottom of the list (AGE-2807). */}
+        {hasQuery && askAiGroup}
       </CommandList>
 
       {/* Keyboard navigation hints */}


### PR DESCRIPTION
## What

Two minor Cmd+K command palette fixes reported by Vishal.

- **AGE-2807 — dropdown loses focus on keypress.** The `forceMount` "Ask AI" row sat near the top of the list. Because `cmdk` unmounts non-matching items but keeps `forceMount` ones, after you typed, its `selectFirstItem()` walked the DOM and landed on the always-present Ask AI row instead of your closest result — so you needed an extra ↓ to reach results. Ask AI now drops **below** the results while searching (and stays near the top at the empty state for discoverability), so the closest match keeps the auto-selected highlight.
- **AGE-2808 — Recently Visited outranks closer matches.** Recently Visited is now a **zero-state affordance**: shown only when the input is empty. Once you type, it's hidden so results rank purely on match quality. Those pages still surface under "Pages" when they match, so nothing becomes unsearchable — they just stop jumping the queue. This also drops the score pollution from the literal word `"recent"` previously baked into every recent's `value`.

This mirrors Linear's own ⌘K behavior.

## Files

- `client/dashboard/src/components/command-palette/CommandPalette.tsx`

## Testing

- `oxfmt --check`, `oxlint`, and `tsc -b` all clean for the touched file.
- Verified the fix against `cmdk@1.1.1`'s selection model (forceMount items stay mounted; `selectFirstItem` walks DOM order; non-matching non-forceMount items unmount). Spin up a preview env to click through both behaviors.

Closes AGE-2807, AGE-2808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+K command palette focus and ranking so typing keeps the highlight on the closest match and results sort by match quality. Addresses Linear AGE-2807 and AGE-2808.

- **Bug Fixes**
  - Assistant row (`forceMount`) moves below results when there’s a query to avoid `cmdk` auto-select stealing focus (AGE-2807).
  - Recently Visited shows only when the input is empty; once you type, it hides so closer text matches appear first (still searchable under Pages) (AGE-2808).

<sup>Written for commit 1bc42d92943f29028a4193f7ae628f8db422b6f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

