### PR TITLE
fix: fallback claude hook attribution to auth email

### DIFF
--- a/.changeset/claude-hook-auth-email-fallback.md
+++ b/.changeset/claude-hook-auth-email-fallback.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Attribute Claude hook sessions to the authenticated API-key user email when payload and OTEL session metadata omit an email.

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -684,15 +684,23 @@ func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 	s.refreshMCPListTTL(ctx, sessionID)
 
 	payloadUserEmail := strings.TrimSpace(conv.PtrValOr(payload.UserEmail, ""))
+	authContextUserEmail := payloadUserEmail
 
 	// Both plugin-authenticated and OTEL-only requests go through the same
 	// Redis-buffered flow: persist when session metadata is in the cache,
 	// buffer otherwise so flushPendingHooks can re-persist with full
 	// attribution once /rpc/hooks.otel.logs lands. Newer plugin hooks may
 	// carry user_email from the device agent; use it immediately when present
-	// so Claude can attribute hooks before OTEL logs arrive. Older hooks still
-	// fall back to buffering.
-	authMetadata, hasAuthMetadata := s.claudeAuthContextMetadata(ctx, sessionID, payloadUserEmail)
+	// so Claude can attribute hooks before OTEL logs arrive. As a last resort,
+	// use the authenticated API-key user's email: shared keys may identify the
+	// key owner rather than the human at the keyboard, so cached OTEL metadata
+	// and payload email always take precedence over this fallback.
+	if authContextUserEmail == "" {
+		if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.Email != nil {
+			authContextUserEmail = strings.TrimSpace(*authCtx.Email)
+		}
+	}
+	authMetadata, hasAuthMetadata := s.claudeAuthContextMetadata(ctx, sessionID, authContextUserEmail)
 
 	metadata, err := s.getSessionMetadata(ctx, sessionID)
 	if err == nil {
@@ -708,7 +716,7 @@ func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 		return
 	}
 
-	if hasAuthMetadata && payloadUserEmail != "" {
+	if hasAuthMetadata && authContextUserEmail != "" {
 		go s.persistHook(ctx, payload, &authMetadata)
 		return
 	}

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -819,11 +819,18 @@ func TestClaude_RecordHook_PersistsAuthContextProjectOverCachedMetadata(t *testi
 	assert.Equal(t, prompt, msgs[0].Content)
 }
 
-func TestClaude_RecordHook_BuffersAuthContextCacheMissWithoutPayloadEmail(t *testing.T) {
+func TestClaude_RecordHook_PersistsAuthContextEmailWhenPayloadAndCacheMissEmail(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	require.NotNil(t, authCtx.Email)
 
 	sessionID := uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
 	prompt := "hello before otel metadata"
 
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
@@ -834,10 +841,22 @@ func TestClaude_RecordHook_BuffersAuthContextCacheMissWithoutPayloadEmail(t *tes
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
+	var msgs []chatRepo.ChatMessage
+	require.Eventually(t, func() bool {
+		var err error
+		msgs, err = chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+			ChatID:    chatID,
+			ProjectID: *authCtx.ProjectID,
+		})
+		return err == nil && len(msgs) == 1
+	}, 2*time.Second, 25*time.Millisecond)
+
+	assert.Equal(t, prompt, msgs[0].Content)
+	assert.Equal(t, *authCtx.Email, msgs[0].ExternalUserID.String)
+
 	var buffered []gen.ClaudePayload
 	require.NoError(t, ti.service.cache.ListRange(ctx, hookPendingCacheKey(sessionID), 0, -1, &buffered))
-	require.Len(t, buffered, 1)
-	assert.Equal(t, "UserPromptSubmit", buffered[0].HookEventName)
+	assert.Empty(t, buffered)
 }
 
 func TestClaude_RecordHook_DoesNotUseAuthUserIDWhenPayloadEmailDoesNotResolve(t *testing.T) {


### PR DESCRIPTION
Local/self-hosted Claude hook session capture drops every session when neither the hook payload nor OTEL logs supply a `user.email`, so nothing is written to `chats`/`chat_messages` even though the API key authenticates fine.

Fix: fall back to the authenticated API-key user email when both are absent. Precedence unchanged: cached OTEL metadata, then payload email, then auth-key email (last resort only).

- Prod-safety: a shared key's owner may not be the operator, so the fallback is strictly last resort; the only behavior change is that otherwise-dropped sessions get attributed.
- Tests: `go test ./server/internal/hooks/...` passes.