### PR TITLE
fix(rbac): show own-sessions banner only when lacking chat:read

### DIFF
--- a/client/dashboard/src/hooks/useRBAC.test.ts
+++ b/client/dashboard/src/hooks/useRBAC.test.ts
@@ -29,6 +29,20 @@ describe("resourceKindForScope", () => {
     expect(resourceKindForScope("environment:write")).toBe("environment");
   });
 
+  it("returns 'risk_policy' for risk_policy scopes", () => {
+    expect(resourceKindForScope("risk_policy:evaluate")).toBe("risk_policy");
+    expect(resourceKindForScope("risk_policy:bypass")).toBe("risk_policy");
+  });
+
+  // Regression: chat scopes must map to "chat" so a restricted chat:read grant
+  // (selector {resource_kind:"chat", resource_id:"*"}) matches the hasScope
+  // check. When this returned "*" the check selector ({resource_kind:"*"}) never
+  // matched the grant, so admins with chat:read still saw the "own sessions
+  // only" banner.
+  it("returns 'chat' for chat scopes", () => {
+    expect(resourceKindForScope("chat:read")).toBe("chat");
+  });
+
   it("returns '*' for unknown scope families", () => {
     expect(resourceKindForScope("root")).toBe("*");
     expect(resourceKindForScope("unknown:thing")).toBe("*");

--- a/client/dashboard/src/hooks/useRBAC.ts
+++ b/client/dashboard/src/hooks/useRBAC.ts
@@ -17,6 +17,8 @@ export function resourceKindForScope(scope: string): string {
   if (scope.startsWith("remote-mcp:") || scope.startsWith("mcp:")) return "mcp";
   if (scope.startsWith("org:")) return "org";
   if (scope.startsWith("environment:")) return "environment";
+  if (scope.startsWith("risk_policy:")) return "risk_policy";
+  if (scope.startsWith("chat:")) return "chat";
   return "*";
 }
 


### PR DESCRIPTION
## Problem

On the agent sessions list, the banner _"Only your own sessions are shown. `chat:read` is required to view other members' sessions."_ rendered **unconditionally** — even for admins who actually hold a `chat:read` grant.

## Root cause

Client/server drift in the scope → resource-kind mapping:

- Server `ResourceKindForScope` (`server/internal/authz/selector.go`) maps `chat:*` → `"chat"` and `risk_policy:*` → `"risk_policy"`.
- Client `resourceKindForScope` (`client/dashboard/src/hooks/useRBAC.ts`) was missing **both** cases and fell through to `"*"`, despite a comment claiming it mirrors the server.

An unrestricted `chat:read` role grant is stored with selector `{resource_kind:"chat", resource_id:"*"}`, which `IsRestricted()` reports as restricted — so the API returns the grant **with** that selector (not nil). The client then built its check selector as `{resourceKind:"*"}`, and `selectorMatches` compared grant `"chat"` against check `"*"` → no match → `hasScope("chat:read")` returned `false` → banner shown.

The server avoids this because `ChatReadCheck` deliberately uses an empty `ResourceKind`, omitting the key from the check selector entirely.

## Fix

Add the missing `chat:` and `risk_policy:` cases to the client `resourceKindForScope`, restoring parity with the server. Now the check selector carries `resource_kind:"chat"`, which matches the grant, so `hasScope("chat:read")` returns `true` and `OwnSessionsNotice` correctly hides for users who hold the grant.

## Tests

Added regression cases to `useRBAC.test.ts` for `chat:*` and `risk_policy:*`. `vitest run src/hooks/useRBAC.test.ts` → 17 passing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix RBAC checks so the “Only your own sessions are shown” banner appears only when the user lacks `chat:read`. Align the client scope→resource-kind mapping with the server so `hasScope('chat:read')` is accurate.

- **Bug Fixes**
  - Map `chat:*` to "chat" and `risk_policy:*` to "risk_policy" in `resourceKindForScope`.
  - Add regression tests for both mappings in `useRBAC.test.ts`.
  - Admins with `chat:read` no longer see the banner on the sessions list.

<sup>Written for commit 2f79d5a29448a7bc006ca8ff75b4832bac5a1226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

