### PR TITLE
chore(ci): authenticate to Docker Hub in build workflows

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,10 +1,12 @@
 server:
+  - ".github/**"
   - "go.mod"
   - "go.sum"
   - "agents/**"
   - "server/**"
 
 client:
+  - ".github/**"
   - "client/**"
   - "package.json"
   - "pnpm-lock.yaml"
@@ -13,6 +15,7 @@ client:
   - "sdks/typescript/**"
 
 functions:
+  - ".github/**"
   - "go.mod"
   - "go.sum"
   - "functions/**"
@@ -58,11 +61,13 @@ db-migrations:
   - "server/clickhouse/migrations/**"
 
 plog:
+  - ".github/**"
   - "go.mod"
   - "go.sum"
   - "plog/**"
 
 infra:
+  - ".github/**"
   - "go.mod"
   - "go.sum"
   - "infra/**"
@@ -75,6 +80,7 @@ infra:
   - ".mise-tasks/gen/infra.sh"
 
 pystreams:
+  - ".github/**"
   - "uv.lock"
   - "pyproject.toml"
   - "pystreams/**"

--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -40,6 +40,12 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
+    - name: Log in to Docker Hub
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Generate preview tag
       id: preview-tag
       shell: bash

--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -2,6 +2,12 @@ name: "Build and Push image"
 description: "Composite action to generate registry images"
 
 inputs:
+  hub-username:
+    required: true
+    description: "Docker Hub username"
+  hub-token:
+    required: true
+    description: "Docker Hub token"
   registry:
     description: "Image registry to use"
     required: true
@@ -43,8 +49,8 @@ runs:
     - name: Log in to Docker Hub
       uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ inputs.hub-username }}
+        password: ${{ inputs.hub-token }}
 
     - name: Generate preview tag
       id: preview-tag

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -400,6 +400,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - id: assistantGcrAuth
         name: "Authenticate to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -556,6 +562,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "[DEV] Login to Fly registry"
         env:
@@ -1608,6 +1620,12 @@ jobs:
       - name: Set up Docker Buildx
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract Docker metadata
         if: github.event.pull_request.user.login != 'dependabot[bot]'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -260,6 +260,8 @@ jobs:
         id: build
         uses: ./.github/workflows/composite/build-push
         with:
+          hub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          hub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
@@ -313,6 +315,8 @@ jobs:
         id: build
         uses: ./.github/workflows/composite/build-push
         with:
+          hub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          hub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
@@ -1266,6 +1270,8 @@ jobs:
         id: build
         uses: ./.github/workflows/composite/build-push
         with:
+          hub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          hub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}


### PR DESCRIPTION
Closes AGE-2391

Unauthenticated pulls share a low per-IP rate limit on Docker Hub, so image pulls in CI intermittently fail with "too many requests" once the shared runner pool exhausts the quota. Logging in with credentials moves these jobs onto the higher authenticated pull limit, making the build and deploy pipelines reliable.