### PR TITLE
mig: adds challenge (WARN) policy type

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3526,6 +3526,57 @@ CREATE INDEX IF NOT EXISTS risk_policy_bypass_requests_project_status_updated_id
 ON risk_policy_bypass_requests (project_id, status, updated_at DESC)
 WHERE deleted IS FALSE;
 
+CREATE TABLE IF NOT EXISTS risk_policy_challenges (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid NOT NULL,
+  risk_policy_id uuid NOT NULL,
+
+  -- The user the warn policy fired for (the one who must acknowledge).
+  user_id TEXT NOT NULL,
+  -- Tool the challenge applies to; NULL for a non-tool (e.g. prompt) challenge.
+  tool_name TEXT,
+
+  status TEXT NOT NULL DEFAULT 'challenged',
+
+  -- Log-safe context for display/audit ONLY. The raw matched value
+  -- (secret/PII) is NEVER stored here — it lives only in the ephemeral
+  -- agent-facing warning message.
+  policy_name TEXT,
+  entity TEXT,
+  rule_id TEXT,
+
+  challenged_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  acknowledged_at timestamptz,
+  -- When an acknowledgement stops suppressing re-challenge (the "remember" window).
+  expires_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT risk_policy_challenges_pkey PRIMARY KEY (id),
+  CONSTRAINT risk_policy_challenges_status_check CHECK (status IN ('challenged', 'acknowledged', 'declined')),
+  CONSTRAINT risk_policy_challenges_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT risk_policy_challenges_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT risk_policy_challenges_risk_policy_id_fkey FOREIGN KEY (risk_policy_id) REFERENCES risk_policies (id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE risk_policy_challenges IS 'Interactive warn/challenge lifecycle for warn-action policies: a warn match records a challenged row; the user self-service acknowledges to proceed on retry. Never stores the raw matched value.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS risk_policy_challenges_current_key
+ON risk_policy_challenges (project_id, user_id, risk_policy_id, tool_name) NULLS NOT DISTINCT
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS risk_policy_challenges_project_status_updated_idx
+ON risk_policy_challenges (project_id, status, updated_at DESC)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS risk_policy_challenges_active_ack_idx
+ON risk_policy_challenges (project_id, user_id, risk_policy_id, tool_name, expires_at)
+WHERE deleted IS FALSE AND status = 'acknowledged';
+
 CREATE TABLE IF NOT EXISTS tool_call_blocks (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3577,6 +3577,19 @@ CREATE INDEX IF NOT EXISTS risk_policy_challenges_active_ack_idx
 ON risk_policy_challenges (project_id, user_id, risk_policy_id, tool_name, expires_at)
 WHERE deleted IS FALSE AND status = 'acknowledged';
 
+-- Non-partial indexes backing the ON DELETE CASCADE foreign keys. The RI
+-- cascade trigger scans child rows with no `deleted IS FALSE` predicate, so it
+-- cannot use the partial indexes above; without these a parent delete (org,
+-- project, or risk policy) degrades to a sequential scan and holds locks longer.
+CREATE INDEX IF NOT EXISTS risk_policy_challenges_organization_id_idx
+ON risk_policy_challenges (organization_id);
+
+CREATE INDEX IF NOT EXISTS risk_policy_challenges_project_id_idx
+ON risk_policy_challenges (project_id);
+
+CREATE INDEX IF NOT EXISTS risk_policy_challenges_risk_policy_id_idx
+ON risk_policy_challenges (risk_policy_id);
+
 CREATE TABLE IF NOT EXISTS tool_call_blocks (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1462,6 +1462,27 @@ type RiskPolicyBypassRequest struct {
 	Deleted              bool
 }
 
+// Interactive warn/challenge lifecycle for warn-action policies: a warn match records a challenged row; the user self-service acknowledges to proceed on retry. Never stores the raw matched value.
+type RiskPolicyChallenge struct {
+	ID             uuid.UUID
+	OrganizationID string
+	ProjectID      uuid.UUID
+	RiskPolicyID   uuid.UUID
+	UserID         string
+	ToolName       pgtype.Text
+	Status         string
+	PolicyName     pgtype.Text
+	Entity         pgtype.Text
+	RuleID         pgtype.Text
+	ChallengedAt   pgtype.Timestamptz
+	AcknowledgedAt pgtype.Timestamptz
+	ExpiresAt      pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
+}
+
 type RiskResult struct {
 	ID                  uuid.UUID
 	ProjectID           uuid.UUID

--- a/server/migrations/20260702131714_risk-policy-challenges.sql
+++ b/server/migrations/20260702131714_risk-policy-challenges.sql
@@ -1,0 +1,33 @@
+-- Create "risk_policy_challenges" table
+CREATE TABLE "risk_policy_challenges" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NOT NULL,
+  "risk_policy_id" uuid NOT NULL,
+  "user_id" text NOT NULL,
+  "tool_name" text NULL,
+  "status" text NOT NULL DEFAULT 'challenged',
+  "policy_name" text NULL,
+  "entity" text NULL,
+  "rule_id" text NULL,
+  "challenged_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "acknowledged_at" timestamptz NULL,
+  "expires_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "risk_policy_challenges_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_policy_challenges_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_policy_challenges_risk_policy_id_fkey" FOREIGN KEY ("risk_policy_id") REFERENCES "risk_policies" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_policy_challenges_status_check" CHECK (status = ANY (ARRAY['challenged'::text, 'acknowledged'::text, 'declined'::text]))
+);
+-- Create index "risk_policy_challenges_active_ack_idx" to table: "risk_policy_challenges"
+CREATE INDEX "risk_policy_challenges_active_ack_idx" ON "risk_policy_challenges" ("project_id", "user_id", "risk_policy_id", "tool_name", "expires_at") WHERE ((deleted IS FALSE) AND (status = 'acknowledged'::text));
+-- Create index "risk_policy_challenges_current_key" to table: "risk_policy_challenges"
+CREATE UNIQUE INDEX "risk_policy_challenges_current_key" ON "risk_policy_challenges" ("project_id", "user_id", "risk_policy_id", "tool_name") NULLS NOT DISTINCT WHERE (deleted IS FALSE);
+-- Create index "risk_policy_challenges_project_status_updated_idx" to table: "risk_policy_challenges"
+CREATE INDEX "risk_policy_challenges_project_status_updated_idx" ON "risk_policy_challenges" ("project_id", "status", "updated_at" DESC) WHERE (deleted IS FALSE);
+-- Set comment to table: "risk_policy_challenges"
+COMMENT ON TABLE "risk_policy_challenges" IS 'Interactive warn/challenge lifecycle for warn-action policies: a warn match records a challenged row; the user self-service acknowledges to proceed on retry. Never stores the raw matched value.';

--- a/server/migrations/20260703095550_risk-policy-challenges-fk-cascade-indexes.sql
+++ b/server/migrations/20260703095550_risk-policy-challenges-fk-cascade-indexes.sql
@@ -1,7 +1,7 @@
 -- atlas:txmode none
 
 -- Create index "risk_policy_challenges_organization_id_idx" to table: "risk_policy_challenges"
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "risk_policy_challenges_organization_id_idx" ON "risk_policy_challenges" ("organization_id");
+CREATE INDEX CONCURRENTLY "risk_policy_challenges_organization_id_idx" ON "risk_policy_challenges" ("organization_id");
 -- Create index "risk_policy_challenges_project_id_idx" to table: "risk_policy_challenges"
 CREATE INDEX CONCURRENTLY "risk_policy_challenges_project_id_idx" ON "risk_policy_challenges" ("project_id");
 -- Create index "risk_policy_challenges_risk_policy_id_idx" to table: "risk_policy_challenges"

--- a/server/migrations/20260703095550_risk-policy-challenges-fk-cascade-indexes.sql
+++ b/server/migrations/20260703095550_risk-policy-challenges-fk-cascade-indexes.sql
@@ -1,7 +1,7 @@
 -- atlas:txmode none
 
 -- Create index "risk_policy_challenges_organization_id_idx" to table: "risk_policy_challenges"
-CREATE INDEX CONCURRENTLY "risk_policy_challenges_organization_id_idx" ON "risk_policy_challenges" ("organization_id");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "risk_policy_challenges_organization_id_idx" ON "risk_policy_challenges" ("organization_id");
 -- Create index "risk_policy_challenges_project_id_idx" to table: "risk_policy_challenges"
 CREATE INDEX CONCURRENTLY "risk_policy_challenges_project_id_idx" ON "risk_policy_challenges" ("project_id");
 -- Create index "risk_policy_challenges_risk_policy_id_idx" to table: "risk_policy_challenges"

--- a/server/migrations/20260703095550_risk-policy-challenges-fk-cascade-indexes.sql
+++ b/server/migrations/20260703095550_risk-policy-challenges-fk-cascade-indexes.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Create index "risk_policy_challenges_organization_id_idx" to table: "risk_policy_challenges"
+CREATE INDEX CONCURRENTLY "risk_policy_challenges_organization_id_idx" ON "risk_policy_challenges" ("organization_id");
+-- Create index "risk_policy_challenges_project_id_idx" to table: "risk_policy_challenges"
+CREATE INDEX CONCURRENTLY "risk_policy_challenges_project_id_idx" ON "risk_policy_challenges" ("project_id");
+-- Create index "risk_policy_challenges_risk_policy_id_idx" to table: "risk_policy_challenges"
+CREATE INDEX CONCURRENTLY "risk_policy_challenges_risk_policy_id_idx" ON "risk_policy_challenges" ("risk_policy_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:BscnDkYEYuaSTU4UqaXjmcf84IhZtqXlEvzlKEthflk=
+h1:tTapezeYfqaqn9WJHhrRH0JrKJb4hlWCk/jnrhly3OI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -239,3 +239,4 @@ h1:BscnDkYEYuaSTU4UqaXjmcf84IhZtqXlEvzlKEthflk=
 20260701215608_billing-mode-declarations.sql h1:wEegAGkGu26TmLNS3jrwPTcPumpS89I7XatrDKoQtJ8=
 20260701230608_session-capture-exclusions.sql h1:0/b+s8X5U0pMrunBZ7OawV5Wm1DdXiPcXrpMnPqhAjY=
 20260702032234_external-credentials-external-keys.sql h1:4H0IHcidOlIv9t9VwJBBLRKFb/nnpCi4vjwOCNkefmo=
+20260702131714_risk-policy-challenges.sql h1:f38+NYpcLxP3/EZAaz1uMUKUsswKlkTWwEMQzH5w+JM=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:tTapezeYfqaqn9WJHhrRH0JrKJb4hlWCk/jnrhly3OI=
+h1:LrMqqyXBxQe5uNGi+HgoJksyRB+vWl3BjZmL1xAfU5U=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -240,3 +240,4 @@ h1:tTapezeYfqaqn9WJHhrRH0JrKJb4hlWCk/jnrhly3OI=
 20260701230608_session-capture-exclusions.sql h1:0/b+s8X5U0pMrunBZ7OawV5Wm1DdXiPcXrpMnPqhAjY=
 20260702032234_external-credentials-external-keys.sql h1:4H0IHcidOlIv9t9VwJBBLRKFb/nnpCi4vjwOCNkefmo=
 20260702131714_risk-policy-challenges.sql h1:f38+NYpcLxP3/EZAaz1uMUKUsswKlkTWwEMQzH5w+JM=
+20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=


### PR DESCRIPTION
Schema and migrations split off `feat/challenge_policy` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `risk_policy_challenges` table and `RiskPolicyChallenge` model with supporting indexes for interactive WARN challenges and user acknowledgements. Adds non‑partial FK indexes for fast ON DELETE CASCADE and restores Atlas‑canonical migration output.

- **New Features**
  - New `risk_policy_challenges` table and `RiskPolicyChallenge` model; tracks status (`challenged`, `acknowledged`, `declined`), timestamps, soft delete; never stores raw matched values.
  - Indexes: unique current key; `(project_id, status, updated_at DESC)`; active acks by `expires_at`; plus CONCURRENT FK indexes on `organization_id`, `project_id`, `risk_policy_id`.

- **Bug Fixes**
  - Reverted `IF NOT EXISTS` in FK index migration and updated `atlas.sum` to match Atlas output, fixing the checksum integrity check.

<sup>Written for commit 074ec75a27956fc2ee29d52dbc958dd85d4117ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

