### PR TITLE
chore(hooks): rework mise `hooks:test-marketplace` task

### DIFF
--- a/.mise-tasks/hooks/test-marketplace.sh
+++ b/.mise-tasks/hooks/test-marketplace.sh
@@ -2,6 +2,31 @@
 
 #MISE description="Test the Gram hooks Claude plugin locally (from marketplace)"
 #MISE dir="{{ config_root }}"
+#USAGE flag "--rm" help="Remove the local Gram hooks Claude plugin from the marketplace after testing"
 
-claude plugin marketplace add "$PWD"
-claude plugin install gram-hooks@gram
+set -euo pipefail
+
+install() {
+	claude plugin marketplace add "$PWD"
+	claude plugin install --scope local gram-hooks@gram
+}
+
+uninstall() {
+	if claude plugin list --json | jq -e 'any(.[]; .id == "gram-hooks@gram")' >/dev/null; then
+		claude plugin uninstall --scope local gram-hooks@gram
+	else
+		echo "Plugin gram-hooks@gram is not installed, skipping uninstall"
+	fi
+
+	if claude plugin marketplace list --json | jq -e 'any(.[]; .name == "gram")' >/dev/null; then
+		claude plugin marketplace remove gram
+	else
+		echo "Marketplace gram is not registered, skipping remove"
+	fi
+}
+
+if [ "${usage_rm:-false}" = "true" ]; then
+	uninstall
+else
+	install
+fi

--- a/.mise-tasks/hooks/test-marketplace.sh
+++ b/.mise-tasks/hooks/test-marketplace.sh
@@ -19,16 +19,16 @@ install() {
 }
 
 uninstall() {
-	if claude plugin list --json | jq -e 'any(.[]; .id == "gram-hooks@gram")' >/dev/null; then
+	if claude plugin list --json | jq -e --arg scope "$scope" 'any(.[]; .id == "gram-hooks@gram" and .scope == $scope)' >/dev/null; then
 		claude plugin uninstall --scope "$scope" gram-hooks@gram
 	else
-		echo "Plugin gram-hooks@gram is not installed, skipping uninstall"
+		echo "Plugin gram-hooks@gram is not installed in scope '$scope', skipping uninstall"
 	fi
 
-	if claude plugin marketplace list --json | jq -e 'any(.[]; .name == "gram")' >/dev/null; then
-		claude plugin marketplace remove --scope "$scope" gram
+	if claude plugin marketplace remove --scope "$scope" gram 2>/dev/null; then
+		echo "Removed marketplace gram from scope '$scope'"
 	else
-		echo "Marketplace gram is not registered, skipping remove"
+		echo "Marketplace gram is not registered in scope '$scope', skipping remove"
 	fi
 }
 

--- a/.mise-tasks/hooks/test-marketplace.sh
+++ b/.mise-tasks/hooks/test-marketplace.sh
@@ -3,23 +3,30 @@
 #MISE description="Test the Gram hooks Claude plugin locally (from marketplace)"
 #MISE dir="{{ config_root }}"
 #USAGE flag "--rm" help="Remove the local Gram hooks Claude plugin from the marketplace after testing"
+#USAGE flag "--scope <scope>" {
+#USAGE   help "Scope for the marketplace and plugin commands"
+#USAGE   default "local"
+#USAGE   choices "local" "user" "project"
+#USAGE }
 
 set -euo pipefail
 
+scope="${usage_scope:-local}"
+
 install() {
-	claude plugin marketplace add "$PWD"
-	claude plugin install --scope local gram-hooks@gram
+	claude plugin marketplace add --scope "$scope" "$PWD"
+	claude plugin install --scope "$scope" gram-hooks@gram
 }
 
 uninstall() {
 	if claude plugin list --json | jq -e 'any(.[]; .id == "gram-hooks@gram")' >/dev/null; then
-		claude plugin uninstall --scope local gram-hooks@gram
+		claude plugin uninstall --scope "$scope" gram-hooks@gram
 	else
 		echo "Plugin gram-hooks@gram is not installed, skipping uninstall"
 	fi
 
 	if claude plugin marketplace list --json | jq -e 'any(.[]; .name == "gram")' >/dev/null; then
-		claude plugin marketplace remove gram
+		claude plugin marketplace remove --scope "$scope" gram
 	else
 		echo "Marketplace gram is not registered, skipping remove"
 	fi


### PR DESCRIPTION
This change facilitates local development of hook by updating the `hooks:test-marketplace` task. It now installs marketplace and plugin with configurable scope, default to `local`. It also exposes an `--rm` flag (i.e. `mise run hooks:test-marketplace --rm`) to uninstall the plugin.

Local scope is a sensible default that does not pollute user settings stored in their home directory though it is still possible to run `mise run hooks:test-marketplace --scope user` and `mise run hooks:test-marketplace --scope user --rm`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the `mise` task `hooks:test-marketplace` to install the Gram marketplace and `gram-hooks@gram` with a configurable scope (default `local`), and added `--rm` to clean them up after testing. Commands now use `--scope` consistently and handle partial states safely to keep local dev self‑contained.

- **New Features**
  - `--scope <local|user|project>` sets install scope; defaults to `local`.
  - `--rm` uninstalls `gram-hooks@gram` and removes the `gram` marketplace in that scope; both steps are skipped if not present to avoid errors.

<sup>Written for commit 3ad231b9905b82a7fe4271e90788b93cf8de777f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

