### PR TITLE
chore: fix spinup false positives

### DIFF
--- a/.mise-tasks/git/squash-gen.mts
+++ b/.mise-tasks/git/squash-gen.mts
@@ -99,9 +99,13 @@ async function assertNoMergeCommits(scopeStart: string): Promise<void> {
     .filter(Boolean);
   for (const c of commits) {
     const raw = await git("cat-file", "-p", c);
-    const parents = raw
-      .split("\n")
-      .filter((l) => l.startsWith("parent ")).length;
+    // `parent` entries live only in the header (before the first blank line).
+    // Scanning the whole object would miscount a message body line that
+    // happens to start with "parent " as an extra parent.
+    const lines = raw.split("\n");
+    const headerEnd = lines.indexOf("");
+    const header = headerEnd === -1 ? lines : lines.slice(0, headerEnd);
+    const parents = header.filter((l) => l.startsWith("parent ")).length;
     if (parents > 1) {
       fail(
         `merge commit in scope: ${c.slice(0, 7)} ${await subjectOf(c)} — refusing`,

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -1000,6 +1000,9 @@ func (f *FlyRunner) tryMarkDeployFailed(
 		}
 	}
 
+	ctx, cancel = context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
 	if state.internalAppID != uuid.Nil {
 		reapColumn := pgtype.Timestamptz{
 			Time:             reapedAt,

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -967,6 +967,15 @@ func (f *FlyRunner) tryMarkDeployFailed(
 	req RunnerDeployRequest,
 	state partialDeploy,
 ) {
+	// Cleanup usually runs precisely because the parent ctx was cancelled (the
+	// deploy was torn down mid-flight). Detach from that cancellation with a
+	// fresh deadline so we can still delete the Fly app and reconcile the DB
+	// row. Otherwise the leaked fly_apps row stays active (reaped_at IS NULL)
+	// and poisons later retries with a duplicate-key collision on
+	// fly_apps_project_deployment_function_active_key.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
 	var reapedAt time.Time
 	if state.appName != "" {
 		if err := f.client.DeleteApp(ctx, state.appName); err != nil {

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -749,7 +749,10 @@ func (f *FlyRunner) launchN(ctx context.Context, logger *slog.Logger, appName st
 				return
 			}
 
-			if err := flapsc.Wait(ctx, appName, m, "started", 30*time.Second); err != nil {
+			// Every deploy creates a brand-new app, so the runner image (tagged
+			// per server version) is always a cold pull on the first machine.
+			// 30s was too tight and misread cold pulls as failures.
+			if err := flapsc.Wait(ctx, appName, m, "started", 60*time.Second); err != nil {
 				errCh <- fmt.Errorf("waiting for machine %s to start: %w", m.ID, err)
 				return
 			}

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -695,13 +695,23 @@ func (f *FlyRunner) newMachineConfig(req RunnerDeployRequest, image string, file
 
 // isFlyAppReady reports whether the error does NOT indicate a transient Fly.io
 // propagation failure where the Machines API hasn't seen the newly-created app
-// yet. Returns true when err is nil or is an unrelated error.
+// yet. Returns true when err is nil or is an unrelated (non-retryable) error.
 func isFlyAppReady(err error) bool {
 	if err == nil {
 		return true
 	}
+
+	// The Machines API answers 404 ("app not found") while an app created via
+	// the GraphQL API is still propagating. Match the typed Flaps status code
+	// rather than relying solely on substrings.
+	if errors.Is(err, flaps.FlapsErrorNotFound) {
+		return false
+	}
+
 	msg := err.Error()
-	return !strings.Contains(msg, "no rows in result set") && !strings.Contains(msg, "failed to get app")
+	return !strings.Contains(msg, "no rows in result set") &&
+		!strings.Contains(msg, "failed to get app") &&
+		!strings.Contains(msg, "app not found")
 }
 
 func (f *FlyRunner) launchN(ctx context.Context, logger *slog.Logger, appName string, flapsc *flaps.Client, region string, config *fly.MachineConfig, minSecretVersion *uint64, n uint8) ([]*fly.Machine, error) {

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -484,8 +484,16 @@ func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *R
 	ms, err := f.launchN(ctx, logger, appName, flapsc, region, machineConfig, minSecretVersion, scale)
 	if err != nil {
 		if len(ms) > 0 {
+			// Partial success is tolerated: the app still serves traffic on the
+			// machines that came up, so this is a warning, not a failure. The
+			// joined err carries each per-machine cause; include the
+			// succeeded/requested counts so it reads as partial rather than as
+			// a hard failure. Only an all-zero result (below) is user-facing.
 			span.RecordError(err)
-			logger.WarnContext(ctx, "failed to spin up some function runner machines", attr.SlogError(err))
+			logger.WarnContext(ctx,
+				fmt.Sprintf("function runner deploy came up partially: %d/%d machines started", len(ms), scale),
+				attr.SlogError(err),
+			)
 		} else {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to spin up function runner machines").LogError(ctx, logger)
 		}

--- a/server/internal/functions/queries.sql
+++ b/server/internal/functions/queries.sql
@@ -69,7 +69,22 @@ INSERT INTO fly_apps (
   , @runner_version
   , @primary_region
   , 'pending'
-) RETURNING id;
+)
+-- Self-heal: if a prior deploy leaked an active row (cleanup never reaped it),
+-- reclaim it instead of colliding on fly_apps_project_deployment_function_active_key.
+ON CONFLICT (project_id, deployment_id, function_id) WHERE reaped_at IS NULL
+DO UPDATE SET
+    access_id = EXCLUDED.access_id
+  , fly_org_id = EXCLUDED.fly_org_id
+  , fly_org_slug = EXCLUDED.fly_org_slug
+  , app_name = EXCLUDED.app_name
+  , app_url = EXCLUDED.app_url
+  , runner_version = EXCLUDED.runner_version
+  , primary_region = EXCLUDED.primary_region
+  , status = 'pending'
+  , reap_error = NULL
+  , updated_at = clock_timestamp()
+RETURNING id;
 
 -- name: FinalizeFlyApp :one
 UPDATE fly_apps SET

--- a/server/internal/functions/repo/queries.sql.go
+++ b/server/internal/functions/repo/queries.sql.go
@@ -326,7 +326,20 @@ INSERT INTO fly_apps (
   , $9
   , $10
   , 'pending'
-) RETURNING id
+)
+ON CONFLICT (project_id, deployment_id, function_id) WHERE reaped_at IS NULL
+DO UPDATE SET
+    access_id = EXCLUDED.access_id
+  , fly_org_id = EXCLUDED.fly_org_id
+  , fly_org_slug = EXCLUDED.fly_org_slug
+  , app_name = EXCLUDED.app_name
+  , app_url = EXCLUDED.app_url
+  , runner_version = EXCLUDED.runner_version
+  , primary_region = EXCLUDED.primary_region
+  , status = 'pending'
+  , reap_error = NULL
+  , updated_at = clock_timestamp()
+RETURNING id
 `
 
 type InitFlyAppParams struct {
@@ -342,6 +355,8 @@ type InitFlyAppParams struct {
 	PrimaryRegion string
 }
 
+// Self-heal: if a prior deploy leaked an active row (cleanup never reaped it),
+// reclaim it instead of colliding on fly_apps_project_deployment_function_active_key.
 func (q *Queries) InitFlyApp(ctx context.Context, arg InitFlyAppParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, initFlyApp,
 		arg.ProjectID,


### PR DESCRIPTION
This PR bundles up some good changes and some risky changes. The possible terrible ones.

Adding multiple replicas seems to cause the age old fly eventual consistency app readiness probing problem. We broaden the classification of errors in order to account for this but a little worried that this classification may be _too_ broad and a little worried about the consequences of being too loose:

https://github.com/speakeasy-api/gram/pull/3610/changes/a4a7748e2d513f7022bdd5327b936b82bb1f11fe#diff-c5eb1ad0c60788874c9cd22dc91ee2fcee2504c6cee18a39aadcb2c06870bd76R707-R709

There are also conditions where app cleanup fails because of context deadline exceeded. This produces unique key conflicts in the database on retry. This block attempts to reuse the conflicting row but this may be grosser than just failing. Would be good to get a second opinion on yea/nay:

https://github.com/speakeasy-api/gram/commit/9232ac5d0cf9740904f8232a1369a7c19ee30e12#diff-f0f79e6987a464abd73dcc78602eada77cd264eebe7ee18cbebb93034310a915R75-R87


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false-positive runner deploy failures by handling Fly control-plane races and hardening retries, timeouts, cleanup, and logging. Addresses Linear AGE-2829 to reduce noisy alerts while keeping real failures visible.

- **Bug Fixes**
  - Launch stability: wait 60s for machine start; retry Fly propagation races by matching `flaps.FlapsErrorNotFound` (with “app not found” fallback).
  - Cleanup safety: run teardown on `context.WithoutCancel` with fresh timeouts for both delete and finalize so Fly app deletion and DB finalization complete.
  - DB self-heal: `InitFlyApp` uses `ON CONFLICT` to reclaim a leaked active `fly_apps` row instead of failing the unique index.
  - Logging: report partial deploys as “X/Y machines started”; only surface a user-facing error when zero machines start.
  - Dev tooling: scope `squash-gen` merge detection to the commit header to prevent false merge positives.

<sup>Written for commit 3acfeffd139c0ad27dc790fc5caa5dbc44f311d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



