### PR TITLE
fix(server): drain in-flight requests fully before cancelling root context on shutdown

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1227,11 +1227,18 @@ func newStartCommand() *cli.Command {
 
 				logger.InfoContext(ctx, "shutting down server")
 
-				graceCtx, graceCancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownDrainTimeout)
+				graceCtx, graceCancel := context.WithTimeoutCause(
+					context.WithoutCancel(ctx),
+					shutdownDrainTimeout,
+					errors.New("graceful shutdown timed out"),
+				)
 				defer graceCancel()
 
 				if err := srv.Shutdown(graceCtx); err != nil {
-					logger.ErrorContext(ctx, "failed to shutdown development server", attr.SlogError(err))
+					if gerr := context.Cause(graceCtx); gerr != nil {
+						err = errors.Join(err, gerr)
+					}
+					logger.ErrorContext(ctx, "failed to shutdown server", attr.SlogError(err))
 				}
 			})
 
@@ -1296,8 +1303,13 @@ func newStartCommand() *cli.Command {
 				}
 			}
 
-			cancel()
+			// ListenAndServe returns ErrServerClosed the instant srv.Shutdown is
+			// called, not when the drain finishes. Wait for the drain goroutine to
+			// fully complete before cancelling ctx: ctx is the server's BaseContext,
+			// so cancelling it here would cancel every in-flight request mid-drain
+			// and they would abort with context.Canceled instead of completing.
 			group.Wait()
+			cancel()
 
 			return nil
 		},


### PR DESCRIPTION
## What

Fixes a graceful-shutdown ordering bug in the server `start` command that lets in-flight requests be cancelled the moment shutdown begins, rather than being allowed to drain.

## Why

On SIGTERM, the drain goroutine calls `srv.Shutdown(graceCtx)`, which closes the listener and makes `ListenAndServe` return `http.ErrServerClosed` **immediately** — not when the drain finishes. The main goroutine then fell straight through to `cancel()`.

Because `ctx` is the server's `BaseContext`, every in-flight request derives `r.Context()` from it. Cancelling it that early aborted those requests with `context.Canceled` (DB queries, outbound calls, the MCP runtime path) instead of letting them complete — so the 60s drain window was largely cosmetic. This is a likely contributor to the brief errors observed during production deploys.

## Changes

- Wait on the drain goroutine (`group.Wait()`) **before** `cancel()`, so in-flight requests keep a live context for the full drain window. Added a comment so the ordering isn't "tidied" back.
- Switch the drain deadline to `context.WithTimeoutCause` and join `context.Cause` into the logged error, so a real drain timeout is distinguishable from other shutdown errors. Fixed the misleading "development server" log wording (this path runs in prod).

## Notes

A companion infra change (preStop hook + `terminationGracePeriodSeconds`) in gram-infra addresses the load-balancer deprogramming race; this PR covers the in-process drain correctness.

## Testing

- `mise build:server` / `go build ./server/cmd/gram/` pass.
- No behavior change outside the shutdown path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix graceful-shutdown ordering so in-flight requests fully drain before the root context is cancelled. Prevents mid-drain aborts with `context.Canceled` during deploys.

- **Bug Fixes**
  - Wait for the drain goroutine (`group.Wait()`) before `cancel()`, keeping the server `BaseContext` alive through the drain window.
  - Use `context.WithTimeoutCause` and join `context.Cause` in shutdown errors to surface real drain timeouts; updated log message to "server".

<sup>Written for commit 59c43c33a4d57ae65ed50d610acc16a14f7a4a26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

