### PR TITLE
chore(costs): fixed no sessions found in drilldown

### DIFF
--- a/server/internal/telemetry/list_sessions_test.go
+++ b/server/internal/telemetry/list_sessions_test.go
@@ -312,6 +312,96 @@ func TestListSessions_CrossRowDirectoryAndHookFilters(t *testing.T) {
 	require.Equal(t, int64(1), session.MessageCount)
 }
 
+func TestListSessions_CoLocatesAttributionFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Now().UTC()
+	matchingChatID := uuid.NewString()
+	nonMatchingChatID := uuid.NewString()
+
+	// This row is the aggregate slice the UI drills into: skill=golang with no
+	// subagent attribution.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-10 * time.Minute),
+		chatID:       matchingChatID,
+		email:        "skill@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		totalTokens:  150,
+		cost:         1.0,
+		skillName:    "golang",
+	})
+	// The same chat later carries a subagent. An independent agent_name=""
+	// HAVING would wrongly reject the whole chat even though the skill row above
+	// belongs to the drilled aggregate slice.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-9 * time.Minute),
+		chatID:       matchingChatID,
+		email:        "skill@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  50,
+		outputTokens: 25,
+		totalTokens:  75,
+		cost:         0.5,
+		skillName:    "claude-api",
+		agentName:    "Explore",
+	})
+	// Another chat has the requested skill, but only on a row with an agent. It
+	// must not match the co-located skill=golang AND agent="" slice.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-8 * time.Minute),
+		chatID:       nonMatchingChatID,
+		email:        "skill@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  200,
+		outputTokens: 50,
+		totalTokens:  250,
+		cost:         2.0,
+		skillName:    "golang",
+		agentName:    "Explore",
+	})
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	res := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From: from,
+		To:   to,
+		Filters: []*gen.QueryFilter{
+			{Dimension: "skill_name", Values: []string{"golang"}},
+			{Dimension: "agent_name", Values: []string{""}},
+		},
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == matchingChatID
+	})
+
+	require.Len(t, res.Sessions, 1)
+	session := res.Sessions[0]
+	require.Equal(t, matchingChatID, session.GramChatID)
+	require.InDelta(t, 1.5, session.TotalCost, 1e-9)
+	require.Equal(t, int64(2), session.MessageCount)
+}
+
 func TestListSessions_IncludesCostBearingAssistantChatCompletions(t *testing.T) {
 	t.Parallel()
 
@@ -501,6 +591,8 @@ type listSessionLogParams struct {
 	cost         float64
 	statusCode   int32
 	toolURN      string
+	skillName    string
+	agentName    string
 }
 
 func insertListSessionCompletionLog(t *testing.T, ctx context.Context, p listSessionLogParams) {
@@ -567,6 +659,12 @@ func insertListSessionClaudeAPIRequestLog(t *testing.T, ctx context.Context, p l
 		"gram.hook.source":                p.hookSource,
 		"user.email":                      p.email,
 		"user.attributes.department_name": p.department,
+	}
+	if p.skillName != "" {
+		attributes["skill.name"] = p.skillName
+	}
+	if p.agentName != "" {
+		attributes["agent.name"] = p.agentName
 	}
 	if p.roles != nil {
 		attributes["user.roles"] = p.roles

--- a/server/internal/telemetry/repo/dimensions.go
+++ b/server/internal/telemetry/repo/dimensions.go
@@ -14,14 +14,16 @@ const (
 )
 
 type attributeDimension struct {
-	column string
-	kind   attributeDimensionKind
+	column                 string
+	kind                   attributeDimensionKind
+	coLocateSessionFilters bool
 }
 
 type telemetryDimension struct {
-	aggregateColumn string
-	rawExpr         string
-	kind            attributeDimensionKind
+	aggregateColumn        string
+	rawExpr                string
+	kind                   attributeDimensionKind
+	coLocateSessionFilters bool
 }
 
 // telemetryDimensionRegistry is the single allowlist for public telemetry
@@ -100,29 +102,34 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:            attributeDimScalar,
 	},
 	"query_source": {
-		aggregateColumn: "query_source",
-		rawExpr:         "toString(attributes.query_source)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "query_source",
+		rawExpr:                "toString(attributes.query_source)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: true,
 	},
 	"skill_name": {
-		aggregateColumn: "skill_name",
-		rawExpr:         "toString(attributes.skill.name)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "skill_name",
+		rawExpr:                "toString(attributes.skill.name)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: true,
 	},
 	"agent_name": {
-		aggregateColumn: "agent_name",
-		rawExpr:         "toString(attributes.agent.name)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "agent_name",
+		rawExpr:                "toString(attributes.agent.name)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: true,
 	},
 	"mcp_server_name": {
-		aggregateColumn: "mcp_server_name",
-		rawExpr:         "toString(attributes.mcp_server.name)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "mcp_server_name",
+		rawExpr:                "toString(attributes.mcp_server.name)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: true,
 	},
 	"mcp_tool_name": {
-		aggregateColumn: "mcp_tool_name",
-		rawExpr:         "toString(attributes.mcp_tool.name)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "mcp_tool_name",
+		rawExpr:                "toString(attributes.mcp_tool.name)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: true,
 	},
 	"role": {
 		aggregateColumn: "roles",
@@ -144,7 +151,11 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 func buildDimensionRegistry(columnFor func(telemetryDimension) string) map[string]attributeDimension {
 	out := make(map[string]attributeDimension, len(telemetryDimensionRegistry))
 	for key, dim := range telemetryDimensionRegistry {
-		out[key] = attributeDimension{column: columnFor(dim), kind: dim.kind}
+		out[key] = attributeDimension{
+			column:                 columnFor(dim),
+			kind:                   dim.kind,
+			coLocateSessionFilters: dim.coLocateSessionFilters,
+		}
 	}
 	return out
 }

--- a/server/internal/telemetry/repo/dimensions.go
+++ b/server/internal/telemetry/repo/dimensions.go
@@ -32,34 +32,40 @@ type telemetryDimension struct {
 // arbitrary columns or JSON paths.
 var telemetryDimensionRegistry = map[string]telemetryDimension{
 	"department_name": {
-		aggregateColumn: "department_name",
-		rawExpr:         "toString(attributes.user.attributes.department_name)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "department_name",
+		rawExpr:                "toString(attributes.user.attributes.department_name)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"job_title": {
-		aggregateColumn: "job_title",
-		rawExpr:         "toString(attributes.user.attributes.job_title)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "job_title",
+		rawExpr:                "toString(attributes.user.attributes.job_title)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"employee_type": {
-		aggregateColumn: "employee_type",
-		rawExpr:         "toString(attributes.user.attributes.employee_type)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "employee_type",
+		rawExpr:                "toString(attributes.user.attributes.employee_type)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"division_name": {
-		aggregateColumn: "division_name",
-		rawExpr:         "toString(attributes.user.attributes.division_name)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "division_name",
+		rawExpr:                "toString(attributes.user.attributes.division_name)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"cost_center_name": {
-		aggregateColumn: "cost_center_name",
-		rawExpr:         "toString(attributes.user.attributes.cost_center_name)",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "cost_center_name",
+		rawExpr:                "toString(attributes.user.attributes.cost_center_name)",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"email": {
-		aggregateColumn: "user_email",
-		rawExpr:         "user_email",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "user_email",
+		rawExpr:                "user_email",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"model": {
 		aggregateColumn: "model",
@@ -67,29 +73,33 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		// attributes.model / gen_ai.request.model, everyone else on
 		// gen_ai.response.model. Matches the aggregate MV + session select so a
 		// Model filter resolves Claude sessions too (see sessionModelExpr).
-		rawExpr: sessionModelExpr,
-		kind:    attributeDimScalar,
+		rawExpr:                sessionModelExpr,
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"hook_source": {
-		aggregateColumn: "hook_source",
-		rawExpr:         "hook_source",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "hook_source",
+		rawExpr:                "hook_source",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"account_type": {
 		// AI account classification: 'team' | 'personal' | '' (unclassified).
 		// Materialized on telemetry_logs and a sort-key dimension on
 		// attribute_metrics_summaries, so the column name is identical on both paths.
-		aggregateColumn: "account_type",
-		rawExpr:         "account_type",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "account_type",
+		rawExpr:                "account_type",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"provider": {
 		// AI provider for the account: 'anthropic' | 'openai' | 'cursor' | ''.
 		// Materialized on telemetry_logs and a sort-key dimension on
 		// attribute_metrics_summaries, so the column name is identical on both paths.
-		aggregateColumn: "provider",
-		rawExpr:         "provider",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "provider",
+		rawExpr:                "provider",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"billing_mode": {
 		// How the account is billed: 'metered' (pay-per-token; cost is real spend)
@@ -97,9 +107,10 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		// Lets the cost view separate real spend from a token×API-rate estimate.
 		// Materialized on telemetry_logs and a sort-key dimension on
 		// attribute_metrics_summaries, so the column name is identical on both paths.
-		aggregateColumn: "billing_mode",
-		rawExpr:         "billing_mode",
-		kind:            attributeDimScalar,
+		aggregateColumn:        "billing_mode",
+		rawExpr:                "billing_mode",
+		kind:                   attributeDimScalar,
+		coLocateSessionFilters: false,
 	},
 	"query_source": {
 		aggregateColumn:        "query_source",
@@ -132,19 +143,22 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: true,
 	},
 	"role": {
-		aggregateColumn: "roles",
-		rawExpr:         "arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)'))",
-		kind:            attributeDimArray,
+		aggregateColumn:        "roles",
+		rawExpr:                "arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)'))",
+		kind:                   attributeDimArray,
+		coLocateSessionFilters: false,
 	},
 	"group": {
-		aggregateColumn: "groups",
-		rawExpr:         "arraySort(JSONExtract(ifNull(toJSONString(attributes.user.groups), '[]'), 'Array(String)'))",
-		kind:            attributeDimArray,
+		aggregateColumn:        "groups",
+		rawExpr:                "arraySort(JSONExtract(ifNull(toJSONString(attributes.user.groups), '[]'), 'Array(String)'))",
+		kind:                   attributeDimArray,
+		coLocateSessionFilters: false,
 	},
 	"project_id": {
-		aggregateColumn: "gram_project_id",
-		rawExpr:         "gram_project_id",
-		kind:            attributeDimProject,
+		aggregateColumn:        "gram_project_id",
+		rawExpr:                "gram_project_id",
+		kind:                   attributeDimProject,
+		coLocateSessionFilters: false,
 	},
 }
 

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -136,14 +136,18 @@ type SessionSummary struct {
 
 // applySessionFilters restricts the session aggregation to chats matching the
 // requested dimension filters. project_id stays a row-level WHERE because it is
-// present on every row and prunes partitions. Every other dimension is matched
+// present on every row and prunes partitions. Identity dimensions are matched
 // per-chat via HAVING: a chat qualifies when ANY of its rows carries the
-// requested value. This is required because the attributes are stamped on
-// different physical rows within the same chat — user-directory attributes
-// (department_name, email, job_title, …) live on gateway-enriched rows, while
-// cost/hook_source/model live on the usage rows — so a row-level AND of those
-// filters would wrongly return nothing even when each filter matches data.
+// requested value. This is required because those attributes can be stamped on
+// different physical rows within the same chat.
+//
+// Claude attribution dimensions are different: the aggregate summary treats
+// query_source/skill/agent/MCP values as a single api_request-row tuple. Keep
+// those filters co-located inside one countIf so drilling from the aggregate
+// table finds chats that have a row matching the same tuple.
 func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter) (squirrel.SelectBuilder, error) {
+	var coLocatedPredicates []squirrel.Sqlizer
+
 	for _, f := range filters {
 		if len(f.Values) == 0 {
 			continue
@@ -156,6 +160,10 @@ func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFi
 		case attributeDimProject:
 			sb = sb.Where(squirrel.Eq{dim.column: f.Values})
 		case attributeDimScalar:
+			if dim.coLocateSessionFilters {
+				coLocatedPredicates = append(coLocatedPredicates, sessionScalarRowPredicate(dim.column, f.Values))
+				continue
+			}
 			sb = sb.Having(sessionScalarHaving(dim.column, f.Values))
 		case attributeDimArray:
 			inner, args, err := arrayDimFilter(dim.column, f.Values).ToSql()
@@ -167,7 +175,45 @@ func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFi
 			return sb, fmt.Errorf("unhandled dimension kind for filter %q", f.Dimension)
 		}
 	}
+	if len(coLocatedPredicates) > 0 {
+		inner, args, err := squirrel.And(coLocatedPredicates).ToSql()
+		if err != nil {
+			return sb, fmt.Errorf("building co-located session filters: %w", err)
+		}
+		sb = sb.Having(squirrel.Expr("countIf("+inner+") > 0", args...))
+	}
 	return sb, nil
+}
+
+// sessionScalarRowPredicate matches a single telemetry row against one scalar
+// dimension filter. Unlike sessionScalarHaving, a requested "" means "this row
+// has an empty value", not "the whole chat has no value anywhere".
+func sessionScalarRowPredicate(expr string, values []string) squirrel.Sqlizer {
+	hasEmpty := false
+	nonEmpty := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			hasEmpty = true
+			continue
+		}
+		nonEmpty = append(nonEmpty, v)
+	}
+
+	emptyPred := squirrel.Expr(expr + " = ''")
+	if len(nonEmpty) == 0 {
+		return emptyPred
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(nonEmpty)), ",")
+	args := make([]any, len(nonEmpty))
+	for i, v := range nonEmpty {
+		args[i] = v
+	}
+	nonEmptyPred := squirrel.Expr(expr+" IN ("+placeholders+")", args...)
+	if !hasEmpty {
+		return nonEmptyPred
+	}
+	return squirrel.Or{nonEmptyPred, emptyPred}
 }
 
 // sessionScalarHaving matches a chat when any of its rows carries one of the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes drilldown that returned “no sessions found” when combining attribution filters. Filters like `skill_name` and `agent_name` are now evaluated on the same API request row, so sessions match the intended tuple.

- **Bug Fixes**
  - Co-located attribution filters (`skill_name`, `agent_name`, `query_source`, `mcp_server_name`, `mcp_tool_name`) using a single countIf over row predicates, and set explicit non-attribution flags to satisfy telemetry dimension lint.
  - Kept other dimensions (project, user identity, roles) with per-chat HAVING semantics.
  - Added `TestListSessions_CoLocatesAttributionFilters` and test helpers to stamp `skill.name`/`agent.name`.

<sup>Written for commit 617d004c9dcb9ec65f1330e4e7b8e3165b94ca93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

