### PR TITLE
feat(dashboard): CEL authoring in policy + detection-rule UI

### DIFF
--- a/client/dashboard/src/pages/chatLogs/chatRisk.tsx
+++ b/client/dashboard/src/pages/chatLogs/chatRisk.tsx
@@ -113,6 +113,27 @@ function MaskedMatchInline({ value }: { value: string }): ReactNode {
   );
 }
 
+type FindingSpan = { match: string; field?: string; path?: string };
+
+// spansOf returns a finding's matched spans: the spans array when the backend
+// attributed several (e.g. a custom rule matching a tool's function and its
+// arguments on the same call), else the single primary match for legacy rows.
+function spansOf(r: RiskResult): FindingSpan[] {
+  const fromSpans = (r.spans ?? [])
+    .filter((s) => s.match)
+    .map((s) => ({ match: s.match, field: s.field, path: s.path }));
+  if (fromSpans.length > 0) return fromSpans;
+  return r.match ? [{ match: r.match }] : [];
+}
+
+// spanFieldLabel renders a span's attribution: the matched message field plus any
+// JSON sub-path, so "Write" reads as "tool.function" and a drilled value as
+// "tool.args.command". Null when the detector didn't attribute a field.
+function spanFieldLabel(span: FindingSpan): string | null {
+  if (!span.field) return null;
+  return span.path ? `${span.field}.${span.path}` : span.field;
+}
+
 /** Compact "N risks" badge with a popover listing each unique finding. */
 export function RiskBadge({
   results,
@@ -126,13 +147,19 @@ export function RiskBadge({
    * to the default destructive badge. */
   trigger?: ReactElement;
 }): ReactNode {
-  const unique = useMemo(() => {
-    const grouped = new Map<string, { result: RiskResult; count: number }>();
+  const findings = useMemo(() => {
+    const grouped = new Map<
+      string,
+      { result: RiskResult; spans: FindingSpan[]; count: number }
+    >();
     for (const r of results) {
-      const key = `${r.source} ${r.ruleId ?? ""} ${r.match ?? ""}`;
+      const spans = spansOf(r);
+      const key = `${r.source}|${r.ruleId ?? ""}|${spans
+        .map((s) => `${s.field ?? ""}:${s.path ?? ""}:${s.match}`)
+        .join("|")}`;
       const hit = grouped.get(key);
       if (hit) hit.count++;
-      else grouped.set(key, { result: r, count: 1 });
+      else grouped.set(key, { result: r, spans, count: 1 });
     }
     return [...grouped.values()];
   }, [results]);
@@ -154,7 +181,7 @@ export function RiskBadge({
                 name="shield-alert"
                 className={`mr-1 ${compact ? "size-2.5" : "size-3"}`}
               />
-              {unique.length} {unique.length === 1 ? "Risk" : "Risks"}
+              {findings.length} {findings.length === 1 ? "Risk" : "Risks"}
             </Badge>
           </button>
         )}
@@ -167,7 +194,7 @@ export function RiskBadge({
         <div className="space-y-3">
           <div className="text-sm font-semibold">Risk Findings</div>
           <div className="divide-border divide-y">
-            {unique.map(({ result: r, count }) => (
+            {findings.map(({ result: r, spans, count }) => (
               <div key={r.id} className="py-2 first:pt-0 last:pb-0">
                 <div className="flex items-center gap-2">
                   <Badge variant="destructive" className="shrink-0 text-[10px]">
@@ -192,7 +219,26 @@ export function RiskBadge({
                     {r.description}
                   </p>
                 )}
-                {r.match && <MaskedMatchInline value={r.match} />}
+                {spans.length > 0 && (
+                  <div className="mt-1 flex flex-col gap-1">
+                    {spans.map((span, i) => {
+                      const label = spanFieldLabel(span);
+                      return (
+                        <div
+                          key={`${label ?? ""}-${span.match}-${i}`}
+                          className="flex flex-wrap items-center gap-1 text-xs"
+                        >
+                          {label && (
+                            <code className="text-muted-foreground font-mono">
+                              {label}:
+                            </code>
+                          )}
+                          <MaskedMatchInline value={span.match} />
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
                 {r.tags && r.tags.length > 0 && (
                   <div className="mt-1 flex flex-wrap gap-1">
                     {r.tags.map((tag) => (

--- a/client/dashboard/src/pages/security/DetectionRules.tsx
+++ b/client/dashboard/src/pages/security/DetectionRules.tsx
@@ -42,14 +42,19 @@ import { useSdkClient } from "@/contexts/Sdk";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   BUILTIN_RULES_BY_CATEGORY,
+  DETECTION_CEL_EXAMPLES,
   SEVERITY_LEVELS,
+  effectiveDetectionExpr,
+  ruleSummary,
   useDetectionRulesStore,
   validateCustomRuleId,
-  validateRegex,
   type BuiltinRule,
   type CustomDetectionRule,
+  type CustomRuleDraft,
   type SeverityLevel,
 } from "./detection-rules-data";
+import { CelExpressionField } from "./cel-field";
+import { useCelStatus } from "./use-cel-status";
 import { RULE_CATEGORY_META, type RuleCategory } from "./policy-data";
 import { getCategoryCodeForFinding } from "./risk-utils";
 
@@ -147,9 +152,8 @@ function DetectionRulesContent() {
       <Page.Section>
         <Page.Section.Title stage="beta">Detection Rules</Page.Section.Title>
         <Page.Section.Description>
-          Built-in detection rules grouped by category. Click a rule to view its
-          description and try it against pasted text, or add your own custom
-          regex rule.
+          Reusable built-in and custom rules your policies use to flag — or
+          exempt — messages.
         </Page.Section.Description>
         <Page.Section.CTA>
           <Button onClick={() => setCreateOpen(true)}>
@@ -242,7 +246,7 @@ function CustomRulesSection({
       <div className="border-border divide-border divide-y rounded-lg border">
         <CategoryHeader
           icon={meta.icon as IconName}
-          label="Custom Patterns"
+          label={meta.label}
           description={`${rules.length} organization-defined rule${rules.length === 1 ? "" : "s"}`}
           expanded={expanded}
           onClick={onToggle}
@@ -254,7 +258,7 @@ function CustomRulesSection({
               <RuleRow
                 key={rule.id}
                 title={rule.title || rule.id}
-                subtitle={rule.id}
+                subtitle={ruleSummary(rule)}
                 onClick={() => onSelect(rule)}
               />
             ))}
@@ -456,7 +460,7 @@ function BuiltinRuleDetail({ rule }: { rule: BuiltinRule }) {
           <p className="text-sm leading-relaxed">{rule.description}</p>
         </DetailField>
 
-        <RulePlayground ruleId={rule.id} regex={null} />
+        <RulePlayground ruleId={rule.id} detectionExpr={null} />
       </div>
     </>
   );
@@ -468,29 +472,37 @@ function CustomRuleDetail({
   onDelete,
 }: {
   rule: CustomDetectionRule;
-  onUpdate: (
-    patch: Partial<Omit<CustomDetectionRule, "id" | "dbId" | "createdAt">>,
-  ) => Promise<void>;
+  onUpdate: (patch: Partial<Omit<CustomRuleDraft, "id">>) => Promise<void>;
   onDelete: () => void;
 }) {
   const [title, setTitle] = useState(rule.title);
   const [description, setDescription] = useState(rule.description);
-  const [regex, setRegex] = useState(rule.regex);
+  const [detectionExpr, setDetectionExpr] = useState(() =>
+    effectiveDetectionExpr(rule),
+  );
   const [saveState, setSaveState] = useState<
     "idle" | "saving" | "saved" | "error"
   >("idle");
   const savedTimerRef = useRef<number | undefined>(undefined);
-  const savedValuesRef = useRef({
+  const savedRef = useRef({
     title: rule.title,
     description: rule.description,
-    regex: rule.regex,
+    matcher: effectiveDetectionExpr(rule),
   });
 
-  const regexError = useMemo(() => validateRegex(regex), [regex]);
+  const celStatus = useCelStatus(detectionExpr);
+  // Block save until the expression is non-empty and compiles (the backend is
+  // authoritative; this just mirrors its gate so we don't round-trip a failure).
+  const celError =
+    detectionExpr.trim() === ""
+      ? "Add a detection expression"
+      : celStatus.kind === "error"
+        ? "Fix the detection expression"
+        : null;
   const dirty =
-    title !== savedValuesRef.current.title ||
-    description !== savedValuesRef.current.description ||
-    regex !== savedValuesRef.current.regex;
+    title !== savedRef.current.title ||
+    description !== savedRef.current.description ||
+    detectionExpr !== savedRef.current.matcher;
 
   useEffect(() => {
     if (dirty && saveState === "error") {
@@ -508,10 +520,22 @@ function CustomRuleDetail({
   );
 
   const handleSave = async () => {
+    if (celError) {
+      toast.error(celError);
+      return;
+    }
     setSaveState("saving");
     try {
-      await onUpdate({ title, description, regex });
-      savedValuesRef.current = { title, description, regex };
+      await onUpdate({
+        title,
+        description,
+        detectionExpr,
+      });
+      savedRef.current = {
+        title,
+        description,
+        matcher: detectionExpr,
+      };
       setSaveState("saved");
       if (savedTimerRef.current !== undefined) {
         window.clearTimeout(savedTimerRef.current);
@@ -556,19 +580,18 @@ function CustomRuleDetail({
         </div>
 
         <div className="space-y-2">
-          <Label className="text-sm font-medium">Regex</Label>
-          <TextArea
-            value={regex}
-            onChange={setRegex}
-            rows={3}
-            className="font-mono text-xs"
+          <Label className="text-sm font-medium">Detection expression</Label>
+          <CelExpressionField
+            value={detectionExpr}
+            onChange={setDetectionExpr}
+            examples={DETECTION_CEL_EXAMPLES}
           />
-          {regexError && (
-            <p className="text-destructive text-xs">{regexError}</p>
-          )}
         </div>
 
-        <RulePlayground ruleId={rule.id} regex={regex} />
+        <RulePlayground
+          ruleId={rule.id}
+          detectionExpr={celStatus.kind === "ok" ? detectionExpr : null}
+        />
       </div>
       <SheetFooter className="border-border flex-row items-center justify-between border-t px-6 py-4">
         <Button
@@ -586,7 +609,11 @@ function CustomRuleDetail({
           )}
           <Button
             disabled={
-              !dirty || !!regexError || !title.trim() || saveState === "saving"
+              !dirty ||
+              !!celError ||
+              celStatus.kind === "validating" ||
+              !title.trim() ||
+              saveState === "saving"
             }
             onClick={() => void handleSave()}
           >
@@ -608,10 +635,10 @@ function CustomRuleDetail({
 
 function RulePlayground({
   ruleId,
-  regex,
+  detectionExpr,
 }: {
   ruleId: string;
-  regex: string | null;
+  detectionExpr: string | null;
 }) {
   const [mode, setMode] = useState<"sample" | "chat">("sample");
 
@@ -643,9 +670,9 @@ function RulePlayground({
       </RadioGroup>
 
       {mode === "sample" ? (
-        <SamplePlayground ruleId={ruleId} regex={regex} />
+        <SamplePlayground ruleId={ruleId} detectionExpr={detectionExpr} />
       ) : (
-        <ChatPlayground ruleId={ruleId} regex={regex} />
+        <ChatPlayground ruleId={ruleId} detectionExpr={detectionExpr} />
       )}
     </DetailField>
   );
@@ -653,10 +680,10 @@ function RulePlayground({
 
 function SamplePlayground({
   ruleId,
-  regex,
+  detectionExpr,
 }: {
   ruleId: string;
-  regex: string | null;
+  detectionExpr: string | null;
 }) {
   const [sample, setSample] = useState("");
   const [matches, setMatches] = useState<TestDetectionRuleMatch[] | null>(null);
@@ -681,7 +708,7 @@ function SamplePlayground({
         testDetectionRuleRequestBody: {
           ruleId,
           text: sample,
-          ...(regex ? { regex } : {}),
+          ...(detectionExpr ? { detectionExpr } : {}),
         },
       },
     });
@@ -776,10 +803,10 @@ type ChatMessageResult = {
 
 function ChatPlayground({
   ruleId,
-  regex,
+  detectionExpr,
 }: {
   ruleId: string;
-  regex: string | null;
+  detectionExpr: string | null;
 }) {
   const client = useSdkClient();
   const chatsQuery = useListChats(undefined, undefined, {
@@ -875,7 +902,7 @@ function ChatPlayground({
             testDetectionRuleRequestBody: {
               ruleId,
               text: item.fullText,
-              ...(regex ? { regex } : {}),
+              ...(detectionExpr ? { detectionExpr } : {}),
             },
           });
           setResults((prev) =>
@@ -1176,20 +1203,14 @@ function CreateCustomRuleSheet({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   existingCustomIds: string[];
-  onCreate: (rule: {
-    id: string;
-    title: string;
-    description: string;
-    regex: string;
-    severity: SeverityLevel;
-  }) => void;
+  onCreate: (rule: CustomRuleDraft) => void;
 }) {
   const [step, setStep] = useState<CreateStep>("prompt");
   const [askPrompt, setAskPrompt] = useState("");
   const [idSuffix, setIdSuffix] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [regex, setRegex] = useState("");
+  const [detectionExpr, setDetectionExpr] = useState("");
   const [severity, setSeverity] = useState<SeverityLevel>("medium");
 
   const reset = () => {
@@ -1198,7 +1219,7 @@ function CreateCustomRuleSheet({
     setIdSuffix("");
     setTitle("");
     setDescription("");
-    setRegex("");
+    setDetectionExpr("");
     setSeverity("medium");
   };
 
@@ -1208,7 +1229,7 @@ function CreateCustomRuleSheet({
       setIdSuffix(customRuleIDSuffix(next.ruleId));
       setTitle(next.title);
       setDescription(next.description);
-      setRegex(next.regex);
+      setDetectionExpr(next.detectionExpr ?? "");
       setSeverity(
         (SEVERITY_LEVELS as readonly string[]).includes(next.severity)
           ? (next.severity as SeverityLevel)
@@ -1243,7 +1264,7 @@ function CreateCustomRuleSheet({
     setIdSuffix("");
     setTitle("");
     setDescription("");
-    setRegex("");
+    setDetectionExpr("");
     setSeverity("medium");
     setStep("review");
   };
@@ -1258,13 +1279,20 @@ function CreateCustomRuleSheet({
         : null,
     [idSuffix, existingCustomIds],
   );
-  const regexError = useMemo(
-    () => (regex ? validateRegex(regex) : null),
-    [regex],
-  );
+  const celStatus = useCelStatus(detectionExpr);
+  const celError =
+    detectionExpr.trim() === ""
+      ? "Add a detection expression"
+      : celStatus.kind === "error"
+        ? "Fix the detection expression"
+        : null;
 
   const canSubmit =
-    idSuffix.trim() && title.trim() && regex.trim() && !idError && !regexError;
+    idSuffix.trim() &&
+    title.trim() &&
+    !idError &&
+    !celError &&
+    celStatus.kind !== "validating";
 
   const handleSubmit = () => {
     const finalRuleId = customRuleIDFromSuffix(idSuffix);
@@ -1273,16 +1301,15 @@ function CreateCustomRuleSheet({
       toast.error(finalIdError);
       return;
     }
-    const finalRegexError = validateRegex(regex);
-    if (finalRegexError) {
-      toast.error(finalRegexError);
+    if (celError) {
+      toast.error(celError);
       return;
     }
     onCreate({
       id: finalRuleId,
       title: title.trim(),
       description: description.trim(),
-      regex: regex.trim(),
+      detectionExpr,
       severity,
     });
     reset();
@@ -1296,12 +1323,12 @@ function CreateCustomRuleSheet({
         if (!next) reset();
       }}
     >
-      <SheetContent className="flex flex-col overflow-y-auto sm:max-w-lg">
+      <SheetContent className="flex flex-col overflow-y-auto sm:max-w-xl">
         <SheetHeader className="px-6 pt-6">
           <SheetTitle>New Custom Detection Rule</SheetTitle>
           <SheetDescription>
             {step === "prompt"
-              ? "Describe what you want to detect. We'll suggest the rule ID, regex, and severity, you tweak before saving."
+              ? "Describe what you want to detect. We'll suggest the rule ID, detection expression, and severity, you tweak before saving."
               : "Review the suggested rule. Adjust any field before saving."}
           </SheetDescription>
         </SheetHeader>
@@ -1320,8 +1347,8 @@ function CreateCustomRuleSheet({
                   placeholder="e.g. internal Acme service tokens that look like acme_ followed by 32 lowercase hex characters"
                 />
                 <p className="text-muted-foreground text-xs">
-                  Tip: include a sample value or the format so the model picks a
-                  tight regex.
+                  Tip: include a sample value or the format so the model writes
+                  a tight expression.
                 </p>
               </div>
             </div>
@@ -1390,22 +1417,14 @@ function CreateCustomRuleSheet({
               </div>
 
               <div className="space-y-2">
-                <Label className="text-sm font-medium">Regex</Label>
-                <TextArea
-                  value={regex}
-                  onChange={setRegex}
-                  rows={3}
-                  className="font-mono text-xs"
-                  placeholder="e.g. acme_[a-z0-9]{32}"
+                <Label className="text-sm font-medium">
+                  Detection expression
+                </Label>
+                <CelExpressionField
+                  value={detectionExpr}
+                  onChange={setDetectionExpr}
+                  examples={DETECTION_CEL_EXAMPLES}
                 />
-                {regexError ? (
-                  <p className="text-destructive text-xs">{regexError}</p>
-                ) : (
-                  <p className="text-muted-foreground text-xs">
-                    Anchors are not required, the pattern is matched against the
-                    full scanned payload.
-                  </p>
-                )}
               </div>
             </div>
             <SheetFooter className="border-border flex-row items-center justify-between border-t px-6 py-4">

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -1,3 +1,4 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { InsightsConfig } from "@/components/insights-dock";
 import { INSIGHTS_SUGGESTIONS } from "@/lib/insights-suggestions";
 import { Page } from "@/components/page-layout";
@@ -18,12 +19,16 @@ import { Switch } from "@/components/ui/switch";
 import { TextArea } from "@/components/ui/textarea";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import {
+  OnboardingStepper,
+  type Step,
+} from "@/pages/setup/components/onboarding-stepper";
+import { useInsightsState } from "@/components/insights-context";
+import {
   Sheet,
   SheetContent,
   SheetHeader,
   SheetTitle,
   SheetDescription,
-  SheetFooter,
 } from "@/components/ui/sheet";
 import { Type } from "@/components/ui/type";
 import {
@@ -55,9 +60,18 @@ import {
   ChevronRight,
   RefreshCw,
   Sparkles,
+  SlidersHorizontal,
+  X,
 } from "lucide-react";
-import { useState, useCallback, useEffect, useMemo, useRef } from "react";
-import type { ReactNode } from "react";
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useLayoutEffect,
+  type ReactNode,
+} from "react";
 import { useQueryState } from "nuqs";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -80,6 +94,9 @@ import {
   RULE_CATEGORY_META,
   DETECTION_RULES,
   POLICY_MESSAGE_TYPE_META,
+  RULE_FAMILY_OF,
+  RULE_FAMILY_ORDER,
+  type DetectionRule,
   type RuleCategory,
   type PolicyAction,
   type PolicyMessageType,
@@ -87,6 +104,8 @@ import {
 import { cn } from "@/lib/utils";
 import { ruleIdToPresidioEntity } from "./rule-ids";
 import { useDetectionRulesStore } from "./detection-rules-data";
+import { CelExpressionField } from "./cel-field";
+import { useCelStatus } from "./use-cel-status";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { PROMPT_POLICY_TEMPLATES } from "./prompt-policy-templates";
 
@@ -127,6 +146,413 @@ const FLAG_ONLY_CATEGORIES: Set<RuleCategory> = new Set([
   "destructive_tool",
   "cli_destructive",
 ]);
+
+/** Steps in the guided standard-policy creation/edit flow. Mirrors the
+ *  enterprise onboarding wizard (left rail + paged content). */
+const POLICY_WIZARD_STEPS: Step[] = [
+  {
+    id: "detect",
+    title: "Detect",
+    description: "What to scan for",
+    badge: "Required",
+  },
+  {
+    id: "scope",
+    title: "Scope",
+    description: "Where it applies",
+    badge: "Optional",
+  },
+  {
+    id: "action",
+    title: "Action",
+    description: "What happens on a match",
+    badge: "Required",
+  },
+  { id: "review", title: "Review", description: "Name & enable" },
+];
+
+/** Prompt-policy flow: same staged shell, but step 0 is the guardrail prompt
+ *  (+ advanced judge config) instead of detectors. */
+const PROMPT_WIZARD_STEPS: Step[] = [
+  {
+    id: "guardrail",
+    title: "Guardrail",
+    description: "What to catch, in plain language",
+    badge: "Required",
+  },
+  POLICY_WIZARD_STEPS[1]!,
+  POLICY_WIZARD_STEPS[2]!,
+  POLICY_WIZARD_STEPS[3]!,
+];
+
+/** Shared wizard chrome: the left step rail + the paged content column. The
+ *  footer (Back/Continue/Create) lives in the page shell, driven by the parent. */
+function WizardShell({
+  steps,
+  currentStep,
+  setCurrentStep,
+  children,
+}: {
+  steps: Step[];
+  currentStep: number;
+  setCurrentStep: (v: number) => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex gap-8">
+      <div className="w-44 flex-shrink-0">
+        <OnboardingStepper
+          steps={steps}
+          currentStep={currentStep}
+          onStepClick={(i) => setCurrentStep(i)}
+          allowJumpAhead
+        />
+      </div>
+      <div className="min-w-0 flex-1 space-y-6">{children}</div>
+    </div>
+  );
+}
+
+function WizardStepHeading({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div>
+      <h3 className="text-base font-semibold">{title}</h3>
+      <p className="text-muted-foreground text-sm">{description}</p>
+    </div>
+  );
+}
+
+function SummaryRow({ label, chips }: { label: string; chips: string[] }) {
+  return (
+    <div className="flex items-start justify-between gap-3 px-4 py-2.5 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="flex flex-wrap justify-end gap-1">
+        {chips.map((chip) => (
+          <span
+            key={chip}
+            className="bg-muted rounded-full px-2 py-0.5 text-xs"
+          >
+            {chip}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Built-in detector categories that only produce findings when Speakeasy hooks
+ *  are installed on the agent (no rule list to customize). */
+const HOOK_REQUIRED_CATEGORIES: Set<RuleCategory> = new Set([
+  "shadow_mcp",
+  "destructive_tool",
+]);
+
+/** One built-in detector as a toggleable card (Detect step). "Customize" opens
+ *  a side-sheet to pick which rules in the category are active. */
+function DetectorCard({
+  category,
+  selected,
+  disabledRules,
+  onToggle,
+  onCustomize,
+}: {
+  category: RuleCategory;
+  selected: boolean;
+  disabledRules: Set<string>;
+  onToggle: (checked: boolean) => void;
+  onCustomize: () => void;
+}) {
+  const meta = RULE_CATEGORY_META[category];
+  const available = AVAILABLE_CATEGORIES.has(category);
+  const rules = DETECTION_RULES[category].filter((r) => !r.hidden);
+  const customizable = available && rules.length > 1;
+  const enabledCount = rules.filter((r) => !disabledRules.has(r.id)).length;
+  const customized = selected && enabledCount < rules.length;
+  const needsHook = HOOK_REQUIRED_CATEGORIES.has(category);
+  return (
+    <div
+      className={cn(
+        "flex gap-3 rounded-lg border p-3 transition-colors",
+        selected ? "border-foreground bg-muted/40" : "border-border",
+      )}
+    >
+      <Icon
+        name={meta.icon as IconName}
+        className="text-muted-foreground mt-0.5 size-5 shrink-0"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{meta.label}</span>
+          {!available && (
+            <Badge variant="neutral">
+              <Badge.Text>Coming soon</Badge.Text>
+            </Badge>
+          )}
+        </div>
+        <p className="text-muted-foreground mt-0.5 text-xs">
+          {meta.description}
+        </p>
+        <div className="mt-2 flex items-center gap-3 text-xs">
+          {needsHook ? (
+            <span className="text-warning">Requires Speakeasy hooks</span>
+          ) : (
+            rules.length > 0 && (
+              <span
+                className={cn(
+                  "bg-muted rounded-full px-2 py-0.5",
+                  customized ? "text-foreground" : "text-muted-foreground",
+                )}
+              >
+                {customized
+                  ? `${enabledCount} of ${rules.length} rules`
+                  : `${rules.length} rules`}
+              </span>
+            )
+          )}
+          {selected && customizable && (
+            <button
+              type="button"
+              onClick={onCustomize}
+              className="text-primary hover:underline"
+            >
+              Customize
+            </button>
+          )}
+        </div>
+      </div>
+      <Switch
+        checked={selected}
+        disabled={!available}
+        onCheckedChange={onToggle}
+      />
+    </div>
+  );
+}
+
+/** Side-sheet to pick which rules within a built-in detector category are
+ *  active. Disabling a rule adds its canonical rule_id to the policy's
+ *  disabled_rules; a search box tames the large categories (e.g. 222 secrets). */
+function CustomizeRulesSheet({
+  category,
+  selectedCategories,
+  setSelectedCategories,
+  disabledRules,
+  setDisabledRules,
+  onClose,
+}: {
+  category: RuleCategory;
+  selectedCategories: Set<RuleCategory>;
+  setSelectedCategories: (v: Set<RuleCategory>) => void;
+  disabledRules: Set<string>;
+  setDisabledRules: (v: Set<string>) => void;
+  onClose: () => void;
+}) {
+  const meta = RULE_CATEGORY_META[category];
+  const rules = DETECTION_RULES[category].filter((r) => !r.hidden);
+  const [search, setSearch] = useState("");
+  const query = search.trim().toLowerCase();
+  const filtered = query
+    ? rules.filter((r) => r.title.toLowerCase().includes(query))
+    : rules;
+  const enabledCount = rules.filter((r) => !disabledRules.has(r.id)).length;
+
+  const setRule = (id: string, on: boolean) => {
+    const next = new Set(disabledRules);
+    if (on) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    setDisabledRules(next);
+    if (on && !selectedCategories.has(category)) {
+      const cats = new Set(selectedCategories);
+      cats.add(category);
+      setSelectedCategories(cats);
+    }
+  };
+  const bulk = (on: boolean) => {
+    const next = new Set(disabledRules);
+    for (const r of rules) {
+      if (on) {
+        next.delete(r.id);
+      } else {
+        next.add(r.id);
+      }
+    }
+    setDisabledRules(next);
+  };
+
+  // Large categories (currently just secrets, ~200 rules) classify into named
+  // families so the list is navigable; everything else renders flat.
+  const grouper = RULE_FAMILY_OF[category];
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const toggleGroup = (family: string) => {
+    const next = new Set(expandedGroups);
+    if (next.has(family)) {
+      next.delete(family);
+    } else {
+      next.add(family);
+    }
+    setExpandedGroups(next);
+  };
+  const bulkGroup = (familyRules: DetectionRule[], on: boolean) => {
+    const next = new Set(disabledRules);
+    for (const r of familyRules) {
+      if (on) {
+        next.delete(r.id);
+      } else {
+        next.add(r.id);
+      }
+    }
+    setDisabledRules(next);
+    if (on && !selectedCategories.has(category)) {
+      const cats = new Set(selectedCategories);
+      cats.add(category);
+      setSelectedCategories(cats);
+    }
+  };
+  // Ordered, non-empty families over the (search-)filtered rules.
+  const groupedRules = grouper
+    ? RULE_FAMILY_ORDER.map((family) => ({
+        family,
+        rules: filtered.filter((r) => grouper(r) === family),
+      })).filter((g) => g.rules.length > 0)
+    : [];
+
+  return (
+    <Sheet
+      open
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <SheetContent side="right" className="flex flex-col p-0 sm:max-w-md">
+        <SheetHeader className="px-6 pt-6">
+          <SheetTitle>Customize {meta.label}</SheetTitle>
+          <SheetDescription>
+            Pick which rules in this category are active. All are on by default.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="px-6 pt-3">
+          <Input
+            value={search}
+            onChange={setSearch}
+            placeholder={`Search ${rules.length} ${meta.label.toLowerCase()} rules…`}
+          />
+        </div>
+        <div className="text-muted-foreground flex items-center justify-between px-6 py-2 text-xs">
+          <span>
+            {enabledCount} of {rules.length} active
+          </span>
+          <span className="flex gap-3">
+            <button
+              type="button"
+              className="text-primary hover:underline"
+              onClick={() => bulk(true)}
+            >
+              Enable all
+            </button>
+            <button
+              type="button"
+              className="text-primary hover:underline"
+              onClick={() => bulk(false)}
+            >
+              Disable all
+            </button>
+          </span>
+        </div>
+        <div className="flex-1 overflow-y-auto px-4 pb-6">
+          {grouper
+            ? groupedRules.map(({ family, rules: familyRules }) => {
+                const open = expandedGroups.has(family) || query.length > 0;
+                const enabled = familyRules.filter(
+                  (r) => !disabledRules.has(r.id),
+                ).length;
+                return (
+                  <div
+                    key={family}
+                    className="border-border border-b last:border-b-0"
+                  >
+                    <div className="flex items-center gap-2 px-2 py-2">
+                      <button
+                        type="button"
+                        onClick={() => toggleGroup(family)}
+                        className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                      >
+                        <ChevronRight
+                          className={cn(
+                            "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
+                            open && "rotate-90",
+                          )}
+                        />
+                        <span className="truncate text-sm font-medium">
+                          {family}
+                        </span>
+                        <span className="text-muted-foreground shrink-0 text-xs">
+                          {enabled}/{familyRules.length}
+                        </span>
+                      </button>
+                      <Switch
+                        checked={enabled === familyRules.length}
+                        onCheckedChange={(on) => bulkGroup(familyRules, on)}
+                      />
+                    </div>
+                    {open && (
+                      <div className="pb-1 pl-4">
+                        {familyRules.map((rule) => (
+                          <RuleToggleRow
+                            key={rule.id}
+                            rule={rule}
+                            checked={!disabledRules.has(rule.id)}
+                            onToggle={(on) => setRule(rule.id, on)}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            : filtered.map((rule) => (
+                <RuleToggleRow
+                  key={rule.id}
+                  rule={rule}
+                  checked={!disabledRules.has(rule.id)}
+                  onToggle={(on) => setRule(rule.id, on)}
+                />
+              ))}
+          {grouper && groupedRules.length === 0 && (
+            <p className="text-muted-foreground px-2 py-6 text-center text-xs">
+              No rules match.
+            </p>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function RuleToggleRow({
+  rule,
+  checked,
+  onToggle,
+}: {
+  rule: DetectionRule;
+  checked: boolean;
+  onToggle: (on: boolean) => void;
+}) {
+  return (
+    <div className="hover:bg-muted flex items-center justify-between gap-3 rounded-md px-2 py-2 text-sm">
+      <span className="min-w-0 truncate">{rule.title}</span>
+      <Switch checked={checked} onCheckedChange={onToggle} />
+    </div>
+  );
+}
 
 type PolicyKind = "risk" | "prompt";
 type PolicyAudienceType = "everyone" | "targeted";
@@ -423,6 +849,36 @@ function promptPolicyName(prompt: string): string {
   return prompt.trim().replace(/\s+/g, " ").slice(0, 60) || "Prompt Policy";
 }
 
+/** Example scope CEL snippets offered beneath the include field — narrow a
+ *  policy to a subset of messages. */
+const SCOPE_INCLUDE_CEL_EXAMPLES: { label: string; expr: string }[] = [
+  {
+    label: "Only a GitHub server",
+    expr: 'tools.exists(t, t.server.matchExact("github"))',
+  },
+  {
+    label: "Production prompts",
+    expr: 'prompt.matchText("production")',
+  },
+  {
+    label: "Delete-style tools",
+    expr: 'tools.exists(t, t.function.matchGlob("*delete*"))',
+  },
+];
+
+/** Example scope CEL snippets offered beneath the exempt field — take matching
+ *  messages out of the policy entirely (an allowlist). */
+const SCOPE_EXEMPT_CEL_EXAMPLES: { label: string; expr: string }[] = [
+  {
+    label: "Read-only tools",
+    expr: 'tools.exists(t, t.function.matchGlob("*get*") || t.function.matchGlob("*list*"))',
+  },
+  {
+    label: "A safelisted server",
+    expr: 'tools.exists(t, t.server.matchExact("internal-docs"))',
+  },
+];
+
 export default function PolicyCenter(): JSX.Element {
   return (
     <RequireScope scope="org:admin" level="page">
@@ -456,17 +912,30 @@ function PolicyCenterContent() {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editingPolicy, setEditingPolicy] = useState<RiskPolicy | null>(null);
   const [createStep, setCreateStep] = useState<"type" | "details">("details");
+  // Active step in the standard-policy guided flow (0=Detect…3=Review).
+  const [wizardStep, setWizardStep] = useState(0);
   const [formPolicyKind, setFormPolicyKind] = useState<PolicyKind>("risk");
   const [formName, setFormName] = useState("");
   const [formEnabled, setFormEnabled] = useState(true);
   const [formPromptInstruction, setFormPromptInstruction] = useState("");
   const [selectedCategories, setSelectedCategories] = useState<
     Set<RuleCategory>
-  >(new Set<RuleCategory>(["secrets", "pii"]));
+  >(new Set<RuleCategory>());
   const [disabledRules, setDisabledRules] = useState<Set<string>>(new Set());
   const [selectedCustomRuleIds, setSelectedCustomRuleIds] = useState<
     Set<string>
   >(new Set<string>());
+  // Fine-grained applicability predicates (scope_include / scope_exempt):
+  // a CEL expression scoping the policy, and one taking matching messages out of
+  // it. Empty => rely on the coarse message_types knob.
+  const [scopeInclude, setScopeInclude] = useState("");
+  const [scopeExempt, setScopeExempt] = useState("");
+  // Scope is defined EITHER by the coarse message-type cards OR by a custom CEL
+  // include predicate — a mutex. message_types is kept either way but only sent
+  // (and only required) in "messageTypes" mode.
+  const [scopeMode, setScopeMode] = useState<"messageTypes" | "cel">(
+    "messageTypes",
+  );
   const [selectedMessageTypes, setSelectedMessageTypes] = useState<
     Set<PolicyMessageType>
   >(new Set(ALL_POLICY_MESSAGE_TYPES));
@@ -506,6 +975,28 @@ function PolicyCenterContent() {
     void setPolicyParam(null);
   }, [setPolicyParam]);
 
+  // The create/edit view is a focused full-screen card (not a Dialog), so wire
+  // Escape to close it. Skip when a layered sub-sheet (e.g. the category
+  // Customize sheet) already handled Escape — it calls preventDefault on dismiss.
+  useEffect(() => {
+    if (!sheetOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      setSheetOpen(false);
+      clearPolicyDeepLink();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [sheetOpen, clearPolicyDeepLink]);
+
+  // While the create/edit card is open it owns the whole viewport, so hide the
+  // floating assistant dock for the duration (it would otherwise float on top).
+  const { registerDockHide } = useInsightsState();
+  useLayoutEffect(() => {
+    if (!sheetOpen) return;
+    return registerDockHide();
+  }, [sheetOpen, registerDockHide]);
+
   const invalidate = useCallback(() => {
     void invalidateAllRiskListPolicies(queryClient);
     void invalidateAllRiskPoliciesStatus(queryClient);
@@ -542,13 +1033,17 @@ function PolicyCenterContent() {
     const nextKind = kind ?? "risk";
     setEditingPolicy(null);
     setCreateStep(kind || !nlEnabled ? "details" : "type");
+    setWizardStep(0);
     setFormPolicyKind(nextKind);
     setFormName("");
     setFormEnabled(true);
     setFormPromptInstruction("");
-    setSelectedCategories(new Set<RuleCategory>(["secrets", "pii"]));
+    setSelectedCategories(new Set<RuleCategory>());
     setDisabledRules(new Set());
     setSelectedCustomRuleIds(new Set<string>());
+    setScopeInclude("");
+    setScopeExempt("");
+    setScopeMode("messageTypes");
     setSelectedMessageTypes(new Set(ALL_POLICY_MESSAGE_TYPES));
     setFormAction("flag");
     setFormAutoName(true);
@@ -574,9 +1069,15 @@ function PolicyCenterContent() {
     const kind: PolicyKind = isPrompt ? "prompt" : "risk";
     setEditingPolicy(policy);
     setCreateStep("details");
+    setWizardStep(0);
     setFormPolicyKind(kind);
     setFormName(policy.name);
     setFormEnabled(policy.enabled);
+    // Scope CEL applies to both kinds; load it before the kind branch.
+    const loadedInclude = policy.scopeInclude ?? "";
+    setScopeInclude(loadedInclude);
+    setScopeExempt(policy.scopeExempt ?? "");
+    setScopeMode(loadedInclude.trim() !== "" ? "cel" : "messageTypes");
     if (isPrompt) {
       setFormPromptInstruction(policy.prompt ?? "");
       setSelectedMessageTypes(policyMessageTypesForForm(policy.messageTypes));
@@ -636,6 +1137,20 @@ function PolicyCenterContent() {
   }, [policyParam, isLoading, data, handleEdit]);
 
   const handleSave = () => {
+    // Fine-grained scope predicates (both kinds). The include applies only in
+    // CEL scope mode; the exempt is additive and always sent. On update we
+    // always send a value (empty string clears) so the omit-to-preserve impl
+    // can replace it; on create we omit when empty.
+    const includeCel = scopeMode === "cel" ? scopeInclude.trim() : "";
+    const exemptCel = scopeExempt.trim();
+    const applicationUpdate = {
+      scopeInclude: includeCel,
+      scopeExempt: exemptCel,
+    };
+    const applicationCreate = {
+      ...(includeCel ? { scopeInclude: includeCel } : {}),
+      ...(exemptCel ? { scopeExempt: exemptCel } : {}),
+    };
     if (formPolicyKind === "prompt") {
       const prompt = formPromptInstruction.trim();
       const name = formAutoName ? promptPolicyName(prompt) : formName;
@@ -671,6 +1186,7 @@ function PolicyCenterContent() {
               messageTypes: promptMessageTypes,
               action: formAction,
               autoName: formAutoName,
+              ...applicationUpdate,
               ...(modelConfig ? { modelConfig } : {}),
               ...userMessagePayload,
             },
@@ -687,6 +1203,7 @@ function PolicyCenterContent() {
               messageTypes: promptMessageTypes,
               action: formAction,
               autoName: formAutoName,
+              ...applicationCreate,
               ...(modelConfig ? { modelConfig } : {}),
               ...userMessagePayload,
             },
@@ -728,6 +1245,7 @@ function PolicyCenterContent() {
             disabledRules: payloadDisabled,
             customRuleIds: [...selectedCustomRuleIds],
             messageTypes,
+            ...applicationUpdate,
             action,
             audienceType: formAudienceType,
             audiencePrincipalUrns,
@@ -748,6 +1266,7 @@ function PolicyCenterContent() {
             disabledRules: payloadDisabled,
             customRuleIds: [...selectedCustomRuleIds],
             messageTypes,
+            ...applicationCreate,
             action,
             audienceType: formAudienceType,
             audiencePrincipalUrns,
@@ -1046,6 +1565,68 @@ function PolicyCenterContent() {
 
   const isChoosingPolicyKind =
     !editingPolicy && nlEnabled && createStep === "type";
+
+  // Footer behaviour for the guided flow. Both standard and prompt policies now
+  // page through steps (Continue, then Create/Update); only the type chooser is
+  // exempt.
+  const isWizard = !isChoosingPolicyKind;
+  const isRiskWizard = isWizard && formPolicyKind === "risk";
+  const wizardSteps =
+    formPolicyKind === "prompt" ? PROMPT_WIZARD_STEPS : POLICY_WIZARD_STEPS;
+  const isLastWizardStep = wizardStep === wizardSteps.length - 1;
+  const showWizardContinue = isWizard && !isLastWizardStep;
+  const mutationPending = createMutation.isPending || updateMutation.isPending;
+  // Scope is satisfied by either a message-type selection or — in CEL mode — a
+  // non-empty include expression (the two are a mutex). Compile validity is
+  // surfaced inline and enforced by the backend on save.
+  const includeCelStatus = useCelStatus(
+    scopeMode === "cel" ? scopeInclude : "",
+  );
+  const exemptCelStatus = useCelStatus(scopeExempt);
+  const scopeMissing =
+    scopeMode === "messageTypes"
+      ? selectedMessageTypes.size === 0
+      : scopeInclude.trim() === "";
+  // A standard policy needs at least one detector that will actually run: a
+  // custom rule, or a selected category with at least one of its rules enabled.
+  const hasEnabledDetector =
+    selectedCustomRuleIds.size > 0 ||
+    [...selectedCategories].some((c) =>
+      DETECTION_RULES[c]?.some((r) => !r.hidden && !disabledRules.has(r.id)),
+    );
+  const continueDisabled =
+    (wizardStep === 0 &&
+      (formPolicyKind === "prompt"
+        ? !formPromptInstruction.trim()
+        : !hasEnabledDetector)) ||
+    (wizardStep === 1 && scopeMissing);
+  // Block save while a scope expression that will be sent fails to compile.
+  const applicationInvalid =
+    (scopeMode === "cel" && includeCelStatus.kind === "error") ||
+    exemptCelStatus.kind === "error";
+  const saveDisabled =
+    (formPolicyKind === "prompt" && !formPromptInstruction.trim()) ||
+    // A standard policy needs at least one detector or custom rule (the step-0
+    // gate, re-checked here since free-jump can skip it).
+    (isRiskWizard && !hasEnabledDetector) ||
+    (!formAutoName && !formName.trim()) ||
+    scopeMissing ||
+    applicationInvalid ||
+    // A targeted audience needs at least one selected principal.
+    (formPolicyKind === "risk" &&
+      formAudienceType === "targeted" &&
+      selectedAudiencePrincipalUrns.size === 0) ||
+    mutationPending;
+  const showFooterBack =
+    (isWizard && wizardStep > 0) || (!editingPolicy && nlEnabled);
+  const onFooterBack = () => {
+    if (isWizard && wizardStep > 0) {
+      setWizardStep(wizardStep - 1);
+    } else {
+      setCreateStep("type");
+    }
+  };
+
   let sheetTitle = "New Policy";
   let sheetDescription = "Create a policy to scan agent session interactions.";
   if (editingPolicy) {
@@ -1060,7 +1641,7 @@ function PolicyCenterContent() {
       sheetTitle = "New Prompt-based Policy";
       sheetDescription = "Describe the tool-call behavior you want to detect.";
     } else {
-      sheetTitle = "New Standard Policy";
+      sheetTitle = "New Policy";
       sheetDescription = "Configure detection rules to scan agent sessions.";
     }
   }
@@ -1142,126 +1723,172 @@ function PolicyCenterContent() {
           </Page.Section.Body>
         </Page.Section>
 
-        {/* Edit/Create Sheet */}
-        <Sheet
+        {/* Edit/Create page: a focused full-screen card that covers the nav
+         *  sidebar and assistant dock, inset by a small gutter so it reads as
+         *  padded rather than full-bleed — mirrors the inset content surface
+         *  (see AGE-2756). */}
+        <DialogPrimitive.Root
           open={sheetOpen}
           onOpenChange={(open) => {
-            setSheetOpen(open);
-            // Drop the deep-link param so the sheet doesn't reopen and the same
-            // id can be deep-linked again later.
-            if (!open) clearPolicyDeepLink();
+            if (!open) {
+              setSheetOpen(false);
+              clearPolicyDeepLink();
+            }
           }}
         >
-          <SheetContent className="flex flex-col overflow-y-auto sm:max-w-lg">
-            <SheetHeader className="px-6 pt-6">
-              <SheetTitle>{sheetTitle}</SheetTitle>
-              <SheetDescription>{sheetDescription}</SheetDescription>
-            </SheetHeader>
-            <div className="flex-1 overflow-y-auto px-6">
-              <div className="space-y-6 py-4">
-                {isChoosingPolicyKind ? (
-                  <PolicyKindChoice onSelect={handleChoosePolicyKind} />
-                ) : formPolicyKind === "risk" ? (
-                  <PolicySheetBody
-                    key={editingPolicy?.id ?? "new-risk-policy"}
-                    formName={formName}
-                    setFormName={setFormName}
-                    formEnabled={formEnabled}
-                    setFormEnabled={setFormEnabled}
-                    selectedCategories={selectedCategories}
-                    setSelectedCategories={setSelectedCategories}
-                    disabledRules={disabledRules}
-                    setDisabledRules={setDisabledRules}
-                    customRules={customRules}
-                    selectedCustomRuleIds={selectedCustomRuleIds}
-                    setSelectedCustomRuleIds={setSelectedCustomRuleIds}
-                    selectedMessageTypes={selectedMessageTypes}
-                    setSelectedMessageTypes={setSelectedMessageTypes}
-                    formAction={formAction}
-                    setFormAction={setFormAction}
-                    formAutoName={formAutoName}
-                    setFormAutoName={setFormAutoName}
-                    formUserMessage={formUserMessage}
-                    setFormUserMessage={setFormUserMessage}
-                    formAudienceType={formAudienceType}
-                    setFormAudienceType={setFormAudienceType}
-                    selectedAudiencePrincipalUrns={
-                      selectedAudiencePrincipalUrns
-                    }
-                    setSelectedAudiencePrincipalUrns={
-                      setSelectedAudiencePrincipalUrns
-                    }
-                  />
-                ) : (
-                  <PromptPolicySheetBody
-                    key={editingPolicy?.id ?? "new-prompt-policy"}
-                    isEditing={!!editingPolicy}
-                    formName={formName}
-                    setFormName={setFormName}
-                    formPromptInstruction={formPromptInstruction}
-                    setFormPromptInstruction={setFormPromptInstruction}
-                    formAction={formAction}
-                    setFormAction={setFormAction}
-                    formAutoName={formAutoName}
-                    setFormAutoName={setFormAutoName}
-                    formEnabled={formEnabled}
-                    setFormEnabled={setFormEnabled}
-                    formModel={formModel}
-                    setFormModel={setFormModel}
-                    formTemperature={formTemperature}
-                    setFormTemperature={setFormTemperature}
-                    formFailOpen={formFailOpen}
-                    setFormFailOpen={setFormFailOpen}
-                    selectedMessageTypes={selectedMessageTypes}
-                    setSelectedMessageTypes={setSelectedMessageTypes}
-                  />
-                )}
-              </div>
-            </div>
-            {!isChoosingPolicyKind && (
-              <SheetFooter className="px-6 pb-6">
-                {!editingPolicy && nlEnabled && (
+          <DialogPrimitive.Portal>
+            <DialogPrimitive.Overlay className="bg-background fixed inset-0 z-50" />
+            <DialogPrimitive.Content
+              onInteractOutside={(e) => e.preventDefault()}
+              className="bg-surface-primary fixed inset-2 z-50 flex flex-col overflow-hidden rounded-xl border shadow-sm focus:outline-none"
+            >
+              <div className="border-border flex items-start justify-between gap-4 border-b px-8 py-5">
+                <div className="mx-auto flex w-full max-w-5xl items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <DialogPrimitive.Title asChild>
+                      <Type variant="subheading">{sheetTitle}</Type>
+                    </DialogPrimitive.Title>
+                    <DialogPrimitive.Description asChild>
+                      <Type small muted className="mt-1">
+                        {sheetDescription}
+                      </Type>
+                    </DialogPrimitive.Description>
+                  </div>
                   <Button
-                    variant="secondary"
-                    onClick={() => setCreateStep("type")}
+                    variant="tertiary"
+                    onClick={() => {
+                      setSheetOpen(false);
+                      clearPolicyDeepLink();
+                    }}
                   >
                     <Button.LeftIcon>
-                      <ArrowLeft className="h-4 w-4" />
+                      <X className="h-4 w-4" />
                     </Button.LeftIcon>
-                    <Button.Text>Back</Button.Text>
+                    <Button.Text>Close</Button.Text>
                   </Button>
-                )}
-                <Button
-                  onClick={handleSave}
-                  disabled={
-                    (formPolicyKind === "prompt" &&
-                      !formPromptInstruction.trim()) ||
-                    (!formAutoName && !formName.trim()) ||
-                    selectedMessageTypes.size === 0 ||
-                    (formPolicyKind === "risk" &&
-                      formAudienceType === "targeted" &&
-                      selectedAudiencePrincipalUrns.size === 0) ||
-                    createMutation.isPending ||
-                    updateMutation.isPending
-                  }
-                >
-                  {(createMutation.isPending || updateMutation.isPending) && (
-                    <Button.LeftIcon>
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    </Button.LeftIcon>
+                </div>
+              </div>
+              <div className="flex-1 overflow-y-auto px-8">
+                <div className="mx-auto w-full max-w-5xl space-y-6 py-8">
+                  {isChoosingPolicyKind ? (
+                    <PolicyKindChoice onSelect={handleChoosePolicyKind} />
+                  ) : formPolicyKind === "risk" ? (
+                    <PolicySheetBody
+                      key={editingPolicy?.id ?? "new-risk-policy"}
+                      wizardStep={wizardStep}
+                      setWizardStep={setWizardStep}
+                      formName={formName}
+                      setFormName={setFormName}
+                      formEnabled={formEnabled}
+                      setFormEnabled={setFormEnabled}
+                      selectedCategories={selectedCategories}
+                      setSelectedCategories={setSelectedCategories}
+                      disabledRules={disabledRules}
+                      setDisabledRules={setDisabledRules}
+                      customRules={customRules}
+                      selectedCustomRuleIds={selectedCustomRuleIds}
+                      setSelectedCustomRuleIds={setSelectedCustomRuleIds}
+                      scopeInclude={scopeInclude}
+                      setScopeInclude={setScopeInclude}
+                      scopeExempt={scopeExempt}
+                      setScopeExempt={setScopeExempt}
+                      scopeMode={scopeMode}
+                      setScopeMode={setScopeMode}
+                      selectedMessageTypes={selectedMessageTypes}
+                      setSelectedMessageTypes={setSelectedMessageTypes}
+                      formAction={formAction}
+                      setFormAction={setFormAction}
+                      formAutoName={formAutoName}
+                      setFormAutoName={setFormAutoName}
+                      formUserMessage={formUserMessage}
+                      setFormUserMessage={setFormUserMessage}
+                      formAudienceType={formAudienceType}
+                      setFormAudienceType={setFormAudienceType}
+                      selectedAudiencePrincipalUrns={
+                        selectedAudiencePrincipalUrns
+                      }
+                      setSelectedAudiencePrincipalUrns={
+                        setSelectedAudiencePrincipalUrns
+                      }
+                    />
+                  ) : (
+                    <PromptPolicySheetBody
+                      key={editingPolicy?.id ?? "new-prompt-policy"}
+                      wizardStep={wizardStep}
+                      setWizardStep={setWizardStep}
+                      isEditing={!!editingPolicy}
+                      formName={formName}
+                      setFormName={setFormName}
+                      formPromptInstruction={formPromptInstruction}
+                      setFormPromptInstruction={setFormPromptInstruction}
+                      formAction={formAction}
+                      setFormAction={setFormAction}
+                      formAutoName={formAutoName}
+                      setFormAutoName={setFormAutoName}
+                      formEnabled={formEnabled}
+                      setFormEnabled={setFormEnabled}
+                      formModel={formModel}
+                      setFormModel={setFormModel}
+                      formTemperature={formTemperature}
+                      setFormTemperature={setFormTemperature}
+                      formFailOpen={formFailOpen}
+                      setFormFailOpen={setFormFailOpen}
+                      selectedMessageTypes={selectedMessageTypes}
+                      setSelectedMessageTypes={setSelectedMessageTypes}
+                    />
                   )}
-                  <Button.Text>
-                    {createMutation.isPending || updateMutation.isPending
-                      ? "Saving..."
-                      : editingPolicy
-                        ? "Update"
-                        : "Create"}
-                  </Button.Text>
-                </Button>
-              </SheetFooter>
-            )}
-          </SheetContent>
-        </Sheet>
+                </div>
+              </div>
+              {!isChoosingPolicyKind && (
+                <div className="border-border bg-background border-t px-8 py-4">
+                  <div className="mx-auto flex w-full max-w-5xl flex-row items-center justify-between">
+                    {isWizard ? (
+                      <span className="text-muted-foreground text-xs">
+                        Step {wizardStep + 1} of {wizardSteps.length} ·{" "}
+                        {wizardSteps[wizardStep]?.title}
+                      </span>
+                    ) : (
+                      <span />
+                    )}
+                    <div className="flex gap-2">
+                      {showFooterBack && (
+                        <Button variant="secondary" onClick={onFooterBack}>
+                          <Button.LeftIcon>
+                            <ArrowLeft className="h-4 w-4" />
+                          </Button.LeftIcon>
+                          <Button.Text>Back</Button.Text>
+                        </Button>
+                      )}
+                      {showWizardContinue ? (
+                        <Button
+                          onClick={() => setWizardStep(wizardStep + 1)}
+                          disabled={continueDisabled}
+                        >
+                          <Button.Text>Continue</Button.Text>
+                        </Button>
+                      ) : (
+                        <Button onClick={handleSave} disabled={saveDisabled}>
+                          {mutationPending && (
+                            <Button.LeftIcon>
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            </Button.LeftIcon>
+                          )}
+                          <Button.Text>
+                            {mutationPending
+                              ? "Saving..."
+                              : editingPolicy
+                                ? "Update"
+                                : "Create"}
+                          </Button.Text>
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </DialogPrimitive.Content>
+          </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
 
         {/* View Run Panel */}
         <Sheet
@@ -1338,6 +1965,8 @@ function PolicyKindChoice({
 /* -------------------------------------------------------------------------- */
 
 function PromptPolicySheetBody({
+  wizardStep,
+  setWizardStep,
   isEditing,
   formName,
   setFormName,
@@ -1358,6 +1987,8 @@ function PromptPolicySheetBody({
   selectedMessageTypes,
   setSelectedMessageTypes,
 }: {
+  wizardStep: number;
+  setWizardStep: (v: number) => void;
   isEditing: boolean;
   formName: string;
   setFormName: (v: string) => void;
@@ -1381,85 +2012,207 @@ function PromptPolicySheetBody({
   const [selectedExampleName, setSelectedExampleName] = useState(
     () => promptTemplateNameForInstruction(formPromptInstruction) ?? "",
   );
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const handlePromptChange = (value: string) => {
     setSelectedExampleName("");
     setFormPromptInstruction(value);
   };
 
-  return (
-    <div className="space-y-6">
-      <PromptPolicyHowItWorks isEditing={isEditing} />
+  const prompt = formPromptInstruction.trim();
+  const summaryScopes =
+    selectedMessageTypes.size === ALL_POLICY_MESSAGE_TYPES.length
+      ? ["All session parts"]
+      : ALL_POLICY_MESSAGE_TYPES.filter((t) =>
+          selectedMessageTypes.has(t as PolicyMessageType),
+        ).map((t) => POLICY_MESSAGE_TYPE_META[t as PolicyMessageType].label);
 
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label className="text-sm font-medium">Policy Name</Label>
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground text-xs">Auto</span>
-            <Switch checked={formAutoName} onCheckedChange={setFormAutoName} />
+  // One-line view of the judge config shown on the collapsed Advanced card, so
+  // authors can see the (sensible) defaults at a glance without expanding it.
+  const judgeModelLabel =
+    JUDGE_MODEL_OPTIONS.find((o) => o.value === formModel)?.label ??
+    (formModel || JUDGE_MODEL_OPTIONS[0]?.label) ??
+    "Default model";
+  const judgeSummary = `${judgeModelLabel} · temp ${formTemperature.toFixed(1)} · ${formFailOpen ? "fail-open" : "fail-closed"}`;
+
+  return (
+    <WizardShell
+      steps={PROMPT_WIZARD_STEPS}
+      currentStep={wizardStep}
+      setCurrentStep={setWizardStep}
+    >
+      {wizardStep === 0 && (
+        <div className="space-y-6">
+          <WizardStepHeading
+            title="What should this policy catch?"
+            description="Describe the behavior to detect in plain language; the LLM judge evaluates each in-scope message against it."
+          />
+          <PromptPolicyHowItWorks isEditing={isEditing} />
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Policy Prompt</Label>
+            <TextArea
+              value={formPromptInstruction}
+              onChange={handlePromptChange}
+              placeholder="Describe the tool-call behavior this policy should match..."
+              rows={5}
+            />
+            {!isEditing && (
+              <PromptExampleChips
+                selectedExampleName={selectedExampleName}
+                onSelect={(template) => {
+                  setSelectedExampleName(template.name);
+                  setFormPromptInstruction(template.prompt);
+                  if (!formName.trim()) {
+                    setFormName(template.name);
+                  }
+                }}
+              />
+            )}
+          </div>
+          <Collapsible
+            open={advancedOpen}
+            onOpenChange={setAdvancedOpen}
+            className="border-border rounded-lg border"
+          >
+            <CollapsibleTrigger className="hover:bg-muted/40 flex w-full items-center gap-3 px-4 py-3 text-left transition-colors">
+              <SlidersHorizontal className="text-muted-foreground h-4 w-4 shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">
+                    Advanced judge settings
+                  </span>
+                  <Badge variant="neutral" className="text-[10px]">
+                    <Badge.Text>Optional</Badge.Text>
+                  </Badge>
+                </div>
+                <div className="text-muted-foreground truncate text-xs">
+                  {advancedOpen
+                    ? "Judge model, temperature, and failure behavior"
+                    : judgeSummary}
+                </div>
+              </div>
+              <ChevronRight
+                className={cn(
+                  "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
+                  advancedOpen && "rotate-90",
+                )}
+              />
+            </CollapsibleTrigger>
+            <CollapsibleContent className="border-border border-t px-4 py-4">
+              <JudgeConfigSection
+                formModel={formModel}
+                setFormModel={setFormModel}
+                formTemperature={formTemperature}
+                setFormTemperature={setFormTemperature}
+                formFailOpen={formFailOpen}
+                setFormFailOpen={setFormFailOpen}
+              />
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      )}
+
+      {wizardStep === 1 && (
+        <div className="space-y-6">
+          <WizardStepHeading
+            title="Where should it evaluate?"
+            description="Narrow the scope to control cost — a prompt policy runs the LLM judge on each in-scope message."
+          />
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {ALL_POLICY_MESSAGE_TYPES.map((type) => (
+              <ScopeCard
+                key={type}
+                type={type as PolicyMessageType}
+                checked={selectedMessageTypes.has(type as PolicyMessageType)}
+                onToggle={(checked) => {
+                  const updated = new Set(selectedMessageTypes);
+                  if (checked) {
+                    updated.add(type as PolicyMessageType);
+                  } else {
+                    updated.delete(type as PolicyMessageType);
+                  }
+                  setSelectedMessageTypes(updated);
+                }}
+              />
+            ))}
+          </div>
+          {selectedMessageTypes.size === 0 && (
+            <p className="text-destructive text-xs">
+              Select at least one session part.
+            </p>
+          )}
+        </div>
+      )}
+
+      {wizardStep === 2 && (
+        <div className="space-y-6">
+          <WizardStepHeading
+            title="What happens on a match?"
+            description="Choose how the policy responds when the judge flags a message."
+          />
+          <ActionPicker formAction={formAction} setFormAction={setFormAction} />
+        </div>
+      )}
+
+      {wizardStep === 3 && (
+        <div className="space-y-6">
+          <WizardStepHeading
+            title="Name & enable"
+            description="Review the policy, then create it."
+          />
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium">Policy Name</Label>
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground text-xs">Auto</span>
+                <Switch
+                  checked={formAutoName}
+                  onCheckedChange={setFormAutoName}
+                />
+              </div>
+            </div>
+            {formAutoName ? (
+              <p className="text-muted-foreground text-xs">
+                Name will be generated from the policy prompt.
+              </p>
+            ) : (
+              <Input
+                value={formName}
+                onChange={setFormName}
+                placeholder="e.g. No Production Deletes"
+              />
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Summary</Label>
+            <div className="border-border divide-border divide-y rounded-lg border">
+              <SummaryRow
+                label="Guardrail"
+                chips={[
+                  prompt
+                    ? `${prompt.slice(0, 48)}${prompt.length > 48 ? "…" : ""}`
+                    : "None",
+                ]}
+              />
+              <SummaryRow label="Scope" chips={summaryScopes} />
+              <SummaryRow
+                label="Action"
+                chips={[formAction === "block" ? "Block" : "Flag"]}
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Label className="text-sm font-medium">Enabled</Label>
+              <p className="text-muted-foreground text-xs">
+                Enable this policy to enforce the prompt.
+              </p>
+            </div>
+            <Switch checked={formEnabled} onCheckedChange={setFormEnabled} />
           </div>
         </div>
-        {formAutoName ? (
-          <p className="text-muted-foreground text-xs">
-            Name will be generated from the policy prompt.
-          </p>
-        ) : (
-          <Input
-            value={formName}
-            onChange={setFormName}
-            placeholder="e.g. No Production Deletes"
-          />
-        )}
-      </div>
-
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">Policy Prompt</Label>
-        <TextArea
-          value={formPromptInstruction}
-          onChange={handlePromptChange}
-          placeholder="Describe the tool-call behavior this policy should match..."
-          rows={5}
-        />
-        {!isEditing && (
-          <PromptExampleChips
-            selectedExampleName={selectedExampleName}
-            onSelect={(template) => {
-              setSelectedExampleName(template.name);
-              setFormPromptInstruction(template.prompt);
-              if (!formName.trim()) {
-                setFormName(template.name);
-              }
-            }}
-          />
-        )}
-      </div>
-
-      <JudgeConfigSection
-        formModel={formModel}
-        setFormModel={setFormModel}
-        formTemperature={formTemperature}
-        setFormTemperature={setFormTemperature}
-        formFailOpen={formFailOpen}
-        setFormFailOpen={setFormFailOpen}
-      />
-
-      <MessageTypesPicker
-        selectedMessageTypes={selectedMessageTypes}
-        setSelectedMessageTypes={setSelectedMessageTypes}
-      />
-
-      <ActionPicker formAction={formAction} setFormAction={setFormAction} />
-
-      <div className="flex items-center justify-between">
-        <div>
-          <Label className="text-sm font-medium">Enabled</Label>
-          <p className="text-muted-foreground text-xs">
-            Enable this policy to enforce the prompt.
-          </p>
-        </div>
-        <Switch checked={formEnabled} onCheckedChange={setFormEnabled} />
-      </div>
-    </div>
+      )}
+    </WizardShell>
   );
 }
 
@@ -1688,7 +2441,8 @@ function PromptPolicyHowItWorks({ isEditing }: { isEditing: boolean }) {
         <div className="min-w-0 flex-1">
           <div className="text-sm font-medium">How this works</div>
           <div className="text-muted-foreground text-xs">
-            An LLM judge checks each matching message against your prompt.
+            An LLM judge reads each in-scope message and flags it when it
+            matches your prompt.
           </div>
         </div>
         <ChevronRight
@@ -1700,11 +2454,12 @@ function PromptPolicyHowItWorks({ isEditing }: { isEditing: boolean }) {
       </CollapsibleTrigger>
       <CollapsibleContent className="border-border border-t px-4 py-3">
         <p className="text-muted-foreground text-sm">
-          Prompt-based policies use an LLM judge, so each evaluated message adds
-          some latency versus standard detection rules. The judge sees one
-          message at a time (a tool call and its inputs, or message content),
-          never a whole conversation. It runs on the message types you select
-          under Applies To.
+          Prompt-based policies call an LLM judge, so every in-scope message
+          adds latency and cost versus the deterministic detection rules. The
+          judge sees one message at a time — a tool call and its inputs, or
+          message content — never the whole conversation. Narrow <b>Scope</b> to
+          control which messages it runs on, and add <b>Exemptions</b> to skip
+          trusted ones and keep cost down.
         </p>
       </CollapsibleContent>
     </Collapsible>
@@ -1716,6 +2471,8 @@ function PromptPolicyHowItWorks({ isEditing }: { isEditing: boolean }) {
 /* -------------------------------------------------------------------------- */
 
 function PolicySheetBody({
+  wizardStep,
+  setWizardStep,
   formName,
   setFormName,
   formEnabled,
@@ -1727,6 +2484,12 @@ function PolicySheetBody({
   customRules,
   selectedCustomRuleIds,
   setSelectedCustomRuleIds,
+  scopeInclude,
+  setScopeInclude,
+  scopeExempt,
+  setScopeExempt,
+  scopeMode,
+  setScopeMode,
   selectedMessageTypes,
   setSelectedMessageTypes,
   formAction,
@@ -1740,6 +2503,8 @@ function PolicySheetBody({
   selectedAudiencePrincipalUrns,
   setSelectedAudiencePrincipalUrns,
 }: {
+  wizardStep: number;
+  setWizardStep: (v: number) => void;
   formName: string;
   setFormName: (v: string) => void;
   formEnabled: boolean;
@@ -1751,6 +2516,12 @@ function PolicySheetBody({
   customRules: ReturnType<typeof useDetectionRulesStore>["customRules"];
   selectedCustomRuleIds: Set<string>;
   setSelectedCustomRuleIds: (v: Set<string>) => void;
+  scopeInclude: string;
+  setScopeInclude: (v: string) => void;
+  scopeExempt: string;
+  setScopeExempt: (v: string) => void;
+  scopeMode: "messageTypes" | "cel";
+  setScopeMode: (v: "messageTypes" | "cel") => void;
   selectedMessageTypes: Set<PolicyMessageType>;
   setSelectedMessageTypes: (v: Set<PolicyMessageType>) => void;
   formAction: PolicyAction;
@@ -1764,298 +2535,352 @@ function PolicySheetBody({
   selectedAudiencePrincipalUrns: Set<string>;
   setSelectedAudiencePrincipalUrns: (v: Set<string>) => void;
 }) {
-  const [expandedCategory, setExpandedCategory] = useState<
-    RuleCategory | "custom" | null
-  >(null);
+  // The org's custom rules collapse into their own section; the Customize sheet
+  // opens for one detector category at a time.
+  const [detectionExpanded, setDetectionExpanded] = useState(true);
+  const [customizeCategory, setCustomizeCategory] =
+    useState<RuleCategory | null>(null);
+  const selectedBuiltinCount = ALL_CATEGORIES.filter((c) =>
+    selectedCategories.has(c),
+  ).length;
+
+  // Toggle a whole built-in detector category on/off (clears any per-rule
+  // disables for it). Flag-only categories force the policy action to flag.
+  const toggleCategory = (cat: RuleCategory, checked: boolean) => {
+    const rules = DETECTION_RULES[cat].filter((r) => !r.hidden);
+    const nextCats = new Set(selectedCategories);
+    const nextDisabled = new Set(disabledRules);
+    if (checked) {
+      nextCats.add(cat);
+    } else {
+      nextCats.delete(cat);
+    }
+    for (const rule of rules) nextDisabled.delete(rule.id);
+    setSelectedCategories(nextCats);
+    setDisabledRules(nextDisabled);
+    if (checked && FLAG_ONLY_CATEGORIES.has(cat) && formAction === "block") {
+      setFormAction("flag");
+    }
+  };
   const flagOnlySelected = [...FLAG_ONLY_CATEGORIES].some((c) =>
     selectedCategories.has(c),
   );
 
+  // Custom rules attach as detectors only; a match records a finding. Message
+  // exemptions are expressed via the policy's scope_exempt, not by rule id.
+  const toggleDetector = (ruleId: string, checked: boolean) => {
+    const next = new Set(selectedCustomRuleIds);
+    if (checked) {
+      next.add(ruleId);
+    } else {
+      next.delete(ruleId);
+    }
+    setSelectedCustomRuleIds(next);
+  };
+
+  // Review-step summary chips.
+  const summaryDetectors = ALL_CATEGORIES.filter((c) =>
+    selectedCategories.has(c),
+  ).map((c) => RULE_CATEGORY_META[c].label);
+  const messageTypeScopeLabels =
+    selectedMessageTypes.size === ALL_POLICY_MESSAGE_TYPES.length
+      ? ["All session parts"]
+      : ALL_POLICY_MESSAGE_TYPES.filter((t) =>
+          selectedMessageTypes.has(t as PolicyMessageType),
+        ).map((t) => POLICY_MESSAGE_TYPE_META[t as PolicyMessageType].label);
+  const summaryScopes =
+    scopeMode === "cel" ? ["CEL expression"] : messageTypeScopeLabels;
+
   return (
-    <div className="space-y-6 py-4">
-      {/* Policy Name */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label className="text-sm font-medium">Policy Name</Label>
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground text-xs">Auto</span>
-            <Switch checked={formAutoName} onCheckedChange={setFormAutoName} />
-          </div>
-        </div>
-        {formAutoName ? (
-          <p className="text-muted-foreground text-xs">
-            Name will be generated automatically based on detection rules and
-            action.
-          </p>
-        ) : (
-          <Input
-            value={formName}
-            onChange={(value) => setFormName(value)}
-            placeholder="e.g. Secret Detection"
-          />
-        )}
-      </div>
+    <>
+      <WizardShell
+        steps={POLICY_WIZARD_STEPS}
+        currentStep={wizardStep}
+        setCurrentStep={setWizardStep}
+      >
+        {wizardStep === 0 && (
+          <div className="space-y-6">
+            <WizardStepHeading
+              title="What should this policy detect?"
+              description="Turn on detector categories and attach your organization's custom rules."
+            />
 
-      {/* Detection Rules */}
-      <div className="space-y-3">
-        <Label className="text-sm font-medium">Detection Rules</Label>
-        <div className="border-border divide-border divide-y rounded-lg border">
-          {ALL_CATEGORIES.map((cat) => {
-            const meta = RULE_CATEGORY_META[cat];
-            const isAvailable = AVAILABLE_CATEGORIES.has(cat);
-            const isExpanded = expandedCategory === cat;
-            // Hidden rules stay in the catalog so legacy risk_results keep
-            // resolving their title via risk-utils, but they are scrubbed
-            // from the form's display, counts, and bulk toggles. The
-            // underlying disabledRules/selectedCategories state is left
-            // untouched so existing policies that pin a hidden rule round-
-            // trip cleanly through edit.
-            const rules = DETECTION_RULES[cat].filter((r) => !r.hidden);
-            const isExpandable = isAvailable && rules.length > 0;
-            const categorySelected = selectedCategories.has(cat);
-            const enabledRuleCount = categorySelected
-              ? rules.filter((r) => !disabledRules.has(r.id)).length
-              : 0;
-            const hasPartialSelection =
-              categorySelected &&
-              rules.length > 0 &&
-              enabledRuleCount > 0 &&
-              enabledRuleCount < rules.length;
-            const headerChecked: boolean | "indeterminate" = hasPartialSelection
-              ? "indeterminate"
-              : categorySelected &&
-                (rules.length === 0 || enabledRuleCount > 0);
-
-            const toggleCategory = (checked: boolean) => {
-              const nextCats = new Set(selectedCategories);
-              const nextDisabled = new Set(disabledRules);
-              if (checked) {
-                nextCats.add(cat);
-                for (const rule of rules) nextDisabled.delete(rule.id);
-              } else {
-                nextCats.delete(cat);
-                for (const rule of rules) nextDisabled.delete(rule.id);
-              }
-              setSelectedCategories(nextCats);
-              setDisabledRules(nextDisabled);
-              if (
-                checked &&
-                cat === "destructive_tool" &&
-                formAction === "block"
-              ) {
-                setFormAction("flag");
-              }
-            };
-
-            const toggleRule = (ruleId: string, enabled: boolean) => {
-              const nextDisabled = new Set(disabledRules);
-              const nextCats = new Set(selectedCategories);
-              if (enabled) {
-                nextDisabled.delete(ruleId);
-                // Enabling any rule inside a category implies the category is
-                // selected. Otherwise the rule wouldn't actually run.
-                nextCats.add(cat);
-              } else {
-                nextDisabled.add(ruleId);
-              }
-              setSelectedCategories(nextCats);
-              setDisabledRules(nextDisabled);
-            };
-
-            return (
-              <div key={cat}>
-                {/* Category header */}
-                <div
-                  className={cn(
-                    "flex items-center gap-3 px-4 py-3",
-                    isExpandable && "cursor-pointer",
-                  )}
-                  onClick={() => {
-                    if (isExpandable) {
-                      setExpandedCategory(isExpanded ? null : cat);
-                    }
-                  }}
-                >
-                  {/* Expand chevron (only for categories with rules to expand) */}
-                  {isExpandable ? (
-                    <ChevronRight
-                      className={cn(
-                        "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
-                        isExpanded && "rotate-90",
-                      )}
-                    />
-                  ) : (
-                    <div className="w-4 shrink-0" />
-                  )}
-
-                  {/* Category icon */}
-                  <Icon
-                    name={meta.icon as IconName}
-                    className="text-muted-foreground size-4 shrink-0"
-                  />
-
-                  {/* Label & description */}
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium">{meta.label}</span>
-                      {!isAvailable && (
-                        <Badge variant="neutral">
-                          <Badge.Text>Coming Soon</Badge.Text>
-                        </Badge>
-                      )}
-                      {isExpandable && categorySelected && (
-                        <Badge variant="neutral">
-                          <Badge.Text>
-                            {enabledRuleCount}/{rules.length}
-                          </Badge.Text>
-                        </Badge>
-                      )}
-                    </div>
-                    <p className="text-muted-foreground text-xs">
-                      {meta.description}
-                    </p>
-                  </div>
-
-                  {/* Category checkbox */}
-                  <Checkbox
-                    checked={headerChecked}
-                    disabled={!isAvailable}
-                    onCheckedChange={(checked) => toggleCategory(!!checked)}
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                </div>
-
-                {/* Expanded per-rule toggles. Each rule is independently
-                    toggleable; unchecking adds the canonical rule_id to the
-                    policy's disabled_rules list and the scanner drops matching
-                    findings. */}
-                {isAvailable && isExpanded && rules.length > 0 && (
-                  <div className="bg-muted/30 border-border border-t px-4 py-2">
-                    <div className="flex items-center justify-between py-1">
-                      <span className="text-muted-foreground text-xs">
-                        {enabledRuleCount} of {rules.length} rules enabled
-                      </span>
-                      <div className="flex gap-3">
-                        <button
-                          type="button"
-                          className="text-primary text-xs underline-offset-2 hover:underline disabled:opacity-50"
-                          disabled={enabledRuleCount === rules.length}
-                          onClick={() => {
-                            const nextDisabled = new Set(disabledRules);
-                            for (const r of rules) nextDisabled.delete(r.id);
-                            setDisabledRules(nextDisabled);
-                            const nextCats = new Set(selectedCategories);
-                            nextCats.add(cat);
-                            setSelectedCategories(nextCats);
-                          }}
-                        >
-                          Enable all
-                        </button>
-                        <button
-                          type="button"
-                          className="text-primary text-xs underline-offset-2 hover:underline disabled:opacity-50"
-                          disabled={!categorySelected || enabledRuleCount === 0}
-                          onClick={() => {
-                            const nextDisabled = new Set(disabledRules);
-                            for (const r of rules) nextDisabled.add(r.id);
-                            setDisabledRules(nextDisabled);
-                          }}
-                        >
-                          Disable all
-                        </button>
-                      </div>
-                    </div>
-                    <div className="space-y-2 py-1">
-                      {rules.map((rule) => {
-                        const ruleEnabled =
-                          categorySelected && !disabledRules.has(rule.id);
-                        return (
-                          <div
-                            key={rule.id}
-                            className="flex items-center gap-3 py-1 pl-8"
-                          >
-                            <Checkbox
-                              id={rule.id}
-                              checked={ruleEnabled}
-                              onCheckedChange={(checked) =>
-                                toggleRule(rule.id, !!checked)
-                              }
-                            />
-                            <label htmlFor={rule.id} className="text-xs">
-                              {rule.title}
-                            </label>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
+            {/* Built-in rules */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <Label className="text-sm font-medium">Built-in rules</Label>
+                <span className="text-muted-foreground text-xs">
+                  {selectedBuiltinCount} on
+                </span>
               </div>
-            );
-          })}
-        </div>
-      </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {ALL_CATEGORIES.map((cat) => (
+                  <DetectorCard
+                    key={cat}
+                    category={cat}
+                    selected={selectedCategories.has(cat)}
+                    disabledRules={disabledRules}
+                    onToggle={(checked) => toggleCategory(cat, checked)}
+                    onCustomize={() => setCustomizeCategory(cat)}
+                  />
+                ))}
+              </div>
+            </div>
 
-      {customRules.length > 0 && (
-        <CustomRulesPicker
-          customRules={customRules}
-          selectedCustomRuleIds={selectedCustomRuleIds}
-          setSelectedCustomRuleIds={setSelectedCustomRuleIds}
-          expanded={expandedCategory === "custom"}
-          onToggle={() =>
-            setExpandedCategory(expandedCategory === "custom" ? null : "custom")
-          }
-        />
-      )}
+            {customRules.length > 0 && (
+              <RuleSelectList
+                title="Custom Rules"
+                description={
+                  <>
+                    Attach your organization's custom rules as{" "}
+                    <span className="text-foreground font-medium">
+                      detectors
+                    </span>{" "}
+                    — a match records a finding.
+                  </>
+                }
+                idPrefix="detector"
+                customRules={customRules}
+                selectedRuleIds={selectedCustomRuleIds}
+                onToggleRule={toggleDetector}
+                expanded={detectionExpanded}
+                onToggle={() => setDetectionExpanded((v) => !v)}
+              />
+            )}
+          </div>
+        )}
 
-      <MessageTypesPicker
-        selectedMessageTypes={selectedMessageTypes}
-        setSelectedMessageTypes={setSelectedMessageTypes}
-      />
+        {wizardStep === 1 && (
+          <div className="space-y-6">
+            <WizardStepHeading
+              title="Where should it evaluate?"
+              description="Apply everywhere, or narrow the scope to reduce noise and cost."
+            />
+            {/* Scope is a mutex: message-type cards (coarse) XOR a CEL include
+                predicate (fine). The segmented control conveys that. */}
+            <div className="space-y-3">
+              <div className="border-border inline-flex rounded-md border p-0.5">
+                {(
+                  [
+                    { key: "messageTypes", label: "Message types" },
+                    { key: "cel", label: "CEL expression" },
+                  ] as const
+                ).map((opt) => (
+                  <button
+                    key={opt.key}
+                    type="button"
+                    onClick={() => setScopeMode(opt.key)}
+                    className={cn(
+                      "rounded px-3 py-1 text-xs font-medium transition-colors",
+                      scopeMode === opt.key
+                        ? "bg-foreground text-background"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-muted-foreground text-xs">
+                {scopeMode === "messageTypes"
+                  ? "Apply to whole session parts. Switch to a CEL expression to match on tool or content attributes instead."
+                  : "Apply only to messages matching the expression below — this replaces the message-type selection."}
+              </p>
+            </div>
 
-      <ActionPicker
-        formAction={formAction}
-        setFormAction={setFormAction}
-        flagOnlySelected={flagOnlySelected}
-      />
+            {scopeMode === "messageTypes" ? (
+              <>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  {ALL_POLICY_MESSAGE_TYPES.map((type) => (
+                    <ScopeCard
+                      key={type}
+                      type={type as PolicyMessageType}
+                      checked={selectedMessageTypes.has(
+                        type as PolicyMessageType,
+                      )}
+                      onToggle={(checked) => {
+                        const updated = new Set(selectedMessageTypes);
+                        if (checked) {
+                          updated.add(type as PolicyMessageType);
+                        } else {
+                          updated.delete(type as PolicyMessageType);
+                        }
+                        setSelectedMessageTypes(updated);
+                      }}
+                    />
+                  ))}
+                </div>
+                {selectedMessageTypes.size === 0 && (
+                  <p className="text-destructive text-xs">
+                    Select at least one session part.
+                  </p>
+                )}
+              </>
+            ) : (
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">
+                  Evaluate messages matching
+                </Label>
+                <p className="text-muted-foreground text-xs">
+                  The policy evaluates a message only when this expression is
+                  true.
+                </p>
+                <CelExpressionField
+                  value={scopeInclude}
+                  onChange={setScopeInclude}
+                  examples={SCOPE_INCLUDE_CEL_EXAMPLES}
+                />
+              </div>
+            )}
 
-      <PolicyAudiencePicker
-        formAudienceType={formAudienceType}
-        setFormAudienceType={setFormAudienceType}
-        selectedAudiencePrincipalUrns={selectedAudiencePrincipalUrns}
-        setSelectedAudiencePrincipalUrns={setSelectedAudiencePrincipalUrns}
-      />
+            {/* Exemptions — always available and additive (not part of the
+                scope mutex). A match here skips the whole policy. */}
+            <div className="border-border space-y-4 border-t pt-6">
+              <div>
+                <Label className="text-sm font-medium">Exemptions</Label>
+                <p className="text-muted-foreground text-xs">
+                  Skip the whole policy for any message matching this expression
+                  — an allowlist, regardless of the scope above.
+                </p>
+              </div>
+              <CelExpressionField
+                value={scopeExempt}
+                onChange={setScopeExempt}
+                examples={SCOPE_EXEMPT_CEL_EXAMPLES}
+              />
+            </div>
+          </div>
+        )}
 
-      {/* Custom message — only relevant for block-action policies that
+        {wizardStep === 2 && (
+          <div className="space-y-6">
+            <WizardStepHeading
+              title="What happens on a match?"
+              description="Choose how the policy responds when its detection rules fire."
+            />
+            <ActionPicker
+              formAction={formAction}
+              setFormAction={setFormAction}
+              flagOnlySelected={flagOnlySelected}
+            />
+
+            {/* Who the policy applies to (audience). */}
+            <PolicyAudiencePicker
+              formAudienceType={formAudienceType}
+              setFormAudienceType={setFormAudienceType}
+              selectedAudiencePrincipalUrns={selectedAudiencePrincipalUrns}
+              setSelectedAudiencePrincipalUrns={
+                setSelectedAudiencePrincipalUrns
+              }
+            />
+
+            {/* Custom message — only relevant for block-action policies that
           surface a user-facing reason at deny time. Flag-action policies
           record findings silently, so no message is needed. */}
-      {formAction === "block" && (
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">Custom Message</Label>
-          <p className="text-muted-foreground text-xs">
-            Shown to the user when this policy blocks a tool call or prompt.
-            Leave blank to use the default message.
-          </p>
-          <TextArea
-            value={formUserMessage}
-            onChange={setFormUserMessage}
-            placeholder="e.g. This action was blocked by your organization's security policy. Contact your admin for help."
-            rows={3}
-          />
-        </div>
-      )}
+            {formAction === "block" && (
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Custom Message</Label>
+                <p className="text-muted-foreground text-xs">
+                  Shown to the user when this policy blocks a tool call or
+                  prompt. Leave blank to use the default message.
+                </p>
+                <TextArea
+                  value={formUserMessage}
+                  onChange={setFormUserMessage}
+                  placeholder="e.g. This action was blocked by your organization's security policy. Contact your admin for help."
+                  rows={3}
+                />
+              </div>
+            )}
+          </div>
+        )}
 
-      {/* Enabled toggle */}
-      <div className="flex items-center justify-between">
-        <div>
-          <Label className="text-sm font-medium">Enabled</Label>
-          <p className="text-muted-foreground text-xs">
-            Enable this policy to begin scanning messages.
-          </p>
-        </div>
-        <Switch checked={formEnabled} onCheckedChange={setFormEnabled} />
-      </div>
-    </div>
+        {wizardStep === 3 && (
+          <div className="space-y-6">
+            <WizardStepHeading
+              title="Name & enable"
+              description="Review the policy, then create it."
+            />
+
+            {/* Policy Name */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label className="text-sm font-medium">Policy Name</Label>
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground text-xs">Auto</span>
+                  <Switch
+                    checked={formAutoName}
+                    onCheckedChange={setFormAutoName}
+                  />
+                </div>
+              </div>
+              {formAutoName ? (
+                <p className="text-muted-foreground text-xs">
+                  Name will be generated automatically based on detection rules
+                  and action.
+                </p>
+              ) : (
+                <Input
+                  value={formName}
+                  onChange={(value) => setFormName(value)}
+                  placeholder="e.g. Secret Detection"
+                />
+              )}
+            </div>
+
+            {/* Summary */}
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Summary</Label>
+              <div className="border-border divide-border divide-y rounded-lg border">
+                <SummaryRow
+                  label="Detectors"
+                  chips={
+                    summaryDetectors.length > 0 ? summaryDetectors : ["None"]
+                  }
+                />
+                <SummaryRow
+                  label="Custom rules"
+                  chips={[
+                    selectedCustomRuleIds.size > 0
+                      ? `${selectedCustomRuleIds.size} attached`
+                      : "None",
+                  ]}
+                />
+                {scopeExempt.trim() !== "" && (
+                  <SummaryRow label="Exemptions" chips={["CEL expression"]} />
+                )}
+                <SummaryRow label="Scope" chips={summaryScopes} />
+                <SummaryRow
+                  label="Action"
+                  chips={[formAction === "block" ? "Block" : "Flag"]}
+                />
+              </div>
+            </div>
+
+            {/* Enabled toggle */}
+            <div className="flex items-center justify-between">
+              <div>
+                <Label className="text-sm font-medium">Enabled</Label>
+                <p className="text-muted-foreground text-xs">
+                  Enable this policy to begin scanning messages.
+                </p>
+              </div>
+              <Switch checked={formEnabled} onCheckedChange={setFormEnabled} />
+            </div>
+          </div>
+        )}
+      </WizardShell>
+      {customizeCategory && (
+        <CustomizeRulesSheet
+          category={customizeCategory}
+          selectedCategories={selectedCategories}
+          setSelectedCategories={setSelectedCategories}
+          disabledRules={disabledRules}
+          setDisabledRules={setDisabledRules}
+          onClose={() => setCustomizeCategory(null)}
+        />
+      )}
+    </>
   );
 }
 
@@ -2611,13 +3436,19 @@ const ACTION_BADGE_CONFIG: Record<
   block: { label: "Block", variant: "destructive" },
 };
 
-const ACTION_OPTIONS: { value: PolicyAction; description: string }[] = [
+const ACTION_OPTIONS: {
+  value: PolicyAction;
+  title: string;
+  description: string;
+}[] = [
   {
     value: "flag",
+    title: "Log for review",
     description: "Log findings for review without interrupting the session",
   },
   {
     value: "block",
+    title: "Deny the request",
     description: "Deny prompts and tool calls that match detection rules",
   },
 ];
@@ -2631,106 +3462,32 @@ function ActionBadge({ action }: { action: PolicyAction }) {
   );
 }
 
-function MessageTypesPicker({
-  selectedMessageTypes,
-  setSelectedMessageTypes,
-}: {
-  selectedMessageTypes: Set<PolicyMessageType>;
-  setSelectedMessageTypes: (v: Set<PolicyMessageType>) => void;
-}) {
-  const [messageTypesOpen, setMessageTypesOpen] = useState(
-    () => selectedMessageTypes.size !== ALL_POLICY_MESSAGE_TYPES.length,
-  );
-
-  return (
-    <Collapsible
-      open={messageTypesOpen}
-      onOpenChange={setMessageTypesOpen}
-      className="space-y-3"
-    >
-      <div className="space-y-1">
-        <Label className="text-sm font-medium">Applies To</Label>
-        <p className="text-muted-foreground text-xs">
-          Choose which parts of an agent session this policy evaluates. Leaving
-          all four selected applies the policy everywhere.
-        </p>
-      </div>
-      <div className="border-border rounded-lg border">
-        <CollapsibleTrigger className="hover:bg-muted/40 flex w-full items-center gap-3 px-4 py-3 text-left transition-colors">
-          <ChevronRight
-            className={cn(
-              "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
-              messageTypesOpen && "rotate-90",
-            )}
-          />
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium">
-              {messageTypesSummary(selectedMessageTypes)}
-            </div>
-            <div className="text-muted-foreground text-xs">
-              Advanced: narrow evaluation to specific parts of a session
-            </div>
-          </div>
-        </CollapsibleTrigger>
-        <CollapsibleContent className="border-border data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden border-t">
-          <div className="divide-border divide-y">
-            {ALL_POLICY_MESSAGE_TYPES.map((type) => (
-              <MessageTypeOptionRow
-                key={type}
-                type={type}
-                checked={selectedMessageTypes.has(type)}
-                onCheckedChange={(next) => {
-                  const updated = new Set(selectedMessageTypes);
-                  if (next) {
-                    updated.add(type);
-                  } else {
-                    updated.delete(type);
-                  }
-                  setSelectedMessageTypes(updated);
-                }}
-              />
-            ))}
-          </div>
-        </CollapsibleContent>
-      </div>
-      {selectedMessageTypes.size === 0 && (
-        <p className="text-destructive text-xs">
-          Select at least one type. An empty API value means “all types,” so the
-          UI keeps that choice explicit here.
-        </p>
-      )}
-    </Collapsible>
-  );
-}
-
-function MessageTypeOptionRow({
+/** One session-part as a selectable card (Scope step). */
+function ScopeCard({
   type,
   checked,
-  disabled = false,
-  onCheckedChange,
+  onToggle,
 }: {
   type: PolicyMessageType;
   checked: boolean;
-  disabled?: boolean;
-  onCheckedChange: (checked: boolean | "indeterminate") => void;
+  onToggle: (checked: boolean) => void;
 }) {
   const meta = POLICY_MESSAGE_TYPE_META[type];
-
   return (
     <label
       className={cn(
-        "flex items-start gap-3 px-4 py-3",
-        disabled
-          ? "cursor-not-allowed opacity-60"
-          : "hover:bg-muted/40 cursor-pointer",
+        "flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors",
+        checked
+          ? "border-foreground bg-muted/40"
+          : "border-border hover:bg-muted/30",
       )}
     >
       <Checkbox
         checked={checked}
-        disabled={disabled}
-        onCheckedChange={disabled ? undefined : onCheckedChange}
+        onCheckedChange={(next) => onToggle(!!next)}
+        className="mt-0.5"
       />
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0">
         <div className="text-sm font-medium">{meta.label}</div>
         <div className="text-muted-foreground text-xs">{meta.description}</div>
       </div>
@@ -2751,170 +3508,141 @@ function ActionPicker({
     flagOnlySelected && formAction === "block" ? "flag" : formAction;
 
   return (
-    <div className="space-y-2">
-      <Label className="text-sm font-medium">Action</Label>
-      <RadioGroup
-        value={actionValue}
-        onValueChange={(v) => {
-          if (flagOnlySelected && v === "block") {
-            return;
-          }
-          setFormAction(v as PolicyAction);
-        }}
-      >
-        <div className="border-border divide-border divide-y rounded-lg border">
-          {ACTION_OPTIONS.map((opt) => {
-            const disabled = flagOnlySelected && opt.value === "block";
+    <RadioGroup
+      value={actionValue}
+      onValueChange={(v) => {
+        if (flagOnlySelected && v === "block") {
+          return;
+        }
+        setFormAction(v as PolicyAction);
+      }}
+      className="space-y-2.5"
+    >
+      {ACTION_OPTIONS.map((opt) => {
+        const disabled = flagOnlySelected && opt.value === "block";
+        const selected = actionValue === opt.value;
 
-            return (
-              <label
-                key={opt.value}
-                htmlFor={`action-${opt.value}`}
-                className={cn(
-                  "flex items-start gap-3 p-3",
-                  disabled
-                    ? "cursor-not-allowed opacity-60"
-                    : "hover:bg-muted/50 cursor-pointer",
-                )}
-              >
-                <RadioGroupItem
-                  value={opt.value}
-                  id={`action-${opt.value}`}
-                  className="mt-0.5"
-                  disabled={disabled}
-                />
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <ActionBadge action={opt.value} />
-                  </div>
-                  <div className="text-muted-foreground mt-1 text-xs">
-                    {opt.description}
-                  </div>
-                  {disabled && (
-                    <div className="text-destructive mt-1 text-xs font-medium">
-                      Destructive Tools and Destructive CLI Commands support
-                      flagging only.
-                    </div>
-                  )}
+        return (
+          <label
+            key={opt.value}
+            htmlFor={`action-${opt.value}`}
+            className={cn(
+              "flex items-start gap-3 rounded-lg border p-3.5 transition-colors",
+              disabled
+                ? "border-border cursor-not-allowed opacity-60"
+                : selected
+                  ? "border-foreground bg-muted/40 cursor-pointer"
+                  : "border-border hover:bg-muted/30 cursor-pointer",
+            )}
+          >
+            <RadioGroupItem
+              value={opt.value}
+              id={`action-${opt.value}`}
+              className="mt-0.5"
+              disabled={disabled}
+            />
+            <div className="flex-1">
+              <div className="flex items-center gap-2">
+                <ActionBadge action={opt.value} />
+                <span className="text-sm font-medium">{opt.title}</span>
+              </div>
+              <div className="text-muted-foreground mt-1.5 text-xs">
+                {opt.description}
+              </div>
+              {disabled && (
+                <div className="text-destructive mt-1 text-xs font-medium">
+                  Destructive Tools and Destructive CLI Commands support
+                  flagging only.
                 </div>
-              </label>
-            );
-          })}
-        </div>
-      </RadioGroup>
-    </div>
+              )}
+            </div>
+          </label>
+        );
+      })}
+    </RadioGroup>
   );
 }
 
 /* -------------------------------------------------------------------------- */
-/*  CustomRulesPicker                                                          */
+/*  RuleSelectList                                                             */
 /* -------------------------------------------------------------------------- */
 
-function CustomRulesPicker({
+/** A collapsible checkbox list of the org's custom rules. Used twice in the
+ *  standard-policy wizard: in the Detect step to attach rules as detectors, and
+ *  in the Scope step to attach them as exemptions. The two lists drive disjoint
+ *  id sets (custom_rule_ids vs exempt_rule_ids); the caller's onToggleRule keeps
+ *  them mutually exclusive. */
+function RuleSelectList({
+  title,
+  description,
+  idPrefix,
   customRules,
-  selectedCustomRuleIds,
-  setSelectedCustomRuleIds,
+  selectedRuleIds,
+  onToggleRule,
   expanded,
   onToggle,
 }: {
+  title: string;
+  description: ReactNode;
+  idPrefix: string;
   customRules: ReturnType<typeof useDetectionRulesStore>["customRules"];
-  selectedCustomRuleIds: Set<string>;
-  setSelectedCustomRuleIds: (v: Set<string>) => void;
+  selectedRuleIds: Set<string>;
+  onToggleRule: (ruleId: string, checked: boolean) => void;
   expanded: boolean;
   onToggle: () => void;
 }) {
-  const meta = RULE_CATEGORY_META.custom;
-  const allSelected =
-    customRules.length > 0 &&
-    customRules.every((r) => selectedCustomRuleIds.has(r.id));
-  const someSelected =
-    !allSelected && customRules.some((r) => selectedCustomRuleIds.has(r.id));
+  const selectedCount = customRules.filter((r) =>
+    selectedRuleIds.has(r.id),
+  ).length;
   return (
     <div className="space-y-3">
-      <Label className="text-sm font-medium">Custom Rules</Label>
-      <div className="border-border divide-border divide-y rounded-lg border">
-        <div
-          className="flex cursor-pointer items-center gap-3 px-4 py-3"
-          onClick={onToggle}
-        >
-          <ChevronRight
-            className={cn(
-              "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
-              expanded && "rotate-90",
-            )}
-          />
-          <Icon
-            name={meta.icon as IconName}
-            className="text-muted-foreground size-4 shrink-0"
-          />
-          <div className="min-w-0 flex-1">
-            <span className="text-sm font-medium">{meta.label}</span>
-            <p className="text-muted-foreground text-xs">
-              {customRules.length} organization-defined rule
-              {customRules.length === 1 ? "" : "s"}
-            </p>
-          </div>
-          <Checkbox
-            checked={
-              allSelected ? true : someSelected ? "indeterminate" : false
-            }
-            onCheckedChange={(checked) => {
-              const next = new Set(selectedCustomRuleIds);
-              if (checked) {
-                customRules.forEach((r) => {
-                  void next.add(r.id);
-                });
-              } else {
-                customRules.forEach((r) => {
-                  void next.delete(r.id);
-                });
-              }
-              setSelectedCustomRuleIds(next);
-            }}
-            onClick={(e) => e.stopPropagation()}
-          />
-        </div>
-        {expanded && (
-          <div className="bg-muted/30 border-border border-t px-4 py-2">
-            <div className="space-y-2 py-1">
-              {customRules.map((rule) => {
-                const checked = selectedCustomRuleIds.has(rule.id);
-                return (
-                  <div
-                    key={rule.id}
-                    className="flex items-center gap-3 py-1 pl-8"
-                  >
-                    <Checkbox
-                      id={`custom-${rule.id}`}
-                      checked={checked}
-                      onCheckedChange={(next) => {
-                        const set = new Set(selectedCustomRuleIds);
-                        if (next) {
-                          set.add(rule.id);
-                        } else {
-                          set.delete(rule.id);
-                        }
-                        setSelectedCustomRuleIds(set);
-                      }}
-                    />
-                    <label
-                      htmlFor={`custom-${rule.id}`}
-                      className="cursor-pointer text-xs"
-                    >
-                      <span className="text-foreground">
-                        {rule.title || rule.id}
-                      </span>
-                      <span className="text-muted-foreground ml-2 font-mono text-[10px]">
-                        {rule.id}
-                      </span>
-                    </label>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2"
+      >
+        <ChevronRight
+          className={cn(
+            "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+        <Label className="cursor-pointer text-sm font-medium">{title}</Label>
+        {selectedCount > 0 && (
+          <Badge variant="neutral">
+            <Badge.Text>{selectedCount} selected</Badge.Text>
+          </Badge>
         )}
-      </div>
+      </button>
+      {expanded && (
+        <div className="border-border divide-border divide-y rounded-lg border">
+          <p className="text-muted-foreground px-4 py-3 text-xs">
+            {description}
+          </p>
+          <div className="space-y-2 px-4 py-3">
+            {customRules.map((rule) => (
+              <div key={rule.id} className="flex items-center gap-3 py-1">
+                <Checkbox
+                  id={`${idPrefix}-${rule.id}`}
+                  checked={selectedRuleIds.has(rule.id)}
+                  onCheckedChange={(next) => onToggleRule(rule.id, !!next)}
+                />
+                <label
+                  htmlFor={`${idPrefix}-${rule.id}`}
+                  className="min-w-0 flex-1 cursor-pointer truncate text-xs"
+                >
+                  <span className="text-foreground">
+                    {rule.title || rule.id}
+                  </span>
+                  <span className="text-muted-foreground ml-2 font-mono text-[10px]">
+                    {rule.id}
+                  </span>
+                </label>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/dashboard/src/pages/security/cel-field.tsx
+++ b/client/dashboard/src/pages/security/cel-field.tsx
@@ -1,0 +1,224 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { Check, ChevronRight, CircleAlert, Loader2 } from "lucide-react";
+import { Suspense, useState, type JSX } from "react";
+import { useCelStatus, type CelStatus } from "./use-cel-status";
+import { useCelEngine } from "./use-cel-engine";
+import { CelMatchPreview } from "./cel-match-preview";
+import type { CelReferenceData } from "./cel-wasm";
+import CelMonacoEditorLazy from "./cel-monaco-editor.lazy";
+
+/** A named, insertable CEL snippet shown beneath the field. */
+export type CelExample = { label: string; expr: string };
+
+// Turn a raw cel-go compiler error into a readable message + optional caret
+// diagram: strip the wrapper and engine jargon, keep the caret.
+function formatCelError(raw: string): { message: string; pointer?: string } {
+  // Drop the `compile "…":` / `program "…":` wrapper the engine adds.
+  const unwrapped = raw
+    .trim()
+    .replace(/^(?:compile|program)\s+"(?:[^"\\]|\\.)*":\s*/, "");
+
+  // Separate the diagnostic (first line) from the cel-go caret diagram (the
+  // `| <source>` / `| ...^` lines that follow).
+  const lines = unwrapped.split("\n");
+  const pointerLines = lines
+    .slice(1)
+    .filter((l) => l.trimStart().startsWith("|"))
+    .map((l) => l.replace(/^\s*\|\s?/, ""));
+  const pointer = pointerLines.length ? pointerLines.join("\n") : undefined;
+
+  const message = (lines[0] ?? unwrapped)
+    .replace(/^ERROR:\s*/, "")
+    .replace(/<input>:\d+:(\d+):\s*/, (_m, col: string) => `Column ${col}: `)
+    .replace(/Syntax error:\s*/i, "")
+    .replace(/no viable alternative at input/i, "unexpected")
+    .replace(/(?:mismatched|extraneous) input/i, "unexpected")
+    .replace(/'<EOF>'/g, "end of expression")
+    .replace(
+      /undeclared reference to '([^']+)'(?:\s*\(in container '[^']*'\))?/i,
+      "unknown name '$1'",
+    )
+    // Surface our opaque CEL types under names authors recognise.
+    .replace(/celenv\.celTool/g, "tool")
+    .replace(/celenv\.field/g, "field")
+    .replace(
+      /expression must evaluate to bool, got (\w+)/i,
+      "expression must be true or false, but it's a $1",
+    );
+
+  return { message, pointer };
+}
+
+function CelStatusLine({ status }: { status: CelStatus }): JSX.Element | null {
+  switch (status.kind) {
+    case "idle":
+    case "unavailable": // engine didn't load; no client-side status, server validates on save
+      return null;
+    case "validating":
+      return (
+        <span className="text-muted-foreground flex items-center gap-1 text-xs">
+          <Loader2 className="h-3 w-3 animate-spin" /> Checking…
+        </span>
+      );
+    case "ok":
+      return (
+        <span className="text-success-foreground flex items-center gap-1 text-xs">
+          <Check className="h-3 w-3" /> Compiles
+        </span>
+      );
+    case "error": {
+      const { message, pointer } = formatCelError(status.message);
+      return (
+        <div className="text-destructive flex min-w-0 items-start gap-1 text-xs">
+          <CircleAlert className="mt-0.5 h-3 w-3 shrink-0" />
+          <div className="min-w-0 space-y-1">
+            <span>{message}</span>
+            {pointer && (
+              <pre className="text-muted-foreground overflow-x-auto font-mono text-[11px] leading-tight whitespace-pre">
+                {pointer}
+              </pre>
+            )}
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+// Collapsible reference of fields, matchers, and macros (from the engine catalog).
+function CelReference({
+  reference,
+}: {
+  reference?: CelReferenceData;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs">
+        <ChevronRight
+          className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
+        />
+        Fields &amp; matchers
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 space-y-3">
+        <ReferenceGroup
+          title="Fields"
+          items={(reference?.variables ?? []).map((v) => ({
+            term: v.name,
+            note: `${v.type} — ${v.description}`,
+          }))}
+        />
+        <ReferenceGroup
+          title="Matchers"
+          items={(reference?.matchers ?? []).map((f) => ({
+            term: f.signature,
+            note: f.description,
+          }))}
+        />
+        <ReferenceGroup
+          title="Macros"
+          items={(reference?.macros ?? []).map((m) => ({
+            term: m.signature,
+            note: m.description,
+          }))}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function ReferenceGroup({
+  title,
+  items,
+}: {
+  title: string;
+  items: { term: string; note: string }[];
+}): JSX.Element | null {
+  if (items.length === 0) return null;
+  return (
+    <div className="space-y-1">
+      <p className="text-muted-foreground text-xs font-medium uppercase">
+        {title}
+      </p>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li key={item.term} className="text-xs">
+            <code className="text-foreground font-mono">{item.term}</code>
+            <span className="text-muted-foreground"> — {item.note}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// The raw-CEL authoring field (Monaco editor + validation + examples +
+// reference), used for detection_expr and the policy scope predicates.
+export function CelExpressionField({
+  value,
+  onChange,
+  examples,
+  disabled,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  examples?: CelExample[];
+  disabled?: boolean;
+}): JSX.Element {
+  const status = useCelStatus(value);
+  const engine = useCelEngine();
+  const ready = engine.status === "ready" ? engine.engine : null;
+
+  return (
+    <div className="space-y-2">
+      <Suspense
+        fallback={
+          <div className="border-input bg-input/30 h-16 w-full animate-pulse rounded-md border" />
+        }
+      >
+        <CelMonacoEditorLazy
+          value={value}
+          onChange={onChange}
+          engine={ready}
+          errorMessage={
+            status.kind === "error"
+              ? formatCelError(status.message).message
+              : null
+          }
+          disabled={disabled}
+        />
+      </Suspense>
+
+      <div className="flex min-h-4 items-start justify-between gap-2">
+        <CelStatusLine status={status} />
+      </div>
+
+      {ready && <CelMatchPreview expr={value} engine={ready} />}
+
+      {examples && examples.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-muted-foreground text-xs">Examples:</span>
+          {examples.map((ex) => (
+            <button
+              key={ex.label}
+              type="button"
+              onClick={() => onChange(ex.expr)}
+              disabled={disabled}
+              className="border-border text-muted-foreground hover:bg-muted hover:text-foreground rounded-full border px-2.5 py-1 text-xs transition-colors disabled:pointer-events-none disabled:opacity-50"
+            >
+              {ex.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <CelReference reference={ready?.reference} />
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/security/cel-match-preview.tsx
+++ b/client/dashboard/src/pages/security/cel-match-preview.tsx
@@ -1,0 +1,273 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { ChevronRight } from "lucide-react";
+import { useEffect, useMemo, useState, type JSX, type ReactNode } from "react";
+import type { CelEngine, CelMessage, CelSpan } from "./cel-wasm";
+
+const DEBOUNCE_MS = 200;
+
+const KINDS: { value: string; label: string; bodyLabel: string }[] = [
+  { value: "user_message", label: "User message", bodyLabel: "Prompt" },
+  {
+    value: "assistant_message",
+    label: "Assistant message",
+    bodyLabel: "Assistant reply",
+  },
+  { value: "tool_request", label: "Tool request", bodyLabel: "" },
+  { value: "tool_response", label: "Tool response", bodyLabel: "Tool output" },
+];
+
+// Targets recorded against the message body (vs. a tool call's fields). All
+// index into the same body text, so their spans highlight the content box.
+const BODY_TARGETS = new Set(["content", "prompt", "assistant", "tool_result"]);
+
+const SAMPLE_TOOLS = JSON.stringify(
+  [
+    {
+      name: "shell",
+      server: "shell",
+      function: "exec",
+      args: '{"command":""}',
+    },
+  ],
+  null,
+  2,
+);
+
+type Verdict =
+  | { kind: "idle" }
+  | { kind: "match"; spans: CelSpan[] }
+  | { kind: "nomatch" }
+  | { kind: "error"; message: string };
+
+// Wraps each matched range in a <mark>. The engine's offsets are UTF-8 bytes, so
+// we slice in byte space and decode (correct for non-ASCII).
+function highlight(text: string, spans: CelSpan[]): ReactNode[] {
+  const ranges = spans
+    .map((s) => ({ start: s.Start, end: s.End }))
+    .filter((r) => r.end > r.start)
+    .sort((a, b) => a.start - b.start);
+  if (ranges.length === 0) return [text];
+
+  const bytes = new TextEncoder().encode(text);
+  const dec = new TextDecoder();
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let key = 0;
+  for (const r of ranges) {
+    if (r.end <= cursor) continue; // already covered by an overlapping range
+    const start = Math.max(r.start, cursor);
+    if (start > cursor) nodes.push(dec.decode(bytes.slice(cursor, start)));
+    nodes.push(
+      <mark
+        key={key++}
+        className="bg-warning/30 text-foreground rounded-sm px-0.5"
+      >
+        {dec.decode(bytes.slice(start, r.end))}
+      </mark>,
+    );
+    cursor = r.end;
+  }
+  if (cursor < bytes.length) nodes.push(dec.decode(bytes.slice(cursor)));
+  return nodes;
+}
+
+function humanizeTarget(target: string): string {
+  return target.replace(/^tool\./, "tool ").replace(/\./g, " ");
+}
+
+// Evaluates the detection expression against a sample message in-browser and
+// shows the verdict plus the matched spans.
+export function CelMatchPreview({
+  expr,
+  engine,
+}: {
+  expr: string;
+  engine: CelEngine;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [kind, setKind] = useState("tool_request");
+  const [content, setContent] = useState("");
+  const [toolsJson, setToolsJson] = useState(SAMPLE_TOOLS);
+
+  const kindMeta = KINDS.find((k) => k.value === kind) ?? KINDS[0]!;
+  const isToolRequest = kind === "tool_request";
+
+  // Debounce the inputs so eval doesn't run on every keystroke.
+  const [debounced, setDebounced] = useState({
+    expr,
+    kind,
+    content,
+    toolsJson,
+  });
+  useEffect(() => {
+    const t = setTimeout(
+      () => setDebounced({ expr, kind, content, toolsJson }),
+      DEBOUNCE_MS,
+    );
+    return () => clearTimeout(t);
+  }, [expr, kind, content, toolsJson]);
+
+  const verdict = useMemo<Verdict>(() => {
+    // Don't evaluate hidden work while the panel is collapsed.
+    if (!open) return { kind: "idle" };
+    const e = debounced.expr.trim();
+    if (!e) return { kind: "idle" };
+
+    let message: CelMessage;
+    if (debounced.kind === "tool_request") {
+      let tools;
+      try {
+        tools = JSON.parse(debounced.toolsJson) as CelMessage["tools"];
+      } catch {
+        return { kind: "error", message: "Tool calls must be valid JSON." };
+      }
+      message = { type: debounced.kind, content: "", tools };
+    } else {
+      message = { type: debounced.kind, content: debounced.content };
+    }
+
+    let result;
+    try {
+      result = engine.evalDetection(e, message);
+    } catch (err) {
+      return {
+        kind: "error",
+        message: err instanceof Error ? err.message : "evaluation failed",
+      };
+    }
+    if (!result.ok) return { kind: "error", message: result.error };
+    return result.matched
+      ? { kind: "match", spans: result.spans }
+      : { kind: "nomatch" };
+  }, [open, debounced, engine]);
+
+  const bodySpans =
+    verdict.kind === "match"
+      ? verdict.spans.filter((s) => BODY_TARGETS.has(s.Target))
+      : [];
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs">
+        <ChevronRight
+          className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
+        />
+        Test against a sample message
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 space-y-3">
+        <div className="flex flex-col gap-2">
+          <select
+            value={kind}
+            onChange={(e) => setKind(e.target.value)}
+            aria-label="Sample message type"
+            className="border-input bg-background w-fit rounded-md border px-2 py-1 text-xs"
+          >
+            {KINDS.map((k) => (
+              <option key={k.value} value={k.value}>
+                {k.label}
+              </option>
+            ))}
+          </select>
+
+          {isToolRequest ? (
+            <label className="space-y-1">
+              <span className="text-muted-foreground text-xs">
+                Tool calls (JSON)
+              </span>
+              <textarea
+                value={toolsJson}
+                onChange={(e) => setToolsJson(e.target.value)}
+                rows={6}
+                spellCheck={false}
+                className="border-input bg-input/30 w-full rounded-md border px-2 py-1 font-mono text-xs"
+              />
+            </label>
+          ) : (
+            <label className="space-y-1">
+              <span className="text-muted-foreground text-xs">
+                {kindMeta.bodyLabel}
+              </span>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                rows={3}
+                className="border-input bg-input/30 w-full rounded-md border px-2 py-1 text-xs"
+              />
+            </label>
+          )}
+        </div>
+
+        <VerdictView
+          verdict={verdict}
+          body={isToolRequest ? "" : content}
+          bodySpans={bodySpans}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function VerdictView({
+  verdict,
+  body,
+  bodySpans,
+}: {
+  verdict: Verdict;
+  body: string;
+  bodySpans: CelSpan[];
+}): JSX.Element | null {
+  if (verdict.kind === "idle") return null;
+
+  if (verdict.kind === "error") {
+    return (
+      <p className="text-destructive text-xs">
+        {verdict.message.replace(/^(?:compile|eval[a-z ]*)\s+"[^"]*":\s*/, "")}
+      </p>
+    );
+  }
+
+  const matched = verdict.kind === "match";
+  return (
+    <div className="space-y-2">
+      <span
+        className={cn(
+          "inline-flex w-fit items-center rounded-full px-2 py-0.5 text-xs font-medium",
+          matched
+            ? "bg-success/15 text-success-foreground"
+            : "bg-muted text-muted-foreground",
+        )}
+      >
+        {matched ? "Matches" : "No match"}
+      </span>
+
+      {body && (
+        <pre className="bg-input/30 overflow-x-auto rounded-md p-2 text-xs whitespace-pre-wrap">
+          {highlight(body, bodySpans)}
+        </pre>
+      )}
+
+      {matched && verdict.spans.length > 0 && (
+        <ul className="flex flex-wrap gap-1.5">
+          {verdict.spans.map((s, i) => (
+            <li
+              key={`${s.Target}-${s.Start}-${i}`}
+              className="border-border text-muted-foreground rounded-full border px-2 py-0.5 text-xs"
+            >
+              <span className="text-foreground">
+                {humanizeTarget(s.Target)}
+              </span>
+              {s.Path && <span className="opacity-70">.{s.Path}</span>}
+              {": "}
+              <code className="font-mono">{s.Value}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/security/cel-monaco-editor.lazy.tsx
+++ b/client/dashboard/src/pages/security/cel-monaco-editor.lazy.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+// Lazy so the heavy monaco-editor module (and its loader/worker side effects)
+// only load when a CEL field actually mounts — not on every security-page
+// render. Mirrors components/monaco-editor.lazy.tsx.
+const CelMonacoEditorLazy = React.lazy(() =>
+  import("./cel-monaco-editor").then((mod) => ({
+    default: mod.CelMonacoEditor,
+  })),
+);
+
+export default CelMonacoEditorLazy;

--- a/client/dashboard/src/pages/security/cel-monaco-editor.tsx
+++ b/client/dashboard/src/pages/security/cel-monaco-editor.tsx
@@ -1,0 +1,429 @@
+import { cn } from "@/lib/utils";
+import Editor, { loader, type OnMount } from "@monaco-editor/react";
+import { useMoonshineConfig } from "@speakeasy-api/moonshine";
+import type * as Monaco from "monaco-editor";
+import * as monaco from "monaco-editor";
+import { useEffect, useRef, type JSX } from "react";
+import type { CelCompletionItem, CelEngine } from "./cel-wasm";
+
+// oxlint-disable-next-line import/default -- Vite ?worker URL imports lack named defaults
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+
+// CEL has no dedicated worker; the base editor worker drives our Monarch
+// language. Only set the environment if the shared MonacoEditor hasn't already.
+if (!self.MonacoEnvironment) {
+  self.MonacoEnvironment = { getWorker: () => new editorWorker() };
+}
+// Point @monaco-editor/react at the bundled monaco. Guarded: a second call after
+// init throws, but it's the same instance, so swallow the duplicate.
+try {
+  loader.config({ monaco });
+} catch {
+  // already configured by another Monaco entry point this session
+}
+
+const CEL_LANGUAGE_ID = "cel";
+
+// Registration state + active engine live on globalThis so they survive Vite HMR
+// (module-level state would reset and stack duplicate completion providers).
+interface CelRuntime {
+  registered: boolean;
+  engine: CelEngine | null;
+}
+
+function celRuntime(): CelRuntime {
+  const holder = globalThis as unknown as { __celRuntime?: CelRuntime };
+  if (!holder.__celRuntime) {
+    holder.__celRuntime = { registered: false, engine: null };
+  }
+  return holder.__celRuntime;
+}
+
+const FIELD_WORDS = [
+  "content",
+  "prompt",
+  "assistant",
+  "tool_result",
+  "tool_calls",
+  "type",
+];
+const MATCHER_WORDS = [
+  "matchRegex",
+  "matchText",
+  "matchExact",
+  "matchPrefix",
+  "matchSuffix",
+  "matchGlob",
+  "present",
+  "get",
+];
+// List macros, for syntax coloring only (completions come from the engine).
+const MACRO_WORDS = [
+  "has",
+  "exists",
+  "exists_one",
+  "all",
+  "filter",
+  "map",
+  "size",
+];
+
+function shouldSuggestLogicalOperators(upto: string): boolean {
+  const trimmed = upto.trimEnd();
+  if (!trimmed) return false;
+  if (/[&|]$/.test(trimmed)) return true;
+  return /(?:\)|\]|\}|"|'|[A-Za-z_]\w*)$/.test(trimmed);
+}
+
+// suggestionFor maps an engine completion item's category to a Monaco icon and
+// insert snippet (the engine already decided what belongs here).
+function suggestionFor(
+  item: CelCompletionItem,
+  range: Monaco.IRange,
+): Monaco.languages.CompletionItem {
+  const snippet = (text: string) => ({
+    insertText: text,
+    insertTextRules:
+      monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+  });
+  const base = {
+    label: item.label,
+    detail: item.detail,
+    documentation: item.doc,
+    range,
+  };
+  switch (item.category) {
+    case "field":
+      return {
+        ...base,
+        kind: monaco.languages.CompletionItemKind.Field,
+        insertText: item.label,
+      };
+    case "variable":
+    case "bind":
+      return {
+        ...base,
+        kind: monaco.languages.CompletionItemKind.Variable,
+        insertText: item.label,
+      };
+    case "macro": // list comprehension macro: exists(t, …)
+      return {
+        ...base,
+        kind: monaco.languages.CompletionItemKind.Method,
+        ...snippet(`${item.label}(\${1:t}, $2)`),
+      };
+    case "matcher":
+    case "globalMacro":
+    default:
+      // present() is the only nullary matcher; everything else takes one arg.
+      return {
+        ...base,
+        kind: monaco.languages.CompletionItemKind.Method,
+        ...(item.label === "present"
+          ? { insertText: "present()" }
+          : snippet(`${item.label}($1)`)),
+      };
+  }
+}
+
+// registerCelLanguage installs the Monarch grammar and the completion provider,
+// once per Monaco instance (survives HMR).
+function registerCelLanguage(m: typeof Monaco): void {
+  const rt = celRuntime();
+  if (rt.registered) return;
+  rt.registered = true;
+
+  m.languages.register({ id: CEL_LANGUAGE_ID });
+
+  // Transparent background + focus ring so the editor blends into the input
+  // chrome instead of showing Monaco's opaque IDE frame.
+  m.editor.defineTheme("cel-dark", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: { "editor.background": "#00000000", focusBorder: "#00000000" },
+  });
+  m.editor.defineTheme("cel-light", {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: { "editor.background": "#00000000", focusBorder: "#00000000" },
+  });
+
+  m.languages.setMonarchTokensProvider(CEL_LANGUAGE_ID, {
+    keywords: ["true", "false", "null", "in"],
+    fields: FIELD_WORDS,
+    matchers: MATCHER_WORDS,
+    macros: MACRO_WORDS,
+    tokenizer: {
+      root: [
+        [
+          /[a-zA-Z_]\w*/,
+          {
+            cases: {
+              "@keywords": "keyword",
+              "@fields": "variable.predefined",
+              "@matchers": "type.identifier",
+              "@macros": "keyword.control",
+              "@default": "identifier",
+            },
+          },
+        ],
+        [/\s+/, "white"],
+        [/"([^"\\]|\\.)*"/, "string"],
+        [/'([^'\\]|\\.)*'/, "string"],
+        [/\d+/, "number"],
+        [/[{}()[\]]/, "@brackets"],
+        [/&&|\|\||==|!=|<=|>=|[!<>+\-*/%?:.]/, "operator"],
+        [/[,;]/, "delimiter"],
+      ],
+    },
+  });
+
+  m.languages.setLanguageConfiguration(CEL_LANGUAGE_ID, {
+    brackets: [
+      ["(", ")"],
+      ["[", "]"],
+      ["{", "}"],
+    ],
+    autoClosingPairs: [
+      { open: "(", close: ")" },
+      { open: "[", close: "]" },
+      { open: '"', close: '"' },
+      { open: "'", close: "'" },
+    ],
+    surroundingPairs: [
+      { open: "(", close: ")" },
+      { open: '"', close: '"' },
+      { open: "'", close: "'" },
+    ],
+  });
+
+  m.languages.registerCompletionItemProvider(CEL_LANGUAGE_ID, {
+    triggerCharacters: [".", "&", "|"],
+    provideCompletionItems(model, position) {
+      const word = model.getWordUntilPosition(position);
+      const range: Monaco.IRange = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+      const engine = celRuntime().engine;
+
+      // Text from the expression start to the cursor — the engine reads this to
+      // resolve the receiver's type and decide what's valid here.
+      const upto = model.getValueInRange({
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column,
+      });
+      const operatorPrefix = upto.match(/[&|]$/)?.[0];
+      const operatorRange: Monaco.IRange = operatorPrefix
+        ? {
+            startLineNumber: position.lineNumber,
+            endLineNumber: position.lineNumber,
+            startColumn: position.column - 1,
+            endColumn: position.column,
+          }
+        : range;
+
+      if (operatorPrefix) {
+        const label = operatorPrefix === "&" ? "&&" : "||";
+        return {
+          suggestions: [
+            {
+              label,
+              kind: monaco.languages.CompletionItemKind.Operator,
+              insertText: `${label} `,
+              detail: "logical operator",
+              range: operatorRange,
+            },
+          ],
+        };
+      }
+
+      // No engine yet (wasm loading/unavailable): offer nothing.
+      if (!engine) return { suggestions: [] };
+
+      // The engine resolves the receiver's type and returns what's valid here.
+      const completion = engine.complete(upto);
+      const suggestions = completion.items.map((item) =>
+        suggestionFor(item, range),
+      );
+
+      // Logical operators aren't part of the engine's vocabulary; offer them at a
+      // name position once there's a complete operand to join onto.
+      if (
+        completion.context === "name" &&
+        shouldSuggestLogicalOperators(upto)
+      ) {
+        suggestions.push(
+          {
+            label: "&&",
+            kind: monaco.languages.CompletionItemKind.Operator,
+            insertText: "&& ",
+            detail: "logical and",
+            range: operatorRange,
+          },
+          {
+            label: "||",
+            kind: monaco.languages.CompletionItemKind.Operator,
+            insertText: "|| ",
+            detail: "logical or",
+            range: operatorRange,
+          },
+        );
+      }
+      return { suggestions };
+    },
+  });
+}
+
+// Register at module load so the grammar exists before any editor mounts.
+registerCelLanguage(monaco);
+
+/** A controlled Monaco editor for a single CEL expression: Monarch syntax
+ *  highlighting, schema-driven autocomplete, and an inline error marker driven
+ *  by the debounced backend compile (errorMessage). Chrome is stripped so it
+ *  reads as a compact code field, not a full IDE pane. */
+export function CelMonacoEditor({
+  value,
+  onChange,
+  engine,
+  errorMessage,
+  errorRange,
+  disabled,
+  className,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  engine?: CelEngine | null;
+  errorMessage?: string | null;
+  // Character offset range of the error within the expression; when present the
+  // marker underlines just that span instead of the whole expression.
+  errorRange?: { start: number; end: number } | null;
+  disabled?: boolean;
+  className?: string;
+}): JSX.Element {
+  const { theme } = useMoonshineConfig();
+  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
+  const monacoRef = useRef<typeof Monaco | null>(null);
+
+  // Publish the engine to the shared completion provider as it loads.
+  useEffect(() => {
+    celRuntime().engine = engine ?? null;
+  }, [engine]);
+
+  // Surface the compile error as an inline marker.
+  useEffect(() => {
+    const m = monacoRef.current;
+    const editor = editorRef.current;
+    if (!m || !editor) return;
+    const model = editor.getModel();
+    if (!model) return;
+    if (errorMessage) {
+      // Underline the offending span when the checker gave us a range; else fall
+      // back to the whole expression.
+      let start = { lineNumber: 1, column: 1 };
+      const lastLine = model.getLineCount();
+      let end = {
+        lineNumber: lastLine,
+        column: model.getLineMaxColumn(lastLine),
+      };
+      if (errorRange && errorRange.end > errorRange.start) {
+        start = model.getPositionAt(errorRange.start);
+        end = model.getPositionAt(errorRange.end);
+      }
+      m.editor.setModelMarkers(model, CEL_LANGUAGE_ID, [
+        {
+          severity: m.MarkerSeverity.Error,
+          message: errorMessage,
+          startLineNumber: start.lineNumber,
+          startColumn: start.column,
+          endLineNumber: end.lineNumber,
+          endColumn: end.column,
+        },
+      ]);
+    } else {
+      m.editor.setModelMarkers(model, CEL_LANGUAGE_ID, []);
+    }
+  }, [errorMessage, errorRange, value]);
+
+  const handleMount: OnMount = (editor, m) => {
+    editorRef.current = editor;
+    monacoRef.current = m;
+    editor.updateOptions({ readOnly: disabled });
+
+    // Expand the suggestion details panel by default. No editor option exists, so
+    // flip it via the suggest controller's widget — a private API, hence guarded.
+    try {
+      const suggest = editor.getContribution(
+        "editor.contrib.suggestController",
+      ) as unknown as {
+        widget?: { value?: { _setDetailsVisible?: (v: boolean) => void } };
+      } | null;
+      suggest?.widget?.value?._setDetailsVisible?.(true);
+    } catch {
+      // Private suggest API changed; details just stay collapsed until toggled.
+    }
+
+    // Open the completion list on focus so fields/matchers are discoverable
+    // without typing first (deferred a tick, after focus + cursor settle).
+    editor.onDidFocusEditorText(() => {
+      setTimeout(() => {
+        editor.trigger("focus", "editor.action.triggerSuggest", {});
+      }, 0);
+    });
+  };
+
+  return (
+    <div
+      className={cn(
+        "border-input dark:bg-input/30 w-full overflow-hidden rounded-md border bg-transparent py-2 shadow-xs",
+        className,
+      )}
+    >
+      <Editor
+        language={CEL_LANGUAGE_ID}
+        value={value}
+        theme={theme === "dark" ? "cel-dark" : "cel-light"}
+        onMount={handleMount}
+        onChange={(v) => onChange(v ?? "")}
+        height="64px"
+        options={{
+          readOnly: disabled,
+          minimap: { enabled: false },
+          lineNumbers: "off",
+          folding: false,
+          glyphMargin: false,
+          // Doubles as the editor's left padding (no line-number gutter) so text
+          // doesn't hug the border, matching the px-3 of a standard input.
+          lineDecorationsWidth: 12,
+          lineNumbersMinChars: 0,
+          overviewRulerLanes: 0,
+          hideCursorInOverviewRuler: true,
+          scrollBeyondLastLine: false,
+          scrollbar: { vertical: "auto", horizontal: "hidden" },
+          wordWrap: "on",
+          fontSize: 14,
+          fontFamily:
+            'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+          automaticLayout: true,
+          contextmenu: false,
+          renderLineHighlight: "none",
+          padding: { top: 2, bottom: 2 },
+          suggestOnTriggerCharacters: true,
+          quickSuggestions: true,
+          // Fixed overflow layer so suggest/hover widgets escape the card's
+          // overflow-hidden.
+          fixedOverflowWidgets: true,
+          // We supply a curated schema; Monaco's word-based completions only add
+          // noise (duplicate bare identifiers pulled from other editor models).
+          wordBasedSuggestions: "off",
+        }}
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/security/cel-wasm.ts
+++ b/client/dashboard/src/pages/security/cel-wasm.ts
@@ -1,0 +1,205 @@
+// Loads the risk CEL engine compiled to WebAssembly (the same celenv the server
+// runs). The asset is built by `mise gen:celwasm` into public/cel/; its
+// wasm_exec.js shim defines globalThis.Go, and go.run() sets the __cel* globals
+// this module wraps. Mirrors the celenv Go types.
+
+interface CelVarRef {
+  name: string;
+  type: string;
+  description: string;
+  matchable: boolean;
+  fields?: CelVarRef[];
+}
+
+interface CelFuncRef {
+  name: string;
+  signature: string;
+  description: string;
+  returnsField: boolean;
+}
+
+interface CelMacroRef {
+  name: string;
+  signature: string;
+  description: string;
+  returnsBool: boolean;
+}
+
+export interface CelReferenceData {
+  variables: CelVarRef[];
+  matchers: CelFuncRef[];
+  macros: CelMacroRef[];
+}
+
+export interface CelMessage {
+  type: string;
+  content: string;
+  tools?: {
+    name: string;
+    server: string;
+    function: string;
+    args: string;
+  }[];
+}
+
+export interface CelSpan {
+  Target: string;
+  ToolCallID: string;
+  Path: string;
+  Start: number;
+  End: number;
+  Value: string;
+}
+
+type CelCompileResult = { ok: true } | { ok: false; error: string };
+type CelEvalResult =
+  | { ok: true; matched: boolean; spans: CelSpan[] }
+  | { ok: false; error: string };
+
+export interface CelCompletionItem {
+  label: string;
+  detail: string;
+  doc: string;
+  category: "matcher" | "macro" | "globalMacro" | "field" | "variable" | "bind";
+}
+
+interface CelCompletion {
+  context: "member" | "name";
+  items: CelCompletionItem[];
+}
+
+// The loaded engine: the same compile/complete/eval the server runs, in-browser.
+export interface CelEngine {
+  reference: CelReferenceData;
+  compile(expr: string): CelCompileResult;
+  complete(srcUpToCursor: string): CelCompletion;
+  evalDetection(expr: string, message: CelMessage): CelEvalResult;
+}
+
+// Raw shapes of the wasm globals (set by server/cmd/celwasm).
+interface CelGlobals {
+  Go?: new () => {
+    importObject: WebAssembly.Imports;
+    run(instance: WebAssembly.Instance): Promise<void>;
+  };
+  __celEngineReady?: boolean;
+  __celInitError?: string;
+  __celReference?: () => string;
+  __celComplete?: (src: string) => string;
+  __celCompile?: (expr: string) => CelCompileResult;
+  __celEval?: (
+    expr: string,
+    messageJSON: string,
+  ) => { ok: boolean; matched?: boolean; spans?: string; error?: string };
+}
+
+const WASM_URL = "/cel/cel.wasm";
+const RUNTIME_URL = "/cel/wasm_exec.js";
+
+function globals(): CelGlobals {
+  return globalThis as unknown as CelGlobals;
+}
+
+// wasm_exec.js is a classic script (defines globalThis.Go), so it's loaded via a
+// tag rather than a static ESM import.
+let runtimePromise: Promise<void> | null = null;
+function loadGoRuntime(): Promise<void> {
+  if (globals().Go) return Promise.resolve();
+  if (!runtimePromise) {
+    runtimePromise = new Promise<void>((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = RUNTIME_URL;
+      script.onload = () => resolve();
+      script.onerror = () =>
+        reject(new Error("failed to load the CEL wasm runtime"));
+      document.head.appendChild(script);
+    });
+    // Clear the cache on failure so a later call can retry a transient error.
+    runtimePromise.catch(() => {
+      runtimePromise = null;
+    });
+  }
+  return runtimePromise;
+}
+
+async function instantiate(
+  go: InstanceType<NonNullable<CelGlobals["Go"]>>,
+): Promise<WebAssembly.Instance> {
+  // Prefer streaming; fall back to arrayBuffer for hosts that don't serve wasm
+  // with the application/wasm content type. Fetch once and clone so the fallback
+  // reuses the response rather than issuing a second request.
+  const response = await fetch(WASM_URL);
+  try {
+    const res = await WebAssembly.instantiateStreaming(
+      response.clone(),
+      go.importObject,
+    );
+    return res.instance;
+  } catch {
+    const bytes = await response.arrayBuffer();
+    const res = await WebAssembly.instantiate(bytes, go.importObject);
+    return res.instance;
+  }
+}
+
+// Go main installs the exported funcs synchronously before parking on select{},
+// so we don't await go.run (it never resolves).
+async function start(): Promise<CelEngine> {
+  await loadGoRuntime();
+  const Go = globals().Go;
+  if (!Go) throw new Error("CEL wasm runtime did not load");
+
+  const go = new Go();
+  const instance = await instantiate(go);
+  void go.run(instance);
+
+  const g = globals();
+  if (g.__celInitError) {
+    throw new Error(`CEL engine failed to initialize: ${g.__celInitError}`);
+  }
+  if (
+    !g.__celEngineReady ||
+    !g.__celReference ||
+    !g.__celComplete ||
+    !g.__celCompile ||
+    !g.__celEval
+  ) {
+    throw new Error("CEL engine did not expose its interface");
+  }
+
+  const reference = JSON.parse(g.__celReference()) as CelReferenceData;
+  const compile = g.__celCompile;
+  const rawComplete = g.__celComplete;
+  const rawEval = g.__celEval;
+
+  return {
+    reference,
+    compile: (expr) => compile(expr),
+    complete: (src) => JSON.parse(rawComplete(src)) as CelCompletion,
+    evalDetection: (expr, message) => {
+      const r = rawEval(expr, JSON.stringify(message));
+      if (!r.ok) return { ok: false, error: r.error ?? "evaluation failed" };
+      return {
+        ok: true,
+        matched: r.matched ?? false,
+        spans: r.spans ? (JSON.parse(r.spans) as CelSpan[]) : [],
+      };
+    },
+  };
+}
+
+// Loaded at most once per session (the wasm asset is large).
+let enginePromise: Promise<CelEngine> | null = null;
+
+// Rejects if the asset is missing or the runtime fails; callers then fall back
+// to server-side validation. The cache is cleared on failure so a later call can
+// retry a transient error.
+export function loadCelEngine(): Promise<CelEngine> {
+  if (!enginePromise) {
+    enginePromise = start();
+    enginePromise.catch(() => {
+      enginePromise = null;
+    });
+  }
+  return enginePromise;
+}

--- a/client/dashboard/src/pages/security/detection-rules-data.ts
+++ b/client/dashboard/src/pages/security/detection-rules-data.ts
@@ -156,10 +156,24 @@ export type CustomDetectionRule = {
   dbId: string;
   title: string;
   description: string;
+  /** Legacy single regex pattern (read-only). Pre-CEL rules surface it via
+   *  effectiveDetectionExpr() as content.matchRegex("<regex>") so editing migrates
+   *  them forward to CEL on save. */
   regex: string;
+  /** CEL detection predicate. Empty for legacy regex-only rules. */
+  detectionExpr: string;
   severity: SeverityLevel;
   createdAt: string;
   updatedAt: string;
+};
+
+/** Fields needed to create or fully edit a custom rule's matcher. */
+export type CustomRuleDraft = {
+  id: string;
+  title: string;
+  description: string;
+  detectionExpr: string;
+  severity: SeverityLevel;
 };
 
 function mapCustomDetectionRule(rule: {
@@ -168,6 +182,7 @@ function mapCustomDetectionRule(rule: {
   title: string;
   description: string;
   regex: string;
+  detectionExpr?: string | null;
   severity: string;
   createdAt: Date;
   updatedAt: Date;
@@ -178,10 +193,21 @@ function mapCustomDetectionRule(rule: {
     title: rule.title,
     description: rule.description,
     regex: rule.regex,
+    detectionExpr: rule.detectionExpr ?? "",
     severity: rule.severity as SeverityLevel,
     createdAt: rule.createdAt.toISOString(),
     updatedAt: rule.updatedAt.toISOString(),
   };
+}
+
+/** The CEL expression to seed the editor with: the rule's detection_expr when
+ *  set, otherwise a content.matchRegex("<regex>") translation of a legacy regex rule
+ *  (so editing migrates it forward to CEL on save), otherwise empty. */
+export function effectiveDetectionExpr(rule: CustomDetectionRule): string {
+  if (rule.detectionExpr.trim()) return rule.detectionExpr;
+  if (rule.regex.trim())
+    return `content.matchRegex(${JSON.stringify(rule.regex)})`;
+  return "";
 }
 
 function useDetectionRulesStoreImpl() {
@@ -209,23 +235,21 @@ function useDetectionRulesStoreImpl() {
     customRules,
     isLoading: rulesQuery.isLoading,
     error: rulesQuery.error,
-    addCustomRule: (
-      rule: Omit<CustomDetectionRule, "dbId" | "createdAt" | "updatedAt">,
-    ) =>
+    addCustomRule: (rule: CustomRuleDraft) =>
       createMutation.mutate({
         request: {
           createCustomDetectionRuleRequestBody: {
             ruleId: rule.id,
             title: rule.title,
             description: rule.description,
-            regex: rule.regex,
+            detectionExpr: rule.detectionExpr,
             severity: rule.severity,
           },
         },
       }),
     updateCustomRule: (
       id: string,
-      patch: Partial<Omit<CustomDetectionRule, "id" | "dbId" | "createdAt">>,
+      patch: Partial<Omit<CustomRuleDraft, "id">>,
     ) => {
       const rule = customRules.find((r) => r.id === id);
       if (!rule) {
@@ -238,7 +262,8 @@ function useDetectionRulesStoreImpl() {
               id: rule.dbId,
               title: patch.title ?? rule.title,
               description: patch.description ?? rule.description,
-              regex: patch.regex ?? rule.regex,
+              detectionExpr:
+                patch.detectionExpr ?? effectiveDetectionExpr(rule),
               severity: patch.severity ?? rule.severity,
             },
           },
@@ -285,15 +310,28 @@ export function validateCustomRuleId(
   return null;
 }
 
-/** Validate a proposed regex pattern. Tries to compile and surface a human
- *  message if the engine rejects it. */
-export function validateRegex(pattern: string): string | null {
-  const trimmed = pattern.trim();
-  if (!trimmed) return "Regex is required";
-  try {
-    new RegExp(trimmed);
-    return null;
-  } catch (err) {
-    return err instanceof Error ? err.message : "Invalid regex";
-  }
+/** Example detection CEL snippets offered beneath the rule editor field. */
+export const DETECTION_CEL_EXAMPLES: { label: string; expr: string }[] = [
+  {
+    label: "Secret in content",
+    expr: 'content.matchRegex("sk-[A-Za-z0-9]{32}")',
+  },
+  {
+    label: "Password in prompt",
+    expr: 'prompt.matchText("password")',
+  },
+  {
+    label: "Destructive shell",
+    expr: 'tool_calls.exists(t, t.function.matchRegex("bash") && t.args.get("command").matchRegex("rm -rf"))',
+  },
+  {
+    label: "Tool error output",
+    expr: 'tool_result.matchText("error")',
+  },
+];
+
+/** List-row summary of a rule's matcher: its effective CEL expression. The
+ *  allow/deny polarity is not a rule property — it is configured per policy. */
+export function ruleSummary(rule: CustomDetectionRule): string {
+  return effectiveDetectionExpr(rule) || "No matcher configured";
 }

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -97,8 +97,9 @@ export const RULE_CATEGORY_META: Record<
     icon: "terminal",
   },
   custom: {
-    label: "Custom Patterns",
-    description: "Organization-specific data patterns (regex)",
+    label: "Custom Rules",
+    description:
+      "Organization-defined detection rules over message content, tool calls, and arguments",
     icon: "regex",
   },
 };
@@ -123,6 +124,181 @@ export const POLICY_MESSAGE_TYPE_META: Record<
     label: "Assistant Messages",
     description: "Assistant text responses that are not tool-call requests",
   },
+};
+
+// Provider -> family for breaking the large `secrets` catalog into navigable
+// sub-groups. Keyed by the token after `secret.` up to the first underscore
+// (e.g. `secret.aws_access_token` -> "aws"). Unmapped/new providers fall into
+// "Other", so the catalog keeps working as gitleaks rules are added upstream.
+const SECRET_FAMILY_BY_PROVIDER: Record<string, string> = {
+  // Cloud & Infrastructure
+  aws: "Cloud & Infrastructure",
+  azure: "Cloud & Infrastructure",
+  gcp: "Cloud & Infrastructure",
+  alibaba: "Cloud & Infrastructure",
+  digitalocean: "Cloud & Infrastructure",
+  heroku: "Cloud & Infrastructure",
+  flyio: "Cloud & Infrastructure",
+  scalingo: "Cloud & Infrastructure",
+  netlify: "Cloud & Infrastructure",
+  fastly: "Cloud & Infrastructure",
+  cloudflare: "Cloud & Infrastructure",
+  openshift: "Cloud & Infrastructure",
+  kubernetes: "Cloud & Infrastructure",
+  pulumi: "Cloud & Infrastructure",
+  hashicorp: "Cloud & Infrastructure",
+  vault: "Cloud & Infrastructure",
+  yandex: "Cloud & Infrastructure",
+  cisco: "Cloud & Infrastructure",
+  // Source Control & Packages
+  github: "Source Control & Packages",
+  gitlab: "Source Control & Packages",
+  bitbucket: "Source Control & Packages",
+  sourcegraph: "Source Control & Packages",
+  jfrog: "Source Control & Packages",
+  artifactory: "Source Control & Packages",
+  npm: "Source Control & Packages",
+  nuget: "Source Control & Packages",
+  pypi: "Source Control & Packages",
+  rubygems: "Source Control & Packages",
+  clojars: "Source Control & Packages",
+  postman: "Source Control & Packages",
+  // CI & DevOps
+  codecov: "CI & DevOps",
+  droneci: "CI & DevOps",
+  travisci: "CI & DevOps",
+  harness: "CI & DevOps",
+  octopus: "CI & DevOps",
+  infracost: "CI & DevOps",
+  doppler: "CI & DevOps",
+  launchdarkly: "CI & DevOps",
+  sidekiq: "CI & DevOps",
+  snyk: "CI & DevOps",
+  sonar: "CI & DevOps",
+  prefect: "CI & DevOps",
+  rapidapi: "CI & DevOps",
+  // Payments & Fintech
+  stripe: "Payments & Fintech",
+  plaid: "Payments & Fintech",
+  square: "Payments & Fintech",
+  coinbase: "Payments & Fintech",
+  kraken: "Payments & Fintech",
+  kucoin: "Payments & Fintech",
+  bittrex: "Payments & Fintech",
+  gocardless: "Payments & Fintech",
+  flutterwave: "Payments & Fintech",
+  finicity: "Payments & Fintech",
+  finnhub: "Payments & Fintech",
+  duffel: "Payments & Fintech",
+  easypost: "Payments & Fintech",
+  shippo: "Payments & Fintech",
+  lob: "Payments & Fintech",
+  freshbooks: "Payments & Fintech",
+  // Communication
+  slack: "Communication",
+  discord: "Communication",
+  telegram: "Communication",
+  twilio: "Communication",
+  messagebird: "Communication",
+  sendbird: "Communication",
+  mattermost: "Communication",
+  intercom: "Communication",
+  zendesk: "Communication",
+  beamer: "Communication",
+  gitter: "Communication",
+  // Email & Marketing
+  mailchimp: "Email & Marketing",
+  mailgun: "Email & Marketing",
+  sendgrid: "Email & Marketing",
+  sendinblue: "Email & Marketing",
+  hubspot: "Email & Marketing",
+  typeform: "Email & Marketing",
+  contentful: "Email & Marketing",
+  freemius: "Email & Marketing",
+  // AI & ML
+  anthropic: "AI & ML",
+  openai: "AI & ML",
+  cohere: "AI & ML",
+  huggingface: "AI & ML",
+  perplexity: "AI & ML",
+  privateai: "AI & ML",
+  // Observability
+  datadog: "Observability",
+  sentry: "Observability",
+  grafana: "Observability",
+  sumologic: "Observability",
+  dynatrace: "Observability",
+  new: "Observability",
+  // Data & Analytics
+  clickhouse: "Data & Analytics",
+  databricks: "Data & Analytics",
+  looker: "Data & Analytics",
+  confluent: "Data & Analytics",
+  planetscale: "Data & Analytics",
+  algolia: "Data & Analytics",
+  mapbox: "Data & Analytics",
+  maxmind: "Data & Analytics",
+  // Identity & Auth
+  "1password": "Identity & Auth",
+  okta: "Identity & Auth",
+  authress: "Identity & Auth",
+  intra42: "Identity & Auth",
+  microsoft: "Identity & Auth",
+  adobe: "Identity & Auth",
+  jwt: "Identity & Auth",
+  pkcs12: "Identity & Auth",
+  age: "Identity & Auth",
+  private: "Identity & Auth",
+  atlassian: "Identity & Auth",
+  // Productivity & SaaS
+  airtable: "Productivity & SaaS",
+  asana: "Productivity & SaaS",
+  linear: "Productivity & SaaS",
+  notion: "Productivity & SaaS",
+  dropbox: "Productivity & SaaS",
+  frameio: "Productivity & SaaS",
+  readme: "Productivity & SaaS",
+  shopify: "Productivity & SaaS",
+  squarespace: "Productivity & SaaS",
+  etsy: "Productivity & SaaS",
+  twitter: "Productivity & SaaS",
+  twitch: "Productivity & SaaS",
+  facebook: "Productivity & SaaS",
+  linkedin: "Productivity & SaaS",
+  flickr: "Productivity & SaaS",
+  nytimes: "Productivity & SaaS",
+};
+
+const SECRET_FAMILY_OTHER = "Other";
+
+// Render order for rule families; "Other" always sorts last.
+export const RULE_FAMILY_ORDER: string[] = [
+  "Cloud & Infrastructure",
+  "Source Control & Packages",
+  "CI & DevOps",
+  "Payments & Fintech",
+  "Communication",
+  "Email & Marketing",
+  "AI & ML",
+  "Observability",
+  "Data & Analytics",
+  "Identity & Auth",
+  "Productivity & SaaS",
+  SECRET_FAMILY_OTHER,
+];
+
+function secretRuleFamily(rule: DetectionRule): string {
+  const provider = rule.id.replace(/^secret\./, "").split("_")[0] ?? "";
+  return SECRET_FAMILY_BY_PROVIDER[provider] ?? SECRET_FAMILY_OTHER;
+}
+
+// Categories large enough to be unnavigable as a flat list get a family
+// classifier; everything else renders flat. Currently just `secrets` (~200
+// rules); other categories are small.
+export const RULE_FAMILY_OF: Partial<
+  Record<RuleCategory, (rule: DetectionRule) => string>
+> = {
+  secrets: secretRuleFamily,
 };
 
 // All available detection rules, organized by category

--- a/client/dashboard/src/pages/security/use-cel-engine.ts
+++ b/client/dashboard/src/pages/security/use-cel-engine.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { type CelEngine, loadCelEngine } from "./cel-wasm";
+
+export type CelEngineState =
+  | { status: "loading" }
+  | { status: "ready"; engine: CelEngine }
+  | { status: "error"; error: string };
+
+/** Load the wasm CEL engine once and expose its state. The engine is the same
+ *  celenv the server runs, so a compile here matches what the server accepts on
+ *  save; on load failure the caller falls back to server-side validation. */
+export function useCelEngine(): CelEngineState {
+  const [state, setState] = useState<CelEngineState>({ status: "loading" });
+
+  useEffect(() => {
+    let alive = true;
+    loadCelEngine().then(
+      (engine) => alive && setState({ status: "ready", engine }),
+      (err: unknown) =>
+        alive &&
+        setState({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        }),
+    );
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/client/dashboard/src/pages/security/use-cel-status.ts
+++ b/client/dashboard/src/pages/security/use-cel-status.ts
@@ -1,0 +1,41 @@
+import { useEffect, useMemo, useState } from "react";
+import { useCelEngine } from "./use-cel-engine";
+
+const DEBOUNCE_MS = 150;
+
+export type CelStatus =
+  | { kind: "idle" }
+  | { kind: "validating" }
+  | { kind: "ok" }
+  | { kind: "unavailable" } // engine failed to load; server validates on save
+  | { kind: "error"; message: string };
+
+/** Live, client-side type-check for a single CEL expression via the wasm engine
+ *  (the same celenv the server compiles with). The server stays authoritative on
+ *  save; if the engine can't load, status is "unavailable" — never a false ok. */
+export function useCelStatus(expr: string): CelStatus {
+  const engine = useCelEngine();
+  const trimmed = expr.trim();
+
+  // Short debounce to coalesce rapid typing; the check itself is local/instant.
+  const [debounced, setDebounced] = useState(trimmed);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(trimmed), DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [trimmed]);
+
+  const result = useMemo(() => {
+    if (engine.status !== "ready" || !debounced) return null;
+    // compile asserts a bool predicate, so its error already covers "must be
+    // true or false" — no separate type check needed.
+    return engine.engine.compile(debounced);
+  }, [engine, debounced]);
+
+  if (trimmed === "") return { kind: "idle" };
+  if (engine.status === "error") return { kind: "unavailable" };
+  if (engine.status === "loading") return { kind: "validating" };
+  if (debounced !== trimmed || !result) return { kind: "validating" };
+
+  if (!result.ok) return { kind: "error", message: result.error };
+  return { kind: "ok" };
+}

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -5,6 +5,8 @@ export interface Step {
   id: string;
   title: string;
   description: string;
+  /** Optional inline marker after the title, e.g. "Required" / "Optional". */
+  badge?: string;
 }
 
 interface OnboardingStepperProps {
@@ -12,6 +14,9 @@ interface OnboardingStepperProps {
   currentStep: number;
   onStepClick?: (index: number) => void;
   maxAllowedStep?: number;
+  /** Allow clicking ahead to upcoming (unlocked) steps, not just back to
+   *  completed ones. Off by default to preserve the linear onboarding flow. */
+  allowJumpAhead?: boolean;
 }
 
 export function OnboardingStepper({
@@ -19,6 +24,7 @@ export function OnboardingStepper({
   currentStep,
   onStepClick,
   maxAllowedStep = steps.length - 1,
+  allowJumpAhead = false,
 }: OnboardingStepperProps): JSX.Element {
   return (
     <nav className="flex flex-col" aria-label="Progress">
@@ -28,6 +34,11 @@ export function OnboardingStepper({
         const isUpcoming = index > currentStep;
         const isLocked = index > maxAllowedStep;
         const isLast = index === steps.length - 1;
+        const canJump =
+          !!onStepClick &&
+          !isLocked &&
+          !isCurrent &&
+          (isCompleted || allowJumpAhead);
 
         return (
           <div key={step.id} className="relative flex gap-4">
@@ -70,16 +81,36 @@ export function OnboardingStepper({
             </div>
 
             {/* Step content */}
-            <div className="min-w-0 pt-1 pb-8">
+            <div
+              className={cn("min-w-0 pt-1 pb-8", canJump && "cursor-pointer")}
+              onClick={canJump ? () => onStepClick?.(index) : undefined}
+              role={canJump ? "button" : undefined}
+              tabIndex={canJump ? 0 : undefined}
+              onKeyDown={
+                canJump
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onStepClick?.(index);
+                      }
+                    }
+                  : undefined
+              }
+            >
               <h3
                 className={cn(
-                  "text-sm leading-tight font-semibold",
+                  "flex items-center gap-2 text-sm leading-tight font-semibold",
                   isCurrent && "text-foreground",
                   isCompleted && "text-foreground",
                   isUpcoming && "text-muted-foreground",
                 )}
               >
                 {step.title}
+                {step.badge && (
+                  <span className="text-muted-foreground text-[10px] font-semibold tracking-wide uppercase">
+                    {step.badge}
+                  </span>
+                )}
               </h3>
               <p
                 className={cn(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a CEL editor with live validation and span-aware preview to PolicyCenter scopes and Detection Rules using the same WebAssembly engine as the server. Updates the rules UI to support CEL beside legacy regex and improves chat detail with clear field/path labels and multi-span highlights.

- **New Features**
  - CEL editor with syntax highlighting, engine-backed autocomplete, and readable inline errors; Monaco loads lazily.
  - Insertable CEL examples; local compile and match-span preview across user/assistant/tool messages with field/path attribution.
  - Detection Rules support `detectionExpr` alongside legacy `regex`; UI shows the effective expression and a concise rule summary.
  - PolicyCenter supports CEL for `scope_include` and `scope_exempt`; secrets catalog grouped by provider family for easier navigation.

- **Migration**
  - Build the wasm engine: `pnpm build:cel-wasm` or `mise run gen:celwasm` (outputs to `client/dashboard/public/cel/`); wired into `mise gen:all` and the dashboard prebuild.
  - Legacy regex rules surface as `content.matchRegex("<regex>")` and upgrade to CEL on edit/save; no manual changes needed.

<sup>Written for commit fe3a71c7172c8ea6eecbf7bc3fa40ce864ccecbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



