### PR TITLE
chore: remove team dimension from cost attribution dashboard

### DIFF
--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -62,7 +62,6 @@ const EMPTY_MEASURES: Measures = { cost: 0, sessions: 0, tools: 0, tokens: 0 };
 const MIX_DIMS: Partial<Record<Dimension, Dimension[]>> = {
   [Dimension.DivisionName]: [Dimension.DepartmentName, Dimension.Email],
   [Dimension.DepartmentName]: [Dimension.Email, Dimension.Model],
-  [Dimension.Group]: [Dimension.Email, Dimension.HookSource],
   [Dimension.Email]: [Dimension.HookSource],
   [Dimension.HookSource]: [Dimension.Model],
   [Dimension.JobTitle]: [Dimension.Email, Dimension.DepartmentName],
@@ -143,7 +142,7 @@ export function CostsExplorer(): JSX.Element {
   // The sessions sentinel swaps the table for the per-session list; the rest of
   // the page (filters, widgets, header stats) is unchanged.
   const sessionsMode = isSessionsAxis(byParam) || atSessionLeaf;
-  // The "Most costly sessions" widget shows on org/division/department/team/user
+  // The "Most costly sessions" widget shows on org/division/department/user
   // (not Agent/Model, which already render the full session table).
   const showSessionsWidget = showsTopSessionsWidget(deepestCrumb);
 
@@ -514,12 +513,12 @@ export function CostsExplorer(): JSX.Element {
         ? "Top spenders"
         : `Spend by ${(LABELS[dim] ?? "").toLowerCase()}`;
     // A mix card's rows are drillable when its dimension has a *populated* level
-    // below it (e.g. Department → Team); leaf dims (Agent) or levels with no data
+    // below it (e.g. Department → User); leaf dims (Agent) or levels with no data
     // beneath them are shown but not clickable.
     const drillableDim = (dim: Dimension) =>
       isSessionLeaf(dim) || nextAvailableDimension(dim, availableDims) !== null;
-    // Team view groups by user, so its table already ranks people — surface the
-    // top spenders as a compact card too (reuses the main rows, no extra query).
+    // A user breakdown already ranks people in its table — surface the top
+    // spenders as a compact card too (reuses the main rows, no extra query).
     if (groupBy === Dimension.Email) {
       const userRows = (data?.table ?? [])
         .filter((r) => r.groupValue !== "Other")

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -24,7 +24,6 @@ import {
   Network,
   Shield,
   UserRound,
-  Users,
   Wallet,
 } from "lucide-react";
 import { CostTable } from "./CostTable";
@@ -158,7 +157,6 @@ function entityPalette(name: string): { mesh: string } {
 const ENTITY_ICONS: Partial<Record<Dimension, LucideIcon>> = {
   [Dimension.DivisionName]: Network,
   [Dimension.DepartmentName]: Building,
-  [Dimension.Group]: Users,
   [Dimension.Email]: UserRound,
   [Dimension.HookSource]: Bot,
   [Dimension.JobTitle]: Briefcase,
@@ -259,7 +257,7 @@ export type EntityProfileProps = {
 
 /**
  * Generalized profile page for one node of the cost taxonomy. The same layout
- * renders the org root, a Division, a Team, a User, an Agent — driven entirely
+ * renders the org root, a Division, a Department, a User, an Agent — driven entirely
  * by props: a bold header (avatar + name + headline stats), the entity's own
  * attribute grid, and the grouped table of its children.
  */

--- a/client/dashboard/src/pages/costs/taxonomy.ts
+++ b/client/dashboard/src/pages/costs/taxonomy.ts
@@ -30,12 +30,11 @@ export type Measures = {
   tokens: number;
 };
 
-// The suggested top-down chain an admin walks. "Team" maps to WorkOS groups[]
-// (no dedicated team dimension yet); "User" is email; "Agent" is hook_source.
+// The suggested top-down chain an admin walks. "User" is email; "Agent" is
+// hook_source.
 const CHAIN: DimMeta[] = [
   { dim: Dimension.DivisionName, label: "Division" },
   { dim: Dimension.DepartmentName, label: "Department" },
-  { dim: Dimension.Group, label: "Team" },
   { dim: Dimension.Email, label: "User" },
   { dim: Dimension.HookSource, label: "Agent" },
 ];
@@ -73,7 +72,6 @@ export function isSessionLeaf(dim: Dimension): boolean {
 const SESSION_WIDGET_DIMS = new Set<Dimension>([
   Dimension.DivisionName,
   Dimension.DepartmentName,
-  Dimension.Group,
   Dimension.Email,
 ]);
 export function showsTopSessionsWidget(entity: Crumb | null): boolean {
@@ -147,7 +145,6 @@ const DIM_ATTRIBUTE_KEY: Partial<Record<Dimension, string>> = {
   [Dimension.EmployeeType]: "user.attributes.employee_type",
   [Dimension.CostCenterName]: "user.attributes.cost_center_name",
   [Dimension.Email]: "user.email",
-  [Dimension.Group]: "user.groups",
   [Dimension.Role]: "user.roles",
   [Dimension.Model]: "gen_ai.response.model",
   [Dimension.HookSource]: "gram.hook.source",


### PR DESCRIPTION
## What

Removes **Team** as a dimension / concern from the cost attribution dashboard UI.

## Why

- "Team" was a UI alias for the WorkOS `group` dimension (`user.groups`) — there's no dedicated team concept under the hood.
- Groups aren't synced reliably from Google for our org (separate bug: only 2 of 3 present in prod).
- Other customers don't use groups to model teams — they use them for integration-scoped membership (e.g. a "Speakeasy users" group). So surfacing it as "Team" is misleading and low-value.

## Changes (dashboard only)

- `taxonomy.ts` — drop `Dimension.Group` ("Team") from the drill `CHAIN` (cascades through `PIVOTS`, `LABELS`, `VALID_DIMS`), from `SESSION_WIDGET_DIMS`, and from `DIM_ATTRIBUTE_KEY` (the kill switch — without the `user.groups` key, `availableDimensions()` can never resurface it).
- `CostsExplorer.tsx` — remove the `Dimension.Group` `MIX_DIMS` entry + stale comments.
- `EntityProfile.tsx` — remove the `Dimension.Group` entity icon + now-orphaned `Users` import + JSDoc.

## Deliberately untouched

- **Backend** telemetry design still supports the `group` dimension (filtering / compat) — this is a UI-only change.
- `insights-suggestions.ts` `level === "group"` is the generic `CostEntityLevel` bucket (Division/Department map there), **not** `Dimension.Group` — left as-is.
- Generated `Dimension` enum keeps `Group`.

## Compat

Old bookmarked URLs with a `group~<team>` drill crumb or `?by=group` degrade gracefully: `isDimension("group")` now returns false, so the crumb is dropped / falls back to `defaultGroupBy`. No crash.

## Verification

- `pnpm -F dashboard type-check`: clean for `costs/` (other pre-existing tsc errors are unrelated SDK drift).
- `hk fix` / oxfmt: clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Team dimension from the cost attribution dashboard UI to simplify the drill path and avoid confusion with `group` membership.

- **Refactors**
  - Dropped `Dimension.Group` from the taxonomy chain, session widget dims, and attribute map in `taxonomy.ts`.
  - Removed `Dimension.Group` from `MIX_DIMS` and cleaned comments in `CostsExplorer.tsx`.
  - Deleted the Group icon and stale import; updated docs in `EntityProfile.tsx`.

- **Migration**
  - No action required. Old URLs with `group` or `?by=group` are ignored and fall back to defaults. Backend still accepts `group` filters.

<sup>Written for commit 9c3edcfdd7c7c0fe622736875aaef6f4dff6bf6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

