### PR TITLE
fix: one-click dropdown dismissal in filter sheets (DNO-393)

### DIFF
--- a/.changeset/time-range-picker-one-click-dismiss.md
+++ b/.changeset/time-range-picker-one-click-dismiss.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+TimeRangePicker: clicking outside while the input is in edit mode now exits editing and closes the dropdown in a single click (previously the first click only blurred the input, and typed-but-uncommitted text made the dropdown undismissable by clicking). Uncommitted input text is discarded on outside click.

--- a/elements/src/components/ui/time-range-picker.tsx
+++ b/elements/src/components/ui/time-range-picker.tsx
@@ -386,6 +386,7 @@ function TimeRangePicker({
     initialCustomLabel || null,
   );
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const triggerRef = React.useRef<HTMLDivElement>(null);
 
   // Sync custom label from props (e.g., when URL changes)
   React.useEffect(() => {
@@ -548,6 +549,7 @@ function TimeRangePicker({
     <Popover open={isOpen} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild disabled={disabled}>
         <div
+          ref={triggerRef}
           className={cn(
             "relative inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-all outline-none",
             "border-border hover:border-border/80",
@@ -615,6 +617,17 @@ function TimeRangePicker({
           // Prevent popover from stealing focus from the input
           e.preventDefault();
           inputRef.current?.focus();
+        }}
+        onPointerDownOutside={(e) => {
+          // handleOpenChange swallows close-while-editing so the input/popover
+          // focus interplay can't dismiss mid-typing — but that makes a genuine
+          // outside click take two clicks (first only blurs the input). Close
+          // directly here, unless the click is on the trigger/input itself.
+          const target = e.target as Node | null;
+          if (target && triggerRef.current?.contains(target)) return;
+          setInputValue("");
+          setIsEditing(false);
+          setIsOpen(false);
         }}
       >
         <div className="flex flex-col">

--- a/elements/src/components/ui/time-range-picker.tsx
+++ b/elements/src/components/ui/time-range-picker.tsx
@@ -623,8 +623,18 @@ function TimeRangePicker({
           // focus interplay can't dismiss mid-typing — but that makes a genuine
           // outside click take two clicks (first only blurs the input). Close
           // directly here, unless the click is on the trigger/input itself.
+          // Inside a ShadowRoot embed, `e.target` is retargeted to the shadow
+          // host, so check the original event's composedPath for the trigger
+          // (same workaround as the tool-ui popover).
+          const trigger = triggerRef.current;
+          const path = e.detail.originalEvent.composedPath?.() ?? [];
           const target = e.target as Node | null;
-          if (target && triggerRef.current?.contains(target)) return;
+          if (
+            trigger &&
+            (path.includes(trigger) || (target && trigger.contains(target)))
+          ) {
+            return;
+          }
           setInputValue("");
           setIsEditing(false);
           setIsOpen(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ catalogs:
 overrides:
   glob@>=10.0 <10.5.0: 10.5.0
   recharts: 2.15.4
+  '@radix-ui/react-dismissable-layer': 1.1.13
 
 importers:
 
@@ -3628,19 +3629,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-dismissable-layer@1.1.12':
-    resolution: {integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.13':
@@ -11905,19 +11893,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   '@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -12043,7 +12018,7 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,11 @@ overrides:
   glob@>=10.0 <10.5.0: 10.5.0
   # Without this, @polar-sh/ui resolves Recharts v3 while Elements/Tremor stay on v2.
   recharts: 2.15.4
+  # Radix sub-packages pin exact react-dismissable-layer versions, so mixed Radix
+  # releases load multiple copies with separate layer-stack contexts — nested dismiss
+  # layers then can't see each other (e.g. the filter sheet closing when dismissing a
+  # dropdown inside it, DNO-393/AIS-168). Force one copy so all primitives share a stack.
+  "@radix-ui/react-dismissable-layer": 1.1.13
 
 allowBuilds:
   bun: true


### PR DESCRIPTION
# Summary

Adds a pnpm override forcing a single copy of `@radix-ui/react-dismissable-layer` (1.1.13) across the workspace.

## Root cause

Radix sub-packages pin **exact** versions of `react-dismissable-layer`, so mixed Radix releases load multiple module copies — each with its own module-level `DismissableLayerContext` (the shared layer stack). Layers from different copies can't see each other, which breaks nested dismiss behavior:

- A modal dropdown (MultiSelect/Select) inside the non-modal filter sheet sets `pointer-events: none` on `<body>`; the sheet's dismiss layer doesn't know a higher modal layer is open, sees the pointerdown as "outside" (target resolves to `<html>`), and closes the whole sheet along with the dropdown (**DNO-393**).
- Previously, option clicks inside popovers were swallowed for the same reason (**AIS-168**, worked around with `modalPopover`).

## What this changes

- `pnpm-workspace.yaml`: override `@radix-ui/react-dismissable-layer` → `1.1.13` (the version `dialog@1.1.17` already ships; no new package enters the graph).
- On current main this collapses the one remaining extra copy (1.1.12, pulled in via `@assistant-ui/react` and `@speakeasy-api/moonshine`'s dropdown menus — so moonshine dropdowns inside dashboard dialogs/sheets currently run a foreign layer stack).
- More importantly it **pins the invariant**: future Radix bumps can't silently re-fragment the layer stack (the state on main before #3815 had three copies).

## Compatibility verification

- Every consumer (popover, select, menu, tooltip, toast, hover-card, nav-menu, dialog) imports only the `DismissableLayer` component (toast: `Root`/`Branch`) — 1.1.13's exports are a strict superset of 1.1.11/1.1.12.
- Diffed the built JS 1.1.11 → 1.1.13: changes are additive/opt-in (`deferPointerDownOutside`, `dismissableSurfaces`, an `instanceof Node` guard) plus a fix to body `pointer-events` cleanup on unmount. No default behavior changes for older callers.
- Audited existing `onInteractOutside` / `modal={false}` workarounds (FilterSheet, MultiSelect `modalPopover`, non-modal DropdownMenus in RolesTab/Team/RemoteIdentityProviders/ExclusionsTab, PolicyCenter, elements tool-ui): all become more correct or are unaffected with a shared stack.
- `pnpm -F dashboard type-check` passes; lockfile diff only collapses 1.1.12 → 1.1.13 (2 references).

Fixes DNO-393. Complements the targeted `FilterSheet` fix (separate PR), which stays as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: TimeRangePicker one-click dismissal

Follow-up commit fixing the remaining two-click dismissal, which turned out to be in `@gram-ai/elements`' `TimeRangePicker`, not Radix: `handleOpenChange` swallows `onOpenChange(false)` while the input is in edit mode, so an outside click only blurred the input (and with typed text, the dropdown couldn't be click-dismissed at all).

Fix: handle `onPointerDownOutside` on the popover content — a genuine outside click (not on the trigger/input) exits edit mode, discards uncommitted text, and closes in one click. The edit-mode guard remains for the input/popover focus interplay it was built for. Includes a patch changeset for `@gram-ai/elements`.

Verified end-to-end against the running dashboard (Playwright, Insights filter sheet): one click out closes the date dropdown and keeps the sheet open (with and without typed text); re-clicking the input keeps it open; preset selection and the calendar view still work.
