### PR TITLE
feat(remotesessions): dual-write organization_id on remote_session_clients

### DIFF
--- a/server/internal/oauthtest/issuergated.go
+++ b/server/internal/oauthtest/issuergated.go
@@ -140,6 +140,7 @@ func CreateIssuerGatedToolset(
 
 	rsc, err := remoteRepo.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
 		ProjectID:             conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:        conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID: rsi.ID,
 		ClientID:              clientID,
 		ClientSecretEncrypted: conv.ToPGText(encSecret),

--- a/server/internal/remotesessions/challenge_audience_e2e_test.go
+++ b/server/internal/remotesessions/challenge_audience_e2e_test.go
@@ -94,6 +94,7 @@ func TestBuildAuthorizationUrl_AudienceResolution(t *testing.T) {
 
 			client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 				ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
+				OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 				RemoteSessionIssuerID:   issuer.ID,
 				ClientID:                "aud-cid",
 				ClientSecretEncrypted:   pgtype.Text{String: "", Valid: false},

--- a/server/internal/remotesessions/challenge_scope_e2e_test.go
+++ b/server/internal/remotesessions/challenge_scope_e2e_test.go
@@ -95,6 +95,7 @@ func TestBuildAuthorizationUrl_ScopeResolution(t *testing.T) {
 
 			client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 				ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
+				OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 				RemoteSessionIssuerID:   issuer.ID,
 				ClientID:                "scope-cid",
 				ClientSecretEncrypted:   pgtype.Text{String: "", Valid: false},

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -185,6 +185,7 @@ func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.Ha
 
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID:   issuer.ID,
 		ClientID:                "synthetic-cid-" + slugSuffix,
 		ClientSecretEncrypted:   pgtype.Text{String: "", Valid: false},

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -177,6 +177,7 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID:   issuerID,
 		ClientID:                clientID,
 		ClientSecretEncrypted:   secretCiphertext,
@@ -347,6 +348,7 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID:   issuerID,
 		ClientID:                clientID,
 		ClientSecretEncrypted:   conv.ToPGText(encrypted),

--- a/server/internal/remotesessions/clienthandlers_test.go
+++ b/server/internal/remotesessions/clienthandlers_test.go
@@ -60,6 +60,38 @@ func TestCreateRemoteSessionClient_Manual(t *testing.T) {
 	require.Equal(t, beforeCount+1, afterCount)
 }
 
+func TestCreateRemoteSessionClient_PersistsOrganizationID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createRemoteIssuer(t, ctx, ti, "rsc-org", "")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-org").String()
+
+	result, err := ti.service.CreateRemoteSessionClient(ctx, &clientsgen.CreateRemoteSessionClientPayload{
+		RemoteSessionIssuerID: issuerID,
+		UserSessionIssuerIds:  []string{userIssuerID},
+		ClientID:              "org-client-id",
+		ClientSecret:          nil,
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+	})
+	require.NoError(t, err)
+
+	clientUUID, err := uuid.Parse(result.ID)
+	require.NoError(t, err)
+
+	// The dual-write sets organization_id to the caller's organization, which is
+	// the owning project's organization.
+	gotOrg := remoteSessionClientOrganizationID(t, ctx, ti.conn, *authCtx.ProjectID, clientUUID)
+	require.Equal(t, authCtx.ActiveOrganizationID, gotOrg)
+}
+
 func TestCreateRemoteSessionClient_RejectsDuplicateRemoteIssuerBinding(t *testing.T) {
 	t.Parallel()
 
@@ -845,6 +877,13 @@ func TestCloneClientFromOAuthProxyProvider_HappyPath(t *testing.T) {
 	require.Equal(t, "upstream-cid", result.ClientID, "preserves upstream client_id so existing registrations keep working")
 	require.Equal(t, issuerID, result.RemoteSessionIssuerID)
 	require.Equal(t, []string{userIssuerID}, result.UserSessionIssuerIds)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	clonedUUID, err := uuid.Parse(result.ID)
+	require.NoError(t, err)
+	require.Equal(t, authCtx.ActiveOrganizationID, remoteSessionClientOrganizationID(t, ctx, ti.conn, *authCtx.ProjectID, clonedUUID))
 
 	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionRemoteSessionClientCreate)
 	require.NoError(t, err)

--- a/server/internal/remotesessions/organizationhandlers.go
+++ b/server/internal/remotesessions/organizationhandlers.go
@@ -900,6 +900,7 @@ func (s *Service) CreateClient(ctx context.Context, payload *orgissuersgen.Creat
 
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               clientProjectID,
+		OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID:   issuerID,
 		ClientID:                clientID,
 		ClientSecretEncrypted:   secretCiphertext,

--- a/server/internal/remotesessions/organizationhandlers_test.go
+++ b/server/internal/remotesessions/organizationhandlers_test.go
@@ -893,6 +893,10 @@ func TestCreateClient_ProjectSpecificIssuerInheritsProject(t *testing.T) {
 	require.Equal(t, authCtx.ProjectID.String(), created.ProjectID)
 	require.Empty(t, created.UserSessionIssuerIds, "standalone client has no attachments")
 
+	createdUUID, err := uuid.Parse(created.ID)
+	require.NoError(t, err)
+	require.Equal(t, authCtx.ActiveOrganizationID, remoteSessionClientOrganizationID(t, ctx, ti.conn, *authCtx.ProjectID, createdUUID))
+
 	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionRemoteSessionClientCreate)
 	require.NoError(t, err)
 	require.Equal(t, before+1, after)
@@ -934,6 +938,10 @@ func TestCreateClient_OrganizationalIssuerDownscope(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, pid, created.ProjectID)
 	require.Equal(t, orgIssuer.ID, created.RemoteSessionIssuerID)
+
+	createdUUID, err := uuid.Parse(created.ID)
+	require.NoError(t, err)
+	require.Equal(t, authCtx.ActiveOrganizationID, remoteSessionClientOrganizationID(t, ctx, ti.conn, *authCtx.ProjectID, createdUUID))
 }
 
 // TestCreateClient_ProjectMismatchForProjectIssuer rejects downscoping a client

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -177,6 +177,7 @@ ON CONFLICT (user_session_issuer_id, client_id) WHERE deleted IS FALSE DO NOTHIN
 -- name: CreateRemoteSessionClient :one
 INSERT INTO remote_session_clients (
     project_id,
+    organization_id,
     remote_session_issuer_id,
     client_id,
     client_secret_encrypted,
@@ -189,6 +190,7 @@ INSERT INTO remote_session_clients (
 )
 VALUES (
     @project_id,
+    @organization_id,
     @remote_session_issuer_id,
     @client_id,
     @client_secret_encrypted,

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -82,6 +82,7 @@ func (q *Queries) CountRemoteSessionClientsByIssuerID(ctx context.Context, remot
 const createRemoteSessionClient = `-- name: CreateRemoteSessionClient :one
 INSERT INTO remote_session_clients (
     project_id,
+    organization_id,
     remote_session_issuer_id,
     client_id,
     client_secret_encrypted,
@@ -100,15 +101,17 @@ VALUES (
     $5,
     $6,
     $7,
-    $8::text[],
-    $9,
-    $10
+    $8,
+    $9::text[],
+    $10,
+    $11
 )
 RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRemoteSessionClientParams struct {
 	ProjectID               uuid.NullUUID
+	OrganizationID          pgtype.Text
 	RemoteSessionIssuerID   uuid.UUID
 	ClientID                string
 	ClientSecretEncrypted   pgtype.Text
@@ -123,6 +126,7 @@ type CreateRemoteSessionClientParams struct {
 func (q *Queries) CreateRemoteSessionClient(ctx context.Context, arg CreateRemoteSessionClientParams) (RemoteSessionClient, error) {
 	row := q.db.QueryRow(ctx, createRemoteSessionClient,
 		arg.ProjectID,
+		arg.OrganizationID,
 		arg.RemoteSessionIssuerID,
 		arg.ClientID,
 		arg.ClientSecretEncrypted,

--- a/server/internal/remotesessions/setup_test.go
+++ b/server/internal/remotesessions/setup_test.go
@@ -246,6 +246,20 @@ func countRemoteSessionClientUserSessionIssuerBindings(t *testing.T, ctx context
 	return int(count)
 }
 
+// remoteSessionClientOrganizationID reads the persisted organization_id of a
+// remote_session_client by id (scoped to its project).
+func remoteSessionClientOrganizationID(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, clientID uuid.UUID) string {
+	t.Helper()
+
+	row, err := repo.New(conn).GetRemoteSessionClientByID(ctx, repo.GetRemoteSessionClientByIDParams{
+		ID:        clientID,
+		ProjectID: conv.ToNullUUID(projectID),
+	})
+	require.NoError(t, err)
+
+	return row.RemoteSessionClient.OrganizationID.String
+}
+
 // createProject creates a second project in the test's organization so tests
 // can exercise cross-project (cross-tenant) rejection paths.
 func createProject(t *testing.T, ctx context.Context, conn *pgxpool.Pool, slug string) uuid.UUID {

--- a/server/internal/remotesessions/tokenservice_audience_test.go
+++ b/server/internal/remotesessions/tokenservice_audience_test.go
@@ -99,6 +99,7 @@ func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *up
 	require.NoError(t, err)
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID:   issuer.ID,
 		ClientID:                "aud-cid",
 		ClientSecretEncrypted:   conv.ToPGText(secretCiphertext),

--- a/server/internal/remotesessions/tokenservice_authmethod_test.go
+++ b/server/internal/remotesessions/tokenservice_authmethod_test.go
@@ -121,6 +121,7 @@ func setupRefreshFixture(t *testing.T, authMethod string, spy *upstreamSpy) (con
 	require.NoError(t, err)
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID:   issuer.ID,
 		ClientID:                externalCID,
 		ClientSecretEncrypted:   conv.ToPGText(secretCiphertext),

--- a/server/internal/remotesessions/tokenservice_resolve_test.go
+++ b/server/internal/remotesessions/tokenservice_resolve_test.go
@@ -52,7 +52,7 @@ func newResolveManager(t *testing.T, conn *pgxpool.Pool, enc *encryption.Client)
 // seedActiveClient creates a remote_session_issuer + remote_session_client
 // (attached to userIssuerID through the join table) and returns the client id
 // and its remote_session_issuer id.
-func seedActiveClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, userIssuerID uuid.UUID, slug string) (clientID, remoteIssuerID uuid.UUID) {
+func seedActiveClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, userIssuerID uuid.UUID, organizationID, slug string) (clientID, remoteIssuerID uuid.UUID) {
 	t.Helper()
 
 	q := repo.New(conn)
@@ -75,6 +75,7 @@ func seedActiveClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, pro
 
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
 		ProjectID:               conv.ToNullUUID(projectID),
+		OrganizationID:          conv.ToPGTextEmpty(organizationID),
 		RemoteSessionIssuerID:   issuer.ID,
 		ClientID:                "cid-" + slug,
 		ClientSecretEncrypted:   pgtype.Text{String: "", Valid: false},
@@ -107,7 +108,7 @@ func TestResolveAccessTokens_SingleClientHappyPath(t *testing.T) {
 	mgr := newResolveManager(t, ti.conn, enc)
 
 	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-resolve-happy")
-	clientID, remoteIssuerID := seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, "rsi-resolve-happy")
+	clientID, remoteIssuerID := seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, authCtx.ActiveOrganizationID, "rsi-resolve-happy")
 
 	subject := urn.NewUserSubject("resolve-happy-subject")
 	accessEnc, err := enc.Encrypt([]byte("upstream-access-token"))
@@ -156,7 +157,7 @@ func TestResolveAccessTokens_MissingSessionReturnsErrNoValidToken(t *testing.T) 
 
 	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-resolve-missing")
 	// Client bound, but the subject has never linked an upstream session.
-	seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, "rsi-resolve-missing")
+	seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, authCtx.ActiveOrganizationID, "rsi-resolve-missing")
 
 	subject := urn.NewUserSubject("resolve-missing-subject")
 	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, userIssuerID, subject)


### PR DESCRIPTION
Populate `organization_id` on every newly created `remote_session_clients` row so the column stays fully populated (AIS-222 dual-write step). Adds `organization_id` to the `CreateRemoteSessionClient` INSERT and sets it from the caller's organization at all three writers: project-scoped standalone create, OAuth proxy clone, and org-admin standalone create. Test seeders and handler assertions cover the populated column. The backfill of pre-existing rows ships separately as a migration-only PR.

Linear: https://linear.app/speakeasy/issue/AIS-222/dual-write-and-backfill-organization-id-on-remote-session-clients

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dual-write `organization_id` on every new `remote_session_clients` row to keep the column fully populated. Aligns with AIS-222; backfill of existing rows will ship in a separate migration PR.

- **New Features**
  - Add `organization_id` to the `CreateRemoteSessionClient` insert and plumb it through the repo; set from the caller’s org in project create, OAuth proxy clone, and org-admin create.
  - Update tests/e2e/seeders to supply and assert the stored `organization_id` (including new helper and assertions on cloned and standalone clients).

<sup>Written for commit e73b59c1d245f95fa3f62d480557ee3d12b6703f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

