### PR TITLE
feat(dashboard): warn instead of blocking multiple OAuth2 schemes

### DIFF
--- a/client/dashboard/src/pages/mcp/oauth-wizard/ExternalOAuthForm.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/ExternalOAuthForm.tsx
@@ -38,9 +38,9 @@ export function ExternalOAuthForm({
             </Type>
             <Type small className="mt-1 text-yellow-700 dark:text-yellow-400">
               This MCP server has {oauth2SecurityCount} OAuth2 security schemes.
-              Speakeasy can't determine which one applies, so double-check that
-              the configuration below matches the scheme you intend to use
-              before continuing.
+              The applicable scheme can't be determined automatically.
+              Double-check that the configuration below matches the scheme you
+              intend to use before continuing.
             </Type>
           </div>
         )}

--- a/client/dashboard/src/pages/mcp/oauth-wizard/ExternalOAuthForm.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/ExternalOAuthForm.tsx
@@ -29,10 +29,18 @@ export function ExternalOAuthForm({
     <>
       <div className="max-h-[60vh] space-y-4 overflow-auto">
         {hasMultipleOAuth2AuthCode && (
-          <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-4">
-            <Type small className="mt-1 text-red-600">
-              Not Supported: This MCP server has {oauth2SecurityCount} OAuth2
-              security schemes detected.
+          <div className="mb-4 rounded-md border border-yellow-500/50 bg-yellow-50 p-4 dark:bg-yellow-950/20">
+            <Type
+              small
+              className="font-medium text-yellow-700 dark:text-yellow-400"
+            >
+              Multiple OAuth2 security schemes detected
+            </Type>
+            <Type small className="mt-1 text-yellow-700 dark:text-yellow-400">
+              This MCP server has {oauth2SecurityCount} OAuth2 security schemes.
+              Speakeasy can't determine which one applies, so double-check that
+              the configuration below matches the scheme you intend to use
+              before continuing.
             </Type>
           </div>
         )}
@@ -144,7 +152,6 @@ export function ExternalOAuthForm({
           <Button
             onClick={() => send({ type: "SUBMIT" })}
             disabled={
-              hasMultipleOAuth2AuthCode ||
               submitting ||
               !external.slug.trim() ||
               !external.metadataJson.trim()

--- a/client/dashboard/src/pages/mcp/oauth-wizard/ExternalOAuthForm.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/ExternalOAuthForm.tsx
@@ -1,3 +1,4 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Link } from "@/components/ui/link";
@@ -29,20 +30,15 @@ export function ExternalOAuthForm({
     <>
       <div className="max-h-[60vh] space-y-4 overflow-auto">
         {hasMultipleOAuth2AuthCode && (
-          <div className="mb-4 rounded-md border border-yellow-500/50 bg-yellow-50 p-4 dark:bg-yellow-950/20">
-            <Type
-              small
-              className="font-medium text-yellow-700 dark:text-yellow-400"
-            >
-              Multiple OAuth2 security schemes detected
-            </Type>
-            <Type small className="mt-1 text-yellow-700 dark:text-yellow-400">
+          <Alert variant="warning">
+            <AlertTitle>Multiple OAuth2 security schemes detected</AlertTitle>
+            <AlertDescription>
               This MCP server has {oauth2SecurityCount} OAuth2 security schemes.
               The applicable scheme can't be determined automatically.
               Double-check that the configuration below matches the scheme you
               intend to use before continuing.
-            </Type>
-          </div>
+            </AlertDescription>
+          </Alert>
         )}
         {discovered && !external.prefilled && (
           <div className="border-border bg-muted/50 mb-4 flex items-start justify-between gap-4 rounded-md border p-4">


### PR DESCRIPTION
The external OAuth config form previously hard-blocked submission when it detected more than one OAuth2 security scheme on the MCP server — the "Configure External OAuth" button was disabled and a red "Not Supported" banner was shown.

Per the discussion on this issue, we shouldn't try to be smart about this. This swaps the blocking behavior for a non-blocking yellow warning that flags the ambiguity but lets the operator proceed and configure OAuth themselves.

The `oauth2SecurityCount` prop is still used to populate the warning copy; only the disabled condition and banner styling changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the external OAuth config form from blocking when multiple OAuth2 schemes are detected to a non-blocking yellow warning using `oauth2SecurityCount`; the submit button stays enabled.
Per AIS-163, the warning copy is in passive voice and now uses the shared Alert component for better accessibility (screen readers via role=alert).

<sup>Written for commit f9814a86c1a4c87bc9438871e89df4f5ca1f3783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

