### PR TITLE
feat(dashboard): add refresh button to shared list-page toolbar

### DIFF
--- a/.agents/skills/page-toolbar/SKILL.md
+++ b/.agents/skills/page-toolbar/SKILL.md
@@ -29,19 +29,21 @@ Import `Page` from `@/components/page-layout` and render the toolbar on its **ow
   <Page.Toolbar.Count>{count} items</Page.Toolbar.Count>
   <Page.Toolbar.ViewAs value={view} onChange={setView} />
   <Page.Toolbar.Actions>{/* page-specific extras, e.g. a SegmentedControl */}</Page.Toolbar.Actions>
+  <Page.Toolbar.Refresh onRefresh={() => void refetch()} isRefreshing={isFetching} />
 </Page.Toolbar>
 ```
 
 The pieces (all optional, written in any order — the toolbar sorts them):
 
-| Piece     | Side  | What it is                                                                             |
-| --------- | ----- | -------------------------------------------------------------------------------------- |
-| `Search`  | left  | Debounced white search box (`debounceMs` optional, built-in clear button)              |
-| `Filters` | left  | Filter chips + "More filters" sheet + "Reset to default"                               |
-| `SortBy`  | right | Sort dropdown, optionally with a built-in asc/desc direction toggle (one bordered box) |
-| `Count`   | right | Result-count text                                                                      |
-| `ViewAs`  | right | Grid/table toggle (grid/table only)                                                    |
-| `Actions` | right | Page-specific right-aligned extras                                                     |
+| Piece     | Side  | What it is                                                                                                                                                                                        |
+| --------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Search`  | left  | Debounced white search box (`debounceMs` optional, built-in clear button)                                                                                                                         |
+| `Filters` | left  | Filter chips + "More filters" sheet + "Reset to default"                                                                                                                                          |
+| `SortBy`  | right | Sort dropdown, optionally with a built-in asc/desc direction toggle (one bordered box)                                                                                                            |
+| `Count`   | right | Result-count text                                                                                                                                                                                 |
+| `ViewAs`  | right | Grid/table toggle (grid/table only)                                                                                                                                                               |
+| `Actions` | right | Page-specific right-aligned extras                                                                                                                                                                |
+| `Refresh` | right | Manual refresh button (`onRefresh` required, `isRefreshing` optional); spins/disables while refreshing and enforces a ~2s minimum visible spin so a fast/cached refetch doesn't look like a no-op |
 
 Layout, height (40px), the grey bar, the search↔filters divider, and the left/right `justify-between` split are all handled by the component — don't re-create them.
 

--- a/.changeset/toolbar-refresh-button.md
+++ b/.changeset/toolbar-refresh-button.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Add a manual refresh button to the shared list-page toolbar (`Page.Toolbar.Refresh`) and wire it into every page using it: Catalog, MCP, Agent Sessions, Employee Insights, User Sessions, Risk Events, and the Observe Tools/Agents log pages. Restores the refresh control that Tool Logs previously had before it was merged into the unified logs page.

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -521,6 +521,20 @@ export function InsightsAgentsContent(): JSX.Element {
               <Page.Toolbar.Actions>
                 <ValueModeToggle mode={valueMode} onChange={setValueMode} />
               </Page.Toolbar.Actions>
+              <Page.Toolbar.Refresh
+                onRefresh={() => {
+                  void usersQuery.refetch();
+                  void projectQuery.refetch();
+                  void overviewQuery.refetch();
+                  void roleUsageQuery.refetch();
+                }}
+                isRefreshing={
+                  usersQuery.isFetching ||
+                  projectQuery.isFetching ||
+                  overviewQuery.isFetching ||
+                  roleUsageQuery.isFetching
+                }
+              />
             </Page.Toolbar>
           </div>
 

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -164,8 +164,15 @@ export function InsightsEmployeesContent(): JSX.Element {
     data: membersData,
     isLoading: membersLoading,
     error: membersError,
+    refetch: refetchMembers,
+    isFetching: membersFetching,
   } = useMembers();
-  const { data: rolesData, isLoading: rolesLoading } = useRoles();
+  const {
+    data: rolesData,
+    isLoading: rolesLoading,
+    refetch: refetchRoles,
+    isFetching: rolesFetching,
+  } = useRoles();
 
   const { values, setValue, clearValue, clearAll } =
     useFilterState(EMPLOYEE_FILTERS);
@@ -385,6 +392,16 @@ export function InsightsEmployeesContent(): JSX.Element {
                   disabled={isLoading}
                 />
               </Page.Toolbar.Actions>
+              <Page.Toolbar.Refresh
+                onRefresh={() => {
+                  void refetchMembers();
+                  void refetchRoles();
+                  void usageQuery.refetch();
+                }}
+                isRefreshing={
+                  membersFetching || rolesFetching || usageQuery.isFetching
+                }
+              />
             </Page.Toolbar>
           </div>
 

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -428,6 +428,8 @@ export function InsightsToolsContent(): JSX.Element {
           summaryIsError={summaryIsError}
           accountType={accountType}
           onAccountTypeChange={handleAccountTypeChange}
+          onRefresh={refetch}
+          isRefreshing={summaryFetching}
         />
       )}
     </>
@@ -465,6 +467,8 @@ function HooksInnerContent({
   summaryIsError,
   accountType,
   onAccountTypeChange,
+  onRefresh,
+  isRefreshing,
 }: {
   isLogsDisabled: boolean;
   isLoading: boolean;
@@ -497,6 +501,8 @@ function HooksInnerContent({
   summaryIsError: boolean;
   accountType: string;
   onAccountTypeChange: (value: string) => void;
+  onRefresh: () => void;
+  isRefreshing: boolean;
 }) {
   const orgRoutes = useOrgRoutes();
   const { from, to } = useMemo(
@@ -564,6 +570,8 @@ function HooksInnerContent({
           serverNameMappings={serverNameMappings}
           accountType={accountType}
           onAccountTypeChange={onAccountTypeChange}
+          onRefresh={onRefresh}
+          isRefreshing={isRefreshing}
         />
 
         <div className="flex min-h-0 flex-1 overflow-hidden">

--- a/client/dashboard/src/components/observe/LogsAgents.tsx
+++ b/client/dashboard/src/components/observe/LogsAgents.tsx
@@ -396,7 +396,7 @@ export function LogsAgentsContent(): JSX.Element {
     [updateSearchParams],
   );
 
-  const { data, isLoading, error, refetch, isLogsDisabled } =
+  const { data, isLoading, isFetching, error, refetch, isLogsDisabled } =
     useLogsEnabledErrorCheck(
       useListChats(
         {
@@ -545,6 +545,8 @@ export function LogsAgentsContent(): JSX.Element {
         error={error}
         isLogsDisabled={isLogsDisabled}
         onLogsEnabled={() => void refetch()}
+        onRefresh={() => void refetch()}
+        isRefreshing={isFetching}
         hasMore={hasMore}
         offset={offset}
         setOffset={setOffset}
@@ -589,6 +591,8 @@ function AgentSessionsPageContent({
   error,
   isLogsDisabled,
   onLogsEnabled,
+  onRefresh,
+  isRefreshing,
   hasMore,
   offset,
   setOffset,
@@ -628,6 +632,8 @@ function AgentSessionsPageContent({
   error: Error | null;
   isLogsDisabled: boolean;
   onLogsEnabled: () => void;
+  onRefresh: () => void;
+  isRefreshing: boolean;
   hasMore: boolean;
   offset: number;
   setOffset: (offset: number) => void;
@@ -762,6 +768,10 @@ function AgentSessionsPageContent({
               ]}
               direction={sortOrder}
               onDirectionChange={setSortOrder}
+            />
+            <Page.Toolbar.Refresh
+              onRefresh={onRefresh}
+              isRefreshing={isRefreshing}
             />
           </Page.Toolbar>
           <OwnSessionsNotice />

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -498,6 +498,7 @@ export function LogsTools(): JSX.Element {
           <LogsToolsContent
             isLoading={isLoading}
             isFetching={isFetching}
+            onRefresh={refetch}
             error={displayError}
             traces={traces}
             serverOptionGroups={serverOptionGroups}
@@ -554,6 +555,7 @@ export function LogsTools(): JSX.Element {
 function LogsToolsContent({
   isLoading,
   isFetching,
+  onRefresh,
   error,
   traces,
   serverOptionGroups,
@@ -601,6 +603,7 @@ function LogsToolsContent({
 }: {
   isLoading: boolean;
   isFetching: boolean;
+  onRefresh: () => void;
   error: Error | null;
   traces: ToolUsageTraceSummary[];
   serverOptionGroups: Parameters<
@@ -711,6 +714,8 @@ function LogsToolsContent({
                 />
               </div>
             }
+            onRefresh={onRefresh}
+            isRefreshing={isFetching}
           />
 
           {isCustomSearchActive(attributeSearchQuery, attributeFilters) && (

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -122,6 +122,8 @@ export function ObserveFilterBar({
   attributeSearchControl,
   accountType,
   onAccountTypeChange,
+  onRefresh,
+  isRefreshing,
 }: {
   serverOptions: string[];
   serverOptionGroups?: MultiSelectGroup[];
@@ -151,6 +153,8 @@ export function ObserveFilterBar({
   // pages whose data source can filter on account_type (e.g. raw logs).
   accountType?: string;
   onAccountTypeChange?: (value: string) => void;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
 }): JSX.Element {
   const valuesByPath = useCallback(
     (path: string) =>
@@ -391,6 +395,12 @@ export function ObserveFilterBar({
         projectSlug={projectSlug}
         customBuilder={attributeSearchControl}
       />
+      {onRefresh && (
+        <Page.Toolbar.Refresh
+          onRefresh={onRefresh}
+          isRefreshing={isRefreshing}
+        />
+      )}
     </Page.Toolbar>
   );
 }

--- a/client/dashboard/src/components/ui/toolbar.tsx
+++ b/client/dashboard/src/components/ui/toolbar.tsx
@@ -3,6 +3,7 @@ import React, { Fragment, useEffect, useState, type ReactNode } from "react";
 import {
   ArrowDownIcon,
   ArrowUpIcon,
+  RefreshCw,
   SearchIcon,
   SlidersHorizontal,
   X,
@@ -42,12 +43,13 @@ import {
  *     <Page.Toolbar.Filters schema={…} values={…} … />
  *     <Page.Toolbar.SortBy value={sort} options={…} onChange={setSort} />
  *     <Page.Toolbar.ViewAs value={view} onChange={setView} />
+ *     <Page.Toolbar.Refresh onRefresh={refetch} isRefreshing={isFetching} />
  *   </Page.Toolbar>
  *
  * Every control is the same height ({@link CONTROL_HEIGHT}) so the row reads
- * flush. The toolbar groups its children: ViewAs and Count anchor the right
- * edge; everything else stays left in source order. Child order otherwise
- * doesn't matter.
+ * flush. The toolbar groups its children: Search and Filters stay left; Sort,
+ * ViewAs, Count, Refresh, and Actions anchor the right edge, in source order.
+ * Child order otherwise doesn't matter.
  */
 
 // Shared height for every control in the toolbar (40px).
@@ -389,6 +391,49 @@ function ToolbarActions({ children }: { children: ReactNode }): JSX.Element {
   return <>{children}</>;
 }
 
+// Minimum time the refresh button stays in its spinning state, so a
+// fast/cached refetch still reads as having done something.
+const MIN_REFRESH_MS = 2000;
+
+/** Refresh button (right-aligned). Spins/disables while refreshing. */
+interface ToolbarRefreshProps {
+  onRefresh: () => void;
+  isRefreshing?: boolean;
+  className?: string;
+}
+
+function ToolbarRefresh({
+  onRefresh,
+  isRefreshing = false,
+  className,
+}: ToolbarRefreshProps): JSX.Element {
+  const [minDurationActive, setMinDurationActive] = useState(false);
+
+  useEffect(() => {
+    if (!minDurationActive) return;
+    const timer = setTimeout(() => setMinDurationActive(false), MIN_REFRESH_MS);
+    return () => clearTimeout(timer);
+  }, [minDurationActive]);
+
+  const showRefreshing = isRefreshing || minDurationActive;
+
+  return (
+    <Button
+      variant="outline"
+      onClick={() => {
+        setMinDurationActive(true);
+        onRefresh();
+      }}
+      disabled={showRefreshing}
+      aria-label="Refresh"
+      className={cn(CONTROL_HEIGHT, "gap-2", className)}
+    >
+      <RefreshCw className={cn("size-4", showRefreshing && "animate-spin")} />
+      Refresh
+    </Button>
+  );
+}
+
 export const Toolbar = Object.assign(ToolbarRoot, {
   Search: ToolbarSearch,
   Filters: ToolbarFilters,
@@ -396,4 +441,5 @@ export const Toolbar = Object.assign(ToolbarRoot, {
   ViewAs: ToolbarViewAs,
   Count: ToolbarCount,
   Actions: ToolbarActions,
+  Refresh: ToolbarRefresh,
 });

--- a/client/dashboard/src/pages/catalog/Catalog.tsx
+++ b/client/dashboard/src/pages/catalog/Catalog.tsx
@@ -81,7 +81,12 @@ function CatalogInner() {
   const [addingServers, setAddingServers] = useState<PulseMCPServer[]>([]);
   const [gridElement, setGridElement] = useState<HTMLDivElement | null>(null);
 
-  const { data, isLoading } = useListMCPCatalog();
+  const {
+    data,
+    isLoading,
+    isFetching,
+    refetch: refetchCatalog,
+  } = useListMCPCatalog();
   const { data: deploymentResult, refetch: refetchDeployment } =
     useLatestDeployment();
   const deployment = deploymentResult?.deployment;
@@ -173,6 +178,10 @@ function CatalogInner() {
                   </Page.Toolbar.Count>
                 )}
                 <Page.Toolbar.ViewAs value={viewMode} onChange={setViewMode} />
+                <Page.Toolbar.Refresh
+                  onRefresh={() => void refetchCatalog()}
+                  isRefreshing={isFetching}
+                />
               </Page.Toolbar>
 
               {/* Server grid / table */}

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -102,7 +102,8 @@ function MCPOverview() {
     void refetchMcpServers();
     void refetchEndpoints();
   };
-  const isRefreshing = isFetchingMcpServers || isFetchingEndpoints;
+  const isRefreshing =
+    isFetchingMcpServers || isFetchingEndpoints || toolsets.isFetching;
   // Filter the listing to Remote-MCP-backed rows for now — the AGE-1902
   // cutover will introduce toolset-backed rows that today still render
   // through the existing Hosted MCPCard path via useToolsets().

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -82,17 +82,27 @@ function MCPOverview() {
   const {
     data: mcpServersResult,
     isLoading: isLoadingMcpServers,
+    isFetching: isFetchingMcpServers,
     isError: isMcpServersError,
+    refetch: refetchMcpServers,
   } = useMcpServers({ gramProject }, undefined, {
     throwOnError: false,
   });
   const {
     data: endpointsResult,
     isLoading: isLoadingEndpoints,
+    isFetching: isFetchingEndpoints,
     isError: isEndpointsError,
+    refetch: refetchEndpoints,
   } = useMcpEndpoints({ gramProject }, undefined, {
     throwOnError: false,
   });
+  const handleRefresh = () => {
+    void toolsets.refetch();
+    void refetchMcpServers();
+    void refetchEndpoints();
+  };
+  const isRefreshing = isFetchingMcpServers || isFetchingEndpoints;
   // Filter the listing to Remote-MCP-backed rows for now — the AGE-1902
   // cutover will introduce toolset-backed rows that today still render
   // through the existing Hosted MCPCard path via useToolsets().
@@ -294,6 +304,10 @@ function MCPOverview() {
                 onClearAll={mcpFilters.clearAll}
               />
               <Page.Toolbar.ViewAs value={viewMode} onChange={setViewMode} />
+              <Page.Toolbar.Refresh
+                onRefresh={handleRefresh}
+                isRefreshing={isRefreshing}
+              />
             </Page.Toolbar>
           )}
           {showNoMatches ? (

--- a/client/dashboard/src/pages/org/UserSessions.tsx
+++ b/client/dashboard/src/pages/org/UserSessions.tsx
@@ -139,6 +139,7 @@ function UserSessionsInner(): JSX.Element {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
+    isFetching,
     refetch,
   } = useUserSessionsInfinite({
     gramProject: projectSlug,
@@ -306,6 +307,10 @@ function UserSessionsInner(): JSX.Element {
               {filteredSessions.length} session
               {filteredSessions.length === 1 ? "" : "s"}
             </Page.Toolbar.Count>
+            <Page.Toolbar.Refresh
+              onRefresh={() => void refetch()}
+              isRefreshing={isFetching}
+            />
           </Page.Toolbar>
 
           {selectionEnabled && selectedIds.length > 0 && (

--- a/client/dashboard/src/pages/security/RiskEvents.tsx
+++ b/client/dashboard/src/pages/security/RiskEvents.tsx
@@ -17,7 +17,7 @@ import {
 import { Button, Icon } from "@speakeasy-api/moonshine";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { History, RefreshCw, Share2 } from "lucide-react";
+import { History, Share2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, type RefObject } from "react";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
@@ -211,30 +211,7 @@ export default function RiskEvents(): JSX.Element {
         title="Risk Events"
         stage="beta"
         description="Review policy findings across recent analyzed chats."
-        actions={
-          <div className="flex items-center gap-2">
-            <RevealAllToggle />
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => {
-                void resultsQuery.refetch();
-              }}
-              disabled={resultsQuery.isFetching}
-              aria-label="Refresh risk events"
-            >
-              <Button.LeftIcon>
-                <RefreshCw
-                  className={cn(
-                    "h-4 w-4",
-                    resultsQuery.isFetching && "animate-spin",
-                  )}
-                />
-              </Button.LeftIcon>
-              <Button.Text>Refresh</Button.Text>
-            </Button>
-          </div>
-        }
+        actions={<RevealAllToggle />}
         filters={
           <Page.Toolbar>
             <Page.Toolbar.Filters
@@ -244,6 +221,10 @@ export default function RiskEvents(): JSX.Element {
               onChange={setValue as (id: string, value: FilterValue) => void}
               onClear={clearValue as (id: string) => void}
               onClearAll={clearAll}
+            />
+            <Page.Toolbar.Refresh
+              onRefresh={() => void resultsQuery.refetch()}
+              isRefreshing={resultsQuery.isFetching}
             />
           </Page.Toolbar>
         }

--- a/client/dashboard/src/pages/toolsets/useToolsets.ts
+++ b/client/dashboard/src/pages/toolsets/useToolsets.ts
@@ -6,6 +6,7 @@ export function useToolsets(): NonNullable<
 >["toolsets"] & {
   refetch: ReturnType<typeof useListToolsets>["refetch"];
   isLoading: ReturnType<typeof useListToolsets>["isLoading"];
+  isFetching: ReturnType<typeof useListToolsets>["isFetching"];
   isError: ReturnType<typeof useListToolsets>["isError"];
 } {
   const gramProject = useProjectSlugForRequests();
@@ -13,6 +14,7 @@ export function useToolsets(): NonNullable<
     data: toolsets,
     refetch,
     isLoading,
+    isFetching,
     isError,
   } = useListToolsets({ gramProject }, undefined, {
     // toolsets.list is non-critical for the MCP screens — degrade to the last
@@ -24,6 +26,7 @@ export function useToolsets(): NonNullable<
   return Object.assign(toolsets?.toolsets || [], {
     refetch,
     isLoading,
+    isFetching,
     isError,
   });
 }


### PR DESCRIPTION
## Summary
- Adds `Page.Toolbar.Refresh` — a right-aligned refresh button (icon + "Refresh" text, spins/disables while refreshing, ~2s minimum visible spin so a fast/cached refetch doesn't look like a no-op) — to the shared `Page.Toolbar` compound component (`client/dashboard/src/components/ui/toolbar.tsx`).
- Wires it into every page that composes `Page.Toolbar`: Catalog, MCP, Agent Sessions (`UserSessions`), Employee Insights, Risk Events, and the Observe pages (Tools/Agents logs + insights), either directly or via `ObserveFilterBar`'s new optional `onRefresh`/`isRefreshing` props.
- Restores the refresh button Tool Logs had before `LogsMCP.tsx` was merged into the unified `LogsTools.tsx` page (#3441) — now generalized as a reusable toolbar piece instead of a one-off.
- Also replaces Risk Events' hand-rolled header refresh button with the shared piece, moving it into the toolbar bar per the new convention.
- Updates the `page-toolbar` skill doc to document the new `Refresh` piece.

## Test plan
- [x] `pnpm tsc -p tsconfig.app.json --noEmit` clean
- [x] `tsc -b --noEmit --force` (CI-equivalent strict check) clean
- [x] `pnpm knip` clean (no unused exports)
- [x] `pnpm lint:format` / `pnpm lint:oxlint` clean
- [x] `pnpm build` succeeds
- [ ] Manual click-through of refresh button on each wired page (not yet done in a running app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCmG8oeZQzx1DAnNXH4Aig

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a right‑aligned refresh button to the shared list-page toolbar so users can manually reload data. It spins/disabled while refreshing and stays visibly spinning for ~2s so fast refetches don’t look like a no-op. Also fixes the MCP page spinner to include toolsets fetch state.

- **New Features**
  - Added `Page.Toolbar.Refresh` (`onRefresh` required, `isRefreshing` optional) with a spinning icon and ~2s minimum spin.
  - Wired into pages using the shared toolbar: Catalog, MCP, User Sessions, Risk Events, and Observe logs (Tools/Agents) and insights (Tools/Agents/Employees).
  - Added optional `onRefresh`/`isRefreshing` passthrough to `ObserveFilterBar`.
  - Replaced Risk Events’ custom refresh with the shared control and restored the refresh button lost in Tool Logs after the unified logs merge.

- **Bug Fixes**
  - MCP: refresh button now stays spinning until all refetches finish by including `toolsets.isFetching` from `useToolsets` in `isRefreshing`.

<sup>Written for commit a4e9bf3d00b3169133081e7a49f2cd59d0123e2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

