### PR TITLE
feat(plugins): publish-on-add affordance on plugin detail

### DIFF
--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -17,11 +17,17 @@ import {
   usePluginSuspense,
 } from "@gram/client/react-query/plugin";
 import { invalidateAllPlugins } from "@gram/client/react-query/plugins";
+import {
+  invalidateAllPublishStatus,
+  usePublishStatus,
+} from "@gram/client/react-query/publishStatus";
+import { usePublishPluginsMutation } from "@gram/client/react-query/publishPlugins";
 import { useUpdatePluginMutation } from "@gram/client/react-query/updatePlugin";
 import { useAddPluginServerMutation } from "@gram/client/react-query/addPluginServer";
 import { useRemovePluginServerMutation } from "@gram/client/react-query/removePluginServer";
 import { useListToolsets } from "@gram/client/react-query/listToolsets";
 import { useMcpServers } from "@gram/client/react-query/mcpServers";
+import type { PublishStatusResult } from "@gram/client/models/components";
 import {
   Button,
   DropdownMenu,
@@ -32,8 +38,9 @@ import {
   Stack,
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
 import { Network, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useParams } from "react-router";
 import type {
   McpServer,
@@ -42,6 +49,8 @@ import type {
 } from "@gram/client/models/components";
 import { useSdkClient } from "@/contexts/Sdk";
 import { toast } from "sonner";
+import { InstallInstructionsButton } from "./InstallInstructionsDialog";
+import { PublishDialog } from "./PublishDialog";
 
 // A selectable server for a plugin, sourced from either a toolset (Hosted) or
 // a Remote MCP-backed mcp_server. The kind determines whether it is submitted
@@ -63,8 +72,10 @@ export default function PluginDetail(): JSX.Element | null {
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isAddServerOpen, setIsAddServerOpen] = useState(false);
   const [isDownloadMenuOpen, setIsDownloadMenuOpen] = useState(false);
+  const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
 
   const { data: plugin } = usePluginSuspense({ id: pluginId! });
+  const { data: publishStatus } = usePublishStatus();
 
   const client = useSdkClient();
 
@@ -89,15 +100,75 @@ export default function PluginDetail(): JSX.Element | null {
 
   const isLoadingServers = isLoadingToolsets || isLoadingMcpServers;
 
+  // Invalidate publish status too so the dirty/up-to-date affordance reflects
+  // the edit the moment a mutation lands.
   const invalidateAll = async () => {
     await invalidateAllPlugin(queryClient);
     await invalidateAllPlugins(queryClient);
+    await invalidateAllPublishStatus(queryClient);
   };
+
+  const publishMutation = usePublishPluginsMutation({
+    onSuccess: (data) => {
+      setIsPublishDialogOpen(false);
+      void invalidateAllPublishStatus(queryClient);
+      toast.success("Plugins published to GitHub", {
+        description: data.repoUrl,
+        action: {
+          label: "Open",
+          onClick: () => {
+            void window.open(data.repoUrl, "_blank", "noopener,noreferrer");
+          },
+        },
+      });
+    },
+    onError: () => {
+      toast.error("Failed to publish plugins to GitHub");
+    },
+  });
+
+  // Destructure mutate so callbacks depend on the stable function rather than
+  // the fresh-per-render wrapper object (mirrors Plugins.tsx).
+  const { mutate: publishMutate } = publishMutation;
+  const handlePublish = useCallback(
+    (githubUsernames: string[]) => {
+      publishMutate({
+        security: { sessionHeaderGramSession: "" },
+        request: { publishPluginsRequestBody: { githubUsernames } },
+      });
+    },
+    [publishMutate],
+  );
+
+  // Nudge the user to publish straight after an edit instead of hunting for
+  // Re-publish on the list page. A connected project republishes in one click;
+  // a configured-but-unconnected project needs the first-publish dialog (it
+  // collects collaborators). Unconfigured projects get no nudge — there's
+  // nowhere to publish to.
+  const offerPublish = useCallback(
+    (message: string) => {
+      if (!publishStatus?.configured) return;
+      toast.success(message, {
+        action: {
+          label: "Publish now",
+          onClick: () => {
+            if (publishStatus.connected) {
+              handlePublish([]);
+            } else {
+              setIsPublishDialogOpen(true);
+            }
+          },
+        },
+      });
+    },
+    [publishStatus?.configured, publishStatus?.connected, handlePublish],
+  );
 
   const updateMutation = useUpdatePluginMutation({
     onSuccess: () => {
       setIsEditOpen(false);
       void invalidateAll();
+      offerPublish("Plugin updated");
     },
   });
 
@@ -105,11 +176,15 @@ export default function PluginDetail(): JSX.Element | null {
     onSuccess: () => {
       setIsAddServerOpen(false);
       void invalidateAll();
+      offerPublish("Server added to plugin");
     },
   });
 
   const removeServerMutation = useRemovePluginServerMutation({
-    onSuccess: () => invalidateAll(),
+    onSuccess: () => {
+      void invalidateAll();
+      offerPublish("Server removed from plugin");
+    },
   });
 
   const handleRemoveServer = (server: PluginServer) => {
@@ -251,11 +326,48 @@ export default function PluginDetail(): JSX.Element | null {
             <Type muted small className="mt-1">
               Slug: <code>{plugin.slug}</code>
             </Type>
+            <PublishFreshnessIndicator publishStatus={publishStatus} />
           </div>
-          <Button variant="secondary" onClick={() => setIsEditOpen(true)}>
-            Edit
-          </Button>
+          <Stack direction="horizontal" gap={2} align="center">
+            <PublishStatusControl
+              publishStatus={publishStatus}
+              isPending={publishMutation.isPending}
+              onRepublish={() => handlePublish([])}
+              onOpenDialog={() => setIsPublishDialogOpen(true)}
+            />
+            <Button variant="secondary" onClick={() => setIsEditOpen(true)}>
+              Edit
+            </Button>
+          </Stack>
         </Stack>
+
+        {/* Marketplace banner — durable path to the install instructions, so the
+            published marketplace URL is reachable without going back to the list. */}
+        {publishStatus?.connected &&
+          publishStatus.repoUrl &&
+          publishStatus.repoOwner &&
+          publishStatus.repoName && (
+            <div className="bg-muted/30 border-border/60 mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                  Marketplace
+                </span>
+                <a
+                  href={publishStatus.repoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-primary text-foreground font-mono text-sm hover:underline"
+                >
+                  {publishStatus.repoOwner}/{publishStatus.repoName}
+                </a>
+              </div>
+              <InstallInstructionsButton
+                repoOwner={publishStatus.repoOwner}
+                repoName={publishStatus.repoName}
+                marketplaceUrl={publishStatus.marketplaceUrl}
+              />
+            </div>
+          )}
 
         {/* Servers section */}
         <Stack
@@ -466,9 +578,104 @@ export default function PluginDetail(): JSX.Element | null {
             </form>
           </Dialog.Content>
         </Dialog>
+        <PublishDialog
+          open={isPublishDialogOpen}
+          onOpenChange={setIsPublishDialogOpen}
+          onPublish={handlePublish}
+          isPending={publishMutation.isPending}
+        />
       </Page.Body>
     </Page>
   );
+}
+
+// Durable publish affordance for the plugin detail header. Renders nothing when
+// the server has no GitHub publishing configured; otherwise it surfaces the
+// project's publish freshness (sourced from getPublishStatus) and a one-click
+// path to publish without returning to the plugins list.
+function PublishStatusControl({
+  publishStatus,
+  isPending,
+  onRepublish,
+  onOpenDialog,
+}: {
+  publishStatus: PublishStatusResult | undefined;
+  isPending: boolean;
+  onRepublish: () => void;
+  onOpenDialog: () => void;
+}): JSX.Element | null {
+  if (!publishStatus?.configured) return null;
+
+  // Never published: the first publish needs the dialog (it collects repo
+  // collaborators), so there's no freshness to show yet.
+  if (!publishStatus.connected) {
+    return (
+      <Button variant="secondary" onClick={onOpenDialog} disabled={isPending}>
+        <Button.LeftIcon>
+          <Icon name="upload" className="h-4 w-4" />
+        </Button.LeftIcon>
+        <Button.Text>
+          {isPending ? "Publishing..." : "Publish Private Marketplace"}
+        </Button.Text>
+      </Button>
+    );
+  }
+
+  // up_to_date is absent when freshness can't be determined (connection
+  // predates fingerprinting) — treat only an explicit false as dirty.
+  const hasUnpublishedChanges = publishStatus.upToDate === false;
+
+  return (
+    <Button
+      variant={hasUnpublishedChanges ? "primary" : "secondary"}
+      onClick={onRepublish}
+      disabled={isPending}
+    >
+      <Button.LeftIcon>
+        <Icon name="refresh-cw" className="h-4 w-4" />
+      </Button.LeftIcon>
+      <Button.Text>
+        {isPending
+          ? "Publishing..."
+          : hasUnpublishedChanges
+            ? "Publish changes"
+            : "Re-publish"}
+      </Button.Text>
+    </Button>
+  );
+}
+
+// Shows the published freshness of a connected project under the plugin
+// metadata: a dirty badge when there are unpublished changes, otherwise a muted
+// "Published <time> ago". Renders nothing when not connected or freshness is
+// unknown.
+function PublishFreshnessIndicator({
+  publishStatus,
+}: {
+  publishStatus: PublishStatusResult | undefined;
+}): JSX.Element | null {
+  if (!publishStatus?.connected) return null;
+
+  if (publishStatus.upToDate === false) {
+    return (
+      <Badge variant="warning" className="mt-2">
+        Unpublished changes
+      </Badge>
+    );
+  }
+
+  if (publishStatus.upToDate && publishStatus.lastPublishedAt) {
+    return (
+      <Type muted small className="mt-2 block">
+        Published{" "}
+        {formatDistanceToNow(publishStatus.lastPublishedAt, {
+          addSuffix: true,
+        })}
+      </Type>
+    );
+  }
+
+  return null;
 }
 
 function PluginServerCard({

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -40,7 +40,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { Network, Trash2 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router";
 import type {
   McpServer,
@@ -130,8 +130,16 @@ export default function PluginDetail(): JSX.Element | null {
   // Destructure mutate so callbacks depend on the stable function rather than
   // the fresh-per-render wrapper object (mirrors Plugins.tsx).
   const { mutate: publishMutate } = publishMutation;
+  // Mirror the in-flight flag into a ref so detached callbacks can gate on the
+  // current pending state. The "Publish now" toast action closure is created
+  // when offerPublish runs (before any publish starts), so it can't read a live
+  // isPending — without this guard, stacking edits into multiple toasts lets a
+  // user fire concurrent publishes that the disabled header button prevents.
+  const isPublishingRef = useRef(publishMutation.isPending);
+  isPublishingRef.current = publishMutation.isPending;
   const handlePublish = useCallback(
     (githubUsernames: string[]) => {
+      if (isPublishingRef.current) return;
       publishMutate({
         security: { sessionHeaderGramSession: "" },
         request: { publishPluginsRequestBody: { githubUsernames } },


### PR DESCRIPTION
## What

Gives a one-click path to publish straight from the plugin detail page instead of returning to the list to Re-publish (Adam's ask #1). DNO-331.

**Stacked on #3690** (DNO-328 backend freshness) — base is `daviddanialy/dno-328-...`, not `main`, so this diff shows only the frontend change. It'll auto-retarget to `main` once #3690 merges. Review/merge #3690 first.

## Changes (`client/dashboard/src/pages/plugins/PluginDetail.tsx`)

- **Post-edit nudge:** after add/remove server and metadata edits, a "Publish now" toast — republishes in one click when connected, opens the first-publish dialog otherwise. No nudge when GitHub publishing isn't configured (`configured: false`), since there's nowhere to publish.
- **Durable header control + marketplace banner:** mirrors the Plugins-list publish flow (`usePublishPluginsMutation`, `PublishDialog`, `InstallInstructionsButton`) so the path survives a refresh, not just a transient toast.
- **Freshness under the plugin metadata** (consumes the new `getPublishStatus` `up_to_date` / `last_published_at`): an amber "Unpublished changes" badge when dirty, muted "Published \<time\> ago" when up to date. Treats only an explicit `up_to_date: false` as dirty (unknown → no badge).

## Reuse / confidence

The publish *action* is a line-for-line reuse of `Plugins.tsx`'s publish path (same mutation, payload, dialog, banner) — only the freshness *display* is new and is driven entirely by the backend fields from #3690.

## Verification

`pnpm -F dashboard type-check` + `lint` (oxfmt, oxlint type-aware, tsc) pass. Visually checked all states locally via a temporary mocked publish status (GitHub publishing is off in local dev, so the real connected flow can only be exercised on a GitHub-configured env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)