### PR TITLE
fix: let org members self-serve hooks API keys

### DIFF
--- a/server/internal/keys/impl.go
+++ b/server/internal/keys/impl.go
@@ -96,7 +96,33 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 	if !ok || authCtx == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
+	scopes := map[string]struct{}{}
+	for _, rawscope := range payload.Scopes {
+		scope, ok := auth.APIKeyScopes[rawscope]
+		if !ok || scope == auth.APIKeyScopeInvalid {
+			return nil, oops.E(oops.CodeBadRequest, nil, "invalid api key scope: %s", scope).LogError(ctx, s.logger)
+		}
+
+		scopes[scope.String()] = struct{}{}
+	}
+
+	if len(scopes) == 0 {
+		scopes = map[string]struct{}{
+			auth.APIKeyScopeConsumer.String(): {},
+		}
+	}
+
+	finalScopes := slices.Sorted(maps.Keys(scopes))
+
+	// A hooks key only attributes a developer's own coding-agent telemetry and
+	// carries no write powers, so any org member can mint one as part of the
+	// self-serve browser sign-in the hook plugins run. Every other scope (and
+	// any mix) stays admin-only.
+	requiredScope := authz.ScopeOrgAdmin
+	if slices.Equal(finalScopes, []string{auth.APIKeyScopeHooks.String()}) {
+		requiredScope = authz.ScopeOrgRead
+	}
+	if err := s.authz.Require(ctx, authz.Check{Scope: requiredScope, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return nil, err
 	}
 
@@ -118,24 +144,6 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 	} else {
 		projectID = uuid.NullUUID{UUID: uuid.UUID{}, Valid: false}
 	}
-
-	scopes := map[string]struct{}{}
-	for _, rawscope := range payload.Scopes {
-		scope, ok := auth.APIKeyScopes[rawscope]
-		if !ok || scope == auth.APIKeyScopeInvalid {
-			return nil, oops.E(oops.CodeBadRequest, nil, "invalid api key scope: %s", scope).LogError(ctx, s.logger)
-		}
-
-		scopes[scope.String()] = struct{}{}
-	}
-
-	if len(scopes) == 0 {
-		scopes = map[string]struct{}{
-			auth.APIKeyScopeConsumer.String(): {},
-		}
-	}
-
-	finalScopes := slices.Sorted(maps.Keys(scopes))
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {

--- a/server/internal/keys/rbac_test.go
+++ b/server/internal/keys/rbac_test.go
@@ -36,6 +36,31 @@ func TestKeysService_CreateKey_AllowsOrgAdminGrant(t *testing.T) {
 	require.Equal(t, "rbac-allow-create", key.Name)
 }
 
+func TestKeysService_CreateKey_AllowsHooksKeyWithOrgReadGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestKeysService(t)
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{Scope: authz.ScopeOrgRead, Selector: authz.NewSelector(authz.ScopeOrgRead, testAuthContext(t, ctx).ActiveOrganizationID)})
+
+	key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-hooks-self-serve", Scopes: []string{"hooks"}})
+	require.NoError(t, err)
+	require.Equal(t, []string{"hooks"}, key.Scopes)
+}
+
+func TestKeysService_CreateKey_ForbidsMixedHooksKeyWithOrgReadGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestKeysService(t)
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{Scope: authz.ScopeOrgRead, Selector: authz.NewSelector(authz.ScopeOrgRead, testAuthContext(t, ctx).ActiveOrganizationID)})
+
+	// A non-admin member may only self-serve a pure hooks key; mixing in any
+	// other scope must still require org admin.
+	_, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-hooks-mixed", Scopes: []string{"hooks", "consumer"}})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
 func TestKeysService_ListKeys_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

The hooks browser sign-in ends by minting a `hooks`-scoped API key on the signed-in user's behalf (`POST /rpc/keys.create` with `key_scope=hooks`). But `CreateKey` unconditionally required **org admin**, so any non-admin member who ran the sign-in hit a **403** that the dashboard surfaces as an error page after login.

Production logs (last 14d, hooks-scope key creation from the browser flow): **27 × 403, 23 × 200, zero 500s**. The 403s span several orgs; on at least one, every attempt over multiple days failed because the users are non-admins. This blocks self-serve hook onboarding for every non-admin.

## Fix

Resolve the requested scopes first, then choose the required authz scope from them:

- A request for **exactly** a `hooks` key → require org membership (`org:read`), which every member has. A hooks key only attributes a developer's own coding-agent telemetry and carries no write powers.
- Every other scope, and any mix that includes a non-hooks scope, still requires **org admin** — so a member can't smuggle a `producer`/`consumer` key in under member permissions.

## Tests

- Member (`org:read`) can mint a `hooks`-only key.
- Member is still forbidden from minting a mixed `hooks`+`consumer` key.
- Existing admin-gate tests unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let org members create `hooks`-only API keys during browser sign-in by requiring `org:read` instead of admin for that specific case. This removes 403s for non-admins while keeping admin-only for all other or mixed scopes.

- **Bug Fixes**
  - Resolve requested scopes first; if exactly `hooks`, require `org:read`, otherwise require org admin.
  - Block mixed `hooks` + other scopes from bypassing admin.
  - Added tests for member creating `hooks`-only key and forbidding mixed scope as member.

<sup>Written for commit 4d1add5c6ab0920b46b322171ef76506cf7ffe05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

