### PR TITLE
feat: add tunnelled MCP database schema

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -91,6 +91,9 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
   -- Day of month (1-31) the billing cycle starts at 00:00 UTC. Clamped to the
   -- last day of shorter months when computing cycle boundaries.
   billing_cycle_anchor_day INT NOT NULL DEFAULT 1,
+  -- Contracted org-level cap for tunnelled MCP server sources. NULL means use
+  -- the plan default, not unlimited.
+  tunnelled_mcp_server_limit INT CHECK (tunnelled_mcp_server_limit IS NULL OR tunnelled_mcp_server_limit >= 0),
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -102,6 +105,8 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
 
 CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_organization_id_key
 ON billing_metadata (organization_id);
+
+COMMENT ON COLUMN billing_metadata.tunnelled_mcp_server_limit IS 'Contracted org-level cap for tunnelled MCP server sources. NULL means use the finite plan default.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
 ON organization_metadata (slug);
@@ -2641,9 +2646,67 @@ CREATE UNIQUE INDEX IF NOT EXISTS remote_mcp_server_headers_remote_mcp_server_id
 ON remote_mcp_server_headers (remote_mcp_server_id, name)
 WHERE deleted IS FALSE;
 
+-- Customer-hosted MCP servers connected through outbound tunnels. Gram stores
+-- the durable management/source record; live connection routing is cached in
+-- Redis by the tunnel gateway.
+CREATE TABLE IF NOT EXISTS tunnelled_mcp_servers (
+  -- Stable UUID for the tunnelled MCP source. Used by management APIs,
+  -- dashboard routes, and Redis connection cache keys.
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  -- Project that owns this source. All management queries are project-scoped.
+  project_id uuid NOT NULL,
+  -- User-facing display name for the tunnelled MCP source.
+  name TEXT NOT NULL CHECK (name <> ''),
+  -- Hash of the one-time tunnel key. The plaintext key is not stored.
+  key_hash TEXT NOT NULL CHECK (key_hash <> ''),
+  -- Non-secret key prefix shown in the UI for user-side key identification.
+  key_prefix TEXT NOT NULL CHECK (key_prefix <> ''),
+  -- Durable source lifecycle. Live connection state is derived from Redis.
+  status TEXT NOT NULL DEFAULT 'created' CHECK (status IN ('created', 'active', 'revoked')),
+  -- Last persisted tunnel agent version reported for this source.
+  agent_version TEXT CHECK (agent_version IS NULL OR agent_version <> ''),
+  -- Most recent persisted heartbeat time, used when Redis liveness data is absent.
+  last_seen_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT tunnelled_mcp_servers_pkey PRIMARY KEY (id),
+  CONSTRAINT tunnelled_mcp_servers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS tunnelled_mcp_servers_project_id_idx
+ON tunnelled_mcp_servers (project_id)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tunnelled_mcp_servers_project_id_name_key
+ON tunnelled_mcp_servers (project_id, name)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tunnelled_mcp_servers_key_hash_key
+ON tunnelled_mcp_servers (key_hash)
+WHERE deleted IS FALSE;
+
+COMMENT ON TABLE tunnelled_mcp_servers IS 'Customer-hosted MCP server sources that connect to Gram through outbound tunnels.';
+COMMENT ON COLUMN tunnelled_mcp_servers.id IS 'Stable UUID for the tunnelled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.';
+COMMENT ON COLUMN tunnelled_mcp_servers.project_id IS 'Project that owns this tunnelled MCP source. All management queries are scoped by project_id.';
+COMMENT ON COLUMN tunnelled_mcp_servers.name IS 'User-facing display name for the tunnelled MCP source.';
+COMMENT ON COLUMN tunnelled_mcp_servers.key_hash IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
+COMMENT ON COLUMN tunnelled_mcp_servers.key_prefix IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
+COMMENT ON COLUMN tunnelled_mcp_servers.status IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
+COMMENT ON COLUMN tunnelled_mcp_servers.agent_version IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
+COMMENT ON COLUMN tunnelled_mcp_servers.last_seen_at IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
+COMMENT ON COLUMN tunnelled_mcp_servers.created_at IS 'Time when the tunnelled MCP source was created.';
+COMMENT ON COLUMN tunnelled_mcp_servers.updated_at IS 'Time when the durable tunnelled MCP source record was last updated.';
+COMMENT ON COLUMN tunnelled_mcp_servers.deleted_at IS 'Soft-delete timestamp for the tunnelled MCP source. NULL means the source is active.';
+COMMENT ON COLUMN tunnelled_mcp_servers.deleted IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
+
 -- MCP Servers: user-facing MCP server configurations that link an MCP
--- backend (either a toolset or a remote MCP server) to environment and
--- OAuth settings. Each server is addressable via one or more mcp_endpoints.
+-- backend (a toolset, a remote MCP server, or a tunnelled MCP server) to
+-- environment and OAuth settings. Each server is addressable via one or more
+-- mcp_endpoints.
 CREATE TABLE IF NOT EXISTS mcp_servers (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,
@@ -2653,6 +2716,7 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   environment_id uuid,
   user_session_issuer_id uuid,
   remote_mcp_server_id uuid,
+  tunnelled_mcp_server_id uuid,
   toolset_id uuid,
   -- Optionally enables a variations group for runtime filtering and
   -- modifications. Otherwise defaults to project global (source-level)
@@ -2670,10 +2734,11 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_environment_id_fkey FOREIGN KEY (environment_id) REFERENCES environments (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE RESTRICT,
+  CONSTRAINT mcp_servers_tunnelled_mcp_server_id_fkey FOREIGN KEY (tunnelled_mcp_server_id) REFERENCES tunnelled_mcp_servers (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_tool_variations_group_id_fkey FOREIGN KEY (tool_variations_group_id) REFERENCES tool_variations_groups (id) ON DELETE SET NULL,
-  -- Exactly one backend must be set: either a remote MCP server or a toolset.
-  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK ((remote_mcp_server_id IS NULL) != (toolset_id IS NULL))
+  -- Exactly one backend must be set.
+  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id) = 1)
 );
 
 CREATE INDEX IF NOT EXISTS mcp_servers_project_id_idx
@@ -2687,6 +2752,12 @@ WHERE deleted IS FALSE;
 CREATE INDEX IF NOT EXISTS mcp_servers_remote_mcp_server_id_idx
 ON mcp_servers (remote_mcp_server_id)
 WHERE remote_mcp_server_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS mcp_servers_tunnelled_mcp_server_id_idx
+ON mcp_servers (tunnelled_mcp_server_id)
+WHERE tunnelled_mcp_server_id IS NOT NULL;
+
+COMMENT ON COLUMN mcp_servers.tunnelled_mcp_server_id IS 'Optional backend reference to a tunnelled MCP source. Exactly one of remote_mcp_server_id, tunnelled_mcp_server_id, or toolset_id must be set.';
 
 CREATE INDEX IF NOT EXISTS mcp_servers_toolset_id_idx
 ON mcp_servers (toolset_id)

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -252,8 +252,10 @@ type BillingMetadatum struct {
 	TumMonthlyTokenLimit  pgtype.Int8
 	AlertEmail            pgtype.Text
 	BillingCycleAnchorDay int32
-	CreatedAt             pgtype.Timestamptz
-	UpdatedAt             pgtype.Timestamptz
+	// Contracted org-level cap for tunnelled MCP server sources. NULL means use the finite plan default.
+	TunnelledMcpServerLimit pgtype.Int4
+	CreatedAt               pgtype.Timestamptz
+	UpdatedAt               pgtype.Timestamptz
 }
 
 type Chat struct {
@@ -786,13 +788,15 @@ type McpRegistry struct {
 }
 
 type McpServer struct {
-	ID                    uuid.UUID
-	ProjectID             uuid.UUID
-	Name                  pgtype.Text
-	Slug                  pgtype.Text
-	EnvironmentID         uuid.NullUUID
-	UserSessionIssuerID   uuid.NullUUID
-	RemoteMcpServerID     uuid.NullUUID
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	Name                pgtype.Text
+	Slug                pgtype.Text
+	EnvironmentID       uuid.NullUUID
+	UserSessionIssuerID uuid.NullUUID
+	RemoteMcpServerID   uuid.NullUUID
+	// Optional backend reference to a tunnelled MCP source. Exactly one of remote_mcp_server_id, tunnelled_mcp_server_id, or toolset_id must be set.
+	TunnelledMcpServerID  uuid.NullUUID
 	ToolsetID             uuid.NullUUID
 	ToolVariationsGroupID uuid.NullUUID
 	Visibility            string
@@ -1600,6 +1604,34 @@ type TriggerInstance struct {
 	UpdatedAt      pgtype.Timestamptz
 	DeletedAt      pgtype.Timestamptz
 	Deleted        bool
+}
+
+// Customer-hosted MCP server sources that connect to Gram through outbound tunnels.
+type TunnelledMcpServer struct {
+	// Stable UUID for the tunnelled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.
+	ID uuid.UUID
+	// Project that owns this tunnelled MCP source. All management queries are scoped by project_id.
+	ProjectID uuid.UUID
+	// User-facing display name for the tunnelled MCP source.
+	Name string
+	// Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.
+	KeyHash string
+	// Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.
+	KeyPrefix string
+	// Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.
+	Status string
+	// Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.
+	AgentVersion pgtype.Text
+	// Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.
+	LastSeenAt pgtype.Timestamptz
+	// Time when the tunnelled MCP source was created.
+	CreatedAt pgtype.Timestamptz
+	// Time when the durable tunnelled MCP source record was last updated.
+	UpdatedAt pgtype.Timestamptz
+	// Soft-delete timestamp for the tunnelled MCP source. NULL means the source is active.
+	DeletedAt pgtype.Timestamptz
+	// Generated soft-delete flag derived from deleted_at and used by partial indexes.
+	Deleted bool
 }
 
 type User struct {

--- a/server/internal/mcpservers/repo/models.go
+++ b/server/internal/mcpservers/repo/models.go
@@ -10,13 +10,15 @@ import (
 )
 
 type McpServer struct {
-	ID                    uuid.UUID
-	ProjectID             uuid.UUID
-	Name                  pgtype.Text
-	Slug                  pgtype.Text
-	EnvironmentID         uuid.NullUUID
-	UserSessionIssuerID   uuid.NullUUID
-	RemoteMcpServerID     uuid.NullUUID
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	Name                pgtype.Text
+	Slug                pgtype.Text
+	EnvironmentID       uuid.NullUUID
+	UserSessionIssuerID uuid.NullUUID
+	RemoteMcpServerID   uuid.NullUUID
+	// Optional backend reference to a tunnelled MCP source. Exactly one of remote_mcp_server_id, tunnelled_mcp_server_id, or toolset_id must be set.
+	TunnelledMcpServerID  uuid.NullUUID
 	ToolsetID             uuid.NullUUID
 	ToolVariationsGroupID uuid.NullUUID
 	Visibility            string

--- a/server/internal/mcpservers/repo/queries.sql.go
+++ b/server/internal/mcpservers/repo/queries.sql.go
@@ -37,7 +37,7 @@ VALUES (
     $9,
     $10
 )
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateMCPServerParams struct {
@@ -75,6 +75,7 @@ func (q *Queries) CreateMCPServer(ctx context.Context, arg CreateMCPServerParams
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
+		&i.TunnelledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -90,7 +91,7 @@ const deleteMCPServer = `-- name: DeleteMCPServer :one
 UPDATE mcp_servers
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteMCPServerParams struct {
@@ -109,6 +110,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
+		&i.TunnelledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -121,7 +123,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 }
 
 const getMCPServerByIDAndOrganizationID = `-- name: GetMCPServerByIDAndOrganizationID :one
-SELECT m.id, m.project_id, m.name, m.slug, m.environment_id, m.user_session_issuer_id, m.remote_mcp_server_id, m.toolset_id, m.tool_variations_group_id, m.visibility, m.created_at, m.updated_at, m.deleted_at, m.deleted
+SELECT m.id, m.project_id, m.name, m.slug, m.environment_id, m.user_session_issuer_id, m.remote_mcp_server_id, m.tunnelled_mcp_server_id, m.toolset_id, m.tool_variations_group_id, m.visibility, m.created_at, m.updated_at, m.deleted_at, m.deleted
 FROM mcp_servers AS m
 JOIN projects AS p ON p.id = m.project_id
 WHERE m.id = $1
@@ -148,6 +150,7 @@ func (q *Queries) GetMCPServerByIDAndOrganizationID(ctx context.Context, arg Get
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
+		&i.TunnelledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -160,7 +163,7 @@ func (q *Queries) GetMCPServerByIDAndOrganizationID(ctx context.Context, arg Get
 }
 
 const getMCPServerByIDAndProjectID = `-- name: GetMCPServerByIDAndProjectID :one
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -181,6 +184,7 @@ func (q *Queries) GetMCPServerByIDAndProjectID(ctx context.Context, arg GetMCPSe
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
+		&i.TunnelledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -193,7 +197,7 @@ func (q *Queries) GetMCPServerByIDAndProjectID(ctx context.Context, arg GetMCPSe
 }
 
 const getMCPServerBySlug = `-- name: GetMCPServerBySlug :one
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE slug = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -214,6 +218,7 @@ func (q *Queries) GetMCPServerBySlug(ctx context.Context, arg GetMCPServerBySlug
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
+		&i.TunnelledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -226,7 +231,7 @@ func (q *Queries) GetMCPServerBySlug(ctx context.Context, arg GetMCPServerBySlug
 }
 
 const listMCPServersByProjectID = `-- name: ListMCPServersByProjectID :many
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -258,6 +263,7 @@ func (q *Queries) ListMCPServersByProjectID(ctx context.Context, arg ListMCPServ
 			&i.EnvironmentID,
 			&i.UserSessionIssuerID,
 			&i.RemoteMcpServerID,
+			&i.TunnelledMcpServerID,
 			&i.ToolsetID,
 			&i.ToolVariationsGroupID,
 			&i.Visibility,
@@ -289,7 +295,7 @@ SET
     visibility = $8,
     updated_at = clock_timestamp()
 WHERE id = $9 AND project_id = $10 AND deleted IS FALSE
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateMCPServerParams struct {
@@ -327,6 +333,7 @@ func (q *Queries) UpdateMCPServer(ctx context.Context, arg UpdateMCPServerParams
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
+		&i.TunnelledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,

--- a/server/internal/usage/repo/models.go
+++ b/server/internal/usage/repo/models.go
@@ -15,6 +15,8 @@ type BillingMetadatum struct {
 	TumMonthlyTokenLimit  pgtype.Int8
 	AlertEmail            pgtype.Text
 	BillingCycleAnchorDay int32
-	CreatedAt             pgtype.Timestamptz
-	UpdatedAt             pgtype.Timestamptz
+	// Contracted org-level cap for tunnelled MCP server sources. NULL means use the finite plan default.
+	TunnelledMcpServerLimit pgtype.Int4
+	CreatedAt               pgtype.Timestamptz
+	UpdatedAt               pgtype.Timestamptz
 }

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getBillingMetadata = `-- name: GetBillingMetadata :one
-SELECT id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, created_at, updated_at
+SELECT id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunnelled_mcp_server_limit, created_at, updated_at
 FROM billing_metadata
 WHERE organization_id = $1
 `
@@ -27,6 +27,7 @@ func (q *Queries) GetBillingMetadata(ctx context.Context, organizationID string)
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,
+		&i.TunnelledMcpServerLimit,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -92,7 +93,7 @@ ON CONFLICT (organization_id) DO UPDATE SET
   , alert_email = EXCLUDED.alert_email
   , billing_cycle_anchor_day = EXCLUDED.billing_cycle_anchor_day
   , updated_at = clock_timestamp()
-RETURNING id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, created_at, updated_at
+RETURNING id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunnelled_mcp_server_limit, created_at, updated_at
 `
 
 type UpsertBillingMetadataParams struct {
@@ -116,6 +117,7 @@ func (q *Queries) UpsertBillingMetadata(ctx context.Context, arg UpsertBillingMe
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,
+		&i.TunnelledMcpServerLimit,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/migrations/20260626112524_tunnelled-mcp-servers.sql
+++ b/server/migrations/20260626112524_tunnelled-mcp-servers.sql
@@ -1,0 +1,72 @@
+-- atlas:txmode none
+
+-- Modify "billing_metadata" table
+ALTER TABLE "billing_metadata" ADD COLUMN "tunnelled_mcp_server_limit" integer NULL;
+ALTER TABLE "billing_metadata" ADD CONSTRAINT "billing_metadata_tunnelled_mcp_server_limit_check" CHECK ((tunnelled_mcp_server_limit IS NULL) OR (tunnelled_mcp_server_limit >= 0)) NOT VALID;
+ALTER TABLE "billing_metadata" VALIDATE CONSTRAINT "billing_metadata_tunnelled_mcp_server_limit_check";
+-- Set comment to column: "tunnelled_mcp_server_limit" on table: "billing_metadata"
+COMMENT ON COLUMN "billing_metadata"."tunnelled_mcp_server_limit" IS 'Contracted org-level cap for tunnelled MCP server sources. NULL means use the finite plan default.';
+-- Create "tunnelled_mcp_servers" table
+CREATE TABLE "tunnelled_mcp_servers" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "name" text NOT NULL,
+  "key_hash" text NOT NULL,
+  "key_prefix" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'created',
+  "agent_version" text NULL,
+  "last_seen_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "tunnelled_mcp_servers_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "tunnelled_mcp_servers_agent_version_check" CHECK ((agent_version IS NULL) OR (agent_version <> ''::text)),
+  CONSTRAINT "tunnelled_mcp_servers_key_hash_check" CHECK (key_hash <> ''::text),
+  CONSTRAINT "tunnelled_mcp_servers_key_prefix_check" CHECK (key_prefix <> ''::text),
+  CONSTRAINT "tunnelled_mcp_servers_name_check" CHECK (name <> ''::text),
+  CONSTRAINT "tunnelled_mcp_servers_status_check" CHECK (status = ANY (ARRAY['created'::text, 'active'::text, 'revoked'::text]))
+);
+-- Create index "tunnelled_mcp_servers_key_hash_key" to table: "tunnelled_mcp_servers"
+CREATE UNIQUE INDEX "tunnelled_mcp_servers_key_hash_key" ON "tunnelled_mcp_servers" ("key_hash") WHERE (deleted IS FALSE);
+-- Create index "tunnelled_mcp_servers_project_id_idx" to table: "tunnelled_mcp_servers"
+CREATE INDEX "tunnelled_mcp_servers_project_id_idx" ON "tunnelled_mcp_servers" ("project_id") WHERE (deleted IS FALSE);
+-- Create index "tunnelled_mcp_servers_project_id_name_key" to table: "tunnelled_mcp_servers"
+CREATE UNIQUE INDEX "tunnelled_mcp_servers_project_id_name_key" ON "tunnelled_mcp_servers" ("project_id", "name") WHERE (deleted IS FALSE);
+-- Set comment to table: "tunnelled_mcp_servers"
+COMMENT ON TABLE "tunnelled_mcp_servers" IS 'Customer-hosted MCP server sources that connect to Gram through outbound tunnels.';
+-- Set comment to column: "id" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."id" IS 'Stable UUID for the tunnelled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.';
+-- Set comment to column: "project_id" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."project_id" IS 'Project that owns this tunnelled MCP source. All management queries are scoped by project_id.';
+-- Set comment to column: "name" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."name" IS 'User-facing display name for the tunnelled MCP source.';
+-- Set comment to column: "key_hash" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."key_hash" IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
+-- Set comment to column: "key_prefix" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."key_prefix" IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
+-- Set comment to column: "status" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."status" IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
+-- Set comment to column: "agent_version" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."agent_version" IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
+-- Set comment to column: "last_seen_at" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."last_seen_at" IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
+-- Set comment to column: "created_at" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."created_at" IS 'Time when the tunnelled MCP source was created.';
+-- Set comment to column: "updated_at" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."updated_at" IS 'Time when the durable tunnelled MCP source record was last updated.';
+-- Set comment to column: "deleted_at" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."deleted_at" IS 'Soft-delete timestamp for the tunnelled MCP source. NULL means the source is active.';
+-- Set comment to column: "deleted" on table: "tunnelled_mcp_servers"
+COMMENT ON COLUMN "tunnelled_mcp_servers"."deleted" IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
+-- Modify "mcp_servers" table
+ALTER TABLE "mcp_servers" ADD COLUMN "tunnelled_mcp_server_id" uuid NULL;
+ALTER TABLE "mcp_servers" ADD CONSTRAINT "mcp_servers_tunnelled_mcp_server_id_fkey" FOREIGN KEY ("tunnelled_mcp_server_id") REFERENCES "tunnelled_mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT NOT VALID;
+ALTER TABLE "mcp_servers" VALIDATE CONSTRAINT "mcp_servers_tunnelled_mcp_server_id_fkey";
+ALTER TABLE "mcp_servers" DROP CONSTRAINT "mcp_servers_backend_exclusivity_check", ADD CONSTRAINT "mcp_servers_backend_exclusivity_check" CHECK (num_nonnulls(remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id) = 1) NOT VALID;
+ALTER TABLE "mcp_servers" VALIDATE CONSTRAINT "mcp_servers_backend_exclusivity_check";
+-- Create index "mcp_servers_tunnelled_mcp_server_id_idx" to table: "mcp_servers"
+CREATE INDEX CONCURRENTLY "mcp_servers_tunnelled_mcp_server_id_idx" ON "mcp_servers" ("tunnelled_mcp_server_id") WHERE (tunnelled_mcp_server_id IS NOT NULL);
+-- Set comment to column: "tunnelled_mcp_server_id" on table: "mcp_servers"
+COMMENT ON COLUMN "mcp_servers"."tunnelled_mcp_server_id" IS 'Optional backend reference to a tunnelled MCP source. Exactly one of remote_mcp_server_id, tunnelled_mcp_server_id, or toolset_id must be set.';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:hpN42+B1DTWy6pPJcrGAp+d9OsjXkBvRRQlGuk49QCc=
+h1:2Yc3+5ImmZ4s6LNr1fG9nE9O37drdxHjsyzM1cvu+aM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -229,3 +229,4 @@ h1:hpN42+B1DTWy6pPJcrGAp+d9OsjXkBvRRQlGuk49QCc=
 20260625131148_remotesession-clients-drop-user-session-issuer-id.sql h1:ffRGv1Izk5BLMnzrMVnv7R+w3bIq71gwjCrOHq+xijs=
 20260625160759_add_tool_call_blocks.sql h1:7agv3Tm4njdomfkTZNzBM3Y4NO27t4bp3ZJoDp8l714=
 20260625174452_remote-session-clients-organization-id.sql h1:58GfJycQkGlaRJ0SVITo7f8+x+G9Vl7oRSHc4l5CpoU=
+20260626112524_tunnelled-mcp-servers.sql h1:GzNGqqfGvwSrCfPMbK5tU9orD2ZkobTkb1QzEQj+HFg=


### PR DESCRIPTION
## Summary
- Add the `tunnelled_mcp_servers` table for customer-hosted MCP sources connected through outbound tunnels
- Add `mcp_servers.tunnelled_mcp_server_id` and update backend exclusivity to allow toolset, remote MCP, or tunnelled MCP backends
- Remove `manifest` / `manifest_at` from the DB model before merge
- Add table and column SQL comments in the same migration as the DDL, with inline source comments beside the new table columns
- Add the new `mcp_servers` check and FK constraints with `NOT VALID` + validation to avoid blocking-table-change Atlas diagnostics
- Include SQLC-generated DB model/query updates produced from the schema change

## Scope
DB migration PR: `server/database/schema.sql`, one Atlas migration, `atlas.sum`, and SQLC-generated database files. No service, UI, seed, Redis, or tunnel transport code.

## Changeset
No changeset included. This matches recent migration-only table PRs such as remote MCP servers, MCP servers/endpoints, billing metadata, directory attributes, and risk-policy bypass requests. Changeset examples in this area are tied to runtime/API behavior changes rather than table DDL alone.

## Validation
- `git diff --cached --check`
- `./.mise-tasks/lint/migrations.sh` with `DB_*` pointed at a disposable clean local Postgres database
- `atlas migrate apply --config file://atlas.hcl` from `server/` against a disposable clean local Postgres database
- `go test -c ./server/internal/mcpservers -o /tmp/gram-mcpservers.test`
- `mise lint:server`

Note: `mise lint:migrations` against the default local `gram` DB was not used for the Atlas step because that DB is already populated; the same lint script passed against a clean disposable local DB.