### PR TITLE
feat(dashboard): distinguish private MCP servers with a blue status indicator

### DIFF
--- a/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
+++ b/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
@@ -19,10 +19,17 @@ function getStatusConfig(
       label: "Disabled",
     };
   }
+  if (!mcpIsPublic) {
+    return {
+      color: "bg-blue-400",
+      pulseColor: "bg-blue-400",
+      label: "Private",
+    };
+  }
   return {
     color: "bg-green-500",
     pulseColor: "bg-green-400",
-    label: mcpIsPublic ? "Public" : "Private",
+    label: "Public",
   };
 }
 


### PR DESCRIPTION
## Summary

Makes MCP server visibility easier to identify at a glance in the dashboard. Previously both **Public** and **Private** servers rendered with the same green status indicator, so the only differentiator was the text label.

Now **Private** servers get a distinct blue indicator, while **Public** servers keep green.

## Changes

- `MCPStatusIndicator.tsx`: add a dedicated blue (`bg-blue-400`) status config for private servers; public stays green (`bg-green-500`).

## Linear

AIS-130
