### PR TITLE
fix: restore Non-Corporate Accounts card, drop duplicate Off-Policy Content (DNO-410)

### DIFF
--- a/.changeset/fix-risk-policy-noncorp-offpolicy.md
+++ b/.changeset/fix-risk-policy-noncorp-offpolicy.md
@@ -1,0 +1,7 @@
+---
+"dashboard": patch
+---
+
+fix: restore Non-Corporate Accounts risk-policy card and remove duplicate Off-Policy Content card
+
+The risk-policy eval refactor dropped the Non-Corporate Accounts detector (including its approved-email-domains config) from the new policy detail form and rendered Off-Policy Content twice. This re-adds `account_identity` to the available/display/flag-only category sets and payload mapping, restores the approved-domains state and Customize-sheet UI, and de-duplicates Off-Policy Content.

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -186,6 +186,35 @@ export function DetectorCard({
   );
 }
 
+/** Per-policy config for the Non-Corporate Accounts category: the list of
+ *  email domains treated as corporate. Rendered inside the category's
+ *  Customize sheet; the parsed list rides on the create/update payload as
+ *  approved_email_domains while the category is selected. */
+function ApprovedDomainsConfig({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">Approved email domains</Label>
+      <p className="text-muted-foreground text-xs">
+        Sessions from AI accounts whose email domain is not in this list are
+        flagged by the unapproved-domain rule. Matching is exact per domain, so
+        list subdomains explicitly; a leading '@' is allowed. Until at least one
+        domain is configured, only the personal-account rule fires.
+      </p>
+      <Input
+        value={value}
+        onChange={onChange}
+        placeholder="e.g. acme.com, corp.acme.com"
+      />
+    </div>
+  );
+}
+
 /** Side-sheet to pick which rules within a built-in detector category are
  *  active. Disabling a rule adds its canonical rule_id to the policy's
  *  disabled_rules; a search box tames the large categories (e.g. 222 secrets). */
@@ -195,6 +224,8 @@ export function CustomizeRulesSheet({
   setSelectedCategories,
   disabledRules,
   setDisabledRules,
+  approvedDomains,
+  setApprovedDomains,
   onClose,
 }: {
   category: RuleCategory;
@@ -202,6 +233,8 @@ export function CustomizeRulesSheet({
   setSelectedCategories: (v: Set<RuleCategory>) => void;
   disabledRules: Set<string>;
   setDisabledRules: (v: Set<string>) => void;
+  approvedDomains: string;
+  setApprovedDomains: (v: string) => void;
   onClose: () => void;
 }): JSX.Element {
   const meta = RULE_CATEGORY_META[category];
@@ -290,6 +323,14 @@ export function CustomizeRulesSheet({
             Pick which rules in this category are active. All are on by default.
           </SheetDescription>
         </SheetHeader>
+        {category === "account_identity" && (
+          <div className="border-border mx-6 mt-3 border-b pb-4">
+            <ApprovedDomainsConfig
+              value={approvedDomains}
+              onChange={setApprovedDomains}
+            />
+          </div>
+        )}
         <div className="px-6 pt-3">
           <Input
             value={search}

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -90,6 +90,7 @@ import {
   SCOPE_EXEMPT_CEL_EXAMPLES,
   SCOPE_INCLUDE_CEL_EXAMPLES,
   categoriesToPayload,
+  parseApprovedEmailDomains,
   pinnedHiddenRuleIds,
   policyMessageTypesForForm,
   policyMessageTypesForPayload,
@@ -2733,6 +2734,7 @@ function StandardPolicyEditor({
       disabledRules: new Set(policy.disabledRules ?? []),
       customRuleIds: new Set(policy.customRuleIds ?? []),
       categories: cats,
+      approvedDomains: (policy.approvedEmailDomains ?? []).join(", "),
       audienceType:
         policy.audienceType === "targeted"
           ? ("targeted" as const)
@@ -2776,6 +2778,11 @@ function StandardPolicyEditor({
     policy?.audienceType === "targeted"
       ? new Set(policy.audiencePrincipalUrns ?? [])
       : new Set<string>(),
+  );
+  // Approved email domains for the Non-Corporate Accounts category, held as
+  // the raw comma-separated input. Only sent when the category is selected.
+  const [approvedDomains, setApprovedDomains] = useState(() =>
+    (policy?.approvedEmailDomains ?? []).join(", "),
   );
   const [customizeCategory, setCustomizeCategory] =
     useState<RuleCategory | null>(null);
@@ -2825,6 +2832,7 @@ function StandardPolicyEditor({
       !sameSet(disabledRules, orig.disabledRules) ||
       !sameSet(selectedCustomRuleIds, orig.customRuleIds) ||
       !sameSet(selectedCategories, orig.categories) ||
+      approvedDomains !== orig.approvedDomains ||
       !sameSet(audiencePrincipalUrns, orig.audiencePrincipalUrns));
 
   const updateMutation = useRiskPoliciesUpdateMutation({
@@ -2881,14 +2889,22 @@ function StandardPolicyEditor({
         : policyMessageTypesForPayload(selectedMessageTypes);
     const includeCel = scopeMode === "cel" ? scopeInclude.trim() : "";
     const exemptCel = scopeExempt.trim();
-    // Destructive-tool sources reject action=block server-side; force flag.
+    // Flag-only sources (destructive_tool, cli_destructive, account_identity)
+    // are rejected by the server with action=block, so force flag as a safety
+    // net in case the form state drifted.
+    const flagOnlyActive = sources.some((s) =>
+      FLAG_ONLY_CATEGORIES.has(s as RuleCategory),
+    );
     const resolvedAction =
-      sources.includes("destructive_tool") && action === "block"
-        ? "flag"
-        : action;
+      flagOnlyActive && action === "block" ? "flag" : action;
     const principals =
       audienceType === "targeted" ? [...audiencePrincipalUrns] : [];
     const autoName = name.trim() === "";
+    // Only send approved domains while the Non-Corporate Accounts category is
+    // selected (an empty array clears them); omit otherwise so the server
+    // preserves whatever is stored.
+    const identityActive = selectedCategories.has("account_identity");
+    const approvedEmailDomains = parseApprovedEmailDomains(approvedDomains);
 
     if (policy) {
       updateMutation.mutate({
@@ -2910,6 +2926,7 @@ function StandardPolicyEditor({
             audiencePrincipalUrns: principals,
             autoName,
             userMessage,
+            ...(identityActive ? { approvedEmailDomains } : {}),
           },
         },
       });
@@ -2932,6 +2949,7 @@ function StandardPolicyEditor({
             audiencePrincipalUrns: principals,
             autoName,
             ...(userMessage.trim() ? { userMessage } : {}),
+            ...(identityActive ? { approvedEmailDomains } : {}),
           },
         },
       });
@@ -3070,6 +3088,8 @@ function StandardPolicyEditor({
           setSelectedCategories={setSelectedCategories}
           disabledRules={disabledRules}
           setDisabledRules={setDisabledRules}
+          approvedDomains={approvedDomains}
+          setApprovedDomains={setApprovedDomains}
           onClose={() => setCustomizeCategory(null)}
         />
       )}

--- a/client/dashboard/src/pages/security/policy-form.ts
+++ b/client/dashboard/src/pages/security/policy-form.ts
@@ -23,19 +23,21 @@ export const AVAILABLE_CATEGORIES: Set<RuleCategory> = new Set([
   "shadow_mcp",
   "destructive_tool",
   "cli_destructive",
+  "account_identity",
   "prompt_injection",
   "custom",
 ]);
 
-/** All rule categories in display order */
+/** All rule categories in display order. off_policy renders via the
+ * PRESIDIO_CATEGORIES spread — don't also list it explicitly. */
 export const ALL_CATEGORIES: RuleCategory[] = [
   "secrets",
   ...PRESIDIO_CATEGORIES,
   "shadow_mcp",
   "destructive_tool",
   "cli_destructive",
+  "account_identity",
   "prompt_injection",
-  "off_policy",
 ];
 
 /** Categories whose source the server rejects with action=block; the form
@@ -44,6 +46,7 @@ export const ALL_CATEGORIES: RuleCategory[] = [
 export const FLAG_ONLY_CATEGORIES: Set<RuleCategory> = new Set([
   "destructive_tool",
   "cli_destructive",
+  "account_identity",
 ]);
 
 /** Built-in detectors that run at the category level and have no individual
@@ -81,6 +84,7 @@ export function policyToCategories(
   if (sources.includes("shadow_mcp")) cats.add("shadow_mcp");
   if (sources.includes("destructive_tool")) cats.add("destructive_tool");
   if (sources.includes("cli_destructive")) cats.add("cli_destructive");
+  if (sources.includes("account_identity")) cats.add("account_identity");
   if (sources.includes("prompt_injection")) cats.add("prompt_injection");
   for (const cat of PRESIDIO_CATEGORIES) {
     const wireEntities = DETECTION_RULES[cat].map((r) =>
@@ -121,6 +125,7 @@ export function categoriesToPayload(
   if (cats.has("shadow_mcp")) sources.push("shadow_mcp");
   if (cats.has("destructive_tool")) sources.push("destructive_tool");
   if (cats.has("cli_destructive")) sources.push("cli_destructive");
+  if (cats.has("account_identity")) sources.push("account_identity");
   if (cats.has("prompt_injection")) sources.push("prompt_injection");
   for (const cat of PRESIDIO_CATEGORIES) {
     if (cats.has(cat)) {
@@ -154,6 +159,16 @@ export function categoriesToPayload(
     promptInjectionRules,
     disabledRules: persistedDisabled,
   };
+}
+
+/** Parse the comma-separated approved-domains input into the array the API
+ *  expects. Splits on commas and whitespace; the server normalizes each entry
+ *  (lowercase, strips a leading '@') and rejects implausible domains. */
+export function parseApprovedEmailDomains(raw: string): string[] {
+  return raw
+    .split(/[,\s]+/)
+    .map((domain) => domain.trim())
+    .filter((domain) => domain.length > 0);
 }
 
 /** Canonical ids of hidden rules an existing policy already pins via its


### PR DESCRIPTION
## What

The risk-policy eval refactor (#3924) extracted the policy form into `PolicyDetail.tsx` from a **pre-#3861 snapshot** of `PolicyCenter.tsx`. That regressed two things on the new/edit risk-policy **Detect** step:

1. **Non-Corporate Accounts detector vanished** — `account_identity` was dropped from `AVAILABLE_CATEGORIES`, `ALL_CATEGORIES`, and `FLAG_ONLY_CATEGORIES`, along with its source↔category payload mapping and the entire approved-email-domains config UI (`ApprovedDomainsConfig`, `parseApprovedEmailDomains`, `approved_email_domains` on save).
2. **Off-Policy Content rendered twice** — `off_policy` was added to `PRESIDIO_CATEGORIES` (which spreads into `ALL_CATEGORIES`) while the old trailing `off_policy` entry was left in place, so the card appeared once after Healthcare and again at the bottom.

The backend from #3861 (categories registry, scan activity, `account_identity` source, `approved_email_domains` validation) was untouched — this was purely the dashboard side.

## Fix

- Re-add `account_identity` to the three category sets and both directions of the `policy-form.ts` payload mapping.
- Remove the duplicate trailing `off_policy` from `ALL_CATEGORIES` (it now renders once via the `PRESIDIO_CATEGORIES` spread).
- Restore `parseApprovedEmailDomains` + `ApprovedDomainsConfig`, thread `approvedDomains` state through `StandardPolicyEditor` and `CustomizeRulesSheet`, and send `approved_email_domains` on create/update while the category is selected.

## Verification

`pnpm -F dashboard type-check` and `pnpm -F dashboard lint` pass. Verified in the running dashboard (see GIF below): Off-Policy Content appears exactly once, Non-Corporate Accounts is back, and its Customize sheet shows the approved-email-domains input plus the two identity rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Non-Corporate Accounts detector and removes the duplicate Off-Policy Content card on the risk-policy Detect step, addressing Linear DNO-410. Brings back approved-domain configuration and fixes category mappings so cards render once and save correctly.

- **Bug Fixes**
  - Re-added `account_identity` to available/display/flag-only category sets and payload mapping.
  - Restored approved email domains parsing and Customize-sheet UI; threads state through the editor and sends domains when the category is selected.
  - Removed the extra `off_policy` entry from display order; it now renders once via `PRESIDIO_CATEGORIES`.
  - Forces flag action when any flag-only category is active (including `account_identity`) to avoid server rejection.

<sup>Written for commit 5064d0a742cbdd642f4f5c20b6876152f35e68a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

