### PR TITLE
feat(infra): attach generated pubsub schemas to their topics

### DIFF
--- a/infra/gen/kcc.yaml
+++ b/infra/gen/kcc.yaml
@@ -156,6 +156,10 @@ pubsub:
     name: gram-ping-v2-message
     spec:
       messageRetentionDuration: 86400s
+      schemaSettings:
+        encoding: BINARY
+        schemaRef:
+          name: gram-ping-v2-message
   - labels:
       dlq_for: gram-ping-v2-processor
       managed_by: proto-pubsub-orchestrator
@@ -174,15 +178,27 @@ pubsub:
     name: gram-risk-v1-finding
     spec:
       messageRetentionDuration: 604800s
+      schemaSettings:
+        encoding: BINARY
+        schemaRef:
+          name: gram-risk-v1-finding
   - labels:
       managed_by: proto-pubsub-orchestrator
       proto_message: gram-risk-v1-gitleaks-analysis
     name: gram-risk-v1-gitleaks-analysis
     spec:
       messageRetentionDuration: 604800s
+      schemaSettings:
+        encoding: BINARY
+        schemaRef:
+          name: gram-risk-v1-gitleaks-analysis
   - labels:
       managed_by: proto-pubsub-orchestrator
       proto_message: gram-risk-v1-presidio-analysis
     name: gram-risk-v1-presidio-analysis
     spec:
       messageRetentionDuration: 604800s
+      schemaSettings:
+        encoding: BINARY
+        schemaRef:
+          name: gram-risk-v1-presidio-analysis

--- a/infra/internal/gcp/cc.go
+++ b/infra/internal/gcp/cc.go
@@ -56,7 +56,7 @@ func (c *ConfigConnectorPubSub) Generate(ctx context.Context) error {
 		return fmt.Errorf("discover pubsub schemas: %w", err)
 	}
 
-	if err := c.writeValues(ctx, buildPubSubValues(desiredTopics, desiredSubs, desiredSchemas)); err != nil {
+	if err := c.writeValues(ctx, buildPubSubValues(ctx, c.logger, desiredTopics, desiredSubs, desiredSchemas)); err != nil {
 		return fmt.Errorf("write pubsub values: %w", err)
 	}
 

--- a/infra/internal/gcp/cc_pubsub.go
+++ b/infra/internal/gcp/cc_pubsub.go
@@ -2,6 +2,8 @@ package gcp
 
 import (
 	"cmp"
+	"context"
+	"log/slog"
 	"maps"
 	"math"
 	"slices"
@@ -9,6 +11,7 @@ import (
 	kccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	pubsubv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/pubsub/v1beta1"
 	"github.com/ettle/strcase"
+	"github.com/speakeasy-api/gram/infra/internal/attr"
 )
 
 // protoMessageLabel is the metadata label key carrying the fully qualified
@@ -19,10 +22,22 @@ const protoMessageLabel = "proto_message"
 // protobuf message name of the topic a subscription consumes.
 const topicMessageLabel = "topic_proto_message"
 
+// schemaEncodingBinary is the Config Connector TopicSchemaSettings `encoding`
+// value for messages validated as wire-format protobuf. The runtime publisher
+// marshals proto messages to binary, so attached schemas validate against the
+// binary encoding rather than JSON.
+const schemaEncodingBinary = "BINARY"
+
 // buildPubSubValues projects the discovered topology into a stable, sorted Helm
 // values document. Topics and subscriptions are sorted by name so the generated
 // file diffs cleanly across runs.
-func buildPubSubValues(topics []DesiredTopic, subs []DesiredSubscription, schemas []DesiredSchema) pubSubValuesDocument {
+//
+// A topic gets its generated schema attached (via schemaSettings) when one was
+// derived from the same proto message. A topic that sets an explicit `name`
+// option is left unattached — its ID may point at a shared, externally-owned
+// topic, so binding a per-message schema to it could collide with other
+// producers — and the skip is logged.
+func buildPubSubValues(ctx context.Context, logger *slog.Logger, topics []DesiredTopic, subs []DesiredSubscription, schemas []DesiredSchema) pubSubValuesDocument {
 	sortedTopics := slices.Clone(topics)
 	slices.SortFunc(sortedTopics, func(a, b DesiredTopic) int {
 		return cmp.Compare(a.Name, b.Name)
@@ -38,12 +53,36 @@ func buildPubSubValues(topics []DesiredTopic, subs []DesiredSubscription, schema
 		return cmp.Compare(a.Name, b.Name)
 	})
 
+	// Index schemas by their source proto message so a topic can find the schema
+	// derived from the same message regardless of the topic's resolved ID.
+	schemaByProtoMessage := make(map[string]DesiredSchema, len(sortedSchemas))
+	for _, schema := range sortedSchemas {
+		schemaByProtoMessage[schema.ProtoMessage] = schema
+	}
+
 	topicValues := make([]pubSubTopicValue, 0, len(sortedTopics))
 	for _, topic := range sortedTopics {
+		spec := topicSpec(topic)
+
+		if schema, ok := schemaByProtoMessage[topic.ProtoMessage]; ok {
+			if topic.NameOverridden {
+				logger.InfoContext(ctx,
+					"skipping pubsub schema attachment for topic with explicit name option",
+					attr.SlogGCPTopicQualifiedName(topic.Name),
+					attr.SlogTopicProtoName(topic.ProtoMessage),
+				)
+			} else {
+				spec.SchemaSettings = &pubsubv1beta1.TopicSchemaSettings{
+					Encoding:  new(schemaEncodingBinary),
+					SchemaRef: kccv1alpha1.ResourceRef{Name: schema.Name},
+				}
+			}
+		}
+
 		topicValues = append(topicValues, pubSubTopicValue{
 			Name:   topic.Name,
 			Labels: labelsWithProtoMessage(topic.Labels, topic.ProtoMessage),
-			Spec:   topicSpec(topic),
+			Spec:   spec,
 		})
 	}
 

--- a/infra/internal/gcp/cc_pubsub_test.go
+++ b/infra/internal/gcp/cc_pubsub_test.go
@@ -169,17 +169,22 @@ func TestBuildPubSubValues_SchemaAttachment(t *testing.T) {
 	}
 
 	// Topic with no name override gets the matching schema attached.
-	event := byName["example-v1-event"].Spec
-	require.NotNil(t, event.SchemaSettings)
-	require.Equal(t, "example-v1-event", event.SchemaSettings.SchemaRef.Name)
-	require.NotNil(t, event.SchemaSettings.Encoding)
-	require.Equal(t, schemaEncodingBinary, *event.SchemaSettings.Encoding)
+	event, ok := byName["example-v1-event"]
+	require.True(t, ok, "topic example-v1-event missing from output")
+	require.NotNil(t, event.Spec.SchemaSettings)
+	require.Equal(t, "example-v1-event", event.Spec.SchemaSettings.SchemaRef.Name)
+	require.NotNil(t, event.Spec.SchemaSettings.Encoding)
+	require.Equal(t, schemaEncodingBinary, *event.Spec.SchemaSettings.Encoding)
 
 	// Topic with an explicit name override is left unattached.
-	require.Nil(t, byName["shared-topic"].Spec.SchemaSettings)
+	shared, ok := byName["shared-topic"]
+	require.True(t, ok, "topic shared-topic missing from output")
+	require.Nil(t, shared.Spec.SchemaSettings)
 
 	// Topic without a matching schema is left unattached.
-	require.Nil(t, byName["example-v1-event-dlq"].Spec.SchemaSettings)
+	dlq, ok := byName["example-v1-event-dlq"]
+	require.True(t, ok, "topic example-v1-event-dlq missing from output")
+	require.Nil(t, dlq.Spec.SchemaSettings)
 }
 
 func TestCCPubSub_WriteValues(t *testing.T) {

--- a/infra/internal/gcp/cc_pubsub_test.go
+++ b/infra/internal/gcp/cc_pubsub_test.go
@@ -68,7 +68,7 @@ func TestBuildPubSubValues_StableOrder(t *testing.T) {
 		},
 	}
 
-	doc := buildPubSubValues(topics, subs, []DesiredSchema{})
+	doc := buildPubSubValues(t.Context(), slog.New(slog.DiscardHandler), topics, subs, []DesiredSchema{})
 
 	require.True(t, doc.PubSub.Enabled)
 	require.Equal(t, []string{pubsubAPI}, doc.PubSub.APIs)
@@ -117,6 +117,71 @@ func TestBuildPubSubValues_StableOrder(t *testing.T) {
 	require.Equal(t, "604800s", *zebra.MessageRetentionDuration)
 }
 
+// TestBuildPubSubValues_SchemaAttachment verifies that a topic derived from the
+// same proto message as a generated schema gets that schema attached via
+// schemaSettings, unless the topic sets an explicit name option (in which case
+// the schema is left unattached).
+func TestBuildPubSubValues_SchemaAttachment(t *testing.T) {
+	t.Parallel()
+
+	topics := []DesiredTopic{
+		{
+			Name:           "example-v1-event",
+			Labels:         map[string]string{"managed_by": managedByLabel},
+			ProtoMessage:   "example.v1.Event",
+			NameOverridden: false,
+		},
+		{
+			// Same proto message as a schema, but an explicit name override.
+			Name:           "shared-topic",
+			Labels:         map[string]string{"managed_by": managedByLabel},
+			ProtoMessage:   "example.v1.Shared",
+			NameOverridden: true,
+		},
+		{
+			// No matching schema (e.g. a synthesized DLQ topic).
+			Name:         "example-v1-event-dlq",
+			Labels:       map[string]string{"managed_by": managedByLabel, "dlq_for": "example-v1-processor"},
+			ProtoMessage: "example.v1.Processor",
+		},
+	}
+
+	schemas := []DesiredSchema{
+		{
+			Name:         "example-v1-event",
+			ProtoMessage: "example.v1.Event",
+			Definition:   "edition = \"2024\";\n",
+			Labels:       map[string]string{"managed_by": managedByLabel},
+		},
+		{
+			Name:         "example-v1-shared",
+			ProtoMessage: "example.v1.Shared",
+			Definition:   "edition = \"2024\";\n",
+			Labels:       map[string]string{"managed_by": managedByLabel},
+		},
+	}
+
+	doc := buildPubSubValues(t.Context(), slog.New(slog.DiscardHandler), topics, nil, schemas)
+
+	byName := map[string]pubSubTopicValue{}
+	for _, topic := range doc.PubSub.Topics {
+		byName[topic.Name] = topic
+	}
+
+	// Topic with no name override gets the matching schema attached.
+	event := byName["example-v1-event"].Spec
+	require.NotNil(t, event.SchemaSettings)
+	require.Equal(t, "example-v1-event", event.SchemaSettings.SchemaRef.Name)
+	require.NotNil(t, event.SchemaSettings.Encoding)
+	require.Equal(t, schemaEncodingBinary, *event.SchemaSettings.Encoding)
+
+	// Topic with an explicit name override is left unattached.
+	require.Nil(t, byName["shared-topic"].Spec.SchemaSettings)
+
+	// Topic without a matching schema is left unattached.
+	require.Nil(t, byName["example-v1-event-dlq"].Spec.SchemaSettings)
+}
+
 func TestCCPubSub_WriteValues(t *testing.T) {
 	t.Parallel()
 
@@ -130,7 +195,7 @@ func TestCCPubSub_WriteValues(t *testing.T) {
 		{Name: "outbox-processor", Topic: "outbox-event", TopicMessage: "gram.outbox.v1.Event", AckDeadline: 30 * time.Second, Labels: map[string]string{"managed_by": managedByLabel}, ProtoMessage: "gram.outbox.v1.Processor"},
 	}
 
-	err := cc.writeValues(t.Context(), buildPubSubValues(topics, subs, []DesiredSchema{}))
+	err := cc.writeValues(t.Context(), buildPubSubValues(t.Context(), slog.New(slog.DiscardHandler), topics, subs, []DesiredSchema{}))
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(out)

--- a/infra/internal/gcp/pubsub_discover.go
+++ b/infra/internal/gcp/pubsub_discover.go
@@ -58,6 +58,12 @@ type DesiredTopic struct {
 	Retention    time.Duration
 	Labels       map[string]string
 	ProtoMessage string
+	// NameOverridden reports whether the topic's `name` option was explicitly
+	// set (rather than the ID being derived from the proto full name). A topic
+	// with an explicit name may map onto a shared, externally-owned topic, so a
+	// generated schema — whose identity is tied to the proto message — must not
+	// be attached to it.
+	NameOverridden bool
 }
 
 type DesiredRetryPolicy struct {
@@ -221,10 +227,11 @@ func desiredTopicFromOptions(message protoreflect.MessageDescriptor, topicOption
 	}
 
 	return DesiredTopic{
-		Name:         ResolveTopicName(message, topicOptions),
-		Retention:    topicOptions.GetRetentionHint().AsDuration(),
-		Labels:       labels,
-		ProtoMessage: string(message.FullName()),
+		Name:           ResolveTopicName(message, topicOptions),
+		Retention:      topicOptions.GetRetentionHint().AsDuration(),
+		Labels:         labels,
+		ProtoMessage:   string(message.FullName()),
+		NameOverridden: strings.TrimSpace(topicOptions.GetName()) != "",
 	}
 }
 

--- a/infra/internal/gcp/pubsub_schema_test.go
+++ b/infra/internal/gcp/pubsub_schema_test.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"log/slog"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -219,7 +220,7 @@ func TestBuildPubSubValues_Schemas(t *testing.T) {
 		},
 	}
 
-	doc := buildPubSubValues([]DesiredTopic{}, []DesiredSubscription{}, schemas)
+	doc := buildPubSubValues(t.Context(), slog.New(slog.DiscardHandler), []DesiredTopic{}, []DesiredSubscription{}, schemas)
 
 	// Sorted alphabetically by name for stable diffs.
 	require.Len(t, doc.PubSub.Schemas, 2)


### PR DESCRIPTION
## What

The infra generation pipeline already emitted `PubSubSchema` resources into `infra/gen/kcc.yaml`, but never attached them to their topics. This wires each generated schema into its topic via `schemaSettings`, so publishes are validated against the declared proto shape at the topic boundary.

## How

- `DesiredTopic` gains a `NameOverridden` flag, set when a topic message's `name` option is explicit (vs. derived from the proto full name).
- `buildPubSubValues` indexes schemas by source proto message and, for each topic, attaches the matching schema (`schemaRef.name` + `encoding: BINARY`).
- **Caveat honored:** a topic that sets an explicit `name` option is left unattached — its ID may point at a shared, externally-owned topic, so binding a per-message schema could collide with other producers. The skip is logged at info level.
- `encoding` is `BINARY` because the runtime publisher marshals proto messages to wire-format binary.

## Result

Regenerated `kcc.yaml`: all four real topics (`gram-ping-v2-message`, `gram-risk-v1-finding`, `gram-risk-v1-gitleaks-analysis`, `gram-risk-v1-presidio-analysis`) now carry `schemaSettings`. DLQ topics correctly get none — their `proto_message` is a subscription marker, which no schema is keyed by.

## Notes

- Matching is by proto message full name, not topic ID, so a topic and its schema match even when the resolved IDs differ.
- No topic currently sets a `name` option, so the skip-and-log branch isn't exercised by the committed `kcc.yaml`, but it's covered by `TestBuildPubSubValues_SchemaAttachment`.

## Testing

- `go test -race ./infra/internal/gcp/` passes (including the new attachment test).
- `mise lint:server` clean.
- `mise run gen:infra` reproduces the committed `kcc.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach generated Pub/Sub schemas to their topics so GCP validates publishes against the declared proto at the topic boundary. Topics with an explicit `name` option are left unattached to avoid conflicts on shared topics.

- **New Features**
  - Attach schemas via `schemaSettings` with `encoding: BINARY`.
  - Match schema by proto message full name; skip and log when the topic sets an explicit `name`.
  - Regenerated `infra/gen/kcc.yaml`; real topics now include `schemaSettings`.

- **Bug Fixes**
  - Hardened tests to assert topic presence before checking for missing `schemaSettings`, preventing false positives.

<sup>Written for commit f9c514c50d504c16672d12d2b3e329b8846fb81b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

