### PR TITLE
chore: promote `./zero` running instructions to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 <p align="center">
   <a href="https://www.getgram.ai/docs/introduction"><strong>Documentation</strong></a> ·
+  <a href="#running-locally"><strong>Running locally</strong></a> ·
   <a href="#tech-stack"><strong>Tech Stack</strong></a> ·
   <a href="./CONTRIBUTING.md"><strong>Contributing</strong></a> ·
   <a href="https://app.getgram.ai/"><strong>Login</strong></a> ·
@@ -65,6 +66,20 @@ Track AI usage across teams and measure impact with either tokens or cost. Deep 
 - Chat with us: [Join our slack](https://join.slack.com/t/speakeasy-dev/shared_invite/zt-3hudfoj4y-9EPqMmHIFhNiTtannqiV3Q) for support and discussions or email us at [support@speakeasy.com](mailto:support@speakeasy.com).
 - Contribute feature requests or report issues [on our roadmap](https://roadmap.speakeasy.com/).
 - Documentation for the platform is available [here](https://www.speakeasy.com/docs/mcp).
+
+## Running locally
+
+Run `./zero` until it succeeds. This script is what you use to run the dashboard and services for local development. It installs dependencies, runs pending database migrations, and starts everything up.
+
+The main dependencies are [Mise](https://mise.jdx.dev/) and [Docker](https://www.docker.com/). The `./zero` script will guide you to install these if they are not found.
+
+Once everything is running, seed the local database with sample data:
+
+```bash
+mise seed
+```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for more detail on local development, auth, and the CLI.
 
 ## Contributing
 


### PR DESCRIPTION
Adds a concise **Running locally** section to the main `README.md` covering `./zero` and `mise seed`, with a link to `CONTRIBUTING.md` for the full details. Also adds a nav link at the top so it's discoverable.

The instructions previously only lived in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `./zero` local running instructions to the main `README.md` and adds a top nav link for easy discovery. Addresses Linear AGE-2830 by documenting `Mise`/`Docker` prerequisites, showing `mise seed`, and linking to `CONTRIBUTING.md` for full setup.

<sup>Written for commit 4ca71dfa8c8a0a9534f111f2305e5f4a1a638843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

