### PR TITLE
fix(hooks): preserve hook telemetry email attribution

### DIFF
--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -1080,7 +1080,7 @@ func (s *Service) writeClaudeBlockToClickHouse(ctx context.Context, payload *gen
 			DeploymentID:   "",
 			FunctionID:     nil,
 		},
-		UserInfo:   telemetry.UserInfoByID(metadata.UserID),
+		UserInfo:   telemetry.UserInfoByIDAndEmail(metadata.UserID, metadata.UserEmail),
 		Attributes: attrs,
 	})
 }

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -282,7 +282,7 @@ func (s *Service) writeCodexHookToClickHouse(ctx context.Context, payload *gen.C
 		s.telemetryLogger.Log(ctx, telemetry.LogParams{
 			Timestamp:  time.Now(),
 			ToolInfo:   toolInfo,
-			UserInfo:   telemetry.UserInfoByID(metadata.UserID),
+			UserInfo:   telemetry.UserInfoByIDAndEmail(metadata.UserID, metadata.UserEmail),
 			Attributes: attrs,
 		})
 

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -265,7 +265,7 @@ func (s *Service) persistCursorHook(ctx context.Context, payload *gen.CursorPayl
 // persistCursorToolCallEvent writes tool call events to both ClickHouse and PostgreSQL
 func (s *Service) persistCursorToolCallEvent(ctx context.Context, payload *gen.CursorPayload, metadata *SessionMetadata, blockReason string, hookEvent HookEvent) error {
 	// Write to ClickHouse for telemetry
-	s.writeCursorHookToClickHouse(ctx, payload, metadata.GramOrgID, metadata.ProjectID, metadata.UserID, blockReason)
+	s.writeCursorHookToClickHouse(ctx, payload, metadata.GramOrgID, metadata.ProjectID, metadata.UserID, metadata.UserEmail, blockReason)
 
 	// Write to PostgreSQL for chat history
 	switch hookEvent {
@@ -291,7 +291,7 @@ func isCursorConversationEvent(hookEvent HookEvent) bool {
 // writeCursorHookToClickHouse writes a Cursor hook event directly to ClickHouse
 // Unlike Claude hooks, Cursor payloads are already authenticated and include user_email,
 // so no Redis buffering is needed.
-func (s *Service) writeCursorHookToClickHouse(ctx context.Context, payload *gen.CursorPayload, orgID string, projectID string, userID string, blockReason string) {
+func (s *Service) writeCursorHookToClickHouse(ctx context.Context, payload *gen.CursorPayload, orgID string, projectID string, userID string, userEmail string, blockReason string) {
 	attrs := s.buildCursorTelemetryAttributes(ctx, payload, orgID, projectID)
 	if blockReason != "" {
 		attrs[attr.HookBlockReasonKey] = blockReason
@@ -318,7 +318,7 @@ func (s *Service) writeCursorHookToClickHouse(ctx context.Context, payload *gen.
 		s.telemetryLogger.Log(ctx, telemetry.LogParams{
 			Timestamp:  time.Now(),
 			ToolInfo:   toolInfo,
-			UserInfo:   telemetry.UserInfoByID(userID),
+			UserInfo:   telemetry.UserInfoByIDAndEmail(userID, userEmail),
 			Attributes: attrs,
 		})
 

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -140,7 +140,7 @@ func (s *Service) persistToolCallEvent(ctx context.Context, payload *gen.ClaudeP
 		s.telemetryLogger.Log(ctx, telemetry.LogParams{
 			Timestamp:  time.Now(),
 			ToolInfo:   toolInfo,
-			UserInfo:   telemetry.UserInfoByID(metadata.UserID),
+			UserInfo:   telemetry.UserInfoByIDAndEmail(metadata.UserID, metadata.UserEmail),
 			Attributes: attrs,
 		})
 

--- a/server/internal/hooks/pending_helpers_test.go
+++ b/server/internal/hooks/pending_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
 // otelOnlyCtx returns a context that simulates the OTEL flow: no auth
@@ -269,6 +270,52 @@ func TestBuildTelemetryAttributesWithMetadata_ResolvesUserIDFromEmail(t *testing
 	assert.NotContains(t, attrs, attr.UserEmailKey)
 	assert.NotContains(t, attrs, attr.UserIDKey)
 	assert.Equal(t, userID, metadata.UserID)
+}
+
+func TestPersistToolCallEvent_PreservesEmailWhenUserIDUnresolved(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	sessionID := uuid.NewString()
+	userEmail := "smartnews-user@example.com"
+	metadata := &SessionMetadata{
+		SessionID: sessionID,
+		UserEmail: userEmail,
+		GramOrgID: authCtx.ActiveOrganizationID,
+		ProjectID: authCtx.ProjectID.String(),
+	}
+	start := time.Now().UTC()
+
+	err := ti.service.persistToolCallEvent(ctx, &hooks.ClaudePayload{
+		HookEventName: "ToolEvent",
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		SessionID:     &sessionID,
+	}, metadata)
+	require.NoError(t, err)
+	require.Empty(t, metadata.UserID, "test email should not resolve to a connected user")
+
+	var logs []telemetryrepo.TelemetryLog
+	require.Eventually(t, func() bool {
+		var err error
+		logs, err = chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     start.Add(-time.Minute).UnixNano(),
+			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
+			GramChatID:    sessionID,
+			EventSource:   "hook",
+			SortOrder:     "desc",
+			Limit:         10,
+		})
+		return err == nil && len(logs) == 1
+	}, 2*time.Second, 50*time.Millisecond)
+
+	require.Len(t, logs, 1)
+	require.Contains(t, logs[0].Attributes, userEmail)
 }
 
 func TestBuildTelemetryAttributesWithMetadata_SetsHookHostname(t *testing.T) {

--- a/server/internal/telemetry/telemetry.go
+++ b/server/internal/telemetry/telemetry.go
@@ -85,6 +85,10 @@ func UserInfoByEmail(email string) UserInfo {
 	return UserInfo{userID: "", email: email}
 }
 
+func UserInfoByIDAndEmail(userID, email string) UserInfo {
+	return UserInfo{userID: userID, email: email}
+}
+
 func (u UserInfo) UserID() string {
 	return u.userID
 }


### PR DESCRIPTION
## Summary
- Preserve hook telemetry email attribution when a session email does not resolve to a connected Gram user ID.
- Pass both user ID and email through hook ClickHouse writes for Claude, Codex, and Cursor tool events.
- Add regression coverage for Claude hook rows retaining `user.email` with an unresolved user ID.

## Test plan
- Pre-commit hook ran during commit.
- Targeted `go test ./server/internal/hooks ./server/internal/telemetry` was started earlier but interrupted before completion.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing user attribution in Tool Logs by preserving session email in hook telemetry when the user ID can’t be resolved. Applies to Claude, Codex, and Cursor tool events, addressing Linear DNO-335 for SmartNews.

- **Bug Fixes**
  - Send both user ID and email to ClickHouse via `server/internal/telemetry.UserInfoByIDAndEmail`.
  - Propagate `userEmail` through Cursor hook writes.
  - Add a regression test to ensure `user.email` is retained when `user_id` is empty.

<sup>Written for commit 4da10339ecc99a9e51b78d0f0b9bb4507bcfb48a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

