### PR TITLE
chore: require mig: prefix for migration PRs

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -52,6 +52,10 @@ database-changes:
   - "server/migrations/**"
   - "server/clickhouse/**"
 
+db-migrations:
+  - "server/migrations/**"
+  - "server/clickhouse/migrations/**"
+
 plog:
   - "go.mod"
   - "go.sum"

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -74,6 +74,29 @@ jobs:
               - "!server/internal/**/repo/**"
               - "!server/internal/testenv/testrepo/**"
 
+      - name: "Require mig: prefix for migration PRs"
+        if: ${{ github.event_name != 'merge_group' && steps.filter.outputs.db-migrations == 'true' }}
+        shell: bash
+        env:
+          MIG_FILES: ${{ steps.filter.outputs.db-migrations_files }}
+        run: |
+          if [[ "$PR_TITLE" =~ ^mig(\([a-zA-Z0-9_-]+\))?!?:\ [a-zA-Z] ]]; then
+            echo "PR title is correctly qualified with 'mig:'."
+            exit 0
+          fi
+
+          echo "❌ This PR includes PostgreSQL or ClickHouse migration changes,"
+          echo "so its title must be qualified with the 'mig:' type (not 'feat', 'fix', or 'chore')."
+          echo ""
+          echo "Migration files changed:"
+          echo "$MIG_FILES" | jq -r '.[]' | sed 's/^/  - /'
+          echo ""
+          echo 'Example: "mig: add supports_dcr column to deployments"'
+          echo 'Example: "mig(catalog): version registry cache key"'
+          echo ""
+          echo "Got: $PR_TITLE"
+          exit 1
+
       - name: Validate migration PR does not mix server changes
         if: ${{ github.event_name != 'merge_group' && steps.filter.outputs.database-changes == 'true' && steps.filter-internal.outputs.server-internal == 'true' }}
         shell: bash


### PR DESCRIPTION
## What

Require PRs that change PostgreSQL or ClickHouse migration files to use the `mig:` conventional-commit type in their title.

## Why

Migration changes are reviewed and rolled out independently from application code. Giving them a distinct, greppable type (rather than letting them hide under `feat:`/`fix:`/`chore:`) makes migration PRs easy to spot and complements the existing rule that migrations must ship in their own PR.

## How

- **`.github/filters.yaml`** — add a `db-migrations` filter scoped precisely to `server/migrations/**` and `server/clickhouse/migrations/**`. (Kept separate from the existing `migrations` filter, which also matches `go.mod`/`go.sum` and would false-trigger on dependency bumps.)
- **`.github/workflows/hygiene.yaml`** — add a `Require mig: prefix for migration PRs` step that fails when migration files are touched but the title doesn't start with `mig:` (allowing the usual optional `(scope)` and `!` breaking marker). Guarded with `event_name != 'merge_group'` like the sibling migration-isolation check.

`mig:` is already accepted by the title-format validator and skipped by the changeset check, so no other changes are needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce `mig:` in PR titles when PostgreSQL or ClickHouse migration files change. Adds a `db-migrations` filter and a hygiene check (skipped for `merge_group`) that fails PRs touching `server/migrations/**` or `server/clickhouse/migrations/**` unless the title starts with `mig:` (optional `(scope)` and `!` allowed).

<sup>Written for commit bc3d72f16c154cd461f6c2b5d32fd94771ac6db5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

