### PR TITLE
chore(pystreams): raise default scan timeout to 60s

### DIFF
--- a/pystreams/src/pystreams/cmd/flags_presidio.py
+++ b/pystreams/src/pystreams/cmd/flags_presidio.py
@@ -42,7 +42,7 @@ def presidio_options() -> Sequence[click.Option]:
         click.Option(
             ["--scan-timeout"],
             type=float,
-            default=30.0,
+            default=60.0,
             envvar="GRAM_PYSTREAMS_SCAN_TIMEOUT",
             help=(
                 "Seconds a single scan may run before it is treated as a failure "


### PR DESCRIPTION
The 30s default was too tight for larger payloads now that scans run in a process pool, causing healthy scans to be flagged as failures. Doubling the ceiling gives slower scans room to complete without masking genuine hangs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the default Presidio scan timeout in `pystreams` from 30s to 60s to prevent healthy scans on larger payloads from being marked as failures in the process pool. Still overridable via `--scan-timeout` or `GRAM_PYSTREAMS_SCAN_TIMEOUT`.

<sup>Written for commit 33bd5acef62a2868e372213d385ef9592dd20657. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

