### PR TITLE
fix: rename conflicting class name in consent templates

### DIFF
--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -14,11 +14,11 @@
       html,
       body {
         --font-diatype:
-          "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          Helvetica, Arial, sans-serif;
+          "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+          sans-serif;
         --font-diatype-mono:
-          "Geist Mono", SFMono-Regular, Menlo, Monaco, Consolas,
-          "Liberation Mono", "Courier New", monospace;
+          "Geist Mono", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+          monospace;
 
         --color-base-white: hsl(0 0% 100%);
         --color-base-black: hsl(0 0% 0%);
@@ -81,7 +81,7 @@
         }
       }
 
-      .consent-container {
+      .auth-consent-container {
         background: var(--bg-surface-primary-default);
         border: solid 1px var(--border-neutral-softest);
         border-radius: 0.5rem;
@@ -324,18 +324,16 @@
   </head>
   <body>
     <main class="main">
-      <div class="consent-container">
+      <div class="auth-consent-container">
         <div class="header">
           {{if .FirstParty}}
           <h1>Connect {{.MCPSlug}}</h1>
-          <p>
-            Link the services this MCP server needs to access on your behalf.
-          </p>
+          <p>Link the services this MCP server needs to access on your behalf.</p>
           {{else}}
           <h1>Authorize {{.ClientName}}</h1>
           <p>
-            <strong>{{.ClientName}}</strong> is requesting access to the MCP
-            server <strong>{{.MCPSlug}}</strong>
+            <strong>{{.ClientName}}</strong> is requesting access to the MCP server
+            <strong>{{.MCPSlug}}</strong>
           </p>
           {{end}}
         </div>
@@ -373,19 +371,11 @@
           </div>
           {{end}}
         </div>
-        {{end}}
-
-        {{if .FirstParty}}
-        <p class="info">
-          When you've connected the services above, you can close this tab.
-        </p>
+        {{end}} {{if .FirstParty}}
+        <p class="info">When you've connected the services above, you can close this tab.</p>
         {{else}}
         <div class="actions">
-          <form
-            method="POST"
-            action="/{{.MCPRouteBase}}/{{.MCPSlug}}/connect"
-            data-approve-form
-          >
+          <form method="POST" action="/{{.MCPRouteBase}}/{{.MCPSlug}}/connect" data-approve-form>
             <input type="hidden" name="state" value="{{.State}}" />
             <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
             <button
@@ -403,12 +393,7 @@
           <form method="POST" action="/{{.MCPRouteBase}}/{{.MCPSlug}}/connect">
             <input type="hidden" name="state" value="{{.State}}" />
             <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
-            <button
-              type="submit"
-              name="action"
-              value="deny"
-              class="btn btn-secondary"
-            >
+            <button type="submit" name="action" value="deny" class="btn btn-secondary">
               Cancel
             </button>
           </form>

--- a/server/internal/oauth/consent_template.html
+++ b/server/internal/oauth/consent_template.html
@@ -6,8 +6,7 @@
     <title>Authorization Request</title>
     <style>
       body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         background-color: #f5f5f5;
         margin: 0;
         padding: 20px;
@@ -16,7 +15,7 @@
         align-items: center;
         min-height: 100vh;
       }
-      .consent-container {
+      .auth-consent-container {
         background: white;
         border-radius: 8px;
         box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
@@ -115,13 +114,11 @@
     </style>
   </head>
   <body>
-    <div class="consent-container">
+    <div class="auth-consent-container">
       <div class="header">
         <h1>Authorization Request</h1>
         {{if .ClientName}}
-        <p>
-          <strong>{{.ClientName}}</strong> is requesting access to your account
-        </p>
+        <p><strong>{{.ClientName}}</strong> is requesting access to your account</p>
         {{else}}
         <p>An application is requesting access to your account</p>
         {{end}}
@@ -151,51 +148,23 @@
       {{end}}
 
       <div class="actions">
-        <form
-          method="POST"
-          action="/oauth/{{.MCPSlug}}/complete"
-          style="flex: 1"
-        >
+        <form method="POST" action="/oauth/{{.MCPSlug}}/complete" style="flex: 1">
           <input type="hidden" name="client_id" value="{{.ClientID}}" />
           <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
           <input type="hidden" name="scope" value="{{.Scope}}" />
           <input type="hidden" name="state" value="{{.State}}" />
-          <input
-            type="hidden"
-            name="code_challenge"
-            value="{{.CodeChallenge}}"
-          />
-          <input
-            type="hidden"
-            name="code_challenge_method"
-            value="{{.CodeChallengeMethod}}"
-          />
+          <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}" />
+          <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
           <input type="hidden" name="response_type" value="{{.ResponseType}}" />
-          <button
-            type="submit"
-            name="action"
-            value="approve"
-            class="btn btn-primary"
-          >
+          <button type="submit" name="action" value="approve" class="btn btn-primary">
             Authorize
           </button>
         </form>
-        <form
-          method="POST"
-          action="/oauth/{{.MCPSlug}}/complete"
-          style="flex: 1"
-        >
+        <form method="POST" action="/oauth/{{.MCPSlug}}/complete" style="flex: 1">
           <input type="hidden" name="client_id" value="{{.ClientID}}" />
           <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
           <input type="hidden" name="state" value="{{.State}}" />
-          <button
-            type="submit"
-            name="action"
-            value="deny"
-            class="btn btn-secondary"
-          >
-            Cancel
-          </button>
+          <button type="submit" name="action" value="deny" class="btn btn-secondary">Cancel</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Renamed `.consent-container` CSS class to a more specific `.auth-consent-container` in both consent templates to avoid collisions with blocking extensions or browser defaults

## Root cause
`.consent-container` is too generic a name. In the Dia browser that class name is stored in a user agent stylesheet, and set to display: none.

Personally this broke the auth flow for me as I couldn't see the content, and required some manual editing of the page styles.

