### PR TITLE
mig: rename tunnelled_ -> tunneled_ MCP columns

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -91,9 +91,9 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
   -- Day of month (1-31) the billing cycle starts at 00:00 UTC. Clamped to the
   -- last day of shorter months when computing cycle boundaries.
   billing_cycle_anchor_day INT NOT NULL DEFAULT 1,
-  -- Contracted org-level cap for tunnelled MCP server sources. NULL means use
+  -- Contracted org-level cap for tunneled MCP server sources. NULL means use
   -- the plan default, not unlimited.
-  tunnelled_mcp_server_limit INT CHECK (tunnelled_mcp_server_limit IS NULL OR tunnelled_mcp_server_limit >= 0),
+  tunneled_mcp_server_limit INT CHECK (tunneled_mcp_server_limit IS NULL OR tunneled_mcp_server_limit >= 0),
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -106,7 +106,7 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
 CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_organization_id_key
 ON billing_metadata (organization_id);
 
-COMMENT ON COLUMN billing_metadata.tunnelled_mcp_server_limit IS 'Contracted org-level cap for tunnelled MCP server sources. NULL means use the finite plan default.';
+COMMENT ON COLUMN billing_metadata.tunneled_mcp_server_limit IS 'Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
 ON organization_metadata (slug);
@@ -2835,13 +2835,13 @@ WHERE deleted IS FALSE;
 -- Customer-hosted MCP servers connected through outbound tunnels. Gram stores
 -- the durable management/source record; live connection routing is cached in
 -- Redis by the tunnel gateway.
-CREATE TABLE IF NOT EXISTS tunnelled_mcp_servers (
-  -- Stable UUID for the tunnelled MCP source. Used by management APIs,
+CREATE TABLE IF NOT EXISTS tunneled_mcp_servers (
+  -- Stable UUID for the tunneled MCP source. Used by management APIs,
   -- dashboard routes, and Redis connection cache keys.
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   -- Project that owns this source. All management queries are project-scoped.
   project_id uuid NOT NULL,
-  -- User-facing display name for the tunnelled MCP source.
+  -- User-facing display name for the tunneled MCP source.
   name TEXT NOT NULL CHECK (name <> ''),
   -- Hash of the one-time tunnel key. The plaintext key is not stored.
   key_hash TEXT NOT NULL CHECK (key_hash <> ''),
@@ -2859,38 +2859,38 @@ CREATE TABLE IF NOT EXISTS tunnelled_mcp_servers (
   deleted_at timestamptz,
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
 
-  CONSTRAINT tunnelled_mcp_servers_pkey PRIMARY KEY (id),
-  CONSTRAINT tunnelled_mcp_servers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+  CONSTRAINT tunneled_mcp_servers_pkey PRIMARY KEY (id),
+  CONSTRAINT tunneled_mcp_servers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS tunnelled_mcp_servers_project_id_idx
-ON tunnelled_mcp_servers (project_id)
+CREATE INDEX IF NOT EXISTS tunneled_mcp_servers_project_id_idx
+ON tunneled_mcp_servers (project_id)
 WHERE deleted IS FALSE;
 
-CREATE UNIQUE INDEX IF NOT EXISTS tunnelled_mcp_servers_project_id_name_key
-ON tunnelled_mcp_servers (project_id, name)
+CREATE UNIQUE INDEX IF NOT EXISTS tunneled_mcp_servers_project_id_name_key
+ON tunneled_mcp_servers (project_id, name)
 WHERE deleted IS FALSE;
 
-CREATE UNIQUE INDEX IF NOT EXISTS tunnelled_mcp_servers_key_hash_key
-ON tunnelled_mcp_servers (key_hash)
+CREATE UNIQUE INDEX IF NOT EXISTS tunneled_mcp_servers_key_hash_key
+ON tunneled_mcp_servers (key_hash)
 WHERE deleted IS FALSE;
 
-COMMENT ON TABLE tunnelled_mcp_servers IS 'Customer-hosted MCP server sources that connect to Gram through outbound tunnels.';
-COMMENT ON COLUMN tunnelled_mcp_servers.id IS 'Stable UUID for the tunnelled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.';
-COMMENT ON COLUMN tunnelled_mcp_servers.project_id IS 'Project that owns this tunnelled MCP source. All management queries are scoped by project_id.';
-COMMENT ON COLUMN tunnelled_mcp_servers.name IS 'User-facing display name for the tunnelled MCP source.';
-COMMENT ON COLUMN tunnelled_mcp_servers.key_hash IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
-COMMENT ON COLUMN tunnelled_mcp_servers.key_prefix IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
-COMMENT ON COLUMN tunnelled_mcp_servers.status IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
-COMMENT ON COLUMN tunnelled_mcp_servers.agent_version IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
-COMMENT ON COLUMN tunnelled_mcp_servers.last_seen_at IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
-COMMENT ON COLUMN tunnelled_mcp_servers.created_at IS 'Time when the tunnelled MCP source was created.';
-COMMENT ON COLUMN tunnelled_mcp_servers.updated_at IS 'Time when the durable tunnelled MCP source record was last updated.';
-COMMENT ON COLUMN tunnelled_mcp_servers.deleted_at IS 'Soft-delete timestamp for the tunnelled MCP source. NULL means the source is active.';
-COMMENT ON COLUMN tunnelled_mcp_servers.deleted IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
+COMMENT ON TABLE tunneled_mcp_servers IS 'Customer-hosted MCP server sources that connect to Gram through outbound tunnels.';
+COMMENT ON COLUMN tunneled_mcp_servers.id IS 'Stable UUID for the tunneled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.';
+COMMENT ON COLUMN tunneled_mcp_servers.project_id IS 'Project that owns this tunneled MCP source. All management queries are scoped by project_id.';
+COMMENT ON COLUMN tunneled_mcp_servers.name IS 'User-facing display name for the tunneled MCP source.';
+COMMENT ON COLUMN tunneled_mcp_servers.key_hash IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
+COMMENT ON COLUMN tunneled_mcp_servers.key_prefix IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
+COMMENT ON COLUMN tunneled_mcp_servers.status IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
+COMMENT ON COLUMN tunneled_mcp_servers.agent_version IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
+COMMENT ON COLUMN tunneled_mcp_servers.last_seen_at IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
+COMMENT ON COLUMN tunneled_mcp_servers.created_at IS 'Time when the tunneled MCP source was created.';
+COMMENT ON COLUMN tunneled_mcp_servers.updated_at IS 'Time when the durable tunneled MCP source record was last updated.';
+COMMENT ON COLUMN tunneled_mcp_servers.deleted_at IS 'Soft-delete timestamp for the tunneled MCP source. NULL means the source is active.';
+COMMENT ON COLUMN tunneled_mcp_servers.deleted IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
 
 -- MCP Servers: user-facing MCP server configurations that link an MCP
--- backend (a toolset, a remote MCP server, or a tunnelled MCP server) to
+-- backend (a toolset, a remote MCP server, or a tunneled MCP server) to
 -- environment and OAuth settings. Each server is addressable via one or more
 -- mcp_endpoints.
 CREATE TABLE IF NOT EXISTS mcp_servers (
@@ -2902,7 +2902,7 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   environment_id uuid,
   user_session_issuer_id uuid,
   remote_mcp_server_id uuid,
-  tunnelled_mcp_server_id uuid,
+  tunneled_mcp_server_id uuid,
   toolset_id uuid,
   -- Optionally enables a variations group for runtime filtering and
   -- modifications. Otherwise defaults to project global (source-level)
@@ -2920,11 +2920,11 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_environment_id_fkey FOREIGN KEY (environment_id) REFERENCES environments (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE RESTRICT,
-  CONSTRAINT mcp_servers_tunnelled_mcp_server_id_fkey FOREIGN KEY (tunnelled_mcp_server_id) REFERENCES tunnelled_mcp_servers (id) ON DELETE RESTRICT,
+  CONSTRAINT mcp_servers_tunneled_mcp_server_id_fkey FOREIGN KEY (tunneled_mcp_server_id) REFERENCES tunneled_mcp_servers (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_tool_variations_group_id_fkey FOREIGN KEY (tool_variations_group_id) REFERENCES tool_variations_groups (id) ON DELETE SET NULL,
   -- Exactly one backend must be set.
-  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id) = 1)
+  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunneled_mcp_server_id, toolset_id) = 1)
 );
 
 CREATE INDEX IF NOT EXISTS mcp_servers_project_id_idx
@@ -2939,11 +2939,11 @@ CREATE INDEX IF NOT EXISTS mcp_servers_remote_mcp_server_id_idx
 ON mcp_servers (remote_mcp_server_id)
 WHERE remote_mcp_server_id IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS mcp_servers_tunnelled_mcp_server_id_idx
-ON mcp_servers (tunnelled_mcp_server_id)
-WHERE tunnelled_mcp_server_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS mcp_servers_tunneled_mcp_server_id_idx
+ON mcp_servers (tunneled_mcp_server_id)
+WHERE tunneled_mcp_server_id IS NOT NULL;
 
-COMMENT ON COLUMN mcp_servers.tunnelled_mcp_server_id IS 'Optional backend reference to a tunnelled MCP source. Exactly one of remote_mcp_server_id, tunnelled_mcp_server_id, or toolset_id must be set.';
+COMMENT ON COLUMN mcp_servers.tunneled_mcp_server_id IS 'Optional backend reference to a tunneled MCP source. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, or toolset_id must be set.';
 
 CREATE INDEX IF NOT EXISTS mcp_servers_toolset_id_idx
 ON mcp_servers (toolset_id)

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -273,10 +273,10 @@ type BillingMetadatum struct {
 	TumMonthlyTokenLimit  pgtype.Int8
 	AlertEmail            pgtype.Text
 	BillingCycleAnchorDay int32
-	// Contracted org-level cap for tunnelled MCP server sources. NULL means use the finite plan default.
-	TunnelledMcpServerLimit pgtype.Int4
-	CreatedAt               pgtype.Timestamptz
-	UpdatedAt               pgtype.Timestamptz
+	// Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.
+	TunneledMcpServerLimit pgtype.Int4
+	CreatedAt              pgtype.Timestamptz
+	UpdatedAt              pgtype.Timestamptz
 }
 
 type Chat struct {
@@ -878,8 +878,8 @@ type McpServer struct {
 	EnvironmentID       uuid.NullUUID
 	UserSessionIssuerID uuid.NullUUID
 	RemoteMcpServerID   uuid.NullUUID
-	// Optional backend reference to a tunnelled MCP source. Exactly one of remote_mcp_server_id, tunnelled_mcp_server_id, or toolset_id must be set.
-	TunnelledMcpServerID  uuid.NullUUID
+	// Optional backend reference to a tunneled MCP source. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, or toolset_id must be set.
+	TunneledMcpServerID   uuid.NullUUID
 	ToolsetID             uuid.NullUUID
 	ToolVariationsGroupID uuid.NullUUID
 	Visibility            string
@@ -1723,12 +1723,12 @@ type TriggerInstance struct {
 }
 
 // Customer-hosted MCP server sources that connect to Gram through outbound tunnels.
-type TunnelledMcpServer struct {
-	// Stable UUID for the tunnelled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.
+type TunneledMcpServer struct {
+	// Stable UUID for the tunneled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.
 	ID uuid.UUID
-	// Project that owns this tunnelled MCP source. All management queries are scoped by project_id.
+	// Project that owns this tunneled MCP source. All management queries are scoped by project_id.
 	ProjectID uuid.UUID
-	// User-facing display name for the tunnelled MCP source.
+	// User-facing display name for the tunneled MCP source.
 	Name string
 	// Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.
 	KeyHash string
@@ -1740,11 +1740,11 @@ type TunnelledMcpServer struct {
 	AgentVersion pgtype.Text
 	// Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.
 	LastSeenAt pgtype.Timestamptz
-	// Time when the tunnelled MCP source was created.
+	// Time when the tunneled MCP source was created.
 	CreatedAt pgtype.Timestamptz
-	// Time when the durable tunnelled MCP source record was last updated.
+	// Time when the durable tunneled MCP source record was last updated.
 	UpdatedAt pgtype.Timestamptz
-	// Soft-delete timestamp for the tunnelled MCP source. NULL means the source is active.
+	// Soft-delete timestamp for the tunneled MCP source. NULL means the source is active.
 	DeletedAt pgtype.Timestamptz
 	// Generated soft-delete flag derived from deleted_at and used by partial indexes.
 	Deleted bool

--- a/server/internal/mcpservers/repo/models.go
+++ b/server/internal/mcpservers/repo/models.go
@@ -17,8 +17,8 @@ type McpServer struct {
 	EnvironmentID       uuid.NullUUID
 	UserSessionIssuerID uuid.NullUUID
 	RemoteMcpServerID   uuid.NullUUID
-	// Optional backend reference to a tunnelled MCP source. Exactly one of remote_mcp_server_id, tunnelled_mcp_server_id, or toolset_id must be set.
-	TunnelledMcpServerID  uuid.NullUUID
+	// Optional backend reference to a tunneled MCP source. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, or toolset_id must be set.
+	TunneledMcpServerID   uuid.NullUUID
 	ToolsetID             uuid.NullUUID
 	ToolVariationsGroupID uuid.NullUUID
 	Visibility            string

--- a/server/internal/mcpservers/repo/queries.sql.go
+++ b/server/internal/mcpservers/repo/queries.sql.go
@@ -37,7 +37,7 @@ VALUES (
     $9,
     $10
 )
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateMCPServerParams struct {
@@ -75,7 +75,7 @@ func (q *Queries) CreateMCPServer(ctx context.Context, arg CreateMCPServerParams
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
-		&i.TunnelledMcpServerID,
+		&i.TunneledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -91,7 +91,7 @@ const deleteMCPServer = `-- name: DeleteMCPServer :one
 UPDATE mcp_servers
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteMCPServerParams struct {
@@ -110,7 +110,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
-		&i.TunnelledMcpServerID,
+		&i.TunneledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -123,7 +123,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 }
 
 const getMCPServerByIDAndOrganizationID = `-- name: GetMCPServerByIDAndOrganizationID :one
-SELECT m.id, m.project_id, m.name, m.slug, m.environment_id, m.user_session_issuer_id, m.remote_mcp_server_id, m.tunnelled_mcp_server_id, m.toolset_id, m.tool_variations_group_id, m.visibility, m.created_at, m.updated_at, m.deleted_at, m.deleted
+SELECT m.id, m.project_id, m.name, m.slug, m.environment_id, m.user_session_issuer_id, m.remote_mcp_server_id, m.tunneled_mcp_server_id, m.toolset_id, m.tool_variations_group_id, m.visibility, m.created_at, m.updated_at, m.deleted_at, m.deleted
 FROM mcp_servers AS m
 JOIN projects AS p ON p.id = m.project_id
 WHERE m.id = $1
@@ -150,7 +150,7 @@ func (q *Queries) GetMCPServerByIDAndOrganizationID(ctx context.Context, arg Get
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
-		&i.TunnelledMcpServerID,
+		&i.TunneledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -163,7 +163,7 @@ func (q *Queries) GetMCPServerByIDAndOrganizationID(ctx context.Context, arg Get
 }
 
 const getMCPServerByIDAndProjectID = `-- name: GetMCPServerByIDAndProjectID :one
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -184,7 +184,7 @@ func (q *Queries) GetMCPServerByIDAndProjectID(ctx context.Context, arg GetMCPSe
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
-		&i.TunnelledMcpServerID,
+		&i.TunneledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -197,7 +197,7 @@ func (q *Queries) GetMCPServerByIDAndProjectID(ctx context.Context, arg GetMCPSe
 }
 
 const getMCPServerBySlug = `-- name: GetMCPServerBySlug :one
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE slug = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -218,7 +218,7 @@ func (q *Queries) GetMCPServerBySlug(ctx context.Context, arg GetMCPServerBySlug
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
-		&i.TunnelledMcpServerID,
+		&i.TunneledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,
@@ -231,7 +231,7 @@ func (q *Queries) GetMCPServerBySlug(ctx context.Context, arg GetMCPServerBySlug
 }
 
 const listMCPServersByProjectID = `-- name: ListMCPServersByProjectID :many
-SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -263,7 +263,7 @@ func (q *Queries) ListMCPServersByProjectID(ctx context.Context, arg ListMCPServ
 			&i.EnvironmentID,
 			&i.UserSessionIssuerID,
 			&i.RemoteMcpServerID,
-			&i.TunnelledMcpServerID,
+			&i.TunneledMcpServerID,
 			&i.ToolsetID,
 			&i.ToolVariationsGroupID,
 			&i.Visibility,
@@ -295,7 +295,7 @@ SET
     visibility = $8,
     updated_at = clock_timestamp()
 WHERE id = $9 AND project_id = $10 AND deleted IS FALSE
-RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, tool_variations_group_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateMCPServerParams struct {
@@ -333,7 +333,7 @@ func (q *Queries) UpdateMCPServer(ctx context.Context, arg UpdateMCPServerParams
 		&i.EnvironmentID,
 		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
-		&i.TunnelledMcpServerID,
+		&i.TunneledMcpServerID,
 		&i.ToolsetID,
 		&i.ToolVariationsGroupID,
 		&i.Visibility,

--- a/server/internal/usage/repo/models.go
+++ b/server/internal/usage/repo/models.go
@@ -15,8 +15,8 @@ type BillingMetadatum struct {
 	TumMonthlyTokenLimit  pgtype.Int8
 	AlertEmail            pgtype.Text
 	BillingCycleAnchorDay int32
-	// Contracted org-level cap for tunnelled MCP server sources. NULL means use the finite plan default.
-	TunnelledMcpServerLimit pgtype.Int4
-	CreatedAt               pgtype.Timestamptz
-	UpdatedAt               pgtype.Timestamptz
+	// Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.
+	TunneledMcpServerLimit pgtype.Int4
+	CreatedAt              pgtype.Timestamptz
+	UpdatedAt              pgtype.Timestamptz
 }

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getBillingMetadata = `-- name: GetBillingMetadata :one
-SELECT id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunnelled_mcp_server_limit, created_at, updated_at
+SELECT id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 FROM billing_metadata
 WHERE organization_id = $1
 `
@@ -27,7 +27,7 @@ func (q *Queries) GetBillingMetadata(ctx context.Context, organizationID string)
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,
-		&i.TunnelledMcpServerLimit,
+		&i.TunneledMcpServerLimit,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -93,7 +93,7 @@ ON CONFLICT (organization_id) DO UPDATE SET
   , alert_email = EXCLUDED.alert_email
   , billing_cycle_anchor_day = EXCLUDED.billing_cycle_anchor_day
   , updated_at = clock_timestamp()
-RETURNING id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunnelled_mcp_server_limit, created_at, updated_at
+RETURNING id, organization_id, tum_monthly_token_limit, alert_email, billing_cycle_anchor_day, tunneled_mcp_server_limit, created_at, updated_at
 `
 
 type UpsertBillingMetadataParams struct {
@@ -117,7 +117,7 @@ func (q *Queries) UpsertBillingMetadata(ctx context.Context, arg UpsertBillingMe
 		&i.TumMonthlyTokenLimit,
 		&i.AlertEmail,
 		&i.BillingCycleAnchorDay,
-		&i.TunnelledMcpServerLimit,
+		&i.TunneledMcpServerLimit,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/migrations/20260703134504_rename-tunneled-mcp-columns.sql
+++ b/server/migrations/20260703134504_rename-tunneled-mcp-columns.sql
@@ -1,3 +1,8 @@
+-- atlas:nolint PG306 CD101
+-- PG306/CD101 are false positives here: atlas diffs the rename as drop+add of
+-- the FK, but the DDL below is ALTER ... RENAME CONSTRAINT (catalog-only, no
+-- scan, no write lock). BC101/BC102 (backward-incompatible rename) are left
+-- visible on purpose — the rename is coordinated with the code deploy.
 -- Rename the tunnelled_* MCP objects to the single-l "tunneled" spelling used
 -- across the Go code, SDK, and dashboard. In-place ALTER ... RENAME (no drops):
 -- the values are all NULL / the table is empty (feature unreleased), and renames

--- a/server/migrations/20260703134504_rename-tunneled-mcp-columns.sql
+++ b/server/migrations/20260703134504_rename-tunneled-mcp-columns.sql
@@ -1,0 +1,43 @@
+-- Rename the tunnelled_* MCP objects to the single-l "tunneled" spelling used
+-- across the Go code, SDK, and dashboard. In-place ALTER ... RENAME (no drops):
+-- the values are all NULL / the table is empty (feature unreleased), and renames
+-- are non-destructive. Atlas cannot infer renames via migrate diff, so this
+-- migration is authored explicitly and atlas.sum re-hashed with the Atlas CLI.
+
+-- billing_metadata.tunnelled_mcp_server_limit
+ALTER TABLE "billing_metadata" RENAME COLUMN "tunnelled_mcp_server_limit" TO "tunneled_mcp_server_limit";
+ALTER TABLE "billing_metadata" RENAME CONSTRAINT "billing_metadata_tunnelled_mcp_server_limit_check" TO "billing_metadata_tunneled_mcp_server_limit_check";
+COMMENT ON COLUMN "billing_metadata"."tunneled_mcp_server_limit" IS 'Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.';
+
+-- tunnelled_mcp_servers table, its constraints and indexes
+ALTER TABLE "tunnelled_mcp_servers" RENAME TO "tunneled_mcp_servers";
+ALTER TABLE "tunneled_mcp_servers" RENAME CONSTRAINT "tunnelled_mcp_servers_pkey" TO "tunneled_mcp_servers_pkey";
+ALTER TABLE "tunneled_mcp_servers" RENAME CONSTRAINT "tunnelled_mcp_servers_project_id_fkey" TO "tunneled_mcp_servers_project_id_fkey";
+ALTER TABLE "tunneled_mcp_servers" RENAME CONSTRAINT "tunnelled_mcp_servers_name_check" TO "tunneled_mcp_servers_name_check";
+ALTER TABLE "tunneled_mcp_servers" RENAME CONSTRAINT "tunnelled_mcp_servers_key_hash_check" TO "tunneled_mcp_servers_key_hash_check";
+ALTER TABLE "tunneled_mcp_servers" RENAME CONSTRAINT "tunnelled_mcp_servers_key_prefix_check" TO "tunneled_mcp_servers_key_prefix_check";
+ALTER TABLE "tunneled_mcp_servers" RENAME CONSTRAINT "tunnelled_mcp_servers_status_check" TO "tunneled_mcp_servers_status_check";
+ALTER TABLE "tunneled_mcp_servers" RENAME CONSTRAINT "tunnelled_mcp_servers_agent_version_check" TO "tunneled_mcp_servers_agent_version_check";
+ALTER INDEX "tunnelled_mcp_servers_project_id_idx" RENAME TO "tunneled_mcp_servers_project_id_idx";
+ALTER INDEX "tunnelled_mcp_servers_project_id_name_key" RENAME TO "tunneled_mcp_servers_project_id_name_key";
+ALTER INDEX "tunnelled_mcp_servers_key_hash_key" RENAME TO "tunneled_mcp_servers_key_hash_key";
+COMMENT ON TABLE "tunneled_mcp_servers" IS 'Customer-hosted MCP server sources that connect to Gram through outbound tunnels.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."id" IS 'Stable UUID for the tunneled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."project_id" IS 'Project that owns this tunneled MCP source. All management queries are scoped by project_id.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."name" IS 'User-facing display name for the tunneled MCP source.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."key_hash" IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."key_prefix" IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."status" IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."agent_version" IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."last_seen_at" IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."created_at" IS 'Time when the tunneled MCP source was created.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."updated_at" IS 'Time when the durable tunneled MCP source record was last updated.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."deleted_at" IS 'Soft-delete timestamp for the tunneled MCP source. NULL means the source is active.';
+COMMENT ON COLUMN "tunneled_mcp_servers"."deleted" IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
+
+-- mcp_servers.tunnelled_mcp_server_id (RENAME COLUMN auto-updates the
+-- backend_exclusivity_check expression that references it).
+ALTER TABLE "mcp_servers" RENAME COLUMN "tunnelled_mcp_server_id" TO "tunneled_mcp_server_id";
+ALTER TABLE "mcp_servers" RENAME CONSTRAINT "mcp_servers_tunnelled_mcp_server_id_fkey" TO "mcp_servers_tunneled_mcp_server_id_fkey";
+ALTER INDEX "mcp_servers_tunnelled_mcp_server_id_idx" RENAME TO "mcp_servers_tunneled_mcp_server_id_idx";
+COMMENT ON COLUMN "mcp_servers"."tunneled_mcp_server_id" IS 'Optional backend reference to a tunneled MCP source. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, or toolset_id must be set.';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:tpyjZTbxdtg3h0+WZmCzZDD1lzFK3qzhbGTdg0fPbfo=
+h1:XwyC7hUtbW+Ff7SzAxn80IlitdF3fpx7LcZSwjZGQy8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -241,4 +241,4 @@ h1:tpyjZTbxdtg3h0+WZmCzZDD1lzFK3qzhbGTdg0fPbfo=
 20260702032234_external-credentials-external-keys.sql h1:4H0IHcidOlIv9t9VwJBBLRKFb/nnpCi4vjwOCNkefmo=
 20260702131714_risk-policy-challenges.sql h1:f38+NYpcLxP3/EZAaz1uMUKUsswKlkTWwEMQzH5w+JM=
 20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=
-20260703134504_rename-tunneled-mcp-columns.sql h1:QSl6kWUChsVOwmB7DCPW8O3rXUO6jVu5ECltRV6VAHs=
+20260703134504_rename-tunneled-mcp-columns.sql h1:httREsZ8T4QWXUQZOpzmv4U7zRybXkB4g5TPOaCskGY=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:LrMqqyXBxQe5uNGi+HgoJksyRB+vWl3BjZmL1xAfU5U=
+h1:tpyjZTbxdtg3h0+WZmCzZDD1lzFK3qzhbGTdg0fPbfo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -241,3 +241,4 @@ h1:LrMqqyXBxQe5uNGi+HgoJksyRB+vWl3BjZmL1xAfU5U=
 20260702032234_external-credentials-external-keys.sql h1:4H0IHcidOlIv9t9VwJBBLRKFb/nnpCi4vjwOCNkefmo=
 20260702131714_risk-policy-challenges.sql h1:f38+NYpcLxP3/EZAaz1uMUKUsswKlkTWwEMQzH5w+JM=
 20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=
+20260703134504_rename-tunneled-mcp-columns.sql h1:QSl6kWUChsVOwmB7DCPW8O3rXUO6jVu5ECltRV6VAHs=


### PR DESCRIPTION
## What

Renames the `tunnelled_*` MCP database objects to the single-l `tunneled_` spelling used everywhere else (Go, SDK, dashboard), so sqlc no longer needs `rename:` overrides. Follow-up to bflad's review on #3703.

Renamed:
- table `tunnelled_mcp_servers` → `tunneled_mcp_servers` (+ its constraints/indexes)
- `mcp_servers.tunnelled_mcp_server_id` → `tunneled_mcp_server_id`
- `billing_metadata.tunnelled_mcp_server_limit` → `tunneled_mcp_server_limit`

## Migration

In-place `ALTER … RENAME` — **non-destructive**. The tunnelled MCP feature is unreleased, so affected values are all NULL / the table is empty. Atlas can't infer renames via `migrate diff`, so the migration is authored explicitly and `atlas.sum` re-hashed with the Atlas CLI. Validated locally:
- `atlas migrate lint` — clean (no destructive findings)
- `atlas migrate diff` — "migration directory is synced with the desired state, no changes" (reaches `schema.sql` exactly)

## Regenerated code in the same PR

`[skip migration check]` — the regenerated sqlc (single-l fields, no rename overrides) ships here so the deployed `SELECT`/`RETURNING` column lists match the renamed columns and the server stays consistent across the rename. Coordinated deploy with the migration is intended.

## Coordination

Overlaps with #3703 (which introduced the sqlc `rename:` overrides). Whichever merges first, the other rebases — #3703 then drops its `rename:` block since the DB columns are single-l.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed all MCP DB objects from tunnelled_* to tunneled_* to match the rest of the codebase and UI, removing `sqlc` rename overrides. Ships an explicit `atlas` migration and regenerated queries to keep everything consistent.

- **Migration**
  - In-place renames: `tunnelled_mcp_servers` → `tunneled_mcp_servers`, `mcp_servers.tunnelled_mcp_server_id` → `tunneled_mcp_server_id`, `billing_metadata.tunnelled_mcp_server_limit` → `tunneled_mcp_server_limit` (including related constraints and indexes).
  - Non-destructive; feature is unreleased and data is empty/null.
  - Explicit `atlas` migration with `nolint` for PG306/CD101 false positives on constraint renames; updated `atlas.sum`.

- **Refactors**
  - Regenerated `sqlc` code to use single-l names and drop rename overrides.

<sup>Written for commit e9a6dc4048e53ba5761034707119093e35751573. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

