### PR TITLE
feat(background): add a temporal worker for backfilling attribute metrics summaries per tenant

### DIFF
--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -100,6 +100,7 @@ type Activities struct {
 	listWorkOSOrganizations         *activities.ListWorkOSOrganizations
 	backfillWorkOSOrganization      *activities.BackfillWorkOSOrganization
 	backfillWorkOSGlobalRoles       *activities.BackfillWorkOSGlobalRoles
+	backfillAttributeMetrics        *activities.BackfillAttributeMetricsSummaries
 	processWorkOSOrganizationEvents *activities.ProcessWorkOSOrganizationEvents
 	processWorkOSGlobalRoleEvents   *activities.ProcessWorkOSGlobalRoleEvents
 	processWorkOSUserEvents         *activities.ProcessWorkOSUserEvents
@@ -199,6 +200,7 @@ func NewActivities(
 		listWorkOSOrganizations:         activities.NewListWorkOSOrganizations(logger, workosClient),
 		backfillWorkOSOrganization:      activities.NewBackfillWorkOSOrganization(logger, db, workosClient),
 		backfillWorkOSGlobalRoles:       activities.NewBackfillWorkOSGlobalRoles(logger, db, workosClient),
+		backfillAttributeMetrics:        activities.NewBackfillAttributeMetricsSummaries(logger, db, chConn),
 		processWorkOSOrganizationEvents: activities.NewProcessWorkOSOrganizationEvents(logger, db, workosClient),
 		processWorkOSGlobalRoleEvents:   activities.NewProcessWorkOSGlobalRoleEvents(logger, db, workosClient),
 		processWorkOSUserEvents:         activities.NewProcessWorkOSUserEvents(logger, db, workosClient),
@@ -219,6 +221,10 @@ func (a *Activities) BackfillWorkOSOrganization(ctx context.Context, params acti
 
 func (a *Activities) BackfillWorkOSGlobalRoles(ctx context.Context) error {
 	return a.backfillWorkOSGlobalRoles.Do(ctx)
+}
+
+func (a *Activities) BackfillAttributeMetricsSummaries(ctx context.Context, params activities.BackfillAttributeMetricsSummariesParams) (*activities.BackfillAttributeMetricsSummariesResult, error) {
+	return a.backfillAttributeMetrics.Do(ctx, params)
 }
 
 func (a *Activities) ProcessWorkOSOrganizationEvents(ctx context.Context, params activities.ProcessWorkOSOrganizationEventsParams) (*activities.ProcessWorkOSOrganizationEventsResult, error) {

--- a/server/internal/background/activities/backfill_attribute_metrics_summaries.go
+++ b/server/internal/background/activities/backfill_attribute_metrics_summaries.go
@@ -1,0 +1,207 @@
+package activities
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+type BackfillAttributeMetricsSummaries struct {
+	logger *slog.Logger
+	db     *pgxpool.Pool
+	chConn clickhouse.Conn
+}
+
+func NewBackfillAttributeMetricsSummaries(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn) *BackfillAttributeMetricsSummaries {
+	return &BackfillAttributeMetricsSummaries{
+		logger: logger.With(attr.SlogComponent("backfill_attribute_metrics_summaries")),
+		db:     db,
+		chConn: chConn,
+	}
+}
+
+type BackfillAttributeMetricsSummariesParams struct {
+	OrganizationID string `json:"organization_id"`
+}
+
+type BackfillAttributeMetricsSummariesResult struct {
+	OrganizationID     string    `json:"organization_id"`
+	ProjectCount       int       `json:"project_count"`
+	UserLookupCount    int       `json:"user_lookup_count"`
+	From               time.Time `json:"from"`
+	Cutoff             time.Time `json:"cutoff"`
+	RebuiltSummaryRows uint64    `json:"rebuilt_summary_rows"`
+}
+
+type attributeMetricsUserLookupItem struct {
+	Email      string          `json:"email"`
+	Attributes json.RawMessage `json:"attributes"`
+}
+
+func (b *BackfillAttributeMetricsSummaries) Do(ctx context.Context, params BackfillAttributeMetricsSummariesParams) (*BackfillAttributeMetricsSummariesResult, error) {
+	if strings.TrimSpace(params.OrganizationID) == "" {
+		return nil, temporal.NewNonRetryableApplicationError("organization_id is required", "InvalidBackfillRequest", nil)
+	}
+
+	cutoff := AttributeMetricsBackfillCutoff()
+	from := cutoff.AddDate(0, 0, -AttributeMetricsBackfillWindowDays)
+	logger := b.logger.With(
+		attr.SlogOrganizationID(params.OrganizationID),
+		slog.Time("from", from),
+		slog.Time("cutoff", cutoff),
+	)
+
+	projects, err := projectsrepo.New(b.db).ListProjectsByOrganization(ctx, params.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("list projects by organization: %w", err)
+	}
+	if len(projects) == 0 {
+		return &BackfillAttributeMetricsSummariesResult{
+			OrganizationID: params.OrganizationID,
+			ProjectCount:   0,
+			From:           from,
+			Cutoff:         cutoff,
+		}, nil
+	}
+
+	lookup, err := b.loadUserLookup(ctx, b.db, params.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("load user lookup: %w", err)
+	}
+
+	activity.RecordHeartbeat(ctx, "deleting existing attribute metrics summaries")
+
+	lookupJSON, err := json.Marshal(lookup)
+	if err != nil {
+		return nil, fmt.Errorf("marshal user lookup: %w", err)
+	}
+
+	backfillParams := telemetryrepo.BackfillAttributeMetricsSummariesParams{
+		ProjectIDs:     projectIDStrings(projects),
+		UserLookupJSON: string(lookupJSON),
+		FromUnixNano:   from.UnixNano(),
+		CutoffUnixNano: cutoff.UnixNano(),
+	}
+
+	telemetryQueries := telemetryrepo.New(b.chConn)
+	if err := telemetryQueries.DeleteAttributeMetricsSummariesBackfillWindow(ctx, backfillParams); err != nil {
+		return nil, fmt.Errorf("delete existing attribute metrics summaries: %w", err)
+	}
+
+	if err := waitForAttributeMetricsSummariesBackfillWindowToClear(ctx, telemetryQueries, backfillParams); err != nil {
+		return nil, err
+	}
+
+	activity.RecordHeartbeat(ctx, "inserting rebuilt attribute metrics summaries")
+
+	if err := telemetryQueries.InsertAttributeMetricsSummariesBackfillWindow(ctx, backfillParams); err != nil {
+		return nil, fmt.Errorf("insert rebuilt attribute metrics summaries: %w", err)
+	}
+
+	rebuiltRows, err := telemetryQueries.CountAttributeMetricsSummariesBackfillWindow(ctx, backfillParams)
+	if err != nil {
+		return nil, fmt.Errorf("count rebuilt attribute metrics summaries: %w", err)
+	}
+
+	logger.InfoContext(ctx, "backfilled attribute metrics summaries",
+		slog.Int("project_count", len(projects)),
+		slog.Int("user_lookup_count", len(lookup)),
+		slog.Uint64("rebuilt_summary_rows", rebuiltRows),
+	)
+
+	return &BackfillAttributeMetricsSummariesResult{
+		OrganizationID:     params.OrganizationID,
+		ProjectCount:       len(projects),
+		UserLookupCount:    len(lookup),
+		From:               from,
+		Cutoff:             cutoff,
+		RebuiltSummaryRows: rebuiltRows,
+	}, nil
+}
+
+func (b *BackfillAttributeMetricsSummaries) loadUserLookup(ctx context.Context, dbtx activitiesrepo.DBTX, organizationID string) ([]attributeMetricsUserLookupItem, error) {
+	rows, err := activitiesrepo.New(dbtx).ListLatestDirectoryUsersForAttributeMetricsBackfill(ctx, organizationID)
+	if err != nil {
+		return nil, fmt.Errorf("query directory users: %w", err)
+	}
+
+	lookup := make([]attributeMetricsUserLookupItem, 0, len(rows))
+	var email string
+	for _, row := range rows {
+		email = conv.NormalizeEmail(conv.FromPGTextOrEmpty[string](row.Email))
+		if email == "" {
+			continue
+		}
+
+		lookup = append(lookup, attributeMetricsUserLookupItem{
+			Email:      email,
+			Attributes: json.RawMessage(row.Attributes),
+		})
+	}
+
+	return lookup, nil
+
+}
+
+func waitForAttributeMetricsSummariesBackfillWindowToClear(ctx context.Context, queries *telemetryrepo.Queries, params telemetryrepo.BackfillAttributeMetricsSummariesParams) error {
+	deadline := time.Now().Add(attributeMetricsBackfillDeleteMaxWait)
+
+	for {
+		rows, err := queries.CountAttributeMetricsSummariesBackfillWindow(ctx, params)
+		if err != nil {
+			return fmt.Errorf("count attribute metrics summaries during delete wait: %w", err)
+		}
+		if rows == 0 {
+			return nil
+		}
+
+		activity.RecordHeartbeat(ctx, fmt.Sprintf("waiting for attribute metrics summaries delete mutation: %d rows remaining", rows))
+
+		sleepFor := attributeMetricsBackfillDeletePollInterval
+		if remaining := time.Until(deadline); remaining <= 0 {
+			return fmt.Errorf("attribute metrics summaries delete mutation did not clear backfill window within %s: %d rows remaining", attributeMetricsBackfillDeleteMaxWait, rows)
+		} else if remaining < sleepFor {
+			sleepFor = remaining
+		}
+
+		timer := time.NewTimer(sleepFor)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func projectIDStrings(projects []projectsrepo.Project) []string {
+	ids := make([]string, 0, len(projects))
+	for _, project := range projects {
+		ids = append(ids, project.ID.String())
+	}
+	return ids
+}
+
+const (
+	AttributeMetricsBackfillWindowDays         = 30
+	attributeMetricsBackfillDeleteMaxWait      = 30 * time.Second
+	attributeMetricsBackfillDeletePollInterval = 5 * time.Second
+)
+
+func AttributeMetricsBackfillCutoff() time.Time {
+	return time.Date(2026, time.June, 20, 0, 0, 0, 0, time.UTC)
+}

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -8,7 +8,7 @@ WITH latest_deployments AS (
   ORDER BY project_id, d.created_at DESC
 ),
 toolset_metrics AS (
-  SELECT 
+  SELECT
     p.organization_id,
     COUNT(CASE WHEN t.mcp_is_public = true AND t.mcp_slug IS NOT NULL THEN 1 END) as public_mcp_servers,
     COUNT(CASE WHEN t.mcp_is_public = false AND t.mcp_slug IS NOT NULL THEN 1 END) as private_mcp_servers,
@@ -19,7 +19,7 @@ toolset_metrics AS (
   GROUP BY p.organization_id
 ),
 tool_metrics AS (
-  SELECT 
+  SELECT
     p.organization_id,
     COUNT(DISTINCT htd.id) as total_tools
   FROM projects p
@@ -27,7 +27,7 @@ tool_metrics AS (
   LEFT JOIN http_tool_definitions htd ON ld.deployment_id = htd.deployment_id AND htd.deleted = false
   GROUP BY p.organization_id
 )
-SELECT 
+SELECT
   COALESCE(tm.organization_id, tlm.organization_id) as organization_id,
   COALESCE(tm.public_mcp_servers, 0) as public_mcp_servers,
   COALESCE(tm.private_mcp_servers, 0) as private_mcp_servers,
@@ -105,6 +105,16 @@ WHERE id = @message_id
   AND (project_id IS NULL OR project_id = @project_id)
   AND role = 'user'
   AND (message_id IS NULL OR message_id = '');
+
+-- name: ListLatestDirectoryUsersForAttributeMetricsBackfill :many
+SELECT DISTINCT ON (lower(email))
+    email,
+    attributes
+FROM directory_users
+WHERE organization_id = @organization_id
+  AND deleted_at IS NULL
+  AND email IS NOT NULL
+ORDER BY lower(email), workos_updated_at DESC, updated_at DESC;
 
 -- name: FetchPendingOutboxIDs :many
 -- Fetch the next batch of outbox row IDs (across all organizations) that the

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -280,7 +280,7 @@ WITH latest_deployments AS (
   ORDER BY project_id, d.created_at DESC
 ),
 toolset_metrics AS (
-  SELECT 
+  SELECT
     p.organization_id,
     COUNT(CASE WHEN t.mcp_is_public = true AND t.mcp_slug IS NOT NULL THEN 1 END) as public_mcp_servers,
     COUNT(CASE WHEN t.mcp_is_public = false AND t.mcp_slug IS NOT NULL THEN 1 END) as private_mcp_servers,
@@ -291,7 +291,7 @@ toolset_metrics AS (
   GROUP BY p.organization_id
 ),
 tool_metrics AS (
-  SELECT 
+  SELECT
     p.organization_id,
     COUNT(DISTINCT htd.id) as total_tools
   FROM projects p
@@ -299,7 +299,7 @@ tool_metrics AS (
   LEFT JOIN http_tool_definitions htd ON ld.deployment_id = htd.deployment_id AND htd.deleted = false
   GROUP BY p.organization_id
 )
-SELECT 
+SELECT
   COALESCE(tm.organization_id, tlm.organization_id) as organization_id,
   COALESCE(tm.public_mcp_servers, 0) as public_mcp_servers,
   COALESCE(tm.private_mcp_servers, 0) as private_mcp_servers,
@@ -378,6 +378,42 @@ func (q *Queries) GetUserEmailsByOrgIDs(ctx context.Context, dollar_1 []string) 
 	for rows.Next() {
 		var i GetUserEmailsByOrgIDsRow
 		if err := rows.Scan(&i.OrganizationID, &i.Email); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listLatestDirectoryUsersForAttributeMetricsBackfill = `-- name: ListLatestDirectoryUsersForAttributeMetricsBackfill :many
+SELECT DISTINCT ON (lower(email))
+    email,
+    attributes
+FROM directory_users
+WHERE organization_id = $1
+  AND deleted_at IS NULL
+  AND email IS NOT NULL
+ORDER BY lower(email), workos_updated_at DESC, updated_at DESC
+`
+
+type ListLatestDirectoryUsersForAttributeMetricsBackfillRow struct {
+	Email      pgtype.Text
+	Attributes []byte
+}
+
+func (q *Queries) ListLatestDirectoryUsersForAttributeMetricsBackfill(ctx context.Context, organizationID string) ([]ListLatestDirectoryUsersForAttributeMetricsBackfillRow, error) {
+	rows, err := q.db.Query(ctx, listLatestDirectoryUsersForAttributeMetricsBackfill, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListLatestDirectoryUsersForAttributeMetricsBackfillRow
+	for rows.Next() {
+		var i ListLatestDirectoryUsersForAttributeMetricsBackfillRow
+		if err := rows.Scan(&i.Email, &i.Attributes); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/internal/background/backfill_attribute_metrics_summaries.go
+++ b/server/internal/background/backfill_attribute_metrics_summaries.go
@@ -1,0 +1,65 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	attributeMetricsBackfillWorkflowTimeout = 2 * time.Hour
+	attributeMetricsBackfillActivityTimeout = 45 * time.Minute
+)
+
+type BackfillAttributeMetricsSummariesParams struct {
+	OrganizationID string `json:"organization_id"`
+}
+
+type BackfillAttributeMetricsSummariesResult = activities.BackfillAttributeMetricsSummariesResult
+
+func ExecuteBackfillAttributeMetricsSummariesWorkflow(ctx context.Context, env *tenv.Environment, params BackfillAttributeMetricsSummariesParams) (client.WorkflowRun, error) {
+	params = normalizeBackfillAttributeMetricsSummariesParams(params)
+	id := fmt.Sprintf("v1:backfill-attribute-metrics-summaries:%s:%s", params.OrganizationID, activities.AttributeMetricsBackfillCutoff().Format("20060102T150405Z"))
+	return env.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    id,
+		TaskQueue:             string(env.Queue()),
+		WorkflowRunTimeout:    attributeMetricsBackfillWorkflowTimeout,
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+	}, BackfillAttributeMetricsSummariesWorkflow, params)
+}
+
+func BackfillAttributeMetricsSummariesWorkflow(ctx workflow.Context, params BackfillAttributeMetricsSummariesParams) (*BackfillAttributeMetricsSummariesResult, error) {
+	params = normalizeBackfillAttributeMetricsSummariesParams(params)
+
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: attributeMetricsBackfillActivityTimeout,
+		HeartbeatTimeout:    5 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    10 * time.Second,
+			MaximumInterval:    2 * time.Minute,
+			BackoffCoefficient: 2,
+			MaximumAttempts:    3,
+		},
+	})
+
+	var a *Activities
+	var result activities.BackfillAttributeMetricsSummariesResult
+	if err := workflow.ExecuteActivity(ctx, a.BackfillAttributeMetricsSummaries, activities.BackfillAttributeMetricsSummariesParams(params)).Get(ctx, &result); err != nil {
+		return nil, fmt.Errorf("backfill attribute metrics summaries: %w", err)
+	}
+	return &result, nil
+}
+
+func normalizeBackfillAttributeMetricsSummariesParams(params BackfillAttributeMetricsSummariesParams) BackfillAttributeMetricsSummariesParams {
+	params.OrganizationID = strings.TrimSpace(params.OrganizationID)
+	return params
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -339,6 +339,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.ListWorkOSOrganizations)
 	temporalWorker.RegisterActivity(activities.BackfillWorkOSOrganization)
 	temporalWorker.RegisterActivity(activities.BackfillWorkOSGlobalRoles)
+	temporalWorker.RegisterActivity(activities.BackfillAttributeMetricsSummaries)
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSOrganizationEvents)
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSGlobalRoleEvents)
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSUserEvents)
@@ -397,6 +398,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(ProcessWorkOSUserEventsWorkflow)
 	temporalWorker.RegisterWorkflow(ProcessWorkOSUserEventsWorkflowDebounced)
 	temporalWorker.RegisterWorkflow(BackfillWorkOSWorkflow)
+	temporalWorker.RegisterWorkflow(BackfillAttributeMetricsSummariesWorkflow)
 	// Assistants signup followups
 	temporalWorker.RegisterWorkflow(CancelAssistantsSubscriptionWorkflow)
 	// Outbox -> Relay workflow and GC

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -4599,6 +4600,182 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 	}
 
 	return events, nil
+}
+
+type BackfillAttributeMetricsSummariesParams struct {
+	ProjectIDs     []string
+	UserLookupJSON string
+	FromUnixNano   int64
+	CutoffUnixNano int64
+}
+
+func (q *Queries) DeleteAttributeMetricsSummariesBackfillWindow(ctx context.Context, arg BackfillAttributeMetricsSummariesParams) error {
+	query, args, err := squirrel.Expr(
+		"ALTER TABLE attribute_metrics_summaries DELETE WHERE ?",
+		squirrel.And{
+			squirrel.Eq{"gram_project_id": arg.ProjectIDs},
+			squirrel.Expr("time_bucket >= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.FromUnixNano),
+			squirrel.Expr("time_bucket < toStartOfHour(fromUnixTimestamp64Nano(?))", arg.CutoffUnixNano),
+		},
+	).ToSql()
+	if err != nil {
+		return fmt.Errorf("building delete attribute metrics summaries backfill query: %w", err)
+	}
+
+	return q.conn.Exec(ctx, query, args...)
+}
+
+func (q *Queries) InsertAttributeMetricsSummariesBackfillWindow(ctx context.Context, arg BackfillAttributeMetricsSummariesParams) error {
+	projectIDsJSON := "[]"
+	if len(arg.ProjectIDs) > 0 {
+		raw, _ := json.Marshal(arg.ProjectIDs)
+		projectIDsJSON = string(raw)
+	}
+	ctx = clickhouse.Context(ctx,
+		clickhouse.WithParameters(clickhouse.Parameters{
+			"user_lookup_json": arg.UserLookupJSON,
+			"project_ids":      projectIDsJSON,
+			"from_unix_nano":   strconv.FormatInt(arg.FromUnixNano, 10),
+			"cutoff_unix_nano": strconv.FormatInt(arg.CutoffUnixNano, 10),
+		}),
+	)
+
+	insertColumns := []string{
+		"gram_project_id",
+		"time_bucket",
+		"department_name",
+		"job_title",
+		"employee_type",
+		"division_name",
+		"cost_center_name",
+		"user_email",
+		"model",
+		"hook_source",
+		"roles",
+		"groups",
+		"total_chats",
+		"total_input_tokens",
+		"total_output_tokens",
+		"total_tokens",
+		"cache_read_input_tokens",
+		"cache_creation_input_tokens",
+		"total_cost",
+		"total_tool_calls",
+	}
+
+	selectQuery := sq.Select(
+		"gram_project_id",
+		"toStartOfHour(fromUnixTimestamp64Nano(time_unix_nano)) AS time_bucket",
+		attributeMetricsLookupStringExpr("department_name", "toString(attributes.user.attributes.department_name)")+" AS department_name",
+		attributeMetricsLookupStringExpr("job_title", "toString(attributes.user.attributes.job_title)")+" AS job_title",
+		attributeMetricsLookupStringExpr("employee_type", "toString(attributes.user.attributes.employee_type)")+" AS employee_type",
+		attributeMetricsLookupStringExpr("division_name", "toString(attributes.user.attributes.division_name)")+" AS division_name",
+		attributeMetricsLookupStringExpr("cost_center_name", "toString(attributes.user.attributes.cost_center_name)")+" AS cost_center_name",
+		"user_email AS user_email",
+		"toString(attributes.gen_ai.response.model) AS model",
+		"hook_source",
+		"arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)')) AS roles",
+		"arraySort(JSONExtract(ifNull(toJSONString(attributes.user.groups), '[]'), 'Array(String)')) AS groups",
+		"uniqExactIfState(toString(attributes.gen_ai.conversation.id), toString(attributes.gen_ai.conversation.id) != '') AS total_chats",
+		"sumIfState(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') AS total_input_tokens",
+		"sumIfState(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.output_tokens) != '') AS total_output_tokens",
+		"sumIfState(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens",
+		"sumIfState(toInt64OrZero(toString(attributes.gen_ai.usage.cache_read.input_tokens)), toString(attributes.gen_ai.usage.cache_read.input_tokens) != '') AS cache_read_input_tokens",
+		"sumIfState(toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens)), toString(attributes.gen_ai.usage.cache_creation.input_tokens) != '') AS cache_creation_input_tokens",
+		"sumIfState(toFloat64OrZero(toString(attributes.gen_ai.usage.cost)), toString(attributes.gen_ai.usage.cost) != '') AS total_cost",
+		"countIfState(startsWith(toString(attributes.gram.tool.urn), 'tools:')) AS total_tool_calls",
+	).
+		Prefix(`WITH
+			JSONExtractArrayRaw({user_lookup_json:String}) AS user_lookup,
+			arrayMap(user -> JSONExtractString(user, 'email'), user_lookup) AS user_lookup_emails`).
+		From("telemetry_logs").
+		Where("gram_project_id IN arrayMap(x -> toUUID(x), JSONExtract({project_ids:String}, 'Array(String)'))").
+		Where("time_unix_nano >= {from_unix_nano:Int64}").
+		Where("time_unix_nano < {cutoff_unix_nano:Int64}").
+		Where(squirrel.Or{
+			squirrel.Expr("startsWith(gram_urn, 'claude-code:usage')"),
+			squirrel.Expr("startsWith(gram_urn, 'codex:usage')"),
+			squirrel.Expr("startsWith(gram_urn, 'cursor:usage')"),
+		}).
+		GroupBy(
+			"gram_project_id",
+			"time_bucket",
+			"department_name",
+			"job_title",
+			"employee_type",
+			"division_name",
+			"cost_center_name",
+			"user_email",
+			"model",
+			"hook_source",
+			"roles",
+			"groups",
+		)
+
+	query, args, err := sq.Insert("attribute_metrics_summaries").
+		Columns(insertColumns...).
+		Select(selectQuery).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("building insert attribute metrics summaries backfill query: %w", err)
+	}
+	if len(args) > 0 {
+		return fmt.Errorf("building insert attribute metrics summaries backfill query: unexpected positional arguments")
+	}
+
+	return q.conn.Exec(ctx, query)
+}
+
+func (q *Queries) CountAttributeMetricsSummariesBackfillWindow(ctx context.Context, arg BackfillAttributeMetricsSummariesParams) (uint64, error) {
+	projectIDsJSON := "[]"
+	if len(arg.ProjectIDs) > 0 {
+		raw, _ := json.Marshal(arg.ProjectIDs)
+		projectIDsJSON = string(raw)
+	}
+	ctx = clickhouse.Context(ctx,
+		clickhouse.WithParameters(clickhouse.Parameters{
+			"user_lookup_json": arg.UserLookupJSON,
+			"project_ids":      projectIDsJSON,
+			"from_unix_nano":   strconv.FormatInt(arg.FromUnixNano, 10),
+			"cutoff_unix_nano": strconv.FormatInt(arg.CutoffUnixNano, 10),
+		}),
+	)
+
+	query, args, err := sq.Select("count()").
+		From("attribute_metrics_summaries").
+		Where("gram_project_id IN arrayMap(x -> toUUID(x), JSONExtract({project_ids:String}, 'Array(String)'))").
+		Where("time_bucket >= toStartOfHour(fromUnixTimestamp64Nano({from_unix_nano:Int64}))").
+		Where("time_bucket < toStartOfHour(fromUnixTimestamp64Nano({cutoff_unix_nano:Int64}))").
+		ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("building count attribute metrics summaries backfill query: %w", err)
+	}
+	if len(args) > 0 {
+		return 0, fmt.Errorf("building count attribute metrics summaries backfill query: unexpected positional arguments")
+	}
+
+	rows, err := q.conn.Query(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	var count uint64
+	if rows.Next() {
+		if err := rows.Scan(&count); err != nil {
+			return 0, fmt.Errorf("scan attribute metrics summaries backfill count: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func attributeMetricsLookupStringExpr(attributeName string, fallbackExpr string) string {
+	lookupIdx := "indexOf(user_lookup_emails, lower(user_email))"
+	lookupAttrs := "JSONExtractRaw(user_lookup[" + lookupIdx + "], 'attributes')"
+	return "if(" + lookupIdx + " > 0, JSONExtractString(" + lookupAttrs + ", '" + attributeName + "'), " + fallbackExpr + ")"
 }
 
 // CountRecentHookEventsForOnboarding returns the total number of hook events


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Temporal workflow and activity to backfill attribute metrics summaries per organization, rebuilding the last-30-day window in ClickHouse using the latest directory user attributes. Improves accuracy of department, title, roles, and groups aggregations by delete-then-insert recomputation.

- **New Features**
  - Activity `BackfillAttributeMetricsSummaries` that:
    - Validates `organization_id`, resolves project IDs, and loads latest directory users per email.
    - Deletes summaries in the backfill window, waits for mutation to clear, then inserts recomputed summaries; returns counts and window bounds.
  - Workflow `BackfillAttributeMetricsSummariesWorkflow` with retries, heartbeats, and 2h run timeout; worker registers both the activity and workflow.
  - ClickHouse queries to delete/insert/count the backfill window using JSON params, hourly buckets, and usage event filters; includes lookup-based attribute fallback.
  - Postgres query to fetch latest directory users for the org; added to `activities/repo`.
  - Constants: 30-day window, delete-wait up to 30s with 5s polling; cutoff fixed at 2026-06-20 UTC.

<sup>Written for commit ca6f179cc20fd7f381c28c923740e428856edaf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

