### PR TITLE
mig: risk policy eval reviews

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3467,28 +3467,10 @@ CREATE TABLE IF NOT EXISTS risk_policy_eval_reviews (
   CONSTRAINT risk_policy_eval_reviews_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
 );
 
--- One active verdict per reviewer per session per policy. Saving a verdict
--- upserts on this key.
+-- One active verdict per reviewer per session per policy.
 CREATE UNIQUE INDEX IF NOT EXISTS risk_policy_eval_reviews_policy_chat_reviewer_key
 ON risk_policy_eval_reviews (project_id, risk_policy_id, chat_id, reviewed_by)
 WHERE deleted IS FALSE;
-
--- List the regression set for a policy.
-CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_policy_idx
-ON risk_policy_eval_reviews (project_id, risk_policy_id)
-WHERE deleted IS FALSE;
-
-CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_chat_id_idx
-ON risk_policy_eval_reviews (chat_id);
-
-CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_organization_id_idx
-ON risk_policy_eval_reviews (organization_id);
-
-CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_project_id_idx
-ON risk_policy_eval_reviews (project_id);
-
-CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_risk_policy_id_idx
-ON risk_policy_eval_reviews (risk_policy_id);
 
 CREATE TABLE IF NOT EXISTS authz_challenge_resolutions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3429,6 +3429,67 @@ CREATE INDEX IF NOT EXISTS risk_results_excluded_exclusion_idx
 ON risk_results (excluded_exclusion_id)
 WHERE excluded_exclusion_id IS NOT NULL;
 
+-- risk_policy_eval_reviews is the durable "regression set" for a prompt-based
+-- risk policy: a reviewer's ground-truth verdict on whether a given chat session
+-- should be flagged by the policy. The policy-eval workbench replays the
+-- guardrail live and scores its agreement against these saved verdicts. A
+-- verdict is the reviewer's judgment of the policy INTENT, so it persists across
+-- guardrail edits; risk_policy_version records the version in effect when the
+-- verdict was recorded (provenance only). Physically separate from risk_results:
+-- eval review activity never touches live findings, the outbox, or enforcement.
+CREATE TABLE IF NOT EXISTS risk_policy_eval_reviews (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  organization_id TEXT NOT NULL,
+  risk_policy_id uuid NOT NULL,
+  -- Policy version in effect when the verdict was recorded. Provenance only; the
+  -- verdict itself is version-independent ground truth.
+  risk_policy_version BIGINT NOT NULL,
+  chat_id uuid NOT NULL,
+  -- The reviewer's ground-truth judgment of this session under the policy:
+  --   correct        -> the guardrail's flag/clean call matched the reviewer
+  --   false_positive -> the guardrail flagged a session it should not (tighten)
+  --   missed         -> the guardrail missed a session it should flag (broaden)
+  verdict TEXT NOT NULL,
+  -- User id of the reviewer who recorded the verdict.
+  reviewed_by TEXT NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT risk_policy_eval_reviews_pkey PRIMARY KEY (id),
+  CONSTRAINT risk_policy_eval_reviews_verdict_check CHECK (verdict IN ('correct', 'false_positive', 'missed')),
+  CONSTRAINT risk_policy_eval_reviews_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+  CONSTRAINT risk_policy_eval_reviews_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE,
+  CONSTRAINT risk_policy_eval_reviews_risk_policy_id_fkey FOREIGN KEY (risk_policy_id) REFERENCES risk_policies(id) ON DELETE CASCADE,
+  CONSTRAINT risk_policy_eval_reviews_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
+);
+
+-- One active verdict per reviewer per session per policy. Saving a verdict
+-- upserts on this key.
+CREATE UNIQUE INDEX IF NOT EXISTS risk_policy_eval_reviews_policy_chat_reviewer_key
+ON risk_policy_eval_reviews (project_id, risk_policy_id, chat_id, reviewed_by)
+WHERE deleted IS FALSE;
+
+-- List the regression set for a policy.
+CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_policy_idx
+ON risk_policy_eval_reviews (project_id, risk_policy_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_chat_id_idx
+ON risk_policy_eval_reviews (chat_id);
+
+CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_organization_id_idx
+ON risk_policy_eval_reviews (organization_id);
+
+CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_project_id_idx
+ON risk_policy_eval_reviews (project_id);
+
+CREATE INDEX IF NOT EXISTS risk_policy_eval_reviews_risk_policy_id_idx
+ON risk_policy_eval_reviews (risk_policy_id);
+
 CREATE TABLE IF NOT EXISTS authz_challenge_resolutions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1516,6 +1516,21 @@ type RiskPolicyChallenge struct {
 	Deleted        bool
 }
 
+type RiskPolicyEvalReview struct {
+	ID                uuid.UUID
+	ProjectID         uuid.UUID
+	OrganizationID    string
+	RiskPolicyID      uuid.UUID
+	RiskPolicyVersion int64
+	ChatID            uuid.UUID
+	Verdict           string
+	ReviewedBy        string
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	DeletedAt         pgtype.Timestamptz
+	Deleted           bool
+}
+
 type RiskResult struct {
 	ID                  uuid.UUID
 	ProjectID           uuid.UUID

--- a/server/migrations/20260704062005_risk-policy-eval-reviews.sql
+++ b/server/migrations/20260704062005_risk-policy-eval-reviews.sql
@@ -1,0 +1,33 @@
+-- Create "risk_policy_eval_reviews" table
+CREATE TABLE "risk_policy_eval_reviews" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "organization_id" text NOT NULL,
+  "risk_policy_id" uuid NOT NULL,
+  "risk_policy_version" bigint NOT NULL,
+  "chat_id" uuid NOT NULL,
+  "verdict" text NOT NULL,
+  "reviewed_by" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "risk_policy_eval_reviews_chat_id_fkey" FOREIGN KEY ("chat_id") REFERENCES "chats" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_policy_eval_reviews_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_policy_eval_reviews_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_policy_eval_reviews_risk_policy_id_fkey" FOREIGN KEY ("risk_policy_id") REFERENCES "risk_policies" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_policy_eval_reviews_verdict_check" CHECK (verdict = ANY (ARRAY['correct'::text, 'false_positive'::text, 'missed'::text]))
+);
+-- Create index "risk_policy_eval_reviews_chat_id_idx" to table: "risk_policy_eval_reviews"
+CREATE INDEX "risk_policy_eval_reviews_chat_id_idx" ON "risk_policy_eval_reviews" ("chat_id");
+-- Create index "risk_policy_eval_reviews_organization_id_idx" to table: "risk_policy_eval_reviews"
+CREATE INDEX "risk_policy_eval_reviews_organization_id_idx" ON "risk_policy_eval_reviews" ("organization_id");
+-- Create index "risk_policy_eval_reviews_policy_chat_reviewer_key" to table: "risk_policy_eval_reviews"
+CREATE UNIQUE INDEX "risk_policy_eval_reviews_policy_chat_reviewer_key" ON "risk_policy_eval_reviews" ("project_id", "risk_policy_id", "chat_id", "reviewed_by") WHERE (deleted IS FALSE);
+-- Create index "risk_policy_eval_reviews_policy_idx" to table: "risk_policy_eval_reviews"
+CREATE INDEX "risk_policy_eval_reviews_policy_idx" ON "risk_policy_eval_reviews" ("project_id", "risk_policy_id") WHERE (deleted IS FALSE);
+-- Create index "risk_policy_eval_reviews_project_id_idx" to table: "risk_policy_eval_reviews"
+CREATE INDEX "risk_policy_eval_reviews_project_id_idx" ON "risk_policy_eval_reviews" ("project_id");
+-- Create index "risk_policy_eval_reviews_risk_policy_id_idx" to table: "risk_policy_eval_reviews"
+CREATE INDEX "risk_policy_eval_reviews_risk_policy_id_idx" ON "risk_policy_eval_reviews" ("risk_policy_id");

--- a/server/migrations/20260707070702_risk-policy-eval-reviews.sql
+++ b/server/migrations/20260707070702_risk-policy-eval-reviews.sql
@@ -19,15 +19,5 @@ CREATE TABLE "risk_policy_eval_reviews" (
   CONSTRAINT "risk_policy_eval_reviews_risk_policy_id_fkey" FOREIGN KEY ("risk_policy_id") REFERENCES "risk_policies" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
   CONSTRAINT "risk_policy_eval_reviews_verdict_check" CHECK (verdict = ANY (ARRAY['correct'::text, 'false_positive'::text, 'missed'::text]))
 );
--- Create index "risk_policy_eval_reviews_chat_id_idx" to table: "risk_policy_eval_reviews"
-CREATE INDEX "risk_policy_eval_reviews_chat_id_idx" ON "risk_policy_eval_reviews" ("chat_id");
--- Create index "risk_policy_eval_reviews_organization_id_idx" to table: "risk_policy_eval_reviews"
-CREATE INDEX "risk_policy_eval_reviews_organization_id_idx" ON "risk_policy_eval_reviews" ("organization_id");
 -- Create index "risk_policy_eval_reviews_policy_chat_reviewer_key" to table: "risk_policy_eval_reviews"
 CREATE UNIQUE INDEX "risk_policy_eval_reviews_policy_chat_reviewer_key" ON "risk_policy_eval_reviews" ("project_id", "risk_policy_id", "chat_id", "reviewed_by") WHERE (deleted IS FALSE);
--- Create index "risk_policy_eval_reviews_policy_idx" to table: "risk_policy_eval_reviews"
-CREATE INDEX "risk_policy_eval_reviews_policy_idx" ON "risk_policy_eval_reviews" ("project_id", "risk_policy_id") WHERE (deleted IS FALSE);
--- Create index "risk_policy_eval_reviews_project_id_idx" to table: "risk_policy_eval_reviews"
-CREATE INDEX "risk_policy_eval_reviews_project_id_idx" ON "risk_policy_eval_reviews" ("project_id");
--- Create index "risk_policy_eval_reviews_risk_policy_id_idx" to table: "risk_policy_eval_reviews"
-CREATE INDEX "risk_policy_eval_reviews_risk_policy_id_idx" ON "risk_policy_eval_reviews" ("risk_policy_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WFNgQB2D1/du354hmlwe7CLHQ21kRVfbP549DWaIGV8=
+h1:7264v3TC7iiL9l9NoxX6T7EKwqCUdSjSAH+cMEL9vPg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -243,6 +243,6 @@ h1:WFNgQB2D1/du354hmlwe7CLHQ21kRVfbP549DWaIGV8=
 20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=
 20260703134504_rename-tunneled-mcp-columns.sql h1:httREsZ8T4QWXUQZOpzmv4U7zRybXkB4g5TPOaCskGY=
 20260703160051_plugins-add-is-default.sql h1:Vd7RqDOV6+53NX5jHTWaEl0OWDmuLdVrDuMiVpRD0Fs=
-20260704062005_risk-policy-eval-reviews.sql h1:nsITaCRtt/dSn1/jTxKlA6oJ/Iy1uVhaCgYlzLG886I=
-20260706170316_json-web-key-sets-json-web-keys.sql h1:C0BsXzAoiem+9bR3ssR1VfliNrI6Yy1h8f3pNBieWNI=
-20260706233448_drop-session-capture-exclusions.sql h1:8Bx4rwhwIrs//o2rVZGk6Fzusqfd4l2/oqhC7WVefbw=
+20260706170316_json-web-key-sets-json-web-keys.sql h1:F7gFxdLCa1Q1gZc19/SrpAIiJgmZ7cUV/49iQD9GbN4=
+20260706233448_drop-session-capture-exclusions.sql h1:CZfr4NqnLrq4r4Av+m/KVY39PEEH6TrBHe8sz61y4Co=
+20260707070702_risk-policy-eval-reviews.sql h1:RjhJvs0KrFmEk9tuNDI9slvcm1uGbnyEf44mDlZ8/MI=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:SxaPLT0Z+0DdubUgImOZAnlq/PCzJuSYuuJMLcmcyxQ=
+h1:WFNgQB2D1/du354hmlwe7CLHQ21kRVfbP549DWaIGV8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -243,5 +243,6 @@ h1:SxaPLT0Z+0DdubUgImOZAnlq/PCzJuSYuuJMLcmcyxQ=
 20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=
 20260703134504_rename-tunneled-mcp-columns.sql h1:httREsZ8T4QWXUQZOpzmv4U7zRybXkB4g5TPOaCskGY=
 20260703160051_plugins-add-is-default.sql h1:Vd7RqDOV6+53NX5jHTWaEl0OWDmuLdVrDuMiVpRD0Fs=
-20260706170316_json-web-key-sets-json-web-keys.sql h1:F7gFxdLCa1Q1gZc19/SrpAIiJgmZ7cUV/49iQD9GbN4=
-20260706233448_drop-session-capture-exclusions.sql h1:CZfr4NqnLrq4r4Av+m/KVY39PEEH6TrBHe8sz61y4Co=
+20260704062005_risk-policy-eval-reviews.sql h1:nsITaCRtt/dSn1/jTxKlA6oJ/Iy1uVhaCgYlzLG886I=
+20260706170316_json-web-key-sets-json-web-keys.sql h1:C0BsXzAoiem+9bR3ssR1VfliNrI6Yy1h8f3pNBieWNI=
+20260706233448_drop-session-capture-exclusions.sql h1:8Bx4rwhwIrs//o2rVZGk6Fzusqfd4l2/oqhC7WVefbw=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a durable review set for prompt‑policy evals by introducing the `risk_policy_eval_reviews` table and corresponding model. It stores ground‑truth reviewer verdicts per policy and chat, separate from `risk_results`, with one active verdict per reviewer.

- **Migration**
  - Creates `risk_policy_eval_reviews` with soft delete, provenance `risk_policy_version`, and `verdict` check (`correct|false_positive|missed`), plus FKs with cascade.
  - Adds a partial unique index on `(project_id, risk_policy_id, chat_id, reviewed_by)` where `deleted` is false.
  - Adds `RiskPolicyEvalReview` to `models.go` to map the table.

<sup>Written for commit 4abc30ccb2c1423af911f839c0b4340f9f346710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

