### PR TITLE
fix(server): flush risk signals before closing Temporal client on shutdown (AIS-186)

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1111,7 +1111,11 @@ func newStartCommand() *cli.Command {
 				30*time.Second,
 				logger,
 			)
-			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
+			// riskSignaler.Shutdown is intentionally NOT registered as a shutdownFunc.
+			// runShutdown runs every func concurrently, which races temporalClient.Close()
+			// against the signaler's trailing-edge flush over the same gRPC connection
+			// ("grpc: the client connection is closing"). Instead it is flushed
+			// synchronously in the drain goroutine below, while Temporal is still open.
 			riskReconciler := &background.TemporalRiskExclusionReconciler{TemporalEnv: temporalEnv, Logger: logger}
 			riskResultsCleaner := &background.TemporalRiskPolicyResultsCleaner{TemporalEnv: temporalEnv, Logger: logger}
 			riskService := risk.NewService(
@@ -1245,6 +1249,13 @@ func newStartCommand() *cli.Command {
 						err = errors.Join(err, gerr)
 					}
 					logger.ErrorContext(ctx, "failed to shutdown server", attr.SlogError(err))
+				}
+
+				// The HTTP server is now fully drained, so no new risk signals are
+				// produced. Flush the throttle's queued trailing signals here while the
+				// Temporal client is still open — runShutdown closes it concurrently.
+				if err := riskSignaler.Shutdown(graceCtx); err != nil {
+					logger.ErrorContext(ctx, "flush pending risk signals", attr.SlogError(err))
 				}
 			})
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -585,7 +585,9 @@ func newWorkerCommand() *cli.Command {
 				30*time.Second,
 				logger,
 			)
-			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
+			// riskSignaler.Shutdown is flushed synchronously after temporalWorker.Run
+			// returns (below), not via shutdownFuncs, to avoid racing the concurrent
+			// temporalClient.Close() over the same gRPC connection.
 			chatWriter.AddObserver(risk.NewObserver(logger, tracerProvider, db, riskSignaler, auditLogger))
 
 			completionsClient := openrouter.NewUnifiedClient(
@@ -786,7 +788,22 @@ func newWorkerCommand() *cli.Command {
 				Publishers:                     publishers,
 			})
 
-			return temporalWorker.Run(worker.InterruptCh())
+			// Flush the throttle's queued trailing risk signals before this Action
+			// returns, while the Temporal client is still open. The cli After hook runs
+			// runShutdown, which closes the client concurrently across shutdownFuncs and
+			// would otherwise race the flush ("grpc: the client connection is closing").
+			// riskSignaler.Shutdown is deliberately not registered as a shutdownFunc.
+			defer func() {
+				if ferr := riskSignaler.Shutdown(ctx); ferr != nil {
+					logger.ErrorContext(ctx, "flush pending risk signals", attr.SlogError(ferr))
+				}
+			}()
+
+			if err := temporalWorker.Run(worker.InterruptCh()); err != nil {
+				return fmt.Errorf("run temporal worker: %w", err)
+			}
+
+			return nil
 		},
 		Before: func(ctx *cli.Context) error {
 			return loadConfigFromFile(ctx, flags)

--- a/server/internal/background/throttled_signaler_test.go
+++ b/server/internal/background/throttled_signaler_test.go
@@ -214,6 +214,38 @@ func TestThrottledSignaler_SuppressedCallsReturnNil(t *testing.T) {
 	require.NoError(t, err, "suppressed calls should return nil")
 }
 
+func TestThrottledSignaler_ShutdownFlushesPending(t *testing.T) {
+	t.Parallel()
+
+	inner := &countingSignaler{}
+	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
+
+	projectID := uuid.New()
+	_ = throttled.Signal(t.Context(), projectID) // leading edge fires immediately
+	_ = throttled.Signal(t.Context(), projectID) // suppressed → pending trailing
+	assert.Equal(t, 1, inner.callCount())
+
+	require.NoError(t, throttled.Shutdown(t.Context()))
+	assert.Equal(t, 2, inner.callCount(), "shutdown should flush the pending trailing signal")
+
+	require.NoError(t, throttled.Shutdown(t.Context()))
+	assert.Equal(t, 2, inner.callCount(), "second shutdown is a no-op once entries are cleared")
+}
+
+func TestThrottledSignaler_ShutdownNoPendingNoFire(t *testing.T) {
+	t.Parallel()
+
+	inner := &countingSignaler{}
+	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
+
+	projectID := uuid.New()
+	_ = throttled.Signal(t.Context(), projectID) // leading edge only, nothing suppressed
+	assert.Equal(t, 1, inner.callCount())
+
+	require.NoError(t, throttled.Shutdown(t.Context()))
+	assert.Equal(t, 1, inner.callCount(), "shutdown fires nothing when no trailing signal is pending")
+}
+
 func TestThrottledSignaler_NegativeCooldownDisablesThrottling(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

On every graceful shutdown (deploys, GKE pod/node ops), the risk-analysis trailing-signal flush raced the Temporal gRPC client `Close()` and logged an error at **error** level:

```
throttled trailing risk signal failed | error.message: signal-with-start coordinator: grpc: the client connection is closing
```

~311 occurrences over 14 days (~22/day) on gram-server in prod. Cosmetic log noise — no data lost (the coordinator workflow is best-effort and re-fetches unanalyzed messages within a 2h lookback) — but it fires at error level and pollutes dashboards/alerting. The same wiring exists in gram-worker (latent, not yet noisy).

## Root cause

`riskSignaler.Shutdown` was registered as a `shutdownFunc`. `runShutdown` runs every registered func **concurrently** with no ordering, so the signaler's trailing-edge flush (`SignalWithStartWorkflow`) could land on the same gRPC connection that `temporalClient.Close()` was closing in a sibling goroutine.

## Fix

Flush the signaler synchronously **while the Temporal client is still open**, instead of via the concurrent `shutdownFuncs` set:

- **server** (`start.go`): flush in the drain goroutine right after `srv.Shutdown` returns. The HTTP server is fully drained at that point, so no new signals are produced; `group.Wait()` guarantees the flush completes before `After → runShutdown` closes Temporal.
- **worker** (`worker.go`): flush in a `defer` before the Action returns, so it precedes `After → runShutdown`.

This converts a concurrent race into a strict happens-before ordering. `runShutdown` itself is **unchanged** — still fully concurrent under one budget (no ordered/LIFO rework, per the ticket's guidance).

## Tests

- `TestThrottledSignaler_ShutdownFlushesPending` — `Shutdown()` delivers the pending trailing signal; a second call is a no-op.
- `TestThrottledSignaler_ShutdownNoPendingNoFire` — no spurious fire when nothing is pending.

`mise build:server`, `mise lint:server`, and the background tests all pass.

## Acceptance criteria

- [x] No `throttled trailing risk signal failed ... the client connection is closing` errors during normal deploys (ordering now guaranteed).
- [x] Pending trailing signals are still delivered when the Temporal client is available at shutdown.
- [x] Fix applied to both gram-server and gram-worker paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
