### PR TITLE
fix: defer dashboard user-session mint until user has connected

### DIFF
--- a/client/dashboard/src/contexts/RemoteMcpConnection.tsx
+++ b/client/dashboard/src/contexts/RemoteMcpConnection.tsx
@@ -1,0 +1,183 @@
+import { Type } from "@/components/ui/type";
+import { useHasUserConnected } from "@/hooks/useHasUserConnected";
+import { useRemoteMcpUserSessionToken } from "@/hooks/useRemoteMcpUserSessionToken";
+import { Button } from "@speakeasy-api/moonshine";
+import { PlugZap } from "lucide-react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+interface RemoteMcpConnectionValue {
+  /** Auth headers for MCP requests; undefined when no credential applies. */
+  headers: Record<string, string> | undefined;
+  /** Opens the first-party connect page; undefined when the URL is unknown. */
+  connect: (() => void) | undefined;
+}
+
+const RemoteMcpConnectionContext =
+  createContext<RemoteMcpConnectionValue | null>(null);
+
+export function useRemoteMcpConnection(): RemoteMcpConnectionValue {
+  const value = useContext(RemoteMcpConnectionContext);
+  if (!value) {
+    throw new Error(
+      "useRemoteMcpConnection must be used within RemoteMcpConnection",
+    );
+  }
+  return value;
+}
+
+type RemoteMcpConnectionProps = {
+  /** The mcp_server id the user-session JWT is minted against. */
+  mcpServerId: string | undefined;
+  /** The server's user_session_issuer id; undefined when not issuer-gated. */
+  userSessionIssuerId: string | undefined;
+  /** The first-party connect page URL (see firstPartyConnectUrl). */
+  authUrl: string | undefined;
+  /** Rendered while connection state / the JWT is still resolving. */
+  fallback: ReactNode;
+  children: ReactNode;
+};
+
+/**
+ * Decides once whether the user can talk to a remote MCP server and tunnels
+ * the resulting connection to consumers via useRemoteMcpConnection.
+ *
+ * Minting a user-session JWT persists a user_sessions row the server operator
+ * can see, so viewing a page must never mint. That invariant is structural:
+ * the mint (MintedConnection) mounts only behind the hasUserConnected gate,
+ * and disconnected users get the Connect prompt with no children rendered.
+ */
+export function RemoteMcpConnection({
+  mcpServerId,
+  userSessionIssuerId,
+  authUrl,
+  fallback,
+  children,
+}: RemoteMcpConnectionProps): JSX.Element {
+  const connect = useMemo(() => {
+    if (!authUrl) return undefined;
+    return () => window.open(authUrl, "_blank", "noopener,noreferrer");
+  }, [authUrl]);
+
+  const anonymous = useMemo<RemoteMcpConnectionValue>(
+    () => ({ headers: undefined, connect }),
+    [connect],
+  );
+
+  if (!userSessionIssuerId) {
+    // Not issuer-gated: connect anonymously, no credential to establish.
+    return (
+      <RemoteMcpConnectionContext.Provider value={anonymous}>
+        {children}
+      </RemoteMcpConnectionContext.Provider>
+    );
+  }
+
+  return (
+    <GatedConnection
+      mcpServerId={mcpServerId}
+      userSessionIssuerId={userSessionIssuerId}
+      connect={connect}
+      fallback={fallback}
+    >
+      {children}
+    </GatedConnection>
+  );
+}
+
+function GatedConnection({
+  mcpServerId,
+  userSessionIssuerId,
+  connect,
+  fallback,
+  children,
+}: {
+  mcpServerId: string | undefined;
+  userSessionIssuerId: string;
+  connect: (() => void) | undefined;
+  fallback: ReactNode;
+  children: ReactNode;
+}): JSX.Element {
+  // No focus listener needed: the gate's queries use the default staleTime of
+  // 0, so react-query's refetchOnWindowFocus re-runs them when the user comes
+  // back from the connect tab and the gate flips on its own.
+  const hasUserConnected = useHasUserConnected({ userSessionIssuerId });
+
+  if (hasUserConnected === undefined) {
+    return <>{fallback}</>;
+  }
+  if (!hasUserConnected) {
+    return <RemoteMcpConnectPrompt onConnect={connect} />;
+  }
+  return (
+    <MintedConnection
+      mcpServerId={mcpServerId}
+      connect={connect}
+      fallback={fallback}
+    >
+      {children}
+    </MintedConnection>
+  );
+}
+
+/**
+ * Mounting this component mints the user-session JWT. It must stay behind
+ * the hasUserConnected gate.
+ */
+function MintedConnection({
+  mcpServerId,
+  connect,
+  fallback,
+  children,
+}: {
+  mcpServerId: string | undefined;
+  connect: (() => void) | undefined;
+  fallback: ReactNode;
+  children: ReactNode;
+}): JSX.Element {
+  const { accessToken, isLoading } = useRemoteMcpUserSessionToken({
+    mcpServerId,
+  });
+
+  const value = useMemo<RemoteMcpConnectionValue>(
+    () => ({
+      headers: accessToken
+        ? { Authorization: `Bearer ${accessToken}` }
+        : undefined,
+      connect,
+    }),
+    [accessToken, connect],
+  );
+
+  // Hold children until the JWT lands; an unauthenticated probe would 401
+  // and cache a spurious needs-auth state.
+  if (isLoading) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <RemoteMcpConnectionContext.Provider value={value}>
+      {children}
+    </RemoteMcpConnectionContext.Provider>
+  );
+}
+
+/** The disconnected state: prompts the user to connect upstream. */
+export function RemoteMcpConnectPrompt({
+  onConnect,
+}: {
+  onConnect?: () => void;
+}): JSX.Element {
+  return (
+    <div className="border-neutral-softest flex flex-col items-center gap-3 rounded-lg border px-6 py-12 text-center">
+      <PlugZap className="text-muted-foreground/70 size-8" />
+      <Type muted small>
+        Connect to this MCP to view the tools.
+      </Type>
+      {onConnect ? (
+        <Button variant="secondary" onClick={onConnect}>
+          <Button.Text>Connect</Button.Text>
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/client/dashboard/src/hooks/useHasUserConnected.test.ts
+++ b/client/dashboard/src/hooks/useHasUserConnected.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { computeHasUserConnected } from "./useHasUserConnected";
+
+function client(id: string) {
+  return { id };
+}
+
+function session(remoteSessionClientId: string) {
+  return { remoteSessionClientId };
+}
+
+describe("computeHasUserConnected", () => {
+  it("is true when the issuer has no bound clients (nothing to link)", () => {
+    expect(computeHasUserConnected([], [])).toBe(true);
+    expect(computeHasUserConnected([], [session("c1")])).toBe(true);
+  });
+
+  it("is true when every bound client has a session", () => {
+    expect(computeHasUserConnected([client("c1")], [session("c1")])).toBe(true);
+    expect(
+      computeHasUserConnected(
+        [client("c1"), client("c2")],
+        [session("c2"), session("c1")],
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when any bound client lacks a session", () => {
+    expect(computeHasUserConnected([client("c1")], [])).toBe(false);
+    expect(
+      computeHasUserConnected([client("c1"), client("c2")], [session("c1")]),
+    ).toBe(false);
+  });
+
+  it("ignores sessions held against unrelated clients", () => {
+    expect(computeHasUserConnected([client("c1")], [session("other")])).toBe(
+      false,
+    );
+  });
+});

--- a/client/dashboard/src/hooks/useHasUserConnected.ts
+++ b/client/dashboard/src/hooks/useHasUserConnected.ts
@@ -1,0 +1,94 @@
+import { useSession } from "@/contexts/Auth";
+import { useAllRemoteSessionClients } from "@/pages/mcp/x/tabs/settings/sections/authentication/useAllRemoteSessionClients";
+import type { RemoteSession } from "@gram/client/models/components/remotesession.js";
+import { GramError } from "@gram/client/models/errors/gramerror.js";
+import { useRemoteSessionsInfinite } from "@gram/client/react-query/remoteSessions.js";
+import { useEffect, useMemo } from "react";
+
+/**
+ * Mirror of the gateway's all-or-nothing rule (remotesessions.ResolveAccessTokens):
+ * connected iff every client bound to the issuer has a session, matched on
+ * client id alone because the gateway's lookup key is (subject, client). Zero
+ * bound clients means nothing to link. Token validity is deliberately ignored —
+ * stale credentials 401 at the gateway and surface the Connect prompt there.
+ */
+export function computeHasUserConnected(
+  boundClients: ReadonlyArray<{ id: string }>,
+  subjectSessions: ReadonlyArray<Pick<RemoteSession, "remoteSessionClientId">>,
+): boolean {
+  const linkedClientIds = new Set(
+    subjectSessions.map((s) => s.remoteSessionClientId),
+  );
+  return boundClients.every((c) => linkedClientIds.has(c.id));
+}
+
+/**
+ * Whether the current user holds the upstream remote_sessions an issuer-gated
+ * remote MCP server requires. Read-only: never mints a user-session JWT.
+ *
+ * `undefined` while resolving. On lookup errors: a 403 resolves to `true` —
+ * the lists need project:read, which a viewer holding only mcp:read may lack,
+ * and an unanswerable pre-check must not block the tools listing; any other
+ * error resolves to `false`, because minting is the one action this hook
+ * exists to prevent and a backend blip must not trigger it.
+ *
+ * Known limit: the session list is project-scoped, so a link made under
+ * another project's issuer on a shared org-level client reads as disconnected.
+ * That fails to the Connect prompt and heals on reconnect.
+ */
+export function useHasUserConnected({
+  userSessionIssuerId,
+}: {
+  userSessionIssuerId: string;
+}): boolean | undefined {
+  const session = useSession();
+
+  const clientsQuery = useAllRemoteSessionClients(
+    { userSessionIssuerId },
+    { throwOnError: false },
+  );
+
+  const sessionsQuery = useRemoteSessionsInfinite(
+    { subjectUrn: `user:${session.user.id}` },
+    undefined,
+    { throwOnError: false },
+  );
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = sessionsQuery;
+  const subjectSessions = useMemo<RemoteSession[]>(
+    () => sessionsQuery.data?.pages.flatMap((page) => page.result.items) ?? [],
+    [sessionsQuery.data],
+  );
+
+  const failure = clientsQuery.error ?? sessionsQuery.error;
+
+  let hasUserConnected: boolean | undefined;
+  if (failure) {
+    hasUserConnected = isForbidden(failure);
+  } else if (clientsQuery.isLoading) {
+    hasUserConnected = undefined;
+  } else if (computeHasUserConnected(clientsQuery.items, subjectSessions)) {
+    // Final even mid-walk: further pages can only add sessions.
+    hasUserConnected = true;
+  } else if (sessionsQuery.isLoading || hasNextPage) {
+    hasUserConnected = undefined;
+  } else {
+    hasUserConnected = false;
+  }
+
+  // Walk further session pages only while the verdict is still open — a
+  // partial list must not be read as disconnected, but once every bound
+  // client is matched there is nothing left to fetch.
+  const undecided = hasUserConnected === undefined;
+  useEffect(() => {
+    if (undecided && hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [undecided, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return hasUserConnected;
+}
+
+function isForbidden(error: Error): boolean {
+  return error instanceof GramError && error.statusCode === 403;
+}

--- a/client/dashboard/src/hooks/useRemoteMcpTools.ts
+++ b/client/dashboard/src/hooks/useRemoteMcpTools.ts
@@ -66,26 +66,20 @@ export interface UseRemoteMcpToolsOptions {
    * dashboard user's stored upstream credentials.
    */
   headers?: Record<string, string>;
-  /**
-   * Gate the connection. Pass `false` while a required credential (the minted
-   * JWT) is still loading so we don't fire an unauthenticated request and cache
-   * a spurious `needsAuth`.
-   */
-  enabled?: boolean;
 }
 
 /**
  * Connects to a Gram-proxied remote MCP endpoint and lists its tools.
  *
  * Issuer-gated servers need a user-session JWT passed via `options.headers`
- * (minted by useRemoteMcpUserSessionToken); without it they surface as
+ * (tunnelled through RemoteMcpConnection); without it they surface as
  * `needsAuth`.
  */
 export function useRemoteMcpTools(
   mcpUrl: string | undefined,
   options?: UseRemoteMcpToolsOptions,
 ): UseRemoteMcpToolsResult {
-  const { headers, enabled = true } = options ?? {};
+  const { headers } = options ?? {};
 
   // Key on the header values so the query refetches once the JWT arrives or
   // rotates, without keying on object identity.
@@ -98,7 +92,7 @@ export function useRemoteMcpTools(
   const query: UseQueryResult<RemoteMcpToolSet, Error> = useQuery({
     queryKey: ["remoteMcpTools", mcpUrl, headersKey],
     queryFn: async () => {
-      // `enabled` guards against an undefined URL, but narrow for the type.
+      // The query is disabled for an undefined URL, but narrow for the type.
       if (!mcpUrl) throw new Error("No MCP URL configured");
 
       const client = await createMCPClient({
@@ -144,7 +138,7 @@ export function useRemoteMcpTools(
         await client.close().catch(() => {});
       }
     },
-    enabled: enabled && !!mcpUrl,
+    enabled: !!mcpUrl,
     // Auth-related failures shouldn't be hammered; the user re-triggers via the
     // Authenticate flow or a manual refetch.
     retry: false,

--- a/client/dashboard/src/hooks/useRemoteMcpUserSessionToken.ts
+++ b/client/dashboard/src/hooks/useRemoteMcpUserSessionToken.ts
@@ -9,30 +9,26 @@ export interface UseRemoteMcpUserSessionTokenResult {
 }
 
 /**
- * Mints a user-session JWT scoped to a remote MCP server, mirroring the
- * playground (see PlaygroundElements.tsx) but passing `mcpServerId` to the
- * unified mint: remote MCP servers are mcp_servers-backed and carry no toolset,
- * so the JWT audience binds to the server's user_session_issuer (the /x/mcp
- * convention).
- * The minted token matches what /x/mcp/{slug}/token would emit after an OAuth
- * dance, so the runtime gateway resolves the dashboard user's stored upstream
- * credentials through the same path a real MCP client would.
+ * Mints a user-session JWT scoped to a remote MCP server. The token matches
+ * what /x/mcp/{slug}/token would emit after an OAuth dance, so the runtime
+ * gateway resolves the dashboard user's stored upstream credentials through
+ * the same path a real MCP client would.
  *
- * Only issuer-gated servers get a token; the mint RPC 400s for the rest, so we
- * leave `accessToken` undefined and let the connection proceed unauthenticated.
+ * Minting persists a user_sessions row visible in the server's "User sessions"
+ * panel, so mounting this hook is the gate: render it only for users who have
+ * already connected (see RemoteMcpConnection), never from a component that
+ * mounts merely because a page was viewed.
  */
 export function useRemoteMcpUserSessionToken({
   mcpServerId,
-  isIssuerGated,
 }: {
   mcpServerId: string | undefined;
-  isIssuerGated: boolean;
 }): UseRemoteMcpUserSessionTokenResult {
   const session = useSession();
   const project = useProject();
   const mintMutation = useMintUserSessionMutation();
 
-  const enabled = !!mcpServerId && isIssuerGated;
+  const enabled = !!mcpServerId;
 
   const query = useQuery({
     queryKey: [
@@ -65,9 +61,6 @@ export function useRemoteMcpUserSessionToken({
   });
 
   return {
-    // Gate on `enabled` so a non-issuer-gated server never surfaces a token
-    // (stale or otherwise) that would get attached to an unauthenticated
-    // connection.
     accessToken: enabled ? query.data?.accessToken : undefined,
     isLoading: enabled && query.isLoading && query.fetchStatus !== "idle",
   };

--- a/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
@@ -17,14 +17,17 @@ import {
   type RemoteMcpTool,
   type RemoteMcpToolAnnotations,
 } from "@/hooks/useRemoteMcpTools";
-import { useRemoteMcpUserSessionToken } from "@/hooks/useRemoteMcpUserSessionToken";
 import { handleError, toError } from "@/lib/errors";
 import { cn, firstPartyConnectUrl, mcpConnectionUrl } from "@/lib/utils";
-import { Badge, Button } from "@speakeasy-api/moonshine";
+import { Badge } from "@speakeasy-api/moonshine";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
-import { PlugZap } from "lucide-react";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+import {
+  RemoteMcpConnection,
+  RemoteMcpConnectPrompt,
+  useRemoteMcpConnection,
+} from "@/contexts/RemoteMcpConnection";
 
 type RemoteMcpToolsSectionProps = {
   /** The Gram-proxied MCP URL to connect to; undefined while endpoints load. */
@@ -33,23 +36,18 @@ type RemoteMcpToolsSectionProps = {
   isResolvingUrl: boolean;
   /** The mcp_server id, used to mint the user-session JWT. */
   mcpServerId: string | undefined;
-  /** Whether the server is issuer-gated (has a user_session_issuer). */
-  isIssuerGated: boolean;
+  /** The server's user_session_issuer id; undefined when not issuer-gated. */
+  userSessionIssuerId: string | undefined;
 };
 
 /**
  * Lists the tools advertised by the remote MCP server, connecting through the
- * Gram-proxied `/mcp/<slug>` endpoint via the AI SDK MCP client.
+ * Gram-proxied `/mcp/<slug>` endpoint via the AI SDK MCP client. The listing
+ * renders inside RemoteMcpConnection, which owns the connect-before-mint gate.
  *
- * For issuer-gated servers we mint a user-session JWT scoped to the mcp_server
- * and connect with it. When no upstream remote_session exists yet the gateway
- * 401s into `needsAuth`, and we surface an Authenticate button that opens the
- * first-party connect page in a new tab; returning focus re-attempts the list.
- *
- * Expected fetch failures are rendered inline (see RemoteMcpToolsBody). The
- * surrounding ErrorBoundary is the defensive layer for unexpected render-time
- * throws — its Retry resets the boundary and any errored queries so a fresh
- * attempt runs without reloading the page.
+ * Expected fetch failures render inline. The surrounding ErrorBoundary is the
+ * defensive layer for unexpected render-time throws — its Retry resets the
+ * boundary and any errored queries without reloading the page.
  */
 export function RemoteMcpToolsSection(
   props: RemoteMcpToolsSectionProps,
@@ -104,38 +102,60 @@ function RemoteMcpToolsSectionInner({
   mcpUrl,
   isResolvingUrl,
   mcpServerId,
-  isIssuerGated,
+  userSessionIssuerId,
 }: RemoteMcpToolsSectionProps): JSX.Element {
-  const { accessToken, isLoading: isTokenLoading } =
-    useRemoteMcpUserSessionToken({ mcpServerId, isIssuerGated });
-
-  // Issuer-gated servers must wait for the JWT before connecting, otherwise the
-  // unauthenticated request 401s and caches a spurious `needsAuth`.
-  const headers = useMemo(
-    () =>
-      accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
-    [accessToken],
-  );
-  const connectionEnabled = !isIssuerGated || !!accessToken;
-
   // Connect through the dev proxy origin (same-origin) so the AI SDK transport
   // carries the gram_session cookie and the gateway's proxied SSE response
   // isn't dropped on a cross-origin hop. No-op in prod / for custom domains.
   const connectUrl = useMemo(() => mcpConnectionUrl(mcpUrl), [mcpUrl]);
 
+  // The first-party connect page is opened as a top-level new tab, so it rides
+  // the gram_session cookie on the backend origin (not the dev proxy).
+  const authUrl = useMemo(() => firstPartyConnectUrl(mcpUrl), [mcpUrl]);
+
+  if (isResolvingUrl) {
+    return (
+      <ToolsSectionShell>
+        <ToolsListSkeleton />
+      </ToolsSectionShell>
+    );
+  }
+
+  return (
+    <ToolsSectionShell>
+      <RemoteMcpConnection
+        mcpServerId={mcpServerId}
+        userSessionIssuerId={userSessionIssuerId}
+        authUrl={authUrl}
+        fallback={<ToolsListSkeleton />}
+      >
+        <RemoteMcpToolsListing connectUrl={connectUrl} />
+      </RemoteMcpConnection>
+    </ToolsSectionShell>
+  );
+}
+
+/**
+ * The connected path: lists tools with the connection's headers. A gateway
+ * 401 (stale upstream credentials, invisible to the gate's pre-check) falls
+ * back to the same Connect prompt; focus returning from connect re-probes.
+ */
+function RemoteMcpToolsListing({
+  connectUrl,
+}: {
+  connectUrl: string | undefined;
+}): JSX.Element {
+  const { headers, connect } = useRemoteMcpConnection();
+
   const { tools, isLoading, needsAuth, isError, refetch } = useRemoteMcpTools(
     connectUrl,
-    { headers, enabled: connectionEnabled },
+    { headers },
   );
 
   const toolEntries = useMemo(
     () => (tools ? Object.entries(tools) : []),
     [tools],
   );
-
-  // The first-party connect page is opened as a top-level new tab, so it rides
-  // the gram_session cookie on the backend origin (not the dev proxy).
-  const authUrl = useMemo(() => firstPartyConnectUrl(mcpUrl), [mcpUrl]);
 
   // When the user comes back from the connect tab, re-attempt the listing so a
   // freshly linked session surfaces without a manual refresh.
@@ -146,54 +166,19 @@ function RemoteMcpToolsSectionInner({
     return () => window.removeEventListener("focus", onFocus);
   }, [needsAuth, refetch]);
 
-  const handleConnect = () => {
-    if (authUrl) window.open(authUrl, "_blank", "noopener,noreferrer");
-  };
-
-  const loading = isResolvingUrl || isTokenLoading || isLoading;
-
-  return (
-    <ToolsSectionShell>
-      <RemoteMcpToolsBody
-        loading={loading}
-        needsAuth={needsAuth}
-        isError={isError}
-        toolEntries={toolEntries}
-        onRetry={refetch}
-        onConnect={authUrl ? handleConnect : undefined}
-      />
-    </ToolsSectionShell>
-  );
-}
-
-function RemoteMcpToolsBody({
-  loading,
-  needsAuth,
-  isError,
-  toolEntries,
-  onRetry,
-  onConnect,
-}: {
-  loading: boolean;
-  needsAuth: boolean;
-  isError: boolean;
-  toolEntries: Array<[string, RemoteMcpTool]>;
-  onRetry: () => void;
-  onConnect?: () => void;
-}): JSX.Element {
-  if (loading) {
+  if (isLoading) {
     return <ToolsListSkeleton />;
   }
 
   if (needsAuth) {
-    return <RemoteMcpToolsConnectPrompt onConnect={onConnect} />;
+    return <RemoteMcpConnectPrompt onConnect={connect} />;
   }
 
   if (isError) {
     return (
       <EmptyState
         message="Couldn't connect to this server to list its tools."
-        onRetry={onRetry}
+        onRetry={refetch}
       />
     );
   }
@@ -426,31 +411,6 @@ function ToolRowSkeleton(): JSX.Element {
     <div className="border-neutral-softest flex flex-col gap-2 border-b py-4 pr-3 pl-4 last:border-b-0">
       <Skeleton className="h-4 w-48" />
       <Skeleton className="h-3 w-80 max-w-full" />
-    </div>
-  );
-}
-
-/**
- * The needs-connect state: a centered card prompting the user to connect
- * upstream before tools can be listed. Connecting opens the first-party connect
- * page; returning focus re-attempts the listing.
- */
-function RemoteMcpToolsConnectPrompt({
-  onConnect,
-}: {
-  onConnect?: () => void;
-}): JSX.Element {
-  return (
-    <div className="border-neutral-softest flex flex-col items-center gap-3 rounded-lg border px-6 py-12 text-center">
-      <PlugZap className="text-muted-foreground/70 size-8" />
-      <Type muted small>
-        Connect to this MCP to view the tools.
-      </Type>
-      {onConnect ? (
-        <Button variant="secondary" onClick={onConnect}>
-          <Button.Text>Connect</Button.Text>
-        </Button>
-      ) : null}
     </div>
   );
 }

--- a/client/dashboard/src/pages/mcp/x/tabs/ToolsTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/ToolsTab.tsx
@@ -25,7 +25,7 @@ export function ToolsTab({
         mcpUrl={mcpUrl}
         isResolvingUrl={loading}
         mcpServerId={mcpServer.id}
-        isIssuerGated={!!mcpServer.userSessionIssuerId}
+        userSessionIssuerId={mcpServer.userSessionIssuerId}
       />
     </div>
   );

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/useAllRemoteSessionClients.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/useAllRemoteSessionClients.ts
@@ -19,10 +19,11 @@ export function useAllRemoteSessionClients(
     ListRemoteSessionClientsRequest,
     "userSessionIssuerId" | "remoteSessionIssuerId"
   >,
-  options?: { enabled?: boolean },
-): { items: RemoteSessionClient[]; isLoading: boolean } {
+  options?: { enabled?: boolean; throwOnError?: boolean },
+): { items: RemoteSessionClient[]; isLoading: boolean; error: Error | null } {
   const query = useRemoteSessionClientsInfinite(filters, undefined, {
     enabled: options?.enabled,
+    throwOnError: options?.throwOnError,
   });
 
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
@@ -43,5 +44,5 @@ export function useAllRemoteSessionClients(
   // coming.
   const isLoading = query.isLoading || hasNextPage;
 
-  return { items, isLoading };
+  return { items, isLoading, error: query.error };
 }


### PR DESCRIPTION
## Problem

Viewing the **Tools** tab of an issuer-gated remote MCP server minted a user-session JWT. The mint persists a `user_sessions` row, so operators saw "active" sessions in **Settings → User sessions** for anyone who merely looked at the tab (re-minted every 45 minutes while it stayed open).

## Change

Connection is decided once, and the mint is structurally gated behind it:

- **`useHasUserConnected`** — read-only pre-check mirroring the gateway's all-or-nothing rule (`remotesessions.ResolveAccessTokens`): connected iff every `remote_session_client` bound to the issuer has a `remote_session` for `user:<me>`, matched on client id like the gateway's (subject, client) lookup. Session pages are walked only until the verdict is decided.
- **`RemoteMcpConnection`** — context gate. Disconnected → Connect prompt; the connected subtree — which contains the mint — never mounts, so viewing a page cannot create a session. Connected → mints and tunnels `{ headers, connect }` to consumers.
- **`RemoteMcpToolsListing`** — consumes the connection and probes `tools/list`. A gateway 401 (stale upstream credentials, invisible to the pre-check) falls back to the same Connect prompt.

Error posture: a **403** on the pre-check fails **open** (the lists need `project:read`, which a viewer holding only `mcp:read` may lack — an unanswerable pre-check must not block the listing); **any other failure fails closed**, because minting is the one action the gate exists to prevent. The gate flips after connecting via react-query's default focus refetch (the gate queries are staleTime-0), no manual listeners.

## Known tradeoffs

- Client-side mirror of the server rule; if AIS-152 softens all-or-nothing to per-tool resolution, this pre-check needs the same change.
- The session list is project-scoped: a link made under another project's issuer on a shared org-level client reads as disconnected → Connect prompt, heals on reconnect. Never mints wrongly.
- A linked-but-expired upstream still mints (that user did connect); the gateway 401 routes them to the prompt.
- The playground still eager-mints for issuer-gated toolsets — follow-up.
- Deeper alternative (mint RPC answering `needs_connect` without persisting) deliberately not taken to keep this dashboard-only.

## Testing

- `pnpm -F dashboard test src/hooks src/pages/mcp` — 125 passed, including unit tests for the pre-check rule.
- Type-check / oxlint / oxfmt clean for touched files (pre-existing `observeTargetFilters.ts` / `LogsTools.tsx` failures reproduce on origin/main with this change stashed).
- 8-angle self-review (line scan, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) fed back into the diff: fail-closed default, early-stop pagination, memoized context value, deleted redundant focus listeners.
