### PR TITLE
fix: add missing node:crypto import to seed script

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -3,6 +3,7 @@
 //MISE description="Seed the local database with data"
 
 import assert from "node:assert";
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";


### PR DESCRIPTION
## Summary

- add missing `import crypto from "node:crypto"` to `.mise-tasks/seed.mts`

## Root cause

`seed.mts` used `crypto.createHash` and `crypto.randomBytes` in 11 places but never imported `node:crypto`. Node's global `crypto` exposes only WebCrypto (no `createHash`/`randomBytes`), so the seed task threw at runtime.

## Test plan

- [x] `mise run seed` completes without a `crypto is not defined` error


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing `node:crypto` import to `.mise-tasks/seed.mts` so the seed script can use `createHash` and `randomBytes` without crashing. This fixes the "crypto is not defined" error and lets `mise run seed` complete.

<sup>Written for commit 1b736a2eb9265f56adf648135c62373bb9efe7f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

