### PR TITLE
feat: capture hook startup MCP URLs into inventory

### DIFF
--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -446,14 +446,17 @@ func (s *Service) captureMCPListSnapshot(ctx context.Context, payload *gen.Claud
 		return
 	}
 	s.cacheMCPListSnapshot(ctx, *payload.SessionID, entries, variant)
+	orgID := ""
 	projectID := ""
 	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ProjectID != nil {
+		orgID = authCtx.ActiveOrganizationID
 		projectID = authCtx.ProjectID.String()
 	} else if metadata, err := s.resolveClaudeSessionMetadata(ctx, *payload.SessionID, strings.TrimSpace(conv.PtrValOr(payload.UserEmail, ""))); err == nil {
+		orgID = metadata.GramOrgID
 		projectID = metadata.ProjectID
 	}
 	if projectID != "" {
-		s.upsertShadowMCPInventoryURLs(ctx, projectID, *payload.SessionID, entries)
+		s.upsertShadowMCPInventoryURLs(ctx, orgID, projectID, *payload.SessionID, entries)
 	}
 }
 

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -446,6 +446,15 @@ func (s *Service) captureMCPListSnapshot(ctx context.Context, payload *gen.Claud
 		return
 	}
 	s.cacheMCPListSnapshot(ctx, *payload.SessionID, entries, variant)
+	projectID := ""
+	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ProjectID != nil {
+		projectID = authCtx.ProjectID.String()
+	} else if metadata, err := s.resolveClaudeSessionMetadata(ctx, *payload.SessionID, strings.TrimSpace(conv.PtrValOr(payload.UserEmail, ""))); err == nil {
+		projectID = metadata.ProjectID
+	}
+	if projectID != "" {
+		s.upsertShadowMCPInventoryURLs(ctx, projectID, *payload.SessionID, entries)
+	}
 }
 
 // parseMCPInventoryFromPayload extracts the MCP inventory carried in the hook

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -276,9 +276,8 @@ func TestClaude_PreToolUse_DeniesWhenMCPListNotCached(t *testing.T) {
 		"deny reason should tell the user to retry or restart so they aren't stuck guessing")
 }
 
-// Gram-hosted MCP servers (URL host == app.getgram.ai) are the only ones
-// the shadow-MCP guard permits — even a server present in the cache is
-// rejected when its URL points elsewhere.
+// Gram-hosted MCP servers are permitted by the shadow-MCP guard. A server
+// present in the cache is rejected when its URL points elsewhere.
 func TestClaude_PreToolUse_DeniesWhenMatchedServerNotGramHosted(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
@@ -471,7 +470,7 @@ func TestClaude_PreToolUse_DoesNotAllowUnconfiguredServerByIdentityRule(t *testi
 }
 
 // Allow path: a cached entry that resolves the tool's server prefix and
-// points at app.getgram.ai must succeed even under a blocking policy.
+// points at a Gram-hosted URL must succeed even under a blocking policy.
 func TestClaude_PreToolUse_AllowsGramHostedServer(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -268,7 +268,7 @@ func (s *Service) recordCodexHook(ctx context.Context, payload *gen.CodexPayload
 	}
 
 	if payload.HookEventName == "SessionStart" {
-		s.captureCodexMCPListSnapshot(ctx, payload)
+		s.captureCodexMCPListSnapshot(ctx, payload, metadata.ProjectID)
 		if metadata.SessionID != "" && metadata.UserEmail != "" {
 			if err := s.cache.Set(ctx, sessionCacheKey(metadata.SessionID), *metadata, 24*time.Hour); err != nil {
 				s.logger.WarnContext(ctx, "failed to cache Codex session metadata",
@@ -309,7 +309,7 @@ func (s *Service) recordCodexHook(ctx context.Context, payload *gen.CodexPayload
 // sessionMCPListCacheKey, sharing the snapshot shape and cache key with the
 // Claude flows so downstream matching and telemetry enrichment work
 // unchanged.
-func (s *Service) captureCodexMCPListSnapshot(ctx context.Context, payload *gen.CodexPayload) {
+func (s *Service) captureCodexMCPListSnapshot(ctx context.Context, payload *gen.CodexPayload, projectID string) {
 	if payload.SessionID == nil || *payload.SessionID == "" || payload.AdditionalData == nil {
 		return
 	}
@@ -319,6 +319,7 @@ func (s *Service) captureCodexMCPListSnapshot(ctx context.Context, payload *gen.
 	}
 
 	entries := ParseCodexMCPList(raw)
+	s.upsertShadowMCPInventoryURLs(ctx, projectID, *payload.SessionID, entries)
 	if err := s.cache.Set(ctx, sessionMCPListCacheKey(*payload.SessionID), entries, sessionMCPListTTL); err != nil {
 		s.logger.WarnContext(ctx, "failed to cache Codex MCP list snapshot",
 			attr.SlogEvent("codex_hook_mcp_list_cache_set_failed"),

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -319,14 +319,15 @@ func (s *Service) captureCodexMCPListSnapshot(ctx context.Context, payload *gen.
 	}
 
 	entries := ParseCodexMCPList(raw)
-	s.upsertShadowMCPInventoryURLs(ctx, projectID, *payload.SessionID, entries)
 	if err := s.cache.Set(ctx, sessionMCPListCacheKey(*payload.SessionID), entries, sessionMCPListTTL); err != nil {
 		s.logger.WarnContext(ctx, "failed to cache Codex MCP list snapshot",
 			attr.SlogEvent("codex_hook_mcp_list_cache_set_failed"),
 			attr.SlogError(err),
 			attr.SlogGenAIConversationID(*payload.SessionID),
 		)
+		return
 	}
+	s.upsertShadowMCPInventoryURLs(ctx, projectID, *payload.SessionID, entries)
 }
 
 func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPayload, orgID, projectID string) *SessionMetadata {

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -268,7 +268,7 @@ func (s *Service) recordCodexHook(ctx context.Context, payload *gen.CodexPayload
 	}
 
 	if payload.HookEventName == "SessionStart" {
-		s.captureCodexMCPListSnapshot(ctx, payload, metadata.ProjectID)
+		s.captureCodexMCPListSnapshot(ctx, payload, metadata.GramOrgID, metadata.ProjectID)
 		if metadata.SessionID != "" && metadata.UserEmail != "" {
 			if err := s.cache.Set(ctx, sessionCacheKey(metadata.SessionID), *metadata, 24*time.Hour); err != nil {
 				s.logger.WarnContext(ctx, "failed to cache Codex session metadata",
@@ -309,7 +309,7 @@ func (s *Service) recordCodexHook(ctx context.Context, payload *gen.CodexPayload
 // sessionMCPListCacheKey, sharing the snapshot shape and cache key with the
 // Claude flows so downstream matching and telemetry enrichment work
 // unchanged.
-func (s *Service) captureCodexMCPListSnapshot(ctx context.Context, payload *gen.CodexPayload, projectID string) {
+func (s *Service) captureCodexMCPListSnapshot(ctx context.Context, payload *gen.CodexPayload, orgID string, projectID string) {
 	if payload.SessionID == nil || *payload.SessionID == "" || payload.AdditionalData == nil {
 		return
 	}
@@ -327,7 +327,7 @@ func (s *Service) captureCodexMCPListSnapshot(ctx context.Context, payload *gen.
 		)
 		return
 	}
-	s.upsertShadowMCPInventoryURLs(ctx, projectID, *payload.SessionID, entries)
+	s.upsertShadowMCPInventoryURLs(ctx, orgID, projectID, *payload.SessionID, entries)
 }
 
 func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPayload, orgID, projectID string) *SessionMetadata {

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -84,7 +84,7 @@ func TestCodex_PreToolUse_ShadowMCPBlocksExternalMetaTool(t *testing.T) {
 		Source:        "local",
 		PluginName:    "",
 		Name:          "platform-logs",
-		URL:           "https://chat.speakeasy.com/mcp/speakeasy-team-62awx",
+		URL:           "https://external.example.com/mcp/speakeasy-team-62awx",
 		Command:       "",
 		Transport:     "HTTP",
 		Status:        "unknown",
@@ -108,7 +108,7 @@ func TestCodex_PreToolUse_ShadowMCPBlocksExternalMetaTool(t *testing.T) {
 	require.Equal(t, "deny", *result.Decision)
 	require.NotNil(t, result.Reason)
 	require.Contains(t, *result.Reason, "not Gram-hosted")
-	require.Contains(t, *result.Reason, "https://chat.speakeasy.com/mcp/speakeasy-team-62awx")
+	require.Contains(t, *result.Reason, "https://external.example.com/mcp/speakeasy-team-62awx")
 	require.Contains(t, *result.Reason, "Request access:")
 }
 

--- a/server/internal/hooks/mcp_codex_parser.go
+++ b/server/internal/hooks/mcp_codex_parser.go
@@ -33,9 +33,6 @@ func ParseCodexMCPList(raw any) []MCPServerEntry {
 			continue
 		}
 		name, _ := m["name"].(string)
-		if name == "" {
-			continue
-		}
 		if enabled, ok := m["enabled"].(bool); ok && !enabled {
 			continue
 		}

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -11,12 +11,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
-// gramHostedMCPHost is the canonical host for Gram-managed MCP servers.
-// The shadow-MCP guard allows a tool call only when the cached server
-// entry's URL exactly matches this host (case-insensitive). We avoid a
-// suffix-match on ".getgram.ai" because a third party squatting on a
-// subdomain (e.g. via a CNAME mistake) could bypass the guard otherwise.
-const gramHostedMCPHost = "app.getgram.ai"
+// gramHostedMCPHosts are the built-in hosts for Gram-managed MCP servers.
+// Exact host matching keeps third-party subdomains from being treated as
+// trusted Gram-hosted MCP servers.
+var gramHostedMCPHosts = []string{
+	"app.getgram.ai",
+	"chat.speakeasy.com",
+}
 
 // parsedClaudeToolName is the result of splitting a Claude Code tool name
 // into its MCP "<server>" and "<tool>" parts. IsMCP is false for native
@@ -236,15 +237,35 @@ func isGramHostedMCPURL(rawURL string, additionalTrustedHosts ...string) bool {
 		return false
 	}
 	hostname := u.Hostname()
-	if strings.EqualFold(hostname, gramHostedMCPHost) {
-		return true
-	}
-	for _, h := range additionalTrustedHosts {
+	for _, h := range gramHostedMCPHosts {
 		if strings.EqualFold(hostname, h) {
 			return true
 		}
 	}
+	for _, h := range additionalTrustedHosts {
+		if trustedGramHostedMCPHostMatches(u, h) {
+			return true
+		}
+	}
 	return false
+}
+
+func trustedGramHostedMCPHostMatches(u *url.URL, trustedHost string) bool {
+	trustedHost = strings.TrimSpace(trustedHost)
+	if trustedHost == "" {
+		return false
+	}
+	if strings.Contains(trustedHost, "://") {
+		parsed, err := url.Parse(trustedHost)
+		if err != nil || parsed.Host == "" {
+			return false
+		}
+		trustedHost = parsed.Host
+	}
+	if strings.Contains(trustedHost, ":") {
+		return strings.EqualFold(u.Host, trustedHost)
+	}
+	return strings.EqualFold(u.Hostname(), trustedHost)
 }
 
 // isGramHostedMCPURLForOrg checks if a URL is a Gram-managed MCP server for
@@ -252,11 +273,11 @@ func isGramHostedMCPURL(rawURL string, additionalTrustedHosts ...string) bool {
 // hit), then falls back to checking the org's custom domain if needed.
 func (s *Service) isGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool {
 	trustedHosts := make([]string, 0, 1)
-	if s.serverURL != nil && s.serverURL.Hostname() != "" {
-		trustedHosts = append(trustedHosts, s.serverURL.Hostname())
+	if s.serverURL != nil && s.serverURL.Host != "" {
+		trustedHosts = append(trustedHosts, s.serverURL.Host)
 	}
 
-	// Fast path: check canonical/configured hosts first to avoid DB lookup for app.getgram.ai URLs.
+	// Fast path: check built-in/configured hosts before consulting custom domains.
 	if isGramHostedMCPURL(rawURL, trustedHosts...) {
 		return true
 	}

--- a/server/internal/hooks/mcp_match_test.go
+++ b/server/internal/hooks/mcp_match_test.go
@@ -174,7 +174,8 @@ func TestIsGramHostedMCPURL(t *testing.T) {
 			{"https://app.getgram.ai/mcp/team-foo", true},
 			{"https://APP.GETGRAM.AI/mcp/team-foo", true}, // case-insensitive
 			{"http://app.getgram.ai/mcp/team-foo", true},  // http allowed (rare but valid)
-			{"https://chat.speakeasy.com/mcp/linear", false},
+			{"https://chat.speakeasy.com/mcp/linear", true},
+			{"https://CHAT.SPEAKEASY.COM/mcp/linear", true},
 			{"https://evil.getgram.ai/mcp/x", false}, // subdomain squat must NOT pass
 			{"https://mcp.slack.com/mcp", false},
 			{"http://localhost:8080/mcp/x", false},
@@ -197,9 +198,10 @@ func TestIsGramHostedMCPURL(t *testing.T) {
 			want        bool
 			description string
 		}{
-			{"https://chat.speakeasy.com/mcp/linear", []string{"chat.speakeasy.com"}, true, "custom domain matches"},
-			{"https://CHAT.SPEAKEASY.COM/mcp/linear", []string{"chat.speakeasy.com"}, true, "custom domain case-insensitive"},
-			{"https://localhost:8080/mcp/local-org", []string{"localhost"}, true, "configured local Gram server host matches"},
+			{"https://docs.example.com/mcp/linear", []string{"docs.example.com"}, true, "custom domain matches"},
+			{"https://DOCS.EXAMPLE.COM/mcp/linear", []string{"docs.example.com"}, true, "custom domain case-insensitive"},
+			{"https://localhost:8080/mcp/local-org", []string{"localhost:8080"}, true, "configured local Gram server host and port matches"},
+			{"https://localhost:35294/mcp/local-shadow", []string{"localhost:8080"}, false, "different local dev port stays external"},
 			{"https://app.getgram.ai/mcp/x", []string{"chat.speakeasy.com"}, true, "canonical still works with extra hosts"},
 			{"https://other.example.com/mcp/x", []string{"chat.speakeasy.com"}, false, "unknown host rejected"},
 			{"https://mcp.slack.com/mcp", []string{"chat.speakeasy.com"}, false, "third party rejected"},

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -184,6 +184,11 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 			entries, err := s.getCachedMCPList(ctx, completeMetadata.SessionID)
 			if err == nil {
 				s.upsertShadowMCPInventoryURLs(ctx, completeMetadata.ProjectID, completeMetadata.SessionID, entries)
+			} else {
+				sessionLogger.WarnContext(ctx, "failed to read cached MCP list for shadow inventory capture",
+					attr.SlogEvent("claude_otel_mcp_list_cache_miss"),
+					attr.SlogError(err),
+				)
 			}
 		}
 

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -183,7 +183,7 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		if metadataErr != nil {
 			entries, err := s.getCachedMCPList(ctx, completeMetadata.SessionID)
 			if err == nil {
-				s.upsertShadowMCPInventoryURLs(ctx, completeMetadata.ProjectID, completeMetadata.SessionID, entries)
+				s.upsertShadowMCPInventoryURLs(ctx, completeMetadata.GramOrgID, completeMetadata.ProjectID, completeMetadata.SessionID, entries)
 			} else {
 				sessionLogger.WarnContext(ctx, "failed to read cached MCP list for shadow inventory capture",
 					attr.SlogEvent("claude_otel_mcp_list_cache_miss"),

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -129,6 +129,8 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 			attr.SlogAuthUserEmail(session.UserEmail),
 		)
 
+		_, metadataErr := s.getSessionMetadata(ctx, completeMetadata.SessionID)
+
 		// Attribute the account: classify team vs personal, link it to the
 		// owning employee (directly for team accounts, via the device bridge for
 		// personal ones), and persist the account entity. Failures are
@@ -176,6 +178,12 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 					attr.SlogEvent("claude_logs_cache_set_failed"),
 					attr.SlogError(err),
 				)
+			}
+		}
+		if metadataErr != nil {
+			entries, err := s.getCachedMCPList(ctx, completeMetadata.SessionID)
+			if err == nil {
+				s.upsertShadowMCPInventoryURLs(ctx, completeMetadata.ProjectID, completeMetadata.SessionID, entries)
 			}
 		}
 

--- a/server/internal/hooks/otel_test.go
+++ b/server/internal/hooks/otel_test.go
@@ -369,12 +369,9 @@ func TestExtractSessionMetadataCapturesDeviceAndAccountIdentity(t *testing.T) {
 func enableHookTelemetryLogger(t *testing.T, ctx context.Context, ti *testInstance) *telemetryrepo.Queries {
 	t.Helper()
 
-	chConn, err := infra.NewClickhouseClient(t)
-	require.NoError(t, err)
-
 	enabled := func(context.Context, string) (bool, error) { return true, nil }
-	ti.service.telemetryLogger = telemetry.NewLogger(ctx, testenv.NewLogger(t), chConn, enabled, enabled, nil)
-	return telemetryrepo.New(chConn)
+	ti.service.telemetryLogger = telemetry.NewLogger(ctx, testenv.NewLogger(t), ti.chConn, enabled, enabled, nil)
+	return telemetryrepo.New(ti.chConn)
 }
 
 func hookAuthContext(t *testing.T, ctx context.Context) *contextvalues.AuthContext {

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -57,6 +58,7 @@ func TestMain(m *testing.M) {
 type testInstance struct {
 	service        *Service
 	conn           *pgxpool.Pool
+	chConn         clickhouse.Conn
 	redisClient    *redis.Client
 	accessStore    accesscontrol.Store
 	sessionManager *sessions.Manager
@@ -123,6 +125,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 	return ctx, &testInstance{
 		service:        svc,
 		conn:           conn,
+		chConn:         chConn,
 		redisClient:    redisClient,
 		accessStore:    accessStore,
 		sessionManager: sessionManager,

--- a/server/internal/hooks/shadow_mcp_inventory.go
+++ b/server/internal/hooks/shadow_mcp_inventory.go
@@ -1,0 +1,46 @@
+package hooks
+
+import (
+	"context"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+)
+
+func (s *Service) upsertShadowMCPInventoryURLs(ctx context.Context, projectID string, sessionID string, entries []MCPServerEntry) {
+	if s.telemetryLogger == nil || projectID == "" || len(entries) == 0 {
+		return
+	}
+
+	seenAt := time.Now()
+	inventoryURLs := make([]telemetry.ShadowMCPInventoryURL, 0, len(entries))
+	for _, entry := range entries {
+		if entry.URL == "" {
+			continue
+		}
+		invURL, ok := shadowmcp.CanonicalizeInventoryURL(entry.URL)
+		if !ok {
+			continue
+		}
+		inventoryURLs = append(inventoryURLs, telemetry.ShadowMCPInventoryURL{
+			GramProjectID: projectID,
+			ServerURL:     invURL,
+			ServerName:    entry.Name,
+			SeenAt:        seenAt,
+		})
+	}
+	if len(inventoryURLs) == 0 {
+		return
+	}
+
+	if err := s.telemetryLogger.UpsertShadowMCPInventoryURLs(ctx, inventoryURLs); err != nil {
+		s.logger.WarnContext(ctx, "shadow MCP inventory URL upsert failed",
+			attr.SlogEvent("shadow_mcp_inventory_url_upsert_failed"),
+			attr.SlogError(err),
+			attr.SlogProjectID(projectID),
+			attr.SlogGenAIConversationID(sessionID),
+		)
+	}
+}

--- a/server/internal/hooks/shadow_mcp_inventory.go
+++ b/server/internal/hooks/shadow_mcp_inventory.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
-func (s *Service) upsertShadowMCPInventoryURLs(ctx context.Context, projectID string, sessionID string, entries []MCPServerEntry) {
+func (s *Service) upsertShadowMCPInventoryURLs(ctx context.Context, orgID string, projectID string, sessionID string, entries []MCPServerEntry) {
 	if s.telemetryLogger == nil || projectID == "" || len(entries) == 0 {
 		return
 	}
@@ -18,6 +18,9 @@ func (s *Service) upsertShadowMCPInventoryURLs(ctx context.Context, projectID st
 	inventoryURLs := make([]telemetry.ShadowMCPInventoryURL, 0, len(entries))
 	for _, entry := range entries {
 		if entry.URL == "" {
+			continue
+		}
+		if s.isGramHostedMCPURLForOrg(ctx, entry.URL, orgID) {
 			continue
 		}
 		invURL, ok := shadowmcp.CanonicalizeInventoryURL(entry.URL)

--- a/server/internal/hooks/shadow_mcp_inventory_capture_test.go
+++ b/server/internal/hooks/shadow_mcp_inventory_capture_test.go
@@ -1,7 +1,11 @@
 package hooks
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
@@ -198,6 +203,148 @@ func TestCodexSessionStartUpsertsShadowMCPInventoryURLs(t *testing.T) {
 	require.Equal(t, "platform-logs", rows[0].ServerName)
 }
 
+func TestCodexSessionStartUpsertsShadowMCPInventoryURLWithoutName(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := uuid.NewString()
+	userEmail := "codex-shadow-inventory-no-name@example.com"
+	_, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "SessionStart",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_codex": []any{
+				map[string]any{
+					"enabled": true,
+					"transport": map[string]any{
+						"type": "streamable_http",
+						"url":  "https://nameless.example.com/mcp?auth=secret",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	require.Equal(t, "https://nameless.example.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "nameless.example.com", rows[0].URLHost)
+	require.Empty(t, rows[0].ServerName)
+}
+
+func TestCodexSessionStartDedupesShadowMCPInventoryURLsByCanonicalURL(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := uuid.NewString()
+	userEmail := "codex-shadow-inventory-dedupe@example.com"
+	_, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "SessionStart",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_codex": []any{
+				map[string]any{
+					"name":    "first",
+					"enabled": true,
+					"transport": map[string]any{
+						"type": "streamable_http",
+						"url":  "https://dedupe.example.com/mcp?token=one",
+					},
+				},
+				map[string]any{
+					"name":    "second",
+					"enabled": true,
+					"transport": map[string]any{
+						"type": "streamable_http",
+						"url":  "https://dedupe.example.com/mcp?token=two",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	require.Equal(t, "https://dedupe.example.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "dedupe.example.com", rows[0].URLHost)
+}
+
+func TestCodexSessionStartSkipsShadowMCPInventoryWhenSnapshotCacheFails(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := uuid.NewString()
+	ti.service.cache = mcpSetErrorCache{
+		Cache:   ti.service.cache,
+		failKey: sessionMCPListCacheKey(sessionID),
+		err:     errors.New("redis: connection refused"),
+	}
+
+	userEmail := "codex-shadow-inventory-cache-fail@example.com"
+	_, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "SessionStart",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_codex": []any{
+				map[string]any{
+					"name":    "cache-fail",
+					"enabled": true,
+					"transport": map[string]any{
+						"type": "streamable_http",
+						"url":  "https://cache-fail.example.com/mcp",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Never(t, func() bool {
+		rows, err := chClient.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			Limit:         50,
+		})
+		require.NoError(t, err)
+		return len(rows) > 0
+	}, 500*time.Millisecond, 50*time.Millisecond)
+}
+
+func TestClaudeOTELLogsWarnsWhenMCPInventorySnapshotMissing(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	var logBuffer bytes.Buffer
+	ti.service.logger = slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	sessionID := uuid.NewString()
+	userEmail := "missing-mcp-list@example.com"
+	err := ti.service.Logs(ctx, claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		&gen.OTELScope{Name: new("claude-code"), Version: new("1.0.0")},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("session api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", sessionID),
+				strAttr("user.email", userEmail),
+				strAttr("organization.id", "claude-org-missing-mcp-list"),
+			},
+		},
+	))
+	require.NoError(t, err)
+	require.Contains(t, logBuffer.String(), "claude_otel_mcp_list_cache_miss")
+	require.Contains(t, logBuffer.String(), sessionID)
+	require.True(t, strings.Contains(logBuffer.String(), "cache miss") || strings.Contains(logBuffer.String(), "cache"))
+}
+
 func requireShadowMCPInventoryURLsFromHooksEventually(
 	ctx context.Context,
 	t *testing.T,
@@ -219,4 +366,18 @@ func requireShadowMCPInventoryURLsFromHooksEventually(
 	}, 5*time.Second, 100*time.Millisecond)
 
 	return rows
+}
+
+type mcpSetErrorCache struct {
+	cache.Cache
+	failKey string
+	err     error
+}
+
+func (c mcpSetErrorCache) Set(ctx context.Context, key string, value any, ttl time.Duration) error {
+	if key == c.failKey {
+		return c.err
+	}
+	//nolint:wrapcheck // test pass-through to the embedded real cache
+	return c.Cache.Set(ctx, key, value, ttl)
 }

--- a/server/internal/hooks/shadow_mcp_inventory_capture_test.go
+++ b/server/internal/hooks/shadow_mcp_inventory_capture_test.go
@@ -1,0 +1,222 @@
+package hooks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+func TestClaudeSessionStartUpsertsShadowMCPInventoryURLs(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := uuid.NewString()
+	userEmail := "claude-shadow-inventory@example.com"
+	_, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "SessionStart",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_claude_code": "" +
+				"speakeasy: https://mcp.speakeasy.com/mcp?token=secret (HTTP) - connected\n" +
+				"local-tools: /usr/local/bin/local-tools (STDIO) - connected",
+		},
+	})
+	require.NoError(t, err)
+
+	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	require.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
+	require.Equal(t, "speakeasy", rows[0].ServerName)
+}
+
+func TestClaudeConfigChangeUpsertsCoworkShadowMCPInventoryURLs(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := uuid.NewString()
+	userEmail := "cowork-shadow-inventory@example.com"
+	_, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "ConfigChange",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_cowork": []any{
+				map[string]any{
+					"name":           "Linear",
+					"url":            "https://mcp.linear.app/mcp?workspace=speakeasy",
+					"transport":      "HTTP",
+					"status":         "connected",
+					"connector_uuid": "linear-connector",
+				},
+				map[string]any{
+					"name":      "Local",
+					"command":   "node local.js",
+					"transport": "STDIO",
+					"status":    "connected",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	require.Equal(t, "https://mcp.linear.app/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "mcp.linear.app", rows[0].URLHost)
+	require.Equal(t, "Linear", rows[0].ServerName)
+}
+
+func TestClaudeSessionStartUpsertsShadowMCPInventoryURLsWhenOTELMetadataArrives(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := uuid.NewString()
+	userEmail := "otel-shadow-inventory@example.com"
+	noAuthCtx := t.Context()
+	_, err := ti.service.Claude(noAuthCtx, &gen.ClaudePayload{
+		HookEventName: "SessionStart",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_claude_code": "" +
+				"notion: https://mcp.notion.com/mcp?auth=secret (HTTP) - connected\n" +
+				"local-tools: /usr/local/bin/local-tools (STDIO) - connected",
+		},
+	})
+	require.NoError(t, err)
+
+	cached, err := ti.service.getCachedMCPList(ctx, sessionID)
+	require.NoError(t, err)
+	require.Len(t, cached, 2)
+
+	err = ti.service.Logs(ctx, claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		&gen.OTELScope{Name: new("claude-code"), Version: new("1.0.0")},
+		&gen.OTELLogRecord{
+			Body: &gen.OTELLogBody{StringValue: new("session api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", sessionID),
+				strAttr("user.email", userEmail),
+				strAttr("organization.id", "claude-org-otel"),
+			},
+		},
+	))
+	require.NoError(t, err)
+
+	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	require.Equal(t, "https://mcp.notion.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "mcp.notion.com", rows[0].URLHost)
+	require.Equal(t, "notion", rows[0].ServerName)
+}
+
+func TestClaudeConfigChangeUpsertsShadowMCPInventoryURLsFromCachedSessionMetadata(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := uuid.NewString()
+	userEmail := "metadata-shadow-inventory@example.com"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:     sessionID,
+		ServiceName:   "claude-code",
+		UserEmail:     userEmail,
+		UserID:        "",
+		ExternalOrgID: "claude-org-metadata",
+		GramOrgID:     authCtx.ActiveOrganizationID,
+		ProjectID:     authCtx.ProjectID.String(),
+	}, 24*time.Hour))
+
+	noAuthCtx := t.Context()
+	_, err := ti.service.Claude(noAuthCtx, &gen.ClaudePayload{
+		HookEventName: "ConfigChange",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_claude_code": "asana: https://mcp.asana.com/mcp?workspace=speakeasy (HTTP) - connected",
+		},
+	})
+	require.NoError(t, err)
+
+	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	require.Equal(t, "https://mcp.asana.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "mcp.asana.com", rows[0].URLHost)
+	require.Equal(t, "asana", rows[0].ServerName)
+}
+
+func TestCodexSessionStartUpsertsShadowMCPInventoryURLs(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := uuid.NewString()
+	userEmail := "codex-shadow-inventory@example.com"
+	_, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "SessionStart",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_codex": []any{
+				map[string]any{
+					"name":    "platform-logs",
+					"enabled": true,
+					"transport": map[string]any{
+						"type": "streamable_http",
+						"url":  "https://logs.example.com/mcp?auth=secret",
+					},
+				},
+				map[string]any{
+					"name":    "filesystem",
+					"enabled": true,
+					"transport": map[string]any{
+						"type":    "stdio",
+						"command": "filesystem",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	require.Equal(t, "https://logs.example.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "logs.example.com", rows[0].URLHost)
+	require.Equal(t, "platform-logs", rows[0].ServerName)
+}
+
+func requireShadowMCPInventoryURLsFromHooksEventually(
+	ctx context.Context,
+	t *testing.T,
+	chClient *telemetryrepo.Queries,
+	projectID string,
+	wantLen int,
+) []telemetryrepo.ShadowMCPInventoryURLRow {
+	t.Helper()
+
+	var rows []telemetryrepo.ShadowMCPInventoryURLRow
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		rows, err = chClient.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
+			GramProjectID: projectID,
+			Limit:         50,
+		})
+		assert.NoError(c, err)
+		assert.Len(c, rows, wantLen)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	return rows
+}

--- a/server/internal/hooks/shadow_mcp_inventory_capture_test.go
+++ b/server/internal/hooks/shadow_mcp_inventory_capture_test.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
@@ -42,6 +44,53 @@ func TestClaudeSessionStartUpsertsShadowMCPInventoryURLs(t *testing.T) {
 	require.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
 	require.Equal(t, "speakeasy", rows[0].ServerName)
+}
+
+func TestClaudeSessionStartSkipsHostedMCPInventoryURLs(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+	customDomain := "hooks-hosted-" + uuid.NewString()[:8] + ".example.com"
+
+	domain, err := customdomainsrepo.New(ti.conn).CreateCustomDomain(ctx, customdomainsrepo.CreateCustomDomainParams{
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		Domain:          customDomain,
+		IngressName:     pgtype.Text{},
+		CertSecretName:  pgtype.Text{},
+		ProvisionerKind: "ingress",
+		IpAllowlist:     []string{},
+	})
+	require.NoError(t, err)
+	_, err = customdomainsrepo.New(ti.conn).UpdateCustomDomain(ctx, customdomainsrepo.UpdateCustomDomainParams{
+		Verified:        true,
+		Activated:       true,
+		IngressName:     pgtype.Text{},
+		CertSecretName:  pgtype.Text{},
+		ProvisionerKind: "ingress",
+		ID:              domain.ID,
+	})
+	require.NoError(t, err)
+
+	sessionID := uuid.NewString()
+	userEmail := "claude-hosted-inventory@example.com"
+	_, err = ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "SessionStart",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		AdditionalData: map[string]any{
+			"mcp_inventory_claude_code": "" +
+				"external: https://external.example.com/mcp?token=secret (HTTP) - connected\n" +
+				"gram: https://app.getgram.ai/mcp/hosted (HTTP) - connected\n" +
+				"custom: https://" + customDomain + "/mcp/custom (HTTP) - connected",
+		},
+	})
+	require.NoError(t, err)
+
+	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	require.Equal(t, "https://external.example.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "external.example.com", rows[0].URLHost)
+	require.Equal(t, "external", rows[0].ServerName)
 }
 
 func TestClaudeConfigChangeUpsertsCoworkShadowMCPInventoryURLs(t *testing.T) {

--- a/server/internal/hooks/shadow_mcp_inventory_capture_test.go
+++ b/server/internal/hooks/shadow_mcp_inventory_capture_test.go
@@ -82,6 +82,7 @@ func TestClaudeSessionStartSkipsHostedMCPInventoryURLs(t *testing.T) {
 			"mcp_inventory_claude_code": "" +
 				"external: https://external.example.com/mcp?token=secret (HTTP) - connected\n" +
 				"gram: https://app.getgram.ai/mcp/hosted (HTTP) - connected\n" +
+				"chat: https://chat.speakeasy.com/mcp/linear (HTTP) - connected\n" +
 				"custom: https://" + customDomain + "/mcp/custom (HTTP) - connected",
 		},
 	})

--- a/server/internal/hooks/shadow_mcp_inventory_capture_test.go
+++ b/server/internal/hooks/shadow_mcp_inventory_capture_test.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestClaudeSessionStartUpsertsShadowMCPInventoryURLs(t *testing.T) {
@@ -40,7 +40,7 @@ func TestClaudeSessionStartUpsertsShadowMCPInventoryURLs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	rows := requireShadowMCPInventoryURLsFromHooks(ctx, t, ti, chClient, authCtx.ProjectID.String(), 1)
 	require.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
 	require.Equal(t, "speakeasy", rows[0].ServerName)
@@ -88,7 +88,7 @@ func TestClaudeSessionStartSkipsHostedMCPInventoryURLs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	rows := requireShadowMCPInventoryURLsFromHooks(ctx, t, ti, chClient, authCtx.ProjectID.String(), 1)
 	require.Equal(t, "https://external.example.com/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "external.example.com", rows[0].URLHost)
 	require.Equal(t, "external", rows[0].ServerName)
@@ -126,7 +126,7 @@ func TestClaudeConfigChangeUpsertsCoworkShadowMCPInventoryURLs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	rows := requireShadowMCPInventoryURLsFromHooks(ctx, t, ti, chClient, authCtx.ProjectID.String(), 1)
 	require.Equal(t, "https://mcp.linear.app/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "mcp.linear.app", rows[0].URLHost)
 	require.Equal(t, "Linear", rows[0].ServerName)
@@ -171,7 +171,7 @@ func TestClaudeSessionStartUpsertsShadowMCPInventoryURLsWhenOTELMetadataArrives(
 	))
 	require.NoError(t, err)
 
-	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	rows := requireShadowMCPInventoryURLsFromHooks(ctx, t, ti, chClient, authCtx.ProjectID.String(), 1)
 	require.Equal(t, "https://mcp.notion.com/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "mcp.notion.com", rows[0].URLHost)
 	require.Equal(t, "notion", rows[0].ServerName)
@@ -206,7 +206,7 @@ func TestClaudeConfigChangeUpsertsShadowMCPInventoryURLsFromCachedSessionMetadat
 	})
 	require.NoError(t, err)
 
-	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	rows := requireShadowMCPInventoryURLsFromHooks(ctx, t, ti, chClient, authCtx.ProjectID.String(), 1)
 	require.Equal(t, "https://mcp.asana.com/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "mcp.asana.com", rows[0].URLHost)
 	require.Equal(t, "asana", rows[0].ServerName)
@@ -247,7 +247,7 @@ func TestCodexSessionStartUpsertsShadowMCPInventoryURLs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	rows := requireShadowMCPInventoryURLsFromHooks(ctx, t, ti, chClient, authCtx.ProjectID.String(), 1)
 	require.Equal(t, "https://logs.example.com/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "logs.example.com", rows[0].URLHost)
 	require.Equal(t, "platform-logs", rows[0].ServerName)
@@ -279,7 +279,7 @@ func TestCodexSessionStartUpsertsShadowMCPInventoryURLWithoutName(t *testing.T) 
 	})
 	require.NoError(t, err)
 
-	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	rows := requireShadowMCPInventoryURLsFromHooks(ctx, t, ti, chClient, authCtx.ProjectID.String(), 1)
 	require.Equal(t, "https://nameless.example.com/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "nameless.example.com", rows[0].URLHost)
 	require.Empty(t, rows[0].ServerName)
@@ -320,7 +320,7 @@ func TestCodexSessionStartDedupesShadowMCPInventoryURLsByCanonicalURL(t *testing
 	})
 	require.NoError(t, err)
 
-	rows := requireShadowMCPInventoryURLsFromHooksEventually(ctx, t, chClient, authCtx.ProjectID.String(), 1)
+	rows := requireShadowMCPInventoryURLsFromHooks(ctx, t, ti, chClient, authCtx.ProjectID.String(), 1)
 	require.Equal(t, "https://dedupe.example.com/mcp", rows[0].CanonicalServerURL)
 	require.Equal(t, "dedupe.example.com", rows[0].URLHost)
 }
@@ -358,14 +358,13 @@ func TestCodexSessionStartSkipsShadowMCPInventoryWhenSnapshotCacheFails(t *testi
 	})
 	require.NoError(t, err)
 
-	require.Never(t, func() bool {
-		rows, err := chClient.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
-			GramProjectID: authCtx.ProjectID.String(),
-			Limit:         50,
-		})
-		require.NoError(t, err)
-		return len(rows) > 0
-	}, 500*time.Millisecond, 50*time.Millisecond)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+	rows, err := chClient.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: authCtx.ProjectID.String(),
+		Limit:         50,
+	})
+	require.NoError(t, err)
+	require.Empty(t, rows)
 }
 
 func TestClaudeOTELLogsWarnsWhenMCPInventorySnapshotMissing(t *testing.T) {
@@ -395,25 +394,23 @@ func TestClaudeOTELLogsWarnsWhenMCPInventorySnapshotMissing(t *testing.T) {
 	require.True(t, strings.Contains(logBuffer.String(), "cache miss") || strings.Contains(logBuffer.String(), "cache"))
 }
 
-func requireShadowMCPInventoryURLsFromHooksEventually(
+func requireShadowMCPInventoryURLsFromHooks(
 	ctx context.Context,
 	t *testing.T,
+	ti *testInstance,
 	chClient *telemetryrepo.Queries,
 	projectID string,
 	wantLen int,
 ) []telemetryrepo.ShadowMCPInventoryURLRow {
 	t.Helper()
 
-	var rows []telemetryrepo.ShadowMCPInventoryURLRow
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var err error
-		rows, err = chClient.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
-			GramProjectID: projectID,
-			Limit:         50,
-		})
-		assert.NoError(c, err)
-		assert.Len(c, rows, wantLen)
-	}, 5*time.Second, 100*time.Millisecond)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+	rows, err := chClient.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
+		GramProjectID: projectID,
+		Limit:         50,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, wantLen)
 
 	return rows
 }


### PR DESCRIPTION
Linear: https://linear.app/speakeasy/issue/DNO-374/feat-capture-hook-startup-mcp-urls-into-inventory

## What changes
- Expands hook processing so Claude/Cowork and Codex startup/config MCP snapshots populate Shadow MCP inventory URLs.
- Reuses the existing cached MCP list snapshot data instead of making a second hook-side fetch for the same server list.
- Filters to URL-backed HTTP(S) MCP servers, canonicalizes URLs, and dedupes repeated servers within the same project.
- Excludes Gram-hosted MCP server hostnames, including hosted custom domains, so managed servers stay out of Shadow MCP inventory.
- Preserves server name as optional display metadata while canonical URL remains the identity.
- Upserts observed URLs into the project inventory so admins can see configured/listed Shadow MCP servers before usage appears in telemetry.

## Review context
This is the ingestion path for configured/listed URLs. Telemetry remains the source for last called and usage counts; this branch makes sure known URL-backed Shadow MCP servers land in inventory.

## Stack
1. #3819 DNO-371
2. #3848 DNO-369
3. #3849 DNO-373
4. #3851 DNO-374 (Current)
5. #3852 DNO-363
6. #3947 DNO-370
7. #4063 DNO-456
8. #4064 DNO-366
9. #4065 DNO-459
