### PR TITLE
fix(hooks): deliver login credentials via form_post token exchange

### DIFF
--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -143,6 +143,7 @@ function AppContent() {
         organizationId={cliFlow.organizationId}
         codeChallenge={cliFlow.codeChallenge}
         codeChallengeMethod={cliFlow.codeChallengeMethod}
+        responseMode={cliFlow.responseMode}
       />
     );
   }
@@ -434,6 +435,7 @@ type LocalAuthFlow = {
   organizationId: string | null;
   codeChallenge: string | null;
   codeChallengeMethod: string | null;
+  responseMode: string | null;
 };
 
 function useCliAuthFlow(): LocalAuthFlow | null {
@@ -447,6 +449,7 @@ function useCliAuthFlow(): LocalAuthFlow | null {
   const organizationId = searchParams.get("organization_id");
   const codeChallenge = searchParams.get("code_challenge");
   const codeChallengeMethod = searchParams.get("code_challenge_method");
+  const responseMode = searchParams.get("response_mode");
 
   if (location.pathname === "/" && fromCli && cliCallbackUrl) {
     return {
@@ -456,6 +459,7 @@ function useCliAuthFlow(): LocalAuthFlow | null {
       organizationId,
       codeChallenge,
       codeChallengeMethod,
+      responseMode,
     };
   }
 

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -17,12 +17,22 @@ interface CliCallbackProps {
    */
   codeChallenge?: string | null;
   codeChallengeMethod?: string | null;
+  /**
+   * When `"form_post"`, credentials are delivered by auto-submitting a POST
+   * form to the localhost callback instead of appending them to its URL. This
+   * keeps the minted key out of the browser history and the local listener's
+   * process arguments. Any other value (or absence) preserves the default
+   * query-parameter redirect, so older clients keep working.
+   */
+  responseMode?: string | null;
 }
 
 /**
  * CliCallback is an authentication handler for local clients such as the CLI
  * and coding-agent hooks. By default it generates an API key in the requested
- * scope and returns it to the localhost callback URL as query parameters.
+ * scope and returns it to the localhost callback URL as query parameters. When
+ * the request sets `response_mode=form_post` it instead POSTs the credentials
+ * as a form body, keeping the minted key out of the callback URL.
  *
  * When the request supplies a PKCE `code_challenge`, it instead runs the PKCE
  * enrollment flow: it exchanges the challenge for a short-lived one-time code
@@ -38,6 +48,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
     organizationId,
     codeChallenge,
     codeChallengeMethod,
+    responseMode,
   } = props;
   const { session, status } = useSessionData();
   const [error, setError] = useState<string | null>(null);
@@ -46,6 +57,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
   const hasCreatedKey = useRef(false);
   const validCallback = isCallbackLocal(localCallbackUrl);
   const isPkceFlow = Boolean(codeChallenge);
+  const useFormPost = responseMode === "form_post";
 
   useEffect(() => {
     if (status === "pending") return;
@@ -95,7 +107,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
         codeChallengeMethod,
         selectedProjectSlug,
       )
-        .then((code) => transmitCode(localCallbackUrl, code))
+        .then((code) => transmitCode(localCallbackUrl, code, useFormPost))
         .catch((err) => {
           setError(
             err instanceof Error ? err.message : "Failed to authorize device",
@@ -112,6 +124,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
           selectedProjectSlug,
           session.user.email,
           session.activeOrganizationId,
+          useFormPost,
         ),
       )
       .catch((err) => {
@@ -131,6 +144,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
     isPkceFlow,
     codeChallenge,
     codeChallengeMethod,
+    useFormPost,
   ]);
 
   if (error) {
@@ -249,22 +263,64 @@ async function transmitKey(
   projectSlug: string | null,
   userEmail: string,
   organizationId?: string | null,
+  useFormPost?: boolean,
 ): Promise<void> {
-  const url = new URL(callbackUrl);
-  url.searchParams.set("api_key", apiKey);
+  const fields: Record<string, string> = { api_key: apiKey };
   if (projectSlug) {
-    url.searchParams.set("project", projectSlug);
+    fields.project = projectSlug;
   }
   if (userEmail) {
-    url.searchParams.set("email", userEmail);
+    fields.email = userEmail;
   }
   // The receiving client binds its credential cache to this org so a cache
   // minted here is never reused by a plugin generated for a different org.
   if (organizationId) {
-    url.searchParams.set("organization_id", organizationId);
+    fields.organization_id = organizationId;
   }
 
+  transmit(callbackUrl, fields, useFormPost);
+}
+
+/**
+ * transmit hands the credential fields to the localhost callback. In form_post
+ * mode it auto-submits a POST form so the secret rides in the request body
+ * (never the URL); otherwise it falls back to a query-parameter redirect.
+ */
+function transmit(
+  callbackUrl: string,
+  fields: Record<string, string>,
+  useFormPost?: boolean,
+): void {
+  if (useFormPost) {
+    postCallback(callbackUrl, fields);
+    return;
+  }
+
+  const url = new URL(callbackUrl);
+  for (const [name, value] of Object.entries(fields)) {
+    url.searchParams.set(name, value);
+  }
   window.location.replace(url.toString());
+}
+
+function postCallback(
+  callbackUrl: string,
+  fields: Record<string, string>,
+): void {
+  const form = document.createElement("form");
+  form.method = "POST";
+  form.action = callbackUrl;
+  // Default enctype (application/x-www-form-urlencoded) URL-encodes the field
+  // values, matching what the localhost listener decodes on the other side.
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+  document.body.appendChild(form);
+  form.submit();
 }
 
 async function authorizePkceCode(
@@ -294,9 +350,10 @@ async function authorizePkceCode(
   return result.code;
 }
 
-async function transmitCode(callbackUrl: string, code: string): Promise<void> {
-  const url = new URL(callbackUrl);
-  url.searchParams.set("code", code);
-
-  window.location.replace(url.toString());
+async function transmitCode(
+  callbackUrl: string,
+  code: string,
+  useFormPost?: boolean,
+): Promise<void> {
+  transmit(callbackUrl, { code }, useFormPost);
 }

--- a/hooks/plugin-claude/hooks/auth.sh
+++ b/hooks/plugin-claude/hooks/auth.sh
@@ -170,24 +170,28 @@ gram_hooks_login_http_response() {
 }
 
 gram_hooks_login_success_html() {
-  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. You can close this tab.</p></body></html>'
+  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. You can close this tab.</p><script>try{window.close()}catch(e){}setTimeout(function(){try{window.close()}catch(e){}},100)</script></body></html>'
 }
 
 # gram_hooks_login_handle_request reads one HTTP request from stdin (the nc
-# pipe), captures the /callback query string into a file, and writes the
-# response to stdout (piped back to the client through the fifo). The probe
-# path echoes a per-attempt marker so the readiness check can tell this
-# listener apart from whatever else answers on the port; other requests
-# without api_key (favicon) get a 204 so the serve loop keeps waiting for the
-# dashboard's real redirect. The callback must echo the unguessable state
-# token minted for this attempt — anyone on this machine can reach the
-# listener, and without the token a racing local process could inject its own
-# key and reroute telemetry to an attacker-controlled project.
+# pipe), captures the callback credentials into a file, and writes the response
+# to stdout (piped back to the client through the fifo). The dashboard delivers
+# credentials one of two ways: a form_post POST whose x-www-form-urlencoded body
+# carries the api_key — so the secret never lands in the URL, browser history,
+# or the listener's argv — or, for older dashboards, a GET whose query string
+# carries it. Either way the request must echo the unguessable state token
+# minted for this attempt (kept in the callback URL, which is not secret):
+# anyone on this machine can reach the listener, and without the token a racing
+# local process could inject its own key and reroute telemetry to an
+# attacker-controlled project. The probe path echoes a per-attempt marker so the
+# readiness check can tell this listener apart from whatever else answers on the
+# port; other requests without credentials (favicon) get a 204 so the serve loop
+# keeps waiting for the dashboard's real redirect.
 gram_hooks_login_handle_request() {
   local dir="$1"
   local state="$2"
   local probe="$3"
-  local request_line="" line="" path_query=""
+  local request_line="" line="" path_query="" method="" content_length=0
   IFS= read -r -t 10 request_line || request_line=""
   request_line="${request_line%$'\r'}"
   if [ -z "$request_line" ]; then
@@ -198,27 +202,70 @@ gram_hooks_login_handle_request() {
     if [ -z "$line" ]; then
       break
     fi
+    case "$line" in
+      [Cc]ontent-[Ll]ength:*)
+        content_length="${line#*:}"
+        content_length="${content_length// /}"
+        ;;
+    esac
   done
+  method="${request_line%% *}"
   path_query="${request_line#* }"
   path_query="${path_query%% *}"
-  case "$path_query" in
-    /callback\?*api_key=*)
-      case "&${path_query#*\?}&" in
-        *"&state=${state}&"*)
-          printf '%s' "${path_query#*\?}" >"$dir/query.tmp"
-          mv "$dir/query.tmp" "$dir/query"
-          gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+  case "$method" in
+    POST)
+      # form_post credential delivery: the api_key rides in the request body,
+      # never the URL. The body is x-www-form-urlencoded (key=value&key=value),
+      # the same shape gram_hooks_login already parses out of the GET query.
+      case "$path_query" in
+        /callback*)
+          case "&${path_query#*\?}&" in
+            *"&state=${state}&"*)
+              case "$content_length" in
+                "" | *[!0-9]*) content_length=0 ;;
+              esac
+              local body=""
+              if [ "$content_length" -gt 0 ]; then
+                # Read exactly Content-Length bytes: dd bs=1 never over-reads the
+                # nc pipe (no seeking, no blocking past the body), and works on
+                # the bash 3.2 shells where read -N is unavailable.
+                body="$(dd bs=1 count="$content_length" 2>/dev/null)"
+              fi
+              printf '%s' "$body" >"$dir/query.tmp"
+              mv "$dir/query.tmp" "$dir/query"
+              gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+              ;;
+            *)
+              gram_hooks_login_http_response 403 ""
+              ;;
+          esac
           ;;
         *)
-          gram_hooks_login_http_response 403 ""
+          gram_hooks_login_http_response 204 ""
           ;;
       esac
       ;;
-    /gram-probe*)
-      gram_hooks_login_http_response 200 "gram-hooks-probe-ok:${probe}"
-      ;;
     *)
-      gram_hooks_login_http_response 204 ""
+      case "$path_query" in
+        /callback\?*api_key=*)
+          case "&${path_query#*\?}&" in
+            *"&state=${state}&"*)
+              printf '%s' "${path_query#*\?}" >"$dir/query.tmp"
+              mv "$dir/query.tmp" "$dir/query"
+              gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+              ;;
+            *)
+              gram_hooks_login_http_response 403 ""
+              ;;
+          esac
+          ;;
+        /gram-probe*)
+          gram_hooks_login_http_response 200 "gram-hooks-probe-ok:${probe}"
+          ;;
+        *)
+          gram_hooks_login_http_response 204 ""
+          ;;
+      esac
       ;;
   esac
 }
@@ -342,7 +389,7 @@ gram_hooks_login() {
       ;;
   esac
   local dep
-  for dep in nc mkfifo curl date; do
+  for dep in nc mkfifo curl date dd; do
     if ! command -v "$dep" >/dev/null 2>&1; then
       echo "Speakeasy hooks: this machine is missing '$dep' for browser login." >&2
       gram_hooks_manual_auth_instructions "$server_url" "$project_hint"
@@ -425,8 +472,12 @@ gram_hooks_login() {
   fi
 
   # The callback URL carries the state token as its own query parameter; the
-  # dashboard preserves existing parameters when appending the credentials.
-  local auth_url="${server_url%/}/?from_cli=true&cli_callback_url=http%3A%2F%2F127.0.0.1%3A${port}%2Fcallback%3Fstate%3D${state}&key_scope=hooks"
+  # dashboard preserves it when posting the credentials back. response_mode=
+  # form_post asks the dashboard to POST the api_key in the request body rather
+  # than append it to the callback URL, keeping the secret out of browser
+  # history; older dashboards ignore it and fall back to the GET redirect, which
+  # this listener still accepts.
+  local auth_url="${server_url%/}/?from_cli=true&cli_callback_url=http%3A%2F%2F127.0.0.1%3A${port}%2Fcallback%3Fstate%3D${state}&key_scope=hooks&response_mode=form_post"
   # Project slugs are URL-safe by construction; anything else would need
   # percent-encoding, so it is dropped rather than corrupt the query string.
   case "$project_hint" in

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1294,24 +1294,28 @@ gram_hooks_login_http_response() {
 }
 
 gram_hooks_login_success_html() {
-  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. You can close this tab.</p></body></html>'
+  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. You can close this tab.</p><script>try{window.close()}catch(e){}setTimeout(function(){try{window.close()}catch(e){}},100)</script></body></html>'
 }
 
 # gram_hooks_login_handle_request reads one HTTP request from stdin (the nc
-# pipe), captures the /callback query string into a file, and writes the
-# response to stdout (piped back to the client through the fifo). The probe
-# path echoes a per-attempt marker so the readiness check can tell this
-# listener apart from whatever else answers on the port; other requests
-# without api_key (favicon) get a 204 so the serve loop keeps waiting for the
-# dashboard's real redirect. The callback must echo the unguessable state
-# token minted for this attempt — anyone on this machine can reach the
-# listener, and without the token a racing local process could inject its own
-# key and reroute telemetry to an attacker-controlled project.
+# pipe), captures the callback credentials into a file, and writes the response
+# to stdout (piped back to the client through the fifo). The dashboard delivers
+# credentials one of two ways: a form_post POST whose x-www-form-urlencoded body
+# carries the api_key — so the secret never lands in the URL, browser history,
+# or the listener's argv — or, for older dashboards, a GET whose query string
+# carries it. Either way the request must echo the unguessable state token
+# minted for this attempt (kept in the callback URL, which is not secret):
+# anyone on this machine can reach the listener, and without the token a racing
+# local process could inject its own key and reroute telemetry to an
+# attacker-controlled project. The probe path echoes a per-attempt marker so the
+# readiness check can tell this listener apart from whatever else answers on the
+# port; other requests without credentials (favicon) get a 204 so the serve loop
+# keeps waiting for the dashboard's real redirect.
 gram_hooks_login_handle_request() {
   local dir="$1"
   local state="$2"
   local probe="$3"
-  local request_line="" line="" path_query=""
+  local request_line="" line="" path_query="" method="" content_length=0
   IFS= read -r -t 10 request_line || request_line=""
   request_line="${request_line%$'\r'}"
   if [ -z "$request_line" ]; then
@@ -1322,27 +1326,70 @@ gram_hooks_login_handle_request() {
     if [ -z "$line" ]; then
       break
     fi
+    case "$line" in
+      [Cc]ontent-[Ll]ength:*)
+        content_length="${line#*:}"
+        content_length="${content_length// /}"
+        ;;
+    esac
   done
+  method="${request_line%% *}"
   path_query="${request_line#* }"
   path_query="${path_query%% *}"
-  case "$path_query" in
-    /callback\?*api_key=*)
-      case "&${path_query#*\?}&" in
-        *"&state=${state}&"*)
-          printf '%s' "${path_query#*\?}" >"$dir/query.tmp"
-          mv "$dir/query.tmp" "$dir/query"
-          gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+  case "$method" in
+    POST)
+      # form_post credential delivery: the api_key rides in the request body,
+      # never the URL. The body is x-www-form-urlencoded (key=value&key=value),
+      # the same shape gram_hooks_login already parses out of the GET query.
+      case "$path_query" in
+        /callback*)
+          case "&${path_query#*\?}&" in
+            *"&state=${state}&"*)
+              case "$content_length" in
+                "" | *[!0-9]*) content_length=0 ;;
+              esac
+              local body=""
+              if [ "$content_length" -gt 0 ]; then
+                # Read exactly Content-Length bytes: dd bs=1 never over-reads the
+                # nc pipe (no seeking, no blocking past the body), and works on
+                # the bash 3.2 shells where read -N is unavailable.
+                body="$(dd bs=1 count="$content_length" 2>/dev/null)"
+              fi
+              printf '%s' "$body" >"$dir/query.tmp"
+              mv "$dir/query.tmp" "$dir/query"
+              gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+              ;;
+            *)
+              gram_hooks_login_http_response 403 ""
+              ;;
+          esac
           ;;
         *)
-          gram_hooks_login_http_response 403 ""
+          gram_hooks_login_http_response 204 ""
           ;;
       esac
       ;;
-    /gram-probe*)
-      gram_hooks_login_http_response 200 "gram-hooks-probe-ok:${probe}"
-      ;;
     *)
-      gram_hooks_login_http_response 204 ""
+      case "$path_query" in
+        /callback\?*api_key=*)
+          case "&${path_query#*\?}&" in
+            *"&state=${state}&"*)
+              printf '%s' "${path_query#*\?}" >"$dir/query.tmp"
+              mv "$dir/query.tmp" "$dir/query"
+              gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+              ;;
+            *)
+              gram_hooks_login_http_response 403 ""
+              ;;
+          esac
+          ;;
+        /gram-probe*)
+          gram_hooks_login_http_response 200 "gram-hooks-probe-ok:${probe}"
+          ;;
+        *)
+          gram_hooks_login_http_response 204 ""
+          ;;
+      esac
       ;;
   esac
 }
@@ -1466,7 +1513,7 @@ gram_hooks_login() {
       ;;
   esac
   local dep
-  for dep in nc mkfifo curl date; do
+  for dep in nc mkfifo curl date dd; do
     if ! command -v "$dep" >/dev/null 2>&1; then
       echo "Speakeasy hooks: this machine is missing '$dep' for browser login." >&2
       gram_hooks_manual_auth_instructions "$server_url" "$project_hint"
@@ -1549,8 +1596,12 @@ gram_hooks_login() {
   fi
 
   # The callback URL carries the state token as its own query parameter; the
-  # dashboard preserves existing parameters when appending the credentials.
-  local auth_url="${server_url%/}/?from_cli=true&cli_callback_url=http%3A%2F%2F127.0.0.1%3A${port}%2Fcallback%3Fstate%3D${state}&key_scope=hooks"
+  # dashboard preserves it when posting the credentials back. response_mode=
+  # form_post asks the dashboard to POST the api_key in the request body rather
+  # than append it to the callback URL, keeping the secret out of browser
+  # history; older dashboards ignore it and fall back to the GET redirect, which
+  # this listener still accepts.
+  local auth_url="${server_url%/}/?from_cli=true&cli_callback_url=http%3A%2F%2F127.0.0.1%3A${port}%2Fcallback%3Fstate%3D${state}&key_scope=hooks&response_mode=form_post"
   # Project slugs are URL-safe by construction; anything else would need
   # percent-encoding, so it is dropped rather than corrupt the query string.
   case "$project_hint" in

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -133,6 +133,9 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 			port = match[1]
 			state = match[2]
 		}
+		// The listener advertises form_post so the dashboard POSTs the key in a
+		// request body instead of exposing it in the callback URL.
+		assert.Contains(c, string(raw), "response_mode=form_post", "auth URL must request the form_post token exchange: %s", string(raw))
 	}, 30*time.Second, 100*time.Millisecond, "browser opener was never invoked: %s", output.String())
 
 	// Process arguments are world-readable; the state token must reach the
@@ -143,12 +146,13 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 	// A callback without the per-attempt state token is an injection attempt
 	// by something else on this machine: rejected, and the listener keeps
 	// waiting for the real redirect.
-	forged := "http://127.0.0.1:" + port + "/callback?api_key=attacker-key&project=evil"
+	forged := "http://127.0.0.1:" + port + "/callback"
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, forged, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, forged, strings.NewReader("api_key=attacker-key&project=evil"))
 		if !assert.NoError(c, err) {
 			return
 		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		resp, err := http.DefaultClient.Do(req)
 		if !assert.NoError(c, err) {
 			return
@@ -157,12 +161,15 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 		assert.Equal(c, http.StatusForbidden, resp.StatusCode)
 	}, 30*time.Second, 200*time.Millisecond, "forged callback was never rejected: %s", output.String())
 
-	callback := "http://127.0.0.1:" + port + "/callback?state=" + state + "&api_key=test-key-123&project=default&email=a%40b.c"
+	// The dashboard's form_post: the state token stays in the callback URL, but
+	// the credentials arrive in the request body so they never touch the URL.
+	callback := "http://127.0.0.1:" + port + "/callback?state=" + state
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, callback, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, callback, strings.NewReader("api_key=test-key-123&project=default&email=a%40b.c"))
 		if !assert.NoError(c, err) {
 			return
 		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		resp, err := http.DefaultClient.Do(req)
 		if !assert.NoError(c, err) {
 			return
@@ -183,6 +190,50 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 	require.Contains(t, cached, "project=default\n")
 	require.Contains(t, cached, "email=a@b.c\n")
 	require.NoFileExists(t, authFile+".login-attempt", "successful login must clear the attempt cooldown marker")
+}
+
+// TestSharedAuthScriptHandleRequestFormPost drives the listener's request
+// handler directly to lock in the form_post token exchange and its safeguards:
+// a POST with the valid state captures the body verbatim, an older dashboard's
+// GET redirect still works (so a new plugin keeps authenticating against a
+// dashboard that has not yet learned form_post), and a POST without the state
+// token is rejected without capturing anything.
+func TestSharedAuthScriptHandleRequestFormPost(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth.sh"), renderSharedAuthScript(), 0o755))
+
+	script := `. ./auth.sh
+run_case() {
+  local label="$1" method="$2" target="$3" body="$4"
+  local work; work="$(mktemp -d)"
+  if [ "$method" = "POST" ]; then
+    printf 'POST %s HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: %s\r\n\r\n%s' "$target" "${#body}" "$body" \
+      | gram_hooks_login_handle_request "$work" tok probe >"$work/resp"
+  else
+    printf 'GET %s HTTP/1.1\r\n\r\n' "$target" \
+      | gram_hooks_login_handle_request "$work" tok probe >"$work/resp"
+  fi
+  printf '%s-STATUS:%s\n' "$label" "$(head -n1 "$work/resp" | tr -d '\r')"
+  printf '%s-QUERY:%s\n' "$label" "$(cat "$work/query" 2>/dev/null)"
+}
+run_case POST POST '/callback?state=tok' 'api_key=post-key&project=proj&email=a%40b.c'
+run_case GET GET '/callback?state=tok&api_key=get-key&project=proj' ''
+run_case FORGED POST '/callback' 'api_key=attacker&project=evil'
+`
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	output := string(out)
+
+	require.Contains(t, output, "POST-STATUS:HTTP/1.1 200 OK", "form_post callback must succeed")
+	require.Contains(t, output, "POST-QUERY:api_key=post-key&project=proj&email=a%40b.c", "form_post body must be captured verbatim")
+	require.Contains(t, output, "GET-STATUS:HTTP/1.1 200 OK", "legacy GET redirect must still succeed")
+	require.Contains(t, output, "GET-QUERY:state=tok&api_key=get-key&project=proj", "legacy GET query must still be captured")
+	require.Contains(t, output, "FORGED-STATUS:HTTP/1.1 403 Forbidden", "a POST without the state token must be rejected")
+	require.Contains(t, output, "FORGED-QUERY:\n", "a rejected POST must not capture credentials")
 }
 
 func TestGeneratePluginWithCustomDomainURL(t *testing.T) {


### PR DESCRIPTION
Hook browser login minted a hooks-scoped API key and handed it back to the localhost listener as **callback URL query parameters**, so the raw key landed in browser history (and briefly in the URL bar). This switches the flow to an Apple-style `form_post` token exchange so the secret never touches the URL.

## What changed
- The generated hook login script advertises `response_mode=form_post` in the auth URL and its localhost listener now reads credentials from an `application/x-www-form-urlencoded` POST body (via `dd`, so it works on bash 3.2 where `read -N` is unavailable).
- The dashboard callback (`CliCallback`) auto-submits a hidden POST form to the localhost callback when `response_mode=form_post` is set, instead of appending credentials to the URL.
- The success page now attempts to close the tab on completion.

The per-attempt `state` token stays in the callback URL (it is a CSRF guard, not a secret) and is still required — a POST without it is rejected with 403.

## Compatibility
The change is gated on `response_mode=form_post`, so version skew is safe both ways:
- **New plugin + old dashboard:** dashboard ignores the param and falls back to the GET redirect, which the listener still accepts.
- **Old plugin + new dashboard:** plugin never sends the param, so the dashboard keeps using the GET redirect.

## Scope
Targeted at the hooks flow (the only one shipping the raw key in the URL). The Gram CLI's Go listener still uses the GET flow — the dashboard support is generic, so it can opt into `form_post` later as a follow-up.

## Testing
- Updated the end-to-end nc listener roundtrip test to POST credentials and assert `response_mode=form_post` in the auth URL.
- Added a handler-level test covering the `form_post` POST path, the legacy GET path (back-compat), and rejection of a POST missing the state token.
- Regenerated the checked-in `hooks/plugin-claude/hooks/auth.sh` to stay byte-identical to `renderSharedAuthScript()`.

> Note: the Go test suite for this package needs Docker (Postgres/Redis/ClickHouse) which isn't available in the agent sandbox, so the shell logic was verified by running the listener functions directly with bash; `go vet` and dashboard `type-check` both pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the hooks login flow to a POST-based form_post token exchange to keep API keys out of URLs and browser history. Backward compatible with older dashboards and plugins. Addresses Linear DNO-419.

- **Bug Fixes**
  - Generated hooks login advertises response_mode=form_post; localhost listener reads an application/x-www-form-urlencoded POST body (via dd; bash 3.2 safe).
  - Dashboard `CliCallback` auto-submits a hidden POST form when response_mode=form_post; falls back to query parameters otherwise.
  - State token stays in the callback URL and is required; POST without it returns 403.
  - Backward compatibility both ways: new plugin + old dashboard and old plugin + new dashboard continue to work.
  - Success page now attempts to close the tab, and tests cover POST delivery, legacy GET, and rejection without state; checked-in auth script regenerated.

<sup>Written for commit e67204ce51207b85efcfc037b5b10a18da7d81a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

