### PR TITLE
mig: extend ClickHouse telemetry TTL from 30 to 90 days

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260706165346_ttl-90d.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260706165346_ttl-90d.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `trace_summaries` MODIFY TTL fromUnixTimestamp64Nano(start_time_unix_nano) + toIntervalDay(30);
+ALTER TABLE `telemetry_logs` MODIFY TTL fromUnixTimestamp64Nano(time_unix_nano) + toIntervalDay(30);
+ALTER TABLE `metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(30);
+ALTER TABLE `attribute_metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(30);
+ALTER TABLE `attribute_keys` MODIFY TTL fromUnixTimestamp64Nano(last_seen_unix_nano) + toIntervalDay(30);

--- a/server/clickhouse/local/golang_migrate/20260706165346_ttl-90d.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260706165346_ttl-90d.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `attribute_keys` MODIFY TTL fromUnixTimestamp64Nano(last_seen_unix_nano) + toIntervalDay(90);
+ALTER TABLE `attribute_metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(90);
+ALTER TABLE `metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(90);
+ALTER TABLE `telemetry_logs` MODIFY TTL fromUnixTimestamp64Nano(time_unix_nano) + toIntervalDay(90);
+ALTER TABLE `trace_summaries` MODIFY TTL fromUnixTimestamp64Nano(start_time_unix_nano) + toIntervalDay(90);

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:asxGoaLNQElfK3GtWa5329B579hSo8ZtIrToF5y6des=
+h1:guPKsC7jt/KtovpxenIU5yELeu0j8XjLxissJ82+rCw=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -49,3 +49,4 @@ h1:asxGoaLNQElfK3GtWa5329B579hSo8ZtIrToF5y6des=
 20260630211520_pat-account-type-and-provider-summaries.up.sql h1:jZcSnDdLvYZZEIl8/M35gAIckJNFbWQ4tGV3tKbrDRw=
 20260701215636_billing-mode-summaries.up.sql h1:QBQWDP1N8QGVVfa3oVOIvfVn6DZXBSuBJ12Pcs+3a70=
 20260702073000_attribute-metrics-attribution-dimensions.up.sql h1:PoTqZiFzKWD7DQ7w+uIPo5RwyerGYoYUHOP+Hfxx6iY=
+20260706165346_ttl-90d.up.sql h1:abSyGD5D2/4V9uClhit0Vf09W3z1rGoQAYGK8Y6GO6M=

--- a/server/clickhouse/migrations/20260706165342_ttl-90d.sql
+++ b/server/clickhouse/migrations/20260706165342_ttl-90d.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `attribute_keys` MODIFY TTL fromUnixTimestamp64Nano(last_seen_unix_nano) + toIntervalDay(90);
+ALTER TABLE `attribute_metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(90);
+ALTER TABLE `metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(90);
+ALTER TABLE `telemetry_logs` MODIFY TTL fromUnixTimestamp64Nano(time_unix_nano) + toIntervalDay(90);
+ALTER TABLE `trace_summaries` MODIFY TTL fromUnixTimestamp64Nano(start_time_unix_nano) + toIntervalDay(90);

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:TELSXn6mONac2Xx3yZ+XTa9Nr0599/Mb5oyM5FPbeY0=
+h1:L+lzULn2h+Y3gfuSKrGqtjEHKrR/cUGMjuwUqUs2BA0=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -54,3 +54,4 @@ h1:TELSXn6mONac2Xx3yZ+XTa9Nr0599/Mb5oyM5FPbeY0=
 20260630211517_pat-account-type-and-provider-summaries.sql h1:xTMHAzIZNnTz4rkpwLeWv28GXEP8lfFrG6YPERYjDpI=
 20260701215632_billing-mode-summaries.sql h1:3QwBy+mTC0pQt3mtO7ZLdjDGN9gMFFHllEB4pr6cjkE=
 20260702073000_attribute-metrics-attribution-dimensions.sql h1:5eoL9P6XNPKtIJYjdsK/VaQS3CFDfOKXbm/hkcZFZlc=
+20260706165342_ttl-90d.sql h1:a8ovzANcapKzIJcB1k8cnCtCO6s4kqZqBYEHFa820jQ=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS telemetry_logs (
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))
 ORDER BY (gram_project_id, time_unix_nano, id)
-TTL fromUnixTimestamp64Nano(time_unix_nano) + INTERVAL 30 DAY
+TTL fromUnixTimestamp64Nano(time_unix_nano) + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Unified OTel-compatible telemetry logs from all Gram sources (HTTP requests, function logs, etc.)';
 
@@ -175,7 +175,7 @@ CREATE TABLE IF NOT EXISTS trace_summaries (
     provider SimpleAggregateFunction(max, String)
 ) ENGINE = AggregatingMergeTree
 ORDER BY (gram_project_id, trace_id)
-TTL fromUnixTimestamp64Nano(start_time_unix_nano) + INTERVAL 30 DAY
+TTL fromUnixTimestamp64Nano(start_time_unix_nano) + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Pre-aggregated trace summaries for fast trace-level queries without needing to scan all logs';
 
@@ -278,7 +278,7 @@ CREATE TABLE IF NOT EXISTS metrics_summaries (
     tool_failure_counts AggregateFunction(sumMapIf, Map(String, UInt64), UInt8)
 ) ENGINE = AggregatingMergeTree
 ORDER BY (gram_project_id, time_bucket)
-TTL time_bucket + INTERVAL 30 DAY
+TTL time_bucket + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Pre-aggregated metrics summaries for fast dashboard reads without scanning all telemetry logs';
 
@@ -429,7 +429,7 @@ CREATE TABLE IF NOT EXISTS attribute_metrics_summaries (
 -- primary key is not supported").
 PRIMARY KEY (gram_project_id, time_bucket, department_name, job_title, employee_type, division_name, cost_center_name, user_email, model, hook_source, roles, groups)
 ORDER BY (gram_project_id, time_bucket, department_name, job_title, employee_type, division_name, cost_center_name, user_email, model, hook_source, roles, groups, account_type, provider, billing_mode, query_source, skill_name, agent_name, mcp_server_name, mcp_tool_name)
-TTL time_bucket + INTERVAL 30 DAY
+TTL time_bucket + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Pre-aggregated cost/token/usage metrics broken down by user-identity and request dimensions, powering the generic telemetry.query analytics endpoint.';
 
@@ -595,7 +595,7 @@ CREATE TABLE IF NOT EXISTS attribute_keys (
     last_seen_unix_nano SimpleAggregateFunction(max, Int64)
 ) ENGINE = AggregatingMergeTree
 ORDER BY (gram_project_id, attribute_key)
-TTL fromUnixTimestamp64Nano(last_seen_unix_nano) + INTERVAL 30 DAY
+TTL fromUnixTimestamp64Nano(last_seen_unix_nano) + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Pre-aggregated attribute keys per project for fast key listing without scanning telemetry_logs JSON';
 


### PR DESCRIPTION
Close AGE-2855

## What

Extends the TTL on the ClickHouse telemetry tables from **30 days → 90 days**:

- `telemetry_logs`
- `trace_summaries`
- `metrics_summaries`
- `attribute_metrics_summaries`
- `attribute_keys`

Schema-only change: regenerated migrations (`migrations/` + local `golang_migrate/`), updated `atlas.sum`, and the `schema.sql` snapshot. No app code.

## Why

Retain telemetry and the pre-aggregated summaries for a full quarter instead of a single month so analytics surfaces can report over a 90-day window.

## Data-safety notes

- **Forward migration is non-destructive.** Increasing a TTL only extends retention; `MODIFY TTL` re-materializes existing parts (default `materialize_ttl_after_modify=1`) against a _looser_ bound, so nothing newly expires.
- **Rollback is destructive by nature.** The `golang_migrate` down file reverts to 30 days; applying it against data older than 30 days will immediately drop the 30–90d range. Expected for a TTL rollback, but worth flagging.
- Storage footprint grows ~3× as data accumulates toward the new window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend ClickHouse telemetry retention from 30 to 90 days so analytics can report over a full quarter. Schema-only change with regenerated migrations and updated `schema.sql`; no app code.

- **Migration**
  - Set TTL to 90 days for `telemetry_logs`, `trace_summaries`, `metrics_summaries`, `attribute_metrics_summaries`, `attribute_keys`.
  - Forward is non-destructive; rolling back to 30 days will drop data in the 30–90 day range.
  - Expect higher storage as the 90-day window fills.

<sup>Written for commit 8aad8682c065593f49a35f4a5950b7e8be9dc6b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

