### PR TITLE
feat: resolve Shadow MCP URL access state

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260630223706_shadow-mcp-inventory-urls.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260630223706_shadow-mcp-inventory-urls.down.sql
@@ -1,0 +1,2 @@
+-- reverse: create "shadow_mcp_inventory_urls" table
+DROP TABLE `shadow_mcp_inventory_urls`;

--- a/server/clickhouse/local/golang_migrate/20260630223706_shadow-mcp-inventory-urls.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260630223706_shadow-mcp-inventory-urls.up.sql
@@ -1,0 +1,11 @@
+-- create "shadow_mcp_inventory_urls" table
+CREATE TABLE `shadow_mcp_inventory_urls` (
+  `gram_project_id` UUID,
+  `canonical_server_url` String,
+  `url_host` String,
+  `server_name` String,
+  `first_seen` DateTime64(9, 'UTC'),
+  `last_seen` DateTime64(9, 'UTC'),
+  `updated_at` DateTime64(9, 'UTC')
+) ENGINE = ReplacingMergeTree(updated_at)
+PRIMARY KEY (`gram_project_id`, `canonical_server_url`) ORDER BY (`gram_project_id`, `canonical_server_url`) SETTINGS index_granularity = 8192 COMMENT 'Project-scoped Shadow MCP inventory URLs and display metadata';

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:guPKsC7jt/KtovpxenIU5yELeu0j8XjLxissJ82+rCw=
+h1:qrggp7vT1+dXOhqY61ZitJHxYsDtqBsKwlxzYbO9/rM=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -47,6 +47,7 @@ h1:guPKsC7jt/KtovpxenIU5yELeu0j8XjLxissJ82+rCw=
 20260626094434_include-chat-completion-usage-cost.up.sql h1:Tqn1gL/ffrZ7ubhcddFKtbTpd165TpPwpaFbYW+r/iM=
 20260629200140_add-personal-account-telemetry-cols.up.sql h1:kRwK9Foo9RtIM+V7sYD+v/B2tEO34JKIZ4ieb3cKlBI=
 20260630211520_pat-account-type-and-provider-summaries.up.sql h1:jZcSnDdLvYZZEIl8/M35gAIckJNFbWQ4tGV3tKbrDRw=
-20260701215636_billing-mode-summaries.up.sql h1:QBQWDP1N8QGVVfa3oVOIvfVn6DZXBSuBJ12Pcs+3a70=
-20260702073000_attribute-metrics-attribution-dimensions.up.sql h1:PoTqZiFzKWD7DQ7w+uIPo5RwyerGYoYUHOP+Hfxx6iY=
-20260706165346_ttl-90d.up.sql h1:abSyGD5D2/4V9uClhit0Vf09W3z1rGoQAYGK8Y6GO6M=
+20260630223706_shadow-mcp-inventory-urls.up.sql h1:k7b3+bIRF4xhfrjIgOcDsZRjISdtAywhG+MsFGW/Vew=
+20260701215636_billing-mode-summaries.up.sql h1:X1GUs6B805ah6ImjwkkhnEW2venwPP8qCoR8LRLmtEw=
+20260702073000_attribute-metrics-attribution-dimensions.up.sql h1:dzZq1cxlbDXHkYtp8JLKSwmfkWq/v4CMv+tk+r6fZbc=
+20260706165346_ttl-90d.up.sql h1:9TwaF8Lf0igzWSZ/4BGb4TgPPp51u6GwHseo27pRj+w=

--- a/server/clickhouse/migrations/20260630223351_shadow-mcp-inventory-urls.sql
+++ b/server/clickhouse/migrations/20260630223351_shadow-mcp-inventory-urls.sql
@@ -1,0 +1,11 @@
+-- Create "shadow_mcp_inventory_urls" table
+CREATE TABLE `shadow_mcp_inventory_urls` (
+  `gram_project_id` UUID,
+  `canonical_server_url` String,
+  `url_host` String,
+  `server_name` String,
+  `first_seen` DateTime64(9, 'UTC'),
+  `last_seen` DateTime64(9, 'UTC'),
+  `updated_at` DateTime64(9, 'UTC')
+) ENGINE = ReplacingMergeTree(updated_at)
+PRIMARY KEY (`gram_project_id`, `canonical_server_url`) ORDER BY (`gram_project_id`, `canonical_server_url`) SETTINGS index_granularity = 8192 COMMENT 'Project-scoped Shadow MCP inventory URLs and display metadata';

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:L+lzULn2h+Y3gfuSKrGqtjEHKrR/cUGMjuwUqUs2BA0=
+h1:dXpKhgLq2JJS99XfQkGofx6qWM9PwjhIH6/G5UyGZK0=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -52,6 +52,7 @@ h1:L+lzULn2h+Y3gfuSKrGqtjEHKrR/cUGMjuwUqUs2BA0=
 20260626094430_include-chat-completion-usage-cost.sql h1:DX0d4cgeANOspCqlTtRxEkoT9zILkr9tckpHFKQkJlA=
 20260629200135_add-personal-account-telemetry-cols.sql h1:e+wJ2NeKzcuzBnCKSqH4JObSNEY44v5m614LaUlU2zA=
 20260630211517_pat-account-type-and-provider-summaries.sql h1:xTMHAzIZNnTz4rkpwLeWv28GXEP8lfFrG6YPERYjDpI=
-20260701215632_billing-mode-summaries.sql h1:3QwBy+mTC0pQt3mtO7ZLdjDGN9gMFFHllEB4pr6cjkE=
-20260702073000_attribute-metrics-attribution-dimensions.sql h1:5eoL9P6XNPKtIJYjdsK/VaQS3CFDfOKXbm/hkcZFZlc=
-20260706165342_ttl-90d.sql h1:a8ovzANcapKzIJcB1k8cnCtCO6s4kqZqBYEHFa820jQ=
+20260630223351_shadow-mcp-inventory-urls.sql h1:gn8f5K4CwPVAo2is0LUw35mNX6Wmy+WS4boFQJpBuyM=
+20260701215632_billing-mode-summaries.sql h1:X4H95Dxv+YqF/q8J7LmMX43jcEO4GHpKsbLKt6UCp8E=
+20260702073000_attribute-metrics-attribution-dimensions.sql h1:VqYkDG/CvWQfr78xbxceOrE9F2N0FRCrncejtKzxsW4=
+20260706165342_ttl-90d.sql h1:CX4vSt3gBGNxD733Vc/zGKqbVFiy/m7t8ykJm+9QrPQ=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -213,6 +213,19 @@ FROM telemetry_logs
 WHERE trace_id IS NOT NULL AND trace_id != '' AND NOT startsWith(telemetry_logs.gram_urn, 'urn:uuid:')
 GROUP BY trace_id, gram_project_id;
 
+CREATE TABLE IF NOT EXISTS shadow_mcp_inventory_urls (
+    gram_project_id UUID,
+    canonical_server_url String,
+    url_host String,
+    server_name String,
+    first_seen DateTime64(9, 'UTC'),
+    last_seen DateTime64(9, 'UTC'),
+    updated_at DateTime64(9, 'UTC')
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (gram_project_id, canonical_server_url)
+SETTINGS index_granularity = 8192
+COMMENT 'Project-scoped Shadow MCP inventory URLs and display metadata';
+
 CREATE TABLE IF NOT EXISTS metrics_summaries (
     -- Key columns
     gram_project_id UUID,

--- a/server/internal/access/shadow_mcp_access_state.go
+++ b/server/internal/access/shadow_mcp_access_state.go
@@ -15,11 +15,8 @@ const (
 )
 
 type shadowMCPInventoryAccessState struct {
-	ExplicitDisposition  string
-	EffectiveDisposition string
-	ExplicitRule         *shadowMCPInventoryAccessRuleMatch
-	EffectiveRule        *shadowMCPInventoryAccessRuleMatch
-	ExplanatoryRules     []shadowMCPInventoryAccessRuleMatch
+	Access string
+	Rule   *shadowMCPInventoryAccessRuleMatch
 }
 
 type shadowMCPInventoryAccessRuleMatch struct {
@@ -34,15 +31,11 @@ type shadowMCPInventoryAccessRuleMatch struct {
 
 func (s *Service) resolveShadowMCPInventoryAccessState(ctx context.Context, organizationID string, projectID string, inventoryURL shadowmcp.InventoryURL) (shadowMCPInventoryAccessState, error) {
 	state := shadowMCPInventoryAccessState{
-		ExplicitDisposition:  shadowMCPInventoryAccessNone,
-		EffectiveDisposition: shadowMCPInventoryAccessNone,
-		ExplicitRule:         nil,
-		EffectiveRule:        nil,
-		ExplanatoryRules:     nil,
+		Access: shadowMCPInventoryAccessNone,
+		Rule:   nil,
 	}
 
-	matchKinds, matchValues := shadowMCPInventoryAccessMatchCandidates(inventoryURL)
-	if len(matchKinds) == 0 {
+	if inventoryURL.CanonicalURL == "" {
 		return state, nil
 	}
 
@@ -50,65 +43,19 @@ func (s *Service) resolveShadowMCPInventoryAccessState(ctx context.Context, orga
 		OrganizationID: organizationID,
 		ProjectID:      projectID,
 		ResourceType:   accesscontrol.ResourceTypeShadowMCP,
-		MatchKinds:     matchKinds,
-		MatchValues:    matchValues,
+		MatchKinds:     []string{accesscontrol.MatchKindFullURL},
+		MatchValues:    []string{inventoryURL.CanonicalURL},
 	})
 	if err != nil {
 		return state, fmt.Errorf("list matching shadow mcp inventory access rules: %w", err)
 	}
 
-	state.ExplicitDisposition, state.ExplicitRule = resolveShadowMCPInventoryExplicitRule(rules, projectID, inventoryURL.CanonicalURL)
-	state.EffectiveDisposition, state.EffectiveRule = resolveShadowMCPInventoryEffectiveRule(rules)
-
-	explanatoryRules, err := s.listShadowMCPInventoryExplanatoryRules(ctx, organizationID, projectID, inventoryURL)
-	if err != nil {
-		return state, err
-	}
-	state.ExplanatoryRules = explanatoryRules
+	state.Access, state.Rule = resolveShadowMCPInventoryURLRule(rules)
 
 	return state, nil
 }
 
-func shadowMCPInventoryAccessMatchCandidates(inventoryURL shadowmcp.InventoryURL) ([]string, []string) {
-	evidence := shadowmcp.NormalizeAccessEvidence(shadowmcp.AccessEvidenceForInventoryURL(inventoryURL))
-	kinds := make([]string, 0, 2)
-	values := make([]string, 0, 2)
-	if evidence.FullURL != "" {
-		kinds = append(kinds, accesscontrol.MatchKindFullURL)
-		values = append(values, evidence.FullURL)
-	}
-	if evidence.URLHost != "" {
-		kinds = append(kinds, accesscontrol.MatchKindURLHost)
-		values = append(values, evidence.URLHost)
-	}
-	return kinds, values
-}
-
-func resolveShadowMCPInventoryExplicitRule(rules []accesscontrol.AccessRule, projectID string, canonicalURL string) (string, *shadowMCPInventoryAccessRuleMatch) {
-	for _, rule := range rules {
-		if !shadowMCPInventoryExplicitURLRule(rule, projectID, canonicalURL) {
-			continue
-		}
-		if rule.Disposition == accesscontrol.DispositionDenied {
-			match := shadowMCPInventoryRuleMatch(rule)
-			return shadowMCPInventoryAccessDenied, &match
-		}
-	}
-
-	for _, rule := range rules {
-		if !shadowMCPInventoryExplicitURLRule(rule, projectID, canonicalURL) {
-			continue
-		}
-		if rule.Disposition == accesscontrol.DispositionAllowed {
-			match := shadowMCPInventoryRuleMatch(rule)
-			return shadowMCPInventoryAccessAllowed, &match
-		}
-	}
-
-	return shadowMCPInventoryAccessNone, nil
-}
-
-func resolveShadowMCPInventoryEffectiveRule(rules []accesscontrol.AccessRule) (string, *shadowMCPInventoryAccessRuleMatch) {
+func resolveShadowMCPInventoryURLRule(rules []accesscontrol.AccessRule) (string, *shadowMCPInventoryAccessRuleMatch) {
 	for _, rule := range rules {
 		if rule.Disposition == accesscontrol.DispositionDenied {
 			match := shadowMCPInventoryRuleMatch(rule)
@@ -124,76 +71,6 @@ func resolveShadowMCPInventoryEffectiveRule(rules []accesscontrol.AccessRule) (s
 	}
 
 	return shadowMCPInventoryAccessNone, nil
-}
-
-func shadowMCPInventoryExplicitURLRule(rule accesscontrol.AccessRule, projectID string, canonicalURL string) bool {
-	return rule.AccessScope == accesscontrol.AccessScopeProject &&
-		rule.ProjectID == projectID &&
-		rule.MatchKind == accesscontrol.MatchKindFullURL &&
-		accesscontrol.CanonicalizeMatchValue(rule.MatchKind, rule.MatchValue) == canonicalURL
-}
-
-func (s *Service) listShadowMCPInventoryExplanatoryRules(ctx context.Context, organizationID string, projectID string, inventoryURL shadowmcp.InventoryURL) ([]shadowMCPInventoryAccessRuleMatch, error) {
-	filters := []accesscontrol.RuleFilters{
-		{
-			OrganizationID: organizationID,
-			ProjectID:      "",
-			AccessScope:    accesscontrol.AccessScopeOrganization,
-			ResourceType:   accesscontrol.ResourceTypeShadowMCP,
-			Disposition:    "",
-			Limit:          shadowMCPMaxPageLimit,
-			Cursor:         "",
-		},
-		{
-			OrganizationID: organizationID,
-			ProjectID:      projectID,
-			AccessScope:    accesscontrol.AccessScopeProject,
-			ResourceType:   accesscontrol.ResourceTypeShadowMCP,
-			Disposition:    "",
-			Limit:          shadowMCPMaxPageLimit,
-			Cursor:         "",
-		},
-	}
-
-	matches := make([]shadowMCPInventoryAccessRuleMatch, 0)
-	for _, filter := range filters {
-		for {
-			result, err := s.accessStore.ListRules(ctx, filter)
-			if err != nil {
-				return nil, fmt.Errorf("list shadow mcp inventory explanatory access rules: %w", err)
-			}
-			for _, rule := range result.Rules {
-				if rule.MatchKind != accesscontrol.MatchKindServerIdentity {
-					continue
-				}
-				if !shadowMCPInventoryObservedSummaryMatchesURL(rule.ObservedSummary, inventoryURL) {
-					continue
-				}
-				matches = append(matches, shadowMCPInventoryRuleMatch(rule))
-			}
-			if result.NextCursor == "" {
-				break
-			}
-			filter.Cursor = result.NextCursor
-		}
-	}
-
-	return matches, nil
-}
-
-func shadowMCPInventoryObservedSummaryMatchesURL(summary accesscontrol.ObservedSummary, inventoryURL shadowmcp.InventoryURL) bool {
-	if summary.FullURL != nil {
-		if observedURL, ok := shadowmcp.CanonicalizeInventoryURL(*summary.FullURL); ok && observedURL.CanonicalURL == inventoryURL.CanonicalURL {
-			return true
-		}
-	}
-	if summary.URLHost != nil {
-		observedHost, err := shadowmcp.NormalizeMatchValue(shadowmcp.MatchBreadthURLHost, *summary.URLHost)
-		if err == nil && observedHost == inventoryURL.URLHost {
-			return true
-		}
-	}
-	return false
 }
 
 func shadowMCPInventoryRuleMatch(rule accesscontrol.AccessRule) shadowMCPInventoryAccessRuleMatch {

--- a/server/internal/access/shadow_mcp_access_state.go
+++ b/server/internal/access/shadow_mcp_access_state.go
@@ -1,0 +1,209 @@
+package access
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/accesscontrol"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+)
+
+const (
+	shadowMCPInventoryAccessNone    = "none"
+	shadowMCPInventoryAccessAllowed = "allowed"
+	shadowMCPInventoryAccessDenied  = "denied"
+)
+
+type shadowMCPInventoryAccessState struct {
+	ExplicitDisposition  string
+	EffectiveDisposition string
+	ExplicitRule         *shadowMCPInventoryAccessRuleMatch
+	EffectiveRule        *shadowMCPInventoryAccessRuleMatch
+	ExplanatoryRules     []shadowMCPInventoryAccessRuleMatch
+}
+
+type shadowMCPInventoryAccessRuleMatch struct {
+	ID          string
+	ProjectID   string
+	AccessScope string
+	Disposition string
+	MatchKind   string
+	MatchValue  string
+	DisplayName string
+}
+
+func (s *Service) resolveShadowMCPInventoryAccessState(ctx context.Context, organizationID string, projectID string, inventoryURL shadowmcp.InventoryURL) (shadowMCPInventoryAccessState, error) {
+	state := shadowMCPInventoryAccessState{
+		ExplicitDisposition:  shadowMCPInventoryAccessNone,
+		EffectiveDisposition: shadowMCPInventoryAccessNone,
+		ExplicitRule:         nil,
+		EffectiveRule:        nil,
+		ExplanatoryRules:     nil,
+	}
+
+	matchKinds, matchValues := shadowMCPInventoryAccessMatchCandidates(inventoryURL)
+	if len(matchKinds) == 0 {
+		return state, nil
+	}
+
+	rules, err := s.accessStore.ListMatchingRules(ctx, accesscontrol.MatchingRuleFilters{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+		ResourceType:   accesscontrol.ResourceTypeShadowMCP,
+		MatchKinds:     matchKinds,
+		MatchValues:    matchValues,
+	})
+	if err != nil {
+		return state, fmt.Errorf("list matching shadow mcp inventory access rules: %w", err)
+	}
+
+	state.ExplicitDisposition, state.ExplicitRule = resolveShadowMCPInventoryExplicitRule(rules, projectID, inventoryURL.CanonicalURL)
+	state.EffectiveDisposition, state.EffectiveRule = resolveShadowMCPInventoryEffectiveRule(rules)
+
+	explanatoryRules, err := s.listShadowMCPInventoryExplanatoryRules(ctx, organizationID, projectID, inventoryURL)
+	if err != nil {
+		return state, err
+	}
+	state.ExplanatoryRules = explanatoryRules
+
+	return state, nil
+}
+
+func shadowMCPInventoryAccessMatchCandidates(inventoryURL shadowmcp.InventoryURL) ([]string, []string) {
+	evidence := shadowmcp.NormalizeAccessEvidence(shadowmcp.AccessEvidenceForInventoryURL(inventoryURL))
+	kinds := make([]string, 0, 2)
+	values := make([]string, 0, 2)
+	if evidence.FullURL != "" {
+		kinds = append(kinds, accesscontrol.MatchKindFullURL)
+		values = append(values, evidence.FullURL)
+	}
+	if evidence.URLHost != "" {
+		kinds = append(kinds, accesscontrol.MatchKindURLHost)
+		values = append(values, evidence.URLHost)
+	}
+	return kinds, values
+}
+
+func resolveShadowMCPInventoryExplicitRule(rules []accesscontrol.AccessRule, projectID string, canonicalURL string) (string, *shadowMCPInventoryAccessRuleMatch) {
+	for _, rule := range rules {
+		if !shadowMCPInventoryExplicitURLRule(rule, projectID, canonicalURL) {
+			continue
+		}
+		if rule.Disposition == accesscontrol.DispositionDenied {
+			match := shadowMCPInventoryRuleMatch(rule)
+			return shadowMCPInventoryAccessDenied, &match
+		}
+	}
+
+	for _, rule := range rules {
+		if !shadowMCPInventoryExplicitURLRule(rule, projectID, canonicalURL) {
+			continue
+		}
+		if rule.Disposition == accesscontrol.DispositionAllowed {
+			match := shadowMCPInventoryRuleMatch(rule)
+			return shadowMCPInventoryAccessAllowed, &match
+		}
+	}
+
+	return shadowMCPInventoryAccessNone, nil
+}
+
+func resolveShadowMCPInventoryEffectiveRule(rules []accesscontrol.AccessRule) (string, *shadowMCPInventoryAccessRuleMatch) {
+	for _, rule := range rules {
+		if rule.Disposition == accesscontrol.DispositionDenied {
+			match := shadowMCPInventoryRuleMatch(rule)
+			return shadowMCPInventoryAccessDenied, &match
+		}
+	}
+
+	for _, rule := range rules {
+		if rule.Disposition == accesscontrol.DispositionAllowed {
+			match := shadowMCPInventoryRuleMatch(rule)
+			return shadowMCPInventoryAccessAllowed, &match
+		}
+	}
+
+	return shadowMCPInventoryAccessNone, nil
+}
+
+func shadowMCPInventoryExplicitURLRule(rule accesscontrol.AccessRule, projectID string, canonicalURL string) bool {
+	return rule.AccessScope == accesscontrol.AccessScopeProject &&
+		rule.ProjectID == projectID &&
+		rule.MatchKind == accesscontrol.MatchKindFullURL &&
+		accesscontrol.CanonicalizeMatchValue(rule.MatchKind, rule.MatchValue) == canonicalURL
+}
+
+func (s *Service) listShadowMCPInventoryExplanatoryRules(ctx context.Context, organizationID string, projectID string, inventoryURL shadowmcp.InventoryURL) ([]shadowMCPInventoryAccessRuleMatch, error) {
+	filters := []accesscontrol.RuleFilters{
+		{
+			OrganizationID: organizationID,
+			ProjectID:      "",
+			AccessScope:    accesscontrol.AccessScopeOrganization,
+			ResourceType:   accesscontrol.ResourceTypeShadowMCP,
+			Disposition:    "",
+			Limit:          shadowMCPMaxPageLimit,
+			Cursor:         "",
+		},
+		{
+			OrganizationID: organizationID,
+			ProjectID:      projectID,
+			AccessScope:    accesscontrol.AccessScopeProject,
+			ResourceType:   accesscontrol.ResourceTypeShadowMCP,
+			Disposition:    "",
+			Limit:          shadowMCPMaxPageLimit,
+			Cursor:         "",
+		},
+	}
+
+	matches := make([]shadowMCPInventoryAccessRuleMatch, 0)
+	for _, filter := range filters {
+		for {
+			result, err := s.accessStore.ListRules(ctx, filter)
+			if err != nil {
+				return nil, fmt.Errorf("list shadow mcp inventory explanatory access rules: %w", err)
+			}
+			for _, rule := range result.Rules {
+				if rule.MatchKind != accesscontrol.MatchKindServerIdentity {
+					continue
+				}
+				if !shadowMCPInventoryObservedSummaryMatchesURL(rule.ObservedSummary, inventoryURL) {
+					continue
+				}
+				matches = append(matches, shadowMCPInventoryRuleMatch(rule))
+			}
+			if result.NextCursor == "" {
+				break
+			}
+			filter.Cursor = result.NextCursor
+		}
+	}
+
+	return matches, nil
+}
+
+func shadowMCPInventoryObservedSummaryMatchesURL(summary accesscontrol.ObservedSummary, inventoryURL shadowmcp.InventoryURL) bool {
+	if summary.FullURL != nil {
+		if observedURL, ok := shadowmcp.CanonicalizeInventoryURL(*summary.FullURL); ok && observedURL.CanonicalURL == inventoryURL.CanonicalURL {
+			return true
+		}
+	}
+	if summary.URLHost != nil {
+		observedHost, err := shadowmcp.NormalizeMatchValue(shadowmcp.MatchBreadthURLHost, *summary.URLHost)
+		if err == nil && observedHost == inventoryURL.URLHost {
+			return true
+		}
+	}
+	return false
+}
+
+func shadowMCPInventoryRuleMatch(rule accesscontrol.AccessRule) shadowMCPInventoryAccessRuleMatch {
+	return shadowMCPInventoryAccessRuleMatch{
+		ID:          rule.ID,
+		ProjectID:   rule.ProjectID,
+		AccessScope: rule.AccessScope,
+		Disposition: rule.Disposition,
+		MatchKind:   rule.MatchKind,
+		MatchValue:  rule.MatchValue,
+		DisplayName: rule.DisplayName,
+	}
+}

--- a/server/internal/access/shadow_mcp_access_state_test.go
+++ b/server/internal/access/shadow_mcp_access_state_test.go
@@ -16,16 +16,14 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                string
-		rules               func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string)
-		rawURL              string
-		wantExplicit        string
-		wantEffective       string
-		wantEffectiveRule   string
-		wantExplanatoryRule string
+		name         string
+		rules        func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string)
+		rawURL       string
+		wantAccess   string
+		wantRuleName string
 	}{
 		{
-			name: "exact project full url allow is explicit and effective",
+			name: "exact project full url allow sets access state",
 			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
 				t.Helper()
 
@@ -42,13 +40,12 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 					},
 				})
 			},
-			rawURL:            "https://mcp.example.com/mcp?token=secret",
-			wantExplicit:      shadowMCPInventoryAccessAllowed,
-			wantEffective:     shadowMCPInventoryAccessAllowed,
-			wantEffectiveRule: "Project allow",
+			rawURL:       "https://mcp.example.com/mcp?token=secret",
+			wantAccess:   shadowMCPInventoryAccessAllowed,
+			wantRuleName: "Project allow",
 		},
 		{
-			name: "exact project full url deny is explicit and effective",
+			name: "exact project full url deny sets access state",
 			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
 				t.Helper()
 
@@ -65,13 +62,12 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 					},
 				})
 			},
-			rawURL:            "https://mcp.example.com/mcp",
-			wantExplicit:      shadowMCPInventoryAccessDenied,
-			wantEffective:     shadowMCPInventoryAccessDenied,
-			wantEffectiveRule: "Project deny",
+			rawURL:       "https://mcp.example.com/mcp",
+			wantAccess:   shadowMCPInventoryAccessDenied,
+			wantRuleName: "Project deny",
 		},
 		{
-			name: "host level organization deny is effective inherited state",
+			name: "host rule does not set inventory url access state",
 			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
 				t.Helper()
 
@@ -88,10 +84,8 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 					},
 				})
 			},
-			rawURL:            "https://mcp.example.com/mcp",
-			wantExplicit:      shadowMCPInventoryAccessNone,
-			wantEffective:     shadowMCPInventoryAccessDenied,
-			wantEffectiveRule: "Org host deny",
+			rawURL:     "https://mcp.example.com/mcp",
+			wantAccess: shadowMCPInventoryAccessNone,
 		},
 		{
 			name: "no matching url rule returns no access state",
@@ -111,12 +105,11 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 					},
 				})
 			},
-			rawURL:        "https://mcp.example.com/mcp",
-			wantExplicit:  shadowMCPInventoryAccessNone,
-			wantEffective: shadowMCPInventoryAccessNone,
+			rawURL:     "https://mcp.example.com/mcp",
+			wantAccess: shadowMCPInventoryAccessNone,
 		},
 		{
-			name: "server identity rule with matching observed url is explanatory only",
+			name: "server identity rule does not set inventory url access state",
 			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
 				t.Helper()
 
@@ -133,10 +126,8 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 					},
 				})
 			},
-			rawURL:              "https://mcp.example.com/mcp",
-			wantExplicit:        shadowMCPInventoryAccessNone,
-			wantEffective:       shadowMCPInventoryAccessNone,
-			wantExplanatoryRule: "Notion identity allow",
+			rawURL:     "https://mcp.example.com/mcp",
+			wantAccess: shadowMCPInventoryAccessNone,
 		},
 		{
 			name: "deny wins over matching allow",
@@ -168,10 +159,9 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 					},
 				})
 			},
-			rawURL:            "https://mcp.example.com/mcp",
-			wantExplicit:      shadowMCPInventoryAccessAllowed,
-			wantEffective:     shadowMCPInventoryAccessDenied,
-			wantEffectiveRule: "Org host deny",
+			rawURL:       "https://mcp.example.com/mcp",
+			wantAccess:   shadowMCPInventoryAccessAllowed,
+			wantRuleName: "Project allow",
 		},
 	}
 
@@ -189,19 +179,12 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 
 			got, err := ti.service.resolveShadowMCPInventoryAccessState(ctx, authCtx.ActiveOrganizationID, projectID, inventoryURL)
 			require.NoError(t, err)
-			require.Equal(t, tt.wantExplicit, got.ExplicitDisposition)
-			require.Equal(t, tt.wantEffective, got.EffectiveDisposition)
-			if tt.wantEffectiveRule == "" {
-				require.Nil(t, got.EffectiveRule)
+			require.Equal(t, tt.wantAccess, got.Access)
+			if tt.wantRuleName == "" {
+				require.Nil(t, got.Rule)
 			} else {
-				require.NotNil(t, got.EffectiveRule)
-				require.Equal(t, tt.wantEffectiveRule, got.EffectiveRule.DisplayName)
-			}
-			if tt.wantExplanatoryRule == "" {
-				require.Empty(t, got.ExplanatoryRules)
-			} else {
-				require.Len(t, got.ExplanatoryRules, 1)
-				require.Equal(t, tt.wantExplanatoryRule, got.ExplanatoryRules[0].DisplayName)
+				require.NotNil(t, got.Rule)
+				require.Equal(t, tt.wantRuleName, got.Rule.DisplayName)
 			}
 		})
 	}

--- a/server/internal/access/shadow_mcp_access_state_test.go
+++ b/server/internal/access/shadow_mcp_access_state_test.go
@@ -130,7 +130,7 @@ func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
 			wantAccess: shadowMCPInventoryAccessNone,
 		},
 		{
-			name: "deny wins over matching allow",
+			name: "host rule does not override matching full url allow",
 			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
 				t.Helper()
 

--- a/server/internal/access/shadow_mcp_access_state_test.go
+++ b/server/internal/access/shadow_mcp_access_state_test.go
@@ -1,0 +1,229 @@
+package access
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/accesscontrol"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+)
+
+func TestResolveShadowMCPInventoryAccessState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		rules               func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string)
+		rawURL              string
+		wantExplicit        string
+		wantEffective       string
+		wantEffectiveRule   string
+		wantExplanatoryRule string
+	}{
+		{
+			name: "exact project full url allow is explicit and effective",
+			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
+				t.Helper()
+
+				createShadowMCPInventoryAccessStateRule(t, ctx, ti, accesscontrol.AccessRule{
+					OrganizationID: orgID,
+					ProjectID:      projectID,
+					AccessScope:    accesscontrol.AccessScopeProject,
+					Disposition:    accesscontrol.DispositionAllowed,
+					MatchKind:      accesscontrol.MatchKindFullURL,
+					MatchValue:     "https://mcp.example.com/mcp",
+					DisplayName:    "Project allow",
+					ObservedSummary: accesscontrol.ObservedSummary{
+						FullURL: new("https://mcp.example.com/mcp"),
+					},
+				})
+			},
+			rawURL:            "https://mcp.example.com/mcp?token=secret",
+			wantExplicit:      shadowMCPInventoryAccessAllowed,
+			wantEffective:     shadowMCPInventoryAccessAllowed,
+			wantEffectiveRule: "Project allow",
+		},
+		{
+			name: "exact project full url deny is explicit and effective",
+			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
+				t.Helper()
+
+				createShadowMCPInventoryAccessStateRule(t, ctx, ti, accesscontrol.AccessRule{
+					OrganizationID: orgID,
+					ProjectID:      projectID,
+					AccessScope:    accesscontrol.AccessScopeProject,
+					Disposition:    accesscontrol.DispositionDenied,
+					MatchKind:      accesscontrol.MatchKindFullURL,
+					MatchValue:     "https://mcp.example.com/mcp",
+					DisplayName:    "Project deny",
+					ObservedSummary: accesscontrol.ObservedSummary{
+						FullURL: new("https://mcp.example.com/mcp"),
+					},
+				})
+			},
+			rawURL:            "https://mcp.example.com/mcp",
+			wantExplicit:      shadowMCPInventoryAccessDenied,
+			wantEffective:     shadowMCPInventoryAccessDenied,
+			wantEffectiveRule: "Project deny",
+		},
+		{
+			name: "host level organization deny is effective inherited state",
+			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
+				t.Helper()
+
+				createShadowMCPInventoryAccessStateRule(t, ctx, ti, accesscontrol.AccessRule{
+					OrganizationID: orgID,
+					ProjectID:      "",
+					AccessScope:    accesscontrol.AccessScopeOrganization,
+					Disposition:    accesscontrol.DispositionDenied,
+					MatchKind:      accesscontrol.MatchKindURLHost,
+					MatchValue:     "mcp.example.com",
+					DisplayName:    "Org host deny",
+					ObservedSummary: accesscontrol.ObservedSummary{
+						URLHost: new("mcp.example.com"),
+					},
+				})
+			},
+			rawURL:            "https://mcp.example.com/mcp",
+			wantExplicit:      shadowMCPInventoryAccessNone,
+			wantEffective:     shadowMCPInventoryAccessDenied,
+			wantEffectiveRule: "Org host deny",
+		},
+		{
+			name: "no matching url rule returns no access state",
+			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
+				t.Helper()
+
+				createShadowMCPInventoryAccessStateRule(t, ctx, ti, accesscontrol.AccessRule{
+					OrganizationID: orgID,
+					ProjectID:      projectID,
+					AccessScope:    accesscontrol.AccessScopeProject,
+					Disposition:    accesscontrol.DispositionAllowed,
+					MatchKind:      accesscontrol.MatchKindFullURL,
+					MatchValue:     "https://other.example.com/mcp",
+					DisplayName:    "Other allow",
+					ObservedSummary: accesscontrol.ObservedSummary{
+						FullURL: new("https://other.example.com/mcp"),
+					},
+				})
+			},
+			rawURL:        "https://mcp.example.com/mcp",
+			wantExplicit:  shadowMCPInventoryAccessNone,
+			wantEffective: shadowMCPInventoryAccessNone,
+		},
+		{
+			name: "server identity rule with matching observed url is explanatory only",
+			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
+				t.Helper()
+
+				createShadowMCPInventoryAccessStateRule(t, ctx, ti, accesscontrol.AccessRule{
+					OrganizationID: orgID,
+					ProjectID:      projectID,
+					AccessScope:    accesscontrol.AccessScopeProject,
+					Disposition:    accesscontrol.DispositionAllowed,
+					MatchKind:      accesscontrol.MatchKindServerIdentity,
+					MatchValue:     "notion",
+					DisplayName:    "Notion identity allow",
+					ObservedSummary: accesscontrol.ObservedSummary{
+						FullURL: new("https://mcp.example.com/mcp"),
+					},
+				})
+			},
+			rawURL:              "https://mcp.example.com/mcp",
+			wantExplicit:        shadowMCPInventoryAccessNone,
+			wantEffective:       shadowMCPInventoryAccessNone,
+			wantExplanatoryRule: "Notion identity allow",
+		},
+		{
+			name: "deny wins over matching allow",
+			rules: func(t *testing.T, ctx context.Context, ti *testInstance, orgID string, projectID string) {
+				t.Helper()
+
+				createShadowMCPInventoryAccessStateRule(t, ctx, ti, accesscontrol.AccessRule{
+					OrganizationID: orgID,
+					ProjectID:      projectID,
+					AccessScope:    accesscontrol.AccessScopeProject,
+					Disposition:    accesscontrol.DispositionAllowed,
+					MatchKind:      accesscontrol.MatchKindFullURL,
+					MatchValue:     "https://mcp.example.com/mcp",
+					DisplayName:    "Project allow",
+					ObservedSummary: accesscontrol.ObservedSummary{
+						FullURL: new("https://mcp.example.com/mcp"),
+					},
+				})
+				createShadowMCPInventoryAccessStateRule(t, ctx, ti, accesscontrol.AccessRule{
+					OrganizationID: orgID,
+					ProjectID:      "",
+					AccessScope:    accesscontrol.AccessScopeOrganization,
+					Disposition:    accesscontrol.DispositionDenied,
+					MatchKind:      accesscontrol.MatchKindURLHost,
+					MatchValue:     "mcp.example.com",
+					DisplayName:    "Org host deny",
+					ObservedSummary: accesscontrol.ObservedSummary{
+						URLHost: new("mcp.example.com"),
+					},
+				})
+			},
+			rawURL:            "https://mcp.example.com/mcp",
+			wantExplicit:      shadowMCPInventoryAccessAllowed,
+			wantEffective:     shadowMCPInventoryAccessDenied,
+			wantEffectiveRule: "Org host deny",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, ti := newTestAccessService(t)
+			authCtx := testAccessAuthContext(t, ctx)
+			projectID := authCtx.ProjectID.String()
+			tt.rules(t, ctx, ti, authCtx.ActiveOrganizationID, projectID)
+
+			inventoryURL, ok := shadowmcp.CanonicalizeInventoryURL(tt.rawURL)
+			require.True(t, ok)
+
+			got, err := ti.service.resolveShadowMCPInventoryAccessState(ctx, authCtx.ActiveOrganizationID, projectID, inventoryURL)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantExplicit, got.ExplicitDisposition)
+			require.Equal(t, tt.wantEffective, got.EffectiveDisposition)
+			if tt.wantEffectiveRule == "" {
+				require.Nil(t, got.EffectiveRule)
+			} else {
+				require.NotNil(t, got.EffectiveRule)
+				require.Equal(t, tt.wantEffectiveRule, got.EffectiveRule.DisplayName)
+			}
+			if tt.wantExplanatoryRule == "" {
+				require.Empty(t, got.ExplanatoryRules)
+			} else {
+				require.Len(t, got.ExplanatoryRules, 1)
+				require.Equal(t, tt.wantExplanatoryRule, got.ExplanatoryRules[0].DisplayName)
+			}
+		})
+	}
+}
+
+func createShadowMCPInventoryAccessStateRule(t *testing.T, ctx context.Context, ti *testInstance, rule accesscontrol.AccessRule) accesscontrol.AccessRule {
+	t.Helper()
+
+	now := time.Now().UTC()
+	if rule.ID == "" {
+		rule.ID = uuid.NewString()
+	}
+	if rule.ResourceType == "" {
+		rule.ResourceType = accesscontrol.ResourceTypeShadowMCP
+	}
+	if rule.CreatedAt.IsZero() {
+		rule.CreatedAt = now
+	}
+	if rule.UpdatedAt.IsZero() {
+		rule.UpdatedAt = now
+	}
+	created, err := ti.service.accessStore.CreateRule(ctx, rule)
+	require.NoError(t, err)
+	return created
+}

--- a/server/internal/shadowmcp/inventory_url.go
+++ b/server/internal/shadowmcp/inventory_url.go
@@ -1,6 +1,7 @@
 package shadowmcp
 
 import (
+	"net"
 	"net/url"
 	"strings"
 )
@@ -28,9 +29,14 @@ func CanonicalizeInventoryURL(raw string) (InventoryURL, bool) {
 	}
 
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	parsed.Host = NormalizeURLHost(parsed.Scheme, parsed.Host)
+	normalizedHost := NormalizeURLHost(parsed.Scheme, parsed.Host)
+	parsed.Host = normalizedHost
+	if strings.Contains(normalizedHost, ":") && net.ParseIP(normalizedHost) != nil {
+		parsed.Host = "[" + normalizedHost + "]"
+	}
 	parsed.User = nil
 	parsed.RawQuery = ""
+	parsed.ForceQuery = false
 	parsed.Fragment = ""
 	sanitized := parsed.String()
 
@@ -44,7 +50,7 @@ func CanonicalizeInventoryURL(raw string) (InventoryURL, bool) {
 
 	return InventoryURL{
 		CanonicalURL: canonical,
-		URLHost:      NormalizeURLHost(parsed.Scheme, parsed.Host),
+		URLHost:      normalizedHost,
 	}, true
 }
 

--- a/server/internal/shadowmcp/inventory_url.go
+++ b/server/internal/shadowmcp/inventory_url.go
@@ -1,0 +1,57 @@
+package shadowmcp
+
+import (
+	"net/url"
+	"strings"
+)
+
+type InventoryURL struct {
+	CanonicalURL string
+	URLHost      string
+}
+
+func CanonicalizeInventoryURL(raw string) (InventoryURL, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return InventoryURL{
+			CanonicalURL: "",
+			URLHost:      "",
+		}, false
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return InventoryURL{
+			CanonicalURL: "",
+			URLHost:      "",
+		}, false
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = NormalizeURLHost(parsed.Scheme, parsed.Host)
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	sanitized := parsed.String()
+
+	canonical, err := NormalizeMatchValue(MatchBreadthFullURL, sanitized)
+	if err != nil {
+		return InventoryURL{
+			CanonicalURL: "",
+			URLHost:      "",
+		}, false
+	}
+
+	return InventoryURL{
+		CanonicalURL: canonical,
+		URLHost:      NormalizeURLHost(parsed.Scheme, parsed.Host),
+	}, true
+}
+
+func AccessEvidenceForInventoryURL(value InventoryURL) AccessEvidence {
+	return AccessEvidence{
+		FullURL:        value.CanonicalURL,
+		URLHost:        value.URLHost,
+		ServerIdentity: "",
+	}
+}

--- a/server/internal/shadowmcp/inventory_url_test.go
+++ b/server/internal/shadowmcp/inventory_url_test.go
@@ -36,6 +36,24 @@ func TestCanonicalizeInventoryURL(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name: "strips empty force query",
+			raw:  "https://mcp.speakeasy.com/mcp?",
+			want: shadowmcp.InventoryURL{
+				CanonicalURL: "https://mcp.speakeasy.com/mcp",
+				URLHost:      "mcp.speakeasy.com",
+			},
+			wantOK: true,
+		},
+		{
+			name: "strips default port from ipv6 host",
+			raw:  "https://[2001:db8::1]:443/mcp",
+			want: shadowmcp.InventoryURL{
+				CanonicalURL: "https://[2001:db8::1]/mcp",
+				URLHost:      "2001:db8::1",
+			},
+			wantOK: true,
+		},
+		{
 			name:   "rejects stdio command",
 			raw:    "node ./server.js",
 			wantOK: false,

--- a/server/internal/shadowmcp/inventory_url_test.go
+++ b/server/internal/shadowmcp/inventory_url_test.go
@@ -1,0 +1,72 @@
+package shadowmcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+)
+
+func TestCanonicalizeInventoryURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		raw    string
+		want   shadowmcp.InventoryURL
+		wantOK bool
+	}{
+		{
+			name: "strips query and fragment",
+			raw:  "HTTPS://MCP.Speakeasy.COM:443/mcp?token=secret#frag",
+			want: shadowmcp.InventoryURL{
+				CanonicalURL: "https://mcp.speakeasy.com/mcp",
+				URLHost:      "mcp.speakeasy.com",
+			},
+			wantOK: true,
+		},
+		{
+			name: "sanitizes embedded credentials",
+			raw:  "https://user:pass@MCP.Speakeasy.COM:443/mcp?token=secret#frag",
+			want: shadowmcp.InventoryURL{
+				CanonicalURL: "https://mcp.speakeasy.com/mcp",
+				URLHost:      "mcp.speakeasy.com",
+			},
+			wantOK: true,
+		},
+		{
+			name:   "rejects stdio command",
+			raw:    "node ./server.js",
+			wantOK: false,
+		},
+		{
+			name:   "rejects url without host",
+			raw:    "https:///mcp",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := shadowmcp.CanonicalizeInventoryURL(tt.raw)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAccessEvidenceForInventoryURL(t *testing.T) {
+	t.Parallel()
+
+	evidence := shadowmcp.AccessEvidenceForInventoryURL(shadowmcp.InventoryURL{
+		CanonicalURL: "https://mcp.speakeasy.com/mcp",
+		URLHost:      "mcp.speakeasy.com",
+	})
+
+	require.Equal(t, "https://mcp.speakeasy.com/mcp", evidence.FullURL)
+	require.Equal(t, "mcp.speakeasy.com", evidence.URLHost)
+	require.Empty(t, evidence.ServerIdentity)
+}

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -263,6 +264,7 @@ type UpsertShadowMCPInventoryURLParams struct {
 type ListShadowMCPInventoryURLsParams struct {
 	GramProjectID string
 	Limit         int
+	Cursor        string
 }
 
 type ShadowMCPInventoryURLRow struct {
@@ -316,6 +318,45 @@ type shadowMCPInventoryURLUpsert struct {
 	FirstSeen          time.Time
 	LastSeen           time.Time
 	UpdatedAt          time.Time
+}
+
+type shadowMCPInventoryURLCursor struct {
+	CanonicalServerURL string `json:"canonical_server_url"`
+	LastSeenUnixNano   int64  `json:"last_seen_unix_nano"`
+}
+
+func EncodeShadowMCPInventoryURLCursor(row ShadowMCPInventoryURLRow) (string, error) {
+	payload := shadowMCPInventoryURLCursor{
+		CanonicalServerURL: row.CanonicalServerURL,
+		LastSeenUnixNano:   row.LastSeen.UTC().UnixNano(),
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encoding shadow mcp inventory url cursor: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodeShadowMCPInventoryURLCursor(cursor string) (shadowMCPInventoryURLCursor, error) {
+	data, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return shadowMCPInventoryURLCursor{}, fmt.Errorf("decoding shadow mcp inventory url cursor: %w", err)
+	}
+
+	var payload shadowMCPInventoryURLCursor
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return shadowMCPInventoryURLCursor{}, fmt.Errorf("parsing shadow mcp inventory url cursor: %w", err)
+	}
+	if payload.CanonicalServerURL == "" {
+		return shadowMCPInventoryURLCursor{}, fmt.Errorf("shadow mcp inventory url cursor canonical server url is required")
+	}
+	if payload.LastSeenUnixNano == 0 {
+		return shadowMCPInventoryURLCursor{}, fmt.Errorf("shadow mcp inventory url cursor last seen is required")
+	}
+
+	return payload, nil
 }
 
 func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []UpsertShadowMCPInventoryURLParams) error {
@@ -487,7 +528,16 @@ func (q *Queries) getShadowMCPInventoryURL(ctx context.Context, projectID string
 
 func (q *Queries) ListShadowMCPInventoryURLs(ctx context.Context, arg ListShadowMCPInventoryURLsParams) ([]ShadowMCPInventoryURLRow, error) {
 	limit := clampShadowMCPInventoryLimit(arg.Limit)
-	sb := sq.Select(
+	var cursor shadowMCPInventoryURLCursor
+	if arg.Cursor != "" {
+		var err error
+		cursor, err = decodeShadowMCPInventoryURLCursor(arg.Cursor)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	inventoryRows := sq.Select(
 		"canonical_server_url",
 		"max(url_host) AS url_host",
 		"argMaxIf(server_name, updated_at, server_name != '') AS server_name",
@@ -496,9 +546,30 @@ func (q *Queries) ListShadowMCPInventoryURLs(ctx context.Context, arg ListShadow
 	).
 		From("shadow_mcp_inventory_urls").
 		Where("gram_project_id = ?", arg.GramProjectID).
-		GroupBy("gram_project_id", "canonical_server_url").
-		OrderBy("last_seen DESC", "canonical_server_url ASC").
+		GroupBy("gram_project_id", "canonical_server_url")
+
+	sb := sq.Select(
+		"canonical_server_url",
+		"url_host",
+		"server_name",
+		"first_seen",
+		"last_seen",
+	).
+		FromSelect(inventoryRows, "inventory_urls").
 		Limit(limit)
+
+	if arg.Cursor != "" {
+		lastSeen := time.Unix(0, cursor.LastSeenUnixNano).UTC()
+		sb = sb.Where(squirrel.Or{
+			squirrel.Expr("last_seen < ?", lastSeen),
+			squirrel.And{
+				squirrel.Expr("last_seen = ?", lastSeen),
+				squirrel.Expr("canonical_server_url > ?", cursor.CanonicalServerURL),
+			},
+		})
+	}
+
+	sb = sb.OrderBy("last_seen DESC", "canonical_server_url ASC")
 
 	query, queryArgs, err := sb.ToSql()
 	if err != nil {

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -5,12 +5,15 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/Masterminds/squirrel"
+
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 )
 
 // validJSONPath matches safe dot-separated JSON paths for ClickHouse attribute access.
@@ -185,8 +188,6 @@ func (q *Queries) InsertTelemetryLog(ctx context.Context, arg InsertTelemetryLog
 
 // InsertTelemetryLogs inserts telemetry log records into ClickHouse in a single
 // synchronous statement.
-//
-//nolint:wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
 func (q *Queries) InsertTelemetryLogs(ctx context.Context, args []InsertTelemetryLogParams) error {
 	if len(args) == 0 {
 		return nil
@@ -241,7 +242,490 @@ func (q *Queries) InsertTelemetryLogs(ctx context.Context, args []InsertTelemetr
 		return fmt.Errorf("building insert query: %w", err)
 	}
 
-	return q.conn.Exec(ctx, query, queryArgs...)
+	if err := q.conn.Exec(ctx, query, queryArgs...); err != nil {
+		return fmt.Errorf("inserting telemetry logs: %w", err)
+	}
+
+	return nil
+}
+
+type UpsertShadowMCPInventoryURLParams struct {
+	GramProjectID      string
+	CanonicalServerURL string
+	URLHost            string
+	ServerName         string
+	SeenAt             time.Time
+	FirstSeen          time.Time
+	LastSeen           time.Time
+	UpdatedAt          time.Time
+}
+
+type ListShadowMCPInventoryURLsParams struct {
+	GramProjectID string
+	Limit         int
+}
+
+type ShadowMCPInventoryURLRow struct {
+	CanonicalServerURL string    `ch:"canonical_server_url"`
+	URLHost            string    `ch:"url_host"`
+	ServerName         string    `ch:"server_name"`
+	FirstSeen          time.Time `ch:"first_seen"`
+	LastSeen           time.Time `ch:"last_seen"`
+}
+
+type ListShadowMCPInventoryUsageParams struct {
+	GramProjectID string
+	Limit         int
+}
+
+type ShadowMCPInventoryUsageRow struct {
+	CanonicalServerURL string
+	ServerName         string
+	FirstCalled        *time.Time
+	LastCalled         *time.Time
+	CallCount          uint64
+	UserCount          uint64
+	TopUsers           []string
+}
+
+type ListShadowMCPInventoryUsersParams struct {
+	GramProjectID      string
+	CanonicalServerURL string
+	Limit              int
+}
+
+type ShadowMCPInventoryUserRow struct {
+	UserKey    string
+	LastCalled time.Time
+	CallCount  uint64
+}
+
+type shadowMCPInventoryTraceUsageRow struct {
+	TraceID    string    `ch:"trace_id"`
+	ServerURL  string    `ch:"server_url"`
+	ServerName string    `ch:"server_name"`
+	UserKey    string    `ch:"user_key"`
+	CalledAt   time.Time `ch:"called_at"`
+}
+
+type shadowMCPInventoryURLUpsert struct {
+	GramProjectID      string
+	CanonicalServerURL string
+	URLHost            string
+	ServerName         string
+	FirstSeen          time.Time
+	LastSeen           time.Time
+	UpdatedAt          time.Time
+}
+
+func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []UpsertShadowMCPInventoryURLParams) error {
+	if len(args) == 0 {
+		return nil
+	}
+
+	upserts := make(map[string]*shadowMCPInventoryURLUpsert, len(args))
+	for _, arg := range args {
+		if arg.GramProjectID == "" || arg.CanonicalServerURL == "" {
+			continue
+		}
+		seenAt := arg.SeenAt
+		if seenAt.IsZero() {
+			seenAt = time.Now()
+		}
+		firstSeen := arg.FirstSeen
+		if firstSeen.IsZero() {
+			firstSeen = seenAt
+		}
+		lastSeen := arg.LastSeen
+		if lastSeen.IsZero() {
+			lastSeen = seenAt
+		}
+		if lastSeen.Before(firstSeen) {
+			firstSeen, lastSeen = lastSeen, firstSeen
+		}
+		updatedAt := arg.UpdatedAt
+		if updatedAt.IsZero() {
+			updatedAt = time.Now()
+		}
+
+		key := arg.GramProjectID + "\x00" + arg.CanonicalServerURL
+		upsert := upserts[key]
+		if upsert == nil {
+			upsert = &shadowMCPInventoryURLUpsert{
+				GramProjectID:      arg.GramProjectID,
+				CanonicalServerURL: arg.CanonicalServerURL,
+				URLHost:            arg.URLHost,
+				ServerName:         arg.ServerName,
+				FirstSeen:          firstSeen.UTC(),
+				LastSeen:           lastSeen.UTC(),
+				UpdatedAt:          updatedAt.UTC(),
+			}
+			upserts[key] = upsert
+			continue
+		}
+		if upsert.URLHost == "" {
+			upsert.URLHost = arg.URLHost
+		}
+		if arg.ServerName != "" {
+			upsert.ServerName = arg.ServerName
+		}
+		if firstSeen.Before(upsert.FirstSeen) {
+			upsert.FirstSeen = firstSeen.UTC()
+		}
+		if lastSeen.After(upsert.LastSeen) {
+			upsert.LastSeen = lastSeen.UTC()
+		}
+		if updatedAt.After(upsert.UpdatedAt) {
+			upsert.UpdatedAt = updatedAt.UTC()
+		}
+	}
+
+	if len(upserts) == 0 {
+		return nil
+	}
+
+	for _, upsert := range upserts {
+		existing, err := q.getShadowMCPInventoryURL(ctx, upsert.GramProjectID, upsert.CanonicalServerURL)
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			continue
+		}
+		if upsert.URLHost == "" {
+			upsert.URLHost = existing.URLHost
+		}
+		if upsert.ServerName == "" {
+			upsert.ServerName = existing.ServerName
+		}
+		if existing.FirstSeen.Before(upsert.FirstSeen) {
+			upsert.FirstSeen = existing.FirstSeen
+		}
+		if existing.LastSeen.After(upsert.LastSeen) {
+			upsert.LastSeen = existing.LastSeen
+		}
+	}
+
+	ctx = clickhouse.Context(ctx, clickhouse.WithAsync(false))
+	builder := sq.Insert("shadow_mcp_inventory_urls").
+		Columns(
+			"gram_project_id",
+			"canonical_server_url",
+			"url_host",
+			"server_name",
+			"first_seen",
+			"last_seen",
+			"updated_at",
+		)
+
+	for _, upsert := range upserts {
+		builder = builder.Values(
+			upsert.GramProjectID,
+			upsert.CanonicalServerURL,
+			upsert.URLHost,
+			upsert.ServerName,
+			upsert.FirstSeen.UTC(),
+			upsert.LastSeen.UTC(),
+			upsert.UpdatedAt.UTC(),
+		)
+	}
+
+	query, queryArgs, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("building shadow mcp inventory url upsert query: %w", err)
+	}
+
+	if err := q.conn.Exec(ctx, query, queryArgs...); err != nil {
+		return fmt.Errorf("upserting shadow mcp inventory urls: %w", err)
+	}
+
+	return nil
+}
+
+func (q *Queries) getShadowMCPInventoryURL(ctx context.Context, projectID string, canonicalURL string) (*ShadowMCPInventoryURLRow, error) {
+	sb := sq.Select(
+		"canonical_server_url",
+		"max(url_host) AS url_host",
+		"argMaxIf(server_name, updated_at, server_name != '') AS server_name",
+		"min(first_seen) AS first_seen",
+		"max(last_seen) AS last_seen",
+	).
+		From("shadow_mcp_inventory_urls").
+		Where("gram_project_id = ?", projectID).
+		Where("canonical_server_url = ?", canonicalURL).
+		GroupBy("gram_project_id", "canonical_server_url").
+		Limit(1)
+
+	query, queryArgs, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building shadow mcp inventory url lookup query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("querying shadow mcp inventory url lookup: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterating shadow mcp inventory url lookup rows: %w", err)
+		}
+		return nil, nil
+	}
+
+	var row ShadowMCPInventoryURLRow
+	if err := rows.ScanStruct(&row); err != nil {
+		return nil, fmt.Errorf("scanning shadow mcp inventory url lookup row: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating shadow mcp inventory url lookup rows: %w", err)
+	}
+
+	return &row, nil
+}
+
+func (q *Queries) ListShadowMCPInventoryURLs(ctx context.Context, arg ListShadowMCPInventoryURLsParams) ([]ShadowMCPInventoryURLRow, error) {
+	limit := clampShadowMCPInventoryLimit(arg.Limit)
+	sb := sq.Select(
+		"canonical_server_url",
+		"max(url_host) AS url_host",
+		"argMaxIf(server_name, updated_at, server_name != '') AS server_name",
+		"min(first_seen) AS first_seen",
+		"max(last_seen) AS last_seen",
+	).
+		From("shadow_mcp_inventory_urls").
+		Where("gram_project_id = ?", arg.GramProjectID).
+		GroupBy("gram_project_id", "canonical_server_url").
+		OrderBy("last_seen DESC", "canonical_server_url ASC").
+		Limit(limit)
+
+	query, queryArgs, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building shadow mcp inventory url query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("querying shadow mcp inventory urls: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	inventoryURLs := make([]ShadowMCPInventoryURLRow, 0)
+	for rows.Next() {
+		var row ShadowMCPInventoryURLRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return nil, fmt.Errorf("scanning shadow mcp inventory url row: %w", err)
+		}
+		inventoryURLs = append(inventoryURLs, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating shadow mcp inventory url rows: %w", err)
+	}
+
+	return inventoryURLs, nil
+}
+
+func (q *Queries) ListShadowMCPInventoryUsage(ctx context.Context, arg ListShadowMCPInventoryUsageParams) ([]ShadowMCPInventoryUsageRow, error) {
+	traceRows, err := q.listShadowMCPInventoryTraceUsage(ctx, arg.GramProjectID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+
+	usageByURL := make(map[string]*ShadowMCPInventoryUsageRow)
+	usersByURL := make(map[string]map[string]*ShadowMCPInventoryUserRow)
+	for _, traceRow := range traceRows {
+		invURL, ok := shadowmcp.CanonicalizeInventoryURL(traceRow.ServerURL)
+		if !ok {
+			continue
+		}
+		usage := usageByURL[invURL.CanonicalURL]
+		if usage == nil {
+			firstCalled := traceRow.CalledAt
+			lastCalled := traceRow.CalledAt
+			usage = &ShadowMCPInventoryUsageRow{
+				CanonicalServerURL: invURL.CanonicalURL,
+				ServerName:         traceRow.ServerName,
+				FirstCalled:        &firstCalled,
+				LastCalled:         &lastCalled,
+				CallCount:          0,
+				UserCount:          0,
+				TopUsers:           nil,
+			}
+			usageByURL[invURL.CanonicalURL] = usage
+		}
+		if traceRow.ServerName != "" {
+			usage.ServerName = traceRow.ServerName
+		}
+		if usage.FirstCalled == nil || traceRow.CalledAt.Before(*usage.FirstCalled) {
+			firstCalled := traceRow.CalledAt
+			usage.FirstCalled = &firstCalled
+		}
+		if usage.LastCalled == nil || traceRow.CalledAt.After(*usage.LastCalled) {
+			lastCalled := traceRow.CalledAt
+			usage.LastCalled = &lastCalled
+		}
+		usage.CallCount++
+
+		if traceRow.UserKey == "" {
+			continue
+		}
+		users := usersByURL[invURL.CanonicalURL]
+		if users == nil {
+			users = make(map[string]*ShadowMCPInventoryUserRow)
+			usersByURL[invURL.CanonicalURL] = users
+		}
+		user := users[traceRow.UserKey]
+		if user == nil {
+			user = &ShadowMCPInventoryUserRow{
+				UserKey:    traceRow.UserKey,
+				LastCalled: traceRow.CalledAt,
+				CallCount:  0,
+			}
+			users[traceRow.UserKey] = user
+		}
+		user.CallCount++
+		if traceRow.CalledAt.After(user.LastCalled) {
+			user.LastCalled = traceRow.CalledAt
+		}
+	}
+
+	usageRows := make([]ShadowMCPInventoryUsageRow, 0, len(usageByURL))
+	for canonicalURL, usage := range usageByURL {
+		users := sortedShadowMCPInventoryUsers(usersByURL[canonicalURL])
+		usage.UserCount = uint64(len(users))
+		topUsers := make([]string, 0, min(len(users), 5))
+		for i := 0; i < len(users) && i < 5; i++ {
+			topUsers = append(topUsers, users[i].UserKey)
+		}
+		usage.TopUsers = topUsers
+		usageRows = append(usageRows, *usage)
+	}
+	sort.Slice(usageRows, func(i, j int) bool {
+		return usageRows[i].CanonicalServerURL < usageRows[j].CanonicalServerURL
+	})
+
+	return usageRows, nil
+}
+
+func (q *Queries) ListShadowMCPInventoryUsers(ctx context.Context, arg ListShadowMCPInventoryUsersParams) ([]ShadowMCPInventoryUserRow, error) {
+	traceRows, err := q.listShadowMCPInventoryTraceUsage(ctx, arg.GramProjectID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+
+	users := make(map[string]*ShadowMCPInventoryUserRow)
+	for _, traceRow := range traceRows {
+		invURL, ok := shadowmcp.CanonicalizeInventoryURL(traceRow.ServerURL)
+		if !ok || invURL.CanonicalURL != arg.CanonicalServerURL || traceRow.UserKey == "" {
+			continue
+		}
+		user := users[traceRow.UserKey]
+		if user == nil {
+			user = &ShadowMCPInventoryUserRow{
+				UserKey:    traceRow.UserKey,
+				LastCalled: traceRow.CalledAt,
+				CallCount:  0,
+			}
+			users[traceRow.UserKey] = user
+		}
+		user.CallCount++
+		if traceRow.CalledAt.After(user.LastCalled) {
+			user.LastCalled = traceRow.CalledAt
+		}
+	}
+
+	userRows := sortedShadowMCPInventoryUsers(users)
+	limit := clampShadowMCPInventoryLimitInt(arg.Limit)
+	if len(userRows) > limit {
+		userRows = userRows[:limit]
+	}
+	return userRows, nil
+}
+
+func (q *Queries) listShadowMCPInventoryTraceUsage(ctx context.Context, projectID string, limit int) ([]shadowMCPInventoryTraceUsageRow, error) {
+	queryLimit := clampShadowMCPInventoryUsageTraceLimit(limit)
+	sb := sq.Select(
+		"trace_id",
+		"max(mcp_server_url) AS server_url",
+		"max(tool_source) AS server_name",
+		"if(max(user_email) != '', max(user_email), max(user_id)) AS user_key",
+		"fromUnixTimestamp64Nano(max(start_time_unix_nano)) AS called_at",
+	).
+		From("trace_summaries").
+		Where("gram_project_id = ?", projectID).
+		GroupBy("trace_id").
+		Having("server_url != ''").
+		OrderBy("max(start_time_unix_nano) DESC", "trace_id ASC").
+		Limit(queryLimit)
+
+	query, queryArgs, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building shadow mcp inventory trace usage query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("querying shadow mcp inventory trace usage: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	traceRows := make([]shadowMCPInventoryTraceUsageRow, 0)
+	for rows.Next() {
+		var row shadowMCPInventoryTraceUsageRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return nil, fmt.Errorf("scanning shadow mcp inventory trace usage row: %w", err)
+		}
+		traceRows = append(traceRows, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating shadow mcp inventory trace usage rows: %w", err)
+	}
+
+	return traceRows, nil
+}
+
+func sortedShadowMCPInventoryUsers(users map[string]*ShadowMCPInventoryUserRow) []ShadowMCPInventoryUserRow {
+	userRows := make([]ShadowMCPInventoryUserRow, 0, len(users))
+	for _, user := range users {
+		userRows = append(userRows, *user)
+	}
+	sort.Slice(userRows, func(i, j int) bool {
+		if userRows[i].CallCount != userRows[j].CallCount {
+			return userRows[i].CallCount > userRows[j].CallCount
+		}
+		if !userRows[i].LastCalled.Equal(userRows[j].LastCalled) {
+			return userRows[i].LastCalled.After(userRows[j].LastCalled)
+		}
+		return userRows[i].UserKey < userRows[j].UserKey
+	})
+	return userRows
+}
+
+func clampShadowMCPInventoryLimit(limit int) uint64 {
+	return uint64(clampShadowMCPInventoryLimitInt(limit)) // #nosec G115 -- clamped to 1..500 by clampShadowMCPInventoryLimitInt.
+}
+
+func clampShadowMCPInventoryLimitInt(limit int) int {
+	switch {
+	case limit <= 0:
+		return 50
+	case limit > 500:
+		return 500
+	default:
+		return limit
+	}
+}
+
+func clampShadowMCPInventoryUsageTraceLimit(limit int) uint64 {
+	switch {
+	case limit <= 0:
+		return 5000
+	case limit > 50000:
+		return 50000
+	default:
+		return uint64(limit)
+	}
 }
 
 // ListTelemetryLogsParams contains the parameters for listing telemetry logs.

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -57,6 +57,7 @@ type testInstance struct {
 	chClient           *repo.Queries
 	sessionManager     *sessions.Manager
 	orgID              string
+	projectID          string
 	disabledLogsOrgID  string
 	enabledToolIOOrgID string
 }
@@ -125,6 +126,7 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 		chClient:           chClient,
 		sessionManager:     sessionManager,
 		orgID:              authCtx.ActiveOrganizationID,
+		projectID:          authCtx.ProjectID.String(),
 		disabledLogsOrgID:  disabledLogsOrgID,
 		enabledToolIOOrgID: enabledToolIOOrgID,
 	}

--- a/server/internal/telemetry/shadow_mcp_inventory.go
+++ b/server/internal/telemetry/shadow_mcp_inventory.go
@@ -2,8 +2,16 @@ package telemetry
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/url"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
@@ -17,8 +25,9 @@ type ShadowMCPInventoryURL struct {
 }
 
 type BackfillShadowMCPInventoryURLsParams struct {
-	GramProjectID string
-	Limit         int
+	GramProjectID      string
+	Limit              int
+	HostedMCPHostnames []string
 }
 
 type BackfillShadowMCPInventoryURLsResult struct {
@@ -69,6 +78,10 @@ func (s *Service) BackfillShadowMCPInventoryURLs(ctx context.Context, params Bac
 	if params.GramProjectID == "" {
 		return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: 0}, nil
 	}
+	hostedHostnames, err := s.shadowMCPHostedHostnames(ctx, params.GramProjectID, params.HostedMCPHostnames)
+	if err != nil {
+		return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: 0}, err
+	}
 
 	usageRows, err := s.chRepo.ListShadowMCPInventoryUsage(ctx, repo.ListShadowMCPInventoryUsageParams{
 		GramProjectID: params.GramProjectID,
@@ -83,6 +96,9 @@ func (s *Service) BackfillShadowMCPInventoryURLs(ctx context.Context, params Bac
 	for _, usageRow := range usageRows {
 		invURL, ok := shadowmcp.CanonicalizeInventoryURL(usageRow.CanonicalServerURL)
 		if !ok || usageRow.FirstCalled == nil || usageRow.LastCalled == nil {
+			continue
+		}
+		if shadowMCPInventoryURLHosted(invURL, hostedHostnames) {
 			continue
 		}
 
@@ -106,5 +122,68 @@ func (s *Service) BackfillShadowMCPInventoryURLs(ctx context.Context, params Bac
 		return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: 0}, oops.E(oops.CodeUnexpected, err, "upsert shadow mcp inventory urls")
 	}
 
-	return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: len(usageRows)}, nil
+	return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: len(upserts)}, nil
+}
+
+func (s *Service) shadowMCPHostedHostnames(ctx context.Context, projectID string, configuredHostnames []string) (map[string]struct{}, error) {
+	hostnames := make(map[string]struct{}, len(configuredHostnames)+1)
+	for _, hostname := range configuredHostnames {
+		if normalized := normalizeShadowMCPHostedHostname(hostname); normalized != "" {
+			hostnames[normalized] = struct{}{}
+		}
+	}
+
+	projectUUID, err := uuid.Parse(projectID)
+	if err != nil {
+		return hostnames, nil
+	}
+	project, err := s.projectsRepo.GetProjectByID(ctx, projectUUID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "load project for shadow mcp hosted hostname exclusions")
+	}
+
+	customDomain, err := customdomainsrepo.New(s.db).GetCustomDomainByOrganization(ctx, project.OrganizationID)
+	switch {
+	case err == nil:
+		if normalized := normalizeShadowMCPHostedHostname(customDomain.Domain); normalized != "" {
+			hostnames[normalized] = struct{}{}
+		}
+	case errors.Is(err, pgx.ErrNoRows):
+	default:
+		return nil, oops.E(oops.CodeUnexpected, err, "load custom domain for shadow mcp hosted hostname exclusions")
+	}
+
+	return hostnames, nil
+}
+
+func shadowMCPInventoryURLHosted(invURL shadowmcp.InventoryURL, hostedHostnames map[string]struct{}) bool {
+	if len(hostedHostnames) == 0 {
+		return false
+	}
+	hostname := normalizeShadowMCPHostedHostname(invURL.URLHost)
+	if hostname == "" {
+		parsed, err := url.Parse(invURL.CanonicalURL)
+		if err != nil {
+			return false
+		}
+		hostname = normalizeShadowMCPHostedHostname(parsed.Hostname())
+	}
+	_, ok := hostedHostnames[hostname]
+	return ok
+}
+
+func normalizeShadowMCPHostedHostname(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Hostname() != "" {
+		value = parsed.Hostname()
+	}
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		value = host
+	}
+	value = strings.Trim(value, "[]")
+	value = strings.TrimSuffix(value, ".")
+	return value
 }

--- a/server/internal/telemetry/shadow_mcp_inventory.go
+++ b/server/internal/telemetry/shadow_mcp_inventory.go
@@ -1,0 +1,110 @@
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+type ShadowMCPInventoryURL struct {
+	GramProjectID string
+	ServerURL     shadowmcp.InventoryURL
+	ServerName    string
+	SeenAt        time.Time
+}
+
+type BackfillShadowMCPInventoryURLsParams struct {
+	GramProjectID string
+	Limit         int
+}
+
+type BackfillShadowMCPInventoryURLsResult struct {
+	InventoryURLCount int
+}
+
+func (l *Logger) UpsertShadowMCPInventoryURLs(ctx context.Context, inventoryURLs []ShadowMCPInventoryURL) error {
+	if len(inventoryURLs) == 0 || l.chConn == nil {
+		return nil
+	}
+
+	params := make([]repo.UpsertShadowMCPInventoryURLParams, 0, len(inventoryURLs))
+	for _, inventoryURL := range inventoryURLs {
+		if inventoryURL.GramProjectID == "" || inventoryURL.ServerURL.CanonicalURL == "" {
+			continue
+		}
+
+		seenAt := inventoryURL.SeenAt
+		if seenAt.IsZero() {
+			seenAt = time.Now()
+		}
+
+		params = append(params, repo.UpsertShadowMCPInventoryURLParams{
+			GramProjectID:      inventoryURL.GramProjectID,
+			CanonicalServerURL: inventoryURL.ServerURL.CanonicalURL,
+			URLHost:            inventoryURL.ServerURL.URLHost,
+			ServerName:         inventoryURL.ServerName,
+			SeenAt:             seenAt,
+			FirstSeen:          time.Time{},
+			LastSeen:           time.Time{},
+			UpdatedAt:          time.Now(),
+		})
+	}
+
+	if len(params) == 0 {
+		return nil
+	}
+
+	chRepo := repo.New(l.chConn)
+	if err := chRepo.UpsertShadowMCPInventoryURLs(l.shutdownCtx(), params); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "upsert shadow mcp inventory urls")
+	}
+
+	return nil
+}
+
+func (s *Service) BackfillShadowMCPInventoryURLs(ctx context.Context, params BackfillShadowMCPInventoryURLsParams) (BackfillShadowMCPInventoryURLsResult, error) {
+	if params.GramProjectID == "" {
+		return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: 0}, nil
+	}
+
+	usageRows, err := s.chRepo.ListShadowMCPInventoryUsage(ctx, repo.ListShadowMCPInventoryUsageParams{
+		GramProjectID: params.GramProjectID,
+		Limit:         params.Limit,
+	})
+	if err != nil {
+		return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: 0}, oops.E(oops.CodeUnexpected, err, "list shadow mcp inventory usage for backfill")
+	}
+
+	upserts := make([]repo.UpsertShadowMCPInventoryURLParams, 0, len(usageRows))
+	now := time.Now()
+	for _, usageRow := range usageRows {
+		invURL, ok := shadowmcp.CanonicalizeInventoryURL(usageRow.CanonicalServerURL)
+		if !ok || usageRow.FirstCalled == nil || usageRow.LastCalled == nil {
+			continue
+		}
+
+		upserts = append(upserts, repo.UpsertShadowMCPInventoryURLParams{
+			GramProjectID:      params.GramProjectID,
+			CanonicalServerURL: invURL.CanonicalURL,
+			URLHost:            invURL.URLHost,
+			ServerName:         usageRow.ServerName,
+			SeenAt:             time.Time{},
+			FirstSeen:          *usageRow.FirstCalled,
+			LastSeen:           *usageRow.LastCalled,
+			UpdatedAt:          now,
+		})
+	}
+
+	if len(upserts) == 0 {
+		return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: 0}, nil
+	}
+
+	if err := s.chRepo.UpsertShadowMCPInventoryURLs(ctx, upserts); err != nil {
+		return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: 0}, oops.E(oops.CodeUnexpected, err, "upsert shadow mcp inventory urls")
+	}
+
+	return BackfillShadowMCPInventoryURLsResult{InventoryURLCount: len(usageRows)}, nil
+}

--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -1,0 +1,350 @@
+package telemetry_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	telemetryRepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+func TestShadowMCPInventoryURLs_UpsertAndList(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	otherProjectID := uuid.NewString()
+	firstSeen := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	lastSeen := firstSeen.Add(time.Hour)
+
+	require.NoError(t, ti.chClient.UpsertShadowMCPInventoryURLs(ctx, []telemetryRepo.UpsertShadowMCPInventoryURLParams{
+		{
+			GramProjectID:      projectID,
+			CanonicalServerURL: "https://mcp.speakeasy.com/mcp",
+			URLHost:            "mcp.speakeasy.com",
+			ServerName:         "",
+			SeenAt:             firstSeen,
+		},
+		{
+			GramProjectID:      projectID,
+			CanonicalServerURL: "https://mcp.speakeasy.com/mcp",
+			URLHost:            "mcp.speakeasy.com",
+			ServerName:         "Speakeasy",
+			SeenAt:             lastSeen,
+		},
+		{
+			GramProjectID:      otherProjectID,
+			CanonicalServerURL: "https://mcp.speakeasy.com/mcp",
+			URLHost:            "mcp.speakeasy.com",
+			ServerName:         "Other",
+			SeenAt:             lastSeen.Add(time.Hour),
+		},
+	}))
+
+	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         50,
+	}, 1)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
+	assert.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
+	assert.Equal(t, "Speakeasy", rows[0].ServerName)
+	assert.Equal(t, firstSeen, rows[0].FirstSeen)
+	assert.Equal(t, lastSeen, rows[0].LastSeen)
+}
+
+func TestShadowMCPInventoryUsage_FromTelemetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	otherProjectID := uuid.NewString()
+	base := time.Date(2026, 6, 29, 13, 0, 0, 0, time.UTC)
+
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp?token=secret",
+		ServerName: "Speakeasy",
+		UserEmail:  "ada@example.com",
+		ObservedAt: base,
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp?other=1#frag",
+		ServerName: "Speakeasy",
+		UserEmail:  "ada@example.com",
+		ObservedAt: base.Add(time.Minute),
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp",
+		ServerName: "Speakeasy",
+		UserEmail:  "grace@example.com",
+		ObservedAt: base.Add(2 * time.Minute),
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  otherProjectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp",
+		ServerName: "Other",
+		UserEmail:  "other@example.com",
+		ObservedAt: base.Add(3 * time.Minute),
+	})
+
+	usage := requireShadowMCPInventoryUsageEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryUsageParams{
+		GramProjectID: projectID,
+		Limit:         50,
+	}, 1)
+
+	require.Len(t, usage, 1)
+	assert.Equal(t, "https://mcp.speakeasy.com/mcp", usage[0].CanonicalServerURL)
+	require.NotNil(t, usage[0].LastCalled)
+	assert.Equal(t, base.Add(2*time.Minute), *usage[0].LastCalled)
+	assert.EqualValues(t, 3, usage[0].CallCount)
+	assert.EqualValues(t, 2, usage[0].UserCount)
+	assert.Equal(t, []string{"ada@example.com", "grace@example.com"}, usage[0].TopUsers)
+}
+
+func TestListShadowMCPInventoryUsers_FromTelemetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	base := time.Date(2026, 6, 29, 14, 0, 0, 0, time.UTC)
+
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp?token=secret",
+		ServerName: "Speakeasy",
+		UserEmail:  "ada@example.com",
+		ObservedAt: base,
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp?other=1",
+		ServerName: "Speakeasy",
+		UserEmail:  "ada@example.com",
+		ObservedAt: base.Add(time.Minute),
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp",
+		ServerName: "Speakeasy",
+		UserEmail:  "grace@example.com",
+		ObservedAt: base.Add(2 * time.Minute),
+	})
+
+	users := requireShadowMCPInventoryUsersEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryUsersParams{
+		GramProjectID:      projectID,
+		CanonicalServerURL: "https://mcp.speakeasy.com/mcp",
+		Limit:              50,
+	}, 2)
+
+	require.Len(t, users, 2)
+	assert.Equal(t, "ada@example.com", users[0].UserKey)
+	assert.EqualValues(t, 2, users[0].CallCount)
+	assert.Equal(t, base.Add(time.Minute), users[0].LastCalled)
+	assert.Equal(t, "grace@example.com", users[1].UserKey)
+	assert.EqualValues(t, 1, users[1].CallCount)
+	assert.Equal(t, base.Add(2*time.Minute), users[1].LastCalled)
+}
+
+func TestLoggerUpsertShadowMCPInventoryURLs(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	seenAt := time.Date(2026, 6, 29, 15, 0, 0, 0, time.UTC)
+	invURL, ok := shadowmcp.CanonicalizeInventoryURL("https://mcp.speakeasy.com/mcp?token=secret")
+	require.True(t, ok)
+
+	require.NoError(t, ti.telemLogger.UpsertShadowMCPInventoryURLs(ctx, []telemetry.ShadowMCPInventoryURL{
+		{
+			GramProjectID: projectID,
+			ServerURL:     invURL,
+			ServerName:    "Speakeasy",
+			SeenAt:        seenAt,
+		},
+	}))
+
+	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         50,
+	}, 1)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
+	assert.Equal(t, "Speakeasy", rows[0].ServerName)
+	assert.Equal(t, seenAt, rows[0].LastSeen)
+}
+
+func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	otherProjectID := uuid.NewString()
+	observedAt := time.Date(2026, 6, 29, 16, 0, 0, 0, time.UTC)
+
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp?token=secret#frag",
+		ServerName: "Speakeasy",
+		UserEmail:  "ada@example.com",
+		ObservedAt: observedAt,
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp?other=1",
+		ServerName: "Speakeasy MCP",
+		UserEmail:  "grace@example.com",
+		ObservedAt: observedAt.Add(time.Minute),
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  otherProjectID,
+		ServerURL:  "https://mcp.speakeasy.com/mcp?token=secret#frag",
+		ServerName: "Other",
+		UserEmail:  "other@example.com",
+		ObservedAt: observedAt.Add(time.Hour),
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
+			GramProjectID: projectID,
+			Limit:         50,
+		})
+		require.NoError(c, err)
+		require.Equal(c, 1, result.InventoryURLCount)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         50,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.InventoryURLCount)
+
+	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         50,
+	}, 1)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
+	assert.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
+	assert.Equal(t, observedAt, rows[0].FirstSeen)
+	assert.Equal(t, observedAt.Add(time.Minute), rows[0].LastSeen)
+}
+
+type historicalShadowMCPCall struct {
+	ProjectID  string
+	ServerURL  string
+	ServerName string
+	UserEmail  string
+	ObservedAt time.Time
+}
+
+func insertHistoricalShadowMCPCall(t *testing.T, ctx context.Context, ti *testInstance, p historicalShadowMCPCall) {
+	t.Helper()
+
+	attrs := map[string]any{
+		"gram.event.source":     "hook",
+		"gram.hook.source":      "claude-code",
+		"gram.mcp.server_url":   p.ServerURL,
+		"gram.tool_call.source": p.ServerName,
+		"gram.tool.name":        "mcp__speakeasy__search",
+		"user.email":            p.UserEmail,
+	}
+	attrsJSON, err := json.Marshal(attrs)
+	require.NoError(t, err)
+
+	spanID := uuid.New().String()[:16]
+	traceID := strings.ReplaceAll(uuid.NewString(), "-", "")
+	err = ti.chClient.InsertTelemetryLog(ctx, telemetryRepo.InsertTelemetryLogParams{
+		ID:                   uuid.NewString(),
+		TimeUnixNano:         p.ObservedAt.UnixNano(),
+		ObservedTimeUnixNano: p.ObservedAt.UnixNano(),
+		SeverityText:         nil,
+		Body:                 "historical shadow mcp call",
+		TraceID:              &traceID,
+		SpanID:               &spanID,
+		Attributes:           string(attrsJSON),
+		ResourceAttributes:   "{}",
+		GramProjectID:        p.ProjectID,
+		GramDeploymentID:     nil,
+		GramFunctionID:       nil,
+		GramURN:              "hooks:mcp__speakeasy__search",
+		ServiceName:          "gram-hooks",
+		ServiceVersion:       nil,
+		GramChatID:           nil,
+	})
+	require.NoError(t, err)
+}
+
+func requireShadowMCPInventoryURLsEventually(
+	ctx context.Context,
+	t *testing.T,
+	ti *testInstance,
+	params telemetryRepo.ListShadowMCPInventoryURLsParams,
+	wantLen int,
+) []telemetryRepo.ShadowMCPInventoryURLRow {
+	t.Helper()
+
+	var rows []telemetryRepo.ShadowMCPInventoryURLRow
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		rows, err = ti.chClient.ListShadowMCPInventoryURLs(ctx, params)
+		require.NoError(c, err)
+		require.Len(c, rows, wantLen)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	return rows
+}
+
+func requireShadowMCPInventoryUsageEventually(
+	ctx context.Context,
+	t *testing.T,
+	ti *testInstance,
+	params telemetryRepo.ListShadowMCPInventoryUsageParams,
+	wantLen int,
+) []telemetryRepo.ShadowMCPInventoryUsageRow {
+	t.Helper()
+
+	var rows []telemetryRepo.ShadowMCPInventoryUsageRow
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		rows, err = ti.chClient.ListShadowMCPInventoryUsage(ctx, params)
+		require.NoError(c, err)
+		require.Len(c, rows, wantLen)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	return rows
+}
+
+func requireShadowMCPInventoryUsersEventually(
+	ctx context.Context,
+	t *testing.T,
+	ti *testInstance,
+	params telemetryRepo.ListShadowMCPInventoryUsersParams,
+	wantLen int,
+) []telemetryRepo.ShadowMCPInventoryUserRow {
+	t.Helper()
+
+	var rows []telemetryRepo.ShadowMCPInventoryUserRow
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		rows, err = ti.chClient.ListShadowMCPInventoryUsers(ctx, params)
+		require.NoError(c, err)
+		require.Len(c, rows, wantLen)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	return rows
+}

--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -2,6 +2,7 @@ package telemetry_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -54,6 +55,7 @@ func TestShadowMCPInventoryURLs_UpsertAndList(t *testing.T) {
 	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
+		Cursor:        "",
 	}, 1)
 
 	require.Len(t, rows, 1)
@@ -62,6 +64,80 @@ func TestShadowMCPInventoryURLs_UpsertAndList(t *testing.T) {
 	assert.Equal(t, "Speakeasy", rows[0].ServerName)
 	assert.Equal(t, firstSeen, rows[0].FirstSeen)
 	assert.Equal(t, lastSeen, rows[0].LastSeen)
+}
+
+func TestShadowMCPInventoryURLs_PaginatesLastSeen(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	base := time.Date(2026, 6, 29, 12, 30, 0, 0, time.UTC)
+
+	require.NoError(t, ti.chClient.UpsertShadowMCPInventoryURLs(ctx, []telemetryRepo.UpsertShadowMCPInventoryURLParams{
+		{GramProjectID: projectID, CanonicalServerURL: "https://gamma.example.com/mcp", URLHost: "gamma.example.com", ServerName: "Gamma", SeenAt: base.Add(3 * time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
+		{GramProjectID: projectID, CanonicalServerURL: "https://alpha.example.com/mcp", URLHost: "alpha.example.com", ServerName: "Alpha", SeenAt: base.Add(2 * time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
+		{GramProjectID: projectID, CanonicalServerURL: "https://beta.example.com/mcp", URLHost: "beta.example.com", ServerName: "Beta", SeenAt: base.Add(2 * time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
+		{GramProjectID: projectID, CanonicalServerURL: "https://delta.example.com/mcp", URLHost: "delta.example.com", ServerName: "Delta", SeenAt: base.Add(time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
+	}))
+
+	firstPage := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         2,
+		Cursor:        "",
+	}, 2)
+	require.Equal(t, []string{
+		"https://gamma.example.com/mcp",
+		"https://alpha.example.com/mcp",
+	}, inventoryURLRows(firstPage))
+
+	cursor, err := telemetryRepo.EncodeShadowMCPInventoryURLCursor(firstPage[1])
+	require.NoError(t, err)
+
+	secondPage := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         2,
+		Cursor:        cursor,
+	}, 2)
+	assert.Equal(t, []string{
+		"https://beta.example.com/mcp",
+		"https://delta.example.com/mcp",
+	}, inventoryURLRows(secondPage))
+}
+
+func TestShadowMCPInventoryURLs_RejectsInvalidCursor(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	lastSeen := time.Date(2026, 6, 29, 12, 45, 0, 0, time.UTC)
+
+	invalidBase64 := "not base64"
+	invalidJSON := base64.RawURLEncoding.EncodeToString([]byte("not-json"))
+	missingURL := encodeRawInventoryURLCursor(t, map[string]any{
+		"last_seen_unix_nano": lastSeen.UnixNano(),
+	})
+	missingLastSeen := encodeRawInventoryURLCursor(t, map[string]any{
+		"canonical_server_url": "https://alpha.example.com/mcp",
+	})
+
+	invalidCursors := []struct {
+		name   string
+		cursor string
+	}{
+		{name: "invalid base64", cursor: invalidBase64},
+		{name: "invalid JSON", cursor: invalidJSON},
+		{name: "missing URL", cursor: missingURL},
+		{name: "missing last seen", cursor: missingLastSeen},
+	}
+
+	for _, invalidCursor := range invalidCursors {
+		_, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
+			GramProjectID: projectID,
+			Limit:         2,
+			Cursor:        invalidCursor.cursor,
+		})
+		require.Error(t, err, invalidCursor.name)
+	}
 }
 
 func TestShadowMCPInventoryUsage_FromTelemetry(t *testing.T) {
@@ -180,6 +256,7 @@ func TestLoggerUpsertShadowMCPInventoryURLs(t *testing.T) {
 	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
+		Cursor:        "",
 	}, 1)
 
 	require.Len(t, rows, 1)
@@ -239,6 +316,7 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
+		Cursor:        "",
 	}, 1)
 
 	require.Len(t, rows, 1)
@@ -410,4 +488,20 @@ func requireShadowMCPInventoryUsersEventually(
 	}, 5*time.Second, 100*time.Millisecond)
 
 	return rows
+}
+
+func inventoryURLRows(rows []telemetryRepo.ShadowMCPInventoryURLRow) []string {
+	urls := make([]string, 0, len(rows))
+	for _, row := range rows {
+		urls = append(urls, row.CanonicalServerURL)
+	}
+	return urls
+}
+
+func encodeRawInventoryURLCursor(t *testing.T, payload map[string]any) string {
+	t.Helper()
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(data)
 }

--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -8,9 +8,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryRepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
@@ -190,7 +192,7 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestLogsService(t)
-	projectID := uuid.NewString()
+	projectID := ti.projectID
 	otherProjectID := uuid.NewString()
 	observedAt := time.Date(2026, 6, 29, 16, 0, 0, 0, time.UTC)
 
@@ -218,16 +220,18 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
-			GramProjectID: projectID,
-			Limit:         50,
+			GramProjectID:      projectID,
+			Limit:              50,
+			HostedMCPHostnames: nil,
 		})
 		require.NoError(c, err)
 		require.Equal(c, 1, result.InventoryURLCount)
 	}, 5*time.Second, 100*time.Millisecond)
 
 	result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
-		GramProjectID: projectID,
-		Limit:         50,
+		GramProjectID:      projectID,
+		Limit:              50,
+		HostedMCPHostnames: nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, result.InventoryURLCount)
@@ -242,6 +246,65 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 	assert.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
 	assert.Equal(t, observedAt, rows[0].FirstSeen)
 	assert.Equal(t, observedAt.Add(time.Minute), rows[0].LastSeen)
+}
+
+func TestBackfillShadowMCPInventoryURLs_ExcludesHostedHostnames(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := ti.projectID
+	observedAt := time.Date(2026, 6, 29, 17, 0, 0, 0, time.UTC)
+	customDomain := "gram-hosted-" + uuid.NewString()[:8] + ".example.com"
+
+	_, err := customdomainsrepo.New(ti.conn).CreateCustomDomain(ctx, customdomainsrepo.CreateCustomDomainParams{
+		OrganizationID:  ti.orgID,
+		Domain:          customDomain,
+		IngressName:     pgtype.Text{},
+		CertSecretName:  pgtype.Text{},
+		ProvisionerKind: "ingress",
+		IpAllowlist:     []string{},
+	})
+	require.NoError(t, err)
+
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://external.example.com/mcp?token=secret",
+		ServerName: "External",
+		UserEmail:  "ada@example.com",
+		ObservedAt: observedAt,
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://app.getgram.ai/mcp/hosted",
+		ServerName: "Gram Hosted",
+		UserEmail:  "grace@example.com",
+		ObservedAt: observedAt.Add(time.Minute),
+	})
+	insertHistoricalShadowMCPCall(t, ctx, ti, historicalShadowMCPCall{
+		ProjectID:  projectID,
+		ServerURL:  "https://" + customDomain + "/mcp/custom",
+		ServerName: "Custom Domain Hosted",
+		UserEmail:  "linus@example.com",
+		ObservedAt: observedAt.Add(2 * time.Minute),
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
+			GramProjectID:      projectID,
+			Limit:              50,
+			HostedMCPHostnames: []string{"https://app.getgram.ai"},
+		})
+		require.NoError(c, err)
+		require.Equal(c, 1, result.InventoryURLCount)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         50,
+	}, 1)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, "https://external.example.com/mcp", rows[0].CanonicalServerURL)
 }
 
 type historicalShadowMCPCall struct {


### PR DESCRIPTION
Linear: https://linear.app/speakeasy/issue/DNO-372/feat-resolve-shadow-mcp-url-access-state

## What changes
- Adds a shared backend resolver for Shadow MCP inventory URL access state.
- Resolves access from project-scoped `full_url` Shadow MCP access rules only.
- Uses the canonical URL from the inventory identity layer when comparing inventory URLs to access rules.
- Applies existing deny-wins precedence when multiple full-URL rules match the same canonical URL.
- Returns one access value and the matching URL rule, when one exists.

## Review context
This PR centralizes the allow/block answer used by later API and UI work. The key review area is canonical full-URL matching for inventory rows.

## Stack
1. #3819 DNO-371
2. #3848 DNO-369
3. #3849 DNO-373
4. #3850 DNO-372 (Current)
5. #3851 DNO-374
6. #3852 DNO-363
7. #3853 DNO-364