### PR TITLE
fix(chat): block deleting a chat that backs an active assistant thread

### DIFF
--- a/.changeset/dno-314-block-delete-assistant-thread-chat.md
+++ b/.changeset/dno-314-block-delete-assistant-thread-chat.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Deleting a chat that backs an active assistant is now blocked and returns a conflict. Previously the chat could be soft-deleted out from under a running assistant, which broke the assistant's ability to load its conversation and could leave it silently wedged.

--- a/server/internal/chat/delete_chat_test.go
+++ b/server/internal/chat/delete_chat_test.go
@@ -1,0 +1,61 @@
+package chat_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/chat"
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// seedAssistantThread inserts an assistant and an active thread backed by chatID.
+func seedAssistantThread(t *testing.T, ctx context.Context, ti *chatTestInstance, chatID uuid.UUID) {
+	t.Helper()
+	r := repo.New(ti.conn)
+	assistantID, err := r.SeedAssistant(ctx, repo.SeedAssistantParams{
+		ProjectID:      ti.projectID,
+		OrganizationID: ti.orgID,
+		Name:           "Test Assistant " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+
+	err = r.SeedAssistantThread(ctx, repo.SeedAssistantThreadParams{
+		AssistantID:   assistantID,
+		ProjectID:     ti.projectID,
+		CorrelationID: "corr-" + uuid.NewString()[:8],
+		ChatID:        chatID,
+	})
+	require.NoError(t, err)
+}
+
+// A chat that backs an active assistant thread must not be deletable: the
+// runtime reloads the conversation every turn, so soft-deleting it wedges the
+// thread. A plain chat still deletes normally.
+func TestService_DeleteChat_BlocksAssistantThreadChat(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := initSessionCtx(t, ti)
+
+	threadChatID := seedChat(t, ctx, ti, "", "ext-user", "Thread Chat")
+	seedAssistantThread(t, ctx, ti, threadChatID)
+
+	err := ti.service.DeleteChat(ctx, &gen.DeleteChatPayload{ID: threadChatID.String()})
+	requireOopsCode(t, err, oops.CodeConflict)
+
+	// Still present (GetChat filters deleted IS FALSE).
+	_, err = repo.New(ti.conn).GetChat(ctx, threadChatID)
+	require.NoError(t, err)
+
+	plainChatID := seedChat(t, ctx, ti, "", "ext-user", "Plain Chat")
+	err = ti.service.DeleteChat(ctx, &gen.DeleteChatPayload{ID: plainChatID.String()})
+	require.NoError(t, err)
+
+	// Now soft-deleted, so GetChat no longer returns it.
+	_, err = repo.New(ti.conn).GetChat(ctx, plainChatID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}

--- a/server/internal/chat/delete_chat_test.go
+++ b/server/internal/chat/delete_chat_test.go
@@ -13,8 +13,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-// seedAssistantThread inserts an assistant and an active thread backed by chatID.
-func seedAssistantThread(t *testing.T, ctx context.Context, ti *chatTestInstance, chatID uuid.UUID) {
+// seedAssistantThread inserts an assistant and an active thread backed by
+// chatID, returning the assistant's id.
+func seedAssistantThread(t *testing.T, ctx context.Context, ti *chatTestInstance, chatID uuid.UUID) uuid.UUID {
 	t.Helper()
 	r := repo.New(ti.conn)
 	assistantID, err := r.SeedAssistant(ctx, repo.SeedAssistantParams{
@@ -31,6 +32,7 @@ func seedAssistantThread(t *testing.T, ctx context.Context, ti *chatTestInstance
 		ChatID:        chatID,
 	})
 	require.NoError(t, err)
+	return assistantID
 }
 
 // A chat that backs an active assistant thread must not be deletable: the
@@ -57,5 +59,18 @@ func TestService_DeleteChat_BlocksAssistantThreadChat(t *testing.T) {
 
 	// Now soft-deleted, so GetChat no longer returns it.
 	_, err = repo.New(ti.conn).GetChat(ctx, plainChatID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	// A chat whose only assistant has been soft-deleted IS deletable — the
+	// leftover thread must not block cleanup forever (DeleteAssistant leaves
+	// threads behind).
+	deadChatID := seedChat(t, ctx, ti, "", "ext-user", "Dead Assistant Chat")
+	deadAssistantID := seedAssistantThread(t, ctx, ti, deadChatID)
+	require.NoError(t, repo.New(ti.conn).SeedSoftDeleteAssistant(ctx, deadAssistantID))
+
+	err = ti.service.DeleteChat(ctx, &gen.DeleteChatPayload{ID: deadChatID.String()})
+	require.NoError(t, err)
+
+	_, err = repo.New(ti.conn).GetChat(ctx, deadChatID)
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 }

--- a/server/internal/chat/heal_deleted_chat_test.go
+++ b/server/internal/chat/heal_deleted_chat_test.go
@@ -11,6 +11,7 @@ import (
 
 	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 )
 
 // seedThreadBackedChat creates a chat backed by a live assistant thread.
@@ -61,9 +62,15 @@ func TestUpsertChat_HealsDeletedThreadBackedChat(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// SoftDeleteChat refuses to delete a chat backing a live thread (that guard is
+	// the point of the sibling PR). To exercise self-heal we have to land in the
+	// wedged state some other way — legacy rows, direct DB manipulation, or a future
+	// code path that bypasses the guard — so use the test-only bypass.
+	tr := testrepo.New(ti.conn)
+
 	// Thread-backed deleted chat heals on the next write.
 	threadChatID := seedThreadBackedChat(t, ctx, ti)
-	require.NoError(t, r.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{ID: threadChatID, ProjectID: ti.projectID}))
+	require.NoError(t, tr.ForceSoftDeleteChat(ctx, threadChatID))
 	_, err := r.GetChat(ctx, threadChatID)
 	require.ErrorIs(t, err, pgx.ErrNoRows, "chat should be soft-deleted before the write")
 
@@ -74,7 +81,8 @@ func TestUpsertChat_HealsDeletedThreadBackedChat(t *testing.T) {
 	// A plain chat with no thread stays deleted: a write must not resurrect a chat
 	// the user intentionally deleted.
 	plainChatID := seedChat(t, ctx, ti, "", "ext-user", "Plain Chat")
-	require.NoError(t, r.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{ID: plainChatID, ProjectID: ti.projectID}))
+	_, err = r.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{ID: plainChatID, ProjectID: ti.projectID})
+	require.NoError(t, err)
 	upsert(plainChatID)
 	_, err = r.GetChat(ctx, plainChatID)
 	require.ErrorIs(t, err, pgx.ErrNoRows, "intentionally-deleted plain chat must stay deleted")

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1125,6 +1125,21 @@ func (s *Service) DeleteChat(ctx context.Context, payload *gen.DeleteChatPayload
 		return oops.E(oops.CodeBadRequest, err, "invalid chat id").LogError(ctx, s.logger)
 	}
 
+	// An assistant thread depends on its backing chat operationally: the runtime
+	// reloads the conversation every turn, so a soft-deleted chat makes that fetch
+	// fail and wedges the thread. Refuse to delete a chat that backs an active
+	// assistant thread.
+	_, err = s.repo.GetAssistantThreadAssistantIDByChatID(ctx, repo.GetAssistantThreadAssistantIDByChatIDParams{
+		ChatID:    chatID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	switch {
+	case err == nil:
+		return oops.E(oops.CodeConflict, nil, "cannot delete a chat that backs an assistant thread").LogError(ctx, s.logger)
+	case !errors.Is(err, pgx.ErrNoRows):
+		return oops.E(oops.CodeUnexpected, err, "check assistant thread for chat").LogError(ctx, s.logger)
+	}
+
 	err = s.repo.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{
 		ID:        chatID,
 		ProjectID: *authCtx.ProjectID,

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1130,7 +1130,10 @@ func (s *Service) DeleteChat(ctx context.Context, payload *gen.DeleteChatPayload
 	// fail and wedges the thread. Refuse to delete a chat that backs a live
 	// assistant thread (a deleted assistant's leftover threads don't count, or the
 	// chat could never be cleaned up).
-	backsThread, err := s.repo.ChatBacksLiveAssistantThread(ctx, chatID)
+	backsThread, err := s.repo.ChatBacksLiveAssistantThread(ctx, repo.ChatBacksLiveAssistantThreadParams{
+		ChatID:    chatID,
+		ProjectID: *authCtx.ProjectID,
+	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "check assistant thread for chat").LogError(ctx, s.logger)
 	}

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1125,28 +1125,32 @@ func (s *Service) DeleteChat(ctx context.Context, payload *gen.DeleteChatPayload
 		return oops.E(oops.CodeBadRequest, err, "invalid chat id").LogError(ctx, s.logger)
 	}
 
-	// An assistant thread depends on its backing chat operationally: the runtime
-	// reloads the conversation every turn, so a soft-deleted chat makes that fetch
-	// fail and wedges the thread. Refuse to delete a chat that backs a live
-	// assistant thread (a deleted assistant's leftover threads don't count, or the
-	// chat could never be cleaned up).
-	backsThread, err := s.repo.ChatBacksLiveAssistantThread(ctx, repo.ChatBacksLiveAssistantThreadParams{
-		ChatID:    chatID,
-		ProjectID: *authCtx.ProjectID,
-	})
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "check assistant thread for chat").LogError(ctx, s.logger)
-	}
-	if backsThread {
-		return oops.E(oops.CodeConflict, nil, "cannot delete a chat that backs an assistant thread").LogError(ctx, s.logger)
-	}
-
-	err = s.repo.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{
+	// SoftDeleteChat refuses to delete a chat that backs a live assistant thread
+	// (the anti-join lives in its WHERE), so the check and the delete are one
+	// atomic statement — a thread created concurrently can't be orphaned by a
+	// racing delete. A live-thread chat reloads its conversation every turn, so a
+	// soft-deleted backing chat would wedge the thread.
+	affected, err := s.repo.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{
 		ID:        chatID,
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "soft delete chat").LogError(ctx, s.logger)
+	}
+	if affected == 0 {
+		// The delete was a no-op: either the chat backs a live assistant thread
+		// (block with a clear conflict) or it doesn't exist / is already deleted
+		// (success, matching the prior project-scoped no-op behavior).
+		backsThread, err := s.repo.ChatBacksLiveAssistantThread(ctx, repo.ChatBacksLiveAssistantThreadParams{
+			ChatID:    chatID,
+			ProjectID: *authCtx.ProjectID,
+		})
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "check assistant thread for chat").LogError(ctx, s.logger)
+		}
+		if backsThread {
+			return oops.E(oops.CodeConflict, nil, "cannot delete a chat that backs an assistant thread").LogError(ctx, s.logger)
+		}
 	}
 
 	return nil

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1127,17 +1127,15 @@ func (s *Service) DeleteChat(ctx context.Context, payload *gen.DeleteChatPayload
 
 	// An assistant thread depends on its backing chat operationally: the runtime
 	// reloads the conversation every turn, so a soft-deleted chat makes that fetch
-	// fail and wedges the thread. Refuse to delete a chat that backs an active
-	// assistant thread.
-	_, err = s.repo.GetAssistantThreadAssistantIDByChatID(ctx, repo.GetAssistantThreadAssistantIDByChatIDParams{
-		ChatID:    chatID,
-		ProjectID: *authCtx.ProjectID,
-	})
-	switch {
-	case err == nil:
-		return oops.E(oops.CodeConflict, nil, "cannot delete a chat that backs an assistant thread").LogError(ctx, s.logger)
-	case !errors.Is(err, pgx.ErrNoRows):
+	// fail and wedges the thread. Refuse to delete a chat that backs a live
+	// assistant thread (a deleted assistant's leftover threads don't count, or the
+	// chat could never be cleaned up).
+	backsThread, err := s.repo.ChatBacksLiveAssistantThread(ctx, chatID)
+	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "check assistant thread for chat").LogError(ctx, s.logger)
+	}
+	if backsThread {
+		return oops.E(oops.CodeConflict, nil, "cannot delete a chat that backs an assistant thread").LogError(ctx, s.logger)
 	}
 
 	err = s.repo.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1125,32 +1125,21 @@ func (s *Service) DeleteChat(ctx context.Context, payload *gen.DeleteChatPayload
 		return oops.E(oops.CodeBadRequest, err, "invalid chat id").LogError(ctx, s.logger)
 	}
 
-	// SoftDeleteChat refuses to delete a chat that backs a live assistant thread
-	// (the anti-join lives in its WHERE), so the check and the delete are one
-	// atomic statement — a thread created concurrently can't be orphaned by a
-	// racing delete. A live-thread chat reloads its conversation every turn, so a
-	// soft-deleted backing chat would wedge the thread.
-	affected, err := s.repo.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{
+	// SoftDeleteChat deletes the chat unless it backs a live assistant thread, and
+	// reports the disposition in one statement (no racy re-query). A live-thread
+	// chat reloads its conversation every turn, so a soft-deleted backing chat
+	// would wedge the thread — refuse with a conflict. A no-op that isn't
+	// thread-backed (chat absent / already deleted / other project) is a success,
+	// matching the prior project-scoped behavior.
+	res, err := s.repo.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{
 		ID:        chatID,
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "soft delete chat").LogError(ctx, s.logger)
 	}
-	if affected == 0 {
-		// The delete was a no-op: either the chat backs a live assistant thread
-		// (block with a clear conflict) or it doesn't exist / is already deleted
-		// (success, matching the prior project-scoped no-op behavior).
-		backsThread, err := s.repo.ChatBacksLiveAssistantThread(ctx, repo.ChatBacksLiveAssistantThreadParams{
-			ChatID:    chatID,
-			ProjectID: *authCtx.ProjectID,
-		})
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "check assistant thread for chat").LogError(ctx, s.logger)
-		}
-		if backsThread {
-			return oops.E(oops.CodeConflict, nil, "cannot delete a chat that backs an assistant thread").LogError(ctx, s.logger)
-		}
+	if !res.Deleted && res.BacksLiveThread {
+		return oops.E(oops.CodeConflict, nil, "cannot delete a chat that backs an assistant thread").LogError(ctx, s.logger)
 	}
 
 	return nil

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -6,6 +6,20 @@ WHERE t.chat_id = @chat_id
   AND t.deleted IS FALSE
 LIMIT 1;
 
+-- name: ChatBacksLiveAssistantThread :one
+-- True when the chat backs a thread of a live (non-deleted) assistant. The
+-- assistant join matters because DeleteAssistant only soft-deletes the
+-- assistant, leaving its threads behind — those orphaned threads must not keep
+-- the backing chat undeletable forever.
+SELECT EXISTS (
+  SELECT 1
+  FROM assistant_threads t
+  JOIN assistants a ON a.id = t.assistant_id
+  WHERE t.chat_id = @chat_id
+    AND t.deleted IS FALSE
+    AND a.deleted IS FALSE
+) AS backs_thread;
+
 -- name: UpsertChat :one
 INSERT INTO chats (
     id
@@ -861,3 +875,8 @@ RETURNING id;
 -- Test fixture: insert an active assistant thread backed by a chat.
 INSERT INTO assistant_threads (assistant_id, project_id, correlation_id, chat_id, source_kind)
 VALUES (@assistant_id, @project_id, @correlation_id, @chat_id, 'cron');
+
+-- name: SeedSoftDeleteAssistant :exec
+-- Test fixture: soft-delete an assistant (mirrors DeleteAssistant, which leaves
+-- its threads behind).
+UPDATE assistants SET deleted_at = clock_timestamp() WHERE id = @id;

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -7,8 +7,10 @@ WHERE t.chat_id = @chat_id
 LIMIT 1;
 
 -- name: ChatBacksLiveAssistantThread :one
--- True when the chat backs a thread of a live (non-deleted) assistant. The
--- assistant join matters because DeleteAssistant only soft-deletes the
+-- True when the chat backs a thread of a live (non-deleted) assistant in the
+-- given project. Project-scoped so a chat ID from another project falls through
+-- to the project-scoped SoftDeleteChat no-op rather than leaking existence via a
+-- 409. The assistant join matters because DeleteAssistant only soft-deletes the
 -- assistant, leaving its threads behind — those orphaned threads must not keep
 -- the backing chat undeletable forever.
 SELECT EXISTS (
@@ -16,6 +18,7 @@ SELECT EXISTS (
   FROM assistant_threads t
   JOIN assistants a ON a.id = t.assistant_id
   WHERE t.chat_id = @chat_id
+    AND t.project_id = @project_id
     AND t.deleted IS FALSE
     AND a.deleted IS FALSE
 ) AS backs_thread;

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -850,3 +850,14 @@ VALUES (
     @project_id, @organization_id, @risk_policy_id, 1,
     @chat_message_id, 'test', @found
 );
+
+-- name: SeedAssistant :one
+-- Test fixture: insert a minimal assistant and return its id.
+INSERT INTO assistants (project_id, organization_id, name, model, instructions)
+VALUES (@project_id, @organization_id, @name, 'anthropic/claude-opus-4.8', 'be helpful')
+RETURNING id;
+
+-- name: SeedAssistantThread :exec
+-- Test fixture: insert an active assistant thread backed by a chat.
+INSERT INTO assistant_threads (assistant_id, project_id, correlation_id, chat_id, source_kind)
+VALUES (@assistant_id, @project_id, @correlation_id, @chat_id, 'cron');

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -743,12 +743,26 @@ UPDATE chat_user_feedback
 SET chat_resolution_id = @chat_resolution_id
 WHERE id = @id;
 
--- name: SoftDeleteChat :exec
+-- name: SoftDeleteChat :execrows
+-- The NOT EXISTS anti-join makes the live-thread check atomic with the delete:
+-- a chat that backs a live assistant thread is never soft-deleted, even if the
+-- thread is created concurrently after a caller's separate pre-check. Returns
+-- the affected row count so the caller can tell "blocked / not found" (0) from
+-- "deleted" (1).
 UPDATE chats
 SET deleted_at = clock_timestamp()
-WHERE id = @id
-  AND project_id = @project_id
-  AND deleted IS FALSE;
+WHERE chats.id = @id
+  AND chats.project_id = @project_id
+  AND chats.deleted IS FALSE
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_threads t
+    JOIN assistants a ON a.id = t.assistant_id
+    WHERE t.chat_id = chats.id
+      AND t.project_id = @project_id
+      AND t.deleted IS FALSE
+      AND a.deleted IS FALSE
+  );
 
 -- name: GetTopUsersByMessages :many
 SELECT

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -6,23 +6,6 @@ WHERE t.chat_id = @chat_id
   AND t.deleted IS FALSE
 LIMIT 1;
 
--- name: ChatBacksLiveAssistantThread :one
--- True when the chat backs a thread of a live (non-deleted) assistant in the
--- given project. Project-scoped so a chat ID from another project falls through
--- to the project-scoped SoftDeleteChat no-op rather than leaking existence via a
--- 409. The assistant join matters because DeleteAssistant only soft-deletes the
--- assistant, leaving its threads behind — those orphaned threads must not keep
--- the backing chat undeletable forever.
-SELECT EXISTS (
-  SELECT 1
-  FROM assistant_threads t
-  JOIN assistants a ON a.id = t.assistant_id
-  WHERE t.chat_id = @chat_id
-    AND t.project_id = @project_id
-    AND t.deleted IS FALSE
-    AND a.deleted IS FALSE
-) AS backs_thread;
-
 -- name: UpsertChat :one
 INSERT INTO chats (
     id
@@ -743,26 +726,44 @@ UPDATE chat_user_feedback
 SET chat_resolution_id = @chat_resolution_id
 WHERE id = @id;
 
--- name: SoftDeleteChat :execrows
--- The NOT EXISTS anti-join makes the live-thread check atomic with the delete:
--- a chat that backs a live assistant thread is never soft-deleted, even if the
--- thread is created concurrently after a caller's separate pre-check. Returns
--- the affected row count so the caller can tell "blocked / not found" (0) from
--- "deleted" (1).
-UPDATE chats
-SET deleted_at = clock_timestamp()
-WHERE chats.id = @id
-  AND chats.project_id = @project_id
-  AND chats.deleted IS FALSE
-  AND NOT EXISTS (
-    SELECT 1
-    FROM assistant_threads t
-    JOIN assistants a ON a.id = t.assistant_id
-    WHERE t.chat_id = chats.id
-      AND t.project_id = @project_id
-      AND t.deleted IS FALSE
-      AND a.deleted IS FALSE
-  );
+-- name: SoftDeleteChat :one
+-- Soft-delete a chat unless it backs a live assistant thread, and report the
+-- disposition in a single statement so the caller never has to re-query (which
+-- would race with concurrent thread create/delete). `guard` snapshots whether
+-- the chat exists in-project, undeleted, and is thread-backed; `del` deletes it
+-- only when not thread-backed. Both CTEs share one statement snapshot, so the
+-- delete and the diagnosis are consistent: a live (existing, undeleted)
+-- thread-backed chat always yields backs_live_thread=true (caller returns 409)
+-- and is never silently reported as a successful no-op.
+WITH guard AS (
+  SELECT
+    c.id,
+    EXISTS (
+      SELECT 1
+      FROM assistant_threads t
+      JOIN assistants a ON a.id = t.assistant_id
+      WHERE t.chat_id = c.id
+        AND t.project_id = @project_id
+        AND t.deleted IS FALSE
+        AND a.deleted IS FALSE
+    ) AS backs_live_thread
+  FROM chats c
+  WHERE c.id = @id
+    AND c.project_id = @project_id
+    AND c.deleted IS FALSE
+),
+del AS (
+  UPDATE chats
+  SET deleted_at = clock_timestamp()
+  WHERE id = @id
+    AND project_id = @project_id
+    AND deleted IS FALSE
+    AND id IN (SELECT id FROM guard WHERE backs_live_thread IS FALSE)
+  RETURNING id
+)
+SELECT
+  EXISTS (SELECT 1 FROM del) AS deleted,
+  COALESCE((SELECT backs_live_thread FROM guard), FALSE)::boolean AS backs_live_thread;
 
 -- name: GetTopUsersByMessages :many
 SELECT

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -34,17 +34,25 @@ SELECT EXISTS (
   FROM assistant_threads t
   JOIN assistants a ON a.id = t.assistant_id
   WHERE t.chat_id = $1
+    AND t.project_id = $2
     AND t.deleted IS FALSE
     AND a.deleted IS FALSE
 ) AS backs_thread
 `
 
-// True when the chat backs a thread of a live (non-deleted) assistant. The
-// assistant join matters because DeleteAssistant only soft-deletes the
+type ChatBacksLiveAssistantThreadParams struct {
+	ChatID    uuid.UUID
+	ProjectID uuid.UUID
+}
+
+// True when the chat backs a thread of a live (non-deleted) assistant in the
+// given project. Project-scoped so a chat ID from another project falls through
+// to the project-scoped SoftDeleteChat no-op rather than leaking existence via a
+// 409. The assistant join matters because DeleteAssistant only soft-deletes the
 // assistant, leaving its threads behind — those orphaned threads must not keep
 // the backing chat undeletable forever.
-func (q *Queries) ChatBacksLiveAssistantThread(ctx context.Context, chatID uuid.UUID) (bool, error) {
-	row := q.db.QueryRow(ctx, chatBacksLiveAssistantThread, chatID)
+func (q *Queries) ChatBacksLiveAssistantThread(ctx context.Context, arg ChatBacksLiveAssistantThreadParams) (bool, error) {
+	row := q.db.QueryRow(ctx, chatBacksLiveAssistantThread, arg.ChatID, arg.ProjectID)
 	var backs_thread bool
 	err := row.Scan(&backs_thread)
 	return backs_thread, err

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -1828,6 +1828,49 @@ func (q *Queries) ListUserFeedbackForChat(ctx context.Context, chatID uuid.UUID)
 	return items, nil
 }
 
+const seedAssistant = `-- name: SeedAssistant :one
+INSERT INTO assistants (project_id, organization_id, name, model, instructions)
+VALUES ($1, $2, $3, 'anthropic/claude-opus-4.8', 'be helpful')
+RETURNING id
+`
+
+type SeedAssistantParams struct {
+	ProjectID      uuid.UUID
+	OrganizationID string
+	Name           string
+}
+
+// Test fixture: insert a minimal assistant and return its id.
+func (q *Queries) SeedAssistant(ctx context.Context, arg SeedAssistantParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, seedAssistant, arg.ProjectID, arg.OrganizationID, arg.Name)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const seedAssistantThread = `-- name: SeedAssistantThread :exec
+INSERT INTO assistant_threads (assistant_id, project_id, correlation_id, chat_id, source_kind)
+VALUES ($1, $2, $3, $4, 'cron')
+`
+
+type SeedAssistantThreadParams struct {
+	AssistantID   uuid.UUID
+	ProjectID     uuid.UUID
+	CorrelationID string
+	ChatID        uuid.UUID
+}
+
+// Test fixture: insert an active assistant thread backed by a chat.
+func (q *Queries) SeedAssistantThread(ctx context.Context, arg SeedAssistantThreadParams) error {
+	_, err := q.db.Exec(ctx, seedAssistantThread,
+		arg.AssistantID,
+		arg.ProjectID,
+		arg.CorrelationID,
+		arg.ChatID,
+	)
+	return err
+}
+
 const seedChatAtTime = `-- name: SeedChatAtTime :one
 INSERT INTO chats (id, project_id, organization_id, user_id, external_user_id, title, created_at, updated_at)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $7)

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -28,6 +28,28 @@ func (q *Queries) AddUserFeedbackChatResolution(ctx context.Context, arg AddUser
 	return err
 }
 
+const chatBacksLiveAssistantThread = `-- name: ChatBacksLiveAssistantThread :one
+SELECT EXISTS (
+  SELECT 1
+  FROM assistant_threads t
+  JOIN assistants a ON a.id = t.assistant_id
+  WHERE t.chat_id = $1
+    AND t.deleted IS FALSE
+    AND a.deleted IS FALSE
+) AS backs_thread
+`
+
+// True when the chat backs a thread of a live (non-deleted) assistant. The
+// assistant join matters because DeleteAssistant only soft-deletes the
+// assistant, leaving its threads behind — those orphaned threads must not keep
+// the backing chat undeletable forever.
+func (q *Queries) ChatBacksLiveAssistantThread(ctx context.Context, chatID uuid.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, chatBacksLiveAssistantThread, chatID)
+	var backs_thread bool
+	err := row.Scan(&backs_thread)
+	return backs_thread, err
+}
+
 const countChatMessages = `-- name: CountChatMessages :one
 SELECT COUNT(*) FROM chat_messages
 WHERE chat_id = $1 AND (project_id IS NULL OR project_id = $2::uuid)
@@ -1973,6 +1995,17 @@ func (q *Queries) SeedRiskResult(ctx context.Context, arg SeedRiskResultParams) 
 		arg.ChatMessageID,
 		arg.Found,
 	)
+	return err
+}
+
+const seedSoftDeleteAssistant = `-- name: SeedSoftDeleteAssistant :exec
+UPDATE assistants SET deleted_at = clock_timestamp() WHERE id = $1
+`
+
+// Test fixture: soft-delete an assistant (mirrors DeleteAssistant, which leaves
+// its threads behind).
+func (q *Queries) SeedSoftDeleteAssistant(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, seedSoftDeleteAssistant, id)
 	return err
 }
 

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -2017,12 +2017,21 @@ func (q *Queries) SeedSoftDeleteAssistant(ctx context.Context, id uuid.UUID) err
 	return err
 }
 
-const softDeleteChat = `-- name: SoftDeleteChat :exec
+const softDeleteChat = `-- name: SoftDeleteChat :execrows
 UPDATE chats
 SET deleted_at = clock_timestamp()
-WHERE id = $1
-  AND project_id = $2
-  AND deleted IS FALSE
+WHERE chats.id = $1
+  AND chats.project_id = $2
+  AND chats.deleted IS FALSE
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_threads t
+    JOIN assistants a ON a.id = t.assistant_id
+    WHERE t.chat_id = chats.id
+      AND t.project_id = $2
+      AND t.deleted IS FALSE
+      AND a.deleted IS FALSE
+  )
 `
 
 type SoftDeleteChatParams struct {
@@ -2030,9 +2039,17 @@ type SoftDeleteChatParams struct {
 	ProjectID uuid.UUID
 }
 
-func (q *Queries) SoftDeleteChat(ctx context.Context, arg SoftDeleteChatParams) error {
-	_, err := q.db.Exec(ctx, softDeleteChat, arg.ID, arg.ProjectID)
-	return err
+// The NOT EXISTS anti-join makes the live-thread check atomic with the delete:
+// a chat that backs a live assistant thread is never soft-deleted, even if the
+// thread is created concurrently after a caller's separate pre-check. Returns
+// the affected row count so the caller can tell "blocked / not found" (0) from
+// "deleted" (1).
+func (q *Queries) SoftDeleteChat(ctx context.Context, arg SoftDeleteChatParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteChat, arg.ID, arg.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateAIIntegrationConfigChatCursor = `-- name: UpdateAIIntegrationConfigChatCursor :exec

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -28,36 +28,6 @@ func (q *Queries) AddUserFeedbackChatResolution(ctx context.Context, arg AddUser
 	return err
 }
 
-const chatBacksLiveAssistantThread = `-- name: ChatBacksLiveAssistantThread :one
-SELECT EXISTS (
-  SELECT 1
-  FROM assistant_threads t
-  JOIN assistants a ON a.id = t.assistant_id
-  WHERE t.chat_id = $1
-    AND t.project_id = $2
-    AND t.deleted IS FALSE
-    AND a.deleted IS FALSE
-) AS backs_thread
-`
-
-type ChatBacksLiveAssistantThreadParams struct {
-	ChatID    uuid.UUID
-	ProjectID uuid.UUID
-}
-
-// True when the chat backs a thread of a live (non-deleted) assistant in the
-// given project. Project-scoped so a chat ID from another project falls through
-// to the project-scoped SoftDeleteChat no-op rather than leaking existence via a
-// 409. The assistant join matters because DeleteAssistant only soft-deletes the
-// assistant, leaving its threads behind — those orphaned threads must not keep
-// the backing chat undeletable forever.
-func (q *Queries) ChatBacksLiveAssistantThread(ctx context.Context, arg ChatBacksLiveAssistantThreadParams) (bool, error) {
-	row := q.db.QueryRow(ctx, chatBacksLiveAssistantThread, arg.ChatID, arg.ProjectID)
-	var backs_thread bool
-	err := row.Scan(&backs_thread)
-	return backs_thread, err
-}
-
 const countChatMessages = `-- name: CountChatMessages :one
 SELECT COUNT(*) FROM chat_messages
 WHERE chat_id = $1 AND (project_id IS NULL OR project_id = $2::uuid)
@@ -2017,39 +1987,61 @@ func (q *Queries) SeedSoftDeleteAssistant(ctx context.Context, id uuid.UUID) err
 	return err
 }
 
-const softDeleteChat = `-- name: SoftDeleteChat :execrows
-UPDATE chats
-SET deleted_at = clock_timestamp()
-WHERE chats.id = $1
-  AND chats.project_id = $2
-  AND chats.deleted IS FALSE
-  AND NOT EXISTS (
-    SELECT 1
-    FROM assistant_threads t
-    JOIN assistants a ON a.id = t.assistant_id
-    WHERE t.chat_id = chats.id
-      AND t.project_id = $2
-      AND t.deleted IS FALSE
-      AND a.deleted IS FALSE
-  )
+const softDeleteChat = `-- name: SoftDeleteChat :one
+WITH guard AS (
+  SELECT
+    c.id,
+    EXISTS (
+      SELECT 1
+      FROM assistant_threads t
+      JOIN assistants a ON a.id = t.assistant_id
+      WHERE t.chat_id = c.id
+        AND t.project_id = $1
+        AND t.deleted IS FALSE
+        AND a.deleted IS FALSE
+    ) AS backs_live_thread
+  FROM chats c
+  WHERE c.id = $2
+    AND c.project_id = $1
+    AND c.deleted IS FALSE
+),
+del AS (
+  UPDATE chats
+  SET deleted_at = clock_timestamp()
+  WHERE id = $2
+    AND project_id = $1
+    AND deleted IS FALSE
+    AND id IN (SELECT id FROM guard WHERE backs_live_thread IS FALSE)
+  RETURNING id
+)
+SELECT
+  EXISTS (SELECT 1 FROM del) AS deleted,
+  COALESCE((SELECT backs_live_thread FROM guard), FALSE)::boolean AS backs_live_thread
 `
 
 type SoftDeleteChatParams struct {
-	ID        uuid.UUID
 	ProjectID uuid.UUID
+	ID        uuid.UUID
 }
 
-// The NOT EXISTS anti-join makes the live-thread check atomic with the delete:
-// a chat that backs a live assistant thread is never soft-deleted, even if the
-// thread is created concurrently after a caller's separate pre-check. Returns
-// the affected row count so the caller can tell "blocked / not found" (0) from
-// "deleted" (1).
-func (q *Queries) SoftDeleteChat(ctx context.Context, arg SoftDeleteChatParams) (int64, error) {
-	result, err := q.db.Exec(ctx, softDeleteChat, arg.ID, arg.ProjectID)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+type SoftDeleteChatRow struct {
+	Deleted         bool
+	BacksLiveThread bool
+}
+
+// Soft-delete a chat unless it backs a live assistant thread, and report the
+// disposition in a single statement so the caller never has to re-query (which
+// would race with concurrent thread create/delete). `guard` snapshots whether
+// the chat exists in-project, undeleted, and is thread-backed; `del` deletes it
+// only when not thread-backed. Both CTEs share one statement snapshot, so the
+// delete and the diagnosis are consistent: a live (existing, undeleted)
+// thread-backed chat always yields backs_live_thread=true (caller returns 409)
+// and is never silently reported as a successful no-op.
+func (q *Queries) SoftDeleteChat(ctx context.Context, arg SoftDeleteChatParams) (SoftDeleteChatRow, error) {
+	row := q.db.QueryRow(ctx, softDeleteChat, arg.ProjectID, arg.ID)
+	var i SoftDeleteChatRow
+	err := row.Scan(&i.Deleted, &i.BacksLiveThread)
+	return i, err
 }
 
 const updateAIIntegrationConfigChatCursor = `-- name: UpdateAIIntegrationConfigChatCursor :exec

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -3,6 +3,14 @@ INSERT INTO chat_messages (chat_id, project_id, role, content)
 VALUES (@chat_id, @project_id, @role, @content)
 RETURNING id;
 
+-- name: ForceSoftDeleteChat :exec
+-- Bypasses the production SoftDeleteChat guard (which refuses to delete a chat
+-- backing a live assistant thread) so tests can wedge the database into the
+-- legacy/abnormal state that the runtime's self-heal exists to recover from.
+UPDATE chats
+SET deleted_at = clock_timestamp()
+WHERE id = @id;
+
 -- name: UpdateChatMessageCreatedAt :exec
 UPDATE chat_messages
 SET created_at = @created_at

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -116,6 +116,20 @@ func (q *Queries) CreateOrganizationUserRelationshipFixture(ctx context.Context,
 	return err
 }
 
+const forceSoftDeleteChat = `-- name: ForceSoftDeleteChat :exec
+UPDATE chats
+SET deleted_at = clock_timestamp()
+WHERE id = $1
+`
+
+// Bypasses the production SoftDeleteChat guard (which refuses to delete a chat
+// backing a live assistant thread) so tests can wedge the database into the
+// legacy/abnormal state that the runtime's self-heal exists to recover from.
+func (q *Queries) ForceSoftDeleteChat(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, forceSoftDeleteChat, id)
+	return err
+}
+
 const getDeploymentFunctionInfraOverrides = `-- name: GetDeploymentFunctionInfraOverrides :many
 SELECT memory_mib_override, scale_override FROM deployments_functions WHERE deployment_id = $1
 `


### PR DESCRIPTION
## Summary

- `chat.delete` now refuses to soft-delete a chat that backs an active assistant thread, returning `409 Conflict`. Assistant threads reload their backing chat every turn, so deleting it wedged the assistant — and, paired with a still-firing trigger, drove runaway token cost (a deleted chat's transcript could never compact and ballooned to 756k tokens replayed every 15 min).
- Reuses the existing `GetAssistantThreadAssistantIDByChatID` query; no new query.
- Integration test covers both the blocked (thread-backed) and allowed (plain) delete.

Closes [DNO-314](https://linear.app/speakeasy/issue/DNO-314)

✻ Clauded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block soft-deleting chats that back live assistant threads to prevent wedged threads and runaway token costs. `chat.delete` now returns 409 Conflict when the chat backs a live assistant; orphaned-thread chats still delete, and the guard is project-scoped (DNO-314).

- **Bug Fixes**
  - Moved the live-thread guard into `repo.SoftDeleteChat`; one SQL with `guard`+`del` CTE returns `{deleted, backs_live_thread}` to avoid a racy re-check.
  - Return 409 only when the chat backs a live assistant thread; missing/already-deleted/out-of-project remain project-scoped no-ops without leaking existence.
  - Added integration tests for blocked deletes, plain deletes, and deletes after assistant soft-delete; added fixtures `SeedAssistant`, `SeedAssistantThread`, `SeedSoftDeleteAssistant`; updated self-heal test to use the test-only `testrepo.ForceSoftDeleteChat` bypass to simulate legacy wedged rows.

<sup>Written for commit 41df66aa50514ba48b0bacf33e15d4746ecb60f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

