### PR TITLE
fix: dedupe Claude Code and drop blank in agent-type filter

### DIFF
--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -359,18 +359,20 @@ func (s *Service) ListSources(ctx context.Context, payload *gen.ListSourcesPaylo
 		return nil, oops.E(oops.CodeUnexpected, err, "list chat sources").LogError(ctx, s.logger)
 	}
 
-	sources := make([]string, 0, len(rows))
+	raws := make([]string, 0, len(rows))
 	for _, row := range rows {
 		if row.Valid {
-			sources = append(sources, row.String)
+			raws = append(raws, row.String)
 		}
 	}
 
-	return &gen.ListSourcesResult{Sources: sources}, nil
+	return &gen.ListSourcesResult{Sources: canonicalizeSources(raws)}, nil
 }
 
 // parseSourceFilter splits the comma-separated `source` filter into the list of
-// exact source strings matched against each chat's inferred source. It always
+// source strings matched against each chat's inferred source. Selected values
+// are canonical (as returned by ListSources), so each is expanded back into its
+// raw aliases to also match sessions recorded under a legacy value. It always
 // returns a non-nil slice so the no-filter case sends an empty text[]
 // (cardinality 0 disables the filter) rather than SQL NULL, which would drop
 // every row.
@@ -388,7 +390,7 @@ func parseSourceFilter(source string) []string {
 		seen[s] = struct{}{}
 		sources = append(sources, s)
 	}
-	return sources
+	return expandSourceAliases(sources)
 }
 
 // chatVisibilityScope resolves the (external_user_id, user_id) scoping shared by

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -801,3 +801,49 @@ func TestListSources(t *testing.T) {
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"Codex", "claude-code"}, result.Sources)
 }
+
+// TestListSources_CanonicalizesAndDropsEmpty covers AIS-233: legacy chats
+// recorded Claude Code as "ClaudeCode" alongside the standardized "claude-code",
+// and some chats have an empty-string source. The filter list must collapse the
+// Claude Code aliases into one entry and never surface a blank option.
+func TestListSources_CanonicalizesAndDropsEmpty(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := grantOrgAdminWithChatRead(t, initSessionCtx(t, ti))
+
+	seedChatWithSource(t, ctx, ti, "ext-src", "claude-code")
+	seedChatWithSource(t, ctx, ti, "ext-src", "ClaudeCode") // legacy alias collapses
+	seedChatWithSource(t, ctx, ti, "ext-src", "Codex")
+	seedChatWithSource(t, ctx, ti, "ext-src", "") // empty is dropped
+
+	result, err := ti.service.ListSources(ctx, &gen.ListSourcesPayload{})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Codex", "claude-code"}, result.Sources)
+}
+
+// TestListChats_Filter_Source_ExpandsAliases verifies that filtering by the
+// canonical "claude-code" also matches sessions stored under the legacy
+// "ClaudeCode" alias.
+func TestListChats_Filter_Source_ExpandsAliases(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := grantOrgAdminWithChatRead(t, initSessionCtx(t, ti))
+
+	newStyle := seedChatWithSource(t, ctx, ti, "ext-src", "claude-code")
+	legacy := seedChatWithSource(t, ctx, ti, "ext-src", "ClaudeCode")
+	_ = seedChatWithSource(t, ctx, ti, "ext-src", "Codex")
+
+	source := "claude-code"
+	payload := defaultPayload()
+	payload.Source = &source
+
+	result, err := ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Total)
+	got := map[string]bool{}
+	for _, c := range result.Chats {
+		got[c.ID] = true
+	}
+	require.True(t, got[newStyle.String()], "expected claude-code chat in results")
+	require.True(t, got[legacy.String()], "expected legacy ClaudeCode chat in results")
+}

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -277,6 +277,7 @@ candidate_chats AS (
         FROM chat_messages cmsrc
         WHERE cmsrc.chat_id = c.id
           AND cmsrc.source IS NOT NULL
+          AND cmsrc.source <> ''
         ORDER BY cmsrc.created_at DESC
         LIMIT 1
       ) = ANY (@sources::text[])
@@ -365,6 +366,7 @@ candidate_chats AS (
         FROM chat_messages cmsrc
         WHERE cmsrc.chat_id = c.id
           AND cmsrc.source IS NOT NULL
+          AND cmsrc.source <> ''
         ORDER BY cmsrc.created_at DESC
         LIMIT 1
       ) = ANY (@sources::text[])
@@ -404,7 +406,7 @@ limited_chats AS (
     fc.created_at,
     fc.updated_at,
     fc.num_messages,
-    (SELECT source FROM chat_messages WHERE chat_id = fc.id AND source IS NOT NULL ORDER BY created_at DESC LIMIT 1) AS source,
+    (SELECT source FROM chat_messages WHERE chat_id = fc.id AND source IS NOT NULL AND source <> '' ORDER BY created_at DESC LIMIT 1) AS source,
     fc.last_message_timestamp,
     fc.risk_findings_count
   FROM filtered_chats fc
@@ -445,6 +447,7 @@ WITH latest_sources AS (
     AND (@external_user_id::text = '' OR c.external_user_id = @external_user_id::text)
     AND (@user_id::text = '' OR c.user_id = @user_id::text)
     AND cm.source IS NOT NULL
+    AND cm.source <> ''
   ORDER BY cm.chat_id, cm.created_at DESC
 )
 SELECT DISTINCT source

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -107,6 +107,7 @@ candidate_chats AS (
         FROM chat_messages cmsrc
         WHERE cmsrc.chat_id = c.id
           AND cmsrc.source IS NOT NULL
+          AND cmsrc.source <> ''
         ORDER BY cmsrc.created_at DESC
         LIMIT 1
       ) = ANY ($11::text[])
@@ -1472,6 +1473,7 @@ WITH latest_sources AS (
     AND ($2::text = '' OR c.external_user_id = $2::text)
     AND ($3::text = '' OR c.user_id = $3::text)
     AND cm.source IS NOT NULL
+    AND cm.source <> ''
   ORDER BY cm.chat_id, cm.created_at DESC
 )
 SELECT DISTINCT source
@@ -1576,6 +1578,7 @@ candidate_chats AS (
         FROM chat_messages cmsrc
         WHERE cmsrc.chat_id = c.id
           AND cmsrc.source IS NOT NULL
+          AND cmsrc.source <> ''
         ORDER BY cmsrc.created_at DESC
         LIMIT 1
       ) = ANY ($9::text[])
@@ -1615,7 +1618,7 @@ limited_chats AS (
     fc.created_at,
     fc.updated_at,
     fc.num_messages,
-    (SELECT source FROM chat_messages WHERE chat_id = fc.id AND source IS NOT NULL ORDER BY created_at DESC LIMIT 1) AS source,
+    (SELECT source FROM chat_messages WHERE chat_id = fc.id AND source IS NOT NULL AND source <> '' ORDER BY created_at DESC LIMIT 1) AS source,
     fc.last_message_timestamp,
     fc.risk_findings_count
   FROM filtered_chats fc

--- a/server/internal/chat/sources.go
+++ b/server/internal/chat/sources.go
@@ -1,0 +1,88 @@
+package chat
+
+import (
+	"sort"
+	"strings"
+)
+
+// sourceAliases maps a canonical agent source to every raw message-source value
+// that should collapse into it. Legacy chats recorded Claude Code as
+// "ClaudeCode" before the hook pipeline standardized on "claude-code"; without
+// this mapping the agent-type filter shows both as separate entries (the
+// dashboard title-cases "claude-code" into "Claude Code" but leaves the
+// delimiter-less "ClaudeCode" untouched). The canonical value is the
+// delimited form so the dashboard renders a single, correctly spaced label.
+var sourceAliases = map[string][]string{
+	"claude-code": {"claude-code", "ClaudeCode"},
+}
+
+// rawToCanonicalSource is the reverse of sourceAliases: each known raw value
+// mapped to its canonical form, built once at init.
+var rawToCanonicalSource = func() map[string]string {
+	m := make(map[string]string)
+	for canonical, raws := range sourceAliases {
+		for _, raw := range raws {
+			m[raw] = canonical
+		}
+	}
+	return m
+}()
+
+// canonicalSource returns the canonical source for a raw message source. Input
+// is trimmed; whitespace-only values return "" so callers can drop them. Values
+// without a known alias are returned trimmed and unchanged.
+func canonicalSource(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	if canonical, ok := rawToCanonicalSource[s]; ok {
+		return canonical
+	}
+	return s
+}
+
+// canonicalizeSources maps raw message sources to their canonical form,
+// dropping empties and duplicates. The result is sorted so the agent-type
+// filter renders a stable, de-duplicated list.
+func canonicalizeSources(raws []string) []string {
+	seen := make(map[string]struct{}, len(raws))
+	out := make([]string, 0, len(raws))
+	for _, raw := range raws {
+		s := canonicalSource(raw)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// expandSourceAliases replaces each canonical source with all of its raw
+// aliases so the source filter matches sessions recorded under any legacy value
+// (e.g. selecting "claude-code" also matches chats stored as "ClaudeCode").
+// Values without aliases pass through unchanged. Duplicates are removed while
+// preserving order.
+func expandSourceAliases(sources []string) []string {
+	seen := make(map[string]struct{}, len(sources))
+	out := make([]string, 0, len(sources))
+	for _, s := range sources {
+		aliases, ok := sourceAliases[s]
+		if !ok {
+			aliases = []string{s}
+		}
+		for _, a := range aliases {
+			if _, dup := seen[a]; dup {
+				continue
+			}
+			seen[a] = struct{}{}
+			out = append(out, a)
+		}
+	}
+	return out
+}

--- a/server/internal/chat/sources_test.go
+++ b/server/internal/chat/sources_test.go
@@ -1,0 +1,54 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalizeSources_CollapsesAliasesAndDropsEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := canonicalizeSources([]string{
+		"claude-code",
+		"ClaudeCode",
+		"Codex",
+		"",
+		"   ",
+		"claude-code",
+	})
+
+	require.Equal(t, []string{"Codex", "claude-code"}, got)
+}
+
+func TestCanonicalizeSources_Empty(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, canonicalizeSources(nil))
+	require.Empty(t, canonicalizeSources([]string{"", "  "}))
+}
+
+func TestExpandSourceAliases_ExpandsCanonical(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"claude-code", "ClaudeCode"}, expandSourceAliases([]string{"claude-code"}))
+}
+
+func TestExpandSourceAliases_PassesThroughUnknown(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"Codex", "playground"}, expandSourceAliases([]string{"Codex", "playground"}))
+}
+
+func TestExpandSourceAliases_Dedupes(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"claude-code", "ClaudeCode"}, expandSourceAliases([]string{"claude-code", "ClaudeCode"}))
+}
+
+func TestParseSourceFilter_ExpandsAliases(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"claude-code", "ClaudeCode", "Codex"}, parseSourceFilter("claude-code, Codex"))
+	require.Empty(t, parseSourceFilter(""))
+}


### PR DESCRIPTION
The Agent Type filter on the Agent Sessions page builds its options from the distinct message sources present in a project's chats. Legacy chats recorded Claude Code as `ClaudeCode` alongside the standardized `claude-code` (which the dashboard title-cases into "Claude Code"), and some chats carry an empty-string source — so the dropdown showed a duplicate `ClaudeCode` entry plus a blank option.

Fix, all on the backend:
- `ListSources` now canonicalizes sources: the Claude Code aliases collapse into one `claude-code` value and empty/whitespace sources are dropped, so the dropdown shows a single, correctly-spaced "Claude Code" and no blank.
- The `source` filter expands a selected canonical value back into its raw aliases, so filtering by Claude Code still matches sessions stored under the legacy `ClaudeCode`.
- SQL that infers a chat's source treats empty-string sources as absent, consistent with the alias/empty handling.

The alias mapping lives in one small table (`sourceAliases`) so future collapses are a one-line addition. No frontend change needed.

Tests: added unit tests for the canonicalization/expansion helpers, plus integration tests covering alias-collapse + empty-drop in `ListSources` and alias expansion in the source filter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AIS-233 by deduping “Claude Code” and removing the blank option in the Agent Type filter on Agent Sessions. Backend now canonicalizes message sources and expands aliases so filtering still matches legacy data.

- **Bug Fixes**
  - Canonicalize sources in `ListSources`: collapse `ClaudeCode` and `claude-code` to `claude-code`; drop empty/whitespace; SQL treats empty `source` as absent.
  - Expand canonical values to raw aliases in the `source` filter so selecting "claude-code" also matches legacy "ClaudeCode".
  - Added unit and integration tests for canonicalization, alias expansion, and filtering behavior.

<sup>Written for commit 45971cfb71d842374b049d23f54e8b870ffb5d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

