### PR TITLE
fix(elements): hide copy button on tool-only assistant messages

### DIFF
--- a/.changeset/tool-call-copy-button.md
+++ b/.changeset/tool-call-copy-button.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+Hide the assistant message copy button on tool-only turns. A message made up solely of tool calls (and/or reasoning) has no copyable text, so the lone Copy button no longer hangs beneath it.

--- a/elements/src/components/assistant-ui/thread.tsx
+++ b/elements/src/components/assistant-ui/thread.tsx
@@ -1147,6 +1147,16 @@ const Image: FC<ImageMessagePartProps> = (props) => {
 };
 
 const AssistantActionBar: FC = () => {
+  // Only the message text is copyable, so a message made up solely of tool
+  // calls (and/or reasoning) has nothing to copy — don't render the bar there.
+  // Otherwise a lone Copy button hangs beneath every tool-only turn.
+  const hasCopyableText = useAssistantState(({ message }) =>
+    message.parts.some(
+      (part) => part.type === "text" && part.text.trim().length > 0,
+    ),
+  );
+  if (!hasCopyableText) return null;
+
   return (
     <ActionBarPrimitive.Root
       hideWhenRunning


### PR DESCRIPTION
The assistant message action bar in the Elements chat (`Thread`) rendered a Copy button beneath every assistant turn, including turns made up solely of tool calls and/or reasoning. Those have no copyable text, so a lone Copy button was left hanging under the tool call UI in the dashboard chat.

Gate `AssistantActionBar` on the message having non-empty text content — same part-inspection pattern already used by `thinking-indicator.tsx`. Messages with text (with or without tool calls) still show Copy; tool-only messages don't.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Copy button on assistant turns that contain only tool calls or reasoning in the dashboard chat (`Thread` in `@gram-ai/elements`). Fixes AIS-184 by showing the action bar only when the message has non-empty text.

- **Bug Fixes**
  - Render `AssistantActionBar` only if `message.parts` includes a trimmed `text` part.
  - Messages with text still show Copy; tool-only turns render no action bar.

<sup>Written for commit 1eea20e1079ae05c71ab6d193345295c25d2ad33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

