### PR TITLE
feat(mcp): log distinct reasons for issuer-gated /mcp 401s

### DIFF
--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -175,11 +175,14 @@ func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 // validateUserSessionToken delegates the JWT verify + revocation check to
 // usersessions.Signer.ValidateBearer, then — for user / API-key subjects —
 // stamps a contextvalues.AuthContext scoped to the endpoint's org/project.
-// Returns ok=false on any of: missing token, bad signature, expired/
-// notBefore, audience mismatch, jti revoked, unparseable subject URN.
+// A nil subject means "not authenticated as a user session"; the returned
+// error carries the reason (bad signature, expired/notBefore, audience
+// mismatch, jti revoked, unparseable subject URN) when a token was presented
+// and rejected, and is nil when no token was presented at all — so the caller
+// can log a real rejection without logging the no-credentials handshake probe.
 //
-// Anonymous subjects deliberately leave the context untouched (ok=true,
-// no AuthContext set). The request belongs to no known principal, so
+// Anonymous subjects deliberately leave the context untouched (non-nil
+// subject, no AuthContext set). The request belongs to no known principal, so
 // stamping the endpoint's org as ActiveOrganizationID would misrepresent
 // the caller as a member of that org. Downstream code on the public
 // path reads org/project off the resolved endpoint directly, the same
@@ -191,32 +194,22 @@ func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 // silently bypasses on enterprise endpoints (ShouldEnforce returns false
 // when AccountType != "enterprise"; PrepareContext skips when SessionID
 // is nil).
-func (s *Service) validateUserSessionToken(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint) (context.Context, *urn.SessionSubject, bool) {
+func (s *Service) validateUserSessionToken(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint) (context.Context, *urn.SessionSubject, error) {
 	if token == "" {
-		return ctx, nil, false
+		return ctx, nil, nil
 	}
 	subject, jti, err := s.userSessionSigner.ValidateBearer(ctx, token, endpoint.AudienceURN, s.chatSessionsManager)
 	if err != nil {
-		// A non-empty token that fails validation is an actionable auth
-		// failure. ValidateBearer folds several distinct causes — audience
-		// mismatch, expiry, bad signature, revoked jti, unparseable subject —
-		// into one error, and the eventual 401 flattens them further, so
-		// surface the underlying reason here instead of dropping it.
-		endpoint.LogWith(s.logger).WarnContext(ctx, "mcp issuer gate rejected bearer token",
-			attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
-			attr.SlogOAuthFailureReason("invalid_bearer_token"),
-			attr.SlogError(err),
-		)
-		return ctx, nil, false
+		return ctx, nil, fmt.Errorf("validate user-session bearer: %w", err)
 	}
 
 	if subject.Kind == urn.SessionSubjectKindAnonymous {
-		return ctx, &subject, true
+		return ctx, &subject, nil
 	}
 
 	orgMetadata, err := mv.DescribeOrganization(ctx, s.logger, s.orgsRepo, s.billingRepository, endpoint.OrganizationID)
 	if err != nil {
-		return ctx, nil, false
+		return ctx, nil, fmt.Errorf("describe organization for issuer-gated endpoint: %w", err)
 	}
 	projectID := endpoint.ProjectID
 	authCtx := &contextvalues.AuthContext{
@@ -246,7 +239,7 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 		// Unreachable: anonymous subjects return ctx untouched above. Listed
 		// for exhaustiveness so the linter doesn't flag the switch.
 	}
-	return contextvalues.SetAuthContext(ctx, authCtx), &subject, true
+	return contextvalues.SetAuthContext(ctx, authCtx), &subject, nil
 }
 
 // AuthenticateChallengeHeader builds the WWW-Authenticate value (RFC 9728
@@ -322,18 +315,30 @@ func (s *Service) ApplyIssuerGate(
 		return ctx, nil, oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, s.logger)
 	}
 
-	newCtx, subject, ok := s.validateUserSessionToken(ctx, authToken, endpoint)
-	if !ok {
+	newCtx, subject, valErr := s.validateUserSessionToken(ctx, authToken, endpoint)
+	if subject == nil {
 		// Accept an assistant-runtime JWT, but only when the assistant
 		// belongs to the endpoint's project — otherwise a token minted
 		// in project A could resolve a remote_session linked under
 		// the same user in project B.
 		if assistCtx, claims, aerr := s.assistantTokens.Authorize(ctx, authToken); aerr == nil && claims.ProjectID == endpoint.ProjectID.String() {
 			ssubj := urn.NewUserSubject(claims.UserID)
-			newCtx, subject, ok = assistCtx, &ssubj, true
+			newCtx, subject = assistCtx, &ssubj
 		}
 	}
-	if !ok {
+	if subject == nil {
+		// Both the user-session and assistant-runtime paths rejected the
+		// token. valErr is set only when a token was presented and failed
+		// validation (audience mismatch / expiry / bad signature / revoked
+		// jti), so this stays silent for the no-credentials handshake probe
+		// and never fires for a token the assistant path just accepted.
+		if valErr != nil {
+			endpoint.LogWith(s.logger).WarnContext(ctx, "mcp issuer gate rejected bearer token",
+				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
+				attr.SlogOAuthFailureReason("invalid_bearer_token"),
+				attr.SlogError(valErr),
+			)
+		}
 		return ctx, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "expired or invalid access token")
 	}
 

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -197,6 +197,16 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	}
 	subject, jti, err := s.userSessionSigner.ValidateBearer(ctx, token, endpoint.AudienceURN, s.chatSessionsManager)
 	if err != nil {
+		// A non-empty token that fails validation is an actionable auth
+		// failure. ValidateBearer folds several distinct causes — audience
+		// mismatch, expiry, bad signature, revoked jti, unparseable subject —
+		// into one error, and the eventual 401 flattens them further, so
+		// surface the underlying reason here instead of dropping it.
+		endpoint.LogWith(s.logger).WarnContext(ctx, "mcp issuer gate rejected bearer token",
+			attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
+			attr.SlogOAuthFailureReason("invalid_bearer_token"),
+			attr.SlogError(err),
+		)
 		return ctx, nil, false
 	}
 
@@ -340,6 +350,18 @@ func (s *Service) ApplyIssuerGate(
 		tokens, rerr := s.remoteChallengeMgr.ResolveAccessTokens(newCtx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, *subject, endpoint.UpstreamResource)
 		switch {
 		case errors.Is(rerr, remotesessions.ErrNoValidToken):
+			// The Gram user-session token is valid, but a required upstream
+			// remote session for this issuer is missing or unusable, so the
+			// runtime issues a re-auth challenge pointing the user at
+			// {routeBase}/{slug}/connect. This 401 is byte-identical to an
+			// invalid-token rejection (both are CodeUnauthorized), so without
+			// this line the two are indistinguishable in production. The
+			// specific broken upstream (and its refresh reason) is logged by
+			// remotesessions.ResolveAccessToken.
+			endpoint.LogWith(s.logger).WarnContext(newCtx, "mcp issuer gate rejected: upstream remote session missing or unusable",
+				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
+				attr.SlogOAuthFailureReason("remote_session_required"),
+			)
 			return ctx, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "")
 		case rerr != nil:
 			return ctx, nil, oops.E(oops.CodeUnexpected, rerr, "resolve remote session").LogError(newCtx, s.logger)

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -172,6 +172,12 @@ func (g UserSessionGrant) AdditionalCacheKeys() []string { return []string{} }
 // enough to limit blast radius if the code leaks.
 func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 
+// errIssuerGateOrgLookup marks the post-validation operational path in
+// validateUserSessionToken: the bearer token itself was accepted but the
+// endpoint's organization could not be described, so the resulting 401 is
+// not a credential rejection.
+var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated endpoint")
+
 // validateUserSessionToken delegates the JWT verify + revocation check to
 // usersessions.Signer.ValidateBearer, then — for user / API-key subjects —
 // stamps a contextvalues.AuthContext scoped to the endpoint's org/project.
@@ -197,12 +203,6 @@ func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 // silently bypasses on enterprise endpoints (ShouldEnforce returns false
 // when AccountType != "enterprise"; PrepareContext skips when SessionID
 // is nil).
-// errIssuerGateOrgLookup marks the post-validation operational path in
-// validateUserSessionToken: the bearer token itself was accepted but the
-// endpoint's organization could not be described, so the resulting 401 is
-// not a credential rejection.
-var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated endpoint")
-
 func (s *Service) validateUserSessionToken(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint) (context.Context, *urn.SessionSubject, error) {
 	if token == "" {
 		return ctx, nil, nil

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -180,6 +180,9 @@ func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 // mismatch, jti revoked, unparseable subject URN) when a token was presented
 // and rejected, and is nil when no token was presented at all — so the caller
 // can log a real rejection without logging the no-credentials handshake probe.
+// One non-rejection error shares this return: a token that validated fine but
+// whose org lookup failed wraps errIssuerGateOrgLookup, letting the caller
+// label it as an operational failure rather than a bad credential.
 //
 // Anonymous subjects deliberately leave the context untouched (non-nil
 // subject, no AuthContext set). The request belongs to no known principal, so
@@ -194,6 +197,12 @@ func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 // silently bypasses on enterprise endpoints (ShouldEnforce returns false
 // when AccountType != "enterprise"; PrepareContext skips when SessionID
 // is nil).
+// errIssuerGateOrgLookup marks the post-validation operational path in
+// validateUserSessionToken: the bearer token itself was accepted but the
+// endpoint's organization could not be described, so the resulting 401 is
+// not a credential rejection.
+var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated endpoint")
+
 func (s *Service) validateUserSessionToken(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint) (context.Context, *urn.SessionSubject, error) {
 	if token == "" {
 		return ctx, nil, nil
@@ -209,7 +218,7 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 
 	orgMetadata, err := mv.DescribeOrganization(ctx, s.logger, s.orgsRepo, s.billingRepository, endpoint.OrganizationID)
 	if err != nil {
-		return ctx, nil, fmt.Errorf("describe organization for issuer-gated endpoint: %w", err)
+		return ctx, nil, fmt.Errorf("%w: %w", errIssuerGateOrgLookup, err)
 	}
 	projectID := endpoint.ProjectID
 	authCtx := &contextvalues.AuthContext{
@@ -328,14 +337,20 @@ func (s *Service) ApplyIssuerGate(
 	}
 	if subject == nil {
 		// Both the user-session and assistant-runtime paths rejected the
-		// token. valErr is set only when a token was presented and failed
-		// validation (audience mismatch / expiry / bad signature / revoked
-		// jti), so this stays silent for the no-credentials handshake probe
-		// and never fires for a token the assistant path just accepted.
+		// token. valErr is nil for the no-credentials handshake probe and
+		// never set for a token the assistant path just accepted. It usually
+		// carries a credential rejection (audience mismatch / expiry / bad
+		// signature / revoked jti), but the errIssuerGateOrgLookup wrap means
+		// the token validated and the org lookup failed — an operational
+		// error, labeled distinctly so nobody chases a phantom bad token.
 		if valErr != nil {
+			failureReason := "invalid_bearer_token"
+			if errors.Is(valErr, errIssuerGateOrgLookup) {
+				failureReason = "org_lookup_failed"
+			}
 			endpoint.LogWith(s.logger).WarnContext(ctx, "mcp issuer gate rejected bearer token",
 				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
-				attr.SlogOAuthFailureReason("invalid_bearer_token"),
+				attr.SlogOAuthFailureReason(failureReason),
 				attr.SlogError(valErr),
 			)
 		}
@@ -365,7 +380,7 @@ func (s *Service) ApplyIssuerGate(
 			// remotesessions.ResolveAccessToken.
 			endpoint.LogWith(s.logger).WarnContext(newCtx, "mcp issuer gate rejected: upstream remote session missing or unusable",
 				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
-				attr.SlogOAuthFailureReason("remote_session_required"),
+				attr.SlogOAuthFailureReason("invalid_remote_session"),
 			)
 			return ctx, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "")
 		case rerr != nil:

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -122,6 +123,26 @@ func (m *ChallengeManager) ResolveAccessToken(
 
 	tok, err := m.validateAndRefresh(ctx, sess, resource)
 	if err != nil {
+		// validateAndRefresh errors only when a refresh was required (the
+		// stored access token is past its usable window) and could not be
+		// completed — the upstream rejected the refresh token, or the stored
+		// token could not be decrypted. That is a broken link needing a
+		// re-connect, distinct from "never linked" (the pgx.ErrNoRows case
+		// above). Both collapse to the same empty-token signal downstream and
+		// then to a byte-identical 401, so log the reason here — using the
+		// public-safe TokenRefreshError.Reason when present — instead of
+		// discarding it silently.
+		reason := "upstream token refresh failed"
+		var refreshErr *TokenRefreshError
+		if errors.As(err, &refreshErr) {
+			reason = refreshErr.Reason
+		}
+		m.logger.WarnContext(ctx, "remote session unusable: upstream token refresh failed",
+			attr.SlogRemoteSessionClientID(clientID.String()),
+			attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
+			attr.SlogOAuthFailureReason(reason),
+			attr.SlogError(err),
+		)
 		return "", nil
 	}
 	return tok, nil


### PR DESCRIPTION
## Problem

Chasing a `/mcp/int-linear` 401 loop (valid Gram user-session JWT, still rejected) surfaced a blind spot: the issuer-gated `/mcp/{slug}` runtime collapses **every** auth failure into a byte-identical, **unlogged** 401 — `CodeUnauthorized` rendered as `{"error":{"code":-32001,"message":"unauthorized access"}}` with a `WWW-Authenticate` header. Nothing lands in Datadog.

Three genuinely different failures are indistinguishable in both logs and response body:

1. **Invalid bearer** — `usersessions.Signer.ValidateBearer` fails (audience mismatch / expiry / bad signature / revoked jti / unparseable subject). The error is discarded at `validateUserSessionToken` and a bare `false` is returned.
2. **Upstream remote session missing/unusable** — the Gram token is valid, but `ResolveAccessTokens` returns `ErrNoValidToken`, so `ApplyIssuerGate` issues a re-auth challenge (`WriteAuthenticateChallenge(w, url, "")`).
3. **Upstream token refresh failed** — the stored upstream access token is expired and the refresh POST to the provider is rejected. `ResolveAccessToken` swallows the error (`if err != nil { return "", nil }`) → looks identical to "never linked".

In the incident that motivated this, the real cause was **#3**: an upstream link whose access token had expired ~3 weeks earlier and whose refresh was failing — while the consent UI still showed it "Connected". It took a JWT decode, four HTTP probes, and a code read to distinguish what one log line would have said.

## Change

Three `WarnContext` lines that name the cause. **Logging only — no behaviour change.**

- `internal/mcp/authnchallenge.go` · `validateUserSessionToken` — log the `ValidateBearer` error (`attr.SlogError`) so audience-mismatch vs expiry vs revocation is visible.
- `internal/mcp/authnchallenge.go` · `ApplyIssuerGate` — on `ErrNoValidToken`, log that the token was valid but a required upstream is missing/unusable (the re-auth-challenge path).
- `internal/remotesessions/tokenservice.go` · `ResolveAccessToken` — before swallowing a refresh failure to the empty-token signal, log it with the **public-safe** `TokenRefreshError.Reason`.

All three use `attr.*` conventions and `WarnContext`. Verified: `go build`, `go vet`, `gofmt`, and `mise lint:server` (glint/loggercheck/exhaustruct) all clean.

## Follow-up (not in this PR)

The consent status predicate (`ListRemoteSessionStatusesForSubject`) reports a session `usable`/"Connected" whenever a non-expiring refresh token exists, even when the runtime's `validateAndRefresh` can't actually complete the refresh — so users get no signal to re-link. Worth reconciling the two predicates (or verifying refresh viability) separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add warning logs that distinguish `/mcp/{slug}` 401 causes: invalid bearer, missing/unusable upstream session, failed refresh. Also label org-lookup failures separately and defer invalid-bearer logs until after assistant fallback; logging only, no behavior change.

- **New Features**
  - `internal/mcp/authnchallenge.go` — `validateUserSessionToken` returns `(ctx, subject, error)` and wraps org-lookup failures with a sentinel; `ApplyIssuerGate` logs `invalid_bearer_token` only after assistant fallback, logs `invalid_remote_session` on `ErrNoValidToken`, and logs `org_lookup_failed` when org lookup fails.
  - `internal/remotesessions/tokenservice.go` — `ResolveAccessToken` logs upstream refresh failures with public-safe `TokenRefreshError.Reason`.

- **Refactors**
  - `internal/mcp/authnchallenge.go` — moved `errIssuerGateOrgLookup` above the function doc block to keep the comment attached to `validateUserSessionToken`; no behavior change.

<sup>Written for commit b44365be8adfc79642e82f549b19241dd5972099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

