### PR TITLE
fix(server): derive session total tokens when provider omits total (DNO-323)

### DIFF
--- a/.changeset/dno-323-costs-session-total-tokens.md
+++ b/.changeset/dno-323-costs-session-total-tokens.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Costs and session views now show a correct total token count for AI-coding sessions (Claude Code, etc.). These providers report input and output tokens but never emit `gen_ai.usage.total_tokens`, which previously made per-session and per-user totals read "0 tokens". The telemetry queries now derive the total from input + output when the provider omits an explicit total, while sessions that do carry one are unchanged.

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -31,6 +31,17 @@ func userIdentifierExpr(col string) string {
 	return "if(telemetry_logs." + col + " != '', telemetry_logs." + col + ", telemetry_logs.user_email)"
 }
 
+// totalTokensExpr is a grouped-aggregate expression that yields a reliable total
+// token count. AI-coding providers like Claude Code report
+// gen_ai.usage.input_tokens and gen_ai.usage.output_tokens but never emit
+// gen_ai.usage.total_tokens, so rows that lack an explicit total fall back to
+// input + output. Rows that do carry an explicit total keep using it (our native
+// chat completions already set total = input + output), so the two row shapes
+// stay consistent. Without the fallback, Claude Code sessions surface "0 tokens"
+// in the costs/session views (DNO-323).
+const totalTokensExpr = "sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') + " +
+	"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)) + toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.total_tokens) = '')"
+
 // AttributeFilter represents a filter on an arbitrary JSON attribute path.
 // Paths prefixed with @ target user-defined attributes (translated to app.<path> in ClickHouse).
 // Bare paths target system/OTel attributes directly.
@@ -987,7 +998,7 @@ func (q *Queries) ListChats(ctx context.Context, arg ListChatsParams) ([]ChatSum
 		"anyIf(toString(attributes.gen_ai.response.model), toString(attributes.gen_ai.response.model) != '') as model",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') as total_input_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.output_tokens) != '') as total_output_tokens",
-		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') as total_tokens",
+		totalTokensExpr+" as total_tokens",
 	).
 		From("telemetry_logs").
 		Where("gram_project_id = ?", arg.GramProjectID).
@@ -1075,7 +1086,7 @@ func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByI
 		"gram_chat_id",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') as total_input_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.output_tokens) != '') as total_output_tokens",
-		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') as total_tokens",
+		totalTokensExpr+" as total_tokens",
 		"sumIf(toFloat64OrZero(toString(attributes.gen_ai.usage.cost)), toString(attributes.gen_ai.usage.cost) != '') as total_cost",
 	).
 		From("telemetry_logs").
@@ -1394,7 +1405,7 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 		// Token metrics (from any event with gen_ai usage data)
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') AS total_input_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.output_tokens) != '') AS total_output_tokens",
-		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens",
+		totalTokensExpr+" AS total_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.cache_read.input_tokens)), toString(attributes.gen_ai.usage.cache_read.input_tokens) != '') AS cache_read_input_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens)), toString(attributes.gen_ai.usage.cache_creation.input_tokens) != '') AS cache_creation_input_tokens",
 		"avgIf(toFloat64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS avg_tokens_per_request",
@@ -1501,7 +1512,7 @@ func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsS
 		// Token metrics (from any event with gen_ai usage data)
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') AS total_input_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.output_tokens) != '') AS total_output_tokens",
-		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens",
+		totalTokensExpr+" AS total_tokens",
 		"avgIf(toFloat64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS avg_tokens_per_request",
 
 		// Chat request metrics

--- a/server/internal/telemetry/search_chats_test.go
+++ b/server/internal/telemetry/search_chats_test.go
@@ -577,6 +577,94 @@ func TestSearchLogs_FilterByGramChatID(t *testing.T) {
 	require.Len(t, result.Logs, 2, "should only return logs matching gram_chat_id")
 }
 
+// TestSearchChats_DerivesTotalTokensWhenProviderOmitsTotal reproduces DNO-323:
+// AI-coding providers like Claude Code report gen_ai.usage.input_tokens and
+// gen_ai.usage.output_tokens but never emit gen_ai.usage.total_tokens (see
+// writeMetricsToClickHouse in internal/hooks). A session built solely from these
+// rows must still surface a non-zero total — derived from input + output —
+// instead of showing "0 tokens".
+func TestSearchChats_DerivesTotalTokensWhenProviderOmitsTotal(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	chatID := uuid.New().String()
+
+	// Two Claude Code metric rows: input/output tokens present, total omitted.
+	insertClaudeCodeMetricLog(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, "claude-sonnet-4")
+	insertClaudeCodeMetricLog(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), chatID, 200, 80, "claude-sonnet-4")
+
+	time.Sleep(200 * time.Millisecond)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	result, err := ti.service.SearchChats(ctx, &gen.SearchChatsPayload{
+		Filter: &gen.SearchChatsFilter{
+			From: &from,
+			To:   &to,
+		},
+		Limit: 100,
+		Sort:  "desc",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Chats, 1)
+
+	chat := result.Chats[0]
+	require.Equal(t, chatID, chat.GramChatID)
+	require.Equal(t, int64(300), chat.TotalInputTokens)  // 100 + 200
+	require.Equal(t, int64(130), chat.TotalOutputTokens) // 50 + 80
+	// Provider never emitted gen_ai.usage.total_tokens; the list must derive it
+	// from input + output rather than report 0.
+	require.Equal(t, int64(430), chat.TotalTokens) // 300 + 130
+}
+
+// insertClaudeCodeMetricLog inserts a Claude Code usage-metric row that mirrors
+// writeMetricsToClickHouse: input/output tokens and cost are reported but
+// gen_ai.usage.total_tokens is deliberately absent, and the row carries
+// hook_source=claude-code rather than a tool URN.
+func insertClaudeCodeMetricLog(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, chatID string, inputTokens, outputTokens int, model string) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attributes := map[string]any{
+		"gen_ai.conversation.id":     chatID,
+		"gen_ai.usage.input_tokens":  inputTokens,
+		"gen_ai.usage.output_tokens": outputTokens,
+		"gen_ai.usage.cost":          0.42,
+		"gen_ai.response.model":      model,
+		"gram.hook.source":           "claude-code",
+		// Note: gen_ai.usage.total_tokens is intentionally omitted.
+	}
+
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	err = conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_deployment_id, gram_urn, service_name,
+			gram_chat_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "claude code metric",
+		nil, nil, string(attrsJSON), "{}",
+		projectID, deploymentID, "", "gram-hooks",
+		chatID)
+	require.NoError(t, err)
+}
+
 // insertChatLogWithChatID inserts a chat completion log with the gram_chat_id column set.
 func insertChatLogWithChatID(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, chatID string, inputTokens, outputTokens, totalTokens int, durationSec float64, finishReason, model, provider string) {
 	t.Helper()

--- a/server/internal/telemetry/search_chats_test.go
+++ b/server/internal/telemetry/search_chats_test.go
@@ -82,9 +82,6 @@ func TestSearchChats_AggregatesByChatID(t *testing.T) {
 	insertChatLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-6*time.Minute), chatID2, 150, 75, 225, 1.8, "stop", "claude-3", "anthropic")
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), chatID2, "tools:http:petstore:getPet", 500, 1.0)
 
-	// Wait for ClickHouse eventual consistency
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
@@ -155,8 +152,6 @@ func TestSearchChats_Pagination(t *testing.T) {
 		insertChatLogWithChatID(t, ctx, projectID, deploymentID, ts, chatID, 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 	}
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
@@ -226,8 +221,6 @@ func TestSearchChats_FilterByDeploymentID(t *testing.T) {
 	insertChatLogWithChatID(t, ctx, projectID, deployment2, now.Add(-9*time.Minute), uuid.New().String(), 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 	insertChatLogWithChatID(t, ctx, projectID, deployment1, now.Add(-8*time.Minute), uuid.New().String(), 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
@@ -262,8 +255,6 @@ func TestSearchChats_PaginationAscOrder(t *testing.T) {
 		ts := now.Add(-time.Duration(50-i*10) * time.Minute)
 		insertChatLogWithChatID(t, ctx, projectID, deploymentID, ts, chatID, 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
 	}
-
-	time.Sleep(200 * time.Millisecond)
 
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
@@ -340,8 +331,6 @@ func TestSearchChats_ChatWithOnlyTools(t *testing.T) {
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, "tools:http:petstore:listPets", 200, 0.5)
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, "tools:http:petstore:getPet", 200, 0.3)
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
@@ -387,8 +376,6 @@ func TestSearchChats_ChatWithOnlyMessages(t *testing.T) {
 	// Insert only completion messages, no tool calls
 	insertChatLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, 150, 1.5, "stop", "gpt-4", "openai")
 	insertChatLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, 200, 100, 300, 2.0, "stop", "gpt-4", "openai")
-
-	time.Sleep(200 * time.Millisecond)
 
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
@@ -440,8 +427,6 @@ func TestSearchChats_FilterByGramURN(t *testing.T) {
 	// Chat 3: another petstore tool
 	chatID3 := uuid.New().String()
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), chatID3, "tools:http:petstore:getPet", 200, 0.4)
-
-	time.Sleep(200 * time.Millisecond)
 
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
@@ -496,8 +481,6 @@ func TestSearchChats_PaginationCursorScopedByProject(t *testing.T) {
 	// subquery is not scoped by project, it would pick up this row's timestamp
 	// and corrupt pagination.
 	insertChatLogWithChatID(t, ctx, otherProjectID, deploymentID, now.Add(-5*time.Hour), chatIDs[0], 100, 50, 150, 1.0, "stop", "gpt-4", "openai")
-
-	time.Sleep(200 * time.Millisecond)
 
 	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
@@ -558,8 +541,6 @@ func TestSearchLogs_FilterByGramChatID(t *testing.T) {
 	insertToolCallLogWithChatID(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, "tools:http:test:op", 200, 0.5)
 	insertTelemetryLog(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), nil, "urn:gram:other", "INFO")
 
-	time.Sleep(200 * time.Millisecond)
-
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
@@ -598,8 +579,6 @@ func TestSearchChats_DerivesTotalTokensWhenProviderOmitsTotal(t *testing.T) {
 	// Two Claude Code metric rows: input/output tokens present, total omitted.
 	insertClaudeCodeMetricLog(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, "claude-sonnet-4")
 	insertClaudeCodeMetricLog(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), chatID, 200, 80, "claude-sonnet-4")
-
-	time.Sleep(200 * time.Millisecond)
 
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)


### PR DESCRIPTION
## What & why

Fixes the **"0 tokens"** symptom in the Costs / session views ([DNO-323](https://linear.app/speakeasy/issue/DNO-323)).

AI-coding providers like **Claude Code** report `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` but **never emit `gen_ai.usage.total_tokens`** (see `writeMetricsToClickHouse` in `internal/hooks/pending_helpers.go`). The telemetry queries summed only the (absent) `total_tokens` attribute, so every Claude Code session showed **0 total tokens** even though input/output were non-zero.

The fix derives `total_tokens = input + output` for rows that lack an explicit total, via a shared `totalTokensExpr`. Rows that **do** carry an explicit total (our native chat completions, which already set `total = input + output`) are unchanged, so the two row shapes stay consistent.

Applied to the four raw-`telemetry_logs` queries that have **no `metrics_summaries` MV counterpart** (so there's no risk of the raw branch disagreeing with the MV branch):

- `ListChats` — the by-sessions list
- `GetChatMetricsByIDs` — per-chat detail enrichment
- `SearchUsers` — per-user cost/token summary
- `GetUserMetricsSummary` — single-user summary

## Test

`TestSearchChats_DerivesTotalTokensWhenProviderOmitsTotal` inserts Claude-Code-shaped rows (input/output present, total omitted) and asserts the session surfaces a derived non-zero total. It **fails before** the change (`total = 0`) and passes after. Existing SearchChats/SearchUsers tests (explicit-total cases) still pass.

## Out of scope — left for [DNO-316](https://linear.app/speakeasy/issue/DNO-316) (cc @chase)

This PR intentionally does **not** touch the deeper architecture items behind the rest of DNO-323. Documenting them here so the boundary is explicit:

1. **Cost/session-count mismatch + "sessions not found" on drill-down.** The dashboard headline/total reads the `metrics_summaries` **`AggregatingMergeTree`** MV, while the per-user/by-session drill-down reads raw `telemetry_logs`. `DeleteChat` → `SoftDeleteChat` only updates Postgres — **ClickHouse is never told** — so a deleted (or 30-day-TTL'd) chat stays baked into the MV rollup but vanishes from the raw-table list. That's the "76 sessions / $65 in the total, 48 / $35 in the list" divergence and the "drill into highest spend → no sessions" report. This is exactly DNO-316's `AggregatingMergeTree` → `CollapsingMergeTree` / delete-cascade redesign.

2. **MV-backed token totals still under-report Claude Code.** `metrics_summaries.total_tokens` is built with `sumIfState(..., gram.resource.urn = 'agents:chat:completion')`, which Claude Code metric rows don't match. I deliberately left `getOverviewSummaryRaw` and `GetTimeSeriesMetrics` (the project-overview / time-series paths that have MV counterparts) **unchanged** here — fixing only their raw branch would make filtered vs unfiltered totals disagree. They need the coordinated MV fix.

3. **`avg_tokens_per_request`** still divides by the explicit-total attribute, so it remains 0 for Claude-Code-only aggregates. Lower-visibility; folded into the same MV/derivation cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "0 tokens" in Costs and session views by deriving totals from input + output when a provider omits `gen_ai.usage.total_tokens` (DNO-323). Rows with an explicit total are unchanged.

- **Bug Fixes**
  - Added a shared `totalTokensExpr` fallback and applied it to four raw queries: ListChats, GetChatMetricsByIDs, SearchUsers, GetUserMetricsSummary.
  - Added a test for Claude Code–shaped rows to assert a non-zero derived total; removed sleeps from chat search tests to reduce flakiness and speed up runs.

<sup>Written for commit f2d7d2a39c4e803c4cedc8210c7a4c057b595762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

