### PR TITLE
chore: drop unused risk analysis prompt rules payload

### DIFF
--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -85,16 +85,15 @@ func NewAnalyzeBatch(
 }
 
 type AnalyzeBatchArgs struct {
-	ProjectID            uuid.UUID
-	OrganizationID       string
-	RiskPolicyID         uuid.UUID
-	PolicyVersion        int64
-	MessageIDs           []uuid.UUID
-	Sources              []string
-	MessageTypes         []string
-	PresidioEntities     []string
-	PromptInjectionRules []string
-	CustomRuleIds        []string
+	ProjectID        uuid.UUID
+	OrganizationID   string
+	RiskPolicyID     uuid.UUID
+	PolicyVersion    int64
+	MessageIDs       []uuid.UUID
+	Sources          []string
+	MessageTypes     []string
+	PresidioEntities []string
+	CustomRuleIds    []string
 }
 
 type AnalyzeBatchResult struct {

--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -73,15 +73,14 @@ func TestAnalyzeBatch_EmptyMessageIDs(t *testing.T) {
 	require.NotNil(t, ab)
 
 	result, err := ab.Do(t.Context(), risk_analysis.AnalyzeBatchArgs{
-		ProjectID:            uuid.Nil,
-		OrganizationID:       "",
-		RiskPolicyID:         uuid.Nil,
-		PolicyVersion:        0,
-		MessageIDs:           nil,
-		Sources:              []string{"gitleaks"},
-		PresidioEntities:     nil,
-		PromptInjectionRules: nil,
-		CustomRuleIds:        nil,
+		ProjectID:        uuid.Nil,
+		OrganizationID:   "",
+		RiskPolicyID:     uuid.Nil,
+		PolicyVersion:    0,
+		MessageIDs:       nil,
+		Sources:          []string{"gitleaks"},
+		PresidioEntities: nil,
+		CustomRuleIds:    nil,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.Processed)
@@ -135,15 +134,14 @@ func TestAnalyzeBatch_GracefulDegradationWhenPresidioDown(t *testing.T) {
 	env.RegisterActivity(ab.Do)
 
 	val, err := env.ExecuteActivity(ab.Do, risk_analysis.AnalyzeBatchArgs{
-		ProjectID:            td.projectID,
-		OrganizationID:       td.orgID,
-		RiskPolicyID:         td.policyID,
-		PolicyVersion:        td.policyVersion,
-		MessageIDs:           []uuid.UUID{msgID},
-		Sources:              []string{"gitleaks", "presidio"},
-		PresidioEntities:     nil,
-		PromptInjectionRules: nil,
-		CustomRuleIds:        nil,
+		ProjectID:        td.projectID,
+		OrganizationID:   td.orgID,
+		RiskPolicyID:     td.policyID,
+		PolicyVersion:    td.policyVersion,
+		MessageIDs:       []uuid.UUID{msgID},
+		Sources:          []string{"gitleaks", "presidio"},
+		PresidioEntities: nil,
+		CustomRuleIds:    nil,
 	})
 	require.NoError(t, err, "should not fail when presidio is down")
 
@@ -226,16 +224,15 @@ func TestAnalyzeBatch_FilteredMessagesStillClearExistingResults(t *testing.T) {
 	env.RegisterActivity(ab.Do)
 
 	val, err := env.ExecuteActivity(ab.Do, risk_analysis.AnalyzeBatchArgs{
-		ProjectID:            td.projectID,
-		OrganizationID:       td.orgID,
-		RiskPolicyID:         td.policyID,
-		PolicyVersion:        td.policyVersion,
-		MessageIDs:           []uuid.UUID{msgID},
-		Sources:              []string{"gitleaks"},
-		MessageTypes:         []string{message.ToolRequest},
-		PresidioEntities:     nil,
-		PromptInjectionRules: nil,
-		CustomRuleIds:        nil,
+		ProjectID:        td.projectID,
+		OrganizationID:   td.orgID,
+		RiskPolicyID:     td.policyID,
+		PolicyVersion:    td.policyVersion,
+		MessageIDs:       []uuid.UUID{msgID},
+		Sources:          []string{"gitleaks"},
+		MessageTypes:     []string{message.ToolRequest},
+		PresidioEntities: nil,
+		CustomRuleIds:    nil,
 	})
 	require.NoError(t, err)
 
@@ -330,16 +327,15 @@ func TestAnalyzeBatch_PromptJudgeUsesToolCallPayload(t *testing.T) {
 	env.RegisterActivity(ab.Do)
 
 	val, err := env.ExecuteActivity(ab.Do, risk_analysis.AnalyzeBatchArgs{
-		ProjectID:            td.projectID,
-		OrganizationID:       td.orgID,
-		RiskPolicyID:         td.policyID,
-		PolicyVersion:        td.policyVersion,
-		MessageIDs:           []uuid.UUID{msgID},
-		Sources:              nil,
-		MessageTypes:         []string{message.ToolRequest},
-		PresidioEntities:     nil,
-		PromptInjectionRules: nil,
-		CustomRuleIds:        nil,
+		ProjectID:        td.projectID,
+		OrganizationID:   td.orgID,
+		RiskPolicyID:     td.policyID,
+		PolicyVersion:    td.policyVersion,
+		MessageIDs:       []uuid.UUID{msgID},
+		Sources:          nil,
+		MessageTypes:     []string{message.ToolRequest},
+		PresidioEntities: nil,
+		CustomRuleIds:    nil,
 	})
 	require.NoError(t, err)
 
@@ -414,16 +410,15 @@ func TestAnalyzeBatch_PromptJudgeMultiToolCallAttribution(t *testing.T) {
 	env.RegisterActivity(ab.Do)
 
 	val, err := env.ExecuteActivity(ab.Do, risk_analysis.AnalyzeBatchArgs{
-		ProjectID:            td.projectID,
-		OrganizationID:       td.orgID,
-		RiskPolicyID:         td.policyID,
-		PolicyVersion:        td.policyVersion,
-		MessageIDs:           []uuid.UUID{msgID},
-		Sources:              nil,
-		MessageTypes:         []string{message.ToolRequest},
-		PresidioEntities:     nil,
-		PromptInjectionRules: nil,
-		CustomRuleIds:        nil,
+		ProjectID:        td.projectID,
+		OrganizationID:   td.orgID,
+		RiskPolicyID:     td.policyID,
+		PolicyVersion:    td.policyVersion,
+		MessageIDs:       []uuid.UUID{msgID},
+		Sources:          nil,
+		MessageTypes:     []string{message.ToolRequest},
+		PresidioEntities: nil,
+		CustomRuleIds:    nil,
 	})
 	require.NoError(t, err)
 
@@ -873,15 +868,14 @@ func executeAnalyzeBatch(t *testing.T, conn *pgxpool.Pool, td testData, messageI
 	env.RegisterActivity(ab.Do)
 
 	val, err := env.ExecuteActivity(ab.Do, risk_analysis.AnalyzeBatchArgs{
-		ProjectID:            td.projectID,
-		OrganizationID:       td.orgID,
-		RiskPolicyID:         td.policyID,
-		PolicyVersion:        td.policyVersion,
-		MessageIDs:           messageIDs,
-		Sources:              sources,
-		PresidioEntities:     nil,
-		PromptInjectionRules: nil,
-		CustomRuleIds:        nil,
+		ProjectID:        td.projectID,
+		OrganizationID:   td.orgID,
+		RiskPolicyID:     td.policyID,
+		PolicyVersion:    td.policyVersion,
+		MessageIDs:       messageIDs,
+		Sources:          sources,
+		PresidioEntities: nil,
+		CustomRuleIds:    nil,
 	})
 	require.NoError(t, err)
 

--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
@@ -34,14 +34,13 @@ func NewFetchUnanalyzed(logger *slog.Logger, tracerProvider trace.TracerProvider
 // PolicyForAnalysis carries the policy metadata the coordinator needs to
 // construct AnalyzeBatchArgs for each active policy.
 type PolicyForAnalysis struct {
-	ID                   uuid.UUID
-	OrganizationID       string
-	Version              int64
-	Sources              []string
-	MessageTypes         []string
-	PresidioEntities     []string
-	PromptInjectionRules []string
-	CustomRuleIds        []string
+	ID               uuid.UUID
+	OrganizationID   string
+	Version          int64
+	Sources          []string
+	MessageTypes     []string
+	PresidioEntities []string
+	CustomRuleIds    []string
 }
 
 type FetchUnanalyzedArgs struct {
@@ -100,14 +99,13 @@ func (a *FetchUnanalyzed) Do(ctx context.Context, args FetchUnanalyzedArgs) (_ *
 	}
 	for i, p := range policies {
 		result.Policies[i] = PolicyForAnalysis{
-			ID:                   p.ID,
-			OrganizationID:       p.OrganizationID,
-			Version:              p.Version,
-			Sources:              p.Sources,
-			MessageTypes:         p.MessageTypes,
-			PresidioEntities:     p.PresidioEntities,
-			PromptInjectionRules: p.PromptInjectionRules,
-			CustomRuleIds:        p.CustomRuleIds,
+			ID:               p.ID,
+			OrganizationID:   p.OrganizationID,
+			Version:          p.Version,
+			Sources:          p.Sources,
+			MessageTypes:     p.MessageTypes,
+			PresidioEntities: p.PresidioEntities,
+			CustomRuleIds:    p.CustomRuleIds,
 		}
 	}
 

--- a/server/internal/background/risk_analysis_coordinator.go
+++ b/server/internal/background/risk_analysis_coordinator.go
@@ -89,16 +89,15 @@ func RiskAnalysisCoordinatorWorkflow(ctx workflow.Context, params RiskAnalysisCo
 		for _, policy := range fetchResult.Policies {
 			for _, batch := range chunkUUIDs(fetchResult.MessageIDs, riskCoordinatorBatchSize) {
 				f := workflow.ExecuteActivity(analyzeBatchCtx, a.AnalyzeBatch, risk_analysis.AnalyzeBatchArgs{
-					ProjectID:            params.ProjectID,
-					OrganizationID:       policy.OrganizationID,
-					RiskPolicyID:         policy.ID,
-					PolicyVersion:        policy.Version,
-					MessageIDs:           batch,
-					Sources:              policy.Sources,
-					MessageTypes:         policy.MessageTypes,
-					PresidioEntities:     policy.PresidioEntities,
-					PromptInjectionRules: policy.PromptInjectionRules,
-					CustomRuleIds:        policy.CustomRuleIds,
+					ProjectID:        params.ProjectID,
+					OrganizationID:   policy.OrganizationID,
+					RiskPolicyID:     policy.ID,
+					PolicyVersion:    policy.Version,
+					MessageIDs:       batch,
+					Sources:          policy.Sources,
+					MessageTypes:     policy.MessageTypes,
+					PresidioEntities: policy.PresidioEntities,
+					CustomRuleIds:    policy.CustomRuleIds,
 				})
 				futures = append(futures, f)
 			}


### PR DESCRIPTION
Removes the unused `PromptInjectionRules` payload field from the risk analysis workflow and activity structs.

### What changed

- Drops the field from `AnalyzeBatchArgs`, `PolicyForAnalysis`, and the coordinator activity call.
- Updates tests and fixtures that constructed those payloads.

### Risk

Low. The field was always passed as nil and never read. Older serialized payloads with the field should still decode because Go JSON ignores unknown keys.
