### PR TITLE
feat: add Cache-Control and ETag to public well-known OAuth metadata

### DIFF
--- a/.changeset/age-2883-cache-control-well-known.md
+++ b/.changeset/age-2883-cache-control-well-known.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Public well-known OAuth/MCP metadata responses now send `Cache-Control: public, max-age=60` and a strong `ETag` with `If-None-Match` 304 revalidation, so clients and proxies can cache them. The OAuth Client ID Metadata Document keeps `max-age=3600` and gains an `ETag`. This is a prerequisite for fronting these responses with an ingress cache or CDN.

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -417,6 +417,7 @@ linters:
         - "github.com/speakeasy-api/gram/server/internal/oops.C("
         - "github.com/speakeasy-api/gram/server/internal/oops.E("
         - "github.com/speakeasy-api/gram/server/internal/oops.Permanent("
+        - "github.com/speakeasy-api/gram/server/internal/httpcache.WriteCacheableJSON("
         - "github.com/speakeasy-api/gram/server/internal/platformtools/core.DecodeInput("
         - "github.com/speakeasy-api/gram/server/internal/platformtools/core.EncodeResult("
         - "(*github.com/speakeasy-api/gram/server/internal/access.Manager).Require("

--- a/server/internal/httpcache/httpcache.go
+++ b/server/internal/httpcache/httpcache.go
@@ -1,0 +1,80 @@
+// Package httpcache provides a shared write path for public, cacheable JSON
+// responses. It centralises the Cache-Control + ETag + conditional-request
+// (304) contract so Gram's public well-known / OAuth-metadata responses cache
+// consistently.
+package httpcache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// WriteCacheableJSON writes body as a public, cacheable JSON response. It always
+// emits a strong ETag derived from body and Cache-Control: public,
+// max-age=<maxAge>, and honours a matching If-None-Match by returning 304 Not
+// Modified with no body. contentType is emitted verbatim so callers can vary
+// the charset parameter.
+//
+// Callers must not have written to w yet and must already hold the marshalled
+// body: like the metadata writers it replaces, this commits the status line, so
+// any marshalling or resolution error must be returned earlier on an unwritten
+// ResponseWriter for the error-handling middleware to emit the real status.
+func WriteCacheableJSON(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, contentType string, maxAge int, body []byte) error {
+	etag := strongETag(body)
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", maxAge))
+
+	if ifNoneMatchSatisfied(r.Header.Get("If-None-Match"), etag) {
+		// RFC 9110 §15.4.5: a 304 carries the validators (ETag, Cache-Control)
+		// already set above but no representation, so Content-Type and the body
+		// are omitted.
+		w.WriteHeader(http.StatusNotModified)
+		return nil
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "write cacheable response body").LogError(ctx, logger)
+	}
+
+	return nil
+}
+
+// strongETag returns a strong ETag (RFC 9110 §8.8.3): a quoted hex SHA-256
+// digest of body. Strong because it is computed from the exact bytes Gram
+// writes, before any downstream compression. Host-derived URLs are part of body,
+// so two hosts of the same resource naturally get distinct ETags without Vary.
+func strongETag(body []byte) string {
+	sum := sha256.Sum256(body)
+	return `"` + hex.EncodeToString(sum[:]) + `"`
+}
+
+// ifNoneMatchSatisfied reports whether an If-None-Match header value matches
+// etag, using the weak comparison RFC 9110 §13.1.2 mandates for If-None-Match
+// (the W/ prefix is ignored on both sides). "*" matches any current
+// representation.
+func ifNoneMatchSatisfied(header, etag string) bool {
+	header = strings.TrimSpace(header)
+	switch header {
+	case "":
+		return false
+	case "*":
+		return true
+	}
+
+	want := strings.TrimPrefix(etag, "W/")
+	for candidate := range strings.SplitSeq(header, ",") {
+		if strings.TrimPrefix(strings.TrimSpace(candidate), "W/") == want {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/httpcache/httpcache_test.go
+++ b/server/internal/httpcache/httpcache_test.go
@@ -1,0 +1,114 @@
+package httpcache_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/httpcache"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestWriteCacheableJSON_OK(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	body := []byte(`{"issuer":"https://example.test/mcp/foo"}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/foo", nil)
+
+	require.NoError(t, httpcache.WriteCacheableJSON(t.Context(), w, r, logger, "application/json", 60, body))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	require.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
+	require.NotEmpty(t, w.Header().Get("ETag"))
+	require.Equal(t, body, w.Body.Bytes())
+}
+
+func TestWriteCacheableJSON_PreservesCharsetContentType(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-client/abc", nil)
+
+	require.NoError(t, httpcache.WriteCacheableJSON(t.Context(), w, r, logger, "application/json; charset=utf-8", 3600, []byte(`{}`)))
+
+	require.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+	require.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
+}
+
+func TestWriteCacheableJSON_NotModifiedOnMatchingIfNoneMatch(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	body := []byte(`{"issuer":"https://example.test/mcp/foo"}`)
+
+	// First request to learn the ETag the server assigns to this body.
+	first := httptest.NewRecorder()
+	require.NoError(t, httpcache.WriteCacheableJSON(t.Context(), first, httptest.NewRequest(http.MethodGet, "/x", nil), logger, "application/json", 60, body))
+	etag := first.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	// Re-request with the learned ETag: expect a bodyless 304 that still carries
+	// the validators but no Content-Type.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("If-None-Match", etag)
+	require.NoError(t, httpcache.WriteCacheableJSON(t.Context(), w, r, logger, "application/json", 60, body))
+
+	require.Equal(t, http.StatusNotModified, w.Code)
+	require.Empty(t, w.Body.Bytes())
+	require.Empty(t, w.Header().Get("Content-Type"))
+	require.Equal(t, etag, w.Header().Get("ETag"))
+	require.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
+}
+
+func TestWriteCacheableJSON_NotModifiedOnStar(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("If-None-Match", "*")
+
+	require.NoError(t, httpcache.WriteCacheableJSON(t.Context(), w, r, logger, "application/json", 60, []byte(`{}`)))
+
+	require.Equal(t, http.StatusNotModified, w.Code)
+	require.Empty(t, w.Body.Bytes())
+}
+
+func TestWriteCacheableJSON_ServesBodyOnMismatchedIfNoneMatch(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	body := []byte(`{"issuer":"https://example.test/mcp/foo"}`)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.Header.Set("If-None-Match", `"some-other-etag"`)
+
+	require.NoError(t, httpcache.WriteCacheableJSON(t.Context(), w, r, logger, "application/json", 60, body))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, body, w.Body.Bytes())
+}
+
+func TestWriteCacheableJSON_ETagVariesWithBody(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+
+	etagFor := func(body string) string {
+		w := httptest.NewRecorder()
+		require.NoError(t, httpcache.WriteCacheableJSON(t.Context(), w, httptest.NewRequest(http.MethodGet, "/x", nil), logger, "application/json", 60, []byte(body)))
+		return w.Header().Get("ETag")
+	}
+
+	firstCall := etagFor(`{"a":1}`)
+	secondCall := etagFor(`{"a":1}`)
+	require.Equal(t, firstCall, secondCall, "identical bodies must share an ETag")
+	require.NotEqual(t, firstCall, etagFor(`{"a":2}`), "different bodies must get different ETags")
+}

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -398,6 +398,5 @@ func writeJSONMetadata(ctx context.Context, w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "marshal metadata").LogError(ctx, logger)
 	}
-	//nolint:wrapcheck // helper writes the response; its error is already a contextual oops error.
 	return httpcache.WriteCacheableJSON(ctx, w, r, logger, "application/json", metadataCacheMaxAgeSeconds, body)
 }

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
@@ -29,6 +30,12 @@ import (
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
 )
+
+// metadataCacheMaxAgeSeconds is the Cache-Control max-age for public well-known
+// OAuth-metadata responses. Deliberately short: the documents change rarely but
+// an issuer's config can, so a 60s TTL caps how long a stale document lingers
+// while still absorbing bursts.
+const metadataCacheMaxAgeSeconds = 60
 
 // supportedBearerMethods advertises what the MCP resource-server surface
 // accepts in the WWW-Authenticate challenge (RFC 9728). The AS-level
@@ -120,7 +127,7 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build legacy resource URL").LogError(ctx, s.logger)
 	}
-	return s.serveLegacyToolsetProtectedResource(ctx, w, logger, toolset, resourceURL)
+	return s.serveLegacyToolsetProtectedResource(ctx, w, r, logger, toolset, resourceURL)
 }
 
 // HandleGetAuthorizationServer serves RFC 8414 authorization-server metadata
@@ -214,7 +221,7 @@ func (s *Service) ServeWellKnownProtectedResourceForServer(
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, logger)
 		}
-		return s.serveLegacyToolsetProtectedResource(ctx, w, logger, toolset, resourceURL)
+		return s.serveLegacyToolsetProtectedResource(ctx, w, r, logger, toolset, resourceURL)
 	default:
 		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").LogError(ctx, logger)
 	}
@@ -285,7 +292,7 @@ func (s *Service) loadToolsetForServer(ctx context.Context, logger *slog.Logger,
 // resolver. A nil result means the toolset carries no OAuth configuration —
 // 404. resourceURL is the runtime URL the caller addressed; it is emitted
 // verbatim as both `resource` and `authorization_servers`.
-func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, toolset *toolsets_repo.Toolset, resourceURL string) error {
+func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, toolset *toolsets_repo.Toolset, resourceURL string) error {
 	metadata, err := wellknown.ResolveOAuthProtectedResourceFromToolset(ctx, logger, s.db, &s.toolsetCache, toolset, resourceURL)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").LogError(ctx, logger)
@@ -293,7 +300,7 @@ func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w htt
 	if metadata == nil {
 		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
 	}
-	return writeOAuthProtectedResourceMetadataResponse(ctx, logger, w, metadata)
+	return writeOAuthProtectedResourceMetadataResponse(ctx, logger, w, r, metadata)
 }
 
 // serveLegacyToolsetAuthorizationServer resolves and writes RFC 8414
@@ -332,7 +339,7 @@ func (s *Service) serveLegacyToolsetAuthorizationServer(ctx context.Context, w h
 		return nil
 	}
 
-	return writeOAuthServerMetadataResponse(ctx, logger, w, result)
+	return writeOAuthServerMetadataResponse(ctx, logger, w, r, result)
 }
 
 // ServeGetProtectedResource is the post-resolution entry point for the
@@ -348,7 +355,7 @@ func (s *Service) ServeGetProtectedResource(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, s.logger)
 	}
-	return writeJSONMetadata(ctx, w, s.logger, oauthProtectedResourceMetadata{
+	return writeJSONMetadata(ctx, w, r, s.logger, oauthProtectedResourceMetadata{
 		Resource:               resource,
 		AuthorizationServers:   []string{resource},
 		ScopesSupported:        nil,
@@ -369,7 +376,7 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build OAuth server URLs").LogError(ctx, s.logger)
 	}
-	return writeJSONMetadata(ctx, w, s.logger, oauthAuthorizationServerMetadata{
+	return writeJSONMetadata(ctx, w, r, s.logger, oauthAuthorizationServerMetadata{
 		Issuer:                            urls.Issuer,
 		AuthorizationEndpoint:             urls.Authorize,
 		TokenEndpoint:                     urls.Token,
@@ -384,16 +391,13 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 }
 
 // writeJSONMetadata is the shared write path for issuer-gated metadata
-// responses. Marshals the value, sets Content-Type, then commits 200.
-func writeJSONMetadata(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, v any) error {
+// responses. Marshals the value, then commits a public, cacheable 200 (or a 304
+// when the caller's If-None-Match matches).
+func writeJSONMetadata(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, v any) error {
 	body, err := json.Marshal(v)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to marshal metadata").LogError(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "marshal metadata").LogError(ctx, logger)
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write response body").LogError(ctx, logger)
-	}
-	return nil
+	//nolint:wrapcheck // helper writes the response; its error is already a contextual oops error.
+	return httpcache.WriteCacheableJSON(ctx, w, r, logger, "application/json", metadataCacheMaxAgeSeconds, body)
 }

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -51,6 +51,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
@@ -408,7 +409,7 @@ func (s *Service) HandleGetServer(w http.ResponseWriter, r *http.Request, metada
 // if marshaling fails or the result kind is unrecognized, the caller's error
 // handler middleware needs an unwritten ResponseWriter so it can emit the real
 // error status — Go's net/http silently drops a second WriteHeader call.
-func writeOAuthServerMetadataResponse(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, result *wellknown.OAuthServerMetadataResult) error {
+func writeOAuthServerMetadataResponse(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, r *http.Request, result *wellknown.OAuthServerMetadataResult) error {
 	var body []byte
 	switch result.Kind {
 	case wellknown.OAuthServerMetadataResultKindRaw:
@@ -423,32 +424,22 @@ func writeOAuthServerMetadataResponse(ctx context.Context, logger *slog.Logger, 
 		return oops.E(oops.CodeUnexpected, nil, "unexpected OAuth server metadata result kind").LogError(ctx, logger)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write response body").LogError(ctx, logger)
-	}
-
-	return nil
+	//nolint:wrapcheck // helper writes the response; its error is already a contextual oops error.
+	return httpcache.WriteCacheableJSON(ctx, w, r, logger, "application/json", metadataCacheMaxAgeSeconds, body)
 }
 
 // writeOAuthProtectedResourceMetadataResponse builds the OAuth protected
 // resource metadata body and only commits the 200 OK status once the body is
 // ready. See writeOAuthServerMetadataResponse for the rationale behind the
 // ordering.
-func writeOAuthProtectedResourceMetadataResponse(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, metadata *wellknown.OAuthProtectedResourceMetadata) error {
+func writeOAuthProtectedResourceMetadataResponse(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, r *http.Request, metadata *wellknown.OAuthProtectedResourceMetadata) error {
 	body, err := json.Marshal(metadata)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth protected resource metadata").LogError(ctx, logger)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(body); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write response body").LogError(ctx, logger)
-	}
-
-	return nil
+	//nolint:wrapcheck // helper writes the response; its error is already a contextual oops error.
+	return httpcache.WriteCacheableJSON(ctx, w, r, logger, "application/json", metadataCacheMaxAgeSeconds, body)
 }
 
 // ServePublic serves /mcp/{mcpSlug}. Resolution tries mcp_endpoints

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -424,7 +424,6 @@ func writeOAuthServerMetadataResponse(ctx context.Context, logger *slog.Logger, 
 		return oops.E(oops.CodeUnexpected, nil, "unexpected OAuth server metadata result kind").LogError(ctx, logger)
 	}
 
-	//nolint:wrapcheck // helper writes the response; its error is already a contextual oops error.
 	return httpcache.WriteCacheableJSON(ctx, w, r, logger, "application/json", metadataCacheMaxAgeSeconds, body)
 }
 
@@ -438,7 +437,6 @@ func writeOAuthProtectedResourceMetadataResponse(ctx context.Context, logger *sl
 		return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth protected resource metadata").LogError(ctx, logger)
 	}
 
-	//nolint:wrapcheck // helper writes the response; its error is already a contextual oops error.
 	return httpcache.WriteCacheableJSON(ctx, w, r, logger, "application/json", metadataCacheMaxAgeSeconds, body)
 }
 

--- a/server/internal/mcp/wellknown_oauth_test.go
+++ b/server/internal/mcp/wellknown_oauth_test.go
@@ -34,10 +34,12 @@ func Test_writeOAuthServerMetadataResponse_Static(t *testing.T) {
 		ProxyURL: "",
 	}
 
-	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, result)
+	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/foo", nil), result)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	require.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
+	require.NotEmpty(t, w.Header().Get("ETag"))
 
 	var got wellknown.OAuthServerMetadata
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
@@ -58,10 +60,12 @@ func Test_writeOAuthServerMetadataResponse_Raw(t *testing.T) {
 		ProxyURL: "",
 	}
 
-	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, result)
+	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/foo", nil), result)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	require.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
+	require.NotEmpty(t, w.Header().Get("ETag"))
 	require.JSONEq(t, string(raw), w.Body.String())
 }
 
@@ -84,7 +88,7 @@ func Test_writeOAuthServerMetadataResponse_UnknownKind_DoesNotWriteResponse(t *t
 		ProxyURL: "",
 	}
 
-	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, result)
+	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/foo", nil), result)
 	require.Error(t, err)
 	require.Empty(t, w.Header().Get("Content-Type"))
 	require.Empty(t, w.Body.Bytes())
@@ -104,10 +108,12 @@ func Test_writeOAuthProtectedResourceMetadataResponse_Success(t *testing.T) {
 		ResourceDocumentation:  "",
 	}
 
-	err := writeOAuthProtectedResourceMetadataResponse(t.Context(), logger, w, metadata)
+	err := writeOAuthProtectedResourceMetadataResponse(t.Context(), logger, w, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp/foo", nil), metadata)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	require.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
+	require.NotEmpty(t, w.Header().Get("ETag"))
 
 	var got wellknown.OAuthProtectedResourceMetadata
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
@@ -134,7 +140,7 @@ func Test_writeOAuthProtectedResourceMetadataResponse_OmitsOptionalFields(t *tes
 		ResourceDocumentation:  "",
 	}
 
-	err := writeOAuthProtectedResourceMetadataResponse(t.Context(), logger, w, metadata)
+	err := writeOAuthProtectedResourceMetadataResponse(t.Context(), logger, w, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp/foo", nil), metadata)
 	require.NoError(t, err)
 
 	const expected = `{
@@ -165,7 +171,7 @@ func Test_writeOAuthProtectedResourceMetadataResponse_EmitsAllFields(t *testing.
 		ResourceDocumentation:  "https://docs.example.test",
 	}
 
-	err := writeOAuthProtectedResourceMetadataResponse(t.Context(), logger, w, metadata)
+	err := writeOAuthProtectedResourceMetadataResponse(t.Context(), logger, w, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp/foo", nil), metadata)
 	require.NoError(t, err)
 
 	const expected = `{

--- a/server/internal/mcp/wellknown_test.go
+++ b/server/internal/mcp/wellknown_test.go
@@ -219,6 +219,8 @@ func TestHandleGetAuthorizationServer_IssuerGatedRemoteBackend(t *testing.T) {
 	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, slug)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
+	require.NotEmpty(t, w.Header().Get("ETag"))
 
 	var metadata map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))

--- a/server/internal/remotesessions/cimd.go
+++ b/server/internal/remotesessions/cimd.go
@@ -141,6 +141,5 @@ func (m *ChallengeManager) HandleClientMetadataDocument(w http.ResponseWriter, r
 		return oops.E(oops.CodeUnexpected, err, "marshal client metadata document").LogError(ctx, m.logger)
 	}
 
-	//nolint:wrapcheck // helper writes the response; its error is already a contextual oops error.
 	return httpcache.WriteCacheableJSON(ctx, w, r, m.logger, "application/json; charset=utf-8", clientMetadataDocumentMaxAgeSeconds, body)
 }

--- a/server/internal/remotesessions/cimd.go
+++ b/server/internal/remotesessions/cimd.go
@@ -22,9 +22,16 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
+
+// clientMetadataDocumentMaxAgeSeconds is the Cache-Control max-age for served
+// CIMD documents. Longer than the well-known metadata TTL: a document is keyed
+// by an immutable client_id and changes only if the client's scope or callback
+// does, so upstream Authorization Servers can safely cache it for an hour.
+const clientMetadataDocumentMaxAgeSeconds = 3600
 
 // cimdClientName is the client_name Gram publishes in every CIMD document. It
 // is what the end user sees on the upstream's consent screen, so it carries the
@@ -134,11 +141,6 @@ func (m *ChallengeManager) HandleClientMetadataDocument(w http.ResponseWriter, r
 		return oops.E(oops.CodeUnexpected, err, "marshal client metadata document").LogError(ctx, m.logger)
 	}
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Header().Set("Cache-Control", "public, max-age=3600")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(body); err != nil {
-		return fmt.Errorf("write client metadata document: %w", err)
-	}
-	return nil
+	//nolint:wrapcheck // helper writes the response; its error is already a contextual oops error.
+	return httpcache.WriteCacheableJSON(ctx, w, r, m.logger, "application/json; charset=utf-8", clientMetadataDocumentMaxAgeSeconds, body)
 }

--- a/server/internal/remotesessions/cimd_test.go
+++ b/server/internal/remotesessions/cimd_test.go
@@ -202,6 +202,7 @@ func TestHandleClientMetadataDocument_ServesDocument(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "application/json; charset=utf-8", rec.Header().Get("Content-Type"))
 	require.Equal(t, "public, max-age=3600", rec.Header().Get("Cache-Control"))
+	require.NotEmpty(t, rec.Header().Get("ETag"))
 
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -278,6 +278,8 @@ func TestHandleWellKnownOAuthServerMetadata_IssuerGatedRemoteBackend(t *testing.
 	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "public, max-age=60", w.Header().Get("Cache-Control"))
+	require.NotEmpty(t, w.Header().Get("ETag"))
 
 	var metadata map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2883/add-cache-control-headers-to-public-well-known-oauth-metadata

Public, unauthenticated OAuth/MCP well-known metadata responses now emit `Cache-Control: public, max-age=60` and a strong `ETag` with `If-None-Match` 304 revalidation, via a new shared `internal/httpcache` helper. Covers the issuer-gated AS/PRM metadata (`/mcp` and `/x/mcp`) and the legacy toolset-backed writers; the CIMD document moves onto the same helper, keeping `max-age=3600` and gaining an `ETag`. The reverse-proxy AS-metadata branch is left untouched so upstream cache headers still pass through.

Prerequisite for the ingress `proxy_cache` work in AGE-2884.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cache-Control and strong ETag headers to public OAuth/MCP well-known metadata to enable client/proxy caching with 304 revalidation. Introduces a shared `server/internal/httpcache` helper and applies it across issuer‑gated endpoints; CIMD keeps max-age=3600 and now has an ETag.

- **New Features**
  - Public OAuth/MCP metadata now returns `Cache-Control: public, max-age=60` and a strong `ETag`, honoring `If-None-Match` with 304.
  - New `server/internal/httpcache` helper centralizes cacheable JSON responses.
  - Applied to AS/PRM metadata for `/mcp` and `/x/mcp`, plus legacy toolset writers; reverse-proxy AS path unchanged (passes upstream headers).
  - CIMD moved to the helper, retains `max-age=3600`, and gains `ETag`.
  - Addresses AGE-2883 and unblocks ingress `proxy_cache` work in AGE-2884.

- **Refactors**
  - Added `httpcache.WriteCacheableJSON` to `wrapcheck` ignore list in `server/.golangci.yaml`.

<sup>Written for commit 4ec6745b4947f41b5f395367114f66813b4d18be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

