### PR TITLE
fix(cursor): enrich MCP hook URLs from plugin manifests

### DIFF
--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1368,10 +1368,116 @@ emit_deny() {
     "$(json_string "$1")" "$(json_string "$1")"
 }
 
+gram_stat_uid_mode() {
+  local path="$1"
+  if stat -c '%%u %%a' "$path" >/dev/null 2>&1; then
+    stat -c '%%u %%a' "$path"
+    return
+  fi
+  stat -f '%%u %%Lp' "$path" 2>/dev/null
+}
+
+gram_trusted_cursor_manifest() {
+  local path="$1"
+  [ -n "$path" ] && [ -f "$path" ] || return 1
+  [ ! -L "$path" ] || return 1
+
+  local dir
+  dir=$(dirname "$path")
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
+
+  local uid file_stat dir_stat file_uid file_mode dir_uid dir_mode
+  uid=$(id -u 2>/dev/null) || return 1
+  file_stat=$(gram_stat_uid_mode "$path") || return 1
+  dir_stat=$(gram_stat_uid_mode "$dir") || return 1
+
+  file_uid="${file_stat%% *}"
+  file_mode="${file_stat#* }"
+  dir_uid="${dir_stat%% *}"
+  dir_mode="${dir_stat#* }"
+
+  [ "$file_uid" = "$uid" ] && [ "$dir_uid" = "$uid" ] || return 1
+  [ -n "$file_mode" ] && [ -n "$dir_mode" ] || return 1
+  # Cursor installs plugin manifests as user-owned files under plugin
+  # directories that may be group/world readable (e.g. 0644/0755). Only reject
+  # writability by group/other users, which is the tampering boundary here.
+  [ $((8#$file_mode & 022)) -eq 0 ] || return 1
+  [ $((8#$dir_mode & 022)) -eq 0 ] || return 1
+}
+
+gram_enrich_cursor_mcp_payload() {
+  local input="$1"
+  if ! command -v jq >/dev/null 2>&1; then
+    printf '%%s' "$input"
+    return
+  fi
+
+  local event
+  event=$(printf '%%s' "$input" | jq -r '.hook_event_name // empty' 2>/dev/null) || {
+    printf '%%s' "$input"
+    return
+  }
+  case "$event" in
+    beforeMCPExecution|afterMCPExecution) ;;
+    *)
+      printf '%%s' "$input"
+      return
+      ;;
+  esac
+
+  local existing_url
+  existing_url=$(printf '%%s' "$input" | jq -r '(.url // .mcp_server_url // "") | select(type == "string")' 2>/dev/null) || true
+  if [ -n "$existing_url" ]; then
+    printf '%%s' "$input"
+    return
+  fi
+
+  local server_name
+  server_name=$(printf '%%s' "$input" | jq -r '(.mcp_server_name // .command // "") | select(type == "string")' 2>/dev/null) || true
+  if [ -z "$server_name" ]; then
+    printf '%%s' "$input"
+    return
+  fi
+
+  local roots=()
+  if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+    roots+=("$(dirname "$CURSOR_PLUGIN_ROOT")")
+  fi
+  roots+=("${HOME}/.cursor/plugins/local")
+
+  local matched_url=""
+  local ambiguous=0
+  local root mcp_file url
+  for root in "${roots[@]}"; do
+    for mcp_file in "$root"/*/mcp.json; do
+      gram_trusted_cursor_manifest "$mcp_file" || continue
+      url=$(jq -r --arg name "$server_name" '.mcpServers[$name].url // empty | select(type == "string")' "$mcp_file" 2>/dev/null) || continue
+      [ -n "$url" ] || continue
+      if [ -z "$matched_url" ]; then
+        matched_url="$url"
+        continue
+      fi
+      if [ "$matched_url" != "$url" ]; then
+        ambiguous=1
+        break
+      fi
+    done
+    [ "$ambiguous" -eq 0 ] || break
+  done
+
+  if [ -z "$matched_url" ] || [ "$ambiguous" -ne 0 ]; then
+    printf '%%s' "$input"
+    return
+  fi
+
+  printf '%%s' "$input" | jq -c --arg url "$matched_url" '. + {url: $url, mcp_server_url: $url}' 2>/dev/null || printf '%%s' "$input"
+}
+
 payload=$(cat)
 if type gram_enrich_identity_payload >/dev/null 2>&1; then
   payload=$(gram_enrich_identity_payload "$payload")
 fi
+payload=$(gram_enrich_cursor_mcp_payload "$payload")
 
 hook_hostname=$(hostname 2>/dev/null || true)
 hook_hostname_header=()

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -869,6 +869,109 @@ printf '{}\n200'
 	require.Equal(t, "cursor@example.com", posted["user_email"])
 }
 
+func TestRenderCursorHookEnrichesMCPURLFromInstalledPluginManifest(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_local_secret_xyz",
+		ProjectSlug: "acme-prod",
+	}
+	script := string(renderHookScript(cfg, "cursor"))
+
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	pluginDir := filepath.Join(home, ".cursor", "plugins", "local", "kitchen-sink-cursor")
+	require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "mcp.json"), []byte(`{
+		"mcpServers": {
+			"GitHub": {"url": "https://chat.speakeasy.com/mcp/int-github"}
+		}
+	}`), 0o644))
+
+	hookPath := filepath.Join(dir, "hook.sh")
+	capturePath := filepath.Join(dir, "payload.json")
+	require.NoError(t, os.WriteFile(hookPath, []byte(script), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "curl"), []byte(`#!/usr/bin/env bash
+cat > "$GRAM_CAPTURE_PAYLOAD"
+printf '{}\n200'
+`), 0o755))
+
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader(`{
+		"hook_event_name": "beforeMCPExecution",
+		"tool_name": "github--get_me",
+		"mcp_server_name": "GitHub",
+		"command": "GitHub",
+		"tool_input": "{\"x-gram-toolset-id\":\"019de58d-ef67-743f-9581-8bf2392c2944\"}"
+	}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"GRAM_CAPTURE_PAYLOAD="+capturePath,
+		"GRAM_DEVICE_AGENT_COMMANDS=missing-agent",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	var posted map[string]any
+	require.NoError(t, json.Unmarshal(requireFileBytes(t, capturePath), &posted))
+	require.Equal(t, "https://chat.speakeasy.com/mcp/int-github", posted["url"])
+	require.Equal(t, "https://chat.speakeasy.com/mcp/int-github", posted["mcp_server_url"])
+}
+
+func TestRenderCursorHookIgnoresWritableMCPManifest(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_local_secret_xyz",
+		ProjectSlug: "acme-prod",
+	}
+	script := string(renderHookScript(cfg, "cursor"))
+
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	pluginDir := filepath.Join(home, ".cursor", "plugins", "local", "tampered-cursor")
+	require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+	manifestPath := filepath.Join(pluginDir, "mcp.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`{
+		"mcpServers": {
+			"GitHub": {"url": "https://attacker.example/mcp"}
+		}
+	}`), 0o644))
+	require.NoError(t, os.Chmod(manifestPath, 0o666))
+
+	hookPath := filepath.Join(dir, "hook.sh")
+	capturePath := filepath.Join(dir, "payload.json")
+	require.NoError(t, os.WriteFile(hookPath, []byte(script), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "curl"), []byte(`#!/usr/bin/env bash
+cat > "$GRAM_CAPTURE_PAYLOAD"
+printf '{}\n200'
+`), 0o755))
+
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader(`{
+		"hook_event_name": "beforeMCPExecution",
+		"tool_name": "github--get_me",
+		"mcp_server_name": "GitHub",
+		"command": "GitHub"
+	}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"GRAM_CAPTURE_PAYLOAD="+capturePath,
+		"GRAM_DEVICE_AGENT_COMMANDS=missing-agent",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	var posted map[string]any
+	require.NoError(t, json.Unmarshal(requireFileBytes(t, capturePath), &posted))
+	require.NotContains(t, posted, "url")
+	require.NotContains(t, posted, "mcp_server_url")
+}
+
 func TestDeviceAgentIdentityScriptHandlesWhitespaceEmptyObject(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- enrich Cursor `beforeMCPExecution` / `afterMCPExecution` hook payloads with missing MCP server URLs by reading installed local Cursor plugin `mcp.json` manifests
- only enrich when the server name resolves to exactly one URL, leaving ambiguous or unknown payloads unchanged
- add a regression test for the Cursor GUI payload shape that sends `mcp_server_name` / `command` without `url`

## Context

Cursor GUI 3.9.16 emits hosted plugin MCP calls like GitHub as:

```json
{
  "hook_event_name": "beforeMCPExecution",
  "mcp_server_name": "GitHub",
  "command": "GitHub"
}
```

without `url` / `mcp_server_url`. The terminal Cursor Agent includes those URL fields, so shadow-MCP authorization succeeds there but fails in the GUI.

The installed Cursor MCP plugin manifest already contains the URL under `~/.cursor/plugins/local/*/mcp.json`, so the observability hook can repair the payload before posting it to Gram.

## Verification

- `go test ./server/internal/plugins`
- `mise lint:server`
- local smoke test against installed Cursor hook confirmed the GUI-shaped GitHub payload is enriched with `https://chat.speakeasy.com/mcp/int-github`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing MCP server URLs in Cursor hook payloads by enriching `beforeMCPExecution`/`afterMCPExecution` events from installed plugin `mcp.json` manifests. Restores GUI shadow-MCP auth when a single trusted manifest URL can be resolved.

- **Bug Fixes**
  - Resolve server URL from trusted manifests in `~/.cursor/plugins/local/*/mcp.json` (and `CURSOR_PLUGIN_ROOT`), using `mcp_server_name` or `command`; set `url` and `mcp_server_url` when exactly one URL matches.
  - Trust rules: ignore symlinked files/dirs; require file and parent dir owned by the current user; skip manifests writable by group/others.
  - Leave payload unchanged if URLs already exist, event differs, payload is invalid, URL resolution is ambiguous, `jq` is unavailable, or the manifest is untrusted.
  - Tests: add GUI-shaped enrichment test (GitHub) and a tamper test that ignores a group/other-writable manifest.

<sup>Written for commit 8c95b510643ab69e3c20eb80126f5d612a6e4e39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

