### PR TITLE
fix(dashboard): show Not found UI for missing chat instead of error boundary

### DIFF
--- a/client/dashboard/src/pages/chatLogs/useLoadChatAllGenerations.ts
+++ b/client/dashboard/src/pages/chatLogs/useLoadChatAllGenerations.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
 import type { Chat, ChatMessage } from "@gram/client/models/components";
+import { GramError } from "@gram/client/models/errors/gramerror.js";
 import {
   buildLoadChatQuery,
   useGramContext,
@@ -26,10 +27,15 @@ export function useLoadChatAllGenerations(
   chatId: string,
 ): LoadChatAllGenerationsResult {
   const client = useGramContext();
+  // Suppress 404s so empty/never-created chats fall through to the panel's
+  // "Not found" UI instead of bubbling to the page-level error boundary.
   const { data: latest, isLoading: latestLoading } = useLoadChat(
     { id: chatId },
     undefined,
-    {},
+    {
+      throwOnError: (error) =>
+        !(error instanceof GramError && error.statusCode === 404),
+    },
   );
 
   const maxGeneration = latest?.maxGeneration ?? 0;


### PR DESCRIPTION
## Why

Clicking certain agent-session rows on the Costs page (e.g. very short, $0, 0-message sessions) crashes the page with a full "Error loading Page / resource not found" error-boundary screen.

These rows exist because Claude Code's `SessionStart` hook fires and creates a session-cost record, but no `UserPromptSubmit`/`Stop` content-bearing hook ever runs (the process exits before any prompt is submitted). As a result no `chats`/`chat_messages` row is ever inserted. When the detail panel loads, `chat.load` returns 404.

`ChatDetailPanel.tsx` already has a graceful `if (!chat) return <Not found>` branch, but it never runs: the QueryClient default `throwOnError` in `contexts/Sdk.tsx` only suppresses 403s, so the 404 from `useLoadChat` bubbles to the page-level error boundary.

## What changed

`client/dashboard/src/pages/chatLogs/useLoadChatAllGenerations.ts`

- Before: `useLoadChat({ id: chatId }, undefined, {})` — inherits the global `throwOnError` that lets 404s through to the error boundary.
- After: pass `throwOnError: (error) => !(error instanceof GramError && error.statusCode === 404)` so 404s resolve as a missing chat and the existing "Not found" panel renders.

Narrowest possible change; other error classes still bubble.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the "Not found" panel for missing chats instead of showing the page-level error screen. Fixes crashes when opening $0 / 0-message sessions from the Costs page.

- **Bug Fixes**
  - In `client/dashboard/src/pages/chatLogs/useLoadChatAllGenerations.ts`, pass `throwOnError: (e) => !(e instanceof GramError && e.statusCode === 404)` to `useLoadChat` so 404s return as missing and the panel shows "Not found".
  - All other errors still bubble to the error boundary.

<sup>Written for commit 381919c9012f7467826eaa2a2e7e0081f1407074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

