### PR TITLE
chore: key finding fingerprints with HMAC and per-tenant HKDF

### DIFF
--- a/server/internal/risk/finding_bq.go
+++ b/server/internal/risk/finding_bq.go
@@ -2,9 +2,7 @@ package risk
 
 import (
 	"context" // #nosec G505 - safe for use for k-anonymization of matches
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
+	"encoding/base64"
 	"log/slog"
 	"strings"
 	"time"
@@ -21,25 +19,26 @@ import (
 )
 
 type FindingBQRow struct {
-	ID                     bigquery.NullString    `bigquery:"id"`
-	RequestID              bigquery.NullString    `bigquery:"request_id"`
-	ChatMessageID          bigquery.NullString    `bigquery:"chat_message_id"`
-	ProjectID              bigquery.NullString    `bigquery:"project_id"`
-	OrganizationID         bigquery.NullString    `bigquery:"organization_id"`
-	RiskPolicyID           bigquery.NullString    `bigquery:"risk_policy_id"`
-	RiskPolicyVersion      bigquery.NullInt64     `bigquery:"risk_policy_version"`
-	CreatedAt              bigquery.NullTimestamp `bigquery:"created_at"`
-	RuleID                 bigquery.NullString    `bigquery:"rule_id"`
-	Description            bigquery.NullString    `bigquery:"description"`
-	Match                  bigquery.NullString    `bigquery:"match"`
-	StartPos               bigquery.NullInt64     `bigquery:"start_pos"`
-	EndPos                 bigquery.NullInt64     `bigquery:"end_pos"`
-	Tags                   []string               `bigquery:"tags,nullable"`
-	Source                 bigquery.NullString    `bigquery:"source"`
-	Confidence             bigquery.NullFloat64   `bigquery:"confidence"`
-	DeadLetterReason       bigquery.NullString    `bigquery:"dead_letter_reason"`
-	FingerprintGlobalHS256 bigquery.NullString    `bigquery:"fingerprint_global_hs256"`
-	FingerprintTenantHS256 bigquery.NullString    `bigquery:"fingerprint_tenant_hs256"`
+	ID                       bigquery.NullString    `bigquery:"id"`
+	RequestID                bigquery.NullString    `bigquery:"request_id"`
+	ChatMessageID            bigquery.NullString    `bigquery:"chat_message_id"`
+	ProjectID                bigquery.NullString    `bigquery:"project_id"`
+	OrganizationID           bigquery.NullString    `bigquery:"organization_id"`
+	RiskPolicyID             bigquery.NullString    `bigquery:"risk_policy_id"`
+	RiskPolicyVersion        bigquery.NullInt64     `bigquery:"risk_policy_version"`
+	CreatedAt                bigquery.NullTimestamp `bigquery:"created_at"`
+	RuleID                   bigquery.NullString    `bigquery:"rule_id"`
+	Description              bigquery.NullString    `bigquery:"description"`
+	Match                    bigquery.NullString    `bigquery:"match"`
+	StartPos                 bigquery.NullInt64     `bigquery:"start_pos"`
+	EndPos                   bigquery.NullInt64     `bigquery:"end_pos"`
+	Tags                     []string               `bigquery:"tags,nullable"`
+	Source                   bigquery.NullString    `bigquery:"source"`
+	Confidence               bigquery.NullFloat64   `bigquery:"confidence"`
+	DeadLetterReason         bigquery.NullString    `bigquery:"dead_letter_reason"`
+	FingerprintPepperVersion bigquery.NullString    `bigquery:"fingerprint_pepper_version"`
+	FingerprintGlobalHS256   bigquery.NullString    `bigquery:"fingerprint_global_hs256"`
+	FingerprintTenantHS256   bigquery.NullString    `bigquery:"fingerprint_tenant_hs256"`
 }
 
 type FindingBQWriter struct {
@@ -79,45 +78,48 @@ func (w *FindingBQWriter) HandleBatch(ctx context.Context, messages []*riskv1.Fi
 			continue
 		}
 
-		// Compute global sha256
-		fgh := sha256.New()
-		fingerprintGSHA256 := ""
+		// Compute global hmac-sha256
+		globalHS256 := ""
 		if !deadLetter && match != "" {
-			if _, err := fmt.Fprintf(fgh, "%s", match); err != nil {
+			if sum, _, err := w.fingerprinter.HS256([]byte(match)); err != nil {
 				logger.ErrorContext(ctx, "failed to compute global fingerprint", attr.SlogError(err))
+			} else {
+				globalHS256 = base64.RawURLEncoding.EncodeToString(sum)
 			}
-			fingerprintGSHA256 = strings.ToUpper(hex.EncodeToString(fgh.Sum(nil)))
 		}
 
-		// Compute tenant-qualified sha256
-		fqh := sha256.New()
-		fingerprintQSHA256 := ""
+		// Compute tenant-qualified hmac-sha256
+		pepperVersion := ""
+		tenantHS256 := ""
 		if !deadLetter && orgID != "" && match != "" {
-			if _, err := fmt.Fprintf(fqh, "%s:%s", orgID, match); err != nil {
+			if sum, pepperver, err := w.fingerprinter.TenantedHS256(orgID, []byte(match)); err != nil {
 				logger.ErrorContext(ctx, "failed to compute tenant-qualified fingerprint", attr.SlogError(err))
+			} else {
+				pepperVersion = pepperver
+				tenantHS256 = base64.RawURLEncoding.EncodeToString(sum)
 			}
-			fingerprintQSHA256 = strings.ToUpper(hex.EncodeToString(fqh.Sum(nil)))
 		}
 
 		item := FindingBQRow{
-			ID:                     bigquery.NullString{StringVal: message.GetId(), Valid: message.HasId()},
-			RequestID:              bigquery.NullString{StringVal: message.GetRequestId(), Valid: message.HasRequestId()},
-			ChatMessageID:          bigquery.NullString{StringVal: message.GetChatMessageId(), Valid: message.HasChatMessageId()},
-			ProjectID:              bigquery.NullString{StringVal: message.GetProjectId(), Valid: message.HasProjectId()},
-			OrganizationID:         bigquery.NullString{StringVal: message.GetOrganizationId(), Valid: message.HasOrganizationId()},
-			RiskPolicyID:           bigquery.NullString{StringVal: message.GetRiskPolicyId(), Valid: message.HasRiskPolicyId()},
-			RiskPolicyVersion:      bigquery.NullInt64{Int64: message.GetRiskPolicyVersion(), Valid: message.HasRiskPolicyVersion()},
-			CreatedAt:              bigquery.NullTimestamp{Timestamp: createdAt, Valid: !createdAt.IsZero()},
-			RuleID:                 bigquery.NullString{StringVal: message.GetRuleId(), Valid: message.HasRuleId()},
-			Description:            bigquery.NullString{StringVal: message.GetDescription(), Valid: message.HasDescription()},
-			StartPos:               bigquery.NullInt64{Int64: int64(message.GetStartPos()), Valid: message.HasStartPos()},
-			EndPos:                 bigquery.NullInt64{Int64: int64(message.GetEndPos()), Valid: message.HasEndPos()},
-			Tags:                   message.GetTags(),
-			Source:                 bigquery.NullString{StringVal: message.GetSource(), Valid: message.HasSource()},
-			Confidence:             bigquery.NullFloat64{Float64: message.GetConfidence(), Valid: message.HasConfidence()},
-			DeadLetterReason:       bigquery.NullString{StringVal: message.GetDeadLetterReason(), Valid: message.HasDeadLetterReason()},
-			FingerprintGlobalHS256: bigquery.NullString{StringVal: fingerprintGSHA256, Valid: fingerprintGSHA256 != ""},
-			FingerprintTenantHS256: bigquery.NullString{StringVal: fingerprintQSHA256, Valid: fingerprintQSHA256 != ""},
+			ID:                       bigquery.NullString{StringVal: message.GetId(), Valid: message.HasId()},
+			RequestID:                bigquery.NullString{StringVal: message.GetRequestId(), Valid: message.HasRequestId()},
+			ChatMessageID:            bigquery.NullString{StringVal: message.GetChatMessageId(), Valid: message.HasChatMessageId()},
+			ProjectID:                bigquery.NullString{StringVal: message.GetProjectId(), Valid: message.HasProjectId()},
+			OrganizationID:           bigquery.NullString{StringVal: message.GetOrganizationId(), Valid: message.HasOrganizationId()},
+			RiskPolicyID:             bigquery.NullString{StringVal: message.GetRiskPolicyId(), Valid: message.HasRiskPolicyId()},
+			RiskPolicyVersion:        bigquery.NullInt64{Int64: message.GetRiskPolicyVersion(), Valid: message.HasRiskPolicyVersion()},
+			CreatedAt:                bigquery.NullTimestamp{Timestamp: createdAt, Valid: !createdAt.IsZero()},
+			RuleID:                   bigquery.NullString{StringVal: message.GetRuleId(), Valid: message.HasRuleId()},
+			Description:              bigquery.NullString{StringVal: message.GetDescription(), Valid: message.HasDescription()},
+			StartPos:                 bigquery.NullInt64{Int64: int64(message.GetStartPos()), Valid: message.HasStartPos()},
+			EndPos:                   bigquery.NullInt64{Int64: int64(message.GetEndPos()), Valid: message.HasEndPos()},
+			Tags:                     message.GetTags(),
+			Source:                   bigquery.NullString{StringVal: message.GetSource(), Valid: message.HasSource()},
+			Confidence:               bigquery.NullFloat64{Float64: message.GetConfidence(), Valid: message.HasConfidence()},
+			DeadLetterReason:         bigquery.NullString{StringVal: message.GetDeadLetterReason(), Valid: message.HasDeadLetterReason()},
+			FingerprintPepperVersion: bigquery.NullString{StringVal: pepperVersion, Valid: pepperVersion != ""},
+			FingerprintGlobalHS256:   bigquery.NullString{StringVal: globalHS256, Valid: globalHS256 != ""},
+			FingerprintTenantHS256:   bigquery.NullString{StringVal: tenantHS256, Valid: tenantHS256 != ""},
 
 			// Filled in below
 			Match: bigquery.NullString{StringVal: "", Valid: false},

--- a/server/internal/risk/finding_bq.go
+++ b/server/internal/risk/finding_bq.go
@@ -65,6 +65,10 @@ func (w *FindingBQWriter) HandleBatch(ctx context.Context, messages []*riskv1.Fi
 
 	captureMatchByOrg := make(map[string]bool)
 
+	// Cache per-tenant derived keys for the lifetime of this batch so repeated
+	// findings from the same org don't each re-run HKDF.
+	tenantKeyCache := make(map[string][]byte)
+
 	items := make([]FindingBQRow, 0, len(messages))
 	for _, message := range messages {
 		orgID := strings.TrimSpace(message.GetOrganizationId())
@@ -92,7 +96,7 @@ func (w *FindingBQWriter) HandleBatch(ctx context.Context, messages []*riskv1.Fi
 		pepperVersion := ""
 		tenantHS256 := ""
 		if !deadLetter && orgID != "" && match != "" {
-			if sum, pepperver, err := w.fingerprinter.TenantedHS256(orgID, []byte(match)); err != nil {
+			if sum, pepperver, err := w.fingerprinter.TenantedHS256(orgID, []byte(match), WithKeyCache(tenantKeyCache)); err != nil {
 				logger.ErrorContext(ctx, "failed to compute tenant-qualified fingerprint", attr.SlogError(err))
 			} else {
 				pepperVersion = pepperver

--- a/server/internal/risk/finding_bq_test.go
+++ b/server/internal/risk/finding_bq_test.go
@@ -2,10 +2,8 @@ package risk_test
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
+	"encoding/base64"
 	"errors"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -61,13 +59,23 @@ func newWriter(t *testing.T, features feature.Provider) (*risk.FindingBQWriter, 
 	return w, ins
 }
 
+// testPepperVersion / testPepperKey are the raw keyring material backing the
+// Fingerprinter the writer uses in these tests. Expected fingerprints are
+// recomputed from this same material via the wantHMAC / wantTenantedHMAC
+// helpers in fingerprint_test.go (same package).
+const testPepperVersion = "v1"
+
+var testPepperKey = []byte("finding-bq-test-pepper-key-material")
+
 func newWriterWithMeter(t *testing.T, features feature.Provider, mp metric.MeterProvider) (*risk.FindingBQWriter, *fakeInserter, *fakeTableHandle) {
 	t.Helper()
 	ins := &fakeInserter{}
 	table := &fakeTableHandle{inserter: ins}
-	// The writer keeps a Fingerprinter but HandleBatch does not consult it, so
-	// a zero value is sufficient here.
-	w := risk.NewFindingBQWriter(testenv.NewLogger(t), mp, table, features, risk.Fingerprinter{})
+	// HandleBatch now fingerprints matches, so the writer needs a usable
+	// keyring rather than a zero-value Fingerprinter.
+	fp, err := risk.ParsePepperKeyRing(keyRingJSON(t, testPepperVersion, map[string][]byte{testPepperVersion: testPepperKey}))
+	require.NoError(t, err)
+	w := risk.NewFindingBQWriter(testenv.NewLogger(t), mp, table, features, fp)
 	return w, ins, table
 }
 
@@ -82,11 +90,17 @@ func rows(t *testing.T, ins *fakeInserter) []risk.FindingBQRow {
 	return out
 }
 
-// upperSHA256 mirrors the writer's fingerprint encoding: uppercase hex of the
-// sha256 digest.
-func upperSHA256(s string) string {
-	sum := sha256.Sum256([]byte(s))
-	return strings.ToUpper(hex.EncodeToString(sum[:]))
+// wantGlobalFingerprint mirrors the writer's global fingerprint encoding:
+// base64url(HMAC-SHA256(pepper, match)).
+func wantGlobalFingerprint(match string) string {
+	return base64.RawURLEncoding.EncodeToString(wantHMAC(testPepperKey, []byte(match)))
+}
+
+// wantTenantFingerprint mirrors the tenant-scoped fingerprint: base64url of an
+// HMAC keyed by the per-tenant key derived from the pepper via HKDF.
+func wantTenantFingerprint(t *testing.T, tenantID, match string) string {
+	t.Helper()
+	return base64.RawURLEncoding.EncodeToString(wantTenantedHMAC(t, testPepperKey, tenantID, []byte(match)))
 }
 
 // finding builds a Finding with every field populated except the dead-letter
@@ -169,8 +183,8 @@ func TestFindingBQWriter_HandleBatch_ComputesFingerprints(t *testing.T) {
 
 	row := rows(t, ins)[0]
 
-	wantGlobal := upperSHA256("hunter2")
-	wantTenant := upperSHA256("org-1:hunter2")
+	wantGlobal := wantGlobalFingerprint("hunter2")
+	wantTenant := wantTenantFingerprint(t, "org-1", "hunter2")
 
 	require.Equal(t, bigquery.NullString{StringVal: wantGlobal, Valid: true}, row.FingerprintGlobalHS256)
 	require.Equal(t, bigquery.NullString{StringVal: wantTenant, Valid: true}, row.FingerprintTenantHS256)
@@ -194,7 +208,7 @@ func TestFindingBQWriter_HandleBatch_TenantFingerprintRequiresOrg(t *testing.T) 
 	row := rows(t, ins)[0]
 
 	// Global fingerprint only needs the match.
-	require.Equal(t, bigquery.NullString{StringVal: upperSHA256("hunter2"), Valid: true}, row.FingerprintGlobalHS256)
+	require.Equal(t, bigquery.NullString{StringVal: wantGlobalFingerprint("hunter2"), Valid: true}, row.FingerprintGlobalHS256)
 	// Without an org id there is no tenant-qualified fingerprint.
 	require.Equal(t, bigquery.NullString{Valid: false}, row.FingerprintTenantHS256)
 }

--- a/server/internal/risk/fingerprint.go
+++ b/server/internal/risk/fingerprint.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	"crypto/hkdf"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -10,6 +11,11 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/inv"
 )
+
+// hkdfInfo is the application-specific context string mixed into HKDF when
+// deriving per-tenant fingerprint keys. It domain-separates these keys from any
+// other use of the same pepper.
+const hkdfInfo = "gram/risk/fingerprint/tenant"
 
 var (
 	ErrInvalidFingerprintPepperJSON    = errors.New("invalid fingerprint pepper keyring json")
@@ -31,7 +37,7 @@ func (p Fingerprinter) get(version string) ([]byte, error) {
 	return key, nil
 }
 
-func (p Fingerprinter) HS256(message []byte) ([]byte, error) {
+func (p Fingerprinter) HS256(message []byte) ([]byte, string, error) {
 	inv.Require(
 		"fingerprint pepper keyring",
 		"current version is set", p.currentVersion != "",
@@ -41,7 +47,12 @@ func (p Fingerprinter) HS256(message []byte) ([]byte, error) {
 		},
 	)
 
-	return p.HS256WithVersion(p.currentVersion, message)
+	s, err := p.HS256WithVersion(p.currentVersion, message)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return s, p.currentVersion, nil
 }
 
 func (p Fingerprinter) HS256WithVersion(version string, message []byte) ([]byte, error) {
@@ -55,6 +66,60 @@ func (p Fingerprinter) HS256WithVersion(version string, message []byte) ([]byte,
 	result := mac.Sum(nil)
 
 	return result, nil
+}
+
+// TenantedHS256 fingerprints message under a per-tenant key derived from the
+// current pepper version, so the same secret in two different tenants produces
+// unrelated fingerprints (tenant isolation).
+func (p Fingerprinter) TenantedHS256(tenantID string, message []byte) ([]byte, string, error) {
+	inv.Require(
+		"fingerprint pepper keyring",
+		"current version is set", p.currentVersion != "",
+		"current version exists in keys", func() bool {
+			_, ok := p.keys[p.currentVersion]
+			return ok
+		},
+	)
+
+	s, err := p.TenantedHS256WithVersion(p.currentVersion, tenantID, message)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return s, p.currentVersion, nil
+}
+
+// TenantedHS256WithVersion is like HS256WithVersion but keys the HMAC with a
+// per-tenant key instead of the raw pepper. See deriveKey for the derivation.
+func (p Fingerprinter) TenantedHS256WithVersion(version string, tenantID string, message []byte) ([]byte, error) {
+	key, err := p.deriveKey(version, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write(message)
+	result := mac.Sum(nil)
+
+	return result, nil
+}
+
+// deriveKey derives a per-tenant 32-byte key from the pepper via HKDF, with the
+// tenant ID as salt. Same pepper + same tenant always yields the same key, so
+// fingerprints are stable; different tenants get independent keys, so the same
+// secret in two tenants produces unrelated fingerprints (tenant isolation).
+func (p Fingerprinter) deriveKey(version string, tenantID string) ([]byte, error) {
+	pepper, err := p.get(version)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := hkdf.Key(sha256.New, pepper, []byte(tenantID), hkdfInfo, 32)
+	if err != nil {
+		return nil, fmt.Errorf("hkdf: %w", err)
+	}
+
+	return key, nil
 }
 
 // ParsePepperKeyRing parses a JSON payload containing the pepper keyring for

--- a/server/internal/risk/fingerprint.go
+++ b/server/internal/risk/fingerprint.go
@@ -28,6 +28,28 @@ type Fingerprinter struct {
 	keys           map[string][]byte
 }
 
+// tenantedOptions holds the configurable behaviour for the tenanted
+// fingerprinting methods.
+type tenantedOptions struct {
+	keyCache map[string][]byte
+}
+
+// TenantedOption customizes the behaviour of TenantedHS256 and
+// TenantedHS256WithVersion.
+type TenantedOption func(*tenantedOptions)
+
+// WithKeyCache supplies a cache for per-tenant derived keys so that repeated
+// fingerprinting under the same (version, tenant) pair does not re-run HKDF.
+// The cache is keyed by version and tenant ID and is read from and written to
+// by the tenanted fingerprinting methods. The caller owns the map and is
+// responsible for its lifetime and any concurrency control; a fresh map scoped
+// to a single batch is the typical usage.
+func WithKeyCache(cache map[string][]byte) TenantedOption {
+	return func(o *tenantedOptions) {
+		o.keyCache = cache
+	}
+}
+
 func (p Fingerprinter) get(version string) ([]byte, error) {
 	key, ok := p.keys[version]
 	if !ok {
@@ -71,7 +93,7 @@ func (p Fingerprinter) HS256WithVersion(version string, message []byte) ([]byte,
 // TenantedHS256 fingerprints message under a per-tenant key derived from the
 // current pepper version, so the same secret in two different tenants produces
 // unrelated fingerprints (tenant isolation).
-func (p Fingerprinter) TenantedHS256(tenantID string, message []byte) ([]byte, string, error) {
+func (p Fingerprinter) TenantedHS256(tenantID string, message []byte, opts ...TenantedOption) ([]byte, string, error) {
 	inv.Require(
 		"fingerprint pepper keyring",
 		"current version is set", p.currentVersion != "",
@@ -81,7 +103,7 @@ func (p Fingerprinter) TenantedHS256(tenantID string, message []byte) ([]byte, s
 		},
 	)
 
-	s, err := p.TenantedHS256WithVersion(p.currentVersion, tenantID, message)
+	s, err := p.TenantedHS256WithVersion(p.currentVersion, tenantID, message, opts...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -91,8 +113,13 @@ func (p Fingerprinter) TenantedHS256(tenantID string, message []byte) ([]byte, s
 
 // TenantedHS256WithVersion is like HS256WithVersion but keys the HMAC with a
 // per-tenant key instead of the raw pepper. See deriveKey for the derivation.
-func (p Fingerprinter) TenantedHS256WithVersion(version string, tenantID string, message []byte) ([]byte, error) {
-	key, err := p.deriveKey(version, tenantID)
+func (p Fingerprinter) TenantedHS256WithVersion(version string, tenantID string, message []byte, opts ...TenantedOption) ([]byte, error) {
+	var o tenantedOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	key, err := p.deriveKey(version, tenantID, o.keyCache)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +135,14 @@ func (p Fingerprinter) TenantedHS256WithVersion(version string, tenantID string,
 // tenant ID as salt. Same pepper + same tenant always yields the same key, so
 // fingerprints are stable; different tenants get independent keys, so the same
 // secret in two tenants produces unrelated fingerprints (tenant isolation).
-func (p Fingerprinter) deriveKey(version string, tenantID string) ([]byte, error) {
+func (p Fingerprinter) deriveKey(version string, tenantID string, cache map[string][]byte) ([]byte, error) {
+	cacheKey := version + "\x00" + tenantID
+	if cache != nil {
+		if key, ok := cache[cacheKey]; ok {
+			return key, nil
+		}
+	}
+
 	pepper, err := p.get(version)
 	if err != nil {
 		return nil, err
@@ -117,6 +151,10 @@ func (p Fingerprinter) deriveKey(version string, tenantID string) ([]byte, error
 	key, err := hkdf.Key(sha256.New, pepper, []byte(tenantID), hkdfInfo, 32)
 	if err != nil {
 		return nil, fmt.Errorf("hkdf: %w", err)
+	}
+
+	if cache != nil {
+		cache[cacheKey] = key
 	}
 
 	return key, nil

--- a/server/internal/risk/fingerprint_test.go
+++ b/server/internal/risk/fingerprint_test.go
@@ -1,6 +1,7 @@
 package risk_test
 
 import (
+	"crypto/hkdf"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -12,6 +13,12 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/risk"
 )
+
+// hkdfInfo mirrors the unexported constant in the risk package. Duplicating it
+// here keeps the test black-box while pinning the exact derivation contract: a
+// change to the production info string must be reflected here (and would change
+// every fingerprint), which is the intended tripwire.
+const hkdfInfo = "gram/risk/fingerprint/tenant"
 
 // keyRingJSON builds the JSON payload ParsePepperKeyRing expects. Keys are
 // supplied as raw bytes and base64-encoded here so tests can recompute the
@@ -33,6 +40,15 @@ func wantHMAC(key, message []byte) []byte {
 	return mac.Sum(nil)
 }
 
+// wantTenantedHMAC recomputes the expected tenant-scoped MAC: derive a
+// per-tenant key from the pepper via HKDF (tenant ID as salt), then HMAC.
+func wantTenantedHMAC(t *testing.T, pepper []byte, tenantID string, message []byte) []byte {
+	t.Helper()
+	key, err := hkdf.Key(sha256.New, pepper, []byte(tenantID), hkdfInfo, 32)
+	require.NoError(t, err)
+	return wantHMAC(key, message)
+}
+
 func TestParsePepperKeyRing_Valid(t *testing.T) {
 	t.Parallel()
 
@@ -45,10 +61,11 @@ func TestParsePepperKeyRing_Valid(t *testing.T) {
 
 	msg := []byte("fingerprint me")
 
-	// HS256 uses the current version (v2).
-	got, err := fp.HS256(msg)
+	// HS256 uses the current version (v2) and reports which version it used.
+	got, version, err := fp.HS256(msg)
 	require.NoError(t, err)
 	assert.Equal(t, wantHMAC(keyV2, msg), got)
+	assert.Equal(t, "v2", version)
 
 	// HS256WithVersion can reach an older key.
 	gotV1, err := fp.HS256WithVersion("v1", msg)
@@ -120,6 +137,72 @@ func TestFingerprinter_HS256_PanicsWithoutCurrentVersion(t *testing.T) {
 	// produce an unkeyed hash.
 	var fp risk.Fingerprinter
 	assert.Panics(t, func() {
-		_, _ = fp.HS256([]byte("msg"))
+		_, _, _ = fp.HS256([]byte("msg"))
+	})
+}
+
+func TestFingerprinter_TenantedHS256(t *testing.T) {
+	t.Parallel()
+
+	keyV1 := []byte("key-material-for-v1")
+	keyV2 := []byte("key-material-for-v2")
+	payload := keyRingJSON(t, "v2", map[string][]byte{"v1": keyV1, "v2": keyV2})
+
+	fp, err := risk.ParsePepperKeyRing(payload)
+	require.NoError(t, err)
+
+	msg := []byte("fingerprint me")
+
+	// TenantedHS256 uses the current version (v2), derives a per-tenant key, and
+	// reports the version it used.
+	got, version, err := fp.TenantedHS256("tenant-a", msg)
+	require.NoError(t, err)
+	assert.Equal(t, wantTenantedHMAC(t, keyV2, "tenant-a", msg), got)
+	assert.Equal(t, "v2", version)
+
+	// Stable: same tenant + same message + same version is deterministic.
+	again, _, err := fp.TenantedHS256("tenant-a", msg)
+	require.NoError(t, err)
+	assert.Equal(t, got, again)
+
+	// Tenant isolation: the same secret under a different tenant must produce
+	// an unrelated fingerprint.
+	otherTenant, _, err := fp.TenantedHS256("tenant-b", msg)
+	require.NoError(t, err)
+	assert.NotEqual(t, got, otherTenant)
+
+	// Tenant scoping must change the MAC versus the un-tenanted HS256.
+	plain, _, err := fp.HS256(msg)
+	require.NoError(t, err)
+	assert.NotEqual(t, plain, got)
+
+	// TenantedHS256WithVersion can reach an older pepper version, and that
+	// produces a different fingerprint than the current version.
+	gotV1, err := fp.TenantedHS256WithVersion("v1", "tenant-a", msg)
+	require.NoError(t, err)
+	assert.Equal(t, wantTenantedHMAC(t, keyV1, "tenant-a", msg), gotV1)
+	assert.NotEqual(t, got, gotV1)
+}
+
+func TestFingerprinter_TenantedHS256WithVersion_UnknownVersion(t *testing.T) {
+	t.Parallel()
+
+	payload := keyRingJSON(t, "v1", map[string][]byte{"v1": []byte("k")})
+	fp, err := risk.ParsePepperKeyRing(payload)
+	require.NoError(t, err)
+
+	_, err = fp.TenantedHS256WithVersion("does-not-exist", "tenant-a", []byte("msg"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, risk.ErrFingerprintPepperKeyNotFound)
+}
+
+func TestFingerprinter_TenantedHS256_PanicsWithoutCurrentVersion(t *testing.T) {
+	t.Parallel()
+
+	// As with HS256, a zero-value Fingerprinter must panic rather than derive a
+	// key from an empty pepper.
+	var fp risk.Fingerprinter
+	assert.Panics(t, func() {
+		_, _, _ = fp.TenantedHS256("tenant-a", []byte("msg"))
 	})
 }

--- a/server/internal/risk/fingerprint_test.go
+++ b/server/internal/risk/fingerprint_test.go
@@ -184,6 +184,45 @@ func TestFingerprinter_TenantedHS256(t *testing.T) {
 	assert.NotEqual(t, got, gotV1)
 }
 
+func TestFingerprinter_TenantedHS256_WithKeyCache(t *testing.T) {
+	t.Parallel()
+
+	keyV1 := []byte("key-material-for-v1")
+	keyV2 := []byte("key-material-for-v2")
+	payload := keyRingJSON(t, "v2", map[string][]byte{"v1": keyV1, "v2": keyV2})
+
+	fp, err := risk.ParsePepperKeyRing(payload)
+	require.NoError(t, err)
+
+	msg := []byte("fingerprint me")
+	cache := make(map[string][]byte)
+
+	// A cached run must match the un-cached fingerprint exactly.
+	uncached, _, err := fp.TenantedHS256("tenant-a", msg)
+	require.NoError(t, err)
+
+	cached, version, err := fp.TenantedHS256("tenant-a", msg, risk.WithKeyCache(cache))
+	require.NoError(t, err)
+	assert.Equal(t, "v2", version)
+	assert.Equal(t, uncached, cached)
+
+	// The derived key is now memoized for (version, tenant) and reused on the
+	// next call without re-running HKDF.
+	require.Len(t, cache, 1)
+
+	again, _, err := fp.TenantedHS256("tenant-a", msg, risk.WithKeyCache(cache))
+	require.NoError(t, err)
+	assert.Equal(t, cached, again)
+	require.Len(t, cache, 1)
+
+	// Distinct tenants and distinct versions each get their own cache entry.
+	_, _, err = fp.TenantedHS256("tenant-b", msg, risk.WithKeyCache(cache))
+	require.NoError(t, err)
+	_, err = fp.TenantedHS256WithVersion("v1", "tenant-a", msg, risk.WithKeyCache(cache))
+	require.NoError(t, err)
+	require.Len(t, cache, 3)
+}
+
 func TestFingerprinter_TenantedHS256WithVersion_UnknownVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Replaces the risk-finding BigQuery writer's plain SHA-256 fingerprints with **keyed HMAC-SHA256**, using the existing pepper keyring:

- **Global fingerprint** — `HMAC-SHA256(pepper, match)`, base64url-encoded.
- **Tenant fingerprint** — `HMAC-SHA256(deriveKey(pepper, orgID), match)`, where the per-tenant key is derived from the pepper via **HKDF** with the tenant id as salt.

Builds on #3718 (shadow-mode writer), which shipped the SHA-256 placeholder.

## Why

Unkeyed `sha256(match)` is reversible: anyone with the BigQuery rows can confirm a guessed secret by hashing candidates, and the old `sha256(orgID:match)` scheme let the same secret be correlated across tenants. Keying with the pepper closes the offline-guessing gap; HKDF-derived per-tenant keys make the same secret produce unrelated fingerprints in different tenants (tenant isolation) while preserving intra-tenant dedup.

## Changes

- `fingerprint.go`: add `TenantedHS256` / `TenantedHS256WithVersion` and an HKDF `deriveKey` helper (stdlib `crypto/hkdf`, Go 1.24+); `hkdfInfo` domain-separation constant.
- `finding_bq.go`: `HandleBatch` now calls `HS256` / `TenantedHS256` and base64url-encodes the result instead of uppercase-hex SHA-256.
- Tests: cover the new fingerprinter methods (determinism, tenant isolation, version reachability, unknown-version and unconfigured-keyring errors); update the writer tests to build a real keyring and recompute expected fingerprints from the same pepper.

## Notes

Still in shadow mode — fingerprint columns are populated but not yet consumed. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch risk finding fingerprints from plain SHA-256 to keyed HMAC-SHA256 with per-tenant HKDF-derived keys to block offline guessing and cross-tenant correlation. Fingerprints are base64url-encoded, written in shadow mode, and we store the pepper version; we also cache per-tenant derived keys per batch to cut HKDF overhead.

- **New Features**
  - Global: HMAC-SHA256(pepper, match) → base64url.
  - Tenant: HMAC-SHA256(HKDF(pepper, orgID), match) for tenant isolation (`crypto/hkdf`).
  - Perf: `WithKeyCache` memoizes per-tenant derived keys; writer uses a batch-scoped cache.
  - Writer uses `Fingerprinter` and persists `fingerprint_pepper_version`; tests cover determinism, tenant isolation, version selection, caching, and error cases.

<sup>Written for commit 8725922d31df66448930a3c31ca3e5f7f8824d58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

