### PR TITLE
chore: auto-size cost session table columns to fit width

### DIFF
--- a/client/dashboard/src/pages/costs/CostTable.tsx
+++ b/client/dashboard/src/pages/costs/CostTable.tsx
@@ -7,22 +7,15 @@ import {
 import { Type } from "@/components/ui/type";
 import { cn } from "@/lib/utils";
 import { Dimension, type QueryRow } from "@gram/client/models/components";
-import {
-  Box,
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
-  ChevronsUpDown,
-  ChevronUp,
-  Info,
-} from "lucide-react";
-import { type CSSProperties, useEffect, useMemo, useState } from "react";
+import { Box, ChevronLeft, ChevronRight, Info } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ClaudeCodeIcon,
   CodexIcon,
   GeminiIcon,
   HookSourceIcon,
 } from "../hooks/HookSourceIcon";
+import { Gutter, SortHeader, SUBGRID_ROW_CLASS } from "./gridTable";
 import { Sparkline } from "./Sparkline";
 import { trendDirection, trendOf } from "./sparkline-math";
 
@@ -130,9 +123,7 @@ export function ModelIcon({
   return <Box className={className} />;
 }
 
-// One parent grid owns the column tracks; the header and every row opt into
-// them via `grid-template-columns: subgrid`, so each column auto-sizes to the
-// widest cell across the whole table and stays aligned — no hardcoded widths.
+// Parent grid track template (see gridTable.tsx for the subgrid mechanism).
 // Track order: gutter | name | Total Cost | % Share | Cost/session | Chats |
 // Tool calls | Tokens | Trend | gutter. Name sizes to its content (min 120px so
 // short names aren't cramped, capped at 24rem so long emails truncate rather
@@ -141,17 +132,6 @@ export function ModelIcon({
 // leftover width on wide viewports spreads across the columns instead of pooling
 // in a dead right gutter. Fixed 8px gutters keep row hover + dividers full-bleed.
 const COLUMNS = "8px minmax(120px,24rem) repeat(7,minmax(max-content,1fr)) 8px";
-
-// Header/row span all parent tracks and re-use them via subgrid.
-const SUBGRID_ROW: CSSProperties = {
-  gridColumn: "1 / -1",
-  gridTemplateColumns: "subgrid",
-};
-
-// Empty cell occupying an edge gutter track.
-function Gutter(): JSX.Element {
-  return <span aria-hidden="true" />;
-}
 
 const PAGE_SIZE = 10;
 
@@ -209,30 +189,13 @@ function HeaderButton({
   sort: Sort;
   onSort: (key: SortKey) => void;
 }): JSX.Element {
-  const active = sort.key === sortKey;
-  let arrow = (
-    <ChevronsUpDown className="text-muted-foreground/40 group-hover:text-foreground size-3.5" />
-  );
-  if (active) {
-    arrow =
-      sort.dir === "asc" ? (
-        <ChevronUp className="size-3.5" />
-      ) : (
-        <ChevronDown className="size-3.5" />
-      );
-  }
   return (
-    <button
-      type="button"
+    <SortHeader
+      label={label}
+      active={sort.key === sortKey}
+      dir={sort.dir}
       onClick={() => onSort(sortKey)}
-      className={cn(
-        "group hover:text-foreground inline-flex items-center gap-1 whitespace-nowrap transition-colors",
-        active && "text-foreground",
-      )}
-    >
-      {label}
-      {arrow}
-    </button>
+    />
   );
 }
 
@@ -318,8 +281,10 @@ export function CostTable({
       style={{ gridTemplateColumns: COLUMNS }}
     >
       <div
-        className="text-muted-foreground grid items-center py-3.5 text-sm font-medium"
-        style={SUBGRID_ROW}
+        className={cn(
+          "text-muted-foreground grid items-center py-3.5 text-sm font-medium",
+          SUBGRID_ROW_CLASS,
+        )}
       >
         <Gutter />
         <span className="flex">
@@ -426,10 +391,10 @@ export function CostTable({
               }}
               className={cn(
                 "grid w-full items-center py-4 text-left text-sm transition-colors",
+                SUBGRID_ROW_CLASS,
                 (safePage * PAGE_SIZE + i) % 2 === 1 && "bg-muted/25",
                 drillable ? "hover:bg-muted cursor-pointer" : "cursor-default",
               )}
-              style={SUBGRID_ROW}
             >
               <Gutter />
               <div className="flex min-w-0 items-center gap-2">

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -32,7 +32,7 @@ import { useRoutes } from "@/routes";
 import { ChatDetailSheet } from "../chatLogs/ChatDetailPanel";
 import { type CardSpec, CostWidgets } from "./CostWidgets";
 import { EntityProfile } from "./EntityProfile";
-import { SessionTable } from "./SessionTable";
+import { SessionTable, type SessionColumnId } from "./SessionTable";
 import {
   type Axis,
   availableDimensions,
@@ -180,6 +180,20 @@ export function CostsExplorer(): JSX.Element {
     if (!project.id) return drill;
     return [{ dimension: Dimension.ProjectId, values: [project.id] }, ...drill];
   }, [path, project.id]);
+
+  // Drop session columns whose dimension the drill path already pins to a single
+  // value — that column would just repeat the same value down every row. Mapped
+  // from drill dimension to the session-table column id it makes redundant.
+  const hiddenSessionColumns = useMemo<SessionColumnId[]>(() => {
+    const byDimension: Partial<Record<Dimension, SessionColumnId>> = {
+      [Dimension.Email]: "user",
+      [Dimension.HookSource]: "agent",
+      [Dimension.Model]: "model",
+    };
+    return path
+      .map((c) => byDimension[c.dim])
+      .filter((id): id is SessionColumnId => id !== undefined);
+  }, [path]);
 
   // The generated useTelemetryQuery hook keys its cache on gramSession only — it
   // ignores the request body — so every drill would return the first cached
@@ -822,6 +836,7 @@ export function CostsExplorer(): JSX.Element {
               isLoading={sessionsFetching && !sessionsData}
               isError={sessionsError}
               onOpen={setOpenChatId}
+              hiddenColumns={hiddenSessionColumns}
             />
           ) : undefined
         }

--- a/client/dashboard/src/pages/costs/SessionTable.tsx
+++ b/client/dashboard/src/pages/costs/SessionTable.tsx
@@ -1,17 +1,19 @@
 import { SkeletonTable } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
+import { cn } from "@/lib/utils";
 import type { SessionSummary } from "@gram/client/models/components";
-import {
-  type Column,
-  type SortDescriptor,
-  sortTableData,
-  Table,
-} from "@speakeasy-api/moonshine";
 import { formatDistanceToNow } from "date-fns";
-import { useMemo, useState } from "react";
-import { HookSourceIcon } from "../hooks/HookSourceIcon";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { formatDurationFromNanos } from "../chatLogs/claudeUsage";
+import { HookSourceIcon } from "../hooks/HookSourceIcon";
 import { ModelIcon } from "./CostTable";
+import {
+  Gutter,
+  type SortDir,
+  SortHeader,
+  SUBGRID_ROW_CLASS,
+} from "./gridTable";
 
 const PAGE_SIZE = 10;
 
@@ -57,163 +59,226 @@ function durationLabel(session: SessionSummary): string {
   );
 }
 
+type SortKey =
+  | "session"
+  | "cost"
+  | "tokens"
+  | "tools"
+  | "messages"
+  | "duration";
+type Sort = { key: SortKey; dir: SortDir };
+
+function sortValue(session: SessionSummary, key: SortKey): number {
+  switch (key) {
+    case "session":
+      return nanosToMillis(session.startTimeUnixNano);
+    case "cost":
+      return session.totalCost;
+    case "tokens":
+      return session.totalTokens;
+    case "tools":
+      return session.toolCallCount;
+    case "messages":
+      return session.messageCount;
+    case "duration":
+      return session.durationSeconds;
+  }
+}
+
+const NUM_CELL = "text-left tabular-nums whitespace-nowrap";
+
+// Every column the table can show, in display order. One descriptor drives the
+// grid track template, the header, and each row cell — so hiding a column (see
+// hiddenColumns) can never desync the three. `track` is the column's grid sizing
+// (see gridTable.tsx); `sortKey` marks a column sortable.
+export type SessionColumnId =
+  | "session"
+  | "user"
+  | "agent"
+  | "model"
+  | "cost"
+  | "tokens"
+  | "tools"
+  | "messages"
+  | "duration";
+
+type SessionColumn = {
+  id: SessionColumnId;
+  header: string;
+  // Grid track sizing. `minmax(max-content,1fr)` never goes narrower than its
+  // content but grows equally to fill the row; the email column is capped at
+  // 24rem so long addresses truncate instead of dominating.
+  track: string;
+  sortKey?: SortKey;
+  render: (session: SessionSummary) => JSX.Element;
+};
+
+const SESSION_COLUMNS: SessionColumn[] = [
+  {
+    id: "session",
+    header: "Session",
+    track: "minmax(max-content,1fr)",
+    sortKey: "session",
+    render: (s) => (
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate font-mono text-xs font-medium">
+          {s.gramChatId.slice(0, 8)}
+        </span>
+        <span className="text-muted-foreground text-xs">
+          {relativeTime(s.startTimeUnixNano)}
+        </span>
+      </div>
+    ),
+  },
+  {
+    id: "user",
+    header: "User",
+    track: "minmax(120px,24rem)",
+    render: (s) => (
+      <div className="flex min-w-0 items-center">
+        <span className="truncate">{displayOrDash(s.userEmail)}</span>
+      </div>
+    ),
+  },
+  {
+    id: "agent",
+    header: "Agent",
+    track: "minmax(max-content,1fr)",
+    render: (s) => (
+      <div className="flex min-w-0 items-center gap-2">
+        {s.hookSource && (
+          <HookSourceIcon source={s.hookSource} className="size-4 shrink-0" />
+        )}
+        <span className="truncate">{displayOrDash(s.hookSource)}</span>
+      </div>
+    ),
+  },
+  {
+    id: "model",
+    header: "Model",
+    track: "minmax(max-content,1fr)",
+    render: (s) => (
+      <div className="flex min-w-0 items-center gap-2">
+        {s.model && <ModelIcon model={s.model} className="size-4 shrink-0" />}
+        <span className="truncate">{displayOrDash(s.model)}</span>
+      </div>
+    ),
+  },
+  {
+    id: "cost",
+    header: "Cost",
+    track: "minmax(max-content,1fr)",
+    sortKey: "cost",
+    render: (s) => (
+      <span className={cn(NUM_CELL, "font-medium")}>
+        {formatCost(s.totalCost)}
+      </span>
+    ),
+  },
+  {
+    id: "tokens",
+    header: "Tokens",
+    track: "minmax(max-content,1fr)",
+    sortKey: "tokens",
+    render: (s) => (
+      <span className={NUM_CELL}>{s.totalTokens.toLocaleString()}</span>
+    ),
+  },
+  {
+    id: "tools",
+    header: "Tool calls",
+    track: "minmax(max-content,1fr)",
+    sortKey: "tools",
+    render: (s) => (
+      <span className={NUM_CELL}>{s.toolCallCount.toLocaleString()}</span>
+    ),
+  },
+  {
+    id: "messages",
+    header: "Messages",
+    track: "minmax(max-content,1fr)",
+    sortKey: "messages",
+    render: (s) => (
+      <span className={NUM_CELL}>{s.messageCount.toLocaleString()}</span>
+    ),
+  },
+  {
+    id: "duration",
+    header: "Duration",
+    track: "minmax(max-content,1fr)",
+    sortKey: "duration",
+    render: (s) => (
+      <span className={cn(NUM_CELL, "text-muted-foreground")}>
+        {durationLabel(s)}
+      </span>
+    ),
+  },
+];
+
 export type SessionTableProps = {
   sessions: SessionSummary[];
   isLoading: boolean;
   isError: boolean;
   // Open one session's detail (the chatLogs ChatDetailSheet, keyed by chat id).
   onOpen: (gramChatId: string) => void;
+  // Columns to drop because the current drill context pins that dimension to a
+  // single value (e.g. drilled into one agent → "agent" is redundant). The
+  // remaining columns auto-size to reclaim the freed width.
+  hiddenColumns?: SessionColumnId[];
 };
 
 /**
  * Per-session list for one cost slice. Deliberately a separate component from
  * {@link CostTable} (which groups by taxonomy dimension): a session is a leaf,
  * so rows open a detail view instead of drilling deeper, and the columns are
- * session-shaped (model, agent, status, duration). The dedicated session
- * drilldown page is still to be designed — for now a row opens the existing
- * ChatDetailSheet via {@link onOpen}.
+ * session-shaped (model, agent, status, duration). It shares CostTable's
+ * subgrid layout primitives ({@link SUBGRID_ROW}, {@link Gutter},
+ * {@link SortHeader}) so columns auto-size to fit the container. The dedicated
+ * session drilldown page is still to be designed — for now a row opens the
+ * existing ChatDetailSheet via {@link onOpen}.
  */
 export function SessionTable({
   sessions,
   isLoading,
   isError,
   onOpen,
+  hiddenColumns,
 }: SessionTableProps): JSX.Element {
-  const [sort, setSort] = useState<SortDescriptor | null>(null);
+  // Server already ranks by cost; mirror that as the default header indicator.
+  const [sort, setSort] = useState<Sort>({ key: "cost", dir: "desc" });
   const [page, setPage] = useState(0);
 
-  // Server already ranks by cost; mirror that as the default header indicator.
-  const effectiveSort = useMemo<SortDescriptor>(
-    () => sort ?? { id: "cost", direction: "desc" },
-    [sort],
+  const onSort = (key: SortKey) => {
+    setPage(0);
+    setSort((s) =>
+      s.key === key
+        ? { key, dir: s.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: "desc" },
+    );
+  };
+
+  // Reset to the first page whenever the underlying data changes (drill, range).
+  useEffect(() => setPage(0), [sessions]);
+
+  const columns = useMemo(() => {
+    const hidden = new Set(hiddenColumns);
+    return SESSION_COLUMNS.filter((c) => !hidden.has(c.id));
+  }, [hiddenColumns]);
+
+  // gutter | …visible column tracks… | gutter
+  const gridTemplate = useMemo(
+    () => ["8px", ...columns.map((c) => c.track), "8px"].join(" "),
+    [columns],
   );
 
-  const columns = useMemo<Column<SessionSummary>[]>(
-    () => [
-      {
-        key: "gramChatId",
-        id: "session",
-        header: "Session",
-        sortable: true,
-        sortValue: (s) => nanosToMillis(s.startTimeUnixNano),
-        width: "1.4fr",
-        render: (s) => (
-          <div className="flex min-w-0 flex-col">
-            <span className="truncate font-mono text-xs font-medium">
-              {s.gramChatId.slice(0, 8)}
-            </span>
-            <span className="text-muted-foreground text-xs">
-              {relativeTime(s.startTimeUnixNano)}
-            </span>
-          </div>
-        ),
-      },
-      {
-        key: "userEmail",
-        header: "User",
-        width: "1.4fr",
-        render: (s) => (
-          <span className="truncate text-sm">{displayOrDash(s.userEmail)}</span>
-        ),
-      },
-      {
-        key: "hookSource",
-        header: "Agent",
-        width: "1fr",
-        render: (s) => (
-          <div className="flex min-w-0 items-center gap-2">
-            {s.hookSource && (
-              <HookSourceIcon
-                source={s.hookSource}
-                className="size-4 shrink-0"
-              />
-            )}
-            <span className="truncate text-sm">
-              {displayOrDash(s.hookSource)}
-            </span>
-          </div>
-        ),
-      },
-      {
-        key: "model",
-        header: "Model",
-        width: "1fr",
-        render: (s) => (
-          <div className="flex min-w-0 items-center gap-2">
-            {s.model && (
-              <ModelIcon model={s.model} className="size-4 shrink-0" />
-            )}
-            <span className="truncate text-sm">{displayOrDash(s.model)}</span>
-          </div>
-        ),
-      },
-      {
-        key: "totalCost",
-        id: "cost",
-        header: "Cost",
-        sortable: true,
-        sortValue: (s) => s.totalCost,
-        width: "0.8fr",
-        render: (s) => (
-          <span className="font-medium tabular-nums">
-            {formatCost(s.totalCost)}
-          </span>
-        ),
-      },
-      {
-        key: "totalTokens",
-        header: "Tokens",
-        sortable: true,
-        sortValue: (s) => s.totalTokens,
-        width: "0.8fr",
-        render: (s) => (
-          <span className="tabular-nums">{s.totalTokens.toLocaleString()}</span>
-        ),
-      },
-      {
-        key: "toolCallCount",
-        header: "Tool calls",
-        sortable: true,
-        sortValue: (s) => s.toolCallCount,
-        width: "0.8fr",
-        render: (s) => (
-          <span className="tabular-nums">
-            {s.toolCallCount.toLocaleString()}
-          </span>
-        ),
-      },
-      {
-        key: "messageCount",
-        header: "Messages",
-        sortable: true,
-        sortValue: (s) => s.messageCount,
-        width: "0.8fr",
-        render: (s) => (
-          <span className="tabular-nums">
-            {s.messageCount.toLocaleString()}
-          </span>
-        ),
-      },
-      {
-        key: "durationSeconds",
-        header: "Duration",
-        sortable: true,
-        sortValue: (s) => s.durationSeconds,
-        width: "0.8fr",
-        render: (s) => (
-          <span className="text-muted-foreground tabular-nums">
-            {durationLabel(s)}
-          </span>
-        ),
-      },
-    ],
-    [],
-  );
-
-  const sorted = useMemo(
-    () => sortTableData(sessions, columns, effectiveSort) as SessionSummary[],
-    [sessions, columns, effectiveSort],
-  );
+  const sorted = useMemo(() => {
+    const arr = [...sessions];
+    arr.sort((a, b) => {
+      const cmp = sortValue(a, sort.key) - sortValue(b, sort.key);
+      return sort.dir === "asc" ? cmp : -cmp;
+    });
+    return arr;
+  }, [sessions, sort]);
 
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
   const safePage = Math.min(page, Math.max(totalPages - 1, 0));
@@ -230,51 +295,100 @@ export function SessionTable({
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      <Table
-        columns={columns}
-        data={pageItems}
-        rowKey={(s) => s.gramChatId}
-        onRowClick={(s) => onOpen(s.gramChatId)}
-        sort={sort}
-        onSortChange={(nextSort) => {
-          setSort(nextSort);
-          setPage(0);
-        }}
-        noResultsMessage={
-          <div className="text-muted-foreground p-6 text-center text-sm">
+    <div
+      className="border-border divide-border grid gap-x-3 gap-y-0 divide-y overflow-x-auto rounded-lg border"
+      style={{ gridTemplateColumns: gridTemplate }}
+    >
+      <div
+        className={cn(
+          "text-muted-foreground grid items-center py-3.5 text-sm font-medium",
+          SUBGRID_ROW_CLASS,
+        )}
+      >
+        <Gutter />
+        {columns.map((c) => (
+          <span key={c.id} className="flex">
+            {c.sortKey ? (
+              <SortHeader
+                label={c.header}
+                active={sort.key === c.sortKey}
+                dir={sort.dir}
+                onClick={() => onSort(c.sortKey!)}
+              />
+            ) : (
+              c.header
+            )}
+          </span>
+        ))}
+        <Gutter />
+      </div>
+
+      {sorted.length === 0 ? (
+        <div
+          className="px-5 py-10 text-center"
+          style={{ gridColumn: "1 / -1" }}
+        >
+          <Type className="text-muted-foreground">
             No sessions in this slice.
-          </div>
-        }
-      />
-      {sessions.length >= DEFAULT_LIMIT && (
-        <Type small className="text-muted-foreground">
-          Showing the {DEFAULT_LIMIT} most expensive sessions in this slice.
-        </Type>
+          </Type>
+        </div>
+      ) : (
+        pageItems.map((s, i) => (
+          <button
+            key={s.gramChatId}
+            type="button"
+            onClick={() => onOpen(s.gramChatId)}
+            className={cn(
+              "hover:bg-muted grid w-full cursor-pointer items-center py-4 text-left text-sm transition-colors",
+              SUBGRID_ROW_CLASS,
+              (safePage * PAGE_SIZE + i) % 2 === 1 && "bg-muted/25",
+            )}
+          >
+            <Gutter />
+            {columns.map((c) => (
+              <Fragment key={c.id}>{c.render(s)}</Fragment>
+            ))}
+            <Gutter />
+          </button>
+        ))
       )}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between border-t px-4 py-3">
+
+      {sessions.length >= DEFAULT_LIMIT && (
+        <div className="px-5 py-3" style={{ gridColumn: "1 / -1" }}>
           <Type small className="text-muted-foreground">
+            Showing the {DEFAULT_LIMIT} most expensive sessions in this slice.
+          </Type>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div
+          className="flex items-center justify-between px-5 py-3"
+          style={{ gridColumn: "1 / -1" }}
+        >
+          <p className="text-muted-foreground text-sm">
             {safePage * PAGE_SIZE + 1}–
             {Math.min((safePage + 1) * PAGE_SIZE, sorted.length)} of{" "}
             {sorted.length.toLocaleString()}
-          </Type>
+          </p>
           <div className="flex items-center gap-1">
             <button
               type="button"
-              className="hover:bg-muted rounded p-1 px-2 text-sm disabled:opacity-40"
+              aria-label="Previous page"
               onClick={() => setPage((p) => p - 1)}
               disabled={safePage === 0}
+              className="hover:bg-muted inline-flex size-8 items-center justify-center rounded-md transition-colors disabled:pointer-events-none disabled:opacity-40"
             >
-              Prev
+              <ChevronLeft className="size-4" />
             </button>
             <button
               type="button"
-              className="hover:bg-muted rounded p-1 px-2 text-sm disabled:opacity-40"
+              aria-label="Next page"
               onClick={() => setPage((p) => p + 1)}
               disabled={safePage >= totalPages - 1}
+              className="hover:bg-muted inline-flex size-8 items-center justify-center rounded-md transition-colors disabled:pointer-events-none disabled:opacity-40"
             >
-              Next
+              <ChevronRight className="size-4" />
             </button>
           </div>
         </div>

--- a/client/dashboard/src/pages/costs/gridTable.tsx
+++ b/client/dashboard/src/pages/costs/gridTable.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronsUpDown, ChevronUp } from "lucide-react";
+
+// Shared layout primitives for the costs-page grid tables (CostTable, SessionTable).
+//
+// One parent grid owns the column tracks; the header and every row span all of
+// them (`col-span-full` → grid-column: 1 / -1) and re-use them via
+// `grid-cols-subgrid` (grid-template-columns: subgrid). Every column therefore
+// auto-sizes to the widest cell across the whole table and stays aligned, with
+// no per-row hardcoded widths — so the table fits its container instead of
+// overflowing horizontally. Apply alongside `grid` on each subgrid row.
+export const SUBGRID_ROW_CLASS = "col-span-full grid-cols-subgrid";
+
+// Empty cell occupying an edge gutter track (keeps row hover + dividers
+// full-bleed while content columns stay inset).
+export function Gutter(): JSX.Element {
+  return <span aria-hidden="true" />;
+}
+
+export type SortDir = "asc" | "desc";
+
+// A sortable column header: label + a tri-state chevron (inactive ⇅ / asc ↑ /
+// desc ↓). Presentational only — callers own the sort state and toggling.
+export function SortHeader({
+  label,
+  active,
+  dir,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  dir: SortDir;
+  onClick: () => void;
+}): JSX.Element {
+  let arrow = (
+    <ChevronsUpDown className="text-muted-foreground/40 group-hover:text-foreground size-3.5" />
+  );
+  if (active) {
+    arrow =
+      dir === "asc" ? (
+        <ChevronUp className="size-3.5" />
+      ) : (
+        <ChevronDown className="size-3.5" />
+      );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "group hover:text-foreground inline-flex items-center gap-1 whitespace-nowrap transition-colors",
+        active && "text-foreground",
+      )}
+    >
+      {label}
+      {arrow}
+    </button>
+  );
+}


### PR DESCRIPTION
## What

The **Costs → Sessions** breakdown table didn't fit its container: it used Moonshine `<Table>` with fixed fractional column widths (`1.4fr` / `0.8fr`), so the columns overflowed horizontally and the right-most ones (Duration) were clipped. The sibling dimension breakdown table (`CostTable`) already auto-sizes correctly via a CSS-grid `subgrid` layout.

This ports `SessionTable` to that same `subgrid` pattern so its columns auto-size to the container, and adds context-aware column hiding.

## Changes

- **New `gridTable.tsx`** — extracts the shared costs-table grid primitives so both tables share one implementation instead of copy-pasting:
  - `SUBGRID_ROW_CLASS` (`col-span-full grid-cols-subgrid`) — header/rows span and inherit the parent grid's tracks.
  - `Gutter` — edge gutter cell.
  - `SortHeader` — tri-state sortable column header.
- **`CostTable.tsx`** — refactored to consume the shared primitives (no behaviour change).
- **`SessionTable.tsx`** — rewritten around the parent-grid + `subgrid` layout. One parent owns `grid-template-columns`; every row inherits the same auto-sized tracks (email column capped at `24rem` so it truncates instead of dominating). Columns are now a declarative descriptor array driving the track template, header, and cells from a single source.
- **Context-aware columns** — a session column is dropped when the drill path already pins that dimension to one value (it would just repeat down every row):
  - drilled into an agent → hide **Agent**
  - drilled into a user → hide **User**
  - drilled into a model → hide **Model**

  `CostsExplorer` derives `hiddenColumns` from the drill `path` (URL-sourced, so it's correct on refresh/share).

## Why subgrid

Moonshine's `Table` sizes each row's grid independently, so fixed `fr` tracks can't shrink and overflow. `subgrid` makes one parent template the source of truth for all rows, so columns auto-size to fit and stay aligned.

## Verification

- `pnpm -F dashboard type-check`, `oxlint --type-aware`, `oxfmt --check` — clean for touched files.
- Visual: please confirm the Sessions table fits and columns hide as expected when drilling into an agent/user/model.

## Follow-up (not in this PR)

Showing the **chat title** instead of the chat id in the Session column needs a backend change — `SessionSummary` (sourced from ClickHouse telemetry) carries no title; titles live in Postgres `chats.title`. Tracking separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Costs → Sessions table so columns auto-size to the container and no longer clip, and hides redundant columns based on drill context. Both cost tables now share one grid system for consistent, responsive sizing.

- **Bug Fixes**
  - Switched the Sessions table to a parent CSS grid with subgrid rows so columns fit and stay aligned; removed fixed fractional widths that caused overflow.
  - When drilling: hide Agent (agent drill), User (user drill), or Model (model drill) to avoid repeating the same value down every row.

- **Refactors**
  - Added shared grid primitives in `gridTable.tsx` (`SUBGRID_ROW_CLASS`, `Gutter`, `SortHeader`); rewrote `SessionTable` to use them and capped the email column at 24rem.
  - Updated `CostTable` to use the same primitives (no behavior change) and `CostsExplorer` to pass `hiddenColumns`; default sort shows cost descending.

<sup>Written for commit a02115283e394907f2a02fb7fc0b9cf2d1a14cbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

