### PR TITLE
fix(dashboard): remove confusing hooks warning from detector cards

### DIFF
--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -316,12 +316,9 @@ function DetectorCard({
         </p>
         <div className="mt-2 flex items-center gap-3 text-xs">
           {needsHook ? (
-            <SimpleTooltip tooltip="Enforcement-only. This detector runs when agents make tool calls through Speakeasy hooks, so it never surfaces in scans. Install the hooks on each agent to enforce it.">
-              <span className="text-warning flex items-center gap-1">
-                <Info className="size-3 shrink-0" />
-                Enforcement-only · requires Speakeasy hooks
-              </span>
-            </SimpleTooltip>
+            <span className="text-warning">
+              Enforcement-only · requires Speakeasy hooks
+            </span>
           ) : (
             rules.length > 0 && (
               <span

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -252,13 +252,6 @@ function SummaryRow({ label, chips }: { label: string; chips: string[] }) {
   );
 }
 
-/** Built-in detector categories that only produce findings when Speakeasy hooks
- *  are installed on the agent (no rule list to customize). */
-const HOOK_REQUIRED_CATEGORIES: Set<RuleCategory> = new Set([
-  "shadow_mcp",
-  "destructive_tool",
-]);
-
 /** Built-in detectors that run at the category level and have no individual
  *  sub-rules in DETECTION_RULES (their rule list is intentionally empty).
  *  Selecting one of these is enough to enable the policy on its own. */
@@ -290,7 +283,6 @@ function DetectorCard({
   const customizable = available && rules.length > 1;
   const enabledCount = rules.filter((r) => !disabledRules.has(r.id)).length;
   const customized = selected && enabledCount < rules.length;
-  const needsHook = HOOK_REQUIRED_CATEGORIES.has(category);
   return (
     <div
       className={cn(
@@ -315,23 +307,17 @@ function DetectorCard({
           {meta.description}
         </p>
         <div className="mt-2 flex items-center gap-3 text-xs">
-          {needsHook ? (
-            <span className="text-warning">
-              Enforcement-only · requires Speakeasy hooks
+          {rules.length > 0 && (
+            <span
+              className={cn(
+                "bg-muted rounded-full px-2 py-0.5",
+                customized ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {customized
+                ? `${enabledCount} of ${rules.length} rules`
+                : `${rules.length} rules`}
             </span>
-          ) : (
-            rules.length > 0 && (
-              <span
-                className={cn(
-                  "bg-muted rounded-full px-2 py-0.5",
-                  customized ? "text-foreground" : "text-muted-foreground",
-                )}
-              >
-                {customized
-                  ? `${enabledCount} of ${rules.length} rules`
-                  : `${rules.length} rules`}
-              </span>
-            )
           )}
           {selected && customizable && (
             <button

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -316,7 +316,12 @@ function DetectorCard({
         </p>
         <div className="mt-2 flex items-center gap-3 text-xs">
           {needsHook ? (
-            <span className="text-warning">Requires Speakeasy hooks</span>
+            <SimpleTooltip tooltip="Enforcement-only. This detector runs when agents make tool calls through Speakeasy hooks, so it never surfaces in scans. Install the hooks on each agent to enforce it.">
+              <span className="text-warning flex items-center gap-1">
+                <Info className="size-3 shrink-0" />
+                Enforcement-only · requires Speakeasy hooks
+              </span>
+            </SimpleTooltip>
           ) : (
             rules.length > 0 && (
               <span


### PR DESCRIPTION
The policy wizard annotated the `shadow_mcp` and `destructive_tool` detector cards with a "requires Speakeasy hooks" warning. Per review this warning is unnecessary and out of place — the hook requirement is already stated in each detector's own description text (`policy-data.ts`), so the separate badge was redundant and confusing.

This removes the badge from `DetectorCard` and the now-unused `HOOK_REQUIRED_CATEGORIES` set. Detector behaviour is unchanged.


---
## Summary by cubic
Clarifies which detectors are enforcement-only in the policy wizard (addresses AIS-237). The label now reads "Enforcement-only · requires Speakeasy hooks" with an info tooltip explaining these rules only trigger via Speakeasy tool-call hooks and never appear in scans.

<sup>Written for commit 973e36138d95ec23b789755e4d84732801878080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3835?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>