### PR TITLE
fix(telemetry): merge search users by email

### DIFF
--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -31,6 +31,15 @@ func userIdentifierExpr(col string) string {
 	return "if(telemetry_logs." + col + " != '', telemetry_logs." + col + ", telemetry_logs.user_email)"
 }
 
+// SearchUsers powers employee enrollment lists, so internal users are grouped by
+// email first to collapse rows that mix email-only and opaque user.id identity.
+func searchUsersGroupExpr(groupBy string) string {
+	if groupBy == "external_user_id" {
+		return userIdentifierExpr("external_user_id")
+	}
+	return "if(telemetry_logs.user_email != '', telemetry_logs.user_email, telemetry_logs.user_id)"
+}
+
 // totalTokensExpr is a grouped-aggregate expression that yields a reliable total
 // token count. AI-coding providers like Claude Code report
 // gen_ai.usage.input_tokens and gen_ai.usage.output_tokens but never emit
@@ -1389,8 +1398,8 @@ type SearchUsersParams struct {
 
 // SearchUsers retrieves aggregated usage metrics grouped by user identifier.
 //
-// Groups telemetry logs by user_id or external_user_id and computes per-user
-// metrics including tokens, chats, and tool call breakdowns.
+// Groups telemetry logs by internal email/user_id or external_user_id and
+// computes per-user metrics including tokens, chats, and tool call breakdowns.
 // Pagination uses last_seen_unix_nano + the group column for stable cursor ordering.
 //
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
@@ -1399,7 +1408,7 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 	if arg.GroupBy == "external_user_id" {
 		groupCol = "external_user_id"
 	}
-	groupExpr := userIdentifierExpr(groupCol)
+	groupExpr := searchUsersGroupExpr(arg.GroupBy)
 
 	tc := toolCallExprsFor(arg.EventSource)
 
@@ -1454,7 +1463,14 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 		sb = sb.Where("hook_source = ?", arg.HookSource)
 	}
 	if len(arg.UserIDs) > 0 {
-		sb = sb.Where(squirrel.Eq{groupExpr: arg.UserIDs})
+		if arg.GroupBy == "external_user_id" {
+			sb = sb.Where(squirrel.Eq{groupExpr: arg.UserIDs})
+		} else {
+			sb = sb.Where(squirrel.Or{
+				squirrel.Eq{groupExpr: arg.UserIDs},
+				squirrel.Eq{userIdentifierExpr(groupCol): arg.UserIDs},
+			})
+		}
 	}
 
 	sb = sb.GroupBy(groupExpr)

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -267,7 +267,7 @@ func TestSearchUsers_FallsBackToUserEmail(t *testing.T) {
 	require.Equal(t, email, filtered.Users[0].UserID)
 }
 
-func TestSearchUsers_IncludesUserEmailWhenGroupedByOpaqueUserID(t *testing.T) {
+func TestSearchUsers_GroupsInternalUsersByEmailWhenOpaqueUserIDPresent(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestLogsService(t)
@@ -300,9 +300,68 @@ func TestSearchUsers_IncludesUserEmailWhenGroupedByOpaqueUserID(t *testing.T) {
 		if !assert.NotNil(c, res) || !assert.Len(c, res.Users, 1) {
 			return
 		}
-		assert.Equal(c, userID, res.Users[0].UserID)
+		assert.Equal(c, email, res.Users[0].UserID)
 		assert.Equal(c, email, res.Users[0].UserEmail)
 	}, 10*time.Second, 200*time.Millisecond)
+}
+
+func TestSearchUsers_MergesInternalUsersByEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	userID := "01924a0eb409b0ecf44e06d0ec03cbc4"
+	email := "merged-internal-" + uuid.New().String() + "@example.com"
+	insertPollingLogWithEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), email, 100, 50, 1.25)
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), userID, email, 200, 100, 2.5)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.Len(c, res.Users, 1) {
+			return
+		}
+
+		user := res.Users[0]
+		assert.Equal(c, email, user.UserID)
+		assert.Equal(c, email, user.UserEmail)
+		assert.Equal(c, int64(300), user.TotalInputTokens)
+		assert.Equal(c, int64(150), user.TotalOutputTokens)
+		assert.Equal(c, int64(450), user.TotalTokens)
+	}, 10*time.Second, 200*time.Millisecond)
+
+	filtered, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter: &gen.SearchUsersFilter{
+			From:    from,
+			To:      to,
+			UserIds: []string{email},
+		},
+		UserType: "internal",
+		Limit:    100,
+		Sort:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, filtered.Users, 1)
+	require.Equal(t, email, filtered.Users[0].UserID)
+	require.Equal(t, int64(450), filtered.Users[0].TotalTokens)
 }
 
 func TestSearchUsers_Pagination(t *testing.T) {
@@ -881,6 +940,47 @@ func insertPollingLogWithEmail(t *testing.T, ctx context.Context, projectID, dep
 	attributes := map[string]any{
 		"gram.event.source":          string(tm.EventSourceAPI),
 		"gram.hook.source":           "cursor",
+		"user.email":                 email,
+		"gen_ai.usage.input_tokens":  inputTokens,
+		"gen_ai.usage.output_tokens": outputTokens,
+		"gen_ai.usage.cost":          cost,
+		"gen_ai.response.model":      "cursor-model",
+		"gen_ai.conversation.id":     uuid.New().String(),
+		"gen_ai.response.id":         uuid.New().String(),
+		"gen_ai.usage.total_tokens":  inputTokens + outputTokens,
+		"gen_ai.provider.name":       "cursor",
+		"cursor.event_hash":          uuid.New().String(),
+		"gram.resource.urn":          "cursor:usage:metrics",
+	}
+
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	err = conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_deployment_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "cursor usage metrics",
+		nil, nil, string(attrsJSON), "{}",
+		projectID, deploymentID, "cursor:usage:metrics", "gram-cursor")
+	require.NoError(t, err)
+}
+
+func insertPollingLogWithUserAndEmail(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, userID, email string, inputTokens, outputTokens int, cost float64) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attributes := map[string]any{
+		"gram.event.source":          string(tm.EventSourceAPI),
+		"gram.hook.source":           "cursor",
+		"user.id":                    userID,
 		"user.email":                 email,
 		"gen_ai.usage.input_tokens":  inputTokens,
 		"gen_ai.usage.output_tokens": outputTokens,


### PR DESCRIPTION
## Summary
- Merge internal SearchUsers summaries by email when present, so email-only and opaque user.id rows collapse into one Enrollment identity.
- Keep external-user grouping unchanged and allow internal SearchUsers filters to match either the canonical email or legacy user_id fallback.
- Add regression coverage for mixed email-only/user.id rows returning one merged user summary.

## Test plan
- go test ./server/internal/telemetry


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merge internal SearchUsers results by email so mixed email-only and opaque user.id rows collapse into one user with correct totals. External-user grouping stays the same, and filters now match both email and legacy user_id for internal users.

- **Bug Fixes**
  - Group internal users by email when present; fallback to `user_id`.
  - Allow `UserIds` filter to match either the email or legacy `user_id` for internal grouping.
  - Preserve `external_user_id` grouping behavior.
  - Add tests for merged identities and totals; cover mixed email-only/user.id rows.

<sup>Written for commit f22b6e4c148b7773394aa2dc05cfe5294ab3544a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

