### PR TITLE
feat: auto-provision Default plugin, auto-attach servers, auto-publish

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -841,7 +841,6 @@ func newStartCommand() *cli.Command {
 			assistantsSvc := assistants.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv}, ratelimit.NewRedisStore(redisClient))
 			triggerApp.RegisterDispatcher(assistantsSvc)
 
-			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
 			mcpMetadataService := mcpmetadata.NewService(logger, tracerProvider, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
 
 			otelForwardClient := otelforwarding.NewClient(logger, db, encryptionClient, cache.NewRedisCacheAdapter(redisClient))
@@ -1066,6 +1065,7 @@ func newStartCommand() *cli.Command {
 			}
 			plugins.Attach(mux, plugins.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, pluginsGitHub, c.String("environment"), c.String("server-url")))
 			productfeatures.Attach(mux, productfeatures.NewService(logger, tracerProvider, db, sessionManager, redisClient, authzEngine))
+			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil)
 			toolsets.Attach(mux, toolsetsSvc)
 			integrations.Attach(mux, integrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			templates.Attach(mux, templates.NewService(logger, tracerProvider, db, sessionManager, toolsetsSvc, authzEngine, auditLogger))
@@ -1077,7 +1077,7 @@ func newStartCommand() *cli.Command {
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))
 			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, auditLogger))
 			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
-			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
+			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
 			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, cache.NewRedisCacheAdapter(redisClient))
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), remoteSessionsService))
 			remotesessions.Attach(mux, remoteSessionsService)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1046,9 +1046,6 @@ func newStartCommand() *cli.Command {
 			))
 			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, serverURL.String(), siteURL.String(), auditLogger, svixClient)
 			organizations.Attach(mux, organizationsService)
-			projects.Attach(mux, projects.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
-			packages.Attach(mux, packages.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
-
 			pluginsGitHub, err := plugins.NewGitHubConfig(plugins.GitHubConfigInput{
 				Client:         ghClient,
 				Org:            c.String("plugins-github-org"),
@@ -1057,6 +1054,9 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("plugins github config: %w", err)
 			}
+			projects.Attach(mux, projects.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
+			packages.Attach(mux, packages.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
+
 			var pluginPublisher *plugins.Service
 			if pluginsGitHub != nil {
 				logger.InfoContext(ctx, "GitHub publishing for plugins: enabled")

--- a/server/internal/background/plugin_generator_rollout.go
+++ b/server/internal/background/plugin_generator_rollout.go
@@ -28,7 +28,7 @@ const (
 	// "trigger every interval unless one is already running" behaviour without a
 	// separate triggering workflow: a run that outlasts the interval just defers
 	// the next tick.
-	pluginGeneratorRolloutInterval         = 5 * time.Minute
+	pluginGeneratorRolloutInterval         = 1 * time.Minute
 	pluginGeneratorRolloutDefaultBatchSize = int32(100)
 	pluginGeneratorRolloutConcurrency      = 5
 )

--- a/server/internal/background/plugin_initial_publish.go
+++ b/server/internal/background/plugin_initial_publish.go
@@ -24,7 +24,10 @@ func ExecutePluginInitialPublishWorkflow(ctx context.Context, temporalEnv *tenv.
 		ID:                    fmt.Sprintf("v1:plugin-initial-publish/%s", input.ProjectID),
 		TaskQueue:             string(temporalEnv.Queue()),
 		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-		WorkflowRunTimeout:    10 * time.Minute,
+		// Must exceed the activity's worst-case retry budget (3 attempts x
+		// 5m StartToCloseTimeout + backoff ~= 16m), or the workflow can expire
+		// mid-retry and drop the final result.
+		WorkflowRunTimeout: 20 * time.Minute,
 	}, PluginInitialPublishWorkflow, input)
 }
 

--- a/server/internal/background/plugin_initial_publish.go
+++ b/server/internal/background/plugin_initial_publish.go
@@ -1,0 +1,48 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/plugins"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+// ExecutePluginInitialPublishWorkflow kicks off the first-time GitHub publish
+// for a newly created project's Default plugin. The rollout schedule (see
+// plugin_generator_rollout.go) only republishes projects that already have a
+// GitHub connection, so a brand new project needs this one-shot trigger to
+// get its marketplace repo without waiting on a human to click Publish.
+func ExecutePluginInitialPublishWorkflow(ctx context.Context, temporalEnv *tenv.Environment, input plugins.PublishProjectInput) (client.WorkflowRun, error) {
+	return temporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    fmt.Sprintf("v1:plugin-initial-publish/%s", input.ProjectID),
+		TaskQueue:             string(temporalEnv.Queue()),
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowRunTimeout:    10 * time.Minute,
+	}, PluginInitialPublishWorkflow, input)
+}
+
+func PluginInitialPublishWorkflow(ctx workflow.Context, input plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    10 * time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    1 * time.Minute,
+		},
+	})
+
+	var a *Activities
+	var result plugins.PublishProjectResult
+	if err := workflow.ExecuteActivity(ctx, a.PublishPluginProject, input).Get(ctx, &result); err != nil {
+		return nil, fmt.Errorf("publish plugin project: %w", err)
+	}
+	return &result, nil
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -418,6 +418,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(ProcessOutboxWorkflow)
 	temporalWorker.RegisterWorkflow(OutboxGCWorkflow)
 	temporalWorker.RegisterWorkflow(PluginGeneratorRolloutWorkflow)
+	temporalWorker.RegisterWorkflow(PluginInitialPublishWorkflow)
 
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {

--- a/server/internal/collections/setup_test.go
+++ b/server/internal/collections/setup_test.go
@@ -87,7 +87,7 @@ func newTestCollectionsService(t *testing.T) (context.Context, *testInstance) {
 	auditLogger := audit.NewLogger()
 
 	svc := collections.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, auditLogger, testenv.DefaultSiteURL(t))
-	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine, auditLogger)
+	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine, auditLogger, nil, false)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/mcpendpoints/createmcpendpoint_test.go
+++ b/server/internal/mcpendpoints/createmcpendpoint_test.go
@@ -12,8 +12,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/remotemcptest"
+	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 )
 
 func TestCreateMcpEndpoint_PlatformDomainWithOrgPrefix(t *testing.T) {
@@ -210,4 +215,105 @@ func TestCreateMcpEndpoint_ConflictOnDuplicateSlugWithCustomDomain(t *testing.T)
 		Slug:             types.McpEndpointSlug(slugVal),
 	})
 	requireOopsCode(t, err, oops.CodeConflict)
+}
+
+func TestCreateMcpEndpoint_AttachesToDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	// A non-disabled mcp_server, unlike seedMcpServer's "disabled" fixture,
+	// since AttachToDefaultPlugin skips disabled servers.
+	remoteServer := remotemcptest.SeedServer(t, ctx, ti.conn, remotemcprepo.CreateServerParams{
+		ProjectID:     *authCtx.ProjectID,
+		TransportType: "streamable-http",
+		Url:           "https://test.example.com/mcp/" + uuid.NewString(),
+	})
+	mcpServerID, err := uuid.NewV7()
+	require.NoError(t, err)
+	_, err = mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ID:                mcpServerID,
+		ProjectID:         *authCtx.ProjectID,
+		Name:              conv.ToPGText("Attach Test Server"),
+		Slug:              conv.ToPGText("attach-test-server-" + uuid.NewString()),
+		EnvironmentID:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		RemoteMcpServerID: uuid.NullUUID{UUID: remoteServer.ID, Valid: true},
+		ToolsetID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		Visibility:        "public",
+	})
+	require.NoError(t, err)
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+
+	_, err = ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		CustomDomainID:   nil,
+		McpServerID:      mcpServerID.String(),
+		Slug:             types.McpEndpointSlug(authCtx.OrganizationSlug + "-attach-test"),
+	})
+	require.NoError(t, err)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.Equal(t, mcpServerID, servers[0].McpServerID.UUID)
+	require.Equal(t, "Attach Test Server", servers[0].DisplayName)
+	require.Equal(t, "required", servers[0].Policy)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount+1, afterCount)
+}
+
+func TestCreateMcpEndpoint_SkipsAttachWhenNoDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	remoteServer := remotemcptest.SeedServer(t, ctx, ti.conn, remotemcprepo.CreateServerParams{
+		ProjectID:     *authCtx.ProjectID,
+		TransportType: "streamable-http",
+		Url:           "https://test.example.com/mcp/" + uuid.NewString(),
+	})
+	mcpServerID, err := uuid.NewV7()
+	require.NoError(t, err)
+	_, err = mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ID:                mcpServerID,
+		ProjectID:         *authCtx.ProjectID,
+		Name:              conv.ToPGText("No Default Plugin Server"),
+		Slug:              conv.ToPGText("no-default-plugin-server-" + uuid.NewString()),
+		EnvironmentID:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		RemoteMcpServerID: uuid.NullUUID{UUID: remoteServer.ID, Valid: true},
+		ToolsetID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		Visibility:        "public",
+	})
+	require.NoError(t, err)
+
+	// No Default plugin exists for this project (the test fixture project is
+	// created directly through projectsrepo, bypassing projects.CreateProject).
+	_, err = ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		CustomDomainID:   nil,
+		McpServerID:      mcpServerID.String(),
+		Slug:             types.McpEndpointSlug(authCtx.OrganizationSlug + "-no-default"),
+	})
+	require.NoError(t, err)
 }

--- a/server/internal/mcpendpoints/createmcpendpoint_test.go
+++ b/server/internal/mcpendpoints/createmcpendpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
@@ -278,7 +279,7 @@ func TestCreateMcpEndpoint_AttachesToDefaultPlugin(t *testing.T) {
 	require.Equal(t, beforeCount+1, afterCount)
 }
 
-func TestCreateMcpEndpoint_SkipsAttachWhenNoDefaultPlugin(t *testing.T) {
+func TestCreateMcpEndpoint_LazilyCreatesDefaultPluginWhenMissing(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -305,8 +306,20 @@ func TestCreateMcpEndpoint_SkipsAttachWhenNoDefaultPlugin(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// No Default plugin exists for this project (the test fixture project is
-	// created directly through projectsrepo, bypassing projects.CreateProject).
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	_, err = pluginsQueries.GetDefaultPlugin(ctx, pluginsrepo.GetDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows, "fixture project (created directly via projectsrepo) has no Default plugin yet")
+
+	beforeCreateCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginCreate)
+	require.NoError(t, err)
+	beforeAddCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+
+	// This project predates the Default-plugin feature (no CreateProject call
+	// ever ran for it) — the endpoint create must lazily provision one.
 	_, err = ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
 		SessionToken:     nil,
 		ApikeyToken:      nil,
@@ -316,4 +329,25 @@ func TestCreateMcpEndpoint_SkipsAttachWhenNoDefaultPlugin(t *testing.T) {
 		Slug:             types.McpEndpointSlug(authCtx.OrganizationSlug + "-no-default"),
 	})
 	require.NoError(t, err)
+
+	defaultPlugin, err := pluginsQueries.GetDefaultPlugin(ctx, pluginsrepo.GetDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Default", defaultPlugin.Name)
+	require.Equal(t, "default", defaultPlugin.Slug)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.Equal(t, mcpServerID, servers[0].McpServerID.UUID)
+
+	afterCreateCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginCreate)
+	require.NoError(t, err)
+	require.Equal(t, beforeCreateCount+1, afterCreateCount)
+
+	afterAddCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+	require.Equal(t, beforeAddCount+1, afterAddCount)
 }

--- a/server/internal/mcpendpoints/createmcpendpoint_test.go
+++ b/server/internal/mcpendpoints/createmcpendpoint_test.go
@@ -1,7 +1,10 @@
 package mcpendpoints_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -350,4 +353,65 @@ func TestCreateMcpEndpoint_LazilyCreatesDefaultPluginWhenMissing(t *testing.T) {
 	afterAddCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
 	require.NoError(t, err)
 	require.Equal(t, beforeAddCount+1, afterAddCount)
+}
+
+// TestCreateMcpEndpoint_LegacyProject_TriggersInitialPublish covers the
+// "legacy project" gap: a project that predates the Default-plugin feature
+// (no CreateProject call ever ran for it, so no Default plugin and no
+// GitHub connection exist) must still get its marketplace repo published
+// the first time a server becomes attachable, not just the plugin_servers
+// row. Uses a real Temporal worker wired with a fake (no-op) GitHub client
+// so the initial-publish workflow runs to actual completion instead of just
+// being enqueued.
+func TestCreateMcpEndpoint_LegacyProject_TriggersInitialPublish(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, temporalEnv := newTestServiceWithGitHubPublishing(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	_, err := pluginsQueries.GetGitHubConnection(ctx, *authCtx.ProjectID)
+	require.Error(t, err, "legacy project fixture must start with no GitHub connection")
+
+	remoteServer := remotemcptest.SeedServer(t, ctx, ti.conn, remotemcprepo.CreateServerParams{
+		ProjectID:     *authCtx.ProjectID,
+		TransportType: "streamable-http",
+		Url:           "https://test.example.com/mcp/" + uuid.NewString(),
+	})
+	mcpServerID, err := uuid.NewV7()
+	require.NoError(t, err)
+	_, err = mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ID:                mcpServerID,
+		ProjectID:         *authCtx.ProjectID,
+		Name:              conv.ToPGText("Legacy Gap Server"),
+		Slug:              conv.ToPGText("legacy-gap-server-" + uuid.NewString()),
+		EnvironmentID:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		RemoteMcpServerID: uuid.NullUUID{UUID: remoteServer.ID, Valid: true},
+		ToolsetID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		Visibility:        "public",
+	})
+	require.NoError(t, err)
+
+	// The server's first endpoint lazily creates the Default plugin, which
+	// should kick off the initial publish.
+	_, err = ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		CustomDomainID:   nil,
+		McpServerID:      mcpServerID.String(),
+		Slug:             types.McpEndpointSlug(authCtx.OrganizationSlug + "-legacy-gap"),
+	})
+	require.NoError(t, err)
+
+	workflowID := fmt.Sprintf("v1:plugin-initial-publish/%s", authCtx.ProjectID.String())
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	require.NoError(t, temporalEnv.Client().GetWorkflow(waitCtx, workflowID, "").Get(waitCtx, nil), "initial publish workflow did not complete")
+
+	conn, err := pluginsQueries.GetGitHubConnection(ctx, *authCtx.ProjectID)
+	require.NoError(t, err, "expected a GitHub connection to have been published for this legacy project")
+	require.NotEmpty(t, conn.RepoName)
 }

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -28,11 +28,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -147,11 +150,85 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 		return nil, oops.E(oops.CodeUnexpected, err, "log mcp endpoint creation").LogError(ctx, logger)
 	}
 
+	if err := s.attachToDefaultPlugin(ctx, dbtx, authCtx, mcpServerID); err != nil {
+		return nil, err
+	}
+
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
 	return mv.BuildMcpEndpointView(created), nil
+}
+
+// attachToDefaultPlugin adds an mcp_server to the project's Default plugin
+// the first time it gets a usable endpoint (this is what AddPluginServer's
+// own publishability check requires), so it's included in the
+// auto-published marketplace without a human visiting the Plugins page.
+// No-op if the project has no Default plugin, the server is disabled, or
+// it's already attached (e.g. a second endpoint on the same server).
+func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, mcpServerID uuid.UUID) error {
+	server, err := mcpserversrepo.New(dbtx).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{
+		ID:        mcpServerID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger)
+	}
+	if server.Visibility == mcpservers.VisibilityDisabled {
+		return nil
+	}
+
+	displayName := mcpServerDisplayName(server)
+
+	attached, err := plugins.AttachToDefaultPlugin(ctx, pluginsrepo.New(dbtx), plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		McpServerID:    uuid.NullUUID{UUID: mcpServerID, Valid: true},
+		DisplayName:    displayName,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
+	}
+	if attached == nil {
+		return nil
+	}
+
+	mcpServerURN := urn.NewMcpServer(mcpServerID)
+	if err := s.audit.LogPluginServerAdd(ctx, dbtx, audit.LogPluginServerAddEvent{
+		OrganizationID:    authCtx.ActiveOrganizationID,
+		ProjectID:         *authCtx.ProjectID,
+		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName:  authCtx.Email,
+		ActorSlug:         nil,
+		PluginID:          attached.PluginID,
+		PluginName:        attached.PluginName,
+		PluginSlug:        attached.PluginSlug,
+		ServerID:          attached.Server.ID,
+		ServerDisplayName: attached.Server.DisplayName,
+		ServerPolicy:      attached.Server.Policy,
+		ServerSortOrder:   attached.Server.SortOrder,
+		ToolsetURN:        nil,
+		McpServerURN:      &mcpServerURN,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "audit log default plugin server add").LogError(ctx, s.logger)
+	}
+
+	return nil
+}
+
+// mcpServerDisplayName derives a default plugin-server display name from an
+// mcp_server, preferring its name, then slug, then id. Mirrors
+// plugins.mcpServerDisplayName, which operates on a different generated row
+// type from a joined query and so can't be reused directly here.
+func mcpServerDisplayName(server mcpserversrepo.McpServer) string {
+	if name := conv.FromPGText[string](server.Name); name != nil && *name != "" {
+		return *name
+	}
+	if slug := conv.FromPGText[string](server.Slug); slug != nil && *slug != "" {
+		return *slug
+	}
+	return server.ID.String()
 }
 
 func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpointPayload) (*types.McpEndpoint, error) {

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
@@ -36,16 +37,19 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type Service struct {
-	tracer trace.Tracer
-	logger *slog.Logger
-	db     *pgxpool.Pool
-	auth   *auth.Auth
-	authz  *authz.Engine
-	audit  *audit.Logger
+	tracer               trace.Tracer
+	logger               *slog.Logger
+	db                   *pgxpool.Pool
+	auth                 *auth.Auth
+	authz                *authz.Engine
+	audit                *audit.Logger
+	temporalEnv          *tenv.Environment
+	pluginsGitHubEnabled bool
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -58,16 +62,20 @@ func NewService(
 	sessions *sessions.Manager,
 	authzEngine *authz.Engine,
 	auditLogger *audit.Logger,
+	temporalEnv *tenv.Environment,
+	pluginsGitHubEnabled bool,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("mcpendpoints"))
 
 	return &Service{
-		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcpendpoints"),
-		logger: logger,
-		db:     db,
-		auth:   auth.New(logger, db, sessions, authzEngine),
-		authz:  authzEngine,
-		audit:  auditLogger,
+		tracer:               tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcpendpoints"),
+		logger:               logger,
+		db:                   db,
+		auth:                 auth.New(logger, db, sessions, authzEngine),
+		authz:                authzEngine,
+		audit:                auditLogger,
+		temporalEnv:          temporalEnv,
+		pluginsGitHubEnabled: pluginsGitHubEnabled,
 	}
 }
 
@@ -184,6 +192,7 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 	attached, err := plugins.AttachToDefaultPlugin(ctx, pluginsrepo.New(dbtx), plugins.AttachToDefaultPluginParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		McpServerID:    uuid.NullUUID{UUID: mcpServerID, Valid: true},
 		DisplayName:    displayName,
 	})
@@ -206,6 +215,23 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 			PluginSlug:       attached.PluginSlug,
 		}); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
+		}
+
+		// This project predates the Default-plugin feature (no CreateProject
+		// call ever fired the initial publish for it) — kick one off now so it
+		// isn't left attached-but-never-published. Best-effort, same as
+		// CreateProject's trigger: a non-cancelable ctx since this runs right
+		// before commit and shouldn't be dropped by the request returning.
+		if s.pluginsGitHubEnabled {
+			enqueueCtx := context.WithoutCancel(ctx)
+			if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+				ProjectID:       *authCtx.ProjectID,
+				CreatedByUserID: authCtx.UserID,
+				CommitMessage:   "Initial marketplace publish",
+				SkipIfUnchanged: false,
+			}); err != nil {
+				s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+			}
 		}
 	}
 

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -158,13 +158,16 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 		return nil, oops.E(oops.CodeUnexpected, err, "log mcp endpoint creation").LogError(ctx, logger)
 	}
 
-	if err := s.attachToDefaultPlugin(ctx, dbtx, authCtx, mcpServerID); err != nil {
+	pluginCreated, err := s.attachToDefaultPlugin(ctx, dbtx, authCtx, mcpServerID)
+	if err != nil {
 		return nil, err
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
+
+	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
 
 	return mv.BuildMcpEndpointView(created), nil
 }
@@ -173,18 +176,22 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 // the first time it gets a usable endpoint (this is what AddPluginServer's
 // own publishability check requires), so it's included in the
 // auto-published marketplace without a human visiting the Plugins page.
-// No-op if the project has no Default plugin, the server is disabled, or
-// it's already attached (e.g. a second endpoint on the same server).
-func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, mcpServerID uuid.UUID) error {
+// No-op if the server is disabled or it's already attached (e.g. a second
+// endpoint on the same server). Returns pluginCreated=true if this call
+// lazily created the Default plugin (project predates this feature) —
+// callers should enqueue an initial publish for it, but only after their
+// own transaction commits, since this runs pre-commit and the DB writes
+// could still roll back.
+func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, mcpServerID uuid.UUID) (bool, error) {
 	server, err := mcpserversrepo.New(dbtx).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{
 		ID:        mcpServerID,
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger)
 	}
 	if server.Visibility == mcpservers.VisibilityDisabled {
-		return nil
+		return false, nil
 	}
 
 	displayName := mcpServerDisplayName(server)
@@ -197,10 +204,10 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		DisplayName:    displayName,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
 	}
 	if attached == nil {
-		return nil
+		return false, nil
 	}
 
 	if attached.PluginCreated {
@@ -214,24 +221,7 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 			PluginName:       attached.PluginName,
 			PluginSlug:       attached.PluginSlug,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
-		}
-
-		// This project predates the Default-plugin feature (no CreateProject
-		// call ever fired the initial publish for it) — kick one off now so it
-		// isn't left attached-but-never-published. Best-effort, same as
-		// CreateProject's trigger: a non-cancelable ctx since this runs right
-		// before commit and shouldn't be dropped by the request returning.
-		if s.pluginsGitHubEnabled {
-			enqueueCtx := context.WithoutCancel(ctx)
-			if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
-				ProjectID:       *authCtx.ProjectID,
-				CreatedByUserID: authCtx.UserID,
-				CommitMessage:   "Initial marketplace publish",
-				SkipIfUnchanged: false,
-			}); err != nil {
-				s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
-			}
+			return false, oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
 		}
 	}
 
@@ -252,10 +242,32 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		ToolsetURN:        nil,
 		McpServerURN:      &mcpServerURN,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "audit log default plugin server add").LogError(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "audit log default plugin server add").LogError(ctx, s.logger)
 	}
 
-	return nil
+	return attached.PluginCreated, nil
+}
+
+// triggerInitialPublishIfNeeded enqueues the first-time GitHub marketplace
+// publish for a project whose Default plugin was just lazily created. Must
+// only be called after the triggering transaction has committed — enqueuing
+// before commit risks Temporal running against state that a later failure
+// in the same transaction rolls back. Best-effort: a non-cancelable ctx
+// since the request returning shouldn't drop the enqueue.
+func (s *Service) triggerInitialPublishIfNeeded(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
+	if !pluginCreated || !s.pluginsGitHubEnabled {
+		return
+	}
+
+	enqueueCtx := context.WithoutCancel(ctx)
+	if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+		ProjectID:       *authCtx.ProjectID,
+		CreatedByUserID: authCtx.UserID,
+		CommitMessage:   "Initial marketplace publish",
+		SkipIfUnchanged: false,
+	}); err != nil {
+		s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+	}
 }
 
 // mcpServerDisplayName derives a default plugin-server display name from an

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -194,6 +194,21 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		return nil
 	}
 
+	if attached.PluginCreated {
+		if err := s.audit.LogPluginCreate(ctx, dbtx, audit.LogPluginCreateEvent{
+			OrganizationID:   authCtx.ActiveOrganizationID,
+			ProjectID:        *authCtx.ProjectID,
+			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName: authCtx.Email,
+			ActorSlug:        nil,
+			PluginID:         attached.PluginID,
+			PluginName:       attached.PluginName,
+			PluginSlug:       attached.PluginSlug,
+		}); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
+		}
+	}
+
 	mcpServerURN := urn.NewMcpServer(mcpServerID)
 	if err := s.audit.LogPluginServerAdd(ctx, dbtx, audit.LogPluginServerAddEvent{
 		OrganizationID:    authCtx.ActiveOrganizationID,

--- a/server/internal/mcpendpoints/setup_test.go
+++ b/server/internal/mcpendpoints/setup_test.go
@@ -11,20 +11,28 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/externalmcptest"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/functionstest"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/remotemcptest"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -33,7 +41,7 @@ import (
 var infra *testenv.Environment
 
 func TestMain(m *testing.M) {
-	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: true})
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: true, Temporal: true})
 	if err != nil {
 		log.Fatalf("launch test infrastructure: %v", err)
 		os.Exit(1)
@@ -80,13 +88,93 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 
 	auditLogger := audit.NewLogger()
 
-	svc := mcpendpoints.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger)
+	svc := mcpendpoints.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil, false)
 
 	return ctx, &testInstance{
 		service:        svc,
 		conn:           conn,
 		sessionManager: sessionManager,
 	}
+}
+
+// fakeGitHubPublisher is a no-op plugins.GitHubPublisher: it never touches
+// the network, so the initial-publish workflow's activity completes
+// successfully and leaves behind a real plugin_github_connections row.
+type fakeGitHubPublisher struct{}
+
+func (fakeGitHubPublisher) CreateRepo(ctx context.Context, installationID int64, org, name string, private bool) error {
+	return nil
+}
+
+func (fakeGitHubPublisher) PushFiles(ctx context.Context, installationID int64, owner, repo, branch, commitMsg string, files map[string][]byte) (string, error) {
+	return "fake-sha", nil
+}
+
+func (fakeGitHubPublisher) AddCollaborator(ctx context.Context, installationID int64, owner, repo, username, permission string) error {
+	return nil
+}
+
+// newTestServiceWithGitHubPublishing is newTestService with GitHub publishing
+// turned on end-to-end: a Temporal worker is started, configured with a
+// plugins.Service backed by a fake (no-op) GitHub client, so an mcp_server's
+// auto-attach-triggered initial publish actually runs its workflow to
+// completion instead of just being enqueued.
+func newTestServiceWithGitHubPublishing(t *testing.T) (context.Context, *testInstance, *temporal.Environment) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	meterProvider := testenv.NewMeterProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	assetStorage := assetstest.NewTestBlobStore(t)
+	enc := testenv.NewEncryptionClient(t)
+	funcs := functionstest.NewOrchestrator(t, assetStorage)
+	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
+	temporalEnv, _ := infra.NewTemporalEnv(t)
+	auditLogger := audit.NewLogger()
+	f := &feature.InMemory{}
+
+	ghConfig := &plugins.GitHubConfig{
+		Client:         fakeGitHubPublisher{},
+		Org:            "test-org",
+		InstallationID: 12345,
+	}
+	pluginPublisher := plugins.NewPublisher(logger, conn, auditLogger, ghConfig, "local", "https://app.getgram.ai")
+
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider,
+		background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient, auditLogger),
+		&background.WorkerOptions{PluginPublisher: pluginPublisher},
+	)
+	t.Cleanup(func() {
+		worker.Stop()
+	})
+	require.NoError(t, worker.Start(), "start temporal worker")
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	billingClient := billing.NewStubClient(logger, tracerProvider)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+
+	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	svc := mcpendpoints.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, temporalEnv, true)
+
+	return ctx, &testInstance{
+		service:        svc,
+		conn:           conn,
+		sessionManager: sessionManager,
+	}, temporalEnv
 }
 
 func withExactAuthzGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...authz.Grant) context.Context {

--- a/server/internal/plugins/default_plugin.go
+++ b/server/internal/plugins/default_plugin.go
@@ -1,0 +1,77 @@
+package plugins
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/speakeasy-api/gram/server/internal/plugins/repo"
+)
+
+// AttachToDefaultPluginParams identifies the server to attach — exactly one
+// of ToolsetID / McpServerID must be Valid, mirroring the plugin_servers
+// backend-exclusivity constraint.
+type AttachToDefaultPluginParams struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	ToolsetID      uuid.NullUUID
+	McpServerID    uuid.NullUUID
+	DisplayName    string
+}
+
+// AttachToDefaultPluginResult is nil when AttachToDefaultPlugin no-ops
+// (no Default plugin for the project, or the server is already attached).
+type AttachToDefaultPluginResult struct {
+	PluginID   uuid.UUID
+	PluginName string
+	PluginSlug string
+	Server     repo.PluginServer
+}
+
+// AttachToDefaultPlugin idempotently adds a server (toolset- or mcp_server-
+// backed) to a project's Default plugin, so it shows up in the
+// auto-published marketplace without a human visiting the Plugins page.
+// Callers (toolsets, on MCP-enable; mcpendpoints, on first endpoint) run this
+// in the same transaction as the triggering write. A project with no Default
+// plugin (predates this feature) or a server that's already attached are
+// both expected no-ops, not errors — reported by a nil result.
+func AttachToDefaultPlugin(ctx context.Context, q *repo.Queries, params AttachToDefaultPluginParams) (*AttachToDefaultPluginResult, error) {
+	defaultPlugin, err := q.GetDefaultPlugin(ctx, repo.GetDefaultPluginParams{
+		OrganizationID: params.OrganizationID,
+		ProjectID:      params.ProjectID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("get default plugin: %w", err)
+	}
+
+	server, err := q.AddPluginServer(ctx, repo.AddPluginServerParams{
+		PluginID:    defaultPlugin.ID,
+		ToolsetID:   params.ToolsetID,
+		McpServerID: params.McpServerID,
+		DisplayName: params.DisplayName,
+		Policy:      "required",
+		SortOrder:   0,
+	})
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("attach server to default plugin: %w", err)
+	}
+
+	return &AttachToDefaultPluginResult{
+		PluginID:   defaultPlugin.ID,
+		PluginName: defaultPlugin.Name,
+		PluginSlug: defaultPlugin.Slug,
+		Server:     server,
+	}, nil
+}

--- a/server/internal/plugins/default_plugin.go
+++ b/server/internal/plugins/default_plugin.go
@@ -13,6 +13,55 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/plugins/repo"
 )
 
+// EnsureDefaultPluginResult reports whether the Default plugin already
+// existed or was just created, so callers can decide whether to audit-log a
+// plugin creation event.
+type EnsureDefaultPluginResult struct {
+	Plugin  repo.Plugin
+	Created bool
+}
+
+// EnsureDefaultPlugin returns a project's Default plugin, creating it if
+// missing — covers projects that predate this feature (created before
+// CreateProject started provisioning one). Concurrent callers racing to
+// create it are resolved by re-fetching on the is_default unique-index
+// violation; any other unique violation (e.g. a pre-existing plugin already
+// named/slugged "Default"/"default") is a real conflict and surfaces as an
+// error rather than masking it.
+func EnsureDefaultPlugin(ctx context.Context, q *repo.Queries, organizationID string, projectID uuid.UUID) (*EnsureDefaultPluginResult, error) {
+	plugin, err := q.GetDefaultPlugin(ctx, repo.GetDefaultPluginParams{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+	})
+	switch {
+	case err == nil:
+		return &EnsureDefaultPluginResult{Plugin: plugin, Created: false}, nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return nil, fmt.Errorf("get default plugin: %w", err)
+	}
+
+	created, err := q.CreateDefaultPlugin(ctx, repo.CreateDefaultPluginParams{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+	})
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == "plugins_project_id_is_default_key" {
+			plugin, err := q.GetDefaultPlugin(ctx, repo.GetDefaultPluginParams{
+				OrganizationID: organizationID,
+				ProjectID:      projectID,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("get default plugin after race: %w", err)
+			}
+			return &EnsureDefaultPluginResult{Plugin: plugin, Created: false}, nil
+		}
+		return nil, fmt.Errorf("create default plugin: %w", err)
+	}
+
+	return &EnsureDefaultPluginResult{Plugin: created, Created: true}, nil
+}
+
 // AttachToDefaultPluginParams identifies the server to attach — exactly one
 // of ToolsetID / McpServerID must be Valid, mirroring the plugin_servers
 // backend-exclusivity constraint.
@@ -25,35 +74,30 @@ type AttachToDefaultPluginParams struct {
 }
 
 // AttachToDefaultPluginResult is nil when AttachToDefaultPlugin no-ops
-// (no Default plugin for the project, or the server is already attached).
+// (the server is already attached).
 type AttachToDefaultPluginResult struct {
-	PluginID   uuid.UUID
-	PluginName string
-	PluginSlug string
-	Server     repo.PluginServer
+	PluginID      uuid.UUID
+	PluginName    string
+	PluginSlug    string
+	PluginCreated bool
+	Server        repo.PluginServer
 }
 
 // AttachToDefaultPlugin idempotently adds a server (toolset- or mcp_server-
-// backed) to a project's Default plugin, so it shows up in the
-// auto-published marketplace without a human visiting the Plugins page.
-// Callers (toolsets, on MCP-enable; mcpendpoints, on first endpoint) run this
-// in the same transaction as the triggering write. A project with no Default
-// plugin (predates this feature) or a server that's already attached are
-// both expected no-ops, not errors — reported by a nil result.
+// backed) to a project's Default plugin — creating the plugin first if the
+// project predates this feature — so it shows up in the auto-published
+// marketplace without a human visiting the Plugins page. Callers (toolsets,
+// on MCP-enable; mcpendpoints, on first endpoint) run this in the same
+// transaction as the triggering write. A server that's already attached is
+// an expected no-op, not an error — reported by a nil result.
 func AttachToDefaultPlugin(ctx context.Context, q *repo.Queries, params AttachToDefaultPluginParams) (*AttachToDefaultPluginResult, error) {
-	defaultPlugin, err := q.GetDefaultPlugin(ctx, repo.GetDefaultPluginParams{
-		OrganizationID: params.OrganizationID,
-		ProjectID:      params.ProjectID,
-	})
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		return nil, nil
-	case err != nil:
-		return nil, fmt.Errorf("get default plugin: %w", err)
+	ensured, err := EnsureDefaultPlugin(ctx, q, params.OrganizationID, params.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("ensure default plugin: %w", err)
 	}
 
 	server, err := q.AddPluginServer(ctx, repo.AddPluginServerParams{
-		PluginID:    defaultPlugin.ID,
+		PluginID:    ensured.Plugin.ID,
 		ToolsetID:   params.ToolsetID,
 		McpServerID: params.McpServerID,
 		DisplayName: params.DisplayName,
@@ -69,9 +113,10 @@ func AttachToDefaultPlugin(ctx context.Context, q *repo.Queries, params AttachTo
 	}
 
 	return &AttachToDefaultPluginResult{
-		PluginID:   defaultPlugin.ID,
-		PluginName: defaultPlugin.Name,
-		PluginSlug: defaultPlugin.Slug,
-		Server:     server,
+		PluginID:      ensured.Plugin.ID,
+		PluginName:    ensured.Plugin.Name,
+		PluginSlug:    ensured.Plugin.Slug,
+		PluginCreated: ensured.Created,
+		Server:        server,
 	}, nil
 }

--- a/server/internal/plugins/default_plugin.go
+++ b/server/internal/plugins/default_plugin.go
@@ -107,7 +107,16 @@ func AttachToDefaultPlugin(ctx context.Context, q *repo.Queries, params AttachTo
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return nil, nil
+			switch pgErr.ConstraintName {
+			case "plugin_servers_plugin_id_toolset_id_key", "plugin_servers_plugin_id_mcp_server_id_key":
+				// Already attached — expected no-op, not an error.
+				return nil, nil
+			default:
+				// display_name collision with a different, already-attached
+				// server (or a manually-added one) is a real conflict, not
+				// "already attached" — surface it instead of silently
+				// dropping the server from the Default plugin.
+			}
 		}
 		return nil, fmt.Errorf("attach server to default plugin: %w", err)
 	}

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -113,3 +113,48 @@ func TestAttachToDefaultPlugin_DisplayNameCollision_ReturnsError(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, servers, 1, "the colliding server must not have been attached")
 }
+
+func TestListPluginPublishCandidates_IncludesNeverPublishedDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	// This project has a Default plugin but has never published — no
+	// plugin_github_connections row and no plugins-mcp API key. It must
+	// still show up as a candidate (the periodic safety net for a lost
+	// initial-publish enqueue), with a 'system' actor fallback.
+	_, err := queries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	candidates, err := queries.ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{
+		AfterProjectID: uuid.Nil,
+		ResultLimit:    100,
+	})
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, *authCtx.ProjectID, candidates[0].ProjectID)
+	require.Equal(t, "system", candidates[0].CreatedByUserID)
+}
+
+func TestListPluginPublishCandidates_ExcludesProjectWithoutDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	candidates, err := queries.ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{
+		AfterProjectID: uuid.Nil,
+		ResultLimit:    100,
+	})
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+}

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -1,0 +1,76 @@
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+)
+
+func TestEnsureDefaultPlugin_CreatesWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	result, err := plugins.EnsureDefaultPlugin(ctx, queries, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
+	require.NoError(t, err)
+	require.True(t, result.Created)
+	require.Equal(t, "Default", result.Plugin.Name)
+	require.Equal(t, "default", result.Plugin.Slug)
+	require.Equal(t, pgtype.Bool{Bool: true, Valid: true}, result.Plugin.IsDefault)
+}
+
+func TestEnsureDefaultPlugin_ReturnsExistingWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	first, err := plugins.EnsureDefaultPlugin(ctx, queries, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
+	require.NoError(t, err)
+	require.True(t, first.Created)
+
+	second, err := plugins.EnsureDefaultPlugin(ctx, queries, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
+	require.NoError(t, err)
+	require.False(t, second.Created)
+	require.Equal(t, first.Plugin.ID, second.Plugin.ID)
+}
+
+func TestEnsureDefaultPlugin_ConflictWithExistingNonDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	// A plugin already occupies the "Default"/"default" name+slug, but isn't
+	// marked is_default — a real conflict, not a race with another Ensure
+	// call, so it must surface as an error rather than being masked.
+	_, err := queries.CreatePlugin(ctx, pluginsrepo.CreatePluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		Name:           "Default",
+		Slug:           "default",
+		Description:    pgtype.Text{},
+	})
+	require.NoError(t, err)
+
+	_, err = plugins.EnsureDefaultPlugin(ctx, queries, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
+	require.Error(t, err)
+}

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -3,10 +3,12 @@ package plugins_test
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 )
@@ -73,4 +75,41 @@ func TestEnsureDefaultPlugin_ConflictWithExistingNonDefaultPlugin(t *testing.T) 
 
 	_, err = plugins.EnsureDefaultPlugin(ctx, queries, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
 	require.Error(t, err)
+}
+
+func TestAttachToDefaultPlugin_DisplayNameCollision_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	first := createTestMcpServer(t, ctx, ti.conn, "Attach Test Server", mcpservers.VisibilityPublic)
+	result, err := plugins.AttachToDefaultPlugin(ctx, queries, plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		McpServerID:    uuid.NullUUID{UUID: first.id, Valid: true},
+		DisplayName:    "Attach Test Server",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// A different mcp_server that happens to derive the same display name
+	// must not be silently dropped — the display_name unique violation is a
+	// different failure mode than "already attached" and must surface.
+	second := createTestMcpServer(t, ctx, ti.conn, "Attach Test Server 2", mcpservers.VisibilityPublic)
+	_, err = plugins.AttachToDefaultPlugin(ctx, queries, plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		McpServerID:    uuid.NullUUID{UUID: second.id, Valid: true},
+		DisplayName:    "Attach Test Server",
+	})
+	require.Error(t, err)
+
+	servers, err := queries.ListPluginServers(ctx, result.PluginID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1, "the colliding server must not have been attached")
 }

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -158,3 +158,37 @@ func TestListPluginPublishCandidates_ExcludesProjectWithoutDefaultPlugin(t *test
 	require.NoError(t, err)
 	require.Empty(t, candidates)
 }
+
+func TestListPluginPublishCandidates_IncludesConnectedProjectWithoutDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	// This project already published before the Default-plugin feature
+	// shipped (a plugin_github_connections row exists) but has had no new
+	// attach activity since, so it never got a Default plugin. It must not
+	// silently drop out of the rollout just because is_default became part
+	// of the candidate signal.
+	_, err := queries.UpsertGitHubConnection(ctx, pluginsrepo.UpsertGitHubConnectionParams{
+		ProjectID:            *authCtx.ProjectID,
+		InstallationID:       12345,
+		RepoOwner:            "test-org",
+		RepoName:             "test-project-plugins",
+		MarketplaceToken:     pgtype.Text{String: "test-token", Valid: true},
+		PublishedFingerprint: pgtype.Text{String: "test-fingerprint", Valid: true},
+	})
+	require.NoError(t, err)
+
+	candidates, err := queries.ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{
+		AfterProjectID: uuid.Nil,
+		ResultLimit:    100,
+	})
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, *authCtx.ProjectID, candidates[0].ProjectID)
+}

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -243,27 +243,38 @@ FROM plugin_github_connections
 WHERE project_id = @project_id;
 
 -- name: ListPluginPublishCandidates :many
--- Lists projects with a GitHub plugin connection for the automated generator
--- rollout, paginated by project_id (pass the zero UUID to start). Each row
--- carries the user that created the project's most recent plugins-mcp API key,
--- used as the publish actor. This is a deliberate cross-project sweep, so unlike
--- the tenant-scoped queries it is not constrained to a single project_id.
+-- Lists every project with a Default plugin for the automated generator
+-- rollout, paginated by project_id (pass the zero UUID to start), whether or
+-- not it has published before. Republishing an unchanged project is cheap
+-- (SkipIfUnchanged short-circuits on the fingerprint before any GitHub/key
+-- work), so including never-published projects here doubles as the periodic
+-- safety net for the best-effort initial-publish trigger fired inline by
+-- CreateProject/toolsets/mcpendpoints: if that enqueue is ever lost (e.g. a
+-- crash between commit and enqueue), this sweep picks it up within one tick
+-- instead of leaving it stuck until a human notices. Each row carries the
+-- user that created the project's most recent plugins-mcp API key as the
+-- publish actor, falling back to 'system' for a project that has never
+-- published (no such key exists yet). This is a deliberate cross-project
+-- sweep, so unlike the tenant-scoped queries it is not constrained to a
+-- single project_id.
 SELECT
-  c.project_id,
-  k.created_by_user_id
-FROM plugin_github_connections c
-JOIN projects p ON p.id = c.project_id AND p.deleted IS FALSE
-JOIN LATERAL (
+  dp.project_id,
+  COALESCE(k.created_by_user_id, 'system') AS created_by_user_id
+FROM plugins dp
+JOIN projects p ON p.id = dp.project_id AND p.deleted IS FALSE
+LEFT JOIN LATERAL (
   SELECT created_by_user_id
   FROM api_keys
-  WHERE project_id = c.project_id
+  WHERE project_id = dp.project_id
     AND deleted IS FALSE
     AND name LIKE 'plugins-mcp-%'
   ORDER BY created_at DESC
   LIMIT 1
 ) k ON TRUE
-WHERE c.project_id > @after_project_id
-ORDER BY c.project_id ASC
+WHERE dp.is_default IS TRUE
+  AND dp.deleted IS FALSE
+  AND dp.project_id > @after_project_id
+ORDER BY dp.project_id ASC
 LIMIT @result_limit;
 
 -- name: GetGitHubConnectionByMarketplaceToken :one

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -6,6 +6,25 @@ INSERT INTO plugins (organization_id, project_id, name, slug, description)
 VALUES (@organization_id, @project_id, @name, @slug, sqlc.narg('description'))
 RETURNING *;
 
+-- name: CreateDefaultPlugin :one
+-- Creates the project's fallback plugin (new servers land here absent explicit
+-- routing to a named plugin). Called once, in the same transaction as project
+-- creation. plugins_project_id_is_default_key enforces at most one per project.
+INSERT INTO plugins (organization_id, project_id, name, slug, is_default)
+VALUES (@organization_id, @project_id, 'Default', 'default', TRUE)
+RETURNING *;
+
+-- name: GetDefaultPlugin :one
+-- Used by AttachToDefaultPlugin to find the fallback plugin new servers get
+-- auto-attached to. No rows is expected for projects that predate the
+-- Default-plugin feature; callers treat pgx.ErrNoRows as a no-op.
+SELECT *
+FROM plugins
+WHERE organization_id = @organization_id
+  AND project_id = @project_id
+  AND is_default IS TRUE
+  AND deleted IS FALSE;
+
 -- name: GetPlugin :one
 SELECT *
 FROM plugins

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -243,38 +243,46 @@ FROM plugin_github_connections
 WHERE project_id = @project_id;
 
 -- name: ListPluginPublishCandidates :many
--- Lists every project with a Default plugin for the automated generator
--- rollout, paginated by project_id (pass the zero UUID to start), whether or
--- not it has published before. Republishing an unchanged project is cheap
--- (SkipIfUnchanged short-circuits on the fingerprint before any GitHub/key
--- work), so including never-published projects here doubles as the periodic
--- safety net for the best-effort initial-publish trigger fired inline by
+-- Lists candidates for the automated generator rollout, paginated by
+-- project_id (pass the zero UUID to start): the union of (a) projects that
+-- have published before (a plugin_github_connections row exists) -- the
+-- original rollout population, kept so an already-connected project isn't
+-- silently dropped just because it predates the Default-plugin feature and
+-- has had no new attach activity since -- and (b) projects with a Default
+-- plugin, published or not. (b) is the periodic safety net for the
+-- best-effort initial-publish trigger fired inline by
 -- CreateProject/toolsets/mcpendpoints: if that enqueue is ever lost (e.g. a
 -- crash between commit and enqueue), this sweep picks it up within one tick
--- instead of leaving it stuck until a human notices. Each row carries the
--- user that created the project's most recent plugins-mcp API key as the
+-- instead of leaving it stuck until a human notices. Republishing an
+-- unchanged project is cheap -- SkipIfUnchanged short-circuits on the
+-- fingerprint check before any GitHub/key work. Each row carries the user
+-- that created the project's most recent plugins-mcp API key as the
 -- publish actor, falling back to 'system' for a project that has never
 -- published (no such key exists yet). This is a deliberate cross-project
 -- sweep, so unlike the tenant-scoped queries it is not constrained to a
--- single project_id.
+-- single project_id. The after_project_id filter is applied inside each
+-- UNION branch rather than the outer query -- sqlc's analyzer can't resolve
+-- an outer WHERE referencing the derived table's alias once a LATERAL join
+-- follows it ("table alias does not exist").
 SELECT
-  dp.project_id,
+  cp.project_id,
   COALESCE(k.created_by_user_id, 'system') AS created_by_user_id
-FROM plugins dp
-JOIN projects p ON p.id = dp.project_id AND p.deleted IS FALSE
+FROM (
+  SELECT c.project_id FROM plugin_github_connections c WHERE c.project_id > @after_project_id
+  UNION
+  SELECT dp.project_id FROM plugins dp WHERE dp.is_default IS TRUE AND dp.deleted IS FALSE AND dp.project_id > @after_project_id
+) cp
+JOIN projects p ON p.id = cp.project_id AND p.deleted IS FALSE
 LEFT JOIN LATERAL (
   SELECT created_by_user_id
   FROM api_keys
-  WHERE project_id = dp.project_id
+  WHERE project_id = cp.project_id
     AND deleted IS FALSE
     AND name LIKE 'plugins-mcp-%'
   ORDER BY created_at DESC
   LIMIT 1
 ) k ON TRUE
-WHERE dp.is_default IS TRUE
-  AND dp.deleted IS FALSE
-  AND dp.project_id > @after_project_id
-ORDER BY dp.project_id ASC
+ORDER BY cp.project_id ASC
 LIMIT @result_limit;
 
 -- name: GetGitHubConnectionByMarketplaceToken :one

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -472,23 +472,24 @@ func (q *Queries) ListPluginAssignments(ctx context.Context, pluginID uuid.UUID)
 
 const listPluginPublishCandidates = `-- name: ListPluginPublishCandidates :many
 SELECT
-  dp.project_id,
+  cp.project_id,
   COALESCE(k.created_by_user_id, 'system') AS created_by_user_id
-FROM plugins dp
-JOIN projects p ON p.id = dp.project_id AND p.deleted IS FALSE
+FROM (
+  SELECT c.project_id FROM plugin_github_connections c WHERE c.project_id > $1
+  UNION
+  SELECT dp.project_id FROM plugins dp WHERE dp.is_default IS TRUE AND dp.deleted IS FALSE AND dp.project_id > $1
+) cp
+JOIN projects p ON p.id = cp.project_id AND p.deleted IS FALSE
 LEFT JOIN LATERAL (
   SELECT created_by_user_id
   FROM api_keys
-  WHERE project_id = dp.project_id
+  WHERE project_id = cp.project_id
     AND deleted IS FALSE
     AND name LIKE 'plugins-mcp-%'
   ORDER BY created_at DESC
   LIMIT 1
 ) k ON TRUE
-WHERE dp.is_default IS TRUE
-  AND dp.deleted IS FALSE
-  AND dp.project_id > $1
-ORDER BY dp.project_id ASC
+ORDER BY cp.project_id ASC
 LIMIT $2
 `
 
@@ -502,20 +503,27 @@ type ListPluginPublishCandidatesRow struct {
 	CreatedByUserID string
 }
 
-// Lists every project with a Default plugin for the automated generator
-// rollout, paginated by project_id (pass the zero UUID to start), whether or
-// not it has published before. Republishing an unchanged project is cheap
-// (SkipIfUnchanged short-circuits on the fingerprint before any GitHub/key
-// work), so including never-published projects here doubles as the periodic
-// safety net for the best-effort initial-publish trigger fired inline by
+// Lists candidates for the automated generator rollout, paginated by
+// project_id (pass the zero UUID to start): the union of (a) projects that
+// have published before (a plugin_github_connections row exists) -- the
+// original rollout population, kept so an already-connected project isn't
+// silently dropped just because it predates the Default-plugin feature and
+// has had no new attach activity since -- and (b) projects with a Default
+// plugin, published or not. (b) is the periodic safety net for the
+// best-effort initial-publish trigger fired inline by
 // CreateProject/toolsets/mcpendpoints: if that enqueue is ever lost (e.g. a
 // crash between commit and enqueue), this sweep picks it up within one tick
-// instead of leaving it stuck until a human notices. Each row carries the
-// user that created the project's most recent plugins-mcp API key as the
+// instead of leaving it stuck until a human notices. Republishing an
+// unchanged project is cheap -- SkipIfUnchanged short-circuits on the
+// fingerprint check before any GitHub/key work. Each row carries the user
+// that created the project's most recent plugins-mcp API key as the
 // publish actor, falling back to 'system' for a project that has never
 // published (no such key exists yet). This is a deliberate cross-project
 // sweep, so unlike the tenant-scoped queries it is not constrained to a
-// single project_id.
+// single project_id. The after_project_id filter is applied inside each
+// UNION branch rather than the outer query -- sqlc's analyzer can't resolve
+// an outer WHERE referencing the derived table's alias once a LATERAL join
+// follows it ("table alias does not exist").
 func (q *Queries) ListPluginPublishCandidates(ctx context.Context, arg ListPluginPublishCandidatesParams) ([]ListPluginPublishCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, listPluginPublishCandidates, arg.AfterProjectID, arg.ResultLimit)
 	if err != nil {

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -472,21 +472,23 @@ func (q *Queries) ListPluginAssignments(ctx context.Context, pluginID uuid.UUID)
 
 const listPluginPublishCandidates = `-- name: ListPluginPublishCandidates :many
 SELECT
-  c.project_id,
-  k.created_by_user_id
-FROM plugin_github_connections c
-JOIN projects p ON p.id = c.project_id AND p.deleted IS FALSE
-JOIN LATERAL (
+  dp.project_id,
+  COALESCE(k.created_by_user_id, 'system') AS created_by_user_id
+FROM plugins dp
+JOIN projects p ON p.id = dp.project_id AND p.deleted IS FALSE
+LEFT JOIN LATERAL (
   SELECT created_by_user_id
   FROM api_keys
-  WHERE project_id = c.project_id
+  WHERE project_id = dp.project_id
     AND deleted IS FALSE
     AND name LIKE 'plugins-mcp-%'
   ORDER BY created_at DESC
   LIMIT 1
 ) k ON TRUE
-WHERE c.project_id > $1
-ORDER BY c.project_id ASC
+WHERE dp.is_default IS TRUE
+  AND dp.deleted IS FALSE
+  AND dp.project_id > $1
+ORDER BY dp.project_id ASC
 LIMIT $2
 `
 
@@ -500,11 +502,20 @@ type ListPluginPublishCandidatesRow struct {
 	CreatedByUserID string
 }
 
-// Lists projects with a GitHub plugin connection for the automated generator
-// rollout, paginated by project_id (pass the zero UUID to start). Each row
-// carries the user that created the project's most recent plugins-mcp API key,
-// used as the publish actor. This is a deliberate cross-project sweep, so unlike
-// the tenant-scoped queries it is not constrained to a single project_id.
+// Lists every project with a Default plugin for the automated generator
+// rollout, paginated by project_id (pass the zero UUID to start), whether or
+// not it has published before. Republishing an unchanged project is cheap
+// (SkipIfUnchanged short-circuits on the fingerprint before any GitHub/key
+// work), so including never-published projects here doubles as the periodic
+// safety net for the best-effort initial-publish trigger fired inline by
+// CreateProject/toolsets/mcpendpoints: if that enqueue is ever lost (e.g. a
+// crash between commit and enqueue), this sweep picks it up within one tick
+// instead of leaving it stuck until a human notices. Each row carries the
+// user that created the project's most recent plugins-mcp API key as the
+// publish actor, falling back to 'system' for a project that has never
+// published (no such key exists yet). This is a deliberate cross-project
+// sweep, so unlike the tenant-scoped queries it is not constrained to a
+// single project_id.
 func (q *Queries) ListPluginPublishCandidates(ctx context.Context, arg ListPluginPublishCandidatesParams) ([]ListPluginPublishCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, listPluginPublishCandidates, arg.AfterProjectID, arg.ResultLimit)
 	if err != nil {

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -91,6 +91,39 @@ func (q *Queries) AddPluginServer(ctx context.Context, arg AddPluginServerParams
 	return i, err
 }
 
+const createDefaultPlugin = `-- name: CreateDefaultPlugin :one
+INSERT INTO plugins (organization_id, project_id, name, slug, is_default)
+VALUES ($1, $2, 'Default', 'default', TRUE)
+RETURNING id, organization_id, project_id, name, slug, description, is_default, created_at, updated_at, deleted_at, deleted
+`
+
+type CreateDefaultPluginParams struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+}
+
+// Creates the project's fallback plugin (new servers land here absent explicit
+// routing to a named plugin). Called once, in the same transaction as project
+// creation. plugins_project_id_is_default_key enforces at most one per project.
+func (q *Queries) CreateDefaultPlugin(ctx context.Context, arg CreateDefaultPluginParams) (Plugin, error) {
+	row := q.db.QueryRow(ctx, createDefaultPlugin, arg.OrganizationID, arg.ProjectID)
+	var i Plugin
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.IsDefault,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const createPlugin = `-- name: CreatePlugin :one
 
 INSERT INTO plugins (organization_id, project_id, name, slug, description)
@@ -152,6 +185,42 @@ type DeletePluginParams struct {
 func (q *Queries) DeletePlugin(ctx context.Context, arg DeletePluginParams) error {
 	_, err := q.db.Exec(ctx, deletePlugin, arg.ID, arg.OrganizationID, arg.ProjectID)
 	return err
+}
+
+const getDefaultPlugin = `-- name: GetDefaultPlugin :one
+SELECT id, organization_id, project_id, name, slug, description, is_default, created_at, updated_at, deleted_at, deleted
+FROM plugins
+WHERE organization_id = $1
+  AND project_id = $2
+  AND is_default IS TRUE
+  AND deleted IS FALSE
+`
+
+type GetDefaultPluginParams struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+}
+
+// Used by AttachToDefaultPlugin to find the fallback plugin new servers get
+// auto-attached to. No rows is expected for projects that predate the
+// Default-plugin feature; callers treat pgx.ErrNoRows as a no-op.
+func (q *Queries) GetDefaultPlugin(ctx context.Context, arg GetDefaultPluginParams) (Plugin, error) {
+	row := q.db.QueryRow(ctx, getDefaultPlugin, arg.OrganizationID, arg.ProjectID)
+	var i Plugin
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.IsDefault,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
 }
 
 const getGitHubConnection = `-- name: GetGitHubConnection :one

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -241,9 +241,12 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 	// Best-effort: the marketplace repo isn't required for the project to
 	// exist. No GitHub collaborators are added here — we don't have a
 	// customer GitHub username yet; that's supplied later via the dashboard
-	// publish/marketplace-settings flow.
+	// publish/marketplace-settings flow. Uses a non-cancelable derived ctx so
+	// the request returning (or its caller disconnecting) right after commit
+	// can't drop the enqueue.
 	if s.pluginsGitHubEnabled {
-		if _, err := background.ExecutePluginInitialPublishWorkflow(ctx, s.temporalEnv, plugins.PublishProjectInput{
+		enqueueCtx := context.WithoutCancel(ctx)
+		if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
 			ProjectID:       prj.ID,
 			CreatedByUserID: authCtx.UserID,
 			CommitMessage:   "Initial marketplace publish",

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -25,26 +25,33 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	envrepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	"github.com/speakeasy-api/gram/server/internal/projects/repo"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type Service struct {
-	tracer   trace.Tracer
-	logger   *slog.Logger
-	db       *pgxpool.Pool
-	repo     *repo.Queries
-	envRepo  *envrepo.Queries
-	sessions *sessions.Manager
-	auth     *auth.Auth
-	authz    *authz.Engine
-	audit    *audit.Logger
+	tracer               trace.Tracer
+	logger               *slog.Logger
+	db                   *pgxpool.Pool
+	repo                 *repo.Queries
+	envRepo              *envrepo.Queries
+	pluginsRepo          *pluginsrepo.Queries
+	sessions             *sessions.Manager
+	auth                 *auth.Auth
+	authz                *authz.Engine
+	audit                *audit.Logger
+	temporalEnv          *tenv.Environment
+	pluginsGitHubEnabled bool
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -56,19 +63,24 @@ func NewService(
 	sessions *sessions.Manager,
 	authzEngine *authz.Engine,
 	auditLogger *audit.Logger,
+	temporalEnv *tenv.Environment,
+	pluginsGitHubEnabled bool,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("projects"))
 
 	return &Service{
-		tracer:   tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/projects"),
-		logger:   logger,
-		db:       db,
-		repo:     repo.New(db),
-		envRepo:  envrepo.New(db),
-		sessions: sessions,
-		auth:     auth.New(logger, db, sessions, authzEngine),
-		authz:    authzEngine,
-		audit:    auditLogger,
+		tracer:               tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/projects"),
+		logger:               logger,
+		db:                   db,
+		repo:                 repo.New(db),
+		envRepo:              envrepo.New(db),
+		pluginsRepo:          pluginsrepo.New(db),
+		sessions:             sessions,
+		auth:                 auth.New(logger, db, sessions, authzEngine),
+		authz:                authzEngine,
+		audit:                auditLogger,
+		temporalEnv:          temporalEnv,
+		pluginsGitHubEnabled: pluginsGitHubEnabled,
 	}
 }
 
@@ -158,6 +170,7 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 
 	pr := s.repo.WithTx(dbtx)
 	er := s.envRepo.WithTx(dbtx)
+	plr := s.pluginsRepo.WithTx(dbtx)
 
 	prj, err := pr.CreateProject(ctx, repo.CreateProjectParams{
 		OrganizationID: payload.OrganizationID,
@@ -186,6 +199,27 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 		return nil, oops.E(oops.CodeUnexpected, err, "error creating default environment").LogError(ctx, s.logger)
 	}
 
+	defaultPlugin, err := plr.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: payload.OrganizationID,
+		ProjectID:      prj.ID,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating default plugin").LogError(ctx, s.logger)
+	}
+
+	if err := s.audit.LogPluginCreate(ctx, dbtx, audit.LogPluginCreateEvent{
+		OrganizationID:   payload.OrganizationID,
+		ProjectID:        prj.ID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		PluginID:         defaultPlugin.ID,
+		PluginName:       defaultPlugin.Name,
+		PluginSlug:       defaultPlugin.Slug,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error creating default plugin audit log").LogError(ctx, s.logger)
+	}
+
 	if err := s.audit.LogProjectCreate(ctx, dbtx, audit.LogProjectCreateEvent{
 		OrganizationID: payload.OrganizationID,
 		ProjectID:      prj.ID,
@@ -202,6 +236,21 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving project creation").LogError(ctx, s.logger)
+	}
+
+	// Best-effort: the marketplace repo isn't required for the project to
+	// exist. No GitHub collaborators are added here — we don't have a
+	// customer GitHub username yet; that's supplied later via the dashboard
+	// publish/marketplace-settings flow.
+	if s.pluginsGitHubEnabled {
+		if _, err := background.ExecutePluginInitialPublishWorkflow(ctx, s.temporalEnv, plugins.PublishProjectInput{
+			ProjectID:       prj.ID,
+			CreatedByUserID: authCtx.UserID,
+			CommitMessage:   "Initial marketplace publish",
+			SkipIfUnchanged: false,
+		}); err != nil {
+			s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+		}
 	}
 
 	project := &gen.CreateProjectResult{

--- a/server/internal/projects/setup_test.go
+++ b/server/internal/projects/setup_test.go
@@ -108,6 +108,8 @@ func newTestProjectsService(t *testing.T, enableRBAC bool) (context.Context, *te
 			workos.NewStubClient(),
 		),
 		auditLogger,
+		nil,
+		false,
 	)
 
 	return ctx, &testInstance{

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -120,7 +120,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine, auditLogger)
 	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine, auditLogger)
 	packagesSvc := packages.NewService(logger, tracerProvider, conn, sessionManager, authzEngine)
-	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
+	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, nil, false)
 	templatesSvc := templates.NewService(logger, tracerProvider, conn, sessionManager, toolsetsSvc, authzEngine, auditLogger)
 
 	return ctx, &testInstance{

--- a/server/internal/toolsets/createtoolset_test.go
+++ b/server/internal/toolsets/createtoolset_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	environmentsRepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
@@ -390,4 +391,91 @@ func TestToolsetsService_CreateToolset_DuplicateSlug_NoAuditLog(t *testing.T) {
 	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionToolsetCreate)
 	require.NoError(t, err)
 	require.Equal(t, middleCount, afterCount)
+}
+
+func TestToolsetsService_CreateToolset_AttachesToDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+
+	// First toolset in a fresh org auto-enables MCP.
+	result, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		Name:                   "Attach Toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           nil,
+		DefaultEnvironmentSlug: nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+	require.True(t, *result.McpEnabled)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.Equal(t, uuid.MustParse(result.ID), servers[0].ToolsetID.UUID)
+	require.Equal(t, "Attach Toolset", servers[0].DisplayName)
+	require.Equal(t, "required", servers[0].Policy)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount+1, afterCount)
+}
+
+func TestToolsetsService_CreateToolset_SecondToolset_DoesNotAutoAttach(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		Name:                   "First Toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           nil,
+		DefaultEnvironmentSlug: nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+
+	second, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		Name:                   "Second Toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           nil,
+		DefaultEnvironmentSlug: nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+	require.False(t, *second.McpEnabled)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1, "only the auto-enabled first toolset should be attached")
+	require.NotEqual(t, uuid.MustParse(second.ID), servers[0].ToolsetID.UUID)
 }

--- a/server/internal/toolsets/createtoolset_test.go
+++ b/server/internal/toolsets/createtoolset_test.go
@@ -1,7 +1,10 @@
 package toolsets_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -478,4 +481,47 @@ func TestToolsetsService_CreateToolset_SecondToolset_DoesNotAutoAttach(t *testin
 	require.NoError(t, err)
 	require.Len(t, servers, 1, "only the auto-enabled first toolset should be attached")
 	require.NotEqual(t, uuid.MustParse(second.ID), servers[0].ToolsetID.UUID)
+}
+
+// TestToolsetsService_CreateToolset_LegacyProject_TriggersInitialPublish
+// covers the "legacy project" gap: a project that predates the
+// Default-plugin feature (no CreateProject call ever ran for it, so no
+// Default plugin and no GitHub connection exist) must still get its
+// marketplace repo published the first time a server becomes attachable,
+// not just the plugin_servers row. Uses a real Temporal worker wired with a
+// fake (no-op) GitHub client so the initial-publish workflow runs to actual
+// completion instead of just being enqueued.
+func TestToolsetsService_CreateToolset_LegacyProject_TriggersInitialPublish(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsServiceWithGitHubPublishing(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	_, err := pluginsQueries.GetGitHubConnection(ctx, *authCtx.ProjectID)
+	require.Error(t, err, "legacy project fixture must start with no GitHub connection")
+
+	// First toolset in the org auto-enables MCP, which lazily creates the
+	// Default plugin and should kick off the initial publish.
+	_, err = ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		Name:                   "Legacy Gap Toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           nil,
+		DefaultEnvironmentSlug: nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+
+	workflowID := fmt.Sprintf("v1:plugin-initial-publish/%s", authCtx.ProjectID.String())
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	require.NoError(t, ti.temporalEnv.Client().GetWorkflow(waitCtx, workflowID, "").Get(waitCtx, nil), "initial publish workflow did not complete")
+
+	conn, err := pluginsQueries.GetGitHubConnection(ctx, *authCtx.ProjectID)
+	require.NoError(t, err, "expected a GitHub connection to have been published for this legacy project")
+	require.NotEmpty(t, conn.RepoName)
 }

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -44,6 +45,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	tplRepo "github.com/speakeasy-api/gram/server/internal/templates/repo"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usageRepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
@@ -58,20 +60,22 @@ var validOAuthProxyAuthMethods = map[string]bool{
 }
 
 type Service struct {
-	tracer          trace.Tracer
-	logger          *slog.Logger
-	db              *pgxpool.Pool
-	repo            *repo.Queries
-	environmentRepo *environmentsRepo.Queries
-	auth            *auth.Auth
-	authz           *authz.Engine
-	toolsets        *Toolsets
-	domainsRepo     *domainsRepo.Queries
-	usageRepo       *usageRepo.Queries
-	oauthRepo       *oauthRepo.Queries
-	mcpmetadataRepo *mcpmetadataRepo.Queries
-	toolsetCache    cache.TypedCacheObject[mv.ToolsetBaseContents]
-	audit           *audit.Logger
+	tracer               trace.Tracer
+	logger               *slog.Logger
+	db                   *pgxpool.Pool
+	repo                 *repo.Queries
+	environmentRepo      *environmentsRepo.Queries
+	auth                 *auth.Auth
+	authz                *authz.Engine
+	toolsets             *Toolsets
+	domainsRepo          *domainsRepo.Queries
+	usageRepo            *usageRepo.Queries
+	oauthRepo            *oauthRepo.Queries
+	mcpmetadataRepo      *mcpmetadataRepo.Queries
+	toolsetCache         cache.TypedCacheObject[mv.ToolsetBaseContents]
+	audit                *audit.Logger
+	temporalEnv          *tenv.Environment
+	pluginsGitHubEnabled bool
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -84,24 +88,28 @@ func NewService(
 	cacheAdapter cache.Cache,
 	authzEngine *authz.Engine,
 	auditLogger *audit.Logger,
+	temporalEnv *tenv.Environment,
+	pluginsGitHubEnabled bool,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("toolsets"))
 
 	return &Service{
-		tracer:          tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/toolsets"),
-		logger:          logger,
-		db:              db,
-		repo:            repo.New(db),
-		auth:            auth.New(logger, db, sessions, authzEngine),
-		authz:           authzEngine,
-		environmentRepo: environmentsRepo.New(db),
-		toolsets:        NewToolsets(db),
-		domainsRepo:     domainsRepo.New(db),
-		usageRepo:       usageRepo.New(db),
-		oauthRepo:       oauthRepo.New(db),
-		mcpmetadataRepo: mcpmetadataRepo.New(db),
-		toolsetCache:    cache.NewTypedObjectCache[mv.ToolsetBaseContents](logger.With(attr.SlogCacheNamespace("toolset")), cacheAdapter, cache.SuffixNone),
-		audit:           auditLogger,
+		tracer:               tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/toolsets"),
+		logger:               logger,
+		db:                   db,
+		repo:                 repo.New(db),
+		auth:                 auth.New(logger, db, sessions, authzEngine),
+		authz:                authzEngine,
+		environmentRepo:      environmentsRepo.New(db),
+		toolsets:             NewToolsets(db),
+		domainsRepo:          domainsRepo.New(db),
+		usageRepo:            usageRepo.New(db),
+		oauthRepo:            oauthRepo.New(db),
+		mcpmetadataRepo:      mcpmetadataRepo.New(db),
+		toolsetCache:         cache.NewTypedObjectCache[mv.ToolsetBaseContents](logger.With(attr.SlogCacheNamespace("toolset")), cacheAdapter, cache.SuffixNone),
+		audit:                auditLogger,
+		temporalEnv:          temporalEnv,
+		pluginsGitHubEnabled: pluginsGitHubEnabled,
 	}
 }
 
@@ -252,6 +260,7 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
 		ToolsetID:      uuid.NullUUID{UUID: toolsetID, Valid: true},
+		McpServerID:    uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		DisplayName:    displayName,
 	})
 	if err != nil {
@@ -273,6 +282,23 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 			PluginSlug:       attached.PluginSlug,
 		}); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
+		}
+
+		// This project predates the Default-plugin feature (no CreateProject
+		// call ever fired the initial publish for it) — kick one off now so it
+		// isn't left attached-but-never-published. Best-effort, same as
+		// CreateProject's trigger: a non-cancelable ctx since this runs right
+		// before commit and shouldn't be dropped by the request returning.
+		if s.pluginsGitHubEnabled {
+			enqueueCtx := context.WithoutCancel(ctx)
+			if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+				ProjectID:       *authCtx.ProjectID,
+				CreatedByUserID: authCtx.UserID,
+				CommitMessage:   "Initial marketplace publish",
+				SkipIfUnchanged: false,
+			}); err != nil {
+				s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+			}
 		}
 	}
 

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -41,6 +41,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oauth"
 	oauthRepo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	tplRepo "github.com/speakeasy-api/gram/server/internal/templates/repo"
 	"github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -223,6 +225,12 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset creation").LogError(ctx, logger)
 	}
 
+	if createToolParams.McpEnabled {
+		if err := s.attachToDefaultPlugin(ctx, dbtx, authCtx, createdToolset.ID, createdToolset.Name); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving toolset").LogError(ctx, logger)
 	}
@@ -233,6 +241,47 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 	}
 
 	return toolsetDetails, nil
+}
+
+// attachToDefaultPlugin adds a newly MCP-enabled toolset to the project's
+// Default plugin so it's included in the auto-published marketplace without
+// a human visiting the Plugins page. No-op if the project has no Default
+// plugin or the toolset is already attached.
+func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, toolsetID uuid.UUID, displayName string) error {
+	attached, err := plugins.AttachToDefaultPlugin(ctx, pluginsrepo.New(dbtx), plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{UUID: toolsetID, Valid: true},
+		DisplayName:    displayName,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "attach toolset to default plugin").LogError(ctx, s.logger)
+	}
+	if attached == nil {
+		return nil
+	}
+
+	toolsetURN := urn.NewToolset(toolsetID)
+	if err := s.audit.LogPluginServerAdd(ctx, dbtx, audit.LogPluginServerAddEvent{
+		OrganizationID:    authCtx.ActiveOrganizationID,
+		ProjectID:         *authCtx.ProjectID,
+		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName:  authCtx.Email,
+		ActorSlug:         nil,
+		PluginID:          attached.PluginID,
+		PluginName:        attached.PluginName,
+		PluginSlug:        attached.PluginSlug,
+		ServerID:          attached.Server.ID,
+		ServerDisplayName: attached.Server.DisplayName,
+		ServerPolicy:      attached.Server.Policy,
+		ServerSortOrder:   attached.Server.SortOrder,
+		ToolsetURN:        &toolsetURN,
+		McpServerURN:      nil,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "audit log default plugin server add").LogError(ctx, s.logger)
+	}
+
+	return nil
 }
 
 func (s *Service) ListToolsets(ctx context.Context, payload *gen.ListToolsetsPayload) (*gen.ListToolsetsResult, error) {
@@ -447,6 +496,12 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 	updatedToolset, err := tr.UpdateToolset(ctx, updateParams)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error updating toolset").LogError(ctx, logger)
+	}
+
+	if !existingToolset.McpEnabled && updatedToolset.McpEnabled {
+		if err := s.attachToDefaultPlugin(ctx, dbtx, authCtx, updatedToolset.ID, updatedToolset.Name); err != nil {
+			return nil, err
+		}
 	}
 
 	if payload.PromptTemplateNames != nil {

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -261,6 +261,21 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		return nil
 	}
 
+	if attached.PluginCreated {
+		if err := s.audit.LogPluginCreate(ctx, dbtx, audit.LogPluginCreateEvent{
+			OrganizationID:   authCtx.ActiveOrganizationID,
+			ProjectID:        *authCtx.ProjectID,
+			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName: authCtx.Email,
+			ActorSlug:        nil,
+			PluginID:         attached.PluginID,
+			PluginName:       attached.PluginName,
+			PluginSlug:       attached.PluginSlug,
+		}); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
+		}
+	}
+
 	toolsetURN := urn.NewToolset(toolsetID)
 	if err := s.audit.LogPluginServerAdd(ctx, dbtx, audit.LogPluginServerAddEvent{
 		OrganizationID:    authCtx.ActiveOrganizationID,

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -233,8 +233,10 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to log toolset creation").LogError(ctx, logger)
 	}
 
+	var pluginCreated bool
 	if createToolParams.McpEnabled {
-		if err := s.attachToDefaultPlugin(ctx, dbtx, authCtx, createdToolset.ID, createdToolset.Name); err != nil {
+		pluginCreated, err = s.attachToDefaultPlugin(ctx, dbtx, authCtx, createdToolset.ID, createdToolset.Name)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -242,6 +244,8 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving toolset").LogError(ctx, logger)
 	}
+
+	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(createdToolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
@@ -253,9 +257,12 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 
 // attachToDefaultPlugin adds a newly MCP-enabled toolset to the project's
 // Default plugin so it's included in the auto-published marketplace without
-// a human visiting the Plugins page. No-op if the project has no Default
-// plugin or the toolset is already attached.
-func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, toolsetID uuid.UUID, displayName string) error {
+// a human visiting the Plugins page. No-op if the toolset is already
+// attached. Returns pluginCreated=true if this call lazily created the
+// Default plugin (project predates this feature) — callers should enqueue
+// an initial publish for it, but only after their own transaction commits,
+// since this runs pre-commit and the DB writes could still roll back.
+func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, toolsetID uuid.UUID, displayName string) (bool, error) {
 	attached, err := plugins.AttachToDefaultPlugin(ctx, pluginsrepo.New(dbtx), plugins.AttachToDefaultPluginParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
@@ -264,10 +271,10 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		DisplayName:    displayName,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "attach toolset to default plugin").LogError(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "attach toolset to default plugin").LogError(ctx, s.logger)
 	}
 	if attached == nil {
-		return nil
+		return false, nil
 	}
 
 	if attached.PluginCreated {
@@ -281,24 +288,7 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 			PluginName:       attached.PluginName,
 			PluginSlug:       attached.PluginSlug,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
-		}
-
-		// This project predates the Default-plugin feature (no CreateProject
-		// call ever fired the initial publish for it) — kick one off now so it
-		// isn't left attached-but-never-published. Best-effort, same as
-		// CreateProject's trigger: a non-cancelable ctx since this runs right
-		// before commit and shouldn't be dropped by the request returning.
-		if s.pluginsGitHubEnabled {
-			enqueueCtx := context.WithoutCancel(ctx)
-			if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
-				ProjectID:       *authCtx.ProjectID,
-				CreatedByUserID: authCtx.UserID,
-				CommitMessage:   "Initial marketplace publish",
-				SkipIfUnchanged: false,
-			}); err != nil {
-				s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
-			}
+			return false, oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
 		}
 	}
 
@@ -319,10 +309,32 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		ToolsetURN:        &toolsetURN,
 		McpServerURN:      nil,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "audit log default plugin server add").LogError(ctx, s.logger)
+		return false, oops.E(oops.CodeUnexpected, err, "audit log default plugin server add").LogError(ctx, s.logger)
 	}
 
-	return nil
+	return attached.PluginCreated, nil
+}
+
+// triggerInitialPublishIfNeeded enqueues the first-time GitHub marketplace
+// publish for a project whose Default plugin was just lazily created. Must
+// only be called after the triggering transaction has committed — enqueuing
+// before commit risks Temporal running against state that a later failure
+// in the same transaction rolls back. Best-effort: a non-cancelable ctx
+// since the request returning shouldn't drop the enqueue.
+func (s *Service) triggerInitialPublishIfNeeded(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
+	if !pluginCreated || !s.pluginsGitHubEnabled {
+		return
+	}
+
+	enqueueCtx := context.WithoutCancel(ctx)
+	if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+		ProjectID:       *authCtx.ProjectID,
+		CreatedByUserID: authCtx.UserID,
+		CommitMessage:   "Initial marketplace publish",
+		SkipIfUnchanged: false,
+	}); err != nil {
+		s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+	}
 }
 
 func (s *Service) ListToolsets(ctx context.Context, payload *gen.ListToolsetsPayload) (*gen.ListToolsetsResult, error) {
@@ -539,8 +551,10 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		return nil, oops.E(oops.CodeUnexpected, err, "error updating toolset").LogError(ctx, logger)
 	}
 
+	var pluginCreated bool
 	if !existingToolset.McpEnabled && updatedToolset.McpEnabled {
-		if err := s.attachToDefaultPlugin(ctx, dbtx, authCtx, updatedToolset.ID, updatedToolset.Name); err != nil {
+		pluginCreated, err = s.attachToDefaultPlugin(ctx, dbtx, authCtx, updatedToolset.ID, updatedToolset.Name)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -620,6 +634,8 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving updated toolset").LogError(ctx, logger)
 	}
+
+	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
 
 	return toolsetDetails, nil
 }

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -125,7 +126,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine, auditLogger)
+	svc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine, auditLogger, temporalEnv, false)
 	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine, auditLogger)
 	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine, auditLogger)
 	packagesSvc := packages.NewService(logger, tracerProvider, conn, sessionManager, authzEngine)
@@ -136,6 +137,91 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 		deployments:    deploymentsSvc,
 		assets:         assetsSvc,
 		packages:       packagesSvc,
+		conn:           conn,
+		temporalEnv:    temporalEnv,
+		sessionManager: sessionManager,
+		assetStorage:   assetStorage,
+	}
+}
+
+// fakeGitHubPublisher is a no-op plugins.GitHubPublisher: it never touches
+// the network, so the initial-publish workflow's activity completes
+// successfully and leaves behind a real plugin_github_connections row.
+type fakeGitHubPublisher struct{}
+
+func (fakeGitHubPublisher) CreateRepo(ctx context.Context, installationID int64, org, name string, private bool) error {
+	return nil
+}
+
+func (fakeGitHubPublisher) PushFiles(ctx context.Context, installationID int64, owner, repo, branch, commitMsg string, files map[string][]byte) (string, error) {
+	return "fake-sha", nil
+}
+
+func (fakeGitHubPublisher) AddCollaborator(ctx context.Context, installationID int64, owner, repo, username, permission string) error {
+	return nil
+}
+
+// newTestToolsetsServiceWithGitHubPublishing is newTestToolsetsService with
+// GitHub publishing turned on end-to-end: the shared Temporal worker is
+// additionally configured with a plugins.Service backed by a fake (no-op)
+// GitHub client, so a toolset's auto-attach-triggered initial publish
+// actually runs its workflow to completion instead of just being enqueued.
+func newTestToolsetsServiceWithGitHubPublishing(t *testing.T) (context.Context, *testInstance) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	meterProvider := testenv.NewMeterProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	assetStorage := assetstest.NewTestBlobStore(t)
+
+	enc := testenv.NewEncryptionClient(t)
+	funcs := functionstest.NewOrchestrator(t, assetStorage)
+	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
+	temporalEnv, _ := infra.NewTemporalEnv(t)
+	auditLogger := audit.NewLogger()
+	f := &feature.InMemory{}
+
+	ghConfig := &plugins.GitHubConfig{
+		Client:         fakeGitHubPublisher{},
+		Org:            "test-org",
+		InstallationID: 12345,
+	}
+	pluginPublisher := plugins.NewPublisher(logger, conn, auditLogger, ghConfig, "local", "https://app.getgram.ai")
+
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider,
+		background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient, auditLogger),
+		&background.WorkerOptions{PluginPublisher: pluginPublisher},
+	)
+	t.Cleanup(func() {
+		worker.Stop()
+	})
+	require.NoError(t, worker.Start(), "start temporal worker")
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	billingClient := billing.NewStubClient(logger, tracerProvider)
+
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+
+	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
+	svc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine, auditLogger, temporalEnv, true)
+
+	return ctx, &testInstance{
+		service:        svc,
 		conn:           conn,
 		temporalEnv:    temporalEnv,
 		sessionManager: sessionManager,

--- a/server/internal/toolsets/updatetoolset_test.go
+++ b/server/internal/toolsets/updatetoolset_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	environmentsRepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 )
 
@@ -727,4 +728,100 @@ func TestToolsetsService_UpdateToolset_NotFound_NoAuditLog(t *testing.T) {
 	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionToolsetUpdate)
 	require.NoError(t, err)
 	require.Equal(t, beforeCount, afterCount)
+}
+
+func TestToolsetsService_UpdateToolset_EnableMcp_AttachesToDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	// First toolset in the org auto-enables MCP (and gets attached).
+	_, err = ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		Name:                   "First Toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           nil,
+		DefaultEnvironmentSlug: nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+
+	// Second toolset in the org does not auto-enable.
+	second, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		Name:                   "Second Toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           nil,
+		DefaultEnvironmentSlug: nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+	require.False(t, *second.McpEnabled)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1, "only the auto-enabled first toolset should be attached so far")
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+
+	result, err := ti.service.UpdateToolset(ctx, &gen.UpdateToolsetPayload{
+		SessionToken:           nil,
+		Slug:                   second.Slug,
+		Name:                   nil,
+		Description:            nil,
+		DefaultEnvironmentSlug: nil,
+		ToolUrns:               nil,
+		ResourceUrns:           nil,
+		PromptTemplateNames:    nil,
+		McpSlug:                nil,
+		McpIsPublic:            nil,
+		McpEnabled:             new(true),
+		CustomDomainID:         nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+	require.True(t, *result.McpEnabled)
+
+	servers, err = pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 2)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount+1, afterCount)
+
+	// Idempotent: re-enabling an already-enabled toolset must not double-attach.
+	_, err = ti.service.UpdateToolset(ctx, &gen.UpdateToolsetPayload{
+		SessionToken:           nil,
+		Slug:                   second.Slug,
+		Name:                   nil,
+		Description:            nil,
+		DefaultEnvironmentSlug: nil,
+		ToolUrns:               nil,
+		ResourceUrns:           nil,
+		PromptTemplateNames:    nil,
+		McpSlug:                nil,
+		McpIsPublic:            nil,
+		McpEnabled:             new(true),
+		CustomDomainID:         nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+
+	servers, err = pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 2, "re-enabling an already-enabled toolset must not double-attach")
 }


### PR DESCRIPTION
## Summary

- Project creation now creates a project-scoped **"Default" plugin** (in the same transaction as the project + default environment) and kicks off an async first-time GitHub marketplace publish — best-effort, no-op if GitHub publishing isn't configured for the deployment.
- Servers auto-attach to the Default plugin as soon as they're publishable:
  - **Toolsets**: on MCP-enable — either at creation (org's first toolset auto-enables) or later via `UpdateToolset`'s `false -> true` transition. Covers the dashboard's external MCP Catalog flow too, since it goes through the same `CreateToolset`/`UpdateToolset` endpoints.
  - **mcp_servers**: once they get their first live endpoint (`mcpendpoints.CreateMcpEndpoint`), mirroring `AddPluginServer`'s own publishability check (skips disabled servers).
- All attaches are idempotent (safe to call twice), run inside the same transaction as the triggering write, and are audit-logged the same way a manual "add server to plugin" is.
- No GitHub collaborators are auto-added — we don't have a customer GitHub username at project-creation time. That stays a manual step via the existing publish/marketplace-settings flow.
- Bumped `PluginGeneratorRolloutWorkflow`'s cadence from 5m to 1m so plugin composition changes reach the published marketplace repo faster (fingerprint-gated, so unchanged projects stay cheap).

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] New tests: toolset attach-on-create, no-auto-attach for org's 2nd toolset, attach-on-enable via update (+ idempotency), mcp_server attach-on-endpoint, no-op when project has no Default plugin
- [x] Full suites green: `toolsets` (113), `mcpendpoints` (38), `plugins` (163), `projects` (38)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically provisions a project-scoped “Default” plugin, auto-attaches publishable toolsets and MCP servers, and auto-publishes to GitHub Marketplace for new projects and for legacy projects on first attach. The rollout now self-heals missed initial publishes by scanning projects with a Default plugin or an existing GitHub connection.

- **New Features**
  - Create a “Default” plugin during project creation (same transaction) and enqueue a best-effort initial publish via Temporal; no GitHub collaborators are auto-added.
  - Auto-attach:
    - Toolsets on MCP enable (at creation for an org’s first toolset, or later via update).
    - mcp_servers on first live endpoint; skips disabled servers.
  - Legacy projects: lazily create the Default plugin on first attach and trigger the initial publish; creation and attaches are idempotent and audit-logged.

- **Bug Fixes**
  - Rollout candidates now include projects with a Default plugin or an existing GitHub connection to avoid dropping already-connected projects; never-published projects fall back to a “system” actor and unchanged projects short-circuit via fingerprint.
  - Increased plugin generator cadence from 5m to 1m; extended the initial-publish workflow run timeout to 20m.
  - Enqueue initial publish only after the surrounding DB transaction commits and with a non-cancelable context.
  - Treat backend-duplicate attaches as no-ops and surface `display_name` collisions as errors.

<sup>Written for commit d7d53ca19e0adebf45c8737e8f80dfd12ae67ae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

