### PR TITLE
fix(catalog): version registry cache key so supports_dcr isn't stale

### DIFF
--- a/server/internal/externalmcp/registry_cache.go
+++ b/server/internal/externalmcp/registry_cache.go
@@ -14,6 +14,15 @@ import (
 
 const registryCacheTTL = 24 * time.Hour
 
+// registryCacheSchemaVersion is baked into every registry cache key. Bump it
+// whenever the cached shape changes (e.g. a new field on ExternalMCPServerEntry)
+// so a deploy can't read blobs written by an older binary. The cache serializes
+// structs as field-name-keyed msgpack maps, so a missing field silently decodes
+// to its zero value rather than erroring — without this version, adding
+// `supports_dcr` made every cached server read back as supports_dcr=false (i.e.
+// "manual") for up to the 24h TTL.
+const registryCacheSchemaVersion = "v2"
+
 // CachedListServersResponse wraps a list of external MCP server summaries for caching.
 type CachedListServersResponse struct {
 	Key        string
@@ -57,5 +66,5 @@ func registryCacheKey(prefix string, req *http.Request) string {
 		_, _ = fmt.Fprintf(h, "%s=%s\n", k, strings.Join(vals, ","))
 	}
 
-	return fmt.Sprintf("registry:%s:%s:%x", prefix, req.URL.String(), h.Sum(nil))
+	return fmt.Sprintf("registry:%s:%s:%s:%x", prefix, registryCacheSchemaVersion, req.URL.String(), h.Sum(nil))
 }

--- a/server/internal/externalmcp/registryclient.go
+++ b/server/internal/externalmcp/registryclient.go
@@ -421,13 +421,13 @@ func toExternalMCPRemoteVariables(variables map[string]RemoteVariable) map[strin
 // ClearCache removes all cached entries for the given registry URL.
 func (c *RegistryClient) ClearCache(ctx context.Context, registryURL string) error {
 	if c.listCache != nil {
-		prefix := fmt.Sprintf("registry:list:%s", registryURL)
+		prefix := fmt.Sprintf("registry:list:%s:%s", registryCacheSchemaVersion, registryURL)
 		if err := c.listCache.DeleteByPrefix(ctx, prefix); err != nil {
 			return fmt.Errorf("clear list cache for registry %s: %w", registryURL, err)
 		}
 	}
 	if c.detailsCache != nil {
-		prefix := fmt.Sprintf("registry:details:%s", registryURL)
+		prefix := fmt.Sprintf("registry:details:%s:%s", registryCacheSchemaVersion, registryURL)
 		if err := c.detailsCache.DeleteByPrefix(ctx, prefix); err != nil {
 			return fmt.Errorf("clear details cache for registry %s: %w", registryURL, err)
 		}


### PR DESCRIPTION
## Incident

After deploying `supports_dcr` (#3687), the production MCP Catalog showed **every** server as "Manual Setup", even DCR-capable ones. Local was correct.

## Root cause

The registry list is cached for **24h** (`registryCacheTTL`) and serialized as **field-name-keyed msgpack**. The cache key (`registryCacheKey`) had no schema version. So after the deploy, the shared cache still held `ExternalMCPServerEntry` blobs written by the *old* binary — which had no `supports_dcr` key. The new binary decoded those blobs with the field defaulting to `false`, i.e. "manual", for the whole TTL. Locally the cache was empty, so `ListServers` recomputed the value correctly.

## Fix

- Bake a `registryCacheSchemaVersion` (`v2`) into every registry cache key. On deploy, the new code reads fresh (versioned) keys → cache miss → recompute with the correct `supports_dcr` → store. Old keys harmlessly expire. Bump this constant on any future change to a cached shape.
- Update `ClearCache` prefixes to include the version so manual invalidation still matches.

**Self-healing:** deploying this fixes prod without manual Redis intervention. (Immediate alternative if needed before deploy: call `mcpRegistries.clearCache`, or let the 24h TTL expire.)

## Verification
- `go build`, `mise lint:server`, registry client tests all green.
- No DB/migration changes.
