### PR TITLE
feat: show chat title in most-costly-sessions widget

### DIFF
--- a/client/dashboard/src/pages/costs/CostWidgets.tsx
+++ b/client/dashboard/src/pages/costs/CostWidgets.tsx
@@ -197,12 +197,16 @@ type MixRow = { label: string; cost: number };
 // hover) when `onSelect` is supplied, so the user can drill straight into it.
 function MixRowItem({
   label,
+  sublabel,
+  clampTitle,
   cost,
   barPct,
   barColor,
   onSelect,
 }: {
   label: string;
+  sublabel?: string;
+  clampTitle?: boolean;
   cost: number;
   barPct: number;
   barColor: string;
@@ -210,9 +214,22 @@ function MixRowItem({
 }): JSX.Element {
   const inner = (
     <>
-      <div className="flex items-center justify-between gap-2 text-sm">
-        <span className="truncate">{label || "(unset)"}</span>
-        <span className="text-muted-foreground tabular-nums">
+      <div className="flex items-start justify-between gap-2 text-sm">
+        <span className="min-w-0">
+          <span
+            className={
+              clampTitle ? "line-clamp-2 text-[13px]" : "block truncate"
+            }
+          >
+            {label || "(unset)"}
+          </span>
+          {sublabel ? (
+            <span className="text-muted-foreground block truncate text-xs">
+              {sublabel}
+            </span>
+          ) : null}
+        </span>
+        <span className="text-muted-foreground shrink-0 tabular-nums">
           {formatCost(cost)}
         </span>
       </div>
@@ -347,6 +364,8 @@ function SessionsCard({
               <MixRowItem
                 key={r.id}
                 label={r.label}
+                sublabel={r.sublabel}
+                clampTitle
                 cost={r.cost}
                 barPct={(r.cost / max) * 100}
                 barColor={gradeColor(t)}
@@ -453,7 +472,12 @@ type StatCardSpec = {
   caption?: string;
   loading: boolean;
 };
-type SessionRow = { id: string; label: string; cost: number };
+type SessionRow = {
+  id: string;
+  label: string;
+  sublabel?: string;
+  cost: number;
+};
 type SessionsCardSpec = {
   kind: "sessions";
   title: string;

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -753,7 +753,13 @@ export function CostsExplorer(): JSX.Element {
     title: "Most costly sessions",
     rows: (topSessionsData?.sessions ?? []).map((s) => ({
       id: s.gramChatId,
-      label: s.userEmail?.length ? s.userEmail : s.gramChatId.slice(0, 8),
+      label: s.title?.length ? s.title : s.gramChatId.slice(0, 8),
+      sublabel:
+        groupBy !== Dimension.Email &&
+        currentEntity?.dim !== Dimension.Email &&
+        s.userEmail?.length
+          ? s.userEmail
+          : undefined,
       cost: s.totalCost,
     })),
     loading: topSessionsFetching && !topSessionsData,


### PR DESCRIPTION
## Summary

- "Most costly sessions" widget on the cost attribution page now shows the chat title as the primary row label instead of the user's email.
- The email is shown as a secondary line below the title, except when the current view is already scoped to a single user (breaking down by user, or viewing a user's profile) where it's redundant.
- Title is clamped to 2 lines to keep row heights predictable for long titles.

## Test plan

- [x] `pnpm -F dashboard type-check` passes
- [ ] Manually verify widget on org-level, department-level, and user-breakdown levels of the cost attribution page


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the chat title as the primary label in the “Most costly sessions” widget to make sessions easier to recognize. The user email now appears as a secondary line only when the view isn’t already scoped to a single user.

- **New Features**
  - Use session title as the main label; fallback to the first 8 chars of `gramChatId` if missing.
  - Show user email as a sublabel unless grouped by user or on a user profile view.
  - Clamp titles to 2 lines for consistent row height.

<sup>Written for commit 4dfacab699b7f1013a6eabdbb26efb2107400bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

