### PR TITLE
fix(plugins): make codex install script config patching idempotent

### DIFF
--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -2563,13 +2563,33 @@ def strip_root_dotted_key(text, key):
     root = re.sub(r'(?m)^' + re.escape(key) + r'\s*=.*\n?', '', root)
     return root + rest
 
+def table_body_bounds(text, table_header):
+    m = re.search(r'(?m)^' + re.escape(table_header) + r'(?:\s*(?:#.*)?)?\n', text)
+    if not m:
+        return None
+    start = m.end()
+    m2 = re.search(r'(?m)^\[', text[start:])
+    end = start + m2.start() if m2 else len(text)
+    return start, end
+
+def table_has_key(text, table_header, key):
+    bounds = table_body_bounds(text, table_header)
+    if bounds is None:
+        return False
+    body = text[bounds[0]:bounds[1]]
+    return re.search(r'(?m)^' + re.escape(key) + r'\s*=', body) is not None
+
 def ensure_table_entry(text, table_header, key, value):
-    if re.search(r'(?m)^' + re.escape(table_header) + r'\s*\n(?:[^\[]*\n)*' + re.escape(key) + r'\s*=', text):
+    if table_has_key(text, table_header, key):
         return text
-    if table_header not in text:
+    if table_body_bounds(text, table_header) is None:
         return text.rstrip('\n') + '\n\n' + table_header + '\n' + key + ' = ' + value + '\n'
-    idx = text.index(table_header) + len(table_header)
-    return text[:idx] + '\n' + key + ' = ' + value + text[idx:]
+    m = re.search(r'(?m)^' + re.escape(table_header) + r'(?:\s*(?:#.*)?)?\n', text)
+    idx = m.end()
+    return text[:idx] + key + ' = ' + value + '\n' + text[idx:]
+
+def has_table_header(text, header):
+    return re.search(r'(?m)^' + re.escape(header) + r'(?:\s*(?:#.*)?)?\s*$', text) is not None
 
 `)
 
@@ -2582,7 +2602,8 @@ content = strip_root_dotted_key(content, "features.plugin_hooks")
 content = ensure_table_entry(content, "[features]", "hooks", "true")
 content = ensure_table_entry(content, "[features]", "plugin_hooks", "true")
 
-if not re.search(r'(?m)^\[hooks\.state\]', content):
+# Qualified [hooks.state."…"] sections do not require a bare parent header.
+if not has_table_header(content, "[hooks.state]") and not re.search(r'(?m)^\[hooks\.state\.', content):
     content = content.rstrip('\n') + '\n\n[hooks.state]\n'
 
 for state_key, trusted_hash in [
@@ -2594,7 +2615,7 @@ for state_key, trusted_hash in [
 
 	b.WriteString(`]:
     section = f'[hooks.state."{state_key}"]'
-    if section not in content:
+    if not has_table_header(content, section):
         entry = f'\n{section}\nenabled = true\ntrusted_hash = "{trusted_hash}"\n'
         content = content.rstrip('\n') + '\n' + entry
     else:

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -2564,7 +2564,7 @@ def strip_root_dotted_key(text, key):
     return root + rest
 
 def table_body_bounds(text, table_header):
-    m = re.search(r'(?m)^' + re.escape(table_header) + r'(?:\s*(?:#.*)?)?\n', text)
+    m = re.search(r'(?m)^' + re.escape(table_header) + r'(?:\s*(?:#.*)?)?(?:\n|$)', text)
     if not m:
         return None
     start = m.end()
@@ -2572,24 +2572,19 @@ def table_body_bounds(text, table_header):
     end = start + m2.start() if m2 else len(text)
     return start, end
 
-def table_has_key(text, table_header, key):
+def ensure_table_entry(text, table_header, key, value):
     bounds = table_body_bounds(text, table_header)
     if bounds is None:
-        return False
-    body = text[bounds[0]:bounds[1]]
-    return re.search(r'(?m)^' + re.escape(key) + r'\s*=', body) is not None
-
-def ensure_table_entry(text, table_header, key, value):
-    if table_has_key(text, table_header, key):
-        return text
-    if table_body_bounds(text, table_header) is None:
         return text.rstrip('\n') + '\n\n' + table_header + '\n' + key + ' = ' + value + '\n'
-    m = re.search(r'(?m)^' + re.escape(table_header) + r'(?:\s*(?:#.*)?)?\n', text)
-    idx = m.end()
-    return text[:idx] + key + ' = ' + value + '\n' + text[idx:]
+    if re.search(r'(?m)^' + re.escape(key) + r'\s*=', text[bounds[0]:bounds[1]]):
+        return text
+    prefix = text[:bounds[0]]
+    if not prefix.endswith('\n'):
+        prefix += '\n'
+    return prefix + key + ' = ' + value + '\n' + text[bounds[0]:]
 
 def has_table_header(text, header):
-    return re.search(r'(?m)^' + re.escape(header) + r'(?:\s*(?:#.*)?)?\s*$', text) is not None
+    return table_body_bounds(text, header) is not None
 
 `)
 

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -3217,11 +3217,6 @@ func TestComputeCodexHookApprovalsIncludesSessionStartPreflight(t *testing.T) {
 func runCodexInstallScript(t *testing.T, script []byte, existingConfig string) (home string, callLog string) {
 	t.Helper()
 
-	bashPath, err := exec.LookPath("bash")
-	require.NoError(t, err, "bash is required to run the generated install script")
-	pythonPath, err := exec.LookPath("python3")
-	require.NoError(t, err, "python3 is required by the generated install script")
-
 	home = t.TempDir()
 	callLog = filepath.Join(home, "codex-calls.log")
 	stub := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"" + callLog + "\"\n"
@@ -3233,6 +3228,19 @@ func runCodexInstallScript(t *testing.T, script []byte, existingConfig string) (
 		require.NoError(t, os.WriteFile(filepath.Join(home, ".codex", "config.toml"), []byte(existingConfig), 0o644))
 	}
 
+	execCodexInstallScript(t, script, home)
+
+	return home, callLog
+}
+
+func execCodexInstallScript(t *testing.T, script []byte, home string) {
+	t.Helper()
+
+	bashPath, err := exec.LookPath("bash")
+	require.NoError(t, err, "bash is required to run the generated install script")
+	pythonPath, err := exec.LookPath("python3")
+	require.NoError(t, err, "python3 is required by the generated install script")
+
 	scriptPath := filepath.Join(t.TempDir(), "install.sh")
 	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
 
@@ -3243,8 +3251,6 @@ func runCodexInstallScript(t *testing.T, script []byte, existingConfig string) (
 	}
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "install script failed: %s", out)
-
-	return home, callLog
 }
 
 func seededCodexInstallConfig(plugin, marketplace string, approvals []codexHookApproval) string {
@@ -3263,27 +3269,11 @@ func runCodexInstallScriptTimes(t *testing.T, script []byte, existingConfig stri
 	require.Positive(t, times)
 
 	home, _ := runCodexInstallScript(t, script, existingConfig)
-	configPath := filepath.Join(home, ".codex", "config.toml")
-
-	bashPath, err := exec.LookPath("bash")
-	require.NoError(t, err)
-	pythonPath, err := exec.LookPath("python3")
-	require.NoError(t, err)
-
-	scriptPath := filepath.Join(t.TempDir(), "install.sh")
-	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
-
 	for range times - 1 {
-		cmd := exec.Command(bashPath, scriptPath)
-		cmd.Env = []string{
-			"HOME=" + home,
-			"PATH=" + filepath.Dir(pythonPath) + ":/usr/bin:/bin",
-		}
-		out, err := cmd.CombinedOutput()
-		require.NoError(t, err, "install script failed on repeat run: %s", out)
+		execCodexInstallScript(t, script, home)
 	}
 
-	return string(requireFileBytes(t, configPath))
+	return string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
 }
 
 func countTableHeaderLines(config, header string) int {
@@ -3535,6 +3525,29 @@ func TestGenerateCodexInstallScriptIsIdempotent(t *testing.T) {
 	}
 
 	require.Contains(t, patched, "js_repl = true", "pre-existing table entries must be preserved")
+}
+
+// A table header sitting at EOF without a trailing newline is still an
+// existing table — the script must insert its entries under that header
+// instead of appending a duplicate one, which would make Codex refuse to
+// load config.toml entirely.
+func TestGenerateCodexInstallScriptReusesTableHeaderAtEOFWithoutNewline(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	patched := runCodexInstallScriptTimes(t, script, "js_repl = true\n\n[features]", 2)
+
+	var decoded map[string]any
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err, "patched config.toml must remain valid TOML without duplicate tables")
+
+	require.Equal(t, 1, countTableHeaderLines(patched, "[features]"))
+	require.Equal(t, 1, countTableKeyLines(patched, "[features]", "hooks"))
+	require.Equal(t, 1, countTableKeyLines(patched, "[features]", "plugin_hooks"))
+	require.Contains(t, patched, "js_repl = true", "pre-existing root-level entries must be preserved")
 }
 
 func TestGenerateReadmeIncludesCodexInstallation(t *testing.T) {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3245,6 +3247,63 @@ func runCodexInstallScript(t *testing.T, script []byte, existingConfig string) (
 	return home, callLog
 }
 
+func seededCodexInstallConfig(plugin, marketplace string, approvals []codexHookApproval) string {
+	var b strings.Builder
+	b.WriteString("[features]\nhooks = true\nplugin_hooks = true\njs_repl = true\n\n")
+	b.WriteString("[hooks.state]\n\n")
+	for _, approval := range approvals {
+		fmt.Fprintf(&b, "[hooks.state.%q]\nenabled = true\ntrusted_hash = %q\n\n", approval.StateKey, approval.TrustedHash)
+	}
+	fmt.Fprintf(&b, "[plugins.%q]\nenabled = true\n", plugin+"@"+marketplace)
+	return b.String()
+}
+
+func runCodexInstallScriptTimes(t *testing.T, script []byte, existingConfig string, times int) string {
+	t.Helper()
+	require.Positive(t, times)
+
+	home, _ := runCodexInstallScript(t, script, existingConfig)
+	configPath := filepath.Join(home, ".codex", "config.toml")
+
+	bashPath, err := exec.LookPath("bash")
+	require.NoError(t, err)
+	pythonPath, err := exec.LookPath("python3")
+	require.NoError(t, err)
+
+	scriptPath := filepath.Join(t.TempDir(), "install.sh")
+	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
+
+	for range times - 1 {
+		cmd := exec.Command(bashPath, scriptPath)
+		cmd.Env = []string{
+			"HOME=" + home,
+			"PATH=" + filepath.Dir(pythonPath) + ":/usr/bin:/bin",
+		}
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "install script failed on repeat run: %s", out)
+	}
+
+	return string(requireFileBytes(t, configPath))
+}
+
+func countTableHeaderLines(config, header string) int {
+	pattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(header) + `(?:\s*(?:#.*)?)?\s*$`)
+	return len(pattern.FindAllStringIndex(config, -1))
+}
+
+func countTableKeyLines(config, tableHeader, key string) int {
+	bounds := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(tableHeader) + `(?:\s*(?:#.*)?)?\n`).FindStringIndex(config)
+	if bounds == nil {
+		return 0
+	}
+	body := config[bounds[1]:]
+	if next := regexp.MustCompile(`(?m)^\[`).FindStringIndex(body); next != nil {
+		body = body[:next[0]]
+	}
+	pattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(key) + `\s*=`)
+	return len(pattern.FindAllStringIndex(body, -1))
+}
+
 func TestGenerateCodexObservabilityPluginScriptEnrichesMCPMetadataOnDemand(t *testing.T) {
 	t.Parallel()
 	cfg := GenerateConfig{
@@ -3434,6 +3493,48 @@ func TestGenerateCodexInstallScriptCreatesFeaturesTable(t *testing.T) {
 	require.Equal(t, 1, strings.Count(patched, "[features]"))
 	require.Equal(t, 1, strings.Count(patched, "\nhooks = true"))
 	require.Equal(t, 1, strings.Count(patched, "\nplugin_hooks = true"))
+}
+
+// Running install.sh twice against a config that already contains every entry
+// the script writes must not duplicate TOML keys — duplicate keys make Codex
+// refuse to load config.toml entirely.
+func TestGenerateCodexInstallScriptIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
+	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
+	plugin := CodexObservabilitySlug(cfg)
+
+	approvals, err := computeCodexHookApprovals(marketplace, plugin)
+	require.NoError(t, err)
+	require.NotEmpty(t, approvals)
+
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	seeded := seededCodexInstallConfig(plugin, marketplace, approvals)
+	patched := runCodexInstallScriptTimes(t, script, seeded, 2)
+
+	var decoded map[string]any
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err, "patched config.toml must remain valid TOML without duplicate keys")
+
+	require.Equal(t, 1, countTableHeaderLines(patched, "[features]"))
+	require.Equal(t, 1, countTableKeyLines(patched, "[features]", "hooks"))
+	require.Equal(t, 1, countTableKeyLines(patched, "[features]", "plugin_hooks"))
+	require.Equal(t, 1, countTableHeaderLines(patched, "[hooks.state]"))
+	require.Equal(t, 1, countTableHeaderLines(patched, fmt.Sprintf(`[plugins."%s@%s"]`, plugin, marketplace)))
+	require.Equal(t, 1, countTableKeyLines(patched, fmt.Sprintf(`[plugins."%s@%s"]`, plugin, marketplace), "enabled"))
+
+	for _, approval := range approvals {
+		section := fmt.Sprintf(`[hooks.state."%s"]`, approval.StateKey)
+		require.Equal(t, 1, countTableHeaderLines(patched, section), "hook approval section %q must appear exactly once", section)
+		require.Equal(t, 1, countTableKeyLines(patched, section, "enabled"))
+		require.Equal(t, 1, countTableKeyLines(patched, section, "trusted_hash"))
+		require.Contains(t, patched, approval.TrustedHash)
+	}
+
+	require.Contains(t, patched, "js_repl = true", "pre-existing table entries must be preserved")
 }
 
 func TestGenerateReadmeIncludesCodexInstallation(t *testing.T) {


### PR DESCRIPTION
## Summary

The generated Codex `install.sh` could append duplicate keys to `~/.codex/config.toml` on re-run (e.g. a second `hooks = true` under `[features]` or a second bare `[hooks.state]` header). Duplicate TOML keys cause the Codex CLI to fail config reload with a duplicate-key parse error.

The install script now uses section-scoped merge helpers: keys are only written when absent from their target table, bare `[hooks.state]` headers are skipped when qualified `[hooks.state."…"]` sections already exist, and hook approval sections are detected by exact table header rather than substring. A test runs the generated script twice against a fully seeded config and asserts valid, duplicate-free TOML.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Codex install script idempotent when patching `~/.codex/config.toml` and handle table headers at EOF without a trailing newline, so reruns don’t create duplicate TOML keys or headers that break CLI config reload. Adds precise, section-scoped merges and tests that validate duplicate-free, valid TOML on repeated runs.

- **Bug Fixes**
  - Added `table_body_bounds` and `has_table_header`; `ensure_table_entry` now writes under existing tables and matches headers at EOF.
  - Skip inserting bare `[hooks.state]` when `[hooks.state."…"]` sections exist.
  - Detect hook approval sections by exact table header, not substring.
  - Preserve existing entries; no duplicate keys on reruns.
  - New tests: idempotency with a fully seeded config and handling a table header at EOF (validated with `github.com/BurntSushi/toml`).

<sup>Written for commit 5be67f61423936d7abca40b51611ed61ce4112ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

