### PR TITLE
feat(functions): retry tool-call POSTs on 429/503 with jittered backoff

### DIFF
--- a/.changeset/age-2828-functions-retry-tool-call-429-503.md
+++ b/.changeset/age-2828-functions-retry-tool-call-429-503.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Gram Functions tool-call and resource-read POSTs now retry on a saturated runner's `429 + Retry-After` and Fly's `503` (both guaranteed before the function runs) instead of surfacing transient saturation as a hard failure, with jittered backoff to spread simultaneous retries and avoid a thundering herd. Transport errors that are transparently retried now log at `WARN` rather than `ERROR`, so recovered attempts no longer look like failures while the final unrecovered failure is still logged as an error.

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -9,16 +9,13 @@ import (
 	"io"
 	"log/slog"
 	"mime"
-	"net"
 	"net/http"
 	"net/url"
 	"reflect"
 	"regexp"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -469,6 +466,7 @@ func (tp *ToolProxy) doFunction(
 			}
 			return nil
 		},
+		RetryConfig:      functionRunnerRetryConfig(),
 		ID:               descriptor.ID,
 		Name:             descriptor.Name,
 		DeploymentID:     descriptor.DeploymentID,
@@ -737,6 +735,7 @@ func (tp *ToolProxy) doHTTP(
 		ResponseStatusCodeCapture: &responseStatusCode,
 		Attributes:                attrRecorder,
 		VerifyResponse:            func(resp *http.Response) error { return nil },
+		RetryConfig:               httpToolRetryConfig(),
 		ID:                        descriptor.ID,
 		Name:                      descriptor.Name,
 		DeploymentID:              descriptor.DeploymentID,
@@ -831,118 +830,6 @@ func (tp *ToolProxy) doExternalMCP(
 	return nil
 }
 
-type retryConfig struct {
-	initialInterval time.Duration
-	maxInterval     time.Duration
-	maxAttempts     int
-	backoffFactor   float64
-	statusCodes     []int
-	methods         []string
-}
-
-func retryWithBackoff(
-	ctx context.Context,
-	retryBackoff retryConfig,
-	doRequest func() (*http.Response, error),
-) (*http.Response, error) {
-	var resp *http.Response
-	var err error
-	delayInterval := retryBackoff.initialInterval
-	for attempt := 0; attempt < retryBackoff.maxAttempts; attempt++ {
-		if attempt > 0 {
-			select {
-			case <-time.After(delayInterval):
-			case <-ctx.Done():
-				return nil, fmt.Errorf("retry context done: %w", ctx.Err())
-			}
-
-			delayInterval = min(time.Duration(float64(delayInterval)*retryBackoff.backoffFactor), retryBackoff.maxInterval)
-		}
-		resp, err = doRequest()
-		if err != nil {
-			// Only retry connection-level failures that happened before the
-			// upstream processed the request, so non-idempotent requests (e.g.
-			// function tool-call POSTs) are never re-executed.
-			if isRetryableTransportError(err) {
-				continue
-			}
-
-			return nil, err
-		}
-		if !slices.Contains(retryBackoff.methods, resp.Request.Method) || !slices.Contains(retryBackoff.statusCodes, resp.StatusCode) {
-			return resp, err
-		}
-
-		if retryAfter := resp.Header.Get("retry-after"); retryAfter != "" {
-			if parsedNumber, err := strconv.ParseInt(retryAfter, 10, 64); err == nil && parsedNumber > 0 {
-				retryAfterDuration := time.Duration(parsedNumber) * time.Second
-				delayInterval = min(retryAfterDuration, retryBackoff.maxInterval)
-				continue
-			}
-
-			if parsedDate, err := time.Parse(time.RFC1123, retryAfter); err == nil {
-				retryAfterDuration := time.Until(parsedDate)
-				if retryAfterDuration > 0 {
-					delayInterval = min(retryAfterDuration, retryBackoff.maxInterval)
-				}
-			}
-		}
-	}
-	return resp, err
-}
-
-// isRetryableTransportError reports whether err returned from http.Client.Do is a
-// connection-level failure that happened before the upstream processed the
-// request. Retrying these is safe even for non-idempotent methods (e.g. function
-// tool-call POSTs) because the request was not acted on. Caller cancellation and
-// deadlines are excluded: the request may already be in flight, so retrying only
-// wastes work.
-func isRetryableTransportError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// The caller gave up (timeout or cancellation); the request may already be in
-	// flight, so do not retry.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-
-	// A bare io.EOF from client.Do means the connection closed during the
-	// request/response-header exchange, before any response was received. For
-	// Fly-hosted function runners this is overwhelmingly the edge closing the
-	// connection before it can route to a machine that is stopped, stopping, or
-	// not yet recognized as started, so the request was not processed. From the
-	// error alone we cannot distinguish that from the rarer case where the runner
-	// processed the request and then the connection dropped before responding;
-	// retrying io.EOF accepts that residual double-execution risk. It is the best
-	// achievable without per-tool idempotency keys, and the observed EOF traffic
-	// is dominated by idempotent reads. io.ErrUnexpectedEOF stays excluded: a
-	// partial response means the request was processed.
-	if errors.Is(err, io.EOF) {
-		return true
-	}
-
-	// Connection refused is always a failed connect: the request was never
-	// delivered.
-	if errors.Is(err, syscall.ECONNREFUSED) {
-		return true
-	}
-
-	// Failures while establishing the connection (dial/connect), including a reset
-	// or timeout before the request is written, are safe to retry. Resets while
-	// reading or writing an in-flight request are intentionally NOT retried here,
-	// to avoid re-executing a request the upstream may have already processed.
-	if netErr, ok := errors.AsType[*net.OpError](err); ok {
-		switch netErr.Op {
-		case "dial", "connect":
-			return true
-		}
-	}
-
-	return false
-}
-
 type ReverseProxyOptions struct {
 	Logger                    *slog.Logger
 	Tracer                    trace.Tracer
@@ -955,6 +842,11 @@ type ReverseProxyOptions struct {
 	ResponseStatusCodeCapture *int
 	VerifyResponse            func(*http.Response) error
 	Attributes                tm.HTTPLogAttributes
+	// RetryConfig is the retry policy applied to the proxied request. Callers
+	// pass functionRunnerRetryConfig (POST retries on the pre-execution-safe
+	// 429/503 set) for function-runner calls and httpToolRetryConfig (GET-only
+	// broad preset) for outbound HTTP tool calls.
+	RetryConfig retryConfig
 	// Descriptor fields
 	ID               string
 	Name             string
@@ -1027,32 +919,7 @@ func reverseProxyRequest(ctx context.Context, opts ReverseProxyOptions) error {
 
 		return client.Do(retryReq)
 	}
-	resp, err := retryWithBackoff(ctx, retryConfig{
-		// Space retries so the later attempts land after a Fly machine cold start
-		// (~2s) has had time to complete, without adding more attempts (which would
-		// only pile load onto an already-saturated runner). With backoffFactor 2
-		// the waits are 1s then 2s.
-		initialInterval: 1 * time.Second,
-		maxInterval:     5 * time.Second,
-		maxAttempts:     3,
-		backoffFactor:   2,
-		statusCodes: []int{ // reasonable status code presets
-			408, // Request Timeout
-			429, // Rate Limit Exceeded
-			500, // Internal Server Error
-			502, // Bad Gateway
-			503, // Service Unavailable
-			504, // Gateway Timeout
-			509, // Bandwidth Limit Exceeded
-			521, // Web Server Is Down (Cloudflare)
-			522, // Connection Timed Out (Cloudflare)
-			523, // Origin Is Unreachable (Cloudflare)
-			524, // A Timeout Occurred (Cloudflare)
-		},
-		methods: []string{
-			http.MethodGet,
-		},
-	}, executeRequest)
+	resp, err := retryWithBackoff(ctx, opts.RetryConfig, executeRequest)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return oops.E(oops.CodeGatewayError, err, "failed to execute request").LogError(ctx, opts.Logger)

--- a/server/internal/gateway/resources.go
+++ b/server/internal/gateway/resources.go
@@ -169,6 +169,7 @@ func (tp *ToolProxy) doFunctionResource(
 			}
 			return nil
 		},
+		RetryConfig:      functionRunnerRetryConfig(),
 		ID:               descriptor.ID,
 		Name:             descriptor.Name,
 		DeploymentID:     descriptor.DeploymentID,

--- a/server/internal/gateway/retry.go
+++ b/server/internal/gateway/retry.go
@@ -181,6 +181,17 @@ func retryWithBackoff(
 
 	for attempt := range maxAttempts {
 		if attempt > 0 {
+			// Discard the previous attempt's response before retrying: drain a bounded
+			// amount so the keep-alive connection can be reused, then close the body so
+			// it (and its connection) is not leaked across attempts. resp is nil after a
+			// retried transport error, so guard it. The final, returned response is
+			// never closed here — the loop exits without re-entering this block — so the
+			// caller still receives an open body.
+			if resp != nil {
+				_, _ = io.CopyN(io.Discard, resp.Body, 64*1024)
+				_ = resp.Body.Close()
+			}
+
 			// Jitter the wait (full jitter on top of delayInterval as a floor) so a
 			// wave of simultaneously-throttled requests does not retry in lockstep.
 			// delayInterval carries either the exponential backoff or a server
@@ -219,7 +230,7 @@ func retryWithBackoff(
 			if parsedNumber, err := strconv.ParseInt(retryAfter, 10, 64); err == nil && parsedNumber > 0 {
 				retryAfterDuration := time.Duration(parsedNumber) * time.Second
 				delayInterval = min(retryAfterDuration, retryBackoff.maxInterval)
-			} else if parsedDate, err := time.Parse(time.RFC1123, retryAfter); err == nil {
+			} else if parsedDate, err := http.ParseTime(retryAfter); err == nil {
 				retryAfterDuration := time.Until(parsedDate)
 				if retryAfterDuration > 0 {
 					delayInterval = min(retryAfterDuration, retryBackoff.maxInterval)

--- a/server/internal/gateway/retry.go
+++ b/server/internal/gateway/retry.go
@@ -1,0 +1,231 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"slices"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// retryConfig is the policy retryWithBackoff applies to a proxied request: how
+// many attempts to make, how long to wait between them, and which responses are
+// safe to retry. Build one with httpToolRetryConfig or functionRunnerRetryConfig
+// rather than assembling it inline, so the retryable-status rules stay in one
+// place.
+type retryConfig struct {
+	// backoffFactor is the multiplier applied to the wait after each attempt,
+	// producing exponential growth (e.g. 2 doubles the interval each time).
+	backoffFactor float64
+
+	// initialInterval is the base wait before the first retry. It is the floor
+	// the first backoff is computed from and grows by backoffFactor on each
+	// subsequent attempt. A server Retry-After header overrides it for that
+	// attempt (capped at maxInterval).
+	initialInterval time.Duration
+
+	// maxAttempts is the total number of attempts, including the first. Values
+	// below 1 are clamped to 1 by retryWithBackoff so the request always runs at
+	// least once.
+	maxAttempts int
+
+	// maxInterval caps the backoff wait — both the exponentially grown interval
+	// and any honored Retry-After — before per-attempt jitter is layered on.
+	maxInterval time.Duration
+
+	// retryableStatus maps an HTTP request method to the response status codes
+	// that are safe to retry for that method. A method absent from the map is
+	// never retried on status (only on pre-execution transport errors). Keying by
+	// method lets idempotent GETs retry a broad transient-status preset while
+	// non-idempotent POSTs (function tool calls / resource reads) retry only the
+	// narrow set that is provably pre-execution, so they are never re-executed.
+	retryableStatus map[string][]int
+}
+
+// functionRunnerRetryConfig is the retry policy for calls to the Fly functions
+// runner (tool calls and resource reads, always POST). The runner sheds an
+// over-capacity request with 429 + Retry-After *before* executing it, and Fly
+// returns 503 when the fleet is full and never delivered the request to a
+// runner, so both are provably pre-execution and safe to retry even though the
+// request is a non-idempotent POST. 500/502/504 are deliberately excluded: those
+// may be post-execution, so retrying them risks double-execution.
+func functionRunnerRetryConfig() retryConfig {
+	return retryConfig{
+		initialInterval: 1 * time.Second,
+		maxInterval:     5 * time.Second,
+		maxAttempts:     3,
+		backoffFactor:   2,
+		retryableStatus: map[string][]int{
+			http.MethodPost: {
+				http.StatusTooManyRequests,    // 429: runner limiter shed it pre-execution
+				http.StatusServiceUnavailable, // 503: Fly fleet full, never delivered
+			},
+		},
+	}
+}
+
+// httpToolRetryConfig is the retry policy for outbound HTTP tool calls. Only
+// idempotent GETs retry, on a broad transient-status preset; non-idempotent
+// methods (POST/PUT/...) are never retried on status because an upstream 429/503
+// is not provably pre-execution for arbitrary APIs, so retrying risks
+// double-execution.
+func httpToolRetryConfig() retryConfig {
+	return retryConfig{
+		// Space retries so the later attempts land after a Fly machine cold start
+		// (~2s) has had time to complete, without adding more attempts (which would
+		// only pile load onto an already-saturated runner). With backoffFactor 2
+		// the base waits are 1s then 2s, before per-attempt jitter is layered on.
+		initialInterval: 1 * time.Second,
+		maxInterval:     5 * time.Second,
+		maxAttempts:     3,
+		backoffFactor:   2,
+		retryableStatus: map[string][]int{
+			http.MethodGet: {
+				408, // Request Timeout
+				429, // Rate Limit Exceeded
+				500, // Internal Server Error
+				502, // Bad Gateway
+				503, // Service Unavailable
+				504, // Gateway Timeout
+				509, // Bandwidth Limit Exceeded
+				521, // Web Server Is Down (Cloudflare)
+				522, // Connection Timed Out (Cloudflare)
+				523, // Origin Is Unreachable (Cloudflare)
+				524, // A Timeout Occurred (Cloudflare)
+			},
+		},
+	}
+}
+
+// isRetryableTransportError reports whether err returned from http.Client.Do is a
+// connection-level failure that happened before the upstream processed the
+// request. Retrying these is safe even for non-idempotent methods (e.g. function
+// tool-call POSTs) because the request was not acted on. Caller cancellation and
+// deadlines are excluded: the request may already be in flight, so retrying only
+// wastes work.
+func isRetryableTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// The caller gave up (timeout or cancellation); the request may already be in
+	// flight, so do not retry.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// A bare io.EOF from client.Do means the connection closed during the
+	// request/response-header exchange, before any response was received. For
+	// Fly-hosted function runners this is overwhelmingly the edge closing the
+	// connection before it can route to a machine that is stopped, stopping, or
+	// not yet recognized as started, so the request was not processed. From the
+	// error alone we cannot distinguish that from the rarer case where the runner
+	// processed the request and then the connection dropped before responding;
+	// retrying io.EOF accepts that residual double-execution risk. It is the best
+	// achievable without per-tool idempotency keys, and the observed EOF traffic
+	// is dominated by idempotent reads. io.ErrUnexpectedEOF stays excluded: a
+	// partial response means the request was processed.
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+
+	// Connection refused is always a failed connect: the request was never
+	// delivered.
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+
+	// Failures while establishing the connection (dial/connect), including a reset
+	// or timeout before the request is written, are safe to retry. Resets while
+	// reading or writing an in-flight request are intentionally NOT retried here,
+	// to avoid re-executing a request the upstream may have already processed.
+	if netErr, ok := errors.AsType[*net.OpError](err); ok {
+		switch netErr.Op {
+		case "dial", "connect":
+			return true
+		}
+	}
+
+	return false
+}
+
+// jitteredBackoff returns base plus a full-jittered spread uniform in [0, base),
+// so the result is uniform in [base, 2*base). base acts as a floor (e.g. a
+// runner Retry-After), and the added jitter spreads concurrent retries so a wave
+// of simultaneously-throttled function calls does not retry in lockstep
+// (thundering herd). Returns 0 when base is non-positive.
+func jitteredBackoff(base time.Duration) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	return base + time.Duration(rand.Int64N(int64(base))) // #nosec G404 retry jitter is not security-sensitive
+}
+
+func retryWithBackoff(
+	ctx context.Context,
+	retryBackoff retryConfig,
+	doRequest func() (*http.Response, error),
+) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+	// Always make at least one attempt, even if a caller supplies a zero-valued
+	// config, so the request is never silently dropped without executing.
+	maxAttempts := max(retryBackoff.maxAttempts, 1)
+	delayInterval := retryBackoff.initialInterval
+
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			// Jitter the wait (full jitter on top of delayInterval as a floor) so a
+			// wave of simultaneously-throttled requests does not retry in lockstep.
+			// delayInterval carries either the exponential backoff or a server
+			// Retry-After (both capped at maxInterval), so the floor is respected on
+			// every path while the spread is layered on here.
+			select {
+			case <-time.After(jitteredBackoff(delayInterval)):
+			case <-ctx.Done():
+				return nil, fmt.Errorf("retry context done: %w", ctx.Err())
+			}
+
+			delayInterval = min(time.Duration(float64(delayInterval)*retryBackoff.backoffFactor), retryBackoff.maxInterval)
+		}
+		resp, err = doRequest()
+		if err != nil {
+			// Only retry connection-level failures that happened before the
+			// upstream processed the request, so non-idempotent requests (e.g.
+			// function tool-call POSTs) are never re-executed.
+			if isRetryableTransportError(err) {
+				continue
+			}
+
+			return nil, err
+		}
+		retryableCodes, ok := retryBackoff.retryableStatus[resp.Request.Method]
+		if !ok || !slices.Contains(retryableCodes, resp.StatusCode) {
+			return resp, err
+		}
+
+		// Retry-After is either delta-seconds or an HTTP-date. Whichever form parses
+		// sets delayInterval as the floor for the next (jittered) backoff, capped at
+		// maxInterval; an unparseable, zero, or past value leaves the exponential
+		// backoff in place. The two forms are mutually exclusive, so the date parse
+		// runs only when the numeric parse does not match.
+		if retryAfter := resp.Header.Get("retry-after"); retryAfter != "" {
+			if parsedNumber, err := strconv.ParseInt(retryAfter, 10, 64); err == nil && parsedNumber > 0 {
+				retryAfterDuration := time.Duration(parsedNumber) * time.Second
+				delayInterval = min(retryAfterDuration, retryBackoff.maxInterval)
+			} else if parsedDate, err := time.Parse(time.RFC1123, retryAfter); err == nil {
+				retryAfterDuration := time.Until(parsedDate)
+				if retryAfterDuration > 0 {
+					delayInterval = min(retryAfterDuration, retryBackoff.maxInterval)
+				}
+			}
+		}
+	}
+	return resp, err
+}

--- a/server/internal/gateway/retry_test.go
+++ b/server/internal/gateway/retry_test.go
@@ -48,16 +48,28 @@ func fastRetryConfig() retryConfig {
 		maxInterval:     time.Millisecond,
 		maxAttempts:     3,
 		backoffFactor:   2,
-		statusCodes:     nil,
-		methods:         nil,
+		retryableStatus: nil,
 	}
 }
 
+// fastRetryConfigWith returns fastRetryConfig with the given per-method
+// retryable-status map, so status-path tests retry within microseconds instead
+// of the production second-scale waits.
+func fastRetryConfigWith(retryableStatus map[string][]int) retryConfig {
+	cfg := fastRetryConfig()
+	cfg.retryableStatus = retryableStatus
+	return cfg
+}
+
 func okResponse() *http.Response {
+	return statusResponse(http.MethodPost, http.StatusOK)
+}
+
+func statusResponse(method string, status int) *http.Response {
 	rec := httptest.NewRecorder()
-	rec.WriteHeader(http.StatusOK)
+	rec.WriteHeader(status)
 	resp := rec.Result()
-	resp.Request = httptest.NewRequest(http.MethodPost, "https://app.fly.dev/tool-call", http.NoBody)
+	resp.Request = httptest.NewRequest(method, "https://app.fly.dev/tool-call", http.NoBody)
 	return resp
 }
 
@@ -131,4 +143,187 @@ func TestRetryWithBackoff_DoesNotRetryContextCanceled(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, resp)
 	require.Equal(t, 1, calls, "caller cancellation must not trigger a retry")
+}
+
+func TestRetryWithBackoff_FunctionPOSTRetriesOn429(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	resp, err := retryWithBackoff(t.Context(), fastRetryConfigWith(map[string][]int{
+		http.MethodPost: {http.StatusTooManyRequests, http.StatusServiceUnavailable},
+	}), func() (*http.Response, error) {
+		calls++
+		if calls < 3 {
+			return statusResponse(http.MethodPost, http.StatusTooManyRequests), nil
+		}
+		return okResponse(), nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 3, calls, "a function POST should retry 429 until it succeeds")
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestRetryWithBackoff_FunctionPOSTRetriesOn503(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	resp, err := retryWithBackoff(t.Context(), fastRetryConfigWith(map[string][]int{
+		http.MethodPost: {http.StatusTooManyRequests, http.StatusServiceUnavailable},
+	}), func() (*http.Response, error) {
+		calls++
+		if calls < 2 {
+			return statusResponse(http.MethodPost, http.StatusServiceUnavailable), nil
+		}
+		return okResponse(), nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, calls, "a function POST should retry 503 until it succeeds")
+	require.NoError(t, resp.Body.Close())
+}
+
+// Server errors that may be post-execution must never be retried for a
+// non-idempotent function POST, or a tool call could be executed twice.
+func TestRetryWithBackoff_FunctionPOSTDoesNotRetryServerErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusGatewayTimeout,      // 504
+	} {
+		calls := 0
+		resp, err := retryWithBackoff(t.Context(), fastRetryConfigWith(map[string][]int{
+			http.MethodPost: {http.StatusTooManyRequests, http.StatusServiceUnavailable},
+		}), func() (*http.Response, error) {
+			calls++
+			return statusResponse(http.MethodPost, status), nil
+		})
+
+		require.NoErrorf(t, err, "status %d", status)
+		require.NotNilf(t, resp, "status %d", status)
+		require.Equalf(t, status, resp.StatusCode, "status %d", status)
+		require.Equalf(t, 1, calls, "function POST must not retry %d (risks double-execution)", status)
+		require.NoErrorf(t, resp.Body.Close(), "status %d", status)
+	}
+}
+
+// The runner advertises Retry-After alongside its 429; the status path must
+// honor it and still retry.
+func TestRetryWithBackoff_FunctionPOSTHonorsRetryAfterOn429(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	resp, err := retryWithBackoff(t.Context(), fastRetryConfigWith(map[string][]int{
+		http.MethodPost: {http.StatusTooManyRequests, http.StatusServiceUnavailable},
+	}), func() (*http.Response, error) {
+		calls++
+		if calls < 2 {
+			r := statusResponse(http.MethodPost, http.StatusTooManyRequests)
+			r.Header.Set("Retry-After", "2")
+			return r, nil
+		}
+		return okResponse(), nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, calls, "a 429 carrying Retry-After should still be retried")
+	require.NoError(t, resp.Body.Close())
+}
+
+// Regression guard: idempotent HTTP GET tool calls keep retrying the broad
+// transient-status preset.
+func TestRetryWithBackoff_HTTPGetRetriesTransientStatus(t *testing.T) {
+	t.Parallel()
+
+	cfg := httpToolRetryConfig()
+	cfg.initialInterval = time.Millisecond
+	cfg.maxInterval = time.Millisecond
+
+	calls := 0
+	resp, err := retryWithBackoff(t.Context(), cfg, func() (*http.Response, error) {
+		calls++
+		if calls < 3 {
+			return statusResponse(http.MethodGet, http.StatusServiceUnavailable), nil
+		}
+		return statusResponse(http.MethodGet, http.StatusOK), nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 3, calls, "an HTTP GET should retry the transient-status preset")
+	require.NoError(t, resp.Body.Close())
+}
+
+// Scope guard: the HTTP tool policy must NOT retry POSTs on the runner's
+// throttle statuses. An upstream 429/503 is not provably pre-execution for
+// arbitrary APIs, so retrying a non-idempotent HTTP POST could double-execute it.
+func TestRetryWithBackoff_HTTPPostNotRetriedOnThrottleStatus(t *testing.T) {
+	t.Parallel()
+
+	cfg := httpToolRetryConfig()
+	cfg.initialInterval = time.Millisecond
+	cfg.maxInterval = time.Millisecond
+
+	for _, status := range []int{
+		http.StatusTooManyRequests,    // 429
+		http.StatusServiceUnavailable, // 503
+	} {
+		calls := 0
+		resp, err := retryWithBackoff(t.Context(), cfg, func() (*http.Response, error) {
+			calls++
+			return statusResponse(http.MethodPost, status), nil
+		})
+
+		require.NoErrorf(t, err, "status %d", status)
+		require.NotNilf(t, resp, "status %d", status)
+		require.Equalf(t, status, resp.StatusCode, "status %d", status)
+		require.Equalf(t, 1, calls, "the HTTP tool policy must not retry POSTs on %d", status)
+		require.NoErrorf(t, resp.Body.Close(), "status %d", status)
+	}
+}
+
+// A zero-value config (no caller wired a RetryConfig) must still run the request
+// exactly once: maxAttempts clamps up to 1, and a nil retryableStatus retries
+// nothing on status.
+func TestRetryWithBackoff_ZeroValueConfigRunsOnceAndNeverRetriesStatus(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	resp, err := retryWithBackoff(t.Context(), retryConfig{}, func() (*http.Response, error) {
+		calls++
+		return statusResponse(http.MethodPost, http.StatusTooManyRequests), nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	require.Equal(t, 1, calls, "a zero-value config must run exactly once and never retry on status")
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestJitteredBackoff_StaysWithinCapAndSpreads(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, jitteredBackoff(0), "non-positive base yields no delay")
+	require.Zero(t, jitteredBackoff(-time.Second), "negative base yields no delay")
+
+	const base = 2 * time.Second
+	seen := make(map[time.Duration]struct{})
+	for range 1000 {
+		got := jitteredBackoff(base)
+		// Full jitter on top of base as a floor: uniform in [base, 2*base).
+		require.GreaterOrEqual(t, got, base, "jittered delay must never drop below the floor")
+		require.Less(t, got, 2*base, "jittered delay must stay within the 2*base cap")
+		seen[got] = struct{}{}
+	}
+	require.Greater(t, len(seen), 1, "jitter must spread delays, not return a constant")
 }

--- a/server/internal/gateway/retry_test.go
+++ b/server/internal/gateway/retry_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -70,6 +71,26 @@ func statusResponse(method string, status int) *http.Response {
 	rec.WriteHeader(status)
 	resp := rec.Result()
 	resp.Request = httptest.NewRequest(method, "https://app.fly.dev/tool-call", http.NoBody)
+	return resp
+}
+
+// countingBody is a response body that records how many times it is closed, so
+// tests can assert the retry loop closes the responses it discards.
+type countingBody struct {
+	io.Reader
+	closes *int
+}
+
+func (b countingBody) Close() error {
+	*b.closes++
+	return nil
+}
+
+// retryableStatusResponse builds a response whose body increments *closes when
+// closed, for asserting the retry loop drains and closes discarded responses.
+func retryableStatusResponse(method string, status int, closes *int) *http.Response {
+	resp := statusResponse(method, status)
+	resp.Body = countingBody{Reader: strings.NewReader("runner at capacity"), closes: closes}
 	return resp
 }
 
@@ -289,6 +310,32 @@ func TestRetryWithBackoff_HTTPPostNotRetriedOnThrottleStatus(t *testing.T) {
 		require.Equalf(t, 1, calls, "the HTTP tool policy must not retry POSTs on %d", status)
 		require.NoErrorf(t, resp.Body.Close(), "status %d", status)
 	}
+}
+
+// A retried 429/503 response must have its body drained and closed before the
+// next attempt, or each retry leaks the body and its keep-alive connection. The
+// final returned response stays open for the caller.
+func TestRetryWithBackoff_ClosesDiscardedResponseBodies(t *testing.T) {
+	t.Parallel()
+
+	closes := 0
+	calls := 0
+	resp, err := retryWithBackoff(t.Context(), fastRetryConfigWith(map[string][]int{
+		http.MethodPost: {http.StatusTooManyRequests},
+	}), func() (*http.Response, error) {
+		calls++
+		if calls < 3 {
+			return retryableStatusResponse(http.MethodPost, http.StatusTooManyRequests, &closes), nil
+		}
+		return okResponse(), nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 3, calls)
+	require.Equal(t, 2, closes, "each discarded 429 response body must be closed to avoid leaking the connection")
+	require.NoError(t, resp.Body.Close())
 }
 
 // A zero-value config (no caller wired a RetryConfig) must still run the request

--- a/server/internal/telemetry/roundtripper.go
+++ b/server/internal/telemetry/roundtripper.go
@@ -147,7 +147,13 @@ func (h *ToolCallLogRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "HTTP request failed")
-		h.logger.ErrorContext(ctx, "HTTP roundtrip failed",
+		// Log at WARN, not ERROR: this fires once per attempt, below the gateway's
+		// retry layer, so a transport error here is frequently retried and recovered
+		// transparently (e.g. the Fly autostop EOF race). Logging ERROR per attempt
+		// floods error dashboards with failures that never reached the caller. The
+		// gateway bubbles up the final, unrecovered failure as an ERROR once retries
+		// are exhausted.
+		h.logger.WarnContext(ctx, "HTTP roundtrip failed",
 			attr.SlogError(err),
 			attr.SlogURLOriginal(req.URL.String()),
 			attr.SlogHTTPRequestMethod(req.Method),

--- a/server/internal/telemetry/roundtripper_test.go
+++ b/server/internal/telemetry/roundtripper_test.go
@@ -1,0 +1,60 @@
+package telemetry_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type stubRoundTripper struct {
+	err error
+}
+
+func (s stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, s.err
+}
+
+// A transport error fires once per attempt, below the gateway's retry layer, so
+// it must log at WARN, not ERROR: retried-and-recovered failures (e.g. the Fly
+// autostop EOF race) should not flood error dashboards. The gateway logs the
+// final, unrecovered failure as an ERROR once retries are exhausted.
+func TestToolCallLogRoundTripper_TransportErrorLogsWarn(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	rt := tm.NewToolCallLogRoundTripper(
+		stubRoundTripper{err: io.EOF},
+		logger,
+		testenv.NewTracerProvider(t).Tracer("test"),
+		tm.ToolInfo{URN: "urn:gram:test"},
+		tm.HTTPLogAttributes{},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "https://app.fly.dev/tool-call", http.NoBody)
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.EOF)
+	require.Nil(t, resp)
+
+	var entry struct {
+		Level string `json:"level"`
+		Msg   string `json:"msg"`
+	}
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &entry))
+	require.Equal(t, "HTTP roundtrip failed", entry.Msg)
+	require.Equal(t, slog.LevelWarn.String(), entry.Level, "transport errors must log at WARN so recovered retries do not look like errors")
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2828/functions-retry-tool-call-posts-on-429-and-503-with-jittered-gateway

The gateway retried function tool-call transport errors but no status code for `POST`. After AGE-2818 a saturated runner sheds with `429 + Retry-After` before executing the function, and Fly returns `503` when the fleet is full and never delivered the request, so both are provably pre-execution and safe to retry even for non-idempotent `POST`s. Today they propagate straight to the agent/MCP client, surfacing transient saturation as hard failures.

- Add a per-method `retryConfig.retryableStatus` map wired per call-site: function tool-call/resource `POST`s retry only on `429`/`503`; HTTP tool `GET`s keep the broad transient-status preset; HTTP `POST`s are unchanged (never retried on status). `500`/`502`/`504` stay non-retried for `POST` to avoid double-execution.
- Jitter the retry backoff (full jitter layered on the delay floor, so a server `Retry-After` is honored as a floor) to spread a wave of simultaneously throttled retries and avoid a thundering herd.
- Demote the per-attempt `HTTP roundtrip failed` transport-error log from `ERROR` to `WARN`: it fires below the retry layer, so recovered retries no longer look like errors. The gateway still logs the final, unrecovered failure as `ERROR`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries function tool-call and resource-read POSTs on 429/503 with jittered backoff and proper Retry-After handling to hide transient runner saturation. Also downgrades per-attempt transport error logs and fixes leaked connections during retries. Addresses Linear AGE-2828.

- **New Features**
  - Function runner POSTs retry only on 429 and 503; honors Retry-After (seconds or HTTP-date); no retry on 500/502/504 to avoid double execution.
  - Per-method policy: function POSTs use the narrow set; HTTP tool GETs keep the broad transient-status preset; HTTP POSTs remain non-retried on status.
  - Jittered exponential backoff spreads retries with server Retry-After as a floor.
  - Transport errors during attempts now log at WARN; the final unrecovered failure still logs as ERROR.

- **Bug Fixes**
  - Discarded retry responses are drained and closed before the next attempt to prevent body/connection leaks and to reuse keep-alive connections.

<sup>Written for commit 4074b2ce8f72979b678d20f29b36b475b678bc02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

