### PR TITLE
feat(rbac): editable system-role permissions and roles UX

### DIFF
--- a/.changeset/editable-system-role-permissions.md
+++ b/.changeset/editable-system-role-permissions.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Allow editing the permissions of system roles (`admin`/`member`) per organization, while keeping their name and description platform-managed. The Admin role is guarded against losing the `org:admin` permission to prevent org lockout. The roles tab is reworked: the whole role row opens the edit sheet (gated on `org:admin`), scope groups no longer auto-expand and show a description when collapsed, and the members column uses a new interactive member facepile (hover focus, click to view all members) that also replaces the facepile on the org home projects list. Adds Directory Sync (SCIM) info alerts on the team, roles, and identity pages explaining that members and roles are managed by the identity provider while SCIM is enabled.

--- a/client/dashboard/src/components/gradient-colors.ts
+++ b/client/dashboard/src/components/gradient-colors.ts
@@ -1,10 +1,28 @@
-// Deterministic gradient colors from any string label (project/org/assistant id).
+// Deterministic gradient colors from any string label (project/org/assistant
+// id, member id). Colors are drawn from the Speakeasy brand spectrum and kept
+// subtle: a single brand hue with a small drift + lightness delta, rather than
+// two clashing random hues.
+
+// Brand spectrum hues (h, s) — the same muted brand palette used elsewhere in
+// the app (e.g. the source activity bars), derived from the brand gradient.
+const BRAND_HUES: { h: number; s: number }[] = [
+  { h: 214, s: 48 }, // blue
+  { h: 4, s: 45 }, // red
+  { h: 108, s: 28 }, // green
+  { h: 23, s: 52 }, // orange
+  { h: 334, s: 36 }, // magenta
+  { h: 68, s: 34 }, // lime
+  { h: 154, s: 36 }, // teal
+  { h: 220, s: 44 }, // indigo
+  { h: 280, s: 32 }, // purple
+];
+
 export function getGradientColors(label: string): {
   from: string;
   to: string;
   angle: number;
 } {
-  // FNV-1a hash function for better distribution
+  // FNV-1a hash for good distribution across short labels.
   const fnv1a = (str: string) => {
     let hash = 2166136261;
     for (let i = 0; i < str.length; i++) {
@@ -16,21 +34,16 @@ export function getGradientColors(label: string): {
   };
 
   const hash = fnv1a(label);
+  const base = BRAND_HUES[hash % BRAND_HUES.length]!;
 
-  // Generate four random-ish numbers from the hash for more variation
-  const n1 = hash % 360;
-  const n2 = (hash >> 8) % 360;
-  const n3 = (hash >> 16) % 100;
-  const n4 = (hash >> 24) % 360; // For gradient angle
-
-  const hue1 = n1;
-  const hue2 = (hue1 + n2) % 360;
-  const saturation = Math.max(65, n3);
-  const angle = n4;
+  // Small hue drift keeps the gradient lively without clashing.
+  const drift = 12 + ((hash >> 10) % 12); // 12–23°
+  // A few pleasing diagonals.
+  const angle = 130 + ((hash >> 18) % 3) * 15; // 130 / 145 / 160
 
   return {
-    from: `hsl(${hue1}, ${saturation}%, 65%)`,
-    to: `hsl(${hue2}, ${saturation}%, 60%)`,
+    from: `hsl(${base.h}, ${base.s}%, 60%)`,
+    to: `hsl(${(base.h + drift) % 360}, ${Math.max(34, base.s - 8)}%, 48%)`,
     angle,
   };
 }

--- a/client/dashboard/src/components/gradient-colors.ts
+++ b/client/dashboard/src/components/gradient-colors.ts
@@ -37,9 +37,11 @@ export function getGradientColors(label: string): {
   const base = BRAND_HUES[hash % BRAND_HUES.length]!;
 
   // Small hue drift keeps the gradient lively without clashing.
-  const drift = 12 + ((hash >> 10) % 12); // 12–23°
+  // Use unsigned shifts: the FNV-1a hash sets bit 31, and a signed `>>`
+  // would yield negative intermediates that skew drift/angle.
+  const drift = 12 + ((hash >>> 10) % 12); // 12–23°
   // A few pleasing diagonals.
-  const angle = 130 + ((hash >> 18) % 3) * 15; // 130 / 145 / 160
+  const angle = 130 + ((hash >>> 18) % 3) * 15; // 130 / 145 / 160
 
   return {
     from: `hsl(${base.h}, ${base.s}%, 60%)`,

--- a/client/dashboard/src/components/member-facepile.tsx
+++ b/client/dashboard/src/components/member-facepile.tsx
@@ -70,11 +70,12 @@ export function MemberFacepile({
   members: FacepileMember[];
   maxFaces?: number;
 }): React.JSX.Element {
+  const [hoveredId, setHoveredId] = React.useState<string | null>(null);
+
   if (members.length === 0) {
     return <span className="text-muted-foreground">—</span>;
   }
 
-  const [hoveredId, setHoveredId] = React.useState<string | null>(null);
   const sorted = [...members].sort((a, b) => a.name.localeCompare(b.name));
   const shown = sorted.slice(0, maxFaces);
   const overflow = sorted.length - shown.length;

--- a/client/dashboard/src/components/member-facepile.tsx
+++ b/client/dashboard/src/components/member-facepile.tsx
@@ -125,7 +125,7 @@ export function MemberFacepile({
                   transition={
                     isHovered
                       ? { type: "spring", stiffness: 400, damping: 20 }
-                      : { type: "tween", duration: 0.5, ease: "easeOut" }
+                      : { type: "tween", duration: 0.3, ease: "easeOut" }
                   }
                 >
                   <Tooltip>
@@ -161,7 +161,7 @@ export function MemberFacepile({
                     transition={
                       isHovered
                         ? { type: "spring", stiffness: 400, damping: 20 }
-                        : { type: "tween", duration: 0.5, ease: "easeOut" }
+                        : { type: "tween", duration: 0.3, ease: "easeOut" }
                     }
                   >
                     <div className="ring-background bg-muted text-muted-foreground flex h-7 items-center justify-center rounded-full px-2.5 text-[11px] font-medium whitespace-nowrap ring-2">

--- a/client/dashboard/src/components/member-facepile.tsx
+++ b/client/dashboard/src/components/member-facepile.tsx
@@ -1,0 +1,204 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getGradientColors } from "@/components/gradient-colors";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Type } from "@/components/ui/type";
+import { motion } from "motion/react";
+import * as React from "react";
+
+export type FacepileMember = {
+  id: string;
+  name: string;
+  email: string;
+  photoUrl?: string;
+};
+
+// Sentinel hover id for the "+N" overflow chip (no real member id collides).
+const OVERFLOW_ID = "__overflow__";
+
+/** Two-letter initials for the avatar fallback. */
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
+}
+
+function MemberAvatar({
+  member,
+  className,
+}: {
+  member: FacepileMember;
+  className?: string;
+}): React.JSX.Element {
+  // Deterministic per-member gradient so each fallback face is unique.
+  const gradient = getGradientColors(member.id || member.name);
+  return (
+    <Avatar className={className}>
+      {member.photoUrl && (
+        <AvatarImage src={member.photoUrl} alt={member.name} />
+      )}
+      <AvatarFallback
+        className="text-[10px] font-semibold text-white"
+        style={{
+          backgroundImage: `linear-gradient(${gradient.angle}deg, ${gradient.from}, ${gradient.to})`,
+        }}
+      >
+        {initials(member.name)}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+
+/**
+ * Compact, overlapping avatar stack that reveals the full member list in a
+ * popover on click. The popover is portaled, so it is never clipped by the
+ * surrounding table row's overflow.
+ */
+export function MemberFacepile({
+  members,
+  maxFaces = 10,
+}: {
+  members: FacepileMember[];
+  maxFaces?: number;
+}): React.JSX.Element {
+  if (members.length === 0) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  const [hoveredId, setHoveredId] = React.useState<string | null>(null);
+  const sorted = [...members].sort((a, b) => a.name.localeCompare(b.name));
+  const shown = sorted.slice(0, maxFaces);
+  const overflow = sorted.length - shown.length;
+  const label = `${members.length} member${members.length === 1 ? "" : "s"}`;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          // Stop the row's onRowClick from firing when opening the popover.
+          onClick={(e) => e.stopPropagation()}
+          className="hover:bg-accent/40 -ml-1 flex w-fit cursor-pointer items-center rounded-full p-1 transition-colors"
+        >
+          {/* Grid overlap: each face sits in a track narrower than itself
+              (auto-cols < avatar width), so faces overlap by a fixed amount and
+              the pile's total width is deterministic — no negative-margin growth
+              that would overflow the table column. */}
+          <div
+            className="grid grid-flow-col items-center justify-start [grid-auto-columns:1.15rem]"
+            // Clear only when leaving the whole pile. Moving between overlapping
+            // faces just updates which is active, avoiding the flicker from
+            // racing per-face enter/leave events.
+            onPointerLeave={() => setHoveredId(null)}
+          >
+            {shown.map((m, i) => {
+              const isHovered = hoveredId === m.id;
+              const dimmed = hoveredId !== null && !isHovered;
+              return (
+                <motion.div
+                  key={m.id}
+                  style={{ gridColumnStart: i + 1 }}
+                  className="relative row-start-1 cursor-pointer"
+                  onPointerEnter={() => setHoveredId(m.id)}
+                  animate={{
+                    scale: isHovered ? 1.25 : dimmed ? 0.92 : 1,
+                    // Dim via filter, not opacity: opacity would make the
+                    // overlapped faces behind this one show through.
+                    filter: dimmed
+                      ? "saturate(0.65) brightness(0.98)"
+                      : "saturate(1) brightness(1)",
+                    zIndex: isHovered ? 30 : 0,
+                  }}
+                  // Snap in on hover, but relax back slowly so flicking the
+                  // mouse across faces leaves a gentle settle rather than a
+                  // jittery snap.
+                  transition={
+                    isHovered
+                      ? { type: "spring", stiffness: 400, damping: 20 }
+                      : { type: "tween", duration: 0.5, ease: "easeOut" }
+                  }
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div>
+                        <MemberAvatar
+                          member={m}
+                          className="ring-background size-7 ring-2"
+                        />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">{m.email}</TooltipContent>
+                  </Tooltip>
+                </motion.div>
+              );
+            })}
+            {overflow > 0 &&
+              (() => {
+                const isHovered = hoveredId === OVERFLOW_ID;
+                const dimmed = hoveredId !== null && !isHovered;
+                return (
+                  <motion.div
+                    style={{ gridColumnStart: shown.length + 1 }}
+                    className="row-start-1 cursor-pointer"
+                    onPointerEnter={() => setHoveredId(OVERFLOW_ID)}
+                    animate={{
+                      scale: isHovered ? 1.25 : dimmed ? 0.92 : 1,
+                      filter: dimmed
+                        ? "saturate(0.65) brightness(0.98)"
+                        : "saturate(1) brightness(1)",
+                      zIndex: isHovered ? 30 : 10,
+                    }}
+                    transition={
+                      isHovered
+                        ? { type: "spring", stiffness: 400, damping: 20 }
+                        : { type: "tween", duration: 0.5, ease: "easeOut" }
+                    }
+                  >
+                    <div className="ring-background bg-muted text-muted-foreground flex h-7 items-center justify-center rounded-full px-2.5 text-[11px] font-medium whitespace-nowrap ring-2">
+                      View all
+                    </div>
+                  </motion.div>
+                );
+              })()}
+          </div>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        onClick={(e) => e.stopPropagation()}
+        className="w-64 overflow-hidden p-0"
+      >
+        <div className="border-border border-b px-3 py-2">
+          <Type small className="font-medium">
+            {label}
+          </Type>
+        </div>
+        <div className="max-h-64 overflow-y-auto py-1">
+          {sorted.map((m) => (
+            <div key={m.id} className="flex items-center gap-2.5 px-3 py-1.5">
+              <MemberAvatar member={m} className="size-6" />
+              <div className="min-w-0">
+                <Type small className="truncate font-medium">
+                  {m.name}
+                </Type>
+                <Type muted small className="truncate text-xs">
+                  {m.email}
+                </Type>
+              </div>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/client/dashboard/src/pages/access/Access.tsx
+++ b/client/dashboard/src/pages/access/Access.tsx
@@ -8,10 +8,13 @@ import {
   TabsList,
 } from "@/components/ui/tabs";
 import { Type } from "@/components/ui/type";
+import { useOrganization } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
+import { useOrgRoutes } from "@/routes";
+import { Alert } from "@speakeasy-api/moonshine";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useRoles } from "@gram/client/react-query/roles.js";
-import { Navigate, useLocation, useNavigate } from "react-router";
+import { Link, Navigate, useLocation, useNavigate } from "react-router";
 import { ChallengesTab } from "./ChallengesTab";
 import { MembersTab } from "./MembersTab";
 import { RolesTab } from "./RolesTab";
@@ -65,6 +68,8 @@ export default function Access(): JSX.Element {
 function AccessInner() {
   const location = useLocation();
   const navigate = useNavigate();
+  const organization = useOrganization();
+  const orgRoutes = useOrgRoutes();
   const { data: rolesData } = useRoles();
   const { data: membersData } = useMembers();
   const roleCount = rolesData?.roles?.length;
@@ -93,6 +98,19 @@ function AccessInner() {
           permissions. View past authorization challenges.
         </Type>
       </div>
+
+      {organization.scimEnabled && (
+        <Alert variant="info" dismissible={false} className="mb-6 text-sm">
+          Directory Sync (SCIM) is enabled. Roles are assigned from your
+          identity provider, not here.{" "}
+          <Link
+            to={orgRoutes.identity.href()}
+            className="underline underline-offset-2"
+          >
+            Manage identity settings
+          </Link>
+        </Alert>
+      )}
 
       <Tabs value={currentTab} onValueChange={handleTabChange}>
         <div className="border-border -mx-8 border-b px-8">

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -24,15 +24,16 @@ import {
 import { invalidateAllRoles } from "@gram/client/react-query/roles.js";
 import { useListScopes } from "@gram/client/react-query/listScopes.js";
 import { useUpdateRoleMutation } from "@gram/client/react-query/updateRole.js";
-import { Button } from "@speakeasy-api/moonshine";
+import { Alert, Button } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { useOrgRoutes } from "@/routes";
 import {
   ArrowLeft,
   Ban,
   Check,
   ChevronDown,
   ChevronRight,
-  Info,
   Loader2,
   Plus,
   X,
@@ -148,6 +149,7 @@ export function CreateRoleDialog({
   // ─── Hooks ────────────────────────────────────────────────────
   const queryClient = useQueryClient();
   const organization = useOrganization();
+  const orgRoutes = useOrgRoutes();
   const { data: membersData } = useMembers();
   const members = [...(membersData?.members ?? [])].sort((a, b) =>
     a.name.localeCompare(b.name),
@@ -168,12 +170,36 @@ export function CreateRoleDialog({
   );
 
   const scopeGroups = useMemo(() => {
-    const groupOrder: { label: string; resourceType: string }[] = [
-      { label: "Organization", resourceType: "org" },
-      { label: "Build & Deploy", resourceType: "project" },
-      { label: "Environments", resourceType: "environment" },
-      { label: "MCP Servers", resourceType: "mcp" },
-      { label: "Agent Sessions", resourceType: "chat" },
+    const groupOrder: {
+      label: string;
+      resourceType: string;
+      description: string;
+    }[] = [
+      {
+        label: "Organization",
+        resourceType: "org",
+        description: "Organization metadata, members, and access settings.",
+      },
+      {
+        label: "Build & Deploy",
+        resourceType: "project",
+        description: "Projects and their related resources.",
+      },
+      {
+        label: "Environments",
+        resourceType: "environment",
+        description: "Environments and their entries within projects.",
+      },
+      {
+        label: "MCP Servers",
+        resourceType: "mcp",
+        description: "MCP server configuration and connections.",
+      },
+      {
+        label: "Agent Sessions",
+        resourceType: "chat",
+        description: "Access to members' agent session transcripts.",
+      },
     ];
     return groupOrder.map((g) => ({
       ...g,
@@ -188,13 +214,9 @@ export function CreateRoleDialog({
     setName(editingRole.name);
     setDescription(editingRole.description);
     const roleGrants = grantsFromRole(editingRole, scopesData.scopes);
-    const grantedScopes = new Set(Object.keys(roleGrants));
-    const autoExpanded = new Set(
-      scopeGroups
-        .filter((g) => g.scopes.some((s) => grantedScopes.has(s.slug)))
-        .map((g) => g.label),
-    );
-    setExpandedGroups(autoExpanded);
+    // Keep all groups collapsed on open; auto-expanding granted groups makes
+    // the sheet scroll on load.
+    setExpandedGroups(new Set());
     setGrants(roleGrants);
     setInitialName(editingRole.name);
     setInitialDescription(editingRole.description);
@@ -461,8 +483,10 @@ export function CreateRoleDialog({
         request: {
           updateRoleForm: {
             id: editingRole.id,
+            // System role name/description are platform-managed; permissions
+            // (grants) are per-org and editable.
             ...(isSystemRole
-              ? {}
+              ? { addGrants, removeGrants }
               : { name, description, addGrants, removeGrants }),
             memberIds:
               selectedMembers.size > 0
@@ -577,6 +601,18 @@ export function CreateRoleDialog({
           >
             {/* ─── Panel 1: Role form ─── */}
             <div className="w-full shrink-0 space-y-4 overflow-y-auto px-4 pt-3">
+              {organization.scimEnabled && (
+                <Alert variant="info" dismissible={false} className="text-sm">
+                  Assign this role from{" "}
+                  <Link
+                    to={orgRoutes.identity.href()}
+                    className="whitespace-nowrap underline underline-offset-2"
+                  >
+                    Identity → SCIM → Configure
+                  </Link>
+                  .
+                </Alert>
+              )}
               <InputField
                 label="Name"
                 placeholder="e.g., Project Manager"
@@ -626,13 +662,6 @@ export function CreateRoleDialog({
 
                 {showPermissions && (
                   <div className="mt-3 space-y-3">
-                    {isSystemRole && (
-                      <div className="bg-muted/60 text-muted-foreground flex items-center gap-2 rounded-md px-3 py-2 text-xs">
-                        <Info className="h-3.5 w-3.5 shrink-0" />
-                        System role permissions are managed by the platform and
-                        cannot be changed.
-                      </div>
-                    )}
                     {scopeGroups.map((group) => {
                       const selectedInGroup = group.scopes.filter(
                         (s) => grants[s.slug],
@@ -659,11 +688,10 @@ export function CreateRoleDialog({
                                 toggleGroup(group.label);
                               }
                             }}
-                            className="hover:bg-muted/50 flex w-full cursor-pointer items-center justify-between rounded-t-md px-3 py-2"
+                            className="hover:bg-muted/50 flex w-full cursor-pointer items-start justify-between gap-2 rounded-t-md px-3 py-2"
                           >
-                            <div className="flex items-center gap-2">
+                            <div className="flex items-start gap-2">
                               <Checkbox
-                                disabled={isSystemRole}
                                 checked={
                                   allSelected
                                     ? true
@@ -675,24 +703,33 @@ export function CreateRoleDialog({
                                   e.stopPropagation();
                                   toggleGroupCheckbox(group.label);
                                 }}
-                                className="cursor-pointer"
+                                className="mt-0.5 cursor-pointer"
                               />
-                              <Type
-                                variant="body"
-                                className="text-sm font-medium"
-                              >
-                                {group.label}
-                              </Type>
-                              <Type
-                                variant="body"
-                                className="text-muted-foreground text-sm"
-                              >
-                                ({selectedInGroup}/{group.scopes.length})
-                              </Type>
+                              <div className="min-w-0">
+                                <div className="flex items-center gap-2">
+                                  <Type
+                                    variant="body"
+                                    className="text-sm font-medium"
+                                  >
+                                    {group.label}
+                                  </Type>
+                                  <Type
+                                    variant="body"
+                                    className="text-muted-foreground text-sm"
+                                  >
+                                    ({selectedInGroup}/{group.scopes.length})
+                                  </Type>
+                                </div>
+                                {!isExpanded && (
+                                  <Type muted small className="mt-0.5 text-xs">
+                                    {group.description}
+                                  </Type>
+                                )}
+                              </div>
                             </div>
                             <ChevronRight
                               className={cn(
-                                "text-muted-foreground h-3.5 w-3.5 transition-transform",
+                                "text-muted-foreground mt-0.5 h-3.5 w-3.5 shrink-0 transition-transform",
                                 isExpanded && "rotate-90",
                               )}
                             />
@@ -712,22 +749,9 @@ export function CreateRoleDialog({
                                 const row = (
                                   <div key={scopeDef.slug}>
                                     {/* Scope checkbox row */}
-                                    <div
-                                      className={cn(
-                                        "hover:bg-muted/50 flex items-start gap-3 px-3 py-2.5",
-                                        isSystemRole && "cursor-default",
-                                      )}
-                                    >
-                                      <label
-                                        className={cn(
-                                          "flex min-w-0 flex-1 items-start gap-3",
-                                          isSystemRole
-                                            ? "cursor-default"
-                                            : "cursor-pointer",
-                                        )}
-                                      >
+                                    <div className="hover:bg-muted/50 flex items-start gap-3 px-3 py-2.5">
+                                      <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-3">
                                         <Checkbox
-                                          disabled={isSystemRole}
                                           checked={isChecked}
                                           onCheckedChange={() =>
                                             toggleScope(scopeDef.slug)
@@ -781,31 +805,20 @@ export function CreateRoleDialog({
                                               scopeDef.resourceType,
                                               projectList,
                                             )}
-                                            onClick={
-                                              isSystemRole
-                                                ? undefined
-                                                : () =>
-                                                    openRuleEditor(
-                                                      scopeDef.slug,
-                                                      ruleIdx,
-                                                    )
+                                            onClick={() =>
+                                              openRuleEditor(
+                                                scopeDef.slug,
+                                                ruleIdx,
+                                              )
                                             }
-                                            onRemove={
-                                              isSystemRole
-                                                ? undefined
-                                                : () =>
-                                                    removeRule(
-                                                      scopeDef.slug,
-                                                      ruleIdx,
-                                                    )
+                                            onRemove={() =>
+                                              removeRule(scopeDef.slug, ruleIdx)
                                             }
-                                            readOnly={isSystemRole}
                                           />
                                         ))}
-                                        {!isSystemRole &&
-                                          !grant.rules.some(
-                                            (r) => r.effect === "deny",
-                                          ) &&
+                                        {!grant.rules.some(
+                                          (r) => r.effect === "deny",
+                                        ) &&
                                           getDenyPanels(
                                             getAllowLevel(grant.rules),
                                           ).length > 0 && (
@@ -829,22 +842,6 @@ export function CreateRoleDialog({
                                     )}
                                   </div>
                                 );
-
-                                if (isSystemRole) {
-                                  return (
-                                    <Tooltip key={scopeDef.slug}>
-                                      <TooltipTrigger asChild>
-                                        {row}
-                                      </TooltipTrigger>
-                                      <TooltipContent
-                                        side="right"
-                                        className="max-w-48"
-                                      >
-                                        Cannot edit system role permissions
-                                      </TooltipContent>
-                                    </Tooltip>
-                                  );
-                                }
 
                                 return row;
                               })}

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -14,21 +14,21 @@ import { useDeleteRoleMutation } from "@gram/client/react-query/deleteRole.js";
 import { SkeletonTable } from "@/components/ui/skeleton";
 import {
   Button,
-  Column,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   Icon,
-  Table,
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router";
 import { CreateRoleDialog } from "./CreateRoleDialog";
 import { DeleteRoleDialog } from "./DeleteRoleDialog";
+import { MemberFacepile } from "@/components/member-facepile";
 import { Ellipsis } from "lucide-react";
 import { RequireScope } from "@/components/require-scope";
+import { useRBAC } from "@/hooks/useRBAC";
 import { cn } from "@/lib/utils";
 import { visiblePermissionCount } from "./roleDialogState";
 
@@ -44,43 +44,127 @@ function RoleActionsMenu({
   const [open, setOpen] = useState(false);
 
   return (
+    // Render-prop form: the dropdown content is portaled to <body>, so it
+    // escapes the pointer-events containment of the node form. Disabling the
+    // Radix trigger directly is what actually prevents the menu from opening.
     <RequireScope scope="org:admin" level="component">
-      <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className={cn(
-              "text-muted-foreground hover:bg-accent hover:text-foreground flex h-8 w-8 cursor-pointer items-center justify-center rounded-md transition-colors",
-              open && "bg-accent text-foreground",
-            )}
-          >
-            <Ellipsis className="h-4 w-4" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onSelect={() => {
-              void setTimeout(onEdit, 0);
-            }}
-          >
-            Edit
-          </DropdownMenuItem>
-          {!role.isSystem && (
+      {({ disabled }) => (
+        <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
+          <DropdownMenuTrigger asChild disabled={disabled}>
+            <button
+              type="button"
+              disabled={disabled}
+              className={cn(
+                "text-muted-foreground hover:bg-accent hover:text-foreground flex h-8 w-8 cursor-pointer items-center justify-center rounded-md transition-colors",
+                open && "bg-accent text-foreground",
+                disabled && "cursor-not-allowed",
+              )}
+            >
+              <Ellipsis className="h-4 w-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
             <DropdownMenuItem
               onSelect={() => {
-                void setTimeout(onDelete, 0);
+                void setTimeout(onEdit, 0);
               }}
             >
-              Delete
+              Edit
             </DropdownMenuItem>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+            {!role.isSystem && (
+              <DropdownMenuItem
+                onSelect={() => {
+                  void setTimeout(onDelete, 0);
+                }}
+              >
+                Delete
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </RequireScope>
   );
 }
 
+type RowMember = {
+  id: string;
+  name: string;
+  email: string;
+  photoUrl?: string;
+  roleIds: string[];
+};
+
+function RoleRow({
+  role,
+  members,
+  canManageRoles,
+  onEdit,
+  onDelete,
+}: {
+  role: Role;
+  members: RowMember[];
+  canManageRoles: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}): JSX.Element {
+  const roleMembers = members
+    .filter((m) => m.roleIds.includes(role.id))
+    .map((m) => ({
+      id: m.id,
+      name: m.name,
+      email: m.email,
+      photoUrl: m.photoUrl,
+    }));
+
+  return (
+    <div
+      role={canManageRoles ? "button" : undefined}
+      tabIndex={canManageRoles ? 0 : undefined}
+      onClick={canManageRoles ? onEdit : undefined}
+      onKeyDown={
+        canManageRoles
+          ? (e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onEdit();
+              }
+            }
+          : undefined
+      }
+      className={cn(
+        "border-border col-span-full grid grid-cols-subgrid items-center gap-x-6 border-b px-4 py-3 last:border-b-0",
+        canManageRoles && "hover:bg-muted/50 cursor-pointer",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Type variant="body" className="font-medium">
+          {role.name}
+        </Type>
+        {role.isSystem && (
+          <Badge variant="outline" size="sm">
+            System
+          </Badge>
+        )}
+      </div>
+      <Type variant="body" className="text-muted-foreground min-w-0 truncate">
+        {role.description}
+      </Type>
+      <Type variant="body">{visiblePermissionCount(role.grants)}</Type>
+      <MemberFacepile members={roleMembers} />
+      <div aria-hidden />
+      <div onClick={(e) => e.stopPropagation()} className="flex justify-end">
+        <RoleActionsMenu role={role} onEdit={onEdit} onDelete={onDelete} />
+      </div>
+    </div>
+  );
+}
+
 export function RolesTab(): JSX.Element {
+  const { hasAnyScope } = useRBAC();
+  // Mirror the row-actions menu gate (org:admin): without it, the row is not
+  // clickable and shows no affordance.
+  const canManageRoles = hasAnyScope(["org:admin"]);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingRole, setEditingRole] = useState<Role | null>(null);
   const [deletingRole, setDeletingRole] = useState<Role | null>(null);
@@ -126,62 +210,6 @@ export function RolesTab(): JSX.Element {
     },
   });
 
-  const columns: Column<Role>[] = [
-    {
-      key: "name",
-      header: "Name",
-      width: "180px",
-      render: (role) => (
-        <div className="flex items-center gap-2">
-          <Type variant="body" className="font-medium">
-            {role.name}
-          </Type>
-          {role.isSystem && (
-            <Badge variant="outline" size="sm">
-              System
-            </Badge>
-          )}
-        </div>
-      ),
-    },
-    {
-      key: "description",
-      header: "Description",
-      width: "1fr",
-      render: (role) => (
-        <Type variant="body" className="text-muted-foreground">
-          {role.description}
-        </Type>
-      ),
-    },
-    {
-      key: "permissions",
-      header: "Permissions",
-      width: "120px",
-      render: (role) => (
-        <Type variant="body">{visiblePermissionCount(role.grants)}</Type>
-      ),
-    },
-    {
-      key: "members",
-      header: "Members",
-      width: "100px",
-      render: (role) => <Type variant="body">{role.memberCount}</Type>,
-    },
-    {
-      key: "actions",
-      header: "",
-      width: "80px",
-      render: (role) => (
-        <RoleActionsMenu
-          role={role}
-          onEdit={() => setEditingRole(role)}
-          onDelete={() => setDeletingRole(role)}
-        />
-      ),
-    },
-  ];
-
   return (
     <div>
       <div className="mb-1 flex items-center justify-between">
@@ -206,15 +234,36 @@ export function RolesTab(): JSX.Element {
           <SkeletonTable />
         </div>
       ) : (
-        <Table
-          columns={columns}
-          data={roles}
-          rowKey={(row) => row.id}
-          className="mt-4"
-          noResultsMessage={
-            <div className="p-4">No roles have been created yet.</div>
-          }
-        />
+        // Grid table: the parent owns the column tracks and each row is a
+        // subgrid spanning them, so cells align across rows. Description uses
+        // minmax(0,1fr) (shrinks, absorbs slack); Members uses max-content
+        // (sizes to the bounded facepile) — neither can overflow the table.
+        <div className="border-border mt-4 grid grid-cols-[max-content_minmax(0,24rem)_max-content_max-content_1fr_max-content] overflow-hidden rounded-lg border">
+          <div className="text-muted-foreground border-border col-span-full grid grid-cols-subgrid items-center gap-x-6 border-b px-4 py-2.5 text-sm">
+            <div>Name</div>
+            <div>Description</div>
+            <div>Permissions</div>
+            <div>Members</div>
+            <div aria-hidden />
+            <div className="sr-only">Actions</div>
+          </div>
+          {roles.length === 0 ? (
+            <div className="text-muted-foreground col-span-full p-4">
+              No roles have been created yet.
+            </div>
+          ) : (
+            roles.map((role) => (
+              <RoleRow
+                key={role.id}
+                role={role}
+                members={members}
+                canManageRoles={canManageRoles}
+                onEdit={() => setEditingRole(role)}
+                onDelete={() => setDeletingRole(role)}
+              />
+            ))
+          )}
+        </div>
       )}
 
       <div className="border-border/50 bg-muted/30 mt-8 rounded-md border px-4 py-3">

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -125,7 +125,7 @@ function RoleRow({
       onKeyDown={
         canManageRoles
           ? (e) => {
-              if (e.key === "Enter") {
+              if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
                 onEdit();
               }

--- a/client/dashboard/src/pages/access/roleDialogState.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.ts
@@ -88,7 +88,6 @@ export function hasFormChanges(input: SaveButtonInput): boolean {
 
 /** Whether the form fields are valid enough to submit */
 function isFormValid(input: SaveButtonInput): boolean {
-  if (input.isSystemRole) return true; // system roles only change members
   return (
     input.name.trim().length > 0 &&
     input.description.trim().length > 0 &&

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -1,5 +1,6 @@
 import { InputDialog } from "@/components/input-dialog";
 import { Page } from "@/components/page-layout";
+import { MemberFacepile } from "@/components/member-facepile";
 import { ProjectAvatar } from "@/components/project-menu";
 import { RequireScope } from "@/components/require-scope";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -534,8 +535,15 @@ function ProjectRow({
         </div>
       </div>
 
-      <div className="pointer-events-none">
-        <Facepile members={facepile} />
+      <div
+        className="relative z-10 hidden md:flex"
+        onClick={(e) => {
+          // Keep clicks on the facepile from triggering the row's Link overlay.
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+      >
+        <MemberFacepile members={facepile} maxFaces={5} />
       </div>
 
       <ProjectRowActions
@@ -597,8 +605,14 @@ function ProjectCard({
       </div>
 
       <div className="flex items-center justify-between gap-2">
-        <div className="pointer-events-none">
-          <Facepile members={facepile} />
+        <div
+          className="relative z-10"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          <MemberFacepile members={facepile} maxFaces={5} />
         </div>
         <ProjectRowActions
           project={project}
@@ -785,39 +799,6 @@ function TimestampDetail({ date }: { date: Date }) {
           {tzAbbr}
         </span>
         <span>{local}</span>
-      </div>
-    </div>
-  );
-}
-
-function Facepile({ members }: { members: AccessMember[] }) {
-  if (members.length === 0) return null;
-  const visible = members.slice(0, FACEPILE_LIMIT);
-  const overflow = Math.max(0, members.length - FACEPILE_LIMIT);
-
-  return (
-    <div className="relative z-10 hidden shrink-0 items-center md:flex">
-      <div className="flex -space-x-1.5">
-        {visible.map((member) => (
-          <Tooltip key={member.id}>
-            <TooltipTrigger asChild>
-              <Avatar className="ring-background size-6 ring-2">
-                {member.photoUrl ? (
-                  <AvatarImage src={member.photoUrl} alt={member.name} />
-                ) : null}
-                <AvatarFallback className="bg-muted text-muted-foreground text-[10px] font-medium">
-                  {getInitials(member.email)}
-                </AvatarFallback>
-              </Avatar>
-            </TooltipTrigger>
-            <TooltipContent>{member.name || member.email}</TooltipContent>
-          </Tooltip>
-        ))}
-        {overflow > 0 && (
-          <div className="bg-muted text-muted-foreground ring-background flex size-6 items-center justify-center rounded-full text-[10px] font-medium ring-2">
-            +{overflow}
-          </div>
-        )}
       </div>
     </div>
   );

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -21,7 +21,7 @@ type IdentitySectionId = "sso" | "directory_sync";
 type IdentityCardProps = {
   sectionId: IdentitySectionId;
   heading: string;
-  description: string;
+  description: React.ReactNode;
   providerIcon: React.ReactNode;
   providerTitle: string;
   providerSubtitle: string;
@@ -241,7 +241,7 @@ function IdentitySection({
         <Heading variant="h5" className="mb-1">
           {heading}
         </Heading>
-        <Type muted small className="mb-4">
+        <Type as="div" muted small className="mb-4">
           {description}
         </Type>
         <div className="border-border overflow-hidden rounded-lg border">
@@ -332,7 +332,19 @@ function OrgIdentityInner() {
         <IdentitySection
           sectionId="directory_sync"
           heading="Directory Sync"
-          description="Automatically provision and deprovision users from your identity provider."
+          description={
+            <>
+              Sync members and roles directly from your identity provider:
+              <ul className="mt-1.5 list-disc space-y-0.5 pl-5">
+                <li>
+                  Members are provisioned automatically from your directory
+                </li>
+                <li>Roles are assigned from your IDP group mappings</li>
+                <li>Members can&apos;t be invited manually</li>
+                <li>Roles can&apos;t be assigned to members manually</li>
+              </ul>
+            </>
+          }
           providerIcon={
             <FolderSync className="text-muted-foreground h-5 w-5" />
           }

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -33,6 +33,7 @@ import {
 } from "@gram/client/models/components";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import {
+  Alert,
   Button,
   Column,
   DropdownMenu,
@@ -523,17 +524,31 @@ function TeamInner() {
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {isRbacEnabled && accessMember && !organization.scimEnabled && (
-                <RequireScope scope="org:admin" level="component">
-                  <DropdownMenuItem
-                    onSelect={() => {
-                      void setTimeout(() => setChangingMember(accessMember), 0);
-                    }}
-                  >
-                    Manage roles
-                  </DropdownMenuItem>
-                </RequireScope>
-              )}
+              {isRbacEnabled &&
+                (organization.scimEnabled ? (
+                  <SimpleTooltip tooltip="Role assignments are managed by your identity provider. Configure them under SSO → SCIM in identity settings.">
+                    <span className="inline-flex w-full">
+                      <DropdownMenuItem disabled className="w-full">
+                        Manage roles
+                      </DropdownMenuItem>
+                    </span>
+                  </SimpleTooltip>
+                ) : (
+                  accessMember && (
+                    <RequireScope scope="org:admin" level="component">
+                      <DropdownMenuItem
+                        onSelect={() => {
+                          void setTimeout(
+                            () => setChangingMember(accessMember),
+                            0,
+                          );
+                        }}
+                      >
+                        Manage roles
+                      </DropdownMenuItem>
+                    </RequireScope>
+                  )
+                ))}
               {isRbacEnabled && (
                 <DropdownMenuItem
                   onSelect={() => {
@@ -796,6 +811,19 @@ function TeamInner() {
               )}
             </RequireScope>
           </Stack>
+
+          {organization.scimEnabled && (
+            <Alert variant="info" dismissible={false} className="mb-8 text-sm">
+              Directory Sync (SCIM) is enabled. Members are provisioned and
+              roles assigned from your identity provider, not here.{" "}
+              <Link
+                to={orgRoutes.identity.href()}
+                className="underline underline-offset-2"
+              >
+                Manage identity settings
+              </Link>
+            </Alert>
+          )}
 
           <div className="relative">
             <Icon

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -319,8 +319,14 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 			}
 		}
 		for _, g := range addGrants {
+			// An org:admin add only counts if it actually writes a grant row:
+			// nil selectors flatten to a wildcard row, a non-empty slice writes
+			// the listed rows. An empty (non-nil) selector slice flattens to
+			// zero rows (see grants.go), so pairing such a no-op add with an
+			// org:admin removal must not satisfy the guardrail — that would
+			// strip org:admin from the Admin role and lock the org out.
 			if g.Scope == string(authz.ScopeOrgAdmin) {
-				addingOrgAdmin = true
+				addingOrgAdmin = addingOrgAdmin || g.Selectors == nil || len(g.Selectors) > 0
 			}
 		}
 		if removingOrgAdmin && !addingOrgAdmin {

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -308,6 +308,26 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, err, "invalid access role grant: %s", err).LogError(ctx, r.logger)
 	}
 
+	// Lockout guardrail: removing org:admin from the Admin role would lock the
+	// org out of administration. Validate against the payload up front so a
+	// rejected request never performs grant writes that have to be rolled back.
+	if currentRole.Slug == authz.SystemRoleAdmin {
+		removingOrgAdmin, addingOrgAdmin := false, false
+		for _, g := range removeGrants {
+			if g.Scope == string(authz.ScopeOrgAdmin) {
+				removingOrgAdmin = true
+			}
+		}
+		for _, g := range addGrants {
+			if g.Scope == string(authz.ScopeOrgAdmin) {
+				addingOrgAdmin = true
+			}
+		}
+		if removingOrgAdmin && !addingOrgAdmin {
+			return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "the Admin role must keep the org:admin permission").LogError(ctx, r.logger)
+		}
+	}
+
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
@@ -371,20 +391,6 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 		syncedGrants, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, currentRole.Slug, currentRole.PrincipalURN, addGrants, removeGrants)
 		if err != nil {
 			return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "patch grants for updated role").LogError(ctx, r.logger)
-		}
-		// Lockout guardrail: the Admin system role must always retain an allow
-		// grant for org:admin, otherwise no one could administer the org.
-		if currentRole.Slug == authz.SystemRoleAdmin {
-			hasOrgAdmin := false
-			for _, grant := range syncedGrants {
-				if grant.Scope == string(authz.ScopeOrgAdmin) && grant.Effect == authz.PolicyEffectAllow {
-					hasOrgAdmin = true
-					break
-				}
-			}
-			if !hasOrgAdmin {
-				return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "the Admin role must keep the org:admin permission").LogError(ctx, r.logger)
-			}
 		}
 		updatedGrants = make([]*gen.RoleGrant, 0, len(syncedGrants))
 		for _, grant := range syncedGrants {

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -288,11 +288,11 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 	}
 
 	sysRole := isSystemRole(currentRole.Slug)
-	if sysRole && (payload.Name != nil || payload.Description != nil || payload.AddGrants != nil || payload.RemoveGrants != nil) {
-		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "system role properties cannot be updated, only member assignment is allowed").LogError(ctx, r.logger)
-	}
-	if sysRole && payload.MemberIds == nil {
-		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "system role update requires member_ids").LogError(ctx, r.logger)
+	// System role names/descriptions are platform-managed and shared globally
+	// (global_roles), so they stay immutable. Grants are stored per-org and may
+	// be customized, so grant and member changes are allowed below.
+	if sysRole && (payload.Name != nil || payload.Description != nil) {
+		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "system role name and description cannot be changed").LogError(ctx, r.logger)
 	}
 	if payload.Name != nil {
 		if _, err := slugify(*payload.Name); err != nil {
@@ -350,17 +350,6 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 			MemberCount:  int(updatedRow.MemberCount),
 		}
 
-		if payload.AddGrants != nil || payload.RemoveGrants != nil {
-			syncedGrants, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, currentRole.Slug, currentRole.PrincipalURN, addGrants, removeGrants)
-			if err != nil {
-				return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "patch grants for updated role").LogError(ctx, r.logger)
-			}
-			updatedGrants = make([]*gen.RoleGrant, 0, len(syncedGrants))
-			for _, grant := range syncedGrants {
-				updatedGrants = append(updatedGrants, scopedGrantToGenRoleGrant(grant))
-			}
-		}
-
 		workosSyncs = append(workosSyncs, func(ctx context.Context) {
 			r.syncWorkOS(ctx, "update role in workos", func() error {
 				_, err := r.roles.UpdateRole(ctx, workosOrgID, currentRole.Slug, workos.UpdateRoleOpts{
@@ -373,6 +362,34 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 				return fmt.Errorf("update role in workos: %w", err)
 			})
 		})
+	}
+
+	// Grants live in the per-org grant store and are patched the same way for
+	// custom and system roles. WorkOS only tracks role identity/membership, not
+	// gram scopes, so no grant sync to WorkOS is needed.
+	if payload.AddGrants != nil || payload.RemoveGrants != nil {
+		syncedGrants, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, currentRole.Slug, currentRole.PrincipalURN, addGrants, removeGrants)
+		if err != nil {
+			return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "patch grants for updated role").LogError(ctx, r.logger)
+		}
+		// Lockout guardrail: the Admin system role must always retain an allow
+		// grant for org:admin, otherwise no one could administer the org.
+		if currentRole.Slug == authz.SystemRoleAdmin {
+			hasOrgAdmin := false
+			for _, grant := range syncedGrants {
+				if grant.Scope == string(authz.ScopeOrgAdmin) && grant.Effect == authz.PolicyEffectAllow {
+					hasOrgAdmin = true
+					break
+				}
+			}
+			if !hasOrgAdmin {
+				return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "the Admin role must keep the org:admin permission").LogError(ctx, r.logger)
+			}
+		}
+		updatedGrants = make([]*gen.RoleGrant, 0, len(syncedGrants))
+		for _, grant := range syncedGrants {
+			updatedGrants = append(updatedGrants, scopedGrantToGenRoleGrant(grant))
+		}
 	}
 
 	if payload.MemberIds != nil {

--- a/server/internal/access/updaterole_test.go
+++ b/server/internal/access/updaterole_test.go
@@ -168,7 +168,7 @@ func TestService_UpdateRole_SystemRole_MemberAssignment(t *testing.T) {
 	ti.roles.AssertNotCalled(t, "UpdateRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestService_UpdateRole_SystemRole_RejectsPropertyChanges(t *testing.T) {
+func TestService_UpdateRole_SystemRole_RejectsNameDescriptionChanges(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestAccessService(t)
@@ -177,13 +177,15 @@ func TestService_UpdateRole_SystemRole_RejectsPropertyChanges(t *testing.T) {
 
 	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockSystemRole("role_member", "Member", authz.SystemRoleMember))
 
+	// Name and description are platform-managed (shared globally) and stay
+	// immutable for system roles.
 	name := "Custom Name"
 	_, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
 		ID:   roleID,
 		Name: &name,
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "system role properties cannot be updated")
+	require.Contains(t, err.Error(), "system role name and description cannot be changed")
 
 	description := "Custom description"
 	_, err = ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
@@ -191,17 +193,40 @@ func TestService_UpdateRole_SystemRole_RejectsPropertyChanges(t *testing.T) {
 		Description: &description,
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "system role properties cannot be updated")
-
-	_, err = ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
-		ID:        roleID,
-		AddGrants: []*gen.RoleGrant{{Scope: string(authz.ScopeProjectRead)}},
-	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "system role properties cannot be updated")
+	require.Contains(t, err.Error(), "system role name and description cannot be changed")
 }
 
-func TestService_UpdateRole_SystemRole_RejectsNoopUpdate(t *testing.T) {
+func TestService_UpdateRole_SystemRole_AllowsGrantEdit(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	// Grants are per-org and may be customized on a system role.
+	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockSystemRole("role_member", "Member", authz.SystemRoleMember))
+
+	role, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
+		ID:        roleID,
+		AddGrants: []*gen.RoleGrant{{Scope: string(authz.ScopeProjectWrite)}},
+	})
+	require.NoError(t, err)
+	require.True(t, role.IsSystem)
+
+	found := false
+	for _, g := range role.Grants {
+		if g.Scope == string(authz.ScopeProjectWrite) {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "added grant should be present on the updated system role")
+
+	// WorkOS only tracks role identity/membership, not gram grants.
+	ti.roles.AssertNotCalled(t, "UpdateRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestService_UpdateRole_SystemRole_AdminMustKeepOrgAdmin(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestAccessService(t)
@@ -210,11 +235,14 @@ func TestService_UpdateRole_SystemRole_RejectsNoopUpdate(t *testing.T) {
 
 	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockSystemRole("role_admin", "Admin", "admin"))
 
+	// Stripping org:admin from the Admin role would lock the org out of
+	// administration, so it is rejected.
 	_, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
-		ID: roleID,
+		ID:           roleID,
+		RemoveGrants: []*gen.RoleGrant{{Scope: string(authz.ScopeOrgAdmin)}},
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "system role update requires member_ids")
+	require.Contains(t, err.Error(), "the Admin role must keep the org:admin permission")
 }
 
 func TestService_UpdateRole_SystemRole_AuditLog(t *testing.T) {

--- a/server/internal/access/updaterole_test.go
+++ b/server/internal/access/updaterole_test.go
@@ -245,6 +245,28 @@ func TestService_UpdateRole_SystemRole_AdminMustKeepOrgAdmin(t *testing.T) {
 	require.Contains(t, err.Error(), "the Admin role must keep the org:admin permission")
 }
 
+func TestService_UpdateRole_SystemRole_AdminOrgAdminEmptySelectorAddRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	roleID := seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockSystemRole("role_admin", "Admin", "admin"))
+
+	// A removal paired with an org:admin add whose selectors are an empty
+	// (non-nil) slice must not satisfy the guardrail: an empty selector slice
+	// flattens to zero grant rows, so org:admin would be removed and never
+	// re-added — locking the org out. The add must be ignored here.
+	_, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
+		ID:           roleID,
+		RemoveGrants: []*gen.RoleGrant{{Scope: string(authz.ScopeOrgAdmin)}},
+		AddGrants:    []*gen.RoleGrant{{Scope: string(authz.ScopeOrgAdmin), Selectors: []*gen.Selector{}}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "the Admin role must keep the org:admin permission")
+}
+
 func TestService_UpdateRole_SystemRole_AuditLog(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Loosens RBAC system-role editing and reworks the roles/team UX around Directory Sync (SCIM).

### Backend (`server/internal/access/role_manager.go`)

- System roles (`admin`/`member`) can now have their **permissions (grants) edited per-org**. Name/description stay platform-managed (they live in the global `global_roles` record), so only those remain immutable.
- Grant-patching moved out of the `if !sysRole` block so it runs for both custom and system roles; WorkOS sync (identity/membership only) stays custom-role-only.
- **Lockout guardrail**: rejects any edit that strips the `org:admin` allow grant from the Admin role.

### Roles tab (`RolesTab.tsx`, `CreateRoleDialog.tsx`, `roleDialogState.ts`)

- System-role permission checkboxes/rules are now editable (removed the disabled states, read-only chips, and "managed by the platform" banner/tooltip); submit sends grants for system roles.
- Scope groups no longer auto-expand on open (was causing the sheet to scroll), and show a muted sub-description when collapsed.
- Whole role row is clickable to open the edit sheet, gated on `org:admin` (no click/affordance without it). Row-actions menu now disables correctly via the render-prop form of `RequireScope` (the portaled dropdown previously escaped the disabled wrapper).
- Roles table rebuilt with **CSS grid + subgrid** so the description column can't balloon/overflow.
- SCIM info alert in the create/edit sheet pointing to Identity → SCIM.

### Member facepile (`components/member-facepile.tsx`, new)

- New shared, interactive facepile: overlapping gradient avatars, hover focus (hovered face scales up, others dim via `filter` desaturation), click opens a portaled popover listing all members (alphabetical), "View all" overflow chip.
- Replaces the old inline facepile on the org home projects list (`OrgHome.tsx`, max 5 there) and powers the new Members column on the roles table.

### Misc

- `gradient-colors.ts`: subtler, brand-aligned gradients (single brand hue + small drift, reduced saturation).
- Team page + roles page: info alerts explaining that members/roles are managed by the IDP while Directory Sync (SCIM) is enabled; `OrgIdentity.tsx` Directory Sync description expanded into a bulleted feature list.

## Linked issues

- Closes AIS-159 (clickable role rows / view role details)
- Relates to AIS-165 (customize the default Member role — this PR makes system-role permissions editable, the enabler)

## Notes

- Migrations: none (app code only).
- `pnpm -F dashboard type-check` and `mise lint:server` pass.
