### PR TITLE
mig: attach MCP servers to assistants

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3042,6 +3042,35 @@ CREATE UNIQUE INDEX IF NOT EXISTS mcp_endpoints_slug_null_custom_domain_id_key
 ON mcp_endpoints (slug)
 WHERE custom_domain_id IS NULL AND deleted IS FALSE;
 
+-- MCP servers attached directly to an assistant. The legacy toolset
+-- attachment path lives in assistant_toolsets; this table covers
+-- mcp_servers-modelled backends (remote, tunnelled) that have no toolsets
+-- row and so cannot be attached there. resolveAssistantMCPServers merges
+-- both into the runtime MCP set. Replace-on-write like assistant_toolsets,
+-- so no soft-delete column.
+CREATE TABLE IF NOT EXISTS assistant_mcp_servers (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  assistant_id uuid NOT NULL,
+  mcp_server_id uuid NOT NULL,
+  environment_id uuid,
+  project_id uuid NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT assistant_mcp_servers_pkey PRIMARY KEY (id),
+  CONSTRAINT assistant_mcp_servers_assistant_id_fkey FOREIGN KEY (assistant_id) REFERENCES assistants (id) ON DELETE CASCADE,
+  -- RESTRICT mirrors plugin_servers: mcp_servers soft-delete, so RESTRICT only
+  -- blocks manual hard deletes; SET NULL is not viable for a required backend.
+  CONSTRAINT assistant_mcp_servers_mcp_server_id_fkey FOREIGN KEY (mcp_server_id) REFERENCES mcp_servers (id) ON DELETE RESTRICT,
+  CONSTRAINT assistant_mcp_servers_environment_id_fkey FOREIGN KEY (environment_id) REFERENCES environments (id) ON DELETE SET NULL,
+  CONSTRAINT assistant_mcp_servers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT assistant_mcp_servers_assistant_id_mcp_server_id_key UNIQUE (assistant_id, mcp_server_id)
+);
+
+CREATE INDEX IF NOT EXISTS assistant_mcp_servers_assistant_id_idx ON assistant_mcp_servers (assistant_id);
+CREATE INDEX IF NOT EXISTS assistant_mcp_servers_mcp_server_id_idx ON assistant_mcp_servers (mcp_server_id);
+
 -- Plugin definitions: project-scoped distributable bundles of MCP servers.
 -- Admins create plugins and assign them to roles for distribution.
 CREATE TABLE IF NOT EXISTS plugins (

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3068,8 +3068,8 @@ CREATE TABLE IF NOT EXISTS assistant_mcp_servers (
   CONSTRAINT assistant_mcp_servers_assistant_id_mcp_server_id_key UNIQUE (assistant_id, mcp_server_id)
 );
 
-CREATE INDEX IF NOT EXISTS assistant_mcp_servers_assistant_id_idx ON assistant_mcp_servers (assistant_id);
 CREATE INDEX IF NOT EXISTS assistant_mcp_servers_mcp_server_id_idx ON assistant_mcp_servers (mcp_server_id);
+CREATE INDEX IF NOT EXISTS assistant_mcp_servers_project_id_idx ON assistant_mcp_servers (project_id);
 
 -- Plugin definitions: project-scoped distributable bundles of MCP servers.
 -- Admins create plugins and assign them to roles for distribution.

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -122,6 +122,16 @@ type AssistantDashboardMessage struct {
 	CreatedAt pgtype.Timestamptz
 }
 
+type AssistantMcpServer struct {
+	ID            uuid.UUID
+	AssistantID   uuid.UUID
+	McpServerID   uuid.UUID
+	EnvironmentID uuid.NullUUID
+	ProjectID     uuid.UUID
+	CreatedAt     pgtype.Timestamptz
+	UpdatedAt     pgtype.Timestamptz
+}
+
 type AssistantMemory struct {
 	ID             uuid.UUID
 	AssistantID    uuid.NullUUID

--- a/server/migrations/20260707101625_assistant-mcp-servers.sql
+++ b/server/migrations/20260707101625_assistant-mcp-servers.sql
@@ -1,0 +1,20 @@
+-- Create "assistant_mcp_servers" table
+CREATE TABLE "assistant_mcp_servers" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "assistant_id" uuid NOT NULL,
+  "mcp_server_id" uuid NOT NULL,
+  "environment_id" uuid NULL,
+  "project_id" uuid NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "assistant_mcp_servers_assistant_id_mcp_server_id_key" UNIQUE ("assistant_id", "mcp_server_id"),
+  CONSTRAINT "assistant_mcp_servers_assistant_id_fkey" FOREIGN KEY ("assistant_id") REFERENCES "assistants" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "assistant_mcp_servers_environment_id_fkey" FOREIGN KEY ("environment_id") REFERENCES "environments" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "assistant_mcp_servers_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT "assistant_mcp_servers_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "assistant_mcp_servers_assistant_id_idx" to table: "assistant_mcp_servers"
+CREATE INDEX "assistant_mcp_servers_assistant_id_idx" ON "assistant_mcp_servers" ("assistant_id");
+-- Create index "assistant_mcp_servers_mcp_server_id_idx" to table: "assistant_mcp_servers"
+CREATE INDEX "assistant_mcp_servers_mcp_server_id_idx" ON "assistant_mcp_servers" ("mcp_server_id");

--- a/server/migrations/20260707120239_assistant-mcp-servers.sql
+++ b/server/migrations/20260707120239_assistant-mcp-servers.sql
@@ -14,7 +14,7 @@ CREATE TABLE "assistant_mcp_servers" (
   CONSTRAINT "assistant_mcp_servers_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT,
   CONSTRAINT "assistant_mcp_servers_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
 );
--- Create index "assistant_mcp_servers_assistant_id_idx" to table: "assistant_mcp_servers"
-CREATE INDEX "assistant_mcp_servers_assistant_id_idx" ON "assistant_mcp_servers" ("assistant_id");
 -- Create index "assistant_mcp_servers_mcp_server_id_idx" to table: "assistant_mcp_servers"
 CREATE INDEX "assistant_mcp_servers_mcp_server_id_idx" ON "assistant_mcp_servers" ("mcp_server_id");
+-- Create index "assistant_mcp_servers_project_id_idx" to table: "assistant_mcp_servers"
+CREATE INDEX "assistant_mcp_servers_project_id_idx" ON "assistant_mcp_servers" ("project_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:7264v3TC7iiL9l9NoxX6T7EKwqCUdSjSAH+cMEL9vPg=
+h1:V6EchR8X86NV2LVg63HB0+1AdcZLWs76TaAHLB2OK2g=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -246,3 +246,4 @@ h1:7264v3TC7iiL9l9NoxX6T7EKwqCUdSjSAH+cMEL9vPg=
 20260706170316_json-web-key-sets-json-web-keys.sql h1:F7gFxdLCa1Q1gZc19/SrpAIiJgmZ7cUV/49iQD9GbN4=
 20260706233448_drop-session-capture-exclusions.sql h1:CZfr4NqnLrq4r4Av+m/KVY39PEEH6TrBHe8sz61y4Co=
 20260707070702_risk-policy-eval-reviews.sql h1:RjhJvs0KrFmEk9tuNDI9slvcm1uGbnyEf44mDlZ8/MI=
+20260707101625_assistant-mcp-servers.sql h1:9CNy5B7BZ4E4ulJNsgkjxXfIxVxQwRcOswdLu7sbI+s=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:V6EchR8X86NV2LVg63HB0+1AdcZLWs76TaAHLB2OK2g=
+h1:KjkDqLFE15cYj9Lg+RbH9oljM1ijoSzuqM99PTrzyQc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -246,4 +246,4 @@ h1:V6EchR8X86NV2LVg63HB0+1AdcZLWs76TaAHLB2OK2g=
 20260706170316_json-web-key-sets-json-web-keys.sql h1:F7gFxdLCa1Q1gZc19/SrpAIiJgmZ7cUV/49iQD9GbN4=
 20260706233448_drop-session-capture-exclusions.sql h1:CZfr4NqnLrq4r4Av+m/KVY39PEEH6TrBHe8sz61y4Co=
 20260707070702_risk-policy-eval-reviews.sql h1:RjhJvs0KrFmEk9tuNDI9slvcm1uGbnyEf44mDlZ8/MI=
-20260707101625_assistant-mcp-servers.sql h1:9CNy5B7BZ4E4ulJNsgkjxXfIxVxQwRcOswdLu7sbI+s=
+20260707120239_assistant-mcp-servers.sql h1:bDNWbd/16MXwFmJBGKVMmnLcxgdiDCCpizKI/ftevrY=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/3831 so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new table to attach MCP servers directly to assistants, separate from the legacy toolset path. Ships a migration, indexes, and a new `AssistantMcpServer` model; runtime will merge these with toolset attachments.

- New Features
  - `assistant_mcp_servers` table for direct attachments; replace-on-write, no soft delete; unique on `(assistant_id, mcp_server_id)`.
  - FKs: assistant CASCADE, project CASCADE, environment SET NULL, mcp_server RESTRICT; indexes on `mcp_server_id` and `project_id` (dropped redundant `assistant_id` index).
  - Added `AssistantMcpServer` in `models.go`.

<sup>Written for commit a693513bc689d2f55859cef188512f24c108fbc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

