### PR TITLE
chore(hk): add infra gen and lint hooks

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -68,6 +68,16 @@ local linters = new Mapping<String, Step> {
   ["ruff"] = (Builtins.ruff) {
     exclude = List("**/vendor/**", "**/node_modules/**", "**/dist/**", "**/*_pb2.*")
   }
+  ["infra-gen"] {
+    glob = List("infra/**/*")
+    exclude = List("infra/gen/**/*", "infra/gen_py/**/*")
+    fix = "mise run -q gen:infra"
+  }
+  ["infra-lint"] {
+    glob = List("infra/**/*")
+    exclude = List("infra/gen/**/*", "infra/gen_py/**/*")
+    check = "mise run -q lint:infra && mise run -q test:infra"
+  }
 }
 
 hooks {


### PR DESCRIPTION
Wire the infra code generation and validation tasks into hk so that changes under infra/ automatically regenerate derived files and are checked against the linters and tests on every run, without authors needing to remember to invoke the mise tasks by hand.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically runs infra code generation, lint, and tests via `hk` so changes under infra/ regenerate derived files and are validated on each run. This removes the need to call `mise` tasks manually.

- **New Features**
  - Added `infra-gen` hook: watches `infra/**/*` (excludes `infra/gen/**/*`, `infra/gen_py/**/*`); runs `mise run -q gen:infra`.
  - Added `infra-lint` hook: watches `infra/**/*` (same excludes); runs `mise run -q lint:infra` and `mise run -q test:infra`.

<sup>Written for commit 3672c04729c784c8ea6036852e283be3e2dd26f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

