### PR TITLE
feat: pagination strategy for composed Shadow MCP inventory

### DIFF
--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -305,6 +306,7 @@ type UpsertShadowMCPInventoryURLParams struct {
 type ListShadowMCPInventoryURLsParams struct {
 	GramProjectID string
 	Limit         int
+	Cursor        string
 }
 
 type ShadowMCPInventoryURLRow struct {
@@ -358,6 +360,45 @@ type shadowMCPInventoryURLUpsert struct {
 	FirstSeen          time.Time
 	LastSeen           time.Time
 	UpdatedAt          time.Time
+}
+
+type shadowMCPInventoryURLCursor struct {
+	CanonicalServerURL string `json:"canonical_server_url"`
+	LastSeenUnixNano   int64  `json:"last_seen_unix_nano"`
+}
+
+func EncodeShadowMCPInventoryURLCursor(row ShadowMCPInventoryURLRow) (string, error) {
+	payload := shadowMCPInventoryURLCursor{
+		CanonicalServerURL: row.CanonicalServerURL,
+		LastSeenUnixNano:   row.LastSeen.UTC().UnixNano(),
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encoding shadow mcp inventory url cursor: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodeShadowMCPInventoryURLCursor(cursor string) (shadowMCPInventoryURLCursor, error) {
+	data, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return shadowMCPInventoryURLCursor{}, fmt.Errorf("decoding shadow mcp inventory url cursor: %w", err)
+	}
+
+	var payload shadowMCPInventoryURLCursor
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return shadowMCPInventoryURLCursor{}, fmt.Errorf("parsing shadow mcp inventory url cursor: %w", err)
+	}
+	if payload.CanonicalServerURL == "" {
+		return shadowMCPInventoryURLCursor{}, fmt.Errorf("shadow mcp inventory url cursor canonical server url is required")
+	}
+	if payload.LastSeenUnixNano == 0 {
+		return shadowMCPInventoryURLCursor{}, fmt.Errorf("shadow mcp inventory url cursor last seen is required")
+	}
+
+	return payload, nil
 }
 
 // UpsertShadowMCPInventoryURLs merges the given rows with any existing
@@ -532,7 +573,16 @@ func (q *Queries) getShadowMCPInventoryURL(ctx context.Context, projectID string
 
 func (q *Queries) ListShadowMCPInventoryURLs(ctx context.Context, arg ListShadowMCPInventoryURLsParams) ([]ShadowMCPInventoryURLRow, error) {
 	limit := clampShadowMCPInventoryLimit(arg.Limit)
-	sb := sq.Select(
+	var cursor shadowMCPInventoryURLCursor
+	if arg.Cursor != "" {
+		var err error
+		cursor, err = decodeShadowMCPInventoryURLCursor(arg.Cursor)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	inventoryRows := sq.Select(
 		"canonical_server_url",
 		"max(url_host) AS url_host",
 		"argMaxIf(server_name, updated_at, server_name != '') AS server_name",
@@ -541,9 +591,30 @@ func (q *Queries) ListShadowMCPInventoryURLs(ctx context.Context, arg ListShadow
 	).
 		From("shadow_mcp_inventory_urls").
 		Where("gram_project_id = ?", arg.GramProjectID).
-		GroupBy("gram_project_id", "canonical_server_url").
-		OrderBy("last_seen DESC", "canonical_server_url ASC").
+		GroupBy("gram_project_id", "canonical_server_url")
+
+	sb := sq.Select(
+		"canonical_server_url",
+		"url_host",
+		"server_name",
+		"first_seen",
+		"last_seen",
+	).
+		FromSelect(inventoryRows, "inventory_urls").
 		Limit(limit)
+
+	if arg.Cursor != "" {
+		lastSeen := time.Unix(0, cursor.LastSeenUnixNano).UTC()
+		sb = sb.Where(squirrel.Or{
+			squirrel.Expr("last_seen < ?", lastSeen),
+			squirrel.And{
+				squirrel.Expr("last_seen = ?", lastSeen),
+				squirrel.Expr("canonical_server_url > ?", cursor.CanonicalServerURL),
+			},
+		})
+	}
+
+	sb = sb.OrderBy("last_seen DESC", "canonical_server_url ASC")
 
 	query, queryArgs, err := sb.ToSql()
 	if err != nil {

--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -2,6 +2,7 @@ package telemetry_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -56,6 +57,7 @@ func TestShadowMCPInventoryURLs_UpsertAndList(t *testing.T) {
 	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
+		Cursor:        "",
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
@@ -64,6 +66,86 @@ func TestShadowMCPInventoryURLs_UpsertAndList(t *testing.T) {
 	require.Equal(t, "Speakeasy", rows[0].ServerName)
 	require.Equal(t, firstSeen, rows[0].FirstSeen)
 	require.Equal(t, lastSeen, rows[0].LastSeen)
+}
+
+func TestShadowMCPInventoryURLs_PaginatesLastSeen(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	base := time.Date(2026, 6, 29, 12, 30, 0, 0, time.UTC)
+
+	require.NoError(t, ti.chClient.UpsertShadowMCPInventoryURLs(ctx, []telemetryRepo.UpsertShadowMCPInventoryURLParams{
+		{GramProjectID: projectID, CanonicalServerURL: "https://gamma.example.com/mcp", URLHost: "gamma.example.com", ServerName: "Gamma", SeenAt: base.Add(3 * time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
+		{GramProjectID: projectID, CanonicalServerURL: "https://alpha.example.com/mcp", URLHost: "alpha.example.com", ServerName: "Alpha", SeenAt: base.Add(2 * time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
+		{GramProjectID: projectID, CanonicalServerURL: "https://beta.example.com/mcp", URLHost: "beta.example.com", ServerName: "Beta", SeenAt: base.Add(2 * time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
+		{GramProjectID: projectID, CanonicalServerURL: "https://delta.example.com/mcp", URLHost: "delta.example.com", ServerName: "Delta", SeenAt: base.Add(time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
+	}))
+
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	firstPage, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         2,
+		Cursor:        "",
+	})
+	require.NoError(t, err)
+	require.Len(t, firstPage, 2)
+	require.Equal(t, []string{
+		"https://gamma.example.com/mcp",
+		"https://alpha.example.com/mcp",
+	}, inventoryURLRows(firstPage))
+
+	cursor, err := telemetryRepo.EncodeShadowMCPInventoryURLCursor(firstPage[1])
+	require.NoError(t, err)
+
+	secondPage, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         2,
+		Cursor:        cursor,
+	})
+	require.NoError(t, err)
+	require.Len(t, secondPage, 2)
+	require.Equal(t, []string{
+		"https://beta.example.com/mcp",
+		"https://delta.example.com/mcp",
+	}, inventoryURLRows(secondPage))
+}
+
+func TestShadowMCPInventoryURLs_RejectsInvalidCursor(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	lastSeen := time.Date(2026, 6, 29, 12, 45, 0, 0, time.UTC)
+
+	invalidBase64 := "not base64"
+	invalidJSON := base64.RawURLEncoding.EncodeToString([]byte("not-json"))
+	missingURL := encodeRawInventoryURLCursor(t, map[string]any{
+		"last_seen_unix_nano": lastSeen.UnixNano(),
+	})
+	missingLastSeen := encodeRawInventoryURLCursor(t, map[string]any{
+		"canonical_server_url": "https://alpha.example.com/mcp",
+	})
+
+	invalidCursors := []struct {
+		name   string
+		cursor string
+	}{
+		{name: "invalid base64", cursor: invalidBase64},
+		{name: "invalid JSON", cursor: invalidJSON},
+		{name: "missing URL", cursor: missingURL},
+		{name: "missing last seen", cursor: missingLastSeen},
+	}
+
+	for _, invalidCursor := range invalidCursors {
+		_, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
+			GramProjectID: projectID,
+			Limit:         2,
+			Cursor:        invalidCursor.cursor,
+		})
+		require.Error(t, err, invalidCursor.name)
+	}
 }
 
 func TestShadowMCPInventoryUsage_FromTelemetry(t *testing.T) {
@@ -188,6 +270,7 @@ func TestLoggerUpsertShadowMCPInventoryURLs(t *testing.T) {
 	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
+		Cursor:        "",
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
@@ -250,6 +333,7 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
+		Cursor:        "",
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
@@ -363,4 +447,19 @@ func insertHistoricalShadowMCPCall(t *testing.T, ctx context.Context, ti *testIn
 		GramChatID:           nil,
 	})
 	require.NoError(t, err)
+}
+func inventoryURLRows(rows []telemetryRepo.ShadowMCPInventoryURLRow) []string {
+	urls := make([]string, 0, len(rows))
+	for _, row := range rows {
+		urls = append(urls, row.CanonicalServerURL)
+	}
+	return urls
+}
+
+func encodeRawInventoryURLCursor(t *testing.T, payload map[string]any) string {
+	t.Helper()
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(data)
 }


### PR DESCRIPTION
Linear: https://linear.app/speakeasy/issue/DNO-373/feat-pagination-strategy-for-composed-shadow-mcp-inventory

## What changes
- Adds cursor pagination for the project-scoped Shadow MCP inventory URL list.
- Orders rows by last called, then last seen, then canonical URL so the backend returns the order the dashboard needs.
- Encodes cursors from the last row in the page so follow-up pages continue from the same stable ordering.
- Keeps pagination anchored on inventory rows while API composition attaches telemetry usage and policy/request state to each row.

## Review context
This PR is intentionally about list shape and paging behavior. The inventory URL table remains the bounded page source, while telemetry is used for usage-aware ordering and row enrichment.

## Stack
1. #3819 DNO-371
2. #3848 DNO-369
3. #3849 DNO-373 (Current)
4. #3851 DNO-374
5. #3852 DNO-363
6. #3947 DNO-370
7. #4063 DNO-456
8. #4064 DNO-366
9. #4065 DNO-459
