### PR TITLE
feat: mask Speakeasy staff in customer audit feeds and block impersonated chat access (DNO-391)

### DIFF
--- a/server/internal/audit/queries.sql
+++ b/server/internal/audit/queries.sql
@@ -71,7 +71,7 @@ LIMIT 51;
 -- Assistant activity events are excluded: facets power the platform audit
 -- feed, which hides them (see ListAuditLogs).
 WITH filtered_logs AS (
-  SELECT actor_id, actor_display_name, seq
+  SELECT actor_id, actor_type, actor_display_name, seq
   FROM audit_logs
   WHERE organization_id = @organization_id
     AND subject_type <> 'assistant'
@@ -80,7 +80,12 @@ WITH filtered_logs AS (
       OR project_id = sqlc.narg(project_id)::uuid
     )
 ), actor_counts AS (
-  SELECT actor_id, COUNT(*)::bigint AS count
+  SELECT
+    actor_id,
+    COUNT(*)::bigint AS count,
+    -- Flags actor ids that appear as user actors, so callers can restrict
+    -- user-specific treatment (e.g. Speakeasy staff masking) to them.
+    BOOL_OR(actor_type = 'user')::boolean AS is_user_actor
   FROM filtered_logs
   GROUP BY actor_id
 ), latest_actor_names AS (
@@ -95,7 +100,8 @@ WITH filtered_logs AS (
 SELECT
   actor_counts.actor_id AS value,
   COALESCE(latest_actor_names.actor_display_name, actor_counts.actor_id) AS display_name,
-  actor_counts.count
+  actor_counts.count,
+  actor_counts.is_user_actor
 FROM actor_counts
 LEFT JOIN latest_actor_names ON latest_actor_names.actor_id = actor_counts.actor_id
 ORDER BY actor_counts.count DESC, actor_counts.actor_id ASC;

--- a/server/internal/audit/repo/queries.sql.go
+++ b/server/internal/audit/repo/queries.sql.go
@@ -142,7 +142,7 @@ func (q *Queries) ListAuditActionFacets(ctx context.Context, arg ListAuditAction
 
 const listAuditActorFacets = `-- name: ListAuditActorFacets :many
 WITH filtered_logs AS (
-  SELECT actor_id, actor_display_name, seq
+  SELECT actor_id, actor_type, actor_display_name, seq
   FROM audit_logs
   WHERE organization_id = $1
     AND subject_type <> 'assistant'
@@ -151,7 +151,12 @@ WITH filtered_logs AS (
       OR project_id = $2::uuid
     )
 ), actor_counts AS (
-  SELECT actor_id, COUNT(*)::bigint AS count
+  SELECT
+    actor_id,
+    COUNT(*)::bigint AS count,
+    -- Flags actor ids that appear as user actors, so callers can restrict
+    -- user-specific treatment (e.g. Speakeasy staff masking) to them.
+    BOOL_OR(actor_type = 'user')::boolean AS is_user_actor
   FROM filtered_logs
   GROUP BY actor_id
 ), latest_actor_names AS (
@@ -166,7 +171,8 @@ WITH filtered_logs AS (
 SELECT
   actor_counts.actor_id AS value,
   COALESCE(latest_actor_names.actor_display_name, actor_counts.actor_id) AS display_name,
-  actor_counts.count
+  actor_counts.count,
+  actor_counts.is_user_actor
 FROM actor_counts
 LEFT JOIN latest_actor_names ON latest_actor_names.actor_id = actor_counts.actor_id
 ORDER BY actor_counts.count DESC, actor_counts.actor_id ASC
@@ -181,6 +187,7 @@ type ListAuditActorFacetsRow struct {
 	Value       string
 	DisplayName string
 	Count       int64
+	IsUserActor bool
 }
 
 // Assistant activity events are excluded: facets power the platform audit
@@ -194,7 +201,12 @@ func (q *Queries) ListAuditActorFacets(ctx context.Context, arg ListAuditActorFa
 	var items []ListAuditActorFacetsRow
 	for rows.Next() {
 		var i ListAuditActorFacetsRow
-		if err := rows.Scan(&i.Value, &i.DisplayName, &i.Count); err != nil {
+		if err := rows.Scan(
+			&i.Value,
+			&i.DisplayName,
+			&i.Count,
+			&i.IsUserActor,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/internal/auditapi/impl.go
+++ b/server/internal/auditapi/impl.go
@@ -30,10 +30,19 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 )
 
 const listAuditLogsPageSize = 50
+
+// Speakeasy staff actions in customer orgs (e.g. via the dev-tools org
+// override) are shown under a collective label instead of the staff member's
+// email. Logs viewed within the Speakeasy org itself are not masked.
+const (
+	speakeasyTeamOrganizationID = "5a25158b-24dc-4d49-b03d-e85acfbea59c"
+	speakeasyTeamActorLabel     = "Speakeasy Team"
+)
 
 type Service struct {
 	tracer trace.Tracer
@@ -128,10 +137,51 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 		logs = logs[:listAuditLogsPageSize]
 	}
 
+	actorIDs := make([]string, 0, len(logs))
+	for _, log := range logs {
+		if log.ActorType == "user" {
+			actorIDs = append(actorIDs, log.ActorID)
+		}
+	}
+	speakeasyActors, err := s.speakeasyActorIDs(ctx, authCtx.ActiveOrganizationID, actorIDs)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error resolving audit actor identities").LogError(ctx, s.logger)
+	}
+	for _, log := range logs {
+		if log.ActorType == "user" && speakeasyActors[log.ActorID] {
+			log.ActorDisplayName = conv.PtrEmpty(speakeasyTeamActorLabel)
+			log.ActorSlug = nil
+		}
+	}
+
 	return &gen.ListAuditLogsResult{
 		Logs:       logs,
 		NextCursor: nextCursor,
 	}, nil
+}
+
+// speakeasyActorIDs returns which of the given user actor IDs belong to the
+// Speakeasy org, so their identities can be masked in customer-facing feeds.
+// It returns nil when the viewer is the Speakeasy org itself.
+func (s *Service) speakeasyActorIDs(ctx context.Context, viewerOrganizationID string, actorIDs []string) (map[string]bool, error) {
+	if viewerOrganizationID == speakeasyTeamOrganizationID || len(actorIDs) == 0 {
+		return nil, nil
+	}
+
+	memberIDs, err := orgrepo.New(s.db).FilterOrganizationMemberUserIDs(ctx, orgrepo.FilterOrganizationMemberUserIDsParams{
+		OrganizationID: speakeasyTeamOrganizationID,
+		UserIds:        actorIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("filter speakeasy org members: %w", err)
+	}
+
+	members := make(map[string]bool, len(memberIDs))
+	for _, id := range memberIDs {
+		members[id] = true
+	}
+
+	return members, nil
 }
 
 func (s *Service) ListFacets(ctx context.Context, payload *gen.ListFacetsPayload) (*gen.ListAuditLogFacetsResult, error) {
@@ -165,8 +215,26 @@ func (s *Service) ListFacets(ctx context.Context, payload *gen.ListFacetsPayload
 		return nil, oops.E(oops.CodeUnexpected, err, "error listing audit action facets").LogError(ctx, s.logger)
 	}
 
+	actors := toAuditActorFacetOptions(actorRows)
+
+	// Facet values are actor IDs, so mask their display names the same way the
+	// log feed does.
+	actorIDs := make([]string, 0, len(actors))
+	for _, actor := range actors {
+		actorIDs = append(actorIDs, actor.Value)
+	}
+	speakeasyActors, err := s.speakeasyActorIDs(ctx, authCtx.ActiveOrganizationID, actorIDs)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error resolving audit actor identities").LogError(ctx, s.logger)
+	}
+	for _, actor := range actors {
+		if speakeasyActors[actor.Value] {
+			actor.DisplayName = speakeasyTeamActorLabel
+		}
+	}
+
 	return &gen.ListAuditLogFacetsResult{
-		Actors:  toAuditActorFacetOptions(actorRows),
+		Actors:  actors,
 		Actions: toAuditActionFacetOptions(actionRows),
 	}, nil
 }

--- a/server/internal/auditapi/impl.go
+++ b/server/internal/auditapi/impl.go
@@ -218,10 +218,13 @@ func (s *Service) ListFacets(ctx context.Context, payload *gen.ListFacetsPayload
 	actors := toAuditActorFacetOptions(actorRows)
 
 	// Facet values are actor IDs, so mask their display names the same way the
-	// log feed does.
-	actorIDs := make([]string, 0, len(actors))
-	for _, actor := range actors {
-		actorIDs = append(actorIDs, actor.Value)
+	// log feed does. Only user actors are candidates — other actor types keep
+	// their labels even if their id collides with a staff user id.
+	actorIDs := make([]string, 0, len(actorRows))
+	for _, row := range actorRows {
+		if row.IsUserActor {
+			actorIDs = append(actorIDs, row.Value)
+		}
 	}
 	speakeasyActors, err := s.speakeasyActorIDs(ctx, authCtx.ActiveOrganizationID, actorIDs)
 	if err != nil {

--- a/server/internal/auditapi/speakeasy_mask_test.go
+++ b/server/internal/auditapi/speakeasy_mask_test.go
@@ -1,0 +1,235 @@
+package auditapi_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/auditlogs"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+)
+
+// Mirrors the unexported constant in the auditapi package so tests fail if the
+// hardcoded Speakeasy org id ever drifts.
+const speakeasyTeamOrganizationID = "5a25158b-24dc-4d49-b03d-e85acfbea59c"
+
+// seedSpeakeasyMember creates the Speakeasy org (if needed) and enrolls the
+// given Gram user id as an active member.
+func seedSpeakeasyMember(t *testing.T, ctx context.Context, ti *testInstance, userID string) {
+	t.Helper()
+
+	queries := orgrepo.New(ti.conn)
+	_, err := queries.UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          speakeasyTeamOrganizationID,
+		Name:        "Speakeasy Team",
+		Slug:        "speakeasy-team",
+		WorkosID:    conv.ToPGTextEmpty(""),
+		Whitelisted: conv.PtrToPGBool(nil),
+	})
+	require.NoError(t, err)
+
+	_, err = queries.UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: speakeasyTeamOrganizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+}
+
+// Audit entries whose actor is a member of the Speakeasy org are surfaced to
+// customer orgs as "Speakeasy Team" instead of the staff member's email.
+func TestAuditService_List_MasksSpeakeasyOrgActors(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAuditService(t)
+	authCtx := testAuthContext(t, ctx)
+
+	staffUserID := uuid.NewString()
+	seedSpeakeasyMember(t, ctx, ti, staffUserID)
+
+	staffLogID := insertAuditLog(t, ctx, ti, auditLogSeed{
+		organizationID:   authCtx.ActiveOrganizationID,
+		projectID:        uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		actorID:          staffUserID,
+		actorType:        "user",
+		actorDisplayName: new("david@speakeasy.com"),
+		actorSlug:        new("david"),
+		action:           "chat_session:access",
+		subjectID:        uuid.NewString(),
+		subjectType:      "chat_session",
+	})
+
+	customerLogID := insertAuditLog(t, ctx, ti, auditLogSeed{
+		organizationID:   authCtx.ActiveOrganizationID,
+		projectID:        uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		actorID:          "customer-user",
+		actorType:        "user",
+		actorDisplayName: new("customer@example.com"),
+		actorSlug:        new("customer"),
+		action:           "project:update",
+		subjectID:        "project-1",
+		subjectType:      "project",
+	})
+
+	result, err := ti.service.List(ctx, &gen.ListPayload{
+		ApikeyToken:  nil,
+		SessionToken: nil,
+		Cursor:       nil,
+		ProjectSlug:  nil,
+		ActorID:      nil,
+		Action:       nil,
+		SubjectType:  nil,
+		SubjectID:    nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Logs, 2)
+
+	byID := make(map[string]*gen.AuditLog, len(result.Logs))
+	for _, log := range result.Logs {
+		byID[log.ID] = log
+	}
+
+	staffLog := byID[staffLogID.String()]
+	require.NotNil(t, staffLog)
+	require.NotNil(t, staffLog.ActorDisplayName)
+	require.Equal(t, "Speakeasy Team", *staffLog.ActorDisplayName, "speakeasy staff email must be masked")
+	require.Nil(t, staffLog.ActorSlug, "speakeasy staff slug must be masked")
+
+	customerLog := byID[customerLogID.String()]
+	require.NotNil(t, customerLog)
+	require.NotNil(t, customerLog.ActorDisplayName)
+	require.Equal(t, "customer@example.com", *customerLog.ActorDisplayName, "non-speakeasy actors are untouched")
+	require.NotNil(t, customerLog.ActorSlug)
+	require.Equal(t, "customer", *customerLog.ActorSlug)
+}
+
+// Non-user actor types are never masked, even if their id happens to collide
+// with a Speakeasy member's user id.
+func TestAuditService_List_MaskSkipsNonUserActors(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAuditService(t)
+	authCtx := testAuthContext(t, ctx)
+
+	staffUserID := uuid.NewString()
+	seedSpeakeasyMember(t, ctx, ti, staffUserID)
+
+	insertAuditLog(t, ctx, ti, auditLogSeed{
+		organizationID:   authCtx.ActiveOrganizationID,
+		projectID:        uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		actorID:          staffUserID,
+		actorType:        "service_account",
+		actorDisplayName: new("automation"),
+		action:           "project:update",
+		subjectID:        "project-1",
+		subjectType:      "project",
+	})
+
+	result, err := ti.service.List(ctx, &gen.ListPayload{
+		ApikeyToken:  nil,
+		SessionToken: nil,
+		Cursor:       nil,
+		ProjectSlug:  nil,
+		ActorID:      nil,
+		Action:       nil,
+		SubjectType:  nil,
+		SubjectID:    nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Logs, 1)
+	require.NotNil(t, result.Logs[0].ActorDisplayName)
+	require.Equal(t, "automation", *result.Logs[0].ActorDisplayName)
+}
+
+// Inside the Speakeasy org itself, staff actors keep their real identities —
+// masking only applies to customer-facing feeds.
+func TestAuditService_List_NoMaskingInsideSpeakeasyOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAuditService(t)
+	authCtx := testAuthContext(t, ctx)
+
+	staffUserID := uuid.NewString()
+	seedSpeakeasyMember(t, ctx, ti, staffUserID)
+
+	// Re-scope the session to the Speakeasy org as the active org.
+	authCtx.ActiveOrganizationID = speakeasyTeamOrganizationID
+
+	insertAuditLog(t, ctx, ti, auditLogSeed{
+		organizationID:   speakeasyTeamOrganizationID,
+		projectID:        uuid.NullUUID{},
+		actorID:          staffUserID,
+		actorType:        "user",
+		actorDisplayName: new("david@speakeasy.com"),
+		actorSlug:        new("david"),
+		action:           "organization:update",
+		subjectID:        speakeasyTeamOrganizationID,
+		subjectType:      "organization",
+	})
+
+	result, err := ti.service.List(ctx, &gen.ListPayload{
+		ApikeyToken:  nil,
+		SessionToken: nil,
+		Cursor:       nil,
+		ProjectSlug:  nil,
+		ActorID:      nil,
+		Action:       nil,
+		SubjectType:  nil,
+		SubjectID:    nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Logs, 1)
+	require.NotNil(t, result.Logs[0].ActorDisplayName)
+	require.Equal(t, "david@speakeasy.com", *result.Logs[0].ActorDisplayName)
+}
+
+// The actor facet list masks Speakeasy staff display names the same way the
+// log feed does, so the audit page filter dropdown doesn't leak emails.
+func TestAuditService_ListFacets_MasksSpeakeasyOrgActors(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAuditService(t)
+	authCtx := testAuthContext(t, ctx)
+
+	staffUserID := uuid.NewString()
+	seedSpeakeasyMember(t, ctx, ti, staffUserID)
+
+	insertAuditLog(t, ctx, ti, auditLogSeed{
+		organizationID:   authCtx.ActiveOrganizationID,
+		projectID:        uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		actorID:          staffUserID,
+		actorType:        "user",
+		actorDisplayName: new("david@speakeasy.com"),
+		action:           "chat_session:access",
+		subjectID:        uuid.NewString(),
+		subjectType:      "chat_session",
+	})
+
+	insertAuditLog(t, ctx, ti, auditLogSeed{
+		organizationID:   authCtx.ActiveOrganizationID,
+		projectID:        uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		actorID:          "customer-user",
+		actorType:        "user",
+		actorDisplayName: new("customer@example.com"),
+		action:           "project:update",
+		subjectID:        "project-1",
+		subjectType:      "project",
+	})
+
+	result, err := ti.service.ListFacets(ctx, &gen.ListFacetsPayload{
+		ApikeyToken:  nil,
+		SessionToken: nil,
+		ProjectSlug:  nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Actors, 2)
+
+	byValue := make(map[string]string, len(result.Actors))
+	for _, actor := range result.Actors {
+		byValue[actor.Value] = actor.DisplayName
+	}
+	require.Equal(t, "Speakeasy Team", byValue[staffUserID])
+	require.Equal(t, "customer@example.com", byValue["customer-user"])
+}

--- a/server/internal/auditapi/speakeasy_mask_test.go
+++ b/server/internal/auditapi/speakeasy_mask_test.go
@@ -233,3 +233,36 @@ func TestAuditService_ListFacets_MasksSpeakeasyOrgActors(t *testing.T) {
 	require.Equal(t, "Speakeasy Team", byValue[staffUserID])
 	require.Equal(t, "customer@example.com", byValue["customer-user"])
 }
+
+// Facets for non-user actors are never masked, even if their id happens to
+// collide with a Speakeasy member's user id.
+func TestAuditService_ListFacets_MaskSkipsNonUserActors(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAuditService(t)
+	authCtx := testAuthContext(t, ctx)
+
+	staffUserID := uuid.NewString()
+	seedSpeakeasyMember(t, ctx, ti, staffUserID)
+
+	insertAuditLog(t, ctx, ti, auditLogSeed{
+		organizationID:   authCtx.ActiveOrganizationID,
+		projectID:        uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		actorID:          staffUserID,
+		actorType:        "service_account",
+		actorDisplayName: new("automation"),
+		action:           "project:update",
+		subjectID:        "project-1",
+		subjectType:      "project",
+	})
+
+	result, err := ti.service.ListFacets(ctx, &gen.ListFacetsPayload{
+		ApikeyToken:  nil,
+		SessionToken: nil,
+		ProjectSlug:  nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Actors, 1)
+	require.Equal(t, staffUserID, result.Actors[0].Value)
+	require.Equal(t, "automation", result.Actors[0].DisplayName)
+}

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -456,6 +456,13 @@ func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	// A Speakeasy admin impersonating an org via the dev-tools override holds
+	// every scope (see authz.Engine), so RBAC cannot stop them — block
+	// transcript access explicitly before any session data is read.
+	if _, impersonating := contextvalues.GetAdminOverrideFromContext(ctx); impersonating && authCtx.IsAdmin {
+		return nil, oops.E(oops.CodeForbidden, nil, "chat sessions cannot be opened while impersonating an organization")
+	}
+
 	chatID, err := uuid.Parse(payload.ID)
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid chat ID")

--- a/server/internal/chat/load_chat_rbac_test.go
+++ b/server/internal/chat/load_chat_rbac_test.go
@@ -116,6 +116,55 @@ func TestLoadChat_AuditsSessionAccess(t *testing.T) {
 	require.Equal(t, ti.projectID, rec.ProjectID.UUID)
 }
 
+// A Speakeasy admin impersonating an org via the dev-tools override is blocked
+// from opening chat sessions outright, even though impersonation grants every
+// scope, and no chat_session:access audit event is written.
+func TestLoadChat_ImpersonatingAdminBlocked(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := initSessionCtx(t, ti)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.IsAdmin = true
+
+	other := seedChat(t, ctx, ti, "someone-else", "", "their session")
+
+	adminCtx := authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeChatRead, authz.WildcardResource))
+	adminCtx = contextvalues.SetAdminOverrideInContext(adminCtx, "customer-org")
+
+	before, err := audittest.AuditLogCountByAction(t.Context(), ti.conn, audit.ActionChatSessionAccess)
+	require.NoError(t, err)
+
+	_, err = ti.service.LoadChat(adminCtx, loadPayload(other.String()))
+	require.Error(t, err)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeForbidden, shareable.Code)
+
+	after, err := audittest.AuditLogCountByAction(t.Context(), ti.conn, audit.ActionChatSessionAccess)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "blocked opens must not record an access audit event")
+}
+
+// A stray admin-override cookie on a non-admin session has no effect: auth
+// ignores the override for non-admins, so LoadChat must not block them.
+func TestLoadChat_OverrideWithoutAdminNotBlocked(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := initSessionCtx(t, ti)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	own := seedChat(t, ctx, ti, authCtx.UserID, "", "my session")
+
+	selfCtx := authztest.WithExactGrants(t, ctx)
+	selfCtx = contextvalues.SetAdminOverrideInContext(selfCtx, "customer-org")
+
+	res, err := ti.service.LoadChat(selfCtx, loadPayload(own.String()))
+	require.NoError(t, err)
+	require.Equal(t, own.String(), res.ID)
+}
+
 // Scroll pagination (before_seq/after_seq) does not emit additional audit
 // events: only the initial open of a session is recorded.
 func TestLoadChat_RBAC_PaginationNotReAudited(t *testing.T) {

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -112,6 +112,16 @@ WHERE our.organization_id = @organization_id
   AND our.deleted_at IS NULL
   AND u.deleted_at IS NULL;
 
+-- name: FilterOrganizationMemberUserIDs :many
+-- Returns the subset of the given Gram user IDs that are active members of
+-- the organization. Used to mask Speakeasy staff identities in customer-facing
+-- audit feeds.
+SELECT user_id::text AS user_id
+FROM organization_user_relationships
+WHERE organization_id = @organization_id
+  AND user_id = ANY(@user_ids::text[])
+  AND deleted_at IS NULL;
+
 -- name: DeleteOrganizationUserRelationship :exec
 UPDATE organization_user_relationships
 SET deleted_at = clock_timestamp()

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -320,6 +320,42 @@ func (q *Queries) ExpireStaleInvitations(ctx context.Context, arg ExpireStaleInv
 	return err
 }
 
+const filterOrganizationMemberUserIDs = `-- name: FilterOrganizationMemberUserIDs :many
+SELECT user_id::text AS user_id
+FROM organization_user_relationships
+WHERE organization_id = $1
+  AND user_id = ANY($2::text[])
+  AND deleted_at IS NULL
+`
+
+type FilterOrganizationMemberUserIDsParams struct {
+	OrganizationID string
+	UserIds        []string
+}
+
+// Returns the subset of the given Gram user IDs that are active members of
+// the organization. Used to mask Speakeasy staff identities in customer-facing
+// audit feeds.
+func (q *Queries) FilterOrganizationMemberUserIDs(ctx context.Context, arg FilterOrganizationMemberUserIDsParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, filterOrganizationMemberUserIDs, arg.OrganizationID, arg.UserIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var user_id string
+		if err := rows.Scan(&user_id); err != nil {
+			return nil, err
+		}
+		items = append(items, user_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getInvitationByID = `-- name: GetInvitationByID :one
 SELECT id, organization_id, email, token_hash, inviter_user_id, role_slug, state, expires_at, accepted_at, revoked_at, created_at, updated_at
 FROM organization_invitations


### PR DESCRIPTION
Fixes DNO-391.

## What

- **Mask Speakeasy staff in customer-facing audit feeds.** `auditlogs.list` and `auditlogs.listFacets` now surface actors who are active members of the Speakeasy org (`speakeasy-team`) as **"Speakeasy Team"** instead of their email (actor slug is nulled). This covers the dashboard Home "Recent Activity" card, the per-project recent-action line on the org home Projects list, and the View-all audit page — all fed by the same endpoint.
- **Block impersonating admins from opening chat transcripts.** A Speakeasy admin impersonating an org via the dev-tools override is rejected by `LoadChat` with `403 Forbidden` before any session data is read, so no `chat_session:access` audit event is emitted either.

## How

- Masking is done at **read time** (not write time) so historical entries are covered. `audit_logs.actor_id` stores the raw Gram user id, so a new `FilterOrganizationMemberUserIDs` query joins it against `organization_user_relationships` for the Speakeasy org. Masking is skipped when the org being viewed *is* speakeasy-team, and only applies to `actor_type = "user"` rows.
- The chat block must be an explicit inline check: the authz engine grants **all** scopes to impersonating admins, so no RBAC check can stop them. A stray override cookie on a non-admin session has no effect (auth ignores the override for non-admins), and such callers are not blocked.

## Tests

- Staff actor masked in `List`; non-Speakeasy actors untouched; non-`user` actor types never masked; no masking when viewing the Speakeasy org itself; actor facet display names masked.
- Impersonating admin gets `403` from `LoadChat` with no audit event written; non-admin with an override cookie can still open their own session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Masks Speakeasy staff identities in customer audit feeds and blocks chat transcript access while an admin is impersonating an org. Prevents staff email leakage and stops privileged access during impersonation (DNO-391).

- **New Features**
  - `auditlogs.list` and `auditlogs.listFacets`: mask `actor_type="user"` members of `speakeasy-team` as "Speakeasy Team" and clear slug; skipped when viewing `speakeasy-team`; applied at read-time; actor facets now flag user actors to avoid masking non-user actors with colliding ids.
  - `LoadChat`: return 403 for impersonating admins before any session data is read; no `chat_session:access` audit event is emitted.

<sup>Written for commit fa98e8b314a56fb0cb5a665b0451145c1c6006a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

