### PR TITLE
fix: gate risk count/flag queries on enabled policy

### DIFF
--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -93,6 +93,32 @@ func seedRiskOnChat(t *testing.T, ctx context.Context, ti *chatTestInstance, cha
 	require.NoError(t, err)
 }
 
+// seedRiskOnChatDisabledPolicy seeds a found risk result whose policy is
+// disabled. The finding row is real, but every risk surface must treat it as
+// absent because the policy is off (mirrors a policy disabled after detection).
+func seedRiskOnChatDisabledPolicy(t *testing.T, ctx context.Context, ti *chatTestInstance, chatID uuid.UUID) {
+	t.Helper()
+	r := repo.New(ti.conn)
+	msgID, err := r.SeedChatMessage(ctx, repo.SeedChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true},
+	})
+	require.NoError(t, err)
+	policyID, err := r.SeedDisabledRiskPolicy(ctx, repo.SeedDisabledRiskPolicyParams{
+		ProjectID:      ti.projectID,
+		OrganizationID: ti.orgID,
+	})
+	require.NoError(t, err)
+	err = r.SeedRiskResult(ctx, repo.SeedRiskResultParams{
+		ProjectID:      ti.projectID,
+		OrganizationID: ti.orgID,
+		RiskPolicyID:   policyID,
+		ChatMessageID:  msgID,
+		Found:          true,
+	})
+	require.NoError(t, err)
+}
+
 // initSessionCtx creates a session-authenticated context and overrides ProjectID
 // to ti.projectID so that ListChats scopes to the same project as seeded chats.
 func initSessionCtx(t *testing.T, ti *chatTestInstance) context.Context {
@@ -617,6 +643,40 @@ func TestListChats_RiskFindingsCountInResult(t *testing.T) {
 	require.Len(t, result.Chats, 1)
 	require.NotNil(t, result.Chats[0].RiskFindingsCount)
 	require.Equal(t, 3, *result.Chats[0].RiskFindingsCount)
+}
+
+// TestListChats_DisabledPolicyFinding_NotCounted verifies that a found risk
+// result under a disabled policy is excluded from the per-chat count and from
+// the has_risk filter — matching the risk.results.list detail view, so the
+// chat-list "N risk" badge can't disagree with an empty detail panel.
+func TestListChats_DisabledPolicyFinding_NotCounted(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := externalUserCtx(t, ti, "ext-disabled")
+
+	chatID := seedChat(t, ctx, ti, "", "ext-disabled", "chat with disabled-policy finding")
+	seedRiskOnChatDisabledPolicy(t, ctx, ti, chatID)
+
+	result, err := ti.service.ListChats(ctx, defaultPayload())
+	require.NoError(t, err)
+	require.Len(t, result.Chats, 1)
+	require.NotNil(t, result.Chats[0].RiskFindingsCount)
+	require.Equal(t, 0, *result.Chats[0].RiskFindingsCount, "disabled-policy finding must not count")
+
+	// has_risk=true must not surface the chat; has_risk=false must.
+	hasRisk := "true"
+	pTrue := defaultPayload()
+	pTrue.HasRisk = &hasRisk
+	resTrue, err := ti.service.ListChats(ctx, pTrue)
+	require.NoError(t, err)
+	require.Empty(t, resTrue.Chats, "disabled-policy finding must not match has_risk=true")
+
+	noRisk := "false"
+	pFalse := defaultPayload()
+	pFalse.HasRisk = &noRisk
+	resFalse, err := ti.service.ListChats(ctx, pFalse)
+	require.NoError(t, err)
+	require.Len(t, resFalse.Chats, 1, "chat with only a disabled-policy finding reads as no-risk")
 }
 
 // TestListChats_InvalidFromTimestamp verifies that a malformed from timestamp returns a bad-request error.

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -223,6 +223,10 @@ WITH risk_counts AS (
   SELECT cm.chat_id, COUNT(*)::integer AS cnt
   FROM risk_results rr
   JOIN chat_messages cm ON cm.id = rr.chat_message_id
+  -- A finding only counts while its policy is still enabled and not deleted, so
+  -- disabling/deleting a policy retires its findings everywhere (keeps this
+  -- count in sync with the risk.results.list detail view).
+  JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
   WHERE rr.project_id = @project_id
     AND rr.found IS TRUE
     AND rr.excluded_at IS NULL
@@ -289,6 +293,10 @@ WITH risk_counts AS (
   SELECT cm.chat_id, COUNT(*)::integer AS cnt
   FROM risk_results rr
   JOIN chat_messages cm ON cm.id = rr.chat_message_id
+  -- A finding only counts while its policy is still enabled and not deleted, so
+  -- disabling/deleting a policy retires its findings everywhere (keeps this
+  -- count in sync with the risk.results.list detail view).
+  JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
   WHERE rr.project_id = @project_id
     AND rr.found IS TRUE
     AND rr.excluded_at IS NULL
@@ -471,6 +479,9 @@ SELECT
     SELECT COUNT(*)::bigint FROM ordered o
     WHERE EXISTS (
       SELECT 1 FROM risk_results rr
+      -- Only count a finding while its policy is enabled and not deleted (see
+      -- the risk_counts CTE / risk.results.list for the same gate).
+      JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
       WHERE rr.chat_message_id = o.id
         AND rr.project_id = @project_id::uuid
         AND rr.found IS TRUE
@@ -552,6 +563,10 @@ risk_rns AS (
   SELECT o.rn FROM ordered o
   WHERE EXISTS (
     SELECT 1 FROM risk_results rr
+    -- is_risk only fires while the finding's policy is enabled and not deleted,
+    -- so a since-disabled policy drops out of the "Risky only" view too (matches
+    -- risk.results.list, which drives the highlight detail).
+    JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
     WHERE rr.chat_message_id = o.id
       AND rr.project_id = @project_id::uuid
       AND rr.found IS TRUE
@@ -737,6 +752,9 @@ WHERE c.project_id = @project_id
       @has_risk_filter::text = 'true' AND EXISTS (
         SELECT 1 FROM risk_results rr
         JOIN chat_messages cm ON cm.id = rr.chat_message_id
+        -- Gate on the policy still being enabled and not deleted so the
+        -- has-risk list filter agrees with the per-chat count and detail view.
+        JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
         WHERE cm.chat_id = c.id
           AND rr.project_id = @project_id
           AND rr.found IS TRUE
@@ -748,6 +766,9 @@ WHERE c.project_id = @project_id
       @has_risk_filter::text = 'false' AND NOT EXISTS (
         SELECT 1 FROM risk_results rr
         JOIN chat_messages cm ON cm.id = rr.chat_message_id
+        -- Gate on the policy still being enabled and not deleted so the
+        -- has-risk list filter agrees with the per-chat count and detail view.
+        JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
         WHERE cm.chat_id = c.id
           AND rr.project_id = @project_id
           AND rr.found IS TRUE
@@ -949,6 +970,14 @@ RETURNING id;
 -- Test fixture: insert a minimal risk policy and return its id.
 INSERT INTO risk_policies (project_id, organization_id, name, sources, enabled, action, auto_name, version)
 VALUES (@project_id, @organization_id, 'test-policy', '{}', TRUE, 'flag', TRUE, 1)
+RETURNING id;
+
+-- name: SeedDisabledRiskPolicy :one
+-- Test fixture: insert a disabled risk policy and return its id. Findings under
+-- a disabled (or deleted) policy must drop out of every risk surface — the
+-- per-chat count, the is_risk flag, and the risk.results.list detail alike.
+INSERT INTO risk_policies (project_id, organization_id, name, sources, enabled, action, auto_name, version)
+VALUES (@project_id, @organization_id, 'test-policy-disabled', '{}', FALSE, 'flag', TRUE, 1)
 RETURNING id;
 
 -- name: SeedRiskResult :exec

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -53,6 +53,10 @@ WITH risk_counts AS (
   SELECT cm.chat_id, COUNT(*)::integer AS cnt
   FROM risk_results rr
   JOIN chat_messages cm ON cm.id = rr.chat_message_id
+  -- A finding only counts while its policy is still enabled and not deleted, so
+  -- disabling/deleting a policy retires its findings everywhere (keeps this
+  -- count in sync with the risk.results.list detail view).
+  JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
   WHERE rr.project_id = $3
     AND rr.found IS TRUE
     AND rr.excluded_at IS NULL
@@ -187,6 +191,9 @@ WHERE c.project_id = $1
       $8::text = 'true' AND EXISTS (
         SELECT 1 FROM risk_results rr
         JOIN chat_messages cm ON cm.id = rr.chat_message_id
+        -- Gate on the policy still being enabled and not deleted so the
+        -- has-risk list filter agrees with the per-chat count and detail view.
+        JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
         WHERE cm.chat_id = c.id
           AND rr.project_id = $1
           AND rr.found IS TRUE
@@ -198,6 +205,9 @@ WHERE c.project_id = $1
       $8::text = 'false' AND NOT EXISTS (
         SELECT 1 FROM risk_results rr
         JOIN chat_messages cm ON cm.id = rr.chat_message_id
+        -- Gate on the policy still being enabled and not deleted so the
+        -- has-risk list filter agrees with the per-chat count and detail view.
+        JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
         WHERE cm.chat_id = c.id
           AND rr.project_id = $1
           AND rr.found IS TRUE
@@ -548,6 +558,9 @@ SELECT
     SELECT COUNT(*)::bigint FROM ordered o
     WHERE EXISTS (
       SELECT 1 FROM risk_results rr
+      -- Only count a finding while its policy is enabled and not deleted (see
+      -- the risk_counts CTE / risk.results.list for the same gate).
+      JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
       WHERE rr.chat_message_id = o.id
         AND rr.project_id = $1::uuid
         AND rr.found IS TRUE
@@ -1440,6 +1453,10 @@ WITH risk_counts AS (
   SELECT cm.chat_id, COUNT(*)::integer AS cnt
   FROM risk_results rr
   JOIN chat_messages cm ON cm.id = rr.chat_message_id
+  -- A finding only counts while its policy is still enabled and not deleted, so
+  -- disabling/deleting a policy retires its findings everywhere (keeps this
+  -- count in sync with the risk.results.list detail view).
+  JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
   WHERE rr.project_id = $1
     AND rr.found IS TRUE
     AND rr.excluded_at IS NULL
@@ -1714,6 +1731,10 @@ risk_rns AS (
   SELECT o.rn FROM ordered o
   WHERE EXISTS (
     SELECT 1 FROM risk_results rr
+    -- is_risk only fires while the finding's policy is enabled and not deleted,
+    -- so a since-disabled policy drops out of the "Risky only" view too (matches
+    -- risk.results.list, which drives the highlight detail).
+    JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
     WHERE rr.chat_message_id = o.id
       AND rr.project_id = $3::uuid
       AND rr.found IS TRUE
@@ -2171,6 +2192,27 @@ type SeedChatMessageContentParams struct {
 // id, for exercising the text-search windowed view.
 func (q *Queries) SeedChatMessageContent(ctx context.Context, arg SeedChatMessageContentParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, seedChatMessageContent, arg.ChatID, arg.ProjectID, arg.Content)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const seedDisabledRiskPolicy = `-- name: SeedDisabledRiskPolicy :one
+INSERT INTO risk_policies (project_id, organization_id, name, sources, enabled, action, auto_name, version)
+VALUES ($1, $2, 'test-policy-disabled', '{}', FALSE, 'flag', TRUE, 1)
+RETURNING id
+`
+
+type SeedDisabledRiskPolicyParams struct {
+	ProjectID      uuid.UUID
+	OrganizationID string
+}
+
+// Test fixture: insert a disabled risk policy and return its id. Findings under
+// a disabled (or deleted) policy must drop out of every risk surface — the
+// per-chat count, the is_risk flag, and the risk.results.list detail alike.
+func (q *Queries) SeedDisabledRiskPolicy(ctx context.Context, arg SeedDisabledRiskPolicyParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, seedDisabledRiskPolicy, arg.ProjectID, arg.OrganizationID)
 	var id uuid.UUID
 	err := row.Scan(&id)
 	return id, err


### PR DESCRIPTION
## What

Risk findings whose policy was **disabled or deleted after detection** showed a `N risk` badge on the chat list and appeared under the chat-detail **"Risky only"** filter, but rendered as **plain text with no highlight** — the detail panel was empty.

## Why it was broken

Two sets of queries answered "is there risk here?" differently:

| Surface                       | Query                        | Policy gate?                              |
| ----------------------------- | ---------------------------- | ----------------------------------------- |
| Chat-list "N risk" badge      | `risk_counts` CTE            | ❌ none                                   |
| `is_risk` flag → "Risky only" | `ListRiskWindowedMessages`   | ❌ none                                   |
| Detail risk-only totals       | chat totals subquery         | ❌ none                                   |
| `has_risk` list filter        | list query EXISTS pair       | ❌ none                                   |
| **Highlight marks + popover** | `ListRiskResultsByChatFound` | ✅ `enabled IS TRUE AND deleted IS FALSE` |

The count/flag side asks only about the _finding_ lifecycle (`found` / `excluded_at` / `false_positive_at`). The detail side additionally requires the _policy_ to still be on. Disable a policy after it has detected → findings keep counting + flagging `is_risk`, but `risk.results.list` returns `[]` → badge + flagged row with no highlight.

Observed on `dev.getgram.ai`: `chat.load` returns `is_risk: true`; `risk.results.list?chat_id=…` returns `{"results":[],"total_count":0}`.

## Fix

Apply the same `enabled IS TRUE AND deleted IS FALSE` policy gate to **every** presence/count/flag query in `server/internal/chat/queries.sql` (both `risk_counts` CTEs, the detail-totals `risk_findings`, `is_risk`, and the `has_risk` filter pair). Now all risk surfaces share one source of truth — disabling/deleting a policy retires its findings everywhere, consistent with `risk.results.list` (and with `CountAllFindings`, which already gated).

## Test

- New `SeedDisabledRiskPolicy` fixture + `TestListChats_DisabledPolicyFinding_NotCounted`: a found finding under a disabled policy is excluded from the per-chat count and the `has_risk` filter.
- Existing risk tests (`TestListChats_Filter_HasRisk_*`, `RiskFindingsCountInResult`, `TestLoadChat_RiskOnly_*`) still green (10/10).

## Notes

- SQLc query change only — **no DB migration**, regenerated `queries.sql.go` included.
- Restart the server to pick up regenerated query code.
- **Out of scope (follow-up):** the risk **overview** dashboard is still internally inconsistent — `CountAllFindings` gates, but `ListRiskOverviewTopUsers` / `TimeSeriesFindings` / `TopRules` + `GetRiskOverviewCounts` do not. Gating those changes historical charts retroactively, so it's deferred.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent risk display by gating all counts and flags on the policy being enabled and not deleted. Disabling or deleting a policy now retires its findings everywhere, so badges, filters, and highlights always agree.

- **Bug Fixes**
  - Applied `enabled IS TRUE AND deleted IS FALSE` gate to all risk presence/count queries in `server/internal/chat/queries.sql` (both `risk_counts` CTEs, detail totals, `is_risk`, and the `has_risk` filter).
  - Ensures no more "N risk" badges or "Risky only" rows without highlights when a policy was disabled/deleted after detection.
  - Added `SeedDisabledRiskPolicy` and a regression test to assert disabled-policy findings are excluded from counts and `has_risk`; regenerated `repo/queries.sql.go`; no DB migration.

<sup>Written for commit f0e5d3fde20768d8a2041d5cff53c9c6012de0a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

