### PR TITLE
feat(chat): collapse injected context block into "Additional context" disclosure

### DIFF
--- a/.changeset/collapse-message-context.md
+++ b/.changeset/collapse-message-context.md
@@ -1,0 +1,6 @@
+---
+"@gram-ai/elements": minor
+"dashboard": minor
+---
+
+Project Assistant: fold the app-injected `<…context>` block in a user turn into a collapsed "Additional context" disclosure (chevron, expand to inspect) instead of rendering the raw tags. The expanded block wraps to the message-bubble width, so opening it no longer widens the bubble.

--- a/elements/src/components/assistant-ui/thread.tsx
+++ b/elements/src/components/assistant-ui/thread.tsx
@@ -57,6 +57,7 @@ import { MessageFeedback } from "@/components/assistant-ui/message-feedback";
 import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning";
 import { ThinkingIndicator } from "@/components/assistant-ui/thinking-indicator";
 import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+import { UserMessageText } from "@/components/assistant-ui/user-message-text";
 import { ToolMentionAutocomplete } from "@/components/assistant-ui/tool-mention-autocomplete";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { Button } from "@/components/ui/button";
@@ -1191,7 +1192,7 @@ const UserMessage: FC = () => {
               r("xl"),
             )}
           >
-            <MessagePrimitive.Parts />
+            <MessagePrimitive.Parts components={{ Text: UserMessageText }} />
           </div>
           {allowEdit && (
             <div className="aui-user-action-bar-wrapper absolute top-1/2 left-0 -translate-x-full -translate-y-1/2 pr-2">

--- a/elements/src/components/assistant-ui/user-message-text.helpers.test.ts
+++ b/elements/src/components/assistant-ui/user-message-text.helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { splitContextBlocks } from "./user-message-text.helpers";
+
+describe("splitContextBlocks", () => {
+  it("peels a leading dashboard_context block off the human text", () => {
+    const text =
+      "<dashboard_context>\nCost dashboard — Engineering.\n</dashboard_context>\n\nWhat caused the spike?";
+    const { blocks, rest } = splitContextBlocks(text);
+    expect(blocks).toEqual([
+      { tag: "dashboard_context", body: "Cost dashboard — Engineering." },
+    ]);
+    expect(rest).toBe("What caused the spike?");
+  });
+
+  it("peels multiple consecutive context blocks", () => {
+    const text =
+      "<message-context>EventID: 1</message-context><dashboard_context>chart=top-users</dashboard_context>hi";
+    const { blocks, rest } = splitContextBlocks(text);
+    expect(blocks.map((b) => b.tag)).toEqual([
+      "message-context",
+      "dashboard_context",
+    ]);
+    expect(rest).toBe("hi");
+  });
+
+  it("leaves a plain message untouched", () => {
+    const { blocks, rest } = splitContextBlocks("just a question");
+    expect(blocks).toEqual([]);
+    expect(rest).toBe("just a question");
+  });
+
+  it("only folds blocks at the start, not context tags inside the message", () => {
+    const text = "explain <foo_context>x</foo_context> please";
+    const { blocks, rest } = splitContextBlocks(text);
+    expect(blocks).toEqual([]);
+    expect(rest).toBe(text);
+  });
+
+  it("handles a context-only turn (no human text)", () => {
+    const { blocks, rest } = splitContextBlocks(
+      "<dashboard_context>only</dashboard_context>",
+    );
+    expect(blocks).toHaveLength(1);
+    expect(rest).toBe("");
+  });
+});

--- a/elements/src/components/assistant-ui/user-message-text.helpers.ts
+++ b/elements/src/components/assistant-ui/user-message-text.helpers.ts
@@ -28,15 +28,15 @@ export interface SplitText {
 export function splitContextBlocks(text: string): SplitText {
   const blocks: ContextBlock[] = [];
   let rest = text;
-  // `CONTEXT_BLOCK_RE` is not global, so `exec` always scans from index 0 with
-  // no `lastIndex` state — we advance by re-slicing `rest`, never by the regex.
-  for (
-    let match = CONTEXT_BLOCK_RE.exec(rest);
-    match;
-    match = CONTEXT_BLOCK_RE.exec(rest)
-  ) {
+  // `CONTEXT_BLOCK_RE` is `^`-anchored and non-global, so each `exec` scans from
+  // index 0 — we peel one leading block per pass by re-slicing `rest`.
+  // `String.matchAll` doesn't fit: it requires a global regex and walks
+  // `lastIndex` forward, which the `^` anchor never matches past position 0.
+  let match = CONTEXT_BLOCK_RE.exec(rest);
+  while (match) {
     blocks.push({ tag: match[1]!, body: match[2]!.trim() });
     rest = rest.slice(match[0].length);
+    match = CONTEXT_BLOCK_RE.exec(rest);
   }
   return { blocks, rest };
 }

--- a/elements/src/components/assistant-ui/user-message-text.helpers.ts
+++ b/elements/src/components/assistant-ui/user-message-text.helpers.ts
@@ -1,0 +1,42 @@
+/**
+ * Apps that drive Elements often prepend a machine-only context block to the
+ * outgoing user turn — e.g. the Gram dashboard prefixes `<dashboard_context>…`
+ * so the model knows which chart/date-range the user was looking at. The block
+ * is meant for the model, not the human, but it rides along in the persisted
+ * turn and reappears verbatim when the thread is reopened from history.
+ *
+ * These helpers split such blocks off the front of a user message so the UI can
+ * fold them into a collapsed disclosure and render the human's text below.
+ *
+ * Matching is intentionally generic: any leading tag whose name ends in
+ * `context` (`dashboard_context`, `message-context`, …) is folded, so this needs
+ * no knowledge of a specific host app's naming.
+ */
+const CONTEXT_BLOCK_RE = /^\s*<([\w-]*context)>([\s\S]*?)<\/\1>\s*/i;
+
+export interface ContextBlock {
+  tag: string;
+  body: string;
+}
+
+export interface SplitText {
+  blocks: ContextBlock[];
+  rest: string;
+}
+
+/** Peel consecutive leading `<…context>` blocks off the front of the text. */
+export function splitContextBlocks(text: string): SplitText {
+  const blocks: ContextBlock[] = [];
+  let rest = text;
+  // `CONTEXT_BLOCK_RE` is not global, so `exec` always scans from index 0 with
+  // no `lastIndex` state — we advance by re-slicing `rest`, never by the regex.
+  for (
+    let match = CONTEXT_BLOCK_RE.exec(rest);
+    match;
+    match = CONTEXT_BLOCK_RE.exec(rest)
+  ) {
+    blocks.push({ tag: match[1]!, body: match[2]!.trim() });
+    rest = rest.slice(match[0].length);
+  }
+  return { blocks, rest };
+}

--- a/elements/src/components/assistant-ui/user-message-text.tsx
+++ b/elements/src/components/assistant-ui/user-message-text.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { ChevronDownIcon } from "lucide-react";
+import { memo, type FC } from "react";
+
+import type { TextMessagePartComponent } from "@assistant-ui/react";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+import {
+  splitContextBlocks,
+  type ContextBlock,
+} from "./user-message-text.helpers";
+
+/**
+ * Folds the app-injected `<…context>` block(s) into a collapsed disclosure —
+ * the same "expand to inspect" affordance as the assistant's Reasoning trace.
+ */
+const ContextDisclosure: FC<{ blocks: ContextBlock[] }> = ({ blocks }) => {
+  return (
+    <Collapsible className="aui-user-context-root mb-2 w-full">
+      <CollapsibleTrigger
+        className={cn(
+          "aui-user-context-trigger group/trigger flex items-center gap-1.5 py-0.5",
+          "text-xs text-muted-foreground transition-colors hover:text-foreground",
+        )}
+      >
+        <ChevronDownIcon
+          className={cn(
+            "aui-user-context-chevron size-3.5 shrink-0 transition-transform",
+            "group-data-[state=closed]/trigger:-rotate-90",
+          )}
+        />
+        <span>Additional context</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="aui-user-context-content overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+        {/* `w-0 min-w-full`: don't let the (often single-line) context grow the
+            shrink-to-fit message bubble — contribute 0 to its intrinsic width,
+            then fill the bubble's resolved width and wrap. Keeps the bubble the
+            same width open or closed. */}
+        <div className="aui-user-context-body mt-1.5 w-0 min-w-full space-y-2 border-l-2 border-border pl-3 text-xs whitespace-pre-line text-muted-foreground">
+          {blocks.map((block, i) => (
+            <p key={i}>{block.body}</p>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+/**
+ * Drop-in replacement for the default user text part. Folds leading
+ * `<…context>` blocks into a collapsed disclosure and renders the remaining
+ * human-authored text exactly as the assistant-ui default does
+ * (`white-space: pre-line`).
+ */
+const UserMessageTextImpl: TextMessagePartComponent = ({ text }) => {
+  const { blocks, rest } = splitContextBlocks(text);
+  if (blocks.length === 0) {
+    return <p className="aui-user-message-text whitespace-pre-line">{text}</p>;
+  }
+  return (
+    <div className="aui-user-message-text-with-context">
+      <ContextDisclosure blocks={blocks} />
+      {rest.trim() !== "" && (
+        <p className="aui-user-message-text whitespace-pre-line">{rest}</p>
+      )}
+    </div>
+  );
+};
+
+export const UserMessageText = memo(UserMessageTextImpl);
+UserMessageText.displayName = "UserMessageText";


### PR DESCRIPTION
## What

In the Project Assistant chat, the dashboard injects a `<dashboard_context>…</dashboard_context>` block into the user's message so the model knows which chart/date-range the user is looking at. On reload from history that block was rendered raw in the user bubble (see before/after).

This folds any leading `<…context>` block into a collapsed **"Additional context"** disclosure — same expand-to-inspect affordance as the assistant's Reasoning trace — and renders the human's text below.

## How

- `elements/src/components/assistant-ui/user-message-text.tsx` — new `UserMessageText` part renderer. Splits leading context block(s) into a collapsed `Collapsible` (chevron, default closed); rest renders as before (`white-space: pre-line`).
- `user-message-text.helpers.ts` (+ tests) — pure `splitContextBlocks`. Matcher is generic: any leading tag whose name ends in `context` (`dashboard_context`, `message-context`, …), so no host-app naming leaks into the shared lib. Anchored at start only — a context tag mid-sentence stays inline.
- `thread.tsx` — `UserMessage` passes `components={{ Text: UserMessageText }}`.
- Expanded body uses `w-0 min-w-full` so a long single-line context wraps to the message-bubble width instead of widening the bubble on open.

## Notes

- Context is injected only on the wire (`insights-dock.tsx`), so a freshly-sent bubble has no block to collapse; the disclosure appears when a thread is reopened from history.
- No public API change to `@gram-ai/elements`.

## Screenshot
<img width="1242" height="480" alt="CleanShot 2026-06-29 at 10 53 55@2x" src="https://github.com/user-attachments/assets/5227b996-53a9-4ea2-874d-fb1656c3bd85" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse the injected `<…context>` block at the start of user messages into an "Additional context" disclosure so users don’t see raw tags on history reload. Expanded content now wraps within the bubble, so opening it doesn’t widen the bubble.

- **New Features**
  - Collapses leading `<…context>` tags (e.g., `<dashboard_context>`, `<message-context>`) into a chevron disclosure; user text renders below.
  - Ensures expanded context wraps to the bubble width; refactors parsing to a simple while loop with unchanged behavior.

<sup>Written for commit 6fef35e0eaf427eb3189009d37dec7ac651fc3b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



