### PR TITLE
feat: add confirmation dialog for deleting risk policies

### DIFF
--- a/.changeset/better-clubs-guess.md
+++ b/.changeset/better-clubs-guess.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+add confirmation dialog for deleting risk policies

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { SearchBar } from "@/components/ui/search-bar";
 import { Switch } from "@/components/ui/switch";
+import { Dialog } from "@/components/ui/dialog";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import {
   Sheet,
@@ -629,6 +630,7 @@ function PolicyCenterContent() {
   );
 
   const [runPanelPolicy, setRunPanelPolicy] = useState<RiskPolicy | null>(null);
+  const [policyToDelete, setPolicyToDelete] = useState<PolicyRow | null>(null);
 
   const [activeTab, setActiveTab] = useState<"policies" | "exclusions">(
     "policies",
@@ -651,7 +653,10 @@ function PolicyCenterContent() {
   });
 
   const deleteMutation = useRiskPoliciesDeleteMutation({
-    onSuccess: invalidate,
+    onSuccess: () => {
+      setPolicyToDelete(null);
+      invalidate();
+    },
   });
 
   // Redirect a deep-linked policy to its detail page once its data has loaded.
@@ -668,7 +673,12 @@ function PolicyCenterContent() {
   }, [policyParam, isLoading, data, routes]);
 
   const handleDelete = (row: PolicyRow) => {
-    deleteMutation.mutate({ request: { id: row.policy.id } });
+    setPolicyToDelete(row);
+  };
+
+  const confirmDelete = () => {
+    if (!policyToDelete) return;
+    deleteMutation.mutate({ request: { id: policyToDelete.policy.id } });
   };
 
   // Empty state for the Policies tab only. It must NOT short-circuit the whole
@@ -884,7 +894,9 @@ function PolicyCenterContent() {
               )}
               <DropdownMenuItem
                 className="text-destructive focus:text-destructive cursor-pointer"
-                onSelect={() => handleDelete(row)}
+                onSelect={() => {
+                  setTimeout(() => handleDelete(row), 0);
+                }}
               >
                 Delete
               </DropdownMenuItem>
@@ -995,6 +1007,44 @@ function PolicyCenterContent() {
             {runPanelPolicy && <RunPanel policy={runPanelPolicy} />}
           </SheetContent>
         </Sheet>
+
+        {/* Delete Policy Confirmation */}
+        <Dialog
+          open={!!policyToDelete}
+          onOpenChange={(open) => {
+            if (!open) setPolicyToDelete(null);
+          }}
+        >
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Delete Policy</Dialog.Title>
+            </Dialog.Header>
+            <div className="space-y-4 py-4">
+              <Type variant="body">
+                <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
+                  {policyToDelete?.policy.name}
+                </code>{" "}
+                policy will be permanently deleted. Any flags or blocks it
+                applies will stop immediately.
+              </Type>
+              <div className="flex justify-end space-x-2">
+                <Button
+                  variant="secondary"
+                  onClick={() => setPolicyToDelete(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive-primary"
+                  onClick={confirmDelete}
+                  disabled={deleteMutation.isPending}
+                >
+                  Delete Policy
+                </Button>
+              </div>
+            </div>
+          </Dialog.Content>
+        </Dialog>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -723,10 +723,10 @@ function PolicyCenterContent() {
         }}
         disabled={createMutation.isPending}
       >
-        <Button.Text>
+        <Button.Text className="flex gap-2">
           {createMutation.isPending ? (
             <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <Loader2 className="h-4 w-4 animate-spin" />
               Creating...
             </>
           ) : (

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -96,6 +96,11 @@ import {
   policyMessageTypesForForm,
   policyToCategories,
 } from "./policy-form";
+import {
+  getPolicyDeleteRuleActionLabel,
+  getPolicyDeleteRuleListItems,
+  getPolicyRuleGroupNamesForDeleteDialog,
+} from "./policy-delete-dialog";
 
 /** Built-in detector categories that only produce findings when Speakeasy hooks
  *  are installed on the agent (no rule list to customize). */
@@ -914,6 +919,14 @@ function PolicyCenterContent() {
           label: "Create Exclusion",
           onClick: () => setExclusionSheet({ mode: "create" }),
         };
+  const policyDeleteRuleListItems = policyToDelete
+    ? getPolicyDeleteRuleListItems(
+        getPolicyRuleGroupNamesForDeleteDialog(policyToDelete.policy),
+      )
+    : [];
+  const policyDeleteRuleActionLabel = policyToDelete
+    ? getPolicyDeleteRuleActionLabel(policyToDelete.policy)
+    : "flag";
 
   let policiesBody = (
     <Table
@@ -1024,9 +1037,25 @@ function PolicyCenterContent() {
                 <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
                   {policyToDelete?.policy.name}
                 </code>{" "}
-                policy will be permanently deleted. Any flags or blocks it
-                applies will stop immediately.
+                policy will be permanently deleted.
               </Type>
+              {policyDeleteRuleListItems.length > 0 && (
+                <div className="space-y-2">
+                  <Type variant="body">
+                    The following {policyDeleteRuleActionLabel} rules will no
+                    longer be enforced.
+                  </Type>
+                  <ul className="list-disc space-y-1 pl-5">
+                    {policyDeleteRuleListItems.map((ruleName, index) => (
+                      <li key={`${ruleName}-${index}`}>
+                        <Type variant="body" muted as="span">
+                          {ruleName}
+                        </Type>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
               <div className="flex justify-end space-x-2">
                 <Button
                   variant="secondary"

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Icon,
+  Stack,
   Table,
 } from "@speakeasy-api/moonshine";
 import type { BadgeProps, IconName } from "@speakeasy-api/moonshine";
@@ -97,7 +98,7 @@ import {
   policyToCategories,
 } from "./policy-form";
 import {
-  getPolicyDeleteRuleActionLabel,
+  getPolicyDeleteImpactText,
   getPolicyDeleteRuleListItems,
   getPolicyRuleGroupNamesForDeleteDialog,
 } from "./policy-delete-dialog";
@@ -924,9 +925,12 @@ function PolicyCenterContent() {
         getPolicyRuleGroupNamesForDeleteDialog(policyToDelete.policy),
       )
     : [];
-  const policyDeleteRuleActionLabel = policyToDelete
-    ? getPolicyDeleteRuleActionLabel(policyToDelete.policy)
-    : "flag";
+  const policyDeleteImpactText = policyToDelete
+    ? getPolicyDeleteImpactText(
+        policyToDelete.policy,
+        policyDeleteRuleListItems.length > 0,
+      )
+    : "";
 
   let policiesBody = (
     <Table
@@ -1032,19 +1036,18 @@ function PolicyCenterContent() {
             <Dialog.Header>
               <Dialog.Title>Delete Policy</Dialog.Title>
             </Dialog.Header>
-            <div className="space-y-4 py-4">
+            <Stack gap={4}>
               <Type variant="body">
                 <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
                   {policyToDelete?.policy.name}
                 </code>{" "}
                 policy will be permanently deleted.
               </Type>
+              {policyDeleteImpactText && (
+                <Type variant="body">{policyDeleteImpactText}</Type>
+              )}
               {policyDeleteRuleListItems.length > 0 && (
                 <div className="space-y-2">
-                  <Type variant="body">
-                    The following {policyDeleteRuleActionLabel} rules will no
-                    longer be enforced.
-                  </Type>
                   <ul className="list-disc space-y-1 pl-5">
                     {policyDeleteRuleListItems.map((ruleName, index) => (
                       <li key={`${ruleName}-${index}`}>
@@ -1056,7 +1059,9 @@ function PolicyCenterContent() {
                   </ul>
                 </div>
               )}
-              <div className="flex justify-end space-x-2">
+            </Stack>
+            <Dialog.Footer>
+              <div className="flex justify-end gap-2">
                 <Button
                   variant="secondary"
                   onClick={() => setPolicyToDelete(null)}
@@ -1071,7 +1076,7 @@ function PolicyCenterContent() {
                   Delete Policy
                 </Button>
               </div>
-            </div>
+            </Dialog.Footer>
           </Dialog.Content>
         </Dialog>
       </Page.Body>

--- a/client/dashboard/src/pages/security/policy-delete-dialog.test.ts
+++ b/client/dashboard/src/pages/security/policy-delete-dialog.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
+import { DETECTION_RULES, type DetectionRule } from "./policy-data";
 import {
+  getPolicyDeleteImpactText,
   getPolicyDeleteRuleActionLabel,
   getPolicyDeleteRuleListItems,
   getPolicyRuleGroupNamesForDeleteDialog,
 } from "./policy-delete-dialog";
+
+function visibleRuleIds(rules: DetectionRule[]): string[] {
+  return rules.filter((rule) => !rule.hidden).map((rule) => rule.id);
+}
 
 function policy(overrides: Partial<RiskPolicy>): RiskPolicy {
   return {
@@ -40,6 +46,30 @@ describe("getPolicyRuleGroupNamesForDeleteDialog", () => {
     expect(ruleGroups).toEqual(["Secrets", "Custom Rules"]);
     expect(ruleGroups).not.toContain("1Password Service Account Token");
     expect(ruleGroups).not.toContain("Password in Plain Text");
+  });
+
+  it("omits a category when every visible source rule is disabled", () => {
+    expect(
+      getPolicyRuleGroupNamesForDeleteDialog(
+        policy({
+          disabledRules: visibleRuleIds(DETECTION_RULES.secrets),
+          sources: ["gitleaks"],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps a category when at least one visible source rule is enabled", () => {
+    const [, ...disabledRules] = visibleRuleIds(DETECTION_RULES.secrets);
+
+    expect(
+      getPolicyRuleGroupNamesForDeleteDialog(
+        policy({
+          disabledRules,
+          sources: ["gitleaks"],
+        }),
+      ),
+    ).toEqual(["Secrets"]);
   });
 
   it("returns each enabled Presidio-backed category", () => {
@@ -90,6 +120,20 @@ describe("getPolicyDeleteRuleActionLabel", () => {
   it("returns flag for flag policies", () => {
     expect(getPolicyDeleteRuleActionLabel(policy({ action: "flag" }))).toBe(
       "flag",
+    );
+  });
+});
+
+describe("getPolicyDeleteImpactText", () => {
+  it("uses the action-specific grouped-rule text when groups are present", () => {
+    expect(getPolicyDeleteImpactText(policy({ action: "block" }), true)).toBe(
+      "The following block rules will no longer be enforced.",
+    );
+  });
+
+  it("uses action-specific fallback text when no groups are present", () => {
+    expect(getPolicyDeleteImpactText(policy({ action: "flag" }), false)).toBe(
+      "Any flag action this policy applies will stop immediately.",
     );
   });
 });

--- a/client/dashboard/src/pages/security/policy-delete-dialog.test.ts
+++ b/client/dashboard/src/pages/security/policy-delete-dialog.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
+import {
+  getPolicyDeleteRuleActionLabel,
+  getPolicyDeleteRuleListItems,
+  getPolicyRuleGroupNamesForDeleteDialog,
+} from "./policy-delete-dialog";
+
+function policy(overrides: Partial<RiskPolicy>): RiskPolicy {
+  return {
+    action: "block",
+    audiencePrincipalUrns: ["user:all"],
+    audienceType: "everyone",
+    autoName: false,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    enabled: true,
+    id: "policy-1",
+    name: "Sensitive Data",
+    pendingMessages: 0,
+    policyType: "standard",
+    projectId: "project-1",
+    sources: [],
+    totalMessages: 0,
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    version: 1,
+    ...overrides,
+  };
+}
+
+describe("getPolicyRuleGroupNamesForDeleteDialog", () => {
+  it("returns readable detector groups for a standard policy", () => {
+    const ruleGroups = getPolicyRuleGroupNamesForDeleteDialog(
+      policy({
+        customRuleIds: ["custom.password"],
+        disabledRules: ["secret.1password_secret_key"],
+        sources: ["gitleaks"],
+      }),
+    );
+
+    expect(ruleGroups).toEqual(["Secrets", "Custom Rules"]);
+    expect(ruleGroups).not.toContain("1Password Service Account Token");
+    expect(ruleGroups).not.toContain("Password in Plain Text");
+  });
+
+  it("returns each enabled Presidio-backed category", () => {
+    expect(
+      getPolicyRuleGroupNamesForDeleteDialog(
+        policy({
+          presidioEntities: ["EMAIL_ADDRESS", "CREDIT_CARD"],
+          sources: ["presidio"],
+        }),
+      ),
+    ).toEqual(["Financial Information", "Personal Identifiable Information"]);
+  });
+
+  it("returns all Presidio-backed categories when Presidio has no entity filter", () => {
+    expect(
+      getPolicyRuleGroupNamesForDeleteDialog(
+        policy({
+          sources: ["presidio"],
+        }),
+      ),
+    ).toEqual([
+      "Financial Information",
+      "Personal Identifiable Information",
+      "Government Identifiers",
+      "Healthcare Information",
+    ]);
+  });
+
+  it("returns no rule groups for prompt policies", () => {
+    expect(
+      getPolicyRuleGroupNamesForDeleteDialog(
+        policy({
+          policyType: "prompt_based",
+          prompt: "Block unsafe support advice",
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("getPolicyDeleteRuleActionLabel", () => {
+  it("returns block for block policies", () => {
+    expect(getPolicyDeleteRuleActionLabel(policy({ action: "block" }))).toBe(
+      "block",
+    );
+  });
+
+  it("returns flag for flag policies", () => {
+    expect(getPolicyDeleteRuleActionLabel(policy({ action: "flag" }))).toBe(
+      "flag",
+    );
+  });
+});
+
+describe("getPolicyDeleteRuleListItems", () => {
+  it("shows up to four rules and appends an and-more item", () => {
+    expect(
+      getPolicyDeleteRuleListItems([
+        "First Rule",
+        "Second Rule",
+        "Third Rule",
+        "Fourth Rule",
+        "Fifth Rule",
+        "Sixth Rule",
+      ]),
+    ).toEqual([
+      "First Rule",
+      "Second Rule",
+      "Third Rule",
+      "Fourth Rule",
+      "and 2 more",
+    ]);
+  });
+
+  it("does not append an and-more item for four rules", () => {
+    expect(
+      getPolicyDeleteRuleListItems([
+        "First Rule",
+        "Second Rule",
+        "Third Rule",
+        "Fourth Rule",
+      ]),
+    ).toEqual(["First Rule", "Second Rule", "Third Rule", "Fourth Rule"]);
+  });
+});

--- a/client/dashboard/src/pages/security/policy-delete-dialog.ts
+++ b/client/dashboard/src/pages/security/policy-delete-dialog.ts
@@ -1,0 +1,86 @@
+import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
+import {
+  DETECTION_RULES,
+  RULE_CATEGORY_META,
+  type RuleCategory,
+} from "./policy-data";
+import { ruleIdToPresidioEntity } from "./rule-ids";
+
+const DELETE_RULE_LIST_LIMIT = 4;
+
+const PRESIDIO_CATEGORIES: RuleCategory[] = [
+  "financial",
+  "pii",
+  "government_ids",
+  "healthcare",
+];
+
+const CATEGORY_LEVEL_SOURCE_BY_CATEGORY: Partial<Record<RuleCategory, string>> =
+  {
+    prompt_injection: "prompt_injection",
+    shadow_mcp: "shadow_mcp",
+    destructive_tool: "destructive_tool",
+    cli_destructive: "cli_destructive",
+  };
+
+function presidioCategories(policy: RiskPolicy): RuleCategory[] {
+  if (!policy.sources.includes("presidio")) {
+    return [];
+  }
+
+  const entitySet = new Set(policy.presidioEntities ?? []);
+  if (entitySet.size === 0) {
+    return PRESIDIO_CATEGORIES;
+  }
+
+  return PRESIDIO_CATEGORIES.filter((category) =>
+    DETECTION_RULES[category].some((rule) =>
+      entitySet.has(ruleIdToPresidioEntity(rule.id)),
+    ),
+  );
+}
+
+export function getPolicyRuleGroupNamesForDeleteDialog(
+  policy: RiskPolicy,
+): string[] {
+  if (policy.policyType === "prompt_based") {
+    return [];
+  }
+
+  const categories: RuleCategory[] = [];
+
+  if (policy.sources.includes("gitleaks")) {
+    categories.push("secrets");
+  }
+
+  categories.push(...presidioCategories(policy));
+
+  for (const [category, source] of Object.entries(
+    CATEGORY_LEVEL_SOURCE_BY_CATEGORY,
+  ) as Array<[RuleCategory, string]>) {
+    if (policy.sources.includes(source)) {
+      categories.push(category);
+    }
+  }
+
+  if (policy.customRuleIds?.length) {
+    categories.push("custom");
+  }
+
+  return categories.map((category) => RULE_CATEGORY_META[category].label);
+}
+
+export function getPolicyDeleteRuleActionLabel(policy: RiskPolicy): string {
+  return policy.action === "block" ? "block" : "flag";
+}
+
+export function getPolicyDeleteRuleListItems(ruleNames: string[]): string[] {
+  if (ruleNames.length <= DELETE_RULE_LIST_LIMIT) {
+    return ruleNames;
+  }
+
+  return [
+    ...ruleNames.slice(0, DELETE_RULE_LIST_LIMIT),
+    `and ${ruleNames.length - DELETE_RULE_LIST_LIMIT} more`,
+  ];
+}

--- a/client/dashboard/src/pages/security/policy-delete-dialog.ts
+++ b/client/dashboard/src/pages/security/policy-delete-dialog.ts
@@ -23,19 +23,34 @@ const CATEGORY_LEVEL_SOURCE_BY_CATEGORY: Partial<Record<RuleCategory, string>> =
     cli_destructive: "cli_destructive",
   };
 
+function hasEnabledVisibleRule(
+  category: RuleCategory,
+  disabledRules: Set<string>,
+): boolean {
+  return DETECTION_RULES[category].some(
+    (rule) => !rule.hidden && !disabledRules.has(rule.id),
+  );
+}
+
 function presidioCategories(policy: RiskPolicy): RuleCategory[] {
   if (!policy.sources.includes("presidio")) {
     return [];
   }
 
+  const disabledRules = new Set(policy.disabledRules ?? []);
   const entitySet = new Set(policy.presidioEntities ?? []);
   if (entitySet.size === 0) {
-    return PRESIDIO_CATEGORIES;
+    return PRESIDIO_CATEGORIES.filter((category) =>
+      hasEnabledVisibleRule(category, disabledRules),
+    );
   }
 
   return PRESIDIO_CATEGORIES.filter((category) =>
-    DETECTION_RULES[category].some((rule) =>
-      entitySet.has(ruleIdToPresidioEntity(rule.id)),
+    DETECTION_RULES[category].some(
+      (rule) =>
+        !rule.hidden &&
+        !disabledRules.has(rule.id) &&
+        entitySet.has(ruleIdToPresidioEntity(rule.id)),
     ),
   );
 }
@@ -48,8 +63,12 @@ export function getPolicyRuleGroupNamesForDeleteDialog(
   }
 
   const categories: RuleCategory[] = [];
+  const disabledRules = new Set(policy.disabledRules ?? []);
 
-  if (policy.sources.includes("gitleaks")) {
+  if (
+    policy.sources.includes("gitleaks") &&
+    hasEnabledVisibleRule("secrets", disabledRules)
+  ) {
     categories.push("secrets");
   }
 
@@ -72,6 +91,18 @@ export function getPolicyRuleGroupNamesForDeleteDialog(
 
 export function getPolicyDeleteRuleActionLabel(policy: RiskPolicy): string {
   return policy.action === "block" ? "block" : "flag";
+}
+
+export function getPolicyDeleteImpactText(
+  policy: RiskPolicy,
+  hasRuleGroups: boolean,
+): string {
+  const action = getPolicyDeleteRuleActionLabel(policy);
+  if (hasRuleGroups) {
+    return `The following ${action} rules will no longer be enforced.`;
+  }
+
+  return `Any ${action} action this policy applies will stop immediately.`;
 }
 
 export function getPolicyDeleteRuleListItems(ruleNames: string[]): string[] {


### PR DESCRIPTION
## Summary
- Add a confirmation dialog before a risk/prompt policy can be deleted in the Policy Center
- Reuses the existing `Dialog` + `destructive-primary` button pattern already used elsewhere in the dashboard (e.g. API key revocation)

## Visual

<img width="1817" height="1260" alt="image" src="https://github.com/user-attachments/assets/786fbcaf-6a4b-4b8c-b0d1-401d94d3b6ba" />

## Root cause
Deleting a policy fired `useRiskPoliciesDeleteMutation` immediately from the row's dropdown menu, with no confirmation step. Since this is a destructive, irreversible action, the UI needed a confirmation gate matching the pattern used for other dangerous actions in the dashboard.

## Test plan
- [x] `tsc -p tsconfig.app.json --noEmit` — no new errors vs. base
- [x] `pnpm lint` — clean
- [x] Manually verified in browser: dropdown "Delete" opens the dialog without deleting; Cancel/Escape/outside-click dismiss without deleting; confirming deletes the policy and refreshes the list

Closes [AGE-2900](https://linear.app/speakeasy/issue/AGE-2900/feat-add-confirmation-dialog-for-deleting-risk-policies)
