### PR TITLE
feat: show most recently used account on employees Last Activity column

### DIFF
--- a/.changeset/employees-last-activity-account.md
+++ b/.changeset/employees-last-activity-account.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+feat: show most recently used account as a dropdown on the employees Last Activity column

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils";
 import {
   buildEmployees,
   type Employee,
+  type EmployeeAccount,
   type EmployeeStatus,
   isUnattributedEmployee,
 } from "@/components/observe/insightsEmployeesData";
@@ -586,9 +587,7 @@ function EmployeeTable({
         sortable: true,
         sortValue: (item) => item.lastActivityTimestamp,
         width: "1fr",
-        render: (item) => (
-          <span className="text-muted-foreground">{item.lastActivity}</span>
-        ),
+        render: (item) => <LastActivityCell employee={item} />,
       },
       {
         key: "action",
@@ -793,15 +792,20 @@ function StatusPill({ status }: { status: EmployeeStatus }) {
   );
 }
 
-// Per-employee accounts cell: a clickable trigger summarizing the linked
-// accounts (count), opening a popover that lists every account with its email,
-// provider, and type. Robust to any number of accounts across providers.
-function AccountsCell({ employee }: { employee: Employee }) {
-  const { accounts } = employee;
-  if (accounts.length === 0) {
-    return <span className="text-muted-foreground/50 text-sm">—</span>;
-  }
-
+// Shared popover shell for table cells that reveal linked accounts: a clickable
+// trigger (label + chevron) opening a popover that lists each account with its
+// email, provider, and type.
+function AccountsPopover({
+  label,
+  labelClassName,
+  title,
+  accounts,
+}: {
+  label: string;
+  labelClassName?: string;
+  title: string;
+  accounts: EmployeeAccount[];
+}) {
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -811,8 +815,8 @@ function AccountsCell({ employee }: { employee: Employee }) {
           onClick={(e) => e.stopPropagation()}
           className="hover:bg-muted/60 -mx-1.5 flex items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors"
         >
-          <span className="text-muted-foreground text-xs">
-            {accounts.length} account{accounts.length === 1 ? "" : "s"}
+          <span className={cn("text-muted-foreground", labelClassName)}>
+            {label}
           </span>
           <Icon
             name="chevron-down"
@@ -822,7 +826,7 @@ function AccountsCell({ employee }: { employee: Employee }) {
       </PopoverTrigger>
       <PopoverContent align="start" className="w-72 p-0">
         <div className="border-b px-3 py-2">
-          <p className="text-xs font-medium">Linked accounts</p>
+          <p className="text-xs font-medium">{title}</p>
         </div>
         <ul className="divide-border/60 max-h-64 divide-y overflow-y-auto">
           {accounts.map((a, i) => (
@@ -833,6 +837,44 @@ function AccountsCell({ employee }: { employee: Employee }) {
         </ul>
       </PopoverContent>
     </Popover>
+  );
+}
+
+// Per-employee accounts cell: a clickable trigger summarizing the linked
+// accounts (count), opening a popover that lists every account with its email,
+// provider, and type. Robust to any number of accounts across providers.
+function AccountsCell({ employee }: { employee: Employee }) {
+  const { accounts } = employee;
+  if (accounts.length === 0) {
+    return <span className="text-muted-foreground/50 text-sm">—</span>;
+  }
+
+  return (
+    <AccountsPopover
+      label={`${accounts.length} account${accounts.length === 1 ? "" : "s"}`}
+      labelClassName="text-xs"
+      title="Linked accounts"
+      accounts={accounts}
+    />
+  );
+}
+
+// Last-activity cell: when the directory knows which account produced the most
+// recent activity, the timestamp becomes a dropdown identifying that account —
+// the workspace the employee was last working in. Plain text otherwise.
+function LastActivityCell({ employee }: { employee: Employee }) {
+  if (!employee.mostRecentAccount) {
+    return (
+      <span className="text-muted-foreground">{employee.lastActivity}</span>
+    );
+  }
+
+  return (
+    <AccountsPopover
+      label={employee.lastActivity}
+      title="Most recent account"
+      accounts={[employee.mostRecentAccount]}
+    />
   );
 }
 

--- a/client/dashboard/src/components/observe/insightsEmployeesData.test.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.test.ts
@@ -234,6 +234,32 @@ describe("buildEmployees most recent account", () => {
     expect(employees[0]!.mostRecentAccount?.accountType).toBe("personal");
   });
 
+  it("ranks accounts at full nanosecond precision", () => {
+    // Both timestamps fall in the same millisecond; the ranking must not
+    // truncate precision or the first account would win the tie.
+    const employees = buildEmployees([member], noRoles, [
+      makeSummary({
+        userId: "member-1",
+        accounts: [
+          {
+            provider: "anthropic",
+            email: "ada@example.com",
+            accountType: "team",
+            lastSeenUnixNano: "1750000000000364000",
+          },
+          {
+            provider: "cursor",
+            email: "ada@personal.com",
+            accountType: "personal",
+            lastSeenUnixNano: "1750000000000400000",
+          },
+        ],
+      }),
+    ]);
+
+    expect(employees[0]!.mostRecentAccount?.provider).toBe("cursor");
+  });
+
   it("skips accounts without a last-seen when ranking", () => {
     const employees = buildEmployees([member], noRoles, [
       makeSummary({

--- a/client/dashboard/src/components/observe/insightsEmployeesData.test.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.test.ts
@@ -201,3 +201,84 @@ describe("buildEmployees attributed/unattributed split", () => {
     );
   });
 });
+
+describe("buildEmployees most recent account", () => {
+  const member = makeMember({
+    id: "member-1",
+    email: "ada@example.com",
+    name: "Ada Lovelace",
+  });
+
+  it("picks the linked account with the latest last-seen", () => {
+    const employees = buildEmployees([member], noRoles, [
+      makeSummary({
+        userId: "member-1",
+        accounts: [
+          {
+            provider: "anthropic",
+            email: "ada@example.com",
+            accountType: "team",
+            lastSeenUnixNano: "1750000000000000000",
+          },
+          {
+            provider: "anthropic",
+            email: "ada@personal.com",
+            accountType: "personal",
+            lastSeenUnixNano: "1760000000000000000",
+          },
+        ],
+      }),
+    ]);
+
+    expect(employees[0]!.mostRecentAccount?.email).toBe("ada@personal.com");
+    expect(employees[0]!.mostRecentAccount?.accountType).toBe("personal");
+  });
+
+  it("skips accounts without a last-seen when ranking", () => {
+    const employees = buildEmployees([member], noRoles, [
+      makeSummary({
+        userId: "member-1",
+        accounts: [
+          {
+            provider: "openai",
+            email: "ada@example.com",
+            accountType: "team",
+          },
+          {
+            provider: "anthropic",
+            email: "ada@example.com",
+            accountType: "team",
+            lastSeenUnixNano: "1750000000000000000",
+          },
+        ],
+      }),
+    ]);
+
+    expect(employees[0]!.mostRecentAccount?.provider).toBe("anthropic");
+  });
+
+  it("returns null when no account has a last-seen", () => {
+    const employees = buildEmployees([member], noRoles, [
+      makeSummary({
+        userId: "member-1",
+        accounts: [
+          {
+            provider: "anthropic",
+            email: "ada@example.com",
+            accountType: "team",
+          },
+        ],
+      }),
+    ]);
+
+    expect(employees[0]!.mostRecentAccount).toBeNull();
+  });
+
+  it("returns null when there are no linked accounts", () => {
+    const employees = buildEmployees([member], noRoles, [
+      makeSummary({ userId: "member-1" }),
+    ]);
+
+    expect(employees[0]!.mostRecentAccount).toBeNull();
+  });
+});

--- a/client/dashboard/src/components/observe/insightsEmployeesData.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.ts
@@ -9,11 +9,14 @@ export type EmployeeStatus = "enrolled" | "not_enrolled";
 
 // One linked AI account for an employee. Identity is (provider, email): the same
 // email on two providers is two distinct accounts, so provider is always shown.
-type EmployeeAccount = {
+export type EmployeeAccount = {
   email: string;
   provider: string;
   // "team" | "personal" | "" (unclassified).
   accountType: string;
+  // Millisecond timestamp of this account's latest activity; null when the
+  // directory has no last-seen recorded for it.
+  lastSeenTimestamp: number | null;
 };
 
 export type Employee = {
@@ -29,6 +32,9 @@ export type Employee = {
   // All of this user's linked AI accounts (team + personal, across providers),
   // from the user_accounts directory.
   accounts: EmployeeAccount[];
+  // The linked account with the latest activity — identifies the workspace the
+  // employee was last working in. Null when no account has a last-seen.
+  mostRecentAccount: EmployeeAccount | null;
   // Convenience flag: any account is personal. Drives the account-type filter.
   hasPersonalAccount: boolean;
 };
@@ -42,7 +48,28 @@ function accountsFromSummary(
     email: a.email ?? "",
     provider: a.provider,
     accountType: a.accountType ?? "",
+    lastSeenTimestamp: a.lastSeenUnixNano
+      ? Number(BigInt(a.lastSeenUnixNano) / 1_000_000n)
+      : null,
   }));
+}
+
+// The account with the latest recorded activity; accounts the directory has no
+// last-seen for can't be ranked and are skipped.
+function mostRecentAccount(
+  accounts: EmployeeAccount[],
+): EmployeeAccount | null {
+  let latest: EmployeeAccount | null = null;
+  for (const account of accounts) {
+    if (account.lastSeenTimestamp == null) continue;
+    if (
+      latest?.lastSeenTimestamp == null ||
+      account.lastSeenTimestamp > latest.lastSeenTimestamp
+    ) {
+      latest = account;
+    }
+  }
+  return latest;
 }
 
 // Unattributed identities are usage rows that matched no org member; they are
@@ -90,6 +117,7 @@ export function buildEmployees(
         .map((id) => roleNameById.get(id))
         .filter(Boolean)
         .join(", ") || "Unknown";
+    const accounts = accountsFromSummary(summary);
 
     return {
       id: member.id,
@@ -105,10 +133,9 @@ export function buildEmployees(
       lastActivity: summary
         ? formatUnixNano(summary.lastSeenUnixNano)
         : "No activity found",
-      accounts: accountsFromSummary(summary),
-      hasPersonalAccount: accountsFromSummary(summary).some(
-        (a) => a.accountType === "personal",
-      ),
+      accounts,
+      mostRecentAccount: mostRecentAccount(accounts),
+      hasPersonalAccount: accounts.some((a) => a.accountType === "personal"),
     };
   });
 
@@ -119,6 +146,7 @@ export function buildEmployees(
       const email =
         summary.userEmail ||
         (summary.userId.includes("@") ? summary.userId : "");
+      const accounts = accountsFromSummary(summary);
       return {
         id: `usage:${summary.userId}`,
         name: email || summary.userId,
@@ -131,10 +159,9 @@ export function buildEmployees(
           BigInt(summary.lastSeenUnixNano) / 1_000_000n,
         ),
         lastActivity: formatUnixNano(summary.lastSeenUnixNano),
-        accounts: accountsFromSummary(summary),
-        hasPersonalAccount: accountsFromSummary(summary).some(
-          (a) => a.accountType === "personal",
-        ),
+        accounts,
+        mostRecentAccount: mostRecentAccount(accounts),
+        hasPersonalAccount: accounts.some((a) => a.accountType === "personal"),
       };
     });
 

--- a/client/dashboard/src/components/observe/insightsEmployeesData.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.ts
@@ -14,9 +14,9 @@ export type EmployeeAccount = {
   provider: string;
   // "team" | "personal" | "" (unclassified).
   accountType: string;
-  // Millisecond timestamp of this account's latest activity; null when the
-  // directory has no last-seen recorded for it.
-  lastSeenTimestamp: number | null;
+  // Latest activity for this account in Unix nanoseconds (string for JS int64
+  // precision); null when the directory has no last-seen recorded for it.
+  lastSeenUnixNano: string | null;
 };
 
 export type Employee = {
@@ -48,23 +48,22 @@ function accountsFromSummary(
     email: a.email ?? "",
     provider: a.provider,
     accountType: a.accountType ?? "",
-    lastSeenTimestamp: a.lastSeenUnixNano
-      ? Number(BigInt(a.lastSeenUnixNano) / 1_000_000n)
-      : null,
+    lastSeenUnixNano: a.lastSeenUnixNano ?? null,
   }));
 }
 
-// The account with the latest recorded activity; accounts the directory has no
-// last-seen for can't be ranked and are skipped.
+// The account with the latest recorded activity, compared at full nanosecond
+// precision. Accounts the directory has no last-seen for can't be ranked and
+// are skipped.
 function mostRecentAccount(
   accounts: EmployeeAccount[],
 ): EmployeeAccount | null {
   let latest: EmployeeAccount | null = null;
   for (const account of accounts) {
-    if (account.lastSeenTimestamp == null) continue;
+    if (account.lastSeenUnixNano == null) continue;
     if (
-      latest?.lastSeenTimestamp == null ||
-      account.lastSeenTimestamp > latest.lastSeenTimestamp
+      latest?.lastSeenUnixNano == null ||
+      BigInt(account.lastSeenUnixNano) > BigInt(latest.lastSeenUnixNano)
     ) {
       latest = account;
     }


### PR DESCRIPTION
Resolves [AGE-2712](https://linear.app/speakeasy/issue/AGE-2712/feedback-request-for-workspace-identification-in-admin-console)

## Summary

Customer ask (MoonPay): identify which workspace/account a user is currently logged into from the admin console. The employees list's **Last Activity** timestamp is now a dropdown revealing the **most recently used account** — the linked account (workspace) that produced the user's latest activity — reusing the same popover + `AccountRow` component as the Accounts column.

## Changes

- `insightsEmployeesData.ts`: expose each linked account's `last_seen_unix_nano` (already returned by `telemetry.searchUsers` from the `user_accounts` directory) as `lastSeenTimestamp`, and derive `Employee.mostRecentAccount` — the account with the latest last-seen. Accounts without a recorded last-seen can't be ranked and are skipped; when none can be ranked the cell stays plain text.
- `InsightsEmployees.tsx`: extracted the linked-accounts popover from `AccountsCell` into a shared `AccountsPopover`, and added a `LastActivityCell` that renders the timestamp as a trigger opening a "Most recent account" popover (email, provider, team/personal badge).
- Tests for the `mostRecentAccount` derivation (latest wins, unranked accounts skipped, null fallbacks).

No backend changes — the per-account last-seen was already populated server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the Employees table’s Last Activity timestamp into a dropdown that shows the account (workspace) tied to the user’s latest activity. Addresses AGE-2712 to help admins quickly see where a user was last active.

- **New Features**
  - Last Activity is now a dropdown showing the most recent linked account (email, provider, team/personal badge).
  - Ranking uses per-account last-seen at nanosecond precision; accounts without last-seen are skipped. Falls back to plain text when none can be ranked.
  - Extracted a shared `AccountsPopover` and added `mostRecentAccount` with `lastSeenUnixNano` in the data layer; tests cover nanosecond ranking and edge cases.
  - No backend changes.

<sup>Written for commit 4907f5673056bf3970edbbc7432d78257b3a04e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

