### PR TITLE
feat(admin): default the toolkit to the Info tab

### DIFF
--- a/client/dashboard/src/components/platform-admin-toolbar.tsx
+++ b/client/dashboard/src/components/platform-admin-toolbar.tsx
@@ -275,7 +275,7 @@ export function PlatformAdminToolbar(): ReactElement | null {
 function PlatformAdminToolbarInner({ onHide }: { onHide: () => void }) {
   const [state, setState] = useState<OverrideState>(loadState);
   const [collapsed, setCollapsed] = useState(true);
-  const [activeTab, setActiveTab] = useState("rbac");
+  const [activeTab, setActiveTab] = useState("info");
   const [pos, setPos] = useState<{ x: number; y: number } | null>(loadPosition);
   const [platformAdmin, setPlatformAdmin] = useState(
     () => localStorage.getItem(PLATFORM_ADMIN_KEY) === "1",
@@ -552,6 +552,14 @@ function PlatformAdminToolbarInner({ onHide }: { onHide: () => void }) {
             <div className="flex overflow-x-auto border-b border-inherit px-2">
               <button
                 type="button"
+                onClick={() => setActiveTab("info")}
+                className={tabClass(activeTab === "info")}
+              >
+                <Info className="h-3 w-3" />
+                Info
+              </button>
+              <button
+                type="button"
                 onClick={() => setActiveTab("rbac")}
                 className={tabClass(activeTab === "rbac")}
               >
@@ -562,14 +570,6 @@ function PlatformAdminToolbarInner({ onHide }: { onHide: () => void }) {
                     {activeCount}/{SCOPE_DEFS.length}
                   </span>
                 )}
-              </button>
-              <button
-                type="button"
-                onClick={() => setActiveTab("info")}
-                className={tabClass(activeTab === "info")}
-              >
-                <Info className="h-3 w-3" />
-                Info
               </button>
               <button
                 type="button"


### PR DESCRIPTION
Make Info the first, default-selected tab (RBAC moves to second) so the org switcher and org override are visible without clicking into a tab.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the Platform Admin toolbar to the Info tab and move RBAC to second, so the org switcher and org override are visible immediately.
Updates the default active tab from "rbac" to "info" and reorders the tab buttons to put Info first.

<sup>Written for commit d5704f6575dcfb01c24fbe11c29ee3769baada43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

