### PR TITLE
feat(access): suppress challenges from users outside the organization

### DIFF
--- a/.changeset/ais-104-suppress-challenges-outside-org.md
+++ b/.changeset/ais-104-suppress-challenges-outside-org.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The Challenge UI now suppresses challenges raised by users outside the organization. Previously, when a Speakeasy staff member impersonated a customer org their authz decisions appeared as challenge entries — and because internal users switch accounts frequently, these entries repeatedly cluttered the list. `access.listChallenges` and `access.listChallengeBuckets` now only return challenges whose principal is an active member of the organization or has no Gram user identity (e.g. API keys and external end-users); challenges from Gram users who are not members of the org are filtered out in ClickHouse so counts and pagination stay correct.

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -672,6 +672,22 @@ type challengeUserInfo struct {
 	photoURL *string
 }
 
+// activeOrgMemberUserIDs returns the Gram user IDs of active members of the
+// organization. The challenge UI uses it to suppress challenges raised by users
+// outside the organization — e.g. Speakeasy staff impersonating a customer org,
+// whose entries otherwise clutter the list while they switch accounts. Always
+// returns a non-nil slice so callers unconditionally apply the suppression.
+func (s *Service) activeOrgMemberUserIDs(ctx context.Context, orgID string) ([]string, error) {
+	ids, err := orgrepo.New(s.db).ListActiveOrganizationUserIDs(ctx, orgID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list active org member ids").LogError(ctx, s.logger)
+	}
+	if ids == nil {
+		ids = []string{}
+	}
+	return ids, nil
+}
+
 func (s *Service) fetchChallengeUserInfo(ctx context.Context, userIDs []string) map[string]challengeUserInfo {
 	userMap := make(map[string]challengeUserInfo, len(userIDs))
 	if len(userIDs) == 0 {
@@ -725,6 +741,13 @@ func (s *Service) ListChallenges(ctx context.Context, payload *gen.ListChallenge
 	// apply the resolved filter in Go, then slice for the requested page.
 	skipPagination := payload.Resolved != nil
 
+	// Suppress challenges from users outside the org so counts and pagination
+	// stay correct (filtering happens in ClickHouse, before grouping/paging).
+	memberIDs, err := s.activeOrgMemberUserIDs(ctx, authCtx.ActiveOrganizationID)
+	if err != nil {
+		return nil, err
+	}
+
 	filters := chrepo.ChallengeListFilters{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      payload.ProjectID,
@@ -734,6 +757,7 @@ func (s *Service) ListChallenges(ctx context.Context, payload *gen.ListChallenge
 		Limit:          uint64(payload.Limit),  //nolint:gosec // Goa validates 1..200
 		Offset:         uint64(payload.Offset), //nolint:gosec // Goa validates >= 0
 		SkipPagination: skipPagination,
+		MemberUserIDs:  memberIDs,
 	}
 
 	var total uint64
@@ -928,6 +952,12 @@ func (s *Service) ListChallengeBuckets(ctx context.Context, payload *gen.ListCha
 
 	skipPagination := payload.Resolved != nil
 
+	// Suppress challenges from users outside the org (see activeOrgMemberUserIDs).
+	memberIDs, err := s.activeOrgMemberUserIDs(ctx, authCtx.ActiveOrganizationID)
+	if err != nil {
+		return nil, err
+	}
+
 	filters := chrepo.ChallengeListFilters{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      payload.ProjectID,
@@ -937,6 +967,7 @@ func (s *Service) ListChallengeBuckets(ctx context.Context, payload *gen.ListCha
 		Limit:          uint64(payload.Limit),  //nolint:gosec // Goa validates 1..200
 		Offset:         uint64(payload.Offset), //nolint:gosec // Goa validates >= 0
 		SkipPagination: skipPagination,
+		MemberUserIDs:  memberIDs,
 	}
 
 	chQueries := chrepo.New(s.chConn)

--- a/server/internal/access/list_challenge_buckets_test.go
+++ b/server/internal/access/list_challenge_buckets_test.go
@@ -249,6 +249,53 @@ func TestListChallengeBuckets_Pagination(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
+// TestListChallengeBuckets_SuppressesUsersOutsideOrg mirrors the row-level test
+// for the bucketed endpoint: member and unknown-principal buckets survive, the
+// outside-org user's bucket is suppressed, and the total reflects the filter.
+func TestListChallengeBuckets_SuppressesUsersOutsideOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newChallengeTestService(t)
+	orgID := challengeAuthContext(t, ctx).ActiveOrganizationID
+
+	memberID := seedOrgMember(t, ctx, ti, orgID, "member@example.com")
+	insertCHChallengeWithUser(t, ti, orgID, uuid.NewString(), "deny", "user:"+memberID, "org:read", &memberID, nil)
+
+	insertCHChallengeWithUser(t, ti, orgID, uuid.NewString(), "deny", "api_key:ext", "org:read", nil, nil)
+
+	outsiderID := seedNonMemberUser(t, ctx, ti, "staff@speakeasy.com")
+	insertCHChallengeWithUser(t, ti, orgID, uuid.NewString(), "deny", "user:"+outsiderID, "org:read", &outsiderID, nil)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      nil,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     nil,
+			Limit:        20,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, result) {
+			return
+		}
+		urns := make(map[string]bool, len(result.Buckets))
+		for _, b := range result.Buckets {
+			urns[b.PrincipalUrn] = true
+		}
+		assert.Len(c, result.Buckets, 2)
+		assert.Equal(c, 2, result.Total)
+		assert.True(c, urns["user:"+memberID], "org member bucket should be present")
+		assert.True(c, urns["api_key:ext"], "unknown principal bucket should be present")
+		assert.False(c, urns["user:"+outsiderID], "outside-org user bucket should be suppressed")
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
 func TestListChallengeBuckets_IsolatesByOrganization(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/access/list_challenges_test.go
+++ b/server/internal/access/list_challenges_test.go
@@ -169,6 +169,14 @@ func TestListChallenges_EnrichesWithUserData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Make the user an active member of the org, otherwise the challenge is
+	// suppressed as belonging to a user outside the organization.
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.PtrToPGText(&userID),
+	})
+	require.NoError(t, err)
+
 	challengeID := uuid.NewString()
 	insertCHChallengeWithUser(t, ti, authCtx.ActiveOrganizationID, challengeID, "deny", fmt.Sprintf("user:%s", userID), "org:read", &userID, nil)
 
@@ -191,6 +199,56 @@ func TestListChallenges_EnrichesWithUserData(t *testing.T) {
 	require.Equal(t, "alice@example.com", *c.UserEmail)
 	require.NotNil(t, c.PhotoURL)
 	require.Equal(t, "https://example.com/alice.jpg", *c.PhotoURL)
+}
+
+// TestListChallenges_SuppressesUsersOutsideOrg proves the suppression boundary:
+// challenges from active org members and from unknown/external principals (no
+// Gram user identity, e.g. api keys) are still returned, while challenges from
+// Gram users who are NOT members of the org (e.g. Speakeasy staff impersonating
+// a customer org) are suppressed.
+func TestListChallenges_SuppressesUsersOutsideOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newChallengeTestService(t)
+	orgID := challengeAuthContext(t, ctx).ActiveOrganizationID
+
+	// 1. Active org member — kept.
+	memberID := seedOrgMember(t, ctx, ti, orgID, "member@example.com")
+	memberChallenge := uuid.NewString()
+	insertCHChallengeWithUser(t, ti, orgID, memberChallenge, "deny", "user:"+memberID, "org:read", &memberID, nil)
+
+	// 2. Unknown principal with no Gram user identity (api key / external
+	//    end-user) — kept; user_id is NULL.
+	unknownChallenge := uuid.NewString()
+	insertCHChallengeWithUser(t, ti, orgID, unknownChallenge, "deny", "api_key:ext", "org:read", nil, nil)
+
+	// 3. Gram user outside the org (Speakeasy staff impersonating) — suppressed.
+	outsiderID := seedNonMemberUser(t, ctx, ti, "staff@speakeasy.com")
+	outsiderChallenge := uuid.NewString()
+	insertCHChallengeWithUser(t, ti, orgID, outsiderChallenge, "deny", "user:"+outsiderID, "org:read", &outsiderID, nil)
+
+	result, err := ti.service.ListChallenges(ctx, &gen.ListChallengesPayload{
+		Outcome:      nil,
+		PrincipalUrn: nil,
+		Scope:        nil,
+		ProjectID:    nil,
+		Resolved:     nil,
+		Limit:        20,
+		Offset:       0,
+		ApikeyToken:  nil,
+		SessionToken: nil,
+	})
+	require.NoError(t, err)
+
+	got := make(map[string]bool, len(result.Challenges))
+	for _, c := range result.Challenges {
+		got[c.ID] = true
+	}
+	require.True(t, got[memberChallenge], "org member's challenge should be returned")
+	require.True(t, got[unknownChallenge], "unknown/external principal's challenge should be returned")
+	require.False(t, got[outsiderChallenge], "challenge from a user outside the org should be suppressed")
+	require.Len(t, result.Challenges, 2)
+	require.Equal(t, 2, result.Total)
 }
 
 func TestListChallenges_FilterByOutcome(t *testing.T) {
@@ -359,6 +417,37 @@ func newChallengeTestService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	return ctx, ti
+}
+
+// seedOrgMember creates a Gram user and makes them an active member of the org,
+// returning the user ID.
+func seedOrgMember(t *testing.T, ctx context.Context, ti *testInstance, orgID, email string) string {
+	t.Helper()
+
+	userID := seedNonMemberUser(t, ctx, ti, email)
+	_, err := orgrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: orgID,
+		UserID:         conv.PtrToPGText(&userID),
+	})
+	require.NoError(t, err)
+	return userID
+}
+
+// seedNonMemberUser creates a Gram user with no org membership (e.g. a Speakeasy
+// staff member impersonating a customer org), returning the user ID.
+func seedNonMemberUser(t *testing.T, ctx context.Context, ti *testInstance, email string) string {
+	t.Helper()
+
+	userID := uuid.NewString()
+	_, err := usersrepo.New(ti.conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: email,
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	return userID
 }
 
 func challengeAuthContext(t *testing.T, ctx context.Context) *contextvalues.AuthContext {

--- a/server/internal/authz/repo/queries.go
+++ b/server/internal/authz/repo/queries.go
@@ -139,6 +139,13 @@ type ChallengeListFilters struct {
 	Limit          uint64
 	Offset         uint64
 	SkipPagination bool // when true, omit LIMIT/OFFSET (used when resolved filter requires post-join pagination)
+
+	// MemberUserIDs, when non-nil, suppresses challenges raised by users outside
+	// the organization (e.g. Speakeasy staff impersonating a customer org). Rows
+	// are kept only when user_id is NULL (non-user principals such as api keys and
+	// assistants) or user_id is one of these active org-member IDs. An empty
+	// non-nil slice keeps only the NULL-user_id rows.
+	MemberUserIDs []string
 }
 
 // challengeWhere applies ChallengeListFilters to a squirrel SelectBuilder.
@@ -155,6 +162,19 @@ func challengeWhere(sb squirrel.SelectBuilder, f ChallengeListFilters) squirrel.
 	}
 	if f.Scope != nil {
 		sb = sb.Where("scope = ?", *f.Scope)
+	}
+	if f.MemberUserIDs != nil {
+		// Keep non-user principals (user_id IS NULL) plus active org members.
+		// squirrel.Eq with an empty slice renders as a false predicate, so an
+		// empty MemberUserIDs collapses this to "user_id IS NULL".
+		//
+		// The column is qualified with the table name because the bucket query
+		// aliases argMax(user_id, timestamp) AS user_id, and ClickHouse resolves
+		// a bare user_id in WHERE to that aggregate alias (illegal in WHERE).
+		sb = sb.Where(squirrel.Or{
+			squirrel.Expr("authz_challenges.user_id IS NULL"),
+			squirrel.Eq{"authz_challenges.user_id": f.MemberUserIDs},
+		})
 	}
 	return sb
 }

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -101,6 +101,17 @@ JOIN users u ON u.id = our.user_id
 WHERE our.organization_id = @organization_id
   AND our.deleted_at IS NULL;
 
+-- name: ListActiveOrganizationUserIDs :many
+-- Returns the Gram user IDs of active members of the organization. Used to
+-- suppress challenges raised by users outside the organization (e.g. Speakeasy
+-- staff impersonating a customer org) from the Challenge UI.
+SELECT u.id
+FROM organization_user_relationships our
+JOIN users u ON u.id = our.user_id
+WHERE our.organization_id = @organization_id
+  AND our.deleted_at IS NULL
+  AND u.deleted_at IS NULL;
+
 -- name: DeleteOrganizationUserRelationship :exec
 UPDATE organization_user_relationships
 SET deleted_at = clock_timestamp()

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -749,6 +749,38 @@ func (q *Queries) LinkRoleAssignmentsToUser(ctx context.Context, arg LinkRoleAss
 	return err
 }
 
+const listActiveOrganizationUserIDs = `-- name: ListActiveOrganizationUserIDs :many
+SELECT u.id
+FROM organization_user_relationships our
+JOIN users u ON u.id = our.user_id
+WHERE our.organization_id = $1
+  AND our.deleted_at IS NULL
+  AND u.deleted_at IS NULL
+`
+
+// Returns the Gram user IDs of active members of the organization. Used to
+// suppress challenges raised by users outside the organization (e.g. Speakeasy
+// staff impersonating a customer org) from the Challenge UI.
+func (q *Queries) ListActiveOrganizationUserIDs(ctx context.Context, organizationID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listActiveOrganizationUserIDs, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listActiveRoleAssignmentsByOrganization = `-- name: ListActiveRoleAssignmentsByOrganization :many
 SELECT
     ora.user_id,


### PR DESCRIPTION
## What

Suppress challenges raised by users **outside the organization** from the Challenge UI.

When a Speakeasy staff member impersonates a customer org, their authz decisions were logged as `user`-principal challenge entries. Because internal users switch accounts frequently, these entries repeatedly cluttered the list (see [AIS-104](https://linear.app/speakeasy/issue/AIS-104)).

## How

Filtering happens **in ClickHouse, before grouping/paging**, so `Total` and pagination stay correct.

- New PG query `ListActiveOrganizationUserIDs` — active member user IDs for an org.
- New `MemberUserIDs` filter on `ChallengeListFilters`; `challengeWhere` keeps a row only when
  `user_id IS NULL` (non-user principals: API keys, external end-users) **or** `user_id` is an active org member.
- `ListChallenges` and `ListChallengeBuckets` fetch member IDs and apply the filter.

**Keep:** org members + unknown/external principals (no Gram user identity).
**Drop:** Gram users not in the org (impersonating staff).

### Note for reviewers

The bucket query aliases `argMax(user_id, timestamp) AS user_id`. ClickHouse resolves a bare `user_id` in `WHERE` to that aggregate alias (illegal in `WHERE`), so the predicate is qualified as `authz_challenges.user_id`.

## Tests

- `TestListChallenges_SuppressesUsersOutsideOrg` / `TestListChallengeBuckets_SuppressesUsersOutsideOrg`: member + unknown-principal challenges returned, outsider suppressed, counts correct.
- `TestListChallenges_EnrichesWithUserData` updated to seed org membership.
- All `internal/access` challenge tests pass; `lint:server` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress challenges from users outside the organization in the Challenge UI to reduce clutter from staff impersonation (AIS-104). Filtering occurs in ClickHouse before grouping and paging, so totals and pagination stay correct.

- **Bug Fixes**
  - `access.listChallenges` and `access.listChallengeBuckets` now only keep rows where `user_id` is NULL or an active org member; outside-org users are dropped.
  - Added `ListActiveOrganizationUserIDs` to fetch active member IDs and passed them via `MemberUserIDs` on `ChallengeListFilters` for server-side filtering.
  - Added tests for suppression in both list and bucket endpoints; updated user enrichment test to seed org membership.

<sup>Written for commit d1e1b98dc601c1d8de0230fc4f889a94670c641d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

