### PR TITLE
fix(plugins): sanitize codex MCP server names to match allowed pattern

### DIFF
--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -526,7 +526,7 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 	}
 	files[path.Join(subdir, ".codex-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]codexMCPServer)
+	mcpServers := make(map[string]codexMCPServer, len(p.Servers))
 	for _, s := range p.Servers {
 		entry := codexMCPServer{
 			URL:               s.MCPURL,
@@ -550,7 +550,14 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 			entry.BearerTokenEnvVar = "GRAM_API_KEY"
 		}
 
-		mcpServers[s.DisplayName] = entry
+		key := codexMCPServerName(s.DisplayName)
+		for i := 2; ; i++ {
+			if _, taken := mcpServers[key]; !taken {
+				break
+			}
+			key = fmt.Sprintf("%s_%d", codexMCPServerName(s.DisplayName), i)
+		}
+		mcpServers[key] = entry
 	}
 	mcpJSON, err := marshalJSON(codexMCPConfig{MCPServers: mcpServers})
 	if err != nil {
@@ -559,6 +566,34 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 	files[path.Join(subdir, ".mcp.json")] = mcpJSON
 
 	return nil
+}
+
+// codexMCPServerName converts a human display name (e.g. "Team Slack") into a
+// Codex-safe MCP server key. Codex validates the keys of .mcp.json against
+// ^[a-zA-Z0-9_-]+$ at MCP client startup and refuses to start clients whose
+// names contain spaces, parentheses, or other punctuation. Each run of
+// disallowed characters collapses into a single underscore; leading and
+// trailing runs are dropped.
+func codexMCPServerName(displayName string) string {
+	var b strings.Builder
+	b.Grow(len(displayName))
+	pendingSep := false
+	for _, r := range displayName {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+		if !valid {
+			pendingSep = true
+			continue
+		}
+		if pendingSep && b.Len() > 0 {
+			b.WriteByte('_')
+		}
+		pendingSep = false
+		b.WriteRune(r)
+	}
+	if b.Len() == 0 {
+		return "mcp-server"
+	}
+	return b.String()
 }
 
 // ClaudeObservabilitySlug / CursorObservabilitySlug derive the observability

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -526,8 +526,42 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 	}
 	files[path.Join(subdir, ".codex-plugin/plugin.json")] = pluginJSON
 
+	// Assign every server its Codex key before building entries. Already-valid
+	// display names reserve their exact key first, so an invalid name that
+	// sanitizes into the same key can never steal it — "Team Slack" must not
+	// displace a server literally named "Team_Slack".
+	keys := make([]string, len(p.Servers))
+	taken := make(map[string]bool, len(p.Servers))
+	for i, s := range p.Servers {
+		if name := codexMCPServerName(s.DisplayName); name == s.DisplayName && !taken[name] {
+			keys[i] = name
+			taken[name] = true
+		}
+	}
+	for i, s := range p.Servers {
+		if keys[i] != "" {
+			continue
+		}
+		base := codexMCPServerName(s.DisplayName)
+		key := base
+		for n := 2; taken[key] && n <= maxCodexServerRenameSuffix; n++ {
+			key = fmt.Sprintf("%s_%d", base, n)
+		}
+		if taken[key] {
+			// Rename attempts exhausted; drop the server rather than
+			// overwrite another entry.
+			continue
+		}
+		keys[i] = key
+		taken[key] = true
+	}
+
 	mcpServers := make(map[string]codexMCPServer, len(p.Servers))
-	for _, s := range p.Servers {
+	for i, s := range p.Servers {
+		if keys[i] == "" {
+			continue
+		}
+
 		entry := codexMCPServer{
 			URL:               s.MCPURL,
 			BearerTokenEnvVar: "",
@@ -550,14 +584,7 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 			entry.BearerTokenEnvVar = "GRAM_API_KEY"
 		}
 
-		key := codexMCPServerName(s.DisplayName)
-		for i := 2; ; i++ {
-			if _, taken := mcpServers[key]; !taken {
-				break
-			}
-			key = fmt.Sprintf("%s_%d", codexMCPServerName(s.DisplayName), i)
-		}
-		mcpServers[key] = entry
+		mcpServers[keys[i]] = entry
 	}
 	mcpJSON, err := marshalJSON(codexMCPConfig{MCPServers: mcpServers})
 	if err != nil {
@@ -567,6 +594,11 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 
 	return nil
 }
+
+// maxCodexServerRenameSuffix bounds the collision-rename attempts for
+// sanitized Codex server keys: a colliding name tries _2 through _6 before
+// the server is dropped from the config.
+const maxCodexServerRenameSuffix = 6
 
 // codexMCPServerName converts a human display name (e.g. "Team Slack") into a
 // Codex-safe MCP server key. Codex validates the keys of .mcp.json against

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -583,6 +583,73 @@ func TestGenerateCodexMCPConfigUsesEnvHTTPHeadersForPublicServers(t *testing.T) 
 	require.Empty(t, server.HTTPHeaders, "public servers should not bake Authorization")
 }
 
+// Codex validates .mcp.json server names against ^[a-zA-Z0-9_-]+$ at MCP
+// client startup, so human display names must be sanitized into valid keys.
+func TestGenerateCodexMCPServerNamesSanitized(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "Team Slack", MCPURL: "https://app.getgram.ai/mcp/team-slack"},
+				{DisplayName: "Slack (Remote)", MCPURL: "https://app.getgram.ai/mcp/slack-remote"},
+				{DisplayName: "already_valid-1", MCPURL: "https://app.getgram.ai/mcp/valid"},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	var mcpConfig codexMCPConfig
+	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+	require.Len(t, mcpConfig.MCPServers, 3)
+
+	codexNamePattern := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	for name := range mcpConfig.MCPServers {
+		require.Regexp(t, codexNamePattern, name, "Codex rejects MCP server names outside its allowed pattern")
+	}
+
+	require.Equal(t, "https://app.getgram.ai/mcp/team-slack", mcpConfig.MCPServers["Team_Slack"].URL)
+	require.Equal(t, "https://app.getgram.ai/mcp/slack-remote", mcpConfig.MCPServers["Slack_Remote"].URL)
+	require.Equal(t, "https://app.getgram.ai/mcp/valid", mcpConfig.MCPServers["already_valid-1"].URL, "already-valid names must pass through unchanged")
+}
+
+// Display names that differ only in punctuation sanitize to the same key;
+// later servers must get a numeric suffix instead of overwriting earlier ones.
+func TestGenerateCodexMCPServerNameCollisionsDeduped(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "Notes App", MCPURL: "https://app.getgram.ai/mcp/notes-one"},
+				{DisplayName: "Notes (App)", MCPURL: "https://app.getgram.ai/mcp/notes-two"},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	var mcpConfig codexMCPConfig
+	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+	require.Len(t, mcpConfig.MCPServers, 2, "colliding names must not overwrite each other")
+
+	require.Equal(t, "https://app.getgram.ai/mcp/notes-one", mcpConfig.MCPServers["Notes_App"].URL)
+	require.Equal(t, "https://app.getgram.ai/mcp/notes-two", mcpConfig.MCPServers["Notes_App_2"].URL)
+}
+
 // TestCodexJSONKeysMatchPinnedSchema asserts the literal JSON key casing in
 // Codex output against the openai/codex source pinned in generate.go. Keys
 // are inspected on the raw JSON bytes (not a round-trip through our own

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -650,6 +650,65 @@ func TestGenerateCodexMCPServerNameCollisionsDeduped(t *testing.T) {
 	require.Equal(t, "https://app.getgram.ai/mcp/notes-two", mcpConfig.MCPServers["Notes_App_2"].URL)
 }
 
+// An already-valid display name must keep its exact key even when an
+// earlier-sorted invalid name sanitizes to the same key — the invalid name
+// takes the suffix, not the valid one.
+func TestGenerateCodexMCPServerValidNamesReservedOverSanitized(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "Team Slack", MCPURL: "https://app.getgram.ai/mcp/spaced"},
+				{DisplayName: "Team_Slack", MCPURL: "https://app.getgram.ai/mcp/literal"},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	var mcpConfig codexMCPConfig
+	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+	require.Len(t, mcpConfig.MCPServers, 2)
+
+	require.Equal(t, "https://app.getgram.ai/mcp/literal", mcpConfig.MCPServers["Team_Slack"].URL, "valid name must keep its exact key")
+	require.Equal(t, "https://app.getgram.ai/mcp/spaced", mcpConfig.MCPServers["Team_Slack_2"].URL, "sanitized name takes the suffix")
+}
+
+// Collision renames are bounded (_2 through _6); servers beyond that are
+// dropped instead of overwriting an earlier entry.
+func TestGenerateCodexMCPServerRenameAttemptsBounded(t *testing.T) {
+	t.Parallel()
+	servers := make([]PluginServerInfo, 8)
+	for i := range servers {
+		servers[i] = PluginServerInfo{
+			DisplayName: "Dup Server",
+			MCPURL:      fmt.Sprintf("https://app.getgram.ai/mcp/dup-%d", i),
+		}
+	}
+	plugins := []PluginInfo{{Name: "Test", Slug: "test", Servers: servers}}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	var mcpConfig codexMCPConfig
+	err = json.Unmarshal(files["test-codex/.mcp.json"], &mcpConfig)
+	require.NoError(t, err)
+
+	require.Len(t, mcpConfig.MCPServers, 6, "base key plus renames _2.._6, remaining collisions dropped")
+	require.Equal(t, "https://app.getgram.ai/mcp/dup-0", mcpConfig.MCPServers["Dup_Server"].URL)
+	require.Equal(t, "https://app.getgram.ai/mcp/dup-5", mcpConfig.MCPServers["Dup_Server_6"].URL)
+}
+
 // TestCodexJSONKeysMatchPinnedSchema asserts the literal JSON key casing in
 // Codex output against the openai/codex source pinned in generate.go. Keys
 // are inspected on the raw JSON bytes (not a round-trip through our own

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -1495,7 +1495,9 @@ func TestPluginsService_PublishPlugins_CodexPackageHappyPath(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(mcpFile, &mcpConfig))
 
-	server, ok := mcpConfig.MCPServers["Codex Server"]
+	// The key is the display name sanitized to Codex's ^[a-zA-Z0-9_-]+$
+	// server-name pattern — "Codex Server" would fail MCP client startup.
+	server, ok := mcpConfig.MCPServers["Codex_Server"]
 	require.True(t, ok)
 	require.Contains(t, server.URL, "/mcp/")
 	require.Contains(t, server.HTTPHeaders["Authorization"], "Bearer gram_local_")
@@ -1599,7 +1601,7 @@ func TestPluginsService_PublishPlugins_CodexPublicToolsetEnvHeaders(t *testing.T
 	}
 	require.NoError(t, json.Unmarshal(mcpFile, &mcpConfig))
 
-	server, ok := mcpConfig.MCPServers["Public Codex Server"]
+	server, ok := mcpConfig.MCPServers["Public_Codex_Server"]
 	require.True(t, ok)
 	// Codex resolves env_http_headers["Authorization"] = "ANALYTICS_API_KEY"
 	// by reading the ANALYTICS_API_KEY env var at runtime and using its
@@ -1651,8 +1653,8 @@ func TestPluginsService_PublishPlugins_CodexSkipsDisabledMCPToolsets(t *testing.
 	}
 	require.NoError(t, json.Unmarshal(mcpFile, &mcpConfig))
 
-	require.Contains(t, mcpConfig.MCPServers, "Server codex-enabled")
-	require.NotContains(t, mcpConfig.MCPServers, "Server codex-disabled")
+	require.Contains(t, mcpConfig.MCPServers, "Server_codex-enabled")
+	require.NotContains(t, mcpConfig.MCPServers, "Server_codex-disabled")
 }
 
 // PublishProject with SkipIfUnchanged set re-publishes the first time (no


### PR DESCRIPTION
Fixes DNO-222

## What

Codex validates the server names (keys) in a plugin's `.mcp.json` against `^[a-zA-Z0-9_-]+$` at MCP client startup. The codex plugin generator keyed servers by their raw human display name, so any server whose display name contains a space, parentheses, or other punctuation failed to start:

```
⚠️ MCP client for `Team Slack` failed to start: MCP startup failed: Invalid MCP server name 'Team Slack': must match pattern ^[a-zA-Z0-9_-]+$
```

## How

- `generateCodexPluginInDir` now sanitizes each display name into a Codex-safe key: every run of disallowed characters collapses into a single underscore, with leading/trailing runs dropped (`Team Slack` → `Team_Slack`, `Slack (Remote)` → `Slack_Remote`). Already-valid names pass through unchanged.
- Display names that differ only in punctuation sanitize to the same key, so colliding keys get a numeric suffix (`_2`, `_3`, …) instead of silently overwriting an earlier server.
- Claude and Cursor configs are untouched — both surfaces accept spaced names (Claude sanitizes them itself when building tool identifiers), and DNO-300 deliberately ships human display names there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes Codex MCP server names in generated `.mcp.json` to match `^[a-zA-Z0-9_-]+$`, reserves already-valid names, and bounds collision renames to `_6` to prevent startup failures and key overwrites. Addresses DNO-222.

- **Bug Fixes**
  - Convert display names to Codex-safe keys: collapse disallowed chars to a single underscore and trim edges; already-valid names pass through unchanged.
  - Handle collisions safely: reserve exact valid names; append numeric suffixes (`_2`…`_6`) to sanitized duplicates and drop extras instead of overwriting. Tests cover sanitization, collisions, reservation, and bounded renames; updated existing expectations to use sanitized keys. Claude and Cursor configs remain unchanged.

<sup>Written for commit 22477cb69248b34adbabed684bffbc1d750e1ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

