### PR TITLE
fix: stop shipping source maps to browsers in prod (DNO-132)

### DIFF
--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -59,7 +59,11 @@ export default defineConfig(({ command }) => {
     },
     build: {
       target: "es2022",
-      sourcemap: true,
+      // DNO-132: Do not ship source maps to browsers in production builds. They expose
+      // the original .tsx source via DevTools. (Ignored by the dev server,
+      // which always serves maps.) Switch to "hidden" if we later wire up
+      // source-map upload for error symbolication (e.g. PostHog/Sentry).
+      sourcemap: false,
       rollupOptions: {
         input: {
           main: path.resolve(__dirname, "index.html"),

--- a/elements/vite.config.ts
+++ b/elements/vite.config.ts
@@ -30,7 +30,11 @@ export default defineConfig({
     }),
   ],
   build: {
-    sourcemap: true,
+    // DNO-132: Do not ship source maps to browsers in production builds. They expose
+    // the original .tsx source via DevTools. (Ignored by the dev server,
+    // which always serves maps.) Switch to "hidden" if we later wire up
+    // source-map upload for error symbolication (e.g. PostHog/Sentry).
+    sourcemap: false,
     minify: "esbuild",
     lib: {
       entry: {


### PR DESCRIPTION
## What

Disable production source maps for both frontend builds:

- `client/dashboard/vite.config.ts` — `build.sourcemap: false`
- `elements/vite.config.ts` — `build.sourcemap: false`

## Why

Production builds were emitting `.map` files **and** appending `//# sourceMappingURL=` comments to the bundles. Chrome DevTools follows those comments, downloads the maps, and reconstructs the original `.tsx` source tree (`src/`, `App.tsx`, `routes.tsx`, …) — visible to anyone on `app.getgram.ai`. There is no source-map upload / symbolication pipeline consuming these maps today, so they were pure exposure.

## Notes

- `build.sourcemap` is only read during `vite build`; the dev server always serves maps, so local debugging is unaffected.
- If we later wire up error symbolication (PostHog/Sentry), switch to `sourcemap: "hidden"` — generates maps for upload without referencing them from the bundles. (With `"hidden"`, do not deploy the `.map` files to the public static host.)
- `elements/` is a published library (`@gram-ai/elements`); its maps already excluded source text via `sourcemapExcludeSources`, but disabling them is consistent and removes the maps entirely.

DNO-132
