### PR TITLE
chore: couple o' test flakes

### DIFF
--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -36,7 +36,7 @@ func TestService_Info(t *testing.T) {
 
 		// Create and store a session first
 		session := sessions.Session{
-			SessionID:            "test-session-id",
+			SessionID:            t.Name(),
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",
@@ -109,7 +109,7 @@ func TestService_Info(t *testing.T) {
 
 		// Create and store a session first
 		session := sessions.Session{
-			SessionID:            "test-session-id",
+			SessionID:            t.Name(),
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID, // First org is active
 			WorkOSSessionID:      "",
@@ -383,7 +383,7 @@ func TestService_Info(t *testing.T) {
 
 		// Create and store a session first
 		session := sessions.Session{
-			SessionID:            "test-session-id",
+			SessionID:            t.Name(),
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",

--- a/server/internal/auth/logout_test.go
+++ b/server/internal/auth/logout_test.go
@@ -22,7 +22,7 @@ func TestService_Logout(t *testing.T) {
 
 		// Create and store a session first
 		session := sessions.Session{
-			SessionID:            "test-session-id",
+			SessionID:            t.Name(),
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID,
 			WorkOSSessionID:      "",

--- a/server/internal/auth/register_test.go
+++ b/server/internal/auth/register_test.go
@@ -27,7 +27,7 @@ func TestService_Register(t *testing.T) {
 
 		// Create and store a session with no active organization
 		session := sessions.Session{
-			SessionID:            "test-session-id",
+			SessionID:            t.Name(),
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "", // No active organization
 			WorkOSSessionID:      "",
@@ -66,7 +66,7 @@ func TestService_Register(t *testing.T) {
 
 		// Create and store a session with active organization
 		session := sessions.Session{
-			SessionID:            "test-session-id",
+			SessionID:            t.Name(),
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: userInfo.Organizations[0].ID, // Has active organization
 			WorkOSSessionID:      "",
@@ -111,7 +111,7 @@ func TestService_Register(t *testing.T) {
 
 		// Create and store a session with no active organization
 		session := sessions.Session{
-			SessionID:            "test-session-id",
+			SessionID:            t.Name(),
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "", // No active organization
 			WorkOSSessionID:      "",
@@ -156,7 +156,7 @@ func TestService_Register(t *testing.T) {
 
 		// Create and store a session with no active organization
 		session := sessions.Session{
-			SessionID:            "test-session-id",
+			SessionID:            t.Name(),
 			UserID:               userInfo.UserID,
 			ActiveOrganizationID: "", // No active organization
 			WorkOSSessionID:      "",

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -748,6 +748,9 @@ printf '{}\n200'
 		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"GRAM_CAPTURE_PAYLOAD="+capturePath,
 		"GRAM_DEVICE_AGENT_COMMANDS=fake-agent",
+		// Pin a generous timeout so CI scheduling jitter can't trip the
+		// device-agent wall-clock timeout (default 1.5s) and flake the test.
+		"GRAM_DEVICE_AGENT_TIMEOUT_TENTHS=600",
 	)
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
@@ -814,6 +817,9 @@ exit 1
 	cmd.Env = append(os.Environ(),
 		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"GRAM_DEVICE_AGENT_COMMANDS=fake-agent",
+		// Pin a generous timeout so CI scheduling jitter can't trip the
+		// device-agent wall-clock timeout (default 1.5s) and flake the test.
+		"GRAM_DEVICE_AGENT_TIMEOUT_TENTHS=600",
 	)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "identity.sh"), renderDeviceAgentIdentityScript(), 0o755))
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
## What

Fixes two parallel-test races that flake under loaded CI (each observed ephemerally in `test:server`).

### `server/internal/auth` — shared Redis session key
`TestService_Register`, `TestService_Logout`, and `TestService_Info` all ran `t.Parallel()` and hardcoded `SessionID: "test-session-id"`. Every `newTestAuthService` instance shares one Redis container on DB `0`, and the session cache uses `SuffixNone`, so that string is a single global key (`sessions:test-session-id`). When a parallel `Logout` → `ClearSession` deleted the key between Register's `StoreSession` and its final `GetSession`, Register failed with `error loading existing session`.

**Fix:** derive each session ID from `t.Name()` (globally unique per subtest) so parallel tests no longer collide. Matches the pattern the package already adopted for its newer subtests.

### `server/internal/plugins` — device-agent identity timeout
The device-agent identity script runs the agent under a hand-rolled 1.5s wall-clock timeout. Locally the `fake-agent` exits in milliseconds, but CI scheduling jitter can exceed 1.5s, killing the agent and skipping enrichment — leaving the original payload (`cursor@example.com` survives, or `user_email` is `nil`).

**Fix:** pin `GRAM_DEVICE_AGENT_TIMEOUT_TENTHS` generously in the two tests that exec a real agent. The agent still exits in milliseconds (loop ends early in the happy path); this only raises the ceiling. Production default (1.5s) unchanged.

## Test
- `go test ./server/internal/auth/ -run 'TestService_Register|TestService_Logout|TestService_Info' -race -count=5` — green
- `go test ./server/internal/plugins/ -run 'Identity|DeviceAgent' -count=5` — green

Test-only changes; no production code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two test flakes by making auth sessions test-local and relaxing the device-agent timeout in tests. Stabilizes server tests under CI load; no production changes.

- **Bug Fixes**
  - `server/internal/auth`: Use `t.Name()` for session IDs in Register/Logout/Info tests to avoid Redis key collisions in parallel runs.
  - `server/internal/plugins`: Set `GRAM_DEVICE_AGENT_TIMEOUT_TENTHS=600` in tests that exec the fake agent so CI jitter doesn’t kill the agent; production default unchanged.

<sup>Written for commit e0f30e8ab92eda638746571f1211d24a3ce52641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

