### PR TITLE
chore: use icons to delineate team/personal accounts

### DIFF
--- a/.changeset/honest-impalas-send.md
+++ b/.changeset/honest-impalas-send.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+chore: use icons to delineate team vs personal accounts

--- a/client/dashboard/src/components/account-type-badge.tsx
+++ b/client/dashboard/src/components/account-type-badge.tsx
@@ -19,8 +19,11 @@ type AccountTypeBadgeProps = {
   className?: string;
 };
 
-const PERSONAL_TOOLTIP =
+export const PERSONAL_TOOLTIP =
   "Personal account — usage from an individual AI account (e.g. Claude Max) signed in on a company device, not your enterprise plan.";
+
+export const TEAM_TOOLTIP =
+  "Team account — usage from a shared AI plan provisioned by your organization's enterprise agreement.";
 
 export function AccountTypeBadge({
   accountType,

--- a/client/dashboard/src/components/account-type-icon.test.tsx
+++ b/client/dashboard/src/components/account-type-icon.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AccountTypeIcon } from "./account-type-icon";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+afterEach(cleanup);
+
+describe("AccountTypeIcon", () => {
+  it("labels a personal account with the single-person glyph", () => {
+    render(<AccountTypeIcon accountType="personal" noTooltip />);
+    expect(screen.getByLabelText("Personal account")).toBeTruthy();
+  });
+
+  it("labels a team account with the group glyph", () => {
+    render(<AccountTypeIcon accountType="team" noTooltip />);
+    expect(screen.getByLabelText("Team account")).toBeTruthy();
+  });
+
+  it("falls back to a neutral owner glyph when unclassified", () => {
+    render(<AccountTypeIcon accountType={undefined} />);
+    expect(screen.getByLabelText("Account owner")).toBeTruthy();
+  });
+
+  it("treats an unrecognized account type as unclassified", () => {
+    render(<AccountTypeIcon accountType="enterprise" />);
+    expect(screen.getByLabelText("Account owner")).toBeTruthy();
+  });
+
+  it("still renders the glyph when wrapped in a tooltip", () => {
+    render(
+      <TooltipProvider>
+        <AccountTypeIcon accountType="team" />
+      </TooltipProvider>,
+    );
+    expect(screen.getByLabelText("Team account")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/account-type-icon.tsx
+++ b/client/dashboard/src/components/account-type-icon.tsx
@@ -53,6 +53,8 @@ function glyphForAccountType(
         tooltip: TEAM_TOOLTIP,
         iconClassName: "opacity-60",
       };
+    case null:
+    case undefined:
     default:
       return {
         iconName: "user",

--- a/client/dashboard/src/components/account-type-icon.tsx
+++ b/client/dashboard/src/components/account-type-icon.tsx
@@ -1,0 +1,86 @@
+import { Icon } from "@speakeasy-api/moonshine";
+
+import { cn } from "@/lib/utils";
+
+import { PERSONAL_TOOLTIP, TEAM_TOOLTIP } from "./account-type-badge";
+import { SimpleTooltip } from "./ui/tooltip";
+
+// Encodes the personal/team distinction in the person glyph itself: a single
+// person for personal accounts, a group for team accounts. This reuses the
+// person-icon slot that already sits next to an account owner in session and
+// tool-log rows, so the distinction is legible at a glance across the app.
+//
+// Unclassified sessions (empty/undefined account type) keep the single-person
+// icon and get no tooltip — there's nothing meaningful to explain yet.
+type AccountTypeIconProps = {
+  /**
+   * The resolved account type. Accepts the raw backend value (`team`,
+   * `personal`, or an unclassified empty/undefined string), so callers can pass
+   * row data verbatim — the runtime guard narrows.
+   */
+  accountType: string | undefined | null;
+  /** When true, omit the tooltip wrapper (e.g. inside a row that already has one). */
+  noTooltip?: boolean;
+  /** Classes applied to the icon. Defaults match the surrounding metadata icons. */
+  className?: string;
+};
+
+type AccountTypeGlyph = {
+  iconName: "user" | "users";
+  label: string;
+  tooltip: string | null;
+  // Personal usage is the thing an admin scans for, so it's tinted with the
+  // warning color and shown at full strength; team/unclassified stay muted like
+  // the surrounding metadata icons.
+  iconClassName: string;
+};
+
+function glyphForAccountType(
+  accountType: string | undefined | null,
+): AccountTypeGlyph {
+  switch (accountType) {
+    case "personal":
+      return {
+        iconName: "user",
+        label: "Personal account",
+        tooltip: PERSONAL_TOOLTIP,
+        iconClassName: "text-warning",
+      };
+    case "team":
+      return {
+        iconName: "users",
+        label: "Team account",
+        tooltip: TEAM_TOOLTIP,
+        iconClassName: "opacity-60",
+      };
+    default:
+      return {
+        iconName: "user",
+        label: "Account owner",
+        tooltip: null,
+        iconClassName: "opacity-60",
+      };
+  }
+}
+
+export function AccountTypeIcon({
+  accountType,
+  noTooltip = false,
+  className,
+}: AccountTypeIconProps): JSX.Element {
+  const { iconName, label, tooltip, iconClassName } =
+    glyphForAccountType(accountType);
+
+  const icon = (
+    <span className="inline-flex items-center" aria-label={label}>
+      <Icon
+        name={iconName}
+        className={cn("size-4", iconClassName, className)}
+      />
+    </span>
+  );
+
+  if (noTooltip || !tooltip) return icon;
+
+  return <SimpleTooltip tooltip={tooltip}>{icon}</SimpleTooltip>;
+}

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -1,4 +1,4 @@
-import { AccountTypeBadge } from "@/components/account-type-badge";
+import { AccountTypeIcon } from "@/components/account-type-icon";
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { EnterpriseGate } from "@/components/enterprise-gate";
 import { InsightsConfig } from "@/components/insights-dock";
@@ -1006,10 +1006,13 @@ function LogsToolsTraceRow({
         </div>
 
         <div className="flex min-w-[200px] flex-1 items-center gap-2 text-xs">
+          <AccountTypeIcon
+            accountType={trace.accountType}
+            className="shrink-0"
+          />
           <span className="text-muted-foreground min-w-0 truncate">
             {userLabel || "—"}
           </span>
-          <AccountTypeBadge accountType={trace.accountType} noTooltip />
         </div>
 
         <div className="flex min-w-28 shrink-0 items-center gap-2">

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
@@ -1,4 +1,4 @@
-import { AccountTypeBadge } from "@/components/account-type-badge";
+import { AccountTypeIcon } from "@/components/account-type-icon";
 import { Dialog } from "@/components/ui/dialog";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -249,12 +249,11 @@ export function ChatLogsTable({
                   {/* Metadata row */}
                   <div className="text-muted-foreground flex items-center gap-4 text-sm">
                     <span className="flex items-center gap-1.5">
-                      <Icon name="user" className="size-4 opacity-60" />
+                      <AccountTypeIcon accountType={chat.accountType} />
                       <span className="max-w-[120px] truncate">
                         {ownerLabel(chat, user)}
                       </span>
                     </span>
-                    <AccountTypeBadge accountType={chat.accountType} />
                     {source && (
                       <span className="flex items-center gap-1.5">
                         <HookSourceIcon source={source} className="size-4" />

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{if .FirstParty}}Connect {{.MCPSlug}}{{else}}Authorize {{.ClientName}}{{end}}</title>
+    <title>
+      {{if .FirstParty}}Connect {{.MCPSlug}}{{else}}Authorize
+      {{.ClientName}}{{end}}
+    </title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -14,11 +17,11 @@
       html,
       body {
         --font-diatype:
-          "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
-          sans-serif;
+          "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          Helvetica, Arial, sans-serif;
         --font-diatype-mono:
-          "Geist Mono", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-          monospace;
+          "Geist Mono", SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
 
         --color-base-white: hsl(0 0% 100%);
         --color-base-black: hsl(0 0% 0%);
@@ -328,11 +331,14 @@
         <div class="header">
           {{if .FirstParty}}
           <h1>Connect {{.MCPSlug}}</h1>
-          <p>Link the services this MCP server needs to access on your behalf.</p>
+          <p>
+            Link the services this MCP server needs to access on your behalf.
+          </p>
           {{else}}
           <h1>Authorize {{.ClientName}}</h1>
           <p>
-            <strong>{{.ClientName}}</strong> is requesting access to the MCP server
+            <strong>{{.ClientName}}</strong> is requesting access to the MCP
+            server
             <strong>{{.MCPSlug}}</strong>
           </p>
           {{end}}
@@ -372,10 +378,16 @@
           {{end}}
         </div>
         {{end}} {{if .FirstParty}}
-        <p class="info">When you've connected the services above, you can close this tab.</p>
+        <p class="info">
+          When you've connected the services above, you can close this tab.
+        </p>
         {{else}}
         <div class="actions">
-          <form method="POST" action="/{{.MCPRouteBase}}/{{.MCPSlug}}/connect" data-approve-form>
+          <form
+            method="POST"
+            action="/{{.MCPRouteBase}}/{{.MCPSlug}}/connect"
+            data-approve-form
+          >
             <input type="hidden" name="state" value="{{.State}}" />
             <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
             <button
@@ -393,7 +405,12 @@
           <form method="POST" action="/{{.MCPRouteBase}}/{{.MCPSlug}}/connect">
             <input type="hidden" name="state" value="{{.State}}" />
             <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
-            <button type="submit" name="action" value="deny" class="btn btn-secondary">
+            <button
+              type="submit"
+              name="action"
+              value="deny"
+              class="btn btn-secondary"
+            >
               Cancel
             </button>
           </form>

--- a/server/internal/oauth/consent_template.html
+++ b/server/internal/oauth/consent_template.html
@@ -6,7 +6,8 @@
     <title>Authorization Request</title>
     <style>
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         background-color: #f5f5f5;
         margin: 0;
         padding: 20px;
@@ -118,7 +119,9 @@
       <div class="header">
         <h1>Authorization Request</h1>
         {{if .ClientName}}
-        <p><strong>{{.ClientName}}</strong> is requesting access to your account</p>
+        <p>
+          <strong>{{.ClientName}}</strong> is requesting access to your account
+        </p>
         {{else}}
         <p>An application is requesting access to your account</p>
         {{end}}
@@ -148,23 +151,51 @@
       {{end}}
 
       <div class="actions">
-        <form method="POST" action="/oauth/{{.MCPSlug}}/complete" style="flex: 1">
+        <form
+          method="POST"
+          action="/oauth/{{.MCPSlug}}/complete"
+          style="flex: 1"
+        >
           <input type="hidden" name="client_id" value="{{.ClientID}}" />
           <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
           <input type="hidden" name="scope" value="{{.Scope}}" />
           <input type="hidden" name="state" value="{{.State}}" />
-          <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}" />
-          <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
+          <input
+            type="hidden"
+            name="code_challenge"
+            value="{{.CodeChallenge}}"
+          />
+          <input
+            type="hidden"
+            name="code_challenge_method"
+            value="{{.CodeChallengeMethod}}"
+          />
           <input type="hidden" name="response_type" value="{{.ResponseType}}" />
-          <button type="submit" name="action" value="approve" class="btn btn-primary">
+          <button
+            type="submit"
+            name="action"
+            value="approve"
+            class="btn btn-primary"
+          >
             Authorize
           </button>
         </form>
-        <form method="POST" action="/oauth/{{.MCPSlug}}/complete" style="flex: 1">
+        <form
+          method="POST"
+          action="/oauth/{{.MCPSlug}}/complete"
+          style="flex: 1"
+        >
           <input type="hidden" name="client_id" value="{{.ClientID}}" />
           <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
           <input type="hidden" name="state" value="{{.State}}" />
-          <button type="submit" name="action" value="deny" class="btn btn-secondary">Cancel</button>
+          <button
+            type="submit"
+            name="action"
+            value="deny"
+            class="btn btn-secondary"
+          >
+            Cancel
+          </button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
Minor UI improvement 

<img width="862" height="1062" alt="CleanShot 2026-07-02 at 13 54 22@2x" src="https://github.com/user-attachments/assets/d14ef038-54dd-4ba2-8cf7-01e59ffb03b8" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use person/group icons to distinguish personal vs team accounts in logs and chat tables. This replaces the badge for cleaner, scannable rows.

- **New Features**
  - Added `AccountTypeIcon` with a warning-tinted single-user icon for personal and a group icon for team; unclassified stays neutral with no tooltip.
  - Exported `PERSONAL_TOOLTIP` and `TEAM_TOOLTIP`; icon shows a tooltip by default and supports `noTooltip`.
  - Replaced `AccountTypeBadge` with the icon in `LogsTools` and `ChatLogsTable`; added tests for labels and fallbacks.

- **Refactors**
  - Reformatted MCP and OAuth consent templates; no functional changes.
  - Added changeset entries to publish patch releases for `dashboard` and `server`.

<sup>Written for commit b7645f8444a31053059030e27e745026c104dfe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

