### PR TITLE
chore(pystreams): rename event-loop lag metric to python.event_loop.lag

### DIFF
--- a/pystreams/src/pystreams/deps/blocking.py
+++ b/pystreams/src/pystreams/deps/blocking.py
@@ -36,7 +36,7 @@ _meter = metrics.get_meter("github.com/speakeasy-api/gram/pystreams")
 # incrementing is cheap; once a provider is installed the count flows out wherever
 # metrics are collected.
 _violations_counter = _meter.create_counter(
-    "pystreams.event_loop.blocking_violations",
+    "python.event_loop.blocking_violations",
     unit="{violation}",
     description="Blocking-IO violations detected on the event loop, by severity.",
 )

--- a/pystreams/src/pystreams/deps/loop_lag.py
+++ b/pystreams/src/pystreams/deps/loop_lag.py
@@ -28,7 +28,7 @@ _meter = metrics.get_meter("github.com/speakeasy-api/gram/pystreams")
 
 # Distribution of event-loop scheduling delay, in seconds.
 _lag_histogram = _meter.create_histogram(
-    "pystreams.event_loop.lag",
+    "python.event_loop.lag",
     unit="s",
     description=(
         "Delay between when a loop timer was scheduled to fire and when the "


### PR DESCRIPTION
Aligns the pystreams event-loop metrics under a shared `python.*` namespace so they group with other language-runtime metrics rather than the pystreams service-specific prefix.

Both event-loop metrics are renamed:

- `pystreams.event_loop.lag` → `python.event_loop.lag`
- `pystreams.event_loop.blocking_violations` → `python.event_loop.blocking_violations`

Histogram/counter semantics, labels, and units are unchanged; only the metric names changed. Update any dashboards or alerts that reference the old names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the event-loop lag histogram from `pystreams.event_loop.lag` to `python.event_loop.lag` so it groups with other language-runtime metrics. Update any dashboards or alerts that reference the old name.

- **Migration**
  - Replace `pystreams.event_loop.lag` with `python.event_loop.lag` in dashboards, alerts, and queries.
  - Histogram semantics, labels, and unit (`s`) are unchanged; only the metric name changed.

<sup>Written for commit 6d0b413d4d6fb4f9548f9ceccb6083d73f3769bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
