### PR TITLE
feat(dashboard): preserve history when reopening assistant setup threads

### DIFF
--- a/.changeset/shaggy-pugs-repeat.md
+++ b/.changeset/shaggy-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+feat(dashboard): preserve history when reopening assistant setup threads

--- a/client/dashboard/src/lib/local-storage-keys.ts
+++ b/client/dashboard/src/lib/local-storage-keys.ts
@@ -3,3 +3,10 @@ export const PROJECT_FAVORITES_STORAGE_PREFIX = "gram:org-favorites:";
 // Command-palette "Recently Visited" pages. User-scoped, so safe to keep across
 // logout (a different user reads their own key); preserved like favorites.
 export const RECENTS_STORAGE_PREFIX = "gram:recents:";
+// Maps an assistant to the chat id of its onboarding "setup" thread so
+// reopening the assistant's setup restores the prior conversation. The setup
+// chat is a plain project chat (not linked to the assistant server-side), so
+// there's no server query for it — the mapping lives here. Not preserved across
+// logout: it's project/assistant data that shouldn't leak to another user.
+export const ASSISTANT_SETUP_THREAD_STORAGE_PREFIX =
+  "gram:assistant-setup-thread:";

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -12,11 +12,17 @@ import {
 import { useListToolsets } from "@gram/client/react-query";
 import { useChatSessionsCreateMutation } from "@gram/client/react-query/chatSessionsCreate.js";
 import { ResizablePanel, useMoonshineConfig } from "@speakeasy-api/moonshine";
+import { useAssistantRuntime, useAssistantState } from "@assistant-ui/react";
 import { Loader2 } from "lucide-react";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { AssistantDraftProvider } from "./AssistantDraftContext";
+import {
+  clearSetupThreadId,
+  readSetupThreadId,
+  writeSetupThreadId,
+} from "./setupThreadStorage";
 import { useAssistantDraft } from "./useAssistantDraft";
 import { AssistantDraftPanel } from "./AssistantDraftPanel";
 import {
@@ -107,7 +113,18 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
   const { theme: resolvedTheme } = useMoonshineConfig();
   const [searchParams] = useSearchParams();
 
-  const initialThreadId = searchParams.get("threadId") ?? undefined;
+  // The chat backing this assistant's setup conversation, resolved once at
+  // mount: an explicit ?threadId (a shared link) wins, otherwise the thread we
+  // remembered for this assistant so reopening its setup restores the history.
+  // undefined starts a fresh thread — the case in "create" mode, where no
+  // assistant exists yet.
+  const [setupThreadId] = useState<string | undefined>(() => {
+    const fromUrl = searchParams.get("threadId");
+    if (fromUrl) return fromUrl;
+    return draft.assistantId
+      ? (readSetupThreadId(project.id, draft.assistantId) ?? undefined)
+      : undefined;
+  });
 
   const onboarding = useOnboardingTools();
 
@@ -220,7 +237,10 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
           history: {
             enabled: true,
             showThreadList: false,
-            initialThreadId,
+            // Reopening the remembered thread is driven by <SetupChatSurface>
+            // below rather than config.initialThreadId: the built-in switch
+            // fires on a fixed 100ms timer that races chat.list and silently
+            // no-ops on a cold load, which is exactly the reopen path here.
           },
           thread: {
             showFeedback: false,
@@ -253,10 +273,105 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
           },
         }}
       >
-        <div className="h-full overflow-hidden">
-          <Chat />
-        </div>
+        <SetupChatSurface
+          projectId={project.id}
+          assistantId={draft.assistantId}
+          target={setupThreadId}
+        />
       </GramElementsProvider>
+    </div>
+  );
+}
+
+// assistant-ui's prefix for local (unpersisted) thread ids. `remoteId` is
+// normally a server chat id, but guard against ever persisting a local id.
+const LOCAL_THREAD_ID_PREFIX = "__LOCALID_";
+
+// Upper bound on how long the surface waits for a reopen switch before showing
+// the chat anyway, so a slow or wedged switch never blocks the composer.
+const REOPEN_TIMEOUT_MS = 6000;
+
+/**
+ * Hosts the onboarding <Chat> and keeps the setup conversation stable across
+ * reopens. Rendered inside GramElementsProvider so it can drive the runtime:
+ *
+ * - Reopen: when `target` names a remembered thread, switch to it once the
+ *   thread list has settled (the same reliable pattern the full chat page uses,
+ *   rather than the racy config.initialThreadId timer). A loader holds the
+ *   surface back until the thread binds, with a failure/timeout escape so a
+ *   stale id never wedges the page.
+ * - Persist: as the active thread adopts a server chat id, remember it against
+ *   the assistant so the next open reopens the same conversation.
+ */
+function SetupChatSurface({
+  projectId,
+  assistantId,
+  target,
+}: {
+  projectId: string;
+  assistantId: string | null;
+  target: string | undefined;
+}): JSX.Element {
+  const runtime = useAssistantRuntime();
+  const isListLoading = useAssistantState(({ threads }) => threads.isLoading);
+  const activeRemoteId = useAssistantState(
+    ({ threadListItem }) => threadListItem.remoteId ?? null,
+  );
+
+  // Nothing to reopen (create mode, first-time setup, shared-link miss) → ready
+  // immediately. Otherwise hold back until the target thread is active.
+  const [reopened, setReopened] = useState(!target);
+  const switchStartedRef = useRef(false);
+
+  useEffect(() => {
+    if (!target || switchStartedRef.current || isListLoading) return;
+    switchStartedRef.current = true;
+    if (activeRemoteId === target) {
+      setReopened(true);
+      return;
+    }
+    runtime.threads
+      .switchToThread(target)
+      .then(() => setReopened(true))
+      .catch(() => {
+        // The remembered chat no longer resolves (deleted, wrong project) —
+        // forget it and fall back to the fresh thread already active.
+        if (assistantId) clearSetupThreadId(projectId, assistantId);
+        setReopened(true);
+      });
+  }, [target, isListLoading, activeRemoteId, runtime, assistantId, projectId]);
+
+  useEffect(() => {
+    if (reopened) return;
+    const timer = setTimeout(() => setReopened(true), REOPEN_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [reopened]);
+
+  // Remember the active thread against the assistant for the next reopen. Skips
+  // local ids and waits until the assistant exists (created mid-conversation in
+  // "create" mode), so the first thing persisted is a real, reopenable chat.
+  useEffect(() => {
+    if (
+      !assistantId ||
+      !activeRemoteId ||
+      activeRemoteId.startsWith(LOCAL_THREAD_ID_PREFIX)
+    ) {
+      return;
+    }
+    writeSetupThreadId(projectId, assistantId, activeRemoteId);
+  }, [assistantId, activeRemoteId, projectId]);
+
+  const showLoader = !reopened && activeRemoteId !== target;
+
+  return (
+    <div className="h-full overflow-hidden">
+      {showLoader ? (
+        <div className="flex h-full items-center justify-center">
+          <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+        </div>
+      ) : (
+        <Chat />
+      )}
     </div>
   );
 }

--- a/client/dashboard/src/pages/assistants/onboarding/setupThreadStorage.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/setupThreadStorage.ts
@@ -1,0 +1,53 @@
+import { ASSISTANT_SETUP_THREAD_STORAGE_PREFIX } from "@/lib/local-storage-keys";
+
+// Remembers which chat backs an assistant's onboarding "setup" thread, so
+// reopening the assistant's setup restores the prior conversation instead of
+// starting a fresh one. The setup chat is a plain project chat created through
+// the completions proxy — it isn't linked to the assistant server-side, so
+// `chat.list?assistant_id` never returns it and there's no server-side lookup.
+// We persist the (project, assistant) → chat id mapping client-side instead.
+//
+// All access is wrapped in try/catch: localStorage throws in private-mode
+// Safari and when the quota is exceeded, and losing the mapping only degrades
+// to the pre-existing "starts a new thread" behaviour, never breaks the page.
+
+function storageKey(projectId: string, assistantId: string): string {
+  return `${ASSISTANT_SETUP_THREAD_STORAGE_PREFIX}${projectId}:${assistantId}`;
+}
+
+export function readSetupThreadId(
+  projectId: string,
+  assistantId: string,
+): string | null {
+  if (!assistantId) return null;
+  try {
+    return window.localStorage.getItem(storageKey(projectId, assistantId));
+  } catch {
+    return null;
+  }
+}
+
+export function writeSetupThreadId(
+  projectId: string,
+  assistantId: string,
+  chatId: string,
+): void {
+  if (!assistantId || !chatId) return;
+  try {
+    window.localStorage.setItem(storageKey(projectId, assistantId), chatId);
+  } catch {
+    // Ignore — see module comment.
+  }
+}
+
+export function clearSetupThreadId(
+  projectId: string,
+  assistantId: string,
+): void {
+  if (!assistantId) return;
+  try {
+    window.localStorage.removeItem(storageKey(projectId, assistantId));
+  } catch {
+    // Ignore — see module comment.
+  }
+}


### PR DESCRIPTION
Reopening an assistant's setup (`/assistants/:assistantId`) started a brand-new thread every time, discarding the prior setup conversation from view.

**Root cause:** the onboarding "setup" chat is a plain project chat (created through the completions proxy, not linked to the assistant server-side), and `ChatPane` only ever read the initial thread from a `?threadId` URL param that nothing ever set. The conversation still existed server-side — it was just orphaned from the UI, since `chat.list?assistant_id` never returns these chats.

**Fix (frontend-only):** remember the setup thread's chat id per-assistant in `localStorage`, and on reopen reliably switch the Elements runtime to it once the thread list has loaded — mirroring the proven switch logic in the full chat page (`Chat.tsx`) rather than the racy built-in `config.initialThreadId` timer, which fires on a fixed 100ms delay that races `chat.list` and silently no-ops on a cold load.

- An explicit `?threadId` (shared link) still takes precedence.
- A stale/deleted remembered id falls back to a fresh thread instead of wedging the page (failure + timeout escape on the reopen switch).
- The mapping clears on logout with the rest of project-scoped storage.

**Files**
- `setupThreadStorage.ts` — per-assistant read/write/clear helper (new).
- `AssistantOnboarding.tsx` — resolve the initial target thread, and add `<SetupChatSurface>` to reopen + persist inside the Elements provider.
- `local-storage-keys.ts` — new storage-key prefix.

**Limitation / possible follow-up:** the mapping is per-browser (`localStorage`). Reopening on a different device/browser still starts fresh. A cross-device fix would require linking the onboarding chat to the assistant server-side (e.g. an `assistant_threads` row for the setup chat) so it's retrievable via `chat.list?assistant_id` — a larger change left out of scope here.

**Testing:** `pnpm -F dashboard type-check` and `pnpm -F dashboard lint` pass. Not yet manually verified in a running dashboard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the setup chat history when reopening `/assistants/:assistantId` by remembering the onboarding thread and switching to it after the thread list loads. Meets Linear AGE-2891.

- **Bug Fixes**
  - Store the per-assistant setup chat id in `localStorage` under `ASSISTANT_SETUP_THREAD_STORAGE_PREFIX` (cleared on logout).
  - On open, choose the target thread in this order: `?threadId` > remembered id > new; switch via the `@assistant-ui/react` runtime after the list settles (avoids the `config.initialThreadId` race).
  - Hold the surface with a loader until the target binds; timeout after 6s, clear a stale id, and fall back to a new thread to keep the page responsive.
  - Persist the active server chat id when available and ignore local-only ids.

<sup>Written for commit 2be974e8532991e3d9f8377fb6a5bfb81698164b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

