### PR TITLE
feat(hooks): add hook event metrics

### DIFF
--- a/.changeset/hook-event-metrics.md
+++ b/.changeset/hook-event-metrics.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Add hook event metrics for Claude, Codex, and Cursor hook traffic.
+Add hook event processing duration metrics for Claude, Codex, and Cursor hook traffic.

--- a/.changeset/hook-event-metrics.md
+++ b/.changeset/hook-event-metrics.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add hook event metrics for Claude, Codex, and Cursor hook traffic.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1028,6 +1028,7 @@ func newStartCommand() *cli.Command {
 				logger,
 				db,
 				tracerProvider,
+				meterProvider,
 				telemLogger,
 				sessionManager,
 				hooksCache,

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -245,6 +245,10 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 	logger.InfoContext(ctx, "claude hook received",
 		attr.SlogEvent("claude_hook"),
 	)
+	hookEventName := payload.HookEventName
+	if parsedEvent, ok := parseClaudeHookEvent(payload.HookEventName); ok {
+		hookEventName = string(parsedEvent)
+	}
 
 	if hasPluginAuth {
 		// Auth is optional. Returning a 401 on failure deadlocks the client:
@@ -267,6 +271,11 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 			)
 		}
 	}
+	orgSlug := ""
+	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
+		orgSlug = authCtx.OrganizationSlug
+	}
+	s.metrics.RecordHookEventReceived(ctx, "claude", hookEventName, hookMetricOutcomeAccepted, orgSlug)
 
 	// Claim the per-invocation idempotency token once, before persistence and
 	// the block side-effects in the handlers below. A retry re-sends the same

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -254,7 +254,7 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (res *
 	orgSlug := ""
 	outcome := hookMetricOutcomeAccepted
 	defer func() {
-		if err != nil {
+		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
 		s.metrics.RecordHookEventDuration(ctx, "claude", hookEventName, outcome, orgSlug, time.Since(start))

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -216,7 +216,9 @@ func (s *Service) Metrics(ctx context.Context, payload *gen.MetricsPayload) erro
 }
 
 // Claude is the unified endpoint for all Claude Code hook events.
-func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.ClaudeHookResult, error) {
+func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (res *gen.ClaudeHookResult, err error) {
+	start := time.Now()
+
 	// project_slug header may be set even when the API key isn't validated
 	// yet on this optional-auth endpoint — log it as a hint up front.
 	projectSlugHint := conv.PtrValOr(payload.ProjectSlugInput, "")
@@ -249,6 +251,14 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 	if parsedEvent, ok := parseClaudeHookEvent(payload.HookEventName); ok {
 		hookEventName = string(parsedEvent)
 	}
+	orgSlug := ""
+	outcome := hookMetricOutcomeAccepted
+	defer func() {
+		if err != nil {
+			outcome = hookMetricOutcomeFailure
+		}
+		s.metrics.RecordHookEventDuration(ctx, "claude", hookEventName, outcome, orgSlug, time.Since(start))
+	}()
 
 	if hasPluginAuth {
 		// Auth is optional. Returning a 401 on failure deadlocks the client:
@@ -271,11 +281,9 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 			)
 		}
 	}
-	orgSlug := ""
 	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
 		orgSlug = authCtx.OrganizationSlug
 	}
-	s.metrics.RecordHookEventReceived(ctx, "claude", hookEventName, hookMetricOutcomeAccepted, orgSlug)
 
 	// Claim the per-invocation idempotency token once, before persistence and
 	// the block side-effects in the handlers below. A retry re-sends the same

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -269,6 +269,7 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (res *
 		// in Redis, and the OTEL Logs endpoint flushes it once the session is
 		// validated. Policies that need auth context degrade gracefully.
 		if authedCtx, err := s.authorizePluginRequest(ctx, conv.PtrValOr(payload.ApikeyToken, ""), projectSlugHint); err != nil {
+			outcome = hookMetricOutcomeUnauthorized
 			logger.WarnContext(ctx, "plugin auth failed on claude hook; falling back to OTEL-buffered path",
 				attr.SlogEvent("claude_hook_auth_failed"),
 				attr.SlogError(err),

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -31,7 +31,7 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (res *ge
 	orgSlug := ""
 	outcome := hookMetricOutcomeAccepted
 	defer func() {
-		if err != nil {
+		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
 		s.metrics.RecordHookEventDuration(ctx, "codex", hookEventName, outcome, orgSlug, time.Since(start))

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -23,15 +23,20 @@ import (
 )
 
 func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.CodexHookResult, error) {
+	hookEventName := payload.HookEventName
+	if parsedEvent, ok := parseCodexHookEvent(payload.HookEventName); ok {
+		hookEventName = string(parsedEvent)
+	}
 	logger := s.logger.With(
 		attr.SlogHookSource("codex"),
-		attr.SlogHookEvent(payload.HookEventName),
+		attr.SlogHookEvent(hookEventName),
 		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
 		attr.SlogGenAIConversationID(conv.PtrValOr(payload.SessionID, "")),
 	)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		s.metrics.RecordHookEventReceived(ctx, "codex", hookEventName, hookMetricOutcomeUnauthorized, "")
 		logger.WarnContext(ctx, "rejected unauthorized codex hook request",
 			attr.SlogEvent("codex_hook_unauthorized"),
 		)
@@ -55,6 +60,7 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 	logger.InfoContext(ctx, "codex hook received",
 		attr.SlogEvent("codex_hook"),
 	)
+	s.metrics.RecordHookEventReceived(ctx, "codex", hookEventName, hookMetricOutcomeAccepted, authCtx.OrganizationSlug)
 
 	// Claim the per-invocation idempotency token before persistence. A retry
 	// re-sends the same token: the decision still re-runs so the user stays

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -22,11 +22,21 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
-func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.CodexHookResult, error) {
+func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (res *gen.CodexHookResult, err error) {
+	start := time.Now()
 	hookEventName := payload.HookEventName
 	if parsedEvent, ok := parseCodexHookEvent(payload.HookEventName); ok {
 		hookEventName = string(parsedEvent)
 	}
+	orgSlug := ""
+	outcome := hookMetricOutcomeAccepted
+	defer func() {
+		if err != nil {
+			outcome = hookMetricOutcomeFailure
+		}
+		s.metrics.RecordHookEventDuration(ctx, "codex", hookEventName, outcome, orgSlug, time.Since(start))
+	}()
+
 	logger := s.logger.With(
 		attr.SlogHookSource("codex"),
 		attr.SlogHookEvent(hookEventName),
@@ -36,7 +46,7 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		s.metrics.RecordHookEventReceived(ctx, "codex", hookEventName, hookMetricOutcomeUnauthorized, "")
+		outcome = hookMetricOutcomeUnauthorized
 		logger.WarnContext(ctx, "rejected unauthorized codex hook request",
 			attr.SlogEvent("codex_hook_unauthorized"),
 		)
@@ -47,6 +57,7 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 	}
 
 	orgID := authCtx.ActiveOrganizationID
+	orgSlug = authCtx.OrganizationSlug
 	projectID := authCtx.ProjectID.String()
 	metadata := s.codexSessionMetadata(ctx, payload, orgID, projectID)
 	if metadata.UserEmail == "" {
@@ -60,7 +71,6 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 	logger.InfoContext(ctx, "codex hook received",
 		attr.SlogEvent("codex_hook"),
 	)
-	s.metrics.RecordHookEventReceived(ctx, "codex", hookEventName, hookMetricOutcomeAccepted, authCtx.OrganizationSlug)
 
 	// Claim the per-invocation idempotency token before persistence. A retry
 	// re-sends the same token: the decision still re-runs so the user stays

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -26,12 +26,21 @@ import (
 )
 
 // Cursor is the endpoint for Cursor hook events
-func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.CursorHookResult, error) {
+func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (res *gen.CursorHookResult, err error) {
+	start := time.Now()
 	parsedEvent, parsedHookEvent := parseCursorHookEvent(payload.HookEventName)
 	logHookEventName := payload.HookEventName
 	if parsedHookEvent {
 		logHookEventName = string(parsedEvent)
 	}
+	orgSlug := ""
+	outcome := hookMetricOutcomeAccepted
+	defer func() {
+		if err != nil {
+			outcome = hookMetricOutcomeFailure
+		}
+		s.metrics.RecordHookEventDuration(ctx, "cursor", logHookEventName, outcome, orgSlug, time.Since(start))
+	}()
 
 	logger := s.logger.With(
 		attr.SlogHookSource("cursor"),
@@ -43,7 +52,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 
 	authCtx, authOK := contextvalues.GetAuthContext(ctx)
 	if !authOK || authCtx == nil || authCtx.ProjectID == nil {
-		s.metrics.RecordHookEventReceived(ctx, "cursor", logHookEventName, hookMetricOutcomeUnauthorized, "")
+		outcome = hookMetricOutcomeUnauthorized
 		logger.WarnContext(ctx, "rejected unauthorized cursor hook request",
 			attr.SlogEvent("cursor_hook_unauthorized"),
 		)
@@ -56,6 +65,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 	}
 
 	orgID := authCtx.ActiveOrganizationID
+	orgSlug = authCtx.OrganizationSlug
 	projectID := authCtx.ProjectID.String()
 	userEmail := strings.TrimSpace(conv.PtrValOr(payload.UserEmail, ""))
 	if userEmail == "" {
@@ -70,7 +80,6 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 	logger.InfoContext(ctx, "cursor hook received",
 		attr.SlogEvent("cursor_hook"),
 	)
-	s.metrics.RecordHookEventReceived(ctx, "cursor", logHookEventName, hookMetricOutcomeAccepted, authCtx.OrganizationSlug)
 
 	// Claim the per-invocation idempotency token before persistence. A retry
 	// re-sends the same token: the decision still re-runs so the user stays

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -36,7 +36,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (res *
 	orgSlug := ""
 	outcome := hookMetricOutcomeAccepted
 	defer func() {
-		if err != nil {
+		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
 		s.metrics.RecordHookEventDuration(ctx, "cursor", logHookEventName, outcome, orgSlug, time.Since(start))

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -43,6 +43,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 
 	authCtx, authOK := contextvalues.GetAuthContext(ctx)
 	if !authOK || authCtx == nil || authCtx.ProjectID == nil {
+		s.metrics.RecordHookEventReceived(ctx, "cursor", logHookEventName, hookMetricOutcomeUnauthorized, "")
 		logger.WarnContext(ctx, "rejected unauthorized cursor hook request",
 			attr.SlogEvent("cursor_hook_unauthorized"),
 		)
@@ -69,6 +70,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 	logger.InfoContext(ctx, "cursor hook received",
 		attr.SlogEvent("cursor_hook"),
 	)
+	s.metrics.RecordHookEventReceived(ctx, "cursor", logHookEventName, hookMetricOutcomeAccepted, authCtx.OrganizationSlug)
 
 	// Claim the per-invocation idempotency token before persistence. A retry
 	// re-sends the same token: the decision still re-runs so the user stays

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
@@ -37,6 +38,7 @@ import (
 
 type Service struct {
 	tracer             trace.Tracer
+	metrics            *metrics
 	logger             *slog.Logger
 	db                 *pgxpool.Pool
 	telemetryLogger    *telemetry.Logger
@@ -95,6 +97,7 @@ func NewService(
 	logger *slog.Logger,
 	db *pgxpool.Pool,
 	tracerProvider trace.TracerProvider,
+	meterProvider metric.MeterProvider,
 	telemetryLogger *telemetry.Logger,
 	sessionsMgr *sessions.Manager,
 	cacheAdapter cache.Cache,
@@ -112,6 +115,7 @@ func NewService(
 ) *Service {
 	return &Service{
 		tracer:             tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/hooks"),
+		metrics:            newMetrics(meterProvider, logger),
 		logger:             logger.With(attr.SlogComponent("hooks")),
 		db:                 db,
 		telemetryLogger:    telemetryLogger,

--- a/server/internal/hooks/metrics.go
+++ b/server/internal/hooks/metrics.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -11,39 +12,45 @@ import (
 )
 
 const (
-	meterHooksEventsReceived = "hooks.events.received"
+	meterHooksEventDuration = "hooks.event.duration"
 
 	hookMetricOutcomeAccepted     = "accepted"
+	hookMetricOutcomeFailure      = "failure"
 	hookMetricOutcomeUnauthorized = "unauthorized"
 )
 
 type metrics struct {
-	eventsReceived metric.Int64Counter
+	eventDuration metric.Float64Histogram
 }
 
 func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metrics {
 	ctx := context.Background()
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/hooks")
 
-	eventsReceived, err := meter.Int64Counter(
-		meterHooksEventsReceived,
-		metric.WithDescription("Number of hook endpoint events received"),
-		metric.WithUnit("{hook}"),
+	eventDuration, err := meter.Float64Histogram(
+		meterHooksEventDuration,
+		metric.WithDescription("Duration of hook endpoint event processing in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
 	)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterHooksEventsReceived), attr.SlogError(err))
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterHooksEventDuration), attr.SlogError(err))
 	}
 
 	return &metrics{
-		eventsReceived: eventsReceived,
+		eventDuration: eventDuration,
 	}
 }
 
-func (m *metrics) RecordHookEventReceived(ctx context.Context, source string, eventName string, outcome string, orgSlug string) {
-	if m == nil || m.eventsReceived == nil {
+func (m *metrics) RecordHookEventDuration(ctx context.Context, source string, eventName string, outcome string, orgSlug string, duration time.Duration) {
+	if m == nil || m.eventDuration == nil {
 		return
 	}
 
+	m.eventDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(hookEventMetricAttributes(source, eventName, outcome, orgSlug)...))
+}
+
+func hookEventMetricAttributes(source string, eventName string, outcome string, orgSlug string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attr.HookSource(source),
 		attr.HookEvent(eventName),
@@ -52,6 +59,5 @@ func (m *metrics) RecordHookEventReceived(ctx context.Context, source string, ev
 	if orgSlug != "" {
 		attrs = append(attrs, attr.OrganizationSlug(orgSlug))
 	}
-
-	m.eventsReceived.Add(ctx, 1, metric.WithAttributes(attrs...))
+	return attrs
 }

--- a/server/internal/hooks/metrics.go
+++ b/server/internal/hooks/metrics.go
@@ -1,0 +1,57 @@
+package hooks
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const (
+	meterHooksEventsReceived = "hooks.events.received"
+
+	hookMetricOutcomeAccepted     = "accepted"
+	hookMetricOutcomeUnauthorized = "unauthorized"
+)
+
+type metrics struct {
+	eventsReceived metric.Int64Counter
+}
+
+func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metrics {
+	ctx := context.Background()
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/hooks")
+
+	eventsReceived, err := meter.Int64Counter(
+		meterHooksEventsReceived,
+		metric.WithDescription("Number of hook endpoint events received"),
+		metric.WithUnit("{hook}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterHooksEventsReceived), attr.SlogError(err))
+	}
+
+	return &metrics{
+		eventsReceived: eventsReceived,
+	}
+}
+
+func (m *metrics) RecordHookEventReceived(ctx context.Context, source string, eventName string, outcome string, orgSlug string) {
+	if m == nil || m.eventsReceived == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attr.HookSource(source),
+		attr.HookEvent(eventName),
+		attr.Outcome(outcome),
+	}
+	if orgSlug != "" {
+		attrs = append(attrs, attr.OrganizationSlug(orgSlug))
+	}
+
+	m.eventsReceived.Add(ctx, 1, metric.WithAttributes(attrs...))
+}

--- a/server/internal/hooks/metrics_test.go
+++ b/server/internal/hooks/metrics_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -11,7 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
-func TestMetrics_RecordHookEventReceived(t *testing.T) {
+func TestMetrics_RecordHookEventDuration(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -19,46 +20,47 @@ func TestMetrics_RecordHookEventReceived(t *testing.T) {
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	metrics := newMetrics(meterProvider, testenv.NewLogger(t))
 
-	metrics.RecordHookEventReceived(ctx, "claude", "PreToolUse", hookMetricOutcomeAccepted, "acme")
+	metrics.RecordHookEventDuration(ctx, "claude", "PreToolUse", hookMetricOutcomeAccepted, "acme", 150*time.Millisecond)
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &rm))
 
-	point := findHookEventsReceivedPoint(t, rm)
-	require.Equal(t, int64(1), point.Value)
+	histogramPoint := findHookEventDurationPoint(t, rm)
+	require.Equal(t, uint64(1), histogramPoint.Count)
+	require.InDelta(t, 0.15, histogramPoint.Sum, 0.0001)
 
-	value, ok := point.Attributes.Value(attr.HookSourceKey)
+	value, ok := histogramPoint.Attributes.Value(attr.HookSourceKey)
 	require.True(t, ok)
 	require.Equal(t, "claude", value.AsString())
 
-	value, ok = point.Attributes.Value(attr.HookEventKey)
+	value, ok = histogramPoint.Attributes.Value(attr.HookEventKey)
 	require.True(t, ok)
 	require.Equal(t, "PreToolUse", value.AsString())
 
-	value, ok = point.Attributes.Value(attr.OutcomeKey)
+	value, ok = histogramPoint.Attributes.Value(attr.OutcomeKey)
 	require.True(t, ok)
 	require.Equal(t, hookMetricOutcomeAccepted, value.AsString())
 
-	value, ok = point.Attributes.Value(attr.OrganizationSlugKey)
+	value, ok = histogramPoint.Attributes.Value(attr.OrganizationSlugKey)
 	require.True(t, ok)
 	require.Equal(t, "acme", value.AsString())
 }
 
-func findHookEventsReceivedPoint(t *testing.T, rm metricdata.ResourceMetrics) metricdata.DataPoint[int64] {
+func findHookEventDurationPoint(t *testing.T, rm metricdata.ResourceMetrics) metricdata.HistogramDataPoint[float64] {
 	t.Helper()
 
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			if m.Name != meterHooksEventsReceived {
+			if m.Name != meterHooksEventDuration {
 				continue
 			}
-			sum, ok := m.Data.(metricdata.Sum[int64])
+			histogram, ok := m.Data.(metricdata.Histogram[float64])
 			require.True(t, ok)
-			require.Len(t, sum.DataPoints, 1)
-			return sum.DataPoints[0]
+			require.Len(t, histogram.DataPoints, 1)
+			return histogram.DataPoints[0]
 		}
 	}
 
-	require.Failf(t, "metric not found", "missing metric %q", meterHooksEventsReceived)
-	return metricdata.DataPoint[int64]{}
+	require.Failf(t, "metric not found", "missing metric %q", meterHooksEventDuration)
+	return metricdata.HistogramDataPoint[float64]{}
 }

--- a/server/internal/hooks/metrics_test.go
+++ b/server/internal/hooks/metrics_test.go
@@ -1,0 +1,64 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestMetrics_RecordHookEventReceived(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics := newMetrics(meterProvider, testenv.NewLogger(t))
+
+	metrics.RecordHookEventReceived(ctx, "claude", "PreToolUse", hookMetricOutcomeAccepted, "acme")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	point := findHookEventsReceivedPoint(t, rm)
+	require.Equal(t, int64(1), point.Value)
+
+	value, ok := point.Attributes.Value(attr.HookSourceKey)
+	require.True(t, ok)
+	require.Equal(t, "claude", value.AsString())
+
+	value, ok = point.Attributes.Value(attr.HookEventKey)
+	require.True(t, ok)
+	require.Equal(t, "PreToolUse", value.AsString())
+
+	value, ok = point.Attributes.Value(attr.OutcomeKey)
+	require.True(t, ok)
+	require.Equal(t, hookMetricOutcomeAccepted, value.AsString())
+
+	value, ok = point.Attributes.Value(attr.OrganizationSlugKey)
+	require.True(t, ok)
+	require.Equal(t, "acme", value.AsString())
+}
+
+func findHookEventsReceivedPoint(t *testing.T, rm metricdata.ResourceMetrics) metricdata.DataPoint[int64] {
+	t.Helper()
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != meterHooksEventsReceived {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			return sum.DataPoints[0]
+		}
+	}
+
+	require.Failf(t, "metric not found", "missing metric %q", meterHooksEventsReceived)
+	return metricdata.DataPoint[int64]{}
+}

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -69,6 +69,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	meterProvider := testenv.NewMeterProvider(t)
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
 
@@ -99,6 +100,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 		logger,
 		conn,
 		tracerProvider,
+		meterProvider,
 		nil,
 		sessionManager,
 		cacheAdapter,


### PR DESCRIPTION
## Summary
- Add a hook event counter for Claude, Codex, and Cursor hook endpoints.
- Tag hook traffic by source, event, outcome, and authenticated organization slug.

## Test plan
- go test ./internal/hooks
- go test ./cmd/gram -run '^$'
- mise lint:server


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenTelemetry duration metrics for hook processing across `claude`, `codex`, and `cursor` endpoints. Records per-request latency with tags for source, normalized event name, outcome, and org slug, with auth failures correctly tagged and preserved.

- **New Features**
  - Added `hooks.event.duration` histogram in `server/internal/hooks` using `go.opentelemetry.io/otel/metric` (seconds, explicit buckets).
  - Records latency in all handlers via defer with attributes: source, event (normalized), outcome (`accepted`, `unauthorized`, `failure`), and `organization.slug` when present; auth failures are tagged `unauthorized` and not overwritten by later errors; includes tests.

- **Migration**
  - `hooks.NewService` now requires a `meterProvider`; `cmd/gram` is wired to pass it.
  - Ensure your environment provides an OTEL `MeterProvider`/exporter.

<sup>Written for commit e578d55c71cf145bcf5d7843cf13e2ed900b6efc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

