### PR TITLE
mig: add chats.pinned_at column

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1205,6 +1205,9 @@ CREATE TABLE IF NOT EXISTS chats (
   -- True when a human explicitly renamed the chat. Auto title generation skips
   -- these so it never overwrites a manually chosen name.
   title_manually_set boolean NOT NULL DEFAULT false,
+  -- When a human pinned the chat (NULL = not pinned). Pinned chats surface in a
+  -- dedicated section above recents; the timestamp orders them by pin time.
+  pinned_at timestamptz,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/chat/repo/models.go
+++ b/server/internal/chat/repo/models.go
@@ -19,6 +19,7 @@ type Chat struct {
 	ExternalChatID   pgtype.Text
 	Title            pgtype.Text
 	TitleManuallySet bool
+	PinnedAt         pgtype.Timestamptz
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz
 	DeletedAt        pgtype.Timestamptz

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -487,7 +487,7 @@ func (q *Queries) GetAssistantThreadAssistantIDByChatID(ctx context.Context, arg
 }
 
 const getChat = `-- name: GetChat :one
-SELECT id, project_id, organization_id, user_id, external_user_id, external_chat_id, title, title_manually_set, created_at, updated_at, deleted_at, deleted FROM chats WHERE id = $1 AND deleted IS FALSE
+SELECT id, project_id, organization_id, user_id, external_user_id, external_chat_id, title, title_manually_set, pinned_at, created_at, updated_at, deleted_at, deleted FROM chats WHERE id = $1 AND deleted IS FALSE
 `
 
 func (q *Queries) GetChat(ctx context.Context, id uuid.UUID) (Chat, error) {
@@ -502,6 +502,7 @@ func (q *Queries) GetChat(ctx context.Context, id uuid.UUID) (Chat, error) {
 		&i.ExternalChatID,
 		&i.Title,
 		&i.TitleManuallySet,
+		&i.PinnedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -267,6 +267,7 @@ type Chat struct {
 	ExternalChatID   pgtype.Text
 	Title            pgtype.Text
 	TitleManuallySet bool
+	PinnedAt         pgtype.Timestamptz
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz
 	DeletedAt        pgtype.Timestamptz

--- a/server/migrations/20260626152018_chats-add-pinned-at.sql
+++ b/server/migrations/20260626152018_chats-add-pinned-at.sql
@@ -1,0 +1,2 @@
+-- Modify "chats" table
+ALTER TABLE "chats" ADD COLUMN "pinned_at" timestamptz NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:2Yc3+5ImmZ4s6LNr1fG9nE9O37drdxHjsyzM1cvu+aM=
+h1:XJwr1Q1aAWyI7F6x9XEXUcbGlJ6UcOwWjROdABFzCS8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -230,3 +230,4 @@ h1:2Yc3+5ImmZ4s6LNr1fG9nE9O37drdxHjsyzM1cvu+aM=
 20260625160759_add_tool_call_blocks.sql h1:7agv3Tm4njdomfkTZNzBM3Y4NO27t4bp3ZJoDp8l714=
 20260625174452_remote-session-clients-organization-id.sql h1:58GfJycQkGlaRJ0SVITo7f8+x+G9Vl7oRSHc4l5CpoU=
 20260626112524_tunnelled-mcp-servers.sql h1:GzNGqqfGvwSrCfPMbK5tU9orD2ZkobTkb1QzEQj+HFg=
+20260626152018_chats-add-pinned-at.sql h1:GeYCKutkPKW+wiILObCtoHI62pR60gSQhUelef/5xLc=


### PR DESCRIPTION
Adds a nullable `pinned_at timestamptz` column to `chats` (NULL = not pinned).

This is the migration-only PR (per the migrations-ship-in-their-own-PR rule). It backs an upcoming **Pinned chats** feature: a dedicated "Pinned" section above Recent Chats on the `/chat` page. The follow-up feature PR (backend `setPinned` + list filter + frontend section/affordance) stacks on top.

- Additive, expand-contract safe (nullable column, no backfill).
- Regenerated sqlc models committed so the `gen:server` + porcelain CI check stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a nullable `pinned_at` timestamptz column to `chats` to support pinned chats ordered by pin time. Migration-only; NULL means not pinned.

- **Migration**
  - Additive and expand-contract safe; no backfill or downtime.
  - Regenerated `sqlc` models and updated `GetChat` to include `pinned_at`; added a new, in-order migration on top of `main`.

<sup>Written for commit cd90cbc96ae80111f09433c2aa9c9ad2c86d391f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

