### PR TITLE
fix: confirm before deleting a risk policy

### DIFF
--- a/.changeset/risk-policy-delete-confirmation.md
+++ b/.changeset/risk-policy-delete-confirmation.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+fix: show a confirmation dialog before deleting a risk policy in the Policy Center

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -10,6 +10,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -1020,6 +1021,7 @@ function PolicyCenterContent() {
     useState<Set<string>>(new Set<string>());
 
   const [runPanelPolicy, setRunPanelPolicy] = useState<RiskPolicy | null>(null);
+  const [deletingPolicy, setDeletingPolicy] = useState<RiskPolicy | null>(null);
 
   const [activeTab, setActiveTab] = useState<"policies" | "exclusions">(
     "policies",
@@ -1093,7 +1095,10 @@ function PolicyCenterContent() {
   });
 
   const deleteMutation = useRiskPoliciesDeleteMutation({
-    onSuccess: invalidate,
+    onSuccess: () => {
+      invalidate();
+      setDeletingPolicy(null);
+    },
   });
 
   const handleCreate = (kind?: PolicyKind) => {
@@ -1422,8 +1427,9 @@ function PolicyCenterContent() {
     }
   };
 
-  const handleDelete = (row: PolicyRow) => {
-    deleteMutation.mutate({ request: { id: row.policy.id } });
+  const handleConfirmDelete = () => {
+    if (!deletingPolicy) return;
+    deleteMutation.mutate({ request: { id: deletingPolicy.id } });
   };
 
   const handleToggle = (policy: RiskPolicy, enabled: boolean) => {
@@ -1688,7 +1694,9 @@ function PolicyCenterContent() {
               )}
               <DropdownMenuItem
                 className="text-destructive focus:text-destructive cursor-pointer"
-                onSelect={() => handleDelete(row)}
+                onSelect={() => {
+                  setTimeout(() => setDeletingPolicy(row.policy), 0);
+                }}
               >
                 Delete
               </DropdownMenuItem>
@@ -2065,6 +2073,47 @@ function PolicyCenterContent() {
             {runPanelPolicy && <RunPanel policy={runPanelPolicy} />}
           </SheetContent>
         </Sheet>
+
+        {/* Delete confirmation */}
+        <Dialog
+          open={!!deletingPolicy}
+          onOpenChange={(open) => {
+            if (!open) setDeletingPolicy(null);
+          }}
+        >
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Delete Policy</Dialog.Title>
+              <Dialog.Description>
+                Are you sure you want to delete{" "}
+                <strong>{deletingPolicy?.name}</strong>? This action cannot be
+                undone.
+              </Dialog.Description>
+            </Dialog.Header>
+            <Dialog.Footer>
+              <Button
+                variant="tertiary"
+                onClick={() => setDeletingPolicy(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive-primary"
+                onClick={handleConfirmDelete}
+                disabled={deleteMutation.isPending}
+              >
+                {deleteMutation.isPending && (
+                  <Button.LeftIcon>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  </Button.LeftIcon>
+                )}
+                <Button.Text>
+                  {deleteMutation.isPending ? "Deleting..." : "Delete"}
+                </Button.Text>
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog>
       </Page.Body>
     </Page>
   );


### PR DESCRIPTION
## Summary

Fixes [DNO-406](https://linear.app/speakeasy/issue/DNO-406/confirmation-toast-before-deleting-a-risk-policy).

Deleting a risk policy from the Policy Center row menu previously fired the delete mutation immediately — one stray click on the ⋯ menu's Delete item destroyed the policy with no way back.

The Delete action now opens a confirmation dialog (the same `Dialog` pattern used for delete confirmations elsewhere in the dashboard, e.g. environment variables and roles) showing the policy name, with Cancel and a destructive-styled Delete button. The confirm button shows a pending spinner while the mutation runs, and the dialog closes on success.

Note: the ticket title says "toast", but a toast isn't a blocking affordance — the established dashboard convention for confirm-before-delete is a dialog, so that's what this implements.

## Changes

- `PolicyCenter.tsx`: the row-menu Delete item now stages the policy in `deletingPolicy` state instead of mutating; a confirmation `Dialog` renders the actual delete.
- Changeset for the dashboard patch release.

## Testing

- `pnpm -F dashboard lint` and `pnpm -F dashboard type-check` pass.
- Verified end-to-end locally against the `ecommerce-api` project: cancel keeps the policy, confirm deletes it (demo GIF in comment below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a confirmation dialog before deleting a risk policy to prevent accidental removals. Implements DNO-406 by replacing the immediate delete with a blocking confirm flow consistent with the dashboard.

- **Bug Fixes**
  - Row-menu Delete now opens a confirmation dialog with the policy name; Cancel and destructive Delete; shows a spinner while deleting; closes on success.
  - Added `deletingPolicy` state and a confirm handler; runs the delete mutation only on confirm and invalidates on success.
  - Added a changeset for a dashboard patch release.

<sup>Written for commit e6b069d28951cdc916f8d5329da320d2d9da2fd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

