### PR TITLE
fix(risk): drop US_DRIVER_LICENSE Presidio findings at the finding level

### DIFF
--- a/.changeset/ais-158-presidio-entity-blocklist.md
+++ b/.changeset/ais-158-presidio-entity-blocklist.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Drop US_DRIVER_LICENSE Presidio findings at the finding level so they never surface, even when a policy pins no entities and Presidio scans its full default recognizer set.

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -53,7 +53,7 @@ export const RULE_CATEGORY_META: Record<
   },
   government_ids: {
     label: "Government Identifiers",
-    description: "SSNs, passport numbers, driver's licenses, tax IDs",
+    description: "SSNs, passport numbers, national IDs, tax IDs",
     icon: "landmark",
   },
   healthcare: {

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -56,6 +56,16 @@ SPACY_MODEL = "en_core_web_lg"
 # DefaultPresidioScoreThreshold so both paths agree on the floor.
 DEFAULT_SCORE_THRESHOLD = 0.5
 
+# Presidio entity types dropped after the scan regardless of how it was scoped.
+# Mirrors the Go scanner's findingLevelDropEntities.
+#
+# A policy that pins no entities makes Presidio scan its full default set, so
+# scan-scoping alone cannot keep US_DRIVER_LICENSE out — its recognizer is pure
+# noise (microsoft/presidio#1063), so it is dropped here (see
+# _scan_to_detections). PERSON is deliberately not included: person-name
+# detection on unpinned scans is intended behaviour, matching the Go path.
+_FINDING_LEVEL_DROP = frozenset({"US_DRIVER_LICENSE"})
+
 _T = TypeVar("_T")
 
 
@@ -408,6 +418,11 @@ def _scan_to_detections(
     # works in character offsets, so a discarded match never costs byte conversion.
     spans: list[tuple[Recognized, int, int, str]] = []
     for r in results:
+        # Drop US_DRIVER_LICENSE regardless of how the scan was scoped: an
+        # unpinned request scans Presidio's full default set, so this gate is
+        # what keeps its noisy license-number matches out (AIS-158).
+        if r.entity_type in _FINDING_LEVEL_DROP:
+            continue
         start = max(0, min(r.start, n))
         end = max(start, min(r.end, n))
         match = content[start:end]

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -155,6 +155,29 @@ async def test_all_false_positives_yields_no_detections():
     assert await _scanner(analyzer).scan(content, None, 0.75) == []
 
 
+async def test_us_driver_license_is_dropped():
+    # Regression for AIS-158: an unpinned scan runs Presidio's full default set,
+    # which includes US_DRIVER_LICENSE. It is dropped at the scanner regardless
+    # of scoping; other matches — including PERSON, whose unpinned detection is
+    # intended — survive.
+    content = "D1234567 Jane Roe a@b.com"
+    analyzer = FakeAnalyzer(
+        {
+            content: [
+                _Result("US_DRIVER_LICENSE", start=0, end=8, score=0.9),
+                _Result("PERSON", start=9, end=17, score=0.85),
+                _Result("EMAIL_ADDRESS", start=18, end=25, score=0.9),
+            ]
+        }
+    )
+
+    detections = await _scanner(analyzer).scan(content, None, 0.75)
+
+    entity_types = {d.entity_type for d in detections}
+    assert "US_DRIVER_LICENSE" not in entity_types
+    assert entity_types == {"PERSON", "EMAIL_ADDRESS"}
+
+
 async def test_nothing_recognized_yields_no_detections():
     analyzer = FakeAnalyzer()  # recognizes nothing
 

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -195,7 +195,7 @@ type presidioResult struct {
 	Score      float64 `json:"score"`
 }
 
-// presidioEntityBlacklist is the set of Presidio entity types we refuse to
+// presidioEntityBlocklist is the set of Presidio entity types we refuse to
 // scan for regardless of what's stored on the policy.
 //
 //   - PERSON: Presidio's NER-backed person detection trips on common
@@ -208,23 +208,49 @@ type presidioResult struct {
 //     and any text containing "lic" via substring context boosting (e.g.
 //     "public", "duplicate"). See microsoft/presidio#1063 — open since 2023.
 //     Re-enable once the upstream regex is tightened.
-var presidioEntityBlacklist = map[string]struct{}{
+var presidioEntityBlocklist = map[string]struct{}{
 	"PERSON":            {},
 	"US_DRIVER_LICENSE": {},
 }
 
-// filterEntities removes blacklisted entity types from the caller's list.
+// findingLevelDropEntities is the subset of the blocklist that must never
+// surface even when a policy pins no entities. filterEntities trims the full
+// blocklist from a caller-pinned list, but a policy that pins nothing makes
+// Presidio scan its full default set, so those types have to be dropped after
+// the scan too (see convertPresidioFindings) or the blocklist is silently
+// bypassed for every default scan.
+//
+// Only US_DRIVER_LICENSE is here — its recognizer is pure noise
+// (microsoft/presidio#1063). PERSON is deliberately excluded: person-name
+// detection on unpinned scans is intended behaviour (see
+// TestPresidio_DetectsPersonName), so it is only trimmed from pinned lists.
+var findingLevelDropEntities = map[string]struct{}{
+	"US_DRIVER_LICENSE": {},
+}
+
+// isFindingLevelDropped reports whether a finding of this Presidio entity type
+// must be dropped regardless of how the scan was scoped.
+func isFindingLevelDropped(entityType string) bool {
+	_, drop := findingLevelDropEntities[entityType]
+	return drop
+}
+
+// filterEntities removes blocklisted entity types from the caller's list.
 // Returns nil unchanged so Presidio's default entity set still applies for
 // callers that didn't pin a list. Returns an empty (non-nil) slice when the
-// caller pinned a list and every entry was blacklisted, so AnalyzeBatch can
+// caller pinned a list and every entry was blocklisted, so AnalyzeBatch can
 // short-circuit instead of falling back to the unbounded default scan.
+//
+// This only bounds what Presidio scans for; the finding-level
+// isFindingLevelDropped gate in convertPresidioFindings is what guarantees
+// US_DRIVER_LICENSE never surfaces even from an unpinned (default) scan.
 func filterEntities(entities []string) []string {
 	if entities == nil {
 		return nil
 	}
 	out := make([]string, 0, len(entities))
 	for _, e := range entities {
-		if _, blocked := presidioEntityBlacklist[e]; blocked {
+		if _, blocked := presidioEntityBlocklist[e]; blocked {
 			continue
 		}
 		out = append(out, e)
@@ -372,11 +398,11 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 		return make([][]Finding, n), nil
 	}
 
-	// Apply the entity blacklist at the lowest level so every caller (hook
+	// Apply the entity blocklist at the lowest level so every caller (hook
 	// scanner + Temporal drain activity) inherits the same policy.
 	filtered := filterEntities(entities)
 	if len(entities) > 0 && len(filtered) == 0 {
-		// Caller pinned only blacklisted entities; nothing to scan for.
+		// Caller pinned only blocklisted entities; nothing to scan for.
 		return make([][]Finding, n), nil
 	}
 	entities = filtered
@@ -631,6 +657,14 @@ func convertPresidioFindings(text string, results []presidioResult) []Finding {
 		end := max(start, min(r.End, len(runes)))
 
 		match := string(runes[start:end])
+
+		// Drop US_DRIVER_LICENSE regardless of how the scan was scoped.
+		// filterEntities only trims a caller-pinned list; an unpinned policy
+		// scans Presidio's full default set, so without this gate its noisy
+		// license-number findings surface (AIS-158).
+		if isFindingLevelDropped(r.EntityType) {
+			continue
+		}
 
 		if isPresidioFalsePositive(r.EntityType, match) {
 			continue

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -41,6 +41,44 @@ func TestConvertPresidioFindings_FiltersIPv6Unspecified(t *testing.T) {
 	assert.Equal(t, "dead::beef", findings[0].Match)
 }
 
+// TestConvertPresidioFindings_DropsUSDriverLicense is the regression test for
+// AIS-158: a policy that pins no Presidio entities makes Presidio scan its full
+// default set, which includes US_DRIVER_LICENSE. filterEntities cannot strip it
+// (there is no pinned list to trim), so the finding-level gate in
+// convertPresidioFindings must drop it. Other findings — including PERSON,
+// whose unpinned detection is intended — still flow through.
+func TestConvertPresidioFindings_DropsUSDriverLicense(t *testing.T) {
+	t.Parallel()
+
+	text := "D1234567 Jane Roe alice@globex.com"
+	results := []presidioResult{
+		{EntityType: "US_DRIVER_LICENSE", Start: 0, End: 8, Score: 0.9},
+		{EntityType: "PERSON", Start: 9, End: 17, Score: 0.85},
+		{EntityType: "EMAIL_ADDRESS", Start: 18, End: 34, Score: 1},
+	}
+
+	findings := convertPresidioFindings(text, results)
+	ruleIDs := make([]string, len(findings))
+	for i, f := range findings {
+		ruleIDs[i] = f.RuleID
+	}
+	assert.NotContains(t, ruleIDs, guard(prefixPII+"us_driver_license"), "US_DRIVER_LICENSE must be dropped")
+	assert.Contains(t, ruleIDs, guard(prefixPII+"person"), "PERSON detection is intended and must survive")
+	assert.Contains(t, ruleIDs, guard(prefixPII+"email_address"))
+}
+
+// TestIsFindingLevelDropped locks the finding-level gate to US_DRIVER_LICENSE
+// only. PERSON is blocklisted from pinned request lists (filterEntities) but is
+// deliberately not dropped here, so unpinned scans still surface it.
+func TestIsFindingLevelDropped(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isFindingLevelDropped("US_DRIVER_LICENSE"))
+	assert.False(t, isFindingLevelDropped("PERSON"))
+	assert.False(t, isFindingLevelDropped("EMAIL_ADDRESS"))
+	assert.False(t, isFindingLevelDropped(""))
+}
+
 // TestIsPresidioFalsePositive_CorpusAllFiltered is the canonical
 // positive-coverage gate: every IP in testdata/fp-ip.txt is an address
 // the catalog must drop. Each line is run through
@@ -611,22 +649,22 @@ func TestTruncateAtRuneBoundaryHandlesMultibyte(t *testing.T) {
 	assert.Empty(t, truncateAtRuneBoundary(in, 0))
 }
 
-// TestFilterEntitiesDropsBlacklistedTypes asserts that PERSON and
+// TestFilterEntitiesDropsBlocklistedTypes asserts that PERSON and
 // US_DRIVER_LICENSE are stripped from any caller-supplied entity list
 // before reaching Presidio. PERSON is dropped because NER trips on
 // capitalized words inside tool calls; US_DRIVER_LICENSE because the
 // upstream regex is unusably broad (microsoft/presidio#1063).
-func TestFilterEntitiesDropsBlacklistedTypes(t *testing.T) {
+func TestFilterEntitiesDropsBlocklistedTypes(t *testing.T) {
 	t.Parallel()
 
 	// nil passes through untouched so Presidio's default entity set still applies.
 	assert.Nil(t, filterEntities(nil))
 
-	// Blacklisted entries are removed; the rest survive in order.
+	// Blocklisted entries are removed; the rest survive in order.
 	got := filterEntities([]string{"EMAIL_ADDRESS", "PERSON", "US_DRIVER_LICENSE", "CREDIT_CARD"})
 	assert.Equal(t, []string{"EMAIL_ADDRESS", "CREDIT_CARD"}, got)
 
-	// All-blacklisted input returns an empty (non-nil) slice so AnalyzeBatch
+	// All-blocklisted input returns an empty (non-nil) slice so AnalyzeBatch
 	// can short-circuit instead of falling back to the unbounded default scan.
 	got = filterEntities([]string{"PERSON", "US_DRIVER_LICENSE"})
 	assert.NotNil(t, got)

--- a/server/internal/risk/categories/categories.go
+++ b/server/internal/risk/categories/categories.go
@@ -123,7 +123,7 @@ var Definitions = []Definition{
 	{
 		Category:    CategoryGovernmentIDs,
 		Label:       "Government Identifiers",
-		Description: "SSNs, passport numbers, driver's licenses, tax IDs",
+		Description: "SSNs, passport numbers, national IDs, tax IDs",
 		Icon:        "landmark",
 		RuleIDs: []string{
 			"pii.us_ssn",


### PR DESCRIPTION
`US_DRIVER_LICENSE` is on `presidioEntityBlocklist`, but the blocklist was only enforced by `filterEntities`, which trims it from a **caller-pinned** entity list. A policy that pins no Presidio entities makes Presidio scan its full default recognizer set — which includes `US_DRIVER_LICENSE` — so the blocklist was silently bypassed for every unpinned scan, and its noisy license-number matches surfaced in the dashboard (the reported false positive; [microsoft/presidio#1063](https://github.com/microsoft/presidio/issues/1063)).

Fix: gate the finding conversion on a finding-level drop set so `US_DRIVER_LICENSE` never surfaces regardless of how the scan was scoped:
- `convertPresidioFindings` (Go / Temporal path) drops it after the scan.
- `_scan_to_detections` (pystreams shadow path) does the same, keeping the two scanners in parity.

`PERSON` (the blocklist's other entry) is deliberately **not** dropped at the finding level — person-name detection on unpinned scans is existing, tested behavior, so it stays trimmed from pinned lists only. `filterEntities` is unchanged and remains a scan-cost optimization for pinned lists.

Also drops the now-misleading "driver's licenses" example from the Government Identifiers category description (`categories.go` + the `policy-data.ts` mirror), since that finding is no longer surfaced.

Tests: regression coverage in `presidio_internal_test.go` and `test_risk_scanner.py` (a `D1234567 Jane Roe a@b.com` batch drops the license number while `PERSON`/`EMAIL_ADDRESS` survive). Python + `go vet` pass locally; Go package tests need Docker (unavailable in the sandbox).