### PR TITLE
fix(telemetry): stop undercounting skill invocations in usage aggregate

### DIFF
--- a/.changeset/brave-parts-open.md
+++ b/.changeset/brave-parts-open.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix(telemetry): stop undercounting skill invocations in usage aggregate

--- a/server/internal/telemetry/get_hooks_summary_test.go
+++ b/server/internal/telemetry/get_hooks_summary_test.go
@@ -626,6 +626,82 @@ func TestGetHooksSummary_SkillBreakdownEmptyWhenNoSkillEvents(t *testing.T) {
 	}, 10*time.Second, 200*time.Millisecond)
 }
 
+// TestGetHooksSummary_SkillCountedWhenSkillNameOnSubsetOfTraceRows guards against
+// the undercount bug (DNO-312): skill_name is materialized only on the Skill tool
+// row, so a skill trace's sibling rows carry an empty skill_name. The
+// trace_summaries MV must let the populated skill name win over those empty
+// siblings (anyIf/max), otherwise the skill-usage aggregate drops the trace.
+func TestGetHooksSummary_SkillCountedWhenSkillNameOnSubsetOfTraceRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+	now := time.Now().UTC()
+
+	// A single skill trace made of two hook rows: a sibling row that does NOT
+	// carry the skill name, plus the Skill tool row that does. Both share one
+	// trace_id so trace_summaries aggregates them into one row.
+	sharedTraceID := uuid.New().String()
+	insertHookEvent(t, ctx, hookEventParams{
+		projectID:      projectID,
+		deploymentID:   deploymentID,
+		timestamp:      now.Add(-10 * time.Minute),
+		traceID:        sharedTraceID,
+		userEmail:      "user@example.com",
+		hookSource:     "local",
+		toolName:       "", // sibling row: empty tool_name => empty skill_name
+		conversationID: "conv-1",
+	})
+	insertHookEvent(t, ctx, hookEventParams{
+		projectID:      projectID,
+		deploymentID:   deploymentID,
+		timestamp:      now.Add(-9 * time.Minute),
+		traceID:        sharedTraceID,
+		userEmail:      "user@example.com",
+		hookSource:     "local",
+		toolName:       "Skill",
+		skillName:      "golang",
+		result:         "done",
+		conversationID: "conv-1",
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		// The skill trace must appear in the aggregate exactly once, despite the
+		// empty-skill_name sibling row in the same trace.
+		if !assert.Len(c, res.Skills, 1) {
+			return
+		}
+		assert.Equal(c, "golang", res.Skills[0].SkillName)
+		assert.Equal(c, int64(1), res.Skills[0].UseCount)
+		assert.Equal(c, int64(1), res.Skills[0].UniqueUsers)
+
+		// And in the breakdown / time series, which key off skill_name != ''.
+		if !assert.Len(c, res.SkillBreakdown, 1) {
+			return
+		}
+		assert.Equal(c, "golang", res.SkillBreakdown[0].SkillName)
+		assert.Equal(c, int64(1), res.SkillBreakdown[0].UseCount)
+		if !assert.Len(c, res.SkillTimeSeries, 1) {
+			return
+		}
+		assert.Equal(c, "golang", res.SkillTimeSeries[0].SkillName)
+		assert.Equal(c, int64(1), res.SkillTimeSeries[0].EventCount)
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
 func TestGetHooksSummary_SkillTimeSeriesWithSkillTypeFilter(t *testing.T) {
 	t.Parallel()
 
@@ -660,8 +736,8 @@ func TestGetHooksSummary_SkillTimeSeriesWithSkillTypeFilter(t *testing.T) {
 		conversationID: "conv-2",
 	})
 
-	// TypesToInclude=["skill"] scopes the overall summary to skill events,
-	// but skill_time_series and skill_breakdown hardcode tool_name='Skill' so they
+	// TypesToInclude=["skill"] scopes the overall summary to skill events;
+	// skill_time_series and skill_breakdown key off skill_name != '' so they
 	// return skill data regardless of TypesToInclude.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{
@@ -723,7 +799,7 @@ func TestGetHooksSummary_SkillFieldsIgnoreTypesToInclude(t *testing.T) {
 	})
 
 	// TypesToInclude=["mcp"] scopes TotalEvents/Servers/Users to MCP events only,
-	// but skill_time_series and skill_breakdown hardcode tool_name='Skill' so they
+	// but skill_time_series and skill_breakdown key off skill_name != '' so they
 	// must always return skill data regardless of TypesToInclude.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		res, err := ti.service.GetHooksSummary(ctx, &gen.GetHooksSummaryPayload{

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -2110,11 +2110,10 @@ func (s *Service) GetHooksSummary(ctx context.Context, payload *telem_gen.GetHoo
 	eg.Go(func() error {
 		var err error
 		skillRows, err = s.chRepo.GetSkillsSummary(egCtx, repo.GetSkillsSummaryParams{
-			GramProjectID:  projectID,
-			TimeStart:      timeStart,
-			TimeEnd:        timeEnd,
-			Filters:        attributeFilters,
-			TypesToInclude: typesToInclude,
+			GramProjectID: projectID,
+			TimeStart:     timeStart,
+			TimeEnd:       timeEnd,
+			Filters:       attributeFilters,
 		})
 		if err != nil {
 			return fmt.Errorf("get skills summary: %w", err)

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -3659,11 +3659,10 @@ type SkillSummaryRow struct {
 
 // GetSkillsSummaryParams defines the parameters for getting skills summary.
 type GetSkillsSummaryParams struct {
-	GramProjectID  string
-	TimeStart      int64
-	TimeEnd        int64
-	Filters        []AttributeFilter
-	TypesToInclude []string
+	GramProjectID string
+	TimeStart     int64
+	TimeEnd       int64
+	Filters       []AttributeFilter
 }
 
 // GetSkillsSummary retrieves aggregated skills usage metrics.
@@ -3682,7 +3681,14 @@ func (q *Queries) GetSkillsSummary(ctx context.Context, arg GetSkillsSummaryPara
 		Where("start_time_unix_nano <= ?", arg.TimeEnd).
 		Where("skill_name != ''")
 
-	sb = applyHookFiltersToBuilder(sb, arg.Filters, arg.TypesToInclude)
+	// Apply attribute filters (user, server) but not type filters: skill_name != ''
+	// is the authoritative skill signal (skill_name is materialized only when
+	// tool_name = 'Skill'). Re-adding a tool_name = 'Skill' condition via the
+	// "skill" type filter would test the any()-aggregated tool_name column, which
+	// may hold a sibling row's value and spuriously drop genuine skill traces.
+	// This mirrors GetSkillBreakdown / GetSkillTimeSeries, which also ignore the
+	// page-level type filter for the skills section.
+	sb = applyHookFiltersToBuilder(sb, arg.Filters, nil)
 
 	sb = sb.GroupBy("skill_name").
 		OrderBy("use_count DESC")
@@ -3733,16 +3739,19 @@ type GetSkillBreakdownParams struct {
 //
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
 func (q *Queries) GetSkillBreakdown(ctx context.Context, arg GetSkillBreakdownParams) ([]SkillBreakdownRow, error) {
+	// skill_name is materialized only for rows where tool_name = 'Skill', so
+	// skill_name != '' is the authoritative skill signal. We deliberately do NOT
+	// also filter on tool_name = 'Skill' / event_source = 'hook': those columns
+	// are any()-aggregated in trace_summaries and may carry a sibling row's value
+	// within the same trace, which would spuriously drop genuine skill traces.
 	sb := sq.Select("skill_name", "user_email", "count(*) as use_count").
 		From("trace_summaries").
 		Where("gram_project_id = ?", arg.GramProjectID).
-		Where("event_source = 'hook'").
-		Where("tool_name = 'Skill'").
 		Where("start_time_unix_nano >= ?", arg.TimeStart).
 		Where("start_time_unix_nano <= ?", arg.TimeEnd).
 		Where("skill_name != ''")
 
-	// Apply attribute filters (user, server) but not type filters — skill type is hardcoded above.
+	// Apply attribute filters (user, server) but not type filters — skill type is implied by skill_name != ''.
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, nil)
 	sb = sb.GroupBy("skill_name", "user_email").OrderBy("skill_name", "use_count DESC").
 		Limit(10000) // Defensive cap
@@ -3941,13 +3950,16 @@ func (q *Queries) GetSkillTimeSeries(ctx context.Context, arg GetSkillTimeSeries
 	).
 		From("trace_summaries").
 		Where("gram_project_id = ?", arg.GramProjectID).
-		Where("event_source = 'hook'").
-		Where("tool_name = 'Skill'").
 		Where("start_time_unix_nano >= ?", arg.TimeStart).
 		Where("start_time_unix_nano <= ?", arg.TimeEnd).
 		Where("skill_name != ''")
 
-	// Apply attribute filters (user, server) but not type filters — skill type is hardcoded above.
+	// skill_name is materialized only for rows where tool_name = 'Skill', so
+	// skill_name != '' is the authoritative skill signal. We deliberately do NOT
+	// also filter on tool_name = 'Skill' / event_source = 'hook': those columns
+	// are any()-aggregated in trace_summaries and may carry a sibling row's value
+	// within the same trace, which would spuriously drop genuine skill traces.
+	// Apply attribute filters (user, server) but not type filters.
 	sb = applyHookFiltersToBuilder(sb, arg.Filters, nil)
 
 	sb = sb.GroupBy("bucket_start", "skill_name").


### PR DESCRIPTION
## Problem

The skill-usage aggregate metric showed fewer skill invocations than the Tool Logs view. As Sagar suspected, the missing skills were being classified as a tool type rather than a skill.

## Root cause

`skill_name` is materialized on `telemetry_logs` only for rows where `tool_name = 'Skill'`, so every other row in a skill trace carries an empty `skill_name`. The `trace_summaries` MV aggregated it with `any(skill_name)`, which can persist/merge an empty string from a sibling row over the real value. When that happened the skill-usage aggregate (which filters `skill_name != ''`) dropped the trace entirely, while the raw-log path recovered it via a windowed `anyIf(...) OVER (PARTITION BY trace)` fallback — which is why the logs view showed more skills than the aggregate.

## Fix (this PR — server side)

- `GetSkillsSummary` / `GetSkillBreakdown` / `GetSkillTimeSeries` now key solely off `skill_name != ''`, dropping the redundant `tool_name = 'Skill'` / `event_source = 'hook'` predicates that read `any()`-aggregated columns and were subject to the same sibling-row fragility. `GetSkillsSummary` no longer re-adds `tool_name = 'Skill'` via the page-level "skill" type filter.
- Regression test inserts a skill trace whose `skill_name` only appears on a subset of its rows and asserts it is counted exactly once across Skills / SkillBreakdown / SkillTimeSeries.

## Stacked on the migration PR

The ClickHouse side of the fix — `trace_summaries.skill_name` → `SimpleAggregateFunction(max, String)` and the MV emitting `anyIf(skill_name, skill_name != '')` — was split out into **#3802** to comply with the migration-isolation policy (migrations ship in their own PR). This PR is based on that branch; **merge #3802 first**, then this one.

DNO-312.

<!-- This is an auto-generated description by cubic. -->