### PR TITLE
chore: forbid time.Sleep in tests and migrate to require.EventuallyWithT/synctest

### DIFF
--- a/.agents/skills/golang/SKILL.md
+++ b/.agents/skills/golang/SKILL.md
@@ -555,6 +555,8 @@ defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 ## Testing
 
 - When writing assertions, use `github.com/stretchr/testify/require` exclusively.
+- Avoid using `time.Sleep` to wait for eventual consistency or async state in tests.It is reported by the `forbidigo` rule `GG013` (enforced repo-wide, with a small grandfathered allowlist in `server/.golangci.yaml`). Poll instead: `require.EventuallyWithT` to wait until assertions pass or `require.Never` to assert a condition never becomes true. Inside an `EventuallyWithT` closure, make assertions with `assert.*` against the supplied `*assert.CollectT` — the one sanctioned use of `assert` over `require`.
+- Prefer `testing/synctest` (`synctest.Test` + `synctest.Wait`) for testing purely in-process timer/debounce logic. This is one of the few allowed `time.Sleep` use cases in tests since it is required for advancing the fake clock inside a synctest bubble.
 - In tests, use `t.Context()` instead of `context.Background()`, except inside `t.Cleanup(func())` callbacks.
 - IMPORTANT: avoid using `t.Run` to create subtests. Prefer writing separate test functions instead.
 - All test setup which includes spinning up databases, caches and background workers must go in `setup_test.go` files. Look for these across the codebase for inspiration and guidance.

--- a/.agents/skills/golang/SKILL.md
+++ b/.agents/skills/golang/SKILL.md
@@ -555,7 +555,7 @@ defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 ## Testing
 
 - When writing assertions, use `github.com/stretchr/testify/require` exclusively.
-- Avoid using `time.Sleep` to wait for eventual consistency or async state in tests.It is reported by the `forbidigo` rule `GG013` (enforced repo-wide, with a small grandfathered allowlist in `server/.golangci.yaml`). Poll instead: `require.EventuallyWithT` to wait until assertions pass or `require.Never` to assert a condition never becomes true. Inside an `EventuallyWithT` closure, make assertions with `assert.*` against the supplied `*assert.CollectT` — the one sanctioned use of `assert` over `require`.
+- Avoid using `time.Sleep` to wait for eventual consistency or async state in tests. It is reported by the `forbidigo` rule `GG013` (enforced repo-wide, with a small grandfathered allowlist in `server/.golangci.yaml`). Poll instead: `require.EventuallyWithT` to wait until assertions pass or `require.Never` to assert a condition never becomes true. Inside an `EventuallyWithT` closure, make assertions with `assert.*` against the supplied `*assert.CollectT` — the one sanctioned use of `assert` over `require`.
 - Prefer `testing/synctest` (`synctest.Test` + `synctest.Wait`) for testing purely in-process timer/debounce logic. This is one of the few allowed `time.Sleep` use cases in tests since it is required for advancing the fake clock inside a synctest bubble.
 - In tests, use `t.Context()` instead of `context.Background()`, except inside `t.Cleanup(func())` callbacks.
 - IMPORTANT: avoid using `t.Run` to create subtests. Prefer writing separate test functions instead.

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -156,6 +156,16 @@ linters:
         linters:
           - forbidigo
         text: GG010
+      # GG013 (no time.Sleep) is enforced repo-wide EXCEPT the files below, which
+      # still hold legitimate or not-yet-reviewed time.Sleep calls: in-process
+      # timing-sensitive tests (rate limiters, debounce, TTL/expiry), infra
+      # readiness polling, and a production retry/backoff. Each is a candidate for
+      # require.EventuallyWithT / require.Never or testing/synctest; drop it from
+      # this list once migrated. (cmd/ is already exempt from all forbidigo above.)
+      - path: internal/background/activities/custom_domain_ingress\.go|internal/guardian/policy_test\.go|internal/hooks/pending_helpers_test\.go|internal/remotemcp/proxy/proxy_test\.go|internal/testenv/redis\.go|internal/testinfra/clickhouse\.go|internal/variations/listglobal_test\.go
+        linters:
+          - forbidigo
+        text: GG013
   settings:
     custom:
       glint:
@@ -246,6 +256,9 @@ linters:
         - pattern: ^os\.Stderr$
           pkg: ^os$
           msg: "GG012: Writing to os.Stderr bypasses structured logging. Use a *slog.Logger instead. The sanctioned slog handler setup in internal/o11y/slog.go is exempt."
+        - pattern: ^time\.Sleep$
+          pkg: ^time$
+          msg: "GG013: Avoid time.Sleep. In tests, poll with require.EventuallyWithT (wait until assertions pass) or require.Never (assert a condition never holds)."
     sloglint:
       no-mixed-args: true
       attr-only: true

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -157,11 +157,7 @@ linters:
           - forbidigo
         text: GG010
       # GG013 (no time.Sleep) is enforced repo-wide EXCEPT the files below, which
-      # still hold legitimate or not-yet-reviewed time.Sleep calls: in-process
-      # timing-sensitive tests (rate limiters, debounce, TTL/expiry), infra
-      # readiness polling, and a production retry/backoff. Each is a candidate for
-      # require.EventuallyWithT / require.Never or testing/synctest; drop it from
-      # this list once migrated. (cmd/ is already exempt from all forbidigo above.)
+      # still hold legitimate or not-yet-reviewed time.Sleep calls.
       - path: internal/background/activities/custom_domain_ingress\.go|internal/guardian/policy_test\.go|internal/hooks/pending_helpers_test\.go|internal/remotemcp/proxy/proxy_test\.go|internal/testenv/redis\.go|internal/testinfra/clickhouse\.go|internal/variations/listglobal_test\.go
         linters:
           - forbidigo

--- a/server/internal/access/list_challenge_buckets_test.go
+++ b/server/internal/access/list_challenge_buckets_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/access"
@@ -73,34 +74,40 @@ func TestListChallengeBuckets_GroupsByDimensions(t *testing.T) {
 	// Insert 1 challenge with a different scope — separate bucket.
 	insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, uuid.NewString(), "deny", "user:u1", "build:read")
 
-	// ClickHouse eventual consistency.
-	time.Sleep(100 * time.Millisecond)
-
-	result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
-		Outcome:      nil,
-		PrincipalUrn: nil,
-		Scope:        nil,
-		ProjectID:    nil,
-		Resolved:     nil,
-		Limit:        20,
-		Offset:       0,
-		ApikeyToken:  nil,
-		SessionToken: nil,
-	})
-	require.NoError(t, err)
-	require.Len(t, result.Buckets, 2)
-
-	// Find the org:admin bucket.
-	var adminBucket *gen.ChallengeBucket
-	for _, b := range result.Buckets {
-		if b.Scope == "org:admin" {
-			adminBucket = b
-			break
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      nil,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     nil,
+			Limit:        20,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
 		}
-	}
-	require.NotNil(t, adminBucket, "expected org:admin bucket")
-	require.Equal(t, 3, adminBucket.ChallengeCount)
-	require.Len(t, adminBucket.ChallengeIds, 3)
+		if !assert.NotNil(c, result) {
+			return
+		}
+		assert.Len(c, result.Buckets, 2)
+
+		// Find the org:admin bucket.
+		var adminBucket *gen.ChallengeBucket
+		for _, b := range result.Buckets {
+			if b.Scope == "org:admin" {
+				adminBucket = b
+				break
+			}
+		}
+		if !assert.NotNil(c, adminBucket, "expected org:admin bucket") {
+			return
+		}
+		assert.Equal(c, 3, adminBucket.ChallengeCount)
+		assert.Len(c, adminBucket.ChallengeIds, 3)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestListChallengeBuckets_FilterByOutcome(t *testing.T) {
@@ -112,23 +119,30 @@ func TestListChallengeBuckets_FilterByOutcome(t *testing.T) {
 	insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, uuid.NewString(), "deny", "user:u1", "org:read")
 	insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, uuid.NewString(), "allow", "user:u1", "org:read")
 
-	time.Sleep(100 * time.Millisecond)
-
 	outcome := "deny"
-	result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
-		Outcome:      &outcome,
-		PrincipalUrn: nil,
-		Scope:        nil,
-		ProjectID:    nil,
-		Resolved:     nil,
-		Limit:        20,
-		Offset:       0,
-		ApikeyToken:  nil,
-		SessionToken: nil,
-	})
-	require.NoError(t, err)
-	require.Len(t, result.Buckets, 1)
-	require.Equal(t, "deny", result.Buckets[0].Outcome)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      &outcome,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     nil,
+			Limit:        20,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, result) {
+			return
+		}
+		if !assert.Len(c, result.Buckets, 1) {
+			return
+		}
+		assert.Equal(c, "deny", result.Buckets[0].Outcome)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestListChallengeBuckets_FilterByResolved(t *testing.T) {
@@ -157,28 +171,35 @@ func TestListChallengeBuckets_FilterByResolved(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
-
 	// Filter: resolved=true
 	resolvedTrue := true
-	result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
-		Outcome:      nil,
-		PrincipalUrn: nil,
-		Scope:        nil,
-		ProjectID:    nil,
-		Resolved:     &resolvedTrue,
-		Limit:        20,
-		Offset:       0,
-		ApikeyToken:  nil,
-		SessionToken: nil,
-	})
-	require.NoError(t, err)
-	require.Len(t, result.Buckets, 1)
-	require.NotNil(t, result.Buckets[0].ResolvedAt)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      nil,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     &resolvedTrue,
+			Limit:        20,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, result) {
+			return
+		}
+		if !assert.Len(c, result.Buckets, 1) {
+			return
+		}
+		assert.NotNil(c, result.Buckets[0].ResolvedAt)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	// Filter: resolved=false
 	resolvedFalse := false
-	result, err = ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+	result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
 		Outcome:      nil,
 		PrincipalUrn: nil,
 		Scope:        nil,
@@ -205,22 +226,27 @@ func TestListChallengeBuckets_Pagination(t *testing.T) {
 		insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, uuid.NewString(), "deny", fmt.Sprintf("user:u%d", i), "org:read")
 	}
 
-	time.Sleep(100 * time.Millisecond)
-
-	result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
-		Outcome:      nil,
-		PrincipalUrn: nil,
-		Scope:        nil,
-		ProjectID:    nil,
-		Resolved:     nil,
-		Limit:        2,
-		Offset:       0,
-		ApikeyToken:  nil,
-		SessionToken: nil,
-	})
-	require.NoError(t, err)
-	require.Len(t, result.Buckets, 2)
-	require.Equal(t, 5, result.Total)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      nil,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     nil,
+			Limit:        2,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, result) {
+			return
+		}
+		assert.Len(c, result.Buckets, 2)
+		assert.Equal(c, 5, result.Total)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestListChallengeBuckets_IsolatesByOrganization(t *testing.T) {
@@ -232,21 +258,26 @@ func TestListChallengeBuckets_IsolatesByOrganization(t *testing.T) {
 	insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, uuid.NewString(), "deny", "user:u1", "org:read")
 	insertCHChallenge(t, ti, "org-other-"+uuid.NewString(), uuid.NewString(), "deny", "user:u1", "org:read")
 
-	time.Sleep(100 * time.Millisecond)
-
-	result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
-		Outcome:      nil,
-		PrincipalUrn: nil,
-		Scope:        nil,
-		ProjectID:    nil,
-		Resolved:     nil,
-		Limit:        20,
-		Offset:       0,
-		ApikeyToken:  nil,
-		SessionToken: nil,
-	})
-	require.NoError(t, err)
-	require.Len(t, result.Buckets, 1)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      nil,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     nil,
+			Limit:        20,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, result) {
+			return
+		}
+		assert.Len(c, result.Buckets, 1)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestListChallengeBuckets_AllChallengeIdsReturned(t *testing.T) {
@@ -263,26 +294,33 @@ func TestListChallengeBuckets_AllChallengeIdsReturned(t *testing.T) {
 		insertCHChallenge(t, ti, authCtx.ActiveOrganizationID, id, "deny", "user:u1", "org:admin")
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      nil,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     nil,
+			Limit:        20,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, result) {
+			return
+		}
+		if !assert.Len(c, result.Buckets, 1) {
+			return
+		}
+		assert.Equal(c, 15, result.Buckets[0].ChallengeCount)
+		assert.Len(c, result.Buckets[0].ChallengeIds, 15)
 
-	result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
-		Outcome:      nil,
-		PrincipalUrn: nil,
-		Scope:        nil,
-		ProjectID:    nil,
-		Resolved:     nil,
-		Limit:        20,
-		Offset:       0,
-		ApikeyToken:  nil,
-		SessionToken: nil,
-	})
-	require.NoError(t, err)
-	require.Len(t, result.Buckets, 1)
-	require.Equal(t, 15, result.Buckets[0].ChallengeCount)
-	require.Len(t, result.Buckets[0].ChallengeIds, 15)
-
-	// Verify all inserted IDs are present.
-	for _, cid := range result.Buckets[0].ChallengeIds {
-		require.True(t, ids[cid], "unexpected challenge ID: %s", cid)
-	}
+		// Verify all inserted IDs are present.
+		for _, cid := range result.Buckets[0].ChallengeIds {
+			assert.True(c, ids[cid], "unexpected challenge ID: %s", cid)
+		}
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/server/internal/auth/assistanttokens/manager_test.go
+++ b/server/internal/auth/assistanttokens/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
@@ -253,10 +254,20 @@ func TestCheckRevocation_cacheRespectsTTL(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(75 * time.Millisecond)
-
-	err = m.checkRevocation(t.Context(), f.projectID, f.assistantID, f.threadID)
-	requireUnauthorized(t, err)
+	// The cached "allowed" answer is honoured until the 50ms TTL drains; once it
+	// expires the next check re-queries the DB and observes the deletion. Poll
+	// rather than sleeping a fixed duration that races the TTL.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		err := m.checkRevocation(t.Context(), f.projectID, f.assistantID, f.threadID)
+		if !assert.Error(c, err) {
+			return
+		}
+		se := &oops.ShareableError{}
+		if !assert.ErrorAs(c, err, &se) {
+			return
+		}
+		assert.Equal(c, oops.CodeUnauthorized, se.Code)
+	}, 10*time.Second, 10*time.Millisecond)
 }
 
 func requireUnauthorized(t *testing.T, err error) {

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -269,17 +269,24 @@ func TestEngineFilter_skipsLogWhenNoChecks(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, resourceIDs)
 
-	// Give async insert a moment, then verify nothing landed.
-	time.Sleep(500 * time.Millisecond)
-	rows, err := chConn.Query(t.Context(), `
-		SELECT count() FROM authz_challenges WHERE organization_id = ? AND operation = 'filter'
-	`, orgID)
-	require.NoError(t, err)
-	defer func() { _ = rows.Close() }()
-	require.True(t, rows.Next())
-	var count uint64
-	require.NoError(t, rows.Scan(&count))
-	require.Equal(t, uint64(0), count)
+	// Empty input must not emit a challenge log entry; confirm none ever lands.
+	require.Never(t, func() bool {
+		rows, err := chConn.Query(t.Context(), `
+			SELECT count() FROM authz_challenges WHERE organization_id = ? AND operation = 'filter'
+		`, orgID)
+		if err != nil {
+			return false
+		}
+		defer func() { _ = rows.Close() }()
+		if !rows.Next() {
+			return false
+		}
+		var count uint64
+		if err := rows.Scan(&count); err != nil {
+			return false
+		}
+		return count > 0
+	}, 500*time.Millisecond, 50*time.Millisecond, "no challenge log entry should be emitted for empty input")
 }
 
 // --- Engine deny-wins tests ---
@@ -751,17 +758,24 @@ func TestEngineFindMatched_emptyInputReturnsEmptySlice(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, matched)
 
-	// Empty input must not emit a challenge log entry.
-	time.Sleep(500 * time.Millisecond)
-	rows, err := chConn.Query(t.Context(), `
-		SELECT count() FROM authz_challenges WHERE organization_id = ? AND operation = 'filter'
-	`, orgID)
-	require.NoError(t, err)
-	defer func() { _ = rows.Close() }()
-	require.True(t, rows.Next())
-	var count uint64
-	require.NoError(t, rows.Scan(&count))
-	require.Zero(t, count, "empty input must skip challenge logging")
+	// Empty input must not emit a challenge log entry; confirm none ever lands.
+	require.Never(t, func() bool {
+		rows, err := chConn.Query(t.Context(), `
+			SELECT count() FROM authz_challenges WHERE organization_id = ? AND operation = 'filter'
+		`, orgID)
+		if err != nil {
+			return false
+		}
+		defer func() { _ = rows.Close() }()
+		if !rows.Next() {
+			return false
+		}
+		var count uint64
+		if err := rows.Scan(&count); err != nil {
+			return false
+		}
+		return count > 0
+	}, 500*time.Millisecond, 50*time.Millisecond, "empty input must skip challenge logging")
 }
 
 func TestEngineFindMatched_missingGrantsReturnsError(t *testing.T) {

--- a/server/internal/background/throttled_signaler_test.go
+++ b/server/internal/background/throttled_signaler_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -47,37 +48,43 @@ func TestThrottledSignaler_FirstCallFiresImmediately(t *testing.T) {
 func TestThrottledSignaler_CoalescesDuringCooldown(t *testing.T) {
 	t.Parallel()
 
-	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
+	synctest.Test(t, func(t *testing.T) {
+		inner := &countingSignaler{}
+		throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
 
-	projectID := uuid.New()
+		projectID := uuid.New()
 
-	_ = throttled.Signal(t.Context(), projectID)
-	assert.Equal(t, 1, inner.callCount())
-
-	for range 50 {
 		_ = throttled.Signal(t.Context(), projectID)
-	}
+		assert.Equal(t, 1, inner.callCount())
 
-	assert.Equal(t, 1, inner.callCount(), "calls during cooldown should be suppressed")
+		for range 50 {
+			_ = throttled.Signal(t.Context(), projectID)
+		}
 
-	time.Sleep(200 * time.Millisecond)
+		assert.Equal(t, 1, inner.callCount(), "calls during cooldown should be suppressed")
 
-	assert.Equal(t, 2, inner.callCount(), "exactly one trailing signal should fire after cooldown")
+		// Advance the fake clock past the cooldown so the single trailing signal fires.
+		time.Sleep(200 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
+		assert.Equal(t, 2, inner.callCount(), "exactly one trailing signal should fire after cooldown")
+	})
 }
 
 func TestThrottledSignaler_NoPendingNoTrailing(t *testing.T) {
 	t.Parallel()
 
-	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
+	synctest.Test(t, func(t *testing.T) {
+		inner := &countingSignaler{}
+		throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
 
-	_ = throttled.Signal(t.Context(), uuid.New())
-	assert.Equal(t, 1, inner.callCount())
+		_ = throttled.Signal(t.Context(), uuid.New())
+		assert.Equal(t, 1, inner.callCount())
 
-	time.Sleep(100 * time.Millisecond)
-
-	assert.Equal(t, 1, inner.callCount(), "no trailing signal when nothing was pending")
+		// Advance past the cooldown; with nothing pending there is no trailing fire.
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
+		assert.Equal(t, 1, inner.callCount(), "no trailing signal when nothing was pending")
+	})
 }
 
 func TestThrottledSignaler_IndependentPerProject(t *testing.T) {
@@ -109,65 +116,79 @@ func TestThrottledSignaler_ZeroCooldownDisablesThrottling(t *testing.T) {
 func TestThrottledSignaler_RecoversAfterCooldown(t *testing.T) {
 	t.Parallel()
 
-	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
+	synctest.Test(t, func(t *testing.T) {
+		inner := &countingSignaler{}
+		throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
 
-	projectID := uuid.New()
+		projectID := uuid.New()
 
-	_ = throttled.Signal(t.Context(), projectID)
-	assert.Equal(t, 1, inner.callCount())
+		_ = throttled.Signal(t.Context(), projectID)
+		assert.Equal(t, 1, inner.callCount())
 
-	time.Sleep(100 * time.Millisecond)
+		// Advance past the cooldown so the entry resets; the next signal is a fresh leading edge.
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
 
-	_ = throttled.Signal(t.Context(), projectID)
-	assert.Equal(t, 2, inner.callCount(), "should fire immediately after cooldown expires")
+		_ = throttled.Signal(t.Context(), projectID)
+		assert.Equal(t, 2, inner.callCount(), "should fire immediately after cooldown expires")
+	})
 }
 
 func TestThrottledSignaler_ConcurrentCallers(t *testing.T) {
 	t.Parallel()
 
-	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
+	synctest.Test(t, func(t *testing.T) {
+		inner := &countingSignaler{}
+		throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
 
-	projectID := uuid.New()
+		projectID := uuid.New()
 
-	var wg sync.WaitGroup
-	for range 100 {
-		wg.Go(func() {
-			_ = throttled.Signal(t.Context(), projectID)
-		})
-	}
-	wg.Wait()
+		var wg sync.WaitGroup
+		for range 100 {
+			wg.Go(func() {
+				_ = throttled.Signal(t.Context(), projectID)
+			})
+		}
+		wg.Wait()
 
-	assert.Equal(t, 1, inner.callCount(), "concurrent callers should result in exactly one immediate signal")
+		assert.Equal(t, 1, inner.callCount(), "concurrent callers should result in exactly one immediate signal")
 
-	time.Sleep(200 * time.Millisecond)
-	assert.Equal(t, 2, inner.callCount(), "one trailing signal after concurrent burst")
+		// Advance past the cooldown so the coalesced trailing signal fires once.
+		time.Sleep(200 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
+		assert.Equal(t, 2, inner.callCount(), "one trailing signal after concurrent burst")
+	})
 }
 
 func TestThrottledSignaler_MultipleBursts(t *testing.T) {
 	t.Parallel()
 
-	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
+	synctest.Test(t, func(t *testing.T) {
+		inner := &countingSignaler{}
+		throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
 
-	projectID := uuid.New()
+		projectID := uuid.New()
 
-	_ = throttled.Signal(t.Context(), projectID)
-	_ = throttled.Signal(t.Context(), projectID)
-	assert.Equal(t, 1, inner.callCount())
+		_ = throttled.Signal(t.Context(), projectID)
+		_ = throttled.Signal(t.Context(), projectID)
+		assert.Equal(t, 1, inner.callCount())
 
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 2, inner.callCount(), "trailing from burst 1")
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
+		assert.Equal(t, 2, inner.callCount(), "trailing from burst 1")
 
-	time.Sleep(100 * time.Millisecond)
+		// Let the entry's cooldown fully elapse so burst 2 starts fresh.
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
 
-	_ = throttled.Signal(t.Context(), projectID)
-	_ = throttled.Signal(t.Context(), projectID)
-	assert.Equal(t, 3, inner.callCount(), "immediate from burst 2")
+		_ = throttled.Signal(t.Context(), projectID)
+		_ = throttled.Signal(t.Context(), projectID)
+		assert.Equal(t, 3, inner.callCount(), "immediate from burst 2")
 
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 4, inner.callCount(), "trailing from burst 2")
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
+		assert.Equal(t, 4, inner.callCount(), "trailing from burst 2")
+	})
 }
 
 func TestThrottledSignaler_FirstCallErrorPropagates(t *testing.T) {

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -444,19 +444,22 @@ func TestListChats_DateRangeAndSortUseLastMessageTimestamp(t *testing.T) {
 	oldCreatedAt := now.Add(-7 * 24 * time.Hour)
 	newCreatedAt := now.Add(-2 * time.Hour)
 
+	// Assign explicit, distinct message timestamps so the last_message_timestamp
+	// ordering is deterministic without relying on a wall-clock gap. resumedOldChat
+	// gets the more recent message, so it sorts first under desc.
 	newerCreatedChat := seedChatAtTime(t, ctx, ti, "ext-activity", newCreatedAt)
 	_, err := repo.New(ti.conn).SeedChatMessage(ctx, repo.SeedChatMessageParams{
 		ChatID:    newerCreatedChat,
 		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: now.Add(-10 * time.Minute), InfinityModifier: pgtype.Finite, Valid: true},
 	})
 	require.NoError(t, err)
-
-	time.Sleep(10 * time.Millisecond)
 
 	resumedOldChat := seedChatAtTime(t, ctx, ti, "ext-activity", oldCreatedAt)
 	_, err = repo.New(ti.conn).SeedChatMessage(ctx, repo.SeedChatMessageParams{
 		ChatID:    resumedOldChat,
 		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: now.Add(-5 * time.Minute), InfinityModifier: pgtype.Finite, Valid: true},
 	})
 	require.NoError(t, err)
 
@@ -481,19 +484,22 @@ func TestListChats_SortByLastMessageTimestampAscending(t *testing.T) {
 	ti := newTestChatService(t)
 	ctx := externalUserCtx(t, ti, "ext-activity-asc")
 
+	// Distinct message timestamps make the asc ordering deterministic without a
+	// wall-clock gap: firstActiveChat's message precedes lastActiveChat's.
+	now := time.Now().UTC()
 	firstActiveChat := seedChat(t, ctx, ti, "", "ext-activity-asc", "first active")
 	_, err := repo.New(ti.conn).SeedChatMessage(ctx, repo.SeedChatMessageParams{
 		ChatID:    firstActiveChat,
 		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: now.Add(-10 * time.Minute), InfinityModifier: pgtype.Finite, Valid: true},
 	})
 	require.NoError(t, err)
-
-	time.Sleep(10 * time.Millisecond)
 
 	lastActiveChat := seedChat(t, ctx, ti, "", "ext-activity-asc", "last active")
 	_, err = repo.New(ti.conn).SeedChatMessage(ctx, repo.SeedChatMessageParams{
 		ChatID:    lastActiveChat,
 		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: now.Add(-5 * time.Minute), InfinityModifier: pgtype.Finite, Valid: true},
 	})
 	require.NoError(t, err)
 

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -701,9 +701,11 @@ ON CONFLICT (id) DO UPDATE SET id = EXCLUDED.id
 RETURNING id;
 
 -- name: SeedChatMessage :one
--- Test fixture: insert a minimal chat message and return its id.
-INSERT INTO chat_messages (chat_id, project_id, role, content)
-VALUES (@chat_id, @project_id, 'user', 'test message')
+-- Test fixture: insert a minimal chat message and return its id. An optional
+-- created_at lets ordering tests assign distinct, deterministic timestamps
+-- instead of relying on wall-clock gaps between inserts.
+INSERT INTO chat_messages (chat_id, project_id, role, content, created_at)
+VALUES (@chat_id, @project_id, 'user', 'test message', COALESCE(sqlc.narg('created_at')::timestamptz, clock_timestamp()))
 RETURNING id;
 
 -- name: SeedRiskPolicy :one

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -1486,19 +1486,22 @@ func (q *Queries) SeedChatAtTime(ctx context.Context, arg SeedChatAtTimeParams) 
 }
 
 const seedChatMessage = `-- name: SeedChatMessage :one
-INSERT INTO chat_messages (chat_id, project_id, role, content)
-VALUES ($1, $2, 'user', 'test message')
+INSERT INTO chat_messages (chat_id, project_id, role, content, created_at)
+VALUES ($1, $2, 'user', 'test message', COALESCE($3::timestamptz, clock_timestamp()))
 RETURNING id
 `
 
 type SeedChatMessageParams struct {
 	ChatID    uuid.UUID
 	ProjectID uuid.NullUUID
+	CreatedAt pgtype.Timestamptz
 }
 
-// Test fixture: insert a minimal chat message and return its id.
+// Test fixture: insert a minimal chat message and return its id. An optional
+// created_at lets ordering tests assign distinct, deterministic timestamps
+// instead of relying on wall-clock gaps between inserts.
 func (q *Queries) SeedChatMessage(ctx context.Context, arg SeedChatMessageParams) (uuid.UUID, error) {
-	row := q.db.QueryRow(ctx, seedChatMessage, arg.ChatID, arg.ProjectID)
+	row := q.db.QueryRow(ctx, seedChatMessage, arg.ChatID, arg.ProjectID, arg.CreatedAt)
 	var id uuid.UUID
 	err := row.Scan(&id)
 	return id, err

--- a/server/internal/oauth/token_service_test.go
+++ b/server/internal/oauth/token_service_test.go
@@ -172,13 +172,12 @@ func TestExchangeRefreshToken_ExpiredUpstreamSecrets(t *testing.T) {
 	env := newTokenTestEnv(t)
 	toolsetID := uuid.New()
 
-	// Issue token with an upstream secret that expires in 200ms
-	upstreamExpiry := time.Now().Add(200 * time.Millisecond)
+	// Issue a token whose upstream secret is already expired (the downstream token
+	// is still valid - 30 day TTL). Setting a past expiry directly is deterministic
+	// and avoids sleeping to wait out a real wall-clock deadline.
+	upstreamExpiry := time.Now().Add(-1 * time.Hour)
 	issued := env.IssueToken(t, ctx, toolsetID,
 		"upstream-access", "upstream-refresh", &upstreamExpiry, []string{"api_key"})
-
-	// Wait for upstream secret to expire (downstream token is still valid - 30 day TTL)
-	time.Sleep(300 * time.Millisecond)
 
 	_, err := env.TokenService.ExchangeRefreshToken(ctx, &oauth.TokenRequest{
 		GrantType:    "refresh_token",

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -261,10 +262,11 @@ func TestScanner_FirstMatchCancelsSiblings(t *testing.T) {
 	require.Less(t, elapsed, 1*time.Second,
 		"wall time %v suggests siblings ran to completion; expected cancellation", elapsed)
 
-	// Give the cancelled goroutines a moment to record their ctx.Err.
-	time.Sleep(100 * time.Millisecond)
-	require.GreaterOrEqual(t, pii.cancellations.Load(), int32(1),
-		"expected at least one slow policy to observe ctx cancellation")
+	// Cancelled goroutines record their ctx.Err asynchronously; poll until observed.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, pii.cancellations.Load(), int32(1),
+			"expected at least one slow policy to observe ctx cancellation")
+	}, 10*time.Second, 10*time.Millisecond)
 }
 
 func TestScanner_CustomDetectionRuleEnforcement(t *testing.T) {

--- a/server/internal/telemetry/README.md
+++ b/server/internal/telemetry/README.md
@@ -370,7 +370,7 @@ Key testing patterns:
 - Use `testenv.Launch()` in `TestMain` to set up infrastructure
 - Create helper functions for inserting test data
 - Use table-driven tests with descriptive names
-- Use `require.Eventually` after inserts to handle ClickHouse eventual consistency — **do not use `time.Sleep`**. This is enforced by the `forbidigo` lint rule `GG013`, currently scoped to this package via `path-except` in `server/.golangci.yaml`.
+- After inserts, wait for ClickHouse eventual consistency by polling with `require.EventuallyWithT`, never `time.Sleep` (see the `golang` skill for the repo-wide convention and its `forbidigo` enforcement).
 
 ## Data Models
 

--- a/server/internal/telemetry/README.md
+++ b/server/internal/telemetry/README.md
@@ -370,7 +370,7 @@ Key testing patterns:
 - Use `testenv.Launch()` in `TestMain` to set up infrastructure
 - Create helper functions for inserting test data
 - Use table-driven tests with descriptive names
-- Use `require.Eventually` after inserts to handle ClickHouse eventual consistency — **do not use `time.Sleep`**
+- Use `require.Eventually` after inserts to handle ClickHouse eventual consistency — **do not use `time.Sleep`**. This is enforced by the `forbidigo` lint rule `GG013`, currently scoped to this package via `path-except` in `server/.golangci.yaml`.
 
 ## Data Models
 

--- a/server/internal/telemetry/get_employee_data_flow_graph_test.go
+++ b/server/internal/telemetry/get_employee_data_flow_graph_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -167,59 +168,64 @@ func TestGetEmployeeDataFlowGraph_WithHookToolCalls(t *testing.T) {
 		},
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
-	result, err := ti.service.GetEmployeeDataFlowGraph(ctx, &gen.GetEmployeeDataFlowGraphPayload{
-		From:   from,
-		To:     to,
-		UserID: &userID,
-	})
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetEmployeeDataFlowGraph(ctx, &gen.GetEmployeeDataFlowGraphPayload{
+			From:   from,
+			To:     to,
+			UserID: &userID,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.NotEmpty(c, res.Nodes)
 
-	originNode := findEmployeeDataFlowNode(result.Nodes, "origin", originHostname)
-	require.NotNil(t, originNode)
-	require.Equal(t, int64(3), originNode.TotalCalls)
-	require.Nil(t, findEmployeeDataFlowNode(result.Nodes, "origin", "https://api.github.com/mcp"))
+		originNode := findEmployeeDataFlowNode(res.Nodes, "origin", originHostname)
+		assert.NotNil(c, originNode)
+		assert.Equal(c, int64(3), originNode.TotalCalls)
+		assert.Nil(c, findEmployeeDataFlowNode(res.Nodes, "origin", "https://api.github.com/mcp"))
 
-	githubNode := findEmployeeDataFlowNode(result.Nodes, "server", "GitHub")
-	require.NotNil(t, githubNode)
-	require.NotNil(t, githubNode.ServerClass)
-	require.Equal(t, "external", *githubNode.ServerClass)
-	require.Equal(t, int64(2), githubNode.TotalCalls)
+		githubNode := findEmployeeDataFlowNode(res.Nodes, "server", "GitHub")
+		assert.NotNil(c, githubNode)
+		assert.NotNil(c, githubNode.ServerClass)
+		assert.Equal(c, "external", *githubNode.ServerClass)
+		assert.Equal(c, int64(2), githubNode.TotalCalls)
 
-	localNode := findEmployeeDataFlowNode(result.Nodes, "server", "local")
-	require.NotNil(t, localNode)
-	require.NotNil(t, localNode.ServerClass)
-	require.Equal(t, "local", *localNode.ServerClass)
-	require.Equal(t, int64(1), localNode.TotalCalls)
+		localNode := findEmployeeDataFlowNode(res.Nodes, "server", "local")
+		assert.NotNil(c, localNode)
+		assert.NotNil(c, localNode.ServerClass)
+		assert.Equal(c, "local", *localNode.ServerClass)
+		assert.Equal(c, int64(1), localNode.TotalCalls)
 
-	cursorNode := findEmployeeDataFlowNode(result.Nodes, "client", "cursor")
-	require.NotNil(t, cursorNode)
-	require.Equal(t, int64(2), cursorNode.TotalCalls)
+		cursorNode := findEmployeeDataFlowNode(res.Nodes, "client", "cursor")
+		assert.NotNil(c, cursorNode)
+		assert.Equal(c, int64(2), cursorNode.TotalCalls)
 
-	edge := findEmployeeDataFlowEdge(result.Edges, originNode.ID, cursorNode.ID)
-	require.NotNil(t, edge)
-	require.Equal(t, int64(2), edge.CallCount)
+		edge := findEmployeeDataFlowEdge(res.Edges, originNode.ID, cursorNode.ID)
+		assert.NotNil(c, edge)
+		assert.Equal(c, int64(2), edge.CallCount)
 
-	listIssuesNode := findEmployeeDataFlowNode(result.Nodes, "tool", "list_issues")
-	require.NotNil(t, listIssuesNode)
-	edge = findEmployeeDataFlowEdge(result.Edges, githubNode.ID, listIssuesNode.ID)
-	require.NotNil(t, edge)
-	require.Equal(t, int64(1), edge.CallCount)
-	require.Equal(t, int64(1), edge.SuccessCount)
-	require.Equal(t, int64(0), edge.FailureCount)
+		listIssuesNode := findEmployeeDataFlowNode(res.Nodes, "tool", "list_issues")
+		assert.NotNil(c, listIssuesNode)
+		edge = findEmployeeDataFlowEdge(res.Edges, githubNode.ID, listIssuesNode.ID)
+		assert.NotNil(c, edge)
+		assert.Equal(c, int64(1), edge.CallCount)
+		assert.Equal(c, int64(1), edge.SuccessCount)
+		assert.Equal(c, int64(0), edge.FailureCount)
 
-	createIssueNode := findEmployeeDataFlowNode(result.Nodes, "tool", "create_issue")
-	require.NotNil(t, createIssueNode)
-	edge = findEmployeeDataFlowEdge(result.Edges, githubNode.ID, createIssueNode.ID)
-	require.NotNil(t, edge)
-	require.Equal(t, int64(1), edge.CallCount)
-	require.Equal(t, int64(0), edge.SuccessCount)
-	require.Equal(t, int64(1), edge.FailureCount)
+		createIssueNode := findEmployeeDataFlowNode(res.Nodes, "tool", "create_issue")
+		assert.NotNil(c, createIssueNode)
+		edge = findEmployeeDataFlowEdge(res.Edges, githubNode.ID, createIssueNode.ID)
+		assert.NotNil(c, edge)
+		assert.Equal(c, int64(1), edge.CallCount)
+		assert.Equal(c, int64(0), edge.SuccessCount)
+		assert.Equal(c, int64(1), edge.FailureCount)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func findEmployeeDataFlowNode(nodes []*gen.EmployeeDataFlowNode, tier, label string) *gen.EmployeeDataFlowNode {

--- a/server/internal/telemetry/get_employee_data_flow_graph_test.go
+++ b/server/internal/telemetry/get_employee_data_flow_graph_test.go
@@ -185,43 +185,68 @@ func TestGetEmployeeDataFlowGraph_WithHookToolCalls(t *testing.T) {
 		}
 		assert.NotEmpty(c, res.Nodes)
 
+		// Guard every node/edge lookup before dereferencing: assert.NotNil only
+		// records a failure, so without an early return a nil hit on a not-yet-
+		// converged poll iteration would panic and abort the whole test.
 		originNode := findEmployeeDataFlowNode(res.Nodes, "origin", originHostname)
-		assert.NotNil(c, originNode)
+		if !assert.NotNil(c, originNode) {
+			return
+		}
 		assert.Equal(c, int64(3), originNode.TotalCalls)
 		assert.Nil(c, findEmployeeDataFlowNode(res.Nodes, "origin", "https://api.github.com/mcp"))
 
 		githubNode := findEmployeeDataFlowNode(res.Nodes, "server", "GitHub")
-		assert.NotNil(c, githubNode)
-		assert.NotNil(c, githubNode.ServerClass)
+		if !assert.NotNil(c, githubNode) {
+			return
+		}
+		if !assert.NotNil(c, githubNode.ServerClass) {
+			return
+		}
 		assert.Equal(c, "external", *githubNode.ServerClass)
 		assert.Equal(c, int64(2), githubNode.TotalCalls)
 
 		localNode := findEmployeeDataFlowNode(res.Nodes, "server", "local")
-		assert.NotNil(c, localNode)
-		assert.NotNil(c, localNode.ServerClass)
+		if !assert.NotNil(c, localNode) {
+			return
+		}
+		if !assert.NotNil(c, localNode.ServerClass) {
+			return
+		}
 		assert.Equal(c, "local", *localNode.ServerClass)
 		assert.Equal(c, int64(1), localNode.TotalCalls)
 
 		cursorNode := findEmployeeDataFlowNode(res.Nodes, "client", "cursor")
-		assert.NotNil(c, cursorNode)
+		if !assert.NotNil(c, cursorNode) {
+			return
+		}
 		assert.Equal(c, int64(2), cursorNode.TotalCalls)
 
 		edge := findEmployeeDataFlowEdge(res.Edges, originNode.ID, cursorNode.ID)
-		assert.NotNil(c, edge)
+		if !assert.NotNil(c, edge) {
+			return
+		}
 		assert.Equal(c, int64(2), edge.CallCount)
 
 		listIssuesNode := findEmployeeDataFlowNode(res.Nodes, "tool", "list_issues")
-		assert.NotNil(c, listIssuesNode)
+		if !assert.NotNil(c, listIssuesNode) {
+			return
+		}
 		edge = findEmployeeDataFlowEdge(res.Edges, githubNode.ID, listIssuesNode.ID)
-		assert.NotNil(c, edge)
+		if !assert.NotNil(c, edge) {
+			return
+		}
 		assert.Equal(c, int64(1), edge.CallCount)
 		assert.Equal(c, int64(1), edge.SuccessCount)
 		assert.Equal(c, int64(0), edge.FailureCount)
 
 		createIssueNode := findEmployeeDataFlowNode(res.Nodes, "tool", "create_issue")
-		assert.NotNil(c, createIssueNode)
+		if !assert.NotNil(c, createIssueNode) {
+			return
+		}
 		edge = findEmployeeDataFlowEdge(res.Edges, githubNode.ID, createIssueNode.ID)
-		assert.NotNil(c, edge)
+		if !assert.NotNil(c, edge) {
+			return
+		}
 		assert.Equal(c, int64(1), edge.CallCount)
 		assert.Equal(c, int64(0), edge.SuccessCount)
 		assert.Equal(c, int64(1), edge.FailureCount)

--- a/server/internal/telemetry/get_hooks_summary_test.go
+++ b/server/internal/telemetry/get_hooks_summary_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,66 +106,75 @@ func TestGetHooksSummary_AggregatesServersUsersAndBreakdown(t *testing.T) {
 		conversationID: "conv-2",
 	})
 
-	time.Sleep(200 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
 
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
+		// Total events = 3 traces (trace_summaries counts at trace level, not log level), sessions = 2 unique conversation IDs
+		assert.Equal(c, int64(3), res.TotalEvents)
+		assert.Equal(c, int64(2), res.TotalSessions)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		// Server aggregation: 2 servers
+		serversByName := make(map[string]*gen.HooksServerSummary)
+		for _, s := range res.Servers {
+			serversByName[s.ServerName] = s
+		}
+		if !assert.Len(c, serversByName, 2) {
+			return
+		}
+		assert.Equal(c, int64(2), serversByName["server-a"].EventCount)
+		assert.Equal(c, int64(1), serversByName["server-a"].SuccessCount)
+		assert.Equal(c, int64(1), serversByName["server-a"].FailureCount)
+		assert.Equal(c, int64(1), serversByName["server-b"].EventCount)
+		assert.Equal(c, int64(1), serversByName["server-b"].SuccessCount)
+		assert.Equal(c, int64(0), serversByName["server-b"].FailureCount)
 
-	// Total events = 3 traces (trace_summaries counts at trace level, not log level), sessions = 2 unique conversation IDs
-	require.Equal(t, int64(3), result.TotalEvents)
-	require.Equal(t, int64(2), result.TotalSessions)
+		// User aggregation: 2 users
+		usersByEmail := make(map[string]*gen.HooksUserSummary)
+		for _, u := range res.Users {
+			usersByEmail[u.UserEmail] = u
+		}
+		if !assert.Len(c, usersByEmail, 2) {
+			return
+		}
+		assert.Equal(c, int64(2), usersByEmail["user1@example.com"].EventCount)
+		assert.Equal(c, int64(1), usersByEmail["user1@example.com"].SuccessCount)
+		assert.Equal(c, int64(1), usersByEmail["user1@example.com"].FailureCount)
+		assert.Equal(c, int64(1), usersByEmail["user2@example.com"].EventCount)
+		assert.Equal(c, int64(1), usersByEmail["user2@example.com"].SuccessCount)
+		assert.Equal(c, int64(0), usersByEmail["user2@example.com"].FailureCount)
 
-	// Server aggregation: 2 servers
-	serversByName := make(map[string]*gen.HooksServerSummary)
-	for _, s := range result.Servers {
-		serversByName[s.ServerName] = s
-	}
-	require.Len(t, serversByName, 2)
-	require.Equal(t, int64(2), serversByName["server-a"].EventCount)
-	require.Equal(t, int64(1), serversByName["server-a"].SuccessCount)
-	require.Equal(t, int64(1), serversByName["server-a"].FailureCount)
-	require.Equal(t, int64(1), serversByName["server-b"].EventCount)
-	require.Equal(t, int64(1), serversByName["server-b"].SuccessCount)
-	require.Equal(t, int64(0), serversByName["server-b"].FailureCount)
+		// Breakdown: one entry for user1/server-a/weather covering both traces.
+		// trace_summaries aggregates has_error=1 for the failure trace via gram.hook.error.
+		breakdownKey := func(b *gen.HooksBreakdownRow) string {
+			return b.UserEmail + "|" + b.ServerName + "|" + b.ToolName
+		}
+		breakdownMap := make(map[string]*gen.HooksBreakdownRow)
+		for _, b := range res.Breakdown {
+			breakdownMap[breakdownKey(b)] = b
+		}
+		row := breakdownMap["user1@example.com|server-a|weather"]
+		if !assert.NotNil(c, row) {
+			return
+		}
+		assert.Equal(c, int64(2), row.EventCount)
+		assert.Equal(c, int64(1), row.FailureCount)
 
-	// User aggregation: 2 users
-	usersByEmail := make(map[string]*gen.HooksUserSummary)
-	for _, u := range result.Users {
-		usersByEmail[u.UserEmail] = u
-	}
-	require.Len(t, usersByEmail, 2)
-	require.Equal(t, int64(2), usersByEmail["user1@example.com"].EventCount)
-	require.Equal(t, int64(1), usersByEmail["user1@example.com"].SuccessCount)
-	require.Equal(t, int64(1), usersByEmail["user1@example.com"].FailureCount)
-	require.Equal(t, int64(1), usersByEmail["user2@example.com"].EventCount)
-	require.Equal(t, int64(1), usersByEmail["user2@example.com"].SuccessCount)
-	require.Equal(t, int64(0), usersByEmail["user2@example.com"].FailureCount)
-
-	// Breakdown: one entry for user1/server-a/weather covering both traces.
-	// trace_summaries aggregates has_error=1 for the failure trace via gram.hook.error.
-	breakdownKey := func(b *gen.HooksBreakdownRow) string {
-		return b.UserEmail + "|" + b.ServerName + "|" + b.ToolName
-	}
-	breakdownMap := make(map[string]*gen.HooksBreakdownRow)
-	for _, b := range result.Breakdown {
-		breakdownMap[breakdownKey(b)] = b
-	}
-	row := breakdownMap["user1@example.com|server-a|weather"]
-	require.NotNil(t, row)
-	require.Equal(t, int64(2), row.EventCount)
-	require.Equal(t, int64(1), row.FailureCount)
-
-	// Time series: at least one point
-	require.NotEmpty(t, result.TimeSeries)
-	for _, pt := range result.TimeSeries {
-		require.NotEmpty(t, pt.BucketStartNs)
-		require.Positive(t, pt.EventCount)
-	}
+		// Time series: at least one point
+		assert.NotEmpty(c, res.TimeSeries)
+		for _, pt := range res.TimeSeries {
+			assert.NotEmpty(c, pt.BucketStartNs)
+			assert.Positive(c, pt.EventCount)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetHooksSummary_FilterByHookType(t *testing.T) {
@@ -205,19 +215,25 @@ func TestGetHooksSummary_FilterByHookType(t *testing.T) {
 		conversationID: "conv-2",
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
 	// Filter to only "mcp" type — tool_source != '' AND tool_name != 'Skill'
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From:           now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:             now.Add(1 * time.Hour).Format(time.RFC3339),
-		TypesToInclude: []string{"mcp"},
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, int64(1), result.TotalEvents)
-	require.Len(t, result.Servers, 1)
-	require.Equal(t, "remote-server", result.Servers[0].ServerName)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From:           now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:             now.Add(1 * time.Hour).Format(time.RFC3339),
+			TypesToInclude: []string{"mcp"},
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(1), res.TotalEvents)
+		if !assert.Len(c, res.Servers, 1) {
+			return
+		}
+		assert.Equal(c, "remote-server", res.Servers[0].ServerName)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetHooksSummary_AttributeFilter(t *testing.T) {
@@ -258,21 +274,27 @@ func TestGetHooksSummary_AttributeFilter(t *testing.T) {
 		conversationID: "conv-2",
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
 	// Filter to only alice's events
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-		Filters: []*gen.LogFilter{
-			{Path: "user.email", Operator: "eq", Values: []string{"alice@example.com"}},
-		},
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, int64(1), result.TotalEvents)
-	require.Len(t, result.Users, 1)
-	require.Equal(t, "alice@example.com", result.Users[0].UserEmail)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+			Filters: []*gen.LogFilter{
+				{Path: "user.email", Operator: "eq", Values: []string{"alice@example.com"}},
+			},
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(1), res.TotalEvents)
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
+		assert.Equal(c, "alice@example.com", res.Users[0].UserEmail)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 // hookEventParams holds parameters for inserting a single hook log event.
@@ -386,23 +408,28 @@ func TestGetHooksSummary_SkillTimeSeriesGroupsBySkill(t *testing.T) {
 		})
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
 
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
+		assert.NotEmpty(c, res.SkillTimeSeries)
 
-	require.NoError(t, err)
-	require.NotEmpty(t, result.SkillTimeSeries)
-
-	countBySkill := make(map[string]int64)
-	for _, pt := range result.SkillTimeSeries {
-		require.NotEmpty(t, pt.BucketStartNs)
-		countBySkill[pt.SkillName] += pt.EventCount
-	}
-	require.Equal(t, int64(2), countBySkill["golang"])
-	require.Equal(t, int64(1), countBySkill["typescript"])
+		countBySkill := make(map[string]int64)
+		for _, pt := range res.SkillTimeSeries {
+			assert.NotEmpty(c, pt.BucketStartNs)
+			countBySkill[pt.SkillName] += pt.EventCount
+		}
+		assert.Equal(c, int64(2), countBySkill["golang"])
+		assert.Equal(c, int64(1), countBySkill["typescript"])
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetHooksSummary_SkillTimeSeriesEmptyWhenNoSkillEvents(t *testing.T) {
@@ -427,15 +454,22 @@ func TestGetHooksSummary_SkillTimeSeriesEmptyWhenNoSkillEvents(t *testing.T) {
 		conversationID: "conv-1",
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
-
-	require.NoError(t, err)
-	require.Empty(t, result.SkillTimeSeries)
+	// Wait for the non-skill event to land (TotalEvents == 1), then assert
+	// SkillTimeSeries stays empty.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(1), res.TotalEvents)
+		assert.Empty(c, res.SkillTimeSeries)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetHooksSummary_SkillTimeSeriesExcludesNonSkillEvents(t *testing.T) {
@@ -473,18 +507,24 @@ func TestGetHooksSummary_SkillTimeSeriesExcludesNonSkillEvents(t *testing.T) {
 		conversationID: "conv-2",
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, int64(2), result.TotalEvents)
-	require.Len(t, result.SkillTimeSeries, 1)
-	require.Equal(t, "golang", result.SkillTimeSeries[0].SkillName)
-	require.Equal(t, int64(1), result.SkillTimeSeries[0].EventCount)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(2), res.TotalEvents)
+		if !assert.Len(c, res.SkillTimeSeries, 1) {
+			return
+		}
+		assert.Equal(c, "golang", res.SkillTimeSeries[0].SkillName)
+		assert.Equal(c, int64(1), res.SkillTimeSeries[0].EventCount)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetHooksSummary_SkillBreakdownGroupsBySkillAndUser(t *testing.T) {
@@ -520,25 +560,30 @@ func TestGetHooksSummary_SkillBreakdownGroupsBySkillAndUser(t *testing.T) {
 		})
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(4), res.TotalEvents)
 
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
+		type key struct{ skill, user string }
+		bySkillUser := make(map[key]int64)
+		for _, row := range res.SkillBreakdown {
+			bySkillUser[key{row.SkillName, row.UserEmail}] += row.UseCount
+		}
 
-	require.NoError(t, err)
-
-	type key struct{ skill, user string }
-	bySkillUser := make(map[key]int64)
-	for _, row := range result.SkillBreakdown {
-		bySkillUser[key{row.SkillName, row.UserEmail}] += row.UseCount
-	}
-
-	require.Equal(t, int64(2), bySkillUser[key{"golang", "user1@example.com"}])
-	require.Equal(t, int64(1), bySkillUser[key{"golang", "user2@example.com"}])
-	require.Equal(t, int64(1), bySkillUser[key{"typescript", "user2@example.com"}])
-	require.NotContains(t, bySkillUser, key{"typescript", "user1@example.com"})
+		assert.Equal(c, int64(2), bySkillUser[key{"golang", "user1@example.com"}])
+		assert.Equal(c, int64(1), bySkillUser[key{"golang", "user2@example.com"}])
+		assert.Equal(c, int64(1), bySkillUser[key{"typescript", "user2@example.com"}])
+		assert.NotContains(c, bySkillUser, key{"typescript", "user1@example.com"})
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetHooksSummary_SkillBreakdownEmptyWhenNoSkillEvents(t *testing.T) {
@@ -563,15 +608,22 @@ func TestGetHooksSummary_SkillBreakdownEmptyWhenNoSkillEvents(t *testing.T) {
 		conversationID: "conv-1",
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
-
-	require.NoError(t, err)
-	require.Empty(t, result.SkillBreakdown)
+	// Wait for the non-skill event to land (TotalEvents == 1), then assert
+	// SkillBreakdown stays empty.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(1), res.TotalEvents)
+		assert.Empty(c, res.SkillBreakdown)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetHooksSummary_SkillTimeSeriesWithSkillTypeFilter(t *testing.T) {
@@ -608,23 +660,31 @@ func TestGetHooksSummary_SkillTimeSeriesWithSkillTypeFilter(t *testing.T) {
 		conversationID: "conv-2",
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
 	// TypesToInclude=["skill"] scopes the overall summary to skill events,
 	// but skill_time_series and skill_breakdown hardcode tool_name='Skill' so they
 	// return skill data regardless of TypesToInclude.
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From:           now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:             now.Add(1 * time.Hour).Format(time.RFC3339),
-		TypesToInclude: []string{"skill"},
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, int64(1), result.TotalEvents)
-	require.Len(t, result.SkillTimeSeries, 1)
-	require.Equal(t, "golang", result.SkillTimeSeries[0].SkillName)
-	require.Len(t, result.SkillBreakdown, 1)
-	require.Equal(t, "golang", result.SkillBreakdown[0].SkillName)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From:           now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:             now.Add(1 * time.Hour).Format(time.RFC3339),
+			TypesToInclude: []string{"skill"},
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(1), res.TotalEvents)
+		if !assert.Len(c, res.SkillTimeSeries, 1) {
+			return
+		}
+		assert.Equal(c, "golang", res.SkillTimeSeries[0].SkillName)
+		if !assert.Len(c, res.SkillBreakdown, 1) {
+			return
+		}
+		assert.Equal(c, "golang", res.SkillBreakdown[0].SkillName)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetHooksSummary_SkillFieldsIgnoreTypesToInclude(t *testing.T) {
@@ -662,21 +722,29 @@ func TestGetHooksSummary_SkillFieldsIgnoreTypesToInclude(t *testing.T) {
 		conversationID: "conv-2",
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
 	// TypesToInclude=["mcp"] scopes TotalEvents/Servers/Users to MCP events only,
 	// but skill_time_series and skill_breakdown hardcode tool_name='Skill' so they
 	// must always return skill data regardless of TypesToInclude.
-	result, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
-		From:           now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:             now.Add(1 * time.Hour).Format(time.RFC3339),
-		TypesToInclude: []string{"mcp"},
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, int64(1), result.TotalEvents) // only MCP event counted
-	require.Len(t, result.SkillTimeSeries, 1)
-	require.Equal(t, "golang", result.SkillTimeSeries[0].SkillName)
-	require.Len(t, result.SkillBreakdown, 1)
-	require.Equal(t, "golang", result.SkillBreakdown[0].SkillName)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From:           now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:             now.Add(1 * time.Hour).Format(time.RFC3339),
+			TypesToInclude: []string{"mcp"},
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(1), res.TotalEvents) // only MCP event counted
+		if !assert.Len(c, res.SkillTimeSeries, 1) {
+			return
+		}
+		assert.Equal(c, "golang", res.SkillTimeSeries[0].SkillName)
+		if !assert.Len(c, res.SkillBreakdown, 1) {
+			return
+		}
+		assert.Equal(c, "golang", res.SkillBreakdown[0].SkillName)
+	}, 10*time.Second, 200*time.Millisecond)
 }

--- a/server/internal/telemetry/get_metrics_summary_test.go
+++ b/server/internal/telemetry/get_metrics_summary_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,70 +78,72 @@ func TestGetProjectMetricsSummary(t *testing.T) {
 	insertToolCallLog(t, ctx, projectID, deploymentID, now.Add(-6*time.Minute), "tools:http:petstore:getPet", 500, 1.0)
 	insertToolCallLog(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), "tools:http:weather:forecast", 200, 0.3)
 
-	// Wait for ClickHouse eventual consistency
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
-		From: from,
-		To:   to,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
+			From: from,
+			To:   to,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
+		m := res.Metrics
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		// Token metrics (sum of all chat completions)
+		assert.Equal(c, int64(450), m.TotalInputTokens)  // 100 + 200 + 150
+		assert.Equal(c, int64(225), m.TotalOutputTokens) // 50 + 100 + 75
+		assert.Equal(c, int64(675), m.TotalTokens)       // 150 + 300 + 225
 
-	m := result.Metrics
-	require.NotNil(t, m)
+		// Chat request metrics
+		assert.Equal(c, int64(3), m.TotalChatRequests)
+		assert.Greater(c, m.AvgChatDurationMs, float64(0))
 
-	// Token metrics (sum of all chat completions)
-	require.Equal(t, int64(450), m.TotalInputTokens)  // 100 + 200 + 150
-	require.Equal(t, int64(225), m.TotalOutputTokens) // 50 + 100 + 75
-	require.Equal(t, int64(675), m.TotalTokens)       // 150 + 300 + 225
+		// Resolution status
+		assert.Equal(c, int64(2), m.FinishReasonStop)      // 2 "stop"
+		assert.Equal(c, int64(1), m.FinishReasonToolCalls) // 1 "tool_calls"
 
-	// Chat request metrics
-	require.Equal(t, int64(3), m.TotalChatRequests)
-	require.Greater(t, m.AvgChatDurationMs, float64(0))
+		// Tool call metrics
+		assert.Equal(c, int64(3), m.TotalToolCalls)
+		assert.Equal(c, int64(2), m.ToolCallSuccess) // 2 with status 200
+		assert.Equal(c, int64(1), m.ToolCallFailure) // 1 with status 500
 
-	// Resolution status
-	require.Equal(t, int64(2), m.FinishReasonStop)      // 2 "stop"
-	require.Equal(t, int64(1), m.FinishReasonToolCalls) // 1 "tool_calls"
+		// Cardinality
+		assert.Equal(c, int64(2), m.TotalChats)        // 2 distinct chat IDs
+		assert.Equal(c, int64(2), m.DistinctModels)    // gpt-4, claude-3
+		assert.Equal(c, int64(2), m.DistinctProviders) // openai, anthropic
 
-	// Tool call metrics
-	require.Equal(t, int64(3), m.TotalToolCalls)
-	require.Equal(t, int64(2), m.ToolCallSuccess) // 2 with status 200
-	require.Equal(t, int64(1), m.ToolCallFailure) // 1 with status 500
+		// Model breakdown
+		if assert.Len(c, m.Models, 2) {
+			modelCounts := make(map[string]int64)
+			for _, model := range m.Models {
+				modelCounts[model.Name] = model.Count
+			}
+			assert.Equal(c, int64(2), modelCounts["gpt-4"])    // 2 chat completions with gpt-4
+			assert.Equal(c, int64(1), modelCounts["claude-3"]) // 1 chat completion with claude-3
+		}
 
-	// Cardinality
-	require.Equal(t, int64(2), m.TotalChats)        // 2 distinct chat IDs
-	require.Equal(t, int64(2), m.DistinctModels)    // gpt-4, claude-3
-	require.Equal(t, int64(2), m.DistinctProviders) // openai, anthropic
-
-	// Model breakdown
-	require.Len(t, m.Models, 2)
-	modelCounts := make(map[string]int64)
-	for _, model := range m.Models {
-		modelCounts[model.Name] = model.Count
-	}
-	require.Equal(t, int64(2), modelCounts["gpt-4"])    // 2 chat completions with gpt-4
-	require.Equal(t, int64(1), modelCounts["claude-3"]) // 1 chat completion with claude-3
-
-	// Tool breakdown
-	require.Len(t, m.Tools, 3)
-	toolStats := make(map[string]*gen.ToolUsage)
-	for _, tool := range m.Tools {
-		toolStats[tool.Urn] = tool
-	}
-	require.Equal(t, int64(1), toolStats["tools:http:petstore:listPets"].Count)
-	require.Equal(t, int64(1), toolStats["tools:http:petstore:listPets"].SuccessCount)
-	require.Equal(t, int64(0), toolStats["tools:http:petstore:listPets"].FailureCount)
-	require.Equal(t, int64(1), toolStats["tools:http:petstore:getPet"].Count)
-	require.Equal(t, int64(0), toolStats["tools:http:petstore:getPet"].SuccessCount)
-	require.Equal(t, int64(1), toolStats["tools:http:petstore:getPet"].FailureCount) // status 500
-	require.Equal(t, int64(1), toolStats["tools:http:weather:forecast"].Count)
-	require.Equal(t, int64(1), toolStats["tools:http:weather:forecast"].SuccessCount)
-	require.Equal(t, int64(0), toolStats["tools:http:weather:forecast"].FailureCount)
+		// Tool breakdown
+		if assert.Len(c, m.Tools, 3) {
+			toolStats := make(map[string]*gen.ToolUsage)
+			for _, tool := range m.Tools {
+				toolStats[tool.Urn] = tool
+			}
+			assert.Equal(c, int64(1), toolStats["tools:http:petstore:listPets"].Count)
+			assert.Equal(c, int64(1), toolStats["tools:http:petstore:listPets"].SuccessCount)
+			assert.Equal(c, int64(0), toolStats["tools:http:petstore:listPets"].FailureCount)
+			assert.Equal(c, int64(1), toolStats["tools:http:petstore:getPet"].Count)
+			assert.Equal(c, int64(0), toolStats["tools:http:petstore:getPet"].SuccessCount)
+			assert.Equal(c, int64(1), toolStats["tools:http:petstore:getPet"].FailureCount) // status 500
+			assert.Equal(c, int64(1), toolStats["tools:http:weather:forecast"].Count)
+			assert.Equal(c, int64(1), toolStats["tools:http:weather:forecast"].SuccessCount)
+			assert.Equal(c, int64(0), toolStats["tools:http:weather:forecast"].FailureCount)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func insertChatCompletionLog(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, chatID string, inputTokens, outputTokens, totalTokens int, durationSec float64, finishReason, model, provider string) {
@@ -236,24 +239,26 @@ func TestGetProjectMetricsSummary_StatusCodeBoundaries(t *testing.T) {
 	insertToolCallLog(t, ctx, projectID, deploymentID, now.Add(-3*time.Minute), "tools:http:test:op8", 500, 0.1) // failure
 	insertToolCallLog(t, ctx, projectID, deploymentID, now.Add(-2*time.Minute), "tools:http:test:op9", 503, 0.1) // failure
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
-		From: from,
-		To:   to,
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, result)
-
-	m := result.Metrics
-	require.Equal(t, int64(9), m.TotalToolCalls)
-	require.Equal(t, int64(3), m.ToolCallSuccess) // 200, 201, 299
-	require.Equal(t, int64(4), m.ToolCallFailure) // 400, 404, 500, 503
-	// Note: 301, 302 are not counted as success (not 200-299) or failure (not 400+)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
+			From: from,
+			To:   to,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
+		m := res.Metrics
+		assert.Equal(c, int64(9), m.TotalToolCalls)
+		assert.Equal(c, int64(3), m.ToolCallSuccess) // 200, 201, 299
+		assert.Equal(c, int64(4), m.ToolCallFailure) // 400, 404, 500, 503
+		// Note: 301, 302 are not counted as success (not 200-299) or failure (not 400+)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetProjectMetricsSummary_OnlyToolCalls(t *testing.T) {
@@ -271,34 +276,36 @@ func TestGetProjectMetricsSummary_OnlyToolCalls(t *testing.T) {
 	insertToolCallLog(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), "tools:http:petstore:listPets", 200, 0.5)
 	insertToolCallLog(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), "tools:http:petstore:getPet", 200, 0.3)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
-		From: from,
-		To:   to,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
+			From: from,
+			To:   to,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
+		m := res.Metrics
+		assert.Equal(c, int64(2), m.TotalToolCalls)
+		assert.Equal(c, int64(2), m.ToolCallSuccess)
+		assert.Equal(c, int64(0), m.ToolCallFailure)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		// Chat-related metrics should be zero
+		assert.Equal(c, int64(0), m.TotalChatRequests)
+		assert.Equal(c, int64(0), m.TotalChats)
+		assert.Equal(c, int64(0), m.TotalInputTokens)
+		assert.Equal(c, int64(0), m.TotalOutputTokens)
+		assert.Equal(c, int64(0), m.TotalTokens)
+		assert.Empty(c, m.Models)
 
-	m := result.Metrics
-	require.Equal(t, int64(2), m.TotalToolCalls)
-	require.Equal(t, int64(2), m.ToolCallSuccess)
-	require.Equal(t, int64(0), m.ToolCallFailure)
-
-	// Chat-related metrics should be zero
-	require.Equal(t, int64(0), m.TotalChatRequests)
-	require.Equal(t, int64(0), m.TotalChats)
-	require.Equal(t, int64(0), m.TotalInputTokens)
-	require.Equal(t, int64(0), m.TotalOutputTokens)
-	require.Equal(t, int64(0), m.TotalTokens)
-	require.Empty(t, m.Models)
-
-	// But tools should be present
-	require.Len(t, m.Tools, 2)
+		// But tools should be present
+		assert.Len(c, m.Tools, 2)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetProjectMetricsSummary_OnlyChatCompletions(t *testing.T) {
@@ -317,34 +324,37 @@ func TestGetProjectMetricsSummary_OnlyChatCompletions(t *testing.T) {
 	insertChatCompletionLog(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, 150, 1.5, "stop", "gpt-4", "openai")
 	insertChatCompletionLog(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, 200, 100, 300, 2.0, "stop", "gpt-4", "openai")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
-		From: from,
-		To:   to,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
+			From: from,
+			To:   to,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
+		m := res.Metrics
+		assert.Equal(c, int64(2), m.TotalChatRequests)
+		assert.Equal(c, int64(1), m.TotalChats) // 1 unique chat ID
+		assert.Equal(c, int64(300), m.TotalInputTokens)
+		assert.Equal(c, int64(150), m.TotalOutputTokens)
+		assert.Equal(c, int64(450), m.TotalTokens)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		// Tool metrics should be zero
+		assert.Equal(c, int64(0), m.TotalToolCalls)
+		assert.Equal(c, int64(0), m.ToolCallSuccess)
+		assert.Equal(c, int64(0), m.ToolCallFailure)
+		assert.Empty(c, m.Tools)
 
-	m := result.Metrics
-	require.Equal(t, int64(2), m.TotalChatRequests)
-	require.Equal(t, int64(1), m.TotalChats) // 1 unique chat ID
-	require.Equal(t, int64(300), m.TotalInputTokens)
-	require.Equal(t, int64(150), m.TotalOutputTokens)
-	require.Equal(t, int64(450), m.TotalTokens)
-
-	// Tool metrics should be zero
-	require.Equal(t, int64(0), m.TotalToolCalls)
-	require.Equal(t, int64(0), m.ToolCallSuccess)
-	require.Equal(t, int64(0), m.ToolCallFailure)
-	require.Empty(t, m.Tools)
-
-	// Models should be present
-	require.Len(t, m.Models, 1)
-	require.Equal(t, "gpt-4", m.Models[0].Name)
-	require.Equal(t, int64(2), m.Models[0].Count)
+		// Models should be present
+		if assert.Len(c, m.Models, 1) {
+			assert.Equal(c, "gpt-4", m.Models[0].Name)
+			assert.Equal(c, int64(2), m.Models[0].Count)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }

--- a/server/internal/telemetry/get_observability_overview_test.go
+++ b/server/internal/telemetry/get_observability_overview_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,33 +63,34 @@ func TestGetObservabilityOverview_WithChatResolutions(t *testing.T) {
 	insertToolCallLog(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), "tools:http:petstore:listPets", 200, 0.5)
 	insertToolCallLog(t, ctx, projectID, deploymentID, now.Add(-7*time.Minute), "tools:http:petstore:getPet", 500, 1.0)
 
-	// Wait for ClickHouse eventual consistency
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
-		From:              from,
-		To:                to,
-		IncludeTimeSeries: true,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
+			From:              from,
+			To:                to,
+			IncludeTimeSeries: true,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.NotNil(t, result.Summary)
+		// Verify chat resolution metrics
+		assert.Equal(c, int64(3), res.Summary.TotalChats)
+		assert.Equal(c, int64(1), res.Summary.ResolvedChats)
+		assert.Equal(c, int64(1), res.Summary.FailedChats)
 
-	// Verify chat resolution metrics
-	require.Equal(t, int64(3), result.Summary.TotalChats)
-	require.Equal(t, int64(1), result.Summary.ResolvedChats)
-	require.Equal(t, int64(1), result.Summary.FailedChats)
+		// Verify tool metrics
+		assert.Equal(c, int64(2), res.Summary.TotalToolCalls)
+		assert.Equal(c, int64(1), res.Summary.FailedToolCalls)
 
-	// Verify tool metrics
-	require.Equal(t, int64(2), result.Summary.TotalToolCalls)
-	require.Equal(t, int64(1), result.Summary.FailedToolCalls)
-
-	// Verify time series is returned
-	require.NotEmpty(t, result.TimeSeries)
+		// Verify time series is returned
+		assert.NotEmpty(c, res.TimeSeries)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetObservabilityOverview_TimeSeriesMetrics(t *testing.T) {
@@ -109,26 +111,32 @@ func TestGetObservabilityOverview_TimeSeriesMetrics(t *testing.T) {
 	insertResolutionLog(t, ctx, projectID, deploymentID, now.Add(-50*time.Minute), chatID1, "success", 90)
 	insertResolutionLog(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID2, "success", 85)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
-		From:              from,
-		To:                to,
-		IncludeTimeSeries: true,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
+			From:              from,
+			To:                to,
+			IncludeTimeSeries: true,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.NotEmpty(t, result.TimeSeries)
+		if !assert.NotEmpty(c, res.TimeSeries) {
+			return
+		}
 
-	// With 2-hour range and auto-calculated 15-min buckets, we should have 8+ buckets
-	require.GreaterOrEqual(t, len(result.TimeSeries), 8)
+		// With 2-hour range and auto-calculated 15-min buckets, we should have 8+ buckets
+		assert.GreaterOrEqual(c, len(res.TimeSeries), 8)
 
-	// Verify the first bucket has a valid timestamp
-	require.Positive(t, result.TimeSeries[0].BucketTimeUnixNano)
+		// Verify the first bucket has a valid timestamp
+		assert.Positive(c, res.TimeSeries[0].BucketTimeUnixNano)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetObservabilityOverview_UnevaluatedChats(t *testing.T) {
@@ -152,37 +160,39 @@ func TestGetObservabilityOverview_UnevaluatedChats(t *testing.T) {
 	// Insert one evaluated chat for comparison
 	insertResolutionLog(t, ctx, projectID, deploymentID, now.Add(-6*time.Minute), chatID3, "success", 90)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
-		From:              from,
-		To:                to,
-		IncludeTimeSeries: true,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
+			From:              from,
+			To:                to,
+			IncludeTimeSeries: true,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.NotNil(t, result.Summary)
+		// All 3 chats must be counted — unevaluated chats should not be excluded
+		assert.Equal(c, int64(3), res.Summary.TotalChats)
 
-	// All 3 chats must be counted — unevaluated chats should not be excluded
-	require.Equal(t, int64(3), result.Summary.TotalChats)
+		// Only the one evaluated-as-success chat counts toward resolved
+		assert.Equal(c, int64(1), res.Summary.ResolvedChats)
+		assert.Equal(c, int64(0), res.Summary.FailedChats)
 
-	// Only the one evaluated-as-success chat counts toward resolved
-	require.Equal(t, int64(1), result.Summary.ResolvedChats)
-	require.Equal(t, int64(0), result.Summary.FailedChats)
+		// Session duration is computed from chat completion events regardless of evaluation label
+		assert.Greater(c, res.Summary.AvgSessionDurationMs, float64(0))
 
-	// Session duration is computed from chat completion events regardless of evaluation label
-	require.Greater(t, result.Summary.AvgSessionDurationMs, float64(0))
-
-	// Time series must also reflect all 3 chats in total
-	totalInTimeSeries := int64(0)
-	for _, b := range result.TimeSeries {
-		totalInTimeSeries += b.TotalChats
-	}
-	require.Equal(t, int64(3), totalInTimeSeries)
+		// Time series must also reflect all 3 chats in total
+		totalInTimeSeries := int64(0)
+		for _, b := range res.TimeSeries {
+			totalInTimeSeries += b.TotalChats
+		}
+		assert.Equal(c, int64(3), totalInTimeSeries)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetObservabilityOverview_FromAfterTo(t *testing.T) {
@@ -221,19 +231,24 @@ func TestGetObservabilityOverview_RemoteMCPServerIDFilter(t *testing.T) {
 	insertRemoteMCPToolCallLog(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), "tools:externalmcp:"+serverA+":createIssue", serverA, 500, 1.2)
 	insertRemoteMCPToolCallLog(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), "tools:externalmcp:"+serverB+":listIssues", serverB, 200, 0.3)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
 	// Without filter: all three tool calls show up.
-	all, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
-		From:              from,
-		To:                to,
-		IncludeTimeSeries: false,
-	})
-	require.NoError(t, err)
-	require.Equal(t, int64(3), all.Summary.TotalToolCalls)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{
+			From:              from,
+			To:                to,
+			IncludeTimeSeries: false,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(3), res.Summary.TotalToolCalls)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Filter by server A: only its two calls show up.
 	scoped, err := ti.service.GetObservabilityOverview(ctx, &gen.GetObservabilityOverviewPayload{

--- a/server/internal/telemetry/get_tool_usage_summary_test.go
+++ b/server/internal/telemetry/get_tool_usage_summary_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	telemetryRepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,48 +120,56 @@ func TestGetToolUsageSummary_AggregatesHostedShadowLocalAndSkills(t *testing.T) 
 		conversationID: "conv-skill",
 	})
 
-	time.Sleep(200 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetToolUsageSummary(ctx, &gen.GetToolUsageSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
 
-	result, err := ti.service.GetToolUsageSummary(ctx, &gen.GetToolUsageSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
+		assert.Equal(c, int64(5), res.Totals.EventCount)
+		assert.Equal(c, int64(4), res.Totals.SuccessCount)
+		assert.Equal(c, int64(1), res.Totals.FailureCount)
+		assert.InEpsilon(c, 0.2, res.Totals.FailureRate, 0.001)
+		assert.Equal(c, int64(4), res.Totals.UniqueTools)
+		assert.Equal(c, int64(4), res.Totals.UniqueUsers)
+		assert.Equal(c, int64(4), res.Totals.UniqueTargets)
 
-	require.NoError(t, err, "cause: %v", errors.Unwrap(err))
-	require.NotNil(t, result)
-	require.Equal(t, int64(5), result.Totals.EventCount)
-	require.Equal(t, int64(4), result.Totals.SuccessCount)
-	require.Equal(t, int64(1), result.Totals.FailureCount)
-	require.InEpsilon(t, 0.2, result.Totals.FailureRate, 0.001)
-	require.Equal(t, int64(4), result.Totals.UniqueTools)
-	require.Equal(t, int64(4), result.Totals.UniqueUsers)
-	require.Equal(t, int64(4), result.Totals.UniqueTargets)
+		targets := toolUsageTargetsByKey(res.Targets)
+		hosted := targets["hosted_mcp_server:server:payments"]
+		if assert.NotNil(c, hosted) {
+			assert.Equal(c, "payments", hosted.TargetLabel)
+			assert.Equal(c, int64(2), hosted.EventCount)
+			assert.Equal(c, int64(1), hosted.SuccessCount)
+			assert.Equal(c, int64(1), hosted.FailureCount)
+			assert.InEpsilon(c, 0.5, hosted.FailureRate, 0.001)
+		}
 
-	targets := toolUsageTargetsByKey(result.Targets)
-	hosted := targets["hosted_mcp_server:server:payments"]
-	require.NotNil(t, hosted)
-	require.Equal(t, "payments", hosted.TargetLabel)
-	require.Equal(t, int64(2), hosted.EventCount)
-	require.Equal(t, int64(1), hosted.SuccessCount)
-	require.Equal(t, int64(1), hosted.FailureCount)
-	require.InEpsilon(t, 0.5, hosted.FailureRate, 0.001)
+		shadow := targets["shadow_mcp_server:server:shadow-db"]
+		if assert.NotNil(c, shadow) {
+			assert.Equal(c, int64(1), shadow.EventCount)
+		}
 
-	shadow := targets["shadow_mcp_server:server:shadow-db"]
-	require.NotNil(t, shadow)
-	require.Equal(t, int64(1), shadow.EventCount)
+		local := targets["local_tool:local_tools:local"]
+		if assert.NotNil(c, local) {
+			assert.Equal(c, "Local Tools", local.TargetLabel)
+		}
 
-	local := targets["local_tool:local_tools:local"]
-	require.NotNil(t, local)
-	require.Equal(t, "Local Tools", local.TargetLabel)
+		skill := targets["skill:skill:golang"]
+		if assert.NotNil(c, skill) {
+			assert.Equal(c, "golang", skill.TargetLabel)
+		}
 
-	skill := targets["skill:skill:golang"]
-	require.NotNil(t, skill)
-	require.Equal(t, "golang", skill.TargetLabel)
-
-	require.NotEmpty(t, result.TargetTimeSeries)
-	require.NotEmpty(t, result.UserTimeSeries)
-	require.NotEmpty(t, result.UsersByTarget)
-	require.NotEmpty(t, result.TargetToolBreakdown)
+		assert.NotEmpty(c, res.TargetTimeSeries)
+		assert.NotEmpty(c, res.UserTimeSeries)
+		assert.NotEmpty(c, res.UsersByTarget)
+		assert.NotEmpty(c, res.TargetToolBreakdown)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetToolUsageSummary_ClassifiesHookObservedHostedMCP(t *testing.T) {
@@ -199,17 +208,25 @@ func TestGetToolUsageSummary_ClassifiesHookObservedHostedMCP(t *testing.T) {
 		conversationID: "conv-hosted-hook",
 	})
 
-	time.Sleep(200 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetToolUsageSummary(ctx, &gen.GetToolUsageSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.NotEmpty(c, res.Targets) {
+			return
+		}
 
-	result, err := ti.service.GetToolUsageSummary(ctx, &gen.GetToolUsageSummaryPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
-
-	require.NoError(t, err, "cause: %v", errors.Unwrap(err))
-	targets := toolUsageTargetsByKey(result.Targets)
-	require.NotNil(t, targets["hosted_mcp_server:server:hosted-payments"])
-	require.Nil(t, targets["shadow_mcp_server:server:hosted.example.com"])
+		targets := toolUsageTargetsByKey(res.Targets)
+		assert.NotNil(c, targets["hosted_mcp_server:server:hosted-payments"])
+		assert.Nil(c, targets["shadow_mcp_server:server:hosted.example.com"])
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetToolUsageSummary_FiltersByHookSource(t *testing.T) {
@@ -302,17 +319,21 @@ func TestGetToolUsageFilterOptions_ReturnsUncappedShadowServersAndUsers(t *testi
 		})
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
-	options, err := ti.service.GetToolUsageFilterOptions(ctx, &gen.GetToolUsageFilterOptionsPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
-
-	require.NoError(t, err, "cause: %v", errors.Unwrap(err))
-	require.Empty(t, options.HostedServers)
-	require.Len(t, options.ShadowServers, 30)
-	require.Len(t, options.Users, 30)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetToolUsageFilterOptions(ctx, &gen.GetToolUsageFilterOptionsPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Empty(c, res.HostedServers)
+		assert.Len(c, res.ShadowServers, 30)
+		assert.Len(c, res.Users, 30)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	userOptionsOnly, err := ti.service.GetToolUsageFilterOptions(ctx, &gen.GetToolUsageFilterOptionsPayload{
 		From:        now.Add(-1 * time.Hour).Format(time.RFC3339),
@@ -370,20 +391,27 @@ func TestGetToolUsageFilterOptions_ClassifiesHookObservedHostedMCP(t *testing.T)
 		conversationID: "conv-hosted-hook",
 	})
 
-	time.Sleep(200 * time.Millisecond)
-
-	options, err := ti.service.GetToolUsageFilterOptions(ctx, &gen.GetToolUsageFilterOptionsPayload{
-		From: now.Add(-1 * time.Hour).Format(time.RFC3339),
-		To:   now.Add(1 * time.Hour).Format(time.RFC3339),
-	})
-
-	require.NoError(t, err, "cause: %v", errors.Unwrap(err))
-	require.Len(t, options.HostedServers, 1)
-	require.Equal(t, "hosted-payments", options.HostedServers[0].ToolsetSlug)
-	require.Equal(t, int64(1), options.HostedServers[0].EventCount)
-	require.Empty(t, options.ShadowServers)
-	require.Len(t, options.Users, 1)
-	require.Equal(t, "alice@example.com", options.Users[0].UserKey)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetToolUsageFilterOptions(ctx, &gen.GetToolUsageFilterOptionsPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.HostedServers, 1) {
+			return
+		}
+		assert.Equal(c, "hosted-payments", res.HostedServers[0].ToolsetSlug)
+		assert.Equal(c, int64(1), res.HostedServers[0].EventCount)
+		assert.Empty(c, res.ShadowServers)
+		if assert.Len(c, res.Users, 1) {
+			assert.Equal(c, "alice@example.com", res.Users[0].UserKey)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 
 	hostedOptionsOnly, err := ti.service.GetToolUsageFilterOptions(ctx, &gen.GetToolUsageFilterOptionsPayload{
 		From:        now.Add(-1 * time.Hour).Format(time.RFC3339),

--- a/server/internal/telemetry/get_user_metrics_summary_test.go
+++ b/server/internal/telemetry/get_user_metrics_summary_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -128,64 +129,67 @@ func TestGetUserMetricsSummary_WithUserID(t *testing.T) {
 	// Insert tool call for different user (should not be included)
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), "tools:http:weather:forecast", 200, 0.3, otherUserID, "")
 
-	// Wait for ClickHouse eventual consistency
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
-		From:   from,
-		To:     to,
-		UserID: &userID,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+			From:   from,
+			To:     to,
+			UserID: &userID,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		m := res.Metrics
 
-	m := result.Metrics
-	require.NotNil(t, m)
+		// Token metrics (sum of chat completions for target user only)
+		assert.Equal(c, int64(300), m.TotalInputTokens)  // 100 + 200
+		assert.Equal(c, int64(150), m.TotalOutputTokens) // 50 + 100
+		assert.Equal(c, int64(450), m.TotalTokens)       // 150 + 300
 
-	// Token metrics (sum of chat completions for target user only)
-	require.Equal(t, int64(300), m.TotalInputTokens)  // 100 + 200
-	require.Equal(t, int64(150), m.TotalOutputTokens) // 50 + 100
-	require.Equal(t, int64(450), m.TotalTokens)       // 150 + 300
+		// Chat request metrics
+		assert.Equal(c, int64(2), m.TotalChatRequests)
+		assert.Greater(c, m.AvgChatDurationMs, float64(0))
 
-	// Chat request metrics
-	require.Equal(t, int64(2), m.TotalChatRequests)
-	require.Greater(t, m.AvgChatDurationMs, float64(0))
+		// Resolution status
+		assert.Equal(c, int64(1), m.FinishReasonStop)      // 1 "stop"
+		assert.Equal(c, int64(1), m.FinishReasonToolCalls) // 1 "tool_calls"
 
-	// Resolution status
-	require.Equal(t, int64(1), m.FinishReasonStop)      // 1 "stop"
-	require.Equal(t, int64(1), m.FinishReasonToolCalls) // 1 "tool_calls"
+		// Tool call metrics (only target user's tools)
+		assert.Equal(c, int64(2), m.TotalToolCalls)
+		assert.Equal(c, int64(1), m.ToolCallSuccess) // 1 with status 200
+		assert.Equal(c, int64(1), m.ToolCallFailure) // 1 with status 500
 
-	// Tool call metrics (only target user's tools)
-	require.Equal(t, int64(2), m.TotalToolCalls)
-	require.Equal(t, int64(1), m.ToolCallSuccess) // 1 with status 200
-	require.Equal(t, int64(1), m.ToolCallFailure) // 1 with status 500
+		// Cardinality
+		assert.Equal(c, int64(1), m.TotalChats)        // 1 distinct chat ID for target user
+		assert.Equal(c, int64(1), m.DistinctModels)    // gpt-4 only
+		assert.Equal(c, int64(1), m.DistinctProviders) // openai only
 
-	// Cardinality
-	require.Equal(t, int64(1), m.TotalChats)        // 1 distinct chat ID for target user
-	require.Equal(t, int64(1), m.DistinctModels)    // gpt-4 only
-	require.Equal(t, int64(1), m.DistinctProviders) // openai only
+		// Model breakdown
+		if assert.Len(c, m.Models, 1) {
+			assert.Equal(c, "gpt-4", m.Models[0].Name)
+			assert.Equal(c, int64(2), m.Models[0].Count)
+		}
 
-	// Model breakdown
-	require.Len(t, m.Models, 1)
-	require.Equal(t, "gpt-4", m.Models[0].Name)
-	require.Equal(t, int64(2), m.Models[0].Count)
-
-	// Tool breakdown
-	require.Len(t, m.Tools, 2)
-	toolStats := make(map[string]*gen.ToolUsage)
-	for _, tool := range m.Tools {
-		toolStats[tool.Urn] = tool
-	}
-	require.Equal(t, int64(1), toolStats["tools:http:petstore:listPets"].Count)
-	require.Equal(t, int64(1), toolStats["tools:http:petstore:listPets"].SuccessCount)
-	require.Equal(t, int64(0), toolStats["tools:http:petstore:listPets"].FailureCount)
-	require.Equal(t, int64(1), toolStats["tools:http:petstore:getPet"].Count)
-	require.Equal(t, int64(0), toolStats["tools:http:petstore:getPet"].SuccessCount)
-	require.Equal(t, int64(1), toolStats["tools:http:petstore:getPet"].FailureCount)
+		// Tool breakdown
+		if assert.Len(c, m.Tools, 2) {
+			toolStats := make(map[string]*gen.ToolUsage)
+			for _, tool := range m.Tools {
+				toolStats[tool.Urn] = tool
+			}
+			assert.Equal(c, int64(1), toolStats["tools:http:petstore:listPets"].Count)
+			assert.Equal(c, int64(1), toolStats["tools:http:petstore:listPets"].SuccessCount)
+			assert.Equal(c, int64(0), toolStats["tools:http:petstore:listPets"].FailureCount)
+			assert.Equal(c, int64(1), toolStats["tools:http:petstore:getPet"].Count)
+			assert.Equal(c, int64(0), toolStats["tools:http:petstore:getPet"].SuccessCount)
+			assert.Equal(c, int64(1), toolStats["tools:http:petstore:getPet"].FailureCount)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetUserMetricsSummary_FallsBackToUserEmail(t *testing.T) {
@@ -201,21 +205,24 @@ func TestGetUserMetricsSummary_FallsBackToUserEmail(t *testing.T) {
 	email := "metrics-unmatched-" + uuid.New().String() + "@example.com"
 	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), email, 100, 50, 1.25)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
-		From:   from,
-		To:     to,
-		UserID: &email,
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Equal(t, int64(100), result.Metrics.TotalInputTokens)
-	require.Equal(t, int64(50), result.Metrics.TotalOutputTokens)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+			From:   from,
+			To:     to,
+			UserID: &email,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
+		assert.Equal(c, int64(100), res.Metrics.TotalInputTokens)
+		assert.Equal(c, int64(50), res.Metrics.TotalOutputTokens)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetUserMetricsSummary_WithExternalUserID(t *testing.T) {
@@ -241,45 +248,47 @@ func TestGetUserMetricsSummary_WithExternalUserID(t *testing.T) {
 	// Insert tool call logs for target external user
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), "tools:http:api:call", 200, 0.5, "", externalUserID)
 
-	// Wait for ClickHouse eventual consistency
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
-		From:           from,
-		To:             to,
-		ExternalUserID: &externalUserID,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+			From:           from,
+			To:             to,
+			ExternalUserID: &externalUserID,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		m := res.Metrics
 
-	m := result.Metrics
-	require.NotNil(t, m)
+		// Token metrics (only for target external user)
+		assert.Equal(c, int64(100), m.TotalInputTokens)
+		assert.Equal(c, int64(50), m.TotalOutputTokens)
+		assert.Equal(c, int64(150), m.TotalTokens)
 
-	// Token metrics (only for target external user)
-	require.Equal(t, int64(100), m.TotalInputTokens)
-	require.Equal(t, int64(50), m.TotalOutputTokens)
-	require.Equal(t, int64(150), m.TotalTokens)
+		// Chat request metrics
+		assert.Equal(c, int64(1), m.TotalChatRequests)
 
-	// Chat request metrics
-	require.Equal(t, int64(1), m.TotalChatRequests)
+		// Tool call metrics
+		assert.Equal(c, int64(1), m.TotalToolCalls)
+		assert.Equal(c, int64(1), m.ToolCallSuccess)
+		assert.Equal(c, int64(0), m.ToolCallFailure)
 
-	// Tool call metrics
-	require.Equal(t, int64(1), m.TotalToolCalls)
-	require.Equal(t, int64(1), m.ToolCallSuccess)
-	require.Equal(t, int64(0), m.ToolCallFailure)
+		// Cardinality
+		assert.Equal(c, int64(1), m.TotalChats)
+		assert.Equal(c, int64(1), m.DistinctModels)
+		assert.Equal(c, int64(1), m.DistinctProviders)
 
-	// Cardinality
-	require.Equal(t, int64(1), m.TotalChats)
-	require.Equal(t, int64(1), m.DistinctModels)
-	require.Equal(t, int64(1), m.DistinctProviders)
-
-	// Model breakdown
-	require.Len(t, m.Models, 1)
-	require.Equal(t, "claude-3", m.Models[0].Name)
+		// Model breakdown
+		if assert.Len(c, m.Models, 1) {
+			assert.Equal(c, "claude-3", m.Models[0].Name)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetUserMetricsSummary_OnlyToolCalls(t *testing.T) {
@@ -298,35 +307,38 @@ func TestGetUserMetricsSummary_OnlyToolCalls(t *testing.T) {
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), "tools:http:petstore:listPets", 200, 0.5, userID, "")
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), "tools:http:petstore:getPet", 200, 0.3, userID, "")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
-		From:   from,
-		To:     to,
-		UserID: &userID,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+			From:   from,
+			To:     to,
+			UserID: &userID,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		m := res.Metrics
+		assert.Equal(c, int64(2), m.TotalToolCalls)
+		assert.Equal(c, int64(2), m.ToolCallSuccess)
+		assert.Equal(c, int64(0), m.ToolCallFailure)
 
-	m := result.Metrics
-	require.Equal(t, int64(2), m.TotalToolCalls)
-	require.Equal(t, int64(2), m.ToolCallSuccess)
-	require.Equal(t, int64(0), m.ToolCallFailure)
+		// Chat-related metrics should be zero
+		assert.Equal(c, int64(0), m.TotalChatRequests)
+		assert.Equal(c, int64(0), m.TotalChats)
+		assert.Equal(c, int64(0), m.TotalInputTokens)
+		assert.Equal(c, int64(0), m.TotalOutputTokens)
+		assert.Equal(c, int64(0), m.TotalTokens)
+		assert.Empty(c, m.Models)
 
-	// Chat-related metrics should be zero
-	require.Equal(t, int64(0), m.TotalChatRequests)
-	require.Equal(t, int64(0), m.TotalChats)
-	require.Equal(t, int64(0), m.TotalInputTokens)
-	require.Equal(t, int64(0), m.TotalOutputTokens)
-	require.Equal(t, int64(0), m.TotalTokens)
-	require.Empty(t, m.Models)
-
-	// But tools should be present
-	require.Len(t, m.Tools, 2)
+		// But tools should be present
+		assert.Len(c, m.Tools, 2)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetUserMetricsSummary_OnlyChatCompletions(t *testing.T) {
@@ -346,37 +358,41 @@ func TestGetUserMetricsSummary_OnlyChatCompletions(t *testing.T) {
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, 150, 1.5, "stop", "gpt-4", "openai", userID, "")
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, 200, 100, 300, 2.0, "stop", "gpt-4", "openai", userID, "")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
-		From:   from,
-		To:     to,
-		UserID: &userID,
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+			From:   from,
+			To:     to,
+			UserID: &userID,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		m := res.Metrics
+		assert.Equal(c, int64(2), m.TotalChatRequests)
+		assert.Equal(c, int64(1), m.TotalChats) // 1 unique chat ID
+		assert.Equal(c, int64(300), m.TotalInputTokens)
+		assert.Equal(c, int64(150), m.TotalOutputTokens)
+		assert.Equal(c, int64(450), m.TotalTokens)
 
-	m := result.Metrics
-	require.Equal(t, int64(2), m.TotalChatRequests)
-	require.Equal(t, int64(1), m.TotalChats) // 1 unique chat ID
-	require.Equal(t, int64(300), m.TotalInputTokens)
-	require.Equal(t, int64(150), m.TotalOutputTokens)
-	require.Equal(t, int64(450), m.TotalTokens)
+		// Tool metrics should be zero
+		assert.Equal(c, int64(0), m.TotalToolCalls)
+		assert.Equal(c, int64(0), m.ToolCallSuccess)
+		assert.Equal(c, int64(0), m.ToolCallFailure)
+		assert.Empty(c, m.Tools)
 
-	// Tool metrics should be zero
-	require.Equal(t, int64(0), m.TotalToolCalls)
-	require.Equal(t, int64(0), m.ToolCallSuccess)
-	require.Equal(t, int64(0), m.ToolCallFailure)
-	require.Empty(t, m.Tools)
-
-	// Models should be present
-	require.Len(t, m.Models, 1)
-	require.Equal(t, "gpt-4", m.Models[0].Name)
-	require.Equal(t, int64(2), m.Models[0].Count)
+		// Models should be present
+		if assert.Len(c, m.Models, 1) {
+			assert.Equal(c, "gpt-4", m.Models[0].Name)
+			assert.Equal(c, int64(2), m.Models[0].Count)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 // insertChatCompletionLogWithUser inserts a chat completion log with user identification attributes.

--- a/server/internal/telemetry/list_filter_options_test.go
+++ b/server/internal/telemetry/list_filter_options_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,26 +55,29 @@ func TestListFilterOptions_FilterByAPIKey(t *testing.T) {
 	// apiKey2 has 1 unique chat
 	insertLogWithAPIKey(t, ctx, projectID, deploymentID, now.Add(-7*time.Minute), uuid.New().String(), apiKey2)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.ListFilterOptions(ctx, &gen.ListFilterOptionsPayload{
-		From:       from,
-		To:         to,
-		FilterType: "api_key",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.ListFilterOptions(ctx, &gen.ListFilterOptionsPayload{
+			From:       from,
+			To:         to,
+			FilterType: "api_key",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Options, 2)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Options, 2)
-
-	// Results should be ordered by count descending
-	require.Equal(t, apiKey1, result.Options[0].ID)
-	require.Equal(t, int64(3), result.Options[0].Count)
-	require.Equal(t, apiKey2, result.Options[1].ID)
-	require.Equal(t, int64(1), result.Options[1].Count)
+		// Results should be ordered by count descending
+		assert.Equal(c, apiKey1, res.Options[0].ID)
+		assert.Equal(c, int64(3), res.Options[0].Count)
+		assert.Equal(c, apiKey2, res.Options[1].ID)
+		assert.Equal(c, int64(1), res.Options[1].Count)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestListFilterOptions_FilterByUser(t *testing.T) {
@@ -99,26 +103,29 @@ func TestListFilterOptions_FilterByUser(t *testing.T) {
 	insertLogWithExternalUser(t, ctx, projectID, deploymentID, now.Add(-7*time.Minute), uuid.New().String(), user2)
 	insertLogWithExternalUser(t, ctx, projectID, deploymentID, now.Add(-6*time.Minute), uuid.New().String(), user2)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.ListFilterOptions(ctx, &gen.ListFilterOptionsPayload{
-		From:       from,
-		To:         to,
-		FilterType: "user",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.ListFilterOptions(ctx, &gen.ListFilterOptionsPayload{
+			From:       from,
+			To:         to,
+			FilterType: "user",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Options, 2)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Options, 2)
-
-	// Results should be ordered by count descending
-	require.Equal(t, user2, result.Options[0].ID)
-	require.Equal(t, int64(3), result.Options[0].Count)
-	require.Equal(t, user1, result.Options[1].ID)
-	require.Equal(t, int64(2), result.Options[1].Count)
+		// Results should be ordered by count descending
+		assert.Equal(c, user2, res.Options[0].ID)
+		assert.Equal(c, int64(3), res.Options[0].Count)
+		assert.Equal(c, user1, res.Options[1].ID)
+		assert.Equal(c, int64(2), res.Options[1].Count)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestListFilterOptions_InvalidFilterType(t *testing.T) {
@@ -180,24 +187,27 @@ func TestListFilterOptions_CountsUniqueChatSessions(t *testing.T) {
 	insertLogWithAPIKey(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, apiKey)
 	insertLogWithAPIKey(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), chatID, apiKey)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.ListFilterOptions(ctx, &gen.ListFilterOptionsPayload{
-		From:       from,
-		To:         to,
-		FilterType: "api_key",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.ListFilterOptions(ctx, &gen.ListFilterOptionsPayload{
+			From:       from,
+			To:         to,
+			FilterType: "api_key",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Options, 1)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Options, 1)
-
-	// Should count as 1 unique chat, not 3
-	require.Equal(t, apiKey, result.Options[0].ID)
-	require.Equal(t, int64(1), result.Options[0].Count)
+		// Should count as 1 unique chat, not 3
+		assert.Equal(c, apiKey, res.Options[0].ID)
+		assert.Equal(c, int64(1), res.Options[0].Count)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestListFilterOptions_TimeRangeFilter(t *testing.T) {
@@ -219,24 +229,27 @@ func TestListFilterOptions_TimeRangeFilter(t *testing.T) {
 	// Insert log outside the time range (2 hours ago)
 	insertLogWithAPIKey(t, ctx, projectID, deploymentID, now.Add(-2*time.Hour), uuid.New().String(), apiKeyOutOfRange)
 
-	time.Sleep(200 * time.Millisecond)
-
 	// Query for last hour only
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.ListFilterOptions(ctx, &gen.ListFilterOptionsPayload{
-		From:       from,
-		To:         to,
-		FilterType: "api_key",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.ListFilterOptions(ctx, &gen.ListFilterOptionsPayload{
+			From:       from,
+			To:         to,
+			FilterType: "api_key",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Options, 1)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Options, 1)
-
-	// Only the in-range API key should be returned
-	require.Equal(t, apiKeyInRange, result.Options[0].ID)
+		// Only the in-range API key should be returned
+		assert.Equal(c, apiKeyInRange, res.Options[0].ID)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 // insertLogWithAPIKey inserts a log with the gram.api_key.id attribute set.

--- a/server/internal/telemetry/search_chats_test.go
+++ b/server/internal/telemetry/search_chats_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,59 +83,65 @@ func TestSearchChats_AggregatesByChatID(t *testing.T) {
 	insertChatLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-6*time.Minute), chatID2, 150, 75, 225, 1.8, "stop", "claude-3", "anthropic")
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), chatID2, "tools:http:petstore:getPet", 500, 1.0)
 
-	// Wait for ClickHouse eventual consistency
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
-		Filter: &gen.SearchChatsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 100,
-		Sort:  "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+			Filter: &gen.SearchChatsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Chats, 2)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Chats, 2)
+		// Find both chats
+		chatsByID := make(map[string]*gen.ChatSummary)
+		for _, chat := range res.Chats {
+			chatsByID[chat.GramChatID] = chat
+		}
 
-	// Find both chats
-	chatsByID := make(map[string]*gen.ChatSummary)
-	for _, chat := range result.Chats {
-		chatsByID[chat.GramChatID] = chat
-	}
+		// Chat 1 assertions
+		c1 := chatsByID[chatID1]
+		if !assert.NotNil(c, c1) {
+			return
+		}
+		assert.Equal(c, uint64(3), c1.LogCount)      // 2 completions + 1 tool call
+		assert.Equal(c, uint64(1), c1.ToolCallCount) // 1 tool call
+		assert.Equal(c, uint64(2), c1.MessageCount)  // 2 completions
+		assert.Greater(c, c1.DurationSeconds, float64(0))
+		assert.Equal(c, "success", c1.Status) // no failed tool calls
+		assert.NotNil(c, c1.Model)
+		assert.Equal(c, "gpt-4", *c1.Model)
+		assert.Equal(c, int64(300), c1.TotalInputTokens)  // 100 + 200
+		assert.Equal(c, int64(150), c1.TotalOutputTokens) // 50 + 100
+		assert.Equal(c, int64(450), c1.TotalTokens)       // 150 + 300
+		assert.Positive(c, c1.StartTimeUnixNano)
+		assert.Positive(c, c1.EndTimeUnixNano)
 
-	// Chat 1 assertions
-	c1 := chatsByID[chatID1]
-	require.NotNil(t, c1)
-	require.Equal(t, uint64(3), c1.LogCount)      // 2 completions + 1 tool call
-	require.Equal(t, uint64(1), c1.ToolCallCount) // 1 tool call
-	require.Equal(t, uint64(2), c1.MessageCount)  // 2 completions
-	require.Greater(t, c1.DurationSeconds, float64(0))
-	require.Equal(t, "success", c1.Status) // no failed tool calls
-	require.NotNil(t, c1.Model)
-	require.Equal(t, "gpt-4", *c1.Model)
-	require.Equal(t, int64(300), c1.TotalInputTokens)  // 100 + 200
-	require.Equal(t, int64(150), c1.TotalOutputTokens) // 50 + 100
-	require.Equal(t, int64(450), c1.TotalTokens)       // 150 + 300
-	require.Positive(t, c1.StartTimeUnixNano)
-	require.Positive(t, c1.EndTimeUnixNano)
-
-	// Chat 2 assertions
-	c2 := chatsByID[chatID2]
-	require.NotNil(t, c2)
-	require.Equal(t, uint64(2), c2.LogCount) // 1 completion + 1 tool call
-	require.Equal(t, uint64(1), c2.ToolCallCount)
-	require.Equal(t, uint64(1), c2.MessageCount)
-	require.Equal(t, "error", c2.Status) // failed tool call (status 500)
-	require.NotNil(t, c2.Model)
-	require.Equal(t, "claude-3", *c2.Model)
-	require.Equal(t, int64(150), c2.TotalInputTokens)
-	require.Equal(t, int64(75), c2.TotalOutputTokens)
-	require.Equal(t, int64(225), c2.TotalTokens)
+		// Chat 2 assertions
+		c2 := chatsByID[chatID2]
+		if !assert.NotNil(c, c2) {
+			return
+		}
+		assert.Equal(c, uint64(2), c2.LogCount) // 1 completion + 1 tool call
+		assert.Equal(c, uint64(1), c2.ToolCallCount)
+		assert.Equal(c, uint64(1), c2.MessageCount)
+		assert.Equal(c, "error", c2.Status) // failed tool call (status 500)
+		assert.NotNil(c, c2.Model)
+		assert.Equal(c, "claude-3", *c2.Model)
+		assert.Equal(c, int64(150), c2.TotalInputTokens)
+		assert.Equal(c, int64(75), c2.TotalOutputTokens)
+		assert.Equal(c, int64(225), c2.TotalTokens)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchChats_Pagination(t *testing.T) {
@@ -155,23 +162,30 @@ func TestSearchChats_Pagination(t *testing.T) {
 		insertChatLogWithChatID(t, ctx, projectID, deploymentID, ts, chatID, 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
 	// Page 1: limit 2
-	page1, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
-		Filter: &gen.SearchChatsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 2,
-		Sort:  "desc",
-	})
-	require.NoError(t, err)
-	require.Len(t, page1.Chats, 2)
-	require.NotNil(t, page1.NextCursor)
+	var page1 *gen.SearchChatsResult
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+			Filter: &gen.SearchChatsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 2,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Chats, 2)
+		assert.NotNil(c, res.NextCursor)
+		page1 = res
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Page 2
 	page2, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
@@ -226,23 +240,27 @@ func TestSearchChats_FilterByDeploymentID(t *testing.T) {
 	insertChatLogWithChatID(t, ctx, projectID, deployment2, now.Add(-9*time.Minute), uuid.New().String(), 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 	insertChatLogWithChatID(t, ctx, projectID, deployment1, now.Add(-8*time.Minute), uuid.New().String(), 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
-		Filter: &gen.SearchChatsFilter{
-			From:         &from,
-			To:           &to,
-			DeploymentID: &deployment1,
-		},
-		Limit: 100,
-		Sort:  "desc",
-	})
-
-	require.NoError(t, err)
-	require.Len(t, result.Chats, 2)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+			Filter: &gen.SearchChatsFilter{
+				From:         &from,
+				To:           &to,
+				DeploymentID: &deployment1,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Chats, 2)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchChats_PaginationAscOrder(t *testing.T) {
@@ -263,23 +281,30 @@ func TestSearchChats_PaginationAscOrder(t *testing.T) {
 		insertChatLogWithChatID(t, ctx, projectID, deploymentID, ts, chatID, 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
 	// Page 1: limit 2 with ascending sort
-	page1, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
-		Filter: &gen.SearchChatsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 2,
-		Sort:  "asc",
-	})
-	require.NoError(t, err)
-	require.Len(t, page1.Chats, 2)
-	require.NotNil(t, page1.NextCursor)
+	var page1 *gen.SearchChatsResult
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+			Filter: &gen.SearchChatsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 2,
+			Sort:  "asc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Chats, 2)
+		assert.NotNil(c, res.NextCursor)
+		page1 = res
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Page 2
 	page2, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
@@ -340,36 +365,43 @@ func TestSearchChats_ChatWithOnlyTools(t *testing.T) {
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, "tools:http:petstore:listPets", 200, 0.5)
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, "tools:http:petstore:getPet", 200, 0.3)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
-		Filter: &gen.SearchChatsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 100,
-		Sort:  "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+			Filter: &gen.SearchChatsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Chats, 1)
+		if len(res.Chats) != 1 {
+			return
+		}
 
-	require.NoError(t, err)
-	require.Len(t, result.Chats, 1)
-
-	chat := result.Chats[0]
-	require.Equal(t, chatID, chat.GramChatID)
-	require.Equal(t, uint64(2), chat.LogCount)
-	require.Equal(t, uint64(2), chat.ToolCallCount)
-	require.Equal(t, uint64(0), chat.MessageCount) // No completion messages
-	// Model is nil or empty string when no completions (anyIf returns empty string)
-	if chat.Model != nil {
-		require.Empty(t, *chat.Model, "Model should be empty when no completions")
-	}
-	require.Equal(t, int64(0), chat.TotalInputTokens)
-	require.Equal(t, int64(0), chat.TotalOutputTokens)
-	require.Equal(t, int64(0), chat.TotalTokens)
-	require.Equal(t, "success", chat.Status) // All tools succeeded (200)
+		chat := res.Chats[0]
+		assert.Equal(c, chatID, chat.GramChatID)
+		assert.Equal(c, uint64(2), chat.LogCount)
+		assert.Equal(c, uint64(2), chat.ToolCallCount)
+		assert.Equal(c, uint64(0), chat.MessageCount) // No completion messages
+		// Model is nil or empty string when no completions (anyIf returns empty string)
+		if chat.Model != nil {
+			assert.Empty(c, *chat.Model, "Model should be empty when no completions")
+		}
+		assert.Equal(c, int64(0), chat.TotalInputTokens)
+		assert.Equal(c, int64(0), chat.TotalOutputTokens)
+		assert.Equal(c, int64(0), chat.TotalTokens)
+		assert.Equal(c, "success", chat.Status) // All tools succeeded (200)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchChats_ChatWithOnlyMessages(t *testing.T) {
@@ -388,34 +420,41 @@ func TestSearchChats_ChatWithOnlyMessages(t *testing.T) {
 	insertChatLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, 150, 1.5, "stop", "gpt-4", "openai")
 	insertChatLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, 200, 100, 300, 2.0, "stop", "gpt-4", "openai")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
-		Filter: &gen.SearchChatsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 100,
-		Sort:  "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+			Filter: &gen.SearchChatsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Chats, 1)
+		if len(res.Chats) != 1 {
+			return
+		}
 
-	require.NoError(t, err)
-	require.Len(t, result.Chats, 1)
-
-	chat := result.Chats[0]
-	require.Equal(t, chatID, chat.GramChatID)
-	require.Equal(t, uint64(2), chat.LogCount)
-	require.Equal(t, uint64(0), chat.ToolCallCount) // No tool calls
-	require.Equal(t, uint64(2), chat.MessageCount)
-	require.NotNil(t, chat.Model)
-	require.Equal(t, "gpt-4", *chat.Model)
-	require.Equal(t, int64(300), chat.TotalInputTokens)  // 100 + 200
-	require.Equal(t, int64(150), chat.TotalOutputTokens) // 50 + 100
-	require.Equal(t, int64(450), chat.TotalTokens)       // 150 + 300
-	require.Equal(t, "success", chat.Status)             // No failed tools
+		chat := res.Chats[0]
+		assert.Equal(c, chatID, chat.GramChatID)
+		assert.Equal(c, uint64(2), chat.LogCount)
+		assert.Equal(c, uint64(0), chat.ToolCallCount) // No tool calls
+		assert.Equal(c, uint64(2), chat.MessageCount)
+		assert.NotNil(c, chat.Model)
+		assert.Equal(c, "gpt-4", *chat.Model)
+		assert.Equal(c, int64(300), chat.TotalInputTokens)  // 100 + 200
+		assert.Equal(c, int64(150), chat.TotalOutputTokens) // 50 + 100
+		assert.Equal(c, int64(450), chat.TotalTokens)       // 150 + 300
+		assert.Equal(c, "success", chat.Status)             // No failed tools
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchChats_FilterByGramURN(t *testing.T) {
@@ -441,34 +480,38 @@ func TestSearchChats_FilterByGramURN(t *testing.T) {
 	chatID3 := uuid.New().String()
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), chatID3, "tools:http:petstore:getPet", 200, 0.4)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
 	// Filter by "petstore" substring - should match 2 chats
 	gramURN := "petstore"
-	result, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
-		Filter: &gen.SearchChatsFilter{
-			From:    &from,
-			To:      &to,
-			GramUrn: &gramURN,
-		},
-		Limit: 100,
-		Sort:  "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+			Filter: &gen.SearchChatsFilter{
+				From:    &from,
+				To:      &to,
+				GramUrn: &gramURN,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Chats, 2, "should match 2 chats with petstore in gram_urn")
 
-	require.NoError(t, err)
-	require.Len(t, result.Chats, 2, "should match 2 chats with petstore in gram_urn")
-
-	// Verify the matched chats are the petstore ones
-	chatIDs := make(map[string]bool)
-	for _, chat := range result.Chats {
-		chatIDs[chat.GramChatID] = true
-	}
-	require.True(t, chatIDs[chatID1], "should include chat with listPets")
-	require.True(t, chatIDs[chatID3], "should include chat with getPet")
-	require.False(t, chatIDs[chatID2], "should not include chat with weather")
+		// Verify the matched chats are the petstore ones
+		chatIDs := make(map[string]bool)
+		for _, chat := range res.Chats {
+			chatIDs[chat.GramChatID] = true
+		}
+		assert.True(c, chatIDs[chatID1], "should include chat with listPets")
+		assert.True(c, chatIDs[chatID3], "should include chat with getPet")
+		assert.False(c, chatIDs[chatID2], "should not include chat with weather")
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchChats_PaginationCursorScopedByProject(t *testing.T) {
@@ -497,23 +540,30 @@ func TestSearchChats_PaginationCursorScopedByProject(t *testing.T) {
 	// and corrupt pagination.
 	insertChatLogWithChatID(t, ctx, otherProjectID, deploymentID, now.Add(-5*time.Hour), chatIDs[0], 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
 	// Page 1: get first 2 chats
-	page1, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
-		Filter: &gen.SearchChatsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 2,
-		Sort:  "desc",
-	})
-	require.NoError(t, err)
-	require.Len(t, page1.Chats, 2)
-	require.NotNil(t, page1.NextCursor)
+	var page1 *gen.SearchChatsResult
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+			Filter: &gen.SearchChatsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 2,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Chats, 2)
+		assert.NotNil(c, res.NextCursor)
+		page1 = res
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Page 2: should return exactly the remaining 1 chat from this project
 	page2, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
@@ -558,23 +608,27 @@ func TestSearchLogs_FilterByGramChatID(t *testing.T) {
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, "tools:http:test:op", 200, 0.5)
 	insertTelemetryLog(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), nil, "urn:gram:other", "INFO")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
-		Filter: &gen.SearchLogsFilter{
-			From:       &from,
-			To:         &to,
-			GramChatID: &chatID,
-		},
-		Limit: 100,
-		Sort:  "desc",
-	})
-
-	require.NoError(t, err)
-	require.Len(t, result.Logs, 2, "should only return logs matching gram_chat_id")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From:       &from,
+				To:         &to,
+				GramChatID: &chatID,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 2, "should only return logs matching gram_chat_id")
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 // insertChatLogWithChatID inserts a chat completion log with the gram_chat_id column set.

--- a/server/internal/telemetry/search_logs_test.go
+++ b/server/internal/telemetry/search_logs_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,25 +80,30 @@ func TestSearchLogs_SortDescending(t *testing.T) {
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
-		Filter: &gen.SearchLogsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 10,
-		// Empty sort should default to desc
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 10,
+			// Empty sort should default to desc
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 5)
+		assert.Nil(c, res.NextCursor)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Logs, 5)
-	require.Nil(t, result.NextCursor)
-
-	// Verify descending order
-	for i := 0; i < len(result.Logs)-1; i++ {
-		require.GreaterOrEqual(t, result.Logs[i].TimeUnixNano, result.Logs[i+1].TimeUnixNano,
-			"logs should be sorted descending by time")
-	}
+		// Verify descending order
+		for i := 0; i < len(res.Logs)-1; i++ {
+			assert.GreaterOrEqual(c, res.Logs[i].TimeUnixNano, res.Logs[i+1].TimeUnixNano,
+				"logs should be sorted descending by time")
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchLogs_SortAscending(t *testing.T) {
@@ -116,25 +122,30 @@ func TestSearchLogs_SortAscending(t *testing.T) {
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
-		Filter: &gen.SearchLogsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 10,
-		Sort:  "asc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 10,
+			Sort:  "asc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 5)
+		assert.Nil(c, res.NextCursor)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Logs, 5)
-	require.Nil(t, result.NextCursor)
-
-	// Verify ascending order
-	for i := 0; i < len(result.Logs)-1; i++ {
-		require.LessOrEqual(t, result.Logs[i].TimeUnixNano, result.Logs[i+1].TimeUnixNano,
-			"logs should be sorted ascending by time")
-	}
+		// Verify ascending order
+		for i := 0; i < len(res.Logs)-1; i++ {
+			assert.LessOrEqual(c, res.Logs[i].TimeUnixNano, res.Logs[i+1].TimeUnixNano,
+				"logs should be sorted ascending by time")
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchLogs_PaginationAscOrder(t *testing.T) {
@@ -152,6 +163,25 @@ func TestSearchLogs_PaginationAscOrder(t *testing.T) {
 	now := time.Now().UTC()
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	// Wait for ClickHouse eventual consistency: all 10 inserted logs visible.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 100,
+			Sort:  "asc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 10)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Get first page (limit 4) with ascending sort
 	page1, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
@@ -220,11 +250,27 @@ func TestSearchLogs_CursorTieBreaking(t *testing.T) {
 		insertTelemetryLogAtExactTime(t, ctx, projectID, deploymentID, sameTimestamp, nil, "urn:gram:test", "INFO")
 	}
 
-	// Wait for ClickHouse eventual consistency
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	// Wait for ClickHouse eventual consistency: all 5 inserted logs visible.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 5)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Get first page (limit 2)
 	page1, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
@@ -292,6 +338,25 @@ func TestSearchLogs_Pagination(t *testing.T) {
 	now := time.Now().UTC()
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	// Wait for ClickHouse eventual consistency: all 10 inserted logs visible.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 10)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Get first page (limit 4)
 	page1, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
@@ -362,25 +427,32 @@ func TestSearchLogs_FilterByTraceID(t *testing.T) {
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
-		Filter: &gen.SearchLogsFilter{
-			From:    &from,
-			To:      &to,
-			TraceID: &traceID1,
-		},
-		Limit: 10,
-		Sort:  "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From:    &from,
+				To:      &to,
+				TraceID: &traceID1,
+			},
+			Limit: 10,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 2)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Logs, 2)
-
-	// Verify all logs have the correct trace ID
-	for _, log := range result.Logs {
-		require.NotNil(t, log.TraceID)
-		require.Equal(t, traceID1, *log.TraceID)
-	}
+		// Verify all logs have the correct trace ID
+		for _, log := range res.Logs {
+			if !assert.NotNil(c, log.TraceID) {
+				continue
+			}
+			assert.Equal(c, traceID1, *log.TraceID)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchLogs_AttributesAreJSON(t *testing.T) {
@@ -398,29 +470,36 @@ func TestSearchLogs_AttributesAreJSON(t *testing.T) {
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
-		Filter: &gen.SearchLogsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 10,
-		Sort:  "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 10,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Logs, 1) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Logs, 1)
+		log := res.Logs[0]
+		assert.NotNil(c, log.Attributes)
+		assert.NotNil(c, log.ResourceAttributes)
 
-	log := result.Logs[0]
-	require.NotNil(t, log.Attributes)
-	require.NotNil(t, log.ResourceAttributes)
+		// Attributes should be parsed as map, not string
+		_, ok := log.Attributes.(map[string]any)
+		assert.True(c, ok, "attributes should be a map[string]any, not a string")
 
-	// Attributes should be parsed as map, not string
-	_, ok := log.Attributes.(map[string]any)
-	require.True(t, ok, "attributes should be a map[string]any, not a string")
-
-	_, ok = log.ResourceAttributes.(map[string]any)
-	require.True(t, ok, "resource_attributes should be a map[string]any, not a string")
+		_, ok = log.ResourceAttributes.(map[string]any)
+		assert.True(c, ok, "resource_attributes should be a map[string]any, not a string")
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchLogs_Filters(t *testing.T) {
@@ -574,11 +653,28 @@ func TestSearchLogs_Filters(t *testing.T) {
 		insertTelemetryLogWithParams(t, ctx, log)
 	}
 
-	// Wait for ClickHouse eventual consistency
-	time.Sleep(200 * time.Millisecond)
-
 	from := baseTime.Add(-10 * time.Minute).Format(time.RFC3339)
 	to := now.Format(time.RFC3339)
+
+	// Wait for ClickHouse eventual consistency: all 10 inserted logs visible
+	// before any subtest issues its filtered query.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			Filter: &gen.SearchLogsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 10)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	tests := []struct {
 		name          string
@@ -890,10 +986,26 @@ func TestSearchLogs_LogFilters(t *testing.T) {
 		insertTelemetryLogWithParams(t, ctx, log)
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := baseTime.Add(-10 * time.Minute).Format(time.RFC3339)
 	to := now.Format(time.RFC3339)
+
+	// Wait for ClickHouse eventual consistency: all 4 inserted logs visible
+	// before any subtest issues its filtered query.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchLogs(ctx, &gen.SearchLogsPayload{
+			From:  &from,
+			To:    &to,
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Logs, 4)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	eq := "eq"
 	notEq := "not_eq"
@@ -1097,39 +1209,46 @@ func TestSearchToolCalls_AggregatesByTraceID(t *testing.T) {
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchToolCalls(ctx, &gen.SearchToolCallsPayload{
-		Filter: &gen.SearchToolCallsFilter{
-			From: &from,
-			To:   &to,
-		},
-		Limit: 100,
-		Sort:  "desc",
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.ToolCalls, 2)
-
-	// Find both tool calls
-	var toolCall1, toolCall2 *gen.ToolCallSummary
-	for i := range result.ToolCalls {
-		switch result.ToolCalls[i].TraceID {
-		case traceID1:
-			toolCall1 = result.ToolCalls[i]
-		case traceID2:
-			toolCall2 = result.ToolCalls[i]
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchToolCalls(ctx, &gen.SearchToolCallsPayload{
+			Filter: &gen.SearchToolCallsFilter{
+				From: &from,
+				To:   &to,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
 		}
-	}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.ToolCalls, 2)
 
-	require.NotNil(t, toolCall1)
-	require.Equal(t, uint64(3), toolCall1.LogCount)
-	require.Positive(t, toolCall1.StartTimeUnixNano)
-	require.Equal(t, "urn:gram:test1", toolCall1.GramUrn)
+		// Find both tool calls
+		var toolCall1, toolCall2 *gen.ToolCallSummary
+		for i := range res.ToolCalls {
+			switch res.ToolCalls[i].TraceID {
+			case traceID1:
+				toolCall1 = res.ToolCalls[i]
+			case traceID2:
+				toolCall2 = res.ToolCalls[i]
+			}
+		}
 
-	require.NotNil(t, toolCall2)
-	require.Equal(t, uint64(2), toolCall2.LogCount)
-	require.Positive(t, toolCall2.StartTimeUnixNano)
-	require.Equal(t, "urn:gram:test2", toolCall2.GramUrn)
+		if assert.NotNil(c, toolCall1) {
+			assert.Equal(c, uint64(3), toolCall1.LogCount)
+			assert.Positive(c, toolCall1.StartTimeUnixNano)
+			assert.Equal(c, "urn:gram:test1", toolCall1.GramUrn)
+		}
+
+		if assert.NotNil(c, toolCall2) {
+			assert.Equal(c, uint64(2), toolCall2.LogCount)
+			assert.Positive(c, toolCall2.StartTimeUnixNano)
+			assert.Equal(c, "urn:gram:test2", toolCall2.GramUrn)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchToolCalls_FilterByGramURN(t *testing.T) {
@@ -1151,11 +1270,30 @@ func TestSearchToolCalls_FilterByGramURN(t *testing.T) {
 	insertTelemetryLog(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), &traceID2, "tools:http:petstore:getPet", "INFO")
 	insertTelemetryLog(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), &traceID3, "tools:http:weather:getForecast", "INFO")
 
-	// Wait for ClickHouse materialized view to process and eventual consistency
-	time.Sleep(500 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	// Wait for ClickHouse materialized view to process and eventual consistency:
+	// all 3 inserted tool calls visible before any subtest issues its query.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		gramUrn := "http"
+		res, err := ti.service.SearchToolCalls(ctx, &gen.SearchToolCallsPayload{
+			Filter: &gen.SearchToolCallsFilter{
+				From:    &from,
+				To:      &to,
+				GramUrn: &gramUrn,
+			},
+			Limit: 100,
+			Sort:  "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.ToolCalls, 3)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	tests := []struct {
 		name          string
@@ -1230,9 +1368,6 @@ func insertTestTelemetryLogs(t *testing.T, ctx context.Context, projectID, deplo
 		timestamp := now.Add(time.Duration(i) * time.Minute)
 		insertTelemetryLog(t, ctx, projectID, deploymentID, timestamp, nil, "urn:gram:test", "INFO")
 	}
-
-	// ClickHouse eventual consistency - sleep once at the end
-	time.Sleep(100 * time.Millisecond)
 }
 
 func insertTelemetryLog(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, traceID *string, gramURN, severityText string) {
@@ -1273,9 +1408,6 @@ func insertTelemetryLog(t *testing.T, ctx context.Context, projectID, deployment
 		traceID, nil, string(attrsJSON), "{}",
 		projectID, deploymentID, gramURN, "test-service")
 	require.NoError(t, err)
-
-	// ClickHouse eventual consistency
-	time.Sleep(100 * time.Millisecond)
 }
 
 // insertTelemetryLogAtExactTime inserts a log without sleeping after, allowing

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -10,6 +10,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,64 +88,75 @@ func TestSearchUsers_GroupByInternalUser(t *testing.T) {
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-6*time.Minute), chatID2, 150, 75, 225, 1.8, "stop", "claude-3", "anthropic", user2, "")
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), "tools:http:petstore:getPet", 500, 1.0, user2, "")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From: from,
-			To:   to,
-		},
-		UserType: "internal",
-		Limit:    100,
-		Sort:     "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 2) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Users, 2)
+		// Index by user ID
+		byUser := make(map[string]*gen.UserSummary)
+		for _, u := range res.Users {
+			byUser[u.UserID] = u
+		}
 
-	// Index by user ID
-	byUser := make(map[string]*gen.UserSummary)
-	for _, u := range result.Users {
-		byUser[u.UserID] = u
-	}
+		// User 1
+		u1 := byUser[user1]
+		if !assert.NotNil(c, u1) {
+			return
+		}
+		assert.Equal(c, int64(1), u1.TotalChats)
+		assert.Equal(c, int64(2), u1.TotalChatRequests)
+		assert.Equal(c, int64(300), u1.TotalInputTokens)  // 100 + 200
+		assert.Equal(c, int64(150), u1.TotalOutputTokens) // 50 + 100
+		assert.Equal(c, int64(450), u1.TotalTokens)       // 150 + 300
+		assert.Equal(c, int64(1), u1.TotalToolCalls)
+		assert.Equal(c, int64(1), u1.ToolCallSuccess)
+		assert.Equal(c, int64(0), u1.ToolCallFailure)
+		if assert.Len(c, u1.Tools, 1) {
+			assert.Equal(c, "tools:http:petstore:listPets", u1.Tools[0].Urn)
+			assert.Equal(c, int64(1), u1.Tools[0].Count)
+			assert.Equal(c, int64(1), u1.Tools[0].SuccessCount)
+			assert.Equal(c, int64(0), u1.Tools[0].FailureCount)
+		}
 
-	// User 1
-	u1 := byUser[user1]
-	require.NotNil(t, u1)
-	require.Equal(t, int64(1), u1.TotalChats)
-	require.Equal(t, int64(2), u1.TotalChatRequests)
-	require.Equal(t, int64(300), u1.TotalInputTokens)  // 100 + 200
-	require.Equal(t, int64(150), u1.TotalOutputTokens) // 50 + 100
-	require.Equal(t, int64(450), u1.TotalTokens)       // 150 + 300
-	require.Equal(t, int64(1), u1.TotalToolCalls)
-	require.Equal(t, int64(1), u1.ToolCallSuccess)
-	require.Equal(t, int64(0), u1.ToolCallFailure)
-	require.Len(t, u1.Tools, 1)
-	require.Equal(t, "tools:http:petstore:listPets", u1.Tools[0].Urn)
-	require.Equal(t, int64(1), u1.Tools[0].Count)
-	require.Equal(t, int64(1), u1.Tools[0].SuccessCount)
-	require.Equal(t, int64(0), u1.Tools[0].FailureCount)
-
-	// User 2
-	u2 := byUser[user2]
-	require.NotNil(t, u2)
-	require.Equal(t, int64(1), u2.TotalChats)
-	require.Equal(t, int64(1), u2.TotalChatRequests)
-	require.Equal(t, int64(150), u2.TotalInputTokens)
-	require.Equal(t, int64(75), u2.TotalOutputTokens)
-	require.Equal(t, int64(225), u2.TotalTokens)
-	require.Equal(t, int64(1), u2.TotalToolCalls)
-	require.Equal(t, int64(0), u2.ToolCallSuccess)
-	require.Equal(t, int64(1), u2.ToolCallFailure)
-	require.Len(t, u2.Tools, 1)
-	require.Equal(t, "tools:http:petstore:getPet", u2.Tools[0].Urn)
-	require.Equal(t, int64(1), u2.Tools[0].Count)
-	require.Equal(t, int64(0), u2.Tools[0].SuccessCount)
-	require.Equal(t, int64(1), u2.Tools[0].FailureCount)
+		// User 2
+		u2 := byUser[user2]
+		if !assert.NotNil(c, u2) {
+			return
+		}
+		assert.Equal(c, int64(1), u2.TotalChats)
+		assert.Equal(c, int64(1), u2.TotalChatRequests)
+		assert.Equal(c, int64(150), u2.TotalInputTokens)
+		assert.Equal(c, int64(75), u2.TotalOutputTokens)
+		assert.Equal(c, int64(225), u2.TotalTokens)
+		assert.Equal(c, int64(1), u2.TotalToolCalls)
+		assert.Equal(c, int64(0), u2.ToolCallSuccess)
+		assert.Equal(c, int64(1), u2.ToolCallFailure)
+		if assert.Len(c, u2.Tools, 1) {
+			assert.Equal(c, "tools:http:petstore:getPet", u2.Tools[0].Urn)
+			assert.Equal(c, int64(1), u2.Tools[0].Count)
+			assert.Equal(c, int64(0), u2.Tools[0].SuccessCount)
+			assert.Equal(c, int64(1), u2.Tools[0].FailureCount)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchUsers_GroupByExternalUser(t *testing.T) {
@@ -163,35 +175,40 @@ func TestSearchUsers_GroupByExternalUser(t *testing.T) {
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, 150, 1.5, "stop", "gpt-4", "openai", "", extUser)
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), "tools:http:api:call", 200, 0.5, "", extUser)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From: from,
-			To:   to,
-		},
-		UserType: "external",
-		Limit:    100,
-		Sort:     "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "external",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Users, 1)
-
-	u := result.Users[0]
-	require.Equal(t, extUser, u.UserID)
-	require.Equal(t, int64(1), u.TotalChats)
-	require.Equal(t, int64(1), u.TotalChatRequests)
-	require.Equal(t, int64(100), u.TotalInputTokens)
-	require.Equal(t, int64(50), u.TotalOutputTokens)
-	require.Equal(t, int64(150), u.TotalTokens)
-	require.Equal(t, int64(1), u.TotalToolCalls)
-	require.Equal(t, int64(1), u.ToolCallSuccess)
-	require.Equal(t, int64(0), u.ToolCallFailure)
+		u := res.Users[0]
+		assert.Equal(c, extUser, u.UserID)
+		assert.Equal(c, int64(1), u.TotalChats)
+		assert.Equal(c, int64(1), u.TotalChatRequests)
+		assert.Equal(c, int64(100), u.TotalInputTokens)
+		assert.Equal(c, int64(50), u.TotalOutputTokens)
+		assert.Equal(c, int64(150), u.TotalTokens)
+		assert.Equal(c, int64(1), u.TotalToolCalls)
+		assert.Equal(c, int64(1), u.ToolCallSuccess)
+		assert.Equal(c, int64(0), u.ToolCallFailure)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchUsers_FallsBackToUserEmail(t *testing.T) {
@@ -207,28 +224,33 @@ func TestSearchUsers_FallsBackToUserEmail(t *testing.T) {
 	email := "unmatched-user-" + uuid.New().String() + "@example.com"
 	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), email, 100, 50, 1.25)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From: from,
-			To:   to,
-		},
-		UserType: "internal",
-		Limit:    100,
-		Sort:     "desc",
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Users, 1)
-	require.Equal(t, email, result.Users[0].UserID)
-	require.Equal(t, int64(100), result.Users[0].TotalInputTokens)
-	require.Equal(t, int64(50), result.Users[0].TotalOutputTokens)
-	require.InDelta(t, 1.25, result.Users[0].TotalCost, 0.000001)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
+		assert.Equal(c, email, res.Users[0].UserID)
+		assert.Equal(c, int64(100), res.Users[0].TotalInputTokens)
+		assert.Equal(c, int64(50), res.Users[0].TotalOutputTokens)
+		assert.InDelta(c, 1.25, res.Users[0].TotalCost, 0.000001)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	filtered, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
 		Filter: &gen.SearchUsersFilter{
@@ -263,24 +285,31 @@ func TestSearchUsers_Pagination(t *testing.T) {
 		insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, ts, uuid.New().String(), 100, 50, 150, 1.0, "stop", "gpt-4", "openai", userID, "")
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
 	// Page 1: limit 2
-	page1, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From: from,
-			To:   to,
-		},
-		UserType: "internal",
-		Limit:    2,
-		Sort:     "desc",
-	})
-	require.NoError(t, err)
-	require.Len(t, page1.Users, 2)
-	require.NotNil(t, page1.NextCursor)
+	var page1 *gen.SearchUsersResult
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    2,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Users, 2)
+		assert.NotNil(c, res.NextCursor)
+		page1 = res
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Page 2
 	page2, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
@@ -339,24 +368,31 @@ func TestSearchUsers_PaginationAscOrder(t *testing.T) {
 		insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, ts, uuid.New().String(), 100, 50, 150, 1.0, "stop", "gpt-4", "openai", userID, "")
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
 	// Page 1
-	page1, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From: from,
-			To:   to,
-		},
-		UserType: "internal",
-		Limit:    2,
-		Sort:     "asc",
-	})
-	require.NoError(t, err)
-	require.Len(t, page1.Users, 2)
-	require.NotNil(t, page1.NextCursor)
+	var page1 *gen.SearchUsersResult
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    2,
+			Sort:     "asc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Len(c, res.Users, 2)
+		assert.NotNil(c, res.NextCursor)
+		page1 = res
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Page 2
 	page2, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
@@ -417,25 +453,31 @@ func TestSearchUsers_FilterByDeploymentID(t *testing.T) {
 	// User 2 in deployment 2
 	insertChatCompletionLogWithUser(t, ctx, projectID, deployment2, now.Add(-9*time.Minute), uuid.New().String(), 100, 50, 150, 1.0, "stop", "gpt-4", "openai", user2, "")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From:         from,
-			To:           to,
-			DeploymentID: &deployment1,
-		},
-		UserType: "internal",
-		Limit:    100,
-		Sort:     "desc",
-	})
-
-	require.NoError(t, err)
-	require.Len(t, result.Users, 1)
-	require.Equal(t, user1, result.Users[0].UserID)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From:         from,
+				To:           to,
+				DeploymentID: &deployment1,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
+		assert.Equal(c, user1, res.Users[0].UserID)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchUsers_FilterByInternalUserIDs(t *testing.T) {
@@ -456,26 +498,32 @@ func TestSearchUsers_FilterByInternalUserIDs(t *testing.T) {
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), uuid.New().String(), 200, 100, 300, 1.0, "stop", "gpt-4", "openai", excludedUser, "")
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), uuid.New().String(), 300, 150, 450, 1.0, "stop", "gpt-4", "openai", userIDAsExternalID, includedUser)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From:    from,
-			To:      to,
-			UserIds: []string{includedUser},
-		},
-		UserType: "internal",
-		Limit:    100,
-		Sort:     "desc",
-	})
-
-	require.NoError(t, err)
-	require.Len(t, result.Users, 1)
-	require.Equal(t, includedUser, result.Users[0].UserID)
-	require.Equal(t, int64(150), result.Users[0].TotalTokens)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From:    from,
+				To:      to,
+				UserIds: []string{includedUser},
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
+		assert.Equal(c, includedUser, res.Users[0].UserID)
+		assert.Equal(c, int64(150), res.Users[0].TotalTokens)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchUsers_FilterByExternalUserIDs(t *testing.T) {
@@ -495,26 +543,32 @@ func TestSearchUsers_FilterByExternalUserIDs(t *testing.T) {
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), uuid.New().String(), 200, 100, 300, 1.0, "stop", "gpt-4", "openai", "internal-b-"+uuid.New().String(), excludedExternalUser)
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), uuid.New().String(), 300, 150, 450, 1.0, "stop", "gpt-4", "openai", includedExternalUser, "external-c-"+uuid.New().String())
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From:    from,
-			To:      to,
-			UserIds: []string{includedExternalUser},
-		},
-		UserType: "external",
-		Limit:    100,
-		Sort:     "desc",
-	})
-
-	require.NoError(t, err)
-	require.Len(t, result.Users, 1)
-	require.Equal(t, includedExternalUser, result.Users[0].UserID)
-	require.Equal(t, int64(150), result.Users[0].TotalTokens)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From:    from,
+				To:      to,
+				UserIds: []string{includedExternalUser},
+			},
+			UserType: "external",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
+		assert.Equal(c, includedExternalUser, res.Users[0].UserID)
+		assert.Equal(c, int64(150), res.Users[0].TotalTokens)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchUsers_HookSourceBreakdown(t *testing.T) {
@@ -535,39 +589,49 @@ func TestSearchUsers_HookSourceBreakdown(t *testing.T) {
 	insertHookLogWithUser(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), userID, "", "claude-code", false)
 	insertHookLogWithUser(t, ctx, projectID, deploymentID, now.Add(-7*time.Minute), excludedUserID, "", "cursor", true)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From:    from,
-			To:      to,
-			UserIds: []string{userID},
-		},
-		UserType: "internal",
-		Limit:    100,
-		Sort:     "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From:    from,
+				To:      to,
+				UserIds: []string{userID},
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
+		assert.Equal(c, userID, res.Users[0].UserID)
+		if !assert.Len(c, res.Users[0].HookSources, 2) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.Len(t, result.Users, 1)
-	require.Equal(t, userID, result.Users[0].UserID)
-	require.Len(t, result.Users[0].HookSources, 2)
+		byHookSource := make(map[string]*gen.HookSourceUsage)
+		for _, source := range res.Users[0].HookSources {
+			byHookSource[source.Source] = source
+		}
 
-	byHookSource := make(map[string]*gen.HookSourceUsage)
-	for _, source := range result.Users[0].HookSources {
-		byHookSource[source.Source] = source
-	}
+		cursor := byHookSource["cursor"]
+		if assert.NotNil(c, cursor) {
+			assert.Equal(c, int64(2), cursor.EventCount)
+		}
 
-	cursor := byHookSource["cursor"]
-	require.NotNil(t, cursor)
-	require.Equal(t, int64(2), cursor.EventCount)
-
-	claudeCode := byHookSource["claude-code"]
-	require.NotNil(t, claudeCode)
-	require.Equal(t, int64(1), claudeCode.EventCount)
+		claudeCode := byHookSource["claude-code"]
+		if assert.NotNil(c, claudeCode) {
+			assert.Equal(c, int64(1), claudeCode.EventCount)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchUsers_ToolsBreakdown(t *testing.T) {
@@ -589,48 +653,58 @@ func TestSearchUsers_ToolsBreakdown(t *testing.T) {
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-7*time.Minute), "tools:http:petstore:getPet", 200, 0.3, userID, "")
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-6*time.Minute), "tools:http:petstore:getPet", 200, 0.2, userID, "")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From: from,
-			To:   to,
-		},
-		UserType: "internal",
-		Limit:    100,
-		Sort:     "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
 
-	require.NoError(t, err)
-	require.Len(t, result.Users, 1)
+		u := res.Users[0]
+		assert.Equal(c, userID, u.UserID)
+		assert.Equal(c, int64(5), u.TotalToolCalls)
+		assert.Equal(c, int64(4), u.ToolCallSuccess) // 2+2
+		assert.Equal(c, int64(1), u.ToolCallFailure) // 1
 
-	u := result.Users[0]
-	require.Equal(t, userID, u.UserID)
-	require.Equal(t, int64(5), u.TotalToolCalls)
-	require.Equal(t, int64(4), u.ToolCallSuccess) // 2+2
-	require.Equal(t, int64(1), u.ToolCallFailure) // 1
+		// Per-tool breakdown
+		if !assert.Len(c, u.Tools, 2) {
+			return
+		}
+		toolStats := make(map[string]*gen.ToolUsage)
+		for _, tool := range u.Tools {
+			toolStats[tool.Urn] = tool
+		}
 
-	// Per-tool breakdown
-	require.Len(t, u.Tools, 2)
-	toolStats := make(map[string]*gen.ToolUsage)
-	for _, tool := range u.Tools {
-		toolStats[tool.Urn] = tool
-	}
+		listPets := toolStats["tools:http:petstore:listPets"]
+		if assert.NotNil(c, listPets) {
+			assert.Equal(c, int64(3), listPets.Count)
+			assert.Equal(c, int64(2), listPets.SuccessCount)
+			assert.Equal(c, int64(1), listPets.FailureCount)
+		}
 
-	listPets := toolStats["tools:http:petstore:listPets"]
-	require.NotNil(t, listPets)
-	require.Equal(t, int64(3), listPets.Count)
-	require.Equal(t, int64(2), listPets.SuccessCount)
-	require.Equal(t, int64(1), listPets.FailureCount)
-
-	getPet := toolStats["tools:http:petstore:getPet"]
-	require.NotNil(t, getPet)
-	require.Equal(t, int64(2), getPet.Count)
-	require.Equal(t, int64(2), getPet.SuccessCount)
-	require.Equal(t, int64(0), getPet.FailureCount)
+		getPet := toolStats["tools:http:petstore:getPet"]
+		if assert.NotNil(c, getPet) {
+			assert.Equal(c, int64(2), getPet.Count)
+			assert.Equal(c, int64(2), getPet.SuccessCount)
+			assert.Equal(c, int64(0), getPet.FailureCount)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchUsers_ScopedByProject(t *testing.T) {
@@ -654,28 +728,34 @@ func TestSearchUsers_ScopedByProject(t *testing.T) {
 	otherUser := "other-project-user-" + uuid.New().String()
 	insertChatCompletionLogWithUser(t, ctx, otherProjectID, deploymentID, now.Add(-8*time.Minute), uuid.New().String(), 200, 100, 300, 1.0, "stop", "gpt-4", "openai", otherUser, "")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-		Filter: &gen.SearchUsersFilter{
-			From: from,
-			To:   to,
-		},
-		UserType: "internal",
-		Limit:    100,
-		Sort:     "desc",
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1, "should only return users from the queried project") {
+			return
+		}
+		assert.Equal(c, sharedUserID, res.Users[0].UserID)
 
-	require.NoError(t, err)
-	require.Len(t, result.Users, 1, "should only return users from the queried project")
-	require.Equal(t, sharedUserID, result.Users[0].UserID)
-
-	// Metrics should only reflect the current project's data
-	require.Equal(t, int64(100), result.Users[0].TotalInputTokens, "should not include tokens from other project")
-	require.Equal(t, int64(150), result.Users[0].TotalTokens, "should not include tokens from other project")
+		// Metrics should only reflect the current project's data
+		assert.Equal(c, int64(100), res.Users[0].TotalInputTokens, "should not include tokens from other project")
+		assert.Equal(c, int64(150), res.Users[0].TotalTokens, "should not include tokens from other project")
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func insertHookLogWithUser(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, userID, externalUserID, hookSource string, success bool) {

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -239,15 +240,33 @@ func TestChatClient_GetCompletion(t *testing.T) {
 	assert.Equal(t, 5, resp.Usage.CompletionTokens)
 	assert.Equal(t, 15, resp.Usage.TotalTokens)
 
-	// Give async operations time to complete
-	time.Sleep(100 * time.Millisecond)
+	// Wait for all async operations to complete. Each flag is set under its own
+	// mutex by a background goroutine, so poll all of them (not just the capture
+	// flags) before asserting on the captured data below.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		captureStrategy.mu.Lock()
+		startResume := captureStrategy.startOrResumeCalled
+		capMsg := captureStrategy.captureMessageCalled
+		captureStrategy.mu.Unlock()
 
-	// Verify all services were called
-	assert.True(t, captureStrategy.startOrResumeCalled, "StartOrResumeChat should be called")
-	assert.True(t, captureStrategy.captureMessageCalled, "CaptureMessage should be called")
-	assert.True(t, trackingStrategy.trackUsageCalled, "TrackUsage should be called")
-	assert.True(t, titleGenerator.called, "ScheduleChatTitleGeneration should be called")
-	assert.True(t, telemetryLogger.called, "CreateLog should be called")
+		trackingStrategy.mu.Lock()
+		trackUsage := trackingStrategy.trackUsageCalled
+		trackingStrategy.mu.Unlock()
+
+		titleGenerator.mu.Lock()
+		titleCalled := titleGenerator.called
+		titleGenerator.mu.Unlock()
+
+		telemetryLogger.mu.Lock()
+		telemetryCalled := telemetryLogger.called
+		telemetryLogger.mu.Unlock()
+
+		assert.True(c, startResume, "StartOrResumeChat should be called")
+		assert.True(c, capMsg, "CaptureMessage should be called")
+		assert.True(c, trackUsage, "TrackUsage should be called")
+		assert.True(c, titleCalled, "ScheduleChatTitleGeneration should be called")
+		assert.True(c, telemetryCalled, "CreateLog should be called")
+	}, 10*time.Second, 10*time.Millisecond)
 
 	// Verify captured data
 	assert.Equal(t, "msg_123", captureStrategy.capturedResponse.MessageID)
@@ -362,15 +381,33 @@ func TestChatClient_GetCompletionStream(t *testing.T) {
 	assert.Contains(t, bodyStr, "Hello")
 	assert.Contains(t, bodyStr, "streaming")
 
-	// Give async operations time to complete
-	time.Sleep(100 * time.Millisecond)
+	// Wait for all async operations to complete. Each flag is set under its own
+	// mutex by a background goroutine, so poll all of them (not just the capture
+	// flags) before asserting on the captured data below.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		captureStrategy.mu.Lock()
+		startResume := captureStrategy.startOrResumeCalled
+		capMsg := captureStrategy.captureMessageCalled
+		captureStrategy.mu.Unlock()
 
-	// Verify all services were called
-	assert.True(t, captureStrategy.startOrResumeCalled, "StartOrResumeChat should be called")
-	assert.True(t, captureStrategy.captureMessageCalled, "CaptureMessage should be called")
-	assert.True(t, trackingStrategy.trackUsageCalled, "TrackUsage should be called")
-	assert.True(t, titleGenerator.called, "ScheduleChatTitleGeneration should be called")
-	assert.True(t, telemetryLogger.called, "CreateLog should be called")
+		trackingStrategy.mu.Lock()
+		trackUsage := trackingStrategy.trackUsageCalled
+		trackingStrategy.mu.Unlock()
+
+		titleGenerator.mu.Lock()
+		titleCalled := titleGenerator.called
+		titleGenerator.mu.Unlock()
+
+		telemetryLogger.mu.Lock()
+		telemetryCalled := telemetryLogger.called
+		telemetryLogger.mu.Unlock()
+
+		assert.True(c, startResume, "StartOrResumeChat should be called")
+		assert.True(c, capMsg, "CaptureMessage should be called")
+		assert.True(c, trackUsage, "TrackUsage should be called")
+		assert.True(c, titleCalled, "ScheduleChatTitleGeneration should be called")
+		assert.True(c, telemetryCalled, "CreateLog should be called")
+	}, 10*time.Second, 10*time.Millisecond)
 
 	// Verify captured data
 	assert.Equal(t, "msg_456", captureStrategy.capturedResponse.MessageID)
@@ -476,12 +513,16 @@ func TestChatClient_GetCompletion_WithToolCalls(t *testing.T) {
 	assert.Equal(t, "call_1", resp.ToolCalls[0].ID)
 	assert.Equal(t, "get_weather", resp.ToolCalls[0].Function.Name)
 
-	// Give async operations time to complete
-	time.Sleep(100 * time.Millisecond)
+	// Wait for async operations to complete and verify telemetry includes tool calls.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		telemetryService.mu.Lock()
+		called := telemetryService.called
+		logs := telemetryService.logs
+		telemetryService.mu.Unlock()
 
-	// Verify telemetry includes tool calls
-	assert.True(t, telemetryService.called)
-	assert.NotEmpty(t, telemetryService.logs)
+		assert.True(c, called, "telemetry should be logged")
+		assert.NotEmpty(c, logs, "telemetry logs should not be empty")
+	}, 10*time.Second, 10*time.Millisecond)
 }
 
 func TestChatClient_NormalizesMixedAssistantOnlyForOpenRouterRequest(t *testing.T) {
@@ -786,14 +827,16 @@ func TestChatClient_MultipleCompletions_TitleAndResolutionScheduling(t *testing.
 		require.NoError(t, err)
 	}
 
-	// Give async operations time to complete
-	time.Sleep(200 * time.Millisecond)
-
+	// Wait for async operations to complete.
 	// Title generation should be scheduled for each completion since the simple mock always reports isFirstMessage=true.
 	// In production, the real capture strategy only returns isFirstMessage=true on the first call.
-	titleGenerator.mu.Lock()
-	assert.Equal(t, 3, titleGenerator.callCount, "Title generation should be scheduled when isFirstMessage=true (mock always returns true)")
-	titleGenerator.mu.Unlock()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		titleGenerator.mu.Lock()
+		count := titleGenerator.callCount
+		titleGenerator.mu.Unlock()
+
+		assert.Equal(c, 3, count, "Title generation should be scheduled when isFirstMessage=true (mock always returns true)")
+	}, 10*time.Second, 10*time.Millisecond)
 }
 
 // trackingTitleGenerator records every ScheduleChatTitleGeneration call with its chatID.
@@ -937,11 +980,11 @@ func TestChatClient_NilChatID_ShouldNotScheduleTitleGeneration(t *testing.T) {
 	_, err = client.GetCompletion(context.Background(), req)
 	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
-
-	titleGenerator.mu.Lock()
-	defer titleGenerator.mu.Unlock()
-	require.Empty(t, titleGenerator.calls,
+	require.Never(t, func() bool {
+		titleGenerator.mu.Lock()
+		defer titleGenerator.mu.Unlock()
+		return len(titleGenerator.calls) > 0
+	}, 100*time.Millisecond, 20*time.Millisecond,
 		"title generation must not be scheduled when ChatID is nil")
 }
 
@@ -997,18 +1040,17 @@ func TestChatClient_TitleGeneration_ScheduledPerCompletionWithValidChatID(t *tes
 	})
 	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
+	// Only the 3 real-chat completions should trigger title gen, not the nil one.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		titleGenerator.mu.Lock()
+		calls := slices.Clone(titleGenerator.calls)
+		titleGenerator.mu.Unlock()
 
-	titleGenerator.mu.Lock()
-	defer titleGenerator.mu.Unlock()
-
-	// Only the 3 real-chat completions should trigger title gen, not the nil one
-	require.Len(t, titleGenerator.calls, 3,
-		"title generation should be scheduled for each completion with a valid ChatID")
-	for _, id := range titleGenerator.calls {
-		require.Equal(t, chatID.String(), id,
-			"all title generation calls should use the real chat ID, never nil")
-	}
+		assert.Len(c, calls, 3, "title generation should be scheduled for each completion with a valid ChatID")
+		for _, id := range calls {
+			assert.Equal(c, chatID.String(), id, "all title generation calls should use the real chat ID, never nil")
+		}
+	}, 10*time.Second, 10*time.Millisecond)
 }
 
 // Verify that reloading a chat and sending a new message does not duplicate

--- a/server/internal/throttle/throttle_test.go
+++ b/server/internal/throttle/throttle_test.go
@@ -3,6 +3,7 @@ package throttle
 import (
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -27,34 +28,42 @@ func TestThrottle_LeadingEdge(t *testing.T) {
 func TestThrottle_TrailingFire(t *testing.T) {
 	t.Parallel()
 
-	var trailingCount atomic.Int64
-	throttle := New[string, string](
-		50*time.Millisecond,
-		func(v string) string { return v },
-		func(v string) error { trailingCount.Add(1); return nil },
-	)
+	synctest.Test(t, func(t *testing.T) {
+		var trailingCount atomic.Int64
+		throttle := New[string, string](
+			50*time.Millisecond,
+			func(v string) string { return v },
+			func(v string) error { trailingCount.Add(1); return nil },
+		)
 
-	throttle.Do("x")
-	throttle.Do("x") // suppressed, marks pending
+		throttle.Do("x")
+		throttle.Do("x") // suppressed, marks pending
 
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, int64(1), trailingCount.Load(), "trailing callback should fire once")
+		// Advance the fake clock past the cooldown so the trailing timer fires.
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
+		assert.Equal(t, int64(1), trailingCount.Load(), "trailing callback should fire once")
+	})
 }
 
 func TestThrottle_NoTrailingWithoutPending(t *testing.T) {
 	t.Parallel()
 
-	var trailingCount atomic.Int64
-	throttle := New[int, int](
-		50*time.Millisecond,
-		func(v int) int { return v },
-		func(v int) error { trailingCount.Add(1); return nil },
-	)
+	synctest.Test(t, func(t *testing.T) {
+		var trailingCount atomic.Int64
+		throttle := New[int, int](
+			50*time.Millisecond,
+			func(v int) int { return v },
+			func(v int) error { trailingCount.Add(1); return nil },
+		)
 
-	throttle.Do(42) // leading fire, no subsequent calls
+		throttle.Do(42) // leading fire, no subsequent calls
 
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, int64(0), trailingCount.Load(), "no trailing when nothing was pending")
+		// Advance the fake clock past the cooldown; with nothing pending, no fire.
+		time.Sleep(100 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
+		assert.Equal(t, int64(0), trailingCount.Load(), "no trailing when nothing was pending")
+	})
 }
 
 func TestThrottle_FlushFiresPending(t *testing.T) {
@@ -127,17 +136,19 @@ func TestThrottle_FlushMultipleKeys(t *testing.T) {
 func TestThrottle_ResetsAfterCooldown(t *testing.T) {
 	t.Parallel()
 
-	throttle := New[string, string](
-		50*time.Millisecond,
-		func(v string) string { return v },
-		func(v string) error { return nil },
-	)
+	synctest.Test(t, func(t *testing.T) {
+		throttle := New[string, string](
+			50*time.Millisecond,
+			func(v string) string { return v },
+			func(v string) error { return nil },
+		)
 
-	assert.True(t, throttle.Do("k"))
-	assert.False(t, throttle.Do("k")) // marks pending → trailing fires at 50ms, resets timer
+		assert.True(t, throttle.Do("k"))
+		assert.False(t, throttle.Do("k")) // marks pending → trailing fires at 50ms, resets timer
 
-	// Wait for both the trailing fire (50ms) and its cooldown (another 50ms).
-	time.Sleep(150 * time.Millisecond)
-
-	assert.True(t, throttle.Do("k"), "should fire again after cooldown expires")
+		// Advance past both the trailing fire (50ms) and its cooldown (another 50ms).
+		time.Sleep(150 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly (the only way to move past a timer inside a synctest.Test bubble); this exemption is valid ONLY within synctest.Test — do not copy it to a real-time time.Sleep
+		synctest.Wait()
+		assert.True(t, throttle.Do("k"), "should fire again after cooldown expires")
+	})
 }

--- a/server/internal/usage/tum_test.go
+++ b/server/internal/usage/tum_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/usage"
@@ -185,18 +186,21 @@ func TestGetTokensUnderManagementQuery_FiltersUnstoredSessions(t *testing.T) {
 	// Stored session rows outside the window. Excluded.
 	insertTokenUsageRow(t, chConn, projectID.String(), now.Add(-5*24*time.Hour), storedToolChat, 9000)
 
-	// Wait for ClickHouse eventual consistency.
-	time.Sleep(200 * time.Millisecond)
-
-	buckets, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-		ProjectIDs:    []string{projectID.String()},
-		StartUnixNano: windowStart.UnixNano(),
-		EndUnixNano:   windowEnd.UnixNano(),
-	})
-	require.NoError(t, err)
-	require.Equal(t, int64(1300), sumTumBuckets(buckets), "should count only sessions with stored non-metrics data inside the window")
-	require.Len(t, buckets, 1, "all in-window rows share one day bucket")
-	require.Equal(t, dayStart, buckets[0].Day.UTC())
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
+			ProjectIDs:    []string{projectID.String()},
+			StartUnixNano: windowStart.UnixNano(),
+			EndUnixNano:   windowEnd.UnixNano(),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, int64(1300), sumTumBuckets(res), "should count only sessions with stored non-metrics data inside the window")
+		if !assert.Len(c, res, 1, "all in-window rows share one day bucket") {
+			return
+		}
+		assert.Equal(c, dayStart, res[0].Day.UTC())
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func sumTumBuckets(buckets []telemetryrepo.TumDayBucket) int64 {
@@ -225,19 +229,23 @@ func TestGetTokensUnderManagementQuery_DailyBreakdown(t *testing.T) {
 	insertTokenUsageRow(t, chConn, projectID.String(), now, chatID, 300)
 	insertTokenUsageRow(t, chConn, projectID.String(), now.Add(-24*time.Hour), chatID, 200)
 
-	time.Sleep(200 * time.Millisecond)
-
-	buckets, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-		ProjectIDs:    []string{projectID.String()},
-		StartUnixNano: windowStart.UnixNano(),
-		EndUnixNano:   windowEnd.UnixNano(),
-	})
-	require.NoError(t, err)
-	require.Len(t, buckets, 2)
-	require.Equal(t, dayStart.Add(-24*time.Hour), buckets[0].Day.UTC())
-	require.Equal(t, int64(200), buckets[0].Tokens)
-	require.Equal(t, dayStart, buckets[1].Day.UTC())
-	require.Equal(t, int64(300), buckets[1].Tokens)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
+			ProjectIDs:    []string{projectID.String()},
+			StartUnixNano: windowStart.UnixNano(),
+			EndUnixNano:   windowEnd.UnixNano(),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.Len(c, res, 2) {
+			return
+		}
+		assert.Equal(c, dayStart.Add(-24*time.Hour), res[0].Day.UTC())
+		assert.Equal(c, int64(200), res[0].Tokens)
+		assert.Equal(c, dayStart, res[1].Day.UTC())
+		assert.Equal(c, int64(300), res[1].Tokens)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestGetTokensUnderManagementQuery_EvidenceOutsideWindowDoesNotCount(t *testing.T) {
@@ -257,7 +265,22 @@ func TestGetTokensUnderManagementQuery_EvidenceOutsideWindowDoesNotCount(t *test
 	insertTokenUsageRow(t, chConn, projectID.String(), now, chatID, 4000)
 	insertToolCallRow(t, chConn, projectID.String(), now.Add(-5*24*time.Hour), chatID)
 
-	time.Sleep(200 * time.Millisecond)
+	// Confirm the inserted rows have propagated using a wider window that
+	// includes the stale evidence, which qualifies the session and surfaces
+	// the in-window tokens. Once visible there, the narrow window below is a
+	// reliable negative.
+	widerStart := dayStart.Add(-7 * 24 * time.Hour)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
+			ProjectIDs:    []string{projectID.String()},
+			StartUnixNano: widerStart.UnixNano(),
+			EndUnixNano:   windowEnd.UnixNano(),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, int64(4000), sumTumBuckets(res))
+	}, 10*time.Second, 200*time.Millisecond)
 
 	buckets, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
 		ProjectIDs:    []string{projectID.String()},
@@ -325,20 +348,25 @@ func TestGetTokensUnderManagement_CountsStoredSessions(t *testing.T) {
 	insertToolCallRow(t, chConn, projectID.String(), now, storedChat)
 	insertTokenUsageRow(t, chConn, projectID.String(), now, forwardedChat, 9000)
 
-	time.Sleep(200 * time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := svc.GetTokensUnderManagement(testAuthContext(orgID), &gen.GetTokensUnderManagementPayload{})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		assert.Equal(c, int64(450), res.Tokens)
 
-	result, err := svc.GetTokensUnderManagement(testAuthContext(orgID), &gen.GetTokensUnderManagementPayload{})
-	require.NoError(t, err)
-	require.Equal(t, int64(450), result.Tokens)
-
-	// The active cycle's daily points sum to the headline number.
-	last := result.History[len(result.History)-1]
-	require.Equal(t, int64(450), last.Tokens)
-	var daySum int64
-	for _, day := range last.Days {
-		daySum += day.Tokens
-	}
-	require.Equal(t, int64(450), daySum)
+		// The active cycle's daily points sum to the headline number.
+		last := res.History[len(res.History)-1]
+		assert.Equal(c, int64(450), last.Tokens)
+		var daySum int64
+		for _, day := range last.Days {
+			daySum += day.Tokens
+		}
+		assert.Equal(c, int64(450), daySum)
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSetBillingMetadata_RequiresPlatformAdmin(t *testing.T) {


### PR DESCRIPTION
Add a forbidigo rule (GG013) banning `time.Sleep`, enforced repo-wide except a small grandfathered list in `server/.golangci.yaml`, and replace the eventual-consistency and timer sleeps it flags with deterministic, poll- or fake-clock-based waits.

- ClickHouse/async tests now use `require.EventuallyWithT` (and `require.Never` for assert-absence cases) across `telemetry`, `usage`, `risk`, `authz`, `openrouter`, `access`, and `assistanttokens`.
- `chat` list-ordering tests assign explicit message timestamps via a new optional `created_at` arg on the `SeedChatMessage` fixture query.
- The `oauth` upstream-secret-expiry test issues an already-expired secret instead of sleeping out a real deadline.
- `throttle` and `throttled_signaler` timer tests use `testing/synctest` so the fake clock advances instantly; the fake-clock `time.Sleep` calls carry a scoped `//nolint:forbidigo` valid only inside a synctest bubble.

Remaining `time.Sleep` sites (real Redis TTL behavior, infra readiness polling, production retry/backoff) stay grandfathered with documented reasons.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Banned `time.Sleep` in tests via a new `forbidigo` rule (`GG013`) and replaced sleeps with deterministic waits (`require.EventuallyWithT`/`require.Never`) or fake clocks (`testing/synctest`) to cut flakiness and speed up ClickHouse- and timer-driven tests. Consolidated testing guidance into the `golang` skill doc and linked from `telemetry/README.md`.

- **Refactors**
  - Replaced sleeps with polling (`require.EventuallyWithT`, `require.Never`) across `telemetry`, `usage`, `risk`, `authz`, `openrouter`, `access`, and `assistanttokens`.
  - Switched `throttle` and `throttled_signaler` tests to `testing/synctest`; fake-clock sleeps are scoped with `//nolint:forbidigo`.
  - Made `oauth` expiry test deterministic by issuing an already-expired upstream secret.
  - Added optional `created_at` to `SeedChatMessage` for deterministic ordering; updated SQL and generated code.
  - Guarded nil node lookups in `telemetry` employee data flow test `EventuallyWithT` closures to avoid transient panics while polling.

- **Migration**
  - Enforced `GG013` in `server/.golangci.yaml` with a small, documented allowlist; clarified linter comments.
  - For async/eventual consistency: use `require.EventuallyWithT` (assert inside the closure) and `require.Never`.
  - For timer logic: wrap tests with `testing/synctest` to advance time instantly.

<sup>Written for commit 36f5b92c5065c2abe6f1e32ce7e53fcc66af143d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

