### PR TITLE
mig(risk): add user_id to tool_call_blocks

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3352,6 +3352,13 @@ CREATE TABLE IF NOT EXISTS tool_call_blocks (
   chat_id uuid,
   chat_message_id uuid,
 
+  -- The Gram user whose agent triggered the block, captured at deny time.
+  -- Used to authorize the durable block page (the owner may view their own
+  -- block). Stored directly rather than derived via chat_id so it is available
+  -- even when session capture is disabled and no chat row was persisted. Empty
+  -- string when the user could not be resolved at deny time.
+  user_id TEXT NOT NULL,
+
   feedback TEXT,
   feedback_user_id TEXT,
   feedback_at timestamptz,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1465,6 +1465,7 @@ type ToolCallBlock struct {
 	RiskResultID   uuid.NullUUID
 	ChatID         uuid.NullUUID
 	ChatMessageID  uuid.NullUUID
+	UserID         string
 	Feedback       pgtype.Text
 	FeedbackUserID pgtype.Text
 	FeedbackAt     pgtype.Timestamptz

--- a/server/migrations/20260626175057_add_user_id_to_tool_call_blocks.sql
+++ b/server/migrations/20260626175057_add_user_id_to_tool_call_blocks.sql
@@ -1,0 +1,2 @@
+-- Modify "tool_call_blocks" table
+ALTER TABLE "tool_call_blocks" ADD COLUMN "user_id" text NOT NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:XJwr1Q1aAWyI7F6x9XEXUcbGlJ6UcOwWjROdABFzCS8=
+h1:Vna/dRPf7u/IqdsO//gG8AvP+dQqKbJObBiyRKj00Kc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -231,3 +231,4 @@ h1:XJwr1Q1aAWyI7F6x9XEXUcbGlJ6UcOwWjROdABFzCS8=
 20260625174452_remote-session-clients-organization-id.sql h1:58GfJycQkGlaRJ0SVITo7f8+x+G9Vl7oRSHc4l5CpoU=
 20260626112524_tunnelled-mcp-servers.sql h1:GzNGqqfGvwSrCfPMbK5tU9orD2ZkobTkb1QzEQj+HFg=
 20260626152018_chats-add-pinned-at.sql h1:GeYCKutkPKW+wiILObCtoHI62pR60gSQhUelef/5xLc=
+20260626175057_add_user_id_to_tool_call_blocks.sql h1:+Mf+8EEzJOBLXgsupc+p4uJ+O7Mx871veaeEYyEAqHE=


### PR DESCRIPTION
## What

Adds a **NOT NULL** `user_id TEXT` column to `tool_call_blocks`, recording the Gram user whose agent triggered the block, captured at deny time (empty string when the user can't be resolved).

## Why

The durable tool-call block page (AIS-189) needs to authorize access on the owning user. Today the only link to a user is `chat_id` → `chats.user_id`, but the backing `chats` row is **only persisted when session capture is enabled**, so that derivation isn't guaranteed. Storing `user_id` directly on the block makes owner-based authorization reliable regardless of session observability.

## Why NOT NULL is safe here

The block **write path does not exist on `main`** (no `InsertToolCallBlock` query, no callers in the hooks) — it lands with the AIS-189 feature branch. So `tool_call_blocks` is empty in every deployed environment, and `ADD COLUMN ... NOT NULL` (no default) runs cleanly everywhere. This also gives the cleaner `UserID string` sqlc type instead of `pgtype.Text`.

## Scope

Migration-only, per repo convention:
- `schema.sql` — add the column (no FK, matching `chats.user_id`/`chat_messages.user_id`).
- atlas-generated migration + `atlas.sum`.
- `models.go` sqlc regen.

App code that populates and reads the column follows on the AIS-189 feature branch (`daviddanialy/ais-189-feat-add-durable-feedback-page-for-tool-call-blocks`).

Note: local `atlas migrate lint` couldn't run (dev scratch DB wasn't clean); CI runs it against a clean DB. The out-of-order and concurrent-index checks passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)