### PR TITLE
fix(telemetry): record assistant chat completion costs

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -50,7 +50,8 @@ migrations:
 
 database-changes:
   - "server/migrations/**"
-  - "server/clickhouse/**"
+  - "server/clickhouse/migrations/**"
+  - "server/clickhouse/schema.sql"
 
 db-migrations:
   - "server/migrations/**"

--- a/server/clickhouse/scripts/seed-costs.mjs
+++ b/server/clickhouse/scripts/seed-costs.mjs
@@ -590,12 +590,12 @@ for (const p of people) {
       "gen_ai.usage.cost": Number(cost),
       "gen_ai.response.model": model,
       "gen_ai.provider.name": provider,
-      "gram.resource.urn": "agents:chat:completion",
+      "gram.resource.urn": "chat:completion",
       "http.response.status_code": rnd() < 0.95 ? 200 : 500,
       ...baseAttrs,
     };
     rows.push(
-      `(${ct}, ${ct}, 'INFO', 'Chat completion', '${traceId}', '${attrJSON(ca)}', '{"gram.deployment.id": "deployment-1"}', '${projectId}', 'agents:chat:completion', 'gram-mcp-gateway', '${chatId}')`,
+      `(${ct}, ${ct}, 'INFO', 'Chat completion', '${traceId}', '${attrJSON(ca)}', '{"gram.deployment.id": "deployment-1"}', '${projectId}', 'chat:completion', 'gram-mcp-gateway', '${chatId}')`,
     );
   }
 }

--- a/server/internal/billing/tracking.go
+++ b/server/internal/billing/tracking.go
@@ -18,7 +18,7 @@ type ModelUsageSource string
 
 const (
 	ModelUsageSourcePlayground ModelUsageSource = "playground"
-	ModelUsageSourceAgents     ModelUsageSource = "agents"
+	ModelUsageSourceAssistants ModelUsageSource = "assistants"
 	ModelUsageSourceElements   ModelUsageSource = "elements"
 	ModelUsageSourceGram       ModelUsageSource = "gram"
 	ModelUsageSourceSlack      ModelUsageSource = "slack"

--- a/server/internal/chat/agent_client.go
+++ b/server/internal/chat/agent_client.go
@@ -196,7 +196,7 @@ func (c *Client) AgentChat(
 			Temperature:               opts.Temperature,
 			Model:                     opts.Model,
 			Stream:                    false,
-			UsageSource:               billing.ModelUsageSourceAgents,
+			UsageSource:               billing.ModelUsageSourceAssistants,
 			ChatID:                    chatID,
 			UserID:                    "",
 			ExternalUserID:            "", // TODO

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -793,20 +793,23 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 
 	orgID := authCtx.ActiveOrganizationID
 	userID := authCtx.UserID
+	source := billing.ModelUsageSource(metadata.Source)
+	if source == "assistant" {
+		source = billing.ModelUsageSourceAssistants
+	}
+	if source == "" {
+		source = billing.ModelUsageSourcePlayground
+	}
+	sourceName := string(source)
 
 	eventProperties := map[string]any{
 		"action":            "chat_request_received",
 		"organization_slug": authCtx.OrganizationSlug,
 		"project_slug":      *authCtx.ProjectSlug,
 		"success":           false,
-		"source":            metadata.Source,
+		"source":            sourceName,
 		"user_agent":        metadata.UserAgent,
 		"origin":            metadata.Origin,
-	}
-
-	source := billing.ModelUsageSource(metadata.Source)
-	if source == "" {
-		source = billing.ModelUsageSourcePlayground
 	}
 
 	defer func() {

--- a/server/internal/telemetry/README.md
+++ b/server/internal/telemetry/README.md
@@ -67,18 +67,18 @@ The table below shows representative keys from each category. See `conventions.g
 
 The `gram.*` prefix is used for attributes that are **Gram system-generated** — they identify internal Gram concepts that have no OTel equivalent. These are not fallbacks; they are explicitly namespaced to make it clear the attribute originates from the Gram platform.
 
-| Key                      | Description                                                   |
-| ------------------------ | ------------------------------------------------------------- |
-| `gram.project.id`        | Gram project UUID                                             |
-| `gram.deployment.id`     | Deployment UUID                                               |
-| `gram.function.id`       | Serverless function UUID                                      |
-| `gram.tool.urn`          | Tool URN (e.g., `tools:function:my-source:my-tool`)           |
-| `gram.tool.name`         | Human-readable tool name                                      |
-| `gram.external_user.id`  | End-user ID from the customer's system                        |
-| `gram.resource.urn`      | Internal resource identifier (e.g., `agents:chat:completion`) |
-| `gram.log.severity_text` | Severity override from caller                                 |
-| `gram.log.body`          | Log body/message content                                      |
-| `gram.api_key.id`        | API key used for the request                                  |
+| Key                      | Description                                            |
+| ------------------------ | ------------------------------------------------------ |
+| `gram.project.id`        | Gram project UUID                                      |
+| `gram.deployment.id`     | Deployment UUID                                        |
+| `gram.function.id`       | Serverless function UUID                               |
+| `gram.tool.urn`          | Tool URN (e.g., `tools:function:my-source:my-tool`)    |
+| `gram.tool.name`         | Human-readable tool name                               |
+| `gram.external_user.id`  | End-user ID from the customer's system                 |
+| `gram.resource.urn`      | Internal resource identifier (e.g., `chat:completion`) |
+| `gram.log.severity_text` | Severity override from caller                          |
+| `gram.log.body`          | Log body/message content                               |
+| `gram.api_key.id`        | API key used for the request                           |
 
 ### Adding new attributes
 
@@ -109,7 +109,7 @@ Build a `map[attr.Key]any`, populate it with typed attribute keys from the `attr
 
 ```go
 attrs := map[attr.Key]any{
-    attr.ResourceURNKey:           "agents:chat:completion",
+    attr.ResourceURNKey:           "chat:completion",
     attr.LogBodyKey:               "LLM chat completion: model=gpt-4o",
     attr.GenAIOperationNameKey:    telemetry.GenAIOperationChat,
     attr.GenAIRequestModelKey:     "gpt-4o",

--- a/server/internal/telemetry/chat_metrics_test.go
+++ b/server/internal/telemetry/chat_metrics_test.go
@@ -1,0 +1,79 @@
+package telemetry_test
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetChatMetricsByIDs_UsesMaterializedChatID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+	chatID := uuid.NewString()
+	now := time.Now().UTC()
+
+	insertChatCompletionMetricLog(t, ctx, projectID, chatID, now, 12, 8, 20, 0.42)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		got, err := ti.chClient.GetChatMetricsByIDs(ctx, repo.GetChatMetricsByIDsParams{
+			GramProjectID: projectID,
+			ChatIDs:       []string{chatID},
+		})
+		require.NoError(c, err)
+		row, ok := got[chatID]
+		require.True(c, ok)
+		require.Equal(c, int64(12), row.TotalInputTokens)
+		require.Equal(c, int64(8), row.TotalOutputTokens)
+		require.Equal(c, int64(20), row.TotalTokens)
+		require.Less(c, math.Abs(row.TotalCost-0.42), 1e-9)
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+func insertChatCompletionMetricLog(t *testing.T, ctx context.Context, projectID, chatID string, timestamp time.Time, inputTokens, outputTokens, totalTokens int, cost float64) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attributes := map[string]any{
+		"gen_ai.conversation.id":     chatID,
+		"gen_ai.operation.name":      "chat",
+		"gen_ai.response.id":         uuid.NewString(),
+		"gen_ai.response.model":      "openai/gpt-5.4",
+		"gen_ai.usage.input_tokens":  inputTokens,
+		"gen_ai.usage.output_tokens": outputTokens,
+		"gen_ai.usage.total_tokens":  totalTokens,
+		"gen_ai.usage.cost":          cost,
+		"gram.hook.source":           "assistants",
+		"gram.resource.urn":          "assistants:chat:completion",
+	}
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	err = conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
+		nil, nil, string(attrsJSON), "{}",
+		projectID, "assistants:chat:completion", "gram-server")
+	require.NoError(t, err)
+}

--- a/server/internal/telemetry/get_metrics_summary_test.go
+++ b/server/internal/telemetry/get_metrics_summary_test.go
@@ -164,7 +164,7 @@ func insertChatCompletionLog(t *testing.T, ctx context.Context, projectID, deplo
 		"gen_ai.usage.total_tokens":      totalTokens,
 		"gen_ai.response.model":          model,
 		"gen_ai.provider.name":           provider,
-		"gram.resource.urn":              "agents:chat:completion",
+		"gram.resource.urn":              "chat:completion",
 	}
 
 	attrsJSON, err := json.Marshal(attributes)
@@ -178,7 +178,7 @@ func insertChatCompletionLog(t *testing.T, ctx context.Context, projectID, deplo
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
 		nil, nil, string(attrsJSON), "{}",
-		projectID, deploymentID, "agents:chat:completion", "gram-agents")
+		projectID, deploymentID, "chat:completion", "gram-server")
 	require.NoError(t, err)
 }
 

--- a/server/internal/telemetry/get_observability_overview_test.go
+++ b/server/internal/telemetry/get_observability_overview_test.go
@@ -422,7 +422,7 @@ func insertResolutionLog(t *testing.T, ctx context.Context, projectID, deploymen
 	attributes := map[string]any{
 		"gen_ai.conversation.id":        chatID,
 		"gen_ai.conversation.duration":  30.0, // 30 seconds
-		"gram.resource.urn":             "agents:chat:resolution",
+		"gram.resource.urn":             "chat:resolution",
 		"evaluation.score":              score,
 		"gen_ai.evaluation.score.label": resolution, // This feeds the MATERIALIZED column
 	}
@@ -439,7 +439,7 @@ func insertResolutionLog(t *testing.T, ctx context.Context, projectID, deploymen
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat resolution",
 		nil, nil, string(attrsJSON), "{}",
-		projectID, deploymentID, "agents:chat:resolution", chatID,
-		"gram-agents")
+		projectID, deploymentID, "chat:resolution", chatID,
+		"gram-server")
 	require.NoError(t, err)
 }

--- a/server/internal/telemetry/get_user_metrics_summary_test.go
+++ b/server/internal/telemetry/get_user_metrics_summary_test.go
@@ -415,7 +415,7 @@ func insertChatCompletionLogWithUser(t *testing.T, ctx context.Context, projectI
 		"gen_ai.usage.total_tokens":      totalTokens,
 		"gen_ai.response.model":          model,
 		"gen_ai.provider.name":           provider,
-		"gram.resource.urn":              "agents:chat:completion",
+		"gram.resource.urn":              "chat:completion",
 	}
 
 	if userID != "" {
@@ -436,7 +436,7 @@ func insertChatCompletionLogWithUser(t *testing.T, ctx context.Context, projectI
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
 		nil, nil, string(attrsJSON), "{}",
-		projectID, deploymentID, "agents:chat:completion", "gram-agents")
+		projectID, deploymentID, "chat:completion", "gram-server")
 	require.NoError(t, err)
 }
 

--- a/server/internal/telemetry/list_sessions_test.go
+++ b/server/internal/telemetry/list_sessions_test.go
@@ -311,6 +311,60 @@ func TestListSessions_CrossRowDirectoryAndHookFilters(t *testing.T) {
 	require.Equal(t, int64(1), session.MessageCount)
 }
 
+func TestListSessions_IncludesCostBearingAssistantChatCompletions(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Now().UTC()
+	chatID := uuid.NewString()
+	insertListSessionRawChatCompletionLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-5 * time.Minute),
+		chatID:       chatID,
+		email:        "assistant@example.com",
+		department:   "Engineering",
+		roles:        []string{"dev"},
+		hookSource:   "assistants",
+		model:        "openai/gpt-5.4",
+		inputTokens:  40,
+		outputTokens: 10,
+		totalTokens:  50,
+		cost:         0.33,
+	})
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	res := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From:   from,
+		To:     to,
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == chatID
+	})
+
+	require.Len(t, res.Sessions, 1)
+	session := res.Sessions[0]
+	require.Equal(t, chatID, session.GramChatID)
+	require.NotNil(t, session.HookSource)
+	require.Equal(t, "assistants", *session.HookSource)
+	require.Equal(t, int64(40), session.TotalInputTokens)
+	require.Equal(t, int64(10), session.TotalOutputTokens)
+	require.Equal(t, int64(50), session.TotalTokens)
+	require.InDelta(t, 0.33, session.TotalCost, 1e-9)
+}
+
 func TestListSessions_CursorPagination(t *testing.T) {
 	t.Parallel()
 
@@ -483,7 +537,7 @@ func insertListSessionCompletionLog(t *testing.T, ctx context.Context, p listSes
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), p.timestamp.UnixNano(), p.timestamp.UnixNano(), "INFO", "chat completion",
 		nil, nil, string(attrsJSON), "{}",
-		p.projectID, usageURN, "gram-agents", p.chatID)
+		p.projectID, usageURN, "gram-server", p.chatID)
 	require.NoError(t, err)
 }
 
@@ -527,7 +581,7 @@ func insertListSessionToolLog(t *testing.T, ctx context.Context, p listSessionLo
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), p.timestamp.UnixNano(), p.timestamp.UnixNano(), "INFO", "tool call",
 		nil, nil, string(attrsJSON), "{}",
-		p.projectID, hookURN, "gram-agents", p.chatID)
+		p.projectID, hookURN, "gram-server", p.chatID)
 	require.NoError(t, err)
 }
 
@@ -542,13 +596,26 @@ func insertListSessionRawChatCompletionLog(t *testing.T, ctx context.Context, p 
 
 	attributes := map[string]any{
 		"gen_ai.conversation.id":          p.chatID,
+		"gen_ai.operation.name":           "chat",
 		"gen_ai.response.id":              uuid.NewString(),
 		"gen_ai.response.model":           p.model,
 		"gram.hook.source":                p.hookSource,
-		"gram.resource.urn":               "agents:chat:completion",
+		"gram.resource.urn":               "assistants:chat:completion",
 		"user.email":                      p.email,
 		"user.attributes.department_name": p.department,
 		"user.roles":                      p.roles,
+	}
+	if p.inputTokens > 0 {
+		attributes["gen_ai.usage.input_tokens"] = p.inputTokens
+	}
+	if p.outputTokens > 0 {
+		attributes["gen_ai.usage.output_tokens"] = p.outputTokens
+	}
+	if p.totalTokens > 0 {
+		attributes["gen_ai.usage.total_tokens"] = p.totalTokens
+	}
+	if p.cost > 0 {
+		attributes["gen_ai.usage.cost"] = p.cost
 	}
 	attrsJSON, err := json.Marshal(attributes)
 	require.NoError(t, err)
@@ -561,6 +628,6 @@ func insertListSessionRawChatCompletionLog(t *testing.T, ctx context.Context, p 
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), p.timestamp.UnixNano(), p.timestamp.UnixNano(), "INFO", "raw chat completion",
 		nil, nil, string(attrsJSON), "{}",
-		p.projectID, "agents:chat:completion", "gram-agents", p.chatID)
+		p.projectID, "assistants:chat:completion", "gram-server", p.chatID)
 	require.NoError(t, err)
 }

--- a/server/internal/telemetry/query_test.go
+++ b/server/internal/telemetry/query_test.go
@@ -54,7 +54,47 @@ func insertAttributeUsageLog(t *testing.T, ctx context.Context, projectID string
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
 		nil, nil, string(attrsJSON), "{}",
-		projectID, usageURN, "gram-agents")
+		projectID, usageURN, "gram-server")
+	require.NoError(t, err)
+}
+
+func insertAttributeAssistantChatCompletionLog(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, chatID string, cost float64, totalTokens int, model, email, department string, roles []string) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attributes := map[string]any{
+		"gen_ai.conversation.id":          chatID,
+		"gen_ai.operation.name":           "chat",
+		"gen_ai.usage.input_tokens":       totalTokens,
+		"gen_ai.usage.total_tokens":       totalTokens,
+		"gen_ai.usage.cost":               cost,
+		"gen_ai.response.model":           model,
+		"gram.hook.source":                "assistants",
+		"gram.resource.urn":               "assistants:chat:completion",
+		"user.email":                      email,
+		"user.attributes.department_name": department,
+	}
+	if roles != nil {
+		attributes["user.roles"] = roles
+	}
+
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	err = conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "assistant chat completion",
+		nil, nil, string(attrsJSON), "{}",
+		projectID, "assistants:chat:completion", "gram-server")
 	require.NoError(t, err)
 }
 
@@ -94,7 +134,7 @@ func insertAttributeHookToolLog(t *testing.T, ctx context.Context, projectID str
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "tool hook",
 		nil, nil, string(attrsJSON), "{}",
-		projectID, gramURN, "gram-agents")
+		projectID, gramURN, "gram-server")
 	require.NoError(t, err)
 }
 
@@ -345,6 +385,48 @@ func TestQuery_CountsToolCalls(t *testing.T) {
 	// Hook tool rows carry no gen_ai.usage.cost, so cost stays sourced from the
 	// single usage row — admitting tool rows must not inflate cost.
 	require.InDelta(t, 0.25, totalResult.Table[0].Measures.TotalCost, 1e-9)
+}
+
+func TestQuery_IncludesCostBearingAssistantChatCompletions(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Date(2026, time.June, 20, 1, 0, 0, 0, time.UTC)
+	ts := now.Add(-10 * time.Minute)
+	insertAttributeAssistantChatCompletionLog(t, ctx, projectID, ts, uuid.NewString(), 0.42, 25, "openai/gpt-5.4", "assistant@example.com", "Engineering", []string{"dev"})
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	var result *gen.QueryResult
+	require.Eventually(t, func() bool {
+		res, err := ti.service.Query(ctx, &gen.QueryPayload{
+			From:    from,
+			To:      to,
+			GroupBy: conv.PtrEmpty("hook_source"),
+			TopN:    10,
+			SortBy:  "total_cost",
+		})
+		if err != nil || res == nil || len(res.Table) != 1 {
+			return false
+		}
+		result = res
+		return res.Table[0].Measures.TotalCost == 0.42
+	}, 10*time.Second, 200*time.Millisecond)
+
+	require.Equal(t, "assistants", result.Table[0].GroupValue)
+	require.InDelta(t, 0.42, result.Table[0].Measures.TotalCost, 1e-9)
+	require.Equal(t, int64(25), result.Table[0].Measures.TotalInputTokens)
 }
 
 func TestQuery_TopNRollupIntoOther(t *testing.T) {

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -1104,7 +1104,7 @@ func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByI
 	}
 
 	sb := sq.Select(
-		"gram_chat_id",
+		"chat_id as gram_chat_id",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') as total_input_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.output_tokens) != '') as total_output_tokens",
 		totalTokensExpr+" as total_tokens",
@@ -1112,8 +1112,8 @@ func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByI
 	).
 		From("telemetry_logs").
 		Where("gram_project_id = ?", arg.GramProjectID).
-		Where(squirrel.Eq{"gram_chat_id": arg.ChatIDs}).
-		GroupBy("gram_chat_id")
+		Where(squirrel.Eq{"chat_id": arg.ChatIDs}).
+		GroupBy("chat_id")
 
 	query, args, err := sb.ToSql()
 	if err != nil {
@@ -4171,7 +4171,7 @@ func (q *Queries) GetTopUsers(ctx context.Context, arg GetTopUsersParams) ([]Top
 	var activityColumn string
 	if arg.SessionMode {
 		// Count chat completion messages
-		activityColumn = "countIf(toString(attributes.gram.resource.urn) = 'agents:chat:completion') as activity_count"
+		activityColumn = "countIf(toString(attributes.gram.resource.urn) IN ('chat:completion', 'assistants:chat:completion')) as activity_count"
 	} else {
 		// Count tool calls
 		activityColumn = "countIf(startsWith(gram_urn, 'tools:')) as activity_count"
@@ -4307,7 +4307,7 @@ func (q *Queries) GetLLMClientBreakdown(ctx context.Context, arg GetLLMClientBre
 	var activityColumn string
 	if arg.SessionMode {
 		// Count chat completion messages
-		activityColumn = "countIf(toString(attributes.gram.resource.urn) = 'agents:chat:completion') as activity_count"
+		activityColumn = "countIf(toString(attributes.gram.resource.urn) IN ('chat:completion', 'assistants:chat:completion')) as activity_count"
 	} else {
 		// Count tool calls
 		activityColumn = "countIf(startsWith(gram_urn, 'tools:')) as activity_count"
@@ -4386,7 +4386,7 @@ func (q *Queries) GetActiveCounts(ctx context.Context, arg GetActiveCountsParams
 	var userCountCondition string
 	if arg.SessionMode {
 		// Count users with chat completion messages
-		userCountCondition = "uniqExactIf(if(external_user_id != '', external_user_id, user_id), toString(attributes.gram.resource.urn) = 'agents:chat:completion' AND if(external_user_id != '', external_user_id, user_id) != '')"
+		userCountCondition = "uniqExactIf(if(external_user_id != '', external_user_id, user_id), toString(attributes.gram.resource.urn) IN ('chat:completion', 'assistants:chat:completion') AND if(external_user_id != '', external_user_id, user_id) != '')"
 	} else {
 		// Count users with tool calls
 		userCountCondition = "uniqExactIf(if(external_user_id != '', external_user_id, user_id), startsWith(gram_urn, 'tools:') AND if(external_user_id != '', external_user_id, user_id) != '')"

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -9,10 +9,15 @@ import (
 )
 
 const (
+	sessionChatCompletionUsageRowPredicate = "(" +
+		"toString(attributes.gen_ai.operation.name) = 'chat' AND " +
+		"toString(attributes.gen_ai.usage.cost) != ''" +
+		")"
 	sessionUsageRowPredicate = "(" +
 		"startsWith(gram_urn, 'claude-code:usage') OR " +
 		"startsWith(gram_urn, 'codex:usage') OR " +
-		"startsWith(gram_urn, 'cursor:usage')" +
+		"startsWith(gram_urn, 'cursor:usage') OR " +
+		sessionChatCompletionUsageRowPredicate +
 		")"
 	sessionHookToolRowPredicate = "(" +
 		"toString(attributes.gram.tool.name) != '' AND " +

--- a/server/internal/telemetry/search_chats_test.go
+++ b/server/internal/telemetry/search_chats_test.go
@@ -737,7 +737,7 @@ func insertChatLogWithChatID(t *testing.T, ctx context.Context, projectID, deplo
 		"gen_ai.usage.total_tokens":      totalTokens,
 		"gen_ai.response.model":          model,
 		"gen_ai.provider.name":           provider,
-		"gram.resource.urn":              "agents:chat:completion",
+		"gram.resource.urn":              "chat:completion",
 	}
 
 	attrsJSON, err := json.Marshal(attributes)
@@ -752,7 +752,7 @@ func insertChatLogWithChatID(t *testing.T, ctx context.Context, projectID, deplo
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
 		nil, nil, string(attrsJSON), "{}",
-		projectID, deploymentID, "agents:chat:completion", "gram-agents",
+		projectID, deploymentID, "chat:completion", "gram-server",
 		chatID)
 	require.NoError(t, err)
 }

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -287,6 +287,7 @@ func (c *ChatClient) onMessageComplete(ctx context.Context, session CaptureSessi
 		req.ExternalUserID,
 		req.UserEmail,
 		req.APIKeyID,
+		string(req.UsageSource),
 		response,
 	)
 }
@@ -702,6 +703,7 @@ func (c *ChatClient) emitGenAITelemetry(
 	ctx context.Context,
 	toolCalls []ToolCall,
 	orgID, projectID, chatID, userID, externalUserID, userEmail, apiKeyID string,
+	usageSource string,
 	result CompletionResponse,
 ) {
 	// Skip telemetry if no telemetry service configured
@@ -710,13 +712,14 @@ func (c *ChatClient) emitGenAITelemetry(
 	}
 
 	duration := float64(time.Since(result.StartTime).Seconds())
+	resourceURN, normalizedSource := completionTelemetryIdentity(usageSource)
 
 	// Build attributes map. Column-mapped keys are extracted to dedicated columns
 	// but remain in the attributes JSON. Resource attributes are auto-partitioned
 	// based on telemetry.ResourceAttributeKeys.
 	attrs := map[attr.Key]any{
 		attr.EventSourceKey: string(telemetry.EventSourceChatCompletion),
-		attr.ResourceURNKey: "agents:chat:completion",
+		attr.ResourceURNKey: resourceURN,
 		attr.LogBodyKey: fmt.Sprintf("LLM chat completion: model=%s, input_tokens=%d, output_tokens=%d",
 			result.Model, result.Usage.PromptTokens, result.Usage.CompletionTokens),
 
@@ -732,8 +735,14 @@ func (c *ChatClient) emitGenAITelemetry(
 		attr.APIKeyIDKey:               apiKeyID,
 	}
 
+	if normalizedSource != "" {
+		attrs[attr.HookSourceKey] = normalizedSource
+	}
 	if result.MessageID != "" {
 		attrs[attr.GenAIResponseIDKey] = result.MessageID
+	}
+	if result.Usage.Cost != nil {
+		attrs[attr.GenAIUsageCostKey] = *result.Usage.Cost
 	}
 	if result.FinishReason != nil {
 		attrs[attr.GenAIResponseFinishReasonsKey] = []string{*result.FinishReason}
@@ -756,7 +765,7 @@ func (c *ChatClient) emitGenAITelemetry(
 
 	toolInfo := telemetry.ToolInfo{
 		ID:             chatID,
-		URN:            "agents:chat:completion",
+		URN:            resourceURN,
 		Name:           "",
 		ProjectID:      projectID,
 		DeploymentID:   "",
@@ -770,6 +779,17 @@ func (c *ChatClient) emitGenAITelemetry(
 		UserInfo:   telemetry.UserInfoByID(userID),
 		Attributes: attrs,
 	})
+}
+
+func completionTelemetryIdentity(source string) (resourceURN, normalizedSource string) {
+	switch source {
+	case "assistant", "assistants":
+		return "assistants:chat:completion", "assistants"
+	case "":
+		return "chat:completion", ""
+	default:
+		return "chat:completion", source
+	}
 }
 
 func (c *ChatClient) CreateEmbeddings(ctx context.Context, orgID string, model string, inputs []string, opts ...EmbeddingOption) ([][]float32, error) {

--- a/server/internal/thirdparty/openrouter/unified_client_telemetry_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_telemetry_test.go
@@ -17,6 +17,7 @@ func TestChatClient_EmitGenAITelemetryUsesStableURN(t *testing.T) {
 	telemetryLogger := &mockTelemetryLogger{}
 	client := &ChatClient{telemetryLogger: telemetryLogger}
 	chatID := uuid.NewString()
+	cost := 0.0125
 
 	client.emitGenAITelemetry(
 		context.Background(),
@@ -28,6 +29,7 @@ func TestChatClient_EmitGenAITelemetryUsesStableURN(t *testing.T) {
 		"",
 		"",
 		"api-key-id",
+		"assistant",
 		CompletionResponse{
 			StartTime: time.Now().Add(-time.Second),
 			Model:     "openai/gpt-5.4",
@@ -35,6 +37,7 @@ func TestChatClient_EmitGenAITelemetryUsesStableURN(t *testing.T) {
 				PromptTokens:     10,
 				CompletionTokens: 5,
 				TotalTokens:      15,
+				Cost:             &cost,
 			},
 		},
 	)
@@ -44,7 +47,9 @@ func TestChatClient_EmitGenAITelemetryUsesStableURN(t *testing.T) {
 	require.Len(t, telemetryLogger.logs, 1)
 	log := telemetryLogger.logs[0]
 	assert.Equal(t, chatID, log.ToolInfo.ID)
-	assert.Equal(t, "agents:chat:completion", log.ToolInfo.URN)
-	assert.Equal(t, "agents:chat:completion", log.Attributes[attr.ResourceURNKey])
+	assert.Equal(t, "assistants:chat:completion", log.ToolInfo.URN)
+	assert.Equal(t, "assistants:chat:completion", log.Attributes[attr.ResourceURNKey])
+	assert.Equal(t, "assistants", log.Attributes[attr.HookSourceKey])
 	assert.Equal(t, chatID, log.Attributes[attr.GenAIConversationIDKey])
+	assert.InDelta(t, cost, log.Attributes[attr.GenAIUsageCostKey], 1e-9)
 }

--- a/server/internal/usage/tum_test.go
+++ b/server/internal/usage/tum_test.go
@@ -120,13 +120,13 @@ func insertTokenUsageRow(t *testing.T, conn driver.Conn, projectID string, times
 		"gen_ai.usage.input_tokens":  totalTokens / 2,
 		"gen_ai.usage.output_tokens": totalTokens - totalTokens/2,
 		"gen_ai.usage.total_tokens":  totalTokens,
-		"gram.resource.urn":          "agents:chat:completion",
+		"gram.resource.urn":          "chat:completion",
 	}
 	if chatID != "" {
 		attributes["gen_ai.conversation.id"] = chatID
 	}
 
-	insertTelemetryRow(t, conn, projectID, timestamp, "agents:chat:completion", attributes)
+	insertTelemetryRow(t, conn, projectID, timestamp, "chat:completion", attributes)
 }
 
 // insertToolCallRow inserts a tool-call row tied to a chat — non-metrics
@@ -146,7 +146,7 @@ func insertToolCallRow(t *testing.T, conn driver.Conn, projectID string, timesta
 func insertChatEventRow(t *testing.T, conn driver.Conn, projectID string, timestamp time.Time, chatID string) {
 	t.Helper()
 
-	insertTelemetryRow(t, conn, projectID, timestamp, "agents:chat:message", map[string]any{
+	insertTelemetryRow(t, conn, projectID, timestamp, "chat:message", map[string]any{
 		"gen_ai.conversation.id": chatID,
 	})
 }


### PR DESCRIPTION
## Summary
- record `gen_ai.usage.cost` on `/chat/completions` telemetry rows
- normalize assistant-originated completion telemetry to `assistants:chat:completion` on the server while accepting the existing `assistant` source header
- include cost-bearing chat completion rows in telemetry query/session read paths
- clean live fixtures from old `agents:chat:*` naming

Stacked on migration PR: #3693

## Testing
- `go test ./server/internal/thirdparty/openrouter ./server/internal/telemetry ./server/internal/chat ./server/internal/usage -count=1`
- `mise lint:server`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records assistant chat completion costs and includes them in chat/session metrics so the dashboard shows correct non‑zero costs for assistant‑run chats. Normalizes telemetry and reads by materialized `chat_id` to avoid misses and double counting. Meets Linear DNO‑349.

- **Bug Fixes**
  - Emission: `server/internal/thirdparty/openrouter` now emits `gen_ai.usage.cost`, sets `gram.hook.source=assistants`, and uses `assistants:chat:completion` for assistant calls (defaulting to `chat:completion` for others); `server/internal/chat` normalizes `assistant` → `assistants`; billing source renamed to `ModelUsageSourceAssistants`.
  - Reads: `GetChatMetricsByIDs` filters/groups by `chat_id`; session usage includes cost‑bearing chat completions via `gen_ai.operation.name='chat'` with cost; top users/client breakdown/active counts recognize both `chat:completion` and `assistants:chat:completion`.
  - Cleanup: replaced legacy `agents:chat:*` with `chat:*` where generic; updated seeds/docs/tests to assert assistant costs flow into ClickHouse and surface in chats, sessions, and queries; CI filters exclude ClickHouse scripts from the migration gate.

<sup>Written for commit fd80b57ab418ac9b3137d89cffec784eb2bc2a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

