### PR TITLE
fix: improve contrast of additional-context disclosure on user message bubble

### DIFF
--- a/elements/src/components/assistant-ui/user-message-text.tsx
+++ b/elements/src/components/assistant-ui/user-message-text.tsx
@@ -27,7 +27,7 @@ const ContextDisclosure: FC<{ blocks: ContextBlock[] }> = ({ blocks }) => {
       <CollapsibleTrigger
         className={cn(
           "aui-user-context-trigger group/trigger flex items-center gap-1.5 py-0.5",
-          "text-xs text-muted-foreground transition-colors hover:text-foreground",
+          "text-xs text-white/70 transition-colors hover:text-white",
         )}
       >
         <ChevronDownIcon
@@ -43,7 +43,7 @@ const ContextDisclosure: FC<{ blocks: ContextBlock[] }> = ({ blocks }) => {
             shrink-to-fit message bubble — contribute 0 to its intrinsic width,
             then fill the bubble's resolved width and wrap. Keeps the bubble the
             same width open or closed. */}
-        <div className="aui-user-context-body mt-1.5 w-0 min-w-full space-y-2 border-l-2 border-border pl-3 text-xs whitespace-pre-line text-muted-foreground">
+        <div className="aui-user-context-body mt-1.5 w-0 min-w-full space-y-2 border-l-2 border-white/30 pl-3 text-xs whitespace-pre-line text-white/70">
           {blocks.map((block, i) => (
             <p key={i}>{block.body}</p>
           ))}


### PR DESCRIPTION
## Summary

- Fixed low-contrast "Additional context" disclosure text on the user message bubble in `@gram-ai/elements`
- The chevron trigger, label, body text, and left border rule used theme tokens (`text-muted-foreground`, `text-foreground`, `border-border`) tuned for neutral light/dark surfaces — nearly unreadable against the bubble's hardcoded `bg-blue-500`
- Swapped to white-opacity variants (`text-white/70`, `hover:text-white`, `border-white/30`) consistent with the bubble's existing `text-white` main text

## Before / After

Before: gray text on blue bubble, barely legible.

## Test plan

- [ ] Rebuild `@gram-ai/elements` and visually verify the "Additional context" disclosure (collapsed + expanded) on a user message bubble in dashboard/Storybook, both expanded/collapsed states


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved contrast of the “Additional context” disclosure on the user message bubble in `@gram-ai/elements` so the label, chevron, body text, and border are readable on the blue bubble. Swapped `text-muted-foreground`/`hover:text-foreground`/`border-border` for `text-white/70`/`hover:text-white`/`border-white/30`.

<sup>Written for commit b77f15b8aeacbd666a7ac20b8bd776527d9367b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

