### PR TITLE
mig: document users.admin as the platform_admin concept

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1920,6 +1920,8 @@ ON device_owners (organization_id);
 CREATE UNIQUE INDEX IF NOT EXISTS users_workos_id_key
 ON users (workos_id);
 
+COMMENT ON COLUMN users.admin IS 'Maps to the application''s platform_admin concept: TRUE marks a Gram/Speakeasy platform admin. Distinct from the org-level admin role.';
+
 CREATE TABLE IF NOT EXISTS directory_groups (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1810,10 +1810,11 @@ type TunneledMcpServer struct {
 }
 
 type User struct {
-	ID              string
-	Email           string
-	DisplayName     string
-	PhotoUrl        pgtype.Text
+	ID          string
+	Email       string
+	DisplayName string
+	PhotoUrl    pgtype.Text
+	// Maps to the application's platform_admin concept: TRUE marks a Gram/Speakeasy platform admin. Distinct from the org-level admin role.
 	Admin           bool
 	LastLogin       pgtype.Timestamptz
 	WorkosID        pgtype.Text

--- a/server/internal/users/repo/models.go
+++ b/server/internal/users/repo/models.go
@@ -9,10 +9,11 @@ import (
 )
 
 type User struct {
-	ID              string
-	Email           string
-	DisplayName     string
-	PhotoUrl        pgtype.Text
+	ID          string
+	Email       string
+	DisplayName string
+	PhotoUrl    pgtype.Text
+	// Maps to the application's platform_admin concept: TRUE marks a Gram/Speakeasy platform admin. Distinct from the org-level admin role.
 	Admin           bool
 	LastLogin       pgtype.Timestamptz
 	WorkosID        pgtype.Text

--- a/server/migrations/20260708221138_comment-users-admin-platform-admin.sql
+++ b/server/migrations/20260708221138_comment-users-admin-platform-admin.sql
@@ -1,0 +1,2 @@
+-- Set comment to column: "admin" on table: "users"
+COMMENT ON COLUMN "users"."admin" IS 'Maps to the application''s platform_admin concept: TRUE marks a Gram/Speakeasy platform admin. Distinct from the org-level admin role.';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GCbKb3KeM5a1z54Tty2s5ByOaSUkxgDRaZs7ZtmADRU=
+h1:TnMhOMHHckSJG4d1P8g3wl3fZC8DSHTOYyUSIOcvpd8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -250,3 +250,4 @@ h1:GCbKb3KeM5a1z54Tty2s5ByOaSUkxgDRaZs7ZtmADRU=
 20260707200235_add-billing-cycle-usage.sql h1:Oma/fS74ZRIZnopKrTdKwxYxtoEO+fPYATfmqeDiudc=
 20260707204416_billing-cycle-usage-tum-tokens-check.sql h1:e0oVX1jZavibZRbsR6pHqmhApLYK0fLjohgqx/kN65g=
 20260708203242_chats-add-project-id-index.sql h1:6mzOm6Z7RUHSx94M5JH93IOTSM5MmtVdgcCbM//86Io=
+20260708221138_comment-users-admin-platform-admin.sql h1:OWKP0Byie6YS9Ji7I3NlK7ik2b6NF6C9T2HyUH/5p7k=


### PR DESCRIPTION
Split out from the AGE-2857 app-code PR so the migration ships on its own (per our migration-PR-separation rule).

Adds a single `COMMENT ON COLUMN` clarifying that `users.admin` is the platform-admin flag (Gram/Speakeasy staff), distinct from the org-level `admin` role.

```sql
COMMENT ON COLUMN users.admin IS 'Maps to the application''s platform_admin concept: TRUE marks a Gram/Speakeasy platform admin. Distinct from the org-level admin role.';
```

- `schema.sql` + the Atlas-generated migration + `atlas.sum` only — no app code.
- `mise lint:migrations` passes (correct ordering, no Atlas diagnostics).

Part of AGE-2857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `users.admin` is the platform_admin flag (Gram/Speakeasy staff), not the org-level admin role. Adds a `COMMENT ON COLUMN` migration and regenerates Go models to carry the doc comment; no behavior change; supports AGE-2857.

<sup>Written for commit 30712e6d5368aa857bc6c7e960f43c50db956a80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

