### PR TITLE
feat(hooks): infer codex skill activations via loose heuristic

### DIFF
--- a/.changeset/codex-skill-activation-tracking.md
+++ b/.changeset/codex-skill-activation-tracking.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Skill activations in Codex sessions are now tracked best-effort: opening a skill's SKILL.md and explicit $skill-name prompt mentions surface as skill.activated events in observability, matching Claude Code sessions.

--- a/.mise-tasks/hooks/e2e.js
+++ b/.mise-tasks/hooks/e2e.js
@@ -279,10 +279,14 @@ async function runProcess(command, args, opts = {}) {
     child.stdin.end();
   });
 }
+// session_capture gates hook ingest; logs gates telemetry_logs writes — the
+// evidence checks read both, so provision both.
 async function enableSessionCapture(organizationId) {
   const sql = `
     INSERT INTO organization_features (organization_id, feature_name)
-    VALUES ('${sqlString(organizationId)}', 'session_capture')
+    VALUES
+      ('${sqlString(organizationId)}', 'session_capture'),
+      ('${sqlString(organizationId)}', 'logs')
     ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE DO NOTHING;
   `;
   const res = await runProcess("psql", psqlArgs(sql));
@@ -1617,7 +1621,7 @@ function featureChecks(provider, evidence, chats, opts = {}) {
         ? "provider rows load in one chat generation"
         : `chat rows split across generations: ${splitGenerationChats.join("; ")}`,
   });
-  if (provider === "claude") {
+  if (provider === "claude" || provider === "codex") {
     const skillName = opts.skillName;
     const skillActivated = evidence.some(
       (r) =>
@@ -1631,11 +1635,13 @@ function featureChecks(provider, evidence, chats, opts = {}) {
       feature: "skill.activated",
       status: skillActivated ? "PASS" : skillName ? "FAIL" : "SKIP",
       detail: skillActivated
-        ? `observed Claude activation of ${skillName ?? "a skill"}`
+        ? `observed ${provider} activation of ${skillName ?? "a skill"}`
         : skillName
           ? `no skill.activated telemetry for ${skillName}; events=${[...events].join(", ") || "(none)"}`
           : "not triggered by the current real-driver scenarios",
     });
+  }
+  if (provider === "claude") {
     checks.push({
       provider,
       feature: "notification.reported",
@@ -1846,9 +1852,9 @@ function shadowMCPChecks(provider, phase, res, evidence, blocks, extra = {}) {
   });
   return checks;
 }
-async function prepareSkillFixture(workdir, runId) {
+async function prepareSkillFixture(skillsRoot, runId, provider) {
   const skillName = `gram-hooks-e2e-skill-${runId.split("-").pop()}`;
-  const skillDir = path.join(workdir, ".claude", "skills", skillName);
+  const skillDir = path.join(skillsRoot, skillName);
   await fs.mkdir(skillDir, { recursive: true });
   await fs.writeFile(
     path.join(skillDir, "SKILL.md"),
@@ -1860,21 +1866,54 @@ async function prepareSkillFixture(workdir, runId) {
       "",
       "# Gram hooks E2E skill probe",
       "",
-      `Once activated, reply with exactly: GRAM_HOOKS_E2E_OK ${runId} claude skill`,
+      `Once activated, reply with exactly: GRAM_HOOKS_E2E_OK ${runId} ${provider} skill`,
       "",
     ].join("\n"),
   );
-  return { skillName };
+  return { skillName, skillDir };
 }
-function skillPrompt(runId, skillName) {
+// Codex has no Skill tool: the sender infers activation from a $name prompt
+// mention (validated against the skill roots on disk) or from a reader tool
+// touching .../skills/<name>/SKILL.md. The prompt covers both arms.
+function skillPrompt(runId, skillName, provider, skillDir) {
+  if (provider === "codex") {
+    return [
+      `Gram hooks E2E skill run ${runId} for codex.`,
+      `Use the $${skillName} skill: read ${path.join(skillDir, "SKILL.md")} and follow its instructions.`,
+      `Then reply with exactly: GRAM_HOOKS_E2E_OK ${runId} codex skill`,
+    ].join(" ");
+  }
   return [
     `Gram hooks E2E skill run ${runId} for claude.`,
     `Run the Gram hooks E2E skill probe by invoking the Skill tool with skill "${skillName}".`,
     `After the ${skillName} skill is activated, reply with exactly: GRAM_HOOKS_E2E_OK ${runId} claude skill`,
   ].join(" ");
 }
-async function runClaudeSkillScenario(args) {
-  const prompt = skillPrompt(args.runId, args.skillName);
+async function runSkillScenario(args) {
+  const prompt = skillPrompt(
+    args.runId,
+    args.skillName,
+    args.provider,
+    args.skillDir,
+  );
+  if (args.provider === "codex") {
+    const res = await runProcess(
+      "codex",
+      [
+        "exec",
+        "--json",
+        "--cd",
+        args.workdir,
+        "--skip-git-repo-check",
+        "--dangerously-bypass-hook-trust",
+        "--dangerously-bypass-approvals-and-sandbox",
+        prompt,
+      ],
+      { cwd: args.workdir, env: args.env, timeoutMs: args.timeoutMs },
+    );
+    res.provider = "codex";
+    return res;
+  }
   const sessionId = crypto.randomUUID();
   const res = await runProcess(
     "claude",
@@ -1966,7 +2005,7 @@ async function runRatchetSuite(args) {
 
 async function runCaptureSuite(args) {
   const commandResults = [];
-  let claudeSkillName = null;
+  const skillNamesByProvider = new Map();
   for (const provider of args.providers) {
     for (const scenario of ["success", "failure"]) {
       log.info(`${provider}: running capture ${scenario} scenario`);
@@ -1995,30 +2034,40 @@ async function runCaptureSuite(args) {
         fail(`${provider} ${scenario} scenario timed out`);
       }
     }
-    if (provider === "claude") {
-      const skill = await prepareSkillFixture(args.workdir, args.runId);
-      claudeSkillName = skill.skillName;
-      log.info("claude: running capture skill-activation scenario");
-      const skillRes = await runClaudeSkillScenario({
-        pluginDir: args.pluginDirs.get("claude"),
+    if (provider === "claude" || provider === "codex") {
+      // Codex validates $name mentions against the skill roots on disk;
+      // CODEX_HOME/skills is the only root the isolated env controls
+      // regardless of the hook process cwd.
+      const skillsRoot =
+        provider === "codex"
+          ? path.join(args.codexEnv.CODEX_HOME, "skills")
+          : path.join(args.workdir, ".claude", "skills");
+      const skill = await prepareSkillFixture(skillsRoot, args.runId, provider);
+      skillNamesByProvider.set(provider, skill.skillName);
+      log.info(`${provider}: running capture skill-activation scenario`);
+      const skillRes = await runSkillScenario({
+        provider,
+        pluginDir: args.pluginDirs.get(provider),
         workdir: args.workdir,
         runId: args.runId,
         skillName: skill.skillName,
+        skillDir: skill.skillDir,
+        env: provider === "codex" ? args.codexEnv : undefined,
         timeoutMs: args.timeoutSeconds * 1000,
       });
       commandResults.push(skillRes);
       await writeCommandArtifacts(
         args.artifactsDir,
-        "claude",
+        provider,
         "capture-skill",
         skillRes,
       );
       if (skillRes.timedOut) {
-        fail("claude skill-activation scenario timed out");
+        fail(`${provider} skill-activation scenario timed out`);
       }
       if (skillRes.exitCode !== 0) {
         fail(
-          `claude skill-activation scenario failed:\n${skillRes.stderr || skillRes.stdout}`,
+          `${provider} skill-activation scenario failed:\n${skillRes.stderr || skillRes.stdout}`,
         );
       }
     }
@@ -2032,7 +2081,7 @@ async function runCaptureSuite(args) {
   });
   const checks = [];
   for (const provider of args.providers) {
-    const skillName = provider === "claude" ? claudeSkillName : null;
+    const skillName = skillNamesByProvider.get(provider) ?? null;
     // Cursor Agent headless does not reliably emit afterAgentResponse
     // (featureChecks marks it SKIP), so don't burn the whole poll window
     // waiting for it.

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -399,6 +399,13 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 	// A policy-blocked event never ran, so it is not an activation.
 	if skill != "" && !isExplicitSkillActivation(payload) && blockReason == "" {
 		attrs = hookTelemetryBaseAttrs(payload, authCtx, eventTypeSkillActivated)
+		// Skill counts aggregate at trace level (trace_summaries). Without a
+		// tool call id the payload-derived trace falls back to the session
+		// hash, which would collapse every prompt-mention activation in a
+		// session into one summary row; mint a per-activation trace instead.
+		if canonicalToolCallID(payload) == "" {
+			attrs[attr.TraceIDKey] = generateTraceID()
+		}
 		attrs[attr.ToolNameKey] = "Skill"
 		attrs[attr.GenAIToolCallArgumentsKey] = jsonString(map[string]string{"skill": skill})
 		s.logHookTelemetry(ctx, authCtx, timestamp, "Skill", attrs)

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -23,6 +23,16 @@ import (
 
 const hookIngestSchemaV1 = "hook.ingest.v1"
 
+// eventTypeSkillActivated is the canonical event type senders use when a
+// provider reports a skill activation directly (Claude's Skill tool). Inferred
+// activations (Codex heuristics) arrive as ordinary events carrying data.skill
+// instead, and are distinguished by isExplicitSkillActivation.
+const eventTypeSkillActivated = "skill.activated"
+
+func isExplicitSkillActivation(payload *gen.IngestPayload) bool {
+	return strings.TrimSpace(payload.Event.Type) == eventTypeSkillActivated
+}
+
 // Ingest is the authenticated, feature-first hook endpoint. Legacy
 // provider-specific endpoints keep their compatibility behavior; this path only
 // accepts the canonical Gram contract and attributes every event to the token
@@ -314,34 +324,13 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 		return
 	}
 
-	projectID := authCtx.ProjectID.String()
-	source := strings.TrimSpace(payload.Source.Adapter)
 	hookEventName := telemetryHookEventName(payload)
-	sessionID := canonicalSessionID(payload)
 	toolName := canonicalTelemetryToolName(payload)
 	if toolName == "" {
 		toolName = hookEventName
 	}
 
-	attrs := map[attr.Key]any{
-		attr.EventSourceKey:    string(telemetry.EventSourceHook),
-		attr.HookEventKey:      hookEventName,
-		attr.HookSourceKey:     source,
-		attr.ProjectIDKey:      projectID,
-		attr.OrganizationIDKey: authCtx.ActiveOrganizationID,
-		attr.SpanIDKey:         generateSpanID(),
-		attr.TraceIDKey:        canonicalTraceID(payload),
-		attr.LogBodyKey:        "Hook: " + hookEventName,
-	}
-	if sessionID != "" {
-		attrs[attr.GenAIConversationIDKey] = sessionID
-	}
-	if hostname := strings.TrimSpace(conv.PtrValOr(payload.Source.Hostname, "")); hostname != "" {
-		attrs[attr.HookHostnameKey] = hostname
-	}
-	if model := canonicalModel(payload); model != "" {
-		attrs[attr.GenAIResponseModelKey] = model
-	}
+	attrs := hookTelemetryBaseAttrs(payload, authCtx, hookEventName)
 	if blockReason != "" {
 		attrs[attr.HookBlockReasonKey] = blockReason
 	}
@@ -396,18 +385,59 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 			attrs[attr.MCPMatchKey] = command
 		}
 	}
-	if skill := canonicalSkillName(payload); skill != "" {
-		attrs[attr.ToolNameKey] = "Skill"
+	skill := canonicalSkillName(payload)
+	if skill != "" && isExplicitSkillActivation(payload) {
 		attrs[attr.GenAIToolCallArgumentsKey] = jsonString(map[string]string{"skill": skill})
-		toolName = "Skill"
 	}
 
+	s.logHookTelemetry(ctx, authCtx, timestamp, toolName, attrs)
+
+	// A skill name on an ordinary tool/prompt event is an inferred activation
+	// (Codex has no dedicated Skill tool): the underlying event was recorded
+	// truthfully above, and the activation gets its own derived row so skill
+	// dashboards see the same skill.activated vocabulary as Claude senders.
+	// A policy-blocked event never ran, so it is not an activation.
+	if skill != "" && !isExplicitSkillActivation(payload) && blockReason == "" {
+		attrs = hookTelemetryBaseAttrs(payload, authCtx, eventTypeSkillActivated)
+		attrs[attr.ToolNameKey] = "Skill"
+		attrs[attr.GenAIToolCallArgumentsKey] = jsonString(map[string]string{"skill": skill})
+		s.logHookTelemetry(ctx, authCtx, timestamp, "Skill", attrs)
+	}
+}
+
+// hookTelemetryBaseAttrs builds the attributes shared by every telemetry row
+// derived from one ingested hook event. Each row gets its own span id; the
+// trace id is payload-derived so sibling rows stay on one trace.
+func hookTelemetryBaseAttrs(payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, hookEventName string) map[attr.Key]any {
+	attrs := map[attr.Key]any{
+		attr.EventSourceKey:    string(telemetry.EventSourceHook),
+		attr.HookEventKey:      hookEventName,
+		attr.HookSourceKey:     strings.TrimSpace(payload.Source.Adapter),
+		attr.ProjectIDKey:      authCtx.ProjectID.String(),
+		attr.OrganizationIDKey: authCtx.ActiveOrganizationID,
+		attr.SpanIDKey:         generateSpanID(),
+		attr.TraceIDKey:        canonicalTraceID(payload),
+		attr.LogBodyKey:        "Hook: " + hookEventName,
+	}
+	if sessionID := canonicalSessionID(payload); sessionID != "" {
+		attrs[attr.GenAIConversationIDKey] = sessionID
+	}
+	if hostname := strings.TrimSpace(conv.PtrValOr(payload.Source.Hostname, "")); hostname != "" {
+		attrs[attr.HookHostnameKey] = hostname
+	}
+	if model := canonicalModel(payload); model != "" {
+		attrs[attr.GenAIResponseModelKey] = model
+	}
+	return attrs
+}
+
+func (s *Service) logHookTelemetry(ctx context.Context, authCtx *contextvalues.AuthContext, timestamp time.Time, toolName string, attrs map[attr.Key]any) {
 	s.telemetryLogger.Log(ctx, telemetry.LogParams{
 		Timestamp: timestamp,
 		ToolInfo: telemetry.ToolInfo{
 			Name:           toolName,
 			OrganizationID: authCtx.ActiveOrganizationID,
-			ProjectID:      projectID,
+			ProjectID:      authCtx.ProjectID.String(),
 			ID:             "",
 			URN:            "",
 			DeploymentID:   "",
@@ -429,8 +459,8 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 func telemetryHookEventName(payload *gen.IngestPayload) string {
 	// Skill activations are a Gram-specific classification layered onto an
 	// ordinary provider tool event; resolving via the raw name would erase it.
-	if strings.TrimSpace(payload.Event.Type) == "skill.activated" {
-		return "skill.activated"
+	if isExplicitSkillActivation(payload) {
+		return eventTypeSkillActivated
 	}
 	raw := strings.TrimSpace(conv.PtrValOr(payload.Source.RawEventName, ""))
 	if raw != "" {
@@ -673,7 +703,10 @@ func canonicalToolName(payload *gen.IngestPayload) string {
 }
 
 func canonicalTelemetryToolName(payload *gen.IngestPayload) string {
-	if skill := canonicalSkillName(payload); skill != "" {
+	// Only explicit skill.activated events are relabeled: an inferred skill on
+	// an ordinary tool/prompt event keeps the event's own tool identity and
+	// gets a separate derived skill row instead.
+	if skill := canonicalSkillName(payload); skill != "" && isExplicitSkillActivation(payload) {
 		return "Skill"
 	}
 	return canonicalToolName(payload)

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -399,13 +399,14 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 	// A policy-blocked event never ran, so it is not an activation.
 	if skill != "" && !isExplicitSkillActivation(payload) && blockReason == "" {
 		attrs = hookTelemetryBaseAttrs(payload, authCtx, eventTypeSkillActivated)
-		// Skill counts aggregate at trace level (trace_summaries). Without a
-		// tool call id the payload-derived trace falls back to the session
-		// hash, which would collapse every prompt-mention activation in a
-		// session into one summary row; mint a per-activation trace instead.
-		if canonicalToolCallID(payload) == "" {
-			attrs[attr.TraceIDKey] = generateTraceID()
-		}
+		// Skill counts aggregate at trace level (trace_summaries), and its MV
+		// resolves tool_name/skill_name with any(): sharing a trace with the
+		// underlying tool or prompt rows lets a non-Skill sibling win the
+		// summary and drop the activation from skill analytics — and the
+		// session-hash fallback would additionally collapse every
+		// prompt-mention activation in a session into one summary row. Every
+		// derived row gets its own trace.
+		attrs[attr.TraceIDKey] = generateTraceID()
 		attrs[attr.ToolNameKey] = "Skill"
 		attrs[attr.GenAIToolCallArgumentsKey] = jsonString(map[string]string{"skill": skill})
 		s.logHookTelemetry(ctx, authCtx, timestamp, "Skill", attrs)

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	riskRepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 // ingestUserScopedShadowMCPScanner reports a blocking shadow-MCP policy for a
@@ -290,6 +292,71 @@ func TestIngest_InferredSkillEmitsDerivedTelemetryRow(t *testing.T) {
 	require.NotNil(t, skillRow.TraceID)
 	require.NotEqual(t, *toolRow.TraceID, *skillRow.TraceID,
 		"the derived skill row must not share a trace with the tool row")
+}
+
+// TestIngest_SkillRowSurvivesToolIOScrub: orgs with tool_io_logs disabled get
+// gen_ai.tool.call.arguments deleted before insert, but ClickHouse
+// materializes skill_name from that JSON — the scrubber must keep the minimal
+// {"skill": name} on Skill rows while still dropping the real tool input.
+func TestIngest_SkillRowSurvivesToolIOScrub(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+	enabled := func(context.Context, string) (bool, error) { return true, nil }
+	disabled := func(context.Context, string) (bool, error) { return false, nil }
+	ti.service.telemetryLogger = telemetry.NewLogger(ctx, testenv.NewLogger(t), chConn, enabled, disabled, nil)
+	chClient := telemetryrepo.New(chConn)
+	authCtx := hookAuthContext(t, ctx)
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	occurredAt := timestamp.Format(time.RFC3339Nano)
+	raw := "PreToolUse"
+	toolName := "Bash"
+	toolID := "call_scrubbed_skill_read"
+	payload := canonicalIngestPayload("codex", "tool.requested", "codex-scrubbed-skill-session")
+	payload.Source.RawEventName = &raw
+	payload.Event.OccurredAt = &occurredAt
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolID,
+			Name:  &toolName,
+			Input: map[string]any{"command": "cat .agents/skills/repo-review/SKILL.md # secret-workspace-path"},
+		},
+		Skill: &gen.HookSkillData{Name: "repo-review"},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "allow", result.Decision)
+
+	var rows []telemetryrepo.TelemetryLog
+	require.Eventually(t, func() bool {
+		var listErr error
+		rows, listErr = chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
+			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
+			GramURNs:      nil,
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		return listErr == nil && len(rows) == 2
+	}, 2*time.Second, 50*time.Millisecond)
+
+	var sawSkillRow bool
+	for _, row := range rows {
+		require.NotContains(t, row.Attributes, "secret-workspace-path",
+			"scrubbed orgs must not retain tool input on any row")
+		if strings.Contains(row.Attributes, "skill.activated") {
+			sawSkillRow = true
+			require.Contains(t, row.Attributes, "repo-review",
+				"the skill name must survive the tool IO scrub")
+		}
+	}
+	require.True(t, sawSkillRow)
 }
 
 // TestIngest_PromptInferredSkillsGetDistinctTraces: skill dashboards count

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -284,6 +284,60 @@ func TestIngest_InferredSkillEmitsDerivedTelemetryRow(t *testing.T) {
 	require.Equal(t, "codex-skill-session", *skillRow.GramChatID)
 }
 
+// TestIngest_PromptInferredSkillsGetDistinctTraces: skill dashboards count
+// activations at trace level, and prompt events carry no tool call id — the
+// session-hash trace fallback would collapse every prompt-mention activation
+// in a session into one summary row, so each derived row mints its own trace.
+func TestIngest_PromptInferredSkillsGetDistinctTraces(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	occurredAt := timestamp.Format(time.RFC3339Nano)
+	for i, promptText := range []string{"use $repo-review on this", "run $repo-review again"} {
+		payload := canonicalIngestPayload("codex", "prompt.submitted", "codex-prompt-skill-session")
+		payload.Event.OccurredAt = &occurredAt
+		key := "prompt-skill-" + uuid.NewString()
+		payload.IdempotencyKey = &key
+		text := promptText
+		payload.Data = &gen.HookIngestData{
+			Prompt: &gen.HookPromptData{Text: &text},
+			Skill:  &gen.HookSkillData{Name: "repo-review"},
+		}
+		result, err := ti.service.Ingest(ctx, payload)
+		require.NoError(t, err, "ingest %d", i)
+		require.Equal(t, "allow", result.Decision)
+	}
+
+	var skillTraces []string
+	require.Eventually(t, func() bool {
+		rows, err := chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
+			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
+			GramURNs:      nil,
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		if err != nil {
+			return false
+		}
+		skillTraces = skillTraces[:0]
+		for _, row := range rows {
+			if strings.Contains(row.Attributes, "skill.activated") && row.TraceID != nil {
+				skillTraces = append(skillTraces, *row.TraceID)
+			}
+		}
+		return len(skillTraces) == 2
+	}, 2*time.Second, 50*time.Millisecond, "expected two derived skill rows")
+	require.NotEqual(t, skillTraces[0], skillTraces[1],
+		"prompt-inferred activations in one session must not share a trace")
+}
+
 // TestIngest_ExplicitSkillActivationEmitsSingleRow pins the other half of the
 // derived-row gate: a sender-classified skill.activated event is already the
 // skill row and must not spawn a duplicate.

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	riskRepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
 // ingestUserScopedShadowMCPScanner reports a blocking shadow-MCP policy for a
@@ -211,6 +212,178 @@ func TestIngest_SkillActivationIsAcceptedAsFeatureEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "allow", result.Decision)
+}
+
+// TestIngest_InferredSkillEmitsDerivedTelemetryRow covers Codex-style skill
+// detection, where the sender attaches data.skill to an ordinary tool event
+// instead of reclassifying it: the underlying tool row must stay truthful
+// (policy scans and tool counts key on it) and the activation must land as a
+// separate skill.activated row matching the Claude vocabulary.
+func TestIngest_InferredSkillEmitsDerivedTelemetryRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	occurredAt := timestamp.Format(time.RFC3339Nano)
+	raw := "PreToolUse"
+	toolName := "Bash"
+	toolID := "call_skill_read"
+	payload := canonicalIngestPayload("codex", "tool.requested", "codex-skill-session")
+	payload.Source.RawEventName = &raw
+	payload.Event.OccurredAt = &occurredAt
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolID,
+			Name:  &toolName,
+			Input: map[string]any{"command": "cat .agents/skills/repo-review/SKILL.md"},
+		},
+		Skill: &gen.HookSkillData{Name: "repo-review"},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "allow", result.Decision)
+
+	var logs []telemetryrepo.TelemetryLog
+	require.Eventually(t, func() bool {
+		logs, err = chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
+			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
+			GramURNs:      nil,
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		return err == nil && len(logs) == 2
+	}, 2*time.Second, 50*time.Millisecond, "expected the tool row plus a derived skill row")
+
+	byEvent := map[string]telemetryrepo.TelemetryLog{}
+	for _, l := range logs {
+		switch {
+		case strings.Contains(l.Attributes, "skill.activated"):
+			byEvent["skill"] = l
+		case strings.Contains(l.Attributes, "PreToolUse"):
+			byEvent["tool"] = l
+		}
+	}
+
+	toolRow, ok := byEvent["tool"]
+	require.True(t, ok, "the underlying tool event must be recorded with its provider event name")
+	require.Contains(t, toolRow.Attributes, `"Bash"`, "the tool row must keep the real tool identity")
+	require.NotContains(t, toolRow.Attributes, "skill.activated")
+
+	skillRow, ok := byEvent["skill"]
+	require.True(t, ok, "an inferred skill must produce a derived skill.activated row")
+	require.Contains(t, skillRow.Attributes, "repo-review")
+	require.Contains(t, skillRow.Attributes, `"Skill"`)
+	require.NotNil(t, skillRow.GramChatID)
+	require.Equal(t, "codex-skill-session", *skillRow.GramChatID)
+}
+
+// TestIngest_ExplicitSkillActivationEmitsSingleRow pins the other half of the
+// derived-row gate: a sender-classified skill.activated event is already the
+// skill row and must not spawn a duplicate.
+func TestIngest_ExplicitSkillActivationEmitsSingleRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	occurredAt := timestamp.Format(time.RFC3339Nano)
+	payload := canonicalIngestPayload("claude", "skill.activated", "claude-skill-session")
+	payload.Event.OccurredAt = &occurredAt
+	payload.Data = &gen.HookIngestData{
+		Skill: &gen.HookSkillData{Name: "repo-review"},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "allow", result.Decision)
+
+	listRows := func() []telemetryrepo.TelemetryLog {
+		rows, err := chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
+			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
+			GramURNs:      nil,
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		return rows
+	}
+
+	require.Eventually(t, func() bool { return len(listRows()) >= 1 }, 2*time.Second, 50*time.Millisecond)
+	require.Never(t, func() bool { return len(listRows()) > 1 }, 500*time.Millisecond, 100*time.Millisecond,
+		"an explicit skill.activated event must not mint a derived duplicate")
+	rows := listRows()
+	require.Len(t, rows, 1)
+	require.Contains(t, rows[0].Attributes, "skill.activated")
+	require.Contains(t, rows[0].Attributes, "repo-review")
+}
+
+// TestIngest_BlockedEventDoesNotEmitDerivedSkillRow: a policy-denied tool call
+// never ran, so an inferred skill on it is not an activation.
+func TestIngest_BlockedEventDoesNotEmitDerivedSkillRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+	ti.service.riskScanner = ingestUserScopedShadowMCPScanner{userID: authCtx.UserID}
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	occurredAt := timestamp.Format(time.RFC3339Nano)
+	toolName := "mcp__local_server__search"
+	serverIdentity := "local-server"
+	toolCallID := "call-blocked-skill"
+	payload := canonicalIngestPayload("codex", "tool.requested", "codex-blocked-skill-session")
+	payload.Event.OccurredAt = &occurredAt
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"query": "cat .agents/skills/repo-review/SKILL.md"},
+		},
+		Mcp:   &gen.HookMCPData{ServerIdentity: &serverIdentity},
+		Skill: &gen.HookSkillData{Name: "repo-review"},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "deny", result.Decision)
+
+	listRows := func() []telemetryrepo.TelemetryLog {
+		rows, err := chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
+			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
+			GramURNs:      nil,
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		require.NoError(t, err)
+		return rows
+	}
+
+	require.Eventually(t, func() bool { return len(listRows()) >= 1 }, 2*time.Second, 50*time.Millisecond)
+	require.Never(t, func() bool {
+		for _, row := range listRows() {
+			if strings.Contains(row.Attributes, "skill.activated") {
+				return true
+			}
+		}
+		return false
+	}, 500*time.Millisecond, 100*time.Millisecond,
+		"a blocked event must not produce a derived activation row")
 }
 
 func TestIngest_ThoughtEventsExcludedFromTranscript(t *testing.T) {

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -306,8 +306,8 @@ func TestIngest_ExplicitSkillActivationEmitsSingleRow(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "allow", result.Decision)
 
-	listRows := func() []telemetryrepo.TelemetryLog {
-		rows, err := chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+	listRows := func() ([]telemetryrepo.TelemetryLog, error) {
+		return chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
 			GramProjectID: authCtx.ProjectID.String(),
 			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
 			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
@@ -316,14 +316,19 @@ func TestIngest_ExplicitSkillActivationEmitsSingleRow(t *testing.T) {
 			Cursor:        "",
 			Limit:         10,
 		})
-		require.NoError(t, err)
-		return rows
 	}
 
-	require.Eventually(t, func() bool { return len(listRows()) >= 1 }, 2*time.Second, 50*time.Millisecond)
-	require.Never(t, func() bool { return len(listRows()) > 1 }, 500*time.Millisecond, 100*time.Millisecond,
+	require.Eventually(t, func() bool {
+		rows, err := listRows()
+		return err == nil && len(rows) >= 1
+	}, 2*time.Second, 50*time.Millisecond)
+	require.Never(t, func() bool {
+		rows, err := listRows()
+		return err == nil && len(rows) > 1
+	}, 500*time.Millisecond, 100*time.Millisecond,
 		"an explicit skill.activated event must not mint a derived duplicate")
-	rows := listRows()
+	rows, err := listRows()
+	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Contains(t, rows[0].Attributes, "skill.activated")
 	require.Contains(t, rows[0].Attributes, "repo-review")
@@ -360,8 +365,8 @@ func TestIngest_BlockedEventDoesNotEmitDerivedSkillRow(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "deny", result.Decision)
 
-	listRows := func() []telemetryrepo.TelemetryLog {
-		rows, err := chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+	listRows := func() ([]telemetryrepo.TelemetryLog, error) {
+		return chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
 			GramProjectID: authCtx.ProjectID.String(),
 			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
 			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
@@ -370,13 +375,18 @@ func TestIngest_BlockedEventDoesNotEmitDerivedSkillRow(t *testing.T) {
 			Cursor:        "",
 			Limit:         10,
 		})
-		require.NoError(t, err)
-		return rows
 	}
 
-	require.Eventually(t, func() bool { return len(listRows()) >= 1 }, 2*time.Second, 50*time.Millisecond)
+	require.Eventually(t, func() bool {
+		rows, err := listRows()
+		return err == nil && len(rows) >= 1
+	}, 2*time.Second, 50*time.Millisecond)
 	require.Never(t, func() bool {
-		for _, row := range listRows() {
+		rows, err := listRows()
+		if err != nil {
+			return false
+		}
+		for _, row := range rows {
 			if strings.Contains(row.Attributes, "skill.activated") {
 				return true
 			}

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -282,6 +282,14 @@ func TestIngest_InferredSkillEmitsDerivedTelemetryRow(t *testing.T) {
 	require.Contains(t, skillRow.Attributes, `"Skill"`)
 	require.NotNil(t, skillRow.GramChatID)
 	require.Equal(t, "codex-skill-session", *skillRow.GramChatID)
+
+	// trace_summaries resolves tool_name with any(): on a shared trace the
+	// Bash sibling could win the summary and hide the activation from
+	// tool_name = 'Skill' skill analytics.
+	require.NotNil(t, toolRow.TraceID)
+	require.NotNil(t, skillRow.TraceID)
+	require.NotEqual(t, *toolRow.TraceID, *skillRow.TraceID,
+		"the derived skill row must not share a trace with the tool row")
 }
 
 // TestIngest_PromptInferredSkillsGetDistinctTraces: skill dashboards count

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2427,6 +2427,7 @@ prompt_miss='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","pr
 prompt_punct='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"please use $home-skill.","cwd":"%[2]s"}'
 prompt_relcwd='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"use $repo-skill","cwd":"nested/sub"}'
 prompt_system='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"use $sys-skill","cwd":"%[2]s"}'
+read_system='{"hook_event_name":"PreToolUse","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"cat /opt/codex/skills/.system/imagegen/SKILL.md"},"tool_use_id":"call_3"}'
 gram_hooks_build_canonical_payload "$read_req" "test-host"
 printf '\n---GRAM---\n'
 gram_hooks_build_canonical_payload "$read_res" "test-host"
@@ -2446,6 +2447,8 @@ printf '\n---GRAM---\n'
 gram_hooks_build_canonical_payload "$prompt_relcwd" "test-host"
 printf '\n---GRAM---\n'
 gram_hooks_build_canonical_payload "$prompt_system" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$read_system" "test-host"
 `, repoDir, cwd)
 	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
 
@@ -2455,7 +2458,7 @@ gram_hooks_build_canonical_payload "$prompt_system" "test-host"
 	require.NoError(t, err, string(output))
 
 	chunks := strings.Split(string(output), "\n---GRAM---\n")
-	require.Len(t, chunks, 10)
+	require.Len(t, chunks, 11)
 
 	parse := func(raw string) (eventType string, skillName string) {
 		var parsed map[string]any
@@ -2507,6 +2510,10 @@ gram_hooks_build_canonical_payload "$prompt_system" "test-host"
 	eventType, skill = parse(chunks[9])
 	require.Equal(t, "prompt.submitted", eventType)
 	require.Equal(t, "sys-skill", skill, "bundled skills under a .system subdirectory must resolve by bare name")
+
+	eventType, skill = parse(chunks[10])
+	require.Equal(t, "tool.requested", eventType)
+	require.Equal(t, "imagegen", skill, "reads of .system skill paths must infer the bare skill name")
 }
 
 // TestRenderHookPayloadNormalizationClaudeSkillStillReclassifies pins the

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2406,11 +2406,14 @@ func TestRenderHookPayloadNormalizationCodexSkillHeuristic(t *testing.T) {
 	homeDir := filepath.Join(dir, "home")
 	repoDir := filepath.Join(dir, "repo")
 	cwd := filepath.Join(repoDir, "nested", "sub")
+	codexHome := filepath.Join(dir, "codex-home")
 	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".agents", "skills", "home-skill"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".agents", "skills", "repo-skill"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(codexHome, "skills", ".system", "sys-skill"), 0o755))
 	require.NoError(t, os.MkdirAll(cwd, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".agents", "skills", "home-skill", "SKILL.md"), []byte("# home"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".agents", "skills", "repo-skill", "SKILL.md"), []byte("# repo"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(codexHome, "skills", ".system", "sys-skill", "SKILL.md"), []byte("# sys"), 0o644))
 
 	scriptPath := filepath.Join(dir, "normalize.sh")
 	script := renderHookPayloadNormalizationSnippet("codex") + fmt.Sprintf(`
@@ -2423,6 +2426,7 @@ prompt_walk='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","pr
 prompt_miss='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"pay $50 to $unknown-skill","cwd":"%[2]s"}'
 prompt_punct='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"please use $home-skill.","cwd":"%[2]s"}'
 prompt_relcwd='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"use $repo-skill","cwd":"nested/sub"}'
+prompt_system='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"use $sys-skill","cwd":"%[2]s"}'
 gram_hooks_build_canonical_payload "$read_req" "test-host"
 printf '\n---GRAM---\n'
 gram_hooks_build_canonical_payload "$read_res" "test-host"
@@ -2440,16 +2444,18 @@ printf '\n---GRAM---\n'
 gram_hooks_build_canonical_payload "$prompt_punct" "test-host"
 printf '\n---GRAM---\n'
 gram_hooks_build_canonical_payload "$prompt_relcwd" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$prompt_system" "test-host"
 `, repoDir, cwd)
 	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
 
 	cmd := exec.Command(bashPath, scriptPath)
-	cmd.Env = append(os.Environ(), "HOME="+homeDir, "XDG_STATE_HOME="+filepath.Join(dir, "state"))
+	cmd.Env = append(os.Environ(), "HOME="+homeDir, "CODEX_HOME="+codexHome, "XDG_STATE_HOME="+filepath.Join(dir, "state"))
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
 	chunks := strings.Split(string(output), "\n---GRAM---\n")
-	require.Len(t, chunks, 9)
+	require.Len(t, chunks, 10)
 
 	parse := func(raw string) (eventType string, skillName string) {
 		var parsed map[string]any
@@ -2497,6 +2503,10 @@ gram_hooks_build_canonical_payload "$prompt_relcwd" "test-host"
 	eventType, skill = parse(chunks[8])
 	require.Equal(t, "prompt.submitted", eventType)
 	require.Empty(t, skill, "a relative cwd must terminate the walk without matching")
+
+	eventType, skill = parse(chunks[9])
+	require.Equal(t, "prompt.submitted", eventType)
+	require.Equal(t, "sys-skill", skill, "bundled skills under a .system subdirectory must resolve by bare name")
 }
 
 // TestRenderHookPayloadNormalizationClaudeSkillStillReclassifies pins the

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2490,10 +2490,12 @@ gram_hooks_build_canonical_payload "$prompt_relcwd" "test-host"
 	require.Equal(t, "prompt.submitted", eventType)
 	require.Empty(t, skill, "$ tokens that resolve to no skill directory must be ignored")
 
-	_, skill = parse(chunks[7])
+	eventType, skill = parse(chunks[7])
+	require.Equal(t, "prompt.submitted", eventType)
 	require.Equal(t, "home-skill", skill, "sentence-final punctuation must not defeat a mention")
 
-	_, skill = parse(chunks[8])
+	eventType, skill = parse(chunks[8])
+	require.Equal(t, "prompt.submitted", eventType)
 	require.Empty(t, skill, "a relative cwd must terminate the walk without matching")
 }
 

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2390,6 +2390,140 @@ gram_hooks_build_canonical_payload "$res" "test-host"
 	require.Equal(t, reqBID, resBID, "second completion must pop the second request's id")
 }
 
+// TestRenderHookPayloadNormalizationCodexSkillHeuristic covers the best-effort
+// Codex skill detection. Codex has no Skill tool: implicit activations surface
+// as a reader tool opening skills/<name>/SKILL.md, and explicit $skill-name
+// prompt mentions are expanded internally without any tool call. Both must
+// attach data.skill while keeping the event's true type on the wire — a
+// reclassified event would skip the server's tool/prompt policy scan.
+func TestRenderHookPayloadNormalizationCodexSkillHeuristic(t *testing.T) {
+	t.Parallel()
+
+	bashPath, err := exec.LookPath("bash")
+	require.NoError(t, err, "bash is required to run generated hook snippets")
+
+	dir := t.TempDir()
+	homeDir := filepath.Join(dir, "home")
+	repoDir := filepath.Join(dir, "repo")
+	cwd := filepath.Join(repoDir, "nested", "sub")
+	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".agents", "skills", "home-skill"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".agents", "skills", "repo-skill"), 0o755))
+	require.NoError(t, os.MkdirAll(cwd, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".agents", "skills", "home-skill", "SKILL.md"), []byte("# home"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".agents", "skills", "repo-skill", "SKILL.md"), []byte("# repo"), 0o644))
+
+	scriptPath := filepath.Join(dir, "normalize.sh")
+	script := renderHookPayloadNormalizationSnippet("codex") + fmt.Sprintf(`
+read_req='{"hook_event_name":"PreToolUse","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"sed -n 1,240p %[1]s/.agents/skills/repo-skill/SKILL.md"},"tool_use_id":"call_1"}'
+read_res='{"hook_event_name":"PostToolUse","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"sed -n 1,240p %[1]s/.agents/skills/repo-skill/SKILL.md"},"tool_response":{"output":"ok"},"tool_use_id":"call_1"}'
+perm_req='{"hook_event_name":"PermissionRequest","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"cat %[1]s/.agents/skills/repo-skill/SKILL.md"},"permission_type":"exec"}'
+patch_req='{"hook_event_name":"PreToolUse","session_id":"sess-skill","tool_name":"apply_patch","tool_input":{"changes":"%[1]s/.agents/skills/repo-skill/SKILL.md"},"tool_use_id":"call_2"}'
+prompt_hit='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"Check $HOME then use $home-skill please","cwd":"%[2]s"}'
+prompt_walk='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"use $repo-skill","cwd":"%[2]s"}'
+prompt_miss='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"pay $50 to $unknown-skill","cwd":"%[2]s"}'
+prompt_punct='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"please use $home-skill.","cwd":"%[2]s"}'
+prompt_relcwd='{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"use $repo-skill","cwd":"nested/sub"}'
+gram_hooks_build_canonical_payload "$read_req" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$read_res" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$perm_req" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$patch_req" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$prompt_hit" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$prompt_walk" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$prompt_miss" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$prompt_punct" "test-host"
+printf '\n---GRAM---\n'
+gram_hooks_build_canonical_payload "$prompt_relcwd" "test-host"
+`, repoDir, cwd)
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	cmd := exec.Command(bashPath, scriptPath)
+	cmd.Env = append(os.Environ(), "HOME="+homeDir, "XDG_STATE_HOME="+filepath.Join(dir, "state"))
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	chunks := strings.Split(string(output), "\n---GRAM---\n")
+	require.Len(t, chunks, 9)
+
+	parse := func(raw string) (eventType string, skillName string) {
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(raw)), &parsed))
+		eventType, _ = requireMapValue(t, parsed, "event")["type"].(string)
+		data, _ := parsed["data"].(map[string]any)
+		if skill, ok := data["skill"].(map[string]any); ok {
+			skillName, _ = skill["name"].(string)
+		}
+		return eventType, skillName
+	}
+
+	eventType, skill := parse(chunks[0])
+	require.Equal(t, "tool.requested", eventType, "a detected skill read must keep its true event type")
+	require.Equal(t, "repo-skill", skill, "SKILL.md path in a reader tool input must resolve the skill name")
+
+	eventType, skill = parse(chunks[1])
+	require.Equal(t, "tool.completed", eventType)
+	require.Empty(t, skill, "completions must not re-report the activation")
+
+	eventType, skill = parse(chunks[2])
+	require.Equal(t, "tool.requested", eventType)
+	require.Empty(t, skill, "permission previews may be denied and must not count as activations")
+
+	eventType, skill = parse(chunks[3])
+	require.Equal(t, "tool.requested", eventType)
+	require.Empty(t, skill, "editing a SKILL.md is not an activation")
+
+	eventType, skill = parse(chunks[4])
+	require.Equal(t, "prompt.submitted", eventType, "a skill mention must keep the prompt event type")
+	require.Equal(t, "home-skill", skill, "$name mentions must resolve against $HOME/.agents/skills")
+
+	eventType, skill = parse(chunks[5])
+	require.Equal(t, "prompt.submitted", eventType)
+	require.Equal(t, "repo-skill", skill, "$name mentions must resolve by walking up from the session cwd")
+
+	eventType, skill = parse(chunks[6])
+	require.Equal(t, "prompt.submitted", eventType)
+	require.Empty(t, skill, "$ tokens that resolve to no skill directory must be ignored")
+
+	_, skill = parse(chunks[7])
+	require.Equal(t, "home-skill", skill, "sentence-final punctuation must not defeat a mention")
+
+	_, skill = parse(chunks[8])
+	require.Empty(t, skill, "a relative cwd must terminate the walk without matching")
+}
+
+// TestRenderHookPayloadNormalizationClaudeSkillStillReclassifies pins the
+// Claude behavior the codex guard must not disturb: the dedicated Skill tool
+// is a benign meta-tool, so its events keep being reclassified to
+// skill.activated on the wire.
+func TestRenderHookPayloadNormalizationClaudeSkillStillReclassifies(t *testing.T) {
+	t.Parallel()
+
+	bashPath, err := exec.LookPath("bash")
+	require.NoError(t, err, "bash is required to run generated hook snippets")
+
+	scriptPath := filepath.Join(t.TempDir(), "normalize.sh")
+	script := renderHookPayloadNormalizationSnippet("claude") + `
+payload='{"hook_event_name":"PreToolUse","session_id":"sess-claude-skill","tool_name":"Skill","tool_input":{"skill":"pdf-tools"},"tool_use_id":"toolu_1"}'
+gram_hooks_build_canonical_payload "$payload" "test-host"
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	output, err := exec.Command(bashPath, scriptPath).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(string(output))), &parsed))
+	require.Equal(t, "skill.activated", requireMapValue(t, parsed, "event")["type"])
+	skill := requireMapValue(t, requireMapValue(t, parsed, "data"), "skill")
+	require.Equal(t, "pdf-tools", skill["name"])
+}
+
 // TestRenderHookPayloadNormalizationCodexMCPExactServerNameWins pins the codex
 // MCP config lookup semantics when server names collide after sanitizing: an
 // exact name match must win, and without one a sanitized match only resolves

--- a/server/internal/plugins/hook_adapters.go
+++ b/server/internal/plugins/hook_adapters.go
@@ -490,13 +490,18 @@ gram_hooks_skill_name() {
 gram_hooks_codex_skill_exists() {
   local name="$1"
   local dir="$2"
+  local root
   [ -n "$name" ] || return 1
   case "$name" in
     */* | .*) return 1 ;;
   esac
   [ -f "${HOME}/.agents/skills/${name}/SKILL.md" ] && return 0
-  [ -f "/etc/codex/skills/${name}/SKILL.md" ] && return 0
-  [ -f "${CODEX_HOME:-${HOME}/.codex}/skills/${name}/SKILL.md" ] && return 0
+  # Bundled/system skills live under a .system subdirectory of the skill
+  # roots (e.g. ~/.codex/skills/.system/plan) but are mentioned by bare name.
+  for root in /etc/codex/skills /opt/codex/skills "${CODEX_HOME:-${HOME}/.codex}/skills"; do
+    [ -f "${root}/${name}/SKILL.md" ] && return 0
+    [ -f "${root}/.system/${name}/SKILL.md" ] && return 0
+  done
   while [ -n "$dir" ] && [ "$dir" != "/" ]; do
     [ -f "${dir}/.agents/skills/${name}/SKILL.md" ] && return 0
     # cwd comes from the provider payload: a value with no slash left would

--- a/server/internal/plugins/hook_adapters.go
+++ b/server/internal/plugins/hook_adapters.go
@@ -534,7 +534,7 @@ gram_hooks_codex_skill_name() {
       esac
       tool_input="$(gram_hooks_json_value "$payload" "tool_input")"
       [ -n "$tool_input" ] || return 0
-      match="$(printf '%%s\n' "$tool_input" | sed -n 's/.*skills\/\([A-Za-z0-9][A-Za-z0-9._-]*\)\/SKILL\.md.*/\1/p' | sed -n '1p')"
+      match="$(printf '%%s\n' "$tool_input" | sed -n 's/.*skills\/\(\.system\/\)\{0,1\}\([A-Za-z0-9][A-Za-z0-9._-]*\)\/SKILL\.md.*/\2/p' | sed -n '1p')"
       printf '%%s' "$match"
       ;;
     UserPromptSubmit)

--- a/server/internal/plugins/hook_adapters.go
+++ b/server/internal/plugins/hook_adapters.go
@@ -478,7 +478,76 @@ gram_hooks_skill_name() {
     fi
     [ -n "$skill" ] || skill="$(gram_hooks_json_string_value "$payload" "name")"
   fi
+  if [ -z "$skill" ] && [ "%s" = "codex" ]; then
+    skill="$(gram_hooks_codex_skill_name "$payload" "$tool_name")"
+  fi
   printf '%%s' "$skill"
+}
+
+# gram_hooks_codex_skill_exists validates a candidate skill name against the
+# directories Codex discovers skills from: .agents/skills walking up from the
+# session cwd, plus the user, admin, and Codex-home locations.
+gram_hooks_codex_skill_exists() {
+  local name="$1"
+  local dir="$2"
+  [ -n "$name" ] || return 1
+  case "$name" in
+    */* | .*) return 1 ;;
+  esac
+  [ -f "${HOME}/.agents/skills/${name}/SKILL.md" ] && return 0
+  [ -f "/etc/codex/skills/${name}/SKILL.md" ] && return 0
+  [ -f "${CODEX_HOME:-${HOME}/.codex}/skills/${name}/SKILL.md" ] && return 0
+  while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+    [ -f "${dir}/.agents/skills/${name}/SKILL.md" ] && return 0
+    # cwd comes from the provider payload: a value with no slash left would
+    # make the strip a no-op and spin this loop forever.
+    case "$dir" in
+      */*) dir="${dir%%/*}" ;;
+      *) dir="" ;;
+    esac
+  done
+  return 1
+}
+
+# gram_hooks_codex_skill_name infers skill activations for Codex, which has no
+# structured skill signal. Two best-effort detections:
+#   - a reader tool opening a skills/<name>/SKILL.md path (implicit
+#     activation: Codex is prompted to open SKILL.md when it picks a skill)
+#   - an explicit $skill-name mention in the submitted prompt, accepted only
+#     when the name resolves to a skill directory on disk (explicit mentions
+#     are expanded internally and never surface as a tool call)
+gram_hooks_codex_skill_name() {
+  local payload="$1"
+  local tool_name="$2"
+  local native tool_input prompt cwd match token
+  native="$(gram_hooks_native_event_name "$payload")"
+  case "$native" in
+    PreToolUse)
+      case "$tool_name" in
+        Bash | shell | Read) ;;
+        *) return 0 ;;
+      esac
+      tool_input="$(gram_hooks_json_value "$payload" "tool_input")"
+      [ -n "$tool_input" ] || return 0
+      match="$(printf '%%s\n' "$tool_input" | sed -n 's/.*skills\/\([A-Za-z0-9][A-Za-z0-9._-]*\)\/SKILL\.md.*/\1/p' | sed -n '1p')"
+      printf '%%s' "$match"
+      ;;
+    UserPromptSubmit)
+      prompt="$(gram_hooks_json_string_value "$payload" "prompt")"
+      [ -n "$prompt" ] || return 0
+      case "$prompt" in
+        *\$*) ;;
+        *) return 0 ;;
+      esac
+      cwd="$(gram_hooks_json_string_value "$payload" "cwd")"
+      for token in $(printf '%%s\n' "$prompt" | tr -c 'A-Za-z0-9._$-' '\n' | sed -n 's/^\$\([A-Za-z0-9][A-Za-z0-9._-]*\)$/\1/p' | sed 's/\.*$//' | sort -u); do
+        if gram_hooks_codex_skill_exists "$token" "$cwd"; then
+          printf '%%s' "$token"
+          return 0
+        fi
+      done
+      ;;
+  esac
 }
 
 gram_hooks_mcp_server_from_tool_name() {
@@ -863,7 +932,12 @@ gram_hooks_build_canonical_payload() {
   event_type="$(gram_hooks_normalized_event_type "$native")"
   [ -n "$event_type" ] || event_type="$native"
   [ -n "$event_type" ] || event_type="session.updated"
-  if [ -n "$(gram_hooks_skill_name "$payload")" ]; then
+  # Codex skill names are inferred from ordinary tool/prompt payloads, so the
+  # wire event keeps its true type there: reclassifying would skip the
+  # server's tool/prompt policy scan for any payload that happens to mention
+  # a SKILL.md path. The skill lands in data.skill and the server layers the
+  # skill.activated classification on top.
+  if [ "%s" != "codex" ] && [ -n "$(gram_hooks_skill_name "$payload")" ]; then
     event_type="skill.activated"
   fi
 
@@ -1099,5 +1173,5 @@ gram_hooks_provider_response() {
       ;;
   esac
 }
-`, spec.Platform, cases.String(), spec.Platform, spec.Platform, spec.Platform)
+`, spec.Platform, cases.String(), spec.Platform, spec.Platform, spec.Platform, spec.Platform, spec.Platform)
 }

--- a/server/internal/telemetry/logger.go
+++ b/server/internal/telemetry/logger.go
@@ -102,9 +102,14 @@ func (l *Logger) checkToolIOLogsEnabled(ctx context.Context, organizationID stri
 	return enabled
 }
 
+// maxScrubbedSkillNameLen bounds the skill name a scrubbed row may retain:
+// real skill names are short identifiers, and the carve-out must not become a
+// channel for bulky payloads past the tool IO scrub.
+const maxScrubbedSkillNameLen = 128
+
 // scrubbedSkillArguments returns the minimal arguments JSON a scrubbed Skill
-// row may keep ({"skill": <name>}), or "" for non-skill rows and unparsable
-// arguments.
+// row may keep ({"skill": <name>}), or "" for non-skill rows, unparsable
+// arguments, and implausibly long names.
 func scrubbedSkillArguments(attrs map[attr.Key]any) string {
 	if name, _ := attrs[attr.ToolNameKey].(string); name != "Skill" {
 		return ""
@@ -116,10 +121,14 @@ func scrubbedSkillArguments(attrs map[attr.Key]any) string {
 	var parsed struct {
 		Skill string `json:"skill"`
 	}
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil || strings.TrimSpace(parsed.Skill) == "" {
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
 		return ""
 	}
-	minimal, err := json.Marshal(map[string]string{"skill": parsed.Skill})
+	skill := strings.TrimSpace(parsed.Skill)
+	if skill == "" || len(skill) > maxScrubbedSkillNameLen {
+		return ""
+	}
+	minimal, err := json.Marshal(map[string]string{"skill": skill})
 	if err != nil {
 		return ""
 	}

--- a/server/internal/telemetry/logger.go
+++ b/server/internal/telemetry/logger.go
@@ -102,6 +102,30 @@ func (l *Logger) checkToolIOLogsEnabled(ctx context.Context, organizationID stri
 	return enabled
 }
 
+// scrubbedSkillArguments returns the minimal arguments JSON a scrubbed Skill
+// row may keep ({"skill": <name>}), or "" for non-skill rows and unparsable
+// arguments.
+func scrubbedSkillArguments(attrs map[attr.Key]any) string {
+	if name, _ := attrs[attr.ToolNameKey].(string); name != "Skill" {
+		return ""
+	}
+	raw, _ := attrs[attr.GenAIToolCallArgumentsKey].(string)
+	if raw == "" {
+		return ""
+	}
+	var parsed struct {
+		Skill string `json:"skill"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil || strings.TrimSpace(parsed.Skill) == "" {
+		return ""
+	}
+	minimal, err := json.Marshal(map[string]string{"skill": parsed.Skill})
+	if err != nil {
+		return ""
+	}
+	return string(minimal)
+}
+
 func (l *Logger) Log(ctx context.Context, params LogParams) {
 	if err := l.LogBulk(ctx, []LogParams{params}); err != nil {
 		l.logger.ErrorContext(ctx, "failed to insert telemetry log", attr.SlogError(err))
@@ -143,9 +167,17 @@ func (l *Logger) LogBulk(ctx context.Context, params []LogParams) error {
 		}
 
 		// Scrub tool IO content if the feature is disabled for this organization.
+		// Skill rows keep only the skill name: ClickHouse materializes
+		// skill_name from the arguments JSON, so a full delete would erase the
+		// activation from skill analytics — while any extra invocation args
+		// are still tool IO and get dropped.
 		if !toolIOEnabled {
+			skillArgs := scrubbedSkillArguments(param.Attributes)
 			delete(param.Attributes, attr.GenAIToolCallArgumentsKey)
 			delete(param.Attributes, attr.GenAIToolCallResultKey)
+			if skillArgs != "" {
+				param.Attributes[attr.GenAIToolCallArgumentsKey] = skillArgs
+			}
 		}
 
 		param = l.hydrateUserInfo(shutdownCtx, param)

--- a/server/internal/telemetry/scrub_test.go
+++ b/server/internal/telemetry/scrub_test.go
@@ -1,0 +1,67 @@
+package telemetry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// The tool IO scrub deletes gen_ai.tool.call.arguments, but ClickHouse
+// materializes skill_name from that JSON — Skill rows keep the minimal
+// {"skill": name} and nothing else.
+func TestScrubbedSkillArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		toolName string
+		raw      string
+		want     string
+	}{
+		{
+			name:     "skill row keeps only the skill name",
+			toolName: "Skill",
+			raw:      `{"skill":"repo-review","args":"sensitive free text"}`,
+			want:     `{"skill":"repo-review"}`,
+		},
+		{
+			name:     "non-skill rows keep nothing",
+			toolName: "Bash",
+			raw:      `{"skill":"repo-review"}`,
+			want:     "",
+		},
+		{
+			name:     "unparsable arguments keep nothing",
+			toolName: "Skill",
+			raw:      `not-json`,
+			want:     "",
+		},
+		{
+			name:     "empty skill keeps nothing",
+			toolName: "Skill",
+			raw:      `{"skill":"   "}`,
+			want:     "",
+		},
+		{
+			name:     "implausibly long names keep nothing",
+			toolName: "Skill",
+			raw:      `{"skill":"` + strings.Repeat("x", maxScrubbedSkillNameLen+1) + `"}`,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attrs := map[attr.Key]any{
+				attr.ToolNameKey:               tt.toolName,
+				attr.GenAIToolCallArgumentsKey: tt.raw,
+			}
+			require.Equal(t, tt.want, scrubbedSkillArguments(attrs))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Codex sessions now report skill activations best-effort. Codex has no Skill tool, so the codex hook sender infers them (probed against codex-cli 0.142.5):
  - a reader tool (`Bash`/`shell`/`Read`) opening a `skills/<name>/SKILL.md` path on `PreToolUse` — how implicit activations surface, since Codex is prompted to open `SKILL.md` when it picks a skill;
  - an explicit `$skill-name` prompt mention, accepted only when the name resolves to a skill directory on disk (`.agents/skills` walking up from the session cwd, `$HOME/.agents/skills`, `/etc/codex/skills`, `$CODEX_HOME/skills`) — Codex expands mentions internally without any tool call, so the prompt text is the only signal.
- Detected names ride as `data.skill` on the event **without reclassifying the wire event type**: turning `tool.requested`/`prompt.submitted` into `skill.activated` would skip the server's tool/prompt policy scans (any command mentioning a SKILL.md path could dodge enforcement) and desync the codex synthetic tool-id ledger.
- Server-side, an inferred skill keeps the underlying telemetry row truthful (real tool name, provider event name) and emits a derived `skill.activated` row — suppressed when the event was policy-blocked — so skill dashboards see one vocabulary across Claude and Codex senders.
- Claude senders are unchanged: their dedicated Skill tool events still reclassify on the wire, and now that relabeling is explicitly gated to sender-classified `skill.activated` events.

Closes [DNO-352](https://linear.app/speakeasy/issue/DNO-352/feat-best-effort-skill-support-via-loose-heuristic-in-codex)

✻ Clauded with care

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds best‑effort skill activation tracking for Codex sessions and emits a unified `skill.activated` telemetry row without bypassing policy scans. Also preserves the skill name on scrubbed telemetry rows so skill analytics remain accurate. Meets DNO-352.

- **New Features**
  - Infer skills when reader tools (`Bash`/`shell`/`Read`) open `skills/<name>/SKILL.md` on `PreToolUse`.
  - Infer skills from `$name` in `UserPromptSubmit` when the name resolves on disk.
  - Keep wire events as `tool.requested`/`prompt.submitted` with `data.skill`; server writes a derived `skill.activated` row (suppressed if policy‑blocked). Claude’s explicit `skill.activated` stays reclassified on the wire and does not duplicate.

- **Bug Fixes**
  - Mint a fresh trace for every derived skill row so each activation is counted.
  - When `tool_io_logs` are disabled, keep minimal `{"skill": "<name>"}` on `Skill` rows while scrubbing tool IO; bound the retained name to 128 chars.
  - Recognize bundled `.system` skills and the `/opt/codex/skills` root in both mention validation and `SKILL.md` read detection; harden telemetry test polling and prompt‑type assertions.
  - E2E: add Codex skill‑activation scenario (covers `$name` mention and `SKILL.md` read) and provision the `logs` org feature so telemetry evidence is written.

<sup>Written for commit 47a03454e4f0b397b931780ee25c8430cd7306b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

