### PR TITLE
fix(costs): reconcile headline session count with breakdown rows

### DIFF
--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -295,10 +295,13 @@ export function CostsExplorer(): JSX.Element {
   // of an empty "no data" flash before the project-scoped queries enable.
   const loadingSlice = (!projectReady || isFetching) && !data;
 
-  // The current entity's own attributes: a no-group_by query over the same
-  // filters returns a single aggregate row whose dimension_values are this
-  // entity's distinct division/department/job_title/roles/etc. Only meaningful
-  // once we've drilled into something.
+  // A no-group_by query over the same filters returns a single aggregate row for
+  // the whole slice. Two things come off it:
+  //   • its dimension_values are the current entity's distinct division/
+  //     department/job_title/roles/etc (only meaningful once drilled in), and
+  //   • its measures are the TRUE slice totals — critically the distinct session
+  //     count, which cannot be recovered by summing the per-group breakdown rows
+  //     (see `stats`). Runs at every level so the root headline is correct too.
   const { data: detailData } = useQuery({
     queryKey: [
       "costs-explorer-detail",
@@ -306,7 +309,7 @@ export function CostsExplorer(): JSX.Element {
       to.toISOString(),
       filters,
     ],
-    enabled: projectReady && path.length > 0,
+    enabled: projectReady,
     throwOnError: false,
     queryFn: () =>
       unwrapAsync(
@@ -320,7 +323,11 @@ export function CostsExplorer(): JSX.Element {
         }),
       ),
   });
-  const attributes = detailData?.table?.[0]?.dimensionValues;
+  const detailRow = detailData?.table?.[0];
+  // Attribute grid + pivot pruning only apply once drilled into an entity; at the
+  // root, keep this undefined so those consumers still fail open (show every
+  // pivot). The row's measures, by contrast, are used at every level.
+  const attributes = path.length > 0 ? detailRow?.dimensionValues : undefined;
 
   // Previous equal-length period (immediately before [from, to]) — for the
   // per-group % change column.
@@ -347,6 +354,29 @@ export function CostsExplorer(): JSX.Element {
             groupBy: groupBy as GroupBy,
             sortBy: "total_cost",
             topN: 100,
+            filters: filters.length ? filters : undefined,
+          },
+        }),
+      ),
+  });
+  // Previous-period slice totals (un-grouped), for a session delta that uses the
+  // same distinct-count basis as the current headline (see `stats`).
+  const { data: prevDetailData } = useQuery({
+    queryKey: [
+      "costs-explorer-prev-detail",
+      prevFrom.toISOString(),
+      prevTo.toISOString(),
+      filters,
+    ],
+    enabled: projectReady,
+    throwOnError: false,
+    queryFn: () =>
+      unwrapAsync(
+        telemetryQuery(client, {
+          queryPayload: {
+            from: prevFrom,
+            to: prevTo,
+            topN: 1,
             filters: filters.length ? filters : undefined,
           },
         }),
@@ -438,12 +468,22 @@ export function CostsExplorer(): JSX.Element {
       ? groupBy
       : null;
 
-  // Roll the child rows up into the current entity's headline stats.
+  // Roll the child rows up into the current entity's headline stats. Cost,
+  // tokens, tool calls and cache tokens are additive, so summing the breakdown
+  // rows gives the correct slice total. Sessions (total_chats) are NOT: it's a
+  // distinct count (uniqExact over conversation ids), so summing it across groups
+  // double-counts any session that spans more than one group (e.g. a chat that
+  // used two models, or hit two agents). That inflated the "Agent sessions" stat
+  // — and every "per session" cost — the moment you drilled or re-pivoted, and
+  // made a user's session count disagree with the parent breakdown's Sessions
+  // column (DNO-390). Take the true distinct count from the un-grouped slice
+  // aggregate instead. Skipped for the root "collection" view, whose hero is
+  // deliberately the attributed-rows-only subtotal, not the whole slice.
   const stats: Measures = useMemo(() => {
     const table = data?.table ?? [];
     const statsRows =
       collectionDim != null ? table.filter((r) => r.groupValue !== "") : table;
-    return statsRows.reduce<Measures>(
+    const summed = statsRows.reduce<Measures>(
       (acc, r) => ({
         cost: acc.cost + (r.measures.totalCost ?? 0),
         sessions: acc.sessions + (r.measures.totalChats ?? 0),
@@ -454,7 +494,10 @@ export function CostsExplorer(): JSX.Element {
       }),
       { ...EMPTY_MEASURES },
     );
-  }, [data, collectionDim]);
+    const trueSessions =
+      collectionDim == null ? detailRow?.measures.totalChats : undefined;
+    return { ...summed, sessions: trueSessions ?? summed.sessions };
+  }, [data, collectionDim, detailRow]);
 
   // Per-group daily cost series for the trend sparklines, keyed by group value.
   const seriesByGroup = useMemo(() => {
@@ -468,12 +511,13 @@ export function CostsExplorer(): JSX.Element {
     return map;
   }, [data]);
 
-  // Previous-period totals per measure (for the KPI deltas).
+  // Previous-period totals per measure (for the KPI deltas). Sessions use the
+  // un-grouped distinct count on the same basis as `stats` (see above).
   const prevTotals: Measures = useMemo(() => {
     const table = prevData?.table ?? [];
     const statsRows =
       collectionDim != null ? table.filter((r) => r.groupValue !== "") : table;
-    return statsRows.reduce<Measures>(
+    const summed = statsRows.reduce<Measures>(
       (acc, r) => ({
         cost: acc.cost + (r.measures.totalCost ?? 0),
         sessions: acc.sessions + (r.measures.totalChats ?? 0),
@@ -484,7 +528,12 @@ export function CostsExplorer(): JSX.Element {
       }),
       { ...EMPTY_MEASURES },
     );
-  }, [prevData, collectionDim]);
+    const trueSessions =
+      collectionDim == null
+        ? prevDetailData?.table?.[0]?.measures.totalChats
+        : undefined;
+    return { ...summed, sessions: trueSessions ?? summed.sessions };
+  }, [prevData, prevDetailData, collectionDim]);
 
   // Each measure summed across groups per time bucket — drives the hero trend
   // chart and the KPI sparklines.


### PR DESCRIPTION
## What

The cost explorer's headline stats (**Agent sessions**, and every derived _"per session"_ cost) were computed by summing the per-group breakdown rows. `total_chats` is a `uniqExact` **distinct** count, so summing it across groups double-counts any session that spans more than one group — a chat that used two models, or hit two agents, is counted once per group.

The effect: the session number inflated the moment you drilled or re-pivoted, and a user's session count on their own page no longer matched the **Sessions** column shown for them on the parent breakdown. That's the "numbers not adding up" reported in this issue's drill-down (project → department → user → agent).

## Fix

Take the true distinct session count from the un-grouped slice aggregate (a single-row `group_by=""` query) instead of summing the rows. That query already existed for the entity attribute grid — it now runs at every level, and a matching previous-period one backs the KPI delta.

- Cost, tokens, tool calls and cache tokens are **additive**, so they still come from the summed rows — no change to those numbers.
- Only `sessions` switches to the distinct-count basis, so the header now reconciles with the parent breakdown's Sessions column and stops changing as you re-pivot.
- The root "collection" view (attribution breakdown at the org root) keeps its intentional attributed-rows-only subtotal.

## Notes

Within a single breakdown table the per-row Sessions values can still legitimately sum to more than the header — that's expected for a distinct count when a session appears under multiple groups. The header is now the accurate figure; before, it matched the (inflated) row sum.

Verified with `type-check` (no errors in the changed file) and the formatter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated “Agent sessions” and per‑session costs in Cost Explorer by using the distinct session count from an ungrouped slice instead of summing group rows. Headers now stay consistent across pivots and drill‑downs and match the parent breakdown’s Sessions column (DNO‑390).

- **Bug Fixes**
  - Compute session headline and deltas from an ungrouped slice aggregate at all levels, with a matching previous‑period query.
  - Keep additive metrics (cost, tokens, tool calls, cache tokens) summed from breakdown rows; values unchanged.
  - Preserve the root “collection” view’s attributed‑rows‑only subtotal.

<sup>Written for commit 5423f5fdef34a74798b217aef3937b78db802b82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

