### PR TITLE
fix(seed): promote dev user to admin before enabling RBAC

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -1955,9 +1955,24 @@ async function enableRBACForDevUser(init: {
   const { sessionId, organizationId, userId, gram } = init;
   log.info("Enabling RBAC + granting dev user full session visibility...");
 
+  // EnableRBAC is gated by requirePlatformAdmin (access/impl.go): the caller
+  // must have a @speakeasy.com/@speakeasyapi.dev email OR the users.admin flag.
+  // Locally the dev user's email is neither (e.g. a personal gmail address) and
+  // admin defaults to false, so the call 403s. Promote the dev user to admin in
+  // the DB first so the platform-admin check passes. Idempotent.
+  try {
+    const dbUser = process.env.DB_USER || "gram";
+    const dbName = process.env.DB_NAME || "gram";
+    await $`docker compose exec gram-db psql -U ${dbUser} -d ${dbName} -v ON_ERROR_STOP=1 -c ${`UPDATE users SET admin = TRUE WHERE id = '${userId.replace(/'/g, "''")}';`}`.quiet();
+  } catch (e: unknown) {
+    const err = e as { stderr?: string; stdout?: string; message?: string };
+    log.warn(
+      `Failed to promote dev user to admin: ${err.message || err.stderr || err.stdout || JSON.stringify(e)}`,
+    );
+    return;
+  }
+
   // EnableRBAC seeds the built-in system roles and flips the org feature flag.
-  // The dev user is a Speakeasy super-admin (email-gated), so this is allowed
-  // even before any grants exist.
   const res = await accessEnableRBAC(gram, undefined, {
     sessionHeaderGramSession: sessionId,
   });


### PR DESCRIPTION
## What

Fix the `mise run seed` step **"Enabling RBAC + granting dev user full session visibility"**, which was failing with `403 permission denied`.

## Why

`access.EnableRBAC` is gated by `requirePlatformAdmin` (`server/internal/access/impl.go`), which passes only if the caller's email is a `@speakeasy.com`/`@speakeasyapi.dev` address **or** the `users.admin` DB flag is `true`.

dev-idp seeds its default user from the machine's `git config user.email`. Contributors whose git email is not a speakeasy address (e.g. a personal address) fall through to the `admin` flag, which defaults to `false` — so the call 403s and RBAC is never enabled locally. The step's existing comment incorrectly assumed the dev user is always email-gated as a super-admin.

## Fix

`enableRBACForDevUser` now sets the dev user's `admin` flag to `true` in Postgres before calling `EnableRBAC`, so the platform-admin gate passes regardless of the configured git email. Idempotent.

## Testing

Re-ran `mise run seed`; the step now succeeds:

```
● Enabled RBAC and granted dev user 10 scopes (admin + chat:read); Agent Sessions now shows all org sessions.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix seed step by promoting the local dev user to platform admin before enabling RBAC, preventing 403s when the git email isn’t a Speakeasy domain. This makes `mise run seed` reliably enable RBAC and grant the dev user full session visibility.

- **Bug Fixes**
  - Set `users.admin = TRUE` for the dev user in Postgres via `docker compose exec ... psql` before calling `EnableRBAC` (idempotent).
  - Gracefully logs a warning on failure; uses `DB_USER`/`DB_NAME` env vars with defaults to `gram`.

<sup>Written for commit 60681443d7c808824655eeeb0db5805ff895283e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

