### PR TITLE
fix(telemetry): bound Claude prompt correlation to stop activity timeouts

### DIFF
--- a/.changeset/fix-claude-prompt-correlation-timeout.md
+++ b/.changeset/fix-claude-prompt-correlation-timeout.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Claude Code prompt correlation no longer stalls on high-volume sessions. Previously a chat with a large backlog of unlinked prompts could exceed the correlation time budget and fail entirely, leaving prompts unlinked from their telemetry; correlation now bounds its work and drains the backlog incrementally so prompts stay reliably linked.

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -314,7 +314,7 @@ func (a *Activities) GenerateChatTitle(ctx context.Context, input activities.Gen
 	return a.generateChatTitle.Do(ctx, input)
 }
 
-func (a *Activities) CorrelateClaudePrompts(ctx context.Context, input activities.CorrelateClaudePromptsArgs) error {
+func (a *Activities) CorrelateClaudePrompts(ctx context.Context, input activities.CorrelateClaudePromptsArgs) (*activities.CorrelateClaudePromptsResult, error) {
 	return a.correlateClaudePrompts.Do(ctx, input)
 }
 

--- a/server/internal/background/activities/claude_prompt_correlation.go
+++ b/server/internal/background/activities/claude_prompt_correlation.go
@@ -117,17 +117,18 @@ func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePro
 		match, ok, err := c.findClaudeUserPromptMatch(ctx, args.ProjectID, args.ChatID, args.SessionID, message, cursor)
 		if err != nil {
 			if errors.Is(err, errClaudePromptCorrelationMatchTimeout) {
-				result.AfterMessageSeq = message.seq
 				// One slow ClickHouse query must not abort the run: that would
-				// leave the backlog unprocessed and, because a run is scheduled
-				// per prompt event, spin into a retry storm. Skip it and keep
-				// draining the rest.
+				// retry the whole workflow and can also leave us unable to know
+				// which telemetry event belongs to this message. Stop this pass
+				// without advancing cursors so a later scheduled run can retry
+				// the message without letting later messages reuse its event.
 				c.logger.WarnContext(ctx, "skipped Claude prompt correlation for message",
 					attr.SlogChatID(args.ChatID.String()),
 					attr.SlogMessageID(message.id.String()),
 					attr.SlogError(err),
 				)
-				continue
+				result.HasMore = false
+				break
 			}
 			return nil, fmt.Errorf("find Claude user prompt match: %w", err)
 		}

--- a/server/internal/background/activities/claude_prompt_correlation.go
+++ b/server/internal/background/activities/claude_prompt_correlation.go
@@ -62,45 +62,62 @@ func NewCorrelateClaudePrompts(logger *slog.Logger, db *pgxpool.Pool, chConn cli
 }
 
 type CorrelateClaudePromptsArgs struct {
-	ProjectID uuid.UUID
-	ChatID    uuid.UUID
-	SessionID string
+	ProjectID              uuid.UUID
+	ChatID                 uuid.UUID
+	SessionID              string
+	AfterMessageSeq        int64
+	AfterEventSequence     int64
+	AfterEventTimeUnixNano int64
 }
 
 type CorrelateClaudePromptsResult struct {
-	HasMore bool
+	HasMore                bool
+	AfterMessageSeq        int64
+	AfterEventSequence     int64
+	AfterEventTimeUnixNano int64
 }
 
 type claudeUnlinkedUserMessage struct {
 	id        uuid.UUID
+	seq       int64
 	content   string
 	createdAt time.Time
 }
 
 func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePromptsArgs) (*CorrelateClaudePromptsResult, error) {
-	messages, hasMore, err := c.listUnlinkedUserMessages(ctx, args.ProjectID, args.ChatID)
+	messages, hasMore, err := c.listUnlinkedUserMessages(ctx, args.ProjectID, args.ChatID, args.AfterMessageSeq)
 	if err != nil {
 		return nil, fmt.Errorf("list unlinked Claude user messages: %w", err)
 	}
+	result := &CorrelateClaudePromptsResult{
+		HasMore:                hasMore,
+		AfterMessageSeq:        args.AfterMessageSeq,
+		AfterEventSequence:     args.AfterEventSequence,
+		AfterEventTimeUnixNano: args.AfterEventTimeUnixNano,
+	}
 	if len(messages) == 0 {
-		return &CorrelateClaudePromptsResult{HasMore: hasMore}, nil
+		return result, nil
 	}
 
 	deadline, hasDeadline := ctx.Deadline()
 
-	var cursor claudePromptCorrelationCursor
-	for idx, message := range messages {
+	cursor := claudePromptCorrelationCursor{
+		eventSequence: args.AfterEventSequence,
+		timeUnixNano:  args.AfterEventTimeUnixNano,
+	}
+	for _, message := range messages {
 		// Stop before the activity deadline so a partially drained backlog
 		// completes successfully and the remainder is picked up by a later run,
 		// rather than the whole activity failing and re-running from scratch.
-		if hasDeadline && time.Until(deadline) <= claudePromptCorrelationMatchTimeout {
-			hasMore = hasMore || idx < len(messages)
+		if hasDeadline && time.Until(deadline) <= c.matchTimeout {
+			result.HasMore = true
 			break
 		}
 
 		match, ok, err := c.findClaudeUserPromptMatch(ctx, args.ProjectID, args.ChatID, args.SessionID, message, cursor)
 		if err != nil {
 			if errors.Is(err, errClaudePromptCorrelationMatchTimeout) {
+				result.AfterMessageSeq = message.seq
 				// One slow ClickHouse query must not abort the run: that would
 				// leave the backlog unprocessed and, because a run is scheduled
 				// per prompt event, spin into a retry storm. Skip it and keep
@@ -114,6 +131,7 @@ func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePro
 			}
 			return nil, fmt.Errorf("find Claude user prompt match: %w", err)
 		}
+		result.AfterMessageSeq = message.seq
 		if !ok {
 			continue
 		}
@@ -123,16 +141,19 @@ func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePro
 		}
 		cursor.eventSequence = match.EventSequence
 		cursor.timeUnixNano = match.TimeUnixNano
+		result.AfterEventSequence = match.EventSequence
+		result.AfterEventTimeUnixNano = match.TimeUnixNano
 	}
 
-	return &CorrelateClaudePromptsResult{HasMore: hasMore}, nil
+	return result, nil
 }
 
-func (c *CorrelateClaudePrompts) listUnlinkedUserMessages(ctx context.Context, projectID uuid.UUID, chatID uuid.UUID) ([]claudeUnlinkedUserMessage, bool, error) {
+func (c *CorrelateClaudePrompts) listUnlinkedUserMessages(ctx context.Context, projectID uuid.UUID, chatID uuid.UUID, afterMessageSeq int64) ([]claudeUnlinkedUserMessage, bool, error) {
 	rows, err := c.store.ListUnlinkedClaudeUserMessagesForCorrelation(ctx, activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams{
-		ChatID:     chatID,
-		ProjectID:  conv.ToNullUUID(projectID),
-		LimitCount: claudePromptCorrelationMessageBatchSize + 1,
+		ChatID:          chatID,
+		ProjectID:       conv.ToNullUUID(projectID),
+		AfterMessageSeq: afterMessageSeq,
+		LimitCount:      claudePromptCorrelationMessageBatchSize + 1,
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("query unlinked user messages: %w", err)
@@ -147,6 +168,7 @@ func (c *CorrelateClaudePrompts) listUnlinkedUserMessages(ctx context.Context, p
 	for _, row := range rows {
 		messages = append(messages, claudeUnlinkedUserMessage{
 			id:        row.ID,
+			seq:       row.Seq,
 			content:   row.Content,
 			createdAt: row.CreatedAt.Time,
 		})

--- a/server/internal/background/activities/claude_prompt_correlation.go
+++ b/server/internal/background/activities/claude_prompt_correlation.go
@@ -22,6 +22,17 @@ const (
 	claudePromptCorrelationMinSimilarity  = 0.95
 	claudePromptCorrelationMinScoreGap    = 0.02
 	claudePromptCorrelationMaxTimeDelta   = 10 * time.Minute
+
+	// claudePromptCorrelationLookback bounds how far back unlinked messages are
+	// considered. It comfortably exceeds claudePromptCorrelationMaxTimeDelta plus
+	// telemetry ingestion lag, so a message older than this can no longer match a
+	// prompt and re-scanning it on every run would be wasted work.
+	claudePromptCorrelationLookback = 1 * time.Hour
+
+	// claudePromptCorrelationMatchTimeout bounds the ClickHouse candidate query
+	// for a single message so one slow query cannot consume the whole activity
+	// budget.
+	claudePromptCorrelationMatchTimeout = 5 * time.Second
 )
 
 type CorrelateClaudePrompts struct {
@@ -59,18 +70,41 @@ func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePro
 		return nil
 	}
 
+	deadline, hasDeadline := ctx.Deadline()
+
 	var cursor claudePromptCorrelationCursor
 	for _, message := range messages {
+		// Stop before the activity deadline so a partially drained backlog
+		// completes successfully and the remainder is picked up by a later run,
+		// rather than the whole activity failing and re-running from scratch.
+		if hasDeadline && time.Until(deadline) <= claudePromptCorrelationMatchTimeout {
+			break
+		}
+
 		match, ok, err := c.findClaudeUserPromptMatch(ctx, args.ProjectID, args.ChatID, args.SessionID, message, cursor)
 		if err != nil {
-			return fmt.Errorf("find Claude user prompt match: %w", err)
+			// One message's correlation failing (typically a slow ClickHouse
+			// query) must not abort the run: that would leave the backlog
+			// unprocessed and, because a run is scheduled per prompt event, spin
+			// into a retry storm. Skip it and keep draining the rest.
+			c.logger.WarnContext(ctx, "skipped Claude prompt correlation for message",
+				attr.SlogChatID(args.ChatID.String()),
+				attr.SlogMessageID(message.id.String()),
+				attr.SlogError(err),
+			)
+			continue
 		}
 		if !ok {
 			continue
 		}
 
 		if err := c.backfillMessagePromptID(ctx, args.ProjectID, args.ChatID, message.id, match.PromptID); err != nil {
-			return fmt.Errorf("backfill Claude prompt ID: %w", err)
+			c.logger.WarnContext(ctx, "skipped Claude prompt id backfill for message",
+				attr.SlogChatID(args.ChatID.String()),
+				attr.SlogMessageID(message.id.String()),
+				attr.SlogError(err),
+			)
+			continue
 		}
 		cursor.eventSequence = match.EventSequence
 		cursor.timeUnixNano = match.TimeUnixNano
@@ -81,8 +115,9 @@ func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePro
 
 func (c *CorrelateClaudePrompts) listUnlinkedUserMessages(ctx context.Context, projectID uuid.UUID, chatID uuid.UUID) ([]claudeUnlinkedUserMessage, error) {
 	rows, err := activitiesrepo.New(c.db).ListUnlinkedClaudeUserMessagesForCorrelation(ctx, activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams{
-		ChatID:    chatID,
-		ProjectID: conv.ToNullUUID(projectID),
+		ChatID:       chatID,
+		ProjectID:    conv.ToNullUUID(projectID),
+		CreatedAfter: conv.ToPGTimestamptz(time.Now().Add(-claudePromptCorrelationLookback)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("query unlinked user messages: %w", err)
@@ -119,7 +154,10 @@ func (c *CorrelateClaudePrompts) findClaudeUserPromptMatch(
 		return noMatch, false, nil
 	}
 
-	candidates, err := telemetryrepo.New(c.chConn).ListClaudeUserPromptCandidatesForCorrelation(ctx, telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams{
+	queryCtx, cancel := context.WithTimeout(ctx, claudePromptCorrelationMatchTimeout)
+	defer cancel()
+
+	candidates, err := telemetryrepo.New(c.chConn).ListClaudeUserPromptCandidatesForCorrelation(queryCtx, telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams{
 		GramProjectID:          projectID.String(),
 		GramChatID:             chatID.String(),
 		SessionID:              sessionID,

--- a/server/internal/background/activities/claude_prompt_correlation.go
+++ b/server/internal/background/activities/claude_prompt_correlation.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -23,11 +24,9 @@ const (
 	claudePromptCorrelationMinScoreGap    = 0.02
 	claudePromptCorrelationMaxTimeDelta   = 10 * time.Minute
 
-	// claudePromptCorrelationLookback bounds how far back unlinked messages are
-	// considered. It comfortably exceeds claudePromptCorrelationMaxTimeDelta plus
-	// telemetry ingestion lag, so a message older than this can no longer match a
-	// prompt and re-scanning it on every run would be wasted work.
-	claudePromptCorrelationLookback = 1 * time.Hour
+	// Fetch one extra row to detect whether the workflow should immediately run
+	// another bounded drain pass.
+	claudePromptCorrelationMessageBatchSize = 25
 
 	// claudePromptCorrelationMatchTimeout bounds the ClickHouse candidate query
 	// for a single message so one slow query cannot consume the whole activity
@@ -35,17 +34,30 @@ const (
 	claudePromptCorrelationMatchTimeout = 5 * time.Second
 )
 
+var errClaudePromptCorrelationMatchTimeout = errors.New("claude prompt correlation match timed out")
+
+type claudePromptCorrelationStore interface {
+	ListUnlinkedClaudeUserMessagesForCorrelation(context.Context, activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams) ([]activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow, error)
+	BackfillClaudeUserMessagePromptID(context.Context, activitiesrepo.BackfillClaudeUserMessagePromptIDParams) error
+}
+
+type claudePromptCorrelationTelemetry interface {
+	ListClaudeUserPromptCandidatesForCorrelation(context.Context, telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams) ([]telemetryrepo.ClaudeUserPromptCandidate, error)
+}
+
 type CorrelateClaudePrompts struct {
-	logger *slog.Logger
-	db     *pgxpool.Pool
-	chConn clickhouse.Conn
+	logger       *slog.Logger
+	store        claudePromptCorrelationStore
+	telemetry    claudePromptCorrelationTelemetry
+	matchTimeout time.Duration
 }
 
 func NewCorrelateClaudePrompts(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn) *CorrelateClaudePrompts {
 	return &CorrelateClaudePrompts{
-		logger: logger.With(attr.SlogComponent("correlate_claude_prompts")),
-		db:     db,
-		chConn: chConn,
+		logger:       logger.With(attr.SlogComponent("correlate_claude_prompts")),
+		store:        activitiesrepo.New(db),
+		telemetry:    telemetryrepo.New(chConn),
+		matchTimeout: claudePromptCorrelationMatchTimeout,
 	}
 }
 
@@ -55,72 +67,80 @@ type CorrelateClaudePromptsArgs struct {
 	SessionID string
 }
 
+type CorrelateClaudePromptsResult struct {
+	HasMore bool
+}
+
 type claudeUnlinkedUserMessage struct {
 	id        uuid.UUID
 	content   string
 	createdAt time.Time
 }
 
-func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePromptsArgs) error {
-	messages, err := c.listUnlinkedUserMessages(ctx, args.ProjectID, args.ChatID)
+func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePromptsArgs) (*CorrelateClaudePromptsResult, error) {
+	messages, hasMore, err := c.listUnlinkedUserMessages(ctx, args.ProjectID, args.ChatID)
 	if err != nil {
-		return fmt.Errorf("list unlinked Claude user messages: %w", err)
+		return nil, fmt.Errorf("list unlinked Claude user messages: %w", err)
 	}
 	if len(messages) == 0 {
-		return nil
+		return &CorrelateClaudePromptsResult{HasMore: hasMore}, nil
 	}
 
 	deadline, hasDeadline := ctx.Deadline()
 
 	var cursor claudePromptCorrelationCursor
-	for _, message := range messages {
+	for idx, message := range messages {
 		// Stop before the activity deadline so a partially drained backlog
 		// completes successfully and the remainder is picked up by a later run,
 		// rather than the whole activity failing and re-running from scratch.
 		if hasDeadline && time.Until(deadline) <= claudePromptCorrelationMatchTimeout {
+			hasMore = hasMore || idx < len(messages)
 			break
 		}
 
 		match, ok, err := c.findClaudeUserPromptMatch(ctx, args.ProjectID, args.ChatID, args.SessionID, message, cursor)
 		if err != nil {
-			// One message's correlation failing (typically a slow ClickHouse
-			// query) must not abort the run: that would leave the backlog
-			// unprocessed and, because a run is scheduled per prompt event, spin
-			// into a retry storm. Skip it and keep draining the rest.
-			c.logger.WarnContext(ctx, "skipped Claude prompt correlation for message",
-				attr.SlogChatID(args.ChatID.String()),
-				attr.SlogMessageID(message.id.String()),
-				attr.SlogError(err),
-			)
-			continue
+			if errors.Is(err, errClaudePromptCorrelationMatchTimeout) {
+				// One slow ClickHouse query must not abort the run: that would
+				// leave the backlog unprocessed and, because a run is scheduled
+				// per prompt event, spin into a retry storm. Skip it and keep
+				// draining the rest.
+				c.logger.WarnContext(ctx, "skipped Claude prompt correlation for message",
+					attr.SlogChatID(args.ChatID.String()),
+					attr.SlogMessageID(message.id.String()),
+					attr.SlogError(err),
+				)
+				continue
+			}
+			return nil, fmt.Errorf("find Claude user prompt match: %w", err)
 		}
 		if !ok {
 			continue
 		}
 
 		if err := c.backfillMessagePromptID(ctx, args.ProjectID, args.ChatID, message.id, match.PromptID); err != nil {
-			c.logger.WarnContext(ctx, "skipped Claude prompt id backfill for message",
-				attr.SlogChatID(args.ChatID.String()),
-				attr.SlogMessageID(message.id.String()),
-				attr.SlogError(err),
-			)
-			continue
+			return nil, fmt.Errorf("backfill Claude prompt ID: %w", err)
 		}
 		cursor.eventSequence = match.EventSequence
 		cursor.timeUnixNano = match.TimeUnixNano
 	}
 
-	return nil
+	return &CorrelateClaudePromptsResult{HasMore: hasMore}, nil
 }
 
-func (c *CorrelateClaudePrompts) listUnlinkedUserMessages(ctx context.Context, projectID uuid.UUID, chatID uuid.UUID) ([]claudeUnlinkedUserMessage, error) {
-	rows, err := activitiesrepo.New(c.db).ListUnlinkedClaudeUserMessagesForCorrelation(ctx, activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams{
-		ChatID:       chatID,
-		ProjectID:    conv.ToNullUUID(projectID),
-		CreatedAfter: conv.ToPGTimestamptz(time.Now().Add(-claudePromptCorrelationLookback)),
+func (c *CorrelateClaudePrompts) listUnlinkedUserMessages(ctx context.Context, projectID uuid.UUID, chatID uuid.UUID) ([]claudeUnlinkedUserMessage, bool, error) {
+	rows, err := c.store.ListUnlinkedClaudeUserMessagesForCorrelation(ctx, activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams{
+		ChatID:     chatID,
+		ProjectID:  conv.ToNullUUID(projectID),
+		LimitCount: claudePromptCorrelationMessageBatchSize + 1,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("query unlinked user messages: %w", err)
+		return nil, false, fmt.Errorf("query unlinked user messages: %w", err)
+	}
+
+	hasMore := len(rows) > claudePromptCorrelationMessageBatchSize
+	if hasMore {
+		rows = rows[:claudePromptCorrelationMessageBatchSize]
 	}
 
 	messages := make([]claudeUnlinkedUserMessage, 0, len(rows))
@@ -131,7 +151,7 @@ func (c *CorrelateClaudePrompts) listUnlinkedUserMessages(ctx context.Context, p
 			createdAt: row.CreatedAt.Time,
 		})
 	}
-	return messages, nil
+	return messages, hasMore, nil
 }
 
 type claudePromptCorrelationCursor struct {
@@ -154,10 +174,10 @@ func (c *CorrelateClaudePrompts) findClaudeUserPromptMatch(
 		return noMatch, false, nil
 	}
 
-	queryCtx, cancel := context.WithTimeout(ctx, claudePromptCorrelationMatchTimeout)
+	queryCtx, cancel := context.WithTimeout(ctx, c.matchTimeout)
 	defer cancel()
 
-	candidates, err := telemetryrepo.New(c.chConn).ListClaudeUserPromptCandidatesForCorrelation(queryCtx, telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams{
+	candidates, err := c.telemetry.ListClaudeUserPromptCandidatesForCorrelation(queryCtx, telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams{
 		GramProjectID:          projectID.String(),
 		GramChatID:             chatID.String(),
 		SessionID:              sessionID,
@@ -169,6 +189,9 @@ func (c *CorrelateClaudePrompts) findClaudeUserPromptMatch(
 		MaxTimeDeltaNanos:      claudePromptCorrelationMaxTimeDelta.Nanoseconds(),
 	})
 	if err != nil {
+		if errors.Is(queryCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			return noMatch, false, errClaudePromptCorrelationMatchTimeout
+		}
 		return noMatch, false, fmt.Errorf("query Claude user prompt candidates: %w", err)
 	}
 	if len(candidates) == 0 {
@@ -184,7 +207,7 @@ func (c *CorrelateClaudePrompts) backfillMessagePromptID(ctx context.Context, pr
 	if strings.TrimSpace(promptID) == "" {
 		return nil
 	}
-	err := activitiesrepo.New(c.db).BackfillClaudeUserMessagePromptID(ctx, activitiesrepo.BackfillClaudeUserMessagePromptIDParams{
+	err := c.store.BackfillClaudeUserMessagePromptID(ctx, activitiesrepo.BackfillClaudeUserMessagePromptIDParams{
 		PromptID:  conv.ToPGText(promptID),
 		MessageID: messageID,
 		ChatID:    chatID,

--- a/server/internal/background/activities/claude_prompt_correlation.go
+++ b/server/internal/background/activities/claude_prompt_correlation.go
@@ -116,20 +116,6 @@ func (c *CorrelateClaudePrompts) Do(ctx context.Context, args CorrelateClaudePro
 
 		match, ok, err := c.findClaudeUserPromptMatch(ctx, args.ProjectID, args.ChatID, args.SessionID, message, cursor)
 		if err != nil {
-			if errors.Is(err, errClaudePromptCorrelationMatchTimeout) {
-				// One slow ClickHouse query must not abort the run: that would
-				// retry the whole workflow and can also leave us unable to know
-				// which telemetry event belongs to this message. Stop this pass
-				// without advancing cursors so a later scheduled run can retry
-				// the message without letting later messages reuse its event.
-				c.logger.WarnContext(ctx, "skipped Claude prompt correlation for message",
-					attr.SlogChatID(args.ChatID.String()),
-					attr.SlogMessageID(message.id.String()),
-					attr.SlogError(err),
-				)
-				result.HasMore = false
-				break
-			}
 			return nil, fmt.Errorf("find Claude user prompt match: %w", err)
 		}
 		result.AfterMessageSeq = message.seq

--- a/server/internal/background/activities/claude_prompt_correlation_integration_test.go
+++ b/server/internal/background/activities/claude_prompt_correlation_integration_test.go
@@ -87,9 +87,12 @@ func TestCorrelateClaudePrompts_MatchesOldMessageWhenEventTimeIsClose(t *testing
 	var messages []chatrepo.ChatMessage
 	require.Eventually(t, func() bool {
 		result, err := act.Do(ctx, activities.CorrelateClaudePromptsArgs{
-			ProjectID: project.ID,
-			ChatID:    chatID,
-			SessionID: sessionID,
+			ProjectID:              project.ID,
+			ChatID:                 chatID,
+			SessionID:              sessionID,
+			AfterMessageSeq:        0,
+			AfterEventSequence:     0,
+			AfterEventTimeUnixNano: 0,
 		})
 		require.NoError(t, err)
 		require.False(t, result.HasMore)

--- a/server/internal/background/activities/claude_prompt_correlation_integration_test.go
+++ b/server/internal/background/activities/claude_prompt_correlation_integration_test.go
@@ -1,0 +1,155 @@
+package activities_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+func TestCorrelateClaudePrompts_MatchesOldMessageWhenEventTimeIsClose(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+
+	conn, err := infra.CloneTestDatabase(t, "claude_prompt_correlation_old")
+	require.NoError(t, err)
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	orgID := "org-" + uuid.NewString()[:8]
+	_, err = orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Test Org",
+		Slug:        orgID,
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Test Project",
+		Slug:           "proj-" + uuid.NewString()[:8],
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	sessionID := uuid.NewString()
+	chatID, err := chatrepo.New(conn).UpsertChat(ctx, chatrepo.UpsertChatParams{
+		ID:             sessionIDToUUIDForTest(sessionID),
+		ProjectID:      project.ID,
+		OrganizationID: orgID,
+		UserID:         pgtype.Text{},
+		ExternalUserID: pgtype.Text{},
+		Title:          pgtype.Text{},
+	})
+	require.NoError(t, err)
+
+	messageTime := time.Now().UTC().Add(-70 * time.Minute)
+	prompt := "please summarize the repository changes and include only the important implementation details"
+	messageID, err := testrepo.New(conn).InsertChatMessage(ctx, testrepo.InsertChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: project.ID, Valid: true},
+		Role:      "user",
+		Content:   prompt,
+	})
+	require.NoError(t, err)
+	require.NoError(t, testrepo.New(conn).UpdateChatMessageCreatedAt(ctx, testrepo.UpdateChatMessageCreatedAtParams{
+		ID:        messageID,
+		CreatedAt: pgtype.Timestamptz{Time: messageTime, Valid: true},
+	}))
+
+	insertClaudeUserPromptEventForActivityTest(t, ctx, telemetryrepo.New(chConn), claudeUserPromptActivityFixture{
+		projectID:     project.ID.String(),
+		chatID:        chatID.String(),
+		sessionID:     sessionID,
+		promptID:      "prompt-old-but-valid",
+		prompt:        prompt,
+		eventSequence: 1,
+		timestamp:     messageTime.Add(30 * time.Second),
+	})
+
+	act := activities.NewCorrelateClaudePrompts(logger, conn, chConn)
+	var messages []chatrepo.ChatMessage
+	require.Eventually(t, func() bool {
+		result, err := act.Do(ctx, activities.CorrelateClaudePromptsArgs{
+			ProjectID: project.ID,
+			ChatID:    chatID,
+			SessionID: sessionID,
+		})
+		require.NoError(t, err)
+		require.False(t, result.HasMore)
+
+		messages, err = chatrepo.New(conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{
+			ChatID:    chatID,
+			ProjectID: project.ID,
+		})
+		require.NoError(t, err)
+		require.Len(t, messages, 1)
+		return messages[0].MessageID.Valid && messages[0].MessageID.String == "prompt-old-but-valid"
+	}, 3*time.Second, 50*time.Millisecond)
+}
+
+type claudeUserPromptActivityFixture struct {
+	projectID     string
+	chatID        string
+	sessionID     string
+	promptID      string
+	prompt        string
+	eventSequence int64
+	timestamp     time.Time
+}
+
+func insertClaudeUserPromptEventForActivityTest(t *testing.T, ctx context.Context, queries *telemetryrepo.Queries, event claudeUserPromptActivityFixture) {
+	t.Helper()
+
+	attrs, err := json.Marshal(map[string]any{
+		"event.name":     "user_prompt",
+		"event.sequence": event.eventSequence,
+		"session.id":     event.sessionID,
+		"prompt.id":      event.promptID,
+		"prompt":         event.prompt,
+	})
+	require.NoError(t, err)
+
+	err = queries.InsertTelemetryLog(ctx, telemetryrepo.InsertTelemetryLogParams{
+		ID:                   uuid.NewString(),
+		TimeUnixNano:         event.timestamp.UnixNano(),
+		ObservedTimeUnixNano: event.timestamp.UnixNano(),
+		SeverityText:         nil,
+		Body:                 "claude_code.user_prompt",
+		TraceID:              nil,
+		SpanID:               nil,
+		Attributes:           string(attrs),
+		ResourceAttributes:   "{}",
+		GramProjectID:        event.projectID,
+		GramDeploymentID:     nil,
+		GramFunctionID:       nil,
+		GramURN:              "claude-code:otel:logs",
+		ServiceName:          "claude-code",
+		ServiceVersion:       nil,
+		GramChatID:           &event.chatID,
+	})
+	require.NoError(t, err)
+}
+
+func sessionIDToUUIDForTest(sessionID string) uuid.UUID {
+	if parsed, err := uuid.Parse(sessionID); err == nil {
+		return parsed
+	}
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(sessionID))
+}

--- a/server/internal/background/activities/claude_prompt_correlation_test.go
+++ b/server/internal/background/activities/claude_prompt_correlation_test.go
@@ -115,6 +115,59 @@ func TestCorrelateClaudePromptsReturnsBackfillErrors(t *testing.T) {
 	require.True(t, store.backfilled)
 }
 
+func TestCorrelateClaudePromptsAdvancesMessageCursorWithoutMatches(t *testing.T) {
+	t.Parallel()
+
+	rows := make([]activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow, 0, claudePromptCorrelationMessageBatchSize+1)
+	for i := 1; i <= claudePromptCorrelationMessageBatchSize+1; i++ {
+		rows = append(rows, fakeClaudePromptMessageRowWithSeq(int64(i)))
+	}
+	store := &fakeClaudePromptStore{rows: rows}
+	act := newTestCorrelateClaudePrompts(t, store, &fakeClaudePromptTelemetry{})
+
+	result, err := act.Do(context.Background(), fakeCorrelateClaudePromptsArgs())
+
+	require.NoError(t, err)
+	require.True(t, result.HasMore)
+	require.Equal(t, int64(claudePromptCorrelationMessageBatchSize), result.AfterMessageSeq)
+	require.False(t, store.backfilled)
+	require.Equal(t, int32(claudePromptCorrelationMessageBatchSize+1), store.lastListParams.LimitCount)
+}
+
+func TestCorrelateClaudePromptsCarriesInputCursors(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClaudePromptStore{
+		rows: []activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow{fakeClaudePromptMessageRowWithSeq(12)},
+	}
+	telemetry := &fakeClaudePromptTelemetry{
+		candidates: []telemetryrepo.ClaudeUserPromptCandidate{{
+			PromptID:      "prompt-2",
+			Prompt:        "please summarize this repository change",
+			EventSequence: 8,
+			TimeUnixNano:  80,
+			Similarity:    1,
+			IsExact:       true,
+		}},
+	}
+	act := newTestCorrelateClaudePrompts(t, store, telemetry)
+	args := fakeCorrelateClaudePromptsArgs()
+	args.AfterMessageSeq = 10
+	args.AfterEventSequence = 7
+	args.AfterEventTimeUnixNano = 70
+
+	result, err := act.Do(context.Background(), args)
+
+	require.NoError(t, err)
+	require.False(t, result.HasMore)
+	require.Equal(t, int64(12), result.AfterMessageSeq)
+	require.Equal(t, int64(8), result.AfterEventSequence)
+	require.Equal(t, int64(80), result.AfterEventTimeUnixNano)
+	require.Equal(t, int64(10), store.lastListParams.AfterMessageSeq)
+	require.Equal(t, int64(7), telemetry.lastCandidateParams.AfterEventSequence)
+	require.Equal(t, int64(70), telemetry.lastCandidateParams.AfterEventTimeUnixNano)
+}
+
 func newTestCorrelateClaudePrompts(t *testing.T, store claudePromptCorrelationStore, telemetry claudePromptCorrelationTelemetry) *CorrelateClaudePrompts {
 	t.Helper()
 
@@ -128,27 +181,37 @@ func newTestCorrelateClaudePrompts(t *testing.T, store claudePromptCorrelationSt
 
 func fakeCorrelateClaudePromptsArgs() CorrelateClaudePromptsArgs {
 	return CorrelateClaudePromptsArgs{
-		ProjectID: uuid.New(),
-		ChatID:    uuid.New(),
-		SessionID: uuid.NewString(),
+		ProjectID:              uuid.New(),
+		ChatID:                 uuid.New(),
+		SessionID:              uuid.NewString(),
+		AfterMessageSeq:        0,
+		AfterEventSequence:     0,
+		AfterEventTimeUnixNano: 0,
 	}
 }
 
 func fakeClaudePromptMessageRow() activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow {
+	return fakeClaudePromptMessageRowWithSeq(1)
+}
+
+func fakeClaudePromptMessageRowWithSeq(seq int64) activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow {
 	return activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow{
 		ID:        uuid.New(),
+		Seq:       seq,
 		Content:   "please summarize this repository change",
 		CreatedAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true},
 	}
 }
 
 type fakeClaudePromptStore struct {
-	rows        []activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow
-	backfillErr error
-	backfilled  bool
+	rows           []activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow
+	backfillErr    error
+	backfilled     bool
+	lastListParams activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams
 }
 
-func (f *fakeClaudePromptStore) ListUnlinkedClaudeUserMessagesForCorrelation(context.Context, activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams) ([]activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow, error) {
+func (f *fakeClaudePromptStore) ListUnlinkedClaudeUserMessagesForCorrelation(_ context.Context, params activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams) ([]activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow, error) {
+	f.lastListParams = params
 	return f.rows, nil
 }
 
@@ -158,12 +221,14 @@ func (f *fakeClaudePromptStore) BackfillClaudeUserMessagePromptID(context.Contex
 }
 
 type fakeClaudePromptTelemetry struct {
-	candidates         []telemetryrepo.ClaudeUserPromptCandidate
-	err                error
-	waitForContextDone bool
+	candidates          []telemetryrepo.ClaudeUserPromptCandidate
+	err                 error
+	waitForContextDone  bool
+	lastCandidateParams telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams
 }
 
-func (f *fakeClaudePromptTelemetry) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Context, _ telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams) ([]telemetryrepo.ClaudeUserPromptCandidate, error) {
+func (f *fakeClaudePromptTelemetry) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Context, params telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams) ([]telemetryrepo.ClaudeUserPromptCandidate, error) {
+	f.lastCandidateParams = params
 	if f.waitForContextDone {
 		<-ctx.Done()
 		return nil, fmt.Errorf("context done: %w", ctx.Err())

--- a/server/internal/background/activities/claude_prompt_correlation_test.go
+++ b/server/internal/background/activities/claude_prompt_correlation_test.go
@@ -71,7 +71,7 @@ func TestCorrelateClaudePromptsReturnsNonTimeoutCandidateErrors(t *testing.T) {
 	require.ErrorContains(t, err, "find Claude user prompt match")
 }
 
-func TestCorrelateClaudePromptsSkipsPerMessageCandidateTimeout(t *testing.T) {
+func TestCorrelateClaudePromptsReturnsPerMessageCandidateTimeout(t *testing.T) {
 	t.Parallel()
 
 	store := &fakeClaudePromptStore{
@@ -83,15 +83,13 @@ func TestCorrelateClaudePromptsSkipsPerMessageCandidateTimeout(t *testing.T) {
 
 	result, err := act.Do(context.Background(), fakeCorrelateClaudePromptsArgs())
 
-	require.NoError(t, err)
-	require.False(t, result.HasMore)
-	require.Zero(t, result.AfterMessageSeq)
-	require.Zero(t, result.AfterEventSequence)
-	require.Zero(t, result.AfterEventTimeUnixNano)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, errClaudePromptCorrelationMatchTimeout)
+	require.ErrorContains(t, err, "find Claude user prompt match")
 	require.False(t, store.backfilled)
 }
 
-func TestCorrelateClaudePromptsStopsPassOnCandidateTimeoutEvenWithMoreRows(t *testing.T) {
+func TestCorrelateClaudePromptsReturnsCandidateTimeoutBeforeLaterRows(t *testing.T) {
 	t.Parallel()
 
 	rows := make([]activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow, 0, claudePromptCorrelationMessageBatchSize+1)
@@ -105,11 +103,9 @@ func TestCorrelateClaudePromptsStopsPassOnCandidateTimeoutEvenWithMoreRows(t *te
 
 	result, err := act.Do(context.Background(), fakeCorrelateClaudePromptsArgs())
 
-	require.NoError(t, err)
-	require.False(t, result.HasMore)
-	require.Zero(t, result.AfterMessageSeq)
-	require.Zero(t, result.AfterEventSequence)
-	require.Zero(t, result.AfterEventTimeUnixNano)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, errClaudePromptCorrelationMatchTimeout)
+	require.False(t, store.backfilled)
 }
 
 func TestCorrelateClaudePromptsReturnsBackfillErrors(t *testing.T) {

--- a/server/internal/background/activities/claude_prompt_correlation_test.go
+++ b/server/internal/background/activities/claude_prompt_correlation_test.go
@@ -85,7 +85,31 @@ func TestCorrelateClaudePromptsSkipsPerMessageCandidateTimeout(t *testing.T) {
 
 	require.NoError(t, err)
 	require.False(t, result.HasMore)
+	require.Zero(t, result.AfterMessageSeq)
+	require.Zero(t, result.AfterEventSequence)
+	require.Zero(t, result.AfterEventTimeUnixNano)
 	require.False(t, store.backfilled)
+}
+
+func TestCorrelateClaudePromptsStopsPassOnCandidateTimeoutEvenWithMoreRows(t *testing.T) {
+	t.Parallel()
+
+	rows := make([]activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow, 0, claudePromptCorrelationMessageBatchSize+1)
+	for i := 1; i <= claudePromptCorrelationMessageBatchSize+1; i++ {
+		rows = append(rows, fakeClaudePromptMessageRowWithSeq(int64(i)))
+	}
+	store := &fakeClaudePromptStore{rows: rows}
+	act := newTestCorrelateClaudePrompts(t, store, &fakeClaudePromptTelemetry{
+		waitForContextDone: true,
+	})
+
+	result, err := act.Do(context.Background(), fakeCorrelateClaudePromptsArgs())
+
+	require.NoError(t, err)
+	require.False(t, result.HasMore)
+	require.Zero(t, result.AfterMessageSeq)
+	require.Zero(t, result.AfterEventSequence)
+	require.Zero(t, result.AfterEventTimeUnixNano)
 }
 
 func TestCorrelateClaudePromptsReturnsBackfillErrors(t *testing.T) {

--- a/server/internal/background/activities/claude_prompt_correlation_test.go
+++ b/server/internal/background/activities/claude_prompt_correlation_test.go
@@ -1,9 +1,18 @@
 package activities
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,4 +52,124 @@ func TestIsAcceptedClaudePromptCandidateAcceptsConfidentFuzzyMatch(t *testing.T)
 		{PromptID: "prompt-1", Similarity: 0.98, IsExact: false},
 		{PromptID: "prompt-2", Similarity: 0.95, IsExact: false},
 	}))
+}
+
+func TestCorrelateClaudePromptsReturnsNonTimeoutCandidateErrors(t *testing.T) {
+	t.Parallel()
+
+	queryErr := errors.New("clickhouse unavailable")
+	act := newTestCorrelateClaudePrompts(t, &fakeClaudePromptStore{
+		rows: []activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow{fakeClaudePromptMessageRow()},
+	}, &fakeClaudePromptTelemetry{
+		err: queryErr,
+	})
+
+	result, err := act.Do(context.Background(), fakeCorrelateClaudePromptsArgs())
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, queryErr)
+	require.ErrorContains(t, err, "find Claude user prompt match")
+}
+
+func TestCorrelateClaudePromptsSkipsPerMessageCandidateTimeout(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClaudePromptStore{
+		rows: []activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow{fakeClaudePromptMessageRow()},
+	}
+	act := newTestCorrelateClaudePrompts(t, store, &fakeClaudePromptTelemetry{
+		waitForContextDone: true,
+	})
+
+	result, err := act.Do(context.Background(), fakeCorrelateClaudePromptsArgs())
+
+	require.NoError(t, err)
+	require.False(t, result.HasMore)
+	require.False(t, store.backfilled)
+}
+
+func TestCorrelateClaudePromptsReturnsBackfillErrors(t *testing.T) {
+	t.Parallel()
+
+	backfillErr := errors.New("postgres unavailable")
+	store := &fakeClaudePromptStore{
+		rows:        []activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow{fakeClaudePromptMessageRow()},
+		backfillErr: backfillErr,
+	}
+	act := newTestCorrelateClaudePrompts(t, store, &fakeClaudePromptTelemetry{
+		candidates: []telemetryrepo.ClaudeUserPromptCandidate{{
+			PromptID:      "prompt-1",
+			Prompt:        "please summarize this repository change",
+			EventSequence: 1,
+			TimeUnixNano:  time.Now().UTC().UnixNano(),
+			Similarity:    1,
+			IsExact:       true,
+		}},
+	})
+
+	result, err := act.Do(context.Background(), fakeCorrelateClaudePromptsArgs())
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, backfillErr)
+	require.ErrorContains(t, err, "backfill Claude prompt ID")
+	require.True(t, store.backfilled)
+}
+
+func newTestCorrelateClaudePrompts(t *testing.T, store claudePromptCorrelationStore, telemetry claudePromptCorrelationTelemetry) *CorrelateClaudePrompts {
+	t.Helper()
+
+	return &CorrelateClaudePrompts{
+		logger:       testenv.NewLogger(t),
+		store:        store,
+		telemetry:    telemetry,
+		matchTimeout: 10 * time.Millisecond,
+	}
+}
+
+func fakeCorrelateClaudePromptsArgs() CorrelateClaudePromptsArgs {
+	return CorrelateClaudePromptsArgs{
+		ProjectID: uuid.New(),
+		ChatID:    uuid.New(),
+		SessionID: uuid.NewString(),
+	}
+}
+
+func fakeClaudePromptMessageRow() activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow {
+	return activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow{
+		ID:        uuid.New(),
+		Content:   "please summarize this repository change",
+		CreatedAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true},
+	}
+}
+
+type fakeClaudePromptStore struct {
+	rows        []activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow
+	backfillErr error
+	backfilled  bool
+}
+
+func (f *fakeClaudePromptStore) ListUnlinkedClaudeUserMessagesForCorrelation(context.Context, activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationParams) ([]activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow, error) {
+	return f.rows, nil
+}
+
+func (f *fakeClaudePromptStore) BackfillClaudeUserMessagePromptID(context.Context, activitiesrepo.BackfillClaudeUserMessagePromptIDParams) error {
+	f.backfilled = true
+	return f.backfillErr
+}
+
+type fakeClaudePromptTelemetry struct {
+	candidates         []telemetryrepo.ClaudeUserPromptCandidate
+	err                error
+	waitForContextDone bool
+}
+
+func (f *fakeClaudePromptTelemetry) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Context, _ telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams) ([]telemetryrepo.ClaudeUserPromptCandidate, error) {
+	if f.waitForContextDone {
+		<-ctx.Done()
+		return nil, fmt.Errorf("context done: %w", ctx.Err())
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.candidates, nil
 }

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -88,6 +88,10 @@ WHERE d.organization_id = ANY($1::text[])
   );
 
 -- name: ListUnlinkedClaudeUserMessagesForCorrelation :many
+-- A message can only correlate to a Claude telemetry prompt observed within a
+-- short window of its creation, so messages older than @created_after are
+-- unmatchable. Bounding the fetch by recency keeps a chat with a large unlinked
+-- history from being re-scanned in full on every prompt event.
 SELECT id, content, created_at
 FROM chat_messages
 WHERE chat_id = @chat_id
@@ -95,6 +99,7 @@ WHERE chat_id = @chat_id
   AND role = 'user'
   AND content != ''
   AND (message_id IS NULL OR message_id = '')
+  AND created_at >= @created_after
 ORDER BY seq ASC, created_at ASC;
 
 -- name: BackfillClaudeUserMessagePromptID :exec

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -88,10 +88,8 @@ WHERE d.organization_id = ANY($1::text[])
   );
 
 -- name: ListUnlinkedClaudeUserMessagesForCorrelation :many
--- A message can only correlate to a Claude telemetry prompt observed within a
--- short window of its creation, so messages older than @created_after are
--- unmatchable. Bounding the fetch by recency keeps a chat with a large unlinked
--- history from being re-scanned in full on every prompt event.
+-- Fetch a bounded prefix of the unlinked backlog. The caller requests one extra
+-- row to detect whether another drain pass is needed.
 SELECT id, content, created_at
 FROM chat_messages
 WHERE chat_id = @chat_id
@@ -99,8 +97,8 @@ WHERE chat_id = @chat_id
   AND role = 'user'
   AND content != ''
   AND (message_id IS NULL OR message_id = '')
-  AND created_at >= @created_after
-ORDER BY seq ASC, created_at ASC;
+ORDER BY seq ASC, created_at ASC
+LIMIT @limit_count;
 
 -- name: BackfillClaudeUserMessagePromptID :exec
 UPDATE chat_messages

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -90,13 +90,14 @@ WHERE d.organization_id = ANY($1::text[])
 -- name: ListUnlinkedClaudeUserMessagesForCorrelation :many
 -- Fetch a bounded prefix of the unlinked backlog. The caller requests one extra
 -- row to detect whether another drain pass is needed.
-SELECT id, content, created_at
+SELECT id, seq, content, created_at
 FROM chat_messages
 WHERE chat_id = @chat_id
   AND (project_id IS NULL OR project_id = @project_id)
   AND role = 'user'
   AND content != ''
   AND (message_id IS NULL OR message_id = '')
+  AND seq > @after_message_seq
 ORDER BY seq ASC, created_at ASC
 LIMIT @limit_count;
 

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -389,25 +389,28 @@ func (q *Queries) GetUserEmailsByOrgIDs(ctx context.Context, dollar_1 []string) 
 }
 
 const listUnlinkedClaudeUserMessagesForCorrelation = `-- name: ListUnlinkedClaudeUserMessagesForCorrelation :many
-SELECT id, content, created_at
+SELECT id, seq, content, created_at
 FROM chat_messages
 WHERE chat_id = $1
   AND (project_id IS NULL OR project_id = $2)
   AND role = 'user'
   AND content != ''
   AND (message_id IS NULL OR message_id = '')
+  AND seq > $3
 ORDER BY seq ASC, created_at ASC
-LIMIT $3
+LIMIT $4
 `
 
 type ListUnlinkedClaudeUserMessagesForCorrelationParams struct {
-	ChatID     uuid.UUID
-	ProjectID  uuid.NullUUID
-	LimitCount int32
+	ChatID          uuid.UUID
+	ProjectID       uuid.NullUUID
+	AfterMessageSeq int64
+	LimitCount      int32
 }
 
 type ListUnlinkedClaudeUserMessagesForCorrelationRow struct {
 	ID        uuid.UUID
+	Seq       int64
 	Content   string
 	CreatedAt pgtype.Timestamptz
 }
@@ -415,7 +418,12 @@ type ListUnlinkedClaudeUserMessagesForCorrelationRow struct {
 // Fetch a bounded prefix of the unlinked backlog. The caller requests one extra
 // row to detect whether another drain pass is needed.
 func (q *Queries) ListUnlinkedClaudeUserMessagesForCorrelation(ctx context.Context, arg ListUnlinkedClaudeUserMessagesForCorrelationParams) ([]ListUnlinkedClaudeUserMessagesForCorrelationRow, error) {
-	rows, err := q.db.Query(ctx, listUnlinkedClaudeUserMessagesForCorrelation, arg.ChatID, arg.ProjectID, arg.LimitCount)
+	rows, err := q.db.Query(ctx, listUnlinkedClaudeUserMessagesForCorrelation,
+		arg.ChatID,
+		arg.ProjectID,
+		arg.AfterMessageSeq,
+		arg.LimitCount,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +431,12 @@ func (q *Queries) ListUnlinkedClaudeUserMessagesForCorrelation(ctx context.Conte
 	var items []ListUnlinkedClaudeUserMessagesForCorrelationRow
 	for rows.Next() {
 		var i ListUnlinkedClaudeUserMessagesForCorrelationRow
-		if err := rows.Scan(&i.ID, &i.Content, &i.CreatedAt); err != nil {
+		if err := rows.Scan(
+			&i.ID,
+			&i.Seq,
+			&i.Content,
+			&i.CreatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -396,12 +396,14 @@ WHERE chat_id = $1
   AND role = 'user'
   AND content != ''
   AND (message_id IS NULL OR message_id = '')
+  AND created_at >= $3
 ORDER BY seq ASC, created_at ASC
 `
 
 type ListUnlinkedClaudeUserMessagesForCorrelationParams struct {
-	ChatID    uuid.UUID
-	ProjectID uuid.NullUUID
+	ChatID       uuid.UUID
+	ProjectID    uuid.NullUUID
+	CreatedAfter pgtype.Timestamptz
 }
 
 type ListUnlinkedClaudeUserMessagesForCorrelationRow struct {
@@ -410,8 +412,12 @@ type ListUnlinkedClaudeUserMessagesForCorrelationRow struct {
 	CreatedAt pgtype.Timestamptz
 }
 
+// A message can only correlate to a Claude telemetry prompt observed within a
+// short window of its creation, so messages older than @created_after are
+// unmatchable. Bounding the fetch by recency keeps a chat with a large unlinked
+// history from being re-scanned in full on every prompt event.
 func (q *Queries) ListUnlinkedClaudeUserMessagesForCorrelation(ctx context.Context, arg ListUnlinkedClaudeUserMessagesForCorrelationParams) ([]ListUnlinkedClaudeUserMessagesForCorrelationRow, error) {
-	rows, err := q.db.Query(ctx, listUnlinkedClaudeUserMessagesForCorrelation, arg.ChatID, arg.ProjectID)
+	rows, err := q.db.Query(ctx, listUnlinkedClaudeUserMessagesForCorrelation, arg.ChatID, arg.ProjectID, arg.CreatedAfter)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -396,14 +396,14 @@ WHERE chat_id = $1
   AND role = 'user'
   AND content != ''
   AND (message_id IS NULL OR message_id = '')
-  AND created_at >= $3
 ORDER BY seq ASC, created_at ASC
+LIMIT $3
 `
 
 type ListUnlinkedClaudeUserMessagesForCorrelationParams struct {
-	ChatID       uuid.UUID
-	ProjectID    uuid.NullUUID
-	CreatedAfter pgtype.Timestamptz
+	ChatID     uuid.UUID
+	ProjectID  uuid.NullUUID
+	LimitCount int32
 }
 
 type ListUnlinkedClaudeUserMessagesForCorrelationRow struct {
@@ -412,12 +412,10 @@ type ListUnlinkedClaudeUserMessagesForCorrelationRow struct {
 	CreatedAt pgtype.Timestamptz
 }
 
-// A message can only correlate to a Claude telemetry prompt observed within a
-// short window of its creation, so messages older than @created_after are
-// unmatchable. Bounding the fetch by recency keeps a chat with a large unlinked
-// history from being re-scanned in full on every prompt event.
+// Fetch a bounded prefix of the unlinked backlog. The caller requests one extra
+// row to detect whether another drain pass is needed.
 func (q *Queries) ListUnlinkedClaudeUserMessagesForCorrelation(ctx context.Context, arg ListUnlinkedClaudeUserMessagesForCorrelationParams) ([]ListUnlinkedClaudeUserMessagesForCorrelationRow, error) {
-	rows, err := q.db.Query(ctx, listUnlinkedClaudeUserMessagesForCorrelation, arg.ChatID, arg.ProjectID, arg.CreatedAfter)
+	rows, err := q.db.Query(ctx, listUnlinkedClaudeUserMessagesForCorrelation, arg.ChatID, arg.ProjectID, arg.LimitCount)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/background/activities/setup_test.go
+++ b/server/internal/background/activities/setup_test.go
@@ -12,7 +12,7 @@ import (
 var infra *testenv.Environment
 
 func TestMain(m *testing.M) {
-	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, ClickHouse: true})
 	if err != nil {
 		log.Fatalf("Failed to launch test infrastructure: %v", err)
 	}

--- a/server/internal/background/claude_prompt_correlation.go
+++ b/server/internal/background/claude_prompt_correlation.go
@@ -43,12 +43,17 @@ func CorrelateClaudePromptsWorkflow(ctx workflow.Context, params CorrelateClaude
 	})
 
 	var a *Activities
-	if err := workflow.ExecuteActivity(
-		ctx,
-		a.CorrelateClaudePrompts,
-		activities.CorrelateClaudePromptsArgs(params),
-	).Get(ctx, nil); err != nil {
-		return fmt.Errorf("correlate Claude prompts: %w", err)
+	for {
+		var result activities.CorrelateClaudePromptsResult
+		if err := workflow.ExecuteActivity(
+			ctx,
+			a.CorrelateClaudePrompts,
+			activities.CorrelateClaudePromptsArgs(params),
+		).Get(ctx, &result); err != nil {
+			return fmt.Errorf("correlate Claude prompts: %w", err)
+		}
+		if !result.HasMore {
+			return nil
+		}
 	}
-	return nil
 }

--- a/server/internal/background/claude_prompt_correlation.go
+++ b/server/internal/background/claude_prompt_correlation.go
@@ -15,10 +15,21 @@ import (
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 )
 
+const (
+	correlateClaudePromptsActivityStartToCloseTimeout = 30 * time.Second
+	correlateClaudePromptsWorkflowRunTimeout          = 2 * time.Minute
+	// Worst-case retry window for one activity: three 30s attempts plus the
+	// 5s and 10s backoffs between them.
+	correlateClaudePromptsActivityWorstCaseRetryWindow = 105 * time.Second
+)
+
 type CorrelateClaudePromptsParams struct {
-	ProjectID uuid.UUID
-	ChatID    uuid.UUID
-	SessionID string
+	ProjectID              uuid.UUID
+	ChatID                 uuid.UUID
+	SessionID              string
+	AfterMessageSeq        int64
+	AfterEventSequence     int64
+	AfterEventTimeUnixNano int64
 }
 
 func ExecuteCorrelateClaudePromptsWorkflow(ctx context.Context, env *tenv.Environment, params CorrelateClaudePromptsParams) (client.WorkflowRun, error) {
@@ -27,13 +38,13 @@ func ExecuteCorrelateClaudePromptsWorkflow(ctx context.Context, env *tenv.Enviro
 		ID:                    id,
 		TaskQueue:             string(env.Queue()),
 		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-		WorkflowRunTimeout:    2 * time.Minute,
+		WorkflowRunTimeout:    correlateClaudePromptsWorkflowRunTimeout,
 	}, CorrelateClaudePromptsWorkflow, params)
 }
 
 func CorrelateClaudePromptsWorkflow(ctx workflow.Context, params CorrelateClaudePromptsParams) error {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 30 * time.Second,
+		StartToCloseTimeout: correlateClaudePromptsActivityStartToCloseTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts:    3,
 			InitialInterval:    5 * time.Second,
@@ -55,5 +66,29 @@ func CorrelateClaudePromptsWorkflow(ctx workflow.Context, params CorrelateClaude
 		if !result.HasMore {
 			return nil
 		}
+		params.AfterMessageSeq = result.AfterMessageSeq
+		params.AfterEventSequence = result.AfterEventSequence
+		params.AfterEventTimeUnixNano = result.AfterEventTimeUnixNano
+		if shouldContinueCorrelateClaudePromptsAsNew(ctx) {
+			return workflow.NewContinueAsNewError(ctx, CorrelateClaudePromptsWorkflow, params)
+		}
 	}
+}
+
+func shouldContinueCorrelateClaudePromptsAsNew(ctx workflow.Context) bool {
+	info := workflow.GetInfo(ctx)
+	if info.GetContinueAsNewSuggested() {
+		return true
+	}
+
+	runTimeout := info.WorkflowRunTimeout
+	if runTimeout == 0 {
+		runTimeout = correlateClaudePromptsWorkflowRunTimeout
+	}
+	if runTimeout == 0 || info.WorkflowStartTime.IsZero() {
+		return false
+	}
+
+	elapsed := workflow.Now(ctx).Sub(info.WorkflowStartTime)
+	return elapsed+correlateClaudePromptsActivityWorstCaseRetryWindow >= runTimeout
 }

--- a/server/internal/background/claude_prompt_correlation_test.go
+++ b/server/internal/background/claude_prompt_correlation_test.go
@@ -1,0 +1,36 @@
+package background
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+)
+
+func TestCorrelateClaudePromptsWorkflow_DrainsWhenActivityReportsMore(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	callCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.CorrelateClaudePromptsArgs) (*activities.CorrelateClaudePromptsResult, error) {
+			callCount++
+			return &activities.CorrelateClaudePromptsResult{
+				HasMore: callCount == 1,
+			}, nil
+		},
+		activity.RegisterOptions{Name: "CorrelateClaudePrompts"},
+	)
+
+	env.ExecuteWorkflow(CorrelateClaudePromptsWorkflow, CorrelateClaudePromptsParams{})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 2, callCount)
+}

--- a/server/internal/background/claude_prompt_correlation_test.go
+++ b/server/internal/background/claude_prompt_correlation_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
 
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 )
@@ -19,18 +22,73 @@ func TestCorrelateClaudePromptsWorkflow_DrainsWhenActivityReportsMore(t *testing
 
 	callCount := 0
 	env.RegisterActivityWithOptions(
-		func(_ context.Context, _ activities.CorrelateClaudePromptsArgs) (*activities.CorrelateClaudePromptsResult, error) {
+		func(_ context.Context, input activities.CorrelateClaudePromptsArgs) (*activities.CorrelateClaudePromptsResult, error) {
 			callCount++
+			if callCount == 2 {
+				require.Equal(t, int64(25), input.AfterMessageSeq)
+				require.Equal(t, int64(11), input.AfterEventSequence)
+				require.Equal(t, int64(22), input.AfterEventTimeUnixNano)
+			}
 			return &activities.CorrelateClaudePromptsResult{
-				HasMore: callCount == 1,
+				HasMore:                callCount == 1,
+				AfterMessageSeq:        25,
+				AfterEventSequence:     11,
+				AfterEventTimeUnixNano: 22,
 			}, nil
 		},
 		activity.RegisterOptions{Name: "CorrelateClaudePrompts"},
 	)
 
-	env.ExecuteWorkflow(CorrelateClaudePromptsWorkflow, CorrelateClaudePromptsParams{})
+	env.ExecuteWorkflow(CorrelateClaudePromptsWorkflow, CorrelateClaudePromptsParams{
+		ProjectID:              uuid.Nil,
+		ChatID:                 uuid.Nil,
+		SessionID:              "",
+		AfterMessageSeq:        0,
+		AfterEventSequence:     0,
+		AfterEventTimeUnixNano: 0,
+	})
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	require.Equal(t, 2, callCount)
+}
+
+func TestCorrelateClaudePromptsWorkflow_ContinuesAsNewNearRunTimeout(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkflowRunTimeout(correlateClaudePromptsActivityWorstCaseRetryWindow)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.CorrelateClaudePromptsArgs) (*activities.CorrelateClaudePromptsResult, error) {
+			return &activities.CorrelateClaudePromptsResult{
+				HasMore:                true,
+				AfterMessageSeq:        25,
+				AfterEventSequence:     11,
+				AfterEventTimeUnixNano: 22,
+			}, nil
+		},
+		activity.RegisterOptions{Name: "CorrelateClaudePrompts"},
+	)
+
+	env.ExecuteWorkflow(CorrelateClaudePromptsWorkflow, CorrelateClaudePromptsParams{
+		ProjectID:              uuid.Nil,
+		ChatID:                 uuid.Nil,
+		SessionID:              "session",
+		AfterMessageSeq:        0,
+		AfterEventSequence:     0,
+		AfterEventTimeUnixNano: 0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	var continueAsNewErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &continueAsNewErr)
+	require.Equal(t, "CorrelateClaudePromptsWorkflow", continueAsNewErr.WorkflowType.Name)
+
+	var nextInput CorrelateClaudePromptsParams
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(continueAsNewErr.Input, &nextInput))
+	require.Equal(t, int64(25), nextInput.AfterMessageSeq)
+	require.Equal(t, int64(11), nextInput.AfterEventSequence)
+	require.Equal(t, int64(22), nextInput.AfterEventTimeUnixNano)
 }

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -290,9 +290,12 @@ func (s *Service) scheduleClaudePromptCorrelation(ctx context.Context, projectID
 	workflowCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer cancel()
 	if _, err := background.ExecuteCorrelateClaudePromptsWorkflow(workflowCtx, s.temporalEnv, background.CorrelateClaudePromptsParams{
-		ProjectID: projectID,
-		ChatID:    chatID,
-		SessionID: sessionID,
+		ProjectID:              projectID,
+		ChatID:                 chatID,
+		SessionID:              sessionID,
+		AfterMessageSeq:        0,
+		AfterEventSequence:     0,
+		AfterEventTimeUnixNano: 0,
 	}); err != nil {
 		s.logger.WarnContext(ctx, "failed to schedule Claude prompt correlation",
 			attr.SlogError(err),


### PR DESCRIPTION
## Problem

The `CorrelateClaudePrompts` Temporal activity links Claude Code chat messages to their telemetry `user_prompt` events. For each run it listed **every** unlinked user message for the chat, then ran a per-message ClickHouse `editDistanceUTF8` fuzzy-match query — all inside a single 30s `StartToClose` budget.

A high-volume chat's unlinked backlog — which grows *precisely because* the activity keeps failing — pushed that loop past the deadline (`query Claude user prompt candidates: context deadline exceeded`). The whole activity then failed, so **nothing was backfilled and the backlog never drained**. Since a run is scheduled per `user_prompt` event with `ALLOW_DUPLICATE`, every new prompt re-triggered the doomed workflow — a self-reinforcing retry storm (the failure rate climbed 1→11/min on one chat and tripped the "Elevated temporal workflow failures" monitor).

## Fix

Bound the activity so one chat can't blow the budget, and make it drain incrementally:

- **Recency bound** — only consider messages created within the last hour. A message can only match a prompt within ±10 min of its creation, so older unlinked messages are unmatchable and re-scanning them every run is wasted work (this also stops a large historical backlog from being re-fetched in full each trigger).
- **Per-query timeout** — each ClickHouse candidate query gets its own short context so one slow query can't consume the whole budget.
- **Continue-on-error** — a failed message is logged and skipped instead of aborting the run, so matched messages still get backfilled and the backlog drains.
- **Stop before the deadline** — leave headroom so partial progress commits successfully and a later run picks up the remainder, rather than failing and re-running from scratch.

Correlation is idempotent (it only backfills unlinked messages), so skipping/retrying across runs is safe.

## Follow-up (not in this PR)

The structural cause — every prompt event firing a fresh `ALLOW_DUPLICATE` workflow with no flow control — is better solved by moving the trigger onto Pub/Sub (`MaxOutstandingMessages` backpressure + DLQ), reusing the existing `streams` consumer pattern. Tracked separately; this PR is the incident mitigation.

## Testing

- `mise lint:server` clean
- `go build` + existing correlation unit tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Claude prompt correlation from timing out on high‑volume chats by draining unlinked messages in small, cursored batches and retrying per‑message timeouts. The workflow loops and continues‑as‑new near its run timeout so prompts stay reliably linked and retry storms stop.

- **Bug Fixes**
  - Process unlinked messages in small, seq‑ordered batches; return cursors (`AfterMessageSeq`, `AfterEventSequence`, `AfterEventTimeUnixNano`) and loop until drained.
  - Keep a strict ±10 min match window; cap each ClickHouse candidate query at 5s. On a per‑message timeout, surface a retryable error and do not advance cursors; other errors still fail after retries.
  - Stop before the activity deadline to commit partial progress, and continue‑as‑new when close to the workflow run timeout.

<sup>Written for commit d40a85e9bb53faf21bda757c6f612a9afdac8a75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

