### PR TITLE
feat: send human display names to Claude Code plugin marketplaces (DNO-300)

### DIFF
--- a/.changeset/plugin-claude-display-names.md
+++ b/.changeset/plugin-claude-display-names.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Plugin marketplaces now send a human-readable `displayName` to Claude Code, so plugins show with their admin-entered name and capitalization (e.g. "MoonPay MCP Servers") instead of the de-slugified lowercase name ("Moonpay mcp servers"). The synthesized observability plugin displays as "<Org> Observability". The plugin `name` remains the kebab-case slug used for namespacing and claude.ai marketplace sync. Older Claude Code clients ignore the field and fall back to prior behavior.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -260,12 +260,14 @@ func GeneratePluginPackages(plugins []PluginInfo, cfg GenerateConfig) (map[strin
 		claudeObservability := ClaudeObservabilitySlug(cfg)
 		claudePlugins = append(claudePlugins, marketplaceEntry{
 			Name:        claudeObservability,
+			DisplayName: cfg.OrgName + " Observability",
 			Source:      "./" + claudeObservability,
 			Description: "Required: Speakeasy observability hooks for " + cfg.OrgName + ".",
 		})
 		cursorObservability := CursorObservabilitySlug(cfg)
 		cursorPlugins = append(cursorPlugins, marketplaceEntry{
 			Name:        cursorObservability,
+			DisplayName: "", // Cursor carries the display name in its own plugin.json.
 			Source:      cursorObservability,
 			Description: "Required: Speakeasy observability hooks for " + cfg.OrgName + ".",
 		})
@@ -295,11 +297,13 @@ func GeneratePluginPackages(plugins []PluginInfo, cfg GenerateConfig) (map[strin
 		}
 		claudePlugins = append(claudePlugins, marketplaceEntry{
 			Name:        p.Slug,
+			DisplayName: p.Name,
 			Source:      "./" + p.Slug,
 			Description: p.Description,
 		})
 		cursorPlugins = append(cursorPlugins, marketplaceEntry{
 			Name:        p.Slug + "-cursor",
+			DisplayName: "", // Cursor carries the display name in its own plugin.json.
 			Source:      p.Slug + "-cursor",
 			Description: p.Description,
 		})
@@ -588,6 +592,7 @@ func generateClaudeObservabilityPluginInDir(files map[string][]byte, subdir stri
 	}
 	pluginJSON, err := marshalJSON(claudePluginMeta{
 		Name:        name,
+		DisplayName: cfg.OrgName + " Observability",
 		Description: "Speakeasy observability hooks for " + cfg.OrgName + ". Install this plugin to forward tool events to your team's Speakeasy dashboard.",
 		Version:     pluginManifestVersion(cfg),
 		Author:      pluginAuthor{Name: cfg.OrgName, URL: "https://getgram.ai"},
@@ -2315,6 +2320,7 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 
 	pluginJSON, err := marshalJSON(claudePluginMeta{
 		Name:        p.Slug,
+		DisplayName: p.Name,
 		Description: p.Description,
 		Version:     pluginManifestVersion(cfg),
 		Author:      pluginAuthor{Name: cfg.OrgName, URL: "https://getgram.ai"},
@@ -2431,6 +2437,7 @@ type marketplaceOwner struct {
 
 type marketplaceEntry struct {
 	Name        string `json:"name"`
+	DisplayName string `json:"displayName,omitempty"`
 	Source      string `json:"source"`
 	Description string `json:"description"`
 }
@@ -2442,6 +2449,7 @@ type pluginAuthor struct {
 
 type claudePluginMeta struct {
 	Name        string                     `json:"name"`
+	DisplayName string                     `json:"displayName,omitempty"`
 	Description string                     `json:"description"`
 	Version     string                     `json:"version"`
 	Author      pluginAuthor               `json:"author"`

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -107,6 +107,57 @@ func TestGeneratePluginPackagesProducesExpectedFiles(t *testing.T) {
 	}
 }
 
+func TestGenerateClaudePluginEmitsHumanDisplayName(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name:        "MoonPay MCP Servers",
+			Slug:        "moonpay-mcp-servers",
+			Description: "MoonPay MCP servers",
+			Servers: []PluginServerInfo{
+				{DisplayName: "crm-tools", MCPURL: "https://app.getgram.ai/mcp/crm"},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:     "MoonPay",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "hooks-key", // triggers the synthesized observability plugin
+	})
+	require.NoError(t, err)
+
+	// plugin.json: name stays the kebab slug (used for namespacing/lookup);
+	// displayName carries the human-friendly, correctly-cased name Claude shows.
+	var pluginMeta claudePluginMeta
+	require.NoError(t, json.Unmarshal(files["moonpay-mcp-servers/.claude-plugin/plugin.json"], &pluginMeta))
+	require.Equal(t, "moonpay-mcp-servers", pluginMeta.Name)
+	require.Equal(t, "MoonPay MCP Servers", pluginMeta.DisplayName)
+
+	// marketplace.json entry mirrors the same contract.
+	var manifest marketplaceManifest
+	require.NoError(t, json.Unmarshal(files[".claude-plugin/marketplace.json"], &manifest))
+
+	entries := make(map[string]marketplaceEntry, len(manifest.Plugins))
+	for _, e := range manifest.Plugins {
+		entries[e.Name] = e
+	}
+
+	feature, ok := entries["moonpay-mcp-servers"]
+	require.True(t, ok, "feature plugin missing from marketplace.json")
+	require.Equal(t, "MoonPay MCP Servers", feature.DisplayName)
+
+	// The synthesized observability plugin gets a human display name too.
+	obs, ok := entries["moonpay-observability"]
+	require.True(t, ok, "observability plugin missing from marketplace.json")
+	require.Equal(t, "MoonPay Observability", obs.DisplayName)
+
+	var obsMeta claudePluginMeta
+	require.NoError(t, json.Unmarshal(files["moonpay-observability/.claude-plugin/plugin.json"], &obsMeta))
+	require.Equal(t, "moonpay-observability", obsMeta.Name)
+	require.Equal(t, "MoonPay Observability", obsMeta.DisplayName)
+}
+
 func TestGenerateClaudeMCPConfigAlwaysHasAuthHeaders(t *testing.T) {
 	t.Parallel()
 	plugins := []PluginInfo{


### PR DESCRIPTION
## What

Claude Code only ever received a plugin's lowercased kebab **slug** as its `name`, so the Claude UI de-slugified it for display — e.g. an admin's "MoonPay MCP Servers" showed up as "Moonpay mcp servers". Claude Code supports a `displayName` field (v2.1.143+, falling back to `name` on older clients), which our Cursor plugins already emit.

This PR emits `displayName` for the Claude surface so the admin-entered, correctly-cased name is what users see:

- Added `DisplayName` to the `marketplaceEntry` and `claudePluginMeta` structs (`json:"displayName,omitempty"`).
- **Feature plugins** → `displayName: p.Name` in both `marketplace.json` and `plugin.json`.
- **Observability plugin** → `displayName: "<OrgName> Observability"`.
- `name` stays the kebab slug (required for namespacing/lookup and claude.ai marketplace sync).
- Cursor/Codex entries unchanged (Cursor already carries its display name in its own `plugin.json`).

## Why

Closes DNO-300. Customer (Moonpay) reported plugin names entered correctly in Speakeasy weren't reflected with correct capitalization in Anthropic.

The ticket's secondary ask — short descriptions — is already supported end-to-end (editable in the dashboard, stored, and already sent to Claude via `description`); no change needed.

## Notes

- Older Claude Code clients ignore the unknown field and fall back to today's behavior (graceful degradation).
- Existing published marketplaces pick this up on their next publish/republish.

## Testing

- New `TestGenerateClaudePluginEmitsHumanDisplayName` asserts `name` stays the slug while `displayName` carries the human name, across `marketplace.json` + `plugin.json` for both a feature plugin and the observability plugin.
- Full `server/internal/plugins` package tests pass; `mise lint:server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send human-readable plugin names to Claude Code so users see correct casing in the marketplace and plugin details. Keeps slugs for lookup and namespacing; addresses DNO-300.

- **New Features**
  - Emit `displayName` in Claude `marketplace.json` and `.claude-plugin/plugin.json` (feature plugins use the admin name; observability uses "<OrgName> Observability").
  - Keep `name` as the kebab-case slug; Cursor entries unchanged.
  - Add tests to confirm `displayName` is used while `name` stays the slug; older Claude clients fall back to `name`.
  - Add changeset for a minor `server` release.

<sup>Written for commit 2ff51541605932b26ce301bd41b774b2a7d4d884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

