### PR TITLE
fix: hide project assistant composer for chats caller doesn't own

### DIFF
--- a/.changeset/hide-composer-non-owned-chats.md
+++ b/.changeset/hide-composer-non-owned-chats.md
@@ -1,0 +1,6 @@
+---
+"@gram-ai/elements": minor
+"dashboard": patch
+---
+
+Hide the chat composer for project assistant threads the signed-in caller didn't create. Elements gains an opt-in `history.isOwnChat` callback (mirrors `resolveCreator`) that reports whether the caller owns a thread-list chat; the dashboard wires it up so admins who open another member's chat via their `chat:read` grant see a read-only transcript instead of a "chat not found" error on send — the backend has always rejected replies into a chat you don't own, this just stops the UI offering an action that was never going to succeed.

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -18,6 +18,7 @@ import {
   useThreadId,
 } from "@gram-ai/elements";
 import { stripMessageContextFraming } from "@/lib/projectAssistantTranscript";
+import { useSession } from "@/contexts/Auth";
 import {
   INSIGHTS_DOCK_CONTENT_VT_CLASS,
   INSIGHTS_DOCK_VT_CLASS,
@@ -765,6 +766,26 @@ export function InsightsProvider({
     [membersData],
   );
 
+  // The backend only lets a chat's creator send into it (see
+  // CheckDashboardChatOwnership) — admins can still open others' chats via
+  // their chat:read grant, so hide the composer for those rather than let a
+  // send 404. Chats started from the dashboard stash the caller's email in
+  // externalUserId instead of userId (see resolveCreator above).
+  const { user } = useSession();
+  const isOwnChat = useCallback(
+    ({
+      userId,
+      externalUserId,
+    }: {
+      userId?: string;
+      externalUserId?: string;
+    }) => {
+      if (!userId && !externalUserId) return true;
+      return userId === user.id || externalUserId === user.email;
+    },
+    [user.id, user.email],
+  );
+
   // Mount the shared runtime only where it's actually used: a chat route (the
   // page owns the chat) or the open dock — and only where the dock is shown.
   // Pages with their own chat runtime (Playground, Elements, assistant
@@ -873,6 +894,7 @@ export function InsightsProvider({
         // drop framing-only turns — before Elements renders the transcript.
         transformChatMessage: stripMessageContextFraming,
         resolveCreator,
+        isOwnChat,
       },
       api: {
         ...mcpConfig.api,
@@ -911,6 +933,7 @@ export function InsightsProvider({
       wrappedTransport,
       managedAssistantId,
       resolveCreator,
+      isOwnChat,
     ],
   );
 

--- a/elements/src/components/assistant-ui/thread.tsx
+++ b/elements/src/components/assistant-ui/thread.tsx
@@ -135,6 +135,10 @@ export const Thread: FC<ThreadProps> = ({ className }) => {
   const [isResolved, setIsResolved] = useState(false);
   const [feedbackHidden, setFeedbackHidden] = useState(false);
   const chatId = useChatId();
+  // Hidden rather than disabled: the backend rejects sends into a chat the
+  // caller can view (e.g. via an admin-level read grant) but didn't create,
+  // so there's no valid action to leave available.
+  const composerHidden = useThreadMeta(chatId ?? undefined)?.readOnly ?? false;
 
   const apiUrl = getApiUrl(config);
   const auth = useAuth({
@@ -235,7 +239,7 @@ export const Thread: FC<ThreadProps> = ({ className }) => {
                 <div className="aui-thread-viewport-spacer min-h-8 grow" />
               </ThreadPrimitive.If>
 
-              <Composer showFeedback={showFeedback} />
+              {!composerHidden && <Composer showFeedback={showFeedback} />}
             </ThreadPrimitive.Viewport>
 
             {/* Resolution overlay - subtle readonly effect */}

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -756,6 +756,7 @@ const ElementsProviderWithHistory = ({
     deferThreadIdMinting: contextValue?.config.history?.deferThreadIdMinting,
     transformChatMessage: contextValue?.config.history?.transformChatMessage,
     resolveCreator: contextValue?.config.history?.resolveCreator,
+    isOwnChat: contextValue?.config.history?.isOwnChat,
   });
   const initialThreadId = contextValue?.config.history?.initialThreadId;
 

--- a/elements/src/contexts/ThreadMetaContext.ts
+++ b/elements/src/contexts/ThreadMetaContext.ts
@@ -25,6 +25,13 @@ export interface ThreadMeta {
     email: string;
     photoUrl?: string;
   };
+  /**
+   * True when the consumer's `history.isOwnChat` callback says the signed-in
+   * caller doesn't own this chat. The composer hides itself when this is set,
+   * since the backend rejects sends into a chat you can view but didn't
+   * create.
+   */
+  readOnly?: boolean;
 }
 
 export const ThreadMetaContext = createContext<Record<string, ThreadMeta>>({});

--- a/elements/src/hooks/useGramThreadListAdapter.tsx
+++ b/elements/src/hooks/useGramThreadListAdapter.tsx
@@ -112,6 +112,8 @@ export interface ThreadListAdapterOptions {
     userId?: string;
     externalUserId?: string;
   }) => { name?: string; email: string; photoUrl?: string } | undefined;
+  /** See {@link HistoryConfig.isOwnChat}. */
+  isOwnChat?: (chat: { userId?: string; externalUserId?: string }) => boolean;
 }
 
 interface ListChatsResponse {
@@ -426,15 +428,17 @@ export function useGramThreadListAdapter(
           // below. `resolveCreator` is consumer-supplied and synchronous (the
           // consumer already holds whatever identity data it needs), so no
           // extra request goes out here.
-          const { resolveCreator } = optionsRef.current;
+          const { resolveCreator, isOwnChat } = optionsRef.current;
           const nextMeta: Record<string, ThreadMeta> = { ...metaRef.current };
           for (const chat of data.chats) {
+            const chatIdentity = {
+              userId: readChatUserId(chat),
+              externalUserId: readChatExternalUserId(chat),
+            };
             nextMeta[chat.id] = {
               createdAt: readChatCreatedAt(chat),
-              owner: resolveCreator?.({
-                userId: readChatUserId(chat),
-                externalUserId: readChatExternalUserId(chat),
-              }),
+              owner: resolveCreator?.(chatIdentity),
+              readOnly: isOwnChat ? !isOwnChat(chatIdentity) : false,
             };
           }
           metaRef.current = nextMeta;

--- a/elements/src/types/index.ts
+++ b/elements/src/types/index.ts
@@ -1165,6 +1165,18 @@ export interface HistoryConfig {
     userId?: string;
     externalUserId?: string;
   }) => { name?: string; email: string; photoUrl?: string } | undefined;
+
+  /**
+   * Report whether the signed-in caller owns a chat returned by the thread
+   * list. Called for every chat with that chat's `userId`/`externalUserId`;
+   * return `false` to hide the composer for that chat — the backend rejects
+   * sends into a chat the caller can view (e.g. via an admin-level read
+   * grant) but didn't create. Omit to always show the composer.
+   *
+   * @example
+   * isOwnChat: ({ userId }) => userId === currentUser.id
+   */
+  isOwnChat?: (chat: { userId?: string; externalUserId?: string }) => boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Sending a follow-up in a project assistant chat you didn't create 404s ("chat not found") — `SendMessage` gates continuing a chat on literal `user_id` ownership (`server/internal/assistants/impl.go:263`, `CallerOwnsDashboardChat`), with no RBAC fallback. That's intentional: only the creator should be able to continue a chat.
- The gap is upstream of that: `LoadChat` (`server/internal/chat/impl.go:507`) _does_ let an admin open another member's chat via their `chat:read` grant, so the dashboard was letting admins type into a chat whose send was always going to fail.
- Adds an opt-in `history.isOwnChat` callback to `@gram-ai/elements` (mirrors the existing `history.resolveCreator`) that reports whether the caller owns a thread-list chat. The dashboard wires it up from the signed-in session, and Elements hides the composer for any chat it says isn't the caller's — no error, no read-only banner, just no compose box.

## Test plan

- [x] `pnpm -F @gram-ai/elements type-check`
- [x] `pnpm -F dashboard type-check`
- [ ] Manually verify in dev: admin opens another member's project assistant chat → composer hidden; own chats and owner-less/legacy chats unaffected


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the project assistant composer when the signed-in user doesn’t own the chat to prevent the “chat not found” 404 on send. Adds an opt-in ownership check to `@gram-ai/elements` and wires it in the dashboard.

- **New Features**
  - Added `history.isOwnChat({ userId, externalUserId }) => boolean` to `@gram-ai/elements`.
  - Populates `ThreadMeta.readOnly`; `Thread` hides the composer when `readOnly` is true.
  - Backward-compatible: omit `isOwnChat` to keep current behavior.

- **Bug Fixes**
  - Dashboard implements `isOwnChat` using session `user.id` or `user.email` vs chat `userId`/`externalUserId`.
  - Admins with `chat:read` can open others’ chats but won’t see a composer; own and legacy/owner-less chats are unchanged.

<sup>Written for commit e3f1e11cce689c1179d33e65bcf70f4f17909f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

