### PR TITLE
perf(db): index observability home-page + risk overview queries

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1505,6 +1505,16 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_idx ON chat_messages (chat_id);
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_generation_seq_idx ON chat_messages (chat_id, generation, seq);
+
+-- Backs the project telemetry aggregations (top users, LLM client breakdown,
+-- active user count, session count, chat metrics summary) that join
+-- chats -> chat_messages and filter messages by created_at within a time
+-- window. Without created_at trailing the join key, the planner falls back to
+-- a full sequential scan of chat_messages (observed at 272k rows / ~3.2s on
+-- large orgs); this composite lets each chat's in-window messages be read from
+-- a bounded index range instead.
+CREATE INDEX IF NOT EXISTS chat_messages_chat_id_created_at_idx
+ON chat_messages (chat_id, created_at);
 CREATE INDEX IF NOT EXISTS chat_messages_project_id_id_idx
 ON chat_messages (project_id, id)
 WHERE project_id IS NOT NULL;
@@ -3434,6 +3444,15 @@ ON risk_results (project_id, chat_message_id);
 CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
 WHERE found IS TRUE AND excluded_at IS NULL AND false_positive_at IS NULL;
+
+-- Backs GetRiskOverviewCounts, which counts ALL risk_results in a project +
+-- time window (including non-found rows, to report messages_scanned). The
+-- partial risk_results_project_found_idx above only covers found rows, so that
+-- query otherwise scanned every finding for the project and filtered created_at
+-- on the heap. This non-partial composite serves the (project_id, created_at
+-- range) scan directly.
+CREATE INDEX IF NOT EXISTS risk_results_project_created_at_idx
+ON risk_results (project_id, created_at);
 
 -- Narrows the exclusion sweeps (exact/rule_id/source) by project + policy +
 -- rule. The verbatim match column is intentionally NOT indexed: it can exceed

--- a/server/migrations/20260702164015_observability-home-page-metrics-indexes.sql
+++ b/server/migrations/20260702164015_observability-home-page-metrics-indexes.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Create index "chat_messages_chat_id_created_at_idx" to table: "chat_messages"
+CREATE INDEX CONCURRENTLY "chat_messages_chat_id_created_at_idx" ON "chat_messages" ("chat_id", "created_at");
+-- Create index "risk_results_project_created_at_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_project_created_at_idx" ON "risk_results" ("project_id", "created_at");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:fB06IY8EIcYsM+1hZUUm1mwgauhRMUqqP+7jCTeuICA=
+h1:MLe5+Ab+sQN7re9CitotHYU7YR5r6faKzX4+ANBuNfU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -238,3 +238,4 @@ h1:fB06IY8EIcYsM+1hZUUm1mwgauhRMUqqP+7jCTeuICA=
 20260630213745_remote-session-issuers-global-slug-key.sql h1:2fXBIcMhRXsLIGrvLEXmzJ0qncFXF7ZI3RbSglU5z5Q=
 20260701215608_billing-mode-declarations.sql h1:wEegAGkGu26TmLNS3jrwPTcPumpS89I7XatrDKoQtJ8=
 20260701230608_session-capture-exclusions.sql h1:0/b+s8X5U0pMrunBZ7OawV5Wm1DdXiPcXrpMnPqhAjY=
+20260702164015_observability-home-page-metrics-indexes.sql h1:JY6LlQgcEeDwEgMgKnf1SGdGtV/F/l0c8J7s1i6YNYU=


### PR DESCRIPTION
Query monitoring on the home-page metrics and risk overview showed table scans dominating DB load — notably a **seq scan on `chat_messages` returning 272k rows (~3.2s)** and `GetRiskOverviewCounts` at ~5.9s. Both come from range-over-time-window queries that had no supporting index.

Adds two indexes (index-only migration, no query changes needed — the existing SQL can use them directly):

- **`chat_messages (chat_id, created_at)`** — the project telemetry aggregations (`GetTopUsersByMessages`, `GetLLMClientBreakdownByMessages`, `GetActiveUserCountByMessages`, `GetChatSessionCount`, `GetChatMetricsSummary`) join `chats → chat_messages` and filter `m.created_at` within a window. With `created_at` trailing the join key, each chat's in-window messages come from a bounded index range instead of a full-table seq scan.
- **`risk_results (project_id, created_at)`** — `GetRiskOverviewCounts` counts *all* rows in a project + window (including non-found rows, for `messages_scanned`), which the partial `risk_results_project_found_idx` can't serve. This non-partial composite serves the range scan directly.

Atlas emits both as `CREATE INDEX CONCURRENTLY` (`txmode none`), so they build without locking the hot tables.

Per repo convention this is a migration-only PR (no application/business-logic changes). A deeper scalability follow-up (project-scoped message filters so message reads don't fan out per-chat, plus dropping the now-redundant `chat_messages_chat_id_idx` via a contract migration) can come separately.

Addresses the same root cause as the duplicate DNO-382 (risk overview slow for large orgs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added composite indexes to `chat_messages` and `risk_results` to eliminate table scans and speed up home page metrics and risk overview. Addresses Linear DNO-375 slow observability queries.

- **Bug Fixes**
  - `chat_messages (chat_id, created_at)`: turns telemetry joins (`chats → chat_messages`) with time-window filters into bounded range scans.
  - `risk_results (project_id, created_at)`: serves `GetRiskOverviewCounts` for project + window (including non-found rows), avoiding heap filters on `created_at`.
  - Built with `CREATE INDEX CONCURRENTLY` (`atlas:txmode none`); migration-only, no query changes.

<sup>Written for commit 03c3bce4f88847b3f580a80d449b31d703dfdeaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

