### PR TITLE
mig: backfill organization_id on remote_session_clients

### DIFF
--- a/server/migrations/20260629141716_backfill-remote-session-clients-organization-id.sql
+++ b/server/migrations/20260629141716_backfill-remote-session-clients-organization-id.sql
@@ -1,0 +1,11 @@
+-- Backfill organization_id on remote_session_clients from each client's owning
+-- project, covering rows created before the AIS-222 dual-write deployed.
+-- Idempotent: only rows still NULL are touched, so re-running is a no-op. Every
+-- client is project-scoped today (organization-level clients arrive in AIS-221),
+-- so the owning project's organization is unambiguous. No deleted filter: the
+-- eventual NOT NULL contract must hold for soft-deleted rows too.
+UPDATE remote_session_clients AS c
+SET organization_id = p.organization_id
+FROM projects AS p
+WHERE c.project_id = p.id
+  AND c.organization_id IS NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lJW4m4ZE+UbVxm0td1NGQ6XrmaiVu2HS3eplKLo+zWw=
+h1:XVMt7zWTwwC/jzWM36RwQFoc113z3zhZCtZQ7xeJclg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -233,3 +233,4 @@ h1:lJW4m4ZE+UbVxm0td1NGQ6XrmaiVu2HS3eplKLo+zWw=
 20260626152018_chats-add-pinned-at.sql h1:GeYCKutkPKW+wiILObCtoHI62pR60gSQhUelef/5xLc=
 20260626175057_add_user_id_to_tool_call_blocks.sql h1:+Mf+8EEzJOBLXgsupc+p4uJ+O7Mx871veaeEYyEAqHE=
 20260629082301_risk-policies-analyzer-config.sql h1:RcX/MVJeVwIUIWxh02Z9WyAF1cfnelNLrYStdv+xrh8=
+20260629141716_backfill-remote-session-clients-organization-id.sql h1:t9goVSzDc3ehzv5LhnkNfnYpHw9vbAaGpVDhlSa/Ujw=


### PR DESCRIPTION
Backfill `organization_id` on every `remote_session_clients` row still missing it, from the owning project's organization, closing rows created before the AIS-222 dual-write (#3698) deployed. Idempotent (`WHERE organization_id IS NULL`), so safe to re-run. Migration-only, no app code.

**Deploy after #3698** so the writer gap is closed before this sweeps it. After it applies, `SELECT COUNT(*) FROM remote_session_clients WHERE organization_id IS NULL` returns 0 (no organization-level clients exist until AIS-221).

Linear: https://linear.app/speakeasy/issue/AIS-222/dual-write-and-backfill-organization-id-on-remote-session-clients

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills `organization_id` on `remote_session_clients` from each row’s owning project, updating only NULLs. This completes AIS-222 by sweeping rows created before the dual-write and ensures the column is fully populated.

- **Migration**
  - Adds an idempotent UPDATE to set `organization_id` from `projects` where it is NULL; includes soft-deleted rows.
  - Deploy after #3698 (AIS-222 dual-write).
  - Includes updated `atlas.sum`.
  - Verify: `SELECT COUNT(*) FROM remote_session_clients WHERE organization_id IS NULL` should return 0.

<sup>Written for commit a6f9459744f50e677773df84593b00e66583f22e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

