### PR TITLE
fix(auth): claim WorkOS membership placeholders on login

### DIFF
--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
@@ -303,6 +304,76 @@ func TestE2E_Callback_NewUserJoiningExistingOrg(t *testing.T) {
 	orgMeta, err := orgQueries.GetOrganizationMetadata(ctx, workosOrgID)
 	require.NoError(t, err)
 	assert.True(t, orgMeta.Whitelisted, "existing org's whitelisted flag must be preserved")
+}
+
+func TestE2E_Callback_ClaimsWorkOSMembershipPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workosUserID     = "user_01WORKOS_PLACEHOLDER"
+		workosOrgID      = "org_01PLACEHOLDER"
+		workosMembership = "om_01PLACEHOLDER"
+		gramOrgID        = "placeholder-org"
+		orgName          = "Placeholder Corp"
+	)
+	gramUserID := users.UserIDFromWorkOSID(workosUserID)
+
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{
+			workosUserID: {
+				{ID: workosMembership, UserID: workosUserID, OrganizationID: workosOrgID, Organization: orgName, RoleSlugs: []string{"member"}},
+			},
+		},
+		orgs: map[string]*workos.Organization{
+			workosOrgID: {ID: workosOrgID, Name: orgName},
+		},
+	}
+
+	userInfo := &MockUserInfo{
+		UserID:        workosUserID,
+		Email:         "placeholder@example.com",
+		Organizations: []MockOrganizationEntry{},
+	}
+
+	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
+	orgQueries := orgRepo.New(inst.conn)
+	_, err := orgQueries.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:       gramOrgID,
+		Name:     orgName,
+		Slug:     "placeholder-corp",
+		WorkosID: pgtype.Text{String: workosOrgID, Valid: true},
+	})
+	require.NoError(t, err)
+
+	err = orgQueries.UpsertWorkOSMembership(ctx, orgRepo.UpsertWorkOSMembershipParams{
+		OrganizationID:     gramOrgID,
+		UserID:             pgtype.Text{},
+		WorkosUserID:       conv.ToPGText(workosUserID),
+		WorkosMembershipID: conv.ToPGText(workosMembership),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now()),
+		WorkosLastEventID:  conv.ToPGText("evt_placeholder"),
+	})
+	require.NoError(t, err)
+
+	before, err := orgQueries.GetRelationshipByMembershipID(ctx, conv.ToPGText(workosMembership))
+	require.NoError(t, err)
+	require.False(t, before.UserID.Valid)
+
+	result, err := inst.callbackWithNonce(ctx, t)
+	require.NoError(t, err)
+	require.NotContains(t, result.Location, "signin_error=")
+	require.NotEmpty(t, result.SessionToken)
+
+	after, err := orgQueries.GetRelationshipByMembershipID(ctx, conv.ToPGText(workosMembership))
+	require.NoError(t, err)
+	require.Equal(t, before.ID, after.ID)
+	require.Equal(t, gramUserID, after.UserID.String)
+
+	ctx, err = inst.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, gramOrgID, authCtx.ActiveOrganizationID)
 }
 
 // TestE2E_Callback_NewUserNoWorkOSOrgs verifies that when a new user has no

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -142,10 +142,34 @@ resolved AS (
     FROM input_memberships
     JOIN organization_metadata ON organization_metadata.workos_id = input_memberships.workos_org_id
 ),
+claimed_placeholders AS (
+    UPDATE organization_user_relationships pending
+    SET user_id = @user_id,
+        deleted_at = NULL,
+        updated_at = clock_timestamp()
+    FROM resolved
+    WHERE pending.workos_membership_id = resolved.workos_membership_id
+      AND pending.user_id IS NULL
+      AND pending.deleted_at IS NULL
+      AND @user_id::text IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM organization_user_relationships existing
+          WHERE existing.organization_id = pending.organization_id
+            AND existing.user_id = @user_id
+            AND existing.deleted_at IS NULL
+      )
+    RETURNING pending.organization_id, pending.workos_membership_id
+),
 upserted AS (
     INSERT INTO organization_user_relationships (organization_id, user_id, workos_membership_id)
     SELECT resolved.organization_id, @user_id, resolved.workos_membership_id
     FROM resolved
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM claimed_placeholders
+        WHERE claimed_placeholders.workos_membership_id = resolved.workos_membership_id
+    )
     ON CONFLICT (organization_id, user_id) DO UPDATE SET
         workos_membership_id = EXCLUDED.workos_membership_id,
         deleted_at = NULL,

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -1254,10 +1254,34 @@ resolved AS (
     FROM input_memberships
     JOIN organization_metadata ON organization_metadata.workos_id = input_memberships.workos_org_id
 ),
+claimed_placeholders AS (
+    UPDATE organization_user_relationships pending
+    SET user_id = $1,
+        deleted_at = NULL,
+        updated_at = clock_timestamp()
+    FROM resolved
+    WHERE pending.workos_membership_id = resolved.workos_membership_id
+      AND pending.user_id IS NULL
+      AND pending.deleted_at IS NULL
+      AND $1::text IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1
+          FROM organization_user_relationships existing
+          WHERE existing.organization_id = pending.organization_id
+            AND existing.user_id = $1
+            AND existing.deleted_at IS NULL
+      )
+    RETURNING pending.organization_id, pending.workos_membership_id
+),
 upserted AS (
     INSERT INTO organization_user_relationships (organization_id, user_id, workos_membership_id)
     SELECT resolved.organization_id, $1, resolved.workos_membership_id
     FROM resolved
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM claimed_placeholders
+        WHERE claimed_placeholders.workos_membership_id = resolved.workos_membership_id
+    )
     ON CONFLICT (organization_id, user_id) DO UPDATE SET
         workos_membership_id = EXCLUDED.workos_membership_id,
         deleted_at = NULL,


### PR DESCRIPTION
## Summary
- Claim active WorkOS membership placeholder rows (`user_id IS NULL`) during login membership sync before inserting new org-user relationships.
- Avoid reassigning memberships already attached to another non-null user.
- Add an auth callback regression test for first login after WorkOS membership sync pre-created the placeholder row.

## Production context
Read-replica investigation found 17 active placeholder membership rows across 10 orgs. 4 already have matching Gram users and can hit the duplicate `organization_user_relationships_workos_membership_id_key` failure today, including the reported Mistral user.

## Validation
- `go test ./server/internal/auth -run TestE2E_Callback_ClaimsWorkOSMembershipPlaceholder -count=1`
- `go test ./server/internal/auth -count=1`
- `mise run gen:sqlc-server`
- `mise lint:server`

Note: commit was created from a clean auxiliary worktree to avoid touching the existing dirty hook/dashboard worktree. The local pre-commit hook in that auxiliary worktree could not run because Node package `zx` was not installed there; validation above passed manually.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claims existing WorkOS membership placeholders during login to prevent duplicate inserts and fix sign-in errors from `workos_membership_id` conflicts. Ensures placeholder rows are correctly attached to the logging-in user.

- **Bug Fixes**
  - During sync, update existing `organization_user_relationships` rows where `workos_membership_id` matches and `user_id IS NULL` instead of inserting a new row.
  - Do not reassign memberships already linked to another user; skip insert if a placeholder was claimed.
  - Added an end-to-end regression test for the first-login flow that pre-creates a placeholder membership.

<sup>Written for commit 60cbbc6697fbdade74900619f38763d039445630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

