### PR TITLE
mig: add external_credentials and external_keys tables

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3626,3 +3626,135 @@ CREATE TABLE IF NOT EXISTS outbox_relays (
 CREATE INDEX IF NOT EXISTS outbox_relays_pending_idx
 ON outbox_relays (outbox_id)
 WHERE processed_at IS NULL AND dead_lettered IS FALSE;
+
+-- Sharable records for how to authenticate into an external service, such as
+-- any ambient infrastructure environment or customer-managed product. This is
+-- implemented using the Class Table Inheritance pattern with provider acting
+-- as the discriminator. Each row in this table has exactly one provider subtype
+-- row (e.g. in tables such as aws_iam_credentials, gcp_iam_credentials, etc.).
+-- The canonical `provider` values are defined in this supertype table, while
+-- subtype tables carry a pinned `external_credentials_provider` that
+-- composite-FKs back to (id, provider) to enforce 1:1 semantics across tables.
+-- Support addititional providers by updating the provider check in this table
+-- and creating a subtype table.
+CREATE TABLE IF NOT EXISTS external_credentials (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT,
+  project_id uuid,
+  provider TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+  CONSTRAINT external_credentials_pkey PRIMARY KEY (id),
+  CONSTRAINT external_credentials_id_provider_key UNIQUE (id, provider),
+  CONSTRAINT external_credentials_provider_check CHECK (provider IN ('aws_iam', 'gcp_iam')),
+  CONSTRAINT external_credentials_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT external_credentials_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS external_credentials_organization_id_idx
+ON external_credentials (organization_id)
+WHERE deleted IS FALSE;
+
+-- AWS credential: AssumeRole+ExternalId | AssumeRoleWithWebIdentity | key-policy grant (mode derived)
+CREATE TABLE IF NOT EXISTS aws_iam_credentials (
+  external_credential_id uuid NOT NULL,
+  external_credentials_provider TEXT NOT NULL DEFAULT 'aws_iam',
+  assume_role_arn TEXT,
+  external_id TEXT,
+  oidc_audience TEXT,
+  oidc_subject TEXT,
+  sts_region TEXT,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT aws_iam_credentials_pkey PRIMARY KEY (external_credential_id),
+  CONSTRAINT aws_iam_credentials_external_credentials_provider_check CHECK (external_credentials_provider = 'aws_iam'),
+  CONSTRAINT aws_iam_credentials_auth_exclusive_check CHECK (num_nonnulls(external_id, oidc_audience) <= 1),
+  CONSTRAINT aws_iam_credentials_fkey FOREIGN KEY (external_credential_id, external_credentials_provider) REFERENCES external_credentials (id, provider) ON DELETE CASCADE
+);
+
+-- GCP credential: ambient | impersonation | WIF (mode derived); keyless, no SA-JSON
+CREATE TABLE IF NOT EXISTS gcp_iam_credentials (
+  external_credential_id uuid NOT NULL,
+  external_credentials_provider TEXT NOT NULL DEFAULT 'gcp_iam',
+  impersonate_service_account TEXT,
+  wif_pool_id TEXT,
+  wif_provider_id TEXT,
+  wif_project_number TEXT,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT gcp_iam_credentials_pkey PRIMARY KEY (external_credential_id),
+  CONSTRAINT gcp_iam_credentials_external_credentials_provider_check CHECK (external_credentials_provider = 'gcp_iam'),
+  CONSTRAINT gcp_iam_credentials_wif_complete_check CHECK (num_nonnulls(wif_pool_id, wif_provider_id, wif_project_number) IN (0, 3)),
+  CONSTRAINT gcp_iam_credentials_fkey FOREIGN KEY (external_credential_id, external_credentials_provider) REFERENCES external_credentials (id, provider) ON DELETE CASCADE
+);
+
+-- Sharable records for referencing an externally-managed key, such as KMS key
+-- for signing. This is implemented using the Class Table Inheritance pattern
+-- with `provider` acting as the discriminator. Each row in
+-- this table has exactly one key provider subtype row (e.g. in tables such as
+-- aws_kms_keys, gcp_kms_keys, etc.). The canonical `provider` values are
+-- defined in this supertype table, while subtype tables carry a pinned
+-- `external_keys_provider` that composite-FKs back to (id, provider) to enforce
+-- 1:1 semantics across tables. Support addititional key providers by updating
+-- the provider check in this table and creating a subtype table.
+CREATE TABLE IF NOT EXISTS external_keys (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT,
+  project_id uuid,
+  external_credential_id uuid NOT NULL,
+  provider TEXT NOT NULL,
+  algorithm TEXT NOT NULL,
+  name TEXT NOT NULL,
+  -- Reference to the access grant the customer configured on their KMS key: the
+  -- gram-owned cloud identity (GCP service-account email or AWS principal ARN)
+  -- they granted. Set only for the "ambient identity" model, where the customer
+  -- grants gram's own principal directly (AWS KMS key policy / GCP IAM binding)
+  -- instead of gram assuming a customer role; NULL for the assume-role models.
+  -- Kept for audit and drift detection: if gram rotates its own identity, this
+  -- can be compared against the current one to flag a stale grant and prompt a
+  -- re-grant before signing starts failing.
+  customer_grant_reference TEXT,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+  CONSTRAINT external_keys_pkey PRIMARY KEY (id),
+  CONSTRAINT external_keys_id_provider_key UNIQUE (id, provider),
+  CONSTRAINT external_keys_provider_check CHECK (provider IN ('aws_kms', 'gcp_kms')),
+  CONSTRAINT external_keys_external_credential_id_fkey FOREIGN KEY (external_credential_id) REFERENCES external_credentials (id),
+  CONSTRAINT external_keys_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT external_keys_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS external_keys_organization_id_idx
+ON external_keys (organization_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS external_keys_external_credential_id_idx
+ON external_keys (external_credential_id)
+WHERE deleted IS FALSE;
+
+CREATE TABLE IF NOT EXISTS aws_kms_keys (
+  external_key_id uuid NOT NULL,
+  external_keys_provider TEXT NOT NULL DEFAULT 'aws_kms',
+  key_arn TEXT NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT aws_kms_keys_pkey PRIMARY KEY (external_key_id),
+  CONSTRAINT aws_kms_keys_external_keys_provider_check CHECK (external_keys_provider = 'aws_kms'),
+  CONSTRAINT aws_kms_keys_fkey FOREIGN KEY (external_key_id, external_keys_provider) REFERENCES external_keys (id, provider) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS gcp_kms_keys (
+  external_key_id uuid NOT NULL,
+  external_keys_provider TEXT NOT NULL DEFAULT 'gcp_kms',
+  resource_name TEXT NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT gcp_kms_keys_pkey PRIMARY KEY (external_key_id),
+  CONSTRAINT gcp_kms_keys_external_keys_provider_check CHECK (external_keys_provider = 'gcp_kms'),
+  CONSTRAINT gcp_kms_keys_fkey FOREIGN KEY (external_key_id, external_keys_provider) REFERENCES external_keys (id, provider) ON DELETE CASCADE
+);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -247,6 +247,26 @@ type AuthzChallengeResolution struct {
 	CreatedAt  pgtype.Timestamptz
 }
 
+type AwsIamCredential struct {
+	ExternalCredentialID        uuid.UUID
+	ExternalCredentialsProvider string
+	AssumeRoleArn               pgtype.Text
+	ExternalID                  pgtype.Text
+	OidcAudience                pgtype.Text
+	OidcSubject                 pgtype.Text
+	StsRegion                   pgtype.Text
+	CreatedAt                   pgtype.Timestamptz
+	UpdatedAt                   pgtype.Timestamptz
+}
+
+type AwsKmsKey struct {
+	ExternalKeyID        uuid.UUID
+	ExternalKeysProvider string
+	KeyArn               string
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
 type BillingMetadatum struct {
 	ID                    uuid.UUID
 	OrganizationID        string
@@ -522,6 +542,33 @@ type EnvironmentEntry struct {
 	UpdatedAt     pgtype.Timestamptz
 }
 
+type ExternalCredential struct {
+	ID             uuid.UUID
+	OrganizationID pgtype.Text
+	ProjectID      uuid.NullUUID
+	Provider       string
+	Name           string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
+}
+
+type ExternalKey struct {
+	ID                     uuid.UUID
+	OrganizationID         pgtype.Text
+	ProjectID              uuid.NullUUID
+	ExternalCredentialID   uuid.UUID
+	Provider               string
+	Algorithm              string
+	Name                   string
+	CustomerGrantReference pgtype.Text
+	CreatedAt              pgtype.Timestamptz
+	UpdatedAt              pgtype.Timestamptz
+	DeletedAt              pgtype.Timestamptz
+	Deleted                bool
+}
+
 type ExternalMcpAttachment struct {
 	ID                                  uuid.UUID
 	DeploymentID                        uuid.UUID
@@ -667,6 +714,25 @@ type FunctionsAccess struct {
 	UpdatedAt     pgtype.Timestamptz
 	DeletedAt     pgtype.Timestamptz
 	Deleted       bool
+}
+
+type GcpIamCredential struct {
+	ExternalCredentialID        uuid.UUID
+	ExternalCredentialsProvider string
+	ImpersonateServiceAccount   pgtype.Text
+	WifPoolID                   pgtype.Text
+	WifProviderID               pgtype.Text
+	WifProjectNumber            pgtype.Text
+	CreatedAt                   pgtype.Timestamptz
+	UpdatedAt                   pgtype.Timestamptz
+}
+
+type GcpKmsKey struct {
+	ExternalKeyID        uuid.UUID
+	ExternalKeysProvider string
+	ResourceName         string
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }
 
 type GlobalRole struct {

--- a/server/migrations/20260702032234_external-credentials-external-keys.sql
+++ b/server/migrations/20260702032234_external-credentials-external-keys.sql
@@ -1,0 +1,97 @@
+-- Create "external_credentials" table
+CREATE TABLE "external_credentials" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NULL,
+  "project_id" uuid NULL,
+  "provider" text NOT NULL,
+  "name" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "external_credentials_id_provider_key" UNIQUE ("id", "provider"),
+  CONSTRAINT "external_credentials_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "external_credentials_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "external_credentials_provider_check" CHECK (provider = ANY (ARRAY['aws_iam'::text, 'gcp_iam'::text]))
+);
+-- Create index "external_credentials_organization_id_idx" to table: "external_credentials"
+CREATE INDEX "external_credentials_organization_id_idx" ON "external_credentials" ("organization_id") WHERE (deleted IS FALSE);
+-- Create "aws_iam_credentials" table
+CREATE TABLE "aws_iam_credentials" (
+  "external_credential_id" uuid NOT NULL,
+  "external_credentials_provider" text NOT NULL DEFAULT 'aws_iam',
+  "assume_role_arn" text NULL,
+  "external_id" text NULL,
+  "oidc_audience" text NULL,
+  "oidc_subject" text NULL,
+  "sts_region" text NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("external_credential_id"),
+  CONSTRAINT "aws_iam_credentials_fkey" FOREIGN KEY ("external_credential_id", "external_credentials_provider") REFERENCES "external_credentials" ("id", "provider") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "aws_iam_credentials_auth_exclusive_check" CHECK (num_nonnulls(external_id, oidc_audience) <= 1),
+  CONSTRAINT "aws_iam_credentials_external_credentials_provider_check" CHECK (external_credentials_provider = 'aws_iam'::text)
+);
+-- Create "external_keys" table
+CREATE TABLE "external_keys" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NULL,
+  "project_id" uuid NULL,
+  "external_credential_id" uuid NOT NULL,
+  "provider" text NOT NULL,
+  "algorithm" text NOT NULL,
+  "name" text NOT NULL,
+  "customer_grant_reference" text NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "external_keys_id_provider_key" UNIQUE ("id", "provider"),
+  CONSTRAINT "external_keys_external_credential_id_fkey" FOREIGN KEY ("external_credential_id") REFERENCES "external_credentials" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "external_keys_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "external_keys_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "external_keys_provider_check" CHECK (provider = ANY (ARRAY['aws_kms'::text, 'gcp_kms'::text]))
+);
+-- Create index "external_keys_external_credential_id_idx" to table: "external_keys"
+CREATE INDEX "external_keys_external_credential_id_idx" ON "external_keys" ("external_credential_id") WHERE (deleted IS FALSE);
+-- Create index "external_keys_organization_id_idx" to table: "external_keys"
+CREATE INDEX "external_keys_organization_id_idx" ON "external_keys" ("organization_id") WHERE (deleted IS FALSE);
+-- Create "aws_kms_keys" table
+CREATE TABLE "aws_kms_keys" (
+  "external_key_id" uuid NOT NULL,
+  "external_keys_provider" text NOT NULL DEFAULT 'aws_kms',
+  "key_arn" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("external_key_id"),
+  CONSTRAINT "aws_kms_keys_fkey" FOREIGN KEY ("external_key_id", "external_keys_provider") REFERENCES "external_keys" ("id", "provider") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "aws_kms_keys_external_keys_provider_check" CHECK (external_keys_provider = 'aws_kms'::text)
+);
+-- Create "gcp_iam_credentials" table
+CREATE TABLE "gcp_iam_credentials" (
+  "external_credential_id" uuid NOT NULL,
+  "external_credentials_provider" text NOT NULL DEFAULT 'gcp_iam',
+  "impersonate_service_account" text NULL,
+  "wif_pool_id" text NULL,
+  "wif_provider_id" text NULL,
+  "wif_project_number" text NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("external_credential_id"),
+  CONSTRAINT "gcp_iam_credentials_fkey" FOREIGN KEY ("external_credential_id", "external_credentials_provider") REFERENCES "external_credentials" ("id", "provider") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "gcp_iam_credentials_external_credentials_provider_check" CHECK (external_credentials_provider = 'gcp_iam'::text),
+  CONSTRAINT "gcp_iam_credentials_wif_complete_check" CHECK (num_nonnulls(wif_pool_id, wif_provider_id, wif_project_number) = ANY (ARRAY[0, 3]))
+);
+-- Create "gcp_kms_keys" table
+CREATE TABLE "gcp_kms_keys" (
+  "external_key_id" uuid NOT NULL,
+  "external_keys_provider" text NOT NULL DEFAULT 'gcp_kms',
+  "resource_name" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("external_key_id"),
+  CONSTRAINT "gcp_kms_keys_fkey" FOREIGN KEY ("external_key_id", "external_keys_provider") REFERENCES "external_keys" ("id", "provider") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "gcp_kms_keys_external_keys_provider_check" CHECK (external_keys_provider = 'gcp_kms'::text)
+);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:fB06IY8EIcYsM+1hZUUm1mwgauhRMUqqP+7jCTeuICA=
+h1:BscnDkYEYuaSTU4UqaXjmcf84IhZtqXlEvzlKEthflk=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -238,3 +238,4 @@ h1:fB06IY8EIcYsM+1hZUUm1mwgauhRMUqqP+7jCTeuICA=
 20260630213745_remote-session-issuers-global-slug-key.sql h1:2fXBIcMhRXsLIGrvLEXmzJ0qncFXF7ZI3RbSglU5z5Q=
 20260701215608_billing-mode-declarations.sql h1:wEegAGkGu26TmLNS3jrwPTcPumpS89I7XatrDKoQtJ8=
 20260701230608_session-capture-exclusions.sql h1:0/b+s8X5U0pMrunBZ7OawV5Wm1DdXiPcXrpMnPqhAjY=
+20260702032234_external-credentials-external-keys.sql h1:4H0IHcidOlIv9t9VwJBBLRKFb/nnpCi4vjwOCNkefmo=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2868/db-migration-external-credentials-external-keys-awsgcp-subtables

First migration for the customer-managed-keys (BYOK) data model, adding two layers modeled with Class Table Inheritance:

- `external_credentials` (+ `aws_iam_credentials`, `gcp_iam_credentials`): how Gram authenticates into a customer cloud, keyless (AssumeRole / web identity / ambient for AWS; impersonation / WIF / ambient for GCP). Shareable and reused across many keys.
- `external_keys` (+ `aws_kms_keys`, `gcp_kms_keys`): a provider KMS key reached through a credential, e.g. for asymmetric token signing.

Each layer is a provider-discriminated supertype plus per-provider subtype tables. Class Table Inheritance is preferred here for a few reasons: each subtype is modeled with descriptive, provider-native columns (e.g. `assume_role_arn` / `external_id` for AWS, `impersonate_service_account` / `wif_pool_id` for GCP) instead of overly generic columns or a JSON blob that require application code transformations or translations; provider-specific fields live in their own tables rather than one wide, mostly-null table; and adding a provider becomes a new subtype table plus a discriminator value rather than a schema change for existing consumers. Composite-FK pins keep provider and tenancy consistent across tables.

The payoff that makes this shape worth it: any other table can reference a credential through a single, generic `external_credential_id` column, with no per-provider columns or branching. The same applies one layer up: any feature that integrates a KMS key references it through a single, generic `external_key_id` column, regardless of provider.

Migration-only; the `models.go` change is regenerated sqlc output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add BYOK schema layers for external credentials and keys using Class Table Inheritance. Enables keyless AWS/GCP auth and lets KMS keys be referenced via generic IDs. Supports AGE-2868.

- **Migration**
  - Added `external_credentials` supertype with `aws_iam_credentials` and `gcp_iam_credentials` subtypes; provider check `('aws_iam','gcp_iam')`, composite-FK pins to `(id, provider)`, soft-delete, org/project FKs, and an org index for non-deleted rows.
  - Added `external_keys` supertype with `aws_kms_keys` and `gcp_kms_keys` subtypes; FK to `external_credentials`, provider check `('aws_kms','gcp_kms')`, soft-delete, indices on org and credential, composite-FK from subtypes, and cascade deletes from subtypes.
  - Migration-only (DDL); `atlas.sum` updated and `models.go` regenerated by sqlc.

<sup>Written for commit 01976e254434b9a692ea4a99cb28a9d9ea4e19cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

