### PR TITLE
fix(pystreams): warm uvicorn config load off the event loop

### DIFF
--- a/pystreams/src/pystreams/health/__init__.py
+++ b/pystreams/src/pystreams/health/__init__.py
@@ -22,6 +22,7 @@ import anyio
 import structlog
 import uvicorn
 from anyio.abc import TaskStatus
+from asyncer import asyncify
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -119,7 +120,7 @@ async def serve_control(
     # synchronous import I/O blocks the loop long enough to trip the blocking-IO
     # detector at startup. Warm the config in a worker thread so the imports
     # happen off the loop; ``serve`` sees ``config.loaded`` and skips the work.
-    await anyio.to_thread.run_sync(config.load)
+    await asyncify(config.load)()
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(server.serve)

--- a/pystreams/src/pystreams/health/__init__.py
+++ b/pystreams/src/pystreams/health/__init__.py
@@ -113,6 +113,14 @@ async def serve_control(
     )
     server = _NoSignalServer(config)
 
+    # uvicorn lazily imports its HTTP/WebSocket protocol implementations
+    # (h11/httptools/websockets/wsproto) on first start, inside ``config.load``,
+    # which ``serve`` otherwise runs on the event-loop thread. That one-time
+    # synchronous import I/O blocks the loop long enough to trip the blocking-IO
+    # detector at startup. Warm the config in a worker thread so the imports
+    # happen off the loop; ``serve`` sees ``config.loaded`` and skips the work.
+    await anyio.to_thread.run_sync(config.load)
+
     async with anyio.create_task_group() as tg:
         tg.start_soon(server.serve)
 


### PR DESCRIPTION
## Problem

`start:pystreams-multi` crashes at startup with `aiocop.exceptions.HighSeverityBlockingIoException`. The blocking-IO detector (enabled locally via `GRAM_PYSTREAMS_DETECT_BLOCKING`) watches the asyncio event loop and raises on a high-severity stall.

The stall comes from the health/control server. uvicorn **lazily imports its HTTP/WebSocket protocol implementations** (`h11`, `httptools`, `websockets`, `wsproto`) on first start, inside `config.load()`, which `Server._serve()` runs *on the event-loop thread*. Those cold imports are synchronous file I/O and on macOS + Python 3.14 sum to ~58ms — over the 50ms threshold → raise → the `multi` worker dies before consuming any messages.

The reported stack confirms it: every high-severity event is an `import(...)` / `open(.../__pycache__/...)` under `uvicorn/config.py:load <- uvicorn/server.py:_serve <- serve`.

## Fix

Warm `config.load()` in a worker thread before starting `serve()`. The one-time protocol imports then happen off the event loop, and uvicorn's `_serve()` — which calls `config.load()` only `if not config.loaded` — finds it already loaded and skips the work.

## Verification

- Instrumented aiocop against `serve_control` in a fresh process: **without** the fix, 14 protocol-import blocking events are attributed to the on-loop `serve` task (the reported stack); **with** the fix, **0** reach the loop.
- Full pystreams suite (enforces aiocop with raise-on-violations across every test): **86 passed**.
- `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warm `uvicorn` `config.load()` off the event loop to stop the `start:pystreams-multi` startup crash. This moves one-time protocol imports out of the loop so the blocking-IO detector doesn’t fire.

- **Bug Fixes**
  - Warm `config.load()` using `asyncer.asyncify`, so `h11`/`httptools`/`websockets`/`wsproto` imports happen off the loop.
  - `Server._serve()` sees `config.loaded` and skips the work; no more `aiocop.exceptions.HighSeverityBlockingIoException` at startup.

<sup>Written for commit f650cc966df1a8247248b32f1a20f0e3b15af2a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

