### PR TITLE
fix: dial fresh connections for function-runner calls

### DIFF
--- a/.changeset/fly-runner-fresh-conns.md
+++ b/.changeset/fly-runner-fresh-conns.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Disable HTTP keep-alives on function-runner calls and give that path its own timeout, so retries dial fresh connections instead of reusing pooled connections to Fly machines that were autostopped mid-flight (which surfaced as instant EOFs). The function-runner timeout now sits above the runner's 5-minute execution budget so long tool calls are no longer cancelled by the caller.

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -759,6 +759,7 @@ func (tp *ToolProxy) doHTTP(
 		ProjectSlug:               descriptor.ProjectSlug,
 		OrganizationID:            descriptor.OrganizationID,
 		OrganizationSlug:          descriptor.OrganizationSlug,
+		DisableKeepAlives:         false,
 	})
 }
 

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -875,7 +875,6 @@ type ReverseProxyOptions struct {
 	// function-runner path sets this so every attempt dials a fresh connection
 	// rather than re-drawing a pooled keep-alive to a Fly machine that may have
 	// been idled/suspended out from under us (which surfaces as an instant EOF).
-	// See FLY_CONN_ISSUES.md.
 	DisableKeepAlives bool
 	// Descriptor fields
 	ID               string

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -52,6 +52,19 @@ const (
 	gramUserEmailEnvVar = "GRAM_USER_EMAIL"
 )
 
+const (
+	// httpToolCallTimeout bounds a single outbound HTTP-tool request attempt.
+	httpToolCallTimeout = 60 * time.Second
+
+	// functionRunnerCallTimeout bounds a single function-runner request attempt.
+	// It sits above the runner's 5-minute per-tool-call execution budget (see
+	// functions/internal/runner/handle_tool_call.go) plus slack so the runner's
+	// own timeout fires first and returns a proper response, rather than the
+	// caller cancelling mid-execution (which yields a non-retryable
+	// context.DeadlineExceeded and a PP03 at the Fly edge).
+	functionRunnerCallTimeout = 6 * time.Minute
+)
+
 var proxiedHeaders = []string{
 	"Cache-Control",
 	"Content-Language",
@@ -466,14 +479,16 @@ func (tp *ToolProxy) doFunction(
 			}
 			return nil
 		},
-		RetryConfig:      functionRunnerRetryConfig(),
-		ID:               descriptor.ID,
-		Name:             descriptor.Name,
-		DeploymentID:     descriptor.DeploymentID,
-		ProjectID:        descriptor.ProjectID,
-		ProjectSlug:      descriptor.ProjectSlug,
-		OrganizationID:   descriptor.OrganizationID,
-		OrganizationSlug: descriptor.OrganizationSlug,
+		RetryConfig:       functionRunnerRetryConfig(),
+		Timeout:           functionRunnerCallTimeout,
+		DisableKeepAlives: true,
+		ID:                descriptor.ID,
+		Name:              descriptor.Name,
+		DeploymentID:      descriptor.DeploymentID,
+		ProjectID:         descriptor.ProjectID,
+		ProjectSlug:       descriptor.ProjectSlug,
+		OrganizationID:    descriptor.OrganizationID,
+		OrganizationSlug:  descriptor.OrganizationSlug,
 	})
 }
 
@@ -736,6 +751,7 @@ func (tp *ToolProxy) doHTTP(
 		Attributes:                attrRecorder,
 		VerifyResponse:            func(resp *http.Response) error { return nil },
 		RetryConfig:               httpToolRetryConfig(),
+		Timeout:                   httpToolCallTimeout,
 		ID:                        descriptor.ID,
 		Name:                      descriptor.Name,
 		DeploymentID:              descriptor.DeploymentID,
@@ -847,6 +863,19 @@ type ReverseProxyOptions struct {
 	// 429/503 set) for function-runner calls and httpToolRetryConfig (GET-only
 	// broad preset) for outbound HTTP tool calls.
 	RetryConfig retryConfig
+	// Timeout bounds the whole request/response (including body read) for a
+	// single attempt. It must be set per path: the outbound HTTP-tool path uses
+	// a short caller timeout, while the function-runner path must allow up to the
+	// runner's full execution budget (5 min, see handle_tool_call.go) plus slack
+	// so a legitimately long tool call is not cancelled mid-flight (which would
+	// surface as a non-retryable context.DeadlineExceeded).
+	Timeout time.Duration
+	// DisableKeepAlives turns off HTTP connection reuse for this path. The
+	// function-runner path sets this so every attempt dials a fresh connection
+	// rather than re-drawing a pooled keep-alive to a Fly machine that may have
+	// been idled/suspended out from under us (which surfaces as an instant EOF).
+	// See FLY_CONN_ISSUES.md.
+	DisableKeepAlives bool
 	// Descriptor fields
 	ID               string
 	Name             string
@@ -882,6 +911,7 @@ func reverseProxyRequest(ctx context.Context, opts ReverseProxyOptions) error {
 		ExpectContinueTimeout: 1 * time.Second,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+		DisableKeepAlives:     opts.DisableKeepAlives,
 	}
 
 	var baseTransport http.RoundTripper = transport
@@ -899,7 +929,7 @@ func reverseProxyRequest(ctx context.Context, opts ReverseProxyOptions) error {
 	)
 
 	client := &http.Client{
-		Timeout:   60 * time.Second,
+		Timeout:   opts.Timeout,
 		Transport: otelTransport,
 	}
 

--- a/server/internal/gateway/resources.go
+++ b/server/internal/gateway/resources.go
@@ -169,13 +169,15 @@ func (tp *ToolProxy) doFunctionResource(
 			}
 			return nil
 		},
-		RetryConfig:      functionRunnerRetryConfig(),
-		ID:               descriptor.ID,
-		Name:             descriptor.Name,
-		DeploymentID:     descriptor.DeploymentID,
-		ProjectID:        descriptor.ProjectID,
-		ProjectSlug:      descriptor.ProjectSlug,
-		OrganizationID:   descriptor.OrganizationID,
-		OrganizationSlug: descriptor.OrganizationSlug,
+		RetryConfig:       functionRunnerRetryConfig(),
+		Timeout:           functionRunnerCallTimeout,
+		DisableKeepAlives: true,
+		ID:                descriptor.ID,
+		Name:              descriptor.Name,
+		DeploymentID:      descriptor.DeploymentID,
+		ProjectID:         descriptor.ProjectID,
+		ProjectSlug:       descriptor.ProjectSlug,
+		OrganizationID:    descriptor.OrganizationID,
+		OrganizationSlug:  descriptor.OrganizationSlug,
 	})
 }


### PR DESCRIPTION
## What

Two fixes to how the gateway calls the Fly function runner:

1. **Disable HTTP keep-alives** on the function-runner transport (tool calls in `proxy.go`, resource reads in `resources.go`), so each attempt dials a fresh connection.
2. **Split the per-attempt client timeout per path** — the function-runner path gets `6m` (above the runner's 5-minute execution budget); the outbound HTTP-tool path keeps `60s`.

## Why

A single high-traffic function app scaling to zero causes **Fly autostop thrash**. The runner is deployed as a `tcp`+`tls` Fly service, so the edge tunnels each pooled connection to **one** machine for its lifetime. When Fly autostops that machine seconds after a traffic lull, the reused keep-alive connection returns an **instant `io.EOF`** (~0.2 ms, pre-execution). Under sustained bursts all 3 retries redraw from a pool of dead connections and the error surfaces to the caller.

- Disabling keep-alives forces each attempt (and each retry) onto a fresh connection that the edge routes to a live machine (tripping autostart), instead of re-using a connection pinned to a stopped machine.
- The old shared `60s` client timeout was below the runner's 5-minute budget, so a legitimately long tool call was cancelled by the caller mid-execution (non-retryable `context.DeadlineExceeded`). The function-runner path now allows the full budget plus slack; the HTTP-tool/SSE path is unchanged at `60s`.

Both EOFs are provably pre-execution, so the existing retry logic is well-behaved — this just ensures retries hit fresh connections.

## Scope / trade-offs

- Adds a TLS handshake per function-runner call (keep-alive reuse is off for that path only).
- A cleaner root-cause alternative — declaring the Fly service as an L7 `http` handler so the edge fans out per-request — was considered but deferred: it depends on Fly's L7 proxy not cutting 5-minute calls / SSE, which needs validation first.

## Test plan

- `go build ./server/...`, `go test -race ./server/internal/gateway/...`, `go test ./server/internal/functions/...` all pass.
- Post-rollout: watch the `HTTP roundtrip failed: EOF` warn rate and `@gram.component:gateway-function-caller status:error` in Datadog.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force fresh connections for function-runner requests and add per-path timeouts (6m for runner, 60s for HTTP-tool). Fixes instant EOFs from stale keep-alives after Fly autostops a machine and stops long calls from being cancelled mid-execution.

- **Bug Fixes**
  - Disabled HTTP keep-alives for function-runner calls in `proxy.go` and `resources.go`; each attempt dials a new connection so retries hit live machines.
  - Plumbed per-path transport settings: function-runner uses a 6m client timeout with keep-alives off; outbound HTTP-tool stays at 60s with keep-alives on.

<sup>Written for commit 87e0d6b36bed95f471f4dcb407aeb339a3ebd04e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



