### PR TITLE
fix: render facepile overflow as +N chip instead of broken View all

### DIFF
--- a/client/dashboard/src/components/member-facepile.tsx
+++ b/client/dashboard/src/components/member-facepile.tsx
@@ -165,8 +165,8 @@ export function MemberFacepile({
                         : { type: "tween", duration: 0.3, ease: "easeOut" }
                     }
                   >
-                    <div className="ring-background bg-muted text-muted-foreground flex h-7 items-center justify-center rounded-full px-2.5 text-[11px] font-medium whitespace-nowrap ring-2">
-                      View all
+                    <div className="ring-background bg-muted text-muted-foreground flex size-7 items-center justify-center rounded-full text-[11px] font-medium ring-2">
+                      +{overflow}
                     </div>
                   </motion.div>
                 );


### PR DESCRIPTION
## What

Facepile overflow chip rendered a fixed-width "View all" pill. The pile uses a
narrow grid track (`[grid-auto-columns:1.15rem]`) for deterministic avatar
overlap, so the content-width pill spilled past its track and visually collided
with the last avatar.

Switch it back to a round `+N` chip sized `size-7` — same as the faces — so it
obeys the same overlap track math and sits flush in the stack.

## Behavior

- Overflow now shows `+N` (count of additional faces) in a circular chip.
- Click target unchanged: the whole pile is the popover trigger and still opens
  the full member list. `aria-label="N members"` keeps it accessible.

## Scope

Single-line change in `client/dashboard/src/components/member-facepile.tsx`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the facepile overflow “View all” pill with a circular +N chip matching avatar size, fixing layout overflow and collisions in the narrow grid track.

- **Bug Fixes**
  - +N chip uses `size-7` and shares the same overlap track, so it sits flush.
  - Interaction unchanged: the pile is still the popover trigger with `aria-label="N members"`.

<sup>Written for commit 63e187d727db1c40cce42ff392734313e018e38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

