### PR TITLE
fix(telemetry): reduce flakiness in tool usage hook-source filter test

### DIFF
--- a/server/internal/telemetry/get_tool_usage_summary_test.go
+++ b/server/internal/telemetry/get_tool_usage_summary_test.go
@@ -286,7 +286,7 @@ func TestGetToolUsageSummary_FiltersByHookSource(t *testing.T) {
 		var err error
 		result, err = ti.service.GetToolUsageSummary(ctx, payload)
 		return err == nil && result != nil && result.Totals.EventCount == 1
-	}, 2*time.Second, 50*time.Millisecond, "expected only the cowork hook event in the filtered summary")
+	}, 10*time.Second, 200*time.Millisecond, "expected only the cowork hook event in the filtered summary")
 
 	targets := toolUsageTargetsByKey(result.Targets)
 	require.NotNil(t, targets["shadow_mcp_server:server:shadow-db"])


### PR DESCRIPTION
`TestGetToolUsageSummary_FiltersByHookSource` polls ClickHouse for eventual consistency, but used a 2s timeout / 50ms interval — whereas every other ClickHouse-backed test in the same file uses 10s / 200ms. Under CI load the materialized view backing the tool-usage query doesn't reflect the inserts within 2s, producing intermittent `Condition never satisfied` failures ([example job](https://github.com/speakeasy-api/gram/actions/runs/28854618266/job/85578042343)).

Bumps the poll timeout to 10s / 200ms to match the rest of the file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the polling timeout and interval in `TestGetToolUsageSummary_FiltersByHookSource` from 2s/50ms to 10s/200ms to account for ClickHouse materialized view lag and fix CI flakiness (AGE-2911). Aligns this test with other ClickHouse-backed tests in the file to prevent intermittent “Condition never satisfied” failures.

<sup>Written for commit c22de15872375ccf22eff6245aabdf9df4ebf94e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

