### PR TITLE
chore(ci): add review:bypass label auto-approval workflow

### DIFF
--- a/.github/workflows/review-bypass.yml
+++ b/.github/workflows/review-bypass.yml
@@ -1,19 +1,38 @@
 name: Review Bypass
 
+# ╔═══════════════════════════════════════════════════════════════════════╗
+# ║ SECURITY: LEAVE THE TRIGGER AS `pull_request`.                         ║
+# ║ NEVER SWITCH THIS WORKFLOW TO `pull_request_target`.                   ║
+# ║                                                                        ║
+# ║ `pull_request_target` hands repository secrets — including             ║
+# ║ GRAM_BOT_PRIVATE_KEY, a key that can mint tokens to approve PRs — to   ║
+# ║ runs triggered by fork PRs. One future edit that checks out or         ║
+# ║ executes PR code would let a fork exfiltrate those secrets.            ║
+# ║                                                                        ║
+# ║ With `pull_request`, secrets never reach fork-triggered runs, so that  ║
+# ║ entire class of mistake is inert. The same-repo guards on each job     ║
+# ║ below make fork PRs skip cleanly instead of failing at token minting.  ║
+# ╚═══════════════════════════════════════════════════════════════════════╝
+#
 # Allows a PR to merge without a human approval when the `review:bypass`
 # label is applied by someone with triage+ access. The gram-bot app submits
 # an approving review that satisfies the "Merge to main" ruleset's required
 # review count. Required status checks and the merge queue are unaffected —
-# CI must still pass before the PR can merge.
-#
-# Runs on pull_request_target so the label event fires with access to
-# secrets, but never checks out PR code, so untrusted code is never executed.
+# CI must still pass before the PR can merge. Removing the label dismisses
+# the bot's approval.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled, unlabeled]
 
 permissions: {}
+
+# Serialize runs per PR so a rapid label -> unlabel can't let the dismiss
+# job list reviews before the approve job has posted its review, which
+# would leave an orphaned approval on an unlabeled PR.
+concurrency:
+  group: review-bypass-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   BYPASS_LABEL: "review:bypass"
@@ -21,7 +40,10 @@ env:
 jobs:
   approve:
     name: Approve on bypass label
-    if: github.event.action == 'labeled' && github.event.label.name == 'review:bypass'
+    if: >
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'review:bypass' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Generate gram-bot token
@@ -45,7 +67,10 @@ jobs:
 
   dismiss:
     name: Dismiss approval on label removal
-    if: github.event.action == 'unlabeled' && github.event.label.name == 'review:bypass'
+    if: >
+      github.event.action == 'unlabeled' &&
+      github.event.label.name == 'review:bypass' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Generate gram-bot token

--- a/.github/workflows/review-bypass.yml
+++ b/.github/workflows/review-bypass.yml
@@ -1,0 +1,76 @@
+name: Review Bypass
+
+# Allows a PR to merge without a human approval when the `review:bypass`
+# label is applied by someone with triage+ access. The gram-bot app submits
+# an approving review that satisfies the "Merge to main" ruleset's required
+# review count. Required status checks and the merge queue are unaffected —
+# CI must still pass before the PR can merge.
+#
+# Runs on pull_request_target so the label event fires with access to
+# secrets, but never checks out PR code, so untrusted code is never executed.
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled]
+
+permissions: {}
+
+env:
+  BYPASS_LABEL: "review:bypass"
+
+jobs:
+  approve:
+    name: Approve on bypass label
+    if: github.event.action == 'labeled' && github.event.label.name == 'review:bypass'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Generate gram-bot token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.GRAM_BOT_APP_ID }}
+          private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Submit approving review
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABELED_BY: ${{ github.actor }}
+        run: |
+          gh api \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+            -f event=APPROVE \
+            -f body="Auto-approved: \`${BYPASS_LABEL}\` label applied by @${LABELED_BY}. Required status checks still gate this merge."
+
+  dismiss:
+    name: Dismiss approval on label removal
+    if: github.event.action == 'unlabeled' && github.event.label.name == 'review:bypass'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Generate gram-bot token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.GRAM_BOT_APP_ID }}
+          private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Dismiss gram-bot approvals
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          UNLABELED_BY: ${{ github.actor }}
+        run: |
+          review_ids=$(gh api \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+            --paginate \
+            --jq '.[] | select(.user.login == "gram-bot[bot]" and .state == "APPROVED") | .id')
+
+          for id in $review_ids; do
+            gh api \
+              --method PUT \
+              "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews/${id}/dismissals" \
+              -f message="\`${BYPASS_LABEL}\` label removed by @${UNLABELED_BY}." \
+              -f event=DISMISS
+          done

--- a/.github/workflows/review-bypass.yml
+++ b/.github/workflows/review-bypass.yml
@@ -10,8 +10,8 @@ name: Review Bypass
 # ║ executes PR code would let a fork exfiltrate those secrets.            ║
 # ║                                                                        ║
 # ║ With `pull_request`, secrets never reach fork-triggered runs, so that  ║
-# ║ entire class of mistake is inert. The same-repo guards on each job     ║
-# ║ below make fork PRs skip cleanly instead of failing at token minting.  ║
+# ║ entire class of mistake is inert. The same-repo guard on the job       ║
+# ║ below makes fork PRs skip cleanly instead of failing at token minting. ║
 # ╚═══════════════════════════════════════════════════════════════════════╝
 #
 # Allows a PR to merge without a human approval when the `review:bypass`
@@ -20,30 +20,33 @@ name: Review Bypass
 # review count. Required status checks and the merge queue are unaffected —
 # CI must still pass before the PR can merge. Removing the label dismisses
 # the bot's approval.
+#
+# The job reconciles state rather than reacting to individual label events:
+# it re-reads the PR's current labels and reviews, then approves or
+# dismisses to converge. This matters because `pull_request` workflows do
+# not run while a PR has merge conflicts — a label added or removed during
+# that window fires no run. Running the same reconciliation on
+# `synchronize` (the push that resolves the conflict) repairs any state
+# that drifted while runs were suppressed.
 
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [labeled, unlabeled, synchronize]
 
 permissions: {}
 
-# Serialize runs per PR so a rapid label -> unlabel can't let the dismiss
-# job list reviews before the approve job has posted its review, which
-# would leave an orphaned approval on an unlabeled PR.
+# Serialize runs per PR so rapid label churn can't interleave; each run
+# reconciles from freshly-read state, so the last run always converges.
 concurrency:
   group: review-bypass-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-env:
-  BYPASS_LABEL: "review:bypass"
-
 jobs:
-  approve:
-    name: Approve on bypass label
+  reconcile:
+    name: Reconcile bypass approval with label
     if: >
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'review:bypass' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action == 'synchronize' || github.event.label.name == 'review:bypass')
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Generate gram-bot token
@@ -54,48 +57,45 @@ jobs:
           private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
           permission-pull-requests: write
 
-      - name: Submit approving review
+      - name: Approve or dismiss to match label state
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          LABELED_BY: ${{ github.actor }}
+          FALLBACK_ACTOR: ${{ github.actor }}
         run: |
-          gh api \
-            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
-            -f event=APPROVE \
-            -f body="Auto-approved: \`${BYPASS_LABEL}\` label applied by @${LABELED_BY}. Required status checks still gate this merge."
+          set -euo pipefail
 
-  dismiss:
-    name: Dismiss approval on label removal
-    if: >
-      github.event.action == 'unlabeled' &&
-      github.event.label.name == 'review:bypass' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    steps:
-      - name: Generate gram-bot token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.GRAM_BOT_APP_ID }}
-          private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
-          permission-pull-requests: write
+          has_label=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" \
+            --jq '[.[].name] | index("review:bypass") != null')
 
-      - name: Dismiss gram-bot approvals
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          UNLABELED_BY: ${{ github.actor }}
-        run: |
-          review_ids=$(gh api \
-            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+          approval_ids=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
             --paginate \
             --jq '.[] | select(.user.login == "gram-bot[bot]" and .state == "APPROVED") | .id')
 
-          for id in $review_ids; do
+          if [[ "$has_label" == "true" && -z "$approval_ids" ]]; then
+            labeled_by=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/events" --paginate \
+              --jq '[.[] | select(.event == "labeled" and .label.name == "review:bypass") | .actor.login] | last // empty' \
+              | tail -1)
+            labeled_by="${labeled_by:-$FALLBACK_ACTOR}"
+            echo "Label present, no gram-bot approval: approving (label applied by ${labeled_by})."
             gh api \
-              --method PUT \
-              "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews/${id}/dismissals" \
-              -f message="\`${BYPASS_LABEL}\` label removed by @${UNLABELED_BY}." \
-              -f event=DISMISS
-          done
+              "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+              -f event=APPROVE \
+              -f body="Auto-approved: \`review:bypass\` label applied by @${labeled_by}. Required status checks still gate this merge."
+          elif [[ "$has_label" != "true" && -n "$approval_ids" ]]; then
+            unlabeled_by=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/events" --paginate \
+              --jq '[.[] | select(.event == "unlabeled" and .label.name == "review:bypass") | .actor.login] | last // empty' \
+              | tail -1)
+            unlabeled_by="${unlabeled_by:-$FALLBACK_ACTOR}"
+            for id in $approval_ids; do
+              echo "Label absent, dismissing gram-bot approval ${id}."
+              gh api \
+                --method PUT \
+                "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${id}/dismissals" \
+                -f message="\`review:bypass\` label removed by @${unlabeled_by}." \
+                -f event=DISMISS
+            done
+          else
+            echo "State already consistent (label present: ${has_label}); nothing to do."
+          fi


### PR DESCRIPTION
Implements [AGE-2901](https://linear.app/speakeasy/issue/AGE-2901/feat-implement-pr-review-bypass-label-for-gram-repo): a `review:bypass` label that lets a PR merge without a human approval, while required status checks and the merge queue still gate the merge.

## How it works

- Applying the **`review:bypass`** label (requires triage+ repo access) triggers this workflow on `pull_request`. The **gram-bot** app (`vars.GRAM_BOT_APP_ID` + `secrets.GRAM_BOT_PRIVATE_KEY`, same as `elements-docs.yml`) submits an approving review whose body records who applied the label.
- Removing the label dismisses gram-bot's approval.
- The "Merge to main" ruleset's required checks (`CI Gate`, `Lint PR Title and Changesets`, `Tag branch changes`), thread-resolution requirement, and squash merge queue are untouched — CI must still pass.
- The trigger is `pull_request` (not `pull_request_target`) per review: secrets never reach fork-triggered runs, so a future edit that checks out PR code can't leak `GRAM_BOT_PRIVATE_KEY` to a fork. Both jobs also carry a same-repo guard so fork PRs skip cleanly, and a per-PR concurrency group prevents a rapid label/unlabel from orphaning an approval.

## Deployment steps (repo settings — done / to do)

- [x] `review:bypass` label created on the repo (red, with description).
- [ ] **Ruleset change required**: the "Merge to main" ruleset has `require_code_owner_review: true`, and a GitHub App can never be a code owner, so the bot approval won't count until code-owner review is turned off (the 1-approval requirement itself stays). One command (payload = current ruleset with only that flag flipped):

  ```sh
  gh api repos/speakeasy-api/gram/rulesets/7225590 \
    | jq '{name, target, enforcement, conditions, bypass_actors,
           rules: (.rules | map(if .type == "pull_request" then .parameters.require_code_owner_review = false else . end))}' \
    | gh api --method PUT repos/speakeasy-api/gram/rulesets/7225590 --input -
  ```

  Practical impact: today `CODEOWNERS` maps `*` to `@speakeasy-api/dev-gram`, so this changes "approval must come from dev-gram" to "approval from anyone with write access".
- [ ] Verify the gram-bot app installation has **Pull requests: Read & write** permission (it's used for contents today; the review API call 403s without PR write).
- [ ] Per the Linear ticket: update the change management + SDLC documents in Drata.

## Testing

With the `pull_request` trigger the workflow runs from the PR's merge ref, so it can be exercised on this PR directly: apply `review:bypass` and confirm gram-bot approves (requires the gram-bot PR-write permission; the approval won't *count* toward the ruleset until the code-owner flag is flipped); remove the label and confirm the approval is dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrDheXXpBVn2WkiSZekvdT
