### PR TITLE
chore(pystreams): raise presidio scan timeout to 5 minutes

### DIFF
--- a/pystreams/src/pystreams/cmd/flags_presidio.py
+++ b/pystreams/src/pystreams/cmd/flags_presidio.py
@@ -42,7 +42,7 @@ def presidio_options() -> Sequence[click.Option]:
         click.Option(
             ["--scan-timeout"],
             type=float,
-            default=60.0,
+            default=300.0,
             envvar="GRAM_PYSTREAMS_SCAN_TIMEOUT",
             help=(
                 "Seconds a single scan may run before it is treated as a failure "

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -198,7 +198,7 @@ class ProcessPoolScanner(_AsyncCloseable):
         self,
         executor: ProcessPoolExecutor,
         *,
-        scan_timeout: float | None = 30.0,
+        scan_timeout: float | None = 300.0,
         wait_limiter: anyio.CapacityLimiter | None = None,
     ):
         self._executor = executor
@@ -214,7 +214,7 @@ class ProcessPoolScanner(_AsyncCloseable):
         *,
         max_workers: int = 4,
         max_tasks_per_child: int | None = 1000,
-        scan_timeout: float | None = 30.0,
+        scan_timeout: float | None = 300.0,
     ) -> ProcessPoolScanner:
         """Build the pool and eagerly warm every worker's analyzer.
 


### PR DESCRIPTION
## What

Raise the default Presidio scan timeout in `pystreams` from 60s to 5 minutes (300s).

## Why

Large payloads were exceeding the previous 60s bound and getting treated as scan failures. Five minutes gives heavy Presidio scans room to complete before the deadline trips.

## Changes

- `cmd/flags_presidio.py`: `--scan-timeout` default `60.0` → `300.0` (env: `GRAM_PYSTREAMS_SCAN_TIMEOUT`)
- `risk/scanner.py`: `ProcessPoolScanner` constructor + `create()` `scan_timeout` defaults `30.0` → `300.0` for consistency with the CLI flag

The CLI flag is the runtime source of truth; the scanner.py defaults are library-level fallbacks bumped to match.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Presidio scan timeout in `pystreams` to 5 minutes to prevent false scan failures on large payloads. The CLI `--scan-timeout` and `ProcessPoolScanner` defaults now use 300s (env `GRAM_PYSTREAMS_SCAN_TIMEOUT`).

<sup>Written for commit 83ed1b9f63b7bf8add2a20ddce23a77e985a74d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

