### PR TITLE
fix(billing): omit empty Polar tool metadata

### DIFF
--- a/server/internal/thirdparty/polar/client.go
+++ b/server/internal/thirdparty/polar/client.go
@@ -265,6 +265,28 @@ func (p *Client) TrackToolCallUsage(ctx context.Context, event billing.ToolCallU
 	ctx, span := p.tracer.Start(ctx, "polar_client.track_tool_call_usage")
 	defer span.End()
 
+	metadata := toolCallUsageMetadata(event)
+
+	_, err := p.polar.Events.Ingest(ctx, polarComponents.EventsIngest{
+		Events: []polarComponents.Events{
+			{
+				Type: polarComponents.EventsTypeEventCreateExternalCustomer,
+				EventCreateExternalCustomer: &polarComponents.EventCreateExternalCustomer{
+					ExternalCustomerID: event.OrganizationID,
+					Name:               "tool-call",
+					Metadata:           metadata,
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		p.logger.ErrorContext(ctx, "failed to ingest usage event to Polar", attr.SlogError(err))
+	}
+}
+
+func toolCallUsageMetadata(event billing.ToolCallUsageEvent) map[string]polarComponents.EventMetadataInput {
 	totalBytes := event.RequestBytes + event.OutputBytes
 	typeStr := string(event.Type)
 
@@ -278,18 +300,24 @@ func (p *Client) TrackToolCallUsage(ctx context.Context, event billing.ToolCallU
 		"total_bytes": {
 			Integer: &totalBytes,
 		},
-		"tool_urn": {
-			Str: &event.ToolURN,
-		},
-		"tool_name": {
-			Str: &event.ToolName,
-		},
 		"project_id": {
 			Str: &event.ProjectID,
 		},
 		"type": {
 			Str: &typeStr,
 		},
+	}
+
+	if event.ToolURN != "" {
+		metadata["tool_urn"] = polarComponents.EventMetadataInput{
+			Str: &event.ToolURN,
+		}
+	}
+
+	if event.ToolName != "" {
+		metadata["tool_name"] = polarComponents.EventMetadataInput{
+			Str: &event.ToolName,
+		}
 	}
 
 	if event.ResourceURI != "" {
@@ -346,23 +374,7 @@ func (p *Client) TrackToolCallUsage(ctx context.Context, event billing.ToolCallU
 		}
 	}
 
-	_, err := p.polar.Events.Ingest(ctx, polarComponents.EventsIngest{
-		Events: []polarComponents.Events{
-			{
-				Type: polarComponents.EventsTypeEventCreateExternalCustomer,
-				EventCreateExternalCustomer: &polarComponents.EventCreateExternalCustomer{
-					ExternalCustomerID: event.OrganizationID,
-					Name:               "tool-call",
-					Metadata:           metadata,
-				},
-			},
-		},
-	})
-
-	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
-		p.logger.ErrorContext(ctx, "failed to ingest usage event to Polar", attr.SlogError(err))
-	}
+	return metadata
 }
 
 func (p *Client) TrackPromptCallUsage(ctx context.Context, event billing.PromptCallUsageEvent) {

--- a/server/internal/thirdparty/polar/client_test.go
+++ b/server/internal/thirdparty/polar/client_test.go
@@ -3,7 +3,10 @@ package polar
 import (
 	"testing"
 
+	polarComponents "github.com/polarsource/polar-go/models/components"
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/billing"
 )
 
 func TestCatalog_IsTopUpProductID(t *testing.T) {
@@ -15,4 +18,80 @@ func TestCatalog_IsTopUpProductID(t *testing.T) {
 	require.True(t, c.IsTopUpProductID("prod_b"))
 	require.False(t, c.IsTopUpProductID("prod_unknown"))
 	require.False(t, c.IsTopUpProductID(""))
+}
+
+func TestToolCallUsageMetadata_OmitsEmptyOptionalStringDimensions(t *testing.T) {
+	t.Parallel()
+
+	event := billing.ToolCallUsageEvent{
+		OrganizationID:        "org_123",
+		RequestBytes:          10,
+		OutputBytes:           20,
+		ToolURN:               "",
+		ToolName:              "",
+		ResourceURI:           "",
+		ProjectID:             "proj_123",
+		ProjectSlug:           nil,
+		OrganizationSlug:      nil,
+		ToolsetSlug:           nil,
+		ChatID:                nil,
+		MCPURL:                nil,
+		Type:                  billing.ToolCallTypeExternalMCP,
+		ResponseStatusCode:    200,
+		ToolsetID:             nil,
+		MCPSessionID:          nil,
+		FunctionCPUUsage:      nil,
+		FunctionMemUsage:      nil,
+		FunctionExecutionTime: nil,
+	}
+
+	metadata := toolCallUsageMetadata(event)
+
+	require.NotContains(t, metadata, "tool_urn")
+	require.NotContains(t, metadata, "tool_name")
+	require.NotContains(t, metadata, "resource_uri")
+	require.Equal(t, "proj_123", metadataString(t, metadata, "project_id"))
+	require.Equal(t, "external-mcp", metadataString(t, metadata, "type"))
+}
+
+func TestToolCallUsageMetadata_IncludesNonEmptyStringDimensions(t *testing.T) {
+	t.Parallel()
+
+	event := billing.ToolCallUsageEvent{
+		OrganizationID:        "org_123",
+		RequestBytes:          10,
+		OutputBytes:           20,
+		ToolURN:               "gram://toolsets/ts_123/tools/search_tickets",
+		ToolName:              "search_tickets",
+		ResourceURI:           "ui://widget/ticket-list",
+		ProjectID:             "proj_123",
+		ProjectSlug:           nil,
+		OrganizationSlug:      nil,
+		ToolsetSlug:           nil,
+		ChatID:                nil,
+		MCPURL:                nil,
+		Type:                  billing.ToolCallTypeExternalMCP,
+		ResponseStatusCode:    200,
+		ToolsetID:             nil,
+		MCPSessionID:          nil,
+		FunctionCPUUsage:      nil,
+		FunctionMemUsage:      nil,
+		FunctionExecutionTime: nil,
+	}
+
+	metadata := toolCallUsageMetadata(event)
+
+	require.Equal(t, "gram://toolsets/ts_123/tools/search_tickets", metadataString(t, metadata, "tool_urn"))
+	require.Equal(t, "search_tickets", metadataString(t, metadata, "tool_name"))
+	require.Equal(t, "ui://widget/ticket-list", metadataString(t, metadata, "resource_uri"))
+}
+
+func metadataString(t *testing.T, metadata map[string]polarComponents.EventMetadataInput, key string) string {
+	t.Helper()
+
+	value, ok := metadata[key]
+	require.True(t, ok)
+	require.NotNil(t, value.Str)
+
+	return *value.Str
 }


### PR DESCRIPTION
## Summary
- omit empty tool_urn and tool_name from Polar tool-call usage metadata
- keep non-empty tool/resource dimensions in billing events
- add regression coverage for external-MCP metadata with empty tool dimensions

## Tests
- go test ./server/internal/thirdparty/polar
- mise lint:server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit empty tool metadata in Polar tool-call usage events to prevent noisy billing dimensions. Non-empty tool/resource fields are still sent, with tests to lock this behavior.

- **Bug Fixes**
  - Stop sending empty `tool_urn` and `tool_name`.
  - Keep non-empty `tool_urn`, `tool_name`, and `resource_uri` in event metadata.

- **Refactors**
  - Extracted `toolCallUsageMetadata` helper to build metadata.
  - Added tests for omission/inclusion of optional string fields.

<sup>Written for commit 7d9b8fbce1dba92f73b65258e25a9ade6f657acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

