### PR TITLE
fix(dashboard): expose policy scoping for prompt-based policies

### DIFF
--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -1173,8 +1173,13 @@ function PolicyCenterContent() {
       const userMessagePayload = formUserMessage.trim()
         ? { userMessage: formUserMessage }
         : {};
+      // In CEL scope mode the include predicate is the sole scope: send no
+      // message-type filter so a stale subset can't intersect it (the two are a
+      // mutex). The selection is preserved in form state for a mode switch-back.
       const promptMessageTypes =
-        policyMessageTypesForPayload(selectedMessageTypes);
+        scopeMode === "cel"
+          ? []
+          : policyMessageTypesForPayload(selectedMessageTypes);
       if (editingPolicy) {
         updateMutation.mutate({
           request: {
@@ -1213,7 +1218,12 @@ function PolicyCenterContent() {
       return;
     }
 
-    const messageTypes = policyMessageTypesForPayload(selectedMessageTypes);
+    // CEL scope mode replaces the message-type selection; send no message-type
+    // filter so a stale subset can't intersect the include predicate.
+    const messageTypes =
+      scopeMode === "cel"
+        ? []
+        : policyMessageTypesForPayload(selectedMessageTypes);
     const {
       sources,
       presidioEntities,

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -1833,6 +1833,12 @@ function PolicyCenterContent() {
                       setFormTemperature={setFormTemperature}
                       formFailOpen={formFailOpen}
                       setFormFailOpen={setFormFailOpen}
+                      scopeInclude={scopeInclude}
+                      setScopeInclude={setScopeInclude}
+                      scopeExempt={scopeExempt}
+                      setScopeExempt={setScopeExempt}
+                      scopeMode={scopeMode}
+                      setScopeMode={setScopeMode}
                       selectedMessageTypes={selectedMessageTypes}
                       setSelectedMessageTypes={setSelectedMessageTypes}
                     />
@@ -1984,6 +1990,12 @@ function PromptPolicySheetBody({
   setFormTemperature,
   formFailOpen,
   setFormFailOpen,
+  scopeInclude,
+  setScopeInclude,
+  scopeExempt,
+  setScopeExempt,
+  scopeMode,
+  setScopeMode,
   selectedMessageTypes,
   setSelectedMessageTypes,
 }: {
@@ -2006,6 +2018,12 @@ function PromptPolicySheetBody({
   setFormTemperature: (v: number) => void;
   formFailOpen: boolean;
   setFormFailOpen: (v: boolean) => void;
+  scopeInclude: string;
+  setScopeInclude: (v: string) => void;
+  scopeExempt: string;
+  setScopeExempt: (v: string) => void;
+  scopeMode: "messageTypes" | "cel";
+  setScopeMode: (v: "messageTypes" | "cel") => void;
   selectedMessageTypes: Set<PolicyMessageType>;
   setSelectedMessageTypes: (v: Set<PolicyMessageType>) => void;
 }) {
@@ -2020,12 +2038,14 @@ function PromptPolicySheetBody({
   };
 
   const prompt = formPromptInstruction.trim();
-  const summaryScopes =
+  const messageTypeScopeLabels =
     selectedMessageTypes.size === ALL_POLICY_MESSAGE_TYPES.length
       ? ["All session parts"]
       : ALL_POLICY_MESSAGE_TYPES.filter((t) =>
           selectedMessageTypes.has(t as PolicyMessageType),
         ).map((t) => POLICY_MESSAGE_TYPE_META[t as PolicyMessageType].label);
+  const summaryScopes =
+    scopeMode === "cel" ? ["CEL expression"] : messageTypeScopeLabels;
 
   // One-line view of the judge config shown on the collapsed Advanced card, so
   // authors can see the (sensible) defaults at a glance without expanding it.
@@ -2118,29 +2138,98 @@ function PromptPolicySheetBody({
             title="Where should it evaluate?"
             description="Narrow the scope to control cost — a prompt policy runs the LLM judge on each in-scope message."
           />
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            {ALL_POLICY_MESSAGE_TYPES.map((type) => (
-              <ScopeCard
-                key={type}
-                type={type as PolicyMessageType}
-                checked={selectedMessageTypes.has(type as PolicyMessageType)}
-                onToggle={(checked) => {
-                  const updated = new Set(selectedMessageTypes);
-                  if (checked) {
-                    updated.add(type as PolicyMessageType);
-                  } else {
-                    updated.delete(type as PolicyMessageType);
-                  }
-                  setSelectedMessageTypes(updated);
-                }}
-              />
-            ))}
-          </div>
-          {selectedMessageTypes.size === 0 && (
-            <p className="text-destructive text-xs">
-              Select at least one session part.
+          {/* Scope is a mutex: message-type cards (coarse) XOR a CEL include
+              predicate (fine). The segmented control conveys that. */}
+          <div className="space-y-3">
+            <div className="border-border inline-flex rounded-md border p-0.5">
+              {(
+                [
+                  { key: "messageTypes", label: "Message types" },
+                  { key: "cel", label: "CEL expression" },
+                ] as const
+              ).map((opt) => (
+                <button
+                  key={opt.key}
+                  type="button"
+                  onClick={() => setScopeMode(opt.key)}
+                  className={cn(
+                    "rounded px-3 py-1 text-xs font-medium transition-colors",
+                    scopeMode === opt.key
+                      ? "bg-foreground text-background"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <p className="text-muted-foreground text-xs">
+              {scopeMode === "messageTypes"
+                ? "Run the judge on whole session parts. Switch to a CEL expression to match on tool or content attributes instead."
+                : "Run the judge only on messages matching the expression below — this replaces the message-type selection."}
             </p>
+          </div>
+
+          {scopeMode === "messageTypes" ? (
+            <>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {ALL_POLICY_MESSAGE_TYPES.map((type) => (
+                  <ScopeCard
+                    key={type}
+                    type={type as PolicyMessageType}
+                    checked={selectedMessageTypes.has(
+                      type as PolicyMessageType,
+                    )}
+                    onToggle={(checked) => {
+                      const updated = new Set(selectedMessageTypes);
+                      if (checked) {
+                        updated.add(type as PolicyMessageType);
+                      } else {
+                        updated.delete(type as PolicyMessageType);
+                      }
+                      setSelectedMessageTypes(updated);
+                    }}
+                  />
+                ))}
+              </div>
+              {selectedMessageTypes.size === 0 && (
+                <p className="text-destructive text-xs">
+                  Select at least one session part.
+                </p>
+              )}
+            </>
+          ) : (
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">
+                Evaluate messages matching
+              </Label>
+              <p className="text-muted-foreground text-xs">
+                The judge runs on a message only when this expression is true.
+              </p>
+              <CelExpressionField
+                value={scopeInclude}
+                onChange={setScopeInclude}
+                examples={SCOPE_INCLUDE_CEL_EXAMPLES}
+              />
+            </div>
           )}
+
+          {/* Exemptions — always available and additive (not part of the
+              scope mutex). A match here skips the whole policy. */}
+          <div className="border-border space-y-4 border-t pt-6">
+            <div>
+              <Label className="text-sm font-medium">Exemptions</Label>
+              <p className="text-muted-foreground text-xs">
+                Skip the whole policy for any message matching this expression —
+                an allowlist, regardless of the scope above.
+              </p>
+            </div>
+            <CelExpressionField
+              value={scopeExempt}
+              onChange={setScopeExempt}
+              examples={SCOPE_EXEMPT_CEL_EXAMPLES}
+            />
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## What

Exposes policy scoping (CEL `scope_include` / `scope_exempt`) in the prompt-based policy creation/edit form. Scoping was already supported end to end except in this form, so prompt policies could not be narrowed or exempted from the dashboard.

## Why

`scope_include` / `scope_exempt` were already:
- applied by the scanner before branching on policy type (`scanner.go`, `analyze_batch.go`),
- validated and persisted ungated for all policy types (`risk/impl.go`, `design/risk`, repo),
- spread into the prompt-policy create/update requests by `handleSave`.

The only gap: `PromptPolicySheetBody` never received the scope state and its "Where should it evaluate?" step rendered message-type cards only. With no way to switch `scopeMode` to `cel`, `scopeInclude`/`scopeExempt` stayed empty and were never sent.

## Changes

`client/dashboard/src/pages/security/PolicyCenter.tsx`:
- Thread `scopeInclude/scopeExempt/scopeMode` (+ setters) into `PromptPolicySheetBody`.
- Step 1 now uses the same scope control as standard policies: `Message types ⨉ CEL expression` segmented toggle, a `scope_include` field, and an additive Exemptions (`scope_exempt`) field — keeping the prompt-specific "run the judge" cost framing.
- Review-step summary shows "CEL expression" in CEL mode.

Shared validation (`scopeMissing`, `saveDisabled`, `applicationInvalid`) and `handleEdit` (loads CEL mode when a stored `scope_include` exists) already keyed off `scopeMode`, so they cover prompt policies automatically.

## Testing

- `pnpm -F dashboard type-check` passes.
- UI-only; no backend/API/schema changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes policy scoping for prompt-based policies in the dashboard and ensures CEL mode doesn’t intersect with old message-type filters. You can now scope by message types or write CEL include/exempt expressions to control when the LLM judge runs.

- **New Features**
  - Added a segmented toggle for scope: “Message types” or “CEL expression” in “Where should it evaluate?”.
  - Added CEL include (`scope_include`) and additive exemptions (`scope_exempt`) fields with example helpers.
  - Review step shows “CEL expression” when CEL mode is selected.
  - Threaded `scopeInclude`, `scopeExempt`, and `scopeMode` into `PromptPolicySheetBody`; existing validation/edit logic covers prompt policies.
  - UI-only; no backend/API changes.

- **Bug Fixes**
  - In CEL scope mode, omit message-type filters from create/update payloads to avoid intersecting with the include predicate.

<sup>Written for commit bb616062e2d472bbb0a36c55cca4d4d321670397. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

