### PR TITLE
fix(seed): abort when RBAC enablement steps fail

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -1966,10 +1966,9 @@ async function enableRBACForDevUser(init: {
     await $`docker compose exec gram-db psql -U ${dbUser} -d ${dbName} -v ON_ERROR_STOP=1 -c ${`UPDATE users SET admin = TRUE WHERE id = '${userId.replace(/'/g, "''")}';`}`.quiet();
   } catch (e: unknown) {
     const err = e as { stderr?: string; stdout?: string; message?: string };
-    log.warn(
+    abort(
       `Failed to promote dev user to admin: ${err.message || err.stderr || err.stdout || JSON.stringify(e)}`,
     );
-    return;
   }
 
   // EnableRBAC seeds the built-in system roles and flips the org feature flag.
@@ -1977,8 +1976,7 @@ async function enableRBACForDevUser(init: {
     sessionHeaderGramSession: sessionId,
   });
   if (!res.ok) {
-    log.warn(`Failed to enable RBAC: ${JSON.stringify(res.error)}`);
-    return;
+    abort("Failed to enable RBAC", res.error);
   }
 
   // The admin system role intentionally omits chat:read, and the dev user has
@@ -2027,7 +2025,7 @@ async function enableRBACForDevUser(init: {
     );
   } catch (e: unknown) {
     const err = e as { stderr?: string; stdout?: string; message?: string };
-    log.warn(
+    abort(
       `Failed to grant dev user RBAC scopes: ${err.message || err.stderr || err.stdout || JSON.stringify(e)}`,
     );
   }


### PR DESCRIPTION
## What

`enableRBACForDevUser` in `.mise-tasks/seed.mts` exists to guarantee the local dev user gets the "see all org sessions" admin view, which is gated behind RBAC enforcement plus a `chat:read` grant. Its three steps previously swallowed failures with `log.warn` + early `return`:

1. Promoting the dev user to `admin` (the `UPDATE users SET admin = TRUE` psql call)
2. The `accessEnableRBAC` API call
3. The `principal_grants` insert

## Problem

On any failure the caller received no error signal and unconditionally set `success = true`. Because the `"Enabling RBAC..."` info log had already been emitted, a silent skip read as a successful run — masking a broken precondition (DB unreachable, wrong container name, user not found). Notably a failed admin promotion also cascades into an `accessEnableRBAC` 403, which was *also* swallowed.

## Fix

Convert all three failure paths to `abort(...)`, matching how the rest of the script handles critical infrastructure failures (`never`-returning `process.exit(1)` with error-level logging, used ~20× elsewhere). The seed now stops loudly instead of misreporting success.

No behavior change on the happy path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort the seed when RBAC enablement fails so we don’t report success on broken setups. This ensures the local dev user either gets the full admin RBAC setup or the script exits with an error.

- **Bug Fixes**
  - Switched from `log.warn` + early return to `abort(...)` for three steps in `.mise-tasks/seed.mts`: admin promotion (psql), `accessEnableRBAC` call, and `principal_grants` insert.
  - Aligns with existing script error handling; no change on the happy path.

<sup>Written for commit d69a5e954dcd991cfabe41cad23c248067fce728. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

