### PR TITLE
fix(chat): self-heal a soft-deleted chat that still backs an assistant thread

### DIFF
--- a/.changeset/dno-315-self-heal-deleted-chat.md
+++ b/.changeset/dno-315-self-heal-deleted-chat.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+A chat that backs an active assistant now clears its soft-deleted state automatically when it receives another message, so an assistant whose chat was deleted out from under it recovers instead of staying wedged. Chats with no active assistant are left deleted, so this never resurrects a chat a user intentionally deleted.

--- a/server/internal/chat/heal_deleted_chat_test.go
+++ b/server/internal/chat/heal_deleted_chat_test.go
@@ -1,0 +1,81 @@
+package chat_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+)
+
+// seedThreadBackedChat creates a chat backed by a live assistant thread.
+func seedThreadBackedChat(t *testing.T, ctx context.Context, ti *chatTestInstance) uuid.UUID {
+	t.Helper()
+	chatID := seedChat(t, ctx, ti, "", "ext-user", "Thread Chat")
+	ar := assistantsrepo.New(ti.conn)
+	a, err := ar.CreateAssistant(ctx, assistantsrepo.CreateAssistantParams{
+		ProjectID:      ti.projectID,
+		OrganizationID: ti.orgID,
+		Name:           "Test Assistant " + uuid.NewString()[:8],
+		Model:          "anthropic/claude-opus-4.8",
+		Instructions:   "be helpful",
+		WarmTtlSeconds: 300,
+		MaxConcurrency: 1,
+		Status:         "active",
+	})
+	require.NoError(t, err)
+	_, err = ar.UpsertAssistantThread(ctx, assistantsrepo.UpsertAssistantThreadParams{
+		AssistantID:   a.ID,
+		ProjectID:     ti.projectID,
+		CorrelationID: "corr-" + uuid.NewString()[:8],
+		ChatID:        chatID,
+		SourceKind:    "cron",
+		SourceRefJson: []byte("{}"),
+	})
+	require.NoError(t, err)
+	return chatID
+}
+
+// A chat that backs a live assistant thread self-heals when it receives another
+// message (UpsertChat clears deleted_at), because the runtime keeps writing to
+// it and a deleted chat wedges the thread. A plain chat the user intentionally
+// deleted is NOT resurrected by a write.
+func TestUpsertChat_HealsDeletedThreadBackedChat(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := initSessionCtx(t, ti)
+	r := repo.New(ti.conn)
+
+	upsert := func(id uuid.UUID) {
+		_, err := r.UpsertChat(ctx, repo.UpsertChatParams{
+			ID:             id,
+			ProjectID:      ti.projectID,
+			OrganizationID: ti.orgID,
+			Title:          pgtype.Text{String: "New Chat", Valid: true},
+		})
+		require.NoError(t, err)
+	}
+
+	// Thread-backed deleted chat heals on the next write.
+	threadChatID := seedThreadBackedChat(t, ctx, ti)
+	require.NoError(t, r.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{ID: threadChatID, ProjectID: ti.projectID}))
+	_, err := r.GetChat(ctx, threadChatID)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "chat should be soft-deleted before the write")
+
+	upsert(threadChatID)
+	_, err = r.GetChat(ctx, threadChatID)
+	require.NoError(t, err, "thread-backed chat should self-heal (deleted_at cleared)")
+
+	// A plain chat with no thread stays deleted: a write must not resurrect a chat
+	// the user intentionally deleted.
+	plainChatID := seedChat(t, ctx, ti, "", "ext-user", "Plain Chat")
+	require.NoError(t, r.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{ID: plainChatID, ProjectID: ti.projectID}))
+	upsert(plainChatID)
+	_, err = r.GetChat(ctx, plainChatID)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "intentionally-deleted plain chat must stay deleted")
+}

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -27,9 +27,26 @@ VALUES (
     NOW(),
     NOW()
 )
--- Use no-op update (id = EXCLUDED.id) to ensure RETURNING always returns a row,
--- whether the chat was newly inserted or already existed.
-ON CONFLICT (id) DO UPDATE SET id = EXCLUDED.id
+-- On conflict, self-heal a soft-deleted chat that still backs a live assistant
+-- thread: the runtime keeps writing to it, so it must not stay marked deleted (a
+-- deleted chat wedges the thread — compaction-persist 404s on it). Scoped to
+-- thread-backed chats so a write does NOT resurrect a plain chat a user
+-- intentionally deleted. The first WHEN keeps the common (non-deleted) path a
+-- no-op without touching assistant_threads, so the EXISTS stays off the
+-- /chat/completions hot path and only runs for the rare already-deleted row. The
+-- assistant join means a deleted assistant's leftover thread can't heal the
+-- chat. The SET also guarantees RETURNING yields a row whether the chat was
+-- newly inserted or already existed.
+ON CONFLICT (id) DO UPDATE SET deleted_at = CASE
+    WHEN chats.deleted_at IS NULL THEN NULL
+    WHEN chats.project_id = EXCLUDED.project_id AND EXISTS (
+        SELECT 1 FROM assistant_threads t
+        JOIN assistants a ON a.id = t.assistant_id
+        WHERE t.chat_id = chats.id AND t.project_id = chats.project_id
+          AND t.deleted IS FALSE AND a.deleted IS FALSE
+    ) THEN NULL
+    ELSE chats.deleted_at
+END
 RETURNING id;
 
 -- name: UpsertExternalChat :one

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -1642,7 +1642,16 @@ VALUES (
     NOW(),
     NOW()
 )
-ON CONFLICT (id) DO UPDATE SET id = EXCLUDED.id
+ON CONFLICT (id) DO UPDATE SET deleted_at = CASE
+    WHEN chats.deleted_at IS NULL THEN NULL
+    WHEN chats.project_id = EXCLUDED.project_id AND EXISTS (
+        SELECT 1 FROM assistant_threads t
+        JOIN assistants a ON a.id = t.assistant_id
+        WHERE t.chat_id = chats.id AND t.project_id = chats.project_id
+          AND t.deleted IS FALSE AND a.deleted IS FALSE
+    ) THEN NULL
+    ELSE chats.deleted_at
+END
 RETURNING id
 `
 
@@ -1655,8 +1664,16 @@ type UpsertChatParams struct {
 	Title          pgtype.Text
 }
 
-// Use no-op update (id = EXCLUDED.id) to ensure RETURNING always returns a row,
-// whether the chat was newly inserted or already existed.
+// On conflict, self-heal a soft-deleted chat that still backs a live assistant
+// thread: the runtime keeps writing to it, so it must not stay marked deleted (a
+// deleted chat wedges the thread — compaction-persist 404s on it). Scoped to
+// thread-backed chats so a write does NOT resurrect a plain chat a user
+// intentionally deleted. The first WHEN keeps the common (non-deleted) path a
+// no-op without touching assistant_threads, so the EXISTS stays off the
+// /chat/completions hot path and only runs for the rare already-deleted row. The
+// assistant join means a deleted assistant's leftover thread can't heal the
+// chat. The SET also guarantees RETURNING yields a row whether the chat was
+// newly inserted or already existed.
 func (q *Queries) UpsertChat(ctx context.Context, arg UpsertChatParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, upsertChat,
 		arg.ID,


### PR DESCRIPTION
## Summary

- On the `/chat/completions` capture path, `UpsertChat` now clears `deleted_at` when the chat still backs an active assistant thread. A chat soft-deleted out from under a running assistant kept accumulating messages while staying `deleted`, so compaction-persist 404'd and the transcript never compacted (the runaway-cost failure mode). It now self-heals on the next message.
- Scoped to thread-backed chats, so a stray completion can't resurrect a chat a user intentionally deleted.
- Folded into the existing upsert (no extra query on the hot path) + integration test.

Stacked on #3592 (DNO-314). Closes [DNO-315](https://linear.app/speakeasy/issue/DNO-315)

✻ Clauded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-heals soft-deleted chats that still back a live assistant thread on the next `/chat/completions` write by clearing `deleted_at`. Prevents compaction 404s and transcript runaway (DNO-315).

- **Bug Fixes**
  - `UpsertChat` now clears `deleted_at` on conflict only for thread-backed chats in the same project; plain chats and cross-project writes stay deleted.
  - Added a test that a deleted thread-backed chat heals on write, while a deleted plain chat remains deleted.

<sup>Written for commit f8ef9b5c350fe35270f38b63d08cf4d4adaca036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

