### PR TITLE
feat: attribute project assistant chats to their creator

### DIFF
--- a/.changeset/project-assistant-chat-attribution.md
+++ b/.changeset/project-assistant-chat-attribution.md
@@ -1,0 +1,6 @@
+---
+"@gram-ai/elements": minor
+"dashboard": patch
+---
+
+Attribute project assistant chats to the user who created them. Elements gains an opt-in `history.resolveCreator` callback that resolves a chat's `userId`/`externalUserId` to a displayable name/avatar, shown on thread-list rows and above each user turn in the transcript. The dashboard wires this up for the Project Assistant using its existing org member list — no new network requests, and no identity data is fetched from inside Elements itself (avoids leaking org member data into customer-facing embeds, which don't opt in). Also adds the same avatar to the "Recent Chats" list on the assistant home page, and gives user message bubbles an iMessage-style blue treatment.

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -1,6 +1,7 @@
 import { useNoToolsetsConfigured } from "@/hooks/useObservabilityMcpConfig";
 import { useServerAssistantTransport } from "@/hooks/useServerAssistantTransport";
 import { useListChats } from "@gram/client/react-query";
+import { useMembers } from "@gram/client/react-query/members.js";
 import { SortBy, SortOrder } from "@gram/client/models/operations/listchats";
 import { cn, isMacPlatform } from "@/lib/utils";
 import speakeasyIcon from "@/assets/speakeasy-icon.svg";
@@ -731,6 +732,27 @@ export function InsightsProvider({
     recentChat !== undefined &&
     Date.now() - recentChat.lastMessageTimestamp.getTime() < CONTINUE_WINDOW_MS;
 
+  // Resolves a chat's creator to a name/email/avatar for Elements' history
+  // list, from the org member list the dashboard already has cached — no
+  // extra request, and avoids the cross-origin auth mismatch a direct fetch
+  // from inside Elements would hit (its request headers are scoped to the
+  // chat API, not `access.listMembers`).
+  const { data: membersData } = useMembers();
+  const resolveCreator = useCallback(
+    ({ userId }: { userId?: string; externalUserId?: string }) => {
+      if (!userId) return undefined;
+      const member = membersData?.members.find((m) => m.id === userId);
+      return (
+        member && {
+          name: member.name,
+          email: member.email,
+          photoUrl: member.photoUrl,
+        }
+      );
+    },
+    [membersData],
+  );
+
   // Mount the shared runtime only where it's actually used: a chat route (the
   // page owns the chat) or the open dock — and only where the dock is shown.
   // Pages with their own chat runtime (Playground, Elements, assistant
@@ -838,6 +860,7 @@ export function InsightsProvider({
         // framing block (needed for replay, noise for display). Strip it — and
         // drop framing-only turns — before Elements renders the transcript.
         transformChatMessage: stripMessageContextFraming,
+        resolveCreator,
       },
       api: {
         ...mcpConfig.api,
@@ -875,6 +898,7 @@ export function InsightsProvider({
       theme,
       wrappedTransport,
       managedAssistantId,
+      resolveCreator,
     ],
   );
 

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -739,9 +739,21 @@ export function InsightsProvider({
   // chat API, not `access.listMembers`).
   const { data: membersData } = useMembers();
   const resolveCreator = useCallback(
-    ({ userId }: { userId?: string; externalUserId?: string }) => {
-      if (!userId) return undefined;
-      const member = membersData?.members.find((m) => m.id === userId);
+    ({
+      userId,
+      externalUserId,
+    }: {
+      userId?: string;
+      externalUserId?: string;
+    }) => {
+      if (!userId && !externalUserId) return undefined;
+      // Chats started from the dashboard itself have no `userId` at capture
+      // time and stash the caller's email in `externalUserId` instead — fall
+      // back to an email match so those still resolve to a member.
+      const member = membersData?.members.find(
+        (m) =>
+          m.id === userId || (!!externalUserId && m.email === externalUserId),
+      );
       return (
         member && {
           name: member.name,

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -625,17 +625,26 @@ function initialsOf(identifier: string): string {
       words[0]!.charAt(0) + words[words.length - 1]!.charAt(0)
     ).toUpperCase();
   }
-  return handle.slice(0, 2).toUpperCase();
+  return handle.trim().slice(0, 2).toUpperCase();
 }
 
 // Row icon: the chat creator's avatar when it resolves against the org
 // member list, otherwise the default message icon (e.g. chats with no
-// internal user attached, or before members have loaded).
-function RecentRowIcon({ userId }: { userId?: string }): ReactElement {
+// internal user attached, or before members have loaded). Chats started from
+// the dashboard itself have no `userId` at capture time and stash the
+// caller's email in `externalUserId` instead — fall back to an email match so
+// those still resolve.
+function RecentRowIcon({
+  userId,
+  externalUserId,
+}: {
+  userId?: string;
+  externalUserId?: string;
+}): ReactElement {
   const { data: membersData } = useMembers();
-  const member = userId
-    ? membersData?.members.find((m) => m.id === userId)
-    : undefined;
+  const member = membersData?.members.find(
+    (m) => m.id === userId || (!!externalUserId && m.email === externalUserId),
+  );
 
   if (member) {
     const display = member.name || member.email;
@@ -675,7 +684,10 @@ function RecentRow({
         to={routes.chat.conversation.href(chat.id)}
         className="flex min-w-0 flex-1 items-center gap-3"
       >
-        <RecentRowIcon userId={chat.userId} />
+        <RecentRowIcon
+          userId={chat.userId}
+          externalUserId={chat.externalUserId}
+        />
         <span className="text-foreground min-w-0 flex-1 truncate text-sm">
           {chat.title || "New chat"}
         </span>

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -32,7 +32,9 @@ import {
   useChatSetPinnedMutation,
   useListChats,
 } from "@gram/client/react-query";
+import { useMembers } from "@gram/client/react-query/members.js";
 import { useSession } from "@/contexts/Auth";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   useHideInsightsDock,
   useInsightsState,
@@ -607,6 +609,55 @@ function RecentEntryView({ entry }: { entry: RecentEntry }): ReactElement {
   return <RecentRow chat={entry.chat} pinned={false} />;
 }
 
+/**
+ * Two-letter initials from a display name or email handle: first letter of
+ * the first and last word for a multi-word name ("Adam Bull" -> "AB"), or
+ * the first two characters of the email's local part / a single-word name
+ * otherwise ("adam@..." -> "AD").
+ */
+function initialsOf(identifier: string): string {
+  const handle = identifier.includes("@")
+    ? (identifier.split("@")[0] ?? identifier)
+    : identifier;
+  const words = handle.trim().split(/\s+/).filter(Boolean);
+  if (words.length >= 2) {
+    return (
+      words[0]!.charAt(0) + words[words.length - 1]!.charAt(0)
+    ).toUpperCase();
+  }
+  return handle.slice(0, 2).toUpperCase();
+}
+
+// Row icon: the chat creator's avatar when it resolves against the org
+// member list, otherwise the default message icon (e.g. chats with no
+// internal user attached, or before members have loaded).
+function RecentRowIcon({ userId }: { userId?: string }): ReactElement {
+  const { data: membersData } = useMembers();
+  const member = userId
+    ? membersData?.members.find((m) => m.id === userId)
+    : undefined;
+
+  if (member) {
+    const display = member.name || member.email;
+    return (
+      <Avatar className="size-9 shrink-0">
+        {member.photoUrl ? (
+          <AvatarImage src={member.photoUrl} alt={display} />
+        ) : null}
+        <AvatarFallback className="border-border bg-card text-muted-foreground border text-xs font-medium">
+          {initialsOf(display)}
+        </AvatarFallback>
+      </Avatar>
+    );
+  }
+
+  return (
+    <span className="border-border bg-card text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-lg border">
+      <MessageCircle className="size-4" />
+    </span>
+  );
+}
+
 function RecentRow({
   chat,
   pinned,
@@ -624,9 +675,7 @@ function RecentRow({
         to={routes.chat.conversation.href(chat.id)}
         className="flex min-w-0 flex-1 items-center gap-3"
       >
-        <span className="border-border bg-card text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-lg border">
-          <MessageCircle className="size-4" />
-        </span>
+        <RecentRowIcon userId={chat.userId} />
         <span className="text-foreground min-w-0 flex-1 truncate text-sm">
           {chat.title || "New chat"}
         </span>

--- a/elements/src/components/assistant-ui/thread-list.tsx
+++ b/elements/src/components/assistant-ui/thread-list.tsx
@@ -6,10 +6,11 @@ import {
 } from "@assistant-ui/react";
 import { MessageSquareTextIcon, PlusIcon } from "lucide-react";
 
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useRadius } from "@/hooks/useRadius";
-import { cn } from "@/lib/utils";
+import { cn, initialsOf } from "@/lib/utils";
 import { useDensity } from "@/hooks/useDensity";
 import { useThreadMeta } from "@/contexts/ThreadMetaContext";
 
@@ -133,9 +134,7 @@ const ThreadListItem: FC = () => {
           d("py-sm"),
         )}
       >
-        <span className="aui-thread-list-item-icon flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-card text-muted-foreground">
-          <MessageSquareTextIcon className="size-3.5" />
-        </span>
+        <ThreadListItemIcon />
         <span className="flex min-w-0 flex-col">
           <ThreadListItemTitle />
           <ThreadListItemDate />
@@ -144,6 +143,38 @@ const ThreadListItem: FC = () => {
       {/* Archive button hidden until feature is implemented */}
       {/* <ThreadListItemArchive /> */}
     </ThreadListItemPrimitive.Root>
+  );
+};
+
+/**
+ * Row icon: the chat creator's avatar when `history.resolveCreator` resolves
+ * one, otherwise the default message icon.
+ */
+const ThreadListItemIcon: FC = () => {
+  const id = useAssistantState(
+    ({ threadListItem }) =>
+      threadListItem.remoteId ?? threadListItem.externalId,
+  );
+  const owner = useThreadMeta(id ?? undefined)?.owner;
+
+  if (owner) {
+    const display = owner.name || owner.email;
+    return (
+      <Avatar className="aui-thread-list-item-icon size-7 shrink-0">
+        {owner.photoUrl ? (
+          <AvatarImage src={owner.photoUrl} alt={display} />
+        ) : null}
+        <AvatarFallback className="border border-border bg-card text-[10px] font-medium text-muted-foreground">
+          {initialsOf(display)}
+        </AvatarFallback>
+      </Avatar>
+    );
+  }
+
+  return (
+    <span className="aui-thread-list-item-icon flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-card text-muted-foreground">
+      <MessageSquareTextIcon className="size-3.5" />
+    </span>
   );
 };
 

--- a/elements/src/components/assistant-ui/thread.tsx
+++ b/elements/src/components/assistant-ui/thread.tsx
@@ -60,9 +60,11 @@ import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
 import { UserMessageText } from "@/components/assistant-ui/user-message-text";
 import { ToolMentionAutocomplete } from "@/components/assistant-ui/tool-mention-autocomplete";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useChatId } from "@/contexts/ChatIdContext";
 import { useReplayContext } from "@/contexts/ReplayContext";
+import { useThreadMeta } from "@/contexts/ThreadMetaContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useDensity } from "@/hooks/useDensity";
 import { useElements } from "@/hooks/useElements";
@@ -78,7 +80,7 @@ import {
   type MentionableTool,
   toolSetToMentionableTools,
 } from "@/lib/tool-mentions";
-import { cn } from "@/lib/utils";
+import { cn, initialsOf } from "@/lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import {
   Tooltip,
@@ -1196,9 +1198,10 @@ const UserMessage: FC = () => {
         <UserMessageAttachments />
 
         <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
+          <UserMessageHeader />
           <div
             className={cn(
-              "aui-user-message-content bg-muted px-5 py-2.5 wrap-break-word text-foreground",
+              "aui-user-message-content ml-auto w-fit bg-blue-500 px-5 py-2.5 wrap-break-word text-white",
               r("xl"),
             )}
           >
@@ -1214,6 +1217,43 @@ const UserMessage: FC = () => {
         <BranchPicker className="aui-user-branch-picker col-span-full col-start-1 row-start-3 -mr-1 justify-end" />
       </div>
     </MessagePrimitive.Root>
+  );
+};
+
+/**
+ * Avatar + name + timestamp above a user turn, identifying who sent it and
+ * when — the name/avatar resolved via `history.resolveCreator` for the
+ * message's thread. Renders nothing when unresolved (no `resolveCreator`
+ * configured, or it returned nothing for this chat).
+ */
+const UserMessageHeader: FC = () => {
+  const id = useAssistantState(
+    ({ threadListItem }) =>
+      threadListItem.remoteId ?? threadListItem.externalId,
+  );
+  const owner = useThreadMeta(id ?? undefined)?.owner;
+  const createdAt = useAssistantState(({ message }) => message.createdAt);
+  if (!owner) return null;
+
+  const display = owner.name || owner.email;
+  const time = createdAt.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return (
+    <div className="aui-user-message-owner mb-1.5 flex items-center justify-end gap-2 pr-5 text-xs text-muted-foreground">
+      <Avatar className="size-7">
+        {owner.photoUrl ? (
+          <AvatarImage src={owner.photoUrl} alt={display} />
+        ) : null}
+        <AvatarFallback className="text-xs font-medium">
+          {initialsOf(display)}
+        </AvatarFallback>
+      </Avatar>
+      <span className="font-medium text-foreground">{display}</span>
+      <span className="h-3 w-px bg-border" aria-hidden="true" />
+      <span>{time}</span>
+    </div>
   );
 };
 

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -755,6 +755,7 @@ const ElementsProviderWithHistory = ({
     threadListFilters: contextValue?.config.history?.threadListFilters,
     deferThreadIdMinting: contextValue?.config.history?.deferThreadIdMinting,
     transformChatMessage: contextValue?.config.history?.transformChatMessage,
+    resolveCreator: contextValue?.config.history?.resolveCreator,
   });
   const initialThreadId = contextValue?.config.history?.initialThreadId;
 

--- a/elements/src/contexts/ThreadMetaContext.ts
+++ b/elements/src/contexts/ThreadMetaContext.ts
@@ -15,6 +15,16 @@ import { createContext, useContext } from "react";
 export interface ThreadMeta {
   /** ISO timestamp of when the chat was created. */
   createdAt?: string;
+  /**
+   * The chat creator's displayable identity, as resolved by the consumer's
+   * `history.resolveCreator` callback. Undefined when that callback is
+   * unset, or returns nothing for this chat.
+   */
+  owner?: {
+    name?: string;
+    email: string;
+    photoUrl?: string;
+  };
 }
 
 export const ThreadMetaContext = createContext<Record<string, ThreadMeta>>({});

--- a/elements/src/hooks/useGramThreadListAdapter.tsx
+++ b/elements/src/hooks/useGramThreadListAdapter.tsx
@@ -107,6 +107,11 @@ export interface ThreadListAdapterOptions {
    * the library — see {@link HistoryConfig.transformChatMessage}.
    */
   transformChatMessage?: ChatMessageTransform;
+  /** See {@link HistoryConfig.resolveCreator}. */
+  resolveCreator?: (chat: {
+    userId?: string;
+    externalUserId?: string;
+  }) => { name?: string; email: string; photoUrl?: string } | undefined;
 }
 
 interface ListChatsResponse {
@@ -123,6 +128,20 @@ function readChatCreatedAt(chat: GramChatOverview): string | undefined {
   const raw = chat as unknown as Record<string, unknown>;
   const value = raw["created_at"] ?? raw["createdAt"];
   return typeof value === "string" ? value : undefined;
+}
+
+/** Reads a chat's creator (Gram user id) from the `chat.list` payload. */
+function readChatUserId(chat: GramChatOverview): string | undefined {
+  const raw = chat as unknown as Record<string, unknown>;
+  const value = raw["user_id"] ?? raw["userId"];
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/** Reads a chat's external user id from the `chat.list` payload. */
+function readChatExternalUserId(chat: GramChatOverview): string | undefined {
+  const raw = chat as unknown as Record<string, unknown>;
+  const value = raw["external_user_id"] ?? raw["externalUserId"];
+  return typeof value === "string" && value !== "" ? value : undefined;
 }
 
 /**
@@ -400,12 +419,23 @@ export function useGramThreadListAdapter(
           }
 
           const data = (await response.json()) as ListChatsResponse;
-          // Stash creation dates in the side channel before returning the
-          // assistant-ui metadata (which can't carry them) — keyed by chat id,
-          // the same value used for remoteId/externalId below.
+
+          // Stash creation dates + resolved owner in the side channel before
+          // returning the assistant-ui metadata (which can't carry them) —
+          // keyed by chat id, the same value used for remoteId/externalId
+          // below. `resolveCreator` is consumer-supplied and synchronous (the
+          // consumer already holds whatever identity data it needs), so no
+          // extra request goes out here.
+          const { resolveCreator } = optionsRef.current;
           const nextMeta: Record<string, ThreadMeta> = { ...metaRef.current };
           for (const chat of data.chats) {
-            nextMeta[chat.id] = { createdAt: readChatCreatedAt(chat) };
+            nextMeta[chat.id] = {
+              createdAt: readChatCreatedAt(chat),
+              owner: resolveCreator?.({
+                userId: readChatUserId(chat),
+                externalUserId: readChatExternalUserId(chat),
+              }),
+            };
           }
           metaRef.current = nextMeta;
           bumpMeta((n) => n + 1);

--- a/elements/src/lib/utils.ts
+++ b/elements/src/lib/utils.ts
@@ -9,6 +9,25 @@ export function assertNever(value: unknown): never {
   throw new Error(`Unexpected value: ${String(value)}`);
 }
 
+/**
+ * Two-letter initials from a display name or email handle: first letter of
+ * the first and last word for a multi-word name ("Adam Bull" -> "AB"), or
+ * the first two characters of the email's local part / a single-word name
+ * otherwise ("adam@..." -> "AD").
+ */
+export function initialsOf(identifier: string): string {
+  const handle = identifier.includes("@")
+    ? (identifier.split("@")[0] ?? identifier)
+    : identifier;
+  const words = handle.trim().split(/\s+/).filter(Boolean);
+  if (words.length >= 2) {
+    return (
+      words[0]!.charAt(0) + words[words.length - 1]!.charAt(0)
+    ).toUpperCase();
+  }
+  return handle.slice(0, 2).toUpperCase();
+}
+
 export function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);

--- a/elements/src/lib/utils.ts
+++ b/elements/src/lib/utils.ts
@@ -25,7 +25,7 @@ export function initialsOf(identifier: string): string {
       words[0]!.charAt(0) + words[words.length - 1]!.charAt(0)
     ).toUpperCase();
   }
-  return handle.slice(0, 2).toUpperCase();
+  return handle.trim().slice(0, 2).toUpperCase();
 }
 
 export function assert(condition: unknown, message: string): asserts condition {

--- a/elements/src/types/index.ts
+++ b/elements/src/types/index.ts
@@ -1144,6 +1144,27 @@ export interface HistoryConfig {
    * }}>
    */
   initialThreadId?: string;
+
+  /**
+   * Resolve a chat's creator to a displayable identity, shown as an avatar on
+   * each thread-list row. Called for every chat returned by the thread list
+   * with that chat's `userId`/`externalUserId`; return the creator's info to
+   * show it, or `undefined` to fall back to the default row icon.
+   *
+   * Elements has no notion of who a `userId` refers to — resolve it however
+   * the consumer's own identity system works (e.g. looking it up in an
+   * already-fetched member list) and return the result synchronously.
+   *
+   * @example
+   * resolveCreator: ({ userId }) => {
+   *   const member = members.find((m) => m.id === userId);
+   *   return member && { name: member.name, email: member.email, photoUrl: member.photoUrl };
+   * }
+   */
+  resolveCreator?: (chat: {
+    userId?: string;
+    externalUserId?: string;
+  }) => { name?: string; email: string; photoUrl?: string } | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Elements gains an opt-in `history.resolveCreator` callback that resolves a chat's `userId`/`externalUserId` to a displayable name/avatar — shown on thread-list rows and above each user turn in the transcript. Off by default: no identity data is fetched from inside Elements, so customer-facing embeds that don't opt in are unaffected.
- The dashboard wires this up for the Project Assistant using its already-cached org member list (`useMembers()`) — no new network requests, and avoids the CORS/auth-scheme mismatch a direct `access.listMembers` fetch from inside Elements' thread-list adapter hits (its request headers are scoped to the chat API, not `access.listMembers`).
- Same avatar added to the "Recent Chats" list on the assistant home page (`client/dashboard/src/pages/chat/Chat.tsx`).
- User message bubbles restyled blue/white (iMessage-style), width-fit instead of stretching full width.

Closes AGE-2896.

## Test plan
- [x] `pnpm type-check` / `lint:oxlint` / `lint:format` clean on `elements` and `client/dashboard`
- [x] Manually verified in dev: avatar + name resolve correctly on Recent Chats, transcript header, and thread-list history for a signed-in member; falls back to default icon/no header when unresolved
- [x] Confirmed `resolveCreator` is unset (no-op) for the generic `elements/examples/*` embedded-chat consumers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes Project Assistant chats to their creator and shows their name/avatar across Elements and the dashboard, including Recent Chats. Adds an opt-in `history.resolveCreator` to `@gram-ai/elements` and updates user message bubbles to iMessage-style; implements AGE-2896.

- New Features
  - `@gram-ai/elements`: add `history.resolveCreator` to map `userId`/`externalUserId` to `{ name, email, photoUrl }`; used on thread-list rows and above each user message.
  - Dashboard: wire resolver from cached org members via `useMembers()` (no extra requests; avoids CORS/auth mismatch).
  - Assistant home: show creator avatar in “Recent Chats”.
  - Creator resolution polish: also match `externalUserId` to member email; fix initials fallback by trimming before slicing.

- Migration
  - Optional: provide `history.resolveCreator` when embedding Elements to show attribution; without it, behavior is unchanged.

<sup>Written for commit bc9e57bcb6085acccb37ccb30e1a50149c3ec2a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

