### PR TITLE
chore: reuse risk analysis helpers in realtime scanner

### DIFF
--- a/server/internal/background/activities/risk_analysis/celadapter.go
+++ b/server/internal/background/activities/risk_analysis/celadapter.go
@@ -8,17 +8,8 @@ import (
 	"github.com/google/cel-go/cel"
 
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
 )
-
-// This file is the CEL evaluation path for custom detection and policy scopes,
-// backed by internal/risk/celenv. Rules store a CEL detection predicate
-// (detection_expr, legacy regex evaluated as content.matchRegex(regex)); policies
-// store CEL scope predicates (scope_include / scope_exempt).
-//
-// The CEL engine is immutable and Eval is thread-safe, so a single instance is
-// constructed once at each composition root (server start, worker activities)
-// and injected into the consumers (Scanner, Service, AnalyzeBatch) rather than
-// reached through a package global.
 
 // celMessage adapts the structured MessageView into the celenv input model.
 func celMessage(view MessageView) celenv.Message {
@@ -29,10 +20,8 @@ func celMessage(view MessageView) celenv.Message {
 	return celenv.Message{Content: view.Content, Type: view.Type, Tools: tools}
 }
 
-// effectiveDetectionExpr returns the CEL predicate a rule should evaluate: its
-// detection_expr when set, else a synthesized content.matchRegex(regex) for a legacy
-// regex rule, else empty (no matcher configured).
-func effectiveDetectionExpr(rule CustomDetectionRule) string {
+// effectiveDetectionExpr returns the stored CEL predicate or a legacy regex fallback.
+func effectiveDetectionExpr(rule customrules.Rule) string {
 	if expr := strings.TrimSpace(rule.DetectionExpr); expr != "" {
 		return expr
 	}
@@ -44,14 +33,12 @@ func effectiveDetectionExpr(rule CustomDetectionRule) string {
 
 // CompiledCELRule is a custom rule whose detection predicate is compiled once.
 type CompiledCELRule struct {
-	rule CustomDetectionRule
+	rule customrules.Rule
 	prg  cel.Program
 }
 
-// CompileCELRules compiles each rule's detection predicate (rules without a
-// matcher are skipped). A nil engine yields no rules, so a failed CEL env skips
-// custom-rule detection rather than panicking in the scan.
-func CompileCELRules(eng *celenv.Engine, rules []CustomDetectionRule) ([]CompiledCELRule, error) {
+// CompileCELRules compiles each rule's detection predicate.
+func CompileCELRules(eng *celenv.Engine, rules []customrules.Rule) ([]CompiledCELRule, error) {
 	if eng == nil {
 		return []CompiledCELRule{}, nil
 	}
@@ -71,9 +58,7 @@ func CompileCELRules(eng *celenv.Engine, rules []CustomDetectionRule) ([]Compile
 	return out, nil
 }
 
-// ScanCELRules evaluates the (detector) rules over a view, producing one Finding
-// per recorded span. Custom rules are pure detectors; message exemptions are
-// handled by the policy's scope_exempt (CompiledScope.Exempts), not by rules.
+// ScanCELRules evaluates custom detector rules over a message view.
 func ScanCELRules(eng *celenv.Engine, view MessageView, rules []CompiledCELRule) ([]Finding, error) {
 	msg := celMessage(view)
 	findings := []Finding{}
@@ -106,7 +91,7 @@ func ScanCELRules(eng *celenv.Engine, view MessageView, rules []CompiledCELRule)
 	return findings, nil
 }
 
-func celRuleDescription(rule CustomDetectionRule) string {
+func celRuleDescription(rule customrules.Rule) string {
 	if strings.TrimSpace(rule.Description) != "" {
 		return rule.Description
 	}
@@ -116,15 +101,14 @@ func celRuleDescription(rule CustomDetectionRule) string {
 	return rule.RuleID
 }
 
-// CompiledScope is a policy's compiled scope predicates. A nil include is
-// all-in; a nil exempt is none-exempt.
+// CompiledScope is a policy's compiled scope predicates.
 type CompiledScope struct {
 	eng     *celenv.Engine
 	include cel.Program
 	exempt  cel.Program
 }
 
-// CompileScope compiles a policy's scope predicates (empty strings -> nil).
+// CompileScope compiles a policy's scope predicates.
 func CompileScope(eng *celenv.Engine, includeCEL, exemptCEL string) (CompiledScope, error) {
 	var s CompiledScope
 	s.eng = eng
@@ -148,8 +132,7 @@ func CompileScope(eng *celenv.Engine, includeCEL, exemptCEL string) (CompiledSco
 // Active reports whether the scope has any predicate to evaluate.
 func (s CompiledScope) Active() bool { return s.include != nil || s.exempt != nil }
 
-// Includes reports whether a message is in scope (nil include = all-in). An
-// eval error fails toward scanning so detection is never silently skipped.
+// Includes reports whether a message is in scope.
 func (s CompiledScope) Includes(view MessageView) bool {
 	if s.include == nil {
 		return true
@@ -161,8 +144,7 @@ func (s CompiledScope) Includes(view MessageView) bool {
 	return in
 }
 
-// Exempts reports whether a message is exempted (nil exempt = none). An eval
-// error fails toward scanning (not exempt).
+// Exempts reports whether a message is exempted.
 func (s CompiledScope) Exempts(view MessageView) bool {
 	if s.exempt == nil {
 		return false

--- a/server/internal/background/activities/risk_analysis/celadapter_test.go
+++ b/server/internal/background/activities/risk_analysis/celadapter_test.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/message"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
 )
 
-func celRules(t *testing.T, rules ...CustomDetectionRule) []CompiledCELRule {
+func celRules(t *testing.T, rules ...customrules.Rule) []CompiledCELRule {
 	t.Helper()
 	eng, err := celenv.New()
 	require.NoError(t, err)
@@ -31,7 +32,7 @@ func scanCEL(t *testing.T, view MessageView, rules []CompiledCELRule) []Finding 
 // matched span.
 func TestScanCELRules_CorrelatedToolRule(t *testing.T) {
 	t.Parallel()
-	rules := celRules(t, CustomDetectionRule{
+	rules := celRules(t, customrules.Rule{
 		RuleID:        "custom.bash_drop",
 		Title:         "bash drop table",
 		Description:   "destructive SQL via a bash tool",
@@ -60,7 +61,7 @@ func TestScanCELRules_CorrelatedToolRule(t *testing.T) {
 // Correlation does not cross tools.
 func TestScanCELRules_CorrelationDoesNotCrossTools(t *testing.T) {
 	t.Parallel()
-	rules := celRules(t, CustomDetectionRule{
+	rules := celRules(t, customrules.Rule{
 		RuleID:        "custom.bash_drop",
 		DetectionExpr: `tool_calls.exists(t, t.function.matchRegex("bash") && t.args.get("command").matchRegex("DROP TABLE"))`,
 	})
@@ -79,7 +80,7 @@ func TestScanCELRules_CorrelationDoesNotCrossTools(t *testing.T) {
 // A content rule yields one finding per occurrence.
 func TestScanCELRules_ContentRule(t *testing.T) {
 	t.Parallel()
-	rules := celRules(t, CustomDetectionRule{
+	rules := celRules(t, customrules.Rule{
 		RuleID:        "custom.secret",
 		DetectionExpr: `content.matchRegex("secret")`,
 	})
@@ -93,7 +94,7 @@ func TestScanCELRules_ContentRule(t *testing.T) {
 // Legacy regex rules (no detection_expr) evaluate as content.matchRegex(regex).
 func TestScanCELRules_LegacyRegexFallback(t *testing.T) {
 	t.Parallel()
-	rules := celRules(t, CustomDetectionRule{
+	rules := celRules(t, customrules.Rule{
 		RuleID: "custom.legacy",
 		Regex:  "AKIA[0-9A-Z]{16}",
 	})

--- a/server/internal/background/activities/risk_analysis/finding.go
+++ b/server/internal/background/activities/risk_analysis/finding.go
@@ -1,8 +1,6 @@
 package risk_analysis
 
 // Finding represents a single secret or sensitive data match found in a message.
-// DeadLetterReason is populated only on synthetic "could not analyze" markers
-// emitted when a scanner exhausts its retry budget for a message.
 type Finding struct {
 	RuleID           string
 	Description      string

--- a/server/internal/background/activities/risk_analysis/message_view.go
+++ b/server/internal/background/activities/risk_analysis/message_view.go
@@ -7,40 +7,18 @@ import (
 
 const SourceCustom = "custom"
 
-// FindingSpan is one matched span attributed to a finding, persisted as an
-// element of risk_results.spans (a JSON array). A finding may carry several
-// correlated spans — e.g. a custom rule matching a tool's function name and its
-// arguments on the same call.
+// FindingSpan is one matched span attributed to a finding.
 type FindingSpan struct {
 	Match string `json:"match"`
-	// Field is the message field the span matched, in author-facing form
-	// (content/prompt/assistant/output or tool.name/tool.server/tool.function/
-	// tool.args). Empty for detectors that don't attribute a field (gitleaks,
-	// presidio, legacy rows).
+	// Field is the author-facing message field the span matched.
 	Field string `json:"field,omitempty"`
-	// Path is the gjson sub-path within Field for `.get(...)` matches (e.g.
-	// "command", "payload.sql"). Empty when the whole field value matched.
+	// Path is the gjson sub-path within Field for `.get(...)` matches.
 	Path     string `json:"path,omitempty"`
 	StartPos int    `json:"start_pos"`
 	EndPos   int    `json:"end_pos"`
 }
 
-// CustomDetectionRule is a policy-selected custom rule as loaded from the
-// database. DetectionExpr is the rule's CEL detection predicate; when empty the
-// rule falls back to its legacy Regex column (evaluated as content.match(regex)).
-// Custom rules are pure detectors. Evaluation goes through CompileCELRules /
-// ScanCELRules.
-type CustomDetectionRule struct {
-	RuleID        string
-	Title         string
-	Description   string
-	DetectionExpr string
-	Regex         string
-}
-
-// ToolView is one tool invocation surfaced from a message's recorded tool
-// calls. Server/Function are the destructured MCP components (Server is "" for
-// native/harness tools); Arguments is the raw arguments JSON.
+// ToolView is one tool invocation surfaced from a message's recorded tool calls.
 type ToolView struct {
 	Name      string
 	Server    string
@@ -48,19 +26,14 @@ type ToolView struct {
 	Arguments string
 }
 
-// MessageView is the structured input the CEL engine evaluates against. Both
-// scan paths (batch analyzer and realtime scanner) build an identical view so a
-// rule behaves the same in either path. Content is the message's raw text body;
-// Tools is populated for tool-request messages.
+// MessageView is the structured input the CEL engine evaluates against.
 type MessageView struct {
 	Content string
 	Type    message.Type
 	Tools   []ToolView
 }
 
-// NewToolView destructures a tool-call name into its MCP server/function
-// components (Server is "" for native/harness tools) and pairs them with the
-// raw arguments JSON, for one entry of a MessageView's Tools.
+// NewToolView destructures a tool-call name and pairs it with raw arguments.
 func NewToolView(name, arguments string) ToolView {
 	return ToolView{
 		Name:      name,

--- a/server/internal/background/activities/risk_analysis/prompt_judge_batch.go
+++ b/server/internal/background/activities/risk_analysis/prompt_judge_batch.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/activity"
 
-	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/risk/policyflags"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 )
 
@@ -70,18 +70,5 @@ func (a *AnalyzeBatch) scanPromptPolicy(ctx context.Context, args AnalyzeBatchAr
 }
 
 func (a *AnalyzeBatch) projectFlagEnabled(ctx context.Context, orgID string, projectID uuid.UUID, flag feature.Flag) bool {
-	if a.flags == nil {
-		return false
-	}
-	groups, err := repo.New(a.db).GetProjectFlagGroups(ctx, projectID)
-	if err != nil {
-		a.logger.WarnContext(ctx, "resolve project flag groups failed", attr.SlogError(err), attr.SlogOrganizationID(orgID), attr.SlogProjectID(projectID.String()))
-		return false
-	}
-	on, err := a.flags.IsFlagEnabled(ctx, flag, orgID, feature.OrgProjectGroups(groups.OrganizationSlug, groups.ProjectSlug))
-	if err != nil {
-		a.logger.WarnContext(ctx, "project flag check failed", attr.SlogError(err), attr.SlogOrganizationID(orgID))
-		return false
-	}
-	return on
+	return policyflags.ProjectFlagEnabled(ctx, a.logger, repo.New(a.db), a.flags, orgID, projectID, flag)
 }

--- a/server/internal/background/activities/risk_analysis/scan_custom_rules.go
+++ b/server/internal/background/activities/risk_analysis/scan_custom_rules.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/activity"
 
+	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 )
 
@@ -24,35 +25,11 @@ func (a *AnalyzeBatch) scanCustomRules(ctx context.Context, messages []batchMess
 }
 
 func (a *AnalyzeBatch) customRulesForPolicy(ctx context.Context, projectID uuid.UUID, detectorIDs []string) ([]CompiledCELRule, error) {
-	if len(detectorIDs) == 0 {
-		return []CompiledCELRule{}, nil
-	}
-
-	rules, err := repo.New(a.db).ListCustomDetectionRules(ctx, projectID)
+	rules, err := customrules.LoadSelected(ctx, repo.New(a.db), projectID, detectorIDs)
 	if err != nil {
-		return []CompiledCELRule{}, fmt.Errorf("list custom detection rules: %w", err)
+		return []CompiledCELRule{}, fmt.Errorf("load custom detection rules: %w", err)
 	}
-
-	detectors := make(map[string]struct{}, len(detectorIDs))
-	for _, id := range detectorIDs {
-		detectors[id] = struct{}{}
-	}
-
-	customRules := make([]CustomDetectionRule, 0, len(detectors))
-	for _, rule := range rules {
-		if _, ok := detectors[rule.RuleID]; !ok {
-			continue
-		}
-		customRules = append(customRules, CustomDetectionRule{
-			RuleID:        rule.RuleID,
-			Title:         rule.Title,
-			Description:   rule.Description,
-			DetectionExpr: rule.DetectionExpr.String,
-			Regex:         rule.Regex.String,
-		})
-	}
-
-	compiled, err := CompileCELRules(a.celEng, customRules)
+	compiled, err := CompileCELRules(a.celEng, rules)
 	if err != nil {
 		return []CompiledCELRule{}, fmt.Errorf("compile custom detection rules: %w", err)
 	}

--- a/server/internal/risk/customrules/customrules.go
+++ b/server/internal/risk/customrules/customrules.go
@@ -1,0 +1,49 @@
+package customrules
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+type Rule struct {
+	RuleID        string
+	Title         string
+	Description   string
+	DetectionExpr string
+	Regex         string
+}
+
+func LoadSelected(ctx context.Context, queries *repo.Queries, projectID uuid.UUID, detectorIDs []string) ([]Rule, error) {
+	if len(detectorIDs) == 0 {
+		return []Rule{}, nil
+	}
+
+	rules, err := queries.ListCustomDetectionRules(ctx, projectID)
+	if err != nil {
+		return []Rule{}, fmt.Errorf("list custom detection rules: %w", err)
+	}
+
+	detectors := make(map[string]struct{}, len(detectorIDs))
+	for _, id := range detectorIDs {
+		detectors[id] = struct{}{}
+	}
+
+	customRules := make([]Rule, 0, len(detectors))
+	for _, rule := range rules {
+		if _, ok := detectors[rule.RuleID]; !ok {
+			continue
+		}
+		customRules = append(customRules, Rule{
+			RuleID:        rule.RuleID,
+			Title:         rule.Title,
+			Description:   rule.Description,
+			DetectionExpr: rule.DetectionExpr.String,
+			Regex:         rule.Regex.String,
+		})
+	}
+	return customRules, nil
+}

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -45,6 +45,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -237,7 +238,7 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 
 	policyType := payload.PolicyType
 	if policyType == "" {
-		policyType = "standard"
+		policyType = ra.PolicyTypeStandard
 	}
 	if err := validatePolicyType(policyType); err != nil {
 		return nil, err
@@ -248,7 +249,7 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 	// during the MVP.
 	var prompt pgtype.Text
 	var modelConfig []byte
-	if policyType == "prompt_based" {
+	if policyType == ra.PolicyTypePromptBased {
 		if !s.promptPoliciesEnabled(ctx, authCtx) {
 			return nil, oops.E(oops.CodeForbidden, nil, "prompt-based policies are not enabled for this organization")
 		}
@@ -264,13 +265,13 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 	}
 
 	sources := payload.Sources
-	if policyType == "prompt_based" {
+	if policyType == ra.PolicyTypePromptBased {
 		// prompt_based policies evaluate the prompt via the LLM judge, not
 		// detection sources. Persist an empty (non-null) source set.
 		sources = []string{}
 	} else {
 		if sources == nil {
-			sources = []string{"gitleaks"}
+			sources = []string{ra.SourceGitleaks}
 		}
 		if err := validateSources(sources); err != nil {
 			return nil, err
@@ -316,7 +317,7 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		for _, p := range existingPolicies {
 			existingNames = append(existingNames, p.Name)
 		}
-		if policyType == "prompt_based" {
+		if policyType == ra.PolicyTypePromptBased {
 			name = s.generatePromptPolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), prompt.String, existingNames)
 		} else {
 			customRuleTitles := s.customRuleTitlesForIDs(ctx, *authCtx.ProjectID, payload.CustomRuleIds)
@@ -487,13 +488,13 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 	}
 
 	// policy_type is immutable; gate edits to prompt_based policies behind the flag.
-	if current.PolicyType == "prompt_based" && !s.promptPoliciesEnabled(ctx, authCtx) {
+	if current.PolicyType == ra.PolicyTypePromptBased && !s.promptPoliciesEnabled(ctx, authCtx) {
 		return nil, oops.E(oops.CodeForbidden, nil, "prompt-based policies are not enabled for this organization")
 	}
-	if current.PolicyType == "standard" && (payload.Prompt != nil || payload.ModelConfig != nil) {
+	if current.PolicyType == ra.PolicyTypeStandard && (payload.Prompt != nil || payload.ModelConfig != nil) {
 		return nil, oops.E(oops.CodeInvalid, nil, "prompt and model_config are only supported for prompt-based policies")
 	}
-	if current.PolicyType == "prompt_based" && payloadHasPromptPolicyDetectionConfig(payload) {
+	if current.PolicyType == ra.PolicyTypePromptBased && payloadHasPromptPolicyDetectionConfig(payload) {
 		return nil, oops.E(oops.CodeInvalid, nil, "prompt-based policies do not support detection source configuration")
 	}
 
@@ -613,7 +614,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 	prompt := current.Prompt
 	if payload.Prompt != nil {
 		p := strings.TrimSpace(*payload.Prompt)
-		if current.PolicyType == "prompt_based" && p == "" {
+		if current.PolicyType == ra.PolicyTypePromptBased && p == "" {
 			return nil, oops.E(oops.CodeInvalid, nil, "prompt must not be empty for prompt-based policies")
 		}
 		if len([]rune(p)) > maxPromptPolicyPromptLength {
@@ -642,7 +643,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 				existingNames = append(existingNames, p.Name)
 			}
 		}
-		if current.PolicyType == "prompt_based" {
+		if current.PolicyType == ra.PolicyTypePromptBased {
 			name = s.generatePromptPolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), prompt.String, existingNames)
 		} else {
 			customRuleTitles := s.customRuleTitlesForIDs(ctx, *authCtx.ProjectID, customRuleIds)
@@ -2270,7 +2271,7 @@ func (s *Service) testCustomRule(ruleID, detectionExpr, text string) (*gen.TestD
 	// The playground only has pasted text, so it evaluates against a user
 	// message (content/prompt populated, no tool calls). Tool-targeted rules
 	// simply won't match here; save them and run analysis to see matches.
-	compiled, err := ra.CompileCELRules(eng, []ra.CustomDetectionRule{{
+	compiled, err := ra.CompileCELRules(eng, []customrules.Rule{{
 		RuleID:        ruleID,
 		Title:         "",
 		Description:   "Custom rule match",
@@ -2281,7 +2282,7 @@ func (s *Service) testCustomRule(ruleID, detectionExpr, text string) (*gen.TestD
 		return nil, oops.E(oops.CodeInvalid, err, "invalid detection_expr")
 	}
 
-	findings, err := ra.ScanCELRules(eng, ra.MessageView{Content: text, Type: message.User, Tools: nil}, compiled)
+	findings, err := ra.ScanCELRules(eng, ra.MessageView{Content: text, Type: message.User, Tools: []ra.ToolView{}}, compiled)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "evaluate detection rule")
 	}
@@ -2516,9 +2517,9 @@ func sourcesToCategoryLabels(sources []string) []string {
 	out := make([]string, 0, len(sources))
 	for _, src := range sources {
 		switch src {
-		case "gitleaks":
+		case ra.SourceGitleaks:
 			out = append(out, "Secrets")
-		case "presidio":
+		case ra.SourcePresidio:
 			out = append(out, "PII")
 		case shadowmcp.SourceShadowMCP:
 			out = append(out, "Shadow MCP")
@@ -2631,7 +2632,7 @@ func validateAction(action string) error {
 func validateSources(sources []string) error {
 	for _, src := range sources {
 		switch src {
-		case "gitleaks", "presidio", shadowmcp.SourceShadowMCP, shadowmcp.SourceDestructiveTool, ra.SourceCLIDestructive, ra.SourcePromptInjection:
+		case ra.SourceGitleaks, ra.SourcePresidio, shadowmcp.SourceShadowMCP, shadowmcp.SourceDestructiveTool, ra.SourceCLIDestructive, ra.SourcePromptInjection:
 		default:
 			return oops.E(oops.CodeInvalid, nil, "source %q is not a recognized policy source", src)
 		}
@@ -2664,7 +2665,7 @@ func validatePolicyName(name string) error {
 // validatePolicyType ensures policy_type is one of the supported discriminators.
 func validatePolicyType(policyType string) error {
 	switch policyType {
-	case "standard", "prompt_based":
+	case ra.PolicyTypeStandard, ra.PolicyTypePromptBased:
 		return nil
 	default:
 		return oops.E(oops.CodeInvalid, nil, "policy_type must be one of: standard, prompt_based")
@@ -2688,7 +2689,7 @@ func payloadHasCreatePromptPolicyDetectionConfig(payload *gen.CreateRiskPolicyPa
 }
 
 func createPolicyDetectionField(policyType string, values []string) []string {
-	if policyType == "prompt_based" {
+	if policyType == ra.PolicyTypePromptBased {
 		return nil
 	}
 	return values

--- a/server/internal/risk/policyflags/policyflags.go
+++ b/server/internal/risk/policyflags/policyflags.go
@@ -1,0 +1,29 @@
+package policyflags
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+func ProjectFlagEnabled(ctx context.Context, logger *slog.Logger, queries *repo.Queries, flags feature.Provider, orgID string, projectID uuid.UUID, flag feature.Flag) bool {
+	if flags == nil {
+		return false
+	}
+	groups, err := queries.GetProjectFlagGroups(ctx, projectID)
+	if err != nil {
+		logger.WarnContext(ctx, "resolve project flag groups failed", attr.SlogError(err), attr.SlogOrganizationID(orgID), attr.SlogProjectID(projectID.String()))
+		return false
+	}
+	on, err := flags.IsFlagEnabled(ctx, flag, orgID, feature.OrgProjectGroups(groups.OrganizationSlug, groups.ProjectSlug))
+	if err != nil {
+		logger.WarnContext(ctx, "project flag check failed", attr.SlogError(err), attr.SlogOrganizationID(orgID))
+		return false
+	}
+	return on
+}

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -23,6 +23,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/message"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
+	"github.com/speakeasy-api/gram/server/internal/risk/policyflags"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 )
 
@@ -64,7 +66,7 @@ type ScanResult struct {
 	Action      string // "block"
 	PolicyID    string
 	PolicyName  string
-	Source      string // "gitleaks" or "presidio"
+	Source      string
 	MessageType message.Type
 	RuleID      string
 	Description string
@@ -195,7 +197,7 @@ func (s *Scanner) ScanForEnforcement(ctx context.Context, organizationID string,
 
 	promptPoliciesOn := false
 	if slices.ContainsFunc(policies, func(p repo.RiskPolicy) bool {
-		return p.PolicyType == "prompt_based" && inMessageScope(p)
+		return p.PolicyType == ra.PolicyTypePromptBased && inMessageScope(p)
 	}) {
 		// All enforcing policies for a project belong to the same org.
 		promptPoliciesOn = s.projectFlagEnabled(ctx, policies[0].OrganizationID, projectID, feature.FlagPromptPolicies)
@@ -206,7 +208,7 @@ func (s *Scanner) ScanForEnforcement(ctx context.Context, organizationID string,
 	// so the slug/flag lookup is skipped for scans that can never run L1.
 	piEngineOn := false
 	if slices.ContainsFunc(policies, func(p repo.RiskPolicy) bool {
-		return p.PolicyType != "prompt_based" &&
+		return p.PolicyType != ra.PolicyTypePromptBased &&
 			slices.Contains(p.Sources, ra.SourcePromptInjection) &&
 			(len(p.MessageTypes) == 0 || slices.Contains(p.MessageTypes, messageType))
 	}) {
@@ -347,7 +349,7 @@ func (s *Scanner) recordScan(ctx context.Context, projectID string, outcome o11y
 func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, text string, messageType message.Type, toolName string, promptPoliciesOn bool, piEngineOn bool) (*ScanResult, error) {
 	// Build the structured view once; the application predicates and custom
 	// rules both evaluate against it.
-	view := ra.MessageView{Content: text, Type: messageType, Tools: nil}
+	view := ra.MessageView{Content: text, Type: messageType, Tools: []ra.ToolView{}}
 	if messageType == message.ToolRequest && toolName != "" {
 		// In realtime a tool-request's text carries the call arguments (the same
 		// body the judge sees), so it doubles as the tool_args source.
@@ -365,7 +367,7 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, text s
 		return nil, nil
 	}
 
-	if policy.PolicyType == "prompt_based" {
+	if policy.PolicyType == ra.PolicyTypePromptBased {
 		return s.scanPromptPolicy(ctx, policy, text, messageType, toolName, promptPoliciesOn), nil
 	}
 
@@ -401,21 +403,21 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, text s
 
 	for _, source := range policy.Sources {
 		switch source {
-		case "gitleaks":
+		case ra.SourceGitleaks:
 			findings := filter(s.scanGitleaks(text))
 			if len(findings) > 0 {
 				return &ScanResult{
 					Action:      policy.Action,
 					PolicyID:    policy.ID.String(),
 					PolicyName:  policy.Name,
-					Source:      "gitleaks",
+					Source:      ra.SourceGitleaks,
 					MessageType: messageType,
 					RuleID:      findings[0].RuleID,
 					Description: findings[0].Description,
 					UserMessage: conv.FromPGText[string](policy.UserMessage),
 				}, nil
 			}
-		case "presidio":
+		case ra.SourcePresidio:
 			if s.piiScanner == nil {
 				continue
 			}
@@ -431,7 +433,7 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, text s
 						Action:      policy.Action,
 						PolicyID:    policy.ID.String(),
 						PolicyName:  policy.Name,
-						Source:      "presidio",
+						Source:      ra.SourcePresidio,
 						MessageType: messageType,
 						RuleID:      f.RuleID,
 						Description: f.Description,
@@ -515,26 +517,8 @@ func (s *Scanner) scanPromptPolicy(ctx context.Context, policy repo.RiskPolicy, 
 	}
 }
 
-// projectFlagEnabled resolves a per-project PostHog feature flag, evaluating it
-// against the same org/project groups the dashboard registers so a
-// group-targeted release matches identically. A nil flag provider, or a failed
-// slug or flag lookup, degrades to disabled. Shared by the prompt-policies and
-// prompt-injection-engine gates.
 func (s *Scanner) projectFlagEnabled(ctx context.Context, orgID string, projectID uuid.UUID, flag feature.Flag) bool {
-	if s.flags == nil {
-		return false
-	}
-	groups, err := s.repo.GetProjectFlagGroups(ctx, projectID)
-	if err != nil {
-		s.logger.WarnContext(ctx, "resolve project flag groups failed", attr.SlogError(err), attr.SlogOrganizationID(orgID), attr.SlogProjectID(projectID.String()))
-		return false
-	}
-	on, err := s.flags.IsFlagEnabled(ctx, flag, orgID, feature.OrgProjectGroups(groups.OrganizationSlug, groups.ProjectSlug))
-	if err != nil {
-		s.logger.WarnContext(ctx, "project flag check failed", attr.SlogError(err), attr.SlogOrganizationID(orgID))
-		return false
-	}
-	return on
+	return policyflags.ProjectFlagEnabled(ctx, s.logger, s.repo, s.flags, orgID, projectID, flag)
 }
 
 func promptPolicyUnavailableResult(policy repo.RiskPolicy, messageType message.Type, cfg ra.JudgeConfig) *ScanResult {
@@ -555,39 +539,18 @@ func promptPolicyUnavailableResult(policy repo.RiskPolicy, messageType message.T
 
 func (s *Scanner) scanCustomRules(ctx context.Context, policy repo.RiskPolicy, view ra.MessageView) ([]ra.Finding, error) {
 	if len(policy.CustomRuleIds) == 0 {
-		return nil, nil
+		return []ra.Finding{}, nil
 	}
 
-	rules, err := s.repo.ListCustomDetectionRules(ctx, policy.ProjectID)
+	rules, err := customrules.LoadSelected(ctx, s.repo, policy.ProjectID, policy.CustomRuleIds)
 	if err != nil {
-		return nil, fmt.Errorf("list custom detection rules: %w", err)
+		return nil, fmt.Errorf("load custom detection rules: %w", err)
 	}
-
-	detectors := make(map[string]struct{}, len(policy.CustomRuleIds))
-	for _, id := range policy.CustomRuleIds {
-		detectors[id] = struct{}{}
-	}
-
-	customRules := make([]ra.CustomDetectionRule, 0, len(detectors))
-	for _, rule := range rules {
-		if _, ok := detectors[rule.RuleID]; !ok {
-			continue
-		}
-		customRules = append(customRules, ra.CustomDetectionRule{
-			RuleID:        rule.RuleID,
-			Title:         rule.Title,
-			Description:   rule.Description,
-			DetectionExpr: rule.DetectionExpr.String,
-			Regex:         rule.Regex.String,
-		})
-	}
-
-	eng := s.celEng
-	compiled, err := ra.CompileCELRules(eng, customRules)
+	compiled, err := ra.CompileCELRules(s.celEng, rules)
 	if err != nil {
 		return nil, fmt.Errorf("compile custom detection rules: %w", err)
 	}
-	findings, err := ra.ScanCELRules(eng, view, compiled)
+	findings, err := ra.ScanCELRules(s.celEng, view, compiled)
 	if err != nil {
 		return nil, fmt.Errorf("scan custom detection rules: %w", err)
 	}


### PR DESCRIPTION
Moves shared risk scanner logic into neutral risk packages and reuses it from batch and realtime paths.

### What changed

- Adds `internal/risk/policyflags` for project-scoped feature flag checks.
- Adds `internal/risk/customrules` for loading policy-selected custom detection rules.
- Reuses those packages from batch analysis and realtime scanning.
- Keeps CEL compilation and evaluation in `risk_analysis`, where the scanner-facing types already live.
- Replaces duplicate policy/source string literals with existing risk-analysis constants.

### Risk

Low. The feature-flag and custom-rule behavior is unchanged. The code now lives where both callers can discover it.
