### PR TITLE
feat(risk): trace the hook risk-scan unit of work

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -980,7 +980,7 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("create cel engine: %w", err)
 			}
-			riskScanner, err := risk.NewScanner(logger, db, hookPIIScanner, hookPIScanner, hookPromptJudge, featureFlags, meterProvider, celEngine)
+			riskScanner, err := risk.NewScanner(logger, db, hookPIIScanner, hookPIScanner, hookPromptJudge, featureFlags, tracerProvider, meterProvider, celEngine)
 			if err != nil {
 				return fmt.Errorf("create risk scanner: %w", err)
 			}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -980,7 +980,7 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("create cel engine: %w", err)
 			}
-			riskScanner, err := risk.NewScanner(logger, db, hookPIIScanner, hookPIScanner, hookPromptJudge, featureFlags, tracerProvider, meterProvider, celEngine)
+			riskScanner, err := risk.NewScanner(logger, tracerProvider, meterProvider, db, hookPIIScanner, hookPIScanner, hookPromptJudge, featureFlags, celEngine)
 			if err != nil {
 				return fmt.Errorf("create risk scanner: %w", err)
 			}

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -276,6 +276,8 @@ const (
 	RiskPolicyCountKey                = attribute.Key("gram.risk.policy_count")
 	RiskPolicyIDKey                   = attribute.Key("gram.risk.policy_id")
 	RiskPolicyNameKey                 = attribute.Key("gram.risk.policy_name")
+	RiskPolicyTypeKey                 = attribute.Key("gram.risk.policy_type")
+	RiskMessageTypeKey                = attribute.Key("gram.risk.message_type")
 	RiskRuleIDKey                     = attribute.Key("gram.risk.rule_id")
 	RiskSourceKey                     = attribute.Key("gram.risk.source")
 	RiskScanAttemptKey                = attribute.Key("gram.risk.scan.attempt")
@@ -1241,6 +1243,12 @@ func SlogRiskPolicyID(v string) slog.Attr      { return slog.String(string(RiskP
 
 func RiskPolicyName(v string) attribute.KeyValue { return RiskPolicyNameKey.String(v) }
 func SlogRiskPolicyName(v string) slog.Attr      { return slog.String(string(RiskPolicyNameKey), v) }
+
+func RiskPolicyType(v string) attribute.KeyValue { return RiskPolicyTypeKey.String(v) }
+func SlogRiskPolicyType(v string) slog.Attr      { return slog.String(string(RiskPolicyTypeKey), v) }
+
+func RiskMessageType(v string) attribute.KeyValue { return RiskMessageTypeKey.String(v) }
+func SlogRiskMessageType(v string) slog.Attr      { return slog.String(string(RiskMessageTypeKey), v) }
 
 func RiskRuleID(v string) attribute.KeyValue { return RiskRuleIDKey.String(v) }
 func SlogRiskRuleID(v string) slog.Attr      { return slog.String(string(RiskRuleIDKey), v) }

--- a/server/internal/risk/policy_audience_test.go
+++ b/server/internal/risk/policy_audience_test.go
@@ -185,6 +185,7 @@ func TestScanner_ScanForEnforcement_RespectsTargetedAudience(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
@@ -228,6 +229,7 @@ func TestScanner_ScanForEnforcement_EveryoneAudienceAppliesWithoutResolvedUser(t
 		nil,
 		nil,
 		nil,
+		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
@@ -275,6 +277,7 @@ func TestScanner_LookupShadowMCPBlockingPolicy_EveryoneAudienceAppliesWithoutRes
 		nil,
 		nil,
 		nil,
+		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)

--- a/server/internal/risk/policy_audience_test.go
+++ b/server/internal/risk/policy_audience_test.go
@@ -180,13 +180,13 @@ func TestScanner_ScanForEnforcement_RespectsTargetedAudience(t *testing.T) {
 	pii := &instrumentedPIIScanner{findOnEntity: "EMAIL_ADDRESS"}
 	scanner, err := risk.NewScanner(
 		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		pii,
 		nil,
 		nil,
 		nil,
-		testenv.NewTracerProvider(t),
-		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -224,13 +224,13 @@ func TestScanner_ScanForEnforcement_EveryoneAudienceAppliesWithoutResolvedUser(t
 	pii := &instrumentedPIIScanner{findOnEntity: "EMAIL_ADDRESS"}
 	scanner, err := risk.NewScanner(
 		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		pii,
 		nil,
 		nil,
 		nil,
-		testenv.NewTracerProvider(t),
-		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -272,13 +272,13 @@ func TestScanner_LookupShadowMCPBlockingPolicy_EveryoneAudienceAppliesWithoutRes
 
 	scanner, err := risk.NewScanner(
 		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		nil,
 		nil,
 		nil,
 		nil,
-		testenv.NewTracerProvider(t),
-		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
 	require.NoError(t, err)

--- a/server/internal/risk/prompt_policy_scanner_test.go
+++ b/server/internal/risk/prompt_policy_scanner_test.go
@@ -100,7 +100,7 @@ func TestScanner_PromptBasedPolicyBlocksToolRequest(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 0.9, Rationale: "destructive delete"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -123,7 +123,7 @@ func TestScanner_PromptBasedPolicyAttributesMCPTool(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-github-writes", "Block writes to the github MCP server", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -148,7 +148,7 @@ func TestScanner_PromptBasedPolicyJudgesNonToolMessages(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", nil)
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -167,7 +167,7 @@ func TestScanner_PromptBasedPolicyRespectsMessageTypes(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -186,7 +186,7 @@ func TestScanner_PromptBasedPolicyNoMatch(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: nil}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -203,7 +203,7 @@ func TestScanner_PromptBasedPolicyDisabledWhenFlagOff(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, &feature.InMemory{}, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, nil, nil, judge, &feature.InMemory{}, testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -222,7 +222,7 @@ func TestScanner_PromptBasedPolicyFailClosedWhenJudgeUnavailable(t *testing.T) {
 	require.NoError(t, err)
 	insertPromptBasedBlockPolicyWithConfig(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest}, modelConfig)
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, nil, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, nil, nil, nil, promptPoliciesFlag(ctx), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)

--- a/server/internal/risk/prompt_policy_scanner_test.go
+++ b/server/internal/risk/prompt_policy_scanner_test.go
@@ -100,7 +100,7 @@ func TestScanner_PromptBasedPolicyBlocksToolRequest(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 0.9, Rationale: "destructive delete"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -123,7 +123,7 @@ func TestScanner_PromptBasedPolicyAttributesMCPTool(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-github-writes", "Block writes to the github MCP server", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -148,7 +148,7 @@ func TestScanner_PromptBasedPolicyJudgesNonToolMessages(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", nil)
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -167,7 +167,7 @@ func TestScanner_PromptBasedPolicyRespectsMessageTypes(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -186,7 +186,7 @@ func TestScanner_PromptBasedPolicyNoMatch(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: nil}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -203,7 +203,7 @@ func TestScanner_PromptBasedPolicyDisabledWhenFlagOff(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: &risk_analysis.JudgeVerdict{Confidence: 1, Rationale: "x"}}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, &feature.InMemory{}, testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, judge, &feature.InMemory{}, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -222,7 +222,7 @@ func TestScanner_PromptBasedPolicyFailClosedWhenJudgeUnavailable(t *testing.T) {
 	require.NoError(t, err)
 	insertPromptBasedBlockPolicyWithConfig(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest}, modelConfig)
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, nil, promptPoliciesFlag(ctx), testenv.NewMeterProvider(t), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), ti.conn, nil, nil, nil, promptPoliciesFlag(ctx), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -135,7 +135,7 @@ type Scanner struct {
 // real-time hook path; returns an error if the detector cannot be built
 // (init relies on viper global state and should never realistically fail,
 // but propagating the error keeps startup honest).
-func NewScanner(logger *slog.Logger, db *pgxpool.Pool, piiScanner ra.PIIScanner, piScanner *ra.PromptInjectionScanner, judge ra.PromptJudge, flags feature.Provider, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, celEng *celenv.Engine) (*Scanner, error) {
+func NewScanner(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, db *pgxpool.Pool, piiScanner ra.PIIScanner, piScanner *ra.PromptInjectionScanner, judge ra.PromptJudge, flags feature.Provider, celEng *celenv.Engine) (*Scanner, error) {
 	gitleaksScanner, err := ra.NewGitleaksScanner()
 	if err != nil {
 		return nil, fmt.Errorf("create gitleaks scanner: %w", err)

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -114,6 +116,7 @@ var _ RiskScanner = (*Scanner)(nil)
 // per-scan mutex+init overhead on the hot path.
 type Scanner struct {
 	logger     *slog.Logger
+	tracer     trace.Tracer
 	db         *pgxpool.Pool
 	repo       *repo.Queries
 	gitleaks   *ra.GitleaksScanner        // pre-created, reused & serialized across scans
@@ -132,7 +135,7 @@ type Scanner struct {
 // real-time hook path; returns an error if the detector cannot be built
 // (init relies on viper global state and should never realistically fail,
 // but propagating the error keeps startup honest).
-func NewScanner(logger *slog.Logger, db *pgxpool.Pool, piiScanner ra.PIIScanner, piScanner *ra.PromptInjectionScanner, judge ra.PromptJudge, flags feature.Provider, meterProvider metric.MeterProvider, celEng *celenv.Engine) (*Scanner, error) {
+func NewScanner(logger *slog.Logger, db *pgxpool.Pool, piiScanner ra.PIIScanner, piScanner *ra.PromptInjectionScanner, judge ra.PromptJudge, flags feature.Provider, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, celEng *celenv.Engine) (*Scanner, error) {
 	gitleaksScanner, err := ra.NewGitleaksScanner()
 	if err != nil {
 		return nil, fmt.Errorf("create gitleaks scanner: %w", err)
@@ -144,6 +147,7 @@ func NewScanner(logger *slog.Logger, db *pgxpool.Pool, piiScanner ra.PIIScanner,
 
 	return &Scanner{
 		logger:     logger.With(attr.SlogComponent("risk-scanner")),
+		tracer:     tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
 		db:         db,
 		repo:       repo.New(db),
 		gitleaks:   gitleaksScanner,
@@ -164,13 +168,28 @@ func (s *Scanner) ScanForEnforcement(
 	text string,
 	messageType message.Type,
 	toolName string,
-) (*ScanResult, error) {
+) (result *ScanResult, retErr error) {
 	// An empty body is only a no-op when there is also no tool attribution: a
 	// no-arg/no-output tool call still names a tool (+ MCP server/function) that
 	// a tool-scoped prompt policy can match, so let those events through.
 	if text == "" && toolName == "" {
 		return nil, nil
 	}
+
+	// Root span for the scan as a unit of work: gitleaks/presidio/judge spans
+	// spawned downstream (through gctx) attribute under this span and its
+	// per-policy children instead of dangling as siblings of the RPC span.
+	ctx, span := s.tracer.Start(ctx, "risk.scanForEnforcement", trace.WithAttributes(
+		attr.OrganizationID(organizationID),
+		attr.ProjectID(projectID.String()),
+		attr.RiskMessageType(string(messageType)),
+	))
+	defer func() {
+		if retErr != nil {
+			span.SetStatus(codes.Error, retErr.Error())
+		}
+		span.End()
+	}()
 
 	start := time.Now()
 
@@ -179,6 +198,7 @@ func (s *Scanner) ScanForEnforcement(
 		s.recordScan(ctx, projectID.String(), o11y.OutcomeFailure, time.Since(start))
 		return nil, fmt.Errorf("list enforcing policies: %w", err)
 	}
+	span.SetAttributes(attr.RiskPolicyCount(len(policies)))
 	if len(policies) == 0 {
 		// No enforcing policies, fast path. Record as "skipped" to track volume.
 		s.recordScan(ctx, projectID.String(), "skipped", time.Since(start))
@@ -354,7 +374,22 @@ func (s *Scanner) recordScan(ctx context.Context, projectID string, outcome o11y
 // text per call — its internal worker pool only fans out when n > 1, so
 // per-policy parallelism over sources buys roughly nothing. The
 // across-policies fan-out in ScanForEnforcement is the real win.
-func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, text string, messageType message.Type, toolName string, promptPoliciesOn bool, piEngineOn bool) (*ScanResult, error) {
+func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, text string, messageType message.Type, toolName string, promptPoliciesOn bool, piEngineOn bool) (result *ScanResult, retErr error) {
+	// Per-policy child span so an individual gitleaks/presidio/judge span
+	// attributes to the policy that spawned it (the g.Go fan-out threads gctx
+	// here, so this span parents under risk.scanForEnforcement).
+	ctx, span := s.tracer.Start(ctx, "risk.scanPolicy", trace.WithAttributes(
+		attr.RiskPolicyID(policy.ID.String()),
+		attr.RiskPolicyName(policy.Name),
+		attr.RiskPolicyType(policy.PolicyType),
+	))
+	defer func() {
+		if retErr != nil {
+			span.SetStatus(codes.Error, retErr.Error())
+		}
+		span.End()
+	}()
+
 	// Build the structured view once; the application predicates and custom
 	// rules both evaluate against it.
 	view := ra.MessageView{Content: text, Type: messageType, Tools: []ra.ToolView{}}

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -182,7 +182,7 @@ func (s *Scanner) ScanForEnforcement(
 	ctx, span := s.tracer.Start(ctx, "risk.scanForEnforcement", trace.WithAttributes(
 		attr.OrganizationID(organizationID),
 		attr.ProjectID(projectID.String()),
-		attr.RiskMessageType(string(messageType)),
+		attr.RiskMessageType(messageType),
 	))
 	defer func() {
 		if retErr != nil {

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -171,13 +171,13 @@ func TestScanner_FanOutAcrossPoliciesIsConcurrent(t *testing.T) {
 	pii := &instrumentedPIIScanner{delay: 200 * time.Millisecond}
 	scanner, err := risk.NewScanner(
 		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		pii,
 		nil,
 		nil,
 		nil,
-		testenv.NewTracerProvider(t),
-		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -207,13 +207,13 @@ func TestScanner_ScanForEnforcement_SkipsGrantResolutionWhenNoPolicies(t *testin
 
 	scanner, err := risk.NewScanner(
 		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		nil,
 		nil,
 		nil,
 		nil,
-		testenv.NewTracerProvider(t),
-		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -244,13 +244,13 @@ func TestScanner_FirstMatchCancelsSiblings(t *testing.T) {
 	}
 	scanner, err := risk.NewScanner(
 		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		pii,
 		nil,
 		nil,
 		nil,
-		testenv.NewTracerProvider(t),
-		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -315,13 +315,13 @@ func TestScanner_CustomDetectionRuleEnforcement(t *testing.T) {
 
 	scanner, err := risk.NewScanner(
 		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		nil,
 		nil,
 		nil,
 		nil,
-		testenv.NewTracerProvider(t),
-		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -344,13 +344,13 @@ func TestScanner_RespectsMessageTypes(t *testing.T) {
 	pii := &instrumentedPIIScanner{findOnEntity: "FAST"}
 	scanner, err := risk.NewScanner(
 		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		pii,
 		nil,
 		nil,
 		nil,
-		testenv.NewTracerProvider(t),
-		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
 	require.NoError(t, err)

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -176,6 +176,7 @@ func TestScanner_FanOutAcrossPoliciesIsConcurrent(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
@@ -211,6 +212,7 @@ func TestScanner_ScanForEnforcement_SkipsGrantResolutionWhenNoPolicies(t *testin
 		nil,
 		nil,
 		nil,
+		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
@@ -247,6 +249,7 @@ func TestScanner_FirstMatchCancelsSiblings(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
@@ -317,6 +320,7 @@ func TestScanner_CustomDetectionRuleEnforcement(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)
@@ -345,6 +349,7 @@ func TestScanner_RespectsMessageTypes(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testCELEngine(t),
 	)


### PR DESCRIPTION
Trace context already threads through the runtime hook path, but there was no dedicated span for the scan itself, so the `presidio` / `risk.judge.evaluate` leaves dangled as siblings under the RPC span with no policy-level attribution.

This gives the `Scanner` a tracer (threaded via `tracerProvider` into `risk.NewScanner`, mirroring `meterProvider`) and opens two spans following the `ProcessDeployment` template:

- `risk.scanForEnforcement` — root span over the whole scan, with org / project / message-type / policy-count attributes.
- `risk.scanPolicy` — per-policy child (opened inside `scanPolicy`, off the fan-out's `gctx`) tagged with policy id/name/type.

Both set an error status and `defer span.End()`. Downstream gitleaks/presidio/judge spans now nest under the policy that spawned them:

```
hooks.claude → risk.scanForEnforcement → risk.scanPolicy[name] → {gitleaks | presidio | judge}
```

No behavior change beyond span emission. Test call sites updated for the new constructor arg.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add end-to-end tracing for the hook risk scan (AIS-123). Downstream `gitleaks`/`presidio`/`risk.judge.evaluate` spans now nest under a single scan span with per-policy attribution; also fixes a minor linter issue. No behavior change.

- **New Features**
  - `risk.NewScanner` now accepts a `trace.TracerProvider` and creates a tracer.
  - Emits a root `risk.scanForEnforcement` span with org, project, message type, and `policy_count`; marks errors on failure.
  - Emits per-policy `risk.scanPolicy` child spans with policy id, name, and type; downstream leaves inherit context.
  - Adds attr helpers for `gram.risk.policy_type` and `gram.risk.message_type`.

- **Migration**
  - Update all `risk.NewScanner` call sites to pass a `tracerProvider` and use the new arg order: `(logger, tracerProvider, meterProvider, db, ...)` (startup and tests).

<sup>Written for commit 123281752e2cd4376b5534ebd2252a4057cd98ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

