### PR TITLE
feat: canonicalize Shadow MCP server URL identity

### DIFF
--- a/server/internal/shadowmcp/inventory_url.go
+++ b/server/internal/shadowmcp/inventory_url.go
@@ -1,6 +1,7 @@
 package shadowmcp
 
 import (
+	"net"
 	"net/url"
 	"strings"
 )
@@ -28,9 +29,14 @@ func CanonicalizeInventoryURL(raw string) (InventoryURL, bool) {
 	}
 
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	parsed.Host = NormalizeURLHost(parsed.Scheme, parsed.Host)
+	normalizedHost := NormalizeURLHost(parsed.Scheme, parsed.Host)
+	parsed.Host = normalizedHost
+	if strings.Contains(normalizedHost, ":") && net.ParseIP(normalizedHost) != nil {
+		parsed.Host = "[" + normalizedHost + "]"
+	}
 	parsed.User = nil
 	parsed.RawQuery = ""
+	parsed.ForceQuery = false
 	parsed.Fragment = ""
 	sanitized := parsed.String()
 
@@ -44,7 +50,7 @@ func CanonicalizeInventoryURL(raw string) (InventoryURL, bool) {
 
 	return InventoryURL{
 		CanonicalURL: canonical,
-		URLHost:      NormalizeURLHost(parsed.Scheme, parsed.Host),
+		URLHost:      normalizedHost,
 	}, true
 }
 

--- a/server/internal/shadowmcp/inventory_url.go
+++ b/server/internal/shadowmcp/inventory_url.go
@@ -1,0 +1,57 @@
+package shadowmcp
+
+import (
+	"net/url"
+	"strings"
+)
+
+type InventoryURL struct {
+	CanonicalURL string
+	URLHost      string
+}
+
+func CanonicalizeInventoryURL(raw string) (InventoryURL, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return InventoryURL{
+			CanonicalURL: "",
+			URLHost:      "",
+		}, false
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return InventoryURL{
+			CanonicalURL: "",
+			URLHost:      "",
+		}, false
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = NormalizeURLHost(parsed.Scheme, parsed.Host)
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	sanitized := parsed.String()
+
+	canonical, err := NormalizeMatchValue(MatchBreadthFullURL, sanitized)
+	if err != nil {
+		return InventoryURL{
+			CanonicalURL: "",
+			URLHost:      "",
+		}, false
+	}
+
+	return InventoryURL{
+		CanonicalURL: canonical,
+		URLHost:      NormalizeURLHost(parsed.Scheme, parsed.Host),
+	}, true
+}
+
+func AccessEvidenceForInventoryURL(value InventoryURL) AccessEvidence {
+	return AccessEvidence{
+		FullURL:        value.CanonicalURL,
+		URLHost:        value.URLHost,
+		ServerIdentity: "",
+	}
+}

--- a/server/internal/shadowmcp/inventory_url_test.go
+++ b/server/internal/shadowmcp/inventory_url_test.go
@@ -36,6 +36,24 @@ func TestCanonicalizeInventoryURL(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name: "strips empty force query",
+			raw:  "https://mcp.speakeasy.com/mcp?",
+			want: shadowmcp.InventoryURL{
+				CanonicalURL: "https://mcp.speakeasy.com/mcp",
+				URLHost:      "mcp.speakeasy.com",
+			},
+			wantOK: true,
+		},
+		{
+			name: "strips default port from ipv6 host",
+			raw:  "https://[2001:db8::1]:443/mcp",
+			want: shadowmcp.InventoryURL{
+				CanonicalURL: "https://[2001:db8::1]/mcp",
+				URLHost:      "2001:db8::1",
+			},
+			wantOK: true,
+		},
+		{
 			name:   "rejects stdio command",
 			raw:    "node ./server.js",
 			wantOK: false,

--- a/server/internal/shadowmcp/inventory_url_test.go
+++ b/server/internal/shadowmcp/inventory_url_test.go
@@ -1,0 +1,72 @@
+package shadowmcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+)
+
+func TestCanonicalizeInventoryURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		raw    string
+		want   shadowmcp.InventoryURL
+		wantOK bool
+	}{
+		{
+			name: "strips query and fragment",
+			raw:  "HTTPS://MCP.Speakeasy.COM:443/mcp?token=secret#frag",
+			want: shadowmcp.InventoryURL{
+				CanonicalURL: "https://mcp.speakeasy.com/mcp",
+				URLHost:      "mcp.speakeasy.com",
+			},
+			wantOK: true,
+		},
+		{
+			name: "sanitizes embedded credentials",
+			raw:  "https://user:pass@MCP.Speakeasy.COM:443/mcp?token=secret#frag",
+			want: shadowmcp.InventoryURL{
+				CanonicalURL: "https://mcp.speakeasy.com/mcp",
+				URLHost:      "mcp.speakeasy.com",
+			},
+			wantOK: true,
+		},
+		{
+			name:   "rejects stdio command",
+			raw:    "node ./server.js",
+			wantOK: false,
+		},
+		{
+			name:   "rejects url without host",
+			raw:    "https:///mcp",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := shadowmcp.CanonicalizeInventoryURL(tt.raw)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAccessEvidenceForInventoryURL(t *testing.T) {
+	t.Parallel()
+
+	evidence := shadowmcp.AccessEvidenceForInventoryURL(shadowmcp.InventoryURL{
+		CanonicalURL: "https://mcp.speakeasy.com/mcp",
+		URLHost:      "mcp.speakeasy.com",
+	})
+
+	require.Equal(t, "https://mcp.speakeasy.com/mcp", evidence.FullURL)
+	require.Equal(t, "mcp.speakeasy.com", evidence.URLHost)
+	require.Empty(t, evidence.ServerIdentity)
+}


### PR DESCRIPTION
Linear: https://linear.app/speakeasy/issue/DNO-371/feat-canonicalize-shadow-mcp-server-url-identity

## What changes
- Adds shared canonicalization for Shadow MCP server URLs so inventory rows, telemetry usage, and policy decisions use the same URL identity.
- Normalizes scheme, host casing, default ports, and path handling.
- Removes query params, fragments, and credentials from canonical identity because allow decisions are based on host/path.
- Returns both canonical URL and URL host for later inventory and API composition work.

## Review context
This is the foundation PR for the stack. The main behavior to review is whether canonical identity matches the product decision: host/path matter, query params do not.

## Stack
1. #3819 DNO-371 (Current)
2. #3848 DNO-369
3. #3849 DNO-373
4. #3851 DNO-374
5. #3852 DNO-363
6. #3947 DNO-370
7. #4063 DNO-456
8. #4064 DNO-366
9. #4065 DNO-459
