### PR TITLE
chore(streams): point streams command at database read replica

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -55,6 +55,7 @@ DB_PORT = "5439"
 ## static connection string. In this case, we use interpolation to point to the
 ## local development database configured above.
 GRAM_DATABASE_URL = "postgres://{{env.DB_USER}}:{{env.DB_PASSWORD}}@{{env.DB_HOST}}:{{env.DB_PORT}}/{{env.DB_NAME}}?sslmode=disable&search_path=public"
+GRAM_DATABASE_READ_REPLICA_URL = "{{env.GRAM_DATABASE_URL}}"
 
 ##############################
 ## ClickHouse configuration ##

--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -216,11 +216,6 @@ func newAdminCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("failed to connect to database: %w", err)
 			}
-			// Ping the database to ensure connectivity
-			if err := db.Ping(ctx); err != nil {
-				logger.ErrorContext(ctx, "failed to ping database", attr.SlogError(err))
-				return fmt.Errorf("database ping failed: %w", err)
-			}
 			defer db.Close()
 
 			err = o11y.StartObservers(meterProvider, db)

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -241,6 +241,14 @@ func newDBClient(ctx context.Context, logger *slog.Logger, meterProvider metric.
 		return nil, fmt.Errorf("unable to record pgx metrics: %w", err)
 	}
 
+	// Ping the database to ensure connectivity
+	pingCtx, pingCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer pingCancel()
+	if err := pool.Ping(pingCtx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("database ping failed: %w", err)
+	}
+
 	return pool, nil
 }
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -468,11 +468,6 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("failed to connect to database: %w", err)
 			}
-			// Ping the database to ensure connectivity
-			if err := db.Ping(ctx); err != nil {
-				logger.ErrorContext(ctx, "failed to ping database", attr.SlogError(err))
-				return fmt.Errorf("database ping failed: %w", err)
-			}
 			defer db.Close()
 
 			chDB, shutdown, err := newClickhouseClient(ctx, logger, c)

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -55,9 +55,9 @@ func newStreamsCommand() *cli.Command {
 			EnvVars:  []string{"GRAM_ENVIRONMENT"},
 		},
 		&cli.StringFlag{
-			Name:     "database-url",
-			Usage:    "Database URL",
-			EnvVars:  []string{"GRAM_DATABASE_URL"},
+			Name:     "database-read-replica-url",
+			Usage:    "Database read replica URL",
+			EnvVars:  []string{"GRAM_DATABASE_READ_REPLICA_URL"},
 			Required: true,
 		},
 		&cli.BoolFlag{
@@ -149,18 +149,13 @@ func newStreamsCommand() *cli.Command {
 			}
 			_ = guardianPolicy
 
-			db, err := newDBClient(ctx, logger, meterProvider, c.String("database-url"), dbClientOptions{
+			replicaDB, err := newDBClient(ctx, logger, meterProvider, c.String("database-read-replica-url"), dbClientOptions{
 				enableUnsafeLogging: c.Bool("unsafe-db-log"),
 			})
 			if err != nil {
 				return fmt.Errorf("failed to connect to database: %w", err)
 			}
-			// Ping the database to ensure connectivity
-			if err := db.Ping(ctx); err != nil {
-				logger.ErrorContext(ctx, "failed to ping database", attr.SlogError(err))
-				return fmt.Errorf("database ping failed: %w", err)
-			}
-			defer db.Close()
+			defer replicaDB.Close()
 
 			redisClient, err := newRedisClient(ctx, redisClientOptions{
 				redisAddr:     c.String("redis-cache-addr"),
@@ -223,7 +218,7 @@ func newStreamsCommand() *cli.Command {
 
 				shutdown, err := controlServer.Start(c.Context, o11y.NewHealthCheckHandler(
 					[]*o11y.NamedResource[*o11y.HTTPEndpoint]{},
-					[]*o11y.NamedResource[*pgxpool.Pool]{{Name: "default", Resource: db}},
+					[]*o11y.NamedResource[*pgxpool.Pool]{{Name: "read-replica", Resource: replicaDB}},
 					[]*o11y.NamedResource[*redis.Client]{{Name: "default", Resource: redisClient}},
 					[]*o11y.NamedResource[client.Client]{},
 				))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -370,11 +370,6 @@ func newWorkerCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			// Ping the database to ensure connectivity
-			if err := db.Ping(ctx); err != nil {
-				logger.ErrorContext(ctx, "failed to ping database", attr.SlogError(err))
-				return fmt.Errorf("database ping failed: %w", err)
-			}
 			defer db.Close()
 
 			redisClient, err := newRedisClient(ctx, redisClientOptions{


### PR DESCRIPTION
The streams command only consumes data, so it should connect to the read replica rather than the primary. Swap its database-url flag for a database-read-replica-url flag (GRAM_DATABASE_READ_REPLICA_URL) and report the pool as "read-replica" in the health check.

While here, fold the database connectivity ping into newDBClient so every command gets it for free, and drop the duplicated post-connect ping blocks from admin, start, streams, and worker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point the `streams` command at the DB read replica and label it "read-replica" in health checks. Move DB ping into `newDBClient` and remove duplicates in `admin`, `start`, `streams`, and `worker`.

- **Migration**
  - For `streams`, replace `--database-url` with `--database-read-replica-url` (env: `GRAM_DATABASE_READ_REPLICA_URL`; defaults to `GRAM_DATABASE_URL` in `mise.toml`).

<sup>Written for commit 57ad103d293efcd65dee73bbbb26fdd2ffba2a73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

