### PR TITLE
feat(risk): run the CEL engine in the browser via wasm

### DIFF
--- a/.mise-tasks/gen/all.sh
+++ b/.mise-tasks/gen/all.sh
@@ -10,6 +10,7 @@ pids=()
 mise run gen:sdk            & pids+=($!)
 mise run gen:devidp         & pids+=($!)
 mise run gen:posting-server & pids+=($!)
+mise run gen:celwasm        & pids+=($!)
 
 status=0
 for pid in "${pids[@]}"; do

--- a/.mise-tasks/gen/celwasm.sh
+++ b/.mise-tasks/gen/celwasm.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#MISE dir="{{ config_root }}/server"
+#MISE description="Build the risk CEL engine to WASM for the dashboard editor"
+
+set -e
+
+# Codegen binaries are throwaway; skip VCS stamping for a stable, cacheable build.
+export GOFLAGS="-buildvcs=false ${GOFLAGS:-}"
+
+root=$(git rev-parse --show-toplevel)
+out="$root/client/dashboard/public/cel"
+mkdir -p "$out"
+
+# The browser engine IS the server engine: same celenv, compiled to wasm. The
+# editor loads this to type-check expressions and preview matched spans with no
+# round-trip and no drift from save-time validation.
+GOOS=js GOARCH=wasm go build -trimpath -o "$out/cel.wasm" ./cmd/celwasm
+
+# wasm_exec.js is the Go runtime shim; it must come from the SAME toolchain that
+# built cel.wasm, so copy it from GOROOT rather than vendoring a stale copy.
+cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" "$out/wasm_exec.js"
+
+echo "built $out/cel.wasm ($(du -h "$out/cel.wasm" | cut -f1)) + wasm_exec.js"

--- a/client/dashboard/.gitignore
+++ b/client/dashboard/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.sln
 *.sw?
 .vercel
+
+# Generated risk CEL wasm engine (build with `mise gen:celwasm`)
+/public/cel/

--- a/client/dashboard/knip.config.ts
+++ b/client/dashboard/knip.config.ts
@@ -6,6 +6,8 @@ const config: KnipConfig = {
   ignoreBinaries: [
     // Invoked from the lint:format script; not on the dep tree.
     "oxfmt",
+    // Invoked from the prebuild script to build cel.wasm; not on the dep tree.
+    "mise",
   ],
   ignore: [
     // Global ambient declarations (FIXME<M> escape-hatch + JSX namespace

--- a/client/dashboard/package.json
+++ b/client/dashboard/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port ${GRAM_SITE_PORT:-5173}",
+    "build:cel-wasm": "mise run gen:celwasm",
+    "prebuild": "if command -v mise >/dev/null 2>&1; then pnpm build:cel-wasm; else echo 'mise/Go unavailable; skipping cel.wasm build (CEL editor falls back to server-side validation)'; fi",
     "build": "vite build",
     "lint": "pnpm lint:format && pnpm lint:no-barrels && pnpm lint:oxlint && pnpm type-check",
     "lint:oxlint": "oxlint --type-aware",

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,3 @@
+
+# stray binary from `go build ./cmd/celwasm` without -o (use mise gen:celwasm)
+/celwasm

--- a/server/cmd/celwasm/main.go
+++ b/server/cmd/celwasm/main.go
@@ -1,0 +1,105 @@
+//go:build js && wasm
+
+// Command celwasm exposes the risk CEL engine to the browser (the same celenv
+// the server runs), built for GOOS=js GOARCH=wasm. It sets globals
+// __celEngineReady (or __celInitError) and the funcs __celReference /
+// __celCompile / __celComplete / __celEval.
+package main
+
+import (
+	"encoding/json"
+	"syscall/js"
+
+	"github.com/google/cel-go/cel"
+	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+)
+
+// maxPrograms bounds the compiled-program cache so a long session can't grow
+// browser memory without limit.
+const maxPrograms = 256
+
+func main() {
+	eng, err := celenv.New()
+	if err != nil {
+		js.Global().Set("__celInitError", js.ValueOf(err.Error()))
+		return
+	}
+
+	h := &handle{eng: eng, programs: map[string]cel.Program{}}
+
+	js.Global().Set("__celReference", js.FuncOf(h.reference))
+	js.Global().Set("__celComplete", js.FuncOf(h.complete))
+	js.Global().Set("__celCompile", js.FuncOf(h.compile))
+	js.Global().Set("__celEval", js.FuncOf(h.eval))
+	js.Global().Set("__celEngineReady", js.ValueOf(true))
+
+	select {} // keep the Go runtime alive so the exported funcs stay callable
+}
+
+type handle struct {
+	eng      *celenv.Engine
+	programs map[string]cel.Program // compiled-program cache; single-threaded wasm, no lock
+}
+
+// arg returns args[i] as a string, or "" when the JS caller passed too few args
+// (which would otherwise panic the module).
+func arg(args []js.Value, i int) string {
+	if i >= len(args) {
+		return ""
+	}
+	return args[i].String()
+}
+
+func (h *handle) put(expr string, prg cel.Program) {
+	if len(h.programs) >= maxPrograms {
+		h.programs = map[string]cel.Program{}
+	}
+	h.programs[expr] = prg
+}
+
+func (h *handle) reference(_ js.Value, _ []js.Value) any {
+	out, _ := json.Marshal(celenv.Describe())
+	return js.ValueOf(string(out))
+}
+
+func (h *handle) complete(_ js.Value, args []js.Value) any {
+	out, _ := json.Marshal(h.eng.Complete(arg(args, 0)))
+	return js.ValueOf(string(out))
+}
+
+func (h *handle) compile(_ js.Value, args []js.Value) any {
+	expr := arg(args, 0)
+	prg, err := h.eng.Compile(expr)
+	if err != nil {
+		return js.ValueOf(map[string]any{"ok": false, "error": err.Error()})
+	}
+	h.put(expr, prg)
+	return js.ValueOf(map[string]any{"ok": true})
+}
+
+// eval(expr, messageJSON) -> {ok, matched, spans(json)} | {ok:false, error}.
+func (h *handle) eval(_ js.Value, args []js.Value) any {
+	expr := arg(args, 0)
+
+	var msg celenv.Message
+	if err := json.Unmarshal([]byte(arg(args, 1)), &msg); err != nil {
+		return js.ValueOf(map[string]any{"ok": false, "error": "bad message json: " + err.Error()})
+	}
+
+	prg, ok := h.programs[expr]
+	if !ok {
+		var err error
+		if prg, err = h.eng.Compile(expr); err != nil {
+			return js.ValueOf(map[string]any{"ok": false, "error": err.Error()})
+		}
+		h.put(expr, prg)
+	}
+
+	spans, matched, err := h.eng.EvalDetection(prg, msg)
+	if err != nil {
+		return js.ValueOf(map[string]any{"ok": false, "error": err.Error()})
+	}
+
+	out, _ := json.Marshal(spans)
+	return js.ValueOf(map[string]any{"ok": true, "matched": matched, "spans": string(out)})
+}

--- a/server/cmd/celwasm/stub.go
+++ b/server/cmd/celwasm/stub.go
@@ -1,0 +1,13 @@
+//go:build !(js && wasm)
+
+package main
+
+// celwasm is built only for GOOS=js GOARCH=wasm (see main.go); it drives the
+// dashboard CEL editor in the browser. This stub keeps the package valid — and
+// `go build/vet/fix ./...` happy — on every other platform, where the real entry
+// point is excluded by build constraints. Build the real artifact with:
+//
+//	mise gen:celwasm   # or: GOOS=js GOARCH=wasm go build ./cmd/celwasm
+func main() {
+	panic("celwasm must be built with GOOS=js GOARCH=wasm")
+}


### PR DESCRIPTION
Compiles the risk CEL engine to `GOOS=js GOARCH=wasm` so the browser runs the *same* engine the server does.

- `server/cmd/celwasm/` exposes `__celReference` / `__celComplete` / `__celCompile` / `__celEval`, plus a non-wasm `stub.go` so `go build/vet/fix ./...` pass on every platform.
- `mise gen:celwasm` builds `cel.wasm` + `wasm_exec.js` into the dashboard assets dir (gitignored); wired into `gen:all` and a tolerant dashboard `prebuild` that **degrades gracefully** when the Go toolchain isn't present.

## Verification
`GOOS=js GOARCH=wasm go build ./cmd/celwasm` and the linux stub build both clean. ~18 MB raw / ~3.4 MB gzip, lazy-loaded behind Monaco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the risk CEL engine in the browser via WebAssembly and adds a Monaco-powered CEL editor with type-directed autocomplete, instant compile checks, and live span previews. Uses the same `celenv` as the server to remove round-trips and prevent drift.

- **New Features**
  - Added `server/cmd/celwasm` exposing `__celReference`, `__celComplete`, `__celCompile`, `__celEval`; built via `mise gen:celwasm` into `client/dashboard/public/cel/` (gitignored), copies `wasm_exec.js` from `GOROOT`, caches up to 256 programs, and includes a non‑wasm `stub.go`. Wired into `gen:all`; added `pnpm build:cel-wasm` and a tolerant dashboard `prebuild` that skips when Go/`mise` are absent.
  - New dashboard CEL editor: Monaco-based with engine-driven completion, inline errors with caret pointers, collapsible reference and examples, and live match preview for user/assistant/tool messages with UTF‑8‑accurate span highlighting. Wasm and editor are lazy-loaded.

<sup>Written for commit 30359de9ece90de2d9bddb5c9639753a0eec9530. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



