### PR TITLE
mig: drop tunnelled_* MCP objects (contract)

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -91,11 +91,6 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
   -- Day of month (1-31) the billing cycle starts at 00:00 UTC. Clamped to the
   -- last day of shorter months when computing cycle boundaries.
   billing_cycle_anchor_day INT NOT NULL DEFAULT 1,
-  -- Contracted org-level cap for tunnelled MCP server sources. NULL means use
-  -- the plan default, not unlimited.
-  -- DEPRECATED: superseded by tunneled_mcp_server_limit (single-l). Kept during
-  -- the expand/contract rename; a later migration drops this column.
-  tunnelled_mcp_server_limit INT CHECK (tunnelled_mcp_server_limit IS NULL OR tunnelled_mcp_server_limit >= 0),
   -- Contracted org-level cap for tunneled MCP server sources. NULL means use
   -- the plan default, not unlimited.
   tunneled_mcp_server_limit INT CHECK (tunneled_mcp_server_limit IS NULL OR tunneled_mcp_server_limit >= 0),
@@ -111,7 +106,6 @@ CREATE TABLE IF NOT EXISTS billing_metadata (
 CREATE UNIQUE INDEX IF NOT EXISTS billing_metadata_organization_id_key
 ON billing_metadata (organization_id);
 
-COMMENT ON COLUMN billing_metadata.tunnelled_mcp_server_limit IS 'Contracted org-level cap for tunnelled MCP server sources. NULL means use the finite plan default.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
 ON organization_metadata (slug);
@@ -2840,63 +2834,6 @@ WHERE deleted IS FALSE;
 -- Customer-hosted MCP servers connected through outbound tunnels. Gram stores
 -- the durable management/source record; live connection routing is cached in
 -- Redis by the tunnel gateway.
-CREATE TABLE IF NOT EXISTS tunnelled_mcp_servers (
-  -- Stable UUID for the tunnelled MCP source. Used by management APIs,
-  -- dashboard routes, and Redis connection cache keys.
-  id uuid NOT NULL DEFAULT generate_uuidv7(),
-  -- Project that owns this source. All management queries are project-scoped.
-  project_id uuid NOT NULL,
-  -- User-facing display name for the tunnelled MCP source.
-  name TEXT NOT NULL CHECK (name <> ''),
-  -- Hash of the one-time tunnel key. The plaintext key is not stored.
-  key_hash TEXT NOT NULL CHECK (key_hash <> ''),
-  -- Non-secret key prefix shown in the UI for user-side key identification.
-  key_prefix TEXT NOT NULL CHECK (key_prefix <> ''),
-  -- Durable source lifecycle. Live connection state is derived from Redis.
-  status TEXT NOT NULL DEFAULT 'created' CHECK (status IN ('created', 'active', 'revoked')),
-  -- Last persisted tunnel agent version reported for this source.
-  agent_version TEXT CHECK (agent_version IS NULL OR agent_version <> ''),
-  -- Most recent persisted heartbeat time, used when Redis liveness data is absent.
-  last_seen_at timestamptz,
-
-  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  deleted_at timestamptz,
-  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
-
-  CONSTRAINT tunnelled_mcp_servers_pkey PRIMARY KEY (id),
-  CONSTRAINT tunnelled_mcp_servers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
-);
-
-CREATE INDEX IF NOT EXISTS tunnelled_mcp_servers_project_id_idx
-ON tunnelled_mcp_servers (project_id)
-WHERE deleted IS FALSE;
-
-CREATE UNIQUE INDEX IF NOT EXISTS tunnelled_mcp_servers_project_id_name_key
-ON tunnelled_mcp_servers (project_id, name)
-WHERE deleted IS FALSE;
-
-CREATE UNIQUE INDEX IF NOT EXISTS tunnelled_mcp_servers_key_hash_key
-ON tunnelled_mcp_servers (key_hash)
-WHERE deleted IS FALSE;
-
-COMMENT ON TABLE tunnelled_mcp_servers IS 'Customer-hosted MCP server sources that connect to Gram through outbound tunnels.';
-COMMENT ON COLUMN tunnelled_mcp_servers.id IS 'Stable UUID for the tunnelled MCP source. Used by management APIs, dashboard routes, and Redis connection cache keys.';
-COMMENT ON COLUMN tunnelled_mcp_servers.project_id IS 'Project that owns this tunnelled MCP source. All management queries are scoped by project_id.';
-COMMENT ON COLUMN tunnelled_mcp_servers.name IS 'User-facing display name for the tunnelled MCP source.';
-COMMENT ON COLUMN tunnelled_mcp_servers.key_hash IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
-COMMENT ON COLUMN tunnelled_mcp_servers.key_prefix IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
-COMMENT ON COLUMN tunnelled_mcp_servers.status IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
-COMMENT ON COLUMN tunnelled_mcp_servers.agent_version IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
-COMMENT ON COLUMN tunnelled_mcp_servers.last_seen_at IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
-COMMENT ON COLUMN tunnelled_mcp_servers.created_at IS 'Time when the tunnelled MCP source was created.';
-COMMENT ON COLUMN tunnelled_mcp_servers.updated_at IS 'Time when the durable tunnelled MCP source record was last updated.';
-COMMENT ON COLUMN tunnelled_mcp_servers.deleted_at IS 'Soft-delete timestamp for the tunnelled MCP source. NULL means the source is active.';
-COMMENT ON COLUMN tunnelled_mcp_servers.deleted IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
-
--- tunneled_mcp_servers is the single-l successor to tunnelled_mcp_servers,
--- added during the expand/contract rename. New code targets this table; the
--- old tunnelled_mcp_servers table is dropped in a later contract migration.
 CREATE TABLE IF NOT EXISTS tunneled_mcp_servers (
   -- Stable UUID for the tunneled MCP source. Used by management APIs,
   -- dashboard routes, and Redis connection cache keys.
@@ -2952,7 +2889,7 @@ COMMENT ON COLUMN tunneled_mcp_servers.deleted_at IS 'Soft-delete timestamp for 
 COMMENT ON COLUMN tunneled_mcp_servers.deleted IS 'Generated soft-delete flag derived from deleted_at and used by partial indexes.';
 
 -- MCP Servers: user-facing MCP server configurations that link an MCP
--- backend (a toolset, a remote MCP server, or a tunnelled MCP server) to
+-- backend (a toolset, a remote MCP server, or a tunneled MCP server) to
 -- environment and OAuth settings. Each server is addressable via one or more
 -- mcp_endpoints.
 CREATE TABLE IF NOT EXISTS mcp_servers (
@@ -2964,9 +2901,6 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   environment_id uuid,
   user_session_issuer_id uuid,
   remote_mcp_server_id uuid,
-  -- DEPRECATED: superseded by tunneled_mcp_server_id (single-l). Kept during the
-  -- expand/contract rename; a later migration drops this column.
-  tunnelled_mcp_server_id uuid,
   tunneled_mcp_server_id uuid,
   toolset_id uuid,
   -- Optionally enables a variations group for runtime filtering and
@@ -2985,13 +2919,11 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_environment_id_fkey FOREIGN KEY (environment_id) REFERENCES environments (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE RESTRICT,
-  CONSTRAINT mcp_servers_tunnelled_mcp_server_id_fkey FOREIGN KEY (tunnelled_mcp_server_id) REFERENCES tunnelled_mcp_servers (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_tunneled_mcp_server_id_fkey FOREIGN KEY (tunneled_mcp_server_id) REFERENCES tunneled_mcp_servers (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_tool_variations_group_id_fkey FOREIGN KEY (tool_variations_group_id) REFERENCES tool_variations_groups (id) ON DELETE SET NULL,
-  -- Exactly one backend must be set. Both the deprecated tunnelled_ and new
-  -- tunneled_ columns are included so exactly-one holds through the rename.
-  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunnelled_mcp_server_id, tunneled_mcp_server_id, toolset_id) = 1)
+  -- Exactly one backend must be set.
+  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunneled_mcp_server_id, toolset_id) = 1)
 );
 
 CREATE INDEX IF NOT EXISTS mcp_servers_project_id_idx
@@ -3006,15 +2938,10 @@ CREATE INDEX IF NOT EXISTS mcp_servers_remote_mcp_server_id_idx
 ON mcp_servers (remote_mcp_server_id)
 WHERE remote_mcp_server_id IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS mcp_servers_tunnelled_mcp_server_id_idx
-ON mcp_servers (tunnelled_mcp_server_id)
-WHERE tunnelled_mcp_server_id IS NOT NULL;
-
 CREATE INDEX IF NOT EXISTS mcp_servers_tunneled_mcp_server_id_idx
 ON mcp_servers (tunneled_mcp_server_id)
 WHERE tunneled_mcp_server_id IS NOT NULL;
 
-COMMENT ON COLUMN mcp_servers.tunnelled_mcp_server_id IS 'Deprecated. Superseded by tunneled_mcp_server_id (single-l); dropped in a later contract migration.';
 COMMENT ON COLUMN mcp_servers.tunneled_mcp_server_id IS 'Optional backend reference to a tunneled MCP source. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, or toolset_id must be set.';
 
 CREATE INDEX IF NOT EXISTS mcp_servers_toolset_id_idx

--- a/server/migrations/20260703143233_drop-tunnelled-mcp-columns.sql
+++ b/server/migrations/20260703143233_drop-tunnelled-mcp-columns.sql
@@ -1,0 +1,15 @@
+-- atlas:txmode none
+-- atlas:nolint DS102 DS103
+-- Contract step of the tunnelled_ -> tunneled_ rename: drop the deprecated
+-- tunnelled_ objects now that all code reads/writes the tunneled_ columns.
+-- Values were all NULL (feature unreleased), so the drops lose no data.
+
+-- Drop the mcp_servers partial index concurrently first, so dropping the
+-- column below does not take an ACCESS EXCLUSIVE lock on the hot table.
+DROP INDEX CONCURRENTLY IF EXISTS "mcp_servers_tunnelled_mcp_server_id_idx";
+-- Modify "billing_metadata" table
+ALTER TABLE "billing_metadata" DROP CONSTRAINT "billing_metadata_tunnelled_mcp_server_limit_check", DROP COLUMN "tunnelled_mcp_server_limit";
+-- Modify "mcp_servers" table
+ALTER TABLE "mcp_servers" DROP CONSTRAINT "mcp_servers_backend_exclusivity_check", ADD CONSTRAINT "mcp_servers_backend_exclusivity_check" CHECK (num_nonnulls(remote_mcp_server_id, tunneled_mcp_server_id, toolset_id) = 1), DROP COLUMN "tunnelled_mcp_server_id";
+-- Drop "tunnelled_mcp_servers" table
+DROP TABLE "tunnelled_mcp_servers";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:dGWh5MOJFD9JncRmLn7iPOghhltyJuqAzPpm/El7liA=
+h1:ZGfyZKYEpxcLbpqHtl+GO2Oqbtm89qJiB8OX9T+lmlU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -242,3 +242,4 @@ h1:dGWh5MOJFD9JncRmLn7iPOghhltyJuqAzPpm/El7liA=
 20260702131714_risk-policy-challenges.sql h1:f38+NYpcLxP3/EZAaz1uMUKUsswKlkTWwEMQzH5w+JM=
 20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=
 20260703142647_add-tunneled-mcp-columns.sql h1:7cl3GZFt/H3Jt9QOJqCb4Jpiw176iKP4Me9jOABeWI8=
+20260703143233_drop-tunnelled-mcp-columns.sql h1:nByJ1TBLbeB4RXid0PHzw2Y4RKjjHiBH5UDHaV9LD3Q=


### PR DESCRIPTION
**DRAFT — contract step (2/2)** of renaming the `tunnelled_*` MCP DB objects to single-l `tunneled_`. Do not merge until the expand PR (#3878) and the code change (#3703) that moves reads/writes to the `tunneled_` columns have shipped.

Based on #3878 so the diff here is only the drop migration; retarget to `main` after #3878 merges.

## This PR

Drops the deprecated `tunnelled_` objects:
- `DROP TABLE tunnelled_mcp_servers`
- `mcp_servers.tunnelled_mcp_server_id` (+ FK, index)
- `billing_metadata.tunnelled_mcp_server_limit`
- reverts `backend_exclusivity_check` to count only the `tunneled_` column

## Safety

- All `tunnelled_` values are NULL (feature unreleased) → drops lose no data.
- The `mcp_servers` partial index is dropped `CONCURRENTLY` (`-- atlas:txmode none`) so the column drop doesn't take an ACCESS EXCLUSIVE lock on the hot table.
- `DS102`/`DS103` are `-- atlas:nolint`-ed as an intentional drop (repo convention).
- `atlas migrate lint` → no diagnostics on this migration; `atlas migrate diff` → dir synced with `schema.sql`.

## Prerequisite

Merge order: **#3878 (expand)** → **#3703 (code switches to `tunneled_`, drops sqlc renames)** → **this (contract)**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Final contract step of the rename from double‑l `tunnelled_*` to single‑l `tunneled_*`. Removes the old table/columns and updates the backend exclusivity check to only use `tunneled_mcp_server_id`.

- **Migration**
  - Drop `tunnelled_mcp_servers`.
  - Remove `mcp_servers.tunnelled_mcp_server_id` and recreate `backend_exclusivity_check` to exclude it.
  - Remove `billing_metadata.tunnelled_mcp_server_limit`.
  - Merge only after the expand migration and the code switch to `tunneled_*` are live.

- **Safety**
  - All `tunnelled_*` values were NULL, so no data loss.
  - Dropped the `mcp_servers` partial index CONCURRENTLY to avoid locking the hot table.

<sup>Written for commit e3251a19a574bbb2138bede28fd77a42888d36bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

