### PR TITLE
fix(catalog): improve tool permission badges on catalog detail (DNO-303)

### DIFF
--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -528,7 +528,7 @@ function ToolCard({ tool }: { tool: Tool }) {
               {tool.annotations?.title || tool.name}
             </Type>
             {tool.annotations?.readOnlyHint && (
-              <Badge variant="neutral" className="text-xs">
+              <Badge variant="neutral" background className="text-xs">
                 Read-only
               </Badge>
             )}
@@ -542,6 +542,13 @@ function ToolCard({ tool }: { tool: Tool }) {
               !tool.annotations?.readOnlyHint && (
                 <Badge variant="information" className="text-xs">
                   Idempotent
+                </Badge>
+              )}
+            {!tool.annotations?.readOnlyHint &&
+              !tool.annotations?.destructiveHint &&
+              !tool.annotations?.idempotentHint && (
+                <Badge variant="information" background className="text-xs">
+                  Write
                 </Badge>
               )}
           </Stack>


### PR DESCRIPTION
## Summary

- Add a **Write** badge on catalog tool cards when a tool has no read-only, destructive, or idempotent annotation — so every tool shows an explicit permission category
- Give the **Read-only** badge the `background` variant for clearer visual distinction

## Test plan

- [ ] Open a catalog detail page with tools that have mixed annotations
- [ ] Confirm read-only tools show a filled **Read-only** badge
- [ ] Confirm tools without any hint show a **Write** badge
- [ ] Confirm destructive/idempotent badges still appear correctly and suppress the Write badge

Fixes DNO-303

<img width="790" height="513" alt="image" src="https://github.com/user-attachments/assets/e927a253-be45-4604-9461-66371786a528" />

