### PR TITLE
mig: add global slug uniqueness index for remote session issuers

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -917,6 +917,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS remote_session_issuers_project_slug_key
 ON remote_session_issuers (project_id, slug)
 WHERE deleted IS FALSE;
 
+-- Slug uniqueness for global issuers (project_id NULL AND organization_id NULL).
+-- The (project_id, slug) index above treats every NULL project_id as distinct,
+-- so it does not constrain globals; this partial index keeps global slugs unique
+-- across the shared catalog.
+CREATE UNIQUE INDEX IF NOT EXISTS remote_session_issuers_global_slug_key
+ON remote_session_issuers (slug)
+WHERE deleted IS FALSE AND project_id IS NULL AND organization_id IS NULL;
+
 CREATE INDEX IF NOT EXISTS remote_session_issuers_organization_id_idx
 ON remote_session_issuers (organization_id)
 WHERE deleted IS FALSE;

--- a/server/migrations/20260630213745_remote-session-issuers-global-slug-key.sql
+++ b/server/migrations/20260630213745_remote-session-issuers-global-slug-key.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "remote_session_issuers_global_slug_key" to table: "remote_session_issuers"
+CREATE UNIQUE INDEX CONCURRENTLY "remote_session_issuers_global_slug_key" ON "remote_session_issuers" ("slug") WHERE ((deleted IS FALSE) AND (project_id IS NULL) AND (organization_id IS NULL));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:epCzB8y8vZlF9Ost/yC1wu8VxmaKDeWuGR5+HhAGNLo=
+h1:desOlKDmtw1FP4GSsri1BdunValCUMKd6DDIwVneLro=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -235,3 +235,4 @@ h1:epCzB8y8vZlF9Ost/yC1wu8VxmaKDeWuGR5+HhAGNLo=
 20260629082301_risk-policies-analyzer-config.sql h1:RcX/MVJeVwIUIWxh02Z9WyAF1cfnelNLrYStdv+xrh8=
 20260629215311_add-personal-account-tracking.sql h1:h9gGKAfEoYa7g1cup/mf4ukQeNiKeZ6IQvxjfcNALKQ=
 20260630164757_device-owners-org-cascade-index.sql h1:xBf3zD9ROt6m/QG74HU1GnRSsM64e6zVSoeN3jQPTi8=
+20260630213745_remote-session-issuers-global-slug-key.sql h1:2fXBIcMhRXsLIGrvLEXmzJ0qncFXF7ZI3RbSglU5z5Q=


### PR DESCRIPTION
## What

Adds partial unique index `remote_session_issuers_global_slug_key` on `remote_session_issuers (slug)` `WHERE deleted IS FALSE AND project_id IS NULL AND organization_id IS NULL`.

Created `CONCURRENTLY` (`-- atlas:txmode none`).

## Why: the state we're preventing

**Bad state to avoid:** two or more active issuer rows that are all _global_ (`project_id IS NULL AND organization_id IS NULL`) and share the same `slug`.

Note up front: globals are **not** slug-addressable at runtime. Like organization-level issuers, they're fetched by id (`GetGlobalRemoteSessionIssuerByID`); there is no `...BySlug` query for them (only project-scoped issuers are slug-addressable, per the comment on `GetRemoteSessionIssuerBySlug`). So this index is **not** about disambiguating a runtime lookup. It buys two things:

1. **Catalog integrity.** Global issuers are a curated, platform-wide catalog maintained by Speakeasy (HubSpot, Google Workspace, …). `slug` is the human-facing stable handle. Two active globals with the same slug is a curation defect: it shows up as a confusing duplicate in the admin surface and muddies any slug-keyed selection an operator makes.
2. **A race-safe 409.** The admin create/update path checks "does this global slug already exist?" with a `SELECT`, then inserts. Without a DB constraint that check is TOCTOU-racy. The unique index is what actually guarantees at most one active global per slug and lets the handler return a clean `409 Conflict` (`isGlobalRemoteSessionIssuerSlugConflict`) instead of silently creating a duplicate.

Aside on the scope asymmetry: org-level issuer slugs are intentionally _not_ uniqueness-constrained (org issuers aren't slug-addressable). Constraining global slugs is a deliberate product choice for the curated catalog, not a correctness requirement inherited from org issuers.

### Why today's indexes don't prevent it

The only existing guard is `remote_session_issuers_project_slug_key` on `(project_id, slug)`. A multi-column unique index treats every `NULL` `project_id` as **distinct**, so it never constrains rows with a NULL `project_id` — including globals. Org-level issuers also have `project_id NULL`, but they carry a non-null `organization_id`, so they're deliberately _excluded_ from this new index by the `organization_id IS NULL` clause.

### How a duplicate could actually arise

It cannot happen on `main` today (no code path inserts a both-NULL row — project create and org create both set `organization_id`, and the global create path is unshipped). This index goes in **first**, before that path exists, precisely so the window below never opens:

1. The global-issuer create path ships in the follow-up `adminRemoteSessions` PR (reusing the plain `CreateRemoteSessionIssuer` INSERT), **without** this index in place.
2. A Speakeasy admin creates a global issuer with slug `hubspot` → row A (`project_id NULL`, `organization_id NULL`, `slug = hubspot`).
3. A second create for slug `hubspot` is submitted. The handler does an application-level "does this global slug already exist?" `SELECT` first, but under concurrency two requests both run that check _before_ either INSERT commits (a classic TOCTOU race), so both see "no conflict."
4. Both INSERTs succeed. The `(project_id, slug)` index accepts them (NULL project_id ⇒ distinct), and there's no other constraint. Result: **two active global `hubspot` issuers** — the bad state. The intended 409 guard never fired.

**With this index:** step 4's second INSERT (or the losing racer) violates `remote_session_issuers_global_slug_key`; the handler maps that violation to a `409 Conflict`, and at most one active global issuer per slug can ever exist — even under concurrent creates.

### Preflight (expected: 0 rows)

Because the guarded set is empty pre-feature, the concurrent index build has nothing to collide with. Confirm before promoting to any environment:

```sql
SELECT slug, count(*) FROM remote_session_issuers
WHERE deleted IS FALSE AND project_id IS NULL AND organization_id IS NULL
GROUP BY slug HAVING count(*) > 1;
```

(And the build is non-blocking regardless: `CREATE UNIQUE INDEX CONCURRENTLY` takes no blocking lock and, on a duplicate, leaves an `INVALID` index to drop/dedupe/recreate rather than causing an outage.)

## Scope

Migration-only PR per the postgresql skill: `schema.sql` + the generated migration + `atlas.sum`, no application logic. The backend service, SDK, and dashboard that consume this ship in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## <!-- This is an auto-generated description by cubic. -->

## Summary by cubic

Add a partial unique index to enforce global slug uniqueness for `remote_session_issuers`. This prevents duplicate platform-wide slugs and supports the 409-on-conflict path in the upcoming `adminRemoteSessions` service.

- **Migration**
  - Create unique partial index `remote_session_issuers_global_slug_key` on `(slug)` where `deleted IS FALSE AND project_id IS NULL AND organization_id IS NULL`, created concurrently (`-- atlas:txmode none`).

<sup>Written for commit d4eaac7824f51d56a9a801e311ae018684d7cdf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
