### PR TITLE
fix: challenge issuer-gated clients with gram metadata on upstream 401

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -12,46 +12,50 @@ import (
 type Key = attribute.Key
 
 const (
-	ErrorIDKey                        = attribute.Key("error.id")
-	ErrorMessageKey                   = attribute.Key("error.message")
-	ErrorStackKey                     = attribute.Key("error.stack")
-	ErrorKindKey                      = attribute.Key("error.kind")
-	ExternalUserIDKey                 = attribute.Key("gram.external_user.id")
-	APIKeyIDKey                       = attribute.Key("gram.api_key.id")
-	ContainerIDKey                    = semconv.ContainerIDKey
-	ContainerNetworkIDKey             = attribute.Key("container.network.id")
-	FilePathKey                       = semconv.FilePathKey
-	HostNameKey                       = semconv.HostNameKey
-	HTTPRefererHostKey                = attribute.Key("http.request.referer_host")
-	HTTPRequestIDKey                  = attribute.Key("http.request_id")
-	HTTPRequestHeaderRefererKey       = attribute.Key("http.request.header.referer")
-	HTTPRequestHeaderContentTypeKey   = attribute.Key("http.request.header.content_type")
-	HTTPRequestHeaderUserAgentKey     = attribute.Key("http.request.header.user_agent")
-	HTTPRequestMethodKey              = semconv.HTTPRequestMethodKey
-	HTTPRequestBodyKey                = attribute.Key("http.request.body")
-	HTTPResponseBodyKey               = attribute.Key("http.response.body")
-	HTTPRequestHeadersKey             = attribute.Key("http.request.headers")
-	HTTPResponseHeadersKey            = attribute.Key("http.response.headers")
-	HTTPResponseHeaderContentTypeKey  = attribute.Key("http.response.header.content_type")
-	HTTPResponseStatusCodeKey         = semconv.HTTPResponseStatusCodeKey
-	HTTPResponseOriginalStatusCodeKey = attribute.Key("http.response.original_status_code")
-	HTTPRouteKey                      = semconv.HTTPRouteKey
-	HTTPServerRequestDurationKey      = attribute.Key("http.server.request.duration")
-	HTTPClientRequestDurationKey      = attribute.Key("http.client.request.duration_ms")
-	HTTPRequestSizeKey                = semconv.HTTPRequestSizeKey
-	HTTPResponseSizeKey               = semconv.HTTPResponseSizeKey
-	ObservedTimeUnixNanoKey           = attribute.Key("observed_time_unix_nano")
-	ServerAddressKey                  = semconv.ServerAddressKey
-	ServiceEnvKey                     = semconv.DeploymentEnvironmentNameKey
-	ServiceNameKey                    = semconv.ServiceNameKey
-	ServiceVersionKey                 = semconv.ServiceVersionKey
-	TimeUnixNanoKey                   = attribute.Key("time_unix_nano")
-	URLDomainKey                      = semconv.URLDomainKey
-	URLFullKey                        = semconv.URLFullKey
-	URLOriginalKey                    = semconv.URLOriginalKey
-	UserIDKey                         = semconv.UserIDKey
-	UserEmailKey                      = semconv.UserEmailKey
-	UserRolesKey                      = semconv.UserRolesKey
+	ErrorIDKey                       = attribute.Key("error.id")
+	ErrorMessageKey                  = attribute.Key("error.message")
+	ErrorStackKey                    = attribute.Key("error.stack")
+	ErrorKindKey                     = attribute.Key("error.kind")
+	ExternalUserIDKey                = attribute.Key("gram.external_user.id")
+	APIKeyIDKey                      = attribute.Key("gram.api_key.id")
+	ContainerIDKey                   = semconv.ContainerIDKey
+	ContainerNetworkIDKey            = attribute.Key("container.network.id")
+	FilePathKey                      = semconv.FilePathKey
+	HostNameKey                      = semconv.HostNameKey
+	HTTPRefererHostKey               = attribute.Key("http.request.referer_host")
+	HTTPRequestIDKey                 = attribute.Key("http.request_id")
+	HTTPRequestHeaderRefererKey      = attribute.Key("http.request.header.referer")
+	HTTPRequestHeaderContentTypeKey  = attribute.Key("http.request.header.content_type")
+	HTTPRequestHeaderUserAgentKey    = attribute.Key("http.request.header.user_agent")
+	HTTPRequestMethodKey             = semconv.HTTPRequestMethodKey
+	HTTPRequestBodyKey               = attribute.Key("http.request.body")
+	HTTPResponseBodyKey              = attribute.Key("http.response.body")
+	HTTPRequestHeadersKey            = attribute.Key("http.request.headers")
+	HTTPResponseHeadersKey           = attribute.Key("http.response.headers")
+	HTTPResponseHeaderContentTypeKey = attribute.Key("http.response.header.content_type")
+	// HTTPResponseHeaderWWWAuthenticateKey carries the RFC 6750 challenge an
+	// upstream returned on 401/403 — the machine-readable rejection reason
+	// (error, error_description) for a refused bearer token.
+	HTTPResponseHeaderWWWAuthenticateKey = attribute.Key("http.response.header.www_authenticate")
+	HTTPResponseStatusCodeKey            = semconv.HTTPResponseStatusCodeKey
+	HTTPResponseOriginalStatusCodeKey    = attribute.Key("http.response.original_status_code")
+	HTTPRouteKey                         = semconv.HTTPRouteKey
+	HTTPServerRequestDurationKey         = attribute.Key("http.server.request.duration")
+	HTTPClientRequestDurationKey         = attribute.Key("http.client.request.duration_ms")
+	HTTPRequestSizeKey                   = semconv.HTTPRequestSizeKey
+	HTTPResponseSizeKey                  = semconv.HTTPResponseSizeKey
+	ObservedTimeUnixNanoKey              = attribute.Key("observed_time_unix_nano")
+	ServerAddressKey                     = semconv.ServerAddressKey
+	ServiceEnvKey                        = semconv.DeploymentEnvironmentNameKey
+	ServiceNameKey                       = semconv.ServiceNameKey
+	ServiceVersionKey                    = semconv.ServiceVersionKey
+	TimeUnixNanoKey                      = attribute.Key("time_unix_nano")
+	URLDomainKey                         = semconv.URLDomainKey
+	URLFullKey                           = semconv.URLFullKey
+	URLOriginalKey                       = semconv.URLOriginalKey
+	UserIDKey                            = semconv.UserIDKey
+	UserEmailKey                         = semconv.UserEmailKey
+	UserRolesKey                         = semconv.UserRolesKey
 
 	// UserAttributesKey and UserGroupsKey carry the denormalized WorkOS
 	// Directory Sync snapshot stamped onto telemetry logs at write time.
@@ -514,6 +518,14 @@ func HTTPResponseHeaderContentType(v string) attribute.KeyValue {
 
 func SlogHTTPResponseHeaderContentType(v string) slog.Attr {
 	return slog.String(string(HTTPResponseHeaderContentTypeKey), v)
+}
+
+func HTTPResponseHeaderWWWAuthenticate(v string) attribute.KeyValue {
+	return HTTPResponseHeaderWWWAuthenticateKey.String(v)
+}
+
+func SlogHTTPResponseHeaderWWWAuthenticate(v string) slog.Attr {
+	return slog.String(string(HTTPResponseHeaderWWWAuthenticateKey), v)
 }
 
 func HTTPResponseStatusCode(v int) attribute.KeyValue { return HTTPResponseStatusCodeKey.Int(v) }

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -237,23 +237,24 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	return contextvalues.SetAuthContext(ctx, authCtx), &subject, true
 }
 
+// AuthenticateChallengeHeader builds the WWW-Authenticate value (RFC 9728
+// §5.3): `Bearer resource_metadata="<protectedResourceURL>"`. The remote-MCP
+// proxy also uses it to replace upstream challenges on relayed 401/403
+// responses.
+func AuthenticateChallengeHeader(protectedResourceURL string) string {
+	return fmt.Sprintf(`Bearer resource_metadata="%s"`, protectedResourceURL)
+}
+
 // WriteAuthenticateChallenge sets the WWW-Authenticate header and returns an
 // oops.CodeUnauthorized error. The 401 status and response body come from
 // the oops error middleware; the helper owns only the header.
-//
-// Header shape (RFC 9728 §5.3):
-//
-//	Bearer resource_metadata="<protectedResourceURL>"
 //
 // Callers build the URL — the canonical RFC 9728 path is
 // `<base>/.well-known/oauth-protected-resource/<routeBase>/<slug>`, which is
 // exactly what a spec-compliant client constructs from a resource URL of
 // `<base>/<routeBase>/<slug>`.
 func WriteAuthenticateChallenge(w http.ResponseWriter, protectedResourceURL, message string) error {
-	w.Header().Set(
-		"WWW-Authenticate",
-		fmt.Sprintf(`Bearer resource_metadata="%s"`, protectedResourceURL),
-	)
+	w.Header().Set("WWW-Authenticate", AuthenticateChallengeHeader(protectedResourceURL))
 	if message == "" {
 		return oops.C(oops.CodeUnauthorized)
 	}

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -153,7 +153,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "resolve upstream token for tunneled MCP backend").LogError(ctx, logger)
 		}
-		return s.serveTunneledBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken)
+		return s.serveTunneledBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken, wwwAuthenticate)
 	case mcpServer.ToolsetID.Valid:
 		// AGE-1902: toolset-backed branch still reads runtime config from the
 		// toolsets row (visibility, OAuth, default environment). Once
@@ -413,6 +413,7 @@ func (s *Service) serveTunneledBackend(
 	endpoint *mcpendpointsrepo.McpEndpoint,
 	mcpServer *mcpserversrepo.McpServer,
 	upstreamAuth string,
+	wwwAuthenticate string,
 ) error {
 	ctx := r.Context()
 	logger = logger.With(attr.SlogTunneledMCPServerID(mcpServer.TunneledMcpServerID.UUID.String()))
@@ -432,7 +433,7 @@ func (s *Service) serveTunneledBackend(
 		return err
 	}
 
-	p, err := s.tunnelManager.buildProxy(ctx, r, logger, endpoint, mcpServer, upstreamAuth)
+	p, err := s.tunnelManager.buildProxy(ctx, r, logger, endpoint, mcpServer, upstreamAuth, wwwAuthenticate)
 	if err != nil {
 		return err
 	}

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -116,6 +116,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 	// remote-backed proxying forwards the upstream remote-session token
 	// via AuthorizationOverride.
 	var upstreamTokens map[uuid.UUID]string
+	var wwwAuthenticate string
 	if issuerGated {
 		resolvedEndpoint, err := s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, mcpRouteBase)
 		if err != nil {
@@ -128,6 +129,16 @@ func (s *Service) serveResolvedMCPEndpoint(
 		ctx = newCtx
 		r = r.WithContext(ctx)
 		upstreamTokens = tokens
+
+		// Issuer-gated clients authenticate with this server's AS, so an
+		// upstream 401/403 relayed by the proxy must challenge them with
+		// this endpoint's resource metadata — the upstream's own challenge
+		// would misdirect their re-auth at the upstream's AS.
+		protectedResourceURL, err := resolvedEndpoint.ProtectedResourceURL(s.BaseURLForRequest(r))
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, logger)
+		}
+		wwwAuthenticate = AuthenticateChallengeHeader(protectedResourceURL)
 	}
 
 	switch {
@@ -136,7 +147,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "resolve upstream token for remote MCP backend").LogError(ctx, logger)
 		}
-		return s.serveRemoteBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken)
+		return s.serveRemoteBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken, wwwAuthenticate)
 	case mcpServer.TunneledMcpServerID.Valid:
 		upstreamToken, err := singleUpstreamToken(upstreamTokens)
 		if err != nil {
@@ -336,6 +347,7 @@ func (s *Service) serveRemoteBackend(
 	endpoint *mcpendpointsrepo.McpEndpoint,
 	mcpServer *mcpserversrepo.McpServer,
 	upstreamAuth string,
+	wwwAuthenticate string,
 ) error {
 	ctx := r.Context()
 	logger = logger.With(attr.SlogRemoteMCPServerID(mcpServer.RemoteMcpServerID.UUID.String()))
@@ -366,7 +378,7 @@ func (s *Service) serveRemoteBackend(
 		return oops.E(oops.CodeUnexpected, nil, "remote MCP proxy manager is unavailable").LogError(ctx, logger)
 	}
 
-	p := s.remoteProxyManager.Build(logger, &server, mcpServer.ID.String(), headers, mcpServer.Visibility, endpoint.ProjectID.String(), upstreamAuth)
+	p := s.remoteProxyManager.Build(logger, &server, mcpServer.ID.String(), headers, mcpServer.Visibility, endpoint.ProjectID.String(), upstreamAuth, wwwAuthenticate)
 
 	return serveProxyBackend(w, r.WithContext(ctx), p)
 }

--- a/server/internal/mcp/tunnel_manager.go
+++ b/server/internal/mcp/tunnel_manager.go
@@ -81,6 +81,7 @@ func (m *tunnelManager) buildProxy(
 		mcpServer.Visibility,
 		endpoint.ProjectID.String(),
 		upstreamAuth,
+		"",
 	)
 	p.UpstreamResponseRetryer = tunnelrouting.Retryer(m.routes, tunnelID, addr, clientAffinityKey, m.forwardToken)
 	if len(m.gatewayCIDRs) > 0 {

--- a/server/internal/mcp/tunnel_manager.go
+++ b/server/internal/mcp/tunnel_manager.go
@@ -44,6 +44,7 @@ func (m *tunnelManager) buildProxy(
 	endpoint *mcpendpointsrepo.McpEndpoint,
 	mcpServer *mcpserversrepo.McpServer,
 	upstreamAuth string,
+	wwwAuthenticate string,
 ) (*proxy.Proxy, error) {
 	if m == nil || m.proxyManager == nil {
 		return nil, oops.E(oops.CodeUnexpected, nil, "remote MCP proxy manager is unavailable").LogError(ctx, logger)
@@ -81,7 +82,7 @@ func (m *tunnelManager) buildProxy(
 		mcpServer.Visibility,
 		endpoint.ProjectID.String(),
 		upstreamAuth,
-		"",
+		wwwAuthenticate,
 	)
 	p.UpstreamResponseRetryer = tunnelrouting.Retryer(m.routes, tunnelID, addr, clientAffinityKey, m.forwardToken)
 	if len(m.gatewayCIDRs) > 0 {

--- a/server/internal/remotemcp/proxy/headers.go
+++ b/server/internal/remotemcp/proxy/headers.go
@@ -77,32 +77,32 @@ func isSkippedResponseHeader(name string) bool {
 // transport-managed headers are not forwarded. Multi-value headers are
 // preserved by appending each value individually rather than joining.
 //
-// When the upstream rejected the request (401/403) and wwwAuthenticateOverride
-// is non-empty, the upstream's WWW-Authenticate is replaced with the override.
-// The upstream challenge names the upstream's own protected-resource metadata,
-// which a spec-following MCP client must reject — it doesn't match the URL the
+// When the upstream rejected the request (401/403) and wwwAuthenticate is
+// non-empty, it replaces the upstream's WWW-Authenticate. The upstream
+// challenge names the upstream's own protected-resource metadata, which a
+// spec-following MCP client must reject — it doesn't match the URL the
 // client connected to — and which otherwise misdirects its re-auth at the
 // upstream's authorization server instead of this server's.
 //
 // Callers ([writeResponse], [Proxy.relaySSEStream]) must invoke this before
 // [http.ResponseWriter.WriteHeader]; once the status line is written, header
 // mutations are silently dropped.
-func applyResponseHeaders(w http.ResponseWriter, remoteResp *http.Response, wwwAuthenticateOverride string) {
-	override := wwwAuthenticateOverride != "" &&
+func applyResponseHeaders(w http.ResponseWriter, remoteResp *http.Response, wwwAuthenticate string) {
+	replaceChallenge := wwwAuthenticate != "" &&
 		(remoteResp.StatusCode == http.StatusUnauthorized || remoteResp.StatusCode == http.StatusForbidden)
 	for name, values := range remoteResp.Header {
 		if isSkippedResponseHeader(name) {
 			continue
 		}
-		if override && strings.EqualFold(name, "WWW-Authenticate") {
+		if replaceChallenge && strings.EqualFold(name, "WWW-Authenticate") {
 			continue
 		}
 		for _, v := range values {
 			w.Header().Add(name, v)
 		}
 	}
-	if override {
-		w.Header().Set("WWW-Authenticate", wwwAuthenticateOverride)
+	if replaceChallenge {
+		w.Header().Set("WWW-Authenticate", wwwAuthenticate)
 	}
 }
 

--- a/server/internal/remotemcp/proxy/headers.go
+++ b/server/internal/remotemcp/proxy/headers.go
@@ -77,17 +77,32 @@ func isSkippedResponseHeader(name string) bool {
 // transport-managed headers are not forwarded. Multi-value headers are
 // preserved by appending each value individually rather than joining.
 //
+// When the upstream rejected the request (401/403) and wwwAuthenticateOverride
+// is non-empty, the upstream's WWW-Authenticate is replaced with the override.
+// The upstream challenge names the upstream's own protected-resource metadata,
+// which a spec-following MCP client must reject — it doesn't match the URL the
+// client connected to — and which otherwise misdirects its re-auth at the
+// upstream's authorization server instead of this server's.
+//
 // Callers ([writeResponse], [Proxy.relaySSEStream]) must invoke this before
 // [http.ResponseWriter.WriteHeader]; once the status line is written, header
 // mutations are silently dropped.
-func applyResponseHeaders(w http.ResponseWriter, remoteResp *http.Response) {
+func applyResponseHeaders(w http.ResponseWriter, remoteResp *http.Response, wwwAuthenticateOverride string) {
+	override := wwwAuthenticateOverride != "" &&
+		(remoteResp.StatusCode == http.StatusUnauthorized || remoteResp.StatusCode == http.StatusForbidden)
 	for name, values := range remoteResp.Header {
 		if isSkippedResponseHeader(name) {
+			continue
+		}
+		if override && strings.EqualFold(name, "WWW-Authenticate") {
 			continue
 		}
 		for _, v := range values {
 			w.Header().Add(name, v)
 		}
+	}
+	if override {
+		w.Header().Set("WWW-Authenticate", wwwAuthenticateOverride)
 	}
 }
 

--- a/server/internal/remotemcp/proxy/headers_internal_test.go
+++ b/server/internal/remotemcp/proxy/headers_internal_test.go
@@ -23,7 +23,7 @@ func TestApplyResponseHeadersStripsTunnelError(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	applyResponseHeaders(rec, upstream)
+	applyResponseHeaders(rec, upstream, "")
 
 	require.Empty(t, rec.Header().Get("X-Gram-Tunnel-Error"))
 	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -723,6 +723,20 @@ func (p *Proxy) forwardRequest(ctx context.Context, r *http.Request, body io.Rea
 		resp.Body = &cancellingBody{ReadCloser: resp.Body, cancel: forwardCancel, timer: phaseTimer}
 	}
 
+	// Upstream auth rejections are the primary diagnostic when a stored or
+	// forwarded token is refused (e.g. audience mismatch, upstream-side
+	// revocation). The upstream's RFC 6750 challenge carries the
+	// machine-readable reason and — for issuer-gated endpoints — is
+	// replaced before relay, so this log line is its only surface.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		p.Logger.WarnContext(ctx, "remote mcp server rejected upstream credentials",
+			attr.SlogComponent("remotemcp.proxy"),
+			attr.SlogHTTPResponseStatusCode(resp.StatusCode),
+			attr.SlogHTTPResponseHeaderWWWAuthenticate(resp.Header.Get("WWW-Authenticate")),
+			attr.SlogRemoteMCPServerID(p.Identity.RemoteMCPServerID),
+			attr.SlogMcpServerID(p.Identity.McpServerID))
+	}
+
 	return upstreamReq, resp, nil
 }
 

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -225,6 +225,15 @@ type Proxy struct {
 	// It is used by tunneled MCP to fail over stale gateway owners.
 	UpstreamResponseRetryer UpstreamResponseRetryer
 
+	// WWWAuthenticateOverride, when non-empty, replaces the upstream's
+	// WWW-Authenticate header on relayed 401/403 responses. Callers whose
+	// clients authenticate with this server's own authorization server
+	// (issuer-gated endpoints) set it to their own challenge so a client's
+	// re-auth is directed here rather than at the upstream's AS. Leave
+	// empty to relay the upstream challenge verbatim (external OAuth
+	// passthrough, where the client's token really is the upstream's).
+	WWWAuthenticateOverride string
+
 	UserRequestInterceptors []UserRequestInterceptor
 
 	// InitializeRequestInterceptors run for inbound "initialize" JSON-RPC
@@ -328,7 +337,7 @@ func (p *Proxy) Delete(w http.ResponseWriter, r *http.Request) (err error) {
 	upstreamStatus = upstreamResp.StatusCode
 	span.SetAttributes(attr.RemoteMCPProxyRemoteStatusCode(upstreamStatus))
 
-	n, err := writeResponse(w, upstreamResp, upstreamResp.Body)
+	n, err := writeResponse(w, upstreamResp, upstreamResp.Body, p.WWWAuthenticateOverride)
 	responseBytes = n
 	if err != nil {
 		return err
@@ -394,7 +403,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 		return nil
 	}
 
-	n, err := writeResponse(w, upstreamResp, upstreamResp.Body)
+	n, err := writeResponse(w, upstreamResp, upstreamResp.Body, p.WWWAuthenticateOverride)
 	responseBytes = n
 	if err != nil {
 		return err
@@ -628,7 +637,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 		}
 	}
 
-	n, err := writeResponse(w, upstreamResp, bytes.NewReader(bodyBytes))
+	n, err := writeResponse(w, upstreamResp, bytes.NewReader(bodyBytes), p.WWWAuthenticateOverride)
 	responseBytes = n
 	if err != nil {
 		return err
@@ -772,7 +781,7 @@ func (p *Proxy) relaySSEStream(
 	resourcesReadReq *ResourcesReadRequest,
 	resourcesListReq *ResourcesListRequest,
 ) (int64, error) {
-	applyResponseHeaders(w, upstreamResp)
+	applyResponseHeaders(w, upstreamResp, p.WWWAuthenticateOverride)
 	w.WriteHeader(upstreamResp.StatusCode)
 
 	if upstreamResp.Body == nil {
@@ -1277,8 +1286,8 @@ func (p *Proxy) dispatchInterceptorError(
 // bounded by its internal buffer, and the body coming from a parsed POST
 // flow was already capped during [readJSONRPCBody] (upstream response) or
 // [UserRequest.ParseJSONRPCMessages] (inbound user request).
-func writeResponse(w http.ResponseWriter, upstreamResp *http.Response, body io.Reader) (int64, error) {
-	applyResponseHeaders(w, upstreamResp)
+func writeResponse(w http.ResponseWriter, upstreamResp *http.Response, body io.Reader, wwwAuthenticateOverride string) (int64, error) {
+	applyResponseHeaders(w, upstreamResp, wwwAuthenticateOverride)
 	w.WriteHeader(upstreamResp.StatusCode)
 
 	if body == nil {

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -225,14 +225,14 @@ type Proxy struct {
 	// It is used by tunneled MCP to fail over stale gateway owners.
 	UpstreamResponseRetryer UpstreamResponseRetryer
 
-	// WWWAuthenticateOverride, when non-empty, replaces the upstream's
-	// WWW-Authenticate header on relayed 401/403 responses. Callers whose
-	// clients authenticate with this server's own authorization server
-	// (issuer-gated endpoints) set it to their own challenge so a client's
-	// re-auth is directed here rather than at the upstream's AS. Leave
-	// empty to relay the upstream challenge verbatim (external OAuth
-	// passthrough, where the client's token really is the upstream's).
-	WWWAuthenticateOverride string
+	// WWWAuthenticate is the challenge relayed to the client when the
+	// upstream rejects a request (401/403), replacing the upstream's own
+	// WWW-Authenticate — the upstream challenge names the upstream's
+	// protected-resource metadata, which misdirects a client that
+	// authenticated with this server. Empty when the endpoint has no
+	// authorization server of its own (nothing to substitute); the
+	// upstream challenge then relays verbatim.
+	WWWAuthenticate string
 
 	UserRequestInterceptors []UserRequestInterceptor
 
@@ -337,7 +337,7 @@ func (p *Proxy) Delete(w http.ResponseWriter, r *http.Request) (err error) {
 	upstreamStatus = upstreamResp.StatusCode
 	span.SetAttributes(attr.RemoteMCPProxyRemoteStatusCode(upstreamStatus))
 
-	n, err := writeResponse(w, upstreamResp, upstreamResp.Body, p.WWWAuthenticateOverride)
+	n, err := writeResponse(w, upstreamResp, upstreamResp.Body, p.WWWAuthenticate)
 	responseBytes = n
 	if err != nil {
 		return err
@@ -403,7 +403,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 		return nil
 	}
 
-	n, err := writeResponse(w, upstreamResp, upstreamResp.Body, p.WWWAuthenticateOverride)
+	n, err := writeResponse(w, upstreamResp, upstreamResp.Body, p.WWWAuthenticate)
 	responseBytes = n
 	if err != nil {
 		return err
@@ -637,7 +637,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 		}
 	}
 
-	n, err := writeResponse(w, upstreamResp, bytes.NewReader(bodyBytes), p.WWWAuthenticateOverride)
+	n, err := writeResponse(w, upstreamResp, bytes.NewReader(bodyBytes), p.WWWAuthenticate)
 	responseBytes = n
 	if err != nil {
 		return err
@@ -781,7 +781,7 @@ func (p *Proxy) relaySSEStream(
 	resourcesReadReq *ResourcesReadRequest,
 	resourcesListReq *ResourcesListRequest,
 ) (int64, error) {
-	applyResponseHeaders(w, upstreamResp, p.WWWAuthenticateOverride)
+	applyResponseHeaders(w, upstreamResp, p.WWWAuthenticate)
 	w.WriteHeader(upstreamResp.StatusCode)
 
 	if upstreamResp.Body == nil {
@@ -1286,8 +1286,8 @@ func (p *Proxy) dispatchInterceptorError(
 // bounded by its internal buffer, and the body coming from a parsed POST
 // flow was already capped during [readJSONRPCBody] (upstream response) or
 // [UserRequest.ParseJSONRPCMessages] (inbound user request).
-func writeResponse(w http.ResponseWriter, upstreamResp *http.Response, body io.Reader, wwwAuthenticateOverride string) (int64, error) {
-	applyResponseHeaders(w, upstreamResp, wwwAuthenticateOverride)
+func writeResponse(w http.ResponseWriter, upstreamResp *http.Response, body io.Reader, wwwAuthenticate string) (int64, error) {
+	applyResponseHeaders(w, upstreamResp, wwwAuthenticate)
 	w.WriteHeader(upstreamResp.StatusCode)
 
 	if body == nil {

--- a/server/internal/remotemcp/proxy/www_authenticate_test.go
+++ b/server/internal/remotemcp/proxy/www_authenticate_test.go
@@ -1,0 +1,88 @@
+package proxy_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// upstream401 serves an upstream that rejects every request with a 401 and
+// its own RFC 6750 challenge naming its own protected-resource metadata.
+func upstream401(t *testing.T) *httptest.Server {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="mcp", resource_metadata="https://upstream.example.com/.well-known/oauth-protected-resource/mcp", error="invalid_token"`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_token","error_description":"Invalid access token"}`))
+	}))
+	t.Cleanup(upstream.Close)
+	return upstream
+}
+
+func TestProxy_Post_Upstream401_ReplacesWWWAuthenticateWhenOverrideSet(t *testing.T) {
+	t.Parallel()
+
+	upstream := upstream401(t)
+	p := newProxyForTest(t, upstream.URL)
+	p.WWWAuthenticateOverride = `Bearer resource_metadata="https://gram.example.com/.well-known/oauth-protected-resource/x/mcp/slug"`
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.Equal(t,
+		`Bearer resource_metadata="https://gram.example.com/.well-known/oauth-protected-resource/x/mcp/slug"`,
+		rr.Header().Get("WWW-Authenticate"),
+		"relayed 401 must challenge the client with this server's resource metadata, not the upstream's")
+	require.Contains(t, rr.Body.String(), "invalid_token", "upstream body still relays")
+}
+
+func TestProxy_Post_Upstream401_RelaysWWWAuthenticateWhenOverrideUnset(t *testing.T) {
+	t.Parallel()
+
+	upstream := upstream401(t)
+	p := newProxyForTest(t, upstream.URL)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.Contains(t, rr.Header().Get("WWW-Authenticate"), "upstream.example.com",
+		"without an override (external OAuth passthrough) the upstream challenge relays verbatim")
+}
+
+func TestProxy_Post_Upstream200_OverrideDoesNotInjectHeader(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.WWWAuthenticateOverride = `Bearer resource_metadata="https://gram.example.com/meta"`
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Empty(t, rr.Header().Get("WWW-Authenticate"), "successful responses carry no challenge")
+}

--- a/server/internal/remotemcp/proxy/www_authenticate_test.go
+++ b/server/internal/remotemcp/proxy/www_authenticate_test.go
@@ -9,14 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// upstream401 serves an upstream that rejects every request with a 401 and
-// its own RFC 6750 challenge naming its own protected-resource metadata.
-func upstream401(t *testing.T) *httptest.Server {
+// upstreamRejecting serves an upstream that rejects every request with the
+// given status and its own RFC 6750 challenge naming its own
+// protected-resource metadata.
+func upstreamRejecting(t *testing.T, status int) *httptest.Server {
 	t.Helper()
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("WWW-Authenticate", `Bearer realm="mcp", resource_metadata="https://upstream.example.com/.well-known/oauth-protected-resource/mcp", error="invalid_token"`)
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(status)
 		_, _ = w.Write([]byte(`{"error":"invalid_token","error_description":"Invalid access token"}`))
 	}))
 	t.Cleanup(upstream.Close)
@@ -26,7 +27,7 @@ func upstream401(t *testing.T) *httptest.Server {
 func TestProxy_Post_Upstream401_ReplacesWWWAuthenticateWhenSet(t *testing.T) {
 	t.Parallel()
 
-	upstream := upstream401(t)
+	upstream := upstreamRejecting(t, http.StatusUnauthorized)
 	p := newProxyForTest(t, upstream.URL)
 	p.WWWAuthenticate = `Bearer resource_metadata="https://gram.example.com/.well-known/oauth-protected-resource/x/mcp/slug"`
 
@@ -45,10 +46,55 @@ func TestProxy_Post_Upstream401_ReplacesWWWAuthenticateWhenSet(t *testing.T) {
 	require.Contains(t, rr.Body.String(), "invalid_token", "upstream body still relays")
 }
 
+func TestProxy_Post_Upstream403_ReplacesWWWAuthenticateWhenSet(t *testing.T) {
+	t.Parallel()
+
+	upstream := upstreamRejecting(t, http.StatusForbidden)
+	p := newProxyForTest(t, upstream.URL)
+	p.WWWAuthenticate = `Bearer resource_metadata="https://gram.example.com/meta"`
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	require.Equal(t, `Bearer resource_metadata="https://gram.example.com/meta"`,
+		rr.Header().Get("WWW-Authenticate"), "403 substitutes the challenge the same as 401")
+}
+
+func TestProxy_Get_UpstreamSSE401_ReplacesWWWAuthenticateWhenSet(t *testing.T) {
+	t.Parallel()
+
+	// A 401 carrying Content-Type: text/event-stream routes through the SSE
+	// relay rather than writeResponse; the challenge must substitute there too.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="mcp", resource_metadata="https://upstream.example.com/.well-known/oauth-protected-resource/mcp"`)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.WWWAuthenticate = `Bearer resource_metadata="https://gram.example.com/meta"`
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x/mcp/id", http.NoBody)
+	req.Header.Set("Accept", "text/event-stream")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Get(rr, req))
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.Equal(t, `Bearer resource_metadata="https://gram.example.com/meta"`,
+		rr.Header().Get("WWW-Authenticate"), "SSE relay path substitutes the challenge too")
+}
+
 func TestProxy_Post_Upstream401_RelaysWWWAuthenticateWhenUnset(t *testing.T) {
 	t.Parallel()
 
-	upstream := upstream401(t)
+	upstream := upstreamRejecting(t, http.StatusUnauthorized)
 	p := newProxyForTest(t, upstream.URL)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))

--- a/server/internal/remotemcp/proxy/www_authenticate_test.go
+++ b/server/internal/remotemcp/proxy/www_authenticate_test.go
@@ -23,12 +23,12 @@ func upstream401(t *testing.T) *httptest.Server {
 	return upstream
 }
 
-func TestProxy_Post_Upstream401_ReplacesWWWAuthenticateWhenOverrideSet(t *testing.T) {
+func TestProxy_Post_Upstream401_ReplacesWWWAuthenticateWhenSet(t *testing.T) {
 	t.Parallel()
 
 	upstream := upstream401(t)
 	p := newProxyForTest(t, upstream.URL)
-	p.WWWAuthenticateOverride = `Bearer resource_metadata="https://gram.example.com/.well-known/oauth-protected-resource/x/mcp/slug"`
+	p.WWWAuthenticate = `Bearer resource_metadata="https://gram.example.com/.well-known/oauth-protected-resource/x/mcp/slug"`
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
 	req.Header.Set("Content-Type", "application/json")
@@ -45,7 +45,7 @@ func TestProxy_Post_Upstream401_ReplacesWWWAuthenticateWhenOverrideSet(t *testin
 	require.Contains(t, rr.Body.String(), "invalid_token", "upstream body still relays")
 }
 
-func TestProxy_Post_Upstream401_RelaysWWWAuthenticateWhenOverrideUnset(t *testing.T) {
+func TestProxy_Post_Upstream401_RelaysWWWAuthenticateWhenUnset(t *testing.T) {
 	t.Parallel()
 
 	upstream := upstream401(t)
@@ -60,10 +60,10 @@ func TestProxy_Post_Upstream401_RelaysWWWAuthenticateWhenOverrideUnset(t *testin
 
 	require.Equal(t, http.StatusUnauthorized, rr.Code)
 	require.Contains(t, rr.Header().Get("WWW-Authenticate"), "upstream.example.com",
-		"without an override (external OAuth passthrough) the upstream challenge relays verbatim")
+		"without a challenge of our own (external OAuth passthrough) the upstream challenge relays verbatim")
 }
 
-func TestProxy_Post_Upstream200_OverrideDoesNotInjectHeader(t *testing.T) {
+func TestProxy_Post_Upstream200_DoesNotInjectHeader(t *testing.T) {
 	t.Parallel()
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -74,7 +74,7 @@ func TestProxy_Post_Upstream200_OverrideDoesNotInjectHeader(t *testing.T) {
 	t.Cleanup(upstream.Close)
 
 	p := newProxyForTest(t, upstream.URL)
-	p.WWWAuthenticateOverride = `Bearer resource_metadata="https://gram.example.com/meta"`
+	p.WWWAuthenticate = `Bearer resource_metadata="https://gram.example.com/meta"`
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
 	req.Header.Set("Content-Type", "application/json")

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -111,6 +111,7 @@ func (f *ProxyManager) Build(
 	visibility string,
 	projectID string,
 	upstreamAuth string,
+	wwwAuthenticate string,
 ) *proxy.Proxy {
 	configured := make([]proxy.ConfiguredHeader, 0, len(headers))
 	for _, h := range headers {
@@ -126,7 +127,7 @@ func (f *ProxyManager) Build(
 		RemoteMCPServerID:   server.ID.String(),
 		TunneledMCPServerID: "",
 		McpServerID:         mcpServerID,
-	}, server.Url, configured, visibility, projectID, upstreamAuth)
+	}, server.Url, configured, visibility, projectID, upstreamAuth, wwwAuthenticate)
 }
 
 func (f *ProxyManager) BuildTarget(
@@ -137,6 +138,7 @@ func (f *ProxyManager) BuildTarget(
 	visibility string,
 	projectID string,
 	upstreamAuth string,
+	wwwAuthenticate string,
 ) *proxy.Proxy {
 	backendID := identity.SourceID()
 
@@ -215,6 +217,7 @@ func (f *ProxyManager) BuildTarget(
 		Headers:                 headers,
 		AuthorizationOverride:   upstreamAuth,
 		UpstreamResponseRetryer: nil,
+		WWWAuthenticateOverride: wwwAuthenticate,
 		UserRequestInterceptors: nil,
 		InitializeRequestInterceptors: []proxy.InitializeRequestInterceptor{
 			NewInitializePostHogEventInterceptor(f.posthog, identity, logger),

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -217,7 +217,7 @@ func (f *ProxyManager) BuildTarget(
 		Headers:                 headers,
 		AuthorizationOverride:   upstreamAuth,
 		UpstreamResponseRetryer: nil,
-		WWWAuthenticateOverride: wwwAuthenticate,
+		WWWAuthenticate:         wwwAuthenticate,
 		UserRequestInterceptors: nil,
 		InitializeRequestInterceptors: []proxy.InitializeRequestInterceptor{
 			NewInitializePostHogEventInterceptor(f.posthog, identity, logger),


### PR DESCRIPTION
## Summary

On upstream 401/403, the remote-MCP proxy now challenges issuer-gated clients with **Gram's** `WWW-Authenticate` (RFC 9728 resource metadata for the endpoint) instead of relaying the upstream's challenge verbatim.

Fixes [AIS-247](https://linear.app/speakeasy/issue/AIS-247/remote-mcp-proxy-relays-upstream-www-authenticate-misdirecting-client).

## Root cause

Issuer-gated clients authenticate with Gram's authorization server, but when the upstream rejected Gram's forwarded token the relayed challenge named the _upstream's_ protected-resource metadata. Client behavior observed against a strict upstream:

1. Client treats the 401 as "my token is bad" → refreshes with Gram (succeeds — its token was fine) → retries → 401 again. Unfixable refresh loop, visible in prod logs as repeated `refresh_token` grants bracketing each relayed 401.
2. Client escalates to full re-auth and follows the relayed `resource_metadata`. A spec-following client must reject it (advertised resource ≠ the URL it connected to) → "Authorization failed". A laxer client dances with the upstream AS and presents an upstream token that Gram's issuer gate rejects.

The working recovery — re-dance with Gram's AS, whose consent flow re-links the upstream session — was never signaled.

## Changes

- `proxy.Proxy.WWWAuthenticate`: the challenge relayed to the client when the upstream rejects a request (401/403, JSON and SSE paths), replacing the upstream's own `WWW-Authenticate`. Empty when the endpoint has no authorization server of its own (external OAuth passthrough, where the client holds the upstream's token); the upstream challenge then relays verbatim.
- Issuer-gated remote-backed servings set it to the endpoint's own challenge (`AuthenticateChallengeHeader`, extracted from `WriteAuthenticateChallenge`).
- Status code and body still relay unchanged.

## Testing

Proxy tests cover: Gram's challenge replaces the upstream's on 401 when set; unset relays verbatim; successful responses never gain the header. Full remotemcp/mcp/xmcp suites + lint green.

## 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces upstream 401/403 challenges with Gram’s RFC 9728 `WWW-Authenticate` for issuer-gated remote‑ and tunneled‑MCP endpoints to stop misdirected re‑auth loops, and logs upstream rejections with the original challenge for debugging. Fixes AIS-247; external OAuth passthrough still relays the upstream challenge.

- **Bug Fixes**
  - Added `proxy.Proxy.WWWAuthenticate` and substitution in `applyResponseHeaders` and SSE relay to replace upstream `WWW-Authenticate` on 401/403 while relaying status and body unchanged.
  - Issuer‑gated endpoints build the header via `AuthenticateChallengeHeader` and pass it through `ProxyManager.Build`, `serveRemoteBackend`, `serveTunneledBackend`, and the tunnel manager; passthrough leaves it empty.
  - Applies on JSON and SSE paths only; never added on success. Tests cover 401/403 (including SSE), passthrough when empty, and no header on 200.

- **New Features**
  - Log upstream 401/403 credential rejections at the forward path with status and the original `WWW-Authenticate` for diagnostics.

<sup>Written for commit 1e5252e9e322cbc8a967db8352f8aee7014029fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

