### PR TITLE
fix: enable Continue on Detect step for category-level risk detectors

### DIFF
--- a/.changeset/fix-detect-step-category-level-detectors.md
+++ b/.changeset/fix-detect-step-category-level-detectors.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the risk policy creation Detect step so the Continue button enables when only category-level detectors (Prompt Injection, Shadow MCP, Destructive Tools, Destructive CLI Commands) are selected. These categories have no individual sub-rules, so the previous `hasEnabledDetector` check treated them as empty and kept Continue/Save disabled.

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -253,6 +253,16 @@ const HOOK_REQUIRED_CATEGORIES: Set<RuleCategory> = new Set([
   "destructive_tool",
 ]);
 
+/** Built-in detectors that run at the category level and have no individual
+ *  sub-rules in DETECTION_RULES (their rule list is intentionally empty).
+ *  Selecting one of these is enough to enable the policy on its own. */
+const CATEGORY_LEVEL_DETECTORS: Set<RuleCategory> = new Set([
+  "prompt_injection",
+  "shadow_mcp",
+  "destructive_tool",
+  "cli_destructive",
+]);
+
 /** One built-in detector as a toggleable card (Detect step). "Customize" opens
  *  a side-sheet to pick which rules in the category are active. */
 function DetectorCard({
@@ -1588,11 +1598,14 @@ function PolicyCenterContent() {
       ? selectedMessageTypes.size === 0
       : scopeInclude.trim() === "";
   // A standard policy needs at least one detector that will actually run: a
-  // custom rule, or a selected category with at least one of its rules enabled.
+  // custom rule, a category-level detector (no sub-rules to enable), or a
+  // selected category with at least one of its rules enabled.
   const hasEnabledDetector =
     selectedCustomRuleIds.size > 0 ||
-    [...selectedCategories].some((c) =>
-      DETECTION_RULES[c]?.some((r) => !r.hidden && !disabledRules.has(r.id)),
+    [...selectedCategories].some(
+      (c) =>
+        CATEGORY_LEVEL_DETECTORS.has(c) ||
+        DETECTION_RULES[c]?.some((r) => !r.hidden && !disabledRules.has(r.id)),
     );
   const continueDisabled =
     (wizardStep === 0 &&


### PR DESCRIPTION
## What

Fixes the risk policy creation **Detect** step where the **Continue** button stayed disabled unless one of the rule-backed categories (Secrets, Financial, PII, Government IDs, Healthcare, Off-Policy) was selected.

## Root cause

The `hasEnabledDetector` gate only counted a selected category as enabled if `DETECTION_RULES[c]` contained a non-hidden, non-disabled rule. The four category-level detectors — **Prompt Injection**, **Shadow MCP**, **Destructive Tools**, **Destructive CLI Commands** — have intentionally empty rule arrays (they run at the category level, no sub-rules), so `.some(...)` over `[]` always returned `false`. Selecting only those left Continue (and Save, which re-checks the same gate) disabled.

## Fix

Added a `CATEGORY_LEVEL_DETECTORS` set and treat a selected member as enabled in `hasEnabledDetector`. This covers both `continueDisabled` (step 0) and `saveDisabled` (free-jump path).

Used an explicit set rather than an "empty rule list = category-level" heuristic, since `custom` is also an empty array (handled separately via `selectedCustomRuleIds`).

## Testing

- `pnpm -F dashboard type-check` passes.
