### PR TITLE
feat(plugins): show "unpublished changes" state on plugin detail page

### DIFF
--- a/.changeset/dno-329-plugin-publish-freshness.md
+++ b/.changeset/dno-329-plugin-publish-freshness.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Plugin detail now shows an explicit "Up to date" badge and surfaces the last-published time even when there are unpublished changes, rounding out the publish-freshness affordance.

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -658,9 +658,11 @@ function PublishStatusControl({
 }
 
 // Shows the published freshness of a connected project under the plugin
-// metadata: a dirty badge when there are unpublished changes, otherwise a muted
-// "Published <time> ago". Renders nothing when not connected or freshness is
-// unknown.
+// metadata: an explicit "Unpublished changes" vs "Up to date" badge, paired
+// with the last-published time. The timestamp shows in both states (it's still
+// useful to know when the last publish happened while there are pending
+// changes). Renders nothing when not connected, or when freshness is unknown
+// and there's no publish timestamp to show.
 function PublishFreshnessIndicator({
   publishStatus,
 }: {
@@ -668,26 +670,33 @@ function PublishFreshnessIndicator({
 }): JSX.Element | null {
   if (!publishStatus?.connected) return null;
 
-  if (publishStatus.upToDate === false) {
-    return (
-      <Badge variant="warning" className="mt-2">
-        Unpublished changes
-      </Badge>
-    );
-  }
+  // up_to_date is absent when freshness can't be determined (connection
+  // predates fingerprinting) — treat only the explicit booleans as known.
+  const hasUnpublishedChanges = publishStatus.upToDate === false;
+  const isUpToDate = publishStatus.upToDate === true;
 
-  if (publishStatus.lastPublishedAt) {
-    return (
-      <Type muted small className="mt-2 block">
-        Published{" "}
-        {formatDistanceToNow(publishStatus.lastPublishedAt, {
-          addSuffix: true,
-        })}
-      </Type>
-    );
-  }
+  const lastPublished = publishStatus.lastPublishedAt ? (
+    <Type muted small>
+      Published{" "}
+      {formatDistanceToNow(publishStatus.lastPublishedAt, {
+        addSuffix: true,
+      })}
+    </Type>
+  ) : null;
 
-  return null;
+  // Freshness unknown and nothing published yet — nothing meaningful to show.
+  if (!hasUnpublishedChanges && !isUpToDate && !lastPublished) return null;
+
+  return (
+    <Stack direction="horizontal" gap={2} align="center" className="mt-2">
+      {hasUnpublishedChanges ? (
+        <Badge variant="warning">Unpublished changes</Badge>
+      ) : isUpToDate ? (
+        <Badge variant="secondary">Up to date</Badge>
+      ) : null}
+      {lastPublished}
+    </Stack>
+  );
 }
 
 function PluginServerCard({


### PR DESCRIPTION
## What

Completes the **DNO-329** ticket — making it obvious on the plugin detail page when a plugin has changes that haven't been published yet (Adam's ask #3).

The core affordance — the "Unpublished changes" warning badge, the publish CTA that flips to a primary "Publish changes" button when dirty, and post-edit invalidation so the state appears immediately — already landed on `main` via #3690 (the DNO-328 API PR bundled the frontend) and #3691 (publish-on-add affordance). This PR adds the two remaining pieces of the ticket's "render up-to-date vs has-unpublished-changes, plus last-published time" requirement:

- **Explicit "Up to date" badge** when `up_to_date === true`, so the clean state is affirmative rather than just the absence of the warning badge.
- **Always surface the last-published time** — including while there are unpublished changes. Previously `Published <time> ago` only rendered in the up-to-date branch, so a dirty plugin showed no "when did I last publish" context.

Renders nothing when not connected, or when freshness is unknown (connection predates fingerprinting) and there's no publish timestamp.

## Touch points

- `client/dashboard/src/pages/plugins/PluginDetail.tsx` — `PublishFreshnessIndicator`.

## Acceptance

After adding/removing a server or editing metadata, plugin detail visibly shows "Unpublished changes" until published; once published it shows "Up to date" alongside the last-published time.

## Notes

GitHub publishing is off in local dev (`configured: false`), so the whole publish affordance is hidden locally — connected-state rendering is exercised on a GitHub-configured env (staging).

## Tests

`pnpm -F dashboard type-check` passes; `hk fix` (oxfmt) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)