### PR TITLE
feat(dashboard): CEL expression editor + live match preview

### DIFF
--- a/client/dashboard/src/pages/security/cel-field.tsx
+++ b/client/dashboard/src/pages/security/cel-field.tsx
@@ -1,0 +1,224 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { Check, ChevronRight, CircleAlert, Loader2 } from "lucide-react";
+import { Suspense, useState, type JSX } from "react";
+import { useCelStatus, type CelStatus } from "./use-cel-status";
+import { useCelEngine } from "./use-cel-engine";
+import { CelMatchPreview } from "./cel-match-preview";
+import type { CelReferenceData } from "./cel-wasm";
+import CelMonacoEditorLazy from "./cel-monaco-editor.lazy";
+
+/** A named, insertable CEL snippet shown beneath the field. */
+export type CelExample = { label: string; expr: string };
+
+// Turn a raw cel-go compiler error into a readable message + optional caret
+// diagram: strip the wrapper and engine jargon, keep the caret.
+function formatCelError(raw: string): { message: string; pointer?: string } {
+  // Drop the `compile "…":` / `program "…":` wrapper the engine adds.
+  const unwrapped = raw
+    .trim()
+    .replace(/^(?:compile|program)\s+"(?:[^"\\]|\\.)*":\s*/, "");
+
+  // Separate the diagnostic (first line) from the cel-go caret diagram (the
+  // `| <source>` / `| ...^` lines that follow).
+  const lines = unwrapped.split("\n");
+  const pointerLines = lines
+    .slice(1)
+    .filter((l) => l.trimStart().startsWith("|"))
+    .map((l) => l.replace(/^\s*\|\s?/, ""));
+  const pointer = pointerLines.length ? pointerLines.join("\n") : undefined;
+
+  const message = (lines[0] ?? unwrapped)
+    .replace(/^ERROR:\s*/, "")
+    .replace(/<input>:\d+:(\d+):\s*/, (_m, col: string) => `Column ${col}: `)
+    .replace(/Syntax error:\s*/i, "")
+    .replace(/no viable alternative at input/i, "unexpected")
+    .replace(/(?:mismatched|extraneous) input/i, "unexpected")
+    .replace(/'<EOF>'/g, "end of expression")
+    .replace(
+      /undeclared reference to '([^']+)'(?:\s*\(in container '[^']*'\))?/i,
+      "unknown name '$1'",
+    )
+    // Surface our opaque CEL types under names authors recognise.
+    .replace(/celenv\.celTool/g, "tool")
+    .replace(/celenv\.field/g, "field")
+    .replace(
+      /expression must evaluate to bool, got (\w+)/i,
+      "expression must be true or false, but it's a $1",
+    );
+
+  return { message, pointer };
+}
+
+function CelStatusLine({ status }: { status: CelStatus }): JSX.Element | null {
+  switch (status.kind) {
+    case "idle":
+    case "unavailable": // engine didn't load; no client-side status, server validates on save
+      return null;
+    case "validating":
+      return (
+        <span className="text-muted-foreground flex items-center gap-1 text-xs">
+          <Loader2 className="h-3 w-3 animate-spin" /> Checking…
+        </span>
+      );
+    case "ok":
+      return (
+        <span className="text-success-foreground flex items-center gap-1 text-xs">
+          <Check className="h-3 w-3" /> Compiles
+        </span>
+      );
+    case "error": {
+      const { message, pointer } = formatCelError(status.message);
+      return (
+        <div className="text-destructive flex min-w-0 items-start gap-1 text-xs">
+          <CircleAlert className="mt-0.5 h-3 w-3 shrink-0" />
+          <div className="min-w-0 space-y-1">
+            <span>{message}</span>
+            {pointer && (
+              <pre className="text-muted-foreground overflow-x-auto font-mono text-[11px] leading-tight whitespace-pre">
+                {pointer}
+              </pre>
+            )}
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+// Collapsible reference of fields, matchers, and macros (from the engine catalog).
+export function CelReference({
+  reference,
+}: {
+  reference?: CelReferenceData;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs">
+        <ChevronRight
+          className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
+        />
+        Fields &amp; matchers
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 space-y-3">
+        <ReferenceGroup
+          title="Fields"
+          items={(reference?.variables ?? []).map((v) => ({
+            term: v.name,
+            note: `${v.type} — ${v.description}`,
+          }))}
+        />
+        <ReferenceGroup
+          title="Matchers"
+          items={(reference?.matchers ?? []).map((f) => ({
+            term: f.signature,
+            note: f.description,
+          }))}
+        />
+        <ReferenceGroup
+          title="Macros"
+          items={(reference?.macros ?? []).map((m) => ({
+            term: m.signature,
+            note: m.description,
+          }))}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function ReferenceGroup({
+  title,
+  items,
+}: {
+  title: string;
+  items: { term: string; note: string }[];
+}): JSX.Element | null {
+  if (items.length === 0) return null;
+  return (
+    <div className="space-y-1">
+      <p className="text-muted-foreground text-xs font-medium uppercase">
+        {title}
+      </p>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li key={item.term} className="text-xs">
+            <code className="text-foreground font-mono">{item.term}</code>
+            <span className="text-muted-foreground"> — {item.note}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// The raw-CEL authoring field (Monaco editor + validation + examples +
+// reference), used for detection_expr and the policy scope predicates.
+export function CelExpressionField({
+  value,
+  onChange,
+  examples,
+  disabled,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  examples?: CelExample[];
+  disabled?: boolean;
+}): JSX.Element {
+  const status = useCelStatus(value);
+  const engine = useCelEngine();
+  const ready = engine.status === "ready" ? engine.engine : null;
+
+  return (
+    <div className="space-y-2">
+      <Suspense
+        fallback={
+          <div className="border-input bg-input/30 h-16 w-full animate-pulse rounded-md border" />
+        }
+      >
+        <CelMonacoEditorLazy
+          value={value}
+          onChange={onChange}
+          engine={ready}
+          errorMessage={
+            status.kind === "error"
+              ? formatCelError(status.message).message
+              : null
+          }
+          disabled={disabled}
+        />
+      </Suspense>
+
+      <div className="flex min-h-4 items-start justify-between gap-2">
+        <CelStatusLine status={status} />
+      </div>
+
+      {ready && <CelMatchPreview expr={value} engine={ready} />}
+
+      {examples && examples.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-muted-foreground text-xs">Examples:</span>
+          {examples.map((ex) => (
+            <button
+              key={ex.label}
+              type="button"
+              onClick={() => onChange(ex.expr)}
+              disabled={disabled}
+              className="border-border text-muted-foreground hover:bg-muted hover:text-foreground rounded-full border px-2.5 py-1 text-xs transition-colors disabled:pointer-events-none disabled:opacity-50"
+            >
+              {ex.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <CelReference reference={ready?.reference} />
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/security/cel-match-preview.tsx
+++ b/client/dashboard/src/pages/security/cel-match-preview.tsx
@@ -1,0 +1,265 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { ChevronRight } from "lucide-react";
+import { useEffect, useMemo, useState, type JSX, type ReactNode } from "react";
+import type { CelEngine, CelMessage, CelSpan } from "./cel-wasm";
+
+const DEBOUNCE_MS = 200;
+
+const KINDS: { value: string; label: string; bodyLabel: string }[] = [
+  { value: "user_message", label: "User message", bodyLabel: "Prompt" },
+  {
+    value: "assistant_message",
+    label: "Assistant message",
+    bodyLabel: "Assistant reply",
+  },
+  { value: "tool_request", label: "Tool request", bodyLabel: "" },
+  { value: "tool_response", label: "Tool response", bodyLabel: "Tool output" },
+];
+
+// Targets recorded against the message body (vs. a tool call's fields). All
+// index into the same body text, so their spans highlight the content box.
+const BODY_TARGETS = new Set(["content", "prompt", "assistant", "tool_result"]);
+
+const SAMPLE_TOOLS = JSON.stringify(
+  [
+    {
+      name: "shell",
+      server: "shell",
+      function: "exec",
+      args: '{"command":""}',
+    },
+  ],
+  null,
+  2,
+);
+
+type Verdict =
+  | { kind: "idle" }
+  | { kind: "match"; spans: CelSpan[] }
+  | { kind: "nomatch" }
+  | { kind: "error"; message: string };
+
+// Wraps each matched range in a <mark>. The engine's offsets are UTF-8 bytes, so
+// we slice in byte space and decode (correct for non-ASCII).
+function highlight(text: string, spans: CelSpan[]): ReactNode[] {
+  const ranges = spans
+    .map((s) => ({ start: s.Start, end: s.End }))
+    .filter((r) => r.end > r.start)
+    .sort((a, b) => a.start - b.start);
+  if (ranges.length === 0) return [text];
+
+  const bytes = new TextEncoder().encode(text);
+  const dec = new TextDecoder();
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let key = 0;
+  for (const r of ranges) {
+    if (r.end <= cursor) continue; // already covered by an overlapping range
+    const start = Math.max(r.start, cursor);
+    if (start > cursor) nodes.push(dec.decode(bytes.slice(cursor, start)));
+    nodes.push(
+      <mark
+        key={key++}
+        className="bg-warning/30 text-foreground rounded-sm px-0.5"
+      >
+        {dec.decode(bytes.slice(start, r.end))}
+      </mark>,
+    );
+    cursor = r.end;
+  }
+  if (cursor < bytes.length) nodes.push(dec.decode(bytes.slice(cursor)));
+  return nodes;
+}
+
+function humanizeTarget(target: string): string {
+  return target.replace(/^tool\./, "tool ").replace(/\./g, " ");
+}
+
+// Evaluates the detection expression against a sample message in-browser and
+// shows the verdict plus the matched spans.
+export function CelMatchPreview({
+  expr,
+  engine,
+}: {
+  expr: string;
+  engine: CelEngine;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [kind, setKind] = useState("tool_request");
+  const [content, setContent] = useState("");
+  const [toolsJson, setToolsJson] = useState(SAMPLE_TOOLS);
+
+  const kindMeta = KINDS.find((k) => k.value === kind) ?? KINDS[0]!;
+  const isToolRequest = kind === "tool_request";
+
+  // Debounce the inputs so eval doesn't run on every keystroke.
+  const [debounced, setDebounced] = useState({
+    expr,
+    kind,
+    content,
+    toolsJson,
+  });
+  useEffect(() => {
+    const t = setTimeout(
+      () => setDebounced({ expr, kind, content, toolsJson }),
+      DEBOUNCE_MS,
+    );
+    return () => clearTimeout(t);
+  }, [expr, kind, content, toolsJson]);
+
+  const verdict = useMemo<Verdict>(() => {
+    // Don't evaluate hidden work while the panel is collapsed.
+    if (!open) return { kind: "idle" };
+    const e = debounced.expr.trim();
+    if (!e) return { kind: "idle" };
+
+    let message: CelMessage;
+    if (debounced.kind === "tool_request") {
+      let tools;
+      try {
+        tools = JSON.parse(debounced.toolsJson) as CelMessage["tools"];
+      } catch {
+        return { kind: "error", message: "Tool calls must be valid JSON." };
+      }
+      message = { type: debounced.kind, content: "", tools };
+    } else {
+      message = { type: debounced.kind, content: debounced.content };
+    }
+
+    const result = engine.evalDetection(e, message);
+    if (!result.ok) return { kind: "error", message: result.error };
+    return result.matched
+      ? { kind: "match", spans: result.spans }
+      : { kind: "nomatch" };
+  }, [open, debounced, engine]);
+
+  const bodySpans =
+    verdict.kind === "match"
+      ? verdict.spans.filter((s) => BODY_TARGETS.has(s.Target))
+      : [];
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs">
+        <ChevronRight
+          className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
+        />
+        Test against a sample message
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 space-y-3">
+        <div className="flex flex-col gap-2">
+          <select
+            value={kind}
+            onChange={(e) => setKind(e.target.value)}
+            aria-label="Sample message type"
+            className="border-input bg-background w-fit rounded-md border px-2 py-1 text-xs"
+          >
+            {KINDS.map((k) => (
+              <option key={k.value} value={k.value}>
+                {k.label}
+              </option>
+            ))}
+          </select>
+
+          {isToolRequest ? (
+            <label className="space-y-1">
+              <span className="text-muted-foreground text-xs">
+                Tool calls (JSON)
+              </span>
+              <textarea
+                value={toolsJson}
+                onChange={(e) => setToolsJson(e.target.value)}
+                rows={6}
+                spellCheck={false}
+                className="border-input bg-input/30 w-full rounded-md border px-2 py-1 font-mono text-xs"
+              />
+            </label>
+          ) : (
+            <label className="space-y-1">
+              <span className="text-muted-foreground text-xs">
+                {kindMeta.bodyLabel}
+              </span>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                rows={3}
+                className="border-input bg-input/30 w-full rounded-md border px-2 py-1 text-xs"
+              />
+            </label>
+          )}
+        </div>
+
+        <VerdictView
+          verdict={verdict}
+          body={isToolRequest ? "" : content}
+          bodySpans={bodySpans}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function VerdictView({
+  verdict,
+  body,
+  bodySpans,
+}: {
+  verdict: Verdict;
+  body: string;
+  bodySpans: CelSpan[];
+}): JSX.Element | null {
+  if (verdict.kind === "idle") return null;
+
+  if (verdict.kind === "error") {
+    return (
+      <p className="text-destructive text-xs">
+        {verdict.message.replace(/^(?:compile|eval[a-z ]*)\s+"[^"]*":\s*/, "")}
+      </p>
+    );
+  }
+
+  const matched = verdict.kind === "match";
+  return (
+    <div className="space-y-2">
+      <span
+        className={cn(
+          "inline-flex w-fit items-center rounded-full px-2 py-0.5 text-xs font-medium",
+          matched
+            ? "bg-success/15 text-success-foreground"
+            : "bg-muted text-muted-foreground",
+        )}
+      >
+        {matched ? "Matches" : "No match"}
+      </span>
+
+      {body && (
+        <pre className="bg-input/30 overflow-x-auto rounded-md p-2 text-xs whitespace-pre-wrap">
+          {highlight(body, bodySpans)}
+        </pre>
+      )}
+
+      {matched && verdict.spans.length > 0 && (
+        <ul className="flex flex-wrap gap-1.5">
+          {verdict.spans.map((s, i) => (
+            <li
+              key={`${s.Target}-${s.Start}-${i}`}
+              className="border-border text-muted-foreground rounded-full border px-2 py-0.5 text-xs"
+            >
+              <span className="text-foreground">
+                {humanizeTarget(s.Target)}
+              </span>
+              {s.Path && <span className="opacity-70">.{s.Path}</span>}
+              {": "}
+              <code className="font-mono">{s.Value}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/security/cel-monaco-editor.lazy.tsx
+++ b/client/dashboard/src/pages/security/cel-monaco-editor.lazy.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+// Lazy so the heavy monaco-editor module (and its loader/worker side effects)
+// only load when a CEL field actually mounts — not on every security-page
+// render. Mirrors components/monaco-editor.lazy.tsx.
+const CelMonacoEditorLazy = React.lazy(() =>
+  import("./cel-monaco-editor").then((mod) => ({
+    default: mod.CelMonacoEditor,
+  })),
+);
+
+export default CelMonacoEditorLazy;

--- a/client/dashboard/src/pages/security/cel-monaco-editor.tsx
+++ b/client/dashboard/src/pages/security/cel-monaco-editor.tsx
@@ -1,0 +1,429 @@
+import { cn } from "@/lib/utils";
+import Editor, { loader, type OnMount } from "@monaco-editor/react";
+import { useMoonshineConfig } from "@speakeasy-api/moonshine";
+import type * as Monaco from "monaco-editor";
+import * as monaco from "monaco-editor";
+import { useEffect, useRef, type JSX } from "react";
+import type { CelCompletionItem, CelEngine } from "./cel-wasm";
+
+// oxlint-disable-next-line import/default -- Vite ?worker URL imports lack named defaults
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+
+// CEL has no dedicated worker; the base editor worker drives our Monarch
+// language. Only set the environment if the shared MonacoEditor hasn't already.
+if (!self.MonacoEnvironment) {
+  self.MonacoEnvironment = { getWorker: () => new editorWorker() };
+}
+// Point @monaco-editor/react at the bundled monaco. Guarded: a second call after
+// init throws, but it's the same instance, so swallow the duplicate.
+try {
+  loader.config({ monaco });
+} catch {
+  // already configured by another Monaco entry point this session
+}
+
+const CEL_LANGUAGE_ID = "cel";
+
+// Registration state + active engine live on globalThis so they survive Vite HMR
+// (module-level state would reset and stack duplicate completion providers).
+interface CelRuntime {
+  registered: boolean;
+  engine: CelEngine | null;
+}
+
+function celRuntime(): CelRuntime {
+  const holder = globalThis as unknown as { __celRuntime?: CelRuntime };
+  if (!holder.__celRuntime) {
+    holder.__celRuntime = { registered: false, engine: null };
+  }
+  return holder.__celRuntime;
+}
+
+const FIELD_WORDS = [
+  "content",
+  "prompt",
+  "assistant",
+  "tool_result",
+  "tool_calls",
+  "type",
+];
+const MATCHER_WORDS = [
+  "matchRegex",
+  "matchText",
+  "matchExact",
+  "matchPrefix",
+  "matchSuffix",
+  "matchGlob",
+  "present",
+  "get",
+];
+// List macros, for syntax coloring only (completions come from the engine).
+const MACRO_WORDS = [
+  "has",
+  "exists",
+  "exists_one",
+  "all",
+  "filter",
+  "map",
+  "size",
+];
+
+function shouldSuggestLogicalOperators(upto: string): boolean {
+  const trimmed = upto.trimEnd();
+  if (!trimmed) return false;
+  if (/[&|]$/.test(trimmed)) return true;
+  return /(?:\)|\]|\}|"|'|[A-Za-z_]\w*)$/.test(trimmed);
+}
+
+// suggestionFor maps an engine completion item's category to a Monaco icon and
+// insert snippet (the engine already decided what belongs here).
+function suggestionFor(
+  item: CelCompletionItem,
+  range: Monaco.IRange,
+): Monaco.languages.CompletionItem {
+  const snippet = (text: string) => ({
+    insertText: text,
+    insertTextRules:
+      monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+  });
+  const base = {
+    label: item.label,
+    detail: item.detail,
+    documentation: item.doc,
+    range,
+  };
+  switch (item.category) {
+    case "field":
+      return {
+        ...base,
+        kind: monaco.languages.CompletionItemKind.Field,
+        insertText: item.label,
+      };
+    case "variable":
+    case "bind":
+      return {
+        ...base,
+        kind: monaco.languages.CompletionItemKind.Variable,
+        insertText: item.label,
+      };
+    case "macro": // list comprehension macro: exists(t, …)
+      return {
+        ...base,
+        kind: monaco.languages.CompletionItemKind.Method,
+        ...snippet(`${item.label}(\${1:t}, $2)`),
+      };
+    case "matcher":
+    case "globalMacro":
+    default:
+      // present() is the only nullary matcher; everything else takes one arg.
+      return {
+        ...base,
+        kind: monaco.languages.CompletionItemKind.Method,
+        ...(item.label === "present"
+          ? { insertText: "present()" }
+          : snippet(`${item.label}($1)`)),
+      };
+  }
+}
+
+// registerCelLanguage installs the Monarch grammar and the completion provider,
+// once per Monaco instance (survives HMR).
+function registerCelLanguage(m: typeof Monaco): void {
+  const rt = celRuntime();
+  if (rt.registered) return;
+  rt.registered = true;
+
+  m.languages.register({ id: CEL_LANGUAGE_ID });
+
+  // Transparent background + focus ring so the editor blends into the input
+  // chrome instead of showing Monaco's opaque IDE frame.
+  m.editor.defineTheme("cel-dark", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: { "editor.background": "#00000000", focusBorder: "#00000000" },
+  });
+  m.editor.defineTheme("cel-light", {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: { "editor.background": "#00000000", focusBorder: "#00000000" },
+  });
+
+  m.languages.setMonarchTokensProvider(CEL_LANGUAGE_ID, {
+    keywords: ["true", "false", "null", "in"],
+    fields: FIELD_WORDS,
+    matchers: MATCHER_WORDS,
+    macros: MACRO_WORDS,
+    tokenizer: {
+      root: [
+        [
+          /[a-zA-Z_]\w*/,
+          {
+            cases: {
+              "@keywords": "keyword",
+              "@fields": "variable.predefined",
+              "@matchers": "type.identifier",
+              "@macros": "keyword.control",
+              "@default": "identifier",
+            },
+          },
+        ],
+        [/\s+/, "white"],
+        [/"([^"\\]|\\.)*"/, "string"],
+        [/'([^'\\]|\\.)*'/, "string"],
+        [/\d+/, "number"],
+        [/[{}()[\]]/, "@brackets"],
+        [/&&|\|\||==|!=|<=|>=|[!<>+\-*/%?:.]/, "operator"],
+        [/[,;]/, "delimiter"],
+      ],
+    },
+  });
+
+  m.languages.setLanguageConfiguration(CEL_LANGUAGE_ID, {
+    brackets: [
+      ["(", ")"],
+      ["[", "]"],
+      ["{", "}"],
+    ],
+    autoClosingPairs: [
+      { open: "(", close: ")" },
+      { open: "[", close: "]" },
+      { open: '"', close: '"' },
+      { open: "'", close: "'" },
+    ],
+    surroundingPairs: [
+      { open: "(", close: ")" },
+      { open: '"', close: '"' },
+      { open: "'", close: "'" },
+    ],
+  });
+
+  m.languages.registerCompletionItemProvider(CEL_LANGUAGE_ID, {
+    triggerCharacters: [".", "&", "|"],
+    provideCompletionItems(model, position) {
+      const word = model.getWordUntilPosition(position);
+      const range: Monaco.IRange = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+      const engine = celRuntime().engine;
+
+      // Text from the expression start to the cursor — the engine reads this to
+      // resolve the receiver's type and decide what's valid here.
+      const upto = model.getValueInRange({
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column,
+      });
+      const operatorPrefix = upto.match(/[&|]$/)?.[0];
+      const operatorRange: Monaco.IRange = operatorPrefix
+        ? {
+            startLineNumber: position.lineNumber,
+            endLineNumber: position.lineNumber,
+            startColumn: position.column - 1,
+            endColumn: position.column,
+          }
+        : range;
+
+      if (operatorPrefix) {
+        const label = operatorPrefix === "&" ? "&&" : "||";
+        return {
+          suggestions: [
+            {
+              label,
+              kind: monaco.languages.CompletionItemKind.Operator,
+              insertText: `${label} `,
+              detail: "logical operator",
+              range: operatorRange,
+            },
+          ],
+        };
+      }
+
+      // No engine yet (wasm loading/unavailable): offer nothing.
+      if (!engine) return { suggestions: [] };
+
+      // The engine resolves the receiver's type and returns what's valid here.
+      const completion = engine.complete(upto);
+      const suggestions = completion.items.map((item) =>
+        suggestionFor(item, range),
+      );
+
+      // Logical operators aren't part of the engine's vocabulary; offer them at a
+      // name position once there's a complete operand to join onto.
+      if (
+        completion.context === "name" &&
+        shouldSuggestLogicalOperators(upto)
+      ) {
+        suggestions.push(
+          {
+            label: "&&",
+            kind: monaco.languages.CompletionItemKind.Operator,
+            insertText: "&& ",
+            detail: "logical and",
+            range: operatorRange,
+          },
+          {
+            label: "||",
+            kind: monaco.languages.CompletionItemKind.Operator,
+            insertText: "|| ",
+            detail: "logical or",
+            range: operatorRange,
+          },
+        );
+      }
+      return { suggestions };
+    },
+  });
+}
+
+// Register at module load so the grammar exists before any editor mounts.
+registerCelLanguage(monaco);
+
+/** A controlled Monaco editor for a single CEL expression: Monarch syntax
+ *  highlighting, schema-driven autocomplete, and an inline error marker driven
+ *  by the debounced backend compile (errorMessage). Chrome is stripped so it
+ *  reads as a compact code field, not a full IDE pane. */
+export function CelMonacoEditor({
+  value,
+  onChange,
+  engine,
+  errorMessage,
+  errorRange,
+  disabled,
+  className,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  engine?: CelEngine | null;
+  errorMessage?: string | null;
+  // Character offset range of the error within the expression; when present the
+  // marker underlines just that span instead of the whole expression.
+  errorRange?: { start: number; end: number } | null;
+  disabled?: boolean;
+  className?: string;
+}): JSX.Element {
+  const { theme } = useMoonshineConfig();
+  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
+  const monacoRef = useRef<typeof Monaco | null>(null);
+
+  // Publish the engine to the shared completion provider as it loads.
+  useEffect(() => {
+    celRuntime().engine = engine ?? null;
+  }, [engine]);
+
+  // Surface the compile error as an inline marker.
+  useEffect(() => {
+    const m = monacoRef.current;
+    const editor = editorRef.current;
+    if (!m || !editor) return;
+    const model = editor.getModel();
+    if (!model) return;
+    if (errorMessage) {
+      // Underline the offending span when the checker gave us a range; else fall
+      // back to the whole expression.
+      let start = { lineNumber: 1, column: 1 };
+      const lastLine = model.getLineCount();
+      let end = {
+        lineNumber: lastLine,
+        column: model.getLineMaxColumn(lastLine),
+      };
+      if (errorRange && errorRange.end > errorRange.start) {
+        start = model.getPositionAt(errorRange.start);
+        end = model.getPositionAt(errorRange.end);
+      }
+      m.editor.setModelMarkers(model, CEL_LANGUAGE_ID, [
+        {
+          severity: m.MarkerSeverity.Error,
+          message: errorMessage,
+          startLineNumber: start.lineNumber,
+          startColumn: start.column,
+          endLineNumber: end.lineNumber,
+          endColumn: end.column,
+        },
+      ]);
+    } else {
+      m.editor.setModelMarkers(model, CEL_LANGUAGE_ID, []);
+    }
+  }, [errorMessage, errorRange, value]);
+
+  const handleMount: OnMount = (editor, m) => {
+    editorRef.current = editor;
+    monacoRef.current = m;
+    editor.updateOptions({ readOnly: disabled });
+
+    // Expand the suggestion details panel by default. No editor option exists, so
+    // flip it via the suggest controller's widget — a private API, hence guarded.
+    try {
+      const suggest = editor.getContribution(
+        "editor.contrib.suggestController",
+      ) as unknown as {
+        widget?: { value?: { _setDetailsVisible?: (v: boolean) => void } };
+      } | null;
+      suggest?.widget?.value?._setDetailsVisible?.(true);
+    } catch {
+      // Private suggest API changed; details just stay collapsed until toggled.
+    }
+
+    // Open the completion list on focus so fields/matchers are discoverable
+    // without typing first (deferred a tick, after focus + cursor settle).
+    editor.onDidFocusEditorText(() => {
+      setTimeout(() => {
+        editor.trigger("focus", "editor.action.triggerSuggest", {});
+      }, 0);
+    });
+  };
+
+  return (
+    <div
+      className={cn(
+        "border-input dark:bg-input/30 w-full overflow-hidden rounded-md border bg-transparent py-2 shadow-xs",
+        className,
+      )}
+    >
+      <Editor
+        language={CEL_LANGUAGE_ID}
+        value={value}
+        theme={theme === "dark" ? "cel-dark" : "cel-light"}
+        onMount={handleMount}
+        onChange={(v) => onChange(v ?? "")}
+        height="64px"
+        options={{
+          readOnly: disabled,
+          minimap: { enabled: false },
+          lineNumbers: "off",
+          folding: false,
+          glyphMargin: false,
+          // Doubles as the editor's left padding (no line-number gutter) so text
+          // doesn't hug the border, matching the px-3 of a standard input.
+          lineDecorationsWidth: 12,
+          lineNumbersMinChars: 0,
+          overviewRulerLanes: 0,
+          hideCursorInOverviewRuler: true,
+          scrollBeyondLastLine: false,
+          scrollbar: { vertical: "auto", horizontal: "hidden" },
+          wordWrap: "on",
+          fontSize: 14,
+          fontFamily:
+            'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+          automaticLayout: true,
+          contextmenu: false,
+          renderLineHighlight: "none",
+          padding: { top: 2, bottom: 2 },
+          suggestOnTriggerCharacters: true,
+          quickSuggestions: true,
+          // Fixed overflow layer so suggest/hover widgets escape the card's
+          // overflow-hidden.
+          fixedOverflowWidgets: true,
+          // We supply a curated schema; Monaco's word-based completions only add
+          // noise (duplicate bare identifiers pulled from other editor models).
+          wordBasedSuggestions: "off",
+        }}
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/security/cel-wasm.ts
+++ b/client/dashboard/src/pages/security/cel-wasm.ts
@@ -1,0 +1,203 @@
+// Loads the risk CEL engine compiled to WebAssembly (the same celenv the server
+// runs). The asset is built by `mise gen:celwasm` into public/cel/; its
+// wasm_exec.js shim defines globalThis.Go, and go.run() sets the __cel* globals
+// this module wraps. Mirrors the celenv Go types.
+
+export interface CelVarRef {
+  name: string;
+  type: string;
+  description: string;
+  matchable: boolean;
+  fields?: CelVarRef[];
+}
+
+export interface CelFuncRef {
+  name: string;
+  signature: string;
+  description: string;
+  returnsField: boolean;
+}
+
+export interface CelMacroRef {
+  name: string;
+  signature: string;
+  description: string;
+  returnsBool: boolean;
+}
+
+export interface CelReferenceData {
+  variables: CelVarRef[];
+  matchers: CelFuncRef[];
+  macros: CelMacroRef[];
+}
+
+export interface CelMessage {
+  type: string;
+  content: string;
+  tools?: {
+    name: string;
+    server: string;
+    function: string;
+    args: string;
+  }[];
+}
+
+export interface CelSpan {
+  Target: string;
+  ToolCallID: string;
+  Path: string;
+  Start: number;
+  End: number;
+  Value: string;
+}
+
+export type CelCompileResult = { ok: true } | { ok: false; error: string };
+export type CelEvalResult =
+  | { ok: true; matched: boolean; spans: CelSpan[] }
+  | { ok: false; error: string };
+
+export interface CelCompletionItem {
+  label: string;
+  detail: string;
+  doc: string;
+  category: "matcher" | "macro" | "globalMacro" | "field" | "variable" | "bind";
+}
+
+export interface CelCompletion {
+  context: "member" | "name";
+  items: CelCompletionItem[];
+}
+
+// The loaded engine: the same compile/complete/eval the server runs, in-browser.
+export interface CelEngine {
+  reference: CelReferenceData;
+  compile(expr: string): CelCompileResult;
+  complete(srcUpToCursor: string): CelCompletion;
+  evalDetection(expr: string, message: CelMessage): CelEvalResult;
+}
+
+// Raw shapes of the wasm globals (set by server/cmd/celwasm).
+interface CelGlobals {
+  Go?: new () => {
+    importObject: WebAssembly.Imports;
+    run(instance: WebAssembly.Instance): Promise<void>;
+  };
+  __celEngineReady?: boolean;
+  __celInitError?: string;
+  __celReference?: () => string;
+  __celComplete?: (src: string) => string;
+  __celCompile?: (expr: string) => CelCompileResult;
+  __celEval?: (
+    expr: string,
+    messageJSON: string,
+  ) => { ok: boolean; matched?: boolean; spans?: string; error?: string };
+}
+
+const WASM_URL = "/cel/cel.wasm";
+const RUNTIME_URL = "/cel/wasm_exec.js";
+
+function globals(): CelGlobals {
+  return globalThis as unknown as CelGlobals;
+}
+
+// wasm_exec.js is a classic script (defines globalThis.Go), so it's loaded via a
+// tag rather than a static ESM import.
+let runtimePromise: Promise<void> | null = null;
+function loadGoRuntime(): Promise<void> {
+  if (globals().Go) return Promise.resolve();
+  if (!runtimePromise) {
+    runtimePromise = new Promise<void>((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = RUNTIME_URL;
+      script.onload = () => resolve();
+      script.onerror = () =>
+        reject(new Error("failed to load the CEL wasm runtime"));
+      document.head.appendChild(script);
+    });
+    // Clear the cache on failure so a later call can retry a transient error.
+    runtimePromise.catch(() => {
+      runtimePromise = null;
+    });
+  }
+  return runtimePromise;
+}
+
+async function instantiate(
+  go: InstanceType<NonNullable<CelGlobals["Go"]>>,
+): Promise<WebAssembly.Instance> {
+  // Prefer streaming; fall back to arrayBuffer for hosts that don't serve wasm
+  // with the application/wasm content type.
+  try {
+    const res = await WebAssembly.instantiateStreaming(
+      fetch(WASM_URL),
+      go.importObject,
+    );
+    return res.instance;
+  } catch {
+    const bytes = await fetch(WASM_URL).then((r) => r.arrayBuffer());
+    const res = await WebAssembly.instantiate(bytes, go.importObject);
+    return res.instance;
+  }
+}
+
+// Go main installs the exported funcs synchronously before parking on select{},
+// so we don't await go.run (it never resolves).
+async function start(): Promise<CelEngine> {
+  await loadGoRuntime();
+  const Go = globals().Go;
+  if (!Go) throw new Error("CEL wasm runtime did not load");
+
+  const go = new Go();
+  const instance = await instantiate(go);
+  void go.run(instance);
+
+  const g = globals();
+  if (g.__celInitError) {
+    throw new Error(`CEL engine failed to initialize: ${g.__celInitError}`);
+  }
+  if (
+    !g.__celEngineReady ||
+    !g.__celReference ||
+    !g.__celComplete ||
+    !g.__celCompile ||
+    !g.__celEval
+  ) {
+    throw new Error("CEL engine did not expose its interface");
+  }
+
+  const reference = JSON.parse(g.__celReference()) as CelReferenceData;
+  const compile = g.__celCompile;
+  const rawComplete = g.__celComplete;
+  const rawEval = g.__celEval;
+
+  return {
+    reference,
+    compile: (expr) => compile(expr),
+    complete: (src) => JSON.parse(rawComplete(src)) as CelCompletion,
+    evalDetection: (expr, message) => {
+      const r = rawEval(expr, JSON.stringify(message));
+      if (!r.ok) return { ok: false, error: r.error ?? "evaluation failed" };
+      return {
+        ok: true,
+        matched: r.matched ?? false,
+        spans: r.spans ? (JSON.parse(r.spans) as CelSpan[]) : [],
+      };
+    },
+  };
+}
+
+// Loaded at most once per session (the wasm asset is large).
+let enginePromise: Promise<CelEngine> | null = null;
+
+// Rejects if the asset is missing or the runtime fails; callers then fall back
+// to server-side validation. The cache is cleared on failure so a later call can
+// retry a transient error.
+export function loadCelEngine(): Promise<CelEngine> {
+  if (!enginePromise) {
+    enginePromise = start();
+    enginePromise.catch(() => {
+      enginePromise = null;
+    });
+  }
+  return enginePromise;
+}

--- a/client/dashboard/src/pages/security/use-cel-engine.ts
+++ b/client/dashboard/src/pages/security/use-cel-engine.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { type CelEngine, loadCelEngine } from "./cel-wasm";
+
+export type CelEngineState =
+  | { status: "loading" }
+  | { status: "ready"; engine: CelEngine }
+  | { status: "error"; error: string };
+
+/** Load the wasm CEL engine once and expose its state. The engine is the same
+ *  celenv the server runs, so a compile here matches what the server accepts on
+ *  save; on load failure the caller falls back to server-side validation. */
+export function useCelEngine(): CelEngineState {
+  const [state, setState] = useState<CelEngineState>({ status: "loading" });
+
+  useEffect(() => {
+    let alive = true;
+    loadCelEngine().then(
+      (engine) => alive && setState({ status: "ready", engine }),
+      (err: unknown) =>
+        alive &&
+        setState({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        }),
+    );
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/client/dashboard/src/pages/security/use-cel-status.ts
+++ b/client/dashboard/src/pages/security/use-cel-status.ts
@@ -1,0 +1,41 @@
+import { useEffect, useMemo, useState } from "react";
+import { useCelEngine } from "./use-cel-engine";
+
+const DEBOUNCE_MS = 150;
+
+export type CelStatus =
+  | { kind: "idle" }
+  | { kind: "validating" }
+  | { kind: "ok" }
+  | { kind: "unavailable" } // engine failed to load; server validates on save
+  | { kind: "error"; message: string };
+
+/** Live, client-side type-check for a single CEL expression via the wasm engine
+ *  (the same celenv the server compiles with). The server stays authoritative on
+ *  save; if the engine can't load, status is "unavailable" — never a false ok. */
+export function useCelStatus(expr: string): CelStatus {
+  const engine = useCelEngine();
+  const trimmed = expr.trim();
+
+  // Short debounce to coalesce rapid typing; the check itself is local/instant.
+  const [debounced, setDebounced] = useState(trimmed);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(trimmed), DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [trimmed]);
+
+  const result = useMemo(() => {
+    if (engine.status !== "ready" || !debounced) return null;
+    // compile asserts a bool predicate, so its error already covers "must be
+    // true or false" — no separate type check needed.
+    return engine.engine.compile(debounced);
+  }, [engine, debounced]);
+
+  if (trimmed === "") return { kind: "idle" };
+  if (engine.status === "error") return { kind: "unavailable" };
+  if (engine.status === "loading") return { kind: "validating" };
+  if (debounced !== trimmed || !result) return { kind: "validating" };
+
+  if (!result.ok) return { kind: "error", message: result.error };
+  return { kind: "ok" };
+}


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a CEL expression editor powered by the in-browser wasm engine, with live compile checks and a live match preview of exact matched spans. Editor components only; wiring into policy/rule pages will follow.

- **New Features**
  - Monaco-based CEL editor with engine-driven, type-directed autocomplete (fields, matchers, macros) and logical operator snippets.
  - Inline compile status with readable, caret-pointed errors; no network calls while editing; falls back to server validation on save.
  - Match preview for user/assistant messages and tool requests/responses, with JSON tool calls, UTF-8 byte-accurate highlighting, and a spans list.
  - Collapsible reference of fields/matchers/macros and one-click examples; wasm engine and editor are lazy-loaded.

<sup>Written for commit 83983b08dc4a455e4a6ac058c4160fa1cc0de049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



