### PR TITLE
feat: default to Claude Sonnet 5 for in-app usage and new assistants

### DIFF
--- a/.changeset/default-sonnet-5.md
+++ b/.changeset/default-sonnet-5.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"@gram-ai/elements": minor
+---
+
+Default to Claude Sonnet 5 (`anthropic/claude-sonnet-5`) for in-app model usage and newly created assistants. The model is added to the allowlist and all model pickers (playground, elements, onboarding). The backend `DefaultChatModel`, the platform-managed assistant, the onboarding assistant default, and the playground/MCP chat surfaces now select Sonnet 5. Specialized models (risk/PromptIntel judges, chat segmentation, embeddings, follow-on suggestions) are unchanged.

--- a/client/dashboard/src/lib/models.ts
+++ b/client/dashboard/src/lib/models.ts
@@ -1,3 +1,5 @@
+import type { Model } from "@gram-ai/elements";
+
 export type AvailableModel = {
   value: string;
   label: string;
@@ -45,3 +47,13 @@ export const AVAILABLE_MODELS: AvailableModel[] = [
   { value: "mistralai/devstral-2512", label: "Devstral 2512" },
   { value: "mistralai/mistral-medium-3.1", label: "Mistral Medium 3.1" },
 ];
+
+// Default model used across in-app chat surfaces (playground, MCP test chat,
+// chat window) when the user has not picked one explicitly. Kept next to
+// AVAILABLE_MODELS so the default is easy to discover and adjust.
+export const DEFAULT_MODEL: Model = "anthropic/claude-sonnet-5";
+
+// Default model assigned to newly created assistants (onboarding flow). Tracked
+// separately from DEFAULT_MODEL so the assistant default can move independently
+// of the general in-app chat default.
+export const DEFAULT_ASSISTANT_MODEL: Model = "anthropic/claude-sonnet-5";

--- a/client/dashboard/src/lib/models.ts
+++ b/client/dashboard/src/lib/models.ts
@@ -4,6 +4,7 @@ export type AvailableModel = {
 };
 
 export const AVAILABLE_MODELS: AvailableModel[] = [
+  { value: "anthropic/claude-sonnet-5", label: "Claude Sonnet 5" },
   { value: "anthropic/claude-opus-4.8", label: "Claude Opus 4.8 (Expensive)" },
   { value: "anthropic/claude-opus-4.7", label: "Claude Opus 4.7 (Expensive)" },
   { value: "anthropic/claude-sonnet-4.6", label: "Claude Sonnet 4.6" },

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -2,12 +2,12 @@ import { Page } from "@/components/page-layout";
 import { useHideInsightsDock } from "@/components/insights-context";
 import { useProject, useSession } from "@/contexts/Auth";
 import { internalMcpUrl } from "@/hooks/useToolsetUrl";
+import { DEFAULT_ASSISTANT_MODEL } from "@/lib/models";
 import { getServerURL } from "@/lib/utils";
 import {
   Chat,
   GramElementsProvider,
   type MCPServerEntry,
-  type Model,
 } from "@gram-ai/elements";
 import { useListToolsets } from "@gram/client/react-query";
 import { useChatSessionsCreateMutation } from "@gram/client/react-query/chatSessionsCreate.js";
@@ -229,7 +229,7 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
           systemPrompt,
           mcps,
           model: {
-            defaultModel: "anthropic/claude-sonnet-5" as Model,
+            defaultModel: DEFAULT_ASSISTANT_MODEL,
             showModelPicker: false,
           },
           welcome,

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -229,7 +229,7 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
           systemPrompt,
           mcps,
           model: {
-            defaultModel: "anthropic/claude-opus-4.7" as Model,
+            defaultModel: "anthropic/claude-sonnet-5" as Model,
             showModelPicker: false,
           },
           welcome,

--- a/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
@@ -44,18 +44,19 @@ Pass section bodies WITHOUT a leading heading — the tool adds it. Inside a sec
 - Integration — packaged toolset from the catalog. \`list_integrations\`.
 
 # Models (pass full id to \`update_assistant\`)
-- Anthropic: \`anthropic/claude-opus-4.8\`, \`anthropic/claude-opus-4.7\` (default), \`anthropic/claude-sonnet-4.6\`, \`anthropic/claude-haiku-4.5\`, \`anthropic/claude-sonnet-4.5\`, \`anthropic/claude-opus-4.6\`, \`anthropic/claude-opus-4.5\`, \`anthropic/claude-sonnet-4\`
+- Anthropic: \`anthropic/claude-sonnet-5\` (default), \`anthropic/claude-opus-4.8\`, \`anthropic/claude-opus-4.7\`, \`anthropic/claude-sonnet-4.6\`, \`anthropic/claude-haiku-4.5\`, \`anthropic/claude-sonnet-4.5\`, \`anthropic/claude-opus-4.6\`, \`anthropic/claude-opus-4.5\`, \`anthropic/claude-sonnet-4\`
 - OpenAI: \`openai/gpt-5.5\`, \`openai/gpt-5.5-pro\`, \`openai/gpt-5.4\`, \`openai/gpt-5.4-mini\`, \`openai/gpt-5.4-nano\`, \`openai/gpt-5.3-codex\`, \`openai/gpt-5.1\`, \`openai/gpt-5\`, \`openai/gpt-4.1\`, \`openai/o4-mini\`, \`openai/o3\`
 - Google: \`google/gemini-3.5-flash\`, \`google/gemini-3.1-pro-preview\`, \`google/gemini-3.1-flash-lite\`, \`google/gemini-2.5-pro\`, \`google/gemini-2.5-flash\`
 - Others: \`deepseek/deepseek-v4-pro\`, \`deepseek/deepseek-v4-flash\`, \`deepseek/deepseek-v3.2\`, \`deepseek/deepseek-r1\`, \`meta-llama/llama-4-maverick\`, \`x-ai/grok-4.3\`, \`x-ai/grok-4.20\`, \`qwen/qwen3.7-max\`, \`qwen/qwen3-coder\`, \`moonshotai/kimi-k2.6\`, \`moonshotai/kimi-k2.5\`, \`mistralai/mistral-medium-3-5\`, \`mistralai/codestral-2508\`, \`mistralai/devstral-2512\`, \`mistralai/mistral-medium-3.1\`
 
 Recommend:
-- Agentic / tool-heavy → \`anthropic/claude-opus-4.7\` (default) or \`anthropic/claude-opus-4.8\` (hardest reasoning, pricier).
+- General default → \`anthropic/claude-sonnet-5\` (strong all-rounder, good price/performance).
+- Agentic / tool-heavy → \`anthropic/claude-sonnet-5\` or \`anthropic/claude-opus-4.8\` (hardest reasoning, pricier).
 - Cheap / fast / high-volume → \`anthropic/claude-haiku-4.5\` or \`openai/gpt-5.4-mini\`.
 - Coding → \`openai/gpt-5.3-codex\`, \`qwen/qwen3-coder\`, \`mistralai/codestral-2508\`.
 - Deep reasoning / math → \`openai/o3\` or \`openai/o4-mini\`.
 - Fast Google → \`google/gemini-2.5-flash\`.
-- Unsure → \`anthropic/claude-opus-4.7\`.
+- Unsure → \`anthropic/claude-sonnet-5\`.
 
 # "How do I connect X?" decision tree
 1. \`list_docs\` — if X has a doc (currently: \`slack\`, \`cron\`), follow it. Slack: route through \`propose_slack_setup\` (the user picks capabilities + events; the tool creates a per-assistant Slack toolset and slack trigger — never reuse a catalog toolset). Then \`add_environment_keys\` → \`show_slack_app_guide\` with the returned webhook_url (skip if SLACK_BOT_TOKEN is already populated; check via \`list_environments\` → \`populated_entry_names\`) → \`request_environment_secrets\`.

--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -226,7 +226,7 @@ async function ensureAssistant(
     createAssistantForm: {
       name: payload.name ?? "Untitled assistant",
       instructions: payload.instructions ?? "You are a helpful assistant.",
-      model: payload.model ?? "anthropic/claude-opus-4.7",
+      model: payload.model ?? "anthropic/claude-sonnet-5",
       status: payload.status,
       toolsets: [],
       ...(payload.warm_ttl_seconds !== undefined

--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -1,5 +1,6 @@
 import { useSession } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
+import { DEFAULT_ASSISTANT_MODEL } from "@/lib/models";
 import { defineFrontendTool, type FrontendTool } from "@gram-ai/elements";
 import { Gram } from "@gram/client";
 import { ToolCallMessagePartComponent } from "@assistant-ui/react";
@@ -226,7 +227,7 @@ async function ensureAssistant(
     createAssistantForm: {
       name: payload.name ?? "Untitled assistant",
       instructions: payload.instructions ?? "You are a helpful assistant.",
-      model: payload.model ?? "anthropic/claude-sonnet-5",
+      model: payload.model ?? DEFAULT_ASSISTANT_MODEL,
       status: payload.status,
       toolsets: [],
       ...(payload.warm_ttl_seconds !== undefined

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1008,7 +1008,7 @@ function GenerateInstructionsButton({
 }) {
   const [generating, setGenerating] = useState(false);
   const { data: fullToolset } = useToolset(toolset.slug);
-  const model = useModel("anthropic/claude-sonnet-4.5");
+  const model = useModel("anthropic/claude-sonnet-5");
 
   const tools = fullToolset?.tools ?? [];
 

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -45,6 +45,7 @@ import { FeatureRequestModal } from "@/components/FeatureRequestModal";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
 import { useProductTier } from "@/hooks/useProductTier";
 import { useCustomDomain, useMcpUrl } from "@/hooks/useToolsetUrl";
+import { DEFAULT_MODEL } from "@/lib/models";
 import { isNotFoundError } from "@/lib/route-errors";
 import { Toolset, useGroupedTools } from "@/lib/toolTypes";
 import { cn, getServerURL } from "@/lib/utils";
@@ -1008,7 +1009,7 @@ function GenerateInstructionsButton({
 }) {
   const [generating, setGenerating] = useState(false);
   const { data: fullToolset } = useToolset(toolset.slug);
-  const model = useModel("anthropic/claude-sonnet-5");
+  const model = useModel(DEFAULT_MODEL);
 
   const tools = fullToolset?.tools ?? [];
 

--- a/client/dashboard/src/pages/playground/ChatWindow.tsx
+++ b/client/dashboard/src/pages/playground/ChatWindow.tsx
@@ -61,8 +61,8 @@ type CoreTool = {
 };
 
 const defaultModel = {
-  label: "Claude 4.5 Sonnet",
-  value: "anthropic/claude-sonnet-4.5",
+  label: "Claude Sonnet 5",
+  value: "anthropic/claude-sonnet-5",
 };
 
 export type ChatConfig = React.RefObject<{

--- a/client/dashboard/src/pages/playground/ChatWindow.tsx
+++ b/client/dashboard/src/pages/playground/ChatWindow.tsx
@@ -23,6 +23,7 @@ import {
 import { HttpRoute } from "@/components/http-route";
 import { useProject, useSession } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
+import { DEFAULT_MODEL } from "@/lib/models";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { extractStreamError } from "@/lib/chat-error";
 import { CustomChatTransport } from "@/lib/CustomChatTransport";
@@ -62,7 +63,7 @@ type CoreTool = {
 
 const defaultModel = {
   label: "Claude Sonnet 5",
-  value: "anthropic/claude-sonnet-5",
+  value: DEFAULT_MODEL,
 };
 
 export type ChatConfig = React.RefObject<{

--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -15,6 +15,7 @@ import {
   useRegisterToolsetTelemetry,
 } from "@/contexts/Telemetry";
 import { useLatestDeployment, useToolset } from "@/hooks/toolTypes";
+import { DEFAULT_MODEL } from "@/lib/models";
 import { Tool } from "@/lib/toolTypes";
 import { useRoutes } from "@/routes";
 import { useHideInsightsDock } from "@/components/insights-context";
@@ -96,7 +97,7 @@ function PlaygroundInner() {
   );
   const [showLogs, setShowLogs] = useState(false);
   const [temperature, setTemperature] = useState(0.5);
-  const [model, setModel] = useState("anthropic/claude-sonnet-5");
+  const [model, setModel] = useState<string>(DEFAULT_MODEL);
   const [maxTokens, setMaxTokens] = useState(4096);
   const [playgroundEnvironmentSlug, setPlaygroundEnvironmentSlug] = useState<
     string | undefined

--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -96,7 +96,7 @@ function PlaygroundInner() {
   );
   const [showLogs, setShowLogs] = useState(false);
   const [temperature, setTemperature] = useState(0.5);
-  const [model, setModel] = useState("anthropic/claude-sonnet-4.5");
+  const [model, setModel] = useState("anthropic/claude-sonnet-5");
   const [maxTokens, setMaxTokens] = useState(4096);
   const [playgroundEnvironmentSlug, setPlaygroundEnvironmentSlug] = useState<
     string | undefined

--- a/elements/src/lib/contextCompaction.ts
+++ b/elements/src/lib/contextCompaction.ts
@@ -32,6 +32,7 @@ export const DEFAULT_CONTEXT_LIMIT = 200_000;
  */
 const MODEL_CONTEXT_LIMITS: Partial<Record<KnownModelId, number>> = {
   // Anthropic (1M tier where available, else 200K)
+  "anthropic/claude-sonnet-5": 1_000_000,
   "anthropic/claude-opus-4.8": 1_000_000,
   "anthropic/claude-opus-4.7": 1_000_000,
   "anthropic/claude-opus-4.6": 1_000_000,

--- a/elements/src/lib/models.ts
+++ b/elements/src/lib/models.ts
@@ -1,6 +1,7 @@
 // List of openrouter models available to the user
 // This list should be updated to match the model whitelist on the backend side.
 export const MODELS = [
+  "anthropic/claude-sonnet-5",
   "anthropic/claude-opus-4.8",
   "anthropic/claude-opus-4.7",
   "anthropic/claude-sonnet-4.6",

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -31,8 +31,8 @@ var managedAssistantInstructions string
 
 const (
 	// managedAssistantModel is the default model for the platform-managed
-	// assistant. Upgraded to Opus 4.7 for the Assistants beta (DNO-264).
-	managedAssistantModel = "anthropic/claude-opus-4.7"
+	// assistant. Defaulted to Sonnet 5, matching the in-app default chat model.
+	managedAssistantModel = "anthropic/claude-sonnet-5"
 
 	// Schema defaults for the assistants table, applied explicitly so the
 	// managed assistant's intent is visible at the call site.

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -34,6 +34,7 @@ const OpenRouterBaseURL = "https://openrouter.ai/api"
 // Just a general allowlist for models we allow to proxy through us for playground usage, chat, or agentic usecases
 // This list can stay sufficiently robust, we should just need to allow list a model before it goes through us
 var allowList = map[string]bool{
+	"anthropic/claude-sonnet-5":     true,
 	"anthropic/claude-opus-4.8":     true,
 	"anthropic/claude-opus-4.7":     true,
 	"anthropic/claude-sonnet-4.6":   true,

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -35,7 +35,7 @@ type TelemetryLogger interface {
 }
 
 const (
-	DefaultChatModel = "openai/gpt-5.4"
+	DefaultChatModel = "anthropic/claude-sonnet-5"
 )
 
 // ChatClient is the single HTTP client for all OpenRouter communication.


### PR DESCRIPTION
## What

Makes **Claude Sonnet 5** (`anthropic/claude-sonnet-5`) the default model for in-app usage and for newly created assistants.

## Why

Sonnet 5 is the current best-balance model; the defaults were lagging on older Opus/Sonnet/GPT versions.

## Changes

**In-app usage default** (used when no model is explicitly selected):

- `openrouter/unified_client.go` — `DefaultChatModel`: `openai/gpt-5.4` → `anthropic/claude-sonnet-5`
- Playground (`Playground.tsx`, `ChatWindow.tsx`) default: `claude-sonnet-4.5` → `claude-sonnet-5`
- MCP details metadata-gen chat (`MCPDetails.tsx`): `claude-sonnet-4.5` → `claude-sonnet-5`

**New assistants default:**

- `assistants/provisioning.go` — `managedAssistantModel`: `claude-opus-4.7` → `claude-sonnet-5`
- `onboarding/tools/useOnboardingTools.tsx` — model written onto a newly created assistant: `claude-opus-4.7` → `claude-sonnet-5`
- `AssistantOnboarding.tsx` + `systemPrompt.ts` — onboarding helper + its model recommendations now default to Sonnet 5

**Model registration** (the coupled list files that must stay ID-identical):

- `openrouter.go` `allowList` (backend security gate), dashboard `AVAILABLE_MODELS`, elements `MODELS`, and `MODEL_CONTEXT_LIMITS` (`1_000_000`) — `claude-sonnet-5` added, listed first.

**Deliberately unchanged:** risk/PromptIntel judges (`gemini-3.1-flash-lite`), background chat segmentation (`haiku-4.5`), RAG embeddings, and follow-on suggestions (`gpt-5.4-mini`) — these select cheap/specialized models on purpose.

## Verification

- `go build` (openrouter + assistants): pass
- `go test -run ResolveModel`: pass (confirms the new ID is accepted by the allowlist gate — an unrecognized ID would silently fall back to Haiku)
- elements `tsc --noEmit`: pass (the `MODELS` ↔ context-limits invariant holds)
- dashboard `tsc -b --noEmit --force` (CI-faithful): pass, 0 errors

## Note for reviewers

The OpenRouter slug used is `anthropic/claude-sonnet-5` (follows the `anthropic/<model-id>` convention and the base-version-has-no-minor pattern like `claude-sonnet-4`). Worth a glance against `openrouter.ai/api/v1/models` before merge — if the upstream slug differs, the default would silently fall back to the alphabetically-first Anthropic model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `anthropic/claude-sonnet-5` as the default model for in-app chat and for newly created assistants to improve default quality and align backend and UI defaults. Centralized default IDs into constants for easier maintenance.

- **New Features**
  - Backend: `DefaultChatModel` switched to `anthropic/claude-sonnet-5`; added to OpenRouter `allowList`.
  - Assistants: platform-managed and onboarding-created assistants now default to Sonnet 5; onboarding guidance updated.
  - Dashboard/Elements: Playground, Chat Window, and MCP defaults updated to Sonnet 5; added to `MODELS` with a `1_000_000` context limit.
  - Specialized paths unchanged (judges, segmentation, embeddings, follow-on suggestions).

- **Refactors**
  - Introduced `DEFAULT_MODEL` and `DEFAULT_ASSISTANT_MODEL` constants in `client/dashboard/src/lib/models.ts` (next to `AVAILABLE_MODELS`), and replaced scattered literals across Playground, MCP, and onboarding to keep in-app and assistant defaults independently adjustable.

<sup>Written for commit adf2d0798aa8273851a409dd5ec70f922664585c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

