### PR TITLE
chore: fix codex usage TTL flake

### DIFF
--- a/server/internal/hooks/otel_test.go
+++ b/server/internal/hooks/otel_test.go
@@ -125,9 +125,19 @@ func TestLogs_CodexPayloadContinuesThroughUsagePath(t *testing.T) {
 	ctx, ti := newTestHooksService(t)
 	chClient := enableHookTelemetryLogger(t, ctx, ti)
 	authCtx := hookAuthContext(t, ctx)
-	timestamp := time.Unix(0, 1780468942284000000)
 
-	err := ti.service.Logs(ctx, codexLogsPayload(tokenBearingRecord()))
+	// Stamp the usage row with a recent time rather than tokenBearingRecord's
+	// fixed 2026-06-03 constant. telemetry_logs carries a 30-day TTL on
+	// time_unix_nano (server/clickhouse/schema.sql), so an absolute past
+	// timestamp ages out: once wall-clock passes constant+30d the row is
+	// TTL-expired and evicted on the next merge (which concurrent inserts from
+	// the parallel suite trigger), making this test rot into a flake. A relative
+	// timestamp keeps the row inside the retention window forever.
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	rec := tokenBearingRecord()
+	rec.ObservedTimeUnixNano = new(nanoString(timestamp))
+
+	err := ti.service.Logs(ctx, codexLogsPayload(rec))
 	require.NoError(t, err)
 
 	codexLogs := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), codexUsageMetricsURN, timestamp, 1)


### PR DESCRIPTION
## Problem

`TestLogs_CodexPayloadContinuesThroughUsagePath` is flaky (seen failing on CI: `Condition never satisfied`, `server/internal/hooks`).

## Root cause

The test stamped its Codex usage row with `tokenBearingRecord`'s hardcoded `1780468942284000000` (2026-06-03). `telemetry_logs` carries a **30-day TTL** on `time_unix_nano` (`server/clickhouse/schema.sql`). Once wall-clock passed `constant + 30d`, the row aged out and got evicted on the next merge — which the parallel test suite's concurrent inserts trigger — so the query returned 0 rows and the assertion timed out. The test passed when written and rots as time advances; `TestLogs_StampsProviderOnCodexUsage` never hit this because it stamps `now`.

Confirmed by probing the write path: the insert always succeeded (`insert OK`), yet the row was absent — merge-time TTL eviction, not a write/read failure.

## Fix

Stamp the usage row with a recent timestamp (mirrors the sibling test), keeping the row inside the retention window permanently.

## Verification

- Before: full `hooks` package failed consistently under parallel load.
- After: 3× full-package runs + 10× single-test stress — all green. `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flake in `TestLogs_CodexPayloadContinuesThroughUsagePath` by using a recent timestamp for Codex usage rows instead of the fixed `tokenBearingRecord` time. This avoids 30‑day TTL eviction in `telemetry_logs` and keeps the query stable under parallel load.

<sup>Written for commit 52d37d0721bd83776df624d9ba017a108f4436f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

