### PR TITLE
chore(deps): roll up runtime image base updates

### DIFF
--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.95-bookworm@sha256:503651ea31e66ecb74623beabde781059a5978df1595a9e8ed03974d5fec1bf0 AS runner-builder
+FROM rust:1.96-bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS runner-builder
 
 WORKDIR /src
 COPY agents/runner/Cargo.toml agents/runner/Cargo.lock ./agents/runner/

--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -30,7 +30,7 @@ RUN target=node_modules/playwright-core/lib/utilsBundle.js \
  && sed -i "s|const ws = exports.ws = require('./utilsBundleImpl').ws;|const ws = exports.ws = 'Bun' in globalThis ? require('ws') : require('./utilsBundleImpl').ws;|" "$target" \
  && grep -q "'Bun' in globalThis ? require('ws')" "$target"
 
-FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS lightpanda
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716 AS lightpanda
 ARG TARGETARCH
 ARG LIGHTPANDA_VERSION=0.2.8
 ARG LIGHTPANDA_SHA256_AMD64=8e3a5e04cf508699990a78a0a8686ea3398912cd9891fda90513429b89230300
@@ -47,7 +47,7 @@ RUN case "${TARGETARCH:-amd64}" in \
  && echo "${sha}  /lightpanda" | sha256sum -c - \
  && chmod 0755 /lightpanda
 
-FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -5,9 +5,9 @@ COPY agents/runner/Cargo.toml agents/runner/Cargo.lock ./agents/runner/
 COPY agents/runner/src ./agents/runner/src
 RUN cargo build --manifest-path ./agents/runner/Cargo.toml --release --bin gram-assistant-runner
 
-FROM oven/bun:1.2.15@sha256:8b5e8d3b6a734ae438c7c6f1bdc23e54eb9c35a0e2e3099ea2ca0ef781aca23b AS bun
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun
 
-FROM oven/bun:1.2.15@sha256:8b5e8d3b6a734ae438c7c6f1bdc23e54eb9c35a0e2e3099ea2ca0ef781aca23b AS sandbox-deps
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS sandbox-deps
 WORKDIR /sandbox
 COPY agents/runtime-image/sandbox/package.json ./
 RUN bun install --production


### PR DESCRIPTION
## Summary
- Roll up Dependabot runtime image updates from #3421, #3422, and #3423.
- Bump debian bookworm-slim digest to 96e378d.
- Bump rust from 1.95-bookworm to 1.96-bookworm.
- Bump oven/bun from 1.2.15 to 1.3.14.

## Validation
- docker buildx build --check --platform linux/amd64 -f agents/runtime-image/Dockerfile .

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls up Dependabot updates to the agent runtime Docker image. Bumps `rust`, `oven/bun`, and `debian:bookworm-slim` to current versions/digest.

- **Dependencies**
  - `rust`: 1.95-bookworm → 1.96-bookworm
  - `oven/bun`: 1.2.15 → 1.3.14
  - `debian:bookworm-slim`: digest → 96e378d

<sup>Written for commit 359ab1cdebb86e133daa0f76653fd31aa6519452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

