### PR TITLE
feat(plugins): emit agent-proxied hook command behind ProxyHooksViaAgent (DNO-377)

### DIFF
--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -80,6 +80,21 @@ type GenerateConfig struct {
 	// path for POC rollouts in orgs that cannot tolerate hook errors or brief
 	// server unavailability disrupting the user.
 	ObservabilityMode bool
+	// ProxyHooksViaAgent emits the device-agent-proxied hook command
+	// (`speakeasyd hook --tool <x>`) instead of the bash `hook.sh` invocation. A
+	// single native-binary command that works on Windows/macOS/Linux for every
+	// tool (no bash/PowerShell), routing the event through the daemon pipeline
+	// (ADR-0010 in the device-agent repo). Opt-in: it makes the running daemon a
+	// hard dependency and the control-plane auth contract for agent-forwarded
+	// hooks is still open (DNO-376), so it stays off until that lands.
+	ProxyHooksViaAgent bool
+}
+
+// agentHookCommand is the device-agent-proxied hook command for a tool: a single
+// native invocation the agent shim handles on every OS. The tool ids match the
+// agent's `--tool` values (and its control-plane endpoint mapping).
+func agentHookCommand(tool string) string {
+	return "speakeasyd hook --tool " + tool
 }
 
 // DefaultMarketplaceName returns the marketplace identifier used when no
@@ -614,12 +629,21 @@ func generateClaudeObservabilityPluginInDir(files map[string][]byte, subdir stri
 	// events use the standard hook.sh.
 	hookEvents := make(map[string][]claudeHookMatcher, len(ClaudeObservabilityHookEvents))
 	for _, event := range ClaudeObservabilityHookEvents {
-		script := "hook.sh"
-		if event == "SessionStart" || event == "ConfigChange" {
-			script = "mcp_inventory.sh"
+		// Under the agent proxy, one command serves every event — the daemon does
+		// identity, MCP-inventory gathering and async routing — so the per-event
+		// script selection (mcp_inventory.sh) collapses. The async flag is kept:
+		// it tells Claude whether to wait, and the daemon still returns fast for
+		// async events.
+		command := agentHookCommand("claude_code")
+		if !cfg.ProxyHooksViaAgent {
+			script := "hook.sh"
+			if event == "SessionStart" || event == "ConfigChange" {
+				script = "mcp_inventory.sh"
+			}
+			command = `bash "$CLAUDE_PLUGIN_ROOT/hooks/` + script + `"`
 		}
 		hookEvents[event] = []claudeHookMatcher{
-			{Matcher: "", Hooks: []claudeHookCommand{{Type: "command", Command: `bash "$CLAUDE_PLUGIN_ROOT/hooks/` + script + `"`, Async: claudeHookAsyncFlag(event, cfg.ObservabilityMode)}}},
+			{Matcher: "", Hooks: []claudeHookCommand{{Type: "command", Command: command, Async: claudeHookAsyncFlag(event, cfg.ObservabilityMode)}}},
 		}
 	}
 	hooksJSON, err := marshalJSON(claudeHooksConfig{Hooks: hookEvents})
@@ -670,9 +694,13 @@ func generateCursorObservabilityPluginInDir(files map[string][]byte, subdir, nam
 	// Same hooks/ subdirectory layout as the Claude side. Cursor follows the
 	// same convention as Claude Code; flat-layout plugins register but their
 	// hooks never fire.
+	cursorCommand := `bash "$CURSOR_PLUGIN_ROOT/hooks/hook.sh"`
+	if cfg.ProxyHooksViaAgent {
+		cursorCommand = agentHookCommand("cursor")
+	}
 	hookEvents := make(map[string][]cursorHookCommand, len(CursorObservabilityHookEvents))
 	for _, event := range CursorObservabilityHookEvents {
-		hookEvents[event] = []cursorHookCommand{{Command: `bash "$CURSOR_PLUGIN_ROOT/hooks/hook.sh"`}}
+		hookEvents[event] = []cursorHookCommand{{Command: cursorCommand}}
 	}
 	hooksJSON, err := marshalJSON(cursorHooksConfig{Version: 1, Hooks: hookEvents})
 	if err != nil {
@@ -763,7 +791,7 @@ func generateCodexObservabilityPluginInDir(files map[string][]byte, subdir strin
 	for _, event := range CodexObservabilityHookEvents {
 		hookEvents[event] = []codexMatcherGroup{{
 			Matcher: "",
-			Hooks:   []codexHookCommand{{Type: "command", Command: codexHookCommandString(marketplace, plugin, codexHookScriptName(event))}},
+			Hooks:   []codexHookCommand{{Type: "command", Command: codexHookCommandString(marketplace, plugin, codexHookScriptName(event), cfg.ProxyHooksViaAgent)}},
 		}}
 	}
 	hooksJSON, err := marshalJSON(codexHooksConfig{Hooks: hookEvents})
@@ -2055,9 +2083,9 @@ func codexEventSnakeCase(event string) string {
 //
 // The command uses the literal string "$HOME" (not expanded), so the hash is
 // deterministic for a given marketplace + plugin name pair.
-func computeCodexHookHash(event, marketplace, plugin string) (string, error) {
+func computeCodexHookHash(event, marketplace, plugin string, proxyViaAgent bool) (string, error) {
 	eventSnake := codexEventSnakeCase(event)
-	command := codexHookCommandString(marketplace, plugin, codexHookScriptName(event))
+	command := codexHookCommandString(marketplace, plugin, codexHookScriptName(event), proxyViaAgent)
 	hook := map[string]any{
 		"async":   false,
 		"command": command,
@@ -2088,11 +2116,11 @@ func computeCodexHookHash(event, marketplace, plugin string) (string, error) {
 
 // computeCodexHookApprovals returns pre-computed [hooks.state] entries for all
 // Codex observability hook events for a given marketplace and plugin name.
-func computeCodexHookApprovals(marketplace, plugin string) ([]codexHookApproval, error) {
+func computeCodexHookApprovals(marketplace, plugin string, proxyViaAgent bool) ([]codexHookApproval, error) {
 	approvals := make([]codexHookApproval, 0, len(CodexObservabilityHookEvents))
 	for _, event := range CodexObservabilityHookEvents {
 		snake := codexEventSnakeCase(event)
-		hash, err := computeCodexHookHash(event, marketplace, plugin)
+		hash, err := computeCodexHookHash(event, marketplace, plugin, proxyViaAgent)
 		if err != nil {
 			return nil, fmt.Errorf("compute hash for %s: %w", event, err)
 		}
@@ -2113,7 +2141,14 @@ func codexHookScriptName(event string) string {
 	}
 }
 
-func codexHookCommandString(marketplace, plugin, script string) string {
+func codexHookCommandString(marketplace, plugin, script string, proxyViaAgent bool) string {
+	if proxyViaAgent {
+		// One native command for every event; the daemon owns identity, MCP
+		// inventory and async routing, so the hook.sh/hook_async.sh split (script)
+		// collapses. This string is part of the Codex trust hash, so
+		// computeCodexHookHash must compute it identically (it does, via this fn).
+		return agentHookCommand("codex")
+	}
 	return fmt.Sprintf(`bash "$HOME/.codex/.tmp/marketplaces/%s/%s/hooks/%s"`, marketplace, plugin, script)
 }
 
@@ -2129,7 +2164,7 @@ func GenerateCodexInstallScript(marketplaceURL string, cfg GenerateConfig) ([]by
 	marketplace := resolveMarketplaceName(cfg)
 	plugin := CodexObservabilitySlug(cfg)
 
-	approvals, err := computeCodexHookApprovals(marketplace, plugin)
+	approvals, err := computeCodexHookApprovals(marketplace, plugin, cfg.ProxyHooksViaAgent)
 	if err != nil {
 		return nil, fmt.Errorf("compute hook approvals: %w", err)
 	}

--- a/server/internal/plugins/generate_agentproxy_test.go
+++ b/server/internal/plugins/generate_agentproxy_test.go
@@ -1,0 +1,91 @@
+package plugins
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// When ProxyHooksViaAgent is set, every tool's hook command becomes the single
+// native `speakeasyd hook --tool <x>` invocation instead of `bash hook.sh`.
+
+func proxyCfg() GenerateConfig {
+	return GenerateConfig{
+		OrgName:            "Acme",
+		ServerURL:          "https://app.getgram.ai",
+		HooksAPIKey:        "gram_local_secret_xyz",
+		ProxyHooksViaAgent: true,
+	}
+}
+
+func TestProxyHooks_CursorCommand(t *testing.T) {
+	t.Parallel()
+	cfg := proxyCfg()
+	files, err := GeneratePluginPackages(nil, cfg)
+	require.NoError(t, err)
+
+	var hooks cursorHooksConfig
+	path := "cursor-plugins/" + CursorObservabilitySlug(cfg) + "/hooks/hooks.json"
+	require.NoError(t, json.Unmarshal(files[path], &hooks))
+	require.NotEmpty(t, hooks.Hooks)
+	for event, cmds := range hooks.Hooks {
+		require.Equal(t, "speakeasyd hook --tool cursor", cmds[0].Command, "event %s", event)
+		require.NotContains(t, cmds[0].Command, "bash")
+	}
+}
+
+func TestProxyHooks_ClaudeCommand(t *testing.T) {
+	t.Parallel()
+	cfg := proxyCfg()
+	files, err := GeneratePluginPackages(nil, cfg)
+	require.NoError(t, err)
+
+	var hooks claudeHooksConfig
+	path := ClaudeObservabilitySlug(cfg) + "/hooks/hooks.json"
+	require.NoError(t, json.Unmarshal(files[path], &hooks))
+	require.NotEmpty(t, hooks.Hooks)
+	for event, matchers := range hooks.Hooks {
+		require.Equal(t, "speakeasyd hook --tool claude_code", matchers[0].Hooks[0].Command, "event %s", event)
+	}
+}
+
+func TestProxyHooks_CodexCommandAndTrustHash(t *testing.T) {
+	t.Parallel()
+	cfg := proxyCfg()
+	files, err := GeneratePluginPackages(nil, cfg)
+	require.NoError(t, err)
+
+	var hooks codexHooksConfig
+	path := CodexObservabilitySlug(cfg) + "/hooks/hooks.json"
+	require.NoError(t, json.Unmarshal(files[path], &hooks))
+	require.NotEmpty(t, hooks.Hooks)
+	for event, groups := range hooks.Hooks {
+		require.Equal(t, "speakeasyd hook --tool codex", groups[0].Hooks[0].Command, "event %s", event)
+	}
+
+	// The command is part of Codex's trust hash, so the proxy command must hash
+	// differently from the bash one — otherwise the pre-approval wouldn't match.
+	mp, plugin := "acme-speakeasy", CodexObservabilitySlug(cfg)
+	bashHash, err := computeCodexHookHash("PreToolUse", mp, plugin, false)
+	require.NoError(t, err)
+	agentHash, err := computeCodexHookHash("PreToolUse", mp, plugin, true)
+	require.NoError(t, err)
+	require.NotEqual(t, bashHash, agentHash, "trust hash must track the command change")
+}
+
+func TestProxyHooks_OffKeepsBashCommand(t *testing.T) {
+	t.Parallel()
+	cfg := proxyCfg()
+	cfg.ProxyHooksViaAgent = false
+	files, err := GeneratePluginPackages(nil, cfg)
+	require.NoError(t, err)
+
+	var hooks cursorHooksConfig
+	path := "cursor-plugins/" + CursorObservabilitySlug(cfg) + "/hooks/hooks.json"
+	require.NoError(t, json.Unmarshal(files[path], &hooks))
+	for _, cmds := range hooks.Hooks {
+		require.True(t, strings.HasPrefix(cmds[0].Command, "bash "), "default must stay bash: %q", cmds[0].Command)
+	}
+}

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1386,7 +1386,7 @@ func TestGenerateCodexInstallScriptRefreshesStaleTrustedHashes(t *testing.T) {
 	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
 	plugin := CodexObservabilitySlug(cfg)
 
-	approvals, err := computeCodexHookApprovals(marketplace, plugin)
+	approvals, err := computeCodexHookApprovals(marketplace, plugin, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, approvals)
 	target := approvals[0]


### PR DESCRIPTION
Part of agent-proxied hooks (device-agent ADR-0010). Fixes [DNO-377](https://linear.app/speakeasy/issue/DNO-377).

**Draft — opt-in scaffolding; the flag is not enabled anywhere yet and stays off until the auth contract (DNO-376) lands.**

## What

Adds an opt-in `GenerateConfig.ProxyHooksViaAgent` that swaps the generated hook command from `bash hook.sh` to the device-agent shim **`speakeasyd hook --tool <x>`** — a single native-binary invocation that works on Windows/macOS/Linux for every tool (no bash/PowerShell), routing the event through the daemon's hook pipeline.

- **Cursor** → `speakeasyd hook --tool cursor`
- **Claude** → `speakeasyd hook --tool claude_code` (Async flag preserved; the per-event `mcp_inventory.sh` selection collapses since the daemon does inventory gathering itself)
- **Codex** → `speakeasyd hook --tool codex` for all events. The command is part of Codex's **trust hash**, so `codexHookCommandString` / `computeCodexHookHash` / `computeCodexHookApprovals` thread the flag and the pre-approval hash tracks the new command.

## Why opt-in / why it does nothing yet

Flipping all hook generation to the agent path would break production today: the daemon forwards the event with its `org_token`, which the `/rpc/hooks.<tool>` endpoints reject (they expect a hooks-scoped `Gram-Key`). Resolving that is **DNO-376** (the auth contract). Until then this flag stays off; it exists so we can generate agent-proxied bundles for the Windows end-to-end test without touching the live bash path. Bundles still ship the bash scripts.

## Tests
Per-tool proxy command; Codex trust-hash tracks the command (bash≠agent hash, so the pre-approval still matches); flag-off keeps the bash command (no regression). `go vet` + gofmt clean.

## Not in this PR
- The control-plane auth contract for agent-forwarded hooks (DNO-376) — separate PR, different review profile (live endpoint + trust model).
- Enabling the flag anywhere (gated on DNO-376).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `GenerateConfig.ProxyHooksViaAgent` that emits agent-proxied hook commands (`speakeasyd hook --tool <x>`) for Cursor, Claude, and Codex, replacing `bash hook.sh` with a single cross-OS command and routing events through the device agent. Default off pending the auth contract in DNO-376; implements DNO-377.

- New Features
  - Cursor: `hooks.json` now uses `speakeasyd hook --tool cursor`.
  - Claude: uses `speakeasyd hook --tool claude_code`; keeps async; removes per-event `mcp_inventory.sh`.
  - Codex: uses `speakeasyd hook --tool codex`; updates trust hash by threading the flag through `codexHookCommandString`, `computeCodexHookHash`, and `computeCodexHookApprovals`.

<sup>Written for commit 34f98bc5d89f909aeeeb783e27f7d9e6cbdfe99d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

