### PR TITLE
mig: add json_web_key_sets and json_web_keys tables

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3813,6 +3813,11 @@ CREATE INDEX IF NOT EXISTS external_keys_external_credential_id_idx
 ON external_keys (external_credential_id)
 WHERE deleted IS FALSE;
 
+-- Composite unique key so tenant-scoped tables (e.g. json_web_key_sets) can
+-- composite-FK to (organization_id, id) and pin the reference to one org.
+CREATE UNIQUE INDEX IF NOT EXISTS external_keys_organization_id_id_key
+ON external_keys (organization_id, id);
+
 CREATE TABLE IF NOT EXISTS aws_kms_keys (
   external_key_id uuid NOT NULL,
   external_keys_provider TEXT NOT NULL DEFAULT 'aws_kms',
@@ -3834,3 +3839,70 @@ CREATE TABLE IF NOT EXISTS gcp_kms_keys (
   CONSTRAINT gcp_kms_keys_external_keys_provider_check CHECK (external_keys_provider = 'gcp_kms'),
   CONSTRAINT gcp_kms_keys_fkey FOREIGN KEY (external_key_id, external_keys_provider) REFERENCES external_keys (id, provider) ON DELETE CASCADE
 );
+
+-- JSON Web Key Set (JWKS): the published collection of public keys for an
+-- issuer. Individual keys are external key based (e.g. KMS keys) and hold
+-- public JWK material only; the private key never leaves the customer KMS and
+-- is only ever called to sign. The backing external key is tenancy-pinned via
+-- a composite FK to (organization_id, id) so a set can only reference a key
+-- owned by the same organization.
+CREATE TABLE IF NOT EXISTS json_web_key_sets (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid,
+  external_key_id uuid NOT NULL,
+  name TEXT NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+  CONSTRAINT json_web_key_sets_pkey PRIMARY KEY (id),
+  CONSTRAINT json_web_key_sets_external_key_tenant_fkey FOREIGN KEY (organization_id, external_key_id) REFERENCES external_keys (organization_id, id),
+  CONSTRAINT json_web_key_sets_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT json_web_key_sets_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+-- Composite unique key so json_web_keys can composite-FK to (organization_id, id)
+-- and pin the reference to one org. A unique index for parity with external_keys.
+CREATE UNIQUE INDEX IF NOT EXISTS json_web_key_sets_organization_id_id_key
+ON json_web_key_sets (organization_id, id);
+
+-- Individual published key entries within a JSON Web Key Set. Each row is one
+-- public JWK (identified by `kid`) with a lifecycle state.
+CREATE TABLE IF NOT EXISTS json_web_keys (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid,
+  json_web_key_set_id uuid NOT NULL,
+  external_key_id uuid NOT NULL,
+  -- Pin the key version for external key providers that support versioning
+  external_key_version TEXT,
+  state TEXT NOT NULL,
+  kid TEXT NOT NULL,
+  public_jwk JSONB NOT NULL,
+  activated_at timestamptz,
+  retired_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+  CONSTRAINT json_web_keys_pkey PRIMARY KEY (id),
+  CONSTRAINT json_web_keys_set_tenant_fkey FOREIGN KEY (organization_id, json_web_key_set_id) REFERENCES json_web_key_sets (organization_id, id) ON DELETE CASCADE,
+  CONSTRAINT json_web_keys_external_key_tenant_fkey FOREIGN KEY (organization_id, external_key_id) REFERENCES external_keys (organization_id, id),
+  CONSTRAINT json_web_keys_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS json_web_keys_one_active_idx
+ON json_web_keys (json_web_key_set_id)
+WHERE state = 'active' AND deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS json_web_keys_set_kid_idx
+ON json_web_keys (json_web_key_set_id, kid)
+WHERE deleted IS FALSE;
+
+-- Non-partial index backing json_web_keys_set_tenant_fkey (ON DELETE CASCADE):
+-- keeps set/org/project cascade deletes off a seq scan, including soft-deleted
+-- rows that the partial unique indexes above exclude.
+CREATE INDEX IF NOT EXISTS json_web_keys_set_tenant_idx
+ON json_web_keys (organization_id, json_web_key_set_id);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -821,6 +821,37 @@ type HttpToolDefinition struct {
 	Deleted             bool
 }
 
+type JsonWebKey struct {
+	ID                 uuid.UUID
+	OrganizationID     string
+	ProjectID          uuid.NullUUID
+	JsonWebKeySetID    uuid.UUID
+	ExternalKeyID      uuid.UUID
+	ExternalKeyVersion pgtype.Text
+	State              string
+	Kid                string
+	PublicJwk          []byte
+	ActivatedAt        pgtype.Timestamptz
+	RetiredAt          pgtype.Timestamptz
+	RevokedAt          pgtype.Timestamptz
+	CreatedAt          pgtype.Timestamptz
+	UpdatedAt          pgtype.Timestamptz
+	DeletedAt          pgtype.Timestamptz
+	Deleted            bool
+}
+
+type JsonWebKeySet struct {
+	ID             uuid.UUID
+	OrganizationID string
+	ProjectID      uuid.NullUUID
+	ExternalKeyID  uuid.UUID
+	Name           string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
+}
+
 type McpEndpoint struct {
 	ID             uuid.UUID
 	ProjectID      uuid.UUID

--- a/server/migrations/20260706170316_json-web-key-sets-json-web-keys.sql
+++ b/server/migrations/20260706170316_json-web-key-sets-json-web-keys.sql
@@ -1,0 +1,51 @@
+-- atlas:txmode none
+
+-- Create index "external_keys_organization_id_id_key" to table: "external_keys"
+CREATE UNIQUE INDEX CONCURRENTLY "external_keys_organization_id_id_key" ON "external_keys" ("organization_id", "id");
+-- Create "json_web_key_sets" table
+CREATE TABLE "json_web_key_sets" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NULL,
+  "external_key_id" uuid NOT NULL,
+  "name" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "json_web_key_sets_external_key_tenant_fkey" FOREIGN KEY ("organization_id", "external_key_id") REFERENCES "external_keys" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "json_web_key_sets_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "json_web_key_sets_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "json_web_key_sets_organization_id_id_key" to table: "json_web_key_sets"
+CREATE UNIQUE INDEX "json_web_key_sets_organization_id_id_key" ON "json_web_key_sets" ("organization_id", "id");
+-- Create "json_web_keys" table
+CREATE TABLE "json_web_keys" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NULL,
+  "json_web_key_set_id" uuid NOT NULL,
+  "external_key_id" uuid NOT NULL,
+  "external_key_version" text NULL,
+  "state" text NOT NULL,
+  "kid" text NOT NULL,
+  "public_jwk" jsonb NOT NULL,
+  "activated_at" timestamptz NULL,
+  "retired_at" timestamptz NULL,
+  "revoked_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "json_web_keys_external_key_tenant_fkey" FOREIGN KEY ("organization_id", "external_key_id") REFERENCES "external_keys" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "json_web_keys_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "json_web_keys_set_tenant_fkey" FOREIGN KEY ("organization_id", "json_web_key_set_id") REFERENCES "json_web_key_sets" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "json_web_keys_one_active_idx" to table: "json_web_keys"
+CREATE UNIQUE INDEX "json_web_keys_one_active_idx" ON "json_web_keys" ("json_web_key_set_id") WHERE ((state = 'active'::text) AND (deleted IS FALSE));
+-- Create index "json_web_keys_set_kid_idx" to table: "json_web_keys"
+CREATE UNIQUE INDEX "json_web_keys_set_kid_idx" ON "json_web_keys" ("json_web_key_set_id", "kid") WHERE (deleted IS FALSE);
+-- Create index "json_web_keys_set_tenant_idx" to table: "json_web_keys"
+CREATE INDEX "json_web_keys_set_tenant_idx" ON "json_web_keys" ("organization_id", "json_web_key_set_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:9f4H/SlzIC1ft75AhM/hC+E/8VA9ovhd8HJ7XwVtuQY=
+h1:0yA0sK7H4GM7//rp+KOQQ4rCNB1CldSkCRM9VX34rHM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -243,3 +243,4 @@ h1:9f4H/SlzIC1ft75AhM/hC+E/8VA9ovhd8HJ7XwVtuQY=
 20260703095550_risk-policy-challenges-fk-cascade-indexes.sql h1:aR2L9eT4Wfdh2L91ZoOLk43oANOAAUDqLjmABGm58RM=
 20260703134504_rename-tunneled-mcp-columns.sql h1:httREsZ8T4QWXUQZOpzmv4U7zRybXkB4g5TPOaCskGY=
 20260703160051_plugins-add-is-default.sql h1:Vd7RqDOV6+53NX5jHTWaEl0OWDmuLdVrDuMiVpRD0Fs=
+20260706170316_json-web-key-sets-json-web-keys.sql h1:F7gFxdLCa1Q1gZc19/SrpAIiJgmZ7cUV/49iQD9GbN4=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-239/db-migration-json-web-key-sets-json-web-keys

First customer-facing use case for `external_keys` (the KMS-backed keys added in AGE-2868): the tables an organization uses to publish a JSON Web Key Set for an OAuth authorization-server issuer, so session tokens can be signed with a customer-managed KMS key while the public keys are served at a JWKS URI.

`json_web_key_sets` is a named, org-scoped JWKS backed by an `external_keys` row (its current signing key). `json_web_keys` are the individual published entries, each a single public JWK identified by a `kid` with a lifecycle state (`standby` -> `active` -> `previously_used` -> `revoked`). Only public material is stored here; the private key never leaves the customer KMS and is only ever called to sign. Partial unique indexes enforce at most one active key per set and a unique `kid` per set.

Also adds `UNIQUE (organization_id, id)` to `external_keys` so a set's backing key is tenancy-pinned via composite FK and can only reference a key owned by the same organization. DDL-only; lifecycle transitions and state value validation live in application code, not the schema.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `json_web_key_sets` and `json_web_keys` to publish org-scoped JWKS backed by `external_keys`, enabling customer-managed KMS signing with public keys served via JWKS. Adds tenant-pinned FKs and composite uniques to enforce per-org ownership; supports AIS-239.

- **Migration**
  - Add `UNIQUE (organization_id, id)` to `external_keys`.
  - Create `json_web_key_sets` with composite FK `(organization_id, external_key_id)` to `external_keys`, org/project FKs, soft delete, and `UNIQUE (organization_id, id)`.
  - Create `json_web_keys` with tenant-scoped FKs to `json_web_key_sets` and `external_keys`; stores public JWKs by `kid` (+ optional `external_key_version`).
  - Add partial unique indexes: one active key per set; unique `kid` per set (non-deleted). Add `json_web_keys_set_tenant_idx` to speed cascade deletes.
  - DDL-only; key state machine and validation remain in application code.

<sup>Written for commit 6dbf6824f24f5553cd695254c7b698488d5d550f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

