### PR TITLE
fix: guard chat search against over-200-char queries

### DIFF
--- a/.changeset/fix-chat-search-query-limit.md
+++ b/.changeset/fix-chat-search-query-limit.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Stop chat-conversation search from erroring on long queries. The `chat.load` API caps `query` at 200 characters, but the find-in-conversation bar sent whatever was typed, so a long query failed with a hard validation error. The bar now gates the request at 200 characters and flags the over-limit state inline: the search icon turns into a red warning icon (with a tooltip) and the match counter shows the live `length/200` count in red.

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -7,6 +7,7 @@ import {
   Search,
   Sparkles,
   SlidersHorizontal,
+  TriangleAlert,
   User,
   Wrench,
   X,
@@ -45,6 +46,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Dialog } from "@/components/ui/dialog";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Switch } from "@/components/ui/switch";
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useRBAC } from "@/hooks/useRBAC";
@@ -83,6 +85,11 @@ import { ToolCallsView } from "./chatLogViews";
 import { exportTraceDataAsJson } from "./chatExport";
 
 const PANEL_TELEMETRY_LOG_LIMIT = 100;
+
+// Mirrors the server-side `MaxLength(200)` on chat.load's `query` param (see
+// server/design/chat/design.go). Queries longer than this are rejected with a
+// hard 400, so we gate the request and flag the input instead of firing it.
+const MAX_SEARCH_QUERY_LEN = 200;
 
 interface ChatDetailPanelProps {
   chatId: string;
@@ -359,12 +366,25 @@ function ThreadSearchBar({
   onPrev: () => void;
   onNext: () => void;
 }) {
-  const hasQuery = value.trim().length > 0;
+  const trimmedLen = value.trim().length;
+  const hasQuery = trimmedLen > 0;
+  // Over the server's query cap: don't pretend to search — show a red counter in
+  // the match-count slot so the user sees why nothing is happening, and hide the
+  // (meaningless) prev/next nav while keeping clear available.
+  const overLimit = trimmedLen > MAX_SEARCH_QUERY_LEN;
   const navBtn =
     "text-muted-foreground hover:text-foreground hover:bg-background flex size-6 shrink-0 items-center justify-center rounded transition-colors disabled:opacity-40";
   return (
     <div className="bg-background focus-within:border-foreground/40 flex h-9 items-center gap-2 rounded-lg border px-2.5 transition-colors">
-      <Search className="text-muted-foreground size-3.5 shrink-0" />
+      {overLimit ? (
+        <SimpleTooltip
+          tooltip={`Queries are limited to ${MAX_SEARCH_QUERY_LEN} characters`}
+        >
+          <TriangleAlert className="text-destructive size-3.5 shrink-0" />
+        </SimpleTooltip>
+      ) : (
+        <Search className="text-muted-foreground size-3.5 shrink-0" />
+      )}
       <input
         type="text"
         value={value}
@@ -392,31 +412,41 @@ function ThreadSearchBar({
       />
       {hasQuery && (
         <>
-          <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-            {loading
-              ? "…"
-              : matchCount > 0
-                ? `${activeIndex + 1}/${matchCount}`
-                : "0/0"}
-          </span>
-          <button
-            type="button"
-            onClick={onPrev}
-            disabled={matchCount === 0}
-            aria-label="Previous match"
-            className={navBtn}
-          >
-            <ChevronUp className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={onNext}
-            disabled={matchCount === 0}
-            aria-label="Next match"
-            className={navBtn}
-          >
-            <ChevronDown className="size-3.5" />
-          </button>
+          {overLimit ? (
+            <span className="text-destructive shrink-0 text-xs tabular-nums">
+              {trimmedLen}/{MAX_SEARCH_QUERY_LEN}
+            </span>
+          ) : (
+            <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+              {loading
+                ? "…"
+                : matchCount > 0
+                  ? `${activeIndex + 1}/${matchCount}`
+                  : "0/0"}
+            </span>
+          )}
+          {!overLimit && (
+            <>
+              <button
+                type="button"
+                onClick={onPrev}
+                disabled={matchCount === 0}
+                aria-label="Previous match"
+                className={navBtn}
+              >
+                <ChevronUp className="size-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={onNext}
+                disabled={matchCount === 0}
+                aria-label="Next match"
+                className={navBtn}
+              >
+                <ChevronDown className="size-3.5" />
+              </button>
+            </>
+          )}
           <button
             type="button"
             onClick={() => onChange("")}
@@ -629,7 +659,10 @@ function ChatDetailPanel({
   const riskTranscript = useChatRiskTranscript(chatId, dimNonRisk);
   // Search is a third windowed mode, available only in the normal (non-risk)
   // view. Disabled (no fetch) until there's a debounced query.
-  const searchActive = !dimNonRisk && searchQuery.length > 0;
+  const searchActive =
+    !dimNonRisk &&
+    searchQuery.length > 0 &&
+    searchQuery.length <= MAX_SEARCH_QUERY_LEN;
   const searchTranscript = useChatSearchTranscript(
     chatId,
     searchQuery,


### PR DESCRIPTION
## What

Searching a conversation in the chat detail view with a query longer than 200 characters crashed with a hard `chat.load` validation error (`length of query must be lesser or equal than 200`). The find-in-conversation bar sent whatever was typed; the server caps `query` at 200 (`MaxLength(200)` in `server/design/chat/design.go`).

## Fix

Client-side only, in `ChatDetailPanel.tsx`:

- **Gate the request** — `searchActive` now requires `searchQuery.length <= 200`, so an over-limit query never reaches the SDK and the server validation never trips.
- **Flag the state inline** where the `2/2` match counter normally renders:
  - search icon → red `TriangleAlert`, with a hover tooltip "Queries are limited to 200 characters"
  - match counter → red live `length/200` count
  - prev/next nav hidden; clear (✕) kept
- New `MAX_SEARCH_QUERY_LEN = 200` constant mirrors the server cap (one source of truth for both the gate and the indicator).

The server cap stays as defense-in-depth for CLI/SDK callers.

## Test plan

- Type a >200-char query in chat detail search → no network request, red warning icon + red `N/200` counter, tooltip on hover, no crash.
- Trim back under 200 → reverts to normal search icon + `active/total` counter, search fires.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented crashes in chat detail search when queries exceed 200 characters. Over-limit queries are blocked client-side and show a clear inline warning instead of sending invalid requests.

- **Bug Fixes**
  - Gate requests: `searchActive` only when `searchQuery.length <= 200`, so no SDK/server call on over-limit input.
  - Inline feedback: red `TriangleAlert` with tooltip and red live `length/200` counter; prev/next hidden, clear stays; added `MAX_SEARCH_QUERY_LEN = 200` constant.

<sup>Written for commit 277ef7ed82e797f42a76e2714c4188042cef8905. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

