### PR TITLE
mig: add is_default column to plugins

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3081,6 +3081,7 @@ CREATE TABLE IF NOT EXISTS plugins (
   name TEXT NOT NULL CHECK (name <> ''),
   slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 60),
   description TEXT,
+  is_default boolean DEFAULT false,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -3095,6 +3096,17 @@ CREATE TABLE IF NOT EXISTS plugins (
 CREATE UNIQUE INDEX IF NOT EXISTS plugins_organization_id_project_id_slug_key
   ON plugins (organization_id, project_id, slug)
   WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS plugins_project_id_idx
+  ON plugins (project_id);
+
+-- Only one plugin per project may be the default (fallback) target that new
+-- servers land in absent explicit routing to a named plugin.
+CREATE UNIQUE INDEX IF NOT EXISTS plugins_project_id_is_default_key
+  ON plugins (project_id)
+  WHERE is_default IS TRUE AND deleted IS FALSE;
+
+COMMENT ON COLUMN plugins.is_default IS 'Marks the fallback plugin new servers land in when not explicitly routed to a named plugin. At most one true per project (see plugins_project_id_is_default_key).';
 
 -- Links a plugin to an MCP server, backed by either a toolset or an
 -- mcp_servers row (exactly one, enforced by the exclusivity check below).

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1153,10 +1153,12 @@ type Plugin struct {
 	Name           string
 	Slug           string
 	Description    pgtype.Text
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
-	DeletedAt      pgtype.Timestamptz
-	Deleted        bool
+	// Marks the fallback plugin new servers land in when not explicitly routed to a named plugin. At most one true per project (see plugins_project_id_is_default_key).
+	IsDefault pgtype.Bool
+	CreatedAt pgtype.Timestamptz
+	UpdatedAt pgtype.Timestamptz
+	DeletedAt pgtype.Timestamptz
+	Deleted   bool
 }
 
 type PluginAssignment struct {

--- a/server/internal/plugins/repo/models.go
+++ b/server/internal/plugins/repo/models.go
@@ -16,10 +16,12 @@ type Plugin struct {
 	Name           string
 	Slug           string
 	Description    pgtype.Text
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
-	DeletedAt      pgtype.Timestamptz
-	Deleted        bool
+	// Marks the fallback plugin new servers land in when not explicitly routed to a named plugin. At most one true per project (see plugins_project_id_is_default_key).
+	IsDefault pgtype.Bool
+	CreatedAt pgtype.Timestamptz
+	UpdatedAt pgtype.Timestamptz
+	DeletedAt pgtype.Timestamptz
+	Deleted   bool
 }
 
 type PluginAssignment struct {

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -95,7 +95,7 @@ const createPlugin = `-- name: CreatePlugin :one
 
 INSERT INTO plugins (organization_id, project_id, name, slug, description)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, organization_id, project_id, name, slug, description, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, is_default, created_at, updated_at, deleted_at, deleted
 `
 
 type CreatePluginParams struct {
@@ -124,6 +124,7 @@ func (q *Queries) CreatePlugin(ctx context.Context, arg CreatePluginParams) (Plu
 		&i.Name,
 		&i.Slug,
 		&i.Description,
+		&i.IsDefault,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -277,7 +278,7 @@ func (q *Queries) GetOrganizationName(ctx context.Context, id string) (string, e
 }
 
 const getPlugin = `-- name: GetPlugin :one
-SELECT id, organization_id, project_id, name, slug, description, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, is_default, created_at, updated_at, deleted_at, deleted
 FROM plugins
 WHERE id = $1
   AND organization_id = $2
@@ -301,6 +302,7 @@ func (q *Queries) GetPlugin(ctx context.Context, arg GetPluginParams) (Plugin, e
 		&i.Name,
 		&i.Slug,
 		&i.Description,
+		&i.IsDefault,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -496,7 +498,7 @@ func (q *Queries) ListPluginServers(ctx context.Context, pluginID uuid.UUID) ([]
 
 const listPlugins = `-- name: ListPlugins :many
 SELECT
-  p.id, p.organization_id, p.project_id, p.name, p.slug, p.description, p.created_at, p.updated_at, p.deleted_at, p.deleted,
+  p.id, p.organization_id, p.project_id, p.name, p.slug, p.description, p.is_default, p.created_at, p.updated_at, p.deleted_at, p.deleted,
   (SELECT count(*) FROM plugin_servers ps WHERE ps.plugin_id = p.id AND ps.deleted IS FALSE) AS server_count,
   (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id) AS assignment_count
 FROM plugins p
@@ -518,6 +520,7 @@ type ListPluginsRow struct {
 	Name            string
 	Slug            string
 	Description     pgtype.Text
+	IsDefault       pgtype.Bool
 	CreatedAt       pgtype.Timestamptz
 	UpdatedAt       pgtype.Timestamptz
 	DeletedAt       pgtype.Timestamptz
@@ -542,6 +545,7 @@ func (q *Queries) ListPlugins(ctx context.Context, arg ListPluginsParams) ([]Lis
 			&i.Name,
 			&i.Slug,
 			&i.Description,
+			&i.IsDefault,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -800,7 +804,7 @@ WHERE id = $4
   AND organization_id = $5
   AND project_id = $6
   AND deleted IS FALSE
-RETURNING id, organization_id, project_id, name, slug, description, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, is_default, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdatePluginParams struct {
@@ -829,6 +833,7 @@ func (q *Queries) UpdatePlugin(ctx context.Context, arg UpdatePluginParams) (Plu
 		&i.Name,
 		&i.Slug,
 		&i.Description,
+		&i.IsDefault,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260703160051_plugins-add-is-default.sql
+++ b/server/migrations/20260703160051_plugins-add-is-default.sql
@@ -1,0 +1,10 @@
+-- atlas:txmode none
+
+-- Modify "plugins" table
+ALTER TABLE "plugins" ADD COLUMN "is_default" boolean NULL DEFAULT false;
+-- Create index "plugins_project_id_idx" to table: "plugins"
+CREATE INDEX CONCURRENTLY "plugins_project_id_idx" ON "plugins" ("project_id");
+-- Create index "plugins_project_id_is_default_key" to table: "plugins"
+CREATE UNIQUE INDEX CONCURRENTLY "plugins_project_id_is_default_key" ON "plugins" ("project_id") WHERE ((is_default IS TRUE) AND (deleted IS FALSE));
+-- Set comment to column: "is_default" on table: "plugins"
+COMMENT ON COLUMN "plugins"."is_default" IS 'Marks the fallback plugin new servers land in when not explicitly routed to a named plugin. At most one true per project (see plugins_project_id_is_default_key).';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:XwyC7hUtbW+Ff7SzAxn80IlitdF3fpx7LcZSwjZGQy8=
+h1:9f4H/SlzIC1ft75AhM/hC+E/8VA9ovhd8HJ7XwVtuQY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -242,3 +242,4 @@ h1:XwyC7hUtbW+Ff7SzAxn80IlitdF3fpx7LcZSwjZGQy8=
 20260702131714_risk-policy-challenges.sql h1:f38+NYpcLxP3/EZAaz1uMUKUsswKlkTWwEMQzH5w+JM=
 20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=
 20260703134504_rename-tunneled-mcp-columns.sql h1:httREsZ8T4QWXUQZOpzmv4U7zRybXkB4g5TPOaCskGY=
+20260703160051_plugins-add-is-default.sql h1:Vd7RqDOV6+53NX5jHTWaEl0OWDmuLdVrDuMiVpRD0Fs=


### PR DESCRIPTION
## Summary

- Add `plugins.is_default` boolean column, `false` by default.
- Add partial unique index `plugins_project_id_is_default_key` on `(project_id) WHERE is_default IS TRUE AND deleted IS FALSE` — at most one plugin per project can be the default (fallback) target.
- Schema-only: no queries, no Go code, no application logic in this PR (per migration hygiene rules — that lands separately).

## Test plan

- [x] `mise run db:reset && mise run db:migrate` — all 243 migrations apply cleanly on a fresh DB.
- [x] `mise run lint:migrations` — ordering + `atlas:txmode none` checks pass; `atlas migrate lint` clean against a scratch dev DB.
- [x] `mise build:server` — green (no code references the new column yet).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `plugins.is_default` boolean (default false) with partial unique index `plugins_project_id_is_default_key` (`deleted IS FALSE`) to enforce one default plugin per project; also add `plugins_project_id_idx` and a column comment using concurrent indexes. Regenerated `sqlc` models/queries to include `is_default` in `Plugin` structs and SELECT/RETURNING columns; no application logic changes.

<sup>Written for commit 894aa280d24ec573369f06267fffcbfec9f18b17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

