### PR TITLE
mig: adds configurable score threshold (AIS-200)

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2950,6 +2950,9 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   policy_type TEXT NOT NULL DEFAULT 'standard',
   sources TEXT[] NOT NULL,
   presidio_entities TEXT[],
+  -- Minimum Presidio confidence (0.0-1.0) a PII match must clear to surface.
+  -- NULL means the scanner applies its default threshold (0.75).
+  presidio_score_threshold DOUBLE PRECISION,
   prompt_injection_rules TEXT[],
   -- Canonical rule_ids (e.g. 'secret.aws_access_token', 'pii.credit_card')
   -- the policy author has unchecked within an otherwise-enabled category.

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1318,31 +1318,32 @@ type RiskExclusion struct {
 }
 
 type RiskPolicy struct {
-	ID                   uuid.UUID
-	ProjectID            uuid.UUID
-	OrganizationID       string
-	Enabled              bool
-	Name                 string
-	PolicyType           string
-	Sources              []string
-	PresidioEntities     []string
-	PromptInjectionRules []string
-	DisabledRules        []string
-	CustomRuleIds        []string
-	MessageTypes         []string
-	ScopeInclude         pgtype.Text
-	ScopeExempt          pgtype.Text
-	Action               string
-	AudienceType         string
-	AutoName             bool
-	UserMessage          pgtype.Text
-	Prompt               pgtype.Text
-	ModelConfig          []byte
-	Version              int64
-	CreatedAt            pgtype.Timestamptz
-	UpdatedAt            pgtype.Timestamptz
-	DeletedAt            pgtype.Timestamptz
-	Deleted              bool
+	ID                     uuid.UUID
+	ProjectID              uuid.UUID
+	OrganizationID         string
+	Enabled                bool
+	Name                   string
+	PolicyType             string
+	Sources                []string
+	PresidioEntities       []string
+	PresidioScoreThreshold pgtype.Float8
+	PromptInjectionRules   []string
+	DisabledRules          []string
+	CustomRuleIds          []string
+	MessageTypes           []string
+	ScopeInclude           pgtype.Text
+	ScopeExempt            pgtype.Text
+	Action                 string
+	AudienceType           string
+	AutoName               bool
+	UserMessage            pgtype.Text
+	Prompt                 pgtype.Text
+	ModelConfig            []byte
+	Version                int64
+	CreatedAt              pgtype.Timestamptz
+	UpdatedAt              pgtype.Timestamptz
+	DeletedAt              pgtype.Timestamptz
+	Deleted                bool
 }
 
 // Risk-policy bypass request workflow. A block records a request here; an admin approves by granting risk_policy:bypass.

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -43,31 +43,32 @@ type RiskExclusion struct {
 }
 
 type RiskPolicy struct {
-	ID                   uuid.UUID
-	ProjectID            uuid.UUID
-	OrganizationID       string
-	Enabled              bool
-	Name                 string
-	PolicyType           string
-	Sources              []string
-	PresidioEntities     []string
-	PromptInjectionRules []string
-	DisabledRules        []string
-	CustomRuleIds        []string
-	MessageTypes         []string
-	ScopeInclude         pgtype.Text
-	ScopeExempt          pgtype.Text
-	Action               string
-	AudienceType         string
-	AutoName             bool
-	UserMessage          pgtype.Text
-	Prompt               pgtype.Text
-	ModelConfig          []byte
-	Version              int64
-	CreatedAt            pgtype.Timestamptz
-	UpdatedAt            pgtype.Timestamptz
-	DeletedAt            pgtype.Timestamptz
-	Deleted              bool
+	ID                     uuid.UUID
+	ProjectID              uuid.UUID
+	OrganizationID         string
+	Enabled                bool
+	Name                   string
+	PolicyType             string
+	Sources                []string
+	PresidioEntities       []string
+	PresidioScoreThreshold pgtype.Float8
+	PromptInjectionRules   []string
+	DisabledRules          []string
+	CustomRuleIds          []string
+	MessageTypes           []string
+	ScopeInclude           pgtype.Text
+	ScopeExempt            pgtype.Text
+	Action                 string
+	AudienceType           string
+	AutoName               bool
+	UserMessage            pgtype.Text
+	Prompt                 pgtype.Text
+	ModelConfig            []byte
+	Version                int64
+	CreatedAt              pgtype.Timestamptz
+	UpdatedAt              pgtype.Timestamptz
+	DeletedAt              pgtype.Timestamptz
+	Deleted                bool
 }
 
 // Risk-policy bypass request workflow. A block records a request here; an admin approves by granting risk_policy:bypass.

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -257,7 +257,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -277,6 +277,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.PolicyType,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PresidioScoreThreshold,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
 		&i.CustomRuleIds,
@@ -592,7 +593,7 @@ VALUES (
   , $20::jsonb
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -651,6 +652,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.PolicyType,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PresidioScoreThreshold,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
 		&i.CustomRuleIds,
@@ -1068,7 +1070,7 @@ func (q *Queries) GetRiskOverviewCounts(ctx context.Context, arg GetRiskOverview
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1092,6 +1094,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.PolicyType,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PresidioScoreThreshold,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
 		&i.CustomRuleIds,
@@ -1154,7 +1157,7 @@ func (q *Queries) GetRiskPolicyBypassRequest(ctx context.Context, arg GetRiskPol
 }
 
 const getRiskPolicyForUpdate = `-- name: GetRiskPolicyForUpdate :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1179,6 +1182,7 @@ func (q *Queries) GetRiskPolicyForUpdate(ctx context.Context, arg GetRiskPolicyF
 		&i.PolicyType,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PresidioScoreThreshold,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
 		&i.CustomRuleIds,
@@ -1295,7 +1299,7 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1321,6 +1325,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.PolicyType,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PresidioScoreThreshold,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
 			&i.CustomRuleIds,
@@ -1401,7 +1406,7 @@ func (q *Queries) ListEnabledExclusionsForPolicy(ctx context.Context, arg ListEn
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1426,6 +1431,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.PolicyType,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PresidioScoreThreshold,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
 			&i.CustomRuleIds,
@@ -1455,7 +1461,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1482,6 +1488,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.PolicyType,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PresidioScoreThreshold,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
 			&i.CustomRuleIds,
@@ -1511,7 +1518,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1541,6 +1548,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.PolicyType,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PresidioScoreThreshold,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
 			&i.CustomRuleIds,
@@ -1854,7 +1862,7 @@ func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, arg ListRiskOver
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -1879,6 +1887,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.PolicyType,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PresidioScoreThreshold,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
 			&i.CustomRuleIds,
@@ -2910,7 +2919,7 @@ SET name = $1
 WHERE id = $17
   AND project_id = $18
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, presidio_score_threshold, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -2965,6 +2974,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.PolicyType,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PresidioScoreThreshold,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
 		&i.CustomRuleIds,

--- a/server/migrations/20260624120126_presidio-score-threshold.sql
+++ b/server/migrations/20260624120126_presidio-score-threshold.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "presidio_score_threshold" double precision NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:/3CGXu85i6RRt6AI67G9nJU0pKqU8NzynaBGHUp39bw=
+h1:/rJyAbs+Jts31lacu4xxU+oSmpJpbi0ffSRY1Uz2iYU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -224,3 +224,4 @@ h1:/3CGXu85i6RRt6AI67G9nJU0pKqU8NzynaBGHUp39bw=
 20260618194743_deployments-functions-add-infra-overrides.sql h1:MNR3+BYsl1tfjLes6MbKUWqGkw/nMs8HO2cfyZvTTPs=
 20260618215143_add_custom_rule_match_config.sql h1:ZALVgDTK3jWQrHREznqnbbQDNdfIuOZAWr3VnqLAgbo=
 20260620160523_policy-scope-columns.sql h1:Nd+/ilugIcMRbweLykPze7LzXxiEmd51qsfla1gj3Ig=
+20260624120126_presidio-score-threshold.sql h1:zyOiaX0UseYGcW/QGxKco9Ll8Wkaccvxh2BPQ39FP8E=


### PR DESCRIPTION
Schema and migrations split off `feat/score_threshold_config` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a nullable presidio_score_threshold to risk_policies to let policies set a minimum Presidio confidence (0.0–1.0) for PII matches. This is backward-compatible; NULL keeps the scanner default (0.75). Models and queries are updated to include the new column.

- **Migration**
  - Run migrations to add presidio_score_threshold (no backfill, no downtime).
  - Existing policies are unchanged until a threshold is set.

<sup>Written for commit a89227fc70c6d0b8cf3019284b07da15fca487f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

