### PR TITLE
fix(telemetry): match listSessions filters per-chat instead of per-row

### DIFF
--- a/.changeset/wild-sessions-filter.md
+++ b/.changeset/wild-sessions-filter.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix(telemetry): match `listSessions` dimension filters per-chat instead of per-row so combining a user-directory filter (e.g. department) with `hook_source` no longer returns empty when those attributes live on different rows of the same chat

--- a/server/internal/telemetry/list_sessions_test.go
+++ b/server/internal/telemetry/list_sessions_test.go
@@ -217,6 +217,81 @@ func TestListSessions_OrgScopedFiltersAndAggregates(t *testing.T) {
 	require.Equal(t, chatID1, byDuration.Sessions[0].GramChatID)
 }
 
+func TestListSessions_CrossRowDirectoryAndHookFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Now().UTC()
+	chatID := uuid.NewString()
+
+	// Usage row carries cost + hook_source but NOT the directory attribute
+	// (mirrors production: usage/OTEL rows aren't enriched with WorkOS attrs).
+	insertListSessionCompletionLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-10 * time.Minute),
+		chatID:       chatID,
+		email:        "sagar@example.com",
+		department:   "", // unset on the cost-bearing row
+		roles:        []string{"dev"},
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		totalTokens:  150,
+		cost:         2.5,
+	})
+	// Tool row carries the directory attribute (department) but an empty
+	// hook_source — the inverse of the usage row, in the same chat.
+	insertListSessionToolLog(t, ctx, listSessionLogParams{
+		projectID:  projectID,
+		timestamp:  now.Add(-9 * time.Minute),
+		chatID:     chatID,
+		email:      "sagar@example.com",
+		department: "Executive",
+		roles:      []string{"dev"},
+		hookSource: "", // unset on the directory-enriched row
+		statusCode: 200,
+		toolURN:    "tools:http:petstore:listPets",
+	})
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	// department_name lives on one row, hook_source on another. A per-row AND
+	// would return nothing; the per-chat HAVING must still match the chat.
+	res := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From: from,
+		To:   to,
+		Filters: []*gen.QueryFilter{
+			{Dimension: "email", Values: []string{"sagar@example.com"}},
+			{Dimension: "department_name", Values: []string{"Executive"}},
+			{Dimension: "hook_source", Values: []string{"claude-code"}},
+		},
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == chatID
+	})
+
+	require.Len(t, res.Sessions, 1)
+	session := res.Sessions[0]
+	require.Equal(t, chatID, session.GramChatID)
+	// Full session cost is reported, not just the cost on rows matching a filter.
+	require.InDelta(t, 2.5, session.TotalCost, 1e-9)
+	require.Equal(t, int64(1), session.ToolCallCount)
+	require.Equal(t, int64(1), session.MessageCount)
+}
+
 func TestListSessions_CursorPagination(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/squirrel"
 )
@@ -70,6 +71,15 @@ type SessionSummary struct {
 	SortValue         float64 `ch:"sort_value"`
 }
 
+// applySessionFilters restricts the session aggregation to chats matching the
+// requested dimension filters. project_id stays a row-level WHERE because it is
+// present on every row and prunes partitions. Every other dimension is matched
+// per-chat via HAVING: a chat qualifies when ANY of its rows carries the
+// requested value. This is required because the attributes are stamped on
+// different physical rows within the same chat — user-directory attributes
+// (department_name, email, job_title, …) live on gateway-enriched rows, while
+// cost/hook_source/model live on the usage rows — so a row-level AND of those
+// filters would wrongly return nothing even when each filter matches data.
 func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter) (squirrel.SelectBuilder, error) {
 	for _, f := range filters {
 		if len(f.Values) == 0 {
@@ -80,15 +90,53 @@ func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFi
 			return sb, fmt.Errorf("unknown filter dimension %q", f.Dimension)
 		}
 		switch dim.kind {
-		case attributeDimArray:
-			sb = sb.Where(arrayDimFilter(dim.column, f.Values))
-		case attributeDimScalar, attributeDimProject:
+		case attributeDimProject:
 			sb = sb.Where(squirrel.Eq{dim.column: f.Values})
+		case attributeDimScalar:
+			sb = sb.Having(sessionScalarHaving(dim.column, f.Values))
+		case attributeDimArray:
+			inner, args, err := arrayDimFilter(dim.column, f.Values).ToSql()
+			if err != nil {
+				return sb, fmt.Errorf("building array filter for %q: %w", f.Dimension, err)
+			}
+			sb = sb.Having(squirrel.Expr("countIf("+inner+") > 0", args...))
 		default:
 			return sb, fmt.Errorf("unhandled dimension kind for filter %q", f.Dimension)
 		}
 	}
 	return sb, nil
+}
+
+// sessionScalarHaving matches a chat when any of its rows carries one of the
+// requested scalar values. A requested "" (the "(unset)" bucket) matches chats
+// that have no non-empty value for the dimension on any row, mirroring how the
+// session's effective value is computed with anyIf(col, col != '').
+func sessionScalarHaving(expr string, values []string) squirrel.Sqlizer {
+	hasEmpty := false
+	nonEmpty := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			hasEmpty = true
+			continue
+		}
+		nonEmpty = append(nonEmpty, v)
+	}
+
+	emptyPred := squirrel.Expr("countIf(" + expr + " != '') = 0")
+	if len(nonEmpty) == 0 {
+		return emptyPred
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(nonEmpty)), ",")
+	args := make([]any, len(nonEmpty))
+	for i, v := range nonEmpty {
+		args[i] = v
+	}
+	nonEmptyPred := squirrel.Expr("countIf("+expr+" IN ("+placeholders+")) > 0", args...)
+	if !hasEmpty {
+		return nonEmptyPred
+	}
+	return squirrel.Or{nonEmptyPred, emptyPred}
 }
 
 // ListSessions retrieves org-scoped session summaries grouped by chat_id from

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -110,7 +110,7 @@ func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFi
 // sessionScalarHaving matches a chat when any of its rows carries one of the
 // requested scalar values. A requested "" (the "(unset)" bucket) matches chats
 // that have no non-empty value for the dimension on any row, mirroring how the
-// session's effective value is computed with anyIf(col, col != '').
+// session's effective value is computed with anyIf over non-empty values.
 func sessionScalarHaving(expr string, values []string) squirrel.Sqlizer {
 	hasEmpty := false
 	nonEmpty := make([]string, 0, len(values))


### PR DESCRIPTION
## Summary

`telemetry.listSessions` applied dimension filters as row-level `WHERE` predicates, ANDed together before grouping by chat. User-directory attributes (`department_name`, `email`, `job_title`, …) are stamped on different physical telemetry rows than `cost`/`hook_source`/`model` within the same chat (directory attributes come from best-effort gateway/usage-time enrichment; cost lives on the usage rows). As a result, combining a directory filter with `hook_source` could return **zero sessions** even though each filter independently matched data, and the cost shown in the org cost dashboard could not be drilled into as sessions.

This change makes filtering chat-scoped:

- `project_id` stays a row-level `WHERE` (present on every row, prunes partitions).
- Every other dimension is evaluated per-chat via `HAVING`: a chat qualifies when **any** of its rows carries the requested value.
  - scalar dims → `countIf(<expr> IN (…)) > 0`; the `(unset)` value maps to `countIf(<expr> != '') = 0`.
  - array dims (`role`/`group`) → `countIf(<arrayDimFilter predicate>) > 0`, reusing the existing helper.

This mirrors how `session_user_email` / `session_hook_source` are already collapsed to one value per chat with `anyIf(...)`, so filtering and display stay consistent, and the full session cost is reported rather than only the cost on rows matching a filter.

## Test plan

- [x] `go build ./internal/telemetry/...`
- [x] `go vet ./internal/telemetry/`
- [ ] `go test ./internal/telemetry/ -run TestListSessions` (requires Docker/ClickHouse test container; not runnable in this environment)
- Added `TestListSessions_CrossRowDirectoryAndHookFilters`: a chat whose directory attribute lives on one row and whose cost/`hook_source` live on another; asserts the combined filter still returns the chat with full cost. This fails under the old per-row behavior and passes with the per-chat `HAVING`.
- Existing `TestListSessions_*` tests are unaffected (they place all attributes on the same row, which per-chat matching still satisfies).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `telemetry.listSessions` to apply filters per chat, so combining directory attributes with `hook_source`/model/cost returns the correct sessions. This keeps filtering consistent with displayed values and restores reliable cost drill-down.

- **Bug Fixes**
  - Keep `project_id` as a row-level WHERE for partition pruning.
  - Match all other dimensions per chat via HAVING; a chat matches if any row has the value.
  - Scalars: `countIf` with “(unset)” via `countIf(col != '') = 0`. Arrays: wrap existing predicate in `countIf(...) > 0`.
  - Added `TestListSessions_CrossRowDirectoryAndHookFilters` to cover cross-row filters and full session cost.
  - Added changeset for patch release and tidied comments.

<sup>Written for commit 14aab6ef08cc9d6e8baa4f9c7cfe2f7381120277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

