### PR TITLE
fix: guard nil filter in telemetry SearchUsers

### DIFF
--- a/.changeset/tame-users-search.md
+++ b/.changeset/tame-users-search.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix a nil pointer panic in telemetry SearchUsers when called without a filter.

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -382,7 +382,14 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 	// an empty filter to avoid a nil pointer dereference.
 	filter := payload.Filter
 	if filter == nil {
-		filter = &telem_gen.SearchUsersFilter{}
+		filter = &telem_gen.SearchUsersFilter{
+			From:         "",
+			To:           "",
+			DeploymentID: nil,
+			UserIds:      nil,
+			EventSource:  nil,
+			HookSource:   nil,
+		}
 	}
 
 	params, err := s.prepareTelemetrySearch(ctx, payload.Limit, payload.Sort, payload.Cursor, &filter.From, &filter.To)
@@ -482,7 +489,14 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 	// an empty filter to avoid a nil pointer dereference.
 	filter := payload.Filter
 	if filter == nil {
-		filter = &telem_gen.SearchUsersFilter{}
+		filter = &telem_gen.SearchUsersFilter{
+			From:         "",
+			To:           "",
+			DeploymentID: nil,
+			UserIds:      nil,
+			EventSource:  nil,
+			HookSource:   nil,
+		}
 	}
 
 	params, err := s.prepareTelemetrySearch(ctx, payload.Limit, payload.Sort, payload.Cursor, &filter.From, &filter.To)

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -377,12 +377,20 @@ func (s *Service) SearchUsers(ctx context.Context, payload *telem_gen.SearchUser
 }
 
 func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.SearchUsersPayload) (*telem_gen.SearchUsersResult, error) {
-	params, err := s.prepareTelemetrySearch(ctx, payload.Limit, payload.Sort, payload.Cursor, &payload.Filter.From, &payload.Filter.To)
+	// Filter is required by the Goa design, but direct callers (e.g. platform
+	// tools) bypass transport validation and may pass a nil filter. Normalize to
+	// an empty filter to avoid a nil pointer dereference.
+	filter := payload.Filter
+	if filter == nil {
+		filter = &telem_gen.SearchUsersFilter{}
+	}
+
+	params, err := s.prepareTelemetrySearch(ctx, payload.Limit, payload.Sort, payload.Cursor, &filter.From, &filter.To)
 	if err != nil {
 		return nil, err
 	}
 
-	deploymentID := conv.PtrValOr(payload.Filter.DeploymentID, "")
+	deploymentID := conv.PtrValOr(filter.DeploymentID, "")
 
 	groupBy := "user_id"
 	if payload.UserType == "external" {
@@ -394,10 +402,10 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 		TimeStart:        params.timeStart,
 		TimeEnd:          params.timeEnd,
 		GramDeploymentID: deploymentID,
-		EventSource:      conv.PtrValOr(payload.Filter.EventSource, ""),
-		HookSource:       conv.PtrValOr(payload.Filter.HookSource, ""),
+		EventSource:      conv.PtrValOr(filter.EventSource, ""),
+		HookSource:       conv.PtrValOr(filter.HookSource, ""),
 		GroupBy:          groupBy,
-		UserIDs:          payload.Filter.UserIds,
+		UserIDs:          filter.UserIds,
 		SortOrder:        params.sortOrder,
 		Cursor:           params.cursor,
 		Limit:            params.limit + 1,
@@ -469,12 +477,20 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 // searchUsersByRole fetches all per-user costs from ClickHouse, joins with role
 // assignments from Postgres, and returns aggregates grouped by role.
 func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.SearchUsersPayload) (*telem_gen.SearchUsersResult, error) {
-	params, err := s.prepareTelemetrySearch(ctx, payload.Limit, payload.Sort, payload.Cursor, &payload.Filter.From, &payload.Filter.To)
+	// Filter is required by the Goa design, but direct callers (e.g. platform
+	// tools) bypass transport validation and may pass a nil filter. Normalize to
+	// an empty filter to avoid a nil pointer dereference.
+	filter := payload.Filter
+	if filter == nil {
+		filter = &telem_gen.SearchUsersFilter{}
+	}
+
+	params, err := s.prepareTelemetrySearch(ctx, payload.Limit, payload.Sort, payload.Cursor, &filter.From, &filter.To)
 	if err != nil {
 		return nil, err
 	}
 
-	deploymentID := conv.PtrValOr(payload.Filter.DeploymentID, "")
+	deploymentID := conv.PtrValOr(filter.DeploymentID, "")
 
 	// Fetch per-user costs from ClickHouse and role assignments from Postgres
 	// concurrently — the two queries are independent.
@@ -489,10 +505,10 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 			TimeStart:        params.timeStart,
 			TimeEnd:          params.timeEnd,
 			GramDeploymentID: deploymentID,
-			EventSource:      conv.PtrValOr(payload.Filter.EventSource, ""),
-			HookSource:       conv.PtrValOr(payload.Filter.HookSource, ""),
+			EventSource:      conv.PtrValOr(filter.EventSource, ""),
+			HookSource:       conv.PtrValOr(filter.HookSource, ""),
 			GroupBy:          "user_id",
-			UserIDs:          payload.Filter.UserIds,
+			UserIDs:          filter.UserIds,
 			SortOrder:        "desc",
 			Cursor:           "",
 			Limit:            10001, // Upper bound; orgs rarely have >10k users

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -64,6 +64,33 @@ func TestSearchUsers_Empty(t *testing.T) {
 	require.Nil(t, result.NextCursor)
 }
 
+// TestSearchUsers_NilFilter guards against the nil pointer dereference that
+// occurred when a direct caller (e.g. a platform tool bypassing Goa transport
+// validation) invoked SearchUsers with a nil Filter. Both the employee and role
+// grouping paths must treat a nil filter as an empty filter (full time range).
+func TestSearchUsers_NilFilter(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	for _, groupBy := range []string{"employee", "role"} {
+		t.Run(groupBy, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+				Filter:   nil,
+				UserType: "internal",
+				GroupBy:  groupBy,
+				Limit:    50,
+				Sort:     "desc",
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+		})
+	}
+}
+
 func TestSearchUsers_GroupByInternalUser(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Guards against a nil `Filter` in `telemetry.SearchUsers` so it no longer panics.

## Why

Datadog shows recurring recovered panics in `gram-server` — all identical nil pointer dereferences at `telemetry/impl.go` in `searchUsersByEmployee`:

```
panic: runtime error: invalid memory address or nil pointer dereference
telemetry.(*Service).searchUsersByEmployee
telemetry.(*Service).SearchUsers
platformtools/logs.(*SearchUsers).Call        ← platform_search_users MCP tool
```

The `platform_search_users` MCP tool calls `SearchUsers` **directly**, bypassing the Goa HTTP transport validation that enforces the design's `Required("filter")`. The tool defaults `Filter: nil`, so when an agent invokes it without a `filter` argument, both grouping branches dereferenced the nil pointer via `&payload.Filter.From` and crashed the request.

`SearchUsers` was the outlier — the sibling methods (`SearchToolCalls`, `SearchLogs`, `SearchChats`) all already guard `payload.Filter != nil`.

## Change

- `searchUsersByEmployee` and `searchUsersByRole` normalize a nil `Filter` to an empty `&SearchUsersFilter{}`. An empty filter is already handled correctly downstream (`parseTimeRange` treats empty `from`/`to` as a full time range), matching how the sibling methods treat a nil filter.
- Added `TestSearchUsers_NilFilter` covering the `employee` and `role` paths; passes with `-race` and reproduces the panic without the fix.

## Testing

- `go test -race` on the telemetry package (nil-filter + empty cases) ✅
- `go vet`, `mise build:server`, `hk fix` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents nil-pointer panics in `telemetry.SearchUsers` by handling a missing `Filter` when `platform_search_users` calls the service directly. Normalizes a nil filter to empty, matching sibling search methods and keeping full-range defaults.

- **Bug Fixes**
  - Guard nil `Filter` in `searchUsersByEmployee` and `searchUsersByRole` by assigning a local empty filter when nil.
  - Preserve behavior: empty `from`/`to` means full time range; avoids crashes from `&payload.Filter.From`.
  - Add `TestSearchUsers_NilFilter` covering `employee` and `role`; passes with `-race`.
  - Add changeset for patch release and fix lint errors.

<sup>Written for commit a146d9ce3327c801a5b5f4f1ac89f168da338c86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

