### PR TITLE
fix: omit permissionDecision on non-blocking Claude PreToolUse paths (DNO-386)

### DIFF
--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -851,7 +851,6 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 		}
 	}
 
-	allow := "allow"
 	deny := "deny"
 	result := makeHookResult(payload.HookEventName)
 	output, _ := result.HookSpecificOutput.(*HookSpecificOutput)
@@ -873,10 +872,11 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 		rawToolName = *payload.ToolName
 	}
 	parsed := parseClaudeToolName(rawToolName)
+	// Non-blocking paths must leave permissionDecision unset. An explicit
+	// "allow" makes Claude Code skip the user's own permission prompts
+	// entirely — silently disabling their allowlists and ask rules (DNO-386).
+	// Omitting the field defers to the client's normal permission flow.
 	if !parsed.IsMCP {
-		if output != nil {
-			output.PermissionDecision = &allow
-		}
 		return result, nil
 	}
 	serverPrefix := parsed.Server
@@ -930,9 +930,6 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 
 	policy := s.lookupShadowMCPBlockingPolicy(ctx, metadata.GramOrgID, metadata.ProjectID, metadata.UserID)
 	if policy == nil {
-		if output != nil {
-			output.PermissionDecision = &allow
-		}
 		return result, nil
 	}
 
@@ -994,12 +991,9 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 		}
 	}
 	// A non-empty detail means this call is blocked. Return immediately for
-	// clean allows; otherwise give a URL-scoped bypass grant a chance to allow
-	// the call before recording and returning the block below.
+	// clean passes; otherwise give a URL-scoped bypass grant a chance to let
+	// the call through before recording and returning the block below.
 	if detail == "" {
-		if output != nil {
-			output.PermissionDecision = &allow
-		}
 		return result, nil
 	}
 
@@ -1019,9 +1013,6 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 				"matchedCommand": matchedCommand,
 			}),
 		)
-		if output != nil {
-			output.PermissionDecision = &allow
-		}
 		return result, nil
 	}
 

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -183,7 +183,7 @@ func TestNormalizeClaudeHookEvent_ResolvesAuthContextActorFromCachedEmail(t *tes
 
 // When the request authenticated via Gram-Key + Gram-Project, handlePreToolUse
 // must build SessionMetadata from the auth context instead of short-circuiting
-// to "allow" because Redis hasn't been seeded by OTEL Logs yet. Otherwise the
+// past the guard because Redis hasn't been seeded by OTEL Logs yet. Otherwise the
 // shadow-MCP guard never fires on the first PreToolUse of a plugin-driven
 // session — exactly when the guard is most needed (no toolset_id present yet
 // in the conversation's tool history).
@@ -192,8 +192,8 @@ func TestClaude_PreToolUse_UsesAuthContextWhenNoCachedMetadata(t *testing.T) {
 	ctx, ti := newTestHooksService(t)
 	ti.service.productFeatures = alwaysEnabledFeatures{}
 	// lookupShadowMCPBlockingPolicy needs a non-nil scanner that reports a
-	// blocking shadow-MCP policy, otherwise the handler short-circuits to
-	// allow before the cached-MCP-list check runs.
+	// blocking shadow-MCP policy, otherwise the handler short-circuits past
+	// the guard before the cached-MCP-list check runs.
 	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -487,8 +487,8 @@ func TestClaude_PreToolUse_AllowsGramHostedServer(t *testing.T) {
 
 	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
 	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
-	require.NotNil(t, output.PermissionDecision)
-	assert.Equal(t, "allow", *output.PermissionDecision)
+	assert.Nil(t, output.PermissionDecision,
+		"non-blocking paths must omit permissionDecision so Claude Code's own permission flow runs")
 }
 
 // DNO-286: the blocking PreToolUse guard must enforce against the inventory
@@ -526,8 +526,7 @@ func TestClaude_PreToolUse_EnforcesFromPayloadInventoryWithoutCache(t *testing.T
 
 	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
 	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
-	require.NotNil(t, output.PermissionDecision)
-	assert.Equal(t, "allow", *output.PermissionDecision,
+	assert.Nil(t, output.PermissionDecision,
 		"payload-supplied inventory must drive enforcement even with no cached snapshot")
 
 	// The payload inventory also self-heals the cache, so the best-effort
@@ -666,8 +665,7 @@ func TestClaude_PreToolUse_StaleReplayDoesNotOverrideCache(t *testing.T) {
 
 	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
 	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
-	require.NotNil(t, output.PermissionDecision)
-	assert.Equal(t, "allow", *output.PermissionDecision,
+	assert.Nil(t, output.PermissionDecision,
 		"a non-fresh replayed inventory must not override the cached snapshot")
 
 	// The cache must remain the Gram-hosted entry, untouched by the replay.


### PR DESCRIPTION
Fixes [DNO-386](https://linear.app/speakeasy/issue/DNO-386/claude-hooks-server-returns-explicit-allow-for-native-tools-bypassing)

rolled into https://github.com/speakeasy-api/gram/pull/3824
## What

The `/rpc/hooks.claude` PreToolUse handler returned an explicit `permissionDecision: "allow"` on every non-blocking path:

- native (non-MCP) tools — Bash, Edit, Write, ...
- MCP calls when no shadow-MCP blocking policy is configured
- MCP calls that pass the policy check cleanly
- MCP calls allowed via a bypass grant

In Claude Code hook semantics, an explicit `"allow"` from a PreToolUse hook is an approval that **bypasses the user's permission flow entirely** — allowlists, ask rules, and prompts never run. Anyone with the hooks plugin enabled was effectively running in permanent `--dangerously-skip-permissions` mode: no tool call ever prompted, including destructive commands.

## Fix

Leave `permissionDecision` unset on all non-blocking paths. The field is `omitempty`, so it disappears from the response JSON and Claude Code falls through to its normal permission evaluation. Deny paths are unchanged — the guard's job is to block shadow MCPs, not to green-light everything else past the user's own settings.

## Testing

- Updated the three tests asserting `"allow"` to assert the decision is omitted.
- Full `server/internal/hooks` suite passes (247 tests); `mise lint:server` clean.
- Root cause was confirmed live by replaying a PreToolUse payload (`rm -rf ...`) through the plugin's `hook.sh` against production and receiving `permissionDecision: "allow"`; after disabling the plugin locally, permission prompts returned.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending `permissionDecision: "allow"` on non-blocking PreToolUse events in `POST /rpc/hooks.claude`. This restores Claude Code’s normal permission prompts and fixes DNO-386.

- **Bug Fixes**
  - Omit `permissionDecision` on native tools and MCP calls that pass or have no blocking policy (including bypass grants).
  - Keep deny paths unchanged; absence of a decision defers to client-side permissions.
  - Updated tests in `server/internal/hooks/claude_hooks_test.go` to assert the field is omitted.

<sup>Written for commit a57b2c62de65efd5de40ce34ab126ed15cdd4bd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

