### PR TITLE
fix: link chats to AI accounts on the canonical ingest path (DNO-405)

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -113,11 +113,16 @@ const (
 	// Personal-account tracking. These are stamped by hook/OTEL ingest and
 	// materialized into ClickHouse columns of the same suffix (provider,
 	// external_org_id, account_type) for org-level usage dashboards.
+	// account_email is the AI account's own (observed) email, kept separate
+	// from user.email — the authenticated actor — so adopting cached
+	// attribution never rewrites the canonical user identity; it has no
+	// materialized column yet.
 	ProviderKey                    = attribute.Key("gram.provider")
 	ExternalOrgIDKey               = attribute.Key("gram.external_org_id")
 	AccountTypeKey                 = attribute.Key("gram.account_type")
 	BillingModeKey                 = attribute.Key("gram.billing_mode")
 	DeviceIDKey                    = attribute.Key("gram.device_id")
+	AccountEmailKey                = attribute.Key("gram.account_email")
 	ChatIDKey                      = attribute.Key("gram.chat.id")
 	MessageIDKey                   = attribute.Key("gram.message.id")
 	MCPRegistryIDKey               = attribute.Key("gram.mcp_registry.id")

--- a/server/internal/hooks/account_attribution.go
+++ b/server/internal/hooks/account_attribution.go
@@ -264,4 +264,10 @@ func stampAccountAttribution(attrs map[attr.Key]any, meta SessionMetadata) {
 	if meta.DeviceID != "" {
 		attrs[attr.DeviceIDKey] = meta.DeviceID
 	}
+	// The account's own email, distinct from user.email (the authenticated
+	// actor). Sourced only from ObservedUserEmail — never UserEmail, which on
+	// merged canonical metadata holds the actor.
+	if meta.ObservedUserEmail != "" {
+		attrs[attr.AccountEmailKey] = meta.ObservedUserEmail
+	}
 }

--- a/server/internal/hooks/account_attribution_test.go
+++ b/server/internal/hooks/account_attribution_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/hooks/repo"
 )
 
@@ -450,6 +451,51 @@ func TestClaude_LinksChatToUserAccount(t *testing.T) {
 	// The bridged owner is preserved through hook persistence (not discarded by
 	// re-resolving the non-resolving personal email).
 	require.Equal(t, "bridged-employee", chat.UserID.String)
+}
+
+// TestLogs_BackfillsChatAccountLinkOnExistingChat covers the hook-first
+// ordering: the session's first persisted message creates the chat before OTEL
+// attribution lands, and chat creation happens only once — so attribution must
+// backfill the chat -> user_accounts link or the chat stays unlinked forever
+// (invisible to the account-identity risk rules and the personal/team split).
+func TestLogs_BackfillsChatAccountLinkOnExistingChat(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	queries := repo.New(ti.conn)
+
+	sessionID := "backfill-link-" + uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
+
+	// The chat already exists, unlinked — as when the first prompt beats the
+	// first OTEL export of the session.
+	_, err := queries.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
+		ID:             chatID,
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGTextEmpty(""),
+		ExternalUserID: conv.ToPGTextEmpty("employee@example.com"),
+		UserAccountID:  conv.StringToNullUUID(""),
+		Title:          conv.ToPGText("hook-first chat"),
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	accountUUID := "acct-" + sessionID
+	claudeAccountSession(t, ctx, ti, sessionID, "someone@gmail.com", "org-"+sessionID, accountUUID, "device-"+sessionID, now)
+
+	account, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
+		OrganizationID:      authCtx.ActiveOrganizationID,
+		Provider:            providerAnthropic,
+		ExternalAccountUuid: accountUUID,
+	})
+	require.NoError(t, err)
+
+	chat, err := chatRepo.New(ti.conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.True(t, chat.UserAccountID.Valid)
+	require.Equal(t, account.ID, chat.UserAccountID.UUID)
 }
 
 // TestLogs_NoAccountIdentityDoesNotCreateUserAccount confirms attribution is a

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -737,6 +737,7 @@ func (s *Service) claudeAuthContextMetadata(ctx context.Context, sessionID, user
 			AccountType:         "",
 			BillingMode:         "",
 			UserAccountID:       "",
+			ObservedUserEmail:   "",
 			GramOrgID:           "",
 			ProjectID:           "",
 		}, false
@@ -755,6 +756,7 @@ func (s *Service) claudeAuthContextMetadata(ctx context.Context, sessionID, user
 		AccountType:         "",
 		BillingMode:         "",
 		UserAccountID:       "",
+		ObservedUserEmail:   "",
 		GramOrgID:           authCtx.ActiveOrganizationID,
 		ProjectID:           authCtx.ProjectID.String(),
 	}
@@ -1155,6 +1157,9 @@ func (s *Service) mergeClaudeAuthContextMetadata(ctx context.Context, metadata S
 	metadata.AccountType = cached.AccountType
 	metadata.BillingMode = cached.BillingMode
 	metadata.UserAccountID = cached.UserAccountID
+	// The OTEL path's UserEmail is the account's own report; fall back to it
+	// for cache entries written before ObservedUserEmail existed.
+	metadata.ObservedUserEmail = conv.Default(cached.ObservedUserEmail, cached.UserEmail)
 	return metadata
 }
 

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -319,6 +319,7 @@ func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPa
 		AccountType:         "",
 		BillingMode:         "",
 		UserAccountID:       "",
+		ObservedUserEmail:   "",
 		GramOrgID:           orgID,
 		ProjectID:           projectID,
 	}

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -286,6 +286,7 @@ func (s *Service) recordCursorHook(ctx context.Context, payload *gen.CursorPaylo
 		AccountType:         "",
 		BillingMode:         "",
 		UserAccountID:       "",
+		ObservedUserEmail:   "",
 		GramOrgID:           orgID,
 		ProjectID:           projectID,
 	}

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -99,8 +99,14 @@ type SessionMetadata struct {
 	// UserAccountID is the user_accounts row id for this session's account, set
 	// once the account entity has been upserted.
 	UserAccountID string
-	GramOrgID     string
-	ProjectID     string
+	// ObservedUserEmail is the email the AI account itself reported (Claude
+	// OTEL user.email) — the value persisted on user_accounts.email. Kept
+	// separate from UserEmail, the authenticated actor, so adopting cached
+	// attribution never rewrites the canonical user identity; telemetry
+	// carries it as the gram.account_email attribute.
+	ObservedUserEmail string
+	GramOrgID         string
+	ProjectID         string
 }
 
 // HookSpecificOutput is the structure for hook-specific output in responses

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -306,8 +306,12 @@ func canonicalShadowMCPEvidence(payload *gen.IngestPayload, rawToolName string) 
 }
 
 func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, timestamp time.Time, blockReason string) {
-	s.writeCanonicalTelemetry(ctx, payload, authCtx, timestamp, blockReason)
-	if err := s.persistCanonicalConversationEvent(ctx, payload, authCtx); err != nil {
+	// Resolve the session identity once, before the telemetry write, so the
+	// hook row and the chat persistence below stamp the same AI-account
+	// attribution.
+	metadata := s.canonicalSessionMetadata(ctx, payload, authCtx)
+	s.writeCanonicalTelemetry(ctx, payload, authCtx, &metadata, timestamp, blockReason)
+	if err := s.persistCanonicalConversationEvent(ctx, payload, authCtx, &metadata); err != nil {
 		s.logger.WarnContext(ctx, "failed to persist canonical hook conversation event",
 			attr.SlogEvent("hooks_ingest_chat_persist_failed"),
 			attr.SlogError(err),
@@ -319,7 +323,67 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 	}
 }
 
-func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, timestamp time.Time, blockReason string) {
+// canonicalSessionMetadata builds the session identity for a canonical hook
+// event: the token owner from the auth context, enriched with the AI-account
+// attribution the OTEL path cached for the session (user_accounts link,
+// account_type, provider identity, device-bridge owner). Canonical payloads
+// carry no account identity of their own, so without the cached attribution
+// telemetry rows and chats captured here reflect only the Gram key owner —
+// invisible to the account-identity risk rules and the personal/team
+// classification. The session cache is keyed by session id alone, so only
+// trust an entry the same org+project seeded.
+func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext) SessionMetadata {
+	actorEmail := ""
+	if authCtx.Email != nil {
+		actorEmail = strings.TrimSpace(*authCtx.Email)
+	}
+	metadata := SessionMetadata{
+		SessionID:           canonicalSessionID(payload),
+		ServiceName:         strings.TrimSpace(payload.Source.Adapter),
+		UserEmail:           actorEmail,
+		UserID:              authCtx.UserID,
+		Provider:            "",
+		ExternalOrgID:       "",
+		ExternalAccountUUID: "",
+		ExternalAccountID:   "",
+		DeviceID:            "",
+		AccountType:         "",
+		BillingMode:         "",
+		UserAccountID:       "",
+		GramOrgID:           authCtx.ActiveOrganizationID,
+		ProjectID:           authCtx.ProjectID.String(),
+	}
+	if metadata.SessionID == "" {
+		return metadata
+	}
+
+	if cached, err := s.getSessionMetadata(ctx, metadata.SessionID); err == nil &&
+		cached.GramOrgID == metadata.GramOrgID && cached.ProjectID == metadata.ProjectID {
+		metadata.Provider = cached.Provider
+		metadata.ExternalOrgID = cached.ExternalOrgID
+		metadata.ExternalAccountUUID = cached.ExternalAccountUUID
+		metadata.ExternalAccountID = cached.ExternalAccountID
+		metadata.DeviceID = cached.DeviceID
+		metadata.AccountType = cached.AccountType
+		metadata.BillingMode = cached.BillingMode
+		metadata.UserAccountID = cached.UserAccountID
+		// The AI account's email wins over the token owner's, matching
+		// mergeClaudeAuthContextMetadata on the legacy path: the session's
+		// identity is the account that produced it, not the key that sent it.
+		if cached.UserEmail != "" {
+			metadata.UserEmail = cached.UserEmail
+		}
+		// A personal account's email never resolves to an org member, but the
+		// OTEL path may have attributed the owning employee via the device
+		// bridge — adopt it rather than dropping the owner.
+		if metadata.UserID == "" {
+			metadata.UserID = cached.UserID
+		}
+	}
+	return metadata
+}
+
+func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, timestamp time.Time, blockReason string) {
 	if s.telemetryLogger == nil {
 		return
 	}
@@ -390,7 +454,12 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 		attrs[attr.GenAIToolCallArgumentsKey] = jsonString(map[string]string{"skill": skill})
 	}
 
-	s.logHookTelemetry(ctx, authCtx, timestamp, toolName, attrs)
+	// Carry the account attribution (provider, external_org_id, account_type,
+	// device_id) onto every hook event row so per-tool-call telemetry can be
+	// split by personal vs team account, matching the legacy per-provider paths.
+	stampAccountAttribution(attrs, *metadata)
+
+	s.logHookTelemetry(ctx, authCtx, metadata, timestamp, toolName, attrs)
 
 	// A skill name on an ordinary tool/prompt event is an inferred activation
 	// (Codex has no dedicated Skill tool): the underlying event was recorded
@@ -409,7 +478,8 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 		attrs[attr.TraceIDKey] = generateTraceID()
 		attrs[attr.ToolNameKey] = "Skill"
 		attrs[attr.GenAIToolCallArgumentsKey] = jsonString(map[string]string{"skill": skill})
-		s.logHookTelemetry(ctx, authCtx, timestamp, "Skill", attrs)
+		stampAccountAttribution(attrs, *metadata)
+		s.logHookTelemetry(ctx, authCtx, metadata, timestamp, "Skill", attrs)
 	}
 }
 
@@ -439,7 +509,7 @@ func hookTelemetryBaseAttrs(payload *gen.IngestPayload, authCtx *contextvalues.A
 	return attrs
 }
 
-func (s *Service) logHookTelemetry(ctx context.Context, authCtx *contextvalues.AuthContext, timestamp time.Time, toolName string, attrs map[attr.Key]any) {
+func (s *Service) logHookTelemetry(ctx context.Context, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, timestamp time.Time, toolName string, attrs map[attr.Key]any) {
 	s.telemetryLogger.Log(ctx, telemetry.LogParams{
 		Timestamp: timestamp,
 		ToolInfo: telemetry.ToolInfo{
@@ -451,7 +521,7 @@ func (s *Service) logHookTelemetry(ctx context.Context, authCtx *contextvalues.A
 			DeploymentID:   "",
 			FunctionID:     nil,
 		},
-		UserInfo:   telemetry.UserInfoByID(authCtx.UserID),
+		UserInfo:   telemetry.UserInfoByIDAndEmail(metadata.UserID, metadata.UserEmail),
 		Attributes: attrs,
 	})
 }
@@ -513,59 +583,10 @@ func telemetryHookEventName(payload *gen.IngestPayload) string {
 	}
 }
 
-func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext) error {
+func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata) error {
 	sessionID := canonicalSessionID(payload)
 	if sessionID == "" || authCtx.ProjectID == nil {
 		return nil
-	}
-
-	actorEmail := ""
-	if authCtx.Email != nil {
-		actorEmail = strings.TrimSpace(*authCtx.Email)
-	}
-	metadata := SessionMetadata{
-		SessionID:           sessionID,
-		ServiceName:         strings.TrimSpace(payload.Source.Adapter),
-		UserEmail:           actorEmail,
-		UserID:              authCtx.UserID,
-		Provider:            "",
-		ExternalOrgID:       "",
-		ExternalAccountUUID: "",
-		ExternalAccountID:   "",
-		DeviceID:            "",
-		AccountType:         "",
-		BillingMode:         "",
-		UserAccountID:       "",
-		GramOrgID:           authCtx.ActiveOrganizationID,
-		ProjectID:           authCtx.ProjectID.String(),
-	}
-
-	// Canonical hook events carry no AI-account identity of their own; the OTEL
-	// ingest path attributes the session's account (user_accounts, account_type,
-	// owning user) and caches it under the session id. Adopt that attribution so
-	// a chat created here is linked to its account — without this the
-	// account-identity risk rules and the personal/team classification never see
-	// sessions captured through this endpoint. The session cache is keyed by
-	// session id alone, so only trust an entry the same org+project seeded.
-	if cached, err := s.getSessionMetadata(ctx, sessionID); err == nil &&
-		cached.GramOrgID == metadata.GramOrgID && cached.ProjectID == metadata.ProjectID {
-		metadata.Provider = cached.Provider
-		metadata.ExternalOrgID = cached.ExternalOrgID
-		metadata.ExternalAccountUUID = cached.ExternalAccountUUID
-		metadata.ExternalAccountID = cached.ExternalAccountID
-		metadata.DeviceID = cached.DeviceID
-		metadata.AccountType = cached.AccountType
-		metadata.BillingMode = cached.BillingMode
-		metadata.UserAccountID = cached.UserAccountID
-		if metadata.UserEmail == "" {
-			metadata.UserEmail = cached.UserEmail
-		}
-		// A personal account's email never resolves to an org member, but the
-		// OTEL path may have attributed the owning employee via the device
-		// bridge — adopt it rather than dropping the owner.
-		if metadata.UserID == "" {
-			metadata.UserID = cached.UserID
-		}
 	}
 	baseMsg := func(role, content string) chatRepo.CreateChatMessageParams {
 		return chatRepo.CreateChatMessageParams{
@@ -579,8 +600,8 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 			Model:            conv.ToPGTextEmpty(canonicalModel(payload)),
 			MessageID:        conv.ToPGTextEmpty(""),
 			ToolCallID:       conv.ToPGTextEmpty(""),
-			UserID:           conv.ToPGTextEmpty(authCtx.UserID),
-			ExternalUserID:   conv.ToPGTextEmpty(actorEmail),
+			UserID:           conv.ToPGTextEmpty(metadata.UserID),
+			ExternalUserID:   conv.ToPGTextEmpty(metadata.UserEmail),
 			FinishReason:     conv.ToPGTextEmpty(""),
 			ToolCalls:        nil,
 			PromptTokens:     0,
@@ -645,7 +666,7 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		return nil
 	}
 
-	return s.insertMessageWithFallbackUpsert(ctx, &metadata, msg.ChatID, *authCtx.ProjectID, msg, canonicalChatTitle(payload, titleContent))
+	return s.insertMessageWithFallbackUpsert(ctx, metadata, msg.ChatID, *authCtx.ProjectID, msg, canonicalChatTitle(payload, titleContent))
 }
 
 func canonicalToolCallsJSON(payload *gen.IngestPayload) ([]byte, error) {

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -539,6 +539,34 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		GramOrgID:           authCtx.ActiveOrganizationID,
 		ProjectID:           authCtx.ProjectID.String(),
 	}
+
+	// Canonical hook events carry no AI-account identity of their own; the OTEL
+	// ingest path attributes the session's account (user_accounts, account_type,
+	// owning user) and caches it under the session id. Adopt that attribution so
+	// a chat created here is linked to its account — without this the
+	// account-identity risk rules and the personal/team classification never see
+	// sessions captured through this endpoint. The session cache is keyed by
+	// session id alone, so only trust an entry the same org+project seeded.
+	if cached, err := s.getSessionMetadata(ctx, sessionID); err == nil &&
+		cached.GramOrgID == metadata.GramOrgID && cached.ProjectID == metadata.ProjectID {
+		metadata.Provider = cached.Provider
+		metadata.ExternalOrgID = cached.ExternalOrgID
+		metadata.ExternalAccountUUID = cached.ExternalAccountUUID
+		metadata.ExternalAccountID = cached.ExternalAccountID
+		metadata.DeviceID = cached.DeviceID
+		metadata.AccountType = cached.AccountType
+		metadata.BillingMode = cached.BillingMode
+		metadata.UserAccountID = cached.UserAccountID
+		if metadata.UserEmail == "" {
+			metadata.UserEmail = cached.UserEmail
+		}
+		// A personal account's email never resolves to an org member, but the
+		// OTEL path may have attributed the owning employee via the device
+		// bridge — adopt it rather than dropping the owner.
+		if metadata.UserID == "" {
+			metadata.UserID = cached.UserID
+		}
+	}
 	baseMsg := func(role, content string) chatRepo.CreateChatMessageParams {
 		return chatRepo.CreateChatMessageParams{
 			ChatID:           sessionIDToUUID(sessionID),

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -330,8 +330,11 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 // carry no account identity of their own, so without the cached attribution
 // telemetry rows and chats captured here reflect only the Gram key owner —
 // invisible to the account-identity risk rules and the personal/team
-// classification. The session cache is keyed by session id alone, so only
-// trust an entry the same org+project seeded.
+// classification. UserID/UserEmail stay the authenticated actor's — the
+// predictable canonical identity — while the AI account's own email rides
+// separately in ObservedUserEmail (the gram.account_email attribute). The
+// session cache is keyed by session id alone, so only trust an entry the
+// same org+project seeded.
 func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext) SessionMetadata {
 	actorEmail := ""
 	if authCtx.Email != nil {
@@ -350,6 +353,7 @@ func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.Ing
 		AccountType:         "",
 		BillingMode:         "",
 		UserAccountID:       "",
+		ObservedUserEmail:   "",
 		GramOrgID:           authCtx.ActiveOrganizationID,
 		ProjectID:           authCtx.ProjectID.String(),
 	}
@@ -367,15 +371,15 @@ func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.Ing
 		metadata.AccountType = cached.AccountType
 		metadata.BillingMode = cached.BillingMode
 		metadata.UserAccountID = cached.UserAccountID
-		// The AI account's email wins over the token owner's, matching
-		// mergeClaudeAuthContextMetadata on the legacy path: the session's
-		// identity is the account that produced it, not the key that sent it.
-		if cached.UserEmail != "" {
+		// The OTEL path's UserEmail is the account's own report; fall back to it
+		// for cache entries written before ObservedUserEmail existed.
+		metadata.ObservedUserEmail = conv.Default(cached.ObservedUserEmail, cached.UserEmail)
+		// Fill identity only when the auth context carried none (org-scoped
+		// ingest keys): the device bridge may have attributed the owning
+		// employee. A token-derived identity is never overwritten.
+		if metadata.UserEmail == "" {
 			metadata.UserEmail = cached.UserEmail
 		}
-		// A personal account's email never resolves to an org member, but the
-		// OTEL path may have attributed the owning employee via the device
-		// bridge — adopt it rather than dropping the owner.
 		if metadata.UserID == "" {
 			metadata.UserID = cached.UserID
 		}

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -614,6 +614,77 @@ func TestIngest_LinksChatToUserAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, chat.UserAccountID.Valid)
 	require.Equal(t, userAccountID, chat.UserAccountID.UUID.String())
+
+	// Message rows carry the same identity as the linked chat — both are
+	// written from the hydrated session metadata, not the raw auth context.
+	msgs, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, chat.UserID.String, msgs[0].UserID.String)
+	require.Equal(t, chat.ExternalUserID.String, msgs[0].ExternalUserID.String)
+}
+
+// TestIngest_StampsAccountAttributionOnTelemetry confirms canonical hook rows
+// carry the cached account attribution (provider, account_type, external org
+// id) and the session's user identity, matching the legacy per-provider hook
+// paths — dashboards and policies reading telemetry must see the AI account
+// behind the session, not just the Gram key owner.
+func TestIngest_StampsAccountAttributionOnTelemetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := "canonical-stamp-" + uuid.NewString()
+	externalOrgID := "stamp-ext-org-" + sessionID
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:     sessionID,
+		ServiceName:   "claude-code",
+		UserEmail:     "personal@gmail.com",
+		UserID:        "bridged-employee",
+		Provider:      providerAnthropic,
+		ExternalOrgID: externalOrgID,
+		AccountType:   accountTypePersonal,
+		UserAccountID: uuid.NewString(),
+		GramOrgID:     authCtx.ActiveOrganizationID,
+		ProjectID:     authCtx.ProjectID.String(),
+	}, time.Hour))
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	occurredAt := timestamp.Format(time.RFC3339Nano)
+	prompt := "attribution should ride on this row"
+	payload := canonicalIngestPayload("claude", "prompt.submitted", sessionID)
+	payload.Event.OccurredAt = &occurredAt
+	payload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &prompt},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "allow", result.Decision)
+
+	var logs []telemetryrepo.TelemetryLog
+	require.Eventually(t, func() bool {
+		logs, err = chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
+			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
+			GramURNs:      nil,
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		return err == nil && len(logs) == 1
+	}, 2*time.Second, 50*time.Millisecond, "expected the hook row to land in telemetry")
+
+	require.Contains(t, logs[0].Attributes, providerAnthropic)
+	require.Contains(t, logs[0].Attributes, accountTypePersonal)
+	require.Contains(t, logs[0].Attributes, externalOrgID)
+	require.Contains(t, logs[0].Attributes, "personal@gmail.com")
 }
 
 func TestIngest_PersistsRenderableToolCalls(t *testing.T) {

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -572,7 +572,10 @@ func TestIngest_ThoughtEventsExcludedFromTranscript(t *testing.T) {
 // created here is linked to its user_accounts row — the join the
 // account-identity risk rules and the personal/team classification read.
 // Without the merge, chats captured through /rpc/hooks.ingest are never
-// linked (the payload itself carries no AI-account identity).
+// linked (the payload itself carries no AI-account identity). The link is
+// adopted without rewriting the canonical user identity: UserID/UserEmail
+// stay the authenticated actor's, and the account's own email rides
+// separately (ObservedUserEmail / gram.account_email).
 func TestIngest_LinksChatToUserAccount(t *testing.T) {
 	t.Parallel()
 
@@ -588,7 +591,8 @@ func TestIngest_LinksChatToUserAccount(t *testing.T) {
 	userAccountID := uuid.NewString()
 
 	// Seed session metadata as the OTEL path would for an attributed personal
-	// account.
+	// account. No ObservedUserEmail: entries cached before the field existed
+	// must still adopt via the UserEmail fallback.
 	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
 		SessionID:     sessionID,
 		ServiceName:   "claude-code",
@@ -615,6 +619,12 @@ func TestIngest_LinksChatToUserAccount(t *testing.T) {
 	require.True(t, chat.UserAccountID.Valid)
 	require.Equal(t, userAccountID, chat.UserAccountID.UUID.String())
 
+	// The canonical identity is the authenticated actor, not the cached
+	// account identity: the session was sent under the actor's token.
+	require.Equal(t, authCtx.UserID, chat.UserID.String)
+	require.NotEqual(t, "personal@gmail.com", chat.ExternalUserID.String,
+		"account email must not replace the actor's on the chat")
+
 	// Message rows carry the same identity as the linked chat — both are
 	// written from the hydrated session metadata, not the raw auth context.
 	msgs, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
@@ -629,9 +639,10 @@ func TestIngest_LinksChatToUserAccount(t *testing.T) {
 
 // TestIngest_StampsAccountAttributionOnTelemetry confirms canonical hook rows
 // carry the cached account attribution (provider, account_type, external org
-// id) and the session's user identity, matching the legacy per-provider hook
-// paths — dashboards and policies reading telemetry must see the AI account
-// behind the session, not just the Gram key owner.
+// id) with the account's own email as the gram.account_email attribute, while
+// user.email stays the authenticated actor — dashboards and policies reading
+// telemetry see both the AI account behind the session and the Gram identity
+// that sent it, without one masquerading as the other.
 func TestIngest_StampsAccountAttributionOnTelemetry(t *testing.T) {
 	t.Parallel()
 
@@ -642,16 +653,17 @@ func TestIngest_StampsAccountAttributionOnTelemetry(t *testing.T) {
 	sessionID := "canonical-stamp-" + uuid.NewString()
 	externalOrgID := "stamp-ext-org-" + sessionID
 	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
-		SessionID:     sessionID,
-		ServiceName:   "claude-code",
-		UserEmail:     "personal@gmail.com",
-		UserID:        "bridged-employee",
-		Provider:      providerAnthropic,
-		ExternalOrgID: externalOrgID,
-		AccountType:   accountTypePersonal,
-		UserAccountID: uuid.NewString(),
-		GramOrgID:     authCtx.ActiveOrganizationID,
-		ProjectID:     authCtx.ProjectID.String(),
+		SessionID:         sessionID,
+		ServiceName:       "claude-code",
+		UserEmail:         "personal@gmail.com",
+		UserID:            "bridged-employee",
+		Provider:          providerAnthropic,
+		ExternalOrgID:     externalOrgID,
+		AccountType:       accountTypePersonal,
+		UserAccountID:     uuid.NewString(),
+		ObservedUserEmail: "personal@gmail.com",
+		GramOrgID:         authCtx.ActiveOrganizationID,
+		ProjectID:         authCtx.ProjectID.String(),
 	}, time.Hour))
 
 	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
@@ -684,7 +696,12 @@ func TestIngest_StampsAccountAttributionOnTelemetry(t *testing.T) {
 	require.Contains(t, logs[0].Attributes, providerAnthropic)
 	require.Contains(t, logs[0].Attributes, accountTypePersonal)
 	require.Contains(t, logs[0].Attributes, externalOrgID)
-	require.Contains(t, logs[0].Attributes, "personal@gmail.com")
+	// Attribute keys nest on dots in the stored JSON: gram.account_email
+	// carries the account's own email while user.email stays the actor.
+	require.Contains(t, logs[0].Attributes, `"account_email":"personal@gmail.com"`,
+		"account email must ride as its own attribute")
+	require.NotContains(t, logs[0].Attributes, `"email":"personal@gmail.com"`,
+		"account email must not replace the actor's user.email")
 }
 
 func TestIngest_PersistsRenderableToolCalls(t *testing.T) {

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -567,6 +567,55 @@ func TestIngest_ThoughtEventsExcludedFromTranscript(t *testing.T) {
 	require.Equal(t, "assistant", msgs[0].Role)
 }
 
+// TestIngest_LinksChatToUserAccount confirms the canonical ingest path adopts
+// the account attribution the OTEL path cached for the session, so a chat
+// created here is linked to its user_accounts row — the join the
+// account-identity risk rules and the personal/team classification read.
+// Without the merge, chats captured through /rpc/hooks.ingest are never
+// linked (the payload itself carries no AI-account identity).
+func TestIngest_LinksChatToUserAccount(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := "canonical-account-link-" + uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
+	userAccountID := uuid.NewString()
+
+	// Seed session metadata as the OTEL path would for an attributed personal
+	// account.
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:     sessionID,
+		ServiceName:   "claude-code",
+		UserEmail:     "personal@gmail.com",
+		UserID:        "bridged-employee",
+		Provider:      providerAnthropic,
+		AccountType:   accountTypePersonal,
+		UserAccountID: userAccountID,
+		GramOrgID:     authCtx.ActiveOrganizationID,
+		ProjectID:     authCtx.ProjectID.String(),
+	}, time.Hour))
+
+	prompt := "hello from a canonical hook"
+	payload := canonicalIngestPayload("claude", "prompt.submitted", sessionID)
+	payload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &prompt},
+	}
+	res, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "allow", res.Decision)
+
+	chat, err := chatRepo.New(ti.conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.True(t, chat.UserAccountID.Valid)
+	require.Equal(t, userAccountID, chat.UserAccountID.UUID.String())
+}
+
 func TestIngest_PersistsRenderableToolCalls(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/hooks/local_cache.go
+++ b/server/internal/hooks/local_cache.go
@@ -96,6 +96,7 @@ func (c *localSessionCache) fallbackSessionMetadata(ctx context.Context, session
 		AccountType:         "",
 		BillingMode:         "",
 		UserAccountID:       "",
+		ObservedUserEmail:   "",
 		GramOrgID:           orgID,
 		ProjectID:           projectID,
 	}

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -139,30 +139,39 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 
 		attributionBySession[completeMetadata.SessionID] = completeMetadata
 
-		// Process each session independently so a single cache failure does not
-		// abort flushing the remaining sessions in the batch.
-		if err := s.cache.Set(ctx, sessionCacheKey(completeMetadata.SessionID), completeMetadata, 24*time.Hour); err != nil {
-			sessionLogger.ErrorContext(ctx, "Failed to store session metadata",
-				attr.SlogEvent("claude_logs_cache_set_failed"),
-				attr.SlogError(err),
-			)
-		}
-
 		// A session's chat row is created once, on its first persisted message.
 		// When that message beat this attribution (hooks and OTEL race at session
 		// start), the chat exists without its account link and no later hook
 		// revisits it — so backfill the link here. Fill-once in SQL; a no-op when
 		// the chat does not exist yet (its eventual creation reads the metadata
-		// cached above) or is already linked. Runs only on the attribution path,
+		// cached below) or is already linked. Runs only on the attribution path,
 		// not the per-batch fast path, so it costs one write per session.
+		linkFailed := false
 		if completeMetadata.UserAccountID != "" {
 			if _, err := s.repo.LinkChatUserAccount(ctx, repo.LinkChatUserAccountParams{
 				UserAccountID: conv.StringToNullUUID(completeMetadata.UserAccountID),
 				ID:            sessionIDToUUID(completeMetadata.SessionID),
 				ProjectID:     *authCtx.ProjectID,
 			}); err != nil {
+				linkFailed = true
 				sessionLogger.ErrorContext(ctx, "failed to backfill chat account link",
 					attr.SlogEvent("chat_account_link_backfill_failed"),
+					attr.SlogError(err),
+				)
+			}
+		}
+
+		// Cache only after the backfill: the once-per-session fast path above
+		// keys on the cached UserAccountID, so caching an attribution whose
+		// backfill just failed would freeze the chat unlinked forever. Skipping
+		// the write keeps this batch's row stamping (attributionBySession) and
+		// lets the next batch re-attribute and retry the link. Process each
+		// session independently so a single cache failure does not abort
+		// flushing the remaining sessions in the batch.
+		if !linkFailed {
+			if err := s.cache.Set(ctx, sessionCacheKey(completeMetadata.SessionID), completeMetadata, 24*time.Hour); err != nil {
+				sessionLogger.ErrorContext(ctx, "Failed to store session metadata",
+					attr.SlogEvent("claude_logs_cache_set_failed"),
 					attr.SlogError(err),
 				)
 			}

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -116,8 +116,11 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 			AccountType:         "",
 			BillingMode:         "",
 			UserAccountID:       "",
-			GramOrgID:           orgID,
-			ProjectID:           projectID,
+			// On this path user.email is the account's own report, so it doubles
+			// as the observed email consumers keep separate from actor identity.
+			ObservedUserEmail: userEmail,
+			GramOrgID:         orgID,
+			ProjectID:         projectID,
 		}
 
 		sessionLogger := logger.With(
@@ -143,9 +146,8 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		// When that message beat this attribution (hooks and OTEL race at session
 		// start), the chat exists without its account link and no later hook
 		// revisits it — so backfill the link here. Fill-once in SQL; a no-op when
-		// the chat does not exist yet (its eventual creation reads the metadata
-		// cached below) or is already linked. Runs only on the attribution path,
-		// not the per-batch fast path, so it costs one write per session.
+		// the chat does not exist yet or is already linked. At most one write per
+		// attributed session, since only the attribution path runs this.
 		linkFailed := false
 		if completeMetadata.UserAccountID != "" {
 			if _, err := s.repo.LinkChatUserAccount(ctx, repo.LinkChatUserAccountParams{

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
@@ -145,6 +146,26 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 				attr.SlogEvent("claude_logs_cache_set_failed"),
 				attr.SlogError(err),
 			)
+		}
+
+		// A session's chat row is created once, on its first persisted message.
+		// When that message beat this attribution (hooks and OTEL race at session
+		// start), the chat exists without its account link and no later hook
+		// revisits it — so backfill the link here. Fill-once in SQL; a no-op when
+		// the chat does not exist yet (its eventual creation reads the metadata
+		// cached above) or is already linked. Runs only on the attribution path,
+		// not the per-batch fast path, so it costs one write per session.
+		if completeMetadata.UserAccountID != "" {
+			if _, err := s.repo.LinkChatUserAccount(ctx, repo.LinkChatUserAccountParams{
+				UserAccountID: conv.StringToNullUUID(completeMetadata.UserAccountID),
+				ID:            sessionIDToUUID(completeMetadata.SessionID),
+				ProjectID:     *authCtx.ProjectID,
+			}); err != nil {
+				sessionLogger.ErrorContext(ctx, "failed to backfill chat account link",
+					attr.SlogEvent("chat_account_link_backfill_failed"),
+					attr.SlogError(err),
+				)
+			}
 		}
 
 		s.flushPendingHooks(ctx, completeMetadata.SessionID, &completeMetadata)

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -46,6 +46,21 @@ RETURNING id;
 -- name: UpdateClaudeCodeSessionTimestamp :exec
 UPDATE chats SET updated_at = NOW() WHERE id = @id AND project_id = @project_id;
 
+-- name: LinkChatUserAccount :execrows
+-- Backfills the chat -> user_accounts link for a session whose chat row was
+-- created before account attribution landed. A chat is created once, on the
+-- session's first persisted message, so a first prompt that beats the first
+-- OTEL export would otherwise leave the chat unlinked forever (and the
+-- account-identity risk rules blind to it). Fill-once: never overwrites a
+-- link that chat creation or an earlier backfill already set.
+UPDATE chats
+SET user_account_id = @user_account_id
+  , updated_at = NOW()
+WHERE id = @id
+  AND project_id = @project_id
+  AND user_account_id IS NULL
+  AND deleted IS FALSE;
+
 -- name: UpsertUserAccount :one
 -- Records the external AI provider account observed for a session, keyed by the
 -- provider's stable per-account id. COALESCE on conflict keeps a previously

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -393,6 +393,36 @@ func (q *Queries) InsertToolCallBlock(ctx context.Context, arg InsertToolCallBlo
 	return err
 }
 
+const linkChatUserAccount = `-- name: LinkChatUserAccount :execrows
+UPDATE chats
+SET user_account_id = $1
+  , updated_at = NOW()
+WHERE id = $2
+  AND project_id = $3
+  AND user_account_id IS NULL
+  AND deleted IS FALSE
+`
+
+type LinkChatUserAccountParams struct {
+	UserAccountID uuid.NullUUID
+	ID            uuid.UUID
+	ProjectID     uuid.UUID
+}
+
+// Backfills the chat -> user_accounts link for a session whose chat row was
+// created before account attribution landed. A chat is created once, on the
+// session's first persisted message, so a first prompt that beats the first
+// OTEL export would otherwise leave the chat unlinked forever (and the
+// account-identity risk rules blind to it). Fill-once: never overwrites a
+// link that chat creation or an earlier backfill already set.
+func (q *Queries) LinkChatUserAccount(ctx context.Context, arg LinkChatUserAccountParams) (int64, error) {
+	result, err := q.db.Exec(ctx, linkChatUserAccount, arg.UserAccountID, arg.ID, arg.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const listHooksServerNameOverrides = `-- name: ListHooksServerNameOverrides :many
 SELECT id, raw_server_name, display_name, created_at, updated_at
 FROM hooks_server_name_overrides


### PR DESCRIPTION
## Problem

Chats captured through the canonical `/rpc/hooks.ingest` endpoint are never linked to their `user_accounts` row. `persistCanonicalConversationEvent` builds `SessionMetadata` from the auth context alone — `UserAccountID`, `AccountType`, `Provider`, etc. all hardcoded empty — ignoring the account attribution the OTEL `Logs` path caches per session id.

As new-gen plugins moved hook traffic from `/rpc/hooks.claude` (which merges the cached attribution) to `/rpc/hooks.ingest`, chat→account linking collapsed in prod (speakeasy org link rate: 43% on 07-01 → &lt;1% by 07-06). Everything reading the `chats.user_account_id → user_accounts` join went blind for those sessions:

- no personal/team account icon on Agent Sessions
- the `account_identity` risk rules (AGE-2711: personal account, unapproved email domain) silently emit nothing — `GetBatchChatIdentities` sees NULL account_type/email

## Fix

1. **Ingest path adopts cached attribution** (`ingest_hooks.go`): `persistCanonicalConversationEvent` reads the session cache and adopts the OTEL-attributed account fields (`user_account_id`, `account_type`, provider/external ids, device-bridge owner), filling `UserEmail`/`UserID` only when empty. Only trusts entries seeded by the same org+project (same guard as `pending_helpers.go`).

2. **Attribution-time backfill** (`otel.go` + new `LinkChatUserAccount` query): a chat is created once, on the session's first persisted message — if that message beats the session's first OTEL export, the chat was frozen unlinked forever. The OTEL attribution path now backfills `chats.user_account_id` (fill-once, project-scoped, no-op when the chat doesn't exist yet or is already linked). Runs only on the once-per-session attribution path, not the per-batch fast path.

## Tests

- `TestIngest_LinksChatToUserAccount` — canonical `prompt.submitted` creates the chat linked to the cached account.
- `TestLogs_BackfillsChatAccountLinkOnExistingChat` — hook-first ordering: pre-existing unlinked chat gets its link backfilled by the real OTEL attribution path.

Full `internal/hooks` suite green; `mise lint:server` clean; sqlc regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link chats created via `/rpc/hooks.ingest` to their `user_accounts` by merging cached OTEL session attribution and stamping the same account data on canonical telemetry. Preserves the actor identity and adds the account’s email as `gram.account_email`, restoring personal/team classification and unapproved-domain checks (DNO-405).

- **Bug Fixes**
  - Resolve session metadata once per request and merge cached OTEL attribution (user_account_id, account_type, provider/external IDs, device-bridge owner); only trust same org+project and only fill UserID/UserEmail when the token has none.
  - Canonical telemetry rows now include account attribution and `gram.account_email` (the AI account’s email); `user.email` stays the authenticated actor.
  - OTEL `Logs` backfills `chats.user_account_id` (fill-once, project-scoped); runs before cache write and skips caching on failure to allow retry on the next batch.
  - Added `LinkChatUserAccount` query and tests for ingest linking, telemetry stamping (including `gram.account_email`), and the backfill path.

<sup>Written for commit 818b6055394ac8a2af38bf7af019b5093425419d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

