### PR TITLE
fix(pystreams): bootstrap scan pool forkserver from a pristine entrypoint

### DIFF
--- a/.mise-tasks/start/pystreams-multi.sh
+++ b/.mise-tasks/start/pystreams-multi.sh
@@ -3,4 +3,4 @@
 #MISE dir="{{ config_root }}/pystreams"
 #MISE description="Start up python stream subscribers"
 
-exec uv run --no-sync multi "$@"
+exec uv run multi "$@"

--- a/pystreams/pyproject.toml
+++ b/pystreams/pyproject.toml
@@ -31,7 +31,9 @@ dev = [
 ]
 
 [project.scripts]
-multi = "pystreams.cmd.multi:cli"
+# Entrypoint stands up the scan pool's forkserver while the process is pristine
+# before handing off to multi:cli — see pystreams.cmd.bootstrap for the why.
+multi = "pystreams.cmd.bootstrap:main"
 presidio-load = "pystreams.cmd.presidio_load:cli"
 
 [build-system]

--- a/pystreams/src/pystreams/cmd/bootstrap.py
+++ b/pystreams/src/pystreams/cmd/bootstrap.py
@@ -1,0 +1,69 @@
+"""Pristine entrypoint that stands up the scan pool's forkserver before the heavy
+scientific stack is imported, then hands off to the real ``multi`` CLI.
+
+Why this exists
+---------------
+:class:`~pystreams.risk.scanner.ProcessPoolScanner` runs Presidio in a
+``forkserver``-backed process pool. The forkserver *process* is itself created by
+``fork()``+``exec()``-ing whichever process first triggers it. By the time the
+``multi`` CLI gets there it has imported numpy/spaCy (via the scanner) and the
+Pub/Sub gRPC clients — on macOS that loads the Objective-C runtime (numpy's BLAS
+backend is Accelerate, a Foundation framework) and spawns helper threads. macOS
+then aborts the forked child if another thread was mid Objective-C ``+initialize``
+at fork time::
+
+    objc[...]: +[NSNumber initialize] may have been in progress in another thread
+    when fork() was called. ... Crashing instead.
+
+The fix is ordering, not a flag. The *only* fork that inherits the laden parent is
+the forkserver bootstrap; every scan worker is forked from the forkserver, never
+from the CLI process. So we bootstrap the forkserver here, while this process is
+still pristine — no numpy, no gRPC, no Objective-C frameworks loaded — by starting
+a throwaway process against the forkserver context. After that the forkserver
+singleton is up; the pool created later in ``multi`` reuses it instead of
+bootstrapping from the (by then numpy-laden) CLI process.
+
+We deliberately do *not* ``set_forkserver_preload`` the scanner module: the
+forkserver only ever ``fork()``s, and each worker imports numpy/Presidio in the
+forked child (post-fork), so the forkserver itself stays single-threaded and every
+worker fork is safe. Preloading would pull numpy into the forkserver and risk it
+gaining background threads, reintroducing the very hazard on each worker fork.
+
+Keep this module's top-level imports trivial: ``pystreams.cmd.multi`` (which drags
+in numpy via the scanner) must not be imported until *after* the forkserver is up,
+so the import lives inside :func:`main`.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+
+
+def _noop() -> None:
+    """Throwaway target whose only job is to force the forkserver to bootstrap.
+
+    Defined at module scope so it is picklable by reference; the forked child
+    imports this module (which stays pristine — just ``multiprocessing``), runs
+    nothing, and exits.
+    """
+
+
+def main() -> None:
+    # Bootstrap the forkserver while this process is still pristine. Starting any
+    # process against the forkserver context triggers its one-time fork()+exec()
+    # bootstrap; doing it now means that bootstrap forks a clean parent rather than
+    # the numpy/gRPC/Objective-C-laden CLI process (which macOS would abort).
+    warm = multiprocessing.get_context("forkserver").Process(target=_noop)
+    warm.start()
+    warm.join()
+
+    # Safe now: the forkserver singleton is running. Importing the CLI (and the
+    # scientific stack it pulls in) no longer affects pool worker spawning, which
+    # forks from the forkserver, not from this process.
+    from pystreams.cmd.multi import cli
+
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -223,6 +223,12 @@ class ProcessPoolScanner(_AsyncCloseable):
         supported with the ``fork`` start method). The warmup forces each worker to
         spawn and load its model up front, so the first real scans don't pay
         model-load latency.
+
+        The forkserver this reuses is bootstrapped pristine by the ``multi``
+        entrypoint (``pystreams.cmd.bootstrap``), before numpy/gRPC are imported, so
+        its one-time fork()+exec() does not inherit a parent that macOS would abort
+        for forking mid Objective-C ``+initialize``. Every worker here forks from
+        that clean forkserver, never from this process.
         """
         executor = ProcessPoolExecutor(
             max_workers=max_workers,


### PR DESCRIPTION
## Problem

`start:pystreams-multi` aborts on startup on **macOS** with an Objective-C fork-safety crash, then `BrokenProcessPool` during scan-pool warmup:

```
objc[...]: +[NSNumber initialize] may have been in progress in another thread when fork() was called.
We cannot safely call it or ignore it in the fork() child process. Crashing instead.
...
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly
```

## Root cause

`ProcessPoolScanner` runs Presidio in a `forkserver`-backed pool. The forkserver process is created by `fork()`+`exec()`-ing whichever process first triggers it — which was the `multi` CLI. By then it has imported **numpy/spaCy** (whose macOS BLAS backend is Accelerate, a Foundation/Objective-C framework) and the Pub/Sub gRPC clients, loading the objc runtime and spawning helper threads. macOS aborts the forked child if another thread is mid Objective-C `+initialize` at fork time.

Confirmed it's the scientific stack, not gRPC: importing `pystreams.risk.scanner` alone pulls in numpy/spaCy/blis (and not grpc), and the crash reproduces with no broker constructed. Reordering *within* the CLI can't fix it — the heavy imports happen at module load, before any CLI code runs. **Linux production is unaffected** (no objc runtime).

## Fix

Add a pristine entrypoint `pystreams.cmd.bootstrap:main` (the `multi` console script now points here). It stands up the forkserver **before importing anything heavy**, then hands off to `multi:cli`:

- The only fork that inherits the laden parent is the forkserver bootstrap; every scan worker forks from the forkserver, not the CLI. So bootstrapping the forkserver while the process is still clean (no numpy/gRPC/objc) is sufficient.
- Workers import numpy in the forked **child** (post-fork), so the forkserver itself stays single-threaded and later worker forks are safe too — hence we deliberately do **not** `set_forkserver_preload`.

No env var (`OBJC_DISABLE_INITIALIZE_FORK_SAFETY`), cross-platform, production-faithful (dev exercises the real pool path).

## Verification

- The forkserver bootstraps **before** numpy is loaded into main, persists, and the pool reuses it without re-bootstrapping (verified the forkserver pid is identical before and after the heavy import).
- End-to-end: bootstrap → build pool → real scan returns detections.
- `ruff` clean; `hk fix` no changes; full pystreams suite — **73 passed**.

Cannot reproduce the macOS abort on Linux CI (no libobjc), so a macOS dev should confirm `start:pystreams-multi` comes up clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)