### PR TITLE
fix(hooks): enforce Codex shadow MCP inventory

### DIFF
--- a/.changeset/codex-shadow-mcp-inventory.md
+++ b/.changeset/codex-shadow-mcp-inventory.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Improved Codex shadow MCP enforcement so calls are checked against the session MCP server inventory.

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -113,17 +113,50 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (res *ge
 			if policy != nil {
 				toolName := ev.ToolName
 				evidence, matched := s.codexShadowMCPEvidence(ctx, payload)
-				detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, metadata.UserID, policy.ID, toolName, evidence)
-				if denied && matched == nil {
-					// Older Codex installs ship no inventory snapshot, so no
-					// server URL resolves; fall back to the echoed id rather
-					// than hard-block them.
-					if _, idDenied := s.shadowMCPClient.ValidateToolsetCall(ctx, ev.ToolInput, toolName, orgID); !idDenied {
-						detail, denied = "", false
+				codexMetaServer, isCodexMetaTool := codexMCPMetaToolServer(payload)
+				var detail string
+				var denied bool
+				if isCodexMetaTool {
+					// Codex's built-in MCP resource tools are not Gram
+					// toolset calls, so they never carry x-gram-toolset-id.
+					// Enforce them from the inventory target instead.
+					if codexMetaServer == "" {
+						detail = fmt.Sprintf("Codex MCP meta-tool %q is missing required tool_input.server", toolName)
+					} else {
+						detail = s.codexInventoryProvenanceDetail(ctx, matched, orgID)
 					}
+					if detail == "" && matched == nil {
+						detail = fmt.Sprintf("MCP server %q could not be verified from Codex inventory", evidence.ServerIdentity)
+					}
+					if detail != "" {
+						if _, allowed := s.canBypassPolicy(ctx, orgID, metadata.UserID, policy.ID, evidence, toolName); !allowed {
+							denied = true
+						}
+					}
+				} else {
+					detail, denied = s.enforceShadowMCPToolAccess(ctx, orgID, projectID, metadata.UserID, policy.ID, toolName, evidence)
+				}
+				if !denied && !isCodexMetaTool {
+					// The inventory snapshot pins where the call actually
+					// routes: deny when it points at a non-Gram target, or
+					// when the active inventory cannot uniquely prove the
+					// target.
+					inventoryDetail := s.codexInventoryProvenanceDetail(ctx, matched, orgID)
+					if inventoryDetail != "" {
+						if _, allowed := s.canBypassPolicy(ctx, orgID, metadata.UserID, policy.ID, evidence, toolName); !allowed {
+							detail, denied = inventoryDetail, true
+						}
+					} else if evidence.ServerIdentity != "" && matched == nil {
+						inventoryDetail = fmt.Sprintf("MCP server %q could not be verified from Codex inventory", evidence.ServerIdentity)
+						if _, allowed := s.canBypassPolicy(ctx, orgID, metadata.UserID, policy.ID, evidence, toolName); !allowed {
+							detail, denied = inventoryDetail, true
+						}
+					}
+				} else if denied && !isCodexMetaTool && evidence.ServerIdentity != "" && matched == nil {
+					detail = fmt.Sprintf("MCP server %q could not be verified from Codex inventory", evidence.ServerIdentity)
 				}
 				if denied {
-					logger.InfoContext(ctx, "denying codex tool call: failed gram toolset validation",
+					logger.InfoContext(ctx, "denying codex tool call: failed shadow mcp validation",
 						attr.SlogEvent("codex_hook_denied"),
 						attr.SlogHookBlockReason(detail),
 						attr.SlogRiskPolicyID(policy.ID),
@@ -376,7 +409,6 @@ func (s *Service) buildCodexTelemetryAttributes(ctx context.Context, payload *ge
 		}
 	}
 
-	// Parse MCP tool names using the mcp__<server>__<tool> convention.
 	if server, fn, ok := toolref.AttributeTool(toolName); ok {
 		attrs[attr.ToolCallSourceKey] = server
 		attrs[attr.ToolNameKey] = fn
@@ -395,6 +427,20 @@ func (s *Service) buildCodexTelemetryAttributes(ctx context.Context, payload *ge
 						attrs[attr.ToolNameKey] = rest
 					}
 				}
+				if v := resolvedMCPMatch(matched, server); v != "" {
+					attrs[attr.MCPMatchKey] = v
+				}
+				applyMCPInventoryAttrs(attrs, matched)
+			}
+		}
+	} else if server, ok := codexMCPMetaToolServer(payload); ok {
+		if server == "" {
+			return attrs
+		}
+		attrs[attr.ToolCallSourceKey] = server
+		if metadata.SessionID != "" {
+			if entries, err := s.getCachedMCPList(ctx, metadata.SessionID); err == nil {
+				matched := matchCodexCachedMCPServerEntry(entries, server)
 				if v := resolvedMCPMatch(matched, server); v != "" {
 					attrs[attr.MCPMatchKey] = v
 				}

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -38,6 +38,138 @@ func TestCodex_PreToolUse_ShadowMCPBlockWithIdentityEvidenceIncludesRequestLink(
 	require.Contains(t, *result.Reason, shadowMCPApprovalRequestPrompt)
 }
 
+func TestCodex_PreToolUse_ShadowMCPAllowsGramHostedMetaTool(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	sessionID := "codex-session-gram-mcp-meta-tool"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID), []MCPServerEntry{{
+		RawLine:       "",
+		Source:        "local",
+		PluginName:    "",
+		Name:          "speakeasy-team",
+		URL:           "https://app.getgram.ai/mcp/speakeasy-team-8g3az",
+		Command:       "",
+		Transport:     "HTTP",
+		Status:        "unknown",
+		StatusRaw:     "o_auth",
+		ConnectorUUID: "",
+		ToolPrefix:    "speakeasy_team",
+	}}, sessionMCPListTTL))
+
+	toolName := "list_mcp_resources"
+	userEmail := "anonymous-codex@example.com"
+	result, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		ToolName:      &toolName,
+		ToolInput:     map[string]any{"server": "speakeasy-team"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.Decision)
+	require.Nil(t, result.Reason)
+}
+
+func TestCodex_PreToolUse_ShadowMCPBlocksExternalMetaTool(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	sessionID := "codex-session-external-mcp-meta-tool"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID), []MCPServerEntry{{
+		RawLine:       "",
+		Source:        "local",
+		PluginName:    "",
+		Name:          "platform-logs",
+		URL:           "https://chat.speakeasy.com/mcp/speakeasy-team-62awx",
+		Command:       "",
+		Transport:     "HTTP",
+		Status:        "unknown",
+		StatusRaw:     "bearer_token",
+		ConnectorUUID: "",
+		ToolPrefix:    "platform_logs",
+	}}, sessionMCPListTTL))
+
+	toolName := "list_mcp_resources"
+	userEmail := "anonymous-codex@example.com"
+	result, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		ToolName:      &toolName,
+		ToolInput:     map[string]any{"server": "platform-logs"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Decision)
+	require.Equal(t, "deny", *result.Decision)
+	require.NotNil(t, result.Reason)
+	require.Contains(t, *result.Reason, "not Gram-hosted")
+	require.Contains(t, *result.Reason, "https://chat.speakeasy.com/mcp/speakeasy-team-62awx")
+	require.Contains(t, *result.Reason, "Request access:")
+}
+
+func TestCodex_PreToolUse_ShadowMCPBlocksUnverifiedMetaTool(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	sessionID := "codex-session-unverified-mcp-meta-tool"
+	toolName := "list_mcp_resources"
+	userEmail := "anonymous-codex@example.com"
+	result, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		ToolName:      &toolName,
+		ToolInput:     map[string]any{"server": "platform-logs"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Decision)
+	require.Equal(t, "deny", *result.Decision)
+	require.NotNil(t, result.Reason)
+	require.Contains(t, *result.Reason, "could not be verified from Codex inventory")
+}
+
+func TestCodex_PreToolUse_ShadowMCPBlocksMetaToolMissingServer(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]any{
+		"nil input":         nil,
+		"missing server":    map[string]any{},
+		"blank server":      map[string]any{"server": "  "},
+		"non-string server": map[string]any{"server": 42},
+	}
+	for name, toolInput := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestHooksService(t)
+			ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+			sessionID := "codex-session-missing-meta-server-" + name
+			toolName := "list_mcp_resources"
+			userEmail := "anonymous-codex@example.com"
+			result, err := ti.service.Codex(ctx, &gen.CodexPayload{
+				HookEventName: "PreToolUse",
+				SessionID:     &sessionID,
+				UserEmail:     &userEmail,
+				ToolName:      &toolName,
+				ToolInput:     toolInput,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotNil(t, result.Decision)
+			require.Equal(t, "deny", *result.Decision)
+			require.NotNil(t, result.Reason)
+			require.Contains(t, *result.Reason, `Codex MCP meta-tool "list_mcp_resources" is missing required tool_input.server`)
+		})
+	}
+}
+
 func TestCodex_PreToolUse_TargetedShadowMCPPolicyUsesResolvedHookUser(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
@@ -211,6 +343,46 @@ func TestBuildCodexTelemetryAttributes_EnrichesMCPToolFromInventory(t *testing.T
 	require.Equal(t, "get_issue", attrs[attr.ToolNameKey])
 }
 
+func TestBuildCodexTelemetryAttributes_EnrichesMCPMetaToolFromInventory(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	sessionID := "codex-session-telemetry-meta-inventory"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID), []MCPServerEntry{{
+		RawLine:       "",
+		Source:        "local",
+		PluginName:    "",
+		Name:          "platform-logs",
+		URL:           "https://chat.example.com/mcp/platform-logs",
+		Command:       "",
+		Transport:     "HTTP",
+		Status:        "unknown",
+		StatusRaw:     "bearer_token",
+		ConnectorUUID: "",
+		ToolPrefix:    "platform_logs",
+	}}, sessionMCPListTTL))
+
+	toolName := "list_mcp_resources"
+	attrs := ti.service.buildCodexTelemetryAttributes(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &toolName,
+		ToolInput:     map[string]any{"server": "platform-logs"},
+	}, &SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "Codex",
+		UserEmail:   "",
+		UserID:      "",
+		ClaudeOrgID: "",
+		GramOrgID:   "org-id",
+		ProjectID:   "project-id",
+	})
+	require.Equal(t, "https://chat.example.com/mcp/platform-logs", attrs[attr.MCPServerURLKey])
+	require.Equal(t, "https://chat.example.com/mcp/platform-logs", attrs[attr.MCPMatchKey])
+	require.Equal(t, "platform-logs", attrs[attr.ToolCallSourceKey])
+	require.Equal(t, "list_mcp_resources", attrs[attr.ToolNameKey])
+}
+
 func TestCodexShadowMCPEvidence_ResolvesURLFromInventory(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
@@ -252,6 +424,77 @@ func TestCodexShadowMCPEvidence_ResolvesURLFromInventory(t *testing.T) {
 	require.Equal(t, "https://chat.example.com/mcp/int-linear", evidence.FullURL)
 	require.NotNil(t, matched)
 
+	metaTool := "list_mcp_resources"
+	evidence, matched = ti.service.codexShadowMCPEvidence(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &metaTool,
+		ToolInput:     map[string]any{"server": "int-linear"},
+	})
+	require.Equal(t, "int-linear", evidence.ServerIdentity)
+	require.Equal(t, "https://chat.example.com/mcp/int-linear", evidence.FullURL)
+	require.NotNil(t, matched)
+
+	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID), []MCPServerEntry{{
+		RawLine:       "",
+		Source:        "local",
+		PluginName:    "",
+		Name:          "datadog",
+		URL:           "https://app.getgram.ai/mcp/datadog",
+		Command:       "",
+		Transport:     "HTTP",
+		Status:        "unknown",
+		StatusRaw:     "o_auth",
+		ConnectorUUID: "",
+		ToolPrefix:    "datadog",
+	}, {
+		RawLine:       "",
+		Source:        "local",
+		PluginName:    "",
+		Name:          "datadog",
+		URL:           "https://third-party.example.com/mcp/datadog",
+		Command:       "",
+		Transport:     "HTTP",
+		Status:        "unknown",
+		StatusRaw:     "unsupported",
+		ConnectorUUID: "",
+		ToolPrefix:    "datadog",
+	}}, sessionMCPListTTL))
+	ambiguousTool := "mcp__datadog__query"
+	evidence, matched = ti.service.codexShadowMCPEvidence(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &ambiguousTool,
+	})
+	require.Equal(t, "datadog", evidence.ServerIdentity)
+	require.Empty(t, evidence.FullURL)
+	require.Nil(t, matched, "ambiguous Codex namespaces must not resolve to the first matching inventory row")
+
+	require.NoError(t, ti.service.cache.Set(ctx, sessionMCPListCacheKey(sessionID), []MCPServerEntry{{
+		RawLine:       "",
+		Source:        "local",
+		PluginName:    "",
+		Name:          "int-linear",
+		URL:           "https://chat.example.com/mcp/int-linear",
+		Command:       "",
+		Transport:     "HTTP",
+		Status:        "unknown",
+		StatusRaw:     "o_auth",
+		ConnectorUUID: "",
+		ToolPrefix:    "int_linear",
+	}, {
+		RawLine:       "",
+		Source:        "local",
+		PluginName:    "",
+		Name:          "local-tool",
+		URL:           "",
+		Command:       "npx -y some-server",
+		Transport:     "STDIO",
+		Status:        "unknown",
+		StatusRaw:     "",
+		ConnectorUUID: "",
+		ToolPrefix:    "local_tool",
+	}}, sessionMCPListTTL))
 	stdioTool := "mcp__local_tool__run"
 	evidence, matched = ti.service.codexShadowMCPEvidence(ctx, &gen.CodexPayload{
 		HookEventName: "PreToolUse",

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -97,18 +97,27 @@ func sanitizeMCPName(name string) string {
 // carry a pre-computed ToolPrefix because Codex's sanitizer differs from
 // Claude's (every non-alphanumeric/underscore character becomes "_").
 func matchCachedMCPEntry(entries []MCPServerEntry, serverPrefix string) *MCPServerEntry {
+	var matched *MCPServerEntry
 	for i := range entries {
-		if entries[i].ToolPrefix != "" && entries[i].ToolPrefix == serverPrefix {
-			return &entries[i]
+		if !mcpEntryMatchesPrefix(entries[i], serverPrefix) {
+			continue
 		}
-		if entries[i].ConnectorUUID != "" && entries[i].ConnectorUUID == serverPrefix {
-			return &entries[i]
+		if matched != nil {
+			return nil
 		}
-		if mcpServerPrefix(entries[i].Source, entries[i].PluginName, entries[i].Name) == serverPrefix {
-			return &entries[i]
-		}
+		matched = &entries[i]
 	}
-	return nil
+	return matched
+}
+
+func mcpEntryMatchesPrefix(entry MCPServerEntry, serverPrefix string) bool {
+	if entry.ToolPrefix != "" && entry.ToolPrefix == serverPrefix {
+		return true
+	}
+	if entry.ConnectorUUID != "" && entry.ConnectorUUID == serverPrefix {
+		return true
+	}
+	return mcpServerPrefix(entry.Source, entry.PluginName, entry.Name) == serverPrefix
 }
 
 // matchCodexCachedMCPEntry resolves a raw Codex tool name
@@ -124,6 +133,7 @@ func matchCodexCachedMCPEntry(entries []MCPServerEntry, rawToolName string) *MCP
 		return nil
 	}
 	var best *MCPServerEntry
+	ambiguous := false
 	for i := range entries {
 		p := entries[i].ToolPrefix
 		if p == "" || !strings.HasPrefix(rest, p+"__") {
@@ -131,12 +141,47 @@ func matchCodexCachedMCPEntry(entries []MCPServerEntry, rawToolName string) *MCP
 		}
 		if best == nil || len(p) > len(best.ToolPrefix) {
 			best = &entries[i]
+			ambiguous = false
+			continue
+		}
+		if len(p) == len(best.ToolPrefix) {
+			ambiguous = true
 		}
 	}
 	if best != nil {
+		if ambiguous {
+			return nil
+		}
 		return best
 	}
 	return matchCachedMCPEntry(entries, mcpServerIdentityFromToolName(rawToolName))
+}
+
+// matchCodexCachedMCPServerEntry resolves the explicit server name Codex
+// sends in built-in MCP meta-tool inputs, such as list_mcp_resources. Unlike
+// mcp__ tool names, this value is the configured server name rather than a
+// sanitized prefix.
+func matchCodexCachedMCPServerEntry(entries []MCPServerEntry, serverName string) *MCPServerEntry {
+	serverName = strings.TrimSpace(serverName)
+	if serverName == "" {
+		return nil
+	}
+	var matched *MCPServerEntry
+	for i := range entries {
+		if entries[i].Name == serverName {
+			if matched != nil {
+				return nil
+			}
+			matched = &entries[i]
+		}
+	}
+	if matched != nil {
+		return matched
+	}
+	if matched := matchCachedMCPEntry(entries, codexSanitizeToolName(serverName)); matched != nil {
+		return matched
+	}
+	return matchCachedMCPEntry(entries, serverName)
 }
 
 // applyMCPInventoryAttrs decorates a telemetry attribute map with the

--- a/server/internal/hooks/mcp_match_test.go
+++ b/server/internal/hooks/mcp_match_test.go
@@ -69,6 +69,52 @@ func TestMatchCachedMCPEntry(t *testing.T) {
 	}
 }
 
+func TestMatchCachedMCPEntry_AmbiguousPrefix(t *testing.T) {
+	t.Parallel()
+	entries := []MCPServerEntry{
+		{Source: "local", Name: "datadog", URL: "https://app.getgram.ai/mcp/datadog", ToolPrefix: "datadog"},
+		{Source: "local", Name: "datadog", URL: "https://third-party.example.com/mcp/datadog", ToolPrefix: "datadog"},
+	}
+
+	assert.Nil(t, matchCachedMCPEntry(entries, "datadog"))
+}
+
+func TestMatchCodexCachedMCPServerEntry(t *testing.T) {
+	t.Parallel()
+	entries := []MCPServerEntry{
+		{Source: "local", Name: "platform-logs", URL: "https://chat.example.com/mcp/platform-logs", ToolPrefix: "platform_logs"},
+		{Source: "local", Name: "Slack (Remote)", URL: "https://app.getgram.ai/mcp/slack", ToolPrefix: "Slack__Remote_"},
+	}
+
+	got := matchCodexCachedMCPServerEntry(entries, "platform-logs")
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "https://chat.example.com/mcp/platform-logs", got.URL)
+	}
+
+	got = matchCodexCachedMCPServerEntry(entries, "Slack (Remote)")
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "https://app.getgram.ai/mcp/slack", got.URL)
+	}
+
+	got = matchCodexCachedMCPServerEntry(entries, "platform_logs")
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "platform-logs", got.Name)
+	}
+
+	assert.Nil(t, matchCodexCachedMCPServerEntry(entries, ""))
+	assert.Nil(t, matchCodexCachedMCPServerEntry(entries, "missing"))
+}
+
+func TestMatchCodexCachedMCPServerEntry_AmbiguousName(t *testing.T) {
+	t.Parallel()
+	entries := []MCPServerEntry{
+		{Source: "local", Name: "Datadog", URL: "https://app.getgram.ai/mcp/datadog", ToolPrefix: "Datadog"},
+		{Source: "local", Name: "Datadog", URL: "https://third-party.example.com/mcp/datadog", ToolPrefix: "Datadog"},
+	}
+
+	assert.Nil(t, matchCodexCachedMCPServerEntry(entries, "Datadog"))
+}
+
 func TestApplyMCPInventoryAttrs(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -81,10 +82,16 @@ func (s *Service) canBypassPolicy(
 // URL rather than just the name.
 func (s *Service) codexShadowMCPEvidence(ctx context.Context, payload *gen.CodexPayload) (shadowmcp.AccessEvidence, *MCPServerEntry) {
 	rawToolName := conv.PtrValOr(payload.ToolName, "")
+	serverIdentity := mcpServerIdentityFromToolName(rawToolName)
+	if serverIdentity == "" {
+		if metaToolServer, ok := codexMCPMetaToolServer(payload); ok {
+			serverIdentity = metaToolServer
+		}
+	}
 	evidence := shadowmcp.AccessEvidence{
 		FullURL:        "",
 		URLHost:        "",
-		ServerIdentity: mcpServerIdentityFromToolName(rawToolName),
+		ServerIdentity: serverIdentity,
 	}
 	sessionID := conv.PtrValOr(payload.SessionID, "")
 	if evidence.ServerIdentity == "" || sessionID == "" {
@@ -94,9 +101,14 @@ func (s *Service) codexShadowMCPEvidence(ctx context.Context, payload *gen.Codex
 	if err != nil {
 		return evidence, nil
 	}
-	matched := matchCodexCachedMCPEntry(entries, rawToolName)
+	var matched *MCPServerEntry
+	if strings.HasPrefix(rawToolName, "mcp__") {
+		matched = matchCodexCachedMCPEntry(entries, rawToolName)
+	} else {
+		matched = matchCodexCachedMCPServerEntry(entries, evidence.ServerIdentity)
+	}
 	if matched != nil {
-		if matched.ToolPrefix != "" {
+		if matched.ToolPrefix != "" && strings.HasPrefix(rawToolName, "mcp__") {
 			// The naive 3-way split truncates prefixes containing "__"; the
 			// matched entry carries the full sanitized prefix.
 			evidence.ServerIdentity = matched.ToolPrefix
@@ -111,6 +123,43 @@ func (s *Service) codexShadowMCPEvidence(ctx context.Context, payload *gen.Codex
 		}
 	}
 	return evidence, matched
+}
+
+func codexMCPMetaToolServer(payload *gen.CodexPayload) (string, bool) {
+	if payload == nil {
+		return "", false
+	}
+	switch conv.PtrValOr(payload.ToolName, "") {
+	case "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource":
+	default:
+		return "", false
+	}
+	input, ok := payload.ToolInput.(map[string]any)
+	if !ok {
+		return "", true
+	}
+	server, _ := input["server"].(string)
+	return strings.TrimSpace(server), true
+}
+
+// codexInventoryProvenanceDetail reports why a Codex MCP call should be
+// denied based on where the SessionStart inventory says the matched server
+// actually routes: an external (non-Gram) URL or a local stdio server. An
+// empty string means the inventory raises no objection — either the entry is
+// Gram-hosted or there is nothing to cross-check (nil entry). Mirrors the
+// target checks of the Claude PreToolUse guard.
+func (s *Service) codexInventoryProvenanceDetail(ctx context.Context, matched *MCPServerEntry, orgID string) string {
+	if matched == nil {
+		return ""
+	}
+	switch {
+	case matched.URL != "" && !s.isGramHostedMCPURLForOrg(ctx, matched.URL, orgID):
+		return fmt.Sprintf("MCP server %q is not Gram-hosted (URL: %s)", matched.Name, matched.URL)
+	case matched.URL == "" && matched.Command != "":
+		return fmt.Sprintf("MCP server %q is a local stdio server (command: %s)", matched.Name, matched.Command)
+	default:
+		return ""
+	}
 }
 
 func cursorShadowMCPEvidence(payload *gen.CursorPayload) shadowmcp.AccessEvidence {
@@ -129,9 +178,10 @@ func claudeShadowMCPEvidence(rawToolName string) shadowmcp.AccessEvidence {
 	}
 }
 
-// mcpServerIdentityFromToolName extracts the MCP server identity from a Codex
-// or Claude tool name. Both hosts emit the "mcp__<server>__<tool>" form, so the
-// shared parser's Cursor "MCP:" branch never fires here.
+// mcpServerIdentityFromToolName extracts the MCP server identity from a
+// Claude-style mcp__ tool name. Some Codex MCP calls arrive as built-in
+// meta-tools with the server name in tool_input.server; those are handled by
+// codexMCPMetaToolServer.
 func mcpServerIdentityFromToolName(rawName string) string {
 	return toolref.MCPServerOf(rawName)
 }


### PR DESCRIPTION
## Summary
- Fixes DNO-207
- Derive Codex Shadow MCP evidence from built-in MCP meta-tool inputs like `list_mcp_resources` / `read_mcp_resource`
- Require a unique Codex MCP inventory match before trusting backend provenance
- Fail closed for missing, ambiguous, external, or local stdio MCP inventory targets unless a bypass applies

## Testing
- `go test -c ./server/internal/hooks -o /tmp/hooks.test`
- `mise lint:server`

Note: `go test ./server/internal/hooks` previously could not complete locally because Docker/Postgres test infrastructure timed out before tests ran.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Codex shadow MCP access against the session MCP inventory and validates Codex MCP meta‑tools using server evidence from `tool_input.server`. Addresses DNO-207 by failing closed when the target cannot be uniquely verified, is external (non‑Gram), or uses local STDIO, while honoring bypass policies.

- **Bug Fixes**
  - Require a single unique inventory match before trusting provenance for Codex calls; treat ambiguous prefixes or server names as unverified.
  - Enforce built-in meta-tools: require non-empty `tool_input.server`; resolve and verify the server by name against the session inventory.
  - Block external URLs and local STDIO targets with clear denial reasons; expand telemetry for meta-tools with resolved server URL, match keys, and source.

<sup>Written for commit bd5fcab7e0d456a3b1e61b7b8ec1089b0cc4b6d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

