### PR TITLE
mig: extend attribute_metrics_summaries TTL to 730d and add billing_cycle_usage table (DNO-403)

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260707200146_attribute-metrics-summaries-ttl-730d.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260707200146_attribute-metrics-summaries-ttl-730d.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `attribute_metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(90);

--- a/server/clickhouse/local/golang_migrate/20260707200146_attribute-metrics-summaries-ttl-730d.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260707200146_attribute-metrics-summaries-ttl-730d.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `attribute_metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(730);

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:guPKsC7jt/KtovpxenIU5yELeu0j8XjLxissJ82+rCw=
+h1:lJKFvWY0zBbwvJnIy+P/un/pwt2j2ybVEKs3iM/2xDE=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -50,3 +50,4 @@ h1:guPKsC7jt/KtovpxenIU5yELeu0j8XjLxissJ82+rCw=
 20260701215636_billing-mode-summaries.up.sql h1:QBQWDP1N8QGVVfa3oVOIvfVn6DZXBSuBJ12Pcs+3a70=
 20260702073000_attribute-metrics-attribution-dimensions.up.sql h1:PoTqZiFzKWD7DQ7w+uIPo5RwyerGYoYUHOP+Hfxx6iY=
 20260706165346_ttl-90d.up.sql h1:abSyGD5D2/4V9uClhit0Vf09W3z1rGoQAYGK8Y6GO6M=
+20260707200146_attribute-metrics-summaries-ttl-730d.up.sql h1:KDvIau/nvNDnU1rbICJ0A2GqmR2hOiK2AGLeLHBMA3s=

--- a/server/clickhouse/migrations/20260707200141_attribute-metrics-summaries-ttl-730d.sql
+++ b/server/clickhouse/migrations/20260707200141_attribute-metrics-summaries-ttl-730d.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `attribute_metrics_summaries` MODIFY TTL time_bucket + toIntervalDay(730);

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:L+lzULn2h+Y3gfuSKrGqtjEHKrR/cUGMjuwUqUs2BA0=
+h1:M0vOJ+IxhhyP+YPwxCxROMfUfC6ZQmsfto6Kjkr80as=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -55,3 +55,4 @@ h1:L+lzULn2h+Y3gfuSKrGqtjEHKrR/cUGMjuwUqUs2BA0=
 20260701215632_billing-mode-summaries.sql h1:3QwBy+mTC0pQt3mtO7ZLdjDGN9gMFFHllEB4pr6cjkE=
 20260702073000_attribute-metrics-attribution-dimensions.sql h1:5eoL9P6XNPKtIJYjdsK/VaQS3CFDfOKXbm/hkcZFZlc=
 20260706165342_ttl-90d.sql h1:a8ovzANcapKzIJcB1k8cnCtCO6s4kqZqBYEHFa820jQ=
+20260707200141_attribute-metrics-summaries-ttl-730d.sql h1:dtRAbVnZUqgtdeoVcfCGDZn/TYxSMIUG4rno2trubFg=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -429,7 +429,10 @@ CREATE TABLE IF NOT EXISTS attribute_metrics_summaries (
 -- primary key is not supported").
 PRIMARY KEY (gram_project_id, time_bucket, department_name, job_title, employee_type, division_name, cost_center_name, user_email, model, hook_source, roles, groups)
 ORDER BY (gram_project_id, time_bucket, department_name, job_title, employee_type, division_name, cost_center_name, user_email, model, hook_source, roles, groups, account_type, provider, billing_mode, query_source, skill_name, agent_name, mcp_server_name, mcp_tool_name)
-TTL time_bucket + INTERVAL 90 DAY
+-- Retained beyond the standard 90-day telemetry window (matching
+-- chat_token_summaries) so the costs page can break down token usage across
+-- the same lookback that TUM billing reports cover.
+TTL time_bucket + INTERVAL 730 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Pre-aggregated cost/token/usage metrics broken down by user-identity and request dimensions, powering the generic telemetry.query analytics endpoint.';
 

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -133,7 +133,10 @@ CREATE TABLE IF NOT EXISTS billing_cycle_usage (
 
   CONSTRAINT billing_cycle_usage_pkey PRIMARY KEY (id),
   CONSTRAINT billing_cycle_usage_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT billing_cycle_usage_cycle_bounds_check CHECK (cycle_end > cycle_start)
+  CONSTRAINT billing_cycle_usage_cycle_bounds_check CHECK (cycle_end > cycle_start),
+  -- Token counts originate from client-supplied OTEL attributes; a negative
+  -- sum must never become part of the permanent billing record.
+  CONSTRAINT billing_cycle_usage_tum_tokens_check CHECK (tum_tokens >= 0)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS billing_cycle_usage_organization_id_cycle_start_key

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -108,6 +108,37 @@ ON billing_metadata (organization_id);
 
 COMMENT ON COLUMN billing_metadata.tunneled_mcp_server_limit IS 'Contracted org-level cap for tunneled MCP server sources. NULL means use the finite plan default.';
 
+-- Durable per-billing-cycle "tokens under management" (TUM) snapshots for an
+-- organization. ClickHouse telemetry expires (telemetry_logs after 90 days,
+-- chat_token_summaries after 730 days), so rows here are the permanent record
+-- of each cycle's usage for billing, overage math, and admin reporting.
+CREATE TABLE IF NOT EXISTS billing_cycle_usage (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+
+  -- [cycle_start, cycle_end) boundaries computed from
+  -- billing_metadata.billing_cycle_anchor_day at snapshot time.
+  cycle_start timestamptz NOT NULL,
+  cycle_end timestamptz NOT NULL,
+
+  -- Total tokens under management observed for the cycle.
+  tum_tokens BIGINT NOT NULL DEFAULT 0,
+
+  -- Set once the cycle has closed plus an ingest grace period, after which the
+  -- row is treated as immutable. NULL while the cycle is still being refreshed.
+  finalized_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT billing_cycle_usage_pkey PRIMARY KEY (id),
+  CONSTRAINT billing_cycle_usage_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT billing_cycle_usage_cycle_bounds_check CHECK (cycle_end > cycle_start)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS billing_cycle_usage_organization_id_cycle_start_key
+ON billing_cycle_usage (organization_id, cycle_start);
+
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
 ON organization_metadata (slug);
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -277,6 +277,17 @@ type AwsKmsKey struct {
 	UpdatedAt            pgtype.Timestamptz
 }
 
+type BillingCycleUsage struct {
+	ID             uuid.UUID
+	OrganizationID string
+	CycleStart     pgtype.Timestamptz
+	CycleEnd       pgtype.Timestamptz
+	TumTokens      int64
+	FinalizedAt    pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
 type BillingMetadatum struct {
 	ID                    uuid.UUID
 	OrganizationID        string

--- a/server/internal/usage/repo/models.go
+++ b/server/internal/usage/repo/models.go
@@ -9,17 +9,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type BillingCycleUsage struct {
-	ID             uuid.UUID
-	OrganizationID string
-	CycleStart     pgtype.Timestamptz
-	CycleEnd       pgtype.Timestamptz
-	TumTokens      int64
-	FinalizedAt    pgtype.Timestamptz
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
-}
-
 type BillingMetadatum struct {
 	ID                    uuid.UUID
 	OrganizationID        string

--- a/server/internal/usage/repo/models.go
+++ b/server/internal/usage/repo/models.go
@@ -9,6 +9,17 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type BillingCycleUsage struct {
+	ID             uuid.UUID
+	OrganizationID string
+	CycleStart     pgtype.Timestamptz
+	CycleEnd       pgtype.Timestamptz
+	TumTokens      int64
+	FinalizedAt    pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
 type BillingMetadatum struct {
 	ID                    uuid.UUID
 	OrganizationID        string

--- a/server/migrations/20260707200235_add-billing-cycle-usage.sql
+++ b/server/migrations/20260707200235_add-billing-cycle-usage.sql
@@ -1,0 +1,16 @@
+-- Create "billing_cycle_usage" table
+CREATE TABLE "billing_cycle_usage" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "cycle_start" timestamptz NOT NULL,
+  "cycle_end" timestamptz NOT NULL,
+  "tum_tokens" bigint NOT NULL DEFAULT 0,
+  "finalized_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "billing_cycle_usage_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "billing_cycle_usage_cycle_bounds_check" CHECK (cycle_end > cycle_start)
+);
+-- Create index "billing_cycle_usage_organization_id_cycle_start_key" to table: "billing_cycle_usage"
+CREATE UNIQUE INDEX "billing_cycle_usage_organization_id_cycle_start_key" ON "billing_cycle_usage" ("organization_id", "cycle_start");

--- a/server/migrations/20260707204416_billing-cycle-usage-tum-tokens-check.sql
+++ b/server/migrations/20260707204416_billing-cycle-usage-tum-tokens-check.sql
@@ -1,0 +1,2 @@
+-- Modify "billing_cycle_usage" table
+ALTER TABLE "billing_cycle_usage" ADD CONSTRAINT "billing_cycle_usage_tum_tokens_check" CHECK (tum_tokens >= 0);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:KjkDqLFE15cYj9Lg+RbH9oljM1ijoSzuqM99PTrzyQc=
+h1:by2co2kzdvKyNJii7UmcHLZnI6+XJvnYq7d2BJN+KIw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -247,3 +247,4 @@ h1:KjkDqLFE15cYj9Lg+RbH9oljM1ijoSzuqM99PTrzyQc=
 20260706233448_drop-session-capture-exclusions.sql h1:CZfr4NqnLrq4r4Av+m/KVY39PEEH6TrBHe8sz61y4Co=
 20260707070702_risk-policy-eval-reviews.sql h1:RjhJvs0KrFmEk9tuNDI9slvcm1uGbnyEf44mDlZ8/MI=
 20260707120239_assistant-mcp-servers.sql h1:bDNWbd/16MXwFmJBGKVMmnLcxgdiDCCpizKI/ftevrY=
+20260707200235_add-billing-cycle-usage.sql h1:Oma/fS74ZRIZnopKrTdKwxYxtoEO+fPYATfmqeDiudc=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:by2co2kzdvKyNJii7UmcHLZnI6+XJvnYq7d2BJN+KIw=
+h1:Uodszq0ITn1QQZq1qg2xR5vP5lb9O2ymmlivpk6WD+U=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -248,3 +248,4 @@ h1:by2co2kzdvKyNJii7UmcHLZnI6+XJvnYq7d2BJN+KIw=
 20260707070702_risk-policy-eval-reviews.sql h1:RjhJvs0KrFmEk9tuNDI9slvcm1uGbnyEf44mDlZ8/MI=
 20260707120239_assistant-mcp-servers.sql h1:bDNWbd/16MXwFmJBGKVMmnLcxgdiDCCpizKI/ftevrY=
 20260707200235_add-billing-cycle-usage.sql h1:Oma/fS74ZRIZnopKrTdKwxYxtoEO+fPYATfmqeDiudc=
+20260707204416_billing-cycle-usage-tum-tokens-check.sql h1:e0oVX1jZavibZRbsR6pHqmhApLYK0fLjohgqx/kN65g=


### PR DESCRIPTION
Part of [DNO-403](https://linear.app/speakeasy/issue/DNO-403/tum-longer-ttl-for-billing-data) — billing metadata needs a longer lookback than the standard 90-day window for stored customer data.

## Changes

**ClickHouse** — extend `attribute_metrics_summaries` TTL from 90 to 730 days (single non-destructive `MODIFY TTL`). This is the only table the costs page reads for breakdowns (`telemetry.query` → `QueryAttributeMetricsTable`/`Timeseries`), so pricing breakdowns by user/model/provider/billing-mode/agent gain the same lookback TUM billing reports cover. Raw `telemetry_logs` (and the session drilldown built on it) stay at 90 days — the retention policy for stored customer data is unchanged; this only retains pre-aggregated per-user usage totals, matching the existing 730-day `chat_token_summaries`.

Size check (prod): the table is currently ~177K rows / 5.2 MiB compressed at ~15K rows/day, so 730 days projects to ~11M rows / ~330 MiB. Reads prune on `(gram_project_id, time_bucket)`, so time-bounded dashboard queries are unaffected by the longer tail.

**Postgres** — new `billing_cycle_usage` table: one row per `(organization_id, cycle_start)` holding the cycle's tokens-under-management total, with `finalized_at` marking closed cycles as immutable. ClickHouse aggregates can't be rebuilt once raw logs expire, so these rows become the permanent billing record (durable input for baseline-lock/overage math and admin reporting).

Includes regenerated sqlc `models.go`. The snapshot pipeline (activity + workflow wiring + queries) follows in a separate app-code PR stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends ClickHouse `attribute_metrics_summaries` TTL to 730 days and adds a Postgres `billing_cycle_usage` table for durable per-cycle TUM snapshots. Supports DNO-403 by enabling long-lookback pricing breakdowns and immutable billing records.

- **Migration**
  - ClickHouse: `ALTER TABLE attribute_metrics_summaries MODIFY TTL time_bucket + toIntervalDay(730)`; only pre-aggregated summaries are extended (raw `telemetry_logs` stay 90d), matching `chat_token_summaries`. Pruning keys unchanged; projected growth ~11M rows/~330 MiB over 730d.
  - Postgres: add `billing_cycle_usage(organization_id, cycle_start, cycle_end, tum_tokens, finalized_at)` with unique `(organization_id, cycle_start)`, FK to `organization_metadata`, and checks `cycle_end > cycle_start` and `tum_tokens >= 0`. Regenerated models with `BillingCycleUsage`; app code follows in a separate PR.

<sup>Written for commit 2f0a7120701a0d350beaab564d4cd739a7cfc41e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

