### PR TITLE
fix(risk): show historical findings for turned-off policies on Risk Events page

### DIFF
--- a/.changeset/risk-events-disabled-policy-history.md
+++ b/.changeset/risk-events-disabled-policy-history.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Risk Events now shows historical findings for turned-off policies. Filtering the Risk Events page by a disabled policy previously returned no results because the query required the policy to be enabled; explicit policy filters now surface a disabled policy's past matches. The dashboard flags the inactive policy (a banner plus an "(inactive)" label in the filter) so it's clear the data is historical. The default unfiltered view is unchanged and still lists only active policies.

--- a/client/dashboard/src/pages/security/RiskEvents.tsx
+++ b/client/dashboard/src/pages/security/RiskEvents.tsx
@@ -17,7 +17,7 @@ import {
 import { Button, Icon } from "@speakeasy-api/moonshine";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { RefreshCw, Share2 } from "lucide-react";
+import { History, RefreshCw, Share2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, type RefObject } from "react";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
@@ -120,10 +120,26 @@ export default function RiskEvents(): JSX.Element {
     return m;
   }, [policies]);
 
+  // The policy currently selected in the filter, if any. When it's disabled the
+  // list still returns its historical findings (the backend drops the
+  // enabled-only filter for explicit policy selections), so we surface a notice
+  // that the user is viewing data for an inactive policy.
+  const selectedPolicy = useMemo(
+    () => policies.find((p) => p.id === policyFilter),
+    [policies, policyFilter],
+  );
+  const viewingInactivePolicy =
+    selectedPolicy != null && selectedPolicy.enabled === false;
+
   // Page-supplied option lists for the schema's select/text dimensions.
+  // Disabled policies stay selectable — they hold historical findings — but are
+  // labelled "(inactive)" so the distinction is clear in the dropdown.
   const filterOptions = useMemo(
     () => ({
-      policy_id: policies.map((p) => ({ label: p.name, value: p.id })),
+      policy_id: policies.map((p) => ({
+        label: p.enabled === false ? `${p.name} (inactive)` : p.name,
+        value: p.id,
+      })),
       rule_id: ruleSuggestions.map((r) => ({ label: r, value: r })),
     }),
     [policies, ruleSuggestions],
@@ -232,11 +248,16 @@ export default function RiskEvents(): JSX.Element {
           </Page.Toolbar>
         }
         status={
-          resultsQuery.isFetching && results.length > 0 ? (
-            <div className="bg-primary/20 h-1 shrink-0">
-              <div className="bg-primary h-full animate-pulse" />
-            </div>
-          ) : null
+          <>
+            {viewingInactivePolicy ? (
+              <InactivePolicyNotice policyName={selectedPolicy?.name} />
+            ) : null}
+            {resultsQuery.isFetching && results.length > 0 ? (
+              <div className="bg-primary/20 h-1 shrink-0">
+                <div className="bg-primary h-full animate-pulse" />
+              </div>
+            ) : null}
+          </>
         }
         header={
           <div className="min-w-[1120px]">
@@ -279,6 +300,33 @@ export default function RiskEvents(): JSX.Element {
         />
       </LogWorkbench>
     </RevealAllProvider>
+  );
+}
+
+// Shown when the active policy filter points at a disabled ("turned off")
+// policy. Those policies no longer produce new findings, so the list is purely
+// historical — make that explicit rather than leaving users to assume the data
+// is current.
+function InactivePolicyNotice({
+  policyName,
+}: {
+  policyName: string | undefined;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-8 py-2 text-sm text-amber-700 dark:text-amber-400">
+      <History className="size-4 shrink-0" />
+      <span>
+        {policyName ? (
+          <>
+            <span className="font-medium">{policyName}</span> is no longer
+            active.
+          </>
+        ) : (
+          "This policy is no longer active."
+        )}{" "}
+        You're viewing historical findings from when it was enabled.
+      </span>
+    </div>
   );
 }
 

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -968,16 +968,18 @@ func (s *Service) listRiskResultsRaw(ctx context.Context, payload *gen.ListRiskR
 
 	pageSize := resolvePageSize(payload.Limit)
 
-	totalCount, err := s.repo.CountAllFindings(ctx, *authCtx.ProjectID)
-	if err != nil {
-		totalCount = 0
-	}
-
 	if payload.ChatID != nil && *payload.ChatID != "" {
+		totalCount, err := s.repo.CountAllFindings(ctx, *authCtx.ProjectID)
+		if err != nil {
+			totalCount = 0
+		}
 		return s.listResultsByChat(ctx, *authCtx.ProjectID, *payload.ChatID, cursor, pageSize, totalCount)
 	}
+	// The by-policy listing includes disabled policies (historical findings),
+	// so its count is computed inside listResultsByPolicy with the same
+	// semantics rather than from the enabled-only project aggregate.
 	if payload.PolicyID != nil && *payload.PolicyID != "" {
-		return s.listResultsByPolicy(ctx, *authCtx.ProjectID, *payload.PolicyID, cursor, pageSize, totalCount)
+		return s.listResultsByPolicy(ctx, *authCtx.ProjectID, *payload.PolicyID, cursor, pageSize)
 	}
 
 	category := ""
@@ -1003,6 +1005,10 @@ func (s *Service) listRiskResultsRaw(ctx context.Context, payload *gen.ListRiskR
 	toTime, err := parseOptionalTimestamptz(payload.To)
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid to").LogError(ctx, s.logger)
+	}
+	totalCount, err := s.repo.CountAllFindings(ctx, *authCtx.ProjectID)
+	if err != nil {
+		totalCount = 0
 	}
 	return s.listResultsByProject(ctx, *authCtx.ProjectID, cursor, pageSize, totalCount, category, ruleID, userID, uniqueMatch, fromTime, toTime)
 }
@@ -1456,10 +1462,17 @@ func (s *Service) listResultsByChat(ctx context.Context, projectID uuid.UUID, ra
 	return s.paginateResults(results, nextCursor, pageSize, totalCount), nil
 }
 
-func (s *Service) listResultsByPolicy(ctx context.Context, projectID uuid.UUID, rawPolicyID string, cursor *riskResultsCursor, pageSize int, totalCount int64) (*gen.ListRiskResultsResult, error) {
+func (s *Service) listResultsByPolicy(ctx context.Context, projectID uuid.UUID, rawPolicyID string, cursor *riskResultsCursor, pageSize int) (*gen.ListRiskResultsResult, error) {
 	policyID, err := uuid.Parse(rawPolicyID)
 	if err != nil {
 		return nil, oops.C(oops.CodeInvalid)
+	}
+	totalCount, err := s.repo.CountRiskResultsByProjectAndPolicy(ctx, repo.CountRiskResultsByProjectAndPolicyParams{
+		ProjectID:    projectID,
+		RiskPolicyID: policyID,
+	})
+	if err != nil {
+		totalCount = 0
 	}
 	cursorCreatedAt, cursorID := cursorToParams(cursor)
 	rows, err := s.repo.ListRiskResultsByProjectAndPolicy(ctx, repo.ListRiskResultsByProjectAndPolicyParams{

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -833,11 +833,16 @@ ORDER BY sub.message_created_at DESC, sub.id DESC
 LIMIT @page_limit;
 
 -- name: ListRiskResultsByProjectAndPolicy :many
+-- Unlike the other list queries, this does NOT require the policy to be
+-- enabled. When the user explicitly filters to a specific policy we surface its
+-- historical findings even after it has been turned off, so disabled policies
+-- still show the matches they produced while active. Deleted policies remain
+-- excluded. The frontend flags the inactive policy as historical data.
 SELECT rr.*, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
-JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
+JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE
 LEFT JOIN LATERAL (
   SELECT tcb.id AS block_id FROM tool_call_blocks tcb
   WHERE tcb.project_id = rr.project_id

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -341,6 +341,17 @@ JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND r
 WHERE rr.project_id = @project_id
   AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL;
 
+-- name: CountRiskResultsByProjectAndPolicy :one
+-- Matches the filter semantics of ListRiskResultsByProjectAndPolicy: a
+-- disabled policy still counts its historical findings, only deleted policies
+-- are excluded.
+SELECT COUNT(*)::BIGINT
+FROM risk_results rr
+JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE
+WHERE rr.project_id = @project_id
+  AND rr.risk_policy_id = @risk_policy_id
+  AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL;
+
 -- name: GetRiskOverviewCounts :one
 SELECT
     COUNT(DISTINCT rr.chat_message_id)::BIGINT AS messages_scanned

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -402,6 +402,30 @@ func (q *Queries) CountRiskResultsByPolicyID(ctx context.Context, arg CountRiskR
 	return column_1, err
 }
 
+const countRiskResultsByProjectAndPolicy = `-- name: CountRiskResultsByProjectAndPolicy :one
+SELECT COUNT(*)::BIGINT
+FROM risk_results rr
+JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE
+WHERE rr.project_id = $1
+  AND rr.risk_policy_id = $2
+  AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
+`
+
+type CountRiskResultsByProjectAndPolicyParams struct {
+	ProjectID    uuid.UUID
+	RiskPolicyID uuid.UUID
+}
+
+// Matches the filter semantics of ListRiskResultsByProjectAndPolicy: a
+// disabled policy still counts its historical findings, only deleted policies
+// are excluded.
+func (q *Queries) CountRiskResultsByProjectAndPolicy(ctx context.Context, arg CountRiskResultsByProjectAndPolicyParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countRiskResultsByProjectAndPolicy, arg.ProjectID, arg.RiskPolicyID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const countTotalMessages = `-- name: CountTotalMessages :one
 SELECT COUNT(*)::BIGINT
 FROM chat_messages cm

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -2210,7 +2210,7 @@ SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_poli
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
-JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
+JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE
 LEFT JOIN LATERAL (
   SELECT tcb.id AS block_id FROM tool_call_blocks tcb
   WHERE tcb.project_id = rr.project_id
@@ -2267,6 +2267,11 @@ type ListRiskResultsByProjectAndPolicyRow struct {
 	BlockID             uuid.UUID
 }
 
+// Unlike the other list queries, this does NOT require the policy to be
+// enabled. When the user explicitly filters to a specific policy we surface its
+// historical findings even after it has been turned off, so disabled policies
+// still show the matches they produced while active. Deleted policies remain
+// excluded. The frontend flags the inactive policy as historical data.
 func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg ListRiskResultsByProjectAndPolicyParams) ([]ListRiskResultsByProjectAndPolicyRow, error) {
 	rows, err := q.db.Query(ctx, listRiskResultsByProjectAndPolicy,
 		arg.ProjectID,

--- a/server/internal/risk/results_test.go
+++ b/server/internal/risk/results_test.go
@@ -141,11 +141,13 @@ func TestListRiskResults_ByPolicy_DisabledPolicyShowsHistoricalFindings(t *testi
 	require.NoError(t, err)
 	require.Len(t, byPolicy.Results, 1, "disabled policy should still show its historical findings when filtered")
 	require.Equal(t, "aws-access-key-id", *byPolicy.Results[0].RuleID)
+	require.Equal(t, int64(1), byPolicy.TotalCount, "by-policy total count should match the listing, not the enabled-only aggregate")
 
 	// The default unfiltered view keeps excluding disabled-policy findings.
 	unfiltered, err := ti.service.ListRiskResults(ctx, &gen.ListRiskResultsPayload{})
 	require.NoError(t, err)
 	require.Empty(t, unfiltered.Results, "unfiltered view should not include disabled-policy findings")
+	require.Equal(t, int64(0), unfiltered.TotalCount, "unfiltered total count should not include disabled-policy findings")
 }
 
 func TestListRiskResults_ByChatID(t *testing.T) {

--- a/server/internal/risk/results_test.go
+++ b/server/internal/risk/results_test.go
@@ -105,6 +105,49 @@ func TestListRiskResults_ByPolicy(t *testing.T) {
 	require.Equal(t, "aws-access-key-id", *result.Results[0].RuleID)
 }
 
+// A disabled ("turned off") policy still holds the findings it produced while
+// active. When the user explicitly filters to that policy the list must surface
+// those historical findings rather than coming back empty, while the default
+// unfiltered view keeps hiding them (only active policies contribute there).
+func TestListRiskResults_ByPolicy_DisabledPolicyShowsHistoricalFindings(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Disabled Policy Test")})
+	require.NoError(t, err)
+
+	policyID, _ := uuid.Parse(policy.ID)
+	_, msgID := seedChatMessage(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID)
+	seedRiskResult(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, policyID, 1, msgID, true)
+
+	// Turn the policy off.
+	disabled := false
+	_, err = ti.service.UpdateRiskPolicy(ctx, &gen.UpdateRiskPolicyPayload{
+		ID:      policy.ID,
+		Name:    policy.Name,
+		Enabled: &disabled,
+	})
+	require.NoError(t, err)
+
+	// Explicit filter on the disabled policy surfaces its historical findings.
+	byPolicy, err := ti.service.ListRiskResults(ctx, &gen.ListRiskResultsPayload{
+		PolicyID: &policy.ID,
+	})
+	require.NoError(t, err)
+	require.Len(t, byPolicy.Results, 1, "disabled policy should still show its historical findings when filtered")
+	require.Equal(t, "aws-access-key-id", *byPolicy.Results[0].RuleID)
+
+	// The default unfiltered view keeps excluding disabled-policy findings.
+	unfiltered, err := ti.service.ListRiskResults(ctx, &gen.ListRiskResultsPayload{})
+	require.NoError(t, err)
+	require.Empty(t, unfiltered.Results, "unfiltered view should not include disabled-policy findings")
+}
+
 func TestListRiskResults_ByChatID(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestRiskService(t)


### PR DESCRIPTION
## What & why

Fixes DNO-356. The Risk Events page returned **no results when filtering by a disabled ("turned off") policy**, even though that policy had historical findings. Enabling the policy made them reappear.

Root cause: `ListRiskResultsByProjectAndPolicy` joined `risk_policies` with `AND rp.enabled IS TRUE`, so an explicitly-selected disabled policy matched zero rows.

Per the ticket, we should show previous matches against no-longer-enabled policies, and indicate that the filtered policy is inactive / the data is historical.

## Changes

**Backend** (`server/internal/risk`)
- Drop the `enabled IS TRUE` condition from `ListRiskResultsByProjectAndPolicy` only — the query used when the user explicitly filters to a specific policy. Deleted policies remain excluded (`deleted IS FALSE` stays).
- The default unfiltered view, chat-filtered view, and grouped views are **untouched** and still list only active policies, so the general page stays clean.
- Regenerated sqlc (`models`/query text only — no struct changes, no schema migration).
- Added a regression test: a disabled policy still surfaces its historical findings when filtered, while the unfiltered view keeps hiding them.

**Frontend** (`client/dashboard` Risk Events page)
- Disabled policies are still selectable in the Policy filter but labelled `"<name> (inactive)"`.
- When a disabled policy is the active filter, a banner explains the findings are historical: *"<name> is no longer active. You're viewing historical findings from when it was enabled."*

## Testing
- `go test ./server/internal/risk/` (new + existing by-policy tests pass)
- `pnpm -F dashboard lint` (oxfmt, oxlint, type-check all pass)
- `mise lint:server` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows historical risk findings when filtering by a turned‑off policy, and fixes the by‑policy total count so it matches the listing. Addresses DNO-356 while keeping the default view limited to active policies.

- **Bug Fixes**
  - Backend (`server/internal/risk`): Dropped `enabled IS TRUE` from `ListRiskResultsByProjectAndPolicy` so disabled policies return past findings; added `CountRiskResultsByProjectAndPolicy` and use it for by‑policy views to fix mismatched totals. Deleted policies remain excluded; other views still only include active policies. Included a regression test and regenerated `sqlc`.
  - Frontend (`client/dashboard`): Disabled policies stay selectable and show as "(inactive)". When selected, a banner explains you're viewing historical findings.

<sup>Written for commit dbb1c9ca7e79f9ad2d2cd47e8d1f5c68cebf360c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

