### PR TITLE
fix(usage): map polar webhook for unknown org to not-found

### DIFF
--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -9,6 +10,7 @@ import (
 	"net/url"
 	"slices"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	srv "github.com/speakeasy-api/gram/server/gen/http/usage/server"
 	gen "github.com/speakeasy-api/gram/server/gen/usage"
@@ -137,7 +139,10 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 	}
 
 	existingOrgMetadata, err := s.orgRepo.GetOrganizationMetadata(ctx, webhookPayload.Data.Customer.ExternalID)
-	if err != nil {
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return oops.E(oops.CodeNotFound, err, "no organization found with polar external id").LogWarn(ctx, logger, attr.SlogOrganizationID(webhookPayload.Data.Customer.ExternalID))
+	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to get organization metadata").LogError(ctx, logger)
 	}
 

--- a/server/internal/usage/impl_test.go
+++ b/server/internal/usage/impl_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -19,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
@@ -105,7 +108,15 @@ func (m *mockBillingRepo) GetUsageTiers(ctx context.Context) (*gen.UsageTiers, e
 }
 
 func (m *mockBillingRepo) ValidateAndParseWebhookEvent(ctx context.Context, payload []byte, header http.Header) (*billing.PolarWebhookPayload, error) {
-	return nil, fmt.Errorf("not implemented")
+	args := m.Called(ctx, payload, header)
+	if args.Get(0) == nil {
+		return nil, fmt.Errorf("mock: %w", args.Error(1))
+	}
+	wp, ok := args.Get(0).(*billing.PolarWebhookPayload)
+	if !ok {
+		return nil, fmt.Errorf("mock: unexpected type %T", args.Get(0))
+	}
+	return wp, args.Error(1)
 }
 
 func (m *mockBillingRepo) InvalidateBillingCustomerCaches(ctx context.Context, orgID string) error {
@@ -151,6 +162,7 @@ func newTestService(t *testing.T, billingRepo billing.Repository, orgID string, 
 		authz:       authzEngine,
 		repo:        repo.New(db),
 		billingRepo: billingRepo,
+		orgRepo:     orgRepo.New(db),
 	}
 }
 
@@ -287,6 +299,32 @@ func TestGetPeriodUsage_ActualServerCountFromDB(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 7, result.ActualEnabledServerCount, "should use DB count, not cached value")
+}
+
+func TestHandlePolarWebhook_OrgNotFound(t *testing.T) {
+	t.Parallel()
+	orgID := "org-does-not-exist"
+
+	payload := &billing.PolarWebhookPayload{Type: "subscription.created"}
+	payload.Data.Customer = &billing.WebhookCustomer{ExternalID: orgID}
+
+	billingMock := &mockBillingRepo{}
+	billingMock.On("ValidateAndParseWebhookEvent", mock.Anything, mock.Anything, mock.Anything).
+		Return(payload, nil)
+	svc := newTestService(t, billingMock, orgID, 0)
+
+	req := httptest.NewRequest(http.MethodPost, "/rpc/polar.webhook", strings.NewReader("{}"))
+	rec := httptest.NewRecorder()
+
+	err := svc.HandlePolarWebhook(rec, req)
+
+	require.Error(t, err)
+	var se *oops.ShareableError
+	require.ErrorAs(t, err, &se)
+	require.Equal(t, oops.CodeNotFound, se.Code,
+		"a webhook for an unknown polar external id should map to CodeNotFound, not CodeUnexpected")
+	// We never get past the org lookup, so no cache invalidation should occur.
+	billingMock.AssertNotCalled(t, "InvalidateBillingCustomerCaches", mock.Anything, mock.Anything)
 }
 
 func TestCreateTopUpCheckout_BillingErrorMapsToCodeUnexpected(t *testing.T) {


### PR DESCRIPTION
## What

When a Polar webhook references a customer `external_id` that has no matching organization, `HandlePolarWebhook` now returns `CodeNotFound` (logged as a warning) instead of `CodeUnexpected` (logged as an error).

## Why

A webhook can reference a customer external id that no longer maps to an org (deleted org, stale Polar customer record). Surfacing this as an unexpected server error pages on-call for a benign, non-actionable condition. A not-found warning keeps it visible without alarming.

## Changes

- `impl.go`: branch on `pgx.ErrNoRows` from `GetOrganizationMetadata` → `CodeNotFound` + `LogWarn`; all other errors stay `CodeUnexpected`.
- `impl_test.go`: add `TestHandlePolarWebhook_OrgNotFound` covering the unknown-org path, and wire `orgRepo` + a controllable `ValidateAndParseWebhookEvent` mock into the test harness.

## Testing

- `go test -race ./server/internal/usage/` ✅
- `mise lint:server` ✅


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Polar webhooks that reference an unknown customer `external_id` as not found (warning) instead of unexpected (error). This stops paging for benign events while keeping them visible.

- **Bug Fixes**
  - Map `pgx.ErrNoRows` from `GetOrganizationMetadata` to `CodeNotFound` with `LogWarn`; keep other errors as `CodeUnexpected`.
  - Added `TestHandlePolarWebhook_OrgNotFound` with a mocked `ValidateAndParseWebhookEvent` and wired `orgRepo` to cover the unknown-org path.

<sup>Written for commit b949852f9bb5a0e062ae089de22bf450b303d351. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

