### PR TITLE
fix(telemetry): stabilize assistant gram urns

### DIFF
--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -242,7 +242,7 @@ func (t *telemetryRuntimeBackend) emit(
 		Timestamp: time.Now().UTC(),
 		ToolInfo: telemetry.ToolInfo{
 			ID:             runtime.AssistantID.String(),
-			URN:            "urn:uuid:" + runtime.AssistantID.String(),
+			URN:            assistantRuntimeTelemetryURN,
 			Name:           name,
 			ProjectID:      runtime.ProjectID.String(),
 			DeploymentID:   "",

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -85,6 +85,9 @@ const (
 	// runs on a fresh deadline rather than the dead request context.
 	teardownCapCleanupTimeout = 30 * time.Second
 
+	assistantPipelineTelemetryURN = "assistants:pipeline"
+	assistantRuntimeTelemetryURN  = "assistants:runtime"
+
 	meterAssistantTurnClassified = "assistant.turn.classified"
 
 	runtimeStartupReapGrace = 2 * time.Minute
@@ -484,7 +487,7 @@ func (s *ServiceCore) emitAssistantTelemetry(
 		Timestamp: time.Now().UTC(),
 		ToolInfo: telemetry.ToolInfo{
 			ID:             assistant.ID.String(),
-			URN:            "urn:uuid:" + assistant.ID.String(),
+			URN:            assistantPipelineTelemetryURN,
 			Name:           "assistant:" + assistant.Name,
 			ProjectID:      assistant.ProjectID.String(),
 			DeploymentID:   "",


### PR DESCRIPTION
## Summary
- Set assistant pipeline telemetry `ToolInfo.URN` to the stable `assistants:pipeline` resource instead of assistant-specific UUID URNs.
- Set runtime backend telemetry `ToolInfo.URN` to the stable `assistants:runtime` resource while keeping assistant IDs in structured attributes.

## Test plan
- `go test ./server/internal/assistants`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes assistant telemetry by using fixed resource URNs for pipeline and runtime events. This lowers metric cardinality and keeps dashboards consistent.

- **Bug Fixes**
  - Pipeline: set `ToolInfo.URN` to `assistants:pipeline` instead of `urn:uuid:{assistantID}`.
  - Runtime backend: set `ToolInfo.URN` to `assistants:runtime`; keep assistant ID in `ToolInfo.ID` and structured attributes.

<sup>Written for commit 761252dfb1f1252e89a0d631cd1a1c21d96193b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

