### PR TITLE
chore: tighten assistant runner setup

### DIFF
--- a/.mise-tasks/build/assistant-runner.sh
+++ b/.mise-tasks/build/assistant-runner.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+#MISE description="Build the assistant runner Rust crate"
+#MISE dir="{{ config_root }}/agents/runner"
+
+set -euo pipefail
+
+exec cargo build --locked "$@"

--- a/.mise-tasks/lint/assistant-runner.sh
+++ b/.mise-tasks/lint/assistant-runner.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#MISE description="Run rustfmt and Clippy on the assistant runner"
+#MISE dir="{{ config_root }}/agents/runner"
+
+set -euo pipefail
+
+cargo fmt --check
+cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/.mise-tasks/test/assistant-runner.sh
+++ b/.mise-tasks/test/assistant-runner.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+#MISE description="Test the assistant runner Rust crate"
+#MISE dir="{{ config_root }}/agents/runner"
+
+set -euo pipefail
+
+exec cargo test --locked "$@"

--- a/agents/runner/.cargo/config.toml
+++ b/agents/runner/.cargo/config.toml
@@ -1,0 +1,12 @@
+[alias]
+ci-check = ["check", "--locked"]
+ci-clippy = [
+  "clippy",
+  "--locked",
+  "--all-targets",
+  "--all-features",
+  "--",
+  "-D",
+  "warnings",
+]
+ci-test = ["test", "--locked"]

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -3,6 +3,11 @@ name = "gram-assistant-runner"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.95"
+description = "HTTP runner for Gram assistant threads"
+repository = "https://github.com/speakeasy-api/gram"
+readme = "README.md"
+license = "AGPL-3.0-only"
+publish = false
 
 [[bin]]
 name = "gram-assistant-runner"
@@ -74,18 +79,23 @@ tokio = { version = "1", features = [
 [lints.rust]
 unsafe_code = "forbid"
 unused_must_use = "deny"
+rust_2018_idioms = { level = "deny", priority = -1 }
 
 [lints.clippy]
-all = { level = "warn", priority = -1 }
+all = { level = "warn", priority = -2 }
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+perf = { level = "deny", priority = -1 }
+complexity = { level = "deny", priority = -1 }
 
-unwrap_used = "warn"
-expect_used = "warn"
-panic = "warn"
-todo = "warn"
-unimplemented = "warn"
-dbg_macro = "warn"
-print_stdout = "warn"
-print_stderr = "warn"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+todo = "deny"
+unimplemented = "deny"
+dbg_macro = "deny"
+print_stdout = "deny"
+print_stderr = "deny"
 
-await_holding_lock = "warn"
-await_holding_refcell_ref = "warn"
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"

--- a/agents/runner/README.md
+++ b/agents/runner/README.md
@@ -1,0 +1,28 @@
+# Gram Assistant Runner
+
+Rust HTTP runner for assistant threads. The crate is intentionally standalone so
+it can be built and tested without the Go/TypeScript workspaces.
+
+## Setup
+
+The crate pins Rust `1.95.0` via `rust-toolchain.toml`.
+
+Common commands:
+
+```sh
+mise run build:assistant-runner
+mise run lint:assistant-runner
+mise run test:assistant-runner
+```
+
+From `agents/runner`, the same CI-oriented Cargo aliases are available:
+
+```sh
+cargo ci-check
+cargo ci-clippy
+cargo ci-test
+```
+
+`cargo ci-clippy` runs all targets and features with `-D warnings`; keep new
+test-only `unwrap`, `expect`, and `panic` usage scoped behind local lint
+allowances.

--- a/agents/runner/rust-toolchain.toml
+++ b/agents/runner/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]

--- a/agents/runner/rustfmt.toml
+++ b/agents/runner/rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2024"
+max_width = 100
+newline_style = "Unix"
+use_field_init_shorthand = true
+use_try_shorthand = true

--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -203,8 +203,7 @@ fn token_threshold_trigger(window: u64, percent: u32, fire_at_turn_end: bool) ->
             .iter()
             .map(estimate_item_chars)
             .sum();
-        let projected =
-            tokens.input_tokens + tokens.output_tokens + (appended_chars / 4) as u64;
+        let projected = tokens.input_tokens + tokens.output_tokens + (appended_chars / 4) as u64;
         (projected >= threshold).then(|| {
             CompactionReason::Custom(format!(
                 "projected_tokens={projected} >= threshold={threshold} (window={window}, {percent}%, {point:?})"
@@ -439,11 +438,7 @@ impl Compactor for CachedCompactor {
         _reason: CompactionReason,
         _cancellation: Option<TurnCancellation>,
     ) -> Result<Vec<Item>, CompactionError> {
-        let cached = self
-            .cache
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .take();
+        let cached = self.cache.lock().unwrap_or_else(|p| p.into_inner()).take();
         match cached {
             Some(c) if c.input_len <= transcript.len() => {
                 let mut out = c.items;


### PR DESCRIPTION
## Summary
- pin the Rust toolchain in mise and add assistant-runner build/lint/test tasks
- add crate-local Cargo aliases, rustfmt config, and setup docs
- promote high-signal runner Clippy checks from warnings to denies

## Tests
- mise run lint:assistant-runner
- mise run test:assistant-runner
- mise run build:assistant-runner

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the Rust toolchain and add reproducible build/lint/test tasks for the assistant runner. Tighten lints and formatting to make local dev and CI strict and consistent.

- **Refactors**
  - Add `mise` tasks to build, lint, and test the runner (`--locked`).
  - Add crate-local `cargo` aliases for CI: `ci-check`, `ci-clippy` (all targets/features, `-D warnings`), `ci-test`.
  - Deny high-signal Clippy groups and risky patterns; add `rustfmt.toml`.
  - Add crate metadata and a `README` with setup commands.
  - Minor formatting cleanups in source.

- **Dependencies**
  - Pin Rust to `1.95.0` via `rust-toolchain.toml` (includes `clippy` and `rustfmt`).

<sup>Written for commit f589f2b2a50c659e9a48f85d75ce5d66648c8192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

