### PR TITLE
mig: add resource column to remote_session_clients

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -945,6 +945,14 @@ CREATE TABLE IF NOT EXISTS remote_session_clients (
   scope TEXT[],
   audience TEXT,
 
+  -- RFC 8707 resource indicator: when non-null, this exact URI is sent as
+  -- the `resource` parameter on the authorize redirect, code exchange, and
+  -- refresh grant so the upstream AS audience-binds the issued tokens. The
+  -- MCP authorization spec requires clients to send the canonical resource
+  -- URI from the server's RFC 9728 protected-resource metadata; NULL keeps
+  -- the historical behaviour of omitting the parameter.
+  resource TEXT CHECK (resource IS NULL OR btrim(resource) <> ''),
+
   -- CIMD: when non-null, Gram publishes its OAuth Client ID Metadata
   -- Document at this HTTPS URL and uses the URL as the client_id on every
   -- outbound /authorize, /token, and refresh call. Per

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1269,6 +1269,7 @@ type RemoteSessionClient struct {
 	TokenEndpointAuthMethod pgtype.Text
 	Scope                   []string
 	Audience                pgtype.Text
+	Resource                pgtype.Text
 	ClientIDMetadataUri     pgtype.Text
 	LegacyCallbackUrl       bool
 	CreatedAt               pgtype.Timestamptz

--- a/server/internal/remotesessions/repo/models.go
+++ b/server/internal/remotesessions/repo/models.go
@@ -38,6 +38,7 @@ type RemoteSessionClient struct {
 	TokenEndpointAuthMethod pgtype.Text
 	Scope                   []string
 	Audience                pgtype.Text
+	Resource                pgtype.Text
 	ClientIDMetadataUri     pgtype.Text
 	LegacyCallbackUrl       bool
 	CreatedAt               pgtype.Timestamptz

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -106,7 +106,7 @@ VALUES (
     $10,
     $11
 )
-RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, resource, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRemoteSessionClientParams struct {
@@ -150,6 +150,7 @@ func (q *Queries) CreateRemoteSessionClient(ctx context.Context, arg CreateRemot
 		&i.TokenEndpointAuthMethod,
 		&i.Scope,
 		&i.Audience,
+		&i.Resource,
 		&i.ClientIDMetadataUri,
 		&i.LegacyCallbackUrl,
 		&i.CreatedAt,
@@ -185,7 +186,7 @@ VALUES (
     $7::text[],
     $8
 )
-RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, resource, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRemoteSessionClientCIMDParams struct {
@@ -228,6 +229,7 @@ func (q *Queries) CreateRemoteSessionClientCIMD(ctx context.Context, arg CreateR
 		&i.TokenEndpointAuthMethod,
 		&i.Scope,
 		&i.Audience,
+		&i.Resource,
 		&i.ClientIDMetadataUri,
 		&i.LegacyCallbackUrl,
 		&i.CreatedAt,
@@ -363,7 +365,7 @@ WHERE c.id = $1
   AND i.organization_id = $2
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
-RETURNING c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted
+RETURNING c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.resource, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted
 `
 
 type DeleteOrganizationRemoteSessionClientParams struct {
@@ -388,6 +390,7 @@ func (q *Queries) DeleteOrganizationRemoteSessionClient(ctx context.Context, arg
 		&i.TokenEndpointAuthMethod,
 		&i.Scope,
 		&i.Audience,
+		&i.Resource,
 		&i.ClientIDMetadataUri,
 		&i.LegacyCallbackUrl,
 		&i.CreatedAt,
@@ -445,7 +448,7 @@ const deleteRemoteSessionClient = `-- name: DeleteRemoteSessionClient :one
 UPDATE remote_session_clients
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, resource, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteRemoteSessionClientParams struct {
@@ -468,6 +471,7 @@ func (q *Queries) DeleteRemoteSessionClient(ctx context.Context, arg DeleteRemot
 		&i.TokenEndpointAuthMethod,
 		&i.Scope,
 		&i.Audience,
+		&i.Resource,
 		&i.ClientIDMetadataUri,
 		&i.LegacyCallbackUrl,
 		&i.CreatedAt,
@@ -699,7 +703,7 @@ func (q *Queries) GetOrganizationRemoteSessionByID(ctx context.Context, arg GetO
 
 const getOrganizationRemoteSessionClientByID = `-- name: GetOrganizationRemoteSessionClientByID :one
 SELECT
-    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
+    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.resource, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
     (
         SELECT COALESCE(array_agg(link.user_session_issuer_id ORDER BY link.user_session_issuer_id), '{}'::uuid[])
         FROM remote_session_client_user_session_issuers AS link
@@ -739,6 +743,7 @@ func (q *Queries) GetOrganizationRemoteSessionClientByID(ctx context.Context, ar
 		&i.RemoteSessionClient.TokenEndpointAuthMethod,
 		&i.RemoteSessionClient.Scope,
 		&i.RemoteSessionClient.Audience,
+		&i.RemoteSessionClient.Resource,
 		&i.RemoteSessionClient.ClientIDMetadataUri,
 		&i.RemoteSessionClient.LegacyCallbackUrl,
 		&i.RemoteSessionClient.CreatedAt,
@@ -833,7 +838,7 @@ func (q *Queries) GetRemoteSessionByID(ctx context.Context, arg GetRemoteSession
 
 const getRemoteSessionClientByID = `-- name: GetRemoteSessionClientByID :one
 SELECT
-    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
+    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.resource, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
     (
         SELECT COALESCE(array_agg(link.user_session_issuer_id ORDER BY link.user_session_issuer_id), '{}'::uuid[])
         FROM remote_session_client_user_session_issuers AS link
@@ -873,6 +878,7 @@ func (q *Queries) GetRemoteSessionClientByID(ctx context.Context, arg GetRemoteS
 		&i.RemoteSessionClient.TokenEndpointAuthMethod,
 		&i.RemoteSessionClient.Scope,
 		&i.RemoteSessionClient.Audience,
+		&i.RemoteSessionClient.Resource,
 		&i.RemoteSessionClient.ClientIDMetadataUri,
 		&i.RemoteSessionClient.LegacyCallbackUrl,
 		&i.RemoteSessionClient.CreatedAt,
@@ -1247,7 +1253,7 @@ func (q *Queries) ListOrganizationMcpServersForClient(ctx context.Context, remot
 
 const listOrganizationRemoteSessionClientsByIssuerID = `-- name: ListOrganizationRemoteSessionClientsByIssuerID :many
 SELECT
-    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
+    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.resource, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
     (
         SELECT COALESCE(array_agg(link.user_session_issuer_id ORDER BY link.user_session_issuer_id), '{}'::uuid[])
         FROM remote_session_client_user_session_issuers AS link
@@ -1327,6 +1333,7 @@ func (q *Queries) ListOrganizationRemoteSessionClientsByIssuerID(ctx context.Con
 			&i.RemoteSessionClient.TokenEndpointAuthMethod,
 			&i.RemoteSessionClient.Scope,
 			&i.RemoteSessionClient.Audience,
+			&i.RemoteSessionClient.Resource,
 			&i.RemoteSessionClient.ClientIDMetadataUri,
 			&i.RemoteSessionClient.LegacyCallbackUrl,
 			&i.RemoteSessionClient.CreatedAt,
@@ -1508,7 +1515,7 @@ func (q *Queries) ListOrganizationRemoteSessionsByClientID(ctx context.Context, 
 
 const listRemoteSessionClientsByProjectID = `-- name: ListRemoteSessionClientsByProjectID :many
 SELECT
-    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
+    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.resource, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
     (
         SELECT COALESCE(array_agg(link.user_session_issuer_id ORDER BY link.user_session_issuer_id), '{}'::uuid[])
         FROM remote_session_client_user_session_issuers AS link
@@ -1565,6 +1572,7 @@ func (q *Queries) ListRemoteSessionClientsByProjectID(ctx context.Context, arg L
 			&i.RemoteSessionClient.TokenEndpointAuthMethod,
 			&i.RemoteSessionClient.Scope,
 			&i.RemoteSessionClient.Audience,
+			&i.RemoteSessionClient.Resource,
 			&i.RemoteSessionClient.ClientIDMetadataUri,
 			&i.RemoteSessionClient.LegacyCallbackUrl,
 			&i.RemoteSessionClient.CreatedAt,
@@ -1585,7 +1593,7 @@ func (q *Queries) ListRemoteSessionClientsByProjectID(ctx context.Context, arg L
 
 const listRemoteSessionClientsByProjectIDForUserSessionIssuer = `-- name: ListRemoteSessionClientsByProjectIDForUserSessionIssuer :many
 SELECT
-    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
+    c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.resource, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
     (
         SELECT COALESCE(array_agg(all_link.user_session_issuer_id ORDER BY all_link.user_session_issuer_id), '{}'::uuid[])
         FROM remote_session_client_user_session_issuers AS all_link
@@ -1654,6 +1662,7 @@ func (q *Queries) ListRemoteSessionClientsByProjectIDForUserSessionIssuer(ctx co
 			&i.RemoteSessionClient.TokenEndpointAuthMethod,
 			&i.RemoteSessionClient.Scope,
 			&i.RemoteSessionClient.Audience,
+			&i.RemoteSessionClient.Resource,
 			&i.RemoteSessionClient.ClientIDMetadataUri,
 			&i.RemoteSessionClient.LegacyCallbackUrl,
 			&i.RemoteSessionClient.CreatedAt,
@@ -2281,7 +2290,7 @@ WHERE c.id = $5
   AND i.organization_id = $6
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
-RETURNING c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted
+RETURNING c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.resource, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted
 `
 
 type UpdateOrganizationRemoteSessionClientParams struct {
@@ -2318,6 +2327,7 @@ func (q *Queries) UpdateOrganizationRemoteSessionClient(ctx context.Context, arg
 		&i.TokenEndpointAuthMethod,
 		&i.Scope,
 		&i.Audience,
+		&i.Resource,
 		&i.ClientIDMetadataUri,
 		&i.LegacyCallbackUrl,
 		&i.CreatedAt,
@@ -2446,7 +2456,7 @@ SET
     audience = COALESCE($5, audience),
     updated_at = clock_timestamp()
 WHERE id = $6 AND project_id = $7 AND deleted IS FALSE
-RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, remote_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, resource, client_id_metadata_uri, legacy_callback_url, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRemoteSessionClientParams struct {
@@ -2482,6 +2492,7 @@ func (q *Queries) UpdateRemoteSessionClient(ctx context.Context, arg UpdateRemot
 		&i.TokenEndpointAuthMethod,
 		&i.Scope,
 		&i.Audience,
+		&i.Resource,
 		&i.ClientIDMetadataUri,
 		&i.LegacyCallbackUrl,
 		&i.CreatedAt,

--- a/server/migrations/20260702113300_remote-session-clients-add-resource.sql
+++ b/server/migrations/20260702113300_remote-session-clients-add-resource.sql
@@ -1,0 +1,2 @@
+-- Modify "remote_session_clients" table
+ALTER TABLE "remote_session_clients" ADD CONSTRAINT "remote_session_clients_resource_check" CHECK ((resource IS NULL) OR (btrim(resource) <> ''::text)), ADD COLUMN "resource" text NULL;

--- a/server/migrations/20260702113300_remote-session-clients-add-resource.sql
+++ b/server/migrations/20260702113300_remote-session-clients-add-resource.sql
@@ -1,2 +1,9 @@
+-- atlas:txmode none
+
 -- Modify "remote_session_clients" table
-ALTER TABLE "remote_session_clients" ADD CONSTRAINT "remote_session_clients_resource_check" CHECK ((resource IS NULL) OR (btrim(resource) <> ''::text)), ADD COLUMN "resource" text NULL;
+ALTER TABLE "remote_session_clients" ADD COLUMN "resource" text NULL;
+-- Add the CHECK as NOT VALID then validate separately: validation only takes
+-- a SHARE UPDATE EXCLUSIVE lock, avoiding the full-table scan under ACCESS
+-- EXCLUSIVE that an inline CHECK would require (PG305).
+ALTER TABLE "remote_session_clients" ADD CONSTRAINT "remote_session_clients_resource_check" CHECK ((resource IS NULL) OR (btrim(resource) <> ''::text)) NOT VALID;
+ALTER TABLE "remote_session_clients" VALIDATE CONSTRAINT "remote_session_clients_resource_check";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:fB06IY8EIcYsM+1hZUUm1mwgauhRMUqqP+7jCTeuICA=
+h1:6iku7/NSS60ZpTp0UX7bODAmVEjdXUsLCpwpIbf8RS0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -238,3 +238,4 @@ h1:fB06IY8EIcYsM+1hZUUm1mwgauhRMUqqP+7jCTeuICA=
 20260630213745_remote-session-issuers-global-slug-key.sql h1:2fXBIcMhRXsLIGrvLEXmzJ0qncFXF7ZI3RbSglU5z5Q=
 20260701215608_billing-mode-declarations.sql h1:wEegAGkGu26TmLNS3jrwPTcPumpS89I7XatrDKoQtJ8=
 20260701230608_session-capture-exclusions.sql h1:0/b+s8X5U0pMrunBZ7OawV5Wm1DdXiPcXrpMnPqhAjY=
+20260702113300_remote-session-clients-add-resource.sql h1:MSnpYevpOQM2trmPyBvOxRLXCNwHG2SviW+xufs8BtI=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:6iku7/NSS60ZpTp0UX7bODAmVEjdXUsLCpwpIbf8RS0=
+h1:Bsr40n31cmCrEeh6/pfRcDpMHSsqVXcmg67B/0FWu2Y=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -238,4 +238,4 @@ h1:6iku7/NSS60ZpTp0UX7bODAmVEjdXUsLCpwpIbf8RS0=
 20260630213745_remote-session-issuers-global-slug-key.sql h1:2fXBIcMhRXsLIGrvLEXmzJ0qncFXF7ZI3RbSglU5z5Q=
 20260701215608_billing-mode-declarations.sql h1:wEegAGkGu26TmLNS3jrwPTcPumpS89I7XatrDKoQtJ8=
 20260701230608_session-capture-exclusions.sql h1:0/b+s8X5U0pMrunBZ7OawV5Wm1DdXiPcXrpMnPqhAjY=
-20260702113300_remote-session-clients-add-resource.sql h1:MSnpYevpOQM2trmPyBvOxRLXCNwHG2SviW+xufs8BtI=
+20260702113300_remote-session-clients-add-resource.sql h1:r34z7DMrAZLA3aX/XjESdMbrWKcAOQjiVRfY+Ly3lYU=


### PR DESCRIPTION
## Summary

Adds a nullable `resource` column to `remote_session_clients` for RFC 8707 resource indicators. Schema only — wiring lands in the stacked follow-up PR.

## Why

The MCP authorization spec requires OAuth clients to send the RFC 8707 `resource` parameter (the MCP server's canonical resource URI) on the authorize, token-exchange, and refresh legs so the upstream AS audience-binds issued tokens. Gram's remote-session dance omits it today. Most upstreams tolerate this, but strict ones reject the resulting tokens: a customer's Zip server dances successfully against `app.ziphq.com`, then every proxied call to `https://mcp.zip.com/mcp` gets `401 {"error":"invalid_token","error_description":"Invalid access token"}` — including 1 second after a successful refresh.

`NULL` (default) preserves current behaviour for every existing client. Rollout: set the value for the single affected client, verify, then derive it automatically for new remote-MCP-backed clients as a follow-up.

## Changes

- `remote_session_clients.resource TEXT NULL` + non-empty CHECK
- Migration generated with `mise db:diff`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nullable `resource` column to `remote_session_clients` for the RFC 8707 resource indicator; `NULL` keeps current behavior. The CHECK is added as NOT VALID and then validated to avoid blocking locks, and `sqlc` models/queries are regenerated; wiring for authorize, token exchange, and refresh comes later.

<sup>Written for commit 0bfe459e055671ae103d4458c16a637a04e42f41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

