### PR TITLE
mig: add tunneled_* MCP columns alongside tunnelled_* (expand)

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -93,7 +93,12 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
   billing_cycle_anchor_day INT NOT NULL DEFAULT 1,
   -- Contracted org-level cap for tunnelled MCP server sources. NULL means use
   -- the plan default, not unlimited.
+  -- DEPRECATED: superseded by tunneled_mcp_server_limit (single-l). Kept during
+  -- the expand/contract rename; a later migration drops this column.
   tunnelled_mcp_server_limit INT CHECK (tunnelled_mcp_server_limit IS NULL OR tunnelled_mcp_server_limit >= 0),
+  -- Contracted org-level cap for tunneled MCP server sources. NULL means use
+  -- the plan default, not unlimited.
+  tunneled_mcp_server_limit INT CHECK (tunneled_mcp_server_limit IS NULL OR tunneled_mcp_server_limit >= 0),
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -2889,6 +2894,63 @@ COMMENT ON COLUMN tunnelled_mcp_servers.updated_at IS 'Time when the durable tun
 COMMENT ON COLUMN tunnelled_mcp_servers.deleted_at IS 'Soft-delete timestamp for the tunnelled MCP source. NULL means the source is active.';
 COMMENT ON COLUMN tunnelled_mcp_servers.deleted IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
 
+-- tunneled_mcp_servers is the single-l successor to tunnelled_mcp_servers,
+-- added during the expand/contract rename. New code targets this table; the
+-- old tunnelled_mcp_servers table is dropped in a later contract migration.
+CREATE TABLE IF NOT EXISTS tunneled_mcp_servers (
+  -- Stable UUID for the tunneled MCP source. Used by management APIs,
+  -- dashboard routes, and Redis connection cache keys.
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  -- Project that owns this source. All management queries are project-scoped.
+  project_id uuid NOT NULL,
+  -- User-facing display name for the tunneled MCP source.
+  name TEXT NOT NULL CHECK (name <> ''),
+  -- Hash of the one-time tunnel key. The plaintext key is not stored.
+  key_hash TEXT NOT NULL CHECK (key_hash <> ''),
+  -- Non-secret key prefix shown in the UI for user-side key identification.
+  key_prefix TEXT NOT NULL CHECK (key_prefix <> ''),
+  -- Durable source lifecycle. Live connection state is derived from Redis.
+  status TEXT NOT NULL DEFAULT 'created' CHECK (status IN ('created', 'active', 'revoked')),
+  -- Last persisted tunnel agent version reported for this source.
+  agent_version TEXT CHECK (agent_version IS NULL OR agent_version <> ''),
+  -- Most recent persisted heartbeat time, used when Redis liveness data is absent.
+  last_seen_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT tunneled_mcp_servers_pkey PRIMARY KEY (id),
+  CONSTRAINT tunneled_mcp_servers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS tunneled_mcp_servers_project_id_idx
+ON tunneled_mcp_servers (project_id)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tunneled_mcp_servers_project_id_name_key
+ON tunneled_mcp_servers (project_id, name)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tunneled_mcp_servers_key_hash_key
+ON tunneled_mcp_servers (key_hash)
+WHERE deleted IS FALSE;
+
+COMMENT ON TABLE tunneled_mcp_servers IS 'Customer-hosted MCP server sources that connect to Gram through outbound tunnels.';
+COMMENT ON COLUMN tunneled_mcp_servers.id IS 'Stable UUID for the tunneled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.';
+COMMENT ON COLUMN tunneled_mcp_servers.project_id IS 'Project that owns this tunneled MCP source. All management queries are scoped by project_id.';
+COMMENT ON COLUMN tunneled_mcp_servers.name IS 'User-facing display name for the tunneled MCP source.';
+COMMENT ON COLUMN tunneled_mcp_servers.key_hash IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
+COMMENT ON COLUMN tunneled_mcp_servers.key_prefix IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
+COMMENT ON COLUMN tunneled_mcp_servers.status IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
+COMMENT ON COLUMN tunneled_mcp_servers.agent_version IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
+COMMENT ON COLUMN tunneled_mcp_servers.last_seen_at IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
+COMMENT ON COLUMN tunneled_mcp_servers.created_at IS 'Time when the tunneled MCP source was created.';
+COMMENT ON COLUMN tunneled_mcp_servers.updated_at IS 'Time when the durable tunneled MCP source record was last updated.';
+COMMENT ON COLUMN tunneled_mcp_servers.deleted_at IS 'Soft-delete timestamp for the tunneled MCP source. NULL means the source is active.';
+COMMENT ON COLUMN tunneled_mcp_servers.deleted IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
+
 -- MCP Servers: user-facing MCP server configurations that link an MCP
 -- backend (a toolset, a remote MCP server, or a tunnelled MCP server) to
 -- environment and OAuth settings. Each server is addressable via one or more
@@ -2902,7 +2964,10 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   environment_id uuid,
   user_session_issuer_id uuid,
   remote_mcp_server_id uuid,
+  -- DEPRECATED: superseded by tunneled_mcp_server_id (single-l). Kept during the
+  -- expand/contract rename; a later migration drops this column.
   tunnelled_mcp_server_id uuid,
+  tunneled_mcp_server_id uuid,
   toolset_id uuid,
   -- Optionally enables a variations group for runtime filtering and
   -- modifications. Otherwise defaults to project global (source-level)
@@ -2921,10 +2986,12 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_tunnelled_mcp_server_id_fkey FOREIGN KEY (tunnelled_mcp_server_id) REFERENCES tunnelled_mcp_servers (id) ON DELETE RESTRICT,
+  CONSTRAINT mcp_servers_tunneled_mcp_server_id_fkey FOREIGN KEY (tunneled_mcp_server_id) REFERENCES tunneled_mcp_servers (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_tool_variations_group_id_fkey FOREIGN KEY (tool_variations_group_id) REFERENCES tool_variations_groups (id) ON DELETE SET NULL,
-  -- Exactly one backend must be set.
-  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunnelled_mcp_server_id, toolset_id) = 1)
+  -- Exactly one backend must be set. Both the deprecated tunnelled_ and new
+  -- tunneled_ columns are included so exactly-one holds through the rename.
+  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunnelled_mcp_server_id, tunneled_mcp_server_id, toolset_id) = 1)
 );
 
 CREATE INDEX IF NOT EXISTS mcp_servers_project_id_idx
@@ -2943,7 +3010,12 @@ CREATE INDEX IF NOT EXISTS mcp_servers_tunnelled_mcp_server_id_idx
 ON mcp_servers (tunnelled_mcp_server_id)
 WHERE tunnelled_mcp_server_id IS NOT NULL;
 
-COMMENT ON COLUMN mcp_servers.tunnelled_mcp_server_id IS 'Optional backend reference to a tunnelled MCP source. Exactly one of remote_mcp_server_id, tunnelled_mcp_server_id, or toolset_id must be set.';
+CREATE INDEX IF NOT EXISTS mcp_servers_tunneled_mcp_server_id_idx
+ON mcp_servers (tunneled_mcp_server_id)
+WHERE tunneled_mcp_server_id IS NOT NULL;
+
+COMMENT ON COLUMN mcp_servers.tunnelled_mcp_server_id IS 'Deprecated. Superseded by tunneled_mcp_server_id (single-l); dropped in a later contract migration.';
+COMMENT ON COLUMN mcp_servers.tunneled_mcp_server_id IS 'Optional backend reference to a tunneled MCP source. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, or toolset_id must be set.';
 
 CREATE INDEX IF NOT EXISTS mcp_servers_toolset_id_idx
 ON mcp_servers (toolset_id)

--- a/server/migrations/20260703142647_add-tunneled-mcp-columns.sql
+++ b/server/migrations/20260703142647_add-tunneled-mcp-columns.sql
@@ -1,0 +1,66 @@
+-- atlas:txmode none
+
+-- Modify "billing_metadata" table
+ALTER TABLE "billing_metadata" ADD CONSTRAINT "billing_metadata_tunneled_mcp_server_limit_check" CHECK ((tunneled_mcp_server_limit IS NULL) OR (tunneled_mcp_server_limit >= 0)), ADD COLUMN "tunneled_mcp_server_limit" integer NULL;
+-- Create "tunneled_mcp_servers" table
+CREATE TABLE "tunneled_mcp_servers" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "name" text NOT NULL,
+  "key_hash" text NOT NULL,
+  "key_prefix" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'created',
+  "agent_version" text NULL,
+  "last_seen_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "tunneled_mcp_servers_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "tunneled_mcp_servers_agent_version_check" CHECK ((agent_version IS NULL) OR (agent_version <> ''::text)),
+  CONSTRAINT "tunneled_mcp_servers_key_hash_check" CHECK (key_hash <> ''::text),
+  CONSTRAINT "tunneled_mcp_servers_key_prefix_check" CHECK (key_prefix <> ''::text),
+  CONSTRAINT "tunneled_mcp_servers_name_check" CHECK (name <> ''::text),
+  CONSTRAINT "tunneled_mcp_servers_status_check" CHECK (status = ANY (ARRAY['created'::text, 'active'::text, 'revoked'::text]))
+);
+-- Create index "tunneled_mcp_servers_key_hash_key" to table: "tunneled_mcp_servers"
+CREATE UNIQUE INDEX "tunneled_mcp_servers_key_hash_key" ON "tunneled_mcp_servers" ("key_hash") WHERE (deleted IS FALSE);
+-- Create index "tunneled_mcp_servers_project_id_idx" to table: "tunneled_mcp_servers"
+CREATE INDEX "tunneled_mcp_servers_project_id_idx" ON "tunneled_mcp_servers" ("project_id") WHERE (deleted IS FALSE);
+-- Create index "tunneled_mcp_servers_project_id_name_key" to table: "tunneled_mcp_servers"
+CREATE UNIQUE INDEX "tunneled_mcp_servers_project_id_name_key" ON "tunneled_mcp_servers" ("project_id", "name") WHERE (deleted IS FALSE);
+-- Set comment to table: "tunneled_mcp_servers"
+COMMENT ON TABLE "tunneled_mcp_servers" IS 'Customer-hosted MCP server sources that connect to Gram through outbound tunnels.';
+-- Set comment to column: "id" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."id" IS 'Stable UUID for the tunneled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.';
+-- Set comment to column: "project_id" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."project_id" IS 'Project that owns this tunneled MCP source. All management queries are scoped by project_id.';
+-- Set comment to column: "name" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."name" IS 'User-facing display name for the tunneled MCP source.';
+-- Set comment to column: "key_hash" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."key_hash" IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
+-- Set comment to column: "key_prefix" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."key_prefix" IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
+-- Set comment to column: "status" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."status" IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
+-- Set comment to column: "agent_version" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."agent_version" IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
+-- Set comment to column: "last_seen_at" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."last_seen_at" IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
+-- Set comment to column: "created_at" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."created_at" IS 'Time when the tunneled MCP source was created.';
+-- Set comment to column: "updated_at" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."updated_at" IS 'Time when the durable tunneled MCP source record was last updated.';
+-- Set comment to column: "deleted_at" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."deleted_at" IS 'Soft-delete timestamp for the tunneled MCP source. NULL means the source is active.';
+-- Set comment to column: "deleted" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."deleted" IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
+-- Modify "mcp_servers" table
+ALTER TABLE "mcp_servers" DROP CONSTRAINT "mcp_servers_backend_exclusivity_check", ADD CONSTRAINT "mcp_servers_backend_exclusivity_check" CHECK (num_nonnulls(remote_mcp_server_id, tunnelled_mcp_server_id, tunneled_mcp_server_id, toolset_id) = 1), ADD COLUMN "tunneled_mcp_server_id" uuid NULL, ADD CONSTRAINT "mcp_servers_tunneled_mcp_server_id_fkey" FOREIGN KEY ("tunneled_mcp_server_id") REFERENCES "tunneled_mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT;
+-- Create index "mcp_servers_tunneled_mcp_server_id_idx" to table: "mcp_servers"
+CREATE INDEX CONCURRENTLY "mcp_servers_tunneled_mcp_server_id_idx" ON "mcp_servers" ("tunneled_mcp_server_id") WHERE (tunneled_mcp_server_id IS NOT NULL);
+-- Set comment to column: "tunnelled_mcp_server_id" on table: "mcp_servers"
+COMMENT ON COLUMN "mcp_servers"."tunnelled_mcp_server_id" IS 'Deprecated. Superseded by tunneled_mcp_server_id (single-l); dropped in a later contract migration.';
+-- Set comment to column: "tunneled_mcp_server_id" on table: "mcp_servers"
+COMMENT ON COLUMN "mcp_servers"."tunneled_mcp_server_id" IS 'Optional backend reference to a tunneled MCP source. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, or toolset_id must be set.';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:LrMqqyXBxQe5uNGi+HgoJksyRB+vWl3BjZmL1xAfU5U=
+h1:dGWh5MOJFD9JncRmLn7iPOghhltyJuqAzPpm/El7liA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -241,3 +241,4 @@ h1:LrMqqyXBxQe5uNGi+HgoJksyRB+vWl3BjZmL1xAfU5U=
 20260702032234_external-credentials-external-keys.sql h1:4H0IHcidOlIv9t9VwJBBLRKFb/nnpCi4vjwOCNkefmo=
 20260702131714_risk-policy-challenges.sql h1:f38+NYpcLxP3/EZAaz1uMUKUsswKlkTWwEMQzH5w+JM=
 20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=
+20260703142647_add-tunneled-mcp-columns.sql h1:7cl3GZFt/H3Jt9QOJqCb4Jpiw176iKP4Me9jOABeWI8=


### PR DESCRIPTION
Expand step (1/2) of renaming the `tunnelled_*` MCP DB objects to the single-l `tunneled_` spelling used across Go/SDK/dashboard. Follow-up to bflad's review on #3703.

## Why expand-contract

Renaming `mcp_servers.tunnelled_mcp_server_id` in place would break the deployed server's `SELECT`/`RETURNING` column lists (sqlc names the column) during the migrate→deploy window. Instead this adds the new columns **alongside** the old ones so nothing breaks; the drop happens later once code has moved over.

## This PR (additive, non-destructive)

- `CREATE TABLE tunneled_mcp_servers` (mirror of `tunnelled_mcp_servers`)
- `mcp_servers.tunneled_mcp_server_id` (+ FK + partial index)
- `billing_metadata.tunneled_mcp_server_limit`
- `backend_exclusivity_check` now counts both the deprecated `tunnelled_` and new `tunneled_` columns, so exactly-one-backend still holds through the transition

Atlas-generated. `atlas migrate lint` clean (no destructive findings); `atlas migrate diff` reports the dir synced with `schema.sql`. Migration-only (no `server/internal` changes) per the migration-PR convention.

## Sequencing

1. **This PR** — add `tunneled_*` (safe to merge now)
2. #3703 rebases → regenerates sqlc, drops the `sqlc.yaml` `rename:` overrides, reads/writes the `tunneled_` columns
3. **Contract PR** (follow-up, draft) — drops the `tunnelled_*` objects once #3703 has shipped and no code references them

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the single-l `tunneled_*` MCP DB objects alongside existing `tunnelled_*` ones to start a safe, no-downtime rename. This expand step is additive and preserves the exactly-one-backend rule.

- **Migration**
  - Create `tunneled_mcp_servers` (mirror of `tunnelled_mcp_servers`) with indexes.
  - Add `mcp_servers.tunneled_mcp_server_id` (FK to `tunneled_mcp_servers` + partial index).
  - Add `billing_metadata.tunneled_mcp_server_limit`.
  - Update `mcp_servers.backend_exclusivity_check` to count both `tunnelled_` and `tunneled_` columns.

<sup>Written for commit cea3e1eaa49af93d103a9f13337808c7746bd470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

