### PR TITLE
fix(telemetry): stabilize chat completion gram urn

### DIFF
--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -756,7 +756,7 @@ func (c *ChatClient) emitGenAITelemetry(
 
 	toolInfo := telemetry.ToolInfo{
 		ID:             chatID,
-		URN:            chatID,
+		URN:            "agents:chat:completion",
 		Name:           "",
 		ProjectID:      projectID,
 		DeploymentID:   "",

--- a/server/internal/thirdparty/openrouter/unified_client_telemetry_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_telemetry_test.go
@@ -1,0 +1,50 @@
+package openrouter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatClient_EmitGenAITelemetryUsesStableURN(t *testing.T) {
+	t.Parallel()
+
+	telemetryLogger := &mockTelemetryLogger{}
+	client := &ChatClient{telemetryLogger: telemetryLogger}
+	chatID := uuid.NewString()
+
+	client.emitGenAITelemetry(
+		context.Background(),
+		nil,
+		"org-id",
+		uuid.NewString(),
+		chatID,
+		"user-id",
+		"",
+		"",
+		"api-key-id",
+		CompletionResponse{
+			StartTime: time.Now().Add(-time.Second),
+			Model:     "openai/gpt-5.4",
+			Usage: Usage{
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+			},
+		},
+	)
+
+	telemetryLogger.mu.Lock()
+	defer telemetryLogger.mu.Unlock()
+	require.Len(t, telemetryLogger.logs, 1)
+	log := telemetryLogger.logs[0]
+	assert.Equal(t, chatID, log.ToolInfo.ID)
+	assert.Equal(t, "agents:chat:completion", log.ToolInfo.URN)
+	assert.Equal(t, "agents:chat:completion", log.Attributes[attr.ResourceURNKey])
+	assert.Equal(t, chatID, log.Attributes[attr.GenAIConversationIDKey])
+}

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -81,8 +81,9 @@ type mockMessageCaptureStrategy struct {
 	capturedResponse     *CompletionResponse
 }
 
+//go:fix inline
 func floatPtr(v float64) *float64 {
-	return &v
+	return new(v)
 }
 
 func (m *mockMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, request CompletionRequest) (CaptureSession, error) {
@@ -290,7 +291,7 @@ func TestChatClient_GetCompletion(t *testing.T) {
 		assert.True(c, telemetryCalled, "CreateLog should be called")
 	}, 10*time.Second, 10*time.Millisecond)
 
-	// Verify captured data — inline usage payload flows through to the tracker.
+	// Verify captured data - inline usage payload flows through to the tracker.
 	assert.Equal(t, "msg_123", captureStrategy.capturedResponse.MessageID)
 	require.NotNil(t, trackingStrategy.usage)
 	assert.Equal(t, "openai/gpt-5.4", trackingStrategy.usage.Model)
@@ -634,7 +635,7 @@ func TestUsageToModelUsagePreservesExplicitZeroCost(t *testing.T) {
 		PromptTokens:            10,
 		CompletionTokens:        0,
 		TotalTokens:             10,
-		Cost:                    floatPtr(0),
+		Cost:                    new(float64(0)),
 		CostDetails:             nil,
 		PromptTokensDetails:     nil,
 		CompletionTokensDetails: nil,
@@ -1199,7 +1200,7 @@ func TestChatClient_NilChatID_ShouldNotScheduleTitleGeneration(t *testing.T) {
 		OrgID:       "test-org",
 		ProjectID:   projectID.String(),
 		Messages:    []or.ChatMessages{CreateMessageUser("Hello")},
-		ChatID:      uuid.Nil, // No chat — like title generation activity's internal call
+		ChatID:      uuid.Nil, // No chat - like title generation activity's internal call
 		UsageSource: billing.ModelUsageSourceGram,
 		APIKeyID:    "",
 	}
@@ -1329,7 +1330,7 @@ func TestChatClient_ReloadChat_NoDuplicateMessages(t *testing.T) {
 	require.Equal(t, "CaptureMessage", tracker.storedMessages[1].source)
 	tracker.mu.Unlock()
 
-	// Round 2: Simulate reload — client sends all history + new user message
+	// Round 2: Simulate reload - client sends all history + new user message
 	req2 := CompletionRequest{
 		OrgID:     "test-org",
 		ProjectID: projectID.String(),

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -82,10 +82,6 @@ type mockMessageCaptureStrategy struct {
 }
 
 //go:fix inline
-func floatPtr(v float64) *float64 {
-	return new(v)
-}
-
 func (m *mockMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, request CompletionRequest) (CaptureSession, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -81,7 +81,6 @@ type mockMessageCaptureStrategy struct {
 	capturedResponse     *CompletionResponse
 }
 
-//go:fix inline
 func (m *mockMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, request CompletionRequest) (CaptureSession, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Summary
- Set chat completion telemetry `ToolInfo.URN` to the stable `agents:chat:completion` resource instead of the per-chat ID.
- Add a regression test that keeps chat identity in GenAI conversation attributes while preserving the stable telemetry URN.

## Test plan
- `go test ./server/internal/thirdparty/openrouter`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes chat completion telemetry by switching to a stable URN and adds tests to prevent regressions. Prevents high-cardinality metrics while keeping per-chat identity in conversation attributes.

- **Bug Fixes**
  - Set `ToolInfo.URN` to `agents:chat:completion` instead of the per-chat ID.
  - Added a regression test to verify the stable URN, `ResourceURN` attribute, and preserved `GenAIConversationID`.

- **Refactors**
  - Removed an unused `openrouter` test helper.
  - Removed a gofix marker from an `openrouter` test.

<sup>Written for commit 05a549215568bd7aef695d88b9200e27032444ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

