### PR TITLE
fix: classify accounts under shared enterprise orgs as team (DNO-389)

### DIFF
--- a/server/internal/hooks/account_attribution.go
+++ b/server/internal/hooks/account_attribution.go
@@ -21,11 +21,13 @@ const (
 	// so the account's provider is Cursor itself).
 	providerCursor = "cursor"
 
-	// accountTypeTeam is a company/enterprise AI account: its session email
-	// resolves to a Gram org member.
+	// accountTypeTeam is a company/enterprise AI account: it lives under a
+	// provider org already shared by resolved org members, or its session email
+	// resolves to a Gram org member (see classifyAccount).
 	accountTypeTeam = "team"
-	// accountTypePersonal is an individual AI account (e.g. Claude Max) whose
-	// email does not resolve to an org member.
+	// accountTypePersonal is an individual AI account (e.g. Claude Max): its
+	// provider org is not a recognized enterprise org and its email does not
+	// resolve to an org member.
 	accountTypePersonal = "personal"
 )
 
@@ -102,44 +104,65 @@ func (s *Service) attributeSession(ctx context.Context, meta *SessionMetadata) e
 }
 
 // classifyAccount determines whether the session's account is team or personal.
-// The base signal is email resolution (classifyAccountType). On top of that it
-// applies the work-email guard: a session that resolved to an org member is
-// downgraded to personal when it looks like a personal account signed in with
-// the employee's work email. meta.UserID must still reflect email resolution
-// only (i.e. call before the device bridge can fill it in).
+//
+// The primary signal is deterministic and data-derived: a provider org already
+// shared by two or more distinct resolved employees is the company's real
+// enterprise org, so every account observed under it is team — including one
+// whose own email has not (yet) resolved to a Gram member. This is what lets a
+// genuine employee on the company Claude org be classified team before they are
+// provisioned in Gram (email resolution alone would call them personal).
+//
+// When the session's org is not (yet) a shared enterprise org, classification
+// falls back to email resolution: a resolved work email is team, anything else
+// (a personal email that does not resolve, or no email) is personal. One
+// correction rides on top of the resolved case — the work-email guard: a
+// resolved email under a solo provider org is downgraded to personal when the
+// same employee also appears under a DIFFERENT shared enterprise org, i.e. a
+// personal account (e.g. Claude Max) signed in with the work email.
+//
+// meta.UserID must still reflect email resolution only (call before the device
+// bridge can fill it in).
+//
+// KNOWN RESIDUAL GAP: an org with fewer than two resolved employees cannot be
+// recognized as an enterprise org from data alone, so a personal account on a
+// work email at a solo/low-adoption company stays labeled team, and an
+// unresolved account there stays personal even if it is a real employee. Closing
+// this deterministically needs an explicit admin-declared enterprise org id (a
+// separate follow-up); accepted because Gram is enterprise software.
 func (s *Service) classifyAccount(ctx context.Context, meta *SessionMetadata) (string, error) {
-	base := classifyAccountType(meta.UserID)
-	if base != accountTypeTeam || meta.ExternalOrgID == "" {
-		return base, nil
+	if meta.ExternalOrgID != "" {
+		shared, err := s.isSharedEnterpriseOrg(ctx, meta)
+		if err != nil {
+			return "", fmt.Errorf("evaluate shared enterprise org: %w", err)
+		}
+		if shared {
+			return accountTypeTeam, nil
+		}
 	}
 
-	personal, err := s.looksLikePersonalAccountOnWorkEmail(ctx, meta)
-	if err != nil {
-		return "", fmt.Errorf("evaluate enterprise org membership: %w", err)
-	}
-	if personal {
+	if classifyAccountType(meta.UserID) != accountTypeTeam {
 		return accountTypePersonal, nil
+	}
+
+	// Resolved work email under a non-shared org: guard against a personal account
+	// signed in with the employee's work email.
+	if meta.ExternalOrgID != "" {
+		personal, err := s.employeeAlsoUsesSharedOrg(ctx, meta)
+		if err != nil {
+			return "", fmt.Errorf("evaluate work-email guard: %w", err)
+		}
+		if personal {
+			return accountTypePersonal, nil
+		}
 	}
 	return accountTypeTeam, nil
 }
 
-// looksLikePersonalAccountOnWorkEmail reports whether a session that resolved to
-// an org member (so it classified team on email alone) is actually a personal
-// account signed in with the employee's work email. The signal: this provider
-// org is solo for the employee (fewer than two distinct employees ever seen
-// under it) while the same employee also appears under a DIFFERENT provider org
-// shared by >= 2 employees — i.e. the company's real enterprise org.
-//
-// This is a best-effort heuristic, not a proof. It never downgrades a normal
-// employee with a single provider org, and it leans team when it cannot tell.
-//
-// KNOWN RESIDUAL GAP: a truly solo company — a single employee whose enterprise
-// org also has just one member — cannot be distinguished from a personal account
-// on a work email, so such a personal account stays labeled team. Accepted
-// because Gram is enterprise software and won't be used by solo companies. The
-// deterministic fix (an admin-declared enterprise organization.id, matched
-// against the stored external_org_id) can close it later if ever needed.
-func (s *Service) looksLikePersonalAccountOnWorkEmail(ctx context.Context, meta *SessionMetadata) (bool, error) {
+// isSharedEnterpriseOrg reports whether the session's provider org is already
+// shared by two or more distinct resolved employees. Such an org is the company's
+// real enterprise org, so any account under it — even one whose email has not
+// resolved — is a team account. Requires meta.ExternalOrgID to be non-empty.
+func (s *Service) isSharedEnterpriseOrg(ctx context.Context, meta *SessionMetadata) (bool, error) {
 	employees, err := s.repo.CountEmployeesForExternalOrg(ctx, repo.CountEmployeesForExternalOrgParams{
 		OrganizationID: meta.GramOrgID,
 		Provider:       meta.Provider,
@@ -148,12 +171,16 @@ func (s *Service) looksLikePersonalAccountOnWorkEmail(ctx context.Context, meta 
 	if err != nil {
 		return false, fmt.Errorf("count employees for external org: %w", err)
 	}
-	// A provider org already shared across employees is the enterprise org, not a
-	// personal one — never downgrade it.
-	if employees >= 2 {
-		return false, nil
-	}
+	return employees >= 2, nil
+}
 
+// employeeAlsoUsesSharedOrg reports whether the resolved employee behind this
+// session also appears under a DIFFERENT provider org shared by >= 2 employees
+// (the company's real enterprise org). If so, this session's solo provider org is
+// almost certainly a personal account signed in with the work email, and should
+// not be classified team. Requires meta.UserID and meta.ExternalOrgID to be
+// non-empty. This is a best-effort heuristic: it leans team when it cannot tell.
+func (s *Service) employeeAlsoUsesSharedOrg(ctx context.Context, meta *SessionMetadata) (bool, error) {
 	hasShared, err := s.repo.EmployeeHasSharedExternalOrg(ctx, repo.EmployeeHasSharedExternalOrgParams{
 		OrganizationID: meta.GramOrgID,
 		Provider:       meta.Provider,

--- a/server/internal/hooks/account_attribution_test.go
+++ b/server/internal/hooks/account_attribution_test.go
@@ -214,6 +214,46 @@ func TestLogs_SingleAccountEnterpriseStaysTeam(t *testing.T) {
 	require.Equal(t, userID, acct.UserID.String)
 }
 
+// TestLogs_PromotesUnresolvedAccountUnderSharedEnterpriseOrg covers the core
+// Path A improvement: once a provider org is shared by >= 2 distinct resolved
+// employees it is recognized as the company's enterprise org, so a later account
+// under that org is classified team even though its own email does not resolve to
+// a Gram member (the case email resolution alone would misclassify personal).
+func TestLogs_PromotesUnresolvedAccountUnderSharedEnterpriseOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	orgID := authCtx.ActiveOrganizationID
+	queries := repo.New(ti.conn)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// The session cache is keyed by session id alone and Redis is shared across
+	// parallel tests, so every id here must be unique to this test — a session id
+	// reused from another test would hit its cached attribution and skip ours.
+	const enterpriseOrg = "promote-enterprise-org"
+	userA, emailA := "promote-employee-a", "promote-a@example.com"
+	userB, emailB := "promote-employee-b", "promote-b@example.com"
+	seedHookUser(t, ctx, ti.conn, orgID, userA, emailA)
+	seedHookUser(t, ctx, ti.conn, orgID, userB, emailB)
+
+	// Two resolved employees under the same org -> it is now a shared enterprise org.
+	claudeAccountSession(t, ctx, ti, "promote-ent-a", emailA, enterpriseOrg, "acct-promote-a", "device-promote-a", now)
+	claudeAccountSession(t, ctx, ti, "promote-ent-b", emailB, enterpriseOrg, "acct-promote-b", "device-promote-b", now.Add(time.Minute))
+
+	// A third account under the same org whose email does NOT resolve to a Gram
+	// member (e.g. an employee not yet provisioned in Gram). It is still team
+	// because the org is a recognized enterprise org.
+	claudeAccountSession(t, ctx, ti, "promote-ent-c", "unprovisioned@example.com", enterpriseOrg, "acct-promote-c", "device-promote-c", now.Add(2*time.Minute))
+
+	acct, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: "acct-promote-c",
+	})
+	require.NoError(t, err)
+	require.Equal(t, accountTypeTeam, acct.AccountType.String, "unresolved account under a shared enterprise org is team")
+	require.Empty(t, acct.UserID.String, "no email resolution and no device owner, so it stays unattributed")
+}
+
 // TestLogs_AttributesOncePerSession confirms attribution runs only on a session's
 // first batch: a later batch for the same session reuses the cached result and
 // does not re-classify, even after the session's email becomes a connected user.

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -85,7 +85,9 @@ RETURNING id;
 -- name: CountEmployeesForExternalOrg :one
 -- Distinct employees (resolved Gram users) ever seen under a provider org. An
 -- enterprise org is shared by many employees; a personal org maps to exactly one.
--- Used to tell an enterprise account from a personal account on a work email.
+-- A count >= 2 marks the org as the company's enterprise org: accounts under it
+-- classify team even when their own email has not resolved, and a resolved work
+-- email under a solo org is checked against the work-email guard instead.
 SELECT COUNT(DISTINCT user_id)::bigint
 FROM user_accounts
 WHERE organization_id = @organization_id

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -61,7 +61,9 @@ type CountEmployeesForExternalOrgParams struct {
 
 // Distinct employees (resolved Gram users) ever seen under a provider org. An
 // enterprise org is shared by many employees; a personal org maps to exactly one.
-// Used to tell an enterprise account from a personal account on a work email.
+// A count >= 2 marks the org as the company's enterprise org: accounts under it
+// classify team even when their own email has not resolved, and a resolved work
+// email under a solo org is checked against the work-email guard instead.
 func (q *Queries) CountEmployeesForExternalOrg(ctx context.Context, arg CountEmployeesForExternalOrgParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countEmployeesForExternalOrg, arg.OrganizationID, arg.Provider, arg.ExternalOrgID)
 	var column_1 int64


### PR DESCRIPTION
Fixes DNO-389

## Problem

`user_accounts.account_type` is derived per-session from email resolution alone: a session whose email resolves to a Gram org member → `team`, anything else → `personal`. This misclassifies real employees whose Claude email isn't a provisioned Gram user.

Concrete prod case: two accounts under the **same** Anthropic org — one email resolved to a Gram user → `team`; the other didn't → `personal`, despite both being on the company's enterprise Claude org.

## Fix

Make the primary classification signal deterministic and data-derived: a provider org already shared by **≥2 distinct resolved employees** is the company's enterprise org, so every account observed under it is `team` — including accounts whose own email hasn't (yet) resolved to a Gram member.

When the session's org isn't a recognized enterprise org, classification falls back to the existing email-resolution signal, with the existing work-email guard (a resolved email under a solo provider org is downgraded to `personal` when the same employee also appears under a different shared enterprise org) unchanged.

No SQL/schema changes — both queries used (`CountEmployeesForExternalOrg`, `EmployeeHasSharedExternalOrg`) already existed; `queries.sql.go` is regenerated for a comment-only update.

Existing misclassified rows self-heal on the account's next observed session (the upsert re-runs classification and overwrites `account_type`). A one-off backfill is an optional follow-up tracked on the ticket.

### Known residual gap (unchanged)

An org with fewer than two resolved employees can't be recognized as an enterprise org from data alone. Closing that deterministically needs an admin-declared enterprise org id (Path B, separate follow-up).

## Testing

- New integration test: an unresolved-email account under an org shared by 2 resolved employees classifies `team`.
- Full `internal/hooks` suite passes; all 5 pre-existing classification behaviors preserved.
- `mise lint:server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deterministically classify accounts under a provider org shared by ≥2 resolved employees as `team` to fix misclassifications when a real employee’s email doesn’t resolve. Addresses DNO-389.

- **Bug Fixes**
  - Treat provider orgs with ≥2 distinct resolved employees as enterprise; all accounts under them classify `team`, even with unresolved emails.
  - When the org isn’t shared, fall back to email resolution and keep the work‑email guard (downgrade if the employee also appears under a different shared org).
  - No schema changes; reused `CountEmployeesForExternalOrg` and `EmployeeHasSharedExternalOrg`, regenerated `queries.sql.go` comments only. Added integration test; suite passes; misclassified rows self‑heal on the next session.

<sup>Written for commit 36e22b36efc51d0fc2272287fe8da93634ca7594. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

