### PR TITLE
feat: add batch receive support to pubsub subscriber

### DIFF
--- a/infra/internal/attr/conventions.go
+++ b/infra/internal/attr/conventions.go
@@ -29,6 +29,9 @@ const (
 	GCPSubscriptionQualifiedNameKey = attribute.Key("gram.subscription.qualified_name")
 	TopicProtoNameKey               = attribute.Key("gram.topic.proto_name")
 	SubscriptionProtoNameKey        = attribute.Key("gram.subscription.proto_name")
+	SubscriberBatchSizeKey          = attribute.Key("gram.subscriber.batch_size")
+	SubscriberMessageIDKey          = attribute.Key("gram.subscriber.message_id")
+	SubscriberDeliveryAttemptKey    = attribute.Key("gram.subscriber.delivery_attempt")
 )
 
 func Error(v error) attribute.KeyValue { return ErrorMessageKey.String(v.Error()) }
@@ -105,4 +108,28 @@ func SubscriptionProtoName[S ~string](v S) attribute.KeyValue {
 }
 func SlogSubscriptionProtoName[S ~string](v S) slog.Attr {
 	return slog.String(string(SubscriptionProtoNameKey), string(v))
+}
+
+func SubscriberBatchSize(v int) attribute.KeyValue { return SubscriberBatchSizeKey.Int(v) }
+func SlogSubscriberBatchSize(v int) slog.Attr      { return slog.Int(string(SubscriberBatchSizeKey), v) }
+
+func SubscriberMessageID[S ~string](v S) attribute.KeyValue {
+	return SubscriberMessageIDKey.String(string(v))
+}
+func SlogSubscriberMessageID[S ~string](v S) slog.Attr {
+	return slog.String(string(SubscriberMessageIDKey), string(v))
+}
+
+func SubscriberDeliveryAttempt(v *int) attribute.KeyValue {
+	if v == nil {
+		return SubscriberDeliveryAttemptKey.Int(-1)
+	}
+
+	return SubscriberDeliveryAttemptKey.Int(*v)
+}
+func SlogSubscriberDeliveryAttempt(v *int) slog.Attr {
+	if v == nil {
+		return slog.Int(string(SubscriberDeliveryAttemptKey), -1)
+	}
+	return slog.Int(string(SubscriberDeliveryAttemptKey), *v)
 }

--- a/infra/pkg/gcp/subscriber.go
+++ b/infra/pkg/gcp/subscriber.go
@@ -5,11 +5,36 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"sync"
+	"time"
 
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/speakeasy-api/gram/infra/internal/attr"
 	"google.golang.org/protobuf/proto"
 )
+
+const (
+	// defaultBatchMaxMessages is the buffer size used by ReceiveBatch when
+	// BatchReceiveSettings.MaxMessages is unset.
+	defaultBatchMaxMessages = 100
+	// defaultBatchMaxLatency is the maximum time a partial batch waits before
+	// being flushed when BatchReceiveSettings.MaxLatency is unset.
+	defaultBatchMaxLatency = time.Second
+)
+
+// BatchReceiveSettings tunes how Subscriber.ReceiveBatch groups messages. A
+// batch is flushed when either MaxMessages have buffered or MaxLatency elapses,
+// whichever happens first.
+type BatchReceiveSettings struct {
+	// MaxMessages is the number of buffered messages that triggers a flush. A
+	// value <= 0 falls back to defaultBatchMaxMessages.
+	MaxMessages int
+	// MaxLatency is how long a partial batch waits before being flushed. A value
+	// <= 0 falls back to defaultBatchMaxLatency. It must stay well below the
+	// subscription's ack deadline (and the receiver's MaxExtension) since
+	// buffered messages remain outstanding until the batch is acked.
+	MaxLatency time.Duration
+}
 
 type SubscriberBroker interface {
 	SubscriberForMessage(ctx context.Context, msg proto.Message, subscription proto.Message) (*pubsub.Subscriber, error)
@@ -57,6 +82,7 @@ type MessageMetadata struct {
 
 type Subscriber[M proto.Message] interface {
 	Receive(context.Context, func(context.Context, M, MessageMetadata) error) error
+	ReceiveBatch(context.Context, BatchReceiveSettings, func(context.Context, []M, []MessageMetadata) error) error
 }
 
 // incomingMessage decouples per-message processing from the concrete
@@ -135,6 +161,183 @@ func (s *psSubscriber[M]) handle(ctx context.Context, m incomingMessage, f func(
 		DeliveryAttempt: m.deliveryAttempt,
 	}); err != nil {
 		m.nack()
+		return
+	}
+}
+
+// ReceiveBatch consumes messages and delivers them to f in batches. The
+// underlying pubsub client only delivers one message per callback, so messages
+// are buffered here and flushed as a slice once settings.MaxMessages are
+// buffered or settings.MaxLatency elapses, whichever comes first.
+//
+// Ack/nack is all-or-nothing: when f returns nil the whole batch is acked; when
+// f returns an error (or panics) the whole batch is nacked. Messages that fail
+// to unmarshal are nacked individually and excluded from the batch handed to f.
+func (s *psSubscriber[M]) ReceiveBatch(ctx context.Context, settings BatchReceiveSettings, f func(context.Context, []M, []MessageMetadata) error) error {
+	return s.batchLoop(ctx, settings, func(ctx context.Context, deliver func(incomingMessage)) error {
+		return s.sub.Receive(ctx, func(_ context.Context, m *pubsub.Message) {
+			deliver(incomingMessage{
+				id:              m.ID,
+				data:            m.Data,
+				attributes:      m.Attributes,
+				deliveryAttempt: m.DeliveryAttempt,
+				ack:             m.Ack,
+				nack:            m.Nack,
+			})
+		})
+	}, f)
+}
+
+// batchLoop holds the buffering, size/latency flushing, and drain logic shared
+// by ReceiveBatch. The delivery source is abstracted behind receive so the loop
+// can be exercised in tests (with a synthetic source and a fake clock) without a
+// live pubsub subscriber: receive must call deliver once per incoming message
+// and return when ctx is cancelled (or on a terminal error).
+func (s *psSubscriber[M]) batchLoop(
+	ctx context.Context,
+	settings BatchReceiveSettings,
+	receive func(ctx context.Context, deliver func(incomingMessage)) error,
+	f func(context.Context, []M, []MessageMetadata) error,
+) error {
+	size := settings.MaxMessages
+	if size <= 0 {
+		size = defaultBatchMaxMessages
+	}
+	latency := settings.MaxLatency
+	if latency <= 0 {
+		latency = defaultBatchMaxLatency
+	}
+
+	newBuf := func() []incomingMessage { return make([]incomingMessage, 0, size) }
+
+	var mu sync.Mutex
+	pending := newBuf()
+
+	take := func() []incomingMessage {
+		mu.Lock()
+		defer mu.Unlock()
+		batch := pending
+		pending = newBuf()
+		return batch
+	}
+
+	flush := func() {
+		if batch := take(); len(batch) > 0 {
+			s.handleBatch(ctx, batch, f)
+		}
+	}
+
+	// Flush partial batches on a timer so messages are not held longer than the
+	// configured latency (and beyond their ack deadline) under low throughput.
+	ticker := time.NewTicker(latency)
+	defer ticker.Stop()
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				flush()
+			}
+		}
+	}()
+
+	err := receive(ctx, func(m incomingMessage) {
+		mu.Lock()
+		pending = append(pending, m)
+		var batch []incomingMessage
+		if len(pending) >= size {
+			batch = pending
+			pending = newBuf()
+		}
+		mu.Unlock()
+
+		if len(batch) > 0 {
+			s.handleBatch(ctx, batch, f)
+		}
+	})
+
+	// Drain any messages still buffered when receive returns so they are acked
+	// or nacked rather than silently dropped.
+	flush()
+
+	if err != nil {
+		return fmt.Errorf("receive batch: %w", err)
+	}
+
+	return nil
+}
+
+func (s *psSubscriber[M]) handleBatch(ctx context.Context, batch []incomingMessage, f func(context.Context, []M, []MessageMetadata) error) {
+	msgs := make([]M, 0, len(batch))
+	metas := make([]MessageMetadata, 0, len(batch))
+	valid := make([]incomingMessage, 0, len(batch))
+
+	logger := s.logger.With(
+		attr.SlogTopicProtoName(s.topicProtoName),
+		attr.SlogSubscriptionProtoName(s.subscriptionProtoName),
+	)
+
+	for _, m := range batch {
+		msg := s.new()
+		if err := proto.Unmarshal(m.data, msg); err != nil {
+			logger.ErrorContext(
+				ctx,
+				"failed to unmarshal pubsub message",
+				attr.SlogError(err),
+				attr.SlogSubscriberMessageID(m.id),
+				attr.SlogSubscriberDeliveryAttempt(m.deliveryAttempt),
+			)
+			m.nack()
+			continue
+		}
+		msgs = append(msgs, msg)
+		metas = append(metas, MessageMetadata{
+			ID:              m.id,
+			Attributes:      m.attributes,
+			DeliveryAttempt: m.deliveryAttempt,
+		})
+		valid = append(valid, m)
+	}
+
+	if len(valid) == 0 {
+		return
+	}
+
+	ackAll := func() {
+		for _, m := range valid {
+			m.ack()
+		}
+	}
+	nackAll := func() {
+		for _, m := range valid {
+			m.nack()
+		}
+	}
+
+	// Registered first so it runs last: on the happy path it acks the batch, and
+	// after a nack it is a no-op since pubsub honours the first ack/nack per
+	// message.
+	defer ackAll()
+
+	defer func() {
+		if r := recover(); r != nil {
+			logger.ErrorContext(ctx, "panic recovered while processing pubsub message batch",
+				attr.SlogErrorMessage(fmt.Sprintf("%v", r)),
+				attr.SlogErrorStack(string(debug.Stack())),
+				attr.SlogTopicProtoName(s.topicProtoName),
+				attr.SlogSubscriptionProtoName(s.subscriptionProtoName),
+				attr.SlogSubscriberMessageID(valid[0].id),
+				attr.SlogSubscriberBatchSize(len(valid)),
+			)
+			nackAll()
+		}
+	}()
+
+	if err := f(ctx, msgs, metas); err != nil {
+		nackAll()
 		return
 	}
 }

--- a/infra/pkg/gcp/subscriber.go
+++ b/infra/pkg/gcp/subscriber.go
@@ -23,8 +23,8 @@ const (
 )
 
 // BatchReceiveSettings tunes how Subscriber.ReceiveBatch groups messages. A
-// batch is flushed when either MaxMessages have buffered or MaxLatency elapses,
-// whichever happens first.
+// batch is flushed when MaxMessages have buffered, the buffered payloads reach
+// MaxBytes, or MaxLatency elapses, whichever happens first.
 type BatchReceiveSettings struct {
 	// MaxMessages is the number of buffered messages that triggers a flush. A
 	// value <= 0 falls back to defaultBatchMaxMessages. Keep it at or below the
@@ -33,6 +33,14 @@ type BatchReceiveSettings struct {
 	// outstanding limit the buffer can never reach the size threshold and every
 	// batch waits the full MaxLatency.
 	MaxMessages int
+	// MaxBytes is the combined size of buffered message payloads, in bytes, that
+	// triggers a flush. A value <= 0 disables byte-based flushing, leaving
+	// MaxMessages and MaxLatency as the only triggers. Like MaxMessages it is a
+	// trigger, not a hard cap: a single payload at or above MaxBytes flushes on
+	// its own, and a batch can overshoot MaxBytes by up to the size of the
+	// message that crossed the threshold. Memory is bounded by the receiver's
+	// ReceiveSettings.MaxOutstandingBytes, not by this setting.
+	MaxBytes int
 	// MaxLatency is how long a partial batch waits before being flushed. A value
 	// <= 0 falls back to defaultBatchMaxLatency. It must stay well below the
 	// subscription's ack deadline (and the receiver's MaxExtension) since
@@ -169,7 +177,8 @@ func (s *psSubscriber[M]) handle(ctx context.Context, m incomingMessage, f func(
 // ReceiveBatch consumes messages and delivers them to f in batches. The
 // underlying pubsub client only delivers one message per callback, so messages
 // are buffered here and flushed as a slice once settings.MaxMessages are
-// buffered or settings.MaxLatency elapses, whichever comes first.
+// buffered, their payloads reach settings.MaxBytes, or settings.MaxLatency
+// elapses, whichever comes first.
 //
 // Ack/nack is all-or-nothing: when f returns nil the whole batch is acked; when
 // f returns an error (or panics) the whole batch is nacked. Messages that fail
@@ -189,11 +198,13 @@ func (s *psSubscriber[M]) ReceiveBatch(ctx context.Context, settings BatchReceiv
 	}, f)
 }
 
-// batchLoop holds the buffering, size/latency flushing, and drain logic shared
-// by ReceiveBatch. The delivery source is abstracted behind receive so the loop
-// can be exercised in tests (with a synthetic source and a fake clock) without a
-// live pubsub subscriber: receive must call deliver once per incoming message
-// and return when ctx is cancelled (or on a terminal error).
+// batchLoop holds the buffering, count/byte/latency flushing, and drain logic
+// shared by ReceiveBatch. The latency timer is armed when a message starts a new
+// batch and stopped when the batch is detached, so the window is measured from
+// each batch's first message. The delivery source is abstracted behind receive
+// so the loop can be exercised in tests (with a synthetic source and a fake
+// clock) without a live pubsub subscriber: receive must call deliver once per
+// incoming message and return when ctx is cancelled (or on a terminal error).
 func (s *psSubscriber[M]) batchLoop(
 	ctx context.Context,
 	settings BatchReceiveSettings,
@@ -208,15 +219,30 @@ func (s *psSubscriber[M]) batchLoop(
 	if latency <= 0 {
 		latency = defaultBatchMaxLatency
 	}
+	// maxBytes is an optional trigger: a value <= 0 leaves count and latency as
+	// the only flush conditions.
+	maxBytes := settings.MaxBytes
 
 	newBuf := func() []incomingMessage { return make([]incomingMessage, 0, size) }
 
 	var mu sync.Mutex
 	pending := newBuf()
+	pendingBytes := 0
+	// flushTimer bounds how long the oldest buffered message waits. It is armed
+	// when a message starts a new batch and stopped whenever the batch is
+	// detached, so the latency window is measured from the first message of each
+	// batch (matching google.golang.org/api/support/bundler) rather than from a
+	// free-running clock. A nil flushTimer means no batch is currently waiting.
+	var flushTimer *time.Timer
+	// timerWG tracks in-flight timer callbacks so shutdown can wait for one that
+	// is mid-flush before draining. Every armed timer adds one; the count is
+	// balanced either by the callback's deferred Done or, when Stop cancels the
+	// callback before it runs, by the stopping goroutine.
+	var timerWG sync.WaitGroup
 
-	// take detaches the buffered messages under the lock. It returns nil (without
-	// reallocating) when nothing is buffered so an idle latency tick does not
-	// churn a fresh size-capacity buffer every interval.
+	// take detaches the buffered messages under the lock and stops the latency
+	// timer. It returns nil (without reallocating) when nothing is buffered so a
+	// no-op flush does not churn a fresh size-capacity buffer.
 	take := func() []incomingMessage {
 		mu.Lock()
 		defer mu.Unlock()
@@ -225,15 +251,23 @@ func (s *psSubscriber[M]) batchLoop(
 		}
 		batch := pending
 		pending = newBuf()
+		pendingBytes = 0
+		if flushTimer != nil {
+			// Stop reports true when it cancels the callback before it runs; in that
+			// case balance the Add here since the callback's Done will not fire.
+			if flushTimer.Stop() {
+				timerWG.Done()
+			}
+			flushTimer = nil
+		}
 		return batch
 	}
 
-	// handlerMu serializes handleBatch so the latency goroutine and the
-	// size-trigger path never invoke f concurrently. Buffering (under mu)
+	// handlerMu serializes handleBatch so the latency callback and the
+	// size/byte-trigger path never invoke f concurrently. Buffering (under mu)
 	// continues while a batch is in flight; only the handler call is serialized.
 	var handlerMu sync.Mutex
-	flush := func() {
-		batch := take()
+	runBatch := func(batch []incomingMessage) {
 		if len(batch) == 0 {
 			return
 		}
@@ -241,28 +275,36 @@ func (s *psSubscriber[M]) batchLoop(
 		defer handlerMu.Unlock()
 		s.handleBatch(ctx, batch, f)
 	}
-
-	// Flush partial batches on a timer so messages are not held longer than the
-	// configured latency (and beyond their ack deadline) under low throughput.
-	ticker := time.NewTicker(latency)
-	defer ticker.Stop()
-	done := make(chan struct{})
-	var tickerWG sync.WaitGroup
-	tickerWG.Go(func() {
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				flush()
-			}
-		}
-	})
+	flush := func() { runBatch(take()) }
 
 	err := receive(ctx, func(m incomingMessage) {
 		mu.Lock()
 		pending = append(pending, m)
-		full := len(pending) >= size
+		pendingBytes += len(m.data)
+		full := len(pending) >= size || (maxBytes > 0 && pendingBytes >= maxBytes)
+		if !full && flushTimer == nil {
+			// This message starts a new batch: arm the timer for its lifetime. The
+			// callback captures its own timer and no-ops if a size/byte flush has
+			// since superseded it, so a stale firing never flushes the next batch
+			// early.
+			timerWG.Add(1)
+			var t *time.Timer
+			t = time.AfterFunc(latency, func() {
+				defer timerWG.Done()
+				mu.Lock()
+				if flushTimer != t || len(pending) == 0 {
+					mu.Unlock()
+					return
+				}
+				batch := pending
+				pending = newBuf()
+				pendingBytes = 0
+				flushTimer = nil
+				mu.Unlock()
+				runBatch(batch)
+			})
+			flushTimer = t
+		}
 		mu.Unlock()
 
 		if full {
@@ -270,11 +312,19 @@ func (s *psSubscriber[M]) batchLoop(
 		}
 	})
 
-	// Stop the latency goroutine and wait for any in-flight flush to finish
-	// before draining, so handleBatch never runs after batchLoop returns and
-	// touches resources the caller tears down on shutdown.
-	close(done)
-	tickerWG.Wait()
+	// Stop a pending timer and wait for any in-flight callback to finish before
+	// draining, so handleBatch never runs after batchLoop returns and touches
+	// resources the caller tears down on shutdown. receive has returned, so no new
+	// timer can be armed past this point.
+	mu.Lock()
+	if flushTimer != nil {
+		if flushTimer.Stop() {
+			timerWG.Done()
+		}
+		flushTimer = nil
+	}
+	mu.Unlock()
+	timerWG.Wait()
 
 	// Drain any messages still buffered when receive returns so they are acked
 	// or nacked rather than silently dropped.

--- a/infra/pkg/gcp/subscriber.go
+++ b/infra/pkg/gcp/subscriber.go
@@ -27,7 +27,11 @@ const (
 // whichever happens first.
 type BatchReceiveSettings struct {
 	// MaxMessages is the number of buffered messages that triggers a flush. A
-	// value <= 0 falls back to defaultBatchMaxMessages.
+	// value <= 0 falls back to defaultBatchMaxMessages. Keep it at or below the
+	// receiver's ReceiveSettings.MaxOutstandingMessages: buffered messages stay
+	// un-acked until their batch flushes, so if MaxMessages exceeds the
+	// outstanding limit the buffer can never reach the size threshold and every
+	// batch waits the full MaxLatency.
 	MaxMessages int
 	// MaxLatency is how long a partial batch waits before being flushed. A value
 	// <= 0 falls back to defaultBatchMaxLatency. It must stay well below the
@@ -133,18 +137,13 @@ func (s *psSubscriber[M]) handle(ctx context.Context, m incomingMessage, f func(
 	// panicking).
 	defer func() {
 		if r := recover(); r != nil {
-			deliveryAttempt := 0
-			if m.deliveryAttempt != nil {
-				deliveryAttempt = *m.deliveryAttempt
-			}
-
 			s.logger.ErrorContext(ctx, "panic recovered while processing pubsub message",
 				attr.SlogErrorMessage(fmt.Sprintf("%v", r)),
 				attr.SlogErrorStack(string(debug.Stack())),
 				attr.SlogTopicProtoName(s.topicProtoName),
 				attr.SlogSubscriptionProtoName(s.subscriptionProtoName),
-				slog.String("message_id", m.id),
-				slog.Int("delivery_attempt", deliveryAttempt),
+				attr.SlogSubscriberMessageID(m.id),
+				attr.SlogSubscriberDeliveryAttempt(m.deliveryAttempt),
 			)
 			m.nack()
 		}
@@ -213,18 +212,32 @@ func (s *psSubscriber[M]) batchLoop(
 	var mu sync.Mutex
 	pending := newBuf()
 
+	// take detaches the buffered messages under the lock. It returns nil (without
+	// reallocating) when nothing is buffered so an idle latency tick does not
+	// churn a fresh size-capacity buffer every interval.
 	take := func() []incomingMessage {
 		mu.Lock()
 		defer mu.Unlock()
+		if len(pending) == 0 {
+			return nil
+		}
 		batch := pending
 		pending = newBuf()
 		return batch
 	}
 
+	// handlerMu serializes handleBatch so the latency goroutine and the
+	// size-trigger path never invoke f concurrently. Buffering (under mu)
+	// continues while a batch is in flight; only the handler call is serialized.
+	var handlerMu sync.Mutex
 	flush := func() {
-		if batch := take(); len(batch) > 0 {
-			s.handleBatch(ctx, batch, f)
+		batch := take()
+		if len(batch) == 0 {
+			return
 		}
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		s.handleBatch(ctx, batch, f)
 	}
 
 	// Flush partial batches on a timer so messages are not held longer than the
@@ -232,8 +245,8 @@ func (s *psSubscriber[M]) batchLoop(
 	ticker := time.NewTicker(latency)
 	defer ticker.Stop()
 	done := make(chan struct{})
-	defer close(done)
-	go func() {
+	var tickerWG sync.WaitGroup
+	tickerWG.Go(func() {
 		for {
 			select {
 			case <-done:
@@ -242,22 +255,24 @@ func (s *psSubscriber[M]) batchLoop(
 				flush()
 			}
 		}
-	}()
+	})
 
 	err := receive(ctx, func(m incomingMessage) {
 		mu.Lock()
 		pending = append(pending, m)
-		var batch []incomingMessage
-		if len(pending) >= size {
-			batch = pending
-			pending = newBuf()
-		}
+		full := len(pending) >= size
 		mu.Unlock()
 
-		if len(batch) > 0 {
-			s.handleBatch(ctx, batch, f)
+		if full {
+			flush()
 		}
 	})
+
+	// Stop the latency goroutine and wait for any in-flight flush to finish
+	// before draining, so handleBatch never runs after batchLoop returns and
+	// touches resources the caller tears down on shutdown.
+	close(done)
+	tickerWG.Wait()
 
 	// Drain any messages still buffered when receive returns so they are acked
 	// or nacked rather than silently dropped.
@@ -271,48 +286,34 @@ func (s *psSubscriber[M]) batchLoop(
 }
 
 func (s *psSubscriber[M]) handleBatch(ctx context.Context, batch []incomingMessage, f func(context.Context, []M, []MessageMetadata) error) {
-	msgs := make([]M, 0, len(batch))
-	metas := make([]MessageMetadata, 0, len(batch))
-	valid := make([]incomingMessage, 0, len(batch))
-
-	logger := s.logger.With(
-		attr.SlogTopicProtoName(s.topicProtoName),
-		attr.SlogSubscriptionProtoName(s.subscriptionProtoName),
-	)
-
-	for _, m := range batch {
-		msg := s.new()
-		if err := proto.Unmarshal(m.data, msg); err != nil {
-			logger.ErrorContext(
-				ctx,
-				"failed to unmarshal pubsub message",
-				attr.SlogError(err),
-				attr.SlogSubscriberMessageID(m.id),
-				attr.SlogSubscriberDeliveryAttempt(m.deliveryAttempt),
-			)
-			m.nack()
-			continue
-		}
-		msgs = append(msgs, msg)
-		metas = append(metas, MessageMetadata{
-			ID:              m.id,
-			Attributes:      m.attributes,
-			DeliveryAttempt: m.deliveryAttempt,
-		})
-		valid = append(valid, m)
-	}
-
-	if len(valid) == 0 {
+	if len(batch) == 0 {
 		return
 	}
 
+	msgs := make([]M, 0, len(batch))
+	metas := make([]MessageMetadata, 0, len(batch))
+
+	// owned reports the messages this batch is responsible for acking/nacking.
+	// While every message decodes that is the whole batch, so we avoid copying it
+	// into a separate slice; once a poison message is dropped (and nacked
+	// individually) we switch to valid, which holds only the decoded messages so
+	// the dropped ones are not acked back into existence.
+	var valid []incomingMessage
+	dropped := false
+	owned := func() []incomingMessage {
+		if dropped {
+			return valid
+		}
+		return batch
+	}
+
 	ackAll := func() {
-		for _, m := range valid {
+		for _, m := range owned() {
 			m.ack()
 		}
 	}
 	nackAll := func() {
-		for _, m := range valid {
+		for _, m := range owned() {
 			m.nack()
 		}
 	}
@@ -322,19 +323,58 @@ func (s *psSubscriber[M]) handleBatch(ctx context.Context, batch []incomingMessa
 	// message.
 	defer ackAll()
 
+	// Registered before the unmarshal loop so a panic anywhere below (in s.new,
+	// proto.Unmarshal, or the handler) is recovered and nacks the batch for
+	// redelivery instead of crashing the receive goroutine, mirroring handle.
 	defer func() {
 		if r := recover(); r != nil {
-			logger.ErrorContext(ctx, "panic recovered while processing pubsub message batch",
+			s.logger.ErrorContext(ctx, "panic recovered while processing pubsub message batch",
 				attr.SlogErrorMessage(fmt.Sprintf("%v", r)),
 				attr.SlogErrorStack(string(debug.Stack())),
 				attr.SlogTopicProtoName(s.topicProtoName),
 				attr.SlogSubscriptionProtoName(s.subscriptionProtoName),
-				attr.SlogSubscriberMessageID(valid[0].id),
-				attr.SlogSubscriberBatchSize(len(valid)),
+				attr.SlogSubscriberMessageID(batch[0].id),
+				attr.SlogSubscriberBatchSize(len(batch)),
 			)
 			nackAll()
 		}
 	}()
+
+	for i, m := range batch {
+		msg := s.new()
+		if err := proto.Unmarshal(m.data, msg); err != nil {
+			s.logger.ErrorContext(
+				ctx,
+				"failed to unmarshal pubsub message",
+				attr.SlogError(err),
+				attr.SlogTopicProtoName(s.topicProtoName),
+				attr.SlogSubscriptionProtoName(s.subscriptionProtoName),
+				attr.SlogSubscriberMessageID(m.id),
+				attr.SlogSubscriberDeliveryAttempt(m.deliveryAttempt),
+			)
+			// First drop: seed valid with the messages decoded so far (all of
+			// batch[:i], since a prior drop would have set dropped already).
+			if !dropped {
+				valid = append(valid, batch[:i]...)
+				dropped = true
+			}
+			m.nack()
+			continue
+		}
+		msgs = append(msgs, msg)
+		metas = append(metas, MessageMetadata{
+			ID:              m.id,
+			Attributes:      m.attributes,
+			DeliveryAttempt: m.deliveryAttempt,
+		})
+		if dropped {
+			valid = append(valid, m)
+		}
+	}
+
+	if len(msgs) == 0 {
+		return
+	}
 
 	if err := f(ctx, msgs, metas); err != nil {
 		nackAll()

--- a/infra/pkg/gcp/subscriber.go
+++ b/infra/pkg/gcp/subscriber.go
@@ -36,7 +36,9 @@ type BatchReceiveSettings struct {
 	// MaxLatency is how long a partial batch waits before being flushed. A value
 	// <= 0 falls back to defaultBatchMaxLatency. It must stay well below the
 	// subscription's ack deadline (and the receiver's MaxExtension) since
-	// buffered messages remain outstanding until the batch is acked.
+	// buffered messages remain outstanding until the batch is acked; cross it and
+	// pubsub redelivers them before the batch flushes, so they get processed
+	// twice and the post-flush ack lands on a stale copy.
 	MaxLatency time.Duration
 }
 

--- a/infra/pkg/gcp/subscriber.go
+++ b/infra/pkg/gcp/subscriber.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/pubsub/v2"
@@ -27,11 +28,13 @@ const (
 // MaxBytes, or MaxLatency elapses, whichever happens first.
 type BatchReceiveSettings struct {
 	// MaxMessages is the number of buffered messages that triggers a flush. A
-	// value <= 0 falls back to defaultBatchMaxMessages. Keep it at or below the
-	// receiver's ReceiveSettings.MaxOutstandingMessages: buffered messages stay
-	// un-acked until their batch flushes, so if MaxMessages exceeds the
-	// outstanding limit the buffer can never reach the size threshold and every
-	// batch waits the full MaxLatency.
+	// value <= 0 falls back to defaultBatchMaxMessages. It bounds how many
+	// messages are held in memory, and left un-acked, per batch. It is
+	// independent of the receiver's ReceiveSettings.MaxOutstandingMessages: the
+	// underlying client releases that limit (really a concurrency cap on in-flight
+	// receive callbacks) when our callback returns after buffering, not when the
+	// message is acked, so buffering does not consume outstanding slots and the
+	// buffer can always reach MaxMessages regardless of the outstanding limit.
 	MaxMessages int
 	// MaxBytes is the combined size of buffered message payloads, in bytes, that
 	// triggers a flush. A value <= 0 disables byte-based flushing, leaving
@@ -43,10 +46,13 @@ type BatchReceiveSettings struct {
 	MaxBytes int
 	// MaxLatency is how long a partial batch waits before being flushed. A value
 	// <= 0 falls back to defaultBatchMaxLatency. It must stay well below the
-	// subscription's ack deadline (and the receiver's MaxExtension) since
-	// buffered messages remain outstanding until the batch is acked; cross it and
-	// pubsub redelivers them before the batch flushes, so they get processed
-	// twice and the post-flush ack lands on a stale copy.
+	// receiver's ReceiveSettings.MaxExtension (default 60m) — the ceiling up to
+	// which the client auto-extends a buffered message's ack deadline. The
+	// subscription's own ackDeadlineSeconds is not the limit: the client keeps
+	// the lease alive past it via modacks. But buffered messages remain leased
+	// (and un-acked) until their batch flushes, so once MaxLatency crosses
+	// MaxExtension the client stops extending, pubsub redelivers them before the
+	// batch flushes, and the eventual ack lands on a stale copy.
 	MaxLatency time.Duration
 }
 
@@ -201,10 +207,14 @@ func (s *psSubscriber[M]) ReceiveBatch(ctx context.Context, settings BatchReceiv
 // batchLoop holds the buffering, count/byte/latency flushing, and drain logic
 // shared by ReceiveBatch. The latency timer is armed when a message starts a new
 // batch and stopped when the batch is detached, so the window is measured from
-// each batch's first message. The delivery source is abstracted behind receive
-// so the loop can be exercised in tests (with a synthetic source and a fake
-// clock) without a live pubsub subscriber: receive must call deliver once per
-// incoming message and return when ctx is cancelled (or on a terminal error).
+// each batch's first message. On cancellation a drainer goroutine flushes the
+// in-flight batch while receive is still running, because ack/nack must reach
+// the live iterator: Subscriber.Receive only returns once every outstanding
+// message is acked/nacked, so the drain cannot wait until after it returns. The
+// delivery source is abstracted behind receive so the loop can be exercised in
+// tests (with a synthetic source and a fake clock) without a live pubsub
+// subscriber: receive must call deliver once per incoming message and return
+// when ctx is cancelled (or on a terminal error).
 func (s *psSubscriber[M]) batchLoop(
 	ctx context.Context,
 	settings BatchReceiveSettings,
@@ -277,11 +287,36 @@ func (s *psSubscriber[M]) batchLoop(
 	}
 	flush := func() { runBatch(take()) }
 
+	// draining is flipped on cancellation so that, during the underlying client's
+	// graceful shutdown, every message the receiver is still delivering flushes
+	// inline instead of waiting out MaxLatency. The cancellation drain itself MUST
+	// run while receive is still in flight: Subscriber.Receive does not return
+	// until every outstanding message is acked/nacked, and once it returns the
+	// iterator is torn down so ack/nack become no-ops. Draining only after receive
+	// returns would deadlock that wait until the messages expire (up to
+	// MaxExtension) and then redeliver the batch instead of acking it.
+	var draining atomic.Bool
+	stopDrainer := make(chan struct{})
+	drainerDone := make(chan struct{})
+	go func() {
+		defer close(drainerDone)
+		select {
+		case <-ctx.Done():
+			draining.Store(true)
+			flush()
+		case <-stopDrainer:
+			// receive returned without ctx being cancelled (e.g. a stream error);
+			// there is nothing to drain into a live iterator.
+		}
+	}()
+
 	err := receive(ctx, func(m incomingMessage) {
 		mu.Lock()
 		pending = append(pending, m)
 		pendingBytes += len(m.data)
-		full := len(pending) >= size || (maxBytes > 0 && pendingBytes >= maxBytes)
+		// draining.Load() forces an immediate flush so messages delivered during
+		// shutdown are acked inline rather than buffered behind the latency timer.
+		full := len(pending) >= size || (maxBytes > 0 && pendingBytes >= maxBytes) || draining.Load()
 		if !full && flushTimer == nil {
 			// This message starts a new batch: arm the timer for its lifetime. The
 			// callback captures its own timer and no-ops if a size/byte flush has
@@ -312,10 +347,10 @@ func (s *psSubscriber[M]) batchLoop(
 		}
 	})
 
-	// Stop a pending timer and wait for any in-flight callback to finish before
-	// draining, so handleBatch never runs after batchLoop returns and touches
-	// resources the caller tears down on shutdown. receive has returned, so no new
-	// timer can be armed past this point.
+	// receive has returned. Stop a pending timer and wait for any in-flight timer
+	// callback, then release and join the cancellation drainer, so no handleBatch
+	// runs after batchLoop returns and touches resources the caller tears down on
+	// shutdown. No new timer can be armed past this point.
 	mu.Lock()
 	if flushTimer != nil {
 		if flushTimer.Stop() {
@@ -326,9 +361,14 @@ func (s *psSubscriber[M]) batchLoop(
 	mu.Unlock()
 	timerWG.Wait()
 
-	// Drain any messages still buffered when receive returns so they are acked
-	// or nacked rather than silently dropped.
-	flush()
+	// On a cancelled shutdown the drainer already emptied the buffer while the
+	// iterator was alive, so closing stopDrainer is a no-op it never observes;
+	// joining it guarantees that drain completed. We deliberately do NOT flush
+	// here: on any non-cancellation return (e.g. a stream error) the iterator is
+	// torn down so ack/nack are no-ops, and flushing would only re-run handlers
+	// against messages pubsub will redeliver anyway.
+	close(stopDrainer)
+	<-drainerDone
 
 	if err != nil {
 		return fmt.Errorf("receive batch: %w", err)

--- a/infra/pkg/gcp/subscriber_test.go
+++ b/infra/pkg/gcp/subscriber_test.go
@@ -339,7 +339,7 @@ func TestBatchLoop_FlushesOnLatency(t *testing.T) {
 
 		// MaxMessages far above the two delivered messages so only the latency
 		// timer can trigger a flush.
-		settings := BatchReceiveSettings{MaxMessages: 100, MaxLatency: time.Second}
+		settings := BatchReceiveSettings{MaxMessages: 100, MaxBytes: 0, MaxLatency: time.Second}
 
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
@@ -378,6 +378,63 @@ func TestBatchLoop_FlushesOnLatency(t *testing.T) {
 	})
 }
 
+// TestBatchLoop_LatencyArmsOnFirstMessage proves the timer is armed when a
+// message starts a batch, not free-running from loop start: a message delivered
+// partway into the first latency window must still wait a full window measured
+// from its own arrival. A free-running ticker would have flushed it early.
+func TestBatchLoop_LatencyArmsOnFirstMessage(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+		data, err := proto.Marshal(&emptypb.Empty{})
+		require.NoError(t, err)
+
+		m1, c1 := newBatchMessage("msg-1", data, nil)
+
+		settings := BatchReceiveSettings{MaxMessages: 100, MaxBytes: 0, MaxLatency: time.Second}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		capt := &batchCapture{} //nolint:exhaustruct // zero values are the initial state under test
+
+		// Idle for 700ms before the first message, so the message arrives partway
+		// into the window a free-running ticker (started at loop start) would use.
+		receive := func(ctx context.Context, deliver func(incomingMessage)) error {
+			time.Sleep(700 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly; valid ONLY within synctest.Test
+			deliver(m1)
+			<-ctx.Done()
+			return nil
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.batchLoop(ctx, settings, receive, func(_ context.Context, _ []*emptypb.Empty, metas []MessageMetadata) error {
+				capt.record(metas)
+				return nil
+			})
+		}()
+
+		// Advance to 1.1s: past the window measured from loop start (1.0s) but
+		// before the window measured from the message at 700ms (1.7s). A ticker
+		// would have flushed here; the per-batch timer must not have.
+		time.Sleep(1100 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly; valid ONLY within synctest.Test
+		synctest.Wait()
+		require.Empty(t, capt.snapshot(), "timer should measure latency from the first message, not loop start")
+
+		// Advance past the message's own window (to ~1.8s) so the timer fires.
+		time.Sleep(700 * time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly; valid ONLY within synctest.Test
+		synctest.Wait()
+		require.Equal(t, [][]string{{"msg-1"}}, capt.snapshot(), "timer should flush a full window after the first message")
+		require.True(t, c1.isAcked())
+
+		cancel()
+		require.NoError(t, <-errCh)
+	})
+}
+
 // TestBatchLoop_FlushesOnSizeAndDrains proves the two non-timer flush paths: a
 // full buffer flushes inline, and whatever remains is drained when the source
 // returns. A huge MaxLatency keeps the ticker out of the picture.
@@ -398,7 +455,7 @@ func TestBatchLoop_FlushesOnSizeAndDrains(t *testing.T) {
 
 		// MaxLatency far in the future so only the size threshold and the final
 		// drain produce batches.
-		settings := BatchReceiveSettings{MaxMessages: 3, MaxLatency: time.Hour}
+		settings := BatchReceiveSettings{MaxMessages: 3, MaxBytes: 0, MaxLatency: time.Hour}
 
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
@@ -438,6 +495,66 @@ func TestBatchLoop_FlushesOnSizeAndDrains(t *testing.T) {
 	})
 }
 
+// TestBatchLoop_FlushesOnBytes proves the byte-size trigger: with MaxMessages
+// and MaxLatency kept out of reach, the buffer flushes precisely when the
+// accumulated payload size reaches MaxBytes, and the remainder drains on
+// shutdown.
+func TestBatchLoop_FlushesOnBytes(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+		// Four bytes of valid wire format that decode as an Empty (the bytes are
+		// retained as unknown fields), so each message has a non-zero size for the
+		// byte trigger to accumulate.
+		data := []byte{0x08, 0x01, 0x10, 0x01}
+		require.NoError(t, proto.Unmarshal(data, &emptypb.Empty{}))
+
+		m1, c1 := newBatchMessage("msg-1", data, nil)
+		m2, c2 := newBatchMessage("msg-2", data, nil)
+		m3, c3 := newBatchMessage("msg-3", data, nil)
+
+		// MaxBytes flushes once two 4-byte payloads (8 bytes) buffer. MaxMessages
+		// and MaxLatency are kept out of reach so only the byte trigger fires.
+		settings := BatchReceiveSettings{MaxMessages: 100, MaxBytes: 8, MaxLatency: time.Hour}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		capt := &batchCapture{} //nolint:exhaustruct // zero values are the initial state under test
+
+		receive := func(ctx context.Context, deliver func(incomingMessage)) error {
+			deliver(m1)
+			deliver(m2)
+			deliver(m3)
+			<-ctx.Done()
+			return nil
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.batchLoop(ctx, settings, receive, func(_ context.Context, _ []*emptypb.Empty, metas []MessageMetadata) error {
+				capt.record(metas)
+				return nil
+			})
+		}()
+
+		// m1 (4 bytes) stays under the threshold; m2 brings the buffer to 8 bytes
+		// and flushes the pair inline. m3 remains buffered.
+		synctest.Wait()
+		require.Equal(t, [][]string{{"msg-1", "msg-2"}}, capt.snapshot(), "buffer should flush once payloads reach MaxBytes")
+		require.True(t, c1.isAcked())
+		require.True(t, c2.isAcked())
+
+		// Cancelling ends the source; batchLoop drains the sub-threshold remainder.
+		cancel()
+		require.NoError(t, <-errCh)
+		require.Equal(t, [][]string{{"msg-1", "msg-2"}, {"msg-3"}}, capt.snapshot(), "remaining message should drain on shutdown")
+		require.True(t, c3.isAcked())
+	})
+}
+
 // TestBatchLoop_NoFlushWhenIdle confirms the latency ticker does not invoke the
 // handler when nothing is buffered.
 func TestBatchLoop_NoFlushWhenIdle(t *testing.T) {
@@ -446,7 +563,7 @@ func TestBatchLoop_NoFlushWhenIdle(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		s := newPanicSubscriber(slog.New(slog.DiscardHandler))
 
-		settings := BatchReceiveSettings{MaxMessages: 10, MaxLatency: time.Second}
+		settings := BatchReceiveSettings{MaxMessages: 10, MaxBytes: 0, MaxLatency: time.Second}
 
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()

--- a/infra/pkg/gcp/subscriber_test.go
+++ b/infra/pkg/gcp/subscriber_test.go
@@ -3,10 +3,13 @@ package gcp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -32,6 +35,12 @@ func (c *captureMessage) onNack() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.nacked = true
+}
+
+func (c *captureMessage) isAcked() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.acked
 }
 
 func newPanicSubscriber(logger *slog.Logger) *psSubscriber[*emptypb.Empty] {
@@ -137,6 +146,333 @@ func TestHandle_SuccessIsAckedOnly(t *testing.T) {
 	require.False(t, cap.nacked, "message should not be nacked on success")
 	require.Equal(t, "msg-ok", gotMeta.ID)
 	require.Equal(t, map[string]string{"k": "v"}, gotMeta.Attributes)
+}
+
+// newBatchMessage builds an incomingMessage wired to its own captureMessage so
+// per-message ack/nack can be asserted independently within a batch.
+func newBatchMessage(id string, data []byte, attributes map[string]string) (incomingMessage, *captureMessage) {
+	cap := &captureMessage{} //nolint:exhaustruct // zero values are the initial state under test
+	m := incomingMessage{
+		id:              id,
+		data:            data,
+		attributes:      attributes,
+		deliveryAttempt: nil,
+		ack:             cap.onAck,
+		nack:            cap.onNack,
+	}
+	return m, cap
+}
+
+func TestHandleBatch_SuccessAllAcked(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	m1, c1 := newBatchMessage("msg-1", data, map[string]string{"k": "1"})
+	m2, c2 := newBatchMessage("msg-2", data, map[string]string{"k": "2"})
+
+	var gotMetas []MessageMetadata
+	var gotLen int
+	s.handleBatch(t.Context(), []incomingMessage{m1, m2}, func(_ context.Context, msgs []*emptypb.Empty, metas []MessageMetadata) error {
+		gotLen = len(msgs)
+		gotMetas = metas
+		return nil
+	})
+
+	require.Equal(t, 2, gotLen, "handler should receive both messages")
+	require.Len(t, gotMetas, 2)
+	require.Equal(t, "msg-1", gotMetas[0].ID, "metadata should preserve batch order")
+	require.Equal(t, "msg-2", gotMetas[1].ID)
+	require.Equal(t, map[string]string{"k": "1"}, gotMetas[0].Attributes)
+
+	require.True(t, c1.acked)
+	require.True(t, c2.acked)
+	require.False(t, c1.nacked)
+	require.False(t, c2.nacked)
+}
+
+func TestHandleBatch_HandlerErrorAllNacked(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	m1, c1 := newBatchMessage("msg-1", data, nil)
+	m2, c2 := newBatchMessage("msg-2", data, nil)
+
+	s.handleBatch(t.Context(), []incomingMessage{m1, m2}, func(context.Context, []*emptypb.Empty, []MessageMetadata) error {
+		return errors.New("boom")
+	})
+
+	require.True(t, c1.nacked, "whole batch should be nacked on handler error")
+	require.True(t, c2.nacked)
+}
+
+func TestHandleBatch_BadMessageNackedIndividually(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	good1, cgood1 := newBatchMessage("msg-good-1", data, nil)
+	bad, cbad := newBatchMessage("msg-bad", []byte("not-a-valid-proto-wire-format-\xff\xff"), nil)
+	good2, cgood2 := newBatchMessage("msg-good-2", data, nil)
+
+	var gotIDs []string
+	s.handleBatch(t.Context(), []incomingMessage{good1, bad, good2}, func(_ context.Context, _ []*emptypb.Empty, metas []MessageMetadata) error {
+		for _, meta := range metas {
+			gotIDs = append(gotIDs, meta.ID)
+		}
+		return nil
+	})
+
+	require.Equal(t, []string{"msg-good-1", "msg-good-2"}, gotIDs, "bad message should be excluded from the batch")
+	require.True(t, cbad.nacked, "unmarshalable message should be nacked individually")
+	require.False(t, cbad.acked)
+	require.True(t, cgood1.acked, "valid messages should be acked")
+	require.True(t, cgood2.acked)
+	require.False(t, cgood1.nacked)
+	require.False(t, cgood2.nacked)
+}
+
+func TestHandleBatch_PanicIsLoggedAndNacked(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		AddSource:   false,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: nil,
+	}))
+
+	s := newPanicSubscriber(logger)
+
+	data, err := proto.Marshal(&emptypb.Empty{})
+	require.NoError(t, err)
+
+	m1, c1 := newBatchMessage("msg-1", data, nil)
+	m2, c2 := newBatchMessage("msg-2", data, nil)
+
+	s.handleBatch(t.Context(), []incomingMessage{m1, m2}, func(context.Context, []*emptypb.Empty, []MessageMetadata) error {
+		panic("boom")
+	})
+
+	require.True(t, c1.nacked, "whole batch should be nacked after a panic")
+	require.True(t, c2.nacked)
+	require.True(t, c1.acked, "deferred ack still runs; pubsub first-call-wins makes it a no-op after nack")
+
+	logged := buf.String()
+	require.Contains(t, logged, "panic recovered while processing pubsub message batch")
+	require.Contains(t, logged, "boom")
+	require.Contains(t, logged, "msg-1")
+	require.Contains(t, logged, "batch_size=2")
+	require.Contains(t, logged, "stack=")
+	require.Contains(t, logged, "test.v1.TopicMessage")
+	require.Contains(t, logged, "test.v1.SubscriptionMarker")
+}
+
+func TestHandleBatch_AllBadMessagesHandlerNotCalled(t *testing.T) {
+	t.Parallel()
+
+	s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+	bad, cbad := newBatchMessage("msg-bad", []byte("not-a-valid-proto-wire-format-\xff\xff"), nil)
+
+	called := false
+	s.handleBatch(t.Context(), []incomingMessage{bad}, func(context.Context, []*emptypb.Empty, []MessageMetadata) error {
+		called = true
+		return nil
+	})
+
+	require.False(t, called, "handler should not run when no message unmarshals")
+	require.True(t, cbad.nacked)
+}
+
+// batchCapture records, in order, the message IDs handed to a batch handler so
+// tests can assert which messages flushed together. Safe for the handler to call
+// from the receive goroutine while the test goroutine reads snapshots.
+type batchCapture struct {
+	mu      sync.Mutex
+	batches [][]string
+}
+
+func (c *batchCapture) record(metas []MessageMetadata) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ids := make([]string, 0, len(metas))
+	for _, meta := range metas {
+		ids = append(ids, meta.ID)
+	}
+	c.batches = append(c.batches, ids)
+}
+
+func (c *batchCapture) snapshot() [][]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([][]string, len(c.batches))
+	copy(out, c.batches)
+	return out
+}
+
+// TestBatchLoop_FlushesOnLatency drives batchLoop with a synthetic source that
+// delivers a partial batch and then idles. Under synctest's fake clock the
+// latency ticker is the only thing that can flush it, so the test can prove the
+// timer path fires (and only after the window elapses) without real waiting.
+func TestBatchLoop_FlushesOnLatency(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+		data, err := proto.Marshal(&emptypb.Empty{})
+		require.NoError(t, err)
+
+		m1, c1 := newBatchMessage("msg-1", data, nil)
+		m2, c2 := newBatchMessage("msg-2", data, nil)
+
+		// MaxMessages far above the two delivered messages so only the latency
+		// timer can trigger a flush.
+		settings := BatchReceiveSettings{MaxMessages: 100, MaxLatency: time.Second}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		capt := &batchCapture{} //nolint:exhaustruct // zero values are the initial state under test
+
+		receive := func(ctx context.Context, deliver func(incomingMessage)) error {
+			deliver(m1)
+			deliver(m2)
+			<-ctx.Done()
+			return nil
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.batchLoop(ctx, settings, receive, func(_ context.Context, _ []*emptypb.Empty, metas []MessageMetadata) error {
+				capt.record(metas)
+				return nil
+			})
+		}()
+
+		// Both messages are buffered but the latency window has not elapsed, so
+		// nothing has flushed yet.
+		synctest.Wait()
+		require.Empty(t, capt.snapshot(), "partial batch should not flush before the latency window")
+
+		// Advance the fake clock past the window so the ticker flushes the batch.
+		time.Sleep(time.Second + 10*time.Millisecond) //nolint:forbidigo // GG013: advances the synctest fake clock instantly; valid ONLY within synctest.Test
+		synctest.Wait()
+		require.Equal(t, [][]string{{"msg-1", "msg-2"}}, capt.snapshot(), "latency timer should flush the buffered batch")
+		require.True(t, c1.isAcked())
+		require.True(t, c2.isAcked())
+
+		cancel()
+		require.NoError(t, <-errCh)
+	})
+}
+
+// TestBatchLoop_FlushesOnSizeAndDrains proves the two non-timer flush paths: a
+// full buffer flushes inline, and whatever remains is drained when the source
+// returns. A huge MaxLatency keeps the ticker out of the picture.
+func TestBatchLoop_FlushesOnSizeAndDrains(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+		data, err := proto.Marshal(&emptypb.Empty{})
+		require.NoError(t, err)
+
+		m1, c1 := newBatchMessage("msg-1", data, nil)
+		m2, c2 := newBatchMessage("msg-2", data, nil)
+		m3, c3 := newBatchMessage("msg-3", data, nil)
+		m4, c4 := newBatchMessage("msg-4", data, nil)
+		m5, c5 := newBatchMessage("msg-5", data, nil)
+
+		// MaxLatency far in the future so only the size threshold and the final
+		// drain produce batches.
+		settings := BatchReceiveSettings{MaxMessages: 3, MaxLatency: time.Hour}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		capt := &batchCapture{} //nolint:exhaustruct // zero values are the initial state under test
+
+		receive := func(ctx context.Context, deliver func(incomingMessage)) error {
+			for _, m := range []incomingMessage{m1, m2, m3, m4, m5} {
+				deliver(m)
+			}
+			<-ctx.Done()
+			return nil
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.batchLoop(ctx, settings, receive, func(_ context.Context, _ []*emptypb.Empty, metas []MessageMetadata) error {
+				capt.record(metas)
+				return nil
+			})
+		}()
+
+		// Delivering the third message hits MaxMessages and flushes inline; the
+		// fourth and fifth stay buffered.
+		synctest.Wait()
+		require.Equal(t, [][]string{{"msg-1", "msg-2", "msg-3"}}, capt.snapshot(), "a full buffer should flush inline")
+		require.True(t, c1.isAcked())
+		require.True(t, c2.isAcked())
+		require.True(t, c3.isAcked())
+
+		// Cancelling ends the source; batchLoop drains the remaining buffer.
+		cancel()
+		require.NoError(t, <-errCh)
+		require.Equal(t, [][]string{{"msg-1", "msg-2", "msg-3"}, {"msg-4", "msg-5"}}, capt.snapshot(), "remaining messages should drain when the source returns")
+		require.True(t, c4.isAcked())
+		require.True(t, c5.isAcked())
+	})
+}
+
+// TestBatchLoop_NoFlushWhenIdle confirms the latency ticker does not invoke the
+// handler when nothing is buffered.
+func TestBatchLoop_NoFlushWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+		settings := BatchReceiveSettings{MaxMessages: 10, MaxLatency: time.Second}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		var calls int
+		receive := func(ctx context.Context, _ func(incomingMessage)) error {
+			<-ctx.Done()
+			return nil
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.batchLoop(ctx, settings, receive, func(context.Context, []*emptypb.Empty, []MessageMetadata) error {
+				calls++
+				return nil
+			})
+		}()
+
+		// Let several latency windows elapse with an empty buffer.
+		time.Sleep(5 * time.Second) //nolint:forbidigo // GG013: advances the synctest fake clock instantly; valid ONLY within synctest.Test
+		synctest.Wait()
+		require.Zero(t, calls, "ticker should not invoke the handler when nothing is buffered")
+
+		cancel()
+		require.NoError(t, <-errCh)
+	})
 }
 
 func TestHandle_DeliveryAttemptOmittedWhenNil(t *testing.T) {

--- a/infra/pkg/gcp/subscriber_test.go
+++ b/infra/pkg/gcp/subscriber_test.go
@@ -592,6 +592,134 @@ func TestBatchLoop_NoFlushWhenIdle(t *testing.T) {
 	})
 }
 
+// TestBatchLoop_DrainsOnCancelBeforeReceiveReturns proves the cancellation drain
+// runs while the delivery source is still in flight, not after it returns. The
+// source mirrors Subscriber.Receive's graceful shutdown: it parks in receive
+// after ctx is cancelled and only returns once the test releases it. With a
+// 1h MaxLatency the timer cannot flush, so the batch can only be flushed and
+// acked by the on-cancel drainer — and the test asserts that happens before the
+// source is allowed to return. Draining after receive returned (the pre-fix
+// behaviour) would leave the batch un-flushed here.
+func TestBatchLoop_DrainsOnCancelBeforeReceiveReturns(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+		data, err := proto.Marshal(&emptypb.Empty{})
+		require.NoError(t, err)
+
+		m1, c1 := newBatchMessage("msg-1", data, nil)
+		m2, c2 := newBatchMessage("msg-2", data, nil)
+
+		// MaxMessages and MaxLatency far out of reach so only the cancellation
+		// drain can flush the buffered pair.
+		settings := BatchReceiveSettings{MaxMessages: 100, MaxBytes: 0, MaxLatency: time.Hour}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		capt := &batchCapture{} //nolint:exhaustruct // zero values are the initial state under test
+
+		releaseReceive := make(chan struct{})
+		receive := func(ctx context.Context, deliver func(incomingMessage)) error {
+			deliver(m1)
+			deliver(m2)
+			<-ctx.Done()
+			// Stay inside receive until the test lets us return, the way the SDK's
+			// graceful shutdown blocks on outstanding messages.
+			<-releaseReceive
+			return nil
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.batchLoop(ctx, settings, receive, func(_ context.Context, _ []*emptypb.Empty, metas []MessageMetadata) error {
+				capt.record(metas)
+				return nil
+			})
+		}()
+
+		synctest.Wait()
+		require.Empty(t, capt.snapshot(), "nothing should flush before cancel with an hour-long latency window")
+
+		cancel()
+		synctest.Wait()
+		// receive is still parked on releaseReceive, yet the batch is already
+		// flushed and acked: the drain ran inside the live receive lifecycle.
+		require.Equal(t, [][]string{{"msg-1", "msg-2"}}, capt.snapshot(), "cancellation should drain the batch while receive is still in flight")
+		require.True(t, c1.isAcked())
+		require.True(t, c2.isAcked())
+
+		close(releaseReceive)
+		require.NoError(t, <-errCh)
+	})
+}
+
+// TestBatchLoop_FlushesInlineWhileDraining proves messages the source keeps
+// delivering during graceful shutdown are flushed inline rather than parked
+// behind the latency timer. With a 1h MaxLatency, a message delivered after
+// cancellation could only be acked promptly if draining forces an immediate
+// flush.
+func TestBatchLoop_FlushesInlineWhileDraining(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		s := newPanicSubscriber(slog.New(slog.DiscardHandler))
+
+		data, err := proto.Marshal(&emptypb.Empty{})
+		require.NoError(t, err)
+
+		m1, c1 := newBatchMessage("msg-1", data, nil)
+		m2, c2 := newBatchMessage("msg-2", data, nil)
+
+		settings := BatchReceiveSettings{MaxMessages: 100, MaxBytes: 0, MaxLatency: time.Hour}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		capt := &batchCapture{} //nolint:exhaustruct // zero values are the initial state under test
+
+		releaseReceive := make(chan struct{})
+		receive := func(ctx context.Context, deliver func(incomingMessage)) error {
+			deliver(m1)
+			<-ctx.Done()
+			// The SDK scheduler can hand over an already-pulled message during
+			// graceful shutdown; this one must not wait out MaxLatency.
+			deliver(m2)
+			<-releaseReceive
+			return nil
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.batchLoop(ctx, settings, receive, func(_ context.Context, _ []*emptypb.Empty, metas []MessageMetadata) error {
+				capt.record(metas)
+				return nil
+			})
+		}()
+
+		synctest.Wait()
+		require.Empty(t, capt.snapshot(), "nothing should flush before cancel")
+
+		cancel()
+		synctest.Wait()
+		// Both the pre-cancel buffer (m1) and the post-cancel delivery (m2) are
+		// acked while receive is still parked, despite the hour-long latency window.
+		require.True(t, c1.isAcked(), "buffered message should drain on cancel")
+		require.True(t, c2.isAcked(), "message delivered during drain should flush inline, not wait for MaxLatency")
+
+		var got []string
+		for _, batch := range capt.snapshot() {
+			got = append(got, batch...)
+		}
+		require.ElementsMatch(t, []string{"msg-1", "msg-2"}, got, "both messages should be flushed during shutdown")
+
+		close(releaseReceive)
+		require.NoError(t, <-errCh)
+	})
+}
+
 func TestHandle_DeliveryAttemptOmittedWhenNil(t *testing.T) {
 	t.Parallel()
 

--- a/infra/pkg/gcp/subscriber_test.go
+++ b/infra/pkg/gcp/subscriber_test.go
@@ -502,5 +502,5 @@ func TestHandle_DeliveryAttemptOmittedWhenNil(t *testing.T) {
 	})
 
 	require.True(t, cap.nacked)
-	require.True(t, strings.Contains(buf.String(), "delivery_attempt=0"), "nil delivery attempt should log as 0")
+	require.True(t, strings.Contains(buf.String(), "delivery_attempt=-1"), "nil delivery attempt should log as the -1 sentinel")
 }

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -361,3 +361,106 @@ func mustReceive[M proto.Message](
 ) {
 	must.Nil(receive(g, msg, subscription, handler, options...))
 }
+
+// receiveBatch is the batch counterpart to receive: it registers a
+// streams.BatchHandler that processes messages in groups. It is part of the
+// streams runner surface so consumers can opt into batch processing; register
+// one with mustReceiveBatch in the receivers block alongside the single-message
+// handlers.
+//
+//nolint:unused // wiring kept available for batch consumers registered later
+func receiveBatch[M proto.Message](
+	g receiverGroup,
+	msg M,
+	subscription proto.Message,
+	settings gcp.BatchReceiveSettings,
+	handler streams.BatchHandler[M],
+	options ...gcp.SubscriberOption,
+) error {
+	ctx := g.getContext()
+	// Prepend so callers can still override the logger via options if needed.
+	options = append([]gcp.SubscriberOption{gcp.WithSubscriberLogger(g.logger)}, options...)
+	sub, err := gcp.PubSubSubscriberForMessage(ctx, g.broker, msg, subscription, options...)
+	if err != nil {
+		return fmt.Errorf("get subscriber for message %T: %T: %w", subscription, msg, err)
+	}
+
+	msgName := proto.MessageName(msg)
+	if !msgName.IsValid() {
+		return fmt.Errorf("invalid proto message name: %T: %s", msg, msgName)
+	}
+
+	subName := proto.MessageName(subscription)
+	if !subName.IsValid() {
+		return fmt.Errorf("invalid proto message name: %T: %s", subscription, subName)
+	}
+
+	ctx = contextvalues.SetPubSubSubscriberContext(ctx, contextvalues.PubSubSubscriberContext{
+		TopicProtoName:        string(msgName),
+		SubscriptionProtoName: string(subName),
+	})
+
+	g.group.Go(func() error {
+		if err := sub.ReceiveBatch(ctx, settings, func(ctx context.Context, msgs []M, metas []gcp.MessageMetadata) (err error) {
+			// Unlike the single-message path we do not extract per-message trace
+			// context: a batch can aggregate messages from different producer
+			// traces, so there is no single parent span to continue. Start a fresh
+			// span for the batch instead.
+			ctx, span := g.tracer.Start(ctx, "stream.handleBatch", trace.WithAttributes(
+				attr.TopicProtoName(msgName),
+				attr.SubscriptionProtoName(subName),
+				attr.PubSubBatchSize(int64(len(msgs))),
+			))
+
+			defer func() {
+				if err != nil {
+					span.RecordError(err)
+					span.SetStatus(codes.Error, err.Error())
+				}
+				span.End()
+			}()
+
+			// Recover from panics in the handler so a single bad batch returns an
+			// error (triggering a nack and eventual dead-lettering) instead of
+			// crashing the receive goroutine. Registered after the span defer so it
+			// runs first and sets err before the span records it.
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic recovered in batch message handler: %v", r)
+					g.logger.ErrorContext(ctx, "panic recovered in batch message handler",
+						attr.SlogError(err),
+						attr.SlogErrorStack(string(debug.Stack())),
+					)
+				}
+			}()
+
+			err = handler.HandleBatch(ctx, msgs, metas)
+			switch {
+			case err == nil:
+				return nil
+			case errors.Is(err, context.Canceled):
+				return nil
+			default:
+				return fmt.Errorf("handle message batch: %w", err)
+			}
+		}); err != nil {
+			return fmt.Errorf("subscriber receive batch error: %w", err)
+		}
+
+		return nil
+	})
+
+	return nil
+}
+
+//nolint:unused // registration helper for batch consumers added later
+func mustReceiveBatch[M proto.Message](
+	g receiverGroup,
+	msg M,
+	subscription proto.Message,
+	settings gcp.BatchReceiveSettings,
+	handler streams.BatchHandler[M],
+	options ...gcp.SubscriberOption,
+) {
+	must.Nil(receiveBatch(g, msg, subscription, settings, handler, options...))
+}

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -2,7 +2,6 @@ package gram
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -17,6 +16,7 @@ import (
 	"go.temporal.io/sdk/client"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/speakeasy-api/gram/infra/gen"
 	pingv2 "github.com/speakeasy-api/gram/infra/gen/gram/ping/v2"
@@ -265,6 +265,44 @@ type receiverGroup struct {
 	broker     gcp.SubscriberBroker
 }
 
+// setupSubscriber resolves the subscriber for a message/subscription pair and
+// stamps the shared pubsub subscriber context. It holds the prologue common to
+// receive and receiveBatch so the wiring (logger option, name validation,
+// context values) cannot drift between the single-message and batch paths. The
+// returned msgName/subName are validated proto message names for use as
+// span/log attributes.
+func setupSubscriber[M proto.Message](
+	g receiverGroup,
+	msg M,
+	subscription proto.Message,
+	options ...gcp.SubscriberOption,
+) (sub gcp.Subscriber[M], msgName, subName protoreflect.FullName, ctx context.Context, err error) {
+	ctx = g.getContext()
+	// Prepend so callers can still override the logger via options if needed.
+	options = append([]gcp.SubscriberOption{gcp.WithSubscriberLogger(g.logger)}, options...)
+	sub, err = gcp.PubSubSubscriberForMessage(ctx, g.broker, msg, subscription, options...)
+	if err != nil {
+		return nil, "", "", nil, fmt.Errorf("get subscriber for message %T: %T: %w", subscription, msg, err)
+	}
+
+	msgName = proto.MessageName(msg)
+	if !msgName.IsValid() {
+		return nil, "", "", nil, fmt.Errorf("invalid proto message name: %T: %s", msg, msgName)
+	}
+
+	subName = proto.MessageName(subscription)
+	if !subName.IsValid() {
+		return nil, "", "", nil, fmt.Errorf("invalid proto message name: %T: %s", subscription, subName)
+	}
+
+	ctx = contextvalues.SetPubSubSubscriberContext(ctx, contextvalues.PubSubSubscriberContext{
+		TopicProtoName:        string(msgName),
+		SubscriptionProtoName: string(subName),
+	})
+
+	return sub, msgName, subName, ctx, nil
+}
+
 func receive[M proto.Message](
 	g receiverGroup,
 	msg M,
@@ -272,28 +310,10 @@ func receive[M proto.Message](
 	handler streams.Handler[M],
 	options ...gcp.SubscriberOption,
 ) error {
-	ctx := g.getContext()
-	// Prepend so callers can still override the logger via options if needed.
-	options = append([]gcp.SubscriberOption{gcp.WithSubscriberLogger(g.logger)}, options...)
-	sub, err := gcp.PubSubSubscriberForMessage(ctx, g.broker, msg, subscription, options...)
+	sub, msgName, subName, ctx, err := setupSubscriber(g, msg, subscription, options...)
 	if err != nil {
-		return fmt.Errorf("get subscriber for message %T: %T: %w", subscription, msg, err)
+		return err
 	}
-
-	msgName := proto.MessageName(msg)
-	if !msgName.IsValid() {
-		return fmt.Errorf("invalid proto message name: %T: %s", msg, msgName)
-	}
-
-	subName := proto.MessageName(subscription)
-	if !subName.IsValid() {
-		return fmt.Errorf("invalid proto message name: %T: %s", subscription, subName)
-	}
-
-	ctx = contextvalues.SetPubSubSubscriberContext(ctx, contextvalues.PubSubSubscriberContext{
-		TopicProtoName:        string(msgName),
-		SubscriptionProtoName: string(subName),
-	})
 
 	g.group.Go(func() error {
 		if err := sub.Receive(ctx, func(ctx context.Context, m M, meta gcp.MessageMetadata) (err error) {
@@ -333,15 +353,15 @@ func receive[M proto.Message](
 				}
 			}()
 
+			// A context.Canceled here means the handler was interrupted (e.g. by
+			// shutdown) before finishing, so the message was not processed. Return
+			// the error so it is nacked and redelivered rather than acked: mapping
+			// cancellation to success would silently drop the in-flight message.
 			err = handler.Handle(ctx, m, meta)
-			switch {
-			case err == nil:
-				return nil
-			case errors.Is(err, context.Canceled):
-				return nil
-			default:
+			if err != nil {
 				return fmt.Errorf("handle message: %w", err)
 			}
+			return nil
 		}); err != nil {
 			return fmt.Errorf("subscriber receive error: %w", err)
 		}
@@ -377,28 +397,10 @@ func receiveBatch[M proto.Message](
 	handler streams.BatchHandler[M],
 	options ...gcp.SubscriberOption,
 ) error {
-	ctx := g.getContext()
-	// Prepend so callers can still override the logger via options if needed.
-	options = append([]gcp.SubscriberOption{gcp.WithSubscriberLogger(g.logger)}, options...)
-	sub, err := gcp.PubSubSubscriberForMessage(ctx, g.broker, msg, subscription, options...)
+	sub, msgName, subName, ctx, err := setupSubscriber(g, msg, subscription, options...)
 	if err != nil {
-		return fmt.Errorf("get subscriber for message %T: %T: %w", subscription, msg, err)
+		return err
 	}
-
-	msgName := proto.MessageName(msg)
-	if !msgName.IsValid() {
-		return fmt.Errorf("invalid proto message name: %T: %s", msg, msgName)
-	}
-
-	subName := proto.MessageName(subscription)
-	if !subName.IsValid() {
-		return fmt.Errorf("invalid proto message name: %T: %s", subscription, subName)
-	}
-
-	ctx = contextvalues.SetPubSubSubscriberContext(ctx, contextvalues.PubSubSubscriberContext{
-		TopicProtoName:        string(msgName),
-		SubscriptionProtoName: string(subName),
-	})
 
 	g.group.Go(func() error {
 		if err := sub.ReceiveBatch(ctx, settings, func(ctx context.Context, msgs []M, metas []gcp.MessageMetadata) (err error) {
@@ -409,7 +411,7 @@ func receiveBatch[M proto.Message](
 			ctx, span := g.tracer.Start(ctx, "stream.handleBatch", trace.WithAttributes(
 				attr.TopicProtoName(msgName),
 				attr.SubscriptionProtoName(subName),
-				attr.PubSubBatchSize(int64(len(msgs))),
+				attr.SubscriberBatchSize(len(msgs)),
 			))
 
 			defer func() {
@@ -434,15 +436,16 @@ func receiveBatch[M proto.Message](
 				}
 			}()
 
+			// A context.Canceled here means the handler was interrupted (e.g. by
+			// shutdown) before finishing, so the batch was not fully processed.
+			// Return the error so the batch is nacked and redelivered rather than
+			// acked: mapping cancellation to success would silently drop every
+			// un-processed message in the batch.
 			err = handler.HandleBatch(ctx, msgs, metas)
-			switch {
-			case err == nil:
-				return nil
-			case errors.Is(err, context.Canceled):
-				return nil
-			default:
+			if err != nil {
 				return fmt.Errorf("handle message batch: %w", err)
 			}
+			return nil
 		}); err != nil {
 			return fmt.Errorf("subscriber receive batch error: %w", err)
 		}

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -106,6 +106,7 @@ const (
 
 	TopicProtoNameKey        = attribute.Key("gram.topic.proto_name")
 	SubscriptionProtoNameKey = attribute.Key("gram.subscription.proto_name")
+	PubSubBatchSizeKey       = attribute.Key("gram.pubsub.batch_size")
 
 	AssetIDKey                     = attribute.Key("gram.asset.id")
 	AssetURLKey                    = attribute.Key("gram.asset.url")
@@ -685,6 +686,9 @@ func SubscriptionProtoName[S ~string](v S) attribute.KeyValue {
 func SlogSubscriptionProtoName[S ~string](v S) slog.Attr {
 	return slog.String(string(SubscriptionProtoNameKey), string(v))
 }
+
+func PubSubBatchSize(v int64) attribute.KeyValue { return PubSubBatchSizeKey.Int64(v) }
+func SlogPubSubBatchSize(v int64) slog.Attr      { return slog.Int64(string(PubSubBatchSizeKey), v) }
 
 func AssetID(v string) attribute.KeyValue { return AssetIDKey.String(v) }
 func SlogAssetID(v string) slog.Attr      { return slog.String(string(AssetIDKey), v) }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -106,7 +106,7 @@ const (
 
 	TopicProtoNameKey        = attribute.Key("gram.topic.proto_name")
 	SubscriptionProtoNameKey = attribute.Key("gram.subscription.proto_name")
-	PubSubBatchSizeKey       = attribute.Key("gram.pubsub.batch_size")
+	SubscriberBatchSizeKey   = attribute.Key("gram.subscriber.batch_size")
 
 	AssetIDKey                     = attribute.Key("gram.asset.id")
 	AssetURLKey                    = attribute.Key("gram.asset.url")
@@ -687,8 +687,8 @@ func SlogSubscriptionProtoName[S ~string](v S) slog.Attr {
 	return slog.String(string(SubscriptionProtoNameKey), string(v))
 }
 
-func PubSubBatchSize(v int64) attribute.KeyValue { return PubSubBatchSizeKey.Int64(v) }
-func SlogPubSubBatchSize(v int64) slog.Attr      { return slog.Int64(string(PubSubBatchSizeKey), v) }
+func SubscriberBatchSize(v int) attribute.KeyValue { return SubscriberBatchSizeKey.Int(v) }
+func SlogSubscriberBatchSize(v int) slog.Attr      { return slog.Int(string(SubscriberBatchSizeKey), v) }
 
 func AssetID(v string) attribute.KeyValue { return AssetIDKey.String(v) }
 func SlogAssetID(v string) slog.Attr      { return slog.String(string(AssetIDKey), v) }

--- a/server/internal/streams/handlers.go
+++ b/server/internal/streams/handlers.go
@@ -15,3 +15,16 @@ type HandlerFunc[M any] func(context.Context, M, gcp.MessageMetadata) error
 func (f HandlerFunc[M]) Handle(ctx context.Context, msg M, meta gcp.MessageMetadata) error {
 	return f(ctx, msg, meta)
 }
+
+// BatchHandler processes a batch of messages at once. The metadata slice is
+// parallel to the message slice (one entry per message, same order). Returning
+// nil acks the whole batch; returning an error nacks the whole batch.
+type BatchHandler[M any] interface {
+	HandleBatch(context.Context, []M, []gcp.MessageMetadata) error
+}
+
+type BatchHandlerFunc[M any] func(context.Context, []M, []gcp.MessageMetadata) error
+
+func (f BatchHandlerFunc[M]) HandleBatch(ctx context.Context, msgs []M, metas []gcp.MessageMetadata) error {
+	return f(ctx, msgs, metas)
+}


### PR DESCRIPTION
## What

Adds batch-receive support to the GCP Pub/Sub subscriber library so consumers can process messages in groups instead of one at a time.

## Why

The existing single-message path acks one message per callback, capping throughput for consumers that can amortize work (DB writes, downstream calls) across many messages. `ReceiveBatch` lets a consumer flush once per batch.

## Changes

- **`infra/pkg/gcp/subscriber.go`** — new `Subscriber.ReceiveBatch(ctx, BatchReceiveSettings, fn)`. Buffers messages and flushes when `MaxMessages` are buffered or `MaxLatency` elapses, whichever comes first (defaults: 100 / 1s). Ack/nack is all-or-nothing per batch; messages that fail to unmarshal are nacked individually and excluded. Panics in the handler are recovered and nack the batch. Core buffering/flush/drain logic factored into `batchLoop` with the delivery source abstracted for testing.
- **`server/internal/streams/handlers.go`** — `BatchHandler[M]` interface + `BatchHandlerFunc` adapter.
- **`server/cmd/gram/streams.go`** — `receiveBatch` / `mustReceiveBatch` wiring. Starts a fresh span per batch (batches can span multiple producer traces) and recovers handler panics into a nack.
- **`infra/internal/attr` & `server/internal/attr`** — new telemetry attributes (`batch_size`, `subscriber.message_id`, `subscriber.delivery_attempt`).

## Tests

Unit tests cover all-acked success, handler-error/panic nacks, individual nack of unmarshalable messages, and the size/latency/drain flush paths (using `testing/synctest` fake clock for the latency timer).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds batch receive to the GCP Pub/Sub subscriber so consumers can process messages in size/latency/byte-bounded groups, cutting per-message acks and boosting throughput. Also hardens shutdown and cancellation: batches drain while the iterator is still alive and messages delivered during shutdown flush immediately.

- **New Features**
  - `Subscriber.ReceiveBatch(ctx, settings, fn)`: buffers and flushes at `MaxMessages`, `MaxBytes`, or `MaxLatency` (defaults: 100 / 1s); all-or-nothing ack/nack; unmarshal failures are nacked individually; panics are recovered; a per-batch latency timer is armed on the first message to avoid early/idle flushes; starts a fresh span per batch; docs call out the `MaxLatency` vs `MaxExtension` hazard and that `MaxBytes` is a trigger (memory is bounded by `MaxOutstandingBytes`).
  - `BatchHandler`/`BatchHandlerFunc` in `server/internal/streams`, plus `receiveBatch`/`mustReceiveBatch` in `server/cmd/gram`; shared setup via `setupSubscriber` to align context/logger; telemetry keys unified: `gram.subscriber.batch_size`, `gram.subscriber.message_id`, `gram.subscriber.delivery_attempt`.

- **Bug Fixes**
  - Nack on `context.Canceled` in single and batch paths.
  - Drain buffered batches on cancel while `Receive` is still running, and flush messages delivered during shutdown inline; stop and join in-flight latency timer callbacks before draining.
  - Serialize batch handler calls; recover panics around the whole unmarshal loop; skip empty flushes and avoid idle-buffer reallocations; log missing delivery attempts as `-1`.

<sup>Written for commit 81ce58d6ff3ee1386ee02abb5182c100b7dd906d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

