### PR TITLE
fix: add linear-code[bot] to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-document: "https://github.com/speakeasy-api/gram/blob/main/CLA.md" # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: "cla-signatures"
-          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot],cursoragent,claude,linear-code
+          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot],cursoragent,claude,linear-code,linear-code[bot]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
## Summary

Adds `linear-code[bot]` to the CLA Assistant `allowlist` so PRs authored by the Linear agent pass the CLA check.

## Context

The Linear agent's PRs (e.g. #3914) are failing the `CLAAssistant` check because the bot commits as `linear-code[bot]`, which cannot sign the CLA by commenting. Bots are exempted via the workflow's `allowlist`, same as `dependabot[bot]`, `renovate[bot]`, and `gram-bot[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `linear-code[bot]` to the CLA Assistant `allowlist` so Linear bot PRs pass CLA checks and don’t block merges.

<sup>Written for commit 9bbb5b035f355df4716ef31af900c03665854185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

