### PR TITLE
fix(plog): keep colors and levels intact under piped log viewers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/moby/moby/client v0.4.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/muesli/termenv v0.16.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/pgvector/pgvector-go v0.3.0
 	github.com/pgx-contrib/pgxotel v0.0.0-20250908221444-24ae56d05ec0
@@ -248,7 +249,6 @@ require (
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/nexus-rpc/nexus-proto-annotations v0.1.0 // indirect

--- a/plog/formatter.go
+++ b/plog/formatter.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 // Formatter formats log records for output.
@@ -16,28 +18,82 @@ type Formatter struct {
 
 // NewFormatter creates a new Formatter with the given config.
 func NewFormatter(cfg *Config) *Formatter {
+	maybeForceColorProfile(cfg)
 	return &Formatter{cfg: cfg}
 }
 
+var forceColorProfileOnce sync.Once
+
+// maybeForceColorProfile rescues colorized output when it is enabled but the
+// destination is not a TTY. lipgloss styles render through a global renderer
+// whose color profile is detected from os.Stdout; when stdout is a pipe (for
+// example when a process manager like pitchfork captures the daemon's output)
+// that profile is Ascii and every ANSI escape is stripped, leaving plain text.
+// We only ever upgrade an Ascii profile to TrueColor, so genuine terminals and
+// an explicit NO_COLOR/CLICOLOR opt-out are left untouched.
+func maybeForceColorProfile(cfg *Config) {
+	if cfg.NoColor {
+		return
+	}
+	forceColorProfileOnce.Do(func() {
+		if termenv.EnvNoColor() {
+			return
+		}
+		if lipgloss.ColorProfile() == termenv.Ascii {
+			lipgloss.SetColorProfile(termenv.TrueColor)
+		}
+	})
+}
+
+// attrLinePrefix marks source/attribute continuation lines. It groups a
+// record's details visually in a terminal and, because it is a single
+// non-whitespace token at the start of the line, it also lets line-oriented log
+// viewers that prefix every physical line with their own timestamp (such as
+// pitchfork) treat it as the leading token: they re-absorb their timestamp
+// instead of stranding it on the indented line, and the bar itself is consumed.
+const attrLinePrefix = "│"
+
+// attrLineSep separates the bar from the detail. The leading space is required:
+// line-oriented viewers like pitchfork split the leading token on a space, so a
+// bare tab there would fail their parse and strand the viewer's timestamp on the
+// line. The trailing tab indents the detail (it survives into the viewer's
+// output, which renders it as leading whitespace).
+const attrLineSep = " \t"
+
 // Format writes a formatted log record to the output.
+//
+// The record's message occupies the first line; its source location and
+// attributes follow on their own lines, each introduced by a vertical bar:
+//
+//	<timestamp> <LEVEL> <message>
+//	│	<source>
+//	│	<key>: <value>
+//
+// When the timestamp is hidden the message line leads with the bar instead, so
+// the leading token that line-oriented viewers discard (see attrLinePrefix) is
+// never the level.
 func (f *Formatter) Format(w io.Writer, record *Record) error {
+	prefix := f.style(f.cfg.Theme.AttrBracket, attrLinePrefix)
+
 	var parts []string
 
-	// Timestamp
+	// Leading token. Line-oriented viewers such as pitchfork discard the first
+	// whitespace-delimited token of every line; the timestamp normally fills
+	// that slot. When it is hidden we lead with the bar instead so the level is
+	// never mistaken for the discarded token.
 	if !f.cfg.HideTimestamp && !record.Time.IsZero() {
 		ts := record.Time.Format("15:04:05.000")
-		ts = f.style(f.cfg.Theme.Timestamp, ts)
-		parts = append(parts, ts)
+		parts = append(parts, f.style(f.cfg.Theme.Timestamp, ts))
+	} else {
+		parts = append(parts, prefix)
 	}
 
 	// Level
-	levelStr := f.formatLevel(record)
-	parts = append(parts, levelStr)
+	parts = append(parts, f.formatLevel(record))
 
 	// Message
 	if record.Message != "" {
-		msg := f.style(f.cfg.Theme.Message, record.Message)
-		parts = append(parts, msg)
+		parts = append(parts, f.style(f.cfg.Theme.Message, record.Message))
 	}
 
 	// Write main log line
@@ -45,33 +101,24 @@ func (f *Formatter) Format(w io.Writer, record *Record) error {
 		return fmt.Errorf("writing log line: %w", err)
 	}
 
-	// Write source and attributes on separate indented lines
-	hasDetails := record.Source != nil || len(record.Attrs) > 0
-	if hasDetails {
-		// Source
-		if record.Source != nil {
-			srcStr := record.Source.RelativePath(f.cfg.WorkingDir)
-			if record.Source.Line > 0 {
-				srcStr = fmt.Sprintf("%s:%d", srcStr, record.Source.Line)
-			}
-			srcStr = f.style(f.cfg.Theme.Source, srcStr)
-			if _, err := fmt.Fprintf(w, "    %s\n", srcStr); err != nil {
-				return fmt.Errorf("writing source: %w", err)
-			}
+	// Source
+	if record.Source != nil {
+		srcStr := record.Source.RelativePath(f.cfg.WorkingDir)
+		if record.Source.Line > 0 {
+			srcStr = fmt.Sprintf("%s:%d", srcStr, record.Source.Line)
 		}
-
-		// Attributes
-		for _, attr := range record.Attrs {
-			key := f.style(f.cfg.Theme.AttrKey, attr.Key)
-			value := f.formatValue(attr.Value)
-			if _, err := fmt.Fprintf(w, "    %s: %s\n", key, value); err != nil {
-				return fmt.Errorf("writing attribute: %w", err)
-			}
+		srcStr = f.style(f.cfg.Theme.Source, srcStr)
+		if _, err := fmt.Fprintf(w, "%s%s%s\n", prefix, attrLineSep, srcStr); err != nil {
+			return fmt.Errorf("writing source: %w", err)
 		}
+	}
 
-		// Blank line after details
-		if _, err := fmt.Fprintln(w); err != nil {
-			return fmt.Errorf("writing blank line: %w", err)
+	// Attributes
+	for _, attr := range record.Attrs {
+		key := f.style(f.cfg.Theme.AttrKey, attr.Key)
+		value := f.formatValue(attr.Value)
+		if _, err := fmt.Fprintf(w, "%s%s%s: %s\n", prefix, attrLineSep, key, value); err != nil {
+			return fmt.Errorf("writing attribute: %w", err)
 		}
 	}
 

--- a/plog/testdata/attributes.golden
+++ b/plog/testdata/attributes.golden
@@ -1,14 +1,11 @@
 12:00:00.000 INFO  request handled
-    latency_ms: 42.5
-    method: GET
-    path: /api/users
-    status: 200
-
+│ 	latency_ms: 42.5
+│ 	method: GET
+│ 	path: /api/users
+│ 	status: 200
 12:00:01.000 ERROR database error
-    attempts: 3
-    error: "connection timeout"
-    retry: true
-
+│ 	attempts: 3
+│ 	error: "connection timeout"
+│ 	retry: true
 12:00:02.000 INFO  user created
-    user: {"id":123,"name":"John Doe"}
-
+│ 	user: {"id":123,"name":"John Doe"}

--- a/plog/testdata/custom_keys.golden
+++ b/plog/testdata/custom_keys.golden
@@ -1,3 +1,2 @@
 12:00:00.000 INFO  custom keys log
-    main.go:10
-
+│ 	main.go:10

--- a/plog/testdata/empty_and_minimal.golden
+++ b/plog/testdata/empty_and_minimal.golden
@@ -1,1 +1,1 @@
-INFO 
+│ INFO 

--- a/plog/testdata/handler_basic.golden
+++ b/plog/testdata/handler_basic.golden
@@ -1,9 +1,6 @@
 00:00:00.000 INFO  server started
-    port: 8080
-
+│ 	port: 8080
 00:00:00.000 WARN  high memory usage
-    percent: 85.5
-
+│ 	percent: 85.5
 00:00:00.000 ERROR connection failed
-    error: timeout
-
+│ 	error: timeout

--- a/plog/testdata/handler_complex_values.golden
+++ b/plog/testdata/handler_complex_values.golden
@@ -1,7 +1,6 @@
 00:00:00.000 INFO  complex values
-    duration: 5s
-    timestamp: 2025-01-30T12:00:00Z
-    count: 42
-    ratio: 0.75
-    enabled: true
-
+│ 	duration: 5s
+│ 	timestamp: 2025-01-30T12:00:00Z
+│ 	count: 42
+│ 	ratio: 0.75
+│ 	enabled: true

--- a/plog/testdata/handler_dedup_attr_keys.golden
+++ b/plog/testdata/handler_dedup_attr_keys.golden
@@ -1,4 +1,3 @@
 00:00:00.000 INFO  response
-    gram.component: final
-    status: 200
-
+│ 	gram.component: final
+│ 	status: 200

--- a/plog/testdata/handler_nested_groups.golden
+++ b/plog/testdata/handler_nested_groups.golden
@@ -1,3 +1,2 @@
 00:00:00.000 INFO  deeply nested
-    outer.inner.key: value
-
+│ 	outer.inner.key: value

--- a/plog/testdata/handler_with_attrs.golden
+++ b/plog/testdata/handler_with_attrs.golden
@@ -1,11 +1,9 @@
 00:00:00.000 INFO  request handled
-    service: api
-    version: 1.0.0
-    path: /users
-
+│ 	service: api
+│ 	version: 1.0.0
+│ 	path: /users
 00:00:00.000 ERROR request failed
-    service: api
-    version: 1.0.0
-    path: /orders
-    error: "not found"
-
+│ 	service: api
+│ 	version: 1.0.0
+│ 	path: /orders
+│ 	error: "not found"

--- a/plog/testdata/handler_with_group.golden
+++ b/plog/testdata/handler_with_group.golden
@@ -1,7 +1,5 @@
 00:00:00.000 INFO  connected
-    db.host: localhost
-    db.port: 5432
-
+│ 	db.host: localhost
+│ 	db.port: 5432
 00:00:00.000 INFO  hit
-    cache.key: user:123
-
+│ 	cache.key: user:123

--- a/plog/testdata/handler_with_source.golden
+++ b/plog/testdata/handler_with_source.golden
@@ -1,3 +1,2 @@
 00:00:00.000 INFO message with source
-test_file.go:1
-
+│ test_file.go:1

--- a/plog/testdata/omit_keys.golden
+++ b/plog/testdata/omit_keys.golden
@@ -1,6 +1,4 @@
 12:00:00.000 INFO  user login
-    path: /login
-
+│ 	path: /login
 12:00:01.000 INFO  api call
-    endpoint: /api/users
-
+│ 	endpoint: /api/users

--- a/plog/testdata/source_locations.golden
+++ b/plog/testdata/source_locations.golden
@@ -1,12 +1,8 @@
 12:00:00.000 INFO  string source
-    server.go:42
-
+│ 	server.go:42
 12:00:01.000 INFO  object source
-    handler.go:128
-
+│ 	handler.go:128
 12:00:02.000 INFO  object with function
-    service.go:256
-
+│ 	service.go:256
 12:00:03.000 INFO  caller key
-    middleware.go:64
-
+│ 	middleware.go:64

--- a/plog/testdata/special_values.golden
+++ b/plog/testdata/special_values.golden
@@ -1,13 +1,10 @@
 12:00:00.000 INFO  special values
-    array: [1,2,3]
-    bool_false: false
-    bool_true: true
-    empty_string: 
-    null_val: null
-
+│ 	array: [1,2,3]
+│ 	bool_false: false
+│ 	bool_true: true
+│ 	empty_string: 
+│ 	null_val: null
 12:00:01.000 INFO  string with spaces
-    description: "this has spaces"
-
+│ 	description: "this has spaces"
 12:00:02.000 INFO  string with quotes
-    query: "SELECT * FROM \"users\""
-
+│ 	query: "SELECT * FROM \"users\""


### PR DESCRIPTION
## Problem

plog's pretty output rendered as plain, level-less text when viewed through a process manager that captures daemon stdout (e.g. **pitchfork**'s web UI), while looking fine in a real terminal or the mprocs TUI. Attribute lines also leaked a stray timestamp prefix on every line.

Compare `gram/server` and `gram/streams` (Go, plog) vs `gram/pystreams-multi` (Python, structlog) — only the plog daemons were affected.

## Root causes

Two independent issues, both fixed **within plog** (no change to how the server configures logging):

1. **Colors stripped.** lipgloss detects its color profile from `os.Stdout`. When output is a pipe rather than a TTY, it picks the `Ascii` profile and drops every ANSI escape, so nothing is colored.

2. **Level stripped + timestamps leaked.** Pitchfork's web log viewer (`ui/src/utils/log.ts`) prefixes every physical line with its own timestamp, then parses `^<ts> <token> <rest>$` and **discards the middle token** — modeled on pitchfork's own `<timestamp> <level> <message>` log format (`src/logger.rs`). The timestamp normally fills that discarded slot, but the server hides plog's timestamp, so the level landed there and vanished. plog's multi-line detail lines didn't match the parser at all, so they showed the prefixed timestamp verbatim.

## Fixes

- **`plog/formatter.go`** — force a `TrueColor` profile when color is enabled and the environment hasn't opted out (`NO_COLOR`/`CLICOLOR`). Pretty logging is an explicitly human-facing, colorized format, so it shouldn't go monochrome just because it's piped.
- **`plog/formatter.go`** — introduce each source/attribute line with a leading vertical bar (`│`) that occupies the viewer's discarded-token slot, so the viewer absorbs its timestamp and the detail survives. A trailing tab indents the detail in both the terminal and the viewer.
- **`plog/formatter.go`** — lead the message line with the same bar whenever no timestamp precedes the level (i.e. when the timestamp is hidden), so the level is never the discarded token. In a real terminal the bar renders as a left gutter down the record.

The server's `WithHideTimestamp(true)` is unchanged.

## Verification

- `go test -race ./plog/` passes; golden files regenerated.
- server builds.
- Ran real piped, colored plog output (with `WithHideTimestamp(true)`) through pitchfork's actual `ui/src/utils/log.ts` parser: every line matches, timestamp absorbed, level preserved, colors intact, detail lines tab-indented.
- Confirmed live in pitchfork's web UI for `gram/server` and `gram/streams`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)