### PR TITLE
feat(rbac): gate risk event secret reveal behind chat:read

### DIFF
--- a/.changeset/chat-read-risk-reveal.md
+++ b/.changeset/chat-read-risk-reveal.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Gate the "click to reveal" secret action in Risk Events behind the `chat:read` scope. Users without `chat:read` now see flagged secret values as a non-interactive "Hidden" placeholder (with an explanatory tooltip) instead of a reveal control, and the page-level "Reveal all" toggle is hidden for them. The `chat:read` scope description in the role editor is updated to note that the grant also controls unmasking flagged secrets in Risk Events.

--- a/client/dashboard/src/pages/security/risk-ui.tsx
+++ b/client/dashboard/src/pages/security/risk-ui.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, Lock } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -16,6 +16,15 @@ import {
   useRevealAll,
   type RevealAllContextValue,
 } from "./reveal-all-context";
+import { useRBAC, type Scope } from "@/hooks/useRBAC";
+
+// Revealing a flagged secret exposes the raw value captured from agent/chat
+// traffic, so it is gated behind the same `chat:read` scope that grants access
+// to other members' session transcripts. hasScope short-circuits to true when
+// RBAC is disabled, preserving existing behavior for non-RBAC orgs.
+const REVEAL_SCOPE: Scope = "chat:read";
+const REVEAL_DENIED_REASON =
+  "You need the chat:read scope to reveal flagged values.";
 
 export function CategoryLabel({
   source,
@@ -85,8 +94,11 @@ export function RevealAllToggle({
 }: {
   className?: string;
 }): JSX.Element | null {
+  const { hasScope } = useRBAC();
   const ctx = useRevealAll();
   if (!ctx) return null;
+  // No point offering a reveal-all control when every value stays masked.
+  if (!hasScope(REVEAL_SCOPE)) return null;
   const { revealAll, setRevealAll } = ctx;
   return (
     <SimpleTooltip
@@ -114,6 +126,8 @@ export function MaskedMatch({
 }: {
   value: string | undefined;
 }): JSX.Element {
+  const { hasScope } = useRBAC();
+  const canReveal = hasScope(REVEAL_SCOPE);
   const ctx = useRevealAll();
   const generation = ctx?.generation;
   const revealAll = ctx?.revealAll ?? false;
@@ -130,6 +144,19 @@ export function MaskedMatch({
   }, [generation, revealAll]);
 
   if (!value) return <span>-</span>;
+
+  // Without chat:read the value can never be revealed — render a static,
+  // non-interactive placeholder so reveal-all can't flip it open either.
+  if (!canReveal) {
+    return (
+      <SimpleTooltip tooltip={REVEAL_DENIED_REASON}>
+        <span className="text-muted-foreground inline-flex items-center gap-1 text-xs">
+          <Lock className="h-3 w-3" />
+          <span>Hidden</span>
+        </span>
+      </SimpleTooltip>
+    );
+  }
 
   if (!revealed) {
     return (

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -259,7 +259,7 @@ func (s *Service) ListScopes(ctx context.Context, _ *gen.ListScopesPayload) (*ge
 		{scope: authz.ScopeEnvironmentBlockedWrite, description: "Store exceptions for environment write access.", resourceType: "environment"},
 		{scope: authz.ScopeRiskPolicyEvaluate, description: "Evaluate risk policies.", resourceType: "risk_policy"},
 		{scope: authz.ScopeRiskPolicyBypass, description: "Bypass risk policies.", resourceType: "risk_policy"},
-		{scope: authz.ScopeChatRead, description: "Read every member's agent session transcripts. Members can always read their own sessions, no one else's; this grant adds access to everyone else's.", resourceType: "chat"},
+		{scope: authz.ScopeChatRead, description: "Read every member's agent session transcripts and reveal the secret values flagged in Risk Events. Members can always read their own sessions, no one else's; this grant adds access to everyone else's sessions and to unmasking flagged secrets.", resourceType: "chat"},
 	}
 	result := make([]*gen.ScopeDefinition, 0, len(scopes))
 	for _, scope := range scopes {


### PR DESCRIPTION
Linear: [AIS-245](https://linear.app/speakeasy/issue/AIS-245/feat-gate-risk-resultsmatch-reveal-behind-chatread-scope-with-a)

## What

Gate the "click to reveal" secret action in **Risk Events** behind the `chat:read` scope (client-side), and clarify the `chat:read` scope description in the role editor.

Follow-up to #3688 (which introduced `chat:read` to gate agent-session transcripts). Revealing a flagged secret exposes the same raw value captured from agent/chat traffic, so it's now gated by the same scope.

## Changes

- **`risk-ui.tsx`** — the shared reveal component used by the `RiskEvents` and `RiskOverviewCategoryDetail` pages:
  - `MaskedMatch` renders a non-interactive **🔒 Hidden** placeholder (with an explanatory tooltip) when the caller lacks `chat:read`. The check sits before the reveal path, so the page-level "Reveal all" can't flip it open either.
  - `RevealAllToggle` is hidden entirely for callers without the scope (nothing left to reveal).
- **`server/internal/access/impl.go`** — reworded the `chat:read` scope description shown in the `/access/roles` edit-role popout to spell out both impacts (reading others' sessions **and** unmasking flagged secrets in Risk Events).

## Notes

- **Client-side only, by request.** The raw `result.match` values are still present in the `listRiskResults` API response — this deters the UI reveal but is not a server-enforced secret boundary. A follow-up can redact `match` server-side for callers lacking `chat:read` if true enforcement is wanted.
- **No behavior change for non-RBAC orgs.** `useRBAC().hasScope()` short-circuits to `true` when RBAC is disabled, so only RBAC-enabled orgs without an explicit `chat:read` grant see the redacted state.

## Testing

- Dashboard `tsc -b --noEmit --force` (after building SDK + elements): 0 errors.
- `oxfmt --check` clean · `oxlint --type-aware` exit 0.
- `go build ./server/internal/access/` clean; no test asserts the description text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1pRhuajQ9dqqyAr7Ezwao
