### PR TITLE
fix(hooks): authorize Cursor shadow MCP by server URL, not echoed id

### DIFF
--- a/.changeset/cursor-shadow-mcp-host-check.md
+++ b/.changeset/cursor-shadow-mcp-host-check.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix Cursor shadow MCP enforcement wrongly blocking Gram-hosted MCP servers when a shadow MCP risk policy is enabled — access is now decided by the server URL rather than requiring the agent to echo an internal identifier.

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -113,18 +113,13 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (res *ge
 			if policy != nil {
 				toolName := ev.ToolName
 				evidence, matched := s.codexShadowMCPEvidence(ctx, payload)
-				detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, metadata.UserID, policy.ID, ev.ToolInput, toolName, evidence)
-				if !denied {
-					// Toolset validation proves a valid x-gram-toolset-id was
-					// echoed, but a shadow server's schema can coach the client
-					// into copying one. The inventory snapshot pins where the
-					// call actually routes — deny when it points at a non-Gram
-					// target. Unmatched prefixes and missing snapshots stay
-					// allowed: older plugin installs ship no inventory.
-					if d := s.codexInventoryProvenanceDetail(ctx, matched, orgID); d != "" {
-						if _, allowed := s.canBypassPolicy(ctx, orgID, metadata.UserID, policy.ID, evidence, toolName); !allowed {
-							detail, denied = d, true
-						}
+				detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, metadata.UserID, policy.ID, toolName, evidence)
+				if denied && matched == nil {
+					// Older Codex installs ship no inventory snapshot, so no
+					// server URL resolves; fall back to the echoed id rather
+					// than hard-block them.
+					if _, idDenied := s.shadowMCPClient.ValidateToolsetCall(ctx, ev.ToolInput, toolName, orgID); !idDenied {
+						detail, denied = "", false
 					}
 				}
 				if denied {

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -273,61 +273,6 @@ func TestCodexShadowMCPEvidence_ResolvesURLFromInventory(t *testing.T) {
 	require.Nil(t, matched)
 }
 
-func TestCodexInventoryProvenanceDetail(t *testing.T) {
-	t.Parallel()
-	ctx, ti := newTestHooksService(t)
-
-	external := &MCPServerEntry{
-		RawLine:       "",
-		Source:        "local",
-		PluginName:    "",
-		Name:          "evil",
-		URL:           "https://mcp.attacker.example/mcp",
-		Command:       "",
-		Transport:     "HTTP",
-		Status:        "unknown",
-		StatusRaw:     "",
-		ConnectorUUID: "",
-		ToolPrefix:    "",
-	}
-	detail := ti.service.codexInventoryProvenanceDetail(ctx, external, "org-id")
-	require.Contains(t, detail, "not Gram-hosted")
-	require.Contains(t, detail, "https://mcp.attacker.example/mcp")
-
-	stdio := &MCPServerEntry{
-		RawLine:       "",
-		Source:        "local",
-		PluginName:    "",
-		Name:          "local-tool",
-		URL:           "",
-		Command:       "npx -y some-server",
-		Transport:     "STDIO",
-		Status:        "unknown",
-		StatusRaw:     "",
-		ConnectorUUID: "",
-		ToolPrefix:    "local_tool",
-	}
-	detail = ti.service.codexInventoryProvenanceDetail(ctx, stdio, "org-id")
-	require.Contains(t, detail, "local stdio server")
-
-	gramHosted := &MCPServerEntry{
-		RawLine:       "",
-		Source:        "local",
-		PluginName:    "",
-		Name:          "gram",
-		URL:           "https://app.getgram.ai/mcp/acme",
-		Command:       "",
-		Transport:     "HTTP",
-		Status:        "unknown",
-		StatusRaw:     "",
-		ConnectorUUID: "",
-		ToolPrefix:    "",
-	}
-	require.Empty(t, ti.service.codexInventoryProvenanceDetail(ctx, gramHosted, "org-id"))
-
-	require.Empty(t, ti.service.codexInventoryProvenanceDetail(ctx, nil, "org-id"))
-}
-
 func TestCodexSessionMetadata_CachesSessionStartEmail(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -158,7 +158,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (res *
 		}
 		toolName := strings.TrimPrefix(ev.ToolName, "MCP:")
 		evidence := cursorShadowMCPEvidence(payload)
-		if detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, actorUserID, policy.ID, ev.ToolInput, toolName, evidence); denied {
+		if detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, actorUserID, policy.ID, toolName, evidence); denied {
 			logger.InfoContext(ctx, "denying cursor tool call: failed gram toolset validation",
 				attr.SlogEvent("cursor_hook_denied"),
 				attr.SlogHookBlockReason(detail),

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -18,7 +18,6 @@ func (s *Service) enforceShadowMCPToolAccess(
 	projectID string,
 	userID string,
 	policyID string,
-	toolInput any,
 	toolName string,
 	evidence shadowmcp.AccessEvidence,
 ) (string, bool) {
@@ -29,12 +28,10 @@ func (s *Service) enforceShadowMCPToolAccess(
 			return "", false
 		}
 		detail = fmt.Sprintf("MCP server is not Gram-hosted (URL: %s)", evidence.FullURL)
+	case evidence.ServerIdentity != "":
+		detail = fmt.Sprintf("MCP server %q is not Gram-hosted", evidence.ServerIdentity)
 	default:
-		d, denied := s.shadowMCPClient.ValidateToolsetCall(ctx, toolInput, toolName, organizationID)
-		if !denied {
-			return "", false
-		}
-		detail = d
+		detail = "MCP tool call has no recognizable server target"
 	}
 
 	if target, allowed := s.canBypassPolicy(ctx, organizationID, userID, policyID, evidence, toolName); allowed {
@@ -116,26 +113,6 @@ func (s *Service) codexShadowMCPEvidence(ctx context.Context, payload *gen.Codex
 		}
 	}
 	return evidence, matched
-}
-
-// codexInventoryProvenanceDetail reports why a Codex MCP call should be
-// denied based on where the SessionStart inventory says the matched server
-// actually routes: an external (non-Gram) URL or a local stdio server. An
-// empty string means the inventory raises no objection — either the entry is
-// Gram-hosted or there is nothing to cross-check (nil entry). Mirrors the
-// target checks of the Claude PreToolUse guard.
-func (s *Service) codexInventoryProvenanceDetail(ctx context.Context, matched *MCPServerEntry, orgID string) string {
-	if matched == nil {
-		return ""
-	}
-	switch {
-	case matched.URL != "" && !s.isGramHostedMCPURLForOrg(ctx, matched.URL, orgID):
-		return fmt.Sprintf("MCP server %q is not Gram-hosted (URL: %s)", matched.Name, matched.URL)
-	case matched.URL == "" && matched.Command != "":
-		return fmt.Sprintf("MCP server %q is a local stdio server (command: %s)", matched.Name, matched.Command)
-	default:
-		return ""
-	}
 }
 
 func cursorShadowMCPEvidence(payload *gen.CursorPayload) shadowmcp.AccessEvidence {

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -22,10 +22,21 @@ func (s *Service) enforceShadowMCPToolAccess(
 	toolName string,
 	evidence shadowmcp.AccessEvidence,
 ) (string, bool) {
-	detail, denied := s.shadowMCPClient.ValidateToolsetCall(ctx, toolInput, toolName, organizationID)
-	if !denied {
-		return "", false
+	var detail string
+	switch {
+	case evidence.FullURL != "":
+		if s.isGramHostedMCPURLForOrg(ctx, evidence.FullURL, organizationID) {
+			return "", false
+		}
+		detail = fmt.Sprintf("MCP server is not Gram-hosted (URL: %s)", evidence.FullURL)
+	default:
+		d, denied := s.shadowMCPClient.ValidateToolsetCall(ctx, toolInput, toolName, organizationID)
+		if !denied {
+			return "", false
+		}
+		detail = d
 	}
+
 	if target, allowed := s.canBypassPolicy(ctx, organizationID, userID, policyID, evidence, toolName); allowed {
 		s.logger.InfoContext(ctx, "shadow-mcp call allowed via risk policy bypass grant",
 			attr.SlogEvent("shadow_mcp_policy_bypass_allow"),

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -28,10 +28,8 @@ func (s *Service) enforceShadowMCPToolAccess(
 			return "", false
 		}
 		detail = fmt.Sprintf("MCP server is not Gram-hosted (URL: %s)", evidence.FullURL)
-	case evidence.ServerIdentity != "":
-		detail = fmt.Sprintf("MCP server %q is not Gram-hosted", evidence.ServerIdentity)
 	default:
-		detail = "MCP tool call has no recognizable server target"
+		detail = "MCP server is not Gram-hosted"
 	}
 
 	if target, allowed := s.canBypassPolicy(ctx, organizationID, userID, policyID, evidence, toolName); allowed {

--- a/server/internal/hooks/shadow_mcp_access_test.go
+++ b/server/internal/hooks/shadow_mcp_access_test.go
@@ -66,7 +66,6 @@ func TestEnforceShadowMCPToolAccess_BypassGrantAllowsBlockedCall(t *testing.T) {
 		authCtx.ProjectID.String(),
 		authCtx.UserID,
 		policyID,
-		map[string]any{},
 		"do_thing",
 		shadowmcp.AccessEvidence{FullURL: serverURL, URLHost: "", ServerIdentity: "blocked-server"},
 	)
@@ -102,13 +101,12 @@ func TestEnforceShadowMCPToolAccess_URLScopedBypassGrantDoesNotAllowIdentityOnly
 		authCtx.ProjectID.String(),
 		authCtx.UserID,
 		policyID,
-		map[string]any{},
 		"do_thing",
 		shadowmcp.AccessEvidence{FullURL: "", URLHost: "", ServerIdentity: "local-server"},
 	)
 
 	require.True(t, denied)
-	require.Contains(t, detail, "missing required")
+	require.Contains(t, detail, "not Gram-hosted")
 }
 
 func TestEnforceShadowMCPToolAccess_IdentityScopedBypassGrantAllowsIdentityOnlyTarget(t *testing.T) {
@@ -139,7 +137,6 @@ func TestEnforceShadowMCPToolAccess_IdentityScopedBypassGrantAllowsIdentityOnlyT
 		authCtx.ProjectID.String(),
 		authCtx.UserID,
 		policyID,
-		map[string]any{},
 		"do_thing",
 		shadowmcp.AccessEvidence{FullURL: "", URLHost: "", ServerIdentity: serverIdentity},
 	)
@@ -174,7 +171,6 @@ func TestEnforceShadowMCPToolAccess_WholePolicyBypassGrantAllowsIdentityOnlyTarg
 		authCtx.ProjectID.String(),
 		authCtx.UserID,
 		policyID,
-		map[string]any{},
 		"do_thing",
 		shadowmcp.AccessEvidence{FullURL: "", URLHost: "", ServerIdentity: "local-server"},
 	)
@@ -215,7 +211,7 @@ func TestCanBypassPolicy_EmptyEvidenceDoesNotUseWholePolicyGrant(t *testing.T) {
 	require.Nil(t, target)
 }
 
-func TestEnforceShadowMCPToolAccess_GramHostedURLAllowedWithoutEchoedID(t *testing.T) {
+func TestEnforceShadowMCPToolAccess_GramHostedURLAllowed(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestHooksService(t)
@@ -223,15 +219,12 @@ func TestEnforceShadowMCPToolAccess_GramHostedURLAllowedWithoutEchoedID(t *testi
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
-	// A Gram-hosted server URL is trusted on the URL alone: the tool input
-	// carries no x-gram-toolset-id, yet the call is allowed.
 	detail, denied := ti.service.enforceShadowMCPToolAccess(
 		ctx,
 		authCtx.ActiveOrganizationID,
 		authCtx.ProjectID.String(),
 		authCtx.UserID,
 		uuid.NewString(),
-		map[string]any{},
 		"do_thing",
 		shadowmcp.AccessEvidence{FullURL: "https://app.getgram.ai/mcp/example", URLHost: "", ServerIdentity: "example"},
 	)
@@ -240,7 +233,7 @@ func TestEnforceShadowMCPToolAccess_GramHostedURLAllowedWithoutEchoedID(t *testi
 	require.Empty(t, detail)
 }
 
-func TestEnforceShadowMCPToolAccess_NonGramURLBlockedDespiteEchoedID(t *testing.T) {
+func TestEnforceShadowMCPToolAccess_NonGramURLBlocked(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestHooksService(t)
@@ -248,18 +241,36 @@ func TestEnforceShadowMCPToolAccess_NonGramURLBlockedDespiteEchoedID(t *testing.
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
-	// Even when the agent echoes a x-gram-toolset-id, a non-Gram-hosted URL is
-	// denied: the URL is the trust signal, not the echoed constant a shadow
-	// server can coach the client into copying.
 	detail, denied := ti.service.enforceShadowMCPToolAccess(
 		ctx,
 		authCtx.ActiveOrganizationID,
 		authCtx.ProjectID.String(),
 		authCtx.UserID,
 		uuid.NewString(),
-		map[string]any{shadowmcp.XGramToolsetIDField: uuid.NewString()},
 		"do_thing",
 		shadowmcp.AccessEvidence{FullURL: "https://mcp.shadow.example/mcp", URLHost: "", ServerIdentity: "mcp.shadow.example"},
+	)
+
+	require.True(t, denied)
+	require.Contains(t, detail, "not Gram-hosted")
+}
+
+func TestEnforceShadowMCPToolAccess_NoURLServerBlocked(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	detail, denied := ti.service.enforceShadowMCPToolAccess(
+		ctx,
+		authCtx.ActiveOrganizationID,
+		authCtx.ProjectID.String(),
+		authCtx.UserID,
+		uuid.NewString(),
+		"do_thing",
+		shadowmcp.AccessEvidence{FullURL: "", URLHost: "", ServerIdentity: "local-stdio"},
 	)
 
 	require.True(t, denied)

--- a/server/internal/hooks/shadow_mcp_access_test.go
+++ b/server/internal/hooks/shadow_mcp_access_test.go
@@ -214,3 +214,54 @@ func TestCanBypassPolicy_EmptyEvidenceDoesNotUseWholePolicyGrant(t *testing.T) {
 	require.False(t, allowed)
 	require.Nil(t, target)
 }
+
+func TestEnforceShadowMCPToolAccess_GramHostedURLAllowedWithoutEchoedID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	// A Gram-hosted server URL is trusted on the URL alone: the tool input
+	// carries no x-gram-toolset-id, yet the call is allowed.
+	detail, denied := ti.service.enforceShadowMCPToolAccess(
+		ctx,
+		authCtx.ActiveOrganizationID,
+		authCtx.ProjectID.String(),
+		authCtx.UserID,
+		uuid.NewString(),
+		map[string]any{},
+		"do_thing",
+		shadowmcp.AccessEvidence{FullURL: "https://app.getgram.ai/mcp/example", URLHost: "", ServerIdentity: "example"},
+	)
+
+	require.False(t, denied)
+	require.Empty(t, detail)
+}
+
+func TestEnforceShadowMCPToolAccess_NonGramURLBlockedDespiteEchoedID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	// Even when the agent echoes a x-gram-toolset-id, a non-Gram-hosted URL is
+	// denied: the URL is the trust signal, not the echoed constant a shadow
+	// server can coach the client into copying.
+	detail, denied := ti.service.enforceShadowMCPToolAccess(
+		ctx,
+		authCtx.ActiveOrganizationID,
+		authCtx.ProjectID.String(),
+		authCtx.UserID,
+		uuid.NewString(),
+		map[string]any{shadowmcp.XGramToolsetIDField: uuid.NewString()},
+		"do_thing",
+		shadowmcp.AccessEvidence{FullURL: "https://mcp.shadow.example/mcp", URLHost: "", ServerIdentity: "mcp.shadow.example"},
+	)
+
+	require.True(t, denied)
+	require.Contains(t, detail, "not Gram-hosted")
+}


### PR DESCRIPTION
## Summary

- Cursor's `beforeMCPExecution` shadow-MCP guard only validated an echoed `x-gram-toolset-id`, so enabling a shadow MCP block policy denied **every** Gram-hosted MCP server. The Claude/Codex guard authorizes on the server URL host and was unaffected.
- `enforceShadowMCPToolAccess` now authorizes on the server URL the hook already carries: a Gram-hosted host (`isGramHostedMCPURLForOrg`) is allowed without depending on the agent echoing an identifier. The echoed-id check (`ValidateToolsetCall`) remains only as a fallback when no URL is present — stdio servers and older Codex installs whose inventory snapshot resolves none — so their leniency is unchanged.
- On URL-based calls a third-party server can no longer be allowed by coaching the agent into echoing a (publicly-published) toolset id.

Closes [DNO-353](https://linear.app/speakeasy/issue/DNO-353)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shadow MCP enforcement to authorize by server URL host and block calls without a Gram-hosted URL, unblocking Gram-hosted servers in Cursor and closing the spoofing gap. Codex keeps a fallback to the echoed id only when no inventory resolves a URL, per DNO-353.

- **Bug Fixes**
  - `enforceShadowMCPToolAccess` now allows only when `evidence.FullURL` is Gram-hosted; no‑URL calls are denied; bypass grants still apply; stops trusting `x-gram-toolset-id`.
  - Cursor path uses the new enforcement: Gram-hosted URLs allowed; stdio/no‑URL blocked.
  - Codex path does the URL-based check; if no inventory match exists it falls back to `ValidateToolsetCall` for backcompat; removed `codexInventoryProvenanceDetail`.
  - Denial messages no longer echo MCP server identity or launch commands; a generic non‑Gram‑hosted reason is returned.

<sup>Written for commit 59ce5ade864d19c01c5bb198b1828ceea06b12b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

