### PR TITLE
fix: attach mcp_servers to Default plugin on enable, guard unpublishable adds

### DIFF
--- a/.changeset/attach-enabled-servers-to-default-plugin.md
+++ b/.changeset/attach-enabled-servers-to-default-plugin.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Attach MCP servers to the Default plugin when they're enabled, not just when their first endpoint is created — remote MCP servers are created disabled with a pre-staged endpoint, so they previously never auto-attached and manually adding them failed with "mcp server is disabled or has no published endpoint". Also fixes creating a second endpoint for an already-attached server (previously failed on a duplicate-attach conflict), hides endpointless servers from the plugin's add-server picker, and asks for confirmation before removing a server's last address.

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/ServerUrlSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/ServerUrlSection.tsx
@@ -23,9 +23,9 @@ import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import { useDeleteMcpEndpointMutation } from "@gram/client/react-query/deleteMcpEndpoint.js";
 import { invalidateAllMcpEndpoints } from "@gram/client/react-query/mcpEndpoints.js";
 import { useUpdateMcpEndpointMutation } from "@gram/client/react-query/updateMcpEndpoint.js";
-import { Button, Stack } from "@speakeasy-api/moonshine";
+import { Button, Dialog, Stack } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { Plus, Trash2, XIcon } from "lucide-react";
+import { Loader2, Plus, Trash2, XIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useMcpEndpointSlugValidation } from "../../../useMcpEndpointSlugValidation";
@@ -139,6 +139,7 @@ export function ServerUrlSection({
                   <AddressRow
                     mcpServer={mcpServer}
                     endpoint={platformEndpoint}
+                    isLastEndpoint={endpoints.length === 1}
                   />
                 ) : addingPlatform ? (
                   <NewPlatformAddressRow
@@ -172,6 +173,7 @@ export function ServerUrlSection({
                     mcpServer={mcpServer}
                     endpoint={endpoint}
                     domains={availableDomains}
+                    isLastEndpoint={endpoints.length === 1}
                   />
                 ))}
                 {addingCustom && (
@@ -214,15 +216,19 @@ export function ServerUrlSection({
 }
 
 // A single editable address. The slug input is always live; Save persists the
-// edit (disabled until dirty + valid) and Remove deletes immediately.
+// edit (disabled until dirty + valid) and Remove deletes immediately — except
+// for the server's last address, which asks for confirmation first since it
+// leaves the server unreachable and unpublishable.
 function AddressRow({
   mcpServer,
   endpoint,
   domains,
+  isLastEndpoint,
 }: {
   mcpServer: McpServer;
   endpoint: McpEndpoint;
   domains?: CustomDomain[];
+  isLastEndpoint: boolean;
 }) {
   const { orgSlug } = useSlugs();
   // Platform endpoints must carry the `${orgSlug}-` prefix. It's folded into
@@ -257,12 +263,15 @@ function AddressRow({
       );
     },
   });
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
   const remove = useDeleteMcpEndpointMutation({
     onSuccess: async () => {
+      setConfirmRemoveOpen(false);
       await invalidateAllMcpEndpoints(queryClient, { refetchType: "all" });
       toast.success("Address removed");
     },
     onError: (error) => {
+      setConfirmRemoveOpen(false);
       toast.error(
         error instanceof Error ? error.message : "Failed to remove address",
       );
@@ -324,7 +333,13 @@ function AddressRow({
             variant="destructive-secondary"
             className="border border-destructive/40 bg-transparent hover:border-destructive"
             disabled={remove.isPending}
-            onClick={() => remove.mutate({ request: { id: endpoint.id } })}
+            onClick={() => {
+              if (isLastEndpoint) {
+                setConfirmRemoveOpen(true);
+                return;
+              }
+              remove.mutate({ request: { id: endpoint.id } });
+            }}
           >
             <Button.LeftIcon>
               <Trash2 className="size-4" />
@@ -334,7 +349,64 @@ function AddressRow({
       </Stack>
       {slugError && <FieldError className="text-xs">{slugError}</FieldError>}
       {update.isError && <FieldError>{update.error.message}</FieldError>}
+      <RemoveLastAddressDialog
+        isOpen={confirmRemoveOpen}
+        isLoading={remove.isPending}
+        onClose={() => setConfirmRemoveOpen(false)}
+        onConfirm={() => remove.mutate({ request: { id: endpoint.id } })}
+      />
     </Field>
+  );
+}
+
+// Confirmation for removing a server's only address. Without an address the
+// server can't serve traffic and stops being publishable — it can't be added
+// to plugins or collections until a new address is created.
+function RemoveLastAddressDialog({
+  isOpen,
+  isLoading,
+  onClose,
+  onConfirm,
+}: {
+  isOpen: boolean;
+  isLoading: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <Dialog.Content className="max-w-md">
+        <Dialog.Header>
+          <Dialog.Title>Remove this server's only address?</Dialog.Title>
+          <Dialog.Description>
+            This is the last address for this MCP server. Removing it means
+            clients can no longer connect, and the server can't be added to
+            plugins or published to collections until you create a new address.
+          </Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Button variant="secondary" disabled={isLoading} onClick={onClose}>
+            <Button.Text>Cancel</Button.Text>
+          </Button>
+          <Button
+            variant="destructive-primary"
+            disabled={isLoading}
+            onClick={onConfirm}
+          >
+            {isLoading ? (
+              <>
+                <Button.LeftIcon>
+                  <Loader2 className="size-4 animate-spin" />
+                </Button.LeftIcon>
+                <Button.Text>Removing</Button.Text>
+              </>
+            ) : (
+              <Button.Text>Remove address</Button.Text>
+            )}
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
   );
 }
 

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -26,7 +26,7 @@ import { useUpdatePluginMutation } from "@gram/client/react-query/updatePlugin";
 import { useAddPluginServerMutation } from "@gram/client/react-query/addPluginServer";
 import { useRemovePluginServerMutation } from "@gram/client/react-query/removePluginServer";
 import { useListToolsets } from "@gram/client/react-query/listToolsets";
-import { useMcpEndpoints } from "@gram/client/react-query/mcpEndpoints";
+import { useMcpEndpoints } from "@gram/client/react-query/mcpEndpoints.js";
 import { useMcpServers } from "@gram/client/react-query/mcpServers";
 import type { PublishStatusResult } from "@gram/client/models/components/publishstatusresult.js";
 import {
@@ -85,25 +85,29 @@ export default function PluginDetail(): JSX.Element | null {
     [toolsetsData?.toolsets],
   );
 
-  // Remote MCP-backed mcp_servers for this project. Only remote-backed,
-  // non-disabled servers with at least one endpoint are publishable —
+  // Remote MCP-backed mcp_servers for this project. All of them back the
+  // cards of already-attached plugin servers (an attached server that's been
+  // disabled or lost its endpoints must still resolve for display), while
+  // only non-disabled servers with at least one endpoint are publishable —
   // mirroring the backend's AddPluginServer check, so the picker never
   // offers a server the API would reject.
   const { data: mcpServersData, isLoading: isLoadingMcpServers } =
     useMcpServers({});
   const { data: mcpEndpointsData, isLoading: isLoadingMcpEndpoints } =
     useMcpEndpoints({});
-  const mcpServers = useMemo(() => {
+  const mcpServers = useMemo(
+    () =>
+      (mcpServersData?.mcpServers ?? []).filter((s) => !!s.remoteMcpServerId),
+    [mcpServersData],
+  );
+  const publishableMcpServers = useMemo(() => {
     const serverIdsWithEndpoint = new Set(
       (mcpEndpointsData?.mcpEndpoints ?? []).map((e) => e.mcpServerId),
     );
-    return (mcpServersData?.mcpServers ?? []).filter(
-      (s) =>
-        !!s.remoteMcpServerId &&
-        s.visibility !== "disabled" &&
-        serverIdsWithEndpoint.has(s.id),
+    return mcpServers.filter(
+      (s) => s.visibility !== "disabled" && serverIdsWithEndpoint.has(s.id),
     );
-  }, [mcpServersData, mcpEndpointsData]);
+  }, [mcpServers, mcpEndpointsData]);
 
   const isLoadingServers =
     isLoadingToolsets || isLoadingMcpServers || isLoadingMcpEndpoints;
@@ -285,14 +289,15 @@ export default function PluginDetail(): JSX.Element | null {
     return map;
   }, [mcpServers]);
 
-  // Merge toolsets and Remote MCP-backed servers into one selectable list.
+  // Merge toolsets and publishable Remote MCP-backed servers into one
+  // selectable list.
   const serverOptions = useMemo<ServerOption[]>(() => {
     const opts: ServerOption[] = toolsets.map((t) => ({
       kind: "toolset",
       id: t.id,
       name: t.name,
     }));
-    for (const s of mcpServers) {
+    for (const s of publishableMcpServers) {
       opts.push({
         kind: "mcpServer",
         id: s.id,
@@ -300,7 +305,7 @@ export default function PluginDetail(): JSX.Element | null {
       });
     }
     return opts;
-  }, [toolsets, mcpServers]);
+  }, [toolsets, publishableMcpServers]);
 
   if (!plugin) return null;
 

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -26,6 +26,7 @@ import { useUpdatePluginMutation } from "@gram/client/react-query/updatePlugin";
 import { useAddPluginServerMutation } from "@gram/client/react-query/addPluginServer";
 import { useRemovePluginServerMutation } from "@gram/client/react-query/removePluginServer";
 import { useListToolsets } from "@gram/client/react-query/listToolsets";
+import { useMcpEndpoints } from "@gram/client/react-query/mcpEndpoints";
 import { useMcpServers } from "@gram/client/react-query/mcpServers";
 import type { PublishStatusResult } from "@gram/client/models/components/publishstatusresult.js";
 import {
@@ -85,18 +86,27 @@ export default function PluginDetail(): JSX.Element | null {
   );
 
   // Remote MCP-backed mcp_servers for this project. Only remote-backed,
-  // non-disabled servers are publishable today.
+  // non-disabled servers with at least one endpoint are publishable —
+  // mirroring the backend's AddPluginServer check, so the picker never
+  // offers a server the API would reject.
   const { data: mcpServersData, isLoading: isLoadingMcpServers } =
     useMcpServers({});
-  const mcpServers = useMemo(
-    () =>
-      (mcpServersData?.mcpServers ?? []).filter(
-        (s) => !!s.remoteMcpServerId && s.visibility !== "disabled",
-      ),
-    [mcpServersData],
-  );
+  const { data: mcpEndpointsData, isLoading: isLoadingMcpEndpoints } =
+    useMcpEndpoints({});
+  const mcpServers = useMemo(() => {
+    const serverIdsWithEndpoint = new Set(
+      (mcpEndpointsData?.mcpEndpoints ?? []).map((e) => e.mcpServerId),
+    );
+    return (mcpServersData?.mcpServers ?? []).filter(
+      (s) =>
+        !!s.remoteMcpServerId &&
+        s.visibility !== "disabled" &&
+        serverIdsWithEndpoint.has(s.id),
+    );
+  }, [mcpServersData, mcpEndpointsData]);
 
-  const isLoadingServers = isLoadingToolsets || isLoadingMcpServers;
+  const isLoadingServers =
+    isLoadingToolsets || isLoadingMcpServers || isLoadingMcpEndpoints;
 
   // Invalidate publish status too so the dirty/up-to-date affordance reflects
   // the edit the moment a mutation lands.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1115,7 +1115,7 @@ func newStartCommand() *cli.Command {
 			cliauth.Attach(mux, cliauth.NewService(logger, tracerProvider, db, sessionManager, authzEngine, redisClient, c.String("environment")))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))
 			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, auditLogger))
-			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
+			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
 			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, cache.NewRedisCacheAdapter(redisClient))
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), remoteSessionsService))

--- a/server/internal/assistants/resolve_mcp_servers_test.go
+++ b/server/internal/assistants/resolve_mcp_servers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
-	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers/visibility"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -209,12 +209,12 @@ func TestResolveAssistantMCPServers_DisabledMCPServerOmitted(t *testing.T) {
 	mcpServers := []assistantMCPServerRow{
 		{
 			ServerSlug:   pgtype.Text{String: "switched-off", Valid: true},
-			Visibility:   mcpservers.VisibilityDisabled,
+			Visibility:   visibility.Disabled,
 			EndpointSlug: "switched-off-endpoint",
 		},
 		{
 			ServerSlug:   pgtype.Text{String: "remote-saas", Valid: true},
-			Visibility:   mcpservers.VisibilityPublic,
+			Visibility:   visibility.Public,
 			EndpointSlug: "team-remote-saas",
 		},
 	}

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -30,7 +30,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers/visibility"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -789,7 +789,7 @@ func (s *ServiceCore) resolveMcpServerRefsForWrite(
 		switch {
 		case row.Tunneled:
 			return nil, assistantValidationError("mcp server %q is tunnel-backed and cannot be attached to an assistant", row.Slug.String)
-		case row.Visibility == mcpservers.VisibilityDisabled:
+		case row.Visibility == visibility.Disabled:
 			return nil, assistantValidationError("mcp server %q is disabled", row.Slug.String)
 		case !row.HasGramEndpoint:
 			return nil, assistantValidationError("mcp server %q has no Gram-hosted MCP endpoint", row.Slug.String)
@@ -2876,7 +2876,7 @@ func resolveAssistantMCPServers(ctx context.Context, logger *slog.Logger, server
 		if m.EndpointSlug == "" {
 			continue
 		}
-		if m.Visibility == mcpservers.VisibilityDisabled {
+		if m.Visibility == visibility.Disabled {
 			logger.WarnContext(ctx, "skipping disabled assistant mcp server",
 				attr.SlogMcpServerID(m.MCPServerID.String()),
 			)

--- a/server/internal/mcpendpoints/createmcpendpoint_test.go
+++ b/server/internal/mcpendpoints/createmcpendpoint_test.go
@@ -415,3 +415,74 @@ func TestCreateMcpEndpoint_LegacyProject_TriggersInitialPublish(t *testing.T) {
 	require.NoError(t, err, "expected a GitHub connection to have been published for this legacy project")
 	require.NotEmpty(t, conn.RepoName)
 }
+
+// TestCreateMcpEndpoint_SecondEndpointOnAttachedServerIsNoOp guards the
+// duplicate-attach path: creating a second endpoint (e.g. a custom-domain
+// address) for a server already in the Default plugin must succeed and leave
+// the plugin membership untouched. A regression here aborts the whole
+// endpoint create — the duplicate plugin_servers insert trips the
+// (plugin_id, display_name) unique index inside the shared transaction.
+func TestCreateMcpEndpoint_SecondEndpointOnAttachedServerIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	remoteServer := remotemcptest.SeedServer(t, ctx, ti.conn, remotemcprepo.CreateServerParams{
+		ProjectID:     *authCtx.ProjectID,
+		TransportType: "streamable-http",
+		Url:           "https://test.example.com/mcp/" + uuid.NewString(),
+	})
+	mcpServerID, err := uuid.NewV7()
+	require.NoError(t, err)
+	_, err = mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ID:                mcpServerID,
+		ProjectID:         *authCtx.ProjectID,
+		Name:              conv.ToPGText("Second Endpoint Server"),
+		Slug:              conv.ToPGText("second-endpoint-server-" + uuid.NewString()),
+		EnvironmentID:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		RemoteMcpServerID: uuid.NullUUID{UUID: remoteServer.ID, Valid: true},
+		ToolsetID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		Visibility:        "public",
+	})
+	require.NoError(t, err)
+
+	// First endpoint attaches the server to the Default plugin.
+	_, err = ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		CustomDomainID:   nil,
+		McpServerID:      mcpServerID.String(),
+		Slug:             types.McpEndpointSlug(authCtx.OrganizationSlug + "-second-ep-first"),
+	})
+	require.NoError(t, err)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+
+	// Second endpoint on the now-attached server: must succeed, no re-attach.
+	_, err = ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		CustomDomainID:   nil,
+		McpServerID:      mcpServerID.String(),
+		Slug:             types.McpEndpointSlug(authCtx.OrganizationSlug + "-second-ep-second"),
+	})
+	require.NoError(t, err)
+
+	servers, err = pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1, "second endpoint must not double-attach the server")
+}

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -36,7 +36,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
-	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -194,58 +193,18 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		return false, nil
 	}
 
-	displayName := mcpServerDisplayName(server)
-
-	attached, err := plugins.AttachToDefaultPlugin(ctx, pluginsrepo.New(dbtx), plugins.AttachToDefaultPluginParams{
+	pluginCreated, err := plugins.AttachToDefaultPluginAudited(ctx, dbtx, s.audit, authCtx, plugins.AttachToDefaultPluginParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
 		ToolsetID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		McpServerID:    uuid.NullUUID{UUID: mcpServerID, Valid: true},
-		DisplayName:    displayName,
+		DisplayName:    mcpservers.ServerDisplayName(server),
 	})
 	if err != nil {
 		return false, oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
 	}
-	if attached == nil {
-		return false, nil
-	}
 
-	if attached.PluginCreated {
-		if err := s.audit.LogPluginCreate(ctx, dbtx, audit.LogPluginCreateEvent{
-			OrganizationID:   authCtx.ActiveOrganizationID,
-			ProjectID:        *authCtx.ProjectID,
-			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-			ActorDisplayName: authCtx.Email,
-			ActorSlug:        nil,
-			PluginID:         attached.PluginID,
-			PluginName:       attached.PluginName,
-			PluginSlug:       attached.PluginSlug,
-		}); err != nil {
-			return false, oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
-		}
-	}
-
-	mcpServerURN := urn.NewMcpServer(mcpServerID)
-	if err := s.audit.LogPluginServerAdd(ctx, dbtx, audit.LogPluginServerAddEvent{
-		OrganizationID:    authCtx.ActiveOrganizationID,
-		ProjectID:         *authCtx.ProjectID,
-		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName:  authCtx.Email,
-		ActorSlug:         nil,
-		PluginID:          attached.PluginID,
-		PluginName:        attached.PluginName,
-		PluginSlug:        attached.PluginSlug,
-		ServerID:          attached.Server.ID,
-		ServerDisplayName: attached.Server.DisplayName,
-		ServerPolicy:      attached.Server.Policy,
-		ServerSortOrder:   attached.Server.SortOrder,
-		ToolsetURN:        nil,
-		McpServerURN:      &mcpServerURN,
-	}); err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "audit log default plugin server add").LogError(ctx, s.logger)
-	}
-
-	return attached.PluginCreated, nil
+	return pluginCreated, nil
 }
 
 // triggerInitialPublishIfNeeded enqueues the first-time GitHub marketplace
@@ -268,20 +227,6 @@ func (s *Service) triggerInitialPublishIfNeeded(ctx context.Context, authCtx *co
 	}); err != nil {
 		s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
 	}
-}
-
-// mcpServerDisplayName derives a default plugin-server display name from an
-// mcp_server, preferring its name, then slug, then id. Mirrors
-// plugins.mcpServerDisplayName, which operates on a different generated row
-// type from a joined query and so can't be reused directly here.
-func mcpServerDisplayName(server mcpserversrepo.McpServer) string {
-	if name := conv.FromPGText[string](server.Name); name != nil && *name != "" {
-		return *name
-	}
-	if slug := conv.FromPGText[string](server.Slug); slug != nil && *slug != "" {
-		return *slug
-	}
-	return server.ID.String()
 }
 
 func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpointPayload) (*types.McpEndpoint, error) {

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	environmentsrepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
@@ -34,7 +35,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	tunneledmcprepo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -43,12 +46,14 @@ import (
 )
 
 type Service struct {
-	tracer trace.Tracer
-	logger *slog.Logger
-	db     *pgxpool.Pool
-	auth   *auth.Auth
-	authz  *authz.Engine
-	audit  *audit.Logger
+	tracer               trace.Tracer
+	logger               *slog.Logger
+	db                   *pgxpool.Pool
+	auth                 *auth.Auth
+	authz                *authz.Engine
+	audit                *audit.Logger
+	temporalEnv          *tenv.Environment
+	pluginsGitHubEnabled bool
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -61,16 +66,20 @@ func NewService(
 	sessions *sessions.Manager,
 	authzEngine *authz.Engine,
 	auditLogger *audit.Logger,
+	temporalEnv *tenv.Environment,
+	pluginsGitHubEnabled bool,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("mcpservers"))
 
 	return &Service{
-		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcpservers"),
-		logger: logger,
-		db:     db,
-		auth:   auth.New(logger, db, sessions, authzEngine),
-		authz:  authzEngine,
-		audit:  auditLogger,
+		tracer:               tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcpservers"),
+		logger:               logger,
+		db:                   db,
+		auth:                 auth.New(logger, db, sessions, authzEngine),
+		authz:                authzEngine,
+		audit:                auditLogger,
+		temporalEnv:          temporalEnv,
+		pluginsGitHubEnabled: pluginsGitHubEnabled,
 	}
 }
 
@@ -488,11 +497,99 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeUnexpected, err, "log mcp server update").LogError(ctx, logger)
 	}
 
+	// A server that was just enabled is publishable if it already has an
+	// endpoint — attach it to the Default plugin so it reaches the
+	// auto-published marketplace. This is the counterpart to
+	// mcpendpoints.CreateMcpEndpoint's attach-on-first-endpoint, which skips
+	// servers still disabled at endpoint-creation time (the dashboard's
+	// remote MCP flow pre-stages an endpoint while the server is parked
+	// disabled for auth configuration, so enabling is what completes
+	// publishability there).
+	pluginCreated := false
+	if existing.Visibility == VisibilityDisabled && updated.Visibility != VisibilityDisabled {
+		pluginCreated, err = s.attachToDefaultPlugin(ctx, dbtx, authCtx, updated)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
+	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
+
 	return afterView, nil
+}
+
+// attachToDefaultPlugin adds a just-enabled mcp_server to the project's
+// Default plugin so it's included in the auto-published marketplace without
+// a human visiting the Plugins page. Mirrors AddPluginServer's own
+// publishability check: a server with no live endpoint isn't publishable and
+// is skipped (mcpendpoints.CreateMcpEndpoint attaches it later when it gets
+// its first endpoint while enabled). Already-attached servers are an
+// idempotent no-op. Returns pluginCreated=true if this call lazily created
+// the Default plugin (project predates the feature) — callers should enqueue
+// an initial publish for it, but only after their own transaction commits,
+// since this runs pre-commit and the DB writes could still roll back.
+func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, server repo.McpServer) (bool, error) {
+	endpoints, err := mcpendpointsrepo.New(dbtx).ListMCPEndpointsByMCPServerID(ctx, mcpendpointsrepo.ListMCPEndpointsByMCPServerIDParams{
+		ProjectID:   *authCtx.ProjectID,
+		McpServerID: server.ID,
+	})
+	if err != nil {
+		return false, oops.E(oops.CodeUnexpected, err, "list mcp server endpoints").LogError(ctx, s.logger)
+	}
+	if len(endpoints) == 0 {
+		return false, nil
+	}
+
+	pluginCreated, err := plugins.AttachToDefaultPluginAudited(ctx, dbtx, s.audit, authCtx, plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		McpServerID:    uuid.NullUUID{UUID: server.ID, Valid: true},
+		DisplayName:    ServerDisplayName(server),
+	})
+	if err != nil {
+		return false, oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
+	}
+
+	return pluginCreated, nil
+}
+
+// triggerInitialPublishIfNeeded enqueues the first-time GitHub marketplace
+// publish for a project whose Default plugin was just lazily created. Must
+// only be called after the triggering transaction has committed — enqueuing
+// before commit risks Temporal running against state that a later failure
+// in the same transaction rolls back. Best-effort: a non-cancelable ctx
+// since the request returning shouldn't drop the enqueue.
+func (s *Service) triggerInitialPublishIfNeeded(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
+	if !pluginCreated || !s.pluginsGitHubEnabled {
+		return
+	}
+
+	enqueueCtx := context.WithoutCancel(ctx)
+	if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+		ProjectID:       *authCtx.ProjectID,
+		CreatedByUserID: authCtx.UserID,
+		CommitMessage:   "Initial marketplace publish",
+		SkipIfUnchanged: false,
+	}); err != nil {
+		s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+	}
+}
+
+// ServerDisplayName derives a default plugin-server display name from an
+// mcp_server, preferring its name, then slug, then id.
+func ServerDisplayName(server repo.McpServer) string {
+	if name := conv.FromPGText[string](server.Name); name != nil && *name != "" {
+		return *name
+	}
+	if slug := conv.FromPGText[string](server.Slug); slug != nil && *slug != "" {
+		return *slug
+	}
+	return server.ID.String()
 }
 
 func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpServerPayload) error {

--- a/server/internal/mcpservers/setup_test.go
+++ b/server/internal/mcpservers/setup_test.go
@@ -81,7 +81,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 
 	auditLogger := audit.NewLogger()
 
-	svc := mcpservers.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger)
+	svc := mcpservers.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil, false)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/mcpservers/updatemcpserver_test.go
+++ b/server/internal/mcpservers/updatemcpserver_test.go
@@ -1,9 +1,12 @@
 package mcpservers_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/mcp_servers"
@@ -11,7 +14,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 )
 
 func TestUpdateMcpServer_FullReplace(t *testing.T) {
@@ -451,4 +456,275 @@ func TestUpdateMcpServer_RBACForbidden(t *testing.T) {
 		Visibility:        types.McpServerVisibility("disabled"),
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+// seedEndpointFor inserts an mcp_endpoints row directly through the generated
+// repo so attach-on-enable tests control endpoint existence without going
+// through the mcpendpoints service (whose create path runs its own
+// default-plugin attach).
+func seedEndpointFor(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, mcpServerID string) {
+	t.Helper()
+
+	_, err := mcpendpointsrepo.New(conn).CreateMCPEndpoint(ctx, mcpendpointsrepo.CreateMCPEndpointParams{
+		ProjectID:      projectID,
+		CustomDomainID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		McpServerID:    uuid.MustParse(mcpServerID),
+		Slug:           "attach-test-" + uuid.NewString(),
+	})
+	require.NoError(t, err)
+}
+
+// createDisabledRemoteServer provisions a remote-backed mcp_server through the
+// service in the "disabled" state the dashboard's remote MCP create flow
+// leaves servers in before auth is configured.
+func createDisabledRemoteServer(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, name string) (*types.McpServer, string) {
+	t.Helper()
+
+	remoteServerID := seedRemoteMcpServer(t, ctx, ti.conn, projectID).String()
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              name,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	require.NoError(t, err)
+
+	return created, remoteServerID
+}
+
+func TestUpdateMcpServer_EnableAttachesToDefaultPlugin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	// The dashboard's remote MCP flow: server created disabled, endpoint
+	// pre-staged while it's still disabled (so no attach fires there).
+	created, remoteServerID := createDisabledRemoteServer(t, ctx, ti, *authCtx.ProjectID, "Attach On Enable Server")
+	seedEndpointFor(t, ctx, ti.conn, *authCtx.ProjectID, created.ID)
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+
+	// Enabling the server is what completes publishability — it must attach.
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		Name:              nil,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("public"),
+	})
+	require.NoError(t, err)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.Equal(t, created.ID, servers[0].McpServerID.UUID.String())
+	require.Equal(t, "Attach On Enable Server", servers[0].DisplayName)
+	require.Equal(t, "required", servers[0].Policy)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount+1, afterCount)
+}
+
+func TestUpdateMcpServer_EnableWithoutEndpointDoesNotAttach(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	created, remoteServerID := createDisabledRemoteServer(t, ctx, ti, *authCtx.ProjectID, "No Endpoint Server")
+
+	// Enabled but endpointless — not publishable, so no attach (matching
+	// AddPluginServer's own rejection of endpointless servers).
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		Name:              nil,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("public"),
+	})
+	require.NoError(t, err)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Empty(t, servers)
+}
+
+func TestUpdateMcpServer_EnableLazilyCreatesDefaultPluginWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	created, remoteServerID := createDisabledRemoteServer(t, ctx, ti, *authCtx.ProjectID, "Lazy Plugin Server")
+	seedEndpointFor(t, ctx, ti.conn, *authCtx.ProjectID, created.ID)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	_, err := pluginsQueries.GetDefaultPlugin(ctx, pluginsrepo.GetDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows, "fixture project (created directly via projectsrepo) has no Default plugin yet")
+
+	beforeCreateCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginCreate)
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		Name:              nil,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("private"),
+	})
+	require.NoError(t, err)
+
+	defaultPlugin, err := pluginsQueries.GetDefaultPlugin(ctx, pluginsrepo.GetDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.Equal(t, created.ID, servers[0].McpServerID.UUID.String())
+
+	afterCreateCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginCreate)
+	require.NoError(t, err)
+	require.Equal(t, beforeCreateCount+1, afterCreateCount)
+}
+
+func TestUpdateMcpServer_EnableAlreadyAttachedIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	created, remoteServerID := createDisabledRemoteServer(t, ctx, ti, *authCtx.ProjectID, "Already Attached Server")
+	seedEndpointFor(t, ctx, ti.conn, *authCtx.ProjectID, created.ID)
+
+	// Manually attached beforehand (e.g. via the Plugins page while the
+	// server was briefly enabled, or by an admin API call).
+	_, err = pluginsQueries.AddPluginServer(ctx, pluginsrepo.AddPluginServerParams{
+		PluginID:    defaultPlugin.ID,
+		ToolsetID:   uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		McpServerID: uuid.NullUUID{UUID: uuid.MustParse(created.ID), Valid: true},
+		DisplayName: "Already Attached Server",
+		Policy:      "required",
+		SortOrder:   0,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		Name:              nil,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("public"),
+	})
+	require.NoError(t, err)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+}
+
+func TestUpdateMcpServer_AlreadyEnabledUpdateDoesNotAttach(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	pluginsQueries := pluginsrepo.New(ti.conn)
+	defaultPlugin, err := pluginsQueries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	remoteServerID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "Already Enabled Server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("public"),
+	})
+	require.NoError(t, err)
+	seedEndpointFor(t, ctx, ti.conn, *authCtx.ProjectID, created.ID)
+
+	// No disabled -> enabled transition here, so the update must not attach;
+	// attach-on-first-endpoint (mcpendpoints) owns the already-enabled case.
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		Name:              nil,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("public"),
+	})
+	require.NoError(t, err)
+
+	servers, err := pluginsQueries.ListPluginServers(ctx, defaultPlugin.ID)
+	require.NoError(t, err)
+	require.Empty(t, servers)
 }

--- a/server/internal/mcpservers/visibility.go
+++ b/server/internal/mcpservers/visibility.go
@@ -1,10 +1,13 @@
 package mcpservers
 
-// Visibility values for mcp_servers.visibility. Mirror the enum declared
-// in the design package (design/mcpservers/design.go) so callers can
-// compare against typed constants instead of bare string literals.
+import "github.com/speakeasy-api/gram/server/internal/mcpservers/visibility"
+
+// Visibility values for mcp_servers.visibility, aliasing the leaf visibility
+// package so callers can compare against typed constants instead of bare
+// string literals. Packages that mcpservers itself depends on (e.g. plugins)
+// import the visibility package directly to avoid an import cycle.
 const (
-	VisibilityPublic   = "public"
-	VisibilityPrivate  = "private"
-	VisibilityDisabled = "disabled"
+	VisibilityPublic   = visibility.Public
+	VisibilityPrivate  = visibility.Private
+	VisibilityDisabled = visibility.Disabled
 )

--- a/server/internal/mcpservers/visibility/visibility.go
+++ b/server/internal/mcpservers/visibility/visibility.go
@@ -1,0 +1,12 @@
+// Package visibility declares the mcp_servers.visibility enum values.
+// It mirrors the enum in the design package (design/mcpservers/design.go)
+// and is a leaf package so that packages mcpservers itself depends on
+// (e.g. plugins) can reference the values without an import cycle. Most
+// callers should keep using the mcpservers.Visibility* aliases.
+package visibility
+
+const (
+	Public   = "public"
+	Private  = "private"
+	Disabled = "disabled"
+)

--- a/server/internal/plugins/default_plugin.go
+++ b/server/internal/plugins/default_plugin.go
@@ -10,7 +10,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 // EnsureDefaultPluginResult reports whether the Default plugin already
@@ -96,6 +99,24 @@ func AttachToDefaultPlugin(ctx context.Context, q *repo.Queries, params AttachTo
 		return nil, fmt.Errorf("ensure default plugin: %w", err)
 	}
 
+	// Check for an existing attachment before inserting rather than relying
+	// on unique-violation classification alone: a duplicate insert of an
+	// attached server trips the (plugin_id, display_name) index (created
+	// before the backend ones, so Postgres reports it first) and the failed
+	// statement aborts the caller's surrounding transaction either way.
+	_, err = q.GetPluginServerByBackend(ctx, repo.GetPluginServerByBackendParams{
+		PluginID:    ensured.Plugin.ID,
+		ToolsetID:   params.ToolsetID,
+		McpServerID: params.McpServerID,
+	})
+	switch {
+	case err == nil:
+		// Already attached — expected no-op, not an error.
+		return nil, nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return nil, fmt.Errorf("check existing default plugin server: %w", err)
+	}
+
 	server, err := q.AddPluginServer(ctx, repo.AddPluginServerParams{
 		PluginID:    ensured.Plugin.ID,
 		ToolsetID:   params.ToolsetID,
@@ -109,7 +130,11 @@ func AttachToDefaultPlugin(ctx context.Context, q *repo.Queries, params AttachTo
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 			switch pgErr.ConstraintName {
 			case "plugin_servers_plugin_id_toolset_id_key", "plugin_servers_plugin_id_mcp_server_id_key":
-				// Already attached — expected no-op, not an error.
+				// Concurrent attach race lost after the existence check —
+				// already attached, an expected no-op. Note the failed insert
+				// has aborted the surrounding transaction, so the caller's
+				// commit will still fail; a retry then hits the existence
+				// check and no-ops cleanly.
 				return nil, nil
 			default:
 				// display_name collision with a different, already-attached
@@ -128,4 +153,73 @@ func AttachToDefaultPlugin(ctx context.Context, q *repo.Queries, params AttachTo
 		PluginCreated: ensured.Created,
 		Server:        server,
 	}, nil
+}
+
+// AttachToDefaultPluginAudited runs AttachToDefaultPlugin and records the
+// same audit trail a manual "add server to plugin" produces: a plugin
+// creation event when the Default plugin was lazily provisioned, and a
+// plugin-server add event for the attached server. Callers (toolsets on
+// MCP-enable, mcpendpoints on first endpoint, mcpservers on visibility
+// enable) run this inside the same transaction as the triggering write.
+// Returns pluginCreated=true when this call created the Default plugin
+// (project predates the feature) — callers should enqueue an initial
+// marketplace publish for it, but only after their own transaction commits,
+// since this runs pre-commit and the DB writes could still roll back.
+func AttachToDefaultPluginAudited(ctx context.Context, dbtx pgx.Tx, auditLogger *audit.Logger, authCtx *contextvalues.AuthContext, params AttachToDefaultPluginParams) (bool, error) {
+	attached, err := AttachToDefaultPlugin(ctx, repo.New(dbtx), params)
+	if err != nil {
+		return false, fmt.Errorf("attach server to default plugin: %w", err)
+	}
+	if attached == nil {
+		return false, nil
+	}
+
+	if attached.PluginCreated {
+		if err := auditLogger.LogPluginCreate(ctx, dbtx, audit.LogPluginCreateEvent{
+			OrganizationID:   authCtx.ActiveOrganizationID,
+			ProjectID:        *authCtx.ProjectID,
+			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName: authCtx.Email,
+			ActorSlug:        nil,
+			PluginID:         attached.PluginID,
+			PluginName:       attached.PluginName,
+			PluginSlug:       attached.PluginSlug,
+		}); err != nil {
+			return false, fmt.Errorf("audit log default plugin create: %w", err)
+		}
+	}
+
+	// Exactly one of the URNs is set, mirroring params' toolset_id XOR
+	// mcp_server_id contract.
+	var toolsetURN *urn.Toolset
+	var mcpServerURN *urn.McpServer
+	if params.ToolsetID.Valid {
+		u := urn.NewToolset(params.ToolsetID.UUID)
+		toolsetURN = &u
+	}
+	if params.McpServerID.Valid {
+		u := urn.NewMcpServer(params.McpServerID.UUID)
+		mcpServerURN = &u
+	}
+
+	if err := auditLogger.LogPluginServerAdd(ctx, dbtx, audit.LogPluginServerAddEvent{
+		OrganizationID:    authCtx.ActiveOrganizationID,
+		ProjectID:         *authCtx.ProjectID,
+		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName:  authCtx.Email,
+		ActorSlug:         nil,
+		PluginID:          attached.PluginID,
+		PluginName:        attached.PluginName,
+		PluginSlug:        attached.PluginSlug,
+		ServerID:          attached.Server.ID,
+		ServerDisplayName: attached.Server.DisplayName,
+		ServerPolicy:      attached.Server.Policy,
+		ServerSortOrder:   attached.Server.SortOrder,
+		ToolsetURN:        toolsetURN,
+		McpServerURN:      mcpServerURN,
+	}); err != nil {
+		return false, fmt.Errorf("audit log default plugin server add: %w", err)
+	}
+
+	return attached.PluginCreated, nil
 }

--- a/server/internal/plugins/default_plugin.go
+++ b/server/internal/plugins/default_plugin.go
@@ -161,8 +161,10 @@ func AttachToDefaultPlugin(ctx context.Context, q *repo.Queries, params AttachTo
 // plugin-server add event for the attached server. Callers (toolsets on
 // MCP-enable, mcpendpoints on first endpoint, mcpservers on visibility
 // enable) run this inside the same transaction as the triggering write.
-// Returns pluginCreated=true when this call created the Default plugin
-// (project predates the feature) — callers should enqueue an initial
+// Both audit events are scoped to params' organization/project — the same
+// values the plugin rows are written with — while authCtx supplies only the
+// acting user. Returns pluginCreated=true when this call created the Default
+// plugin (project predates the feature) — callers should enqueue an initial
 // marketplace publish for it, but only after their own transaction commits,
 // since this runs pre-commit and the DB writes could still roll back.
 func AttachToDefaultPluginAudited(ctx context.Context, dbtx pgx.Tx, auditLogger *audit.Logger, authCtx *contextvalues.AuthContext, params AttachToDefaultPluginParams) (bool, error) {
@@ -176,8 +178,8 @@ func AttachToDefaultPluginAudited(ctx context.Context, dbtx pgx.Tx, auditLogger 
 
 	if attached.PluginCreated {
 		if err := auditLogger.LogPluginCreate(ctx, dbtx, audit.LogPluginCreateEvent{
-			OrganizationID:   authCtx.ActiveOrganizationID,
-			ProjectID:        *authCtx.ProjectID,
+			OrganizationID:   params.OrganizationID,
+			ProjectID:        params.ProjectID,
 			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
 			ActorDisplayName: authCtx.Email,
 			ActorSlug:        nil,
@@ -203,8 +205,8 @@ func AttachToDefaultPluginAudited(ctx context.Context, dbtx pgx.Tx, auditLogger 
 	}
 
 	if err := auditLogger.LogPluginServerAdd(ctx, dbtx, audit.LogPluginServerAddEvent{
-		OrganizationID:    authCtx.ActiveOrganizationID,
-		ProjectID:         *authCtx.ProjectID,
+		OrganizationID:    params.OrganizationID,
+		ProjectID:         params.ProjectID,
 		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
 		ActorDisplayName:  authCtx.Email,
 		ActorSlug:         nil,

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -38,7 +38,7 @@ import (
 	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	"github.com/speakeasy-api/gram/server/internal/marketplace"
 	mcpmetarepo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
-	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers/visibility"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -561,7 +561,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 			}
 			return nil, oops.E(oops.CodeUnexpected, mcpErr, "verify mcp server").LogError(ctx, s.logger)
 		}
-		if server.Visibility == mcpservers.VisibilityDisabled || !server.HasEndpoint {
+		if server.Visibility == visibility.Disabled || !server.HasEndpoint {
 			return nil, oops.E(oops.CodeBadRequest, nil, "mcp server is disabled or has no published endpoint")
 		}
 		if displayName == "" {

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -73,6 +73,18 @@ WHERE id = @id
   AND project_id = @project_id
   AND deleted IS FALSE;
 
+-- name: GetPluginServerByBackend :one
+-- Look up a live plugin server by its backend (toolset or mcp_server).
+-- Used by AttachToDefaultPlugin to no-op on already-attached servers before
+-- inserting: a duplicate insert can trip the (plugin_id, display_name)
+-- unique index rather than a backend one, and either way the failed
+-- statement aborts the caller's surrounding transaction.
+SELECT * FROM plugin_servers
+WHERE plugin_id = @plugin_id
+  AND toolset_id IS NOT DISTINCT FROM sqlc.narg('toolset_id')::uuid
+  AND mcp_server_id IS NOT DISTINCT FROM sqlc.narg('mcp_server_id')::uuid
+  AND deleted IS FALSE;
+
 -- name: AddPluginServer :one
 -- Inserts a plugin server backed by exactly one of a toolset or an mcp_server.
 -- The plugin_servers backend-exclusivity CHECK enforces the XOR; callers must

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -380,6 +380,44 @@ func (q *Queries) GetPlugin(ctx context.Context, arg GetPluginParams) (Plugin, e
 	return i, err
 }
 
+const getPluginServerByBackend = `-- name: GetPluginServerByBackend :one
+SELECT id, plugin_id, toolset_id, mcp_server_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted FROM plugin_servers
+WHERE plugin_id = $1
+  AND toolset_id IS NOT DISTINCT FROM $2::uuid
+  AND mcp_server_id IS NOT DISTINCT FROM $3::uuid
+  AND deleted IS FALSE
+`
+
+type GetPluginServerByBackendParams struct {
+	PluginID    uuid.UUID
+	ToolsetID   uuid.NullUUID
+	McpServerID uuid.NullUUID
+}
+
+// Look up a live plugin server by its backend (toolset or mcp_server).
+// Used by AttachToDefaultPlugin to no-op on already-attached servers before
+// inserting: a duplicate insert can trip the (plugin_id, display_name)
+// unique index rather than a backend one, and either way the failed
+// statement aborts the caller's surrounding transaction.
+func (q *Queries) GetPluginServerByBackend(ctx context.Context, arg GetPluginServerByBackendParams) (PluginServer, error) {
+	row := q.db.QueryRow(ctx, getPluginServerByBackend, arg.PluginID, arg.ToolsetID, arg.McpServerID)
+	var i PluginServer
+	err := row.Scan(
+		&i.ID,
+		&i.PluginID,
+		&i.ToolsetID,
+		&i.McpServerID,
+		&i.DisplayName,
+		&i.Policy,
+		&i.SortOrder,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getProjectMarketplaceNameContext = `-- name: GetProjectMarketplaceNameContext :one
 SELECT
   pr.slug AS project_slug,

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -43,7 +43,6 @@ import (
 	oauthRepo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
-	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	tplRepo "github.com/speakeasy-api/gram/server/internal/templates/repo"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -263,7 +262,7 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 // an initial publish for it, but only after their own transaction commits,
 // since this runs pre-commit and the DB writes could still roll back.
 func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, toolsetID uuid.UUID, displayName string) (bool, error) {
-	attached, err := plugins.AttachToDefaultPlugin(ctx, pluginsrepo.New(dbtx), plugins.AttachToDefaultPluginParams{
+	pluginCreated, err := plugins.AttachToDefaultPluginAudited(ctx, dbtx, s.audit, authCtx, plugins.AttachToDefaultPluginParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
 		ToolsetID:      uuid.NullUUID{UUID: toolsetID, Valid: true},
@@ -273,46 +272,8 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 	if err != nil {
 		return false, oops.E(oops.CodeUnexpected, err, "attach toolset to default plugin").LogError(ctx, s.logger)
 	}
-	if attached == nil {
-		return false, nil
-	}
 
-	if attached.PluginCreated {
-		if err := s.audit.LogPluginCreate(ctx, dbtx, audit.LogPluginCreateEvent{
-			OrganizationID:   authCtx.ActiveOrganizationID,
-			ProjectID:        *authCtx.ProjectID,
-			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-			ActorDisplayName: authCtx.Email,
-			ActorSlug:        nil,
-			PluginID:         attached.PluginID,
-			PluginName:       attached.PluginName,
-			PluginSlug:       attached.PluginSlug,
-		}); err != nil {
-			return false, oops.E(oops.CodeUnexpected, err, "audit log default plugin create").LogError(ctx, s.logger)
-		}
-	}
-
-	toolsetURN := urn.NewToolset(toolsetID)
-	if err := s.audit.LogPluginServerAdd(ctx, dbtx, audit.LogPluginServerAddEvent{
-		OrganizationID:    authCtx.ActiveOrganizationID,
-		ProjectID:         *authCtx.ProjectID,
-		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName:  authCtx.Email,
-		ActorSlug:         nil,
-		PluginID:          attached.PluginID,
-		PluginName:        attached.PluginName,
-		PluginSlug:        attached.PluginSlug,
-		ServerID:          attached.Server.ID,
-		ServerDisplayName: attached.Server.DisplayName,
-		ServerPolicy:      attached.Server.Policy,
-		ServerSortOrder:   attached.Server.SortOrder,
-		ToolsetURN:        &toolsetURN,
-		McpServerURN:      nil,
-	}); err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "audit log default plugin server add").LogError(ctx, s.logger)
-	}
-
-	return attached.PluginCreated, nil
+	return pluginCreated, nil
 }
 
 // triggerInitialPublishIfNeeded enqueues the first-time GitHub marketplace


### PR DESCRIPTION
## Summary

After adding a remote MCP server, trying to add it to the Default plugin fails with `"mcp server is disabled or has no published endpoint"`.

Root cause: the dashboard's remote MCP create flow parks the server **disabled** while auth is configured and pre-stages its default endpoint during that window — so #3902's attach-on-first-endpoint (which skips disabled servers) never fired, and nothing re-attached when the server was later enabled.

- **Attach on enable**: `UpdateMcpServer` now attaches the server to the Default plugin on the `disabled -> enabled` visibility transition when it has at least one live endpoint — same transaction, audit trail, lazy-plugin-create, and initial-publish behavior as the toolsets/mcpendpoints attach paths.
- **Fix latent duplicate-attach bug from #3902**: `AttachToDefaultPlugin` now checks for an existing attachment before inserting. The unique-violation classification never worked for duplicates — Postgres reports the `(plugin_id, display_name)` index first (created before the backend ones), and the failed insert aborts the caller's transaction either way. Concretely, creating a **second endpoint** for an already-attached server failed the whole request on main. Regression test added.
- **Dedup**: the attach + audit block copied across toolsets and mcpendpoints is extracted to `plugins.AttachToDefaultPluginAudited`. The visibility constants move to a leaf package (`mcpservers/visibility`, aliases kept in `mcpservers`) so `plugins`/`assistants` no longer import `mcpservers`, breaking the import cycle that `mcpservers -> plugins/background` would otherwise create.
- **Dashboard**: the Plugin detail server picker now also requires a server to have an endpoint (mirroring the backend check instead of surfacing its raw error), and removing a server's **last** address asks for confirmation since it leaves the server unreachable and unpublishable.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `mise lint:server` clean
- [x] New tests: attach-on-enable (with endpoint), no-attach without endpoint, lazy Default-plugin creation, idempotent re-attach, no-attach on already-enabled update, second-endpoint-on-attached-server regression
- [x] Full suites green: `mcpservers`, `mcpendpoints`, `plugins`, `toolsets`, `assistants`
- [x] `pnpm -F dashboard type-check` / lint: zero findings in touched files (pre-existing failures on main in `TunneledMCPDetails.tsx` / `PolicyDetail.tsx` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed adds of remote MCP servers to the Default plugin by auto-attaching on enable when an endpoint exists, and by blocking unpublishable servers. Also scopes Default-plugin audit events correctly and keeps attached server cards visible in the dashboard.

- **Bug Fixes**
  - Attach on enable: `mcpservers.UpdateMcpServer` now adds the server to the Default plugin on disabled → enabled when it already has an endpoint; same transaction, audited via `plugins.AttachToDefaultPluginAudited`, lazy plugin create, then initial publish queued.
  - Duplicate attach no-op: `plugins.AttachToDefaultPlugin` checks for existing membership before insert, so creating a second endpoint for an attached server no longer aborts the request.
  - Audit scope: `plugins.AttachToDefaultPluginAudited` stamps org/project from params and uses `authCtx` only for the actor to avoid nil derefs.
  - Dashboard: attached server cards still render for all remote-backed servers; the add-server picker only shows remote, enabled servers with at least one endpoint. Removing a server’s last address now asks for confirmation.

- **Refactors**
  - Centralized attach + audit into `plugins.AttachToDefaultPluginAudited`, removing duplicate blocks in `mcpendpoints` and `toolsets`.
  - Introduced `mcpservers/visibility` leaf package and updated imports to avoid cycles; kept `mcpservers.Visibility*` aliases.
  - Added `plugins.GetPluginServerByBackend` for safe existence checks; passed Temporal/env flags into `mcpservers.NewService` to enqueue initial publishes.
  - Added tests for attach-on-enable, no-op re-attach, lazy Default-plugin creation, and duplicate-attach regression.

<sup>Written for commit bcc44fd8d105a2c00e0aac7c67bac671ce1a08bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



