### PR TITLE
chore: add linear-code to cla allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-document: "https://github.com/speakeasy-api/gram/blob/main/CLA.md" # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: "cla-signatures"
-          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot],cursoragent,claude
+          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot],cursoragent,claude,linear-code
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `linear-code` to the CLA allowlist so PRs from our Linear integration bypass CLA checks and aren’t blocked from merging.

<sup>Written for commit 30bce3c3b7181a6a66f5dc7919892eb43592065d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

