### PR TITLE
feat: send RFC 8707 resource indicator in remote session OAuth dance

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -212,10 +212,13 @@ const (
 	// OAuthFlowStageKey is the coarse, low-cardinality stage at which an OAuth
 	// flow terminated (see the oauthFlowStage enum in the mcp package). Used
 	// as a metric dimension on oauth.flow.failed and in failure logs.
-	OAuthFlowStageKey                 = attribute.Key("gram.oauth.flow_stage")
-	OAuthGrantKey                     = attribute.Key("gram.oauth.grant")
-	OAuthIssuerKey                    = attribute.Key("gram.oauth.issuer")
-	OAuthPresentedAuthMethodKey       = attribute.Key("gram.oauth.presented_auth_method")
+	OAuthFlowStageKey           = attribute.Key("gram.oauth.flow_stage")
+	OAuthGrantKey               = attribute.Key("gram.oauth.grant")
+	OAuthIssuerKey              = attribute.Key("gram.oauth.issuer")
+	OAuthPresentedAuthMethodKey = attribute.Key("gram.oauth.presented_auth_method")
+	// OAuthResourceKey is the RFC 8707 resource indicator sent to an
+	// upstream authorization server during the remote-session dance.
+	OAuthResourceKey                  = attribute.Key("gram.oauth.resource")
 	OAuthProviderKey                  = attribute.Key("gram.oauth.provider")
 	OAuthRedirectURICountKey          = attribute.Key("gram.oauth.redirect_uri.count")
 	OAuthRedirectURIFullKey           = attribute.Key("gram.oauth.redirect_uri.full")
@@ -915,6 +918,9 @@ func SlogOAuthAuthorizationEndpoint(v string) slog.Attr {
 
 func OAuthClientID(v string) attribute.KeyValue { return OAuthClientIDKey.String(v) }
 func SlogOAuthClientID(v string) slog.Attr      { return slog.String(string(OAuthClientIDKey), v) }
+
+func OAuthResource(v string) attribute.KeyValue { return OAuthResourceKey.String(v) }
+func SlogOAuthResource(v string) slog.Attr      { return slog.String(string(OAuthResourceKey), v) }
 
 func OAuthClientName(v string) attribute.KeyValue { return OAuthClientNameKey.String(v) }
 func SlogOAuthClientName(v string) slog.Attr      { return slog.String(string(OAuthClientNameKey), v) }

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -334,7 +334,7 @@ func (s *Service) ApplyIssuerGate(
 	// user resolves by re-linking via {routeBase}/{slug}/connect.
 	var upstreamTokens map[uuid.UUID]string
 	if subject != nil {
-		tokens, rerr := s.remoteChallengeMgr.ResolveAccessTokens(newCtx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, *subject)
+		tokens, rerr := s.remoteChallengeMgr.ResolveAccessTokens(newCtx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, *subject, endpoint.UpstreamResource)
 		switch {
 		case errors.Is(rerr, remotesessions.ErrNoValidToken):
 			return ctx, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "")

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -476,6 +476,7 @@ func (s *Service) buildRemoteSessionCards(
 		McpSlug:             endpoint.Slug,
 		RouteBase:           endpoint.RouteBase,
 		FinalRedirectURI:    "",
+		Resource:            endpoint.UpstreamResource,
 	}
 
 	cards := make([]remoteSessionCard, 0, len(clients))

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -338,7 +338,13 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 		case err != nil:
 			return nil, oops.E(oops.CodeUnexpected, err, "load project").LogError(ctx, s.logger)
 		}
-		return NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID), nil
+		endpoint := NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
+		upstreamResource, err := s.resolveUpstreamResource(ctx, s.logger, mcpEndpoint.ProjectID, &mcpServer)
+		if err != nil {
+			return nil, err
+		}
+		endpoint.UpstreamResource = upstreamResource
+		return endpoint, nil
 	}
 
 	toolset, err := s.loadToolset(ctx, ref.McpSlug, ref.CustomDomainID, true)

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -70,6 +70,11 @@ type ResolvedMcpEndpoint struct {
 	// resolutions. Used for telemetry / log attribution.
 	ToolsetID uuid.NullUUID
 
+	// UpstreamResource is the RFC 8707 resource indicator for the
+	// endpoint's upstream — the remote backend URL for remote-backed
+	// servers, empty otherwise.
+	UpstreamResource string
+
 	// UserSessionIssuerID is the user_session_issuer the endpoint is
 	// gated on.
 	UserSessionIssuerID uuid.UUID
@@ -247,6 +252,7 @@ func NewResolvedMcpEndpointFromMcpServer(
 		RouteBase:           "x/mcp",
 		Slug:                mcpEndpoint.Slug,
 		ToolsetID:           mcpServer.ToolsetID,
+		UpstreamResource:    "",
 		UserSessionIssuerID: mcpServer.UserSessionIssuerID.UUID,
 	}
 }
@@ -269,6 +275,7 @@ func newResolvedMcpEndpointFromToolset(toolset *toolsets_repo.Toolset, routeBase
 		RouteBase:           routeBase,
 		Slug:                conv.PtrValOr(conv.FromPGText[string](toolset.McpSlug), ""),
 		ToolsetID:           uuid.NullUUID{UUID: toolset.ID, Valid: true},
+		UpstreamResource:    "",
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
 	}
 }

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -284,6 +285,19 @@ func (s *Service) BuildResolvedMcpEndpointForServer(
 	}
 	resolved := NewResolvedMcpEndpointFromMcpServer(mcpEndpoint, mcpServer, project.OrganizationID)
 	resolved.RouteBase = mcpRouteBase
+	if mcpServer.RemoteMcpServerID.Valid {
+		remote, rerr := remotemcprepo.New(s.db).GetServerByID(ctx, remotemcprepo.GetServerByIDParams{
+			ID:        mcpServer.RemoteMcpServerID.UUID,
+			ProjectID: mcpEndpoint.ProjectID,
+		})
+		switch {
+		case errors.Is(rerr, pgx.ErrNoRows):
+			return nil, oops.E(oops.CodeNotFound, rerr, "remote mcp server not found")
+		case rerr != nil:
+			return nil, oops.E(oops.CodeUnexpected, rerr, "load remote mcp server").LogError(ctx, logger)
+		}
+		resolved.UpstreamResource = strings.TrimRight(remote.Url, "/")
+	}
 	if err := s.RequireUserSessionIssuer(ctx, resolved); err != nil {
 		return nil, fmt.Errorf("require user session issuer: %w", err)
 	}

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -285,23 +285,40 @@ func (s *Service) BuildResolvedMcpEndpointForServer(
 	}
 	resolved := NewResolvedMcpEndpointFromMcpServer(mcpEndpoint, mcpServer, project.OrganizationID)
 	resolved.RouteBase = mcpRouteBase
-	if mcpServer.RemoteMcpServerID.Valid {
-		remote, rerr := remotemcprepo.New(s.db).GetServerByID(ctx, remotemcprepo.GetServerByIDParams{
-			ID:        mcpServer.RemoteMcpServerID.UUID,
-			ProjectID: mcpEndpoint.ProjectID,
-		})
-		switch {
-		case errors.Is(rerr, pgx.ErrNoRows):
-			return nil, oops.E(oops.CodeNotFound, rerr, "remote mcp server not found")
-		case rerr != nil:
-			return nil, oops.E(oops.CodeUnexpected, rerr, "load remote mcp server").LogError(ctx, logger)
-		}
-		resolved.UpstreamResource = strings.TrimRight(remote.Url, "/")
+	upstreamResource, err := s.resolveUpstreamResource(ctx, logger, mcpEndpoint.ProjectID, mcpServer)
+	if err != nil {
+		return nil, err
 	}
+	resolved.UpstreamResource = upstreamResource
 	if err := s.RequireUserSessionIssuer(ctx, resolved); err != nil {
 		return nil, fmt.Errorf("require user session issuer: %w", err)
 	}
 	return resolved, nil
+}
+
+// resolveUpstreamResource derives the RFC 8707 resource indicator for an
+// mcp_server's upstream: the remote backend URL (sans trailing slash) for
+// remote-backed servers, empty otherwise.
+func (s *Service) resolveUpstreamResource(
+	ctx context.Context,
+	logger *slog.Logger,
+	projectID uuid.UUID,
+	mcpServer *mcpserversrepo.McpServer,
+) (string, error) {
+	if !mcpServer.RemoteMcpServerID.Valid {
+		return "", nil
+	}
+	remote, err := remotemcprepo.New(s.db).GetServerByID(ctx, remotemcprepo.GetServerByIDParams{
+		ID:        mcpServer.RemoteMcpServerID.UUID,
+		ProjectID: projectID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return "", oops.E(oops.CodeNotFound, err, "remote mcp server not found")
+	case err != nil:
+		return "", oops.E(oops.CodeUnexpected, err, "load remote mcp server").LogError(ctx, logger)
+	}
+	return strings.TrimRight(remote.Url, "/"), nil
 }
 
 // serveRemoteBackend handles an mcp_server backed by a remote_mcp_server.

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -490,6 +490,7 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 		RouteBase:           "mcp",
 		McpSlug:             mcpSlug,
 		FinalRedirectURI:    parsedRedirect.String(),
+		Resource:            "",
 	}
 	authURL, err := s.remoteChallengeMgr.BuildAuthorizationUrl(ctx, parent, selected)
 	if err != nil {
@@ -777,7 +778,7 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 // would lie about a connection that the next /mcp/{slug} call will 401 on.
 func (s *ExternalOAuthService) writeIssuerGatedStatus(ctx context.Context, w http.ResponseWriter, userID string, projectID uuid.UUID, organizationID string, issuerID uuid.UUID) error {
 	subject := urn.NewUserSubject(userID)
-	tokens, err := s.remoteChallengeMgr.ResolveAccessTokens(ctx, projectID, organizationID, issuerID, subject)
+	tokens, err := s.remoteChallengeMgr.ResolveAccessTokens(ctx, projectID, organizationID, issuerID, subject, "")
 
 	status := "needs_auth"
 	switch {

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -421,6 +421,9 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		attr.SlogToolsetMCPSlug(mcpSlug),
 		attr.SlogProjectID(state.ProjectID.String()),
 	)
+	if state.Resource != "" {
+		logger = logger.With(attr.SlogOAuthResource(state.Resource))
+	}
 
 	// Hoisted above the DB lookup + upstream code exchange so a state with a
 	// missing/zero Subject fails fast — otherwise we burn the single-use

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -77,6 +77,9 @@ type ParentChallenge struct {
 	McpSlug             string
 	RouteBase           string
 	FinalRedirectURI    string
+	// Resource is the RFC 8707 resource indicator sent on the authorize
+	// redirect and code exchange. Empty omits the parameter.
+	Resource string
 }
 
 // RemoteLoginState is the per-remote-leg Redis state, keyed by the opaque
@@ -95,6 +98,7 @@ type RemoteLoginState struct {
 	TokenEndpoint         string              `json:"token_endpoint"`
 	RedirectURI           string              `json:"redirect_uri"`
 	CodeVerifier          string              `json:"code_verifier"`
+	Resource              string              `json:"resource,omitempty"`
 	Subject               *urn.SessionSubject `json:"subject,omitempty"`
 	McpSlug               string              `json:"mcp_slug"`
 	// RouteBase is "mcp" or "x/mcp" — drives the post-callback redirect
@@ -328,6 +332,7 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 		TokenEndpoint:         client.TokenEndpoint,
 		RedirectURI:           redirectURI,
 		CodeVerifier:          verifier,
+		Resource:              parent.Resource,
 		Subject:               parent.Subject,
 		McpSlug:               parent.McpSlug,
 		RouteBase:             parent.RouteBase,
@@ -350,6 +355,9 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 	}
 	if client.Audience != "" {
 		q.Set("audience", client.Audience)
+	}
+	if parent.Resource != "" {
+		q.Set("resource", parent.Resource)
 	}
 	for _, ic := range m.authorizeInterceptors {
 		if ic.Match(client.IssuerURL) {
@@ -552,6 +560,9 @@ func (m *ChallengeManager) exchangeCode(
 	form.Set("code_verifier", state.CodeVerifier)
 	if audience != "" {
 		form.Set("audience", audience)
+	}
+	if state.Resource != "" {
+		form.Set("resource", state.Resource)
 	}
 
 	req, err := newTokenEndpointRequest(ctx, state.TokenEndpoint, form, authMethod, externalClientID, clientSecret)

--- a/server/internal/remotesessions/challenge_resource_e2e_test.go
+++ b/server/internal/remotesessions/challenge_resource_e2e_test.go
@@ -1,0 +1,194 @@
+// challenge_resource_e2e_test.go drives ListClients → BuildAuthorizationUrl →
+// HandleRemoteLoginCallback against a real ChallengeManager + database to
+// assert that the RFC 8707 `resource` parameter from the parent challenge is
+// attached to the authorize redirect and repeated on the code exchange, and
+// omitted on both legs when the parent carries none.
+
+package remotesessions_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type resourceDanceFixture struct {
+	mgr     *remotesessions.ChallengeManager
+	parent  remotesessions.ParentChallenge
+	clients []remotesessions.Client
+}
+
+// setupResourceDanceFixture seeds an issuer (whose token endpoint is the
+// spy's httptest server) plus a bound client, and returns a parent challenge
+// carrying the given resource.
+func setupResourceDanceFixture(t *testing.T, resource string, slugSuffix string, spy *upstreamSpy) (context.Context, resourceDanceFixture) {
+	t.Helper()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			spy.handlerErr = err
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		spy.form = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"exchanged-access","token_type":"Bearer","expires_in":3600,"refresh_token":"exchanged-refresh"}`))
+	}))
+	t.Cleanup(tokenServer.Close)
+
+	enc := testenv.NewEncryptionClient(t)
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	mgr := remotesessions.NewChallengeManager(
+		logger,
+		ti.conn,
+		enc,
+		policy,
+		ti.redisCache,
+		mustURL(t, "http://localhost"),
+	)
+
+	q := repo.New(ti.conn)
+	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		Slug:                              "auth-res-" + slugSuffix,
+		Issuer:                            tokenServer.URL,
+		AuthorizationEndpoint:             conv.ToPGText(tokenServer.URL + "/authorize"),
+		TokenEndpoint:                     conv.ToPGText(tokenServer.URL + "/token"),
+		RegistrationEndpoint:              pgtype.Text{String: "", Valid: false},
+		JwksUri:                           pgtype.Text{String: "", Valid: false},
+		ScopesSupported:                   []string{"openid"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_post"},
+		Oidc:                              false,
+		Passthrough:                       false,
+	})
+	require.NoError(t, err)
+
+	userIssuer := createUserSessionIssuer(t, ctx, ti.conn, "usi-res-"+slugSuffix)
+
+	secretCiphertext, err := enc.Encrypt([]byte("res-secret"))
+	require.NoError(t, err)
+	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
+		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:          conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
+		RemoteSessionIssuerID:   issuer.ID,
+		ClientID:                "res-cid",
+		ClientSecretEncrypted:   conv.ToPGText(secretCiphertext),
+		ClientIDIssuedAt:        conv.ToPGTimestamptz(time.Now()),
+		ClientSecretExpiresAt:   pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},
+		TokenEndpointAuthMethod: conv.ToPGText("client_secret_post"),
+		Scope:                   nil,
+		Audience:                pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	err = q.AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: client.ID,
+		UserSessionIssuerID:   userIssuer,
+	})
+	require.NoError(t, err)
+
+	clients, err := mgr.ListClients(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuer)
+	require.NoError(t, err)
+	require.Len(t, clients, 1)
+
+	subject := urn.NewUserSubject("res-subject-" + slugSuffix)
+	return ctx, resourceDanceFixture{
+		mgr: mgr,
+		parent: remotesessions.ParentChallenge{
+			ID:                  uuid.NewString(),
+			ProjectID:           *authCtx.ProjectID,
+			OrganizationID:      authCtx.ActiveOrganizationID,
+			UserSessionIssuerID: userIssuer,
+			Subject:             &subject,
+			McpSlug:             "res-" + slugSuffix,
+			RouteBase:           "mcp",
+			FinalRedirectURI:    "",
+			Resource:            resource,
+		},
+		clients: clients,
+	}
+}
+
+// runCallback exchanges a fake code through HandleRemoteLoginCallback using
+// the state minted by BuildAuthorizationUrl, so the spy token endpoint sees
+// the real exchange form.
+func runCallback(t *testing.T, ctx context.Context, fx resourceDanceFixture, authURL string) {
+	t.Helper()
+
+	parsed, err := url.Parse(authURL)
+	require.NoError(t, err)
+	state := parsed.Query().Get("state")
+	require.NotEmpty(t, state)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/mcp/remote_login_callback?code=fake-code&state="+url.QueryEscape(state), nil)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	require.NoError(t, fx.mgr.HandleRemoteLoginCallback(w, req))
+	require.Equal(t, http.StatusSeeOther, w.Code)
+}
+
+func TestRemoteLoginDance_ResourceOnAuthorizeAndExchange(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, fx := setupResourceDanceFixture(t, "https://mcp.example.com/mcp", "set", &spy)
+
+	authURL, err := fx.mgr.BuildAuthorizationUrl(ctx, fx.parent, fx.clients[0])
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(authURL)
+	require.NoError(t, err)
+	require.Equal(t, "https://mcp.example.com/mcp", parsed.Query().Get("resource"),
+		"authorize URL must carry the parent challenge's RFC 8707 resource")
+
+	runCallback(t, ctx, fx, authURL)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "https://mcp.example.com/mcp", spy.form.Get("resource"),
+		"code exchange must repeat the resource sent on the authorize leg")
+}
+
+func TestRemoteLoginDance_ResourceOmittedWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, fx := setupResourceDanceFixture(t, "", "unset", &spy)
+
+	authURL, err := fx.mgr.BuildAuthorizationUrl(ctx, fx.parent, fx.clients[0])
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(authURL)
+	require.NoError(t, err)
+	require.False(t, parsed.Query().Has("resource"),
+		"authorize URL must omit resource when the parent challenge carries none")
+
+	runCallback(t, ctx, fx, authURL)
+	require.NoError(t, spy.handlerErr)
+	require.False(t, spy.form.Has("resource"),
+		"code exchange must omit resource when the parent challenge carries none")
+}

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -62,7 +62,7 @@ func TestRemoteLoginCallback_NoExpiresIn_NoRefresh_NonExpiring(t *testing.T) {
 	// The gate treats NULL-with-no-refresh as non-expiring and keeps returning
 	// the token, rather than rejecting it as ErrNoValidToken once a synthetic
 	// hour lapses.
-	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject)
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 	require.NoError(t, err)
 	require.Equal(t, upstreamAccessToken, resolved, "non-expiring token must keep resolving")
 }
@@ -96,7 +96,7 @@ func TestRemoteLoginCallback_NoExpiresIn_WithRefresh_HourlyCadence(t *testing.T)
 
 	// Inside the cadence window (updated_at ≈ now): the stored token is served
 	// and no refresh is attempted.
-	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject)
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 	require.NoError(t, err)
 	require.Equal(t, initialAccess, resolved)
 	require.Equal(t, int64(0), refreshCount.Load(), "must not refresh inside the cadence window")
@@ -108,7 +108,7 @@ func TestRemoteLoginCallback_NoExpiresIn_WithRefresh_HourlyCadence(t *testing.T)
 		ProjectID: conv.ToNullUUID(env.projectID),
 		UpdatedAt: conv.ToPGTimestamptz(time.Now().Add(-2 * time.Hour)),
 	}))
-	resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject)
+	resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 	require.NoError(t, err)
 	require.Equal(t, rotatedAccess, resolved, "past the cadence window the token is refreshed")
 	require.Equal(t, int64(1), refreshCount.Load(), "exactly one refresh attempt past the window")

--- a/server/internal/remotesessions/cimd_test.go
+++ b/server/internal/remotesessions/cimd_test.go
@@ -388,7 +388,7 @@ func TestCIMD_RefreshUsesMetadataURLAsClientIDWithoutBasicAuth(t *testing.T) {
 	subject := urn.NewUserSubject("cimd-refresh-subject")
 	seedExpiredRemoteSession(t, ctx, ti, enc, subject, userIssuer, uuid.MustParse(created.ID))
 
-	tok, err := mgr.ResolveAccessToken(ctx, uuid.MustParse(created.ID), subject)
+	tok, err := mgr.ResolveAccessToken(ctx, uuid.MustParse(created.ID), subject, "")
 	require.NoError(t, err)
 	require.NoError(t, spy.handlerErr)
 	require.Equal(t, "refreshed-access", tok)

--- a/server/internal/remotesessions/organizationhandlers.go
+++ b/server/internal/remotesessions/organizationhandlers.go
@@ -1407,7 +1407,7 @@ func (s *Service) RefreshSession(ctx context.Context, payload *orgissuersgen.Ref
 	}
 
 	// Refresh on the pool — the upstream token POST must not run inside a tx.
-	updated, _, err := refreshSessionTokens(ctx, repo.New(s.db), s.enc, s.policy, row.RemoteSession)
+	updated, _, err := refreshSessionTokens(ctx, repo.New(s.db), s.enc, s.policy, row.RemoteSession, "")
 	if err != nil {
 		// Operator-actionable failures carry a public-safe reason; surface it so
 		// the admin sees why the refresh failed instead of a generic error.

--- a/server/internal/remotesessions/organizationhandlers.go
+++ b/server/internal/remotesessions/organizationhandlers.go
@@ -38,6 +38,26 @@ func orgDisplayName(name *string, url string) string {
 	return url
 }
 
+// clientUpstreamResource derives the RFC 8707 resource for a client's
+// sessions from its attached MCP servers. Exactly one distinct upstream URL
+// binds the audience; zero or multiple return "" so the parameter is omitted
+// (matching pre-resource behavior — an ambiguous multi-upstream client can't
+// be bound to a single audience). Url is empty for non-remote backends.
+func clientUpstreamResource(rows []repo.ListOrganizationMcpServersForClientRow) string {
+	resource := ""
+	for _, row := range rows {
+		url := strings.TrimRight(row.Url, "/")
+		if url == "" {
+			continue
+		}
+		if resource != "" && resource != url {
+			return ""
+		}
+		resource = url
+	}
+	return resource
+}
+
 // CreateIssuer creates an issuer in the caller's organization. With no
 // project_id the issuer is organization-level (project_id NULL); with a
 // project_id (validated to belong to the org) it is project-specific. Gated on
@@ -1406,8 +1426,15 @@ func (s *Service) RefreshSession(ctx context.Context, payload *orgissuersgen.Ref
 		return nil, oops.E(oops.CodeBadRequest, nil, "remote session has no refresh token").LogError(ctx, logger)
 	}
 
+	// Recover the session's RFC 8707 audience binding from the client's
+	// attached MCP servers so the refreshed token keeps it.
+	mcpRows, err := repo.New(s.db).ListOrganizationMcpServersForClient(ctx, row.RemoteSession.RemoteSessionClientID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list mcp servers for client").LogError(ctx, logger)
+	}
+
 	// Refresh on the pool — the upstream token POST must not run inside a tx.
-	updated, _, err := refreshSessionTokens(ctx, repo.New(s.db), s.enc, s.policy, row.RemoteSession, "")
+	updated, _, err := refreshSessionTokens(ctx, repo.New(s.db), s.enc, s.policy, row.RemoteSession, clientUpstreamResource(mcpRows))
 	if err != nil {
 		// Operator-actionable failures carry a public-safe reason; surface it so
 		// the admin sees why the refresh failed instead of a generic error.

--- a/server/internal/remotesessions/organizationhandlers_resource_test.go
+++ b/server/internal/remotesessions/organizationhandlers_resource_test.go
@@ -1,0 +1,68 @@
+// clientUpstreamResource derives the RFC 8707 resource the org-admin manual
+// refresh sends: exactly one distinct non-empty upstream URL across the
+// client's MCP servers binds the audience; anything else omits it.
+
+package remotesessions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+func TestClientUpstreamResource_NoRowsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, clientUpstreamResource(nil))
+}
+
+func TestClientUpstreamResource_SingleURLTrimsTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	rows := []repo.ListOrganizationMcpServersForClientRow{
+		{Url: "https://mcp.example.com/mcp/"},
+	}
+	require.Equal(t, "https://mcp.example.com/mcp", clientUpstreamResource(rows))
+}
+
+func TestClientUpstreamResource_DuplicateURLsCollapse(t *testing.T) {
+	t.Parallel()
+
+	rows := []repo.ListOrganizationMcpServersForClientRow{
+		{Url: "https://mcp.example.com/mcp"},
+		{Url: "https://mcp.example.com/mcp/"},
+	}
+	require.Equal(t, "https://mcp.example.com/mcp", clientUpstreamResource(rows))
+}
+
+func TestClientUpstreamResource_NonRemoteRowsIgnored(t *testing.T) {
+	t.Parallel()
+
+	rows := []repo.ListOrganizationMcpServersForClientRow{
+		{Url: ""},
+		{Url: "https://mcp.example.com/mcp"},
+	}
+	require.Equal(t, "https://mcp.example.com/mcp", clientUpstreamResource(rows))
+}
+
+func TestClientUpstreamResource_AllNonRemoteReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	rows := []repo.ListOrganizationMcpServersForClientRow{
+		{Url: ""},
+		{Url: ""},
+	}
+	require.Empty(t, clientUpstreamResource(rows))
+}
+
+func TestClientUpstreamResource_MultipleDistinctURLsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	rows := []repo.ListOrganizationMcpServersForClientRow{
+		{Url: "https://mcp.example.com/mcp"},
+		{Url: "https://other.example.com/mcp"},
+	}
+	require.Empty(t, clientUpstreamResource(rows))
+}

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -100,6 +100,7 @@ func (m *ChallengeManager) ResolveAccessToken(
 	ctx context.Context,
 	clientID uuid.UUID,
 	subject urn.SessionSubject,
+	resource string,
 ) (string, error) {
 	sess, err := remotesessions_repo.New(m.db).GetActiveRemoteSession(ctx, remotesessions_repo.GetActiveRemoteSessionParams{
 		SubjectUrn:            subject,
@@ -112,7 +113,7 @@ func (m *ChallengeManager) ResolveAccessToken(
 		return "", fmt.Errorf("get active remote_session: %w", err)
 	}
 
-	tok, err := m.validateAndRefresh(ctx, sess)
+	tok, err := m.validateAndRefresh(ctx, sess, resource)
 	if err != nil {
 		return "", nil
 	}
@@ -157,6 +158,7 @@ func (m *ChallengeManager) ResolveAccessTokens(
 	organizationID string,
 	userSessionIssuerID uuid.UUID,
 	subject urn.SessionSubject,
+	resource string,
 ) (map[uuid.UUID]string, error) {
 	clients, err := m.listRemoteSessionClientRowsForUserSessionIssuer(ctx, projectID, organizationID, userSessionIssuerID)
 	if err != nil {
@@ -183,7 +185,7 @@ func (m *ChallengeManager) ResolveAccessTokens(
 
 	tokens := make(map[uuid.UUID]string, len(clients))
 	for _, c := range clients {
-		tok, err := m.ResolveAccessToken(ctx, c.ClientID, subject)
+		tok, err := m.ResolveAccessToken(ctx, c.ClientID, subject, resource)
 		if err != nil {
 			return nil, fmt.Errorf("resolve access token: %w", err)
 		}
@@ -217,6 +219,7 @@ const defaultNoExpiryRefreshInterval = time.Hour
 func (m *ChallengeManager) validateAndRefresh(
 	ctx context.Context,
 	sess remotesessions_repo.RemoteSession,
+	resource string,
 ) (string, error) {
 	hasRefresh := sess.RefreshTokenEncrypted.Valid && sess.RefreshTokenEncrypted.String != ""
 
@@ -244,7 +247,7 @@ func (m *ChallengeManager) validateAndRefresh(
 	if !hasRefresh {
 		return "", ErrNoValidToken
 	}
-	return m.refreshAccessToken(ctx, sess)
+	return m.refreshAccessToken(ctx, sess, resource)
 }
 
 // refreshAccessToken is the lazy-path wrapper: it runs the shared refresh and
@@ -252,8 +255,9 @@ func (m *ChallengeManager) validateAndRefresh(
 func (m *ChallengeManager) refreshAccessToken(
 	ctx context.Context,
 	sess remotesessions_repo.RemoteSession,
+	resource string,
 ) (string, error) {
-	_, accessToken, err := refreshSessionTokens(ctx, remotesessions_repo.New(m.db), m.enc, m.policy, sess)
+	_, accessToken, err := refreshSessionTokens(ctx, remotesessions_repo.New(m.db), m.enc, m.policy, sess, resource)
 	if err != nil {
 		return "", err
 	}
@@ -279,6 +283,7 @@ func refreshSessionTokens(
 	enc *encryption.Client,
 	policy *guardian.Policy,
 	sess remotesessions_repo.RemoteSession,
+	resource string,
 ) (remotesessions_repo.RemoteSession, string, error) {
 	var zero remotesessions_repo.RemoteSession
 
@@ -311,6 +316,9 @@ func refreshSessionTokens(
 	form.Set("client_id", client.ExternalClientID)
 	if audience := conv.FromPGTextOrEmpty[string](client.ClientAudience); audience != "" {
 		form.Set("audience", audience)
+	}
+	if resource != "" {
+		form.Set("resource", resource)
 	}
 
 	req, err := newTokenEndpointRequest(ctx, client.TokenEndpoint.String, form, authMethod, client.ExternalClientID, clientSecret)

--- a/server/internal/remotesessions/tokenservice_audience_test.go
+++ b/server/internal/remotesessions/tokenservice_audience_test.go
@@ -129,7 +129,7 @@ func TestResolveAccessToken_RefreshIncludesAudience(t *testing.T) {
 	var spy upstreamSpy
 	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
 
-	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject)
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)
 	require.NoError(t, spy.handlerErr)
 	require.Equal(t, "refreshed-access", tok)
@@ -143,7 +143,7 @@ func TestResolveAccessToken_RefreshOmitsAudienceWhenUnset(t *testing.T) {
 	var spy upstreamSpy
 	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
 
-	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject)
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)
 	require.NoError(t, spy.handlerErr)
 	require.Equal(t, "refreshed-access", tok)

--- a/server/internal/remotesessions/tokenservice_authmethod_test.go
+++ b/server/internal/remotesessions/tokenservice_authmethod_test.go
@@ -174,7 +174,7 @@ func TestResolveAccessToken_RefreshUsesClientSecretPost(t *testing.T) {
 	var spy upstreamSpy
 	ctx, mgr, clientID, subject, clientSecret, externalCID := setupRefreshFixture(t, "client_secret_post", &spy)
 
-	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject)
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)
 	require.NoError(t, spy.handlerErr)
 	require.Equal(t, "refreshed-access", tok)
@@ -190,7 +190,7 @@ func TestResolveAccessToken_RefreshUsesClientSecretBasic(t *testing.T) {
 	var spy upstreamSpy
 	ctx, mgr, clientID, subject, _, _ := setupRefreshFixture(t, "client_secret_basic", &spy)
 
-	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject)
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
 	require.NoError(t, err)
 	require.NoError(t, spy.handlerErr)
 	require.Equal(t, "refreshed-access", tok)

--- a/server/internal/remotesessions/tokenservice_resolve_test.go
+++ b/server/internal/remotesessions/tokenservice_resolve_test.go
@@ -122,7 +122,7 @@ func TestResolveAccessTokens_SingleClientHappyPath(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]string{remoteIssuerID: "upstream-access-token"}, tokens)
 }
@@ -140,7 +140,7 @@ func TestResolveAccessTokens_NoClientsReturnsNil(t *testing.T) {
 	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-resolve-empty")
 	subject := urn.NewUserSubject("resolve-empty-subject")
 
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
 	require.NoError(t, err)
 	require.Nil(t, tokens)
 }
@@ -160,7 +160,7 @@ func TestResolveAccessTokens_MissingSessionReturnsErrNoValidToken(t *testing.T) 
 	seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, authCtx.ActiveOrganizationID, "rsi-resolve-missing")
 
 	subject := urn.NewUserSubject("resolve-missing-subject")
-	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
 	require.ErrorIs(t, err, remotesessions.ErrNoValidToken)
 	require.Nil(t, tokens)
 }

--- a/server/internal/remotesessions/tokenservice_resource_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_test.go
@@ -1,0 +1,43 @@
+// tokenservice_resource_test.go drives the refresh path against an httptest
+// token endpoint and asserts that the RFC 8707 resource passed to
+// ResolveAccessToken is included in the refresh grant, and omitted when
+// empty.
+
+package remotesessions_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+func TestResolveAccessToken_RefreshIncludesResource(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, pgtype.Text{String: "", Valid: false}, &spy)
+
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "https://mcp.example.com/mcp")
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refreshed-access", tok)
+
+	require.Equal(t, "https://mcp.example.com/mcp", spy.form.Get("resource"), "refresh body must carry the caller's resource")
+}
+
+func TestResolveAccessToken_RefreshOmitsResourceWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, clientID, subject := setupRefreshFixtureWithAudience(t, conv.ToPGText("https://api.example.com"), &spy)
+
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refreshed-access", tok)
+
+	require.False(t, spy.form.Has("resource"), "refresh body must omit resource when the caller passes none")
+}


### PR DESCRIPTION
## Summary

Sends the RFC 8707 `resource` parameter through the remote-session OAuth dance, derived from the request — no configuration, no schema change, no UI. Replaces #3826/#3827 per review discussion.

## Why

The MCP authorization spec requires OAuth clients to send the `resource` indicator (the canonical URI of the MCP server) on the authorize and token requests so the AS audience-binds issued tokens. Gram omits it today. Most upstreams tolerate that; strict ones don't: a strict upstream completes the dance and refresh successfully, then every proxied call to its MCP endpoint is rejected with `401 {"error":"invalid_token"}` — the signature of an audience-unbound token. Reference clients get this for free: the rmcp SDK (used by codex) sends `resource=<server URL>` automatically.

## How

"What URI did this come in from" — the resource is resolved from the MCP server the request is for, not stored anywhere:

- `ResolvedMcpEndpoint.UpstreamResource`: populated with the remote backend URL (trailing slash trimmed) when the endpoint resolves to a remote-backed `mcp_server`; empty otherwise.
- Authorize leg: `ParentChallenge.Resource` → query param on the upstream authorize redirect.
- Exchange leg: the value rides the Redis `RemoteLoginState` so the code exchange repeats exactly what was authorized.
- Refresh leg: threaded through `ResolveAccessTokens` from the issuer gate, so rotated tokens keep the binding. (Notably the rmcp SDK omits resource on refresh — we cover all three legs.)

Empty resource omits the parameter everywhere, so toolset-backed endpoints, the legacy external-oauth flow, and the org-admin manual refresh are behavior-unchanged.

## Testing

- `challenge_resource_e2e_test.go`: real ChallengeManager + DB dance against an httptest AS — asserts the authorize URL carries the resource and the code-exchange form repeats it, and that both legs omit it when the parent challenge carries none.
- `tokenservice_resource_test.go`: refresh grant carries/omits the resource per the caller.
- Full end-to-end validated against a strict test AS (audience-binds tokens, resource server rejects unbound ones): with this change all three legs carry the resource and MCP calls through Gram succeed; without it the prod failure reproduces byte-for-byte.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the RFC 8707 `resource` parameter to the remote-session OAuth dance (authorize, token, refresh), derived from the remote MCP server URL to audience-bind tokens and avoid invalid_token with strict providers. Preserves this binding on consent resume and org-admin manual refresh, and tags remote-login callback logs with `gram.oauth.resource`; non-remote endpoints and `external_oauth` remain unchanged with no config/schema changes.

- **New Features**
  - Derives `resource` from the remote MCP backend and stores it in `ResolvedMcpEndpoint.UpstreamResource` (trailing slash trimmed).
  - Threads `resource` through `ParentChallenge` and `RemoteLoginState`.
  - Sends `resource` on authorize redirect, code exchange, and refresh.
  - Tags remote-login callback logs with `gram.oauth.resource` when present.
  - Omits the param when empty, keeping toolset-backed endpoints and `external_oauth` behavior unchanged.

- **Bug Fixes**
  - Audience-binds tokens so strict AS stop rejecting proxied calls with 401 invalid_token.
  - Keeps the binding on IDP-callback/consent resume (byRef path) and on org-admin manual refresh when exactly one upstream is attached; omits when none or multiple.

<sup>Written for commit acacf8ee899ad56553ff469efe28ad286912afe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

