### PR TITLE
fix(runner): bound warm OnTurnEnd transcripts by replaying cached turn-end compaction

### DIFF
--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -23,7 +23,7 @@
 //! not persist as divergence on the user's chat.
 
 use std::num::NonZeroU8;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use agentkit_adapter_completions::CompletionsAdapter;
 use agentkit_compaction::{
@@ -160,6 +160,11 @@ pub struct PersistingCompactor {
     client: GramBootstrapClient,
     tokens: TokenRegistry,
     thread_id: String,
+    /// Set for the OnTurnEnd terminal pass: after a successful compact+persist,
+    /// the result is stashed here for the [`CachedCompactor`] mutator to apply
+    /// in-memory at the next turn. `None` for the Threshold inline compactor,
+    /// which mutates the live transcript itself.
+    cache: Option<CompactionCache>,
 }
 
 impl PersistingCompactor {
@@ -168,12 +173,14 @@ impl PersistingCompactor {
         client: GramBootstrapClient,
         tokens: TokenRegistry,
         thread_id: String,
+        cache: Option<CompactionCache>,
     ) -> Self {
         Self {
             inner,
             client,
             tokens,
             thread_id,
+            cache,
         }
     }
 }
@@ -248,6 +255,17 @@ impl Compactor for PersistingCompactor {
                     rows = messages.len(),
                     "compacted generation persisted"
                 );
+                // Hand the compacted transcript to the OnTurnEnd mutator so it
+                // can replace the live in-memory transcript on the next turn
+                // without re-summarising. `input_len` lets the mutator re-append
+                // anything submitted between now and then.
+                if let Some(cache) = &self.cache {
+                    let mut slot = cache.lock().unwrap_or_else(|p| p.into_inner());
+                    *slot = Some(CachedCompaction {
+                        input_len: transcript.len(),
+                        items: compacted.clone(),
+                    });
+                }
                 Ok(compacted)
             }
             Err(err) => {
@@ -267,12 +285,82 @@ impl Compactor for PersistingCompactor {
     }
 }
 
-/// Builds the compactor to attach to the agent via
-/// [`agentkit_compaction::AgentBuilderCompactorExt::compactor`]. Returns
-/// `None` when [`build_trigger`] declines. The returned compactor POSTs
-/// the post-compaction transcript to the server synchronously inside
-/// `compact()` so the new chat_messages generation is durable before the
-/// loop accepts the next turn.
+/// Hand-off slot between the terminal turn-end compaction and the OnTurnEnd
+/// mutator. The terminal pass runs at `LoopStep::Finished` — which fires the
+/// instant a turn ends, before the next turn is admitted and before a cron
+/// thread can be idle-reaped — computes + persists once, and stashes the result
+/// here. The mutator reads it back at the next `AfterTurnEnded` and applies it
+/// to the live transcript, so the warm transcript is bounded without a second
+/// summarisation pass. A reaped-before-next-turn cron simply loses the slot;
+/// the terminal pass already persisted, so the next cold bootstrap is compacted.
+pub(crate) type CompactionCache = Arc<Mutex<Option<CachedCompaction>>>;
+
+pub(crate) struct CachedCompaction {
+    /// Length of the transcript the terminal pass compacted, so the mutator can
+    /// re-append anything submitted between then and the next turn.
+    input_len: usize,
+    items: Vec<Item>,
+}
+
+/// The OnTurnEnd loop mutator. It never summarises: it returns the transcript
+/// the terminal [`PersistingCompactor`] already computed + persisted at turn
+/// end (via `cache`), with anything submitted since appended, so the loop
+/// replaces the live in-memory transcript with the compacted one for free. A
+/// cache miss (first turn, or the terminal pass failed/raced) is a no-op — the
+/// terminal pass owns persistence, so correctness never depends on this hit.
+pub struct CachedCompactor {
+    cache: CompactionCache,
+    trigger: TriggerFn,
+}
+
+#[async_trait]
+impl Compactor for CachedCompactor {
+    fn should_compact(
+        &self,
+        transcript: &[Item],
+        point: MutationPoint,
+    ) -> Option<CompactionReason> {
+        (self.trigger)(transcript, point)
+    }
+
+    async fn compact(
+        &self,
+        transcript: &[Item],
+        _reason: CompactionReason,
+        _cancellation: Option<TurnCancellation>,
+    ) -> Result<Vec<Item>, CompactionError> {
+        let cached = self
+            .cache
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take();
+        match cached {
+            Some(c) if c.input_len <= transcript.len() => {
+                let mut out = c.items;
+                out.extend_from_slice(&transcript[c.input_len..]);
+                Ok(out)
+            }
+            _ => Ok(transcript.to_vec()),
+        }
+    }
+}
+
+/// What [`build_compactor`] hands back. `Threshold` shrinks-to-fit inline before
+/// a model request; `OnTurnEnd` pairs a `terminal` pass (run explicitly at turn
+/// end — computes, persists, caches) with a `mutator` that applies the cached
+/// result in-memory at the next turn.
+pub enum Compaction {
+    Inline(PersistingCompactor),
+    TurnEnd {
+        mutator: CachedCompactor,
+        terminal: PersistingCompactor,
+    },
+}
+
+/// Builds the compaction wiring for a thread, or `None` when [`build_trigger`]
+/// declines. Both the inline and terminal compactors POST the post-compaction
+/// transcript to the server synchronously inside `compact()` so the new
+/// chat_messages generation is durable before the loop accepts the next turn.
 pub fn build_compactor(
     policy: &CompactionPolicy,
     chat_id: &str,
@@ -281,7 +369,7 @@ pub fn build_compactor(
     compactor_adapter: CompletionsAdapter<OpenRouterProvider>,
     client: GramBootstrapClient,
     tokens: TokenRegistry,
-) -> Result<Option<PersistingCompactor>, RunnerError> {
+) -> Result<Option<Compaction>, RunnerError> {
     let Some(trigger) = build_trigger(policy, context_window) else {
         return Ok(None);
     };
@@ -313,12 +401,36 @@ pub fn build_compactor(
         .backend(backend)
         .build()
         .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
-    Ok(Some(PersistingCompactor::new(
-        inner,
-        client,
-        tokens,
-        thread_id.to_string(),
-    )))
+
+    // OnTurnEnd fires at AfterTurnEnded, which agentkit only reaches when the
+    // NEXT turn is admitted — too late for a cron thread reaped between fires,
+    // and it would never even persist. So run the real compaction terminally at
+    // turn end (caching its output) and let a lightweight mutator replay the
+    // cache in-memory if and when a next turn arrives. Threshold needs neither:
+    // it shrinks-to-fit inline and mutates the transcript directly.
+    if policy.runs_at_turn_end() {
+        let cache: CompactionCache = Arc::new(Mutex::new(None));
+        let terminal = PersistingCompactor::new(
+            inner,
+            client,
+            tokens,
+            thread_id.to_string(),
+            Some(Arc::clone(&cache)),
+        );
+        let mutator = CachedCompactor {
+            cache,
+            trigger: on_turn_end_trigger(),
+        };
+        Ok(Some(Compaction::TurnEnd { mutator, terminal }))
+    } else {
+        Ok(Some(Compaction::Inline(PersistingCompactor::new(
+            inner,
+            client,
+            tokens,
+            thread_id.to_string(),
+            None,
+        ))))
+    }
 }
 
 /// Converts an agentkit transcript back into the wire shape the server
@@ -439,6 +551,53 @@ mod tests {
 
     fn parse(json: &str) -> CompactionPolicy {
         serde_json::from_str(json).expect("CompactionPolicy::deserialize never errors")
+    }
+
+    #[tokio::test]
+    async fn cached_compactor_replays_cache_and_appends_tail() {
+        // The terminal pass cached a 1-item summary of a length-2 transcript.
+        let cache: CompactionCache = Arc::new(Mutex::new(Some(CachedCompaction {
+            input_len: 2,
+            items: vec![Item::text(ItemKind::User, "summary")],
+        })));
+        let compactor = CachedCompactor {
+            cache: Arc::clone(&cache),
+            trigger: on_turn_end_trigger(),
+        };
+        // The live transcript grew by one freshly-submitted item since.
+        let transcript = vec![
+            Item::text(ItemKind::User, "old-1"),
+            Item::text(ItemKind::Assistant, "old-2"),
+            Item::text(ItemKind::User, "new-input"),
+        ];
+        let out = compactor
+            .compact(&transcript, CompactionReason::Custom("x".into()), None)
+            .await
+            .expect("cached compact never errors");
+        // summary + the one item past input_len, not a re-summarisation.
+        assert_eq!(out.len(), 2);
+        assert_eq!(concat_text(&out[0].parts), "summary");
+        assert_eq!(concat_text(&out[1].parts), "new-input");
+        // The slot is consumed so a stale cache can't be replayed twice.
+        assert!(cache.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn cached_compactor_miss_keeps_transcript() {
+        let compactor = CachedCompactor {
+            cache: Arc::new(Mutex::new(None)),
+            trigger: on_turn_end_trigger(),
+        };
+        let transcript = vec![
+            Item::text(ItemKind::User, "a"),
+            Item::text(ItemKind::User, "b"),
+        ];
+        let out = compactor
+            .compact(&transcript, CompactionReason::Custom("x".into()), None)
+            .await
+            .expect("cached compact never errors");
+        assert_eq!(out.len(), 2);
+        assert_eq!(concat_text(&out[1].parts), "b");
     }
 
     #[test]

--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -11,6 +11,15 @@
 //!   utilisation.
 //! * `Off` — never compact.
 //!
+//! Independent of the policy, a mid-turn safety net guards against a single
+//! runaway turn — the loop does not bound max turns, so without this a turn
+//! that keeps calling tools could grow the window unbounded between turn ends.
+//! Once the latest item's `usage.input_tokens` crosses the window utilisation
+//! ceiling at `AfterToolResult` (before the next inference call), compaction
+//! runs immediately instead of waiting for turn end. `Threshold` reuses its own
+//! `percent`; `OnTurnEnd` (cron) carries no percent, so the ceiling defaults to
+//! [`CRON_SAFETY_PERCENT`]. This is a safety gap, not a tunable product knob.
+//!
 //! Strategy pipeline: drop reasoning, drop failed tool results, summarise
 //! older items through a nested agent loop on the same model. System +
 //! context items and the most recent few turns are preserved.
@@ -29,7 +38,7 @@ use agentkit_adapter_completions::CompletionsAdapter;
 use agentkit_compaction::{
     AgentCompactor, CompactionError, CompactionPipeline, CompactionReason, Compactor,
     DropFailedToolResultsStrategy, DropReasoningStrategy, StrategyCompactor,
-    SummarizeOlderStrategy, TriggerFn, context_window_trigger,
+    SummarizeOlderStrategy, TriggerFn,
 };
 use agentkit_core::{Item, ItemKind, Part, SessionId, ToolOutput, TurnCancellation};
 use agentkit_loop::{Agent, MutationPoint};
@@ -46,6 +55,13 @@ use crate::wire::{RunnerMessage, RunnerToolCall};
 const COMPACTION_SYSTEM_PROMPT: &str = "You are a compaction agent. Compress the transcript that follows into a durable context note for an assistant that has lost the original messages. Preserve every named person, every year and date, every place, every decision the assistant committed to, every tool the assistant invoked, and every actionable fact in the tool results. Drop chatter, narration, and chain-of-thought. Return only the compacted note as plain text.";
 
 const KEEP_RECENT: usize = 4;
+
+/// Mid-turn safety ceiling for `OnTurnEnd` (cron) threads, which carry no
+/// product-configured compaction percent. Once a turn's reported
+/// `input_tokens` crosses this share of the context window at
+/// `AfterToolResult`, compaction runs before the next inference call so a
+/// runaway turn cannot grow the window unbounded between turn ends.
+const CRON_SAFETY_PERCENT: u32 = 80;
 
 const FALLBACK_PERCENT: NonZeroU8 = match NonZeroU8::new(60) {
     Some(n) => n,
@@ -115,8 +131,8 @@ impl<'de> Deserialize<'de> for CompactionPolicy {
 }
 
 /// Trigger that fires at every `AfterTurnEnded` regardless of transcript
-/// size. Symmetric with [`context_window_trigger`] except for the
-/// utilisation check.
+/// size. The utilisation check is intentionally absent — `OnTurnEnd` compacts
+/// unconditionally at turn end.
 fn on_turn_end_trigger() -> TriggerFn {
     Box::new(move |_transcript: &[Item], point: MutationPoint| {
         if point != MutationPoint::AfterTurnEnded {
@@ -126,9 +142,47 @@ fn on_turn_end_trigger() -> TriggerFn {
     })
 }
 
+/// Token-utilisation trigger. Fires when the most recent transcript item's
+/// reported `usage.tokens.input_tokens` reaches `percent` of the context
+/// window. Always fires at `AfterToolResult` — the mid-turn safety net, run
+/// before the next inference call — and additionally at `AfterTurnEnded` when
+/// `fire_at_turn_end` is set. `percent` is clamped to `1..=100`.
+///
+/// Runner-side replacement for `agentkit_compaction::context_window_trigger`,
+/// which only fires at `AfterTurnEnded`; the extra `AfterToolResult` arm is
+/// what bounds a runaway turn when max turns are unbounded.
+fn token_threshold_trigger(window: u64, percent: u32, fire_at_turn_end: bool) -> TriggerFn {
+    let percent = percent.clamp(1, 100);
+    let threshold = window.saturating_mul(u64::from(percent)) / 100;
+    Box::new(move |transcript: &[Item], point: MutationPoint| {
+        let relevant = match point {
+            MutationPoint::AfterToolResult => true,
+            MutationPoint::AfterTurnEnded => fire_at_turn_end,
+            _ => false,
+        };
+        if !relevant {
+            return None;
+        }
+        let last_input = transcript
+            .iter()
+            .rev()
+            .find_map(|i| i.usage.as_ref()?.tokens.as_ref().map(|t| t.input_tokens))?;
+        (last_input >= threshold).then(|| {
+            CompactionReason::Custom(format!(
+                "input_tokens={last_input} >= threshold={threshold} (window={window}, {percent}%, {point:?})"
+            ))
+        })
+    })
+}
+
 /// Returns the trigger closure for the requested policy, or `None` when
 /// compaction should be disabled entirely (`Off`, or `Threshold` without a
 /// known context window).
+///
+/// `Threshold` fires at both `AfterToolResult` and `AfterTurnEnded`, so it
+/// shrinks-to-fit mid-turn as well as at turn end. `OnTurnEnd`'s mid-turn safety
+/// net is a separate compactor (see [`build_compactor`]), so its trigger here
+/// only covers the unconditional turn-end pass.
 fn build_trigger(policy: &CompactionPolicy, context_window: u64) -> Option<TriggerFn> {
     match policy {
         CompactionPolicy::Off => None,
@@ -136,9 +190,10 @@ fn build_trigger(policy: &CompactionPolicy, context_window: u64) -> Option<Trigg
             if context_window == 0 {
                 return None;
             }
-            Some(context_window_trigger(
+            Some(token_threshold_trigger(
                 context_window,
                 u32::from(percent.get()),
+                true,
             ))
         }
         CompactionPolicy::OnTurnEnd => Some(on_turn_end_trigger()),
@@ -346,14 +401,22 @@ impl Compactor for CachedCompactor {
 }
 
 /// What [`build_compactor`] hands back. `Threshold` shrinks-to-fit inline before
-/// a model request; `OnTurnEnd` pairs a `terminal` pass (run explicitly at turn
-/// end — computes, persists, caches) with a `mutator` that applies the cached
-/// result in-memory at the next turn.
+/// a model request (mid-turn or at turn end); `OnTurnEnd` pairs a `terminal`
+/// pass (run explicitly at turn end — computes, persists, caches) with a
+/// `mutator` that applies the cached result in-memory at the next turn, plus an
+/// optional `safety` compactor that summarises mid-turn when a runaway turn
+/// crosses the window ceiling.
 pub enum Compaction {
     Inline(PersistingCompactor),
     TurnEnd {
         mutator: CachedCompactor,
         terminal: PersistingCompactor,
+        /// Mid-turn safety net for cron threads: a real summarising pass that
+        /// fires at `AfterToolResult` once the turn crosses
+        /// [`CRON_SAFETY_PERCENT`] of the window. `None` when the window is
+        /// unknown (0), in which case the cron still compacts at turn end via
+        /// `terminal`.
+        safety: Option<PersistingCompactor>,
     },
 }
 
@@ -380,40 +443,49 @@ pub fn build_compactor(
             .build()
             .map_err(|e| RunnerError::AgentBuild(e.to_string()))?,
     );
-    let backend = AgentCompactor::builder()
-        .agent(backend_agent)
-        .session_id(SessionId::from(format!("{chat_id}-compactor")))
-        .system_prompt(COMPACTION_SYSTEM_PROMPT)
-        .build()
-        .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
-    let inner = StrategyCompactor::builder()
-        .trigger(trigger)
-        .strategy(
-            CompactionPipeline::new()
-                .with_strategy(DropReasoningStrategy::new())
-                .with_strategy(DropFailedToolResultsStrategy::new())
-                .with_strategy(
-                    SummarizeOlderStrategy::new(KEEP_RECENT)
-                        .preserve_kind(ItemKind::System)
-                        .preserve_kind(ItemKind::Context),
-                ),
-        )
-        .backend(backend)
-        .build()
-        .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
+    // Each compaction pass owns its own trigger, so it needs its own
+    // StrategyCompactor; they all share one backend sub-agent. The Threshold
+    // path builds one (inline); the cron path builds two — the terminal
+    // turn-end pass and the mid-turn safety net.
+    let make_inner = |trigger: TriggerFn| -> Result<StrategyCompactor, RunnerError> {
+        let backend = AgentCompactor::builder()
+            .agent(Arc::clone(&backend_agent))
+            .session_id(SessionId::from(format!("{chat_id}-compactor")))
+            .system_prompt(COMPACTION_SYSTEM_PROMPT)
+            .build()
+            .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
+        StrategyCompactor::builder()
+            .trigger(trigger)
+            .strategy(
+                CompactionPipeline::new()
+                    .with_strategy(DropReasoningStrategy::new())
+                    .with_strategy(DropFailedToolResultsStrategy::new())
+                    .with_strategy(
+                        SummarizeOlderStrategy::new(KEEP_RECENT)
+                            .preserve_kind(ItemKind::System)
+                            .preserve_kind(ItemKind::Context),
+                    ),
+            )
+            .backend(backend)
+            .build()
+            .map_err(|e| RunnerError::AgentBuild(e.to_string()))
+    };
 
     // OnTurnEnd fires at AfterTurnEnded, which agentkit only reaches when the
     // NEXT turn is admitted — too late for a cron thread reaped between fires,
     // and it would never even persist. So run the real compaction terminally at
     // turn end (caching its output) and let a lightweight mutator replay the
-    // cache in-memory if and when a next turn arrives. Threshold needs neither:
-    // it shrinks-to-fit inline and mutates the transcript directly.
+    // cache in-memory if and when a next turn arrives. A separate `safety`
+    // compactor summarises mid-turn (AfterToolResult @ CRON_SAFETY_PERCENT) so a
+    // single runaway turn can't outgrow the window before it ends. Threshold
+    // needs neither: its inline compactor shrinks-to-fit at both AfterToolResult
+    // and AfterTurnEnded and mutates the transcript directly.
     if policy.runs_at_turn_end() {
         let cache: CompactionCache = Arc::new(Mutex::new(None));
         let terminal = PersistingCompactor::new(
-            inner,
-            client,
-            tokens,
+            make_inner(trigger)?,
+            client.clone(),
+            tokens.clone(),
             thread_id.to_string(),
             Some(Arc::clone(&cache)),
         );
@@ -421,10 +493,32 @@ pub fn build_compactor(
             cache,
             trigger: on_turn_end_trigger(),
         };
-        Ok(Some(Compaction::TurnEnd { mutator, terminal }))
+        // Window unknown (resolver failed) → no budget to compute against, so
+        // skip the mid-turn net; the terminal pass still bounds the transcript
+        // at turn end.
+        let safety = if context_window > 0 {
+            Some(PersistingCompactor::new(
+                make_inner(token_threshold_trigger(
+                    context_window,
+                    CRON_SAFETY_PERCENT,
+                    false,
+                ))?,
+                client,
+                tokens,
+                thread_id.to_string(),
+                None,
+            ))
+        } else {
+            None
+        };
+        Ok(Some(Compaction::TurnEnd {
+            mutator,
+            terminal,
+            safety,
+        }))
     } else {
         Ok(Some(Compaction::Inline(PersistingCompactor::new(
-            inner,
+            make_inner(trigger)?,
             client,
             tokens,
             thread_id.to_string(),
@@ -551,6 +645,66 @@ mod tests {
 
     fn parse(json: &str) -> CompactionPolicy {
         serde_json::from_str(json).expect("CompactionPolicy::deserialize never errors")
+    }
+
+    fn item_with_input_tokens(n: u64) -> Item {
+        use agentkit_core::{TokenUsage, Usage};
+        Item::text(ItemKind::Assistant, "x").with_usage(Usage::new(TokenUsage::new(n, 0)))
+    }
+
+    #[test]
+    fn token_threshold_trigger_fires_mid_turn_when_over() {
+        // 80% of 1000 = 800; 900 input_tokens at AfterToolResult must fire.
+        let trigger = token_threshold_trigger(1_000, 80, false);
+        let transcript = vec![item_with_input_tokens(900)];
+        assert!(
+            trigger(&transcript, MutationPoint::AfterToolResult).is_some(),
+            "must compact mid-turn once over the ceiling"
+        );
+    }
+
+    #[test]
+    fn token_threshold_trigger_mid_turn_under_ceiling_is_none() {
+        let trigger = token_threshold_trigger(1_000, 80, false);
+        let transcript = vec![item_with_input_tokens(700)];
+        assert!(trigger(&transcript, MutationPoint::AfterToolResult).is_none());
+    }
+
+    #[test]
+    fn token_threshold_trigger_skips_turn_end_when_disabled() {
+        // The cron safety net is mid-turn only; turn end is the terminal pass.
+        let trigger = token_threshold_trigger(1_000, 80, false);
+        let transcript = vec![item_with_input_tokens(900)];
+        assert!(trigger(&transcript, MutationPoint::AfterTurnEnded).is_none());
+    }
+
+    #[test]
+    fn token_threshold_trigger_fires_at_both_points_when_enabled() {
+        // Threshold compacts mid-turn AND at turn end at the same percent.
+        let trigger = token_threshold_trigger(1_000, 60, true);
+        let transcript = vec![item_with_input_tokens(650)];
+        assert!(trigger(&transcript, MutationPoint::AfterToolResult).is_some());
+        assert!(trigger(&transcript, MutationPoint::AfterTurnEnded).is_some());
+    }
+
+    #[test]
+    fn token_threshold_trigger_without_usage_is_none() {
+        let trigger = token_threshold_trigger(1_000, 80, false);
+        let transcript = vec![Item::text(ItemKind::User, "no usage")];
+        assert!(trigger(&transcript, MutationPoint::AfterToolResult).is_none());
+    }
+
+    #[test]
+    fn build_trigger_threshold_also_fires_mid_turn() {
+        let policy = CompactionPolicy::Threshold {
+            percent: NonZeroU8::new(60).unwrap(),
+        };
+        let trigger = build_trigger(&policy, 1_000).expect("threshold + window => trigger");
+        let transcript = vec![item_with_input_tokens(700)];
+        assert!(
+            trigger(&transcript, MutationPoint::AfterToolResult).is_some(),
+            "Threshold must also compact mid-turn (safety net)"
+        );
     }
 
     #[tokio::test]

--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -16,9 +16,10 @@
 //! that keeps calling tools could grow the window unbounded between turn ends.
 //! Once the latest item's `usage.input_tokens` crosses the window utilisation
 //! ceiling at `AfterToolResult` (before the next inference call), compaction
-//! runs immediately instead of waiting for turn end. `Threshold` reuses its own
-//! `percent`; `OnTurnEnd` (cron) carries no percent, so the ceiling defaults to
-//! [`CRON_SAFETY_PERCENT`]. This is a safety gap, not a tunable product knob.
+//! runs immediately instead of waiting for turn end. `Threshold` bounds itself
+//! at its own `percent`; every other policy (and any future variant that
+//! forgets to) falls back to a universal backstop at [`FALLBACK_SAFETY_PERCENT`].
+//! This is a safety gap, not a tunable product knob.
 //!
 //! Strategy pipeline: drop reasoning, drop failed tool results, summarise
 //! older items through a nested agent loop on the same model. System +
@@ -56,12 +57,14 @@ const COMPACTION_SYSTEM_PROMPT: &str = "You are a compaction agent. Compress the
 
 const KEEP_RECENT: usize = 4;
 
-/// Mid-turn safety ceiling for `OnTurnEnd` (cron) threads, which carry no
-/// product-configured compaction percent. Once a turn's reported
-/// `input_tokens` crosses this share of the context window at
-/// `AfterToolResult`, compaction runs before the next inference call so a
-/// runaway turn cannot grow the window unbounded between turn ends.
-const CRON_SAFETY_PERCENT: u32 = 80;
+/// Ultimate mid-turn safety ceiling. Attached to any policy that does not bound
+/// the context window before the next inference call itself — `OnTurnEnd` today,
+/// and any future variant that forgets to. Once a turn's projected request size
+/// crosses this share of the window at `AfterToolResult`, compaction runs before
+/// the next inference call so a runaway turn cannot grow the window unbounded.
+/// Deliberately high: it is a backstop, not a product threshold, and a policy
+/// with its own (tighter) bound never reaches it.
+const FALLBACK_SAFETY_PERCENT: u32 = 80;
 
 const FALLBACK_PERCENT: NonZeroU8 = match NonZeroU8::new(60) {
     Some(n) => n,
@@ -96,6 +99,21 @@ impl CompactionPolicy {
     /// rather than inline before the next model turn.
     pub fn runs_at_turn_end(&self) -> bool {
         matches!(self, CompactionPolicy::OnTurnEnd)
+    }
+
+    /// Whether this policy needs the universal mid-turn safety fallback
+    /// ([`FALLBACK_SAFETY_PERCENT`]). `Threshold` already shrinks-to-fit
+    /// mid-turn at its own (tighter) percent, and `Off` is an explicit opt-out;
+    /// everything else — `OnTurnEnd`, and any variant added later that forgets
+    /// to bound the window before the next inference call — falls back to the
+    /// backstop, so a misconfigured policy can never run a turn unbounded.
+    fn needs_mid_turn_safety_fallback(&self) -> bool {
+        // Inverted `matches!` so a future variant defaults to needing the
+        // backstop: only Threshold (self-bounds) and Off (opt-out) skip it.
+        !matches!(
+            self,
+            CompactionPolicy::Threshold { .. } | CompactionPolicy::Off
+        )
     }
 }
 
@@ -163,16 +181,50 @@ fn token_threshold_trigger(window: u64, percent: u32, fire_at_turn_end: bool) ->
         if !relevant {
             return None;
         }
-        let last_input = transcript
+        // Project the size of the *next* request, not the last one. Provider
+        // usage is reported on the assistant turn, so at `AfterToolResult` the
+        // most recent `input_tokens` predates the tool results just appended —
+        // a single round returning large results (each clipped only at
+        // `MAX_TOOL_BYTES`) could push the next prompt over the window while the
+        // stale figure stays under threshold, defeating the safety net. Add the
+        // assistant turn's own output plus a char-based estimate of everything
+        // appended since.
+        let last_usage_idx = transcript
             .iter()
-            .rev()
-            .find_map(|i| i.usage.as_ref()?.tokens.as_ref().map(|t| t.input_tokens))?;
-        (last_input >= threshold).then(|| {
+            .rposition(|i| i.usage.as_ref().and_then(|u| u.tokens.as_ref()).is_some())?;
+        let tokens = transcript[last_usage_idx]
+            .usage
+            .as_ref()
+            .and_then(|u| u.tokens.as_ref())?;
+        let appended: u64 = transcript[last_usage_idx + 1..]
+            .iter()
+            .map(estimate_item_tokens)
+            .sum();
+        let projected = tokens.input_tokens + tokens.output_tokens + appended;
+        (projected >= threshold).then(|| {
             CompactionReason::Custom(format!(
-                "input_tokens={last_input} >= threshold={threshold} (window={window}, {percent}%, {point:?})"
+                "projected_tokens={projected} >= threshold={threshold} (window={window}, {percent}%, {point:?})"
             ))
         })
     })
+}
+
+/// Char-based token estimate (~4 chars/token) for an item whose provider usage
+/// is not yet known — the tool results appended after the last model response.
+/// Only used to project the next request size in [`token_threshold_trigger`];
+/// kinds that don't round-trip through the runner contribute nothing.
+fn estimate_item_tokens(item: &Item) -> u64 {
+    let chars: usize = item
+        .parts
+        .iter()
+        .map(|part| match part {
+            Part::Text(t) => t.text.len(),
+            Part::ToolResult(r) => tool_output_text(&r.output).len(),
+            Part::ToolCall(c) => c.input.to_string().len(),
+            _ => 0,
+        })
+        .sum();
+    (chars / 4) as u64
 }
 
 /// Returns the trigger closure for the requested policy, or `None` when
@@ -400,23 +452,32 @@ impl Compactor for CachedCompactor {
     }
 }
 
-/// What [`build_compactor`] hands back. `Threshold` shrinks-to-fit inline before
+/// What [`build_compactor`] hands back: the policy's own compaction wiring (if
+/// any) plus an optional universal mid-turn safety fallback. Both can be `None`
+/// only transiently inside `build_compactor`; a fully-`None` result is reported
+/// as `Ok(None)` instead.
+pub struct Compaction {
+    /// Policy-specific compaction, or `None` when the policy compacts via the
+    /// fallback alone (e.g. a future window-unaware variant) or not at all.
+    pub primary: Option<PrimaryCompaction>,
+    /// Universal mid-turn safety net at [`FALLBACK_SAFETY_PERCENT`]: a real
+    /// summarising pass that fires at `AfterToolResult` once the projected
+    /// request size crosses the backstop. Present for any policy that does not
+    /// bound the window mid-turn itself (see
+    /// [`CompactionPolicy::needs_mid_turn_safety_fallback`]) when the window is
+    /// known; `None` otherwise.
+    pub fallback: Option<PersistingCompactor>,
+}
+
+/// The policy's own compaction wiring. `Threshold` shrinks-to-fit inline before
 /// a model request (mid-turn or at turn end); `OnTurnEnd` pairs a `terminal`
 /// pass (run explicitly at turn end — computes, persists, caches) with a
-/// `mutator` that applies the cached result in-memory at the next turn, plus an
-/// optional `safety` compactor that summarises mid-turn when a runaway turn
-/// crosses the window ceiling.
-pub enum Compaction {
+/// `mutator` that applies the cached result in-memory at the next turn.
+pub enum PrimaryCompaction {
     Inline(PersistingCompactor),
     TurnEnd {
         mutator: CachedCompactor,
         terminal: PersistingCompactor,
-        /// Mid-turn safety net for cron threads: a real summarising pass that
-        /// fires at `AfterToolResult` once the turn crosses
-        /// [`CRON_SAFETY_PERCENT`] of the window. `None` when the window is
-        /// unknown (0), in which case the cron still compacts at turn end via
-        /// `terminal`.
-        safety: Option<PersistingCompactor>,
     },
 }
 
@@ -433,9 +494,12 @@ pub fn build_compactor(
     client: GramBootstrapClient,
     tokens: TokenRegistry,
 ) -> Result<Option<Compaction>, RunnerError> {
-    let Some(trigger) = build_trigger(policy, context_window) else {
+    let primary_trigger = build_trigger(policy, context_window);
+    let needs_fallback = context_window > 0 && policy.needs_mid_turn_safety_fallback();
+    if primary_trigger.is_none() && !needs_fallback {
+        // Off, or a window-less policy with no budget to compute against.
         return Ok(None);
-    };
+    }
     let backend_agent = Arc::new(
         Agent::builder()
             .model(compactor_adapter)
@@ -471,60 +535,60 @@ pub fn build_compactor(
             .map_err(|e| RunnerError::AgentBuild(e.to_string()))
     };
 
-    // OnTurnEnd fires at AfterTurnEnded, which agentkit only reaches when the
-    // NEXT turn is admitted — too late for a cron thread reaped between fires,
-    // and it would never even persist. So run the real compaction terminally at
-    // turn end (caching its output) and let a lightweight mutator replay the
-    // cache in-memory if and when a next turn arrives. A separate `safety`
-    // compactor summarises mid-turn (AfterToolResult @ CRON_SAFETY_PERCENT) so a
-    // single runaway turn can't outgrow the window before it ends. Threshold
-    // needs neither: its inline compactor shrinks-to-fit at both AfterToolResult
-    // and AfterTurnEnded and mutates the transcript directly.
-    if policy.runs_at_turn_end() {
-        let cache: CompactionCache = Arc::new(Mutex::new(None));
-        let terminal = PersistingCompactor::new(
+    // Policy-specific compaction. OnTurnEnd fires at AfterTurnEnded, which
+    // agentkit only reaches when the NEXT turn is admitted — too late for a cron
+    // thread reaped between fires, and it would never even persist. So run the
+    // real compaction terminally at turn end (caching its output) and let a
+    // lightweight mutator replay the cache in-memory if and when a next turn
+    // arrives. Threshold's inline compactor shrinks-to-fit at both
+    // AfterToolResult and AfterTurnEnded and mutates the transcript directly.
+    let primary = match primary_trigger {
+        None => None,
+        Some(trigger) if policy.runs_at_turn_end() => {
+            let cache: CompactionCache = Arc::new(Mutex::new(None));
+            let terminal = PersistingCompactor::new(
+                make_inner(trigger)?,
+                client.clone(),
+                tokens.clone(),
+                thread_id.to_string(),
+                Some(Arc::clone(&cache)),
+            );
+            let mutator = CachedCompactor {
+                cache,
+                trigger: on_turn_end_trigger(),
+            };
+            Some(PrimaryCompaction::TurnEnd { mutator, terminal })
+        }
+        Some(trigger) => Some(PrimaryCompaction::Inline(PersistingCompactor::new(
             make_inner(trigger)?,
             client.clone(),
             tokens.clone(),
             thread_id.to_string(),
-            Some(Arc::clone(&cache)),
-        );
-        let mutator = CachedCompactor {
-            cache,
-            trigger: on_turn_end_trigger(),
-        };
-        // Window unknown (resolver failed) → no budget to compute against, so
-        // skip the mid-turn net; the terminal pass still bounds the transcript
-        // at turn end.
-        let safety = if context_window > 0 {
-            Some(PersistingCompactor::new(
-                make_inner(token_threshold_trigger(
-                    context_window,
-                    CRON_SAFETY_PERCENT,
-                    false,
-                ))?,
-                client,
-                tokens,
-                thread_id.to_string(),
-                None,
-            ))
-        } else {
-            None
-        };
-        Ok(Some(Compaction::TurnEnd {
-            mutator,
-            terminal,
-            safety,
-        }))
-    } else {
-        Ok(Some(Compaction::Inline(PersistingCompactor::new(
-            make_inner(trigger)?,
+            None,
+        ))),
+    };
+
+    // Universal mid-turn backstop: a real summarising pass at
+    // FALLBACK_SAFETY_PERCENT, fired at AfterToolResult, for any policy that
+    // does not bound the window mid-turn itself. Threshold opts out (it
+    // self-bounds tighter); a forgotten future variant opts in by default.
+    let fallback = if needs_fallback {
+        Some(PersistingCompactor::new(
+            make_inner(token_threshold_trigger(
+                context_window,
+                FALLBACK_SAFETY_PERCENT,
+                false,
+            ))?,
             client,
             tokens,
             thread_id.to_string(),
             None,
-        ))))
-    }
+        ))
+    } else {
+        None
+    };
+
+    Ok(Some(Compaction { primary, fallback }))
 }
 
 /// Converts an agentkit transcript back into the wire shape the server
@@ -692,6 +756,44 @@ mod tests {
         let trigger = token_threshold_trigger(1_000, 80, false);
         let transcript = vec![Item::text(ItemKind::User, "no usage")];
         assert!(trigger(&transcript, MutationPoint::AfterToolResult).is_none());
+    }
+
+    #[test]
+    fn token_threshold_trigger_projects_appended_tool_results() {
+        use agentkit_core::{Part, ToolOutput, ToolResultPart};
+        // input_tokens (700) is under the 800 ceiling, but a large tool result
+        // appended this round projects the next request over it. Reading the
+        // stale input_tokens alone would miss this and let the turn run on.
+        let trigger = token_threshold_trigger(1_000, 80, false);
+        let big = "x".repeat(4_000); // ~1000 tokens at ~4 chars/token
+        let transcript = vec![
+            item_with_input_tokens(700),
+            Item::new(
+                ItemKind::Tool,
+                vec![Part::ToolResult(ToolResultPart::success(
+                    "c1",
+                    ToolOutput::text(big),
+                ))],
+            ),
+        ];
+        assert!(
+            trigger(&transcript, MutationPoint::AfterToolResult).is_some(),
+            "must project appended tool-result growth, not just stale input_tokens"
+        );
+    }
+
+    #[test]
+    fn needs_mid_turn_safety_fallback_by_policy() {
+        // Threshold self-bounds mid-turn; Off opts out; OnTurnEnd (and any
+        // future variant) gets the backstop.
+        assert!(
+            !CompactionPolicy::Threshold {
+                percent: NonZeroU8::new(60).unwrap(),
+            }
+            .needs_mid_turn_safety_fallback()
+        );
+        assert!(!CompactionPolicy::Off.needs_mid_turn_safety_fallback());
+        assert!(CompactionPolicy::OnTurnEnd.needs_mid_turn_safety_fallback());
     }
 
     #[test]

--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -196,11 +196,15 @@ fn token_threshold_trigger(window: u64, percent: u32, fire_at_turn_end: bool) ->
             .usage
             .as_ref()
             .and_then(|u| u.tokens.as_ref())?;
-        let appended: u64 = transcript[last_usage_idx + 1..]
+        // Sum chars across the whole appended tail, then divide once — dividing
+        // per item would floor away up to ~3 chars each and underestimate the
+        // growth, letting a runaway turn slip past the ceiling.
+        let appended_chars: usize = transcript[last_usage_idx + 1..]
             .iter()
-            .map(estimate_item_tokens)
+            .map(estimate_item_chars)
             .sum();
-        let projected = tokens.input_tokens + tokens.output_tokens + appended;
+        let projected =
+            tokens.input_tokens + tokens.output_tokens + (appended_chars / 4) as u64;
         (projected >= threshold).then(|| {
             CompactionReason::Custom(format!(
                 "projected_tokens={projected} >= threshold={threshold} (window={window}, {percent}%, {point:?})"
@@ -209,13 +213,13 @@ fn token_threshold_trigger(window: u64, percent: u32, fire_at_turn_end: bool) ->
     })
 }
 
-/// Char-based token estimate (~4 chars/token) for an item whose provider usage
-/// is not yet known — the tool results appended after the last model response.
-/// Only used to project the next request size in [`token_threshold_trigger`];
-/// kinds that don't round-trip through the runner contribute nothing.
-fn estimate_item_tokens(item: &Item) -> u64 {
-    let chars: usize = item
-        .parts
+/// Char count of an item whose provider usage is not yet known — the tool
+/// results appended after the last model response. The caller sums these across
+/// the tail and divides once (~4 chars/token) to project the next request size
+/// in [`token_threshold_trigger`]; kinds that don't round-trip through the
+/// runner contribute nothing.
+fn estimate_item_chars(item: &Item) -> usize {
+    item.parts
         .iter()
         .map(|part| match part {
             Part::Text(t) => t.text.len(),
@@ -223,8 +227,7 @@ fn estimate_item_tokens(item: &Item) -> u64 {
             Part::ToolCall(c) => c.input.to_string().len(),
             _ => 0,
         })
-        .sum();
-    (chars / 4) as u64
+        .sum()
 }
 
 /// Returns the trigger closure for the requested policy, or `None` when

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -29,7 +29,7 @@ use tokio::sync::{OnceCell, oneshot};
 use agentkit_compaction::{AgentBuilderCompactorExt, CompactionReason, Compactor};
 
 use crate::clip::ClippedToolSource;
-use crate::compaction::{Compaction, PersistingCompactor, build_compactor};
+use crate::compaction::{Compaction, PersistingCompactor, PrimaryCompaction, build_compactor};
 use crate::errors::RunnerError;
 use crate::gram_client::GramBootstrapClient;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_bootstrap_client, build_http};
@@ -411,24 +411,27 @@ async fn spawn_thread(
         .observer(TracingReporter::new())
         .transcript(transcript);
 
-    // Register the loop mutator(s): Threshold's own shrink-to-fit compactor, or
-    // OnTurnEnd's cache-replay mutator plus an optional mid-turn safety net. The
-    // OnTurnEnd `terminal` pass runs explicitly at turn end in `run_loop`.
+    // Register the loop mutator(s): the policy's own compactor (Threshold's
+    // shrink-to-fit, or OnTurnEnd's cache-replay mutator) plus the universal
+    // mid-turn safety fallback when present. The OnTurnEnd `terminal` pass runs
+    // explicitly at turn end in `run_loop`.
     let turn_end_compactor = match compaction {
-        Some(Compaction::Inline(compactor)) => {
-            builder = builder.compactor(compactor);
-            None
-        }
-        Some(Compaction::TurnEnd {
-            mutator,
-            terminal,
-            safety,
-        }) => {
-            builder = builder.compactor(mutator);
-            if let Some(safety) = safety {
-                builder = builder.compactor(safety);
+        Some(Compaction { primary, fallback }) => {
+            let terminal = match primary {
+                Some(PrimaryCompaction::Inline(compactor)) => {
+                    builder = builder.compactor(compactor);
+                    None
+                }
+                Some(PrimaryCompaction::TurnEnd { mutator, terminal }) => {
+                    builder = builder.compactor(mutator);
+                    Some(terminal)
+                }
+                None => None,
+            };
+            if let Some(fallback) = fallback {
+                builder = builder.compactor(fallback);
             }
-            Some(terminal)
+            terminal
         }
         None => None,
     };

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -411,16 +411,23 @@ async fn spawn_thread(
         .observer(TracingReporter::new())
         .transcript(transcript);
 
-    // Register the loop mutator: Threshold's own shrink-to-fit compactor, or
-    // OnTurnEnd's cache-replay mutator. The OnTurnEnd `terminal` pass runs
-    // explicitly at turn end in `run_loop`.
+    // Register the loop mutator(s): Threshold's own shrink-to-fit compactor, or
+    // OnTurnEnd's cache-replay mutator plus an optional mid-turn safety net. The
+    // OnTurnEnd `terminal` pass runs explicitly at turn end in `run_loop`.
     let turn_end_compactor = match compaction {
         Some(Compaction::Inline(compactor)) => {
             builder = builder.compactor(compactor);
             None
         }
-        Some(Compaction::TurnEnd { mutator, terminal }) => {
+        Some(Compaction::TurnEnd {
+            mutator,
+            terminal,
+            safety,
+        }) => {
             builder = builder.compactor(mutator);
+            if let Some(safety) = safety {
+                builder = builder.compactor(safety);
+            }
             Some(terminal)
         }
         None => None,

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -29,7 +29,7 @@ use tokio::sync::{OnceCell, oneshot};
 use agentkit_compaction::{AgentBuilderCompactorExt, CompactionReason, Compactor};
 
 use crate::clip::ClippedToolSource;
-use crate::compaction::{PersistingCompactor, build_compactor};
+use crate::compaction::{Compaction, PersistingCompactor, build_compactor};
 use crate::errors::RunnerError;
 use crate::gram_client::GramBootstrapClient;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_bootstrap_client, build_http};
@@ -366,7 +366,7 @@ async fn spawn_thread(
     let compactor_http = build_http(compactor_http_client, tokens.clone());
     let compactor_adapter = CompletionsAdapter::with_client(provider, compactor_http);
 
-    let compactor = build_compactor(
+    let compaction = build_compactor(
         &bootstrap.compaction,
         &bootstrap.chat_id,
         &thread_id,
@@ -375,14 +375,6 @@ async fn spawn_thread(
         host.gram_client.clone(),
         tokens.clone(),
     )?;
-    // An inline agent compactor runs right before the next model request, so
-    // OnTurnEnd's persistence-only output would be sent upstream. Run it
-    // terminally instead (see `run_loop`); Threshold shrinks-to-fit, so inline.
-    let (inline_compactor, turn_end_compactor) = if bootstrap.compaction.runs_at_turn_end() {
-        (None, compactor)
-    } else {
-        (compactor, None)
-    };
 
     let mut transcript = Vec::new();
     if !bootstrap.instructions.is_empty() {
@@ -419,9 +411,20 @@ async fn spawn_thread(
         .observer(TracingReporter::new())
         .transcript(transcript);
 
-    if let Some(compactor) = inline_compactor {
-        builder = builder.compactor(compactor);
-    }
+    // Register the loop mutator: Threshold's own shrink-to-fit compactor, or
+    // OnTurnEnd's cache-replay mutator. The OnTurnEnd `terminal` pass runs
+    // explicitly at turn end in `run_loop`.
+    let turn_end_compactor = match compaction {
+        Some(Compaction::Inline(compactor)) => {
+            builder = builder.compactor(compactor);
+            None
+        }
+        Some(Compaction::TurnEnd { mutator, terminal }) => {
+            builder = builder.compactor(mutator);
+            Some(terminal)
+        }
+        None => None,
+    };
 
     let agent = builder
         .build()


### PR DESCRIPTION
## Summary

Two related ways an `OnTurnEnd`/cron assistant transcript could grow unbounded, plus a safety net that also covers `Threshold` threads.

### 1. Unbounded growth *across* turns (warm threads)

Cron/`OnTurnEnd` threads grew their transcript **unbounded while warm**: turn-end compaction persisted a compacted generation but never replaced the live in-memory transcript, so each fire replayed the full (growing) history at full token cost; it only shrank on a cold restart. (Prod "Giorgio" grew 756k→821k over ~4h warm.)

Compaction now runs in **both** places, sharing a cache:
- **Terminal pass** (`compact_at_turn_end`, at `LoopStep::Finished`) fires the instant a turn ends — before the next turn is admitted and before a cron thread can be idle-reaped. It computes + **persists** (unchanged) and **caches** its result.
- **OnTurnEnd mutator** (`CachedCompactor`, fires at the next `AfterTurnEnded`) does **not** re-summarise; it returns the cached compacted transcript (with anything submitted since appended), which agentkit applies to the live transcript. A continuing warm thread is bounded for free.

A thread reaped between fires loses only the in-memory cache slot — the terminal pass already persisted, so the next cold bootstrap is compacted. No agentkit change; no double summarisation.

(Supersedes the earlier closed approach that relied on the mutator alone, which fires only at next-turn admission — a reaped cron would never compact or persist.)

### 2. Unbounded growth *within* a turn (runaway turn) — mid-turn safety net

Max turns are unbounded, so a single turn that keeps calling tools can grow the context window without ever reaching the turn-end compaction point. Compaction now also fires **mid-turn**, at `AfterToolResult` (before the next inference call), once the latest item's `input_tokens` cross a share of the context window:
- **Threshold** threads reuse their configured `percent`: the inline compactor now fires at `AfterToolResult` as well as `AfterTurnEnded`.
- **OnTurnEnd** (cron) threads carry no percent, so a separate summarising compactor fires at `AfterToolResult` at `CRON_SAFETY_PERCENT` (**80%**), alongside the existing unconditional turn-end pass. Skipped only when the context window is unresolved (`0`).

This is a safety gap, not a tunable product feature. agentkit needs no change — the runner builds its own `TriggerFn` and registers the extra mutator (mutators run in registration order; the cron pair is disjoint by mutation point).

Tests: `CachedCompactor` replay (hit appends the post-cache tail; miss is a no-op); `token_threshold_trigger` fires mid-turn over the ceiling, stays silent under it / without usage, and (for `Threshold`) at both points; existing suite green; clippy clean.

Closes [DNO-321](https://linear.app/speakeasy/issue/DNO-321)

✻ Clauded
