### PR TITLE
feat: show redirect URI callout for manual remote identity provider clients

### DIFF
--- a/.changeset/wet-pandas-lie.md
+++ b/.changeset/wet-pandas-lie.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add callback URL to the Remote Session Client form

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IssuerFormFields.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IssuerFormFields.tsx
@@ -1,3 +1,4 @@
+import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -8,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Type } from "@/components/ui/type";
+import { getServerURL } from "@/lib/utils";
 import { CreateRemoteSessionClientFormTokenEndpointAuthMethod } from "@gram/client/models/components";
 import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
 import {
@@ -15,6 +17,42 @@ import {
   clientTypeHelp,
   type ClientType,
 } from "./issuerFormUtils";
+
+// remoteLoginCallbackURL is the single stable redirect_uri Gram uses for
+// every upstream OAuth provider, regardless of MCP server or slug (see
+// canonicalCallbackRouteBase in server/internal/remotesessions/challenge.go).
+// Manual clients need it registered on the upstream's app out-of-band; DCR
+// and CIMD clients send/publish it automatically, so this only surfaces
+// where the operator has to do that registration by hand.
+function remoteLoginCallbackURL(): string {
+  return `${getServerURL()}/mcp/remote_login_callback`;
+}
+
+// RedirectURICallout shows the redirect_uri operators must register on the
+// upstream provider's OAuth app before a Manual client's credentials will
+// work.
+function RedirectURICallout(): JSX.Element {
+  const redirectURI = remoteLoginCallbackURL();
+  return (
+    <Stack gap={2}>
+      <Label className="text-muted-foreground text-xs">Redirect URI</Label>
+      <div className="bg-muted/50 rounded-lg p-4 font-mono text-sm">
+        <div className="flex items-center justify-between gap-2">
+          <code className="break-all">{redirectURI}</code>
+          <CopyButton
+            size="inline"
+            text={redirectURI}
+            tooltip="Copy redirect URI"
+          />
+        </div>
+      </div>
+      <Type muted small>
+        Register this as the callback / redirect URI on the upstream provider's
+        OAuth app before pasting credentials below.
+      </Type>
+    </Stack>
+  );
+}
 
 // Shared form-field components used by both AttachRemoteIdentityProviderSheet
 // and ModifyRemoteIdentityProviderSheet. The state lives in the parent sheet;
@@ -423,15 +461,18 @@ export function ClientTypeFields({
       break;
     case "manual":
       credentials = (
-        <ClientCredentialsFields
-          showHeading={false}
-          clientId={clientId}
-          clientSecret={clientSecret}
-          tokenEndpointAuthMethod={tokenEndpointAuthMethod}
-          onClientIdChange={onClientIdChange}
-          onClientSecretChange={onClientSecretChange}
-          onTokenEndpointAuthMethodChange={onTokenEndpointAuthMethodChange}
-        />
+        <Stack gap={4}>
+          <RedirectURICallout />
+          <ClientCredentialsFields
+            showHeading={false}
+            clientId={clientId}
+            clientSecret={clientSecret}
+            tokenEndpointAuthMethod={tokenEndpointAuthMethod}
+            onClientIdChange={onClientIdChange}
+            onClientSecretChange={onClientSecretChange}
+            onTokenEndpointAuthMethodChange={onTokenEndpointAuthMethodChange}
+          />
+        </Stack>
       );
   }
 

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IssuerFormFields.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IssuerFormFields.tsx
@@ -29,8 +29,9 @@ function remoteLoginCallbackURL(): string {
 }
 
 // RedirectURICallout shows the redirect_uri operators must register on the
-// upstream provider's OAuth app before a Manual client's credentials will
-// work.
+// upstream provider's OAuth app before typed-in client credentials will
+// work. Rendered inside ClientCredentialsFields so both the Attach sheet's
+// Manual add path and the Modify sheet's existing-client edit path show it.
 function RedirectURICallout(): JSX.Element {
   const redirectURI = remoteLoginCallbackURL();
   return (
@@ -324,6 +325,8 @@ export function ClientCredentialsFields({
         </Stack>
       )}
 
+      <RedirectURICallout />
+
       <Stack gap={2}>
         <Label className="text-muted-foreground text-xs">Client ID</Label>
         {clientIdEditable ? (
@@ -461,18 +464,15 @@ export function ClientTypeFields({
       break;
     case "manual":
       credentials = (
-        <Stack gap={4}>
-          <RedirectURICallout />
-          <ClientCredentialsFields
-            showHeading={false}
-            clientId={clientId}
-            clientSecret={clientSecret}
-            tokenEndpointAuthMethod={tokenEndpointAuthMethod}
-            onClientIdChange={onClientIdChange}
-            onClientSecretChange={onClientSecretChange}
-            onTokenEndpointAuthMethodChange={onTokenEndpointAuthMethodChange}
-          />
-        </Stack>
+        <ClientCredentialsFields
+          showHeading={false}
+          clientId={clientId}
+          clientSecret={clientSecret}
+          tokenEndpointAuthMethod={tokenEndpointAuthMethod}
+          onClientIdChange={onClientIdChange}
+          onClientSecretChange={onClientSecretChange}
+          onTokenEndpointAuthMethodChange={onTokenEndpointAuthMethodChange}
+        />
       );
   }
 


### PR DESCRIPTION
## Summary

- Adds a copy-able "Redirect URI" callout to the Manual client credentials form under the Attach/Modify Remote Identity Provider sheets, so operators know what callback URL to register on an upstream OAuth app that has no dynamic client registration (e.g. X).
- The redirect URI is Gram's single stable `<serverURL>/mcp/remote_login_callback`, shared across all MCP servers — only surfaced for Manual clients, since DCR and CIMD already send/publish it automatically.

## Test plan

- [x] `pnpm -F dashboard type-check` — no new errors introduced (pre-existing unrelated errors on branch from stale generated SDK types)
- [ ] Visually verify the callout renders and copies correctly in the Attach Remote Identity Provider sheet (Manual client type)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copyable Redirect URI callout to the Manual client credentials form in the Remote Identity Provider sheets. It shows the fixed callback URL `<serverURL>/mcp/remote_login_callback` so operators can register it on upstream OAuth apps without dynamic client registration.

- **New Features**
  - Shows a “Redirect URI” box with a one-click copy button.
  - Only for Manual clients; DCR and CIMD already handle redirect URIs.
  - Renders above the credentials in both Attach and Modify sheets; implemented inside `ClientCredentialsFields` so both paths show it.

<sup>Written for commit 81fa70719f25f4146dc5f4644dc200d1f16846c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

