### PR TITLE
fix: deliver hook auth credentials via form POST token exchange

### DIFF
--- a/.changeset/hooks-post-token-exchange.md
+++ b/.changeset/hooks-post-token-exchange.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Hook browser login now delivers the minted API key to the local listener as a form POST instead of appending it to the callback URL, keeping the key out of browser history and request logs, and the sign-in tab closes itself once authentication completes. Older dashboards that still redirect with query parameters keep working.

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -143,6 +143,7 @@ function AppContent() {
         organizationId={cliFlow.organizationId}
         codeChallenge={cliFlow.codeChallenge}
         codeChallengeMethod={cliFlow.codeChallengeMethod}
+        callbackMethod={cliFlow.callbackMethod}
       />
     );
   }
@@ -434,6 +435,7 @@ type LocalAuthFlow = {
   organizationId: string | null;
   codeChallenge: string | null;
   codeChallengeMethod: string | null;
+  callbackMethod: "get" | "post";
 };
 
 function useCliAuthFlow(): LocalAuthFlow | null {
@@ -447,6 +449,7 @@ function useCliAuthFlow(): LocalAuthFlow | null {
   const organizationId = searchParams.get("organization_id");
   const codeChallenge = searchParams.get("code_challenge");
   const codeChallengeMethod = searchParams.get("code_challenge_method");
+  const callbackMethod = searchParams.get("callback_method");
 
   if (location.pathname === "/" && fromCli && cliCallbackUrl) {
     return {
@@ -456,6 +459,7 @@ function useCliAuthFlow(): LocalAuthFlow | null {
       organizationId,
       codeChallenge,
       codeChallengeMethod,
+      callbackMethod: callbackMethod === "post" ? "post" : "get",
     };
   }
 

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -258,11 +258,11 @@ function selectCallbackProjectSlug(
   return null;
 }
 
-async function transmitKey(
+function transmitKey(
   callbackUrl: string,
   callbackMethod: "get" | "post",
   fields: Record<string, string>,
-): Promise<void> {
+): void {
   if (callbackMethod === "post") {
     // A form navigation (not fetch) so the localhost listener does not need
     // CORS or private-network-access preflight handling. The callback URL's

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -17,6 +17,12 @@ interface CliCallbackProps {
    */
   codeChallenge?: string | null;
   codeChallengeMethod?: string | null;
+  /**
+   * How the credentials travel to the local callback. "post" submits them as
+   * an auto-submitted form body (Apple-style form_post) so the API key never
+   * appears in a URL; "get" is the legacy query-string redirect.
+   */
+  callbackMethod: "get" | "post";
 }
 
 /**
@@ -38,6 +44,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
     organizationId,
     codeChallenge,
     codeChallengeMethod,
+    callbackMethod,
   } = props;
   const { session, status } = useSessionData();
   const [error, setError] = useState<string | null>(null);
@@ -105,15 +112,22 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
     }
 
     createScopedKey(createKey, session.session, keyScope)
-      .then((key) =>
-        transmitKey(
-          localCallbackUrl,
-          key,
-          selectedProjectSlug,
-          session.user.email,
-          session.activeOrganizationId,
-        ),
-      )
+      .then((key) => {
+        const fields: Record<string, string> = { api_key: key };
+        if (selectedProjectSlug) {
+          fields.project = selectedProjectSlug;
+        }
+        if (session.user.email) {
+          fields.email = session.user.email;
+        }
+        // The receiving client binds its credential cache to this org so a
+        // cache minted here is never reused by a plugin generated for a
+        // different org.
+        if (session.activeOrganizationId) {
+          fields.organization_id = session.activeOrganizationId;
+        }
+        transmitKey(localCallbackUrl, callbackMethod, fields);
+      })
       .catch((err) => {
         setError(
           err instanceof Error ? err.message : "Failed to create API key",
@@ -124,6 +138,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
     authorizeCode,
     keyScope,
     localCallbackUrl,
+    callbackMethod,
     projectSlug,
     organizationId,
     session,
@@ -245,26 +260,42 @@ function selectCallbackProjectSlug(
 
 async function transmitKey(
   callbackUrl: string,
-  apiKey: string,
-  projectSlug: string | null,
-  userEmail: string,
-  organizationId?: string | null,
+  callbackMethod: "get" | "post",
+  fields: Record<string, string>,
 ): Promise<void> {
+  if (callbackMethod === "post") {
+    // A form navigation (not fetch) so the localhost listener does not need
+    // CORS or private-network-access preflight handling. The callback URL's
+    // own query string (the client's state token) is preserved by POST.
+    submitCallbackForm(callbackUrl, fields);
+    return;
+  }
+
   const url = new URL(callbackUrl);
-  url.searchParams.set("api_key", apiKey);
-  if (projectSlug) {
-    url.searchParams.set("project", projectSlug);
-  }
-  if (userEmail) {
-    url.searchParams.set("email", userEmail);
-  }
-  // The receiving client binds its credential cache to this org so a cache
-  // minted here is never reused by a plugin generated for a different org.
-  if (organizationId) {
-    url.searchParams.set("organization_id", organizationId);
+  for (const [name, value] of Object.entries(fields)) {
+    url.searchParams.set(name, value);
   }
 
   window.location.replace(url.toString());
+}
+
+function submitCallbackForm(
+  actionUrl: string,
+  fields: Record<string, string>,
+): void {
+  const form = document.createElement("form");
+  form.method = "post";
+  form.action = actionUrl;
+  form.style.display = "none";
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+  document.body.appendChild(form);
+  form.submit();
 }
 
 async function authorizePkceCode(

--- a/hooks/plugin-claude/hooks/auth.sh
+++ b/hooks/plugin-claude/hooks/auth.sh
@@ -170,47 +170,82 @@ gram_hooks_login_http_response() {
 }
 
 gram_hooks_login_success_html() {
-  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. You can close this tab.</p></body></html>'
+  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. This tab will close itself; if it stays open, you can close it.</p><script>window.close()</script></body></html>'
 }
 
 # gram_hooks_login_handle_request reads one HTTP request from stdin (the nc
-# pipe), captures the /callback query string into a file, and writes the
-# response to stdout (piped back to the client through the fifo). The probe
-# path echoes a per-attempt marker so the readiness check can tell this
-# listener apart from whatever else answers on the port; other requests
-# without api_key (favicon) get a 204 so the serve loop keeps waiting for the
-# dashboard's real redirect. The callback must echo the unguessable state
-# token minted for this attempt — anyone on this machine can reach the
-# listener, and without the token a racing local process could inject its own
-# key and reroute telemetry to an attacker-controlled project.
+# pipe), captures the credential fields into a file, and writes the response
+# to stdout (piped back to the client through the fifo). Dashboards honoring
+# callback_method=post deliver the credentials as a form POST body so the API
+# key never appears in a URL; older dashboards send them in the /callback
+# query string, and both shapes are accepted. The probe path echoes a
+# per-attempt marker so the readiness check can tell this listener apart from
+# whatever else answers on the port; other requests without api_key (favicon)
+# get a 204 so the serve loop keeps waiting for the dashboard's real
+# response. The callback must echo the unguessable state token minted for
+# this attempt — anyone on this machine can reach the listener, and without
+# the token a racing local process could inject its own key and reroute
+# telemetry to an attacker-controlled project.
 gram_hooks_login_handle_request() {
   local dir="$1"
   local state="$2"
   local probe="$3"
-  local request_line="" line="" path_query=""
+  local request_line="" line="" path_query="" method="" content_length=""
   IFS= read -r -t 10 request_line || request_line=""
   request_line="${request_line%$'\r'}"
   if [ -z "$request_line" ]; then
     return 0
   fi
+  method="${request_line%% *}"
   while IFS= read -r -t 10 line; do
     line="${line%$'\r'}"
     if [ -z "$line" ]; then
       break
     fi
+    case "$line" in
+      [Cc][Oo][Nn][Tt][Ee][Nn][Tt]-[Ll][Ee][Nn][Gg][Tt][Hh]:*)
+        content_length="${line#*:}"
+        content_length="${content_length//[[:space:]]/}"
+        # A malformed length must be rejected, not digit-stripped into a
+        # different valid number that would truncate or garble the body.
+        case "$content_length" in
+          '' | *[!0-9]*) content_length="" ;;
+        esac
+        ;;
+    esac
   done
   path_query="${request_line#* }"
   path_query="${path_query%% *}"
   case "$path_query" in
-    /callback\?*api_key=*)
-      case "&${path_query#*\?}&" in
-        *"&state=${state}&"*)
-          printf '%s' "${path_query#*\?}" >"$dir/query.tmp"
-          mv "$dir/query.tmp" "$dir/query"
-          gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+    /callback\?*)
+      local cb_query="${path_query#*\?}" creds=""
+      if [ "$method" = "POST" ]; then
+        # read -n, not -N: macOS ships bash 3.2, which lacks -N, and -n reads
+        # the exact count anyway because the urlencoded body is newline-free
+        # ASCII. The length-of-length guard keeps oversized values out of the
+        # arithmetic tests, and the size cap plus timeout keep a hostile
+        # local client from ballooning or stalling the capture.
+        if [ -n "$content_length" ] && [ "${#content_length}" -le 5 ] && [ "$content_length" -gt 0 ] && [ "$content_length" -le 16384 ]; then
+          IFS= read -r -t 10 -n "$content_length" creds || true
+        fi
+      else
+        creds="$cb_query"
+      fi
+      case "$creds" in
+        *api_key=*)
+          case "&${cb_query}&" in
+            *"&state=${state}&"*)
+              printf '%s' "$creds" >"$dir/query.tmp"
+              mv "$dir/query.tmp" "$dir/query"
+              gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+              ;;
+            *)
+              gram_hooks_login_http_response 403 ""
+              ;;
+          esac
           ;;
         *)
-          gram_hooks_login_http_response 403 ""
+          gram_hooks_login_http_response 204 ""
           ;;
       esac
       ;;
@@ -425,8 +460,10 @@ gram_hooks_login() {
   fi
 
   # The callback URL carries the state token as its own query parameter; the
-  # dashboard preserves existing parameters when appending the credentials.
-  local auth_url="${server_url%/}/?from_cli=true&cli_callback_url=http%3A%2F%2F127.0.0.1%3A${port}%2Fcallback%3Fstate%3D${state}&key_scope=hooks"
+  # dashboard preserves it whether it appends the credentials to the query
+  # string (legacy) or, per callback_method=post, delivers them as a form
+  # body that keeps the API key out of URLs.
+  local auth_url="${server_url%/}/?from_cli=true&cli_callback_url=http%3A%2F%2F127.0.0.1%3A${port}%2Fcallback%3Fstate%3D${state}&key_scope=hooks&callback_method=post"
   # Project slugs are URL-safe by construction; anything else would need
   # percent-encoding, so it is dropped rather than corrupt the query string.
   case "$project_hint" in

--- a/hooks/plugin-claude/hooks/auth.sh
+++ b/hooks/plugin-claude/hooks/auth.sh
@@ -170,7 +170,7 @@ gram_hooks_login_http_response() {
 }
 
 gram_hooks_login_success_html() {
-  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. This tab will close itself; if it stays open, you can close it.</p><script>window.close()</script></body></html>'
+  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. You can close this tab.</p><script>window.close()</script></body></html>'
 }
 
 # gram_hooks_login_handle_request reads one HTTP request from stdin (the nc

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1294,47 +1294,82 @@ gram_hooks_login_http_response() {
 }
 
 gram_hooks_login_success_html() {
-  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. You can close this tab.</p></body></html>'
+  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. This tab will close itself; if it stays open, you can close it.</p><script>window.close()</script></body></html>'
 }
 
 # gram_hooks_login_handle_request reads one HTTP request from stdin (the nc
-# pipe), captures the /callback query string into a file, and writes the
-# response to stdout (piped back to the client through the fifo). The probe
-# path echoes a per-attempt marker so the readiness check can tell this
-# listener apart from whatever else answers on the port; other requests
-# without api_key (favicon) get a 204 so the serve loop keeps waiting for the
-# dashboard's real redirect. The callback must echo the unguessable state
-# token minted for this attempt — anyone on this machine can reach the
-# listener, and without the token a racing local process could inject its own
-# key and reroute telemetry to an attacker-controlled project.
+# pipe), captures the credential fields into a file, and writes the response
+# to stdout (piped back to the client through the fifo). Dashboards honoring
+# callback_method=post deliver the credentials as a form POST body so the API
+# key never appears in a URL; older dashboards send them in the /callback
+# query string, and both shapes are accepted. The probe path echoes a
+# per-attempt marker so the readiness check can tell this listener apart from
+# whatever else answers on the port; other requests without api_key (favicon)
+# get a 204 so the serve loop keeps waiting for the dashboard's real
+# response. The callback must echo the unguessable state token minted for
+# this attempt — anyone on this machine can reach the listener, and without
+# the token a racing local process could inject its own key and reroute
+# telemetry to an attacker-controlled project.
 gram_hooks_login_handle_request() {
   local dir="$1"
   local state="$2"
   local probe="$3"
-  local request_line="" line="" path_query=""
+  local request_line="" line="" path_query="" method="" content_length=""
   IFS= read -r -t 10 request_line || request_line=""
   request_line="${request_line%$'\r'}"
   if [ -z "$request_line" ]; then
     return 0
   fi
+  method="${request_line%% *}"
   while IFS= read -r -t 10 line; do
     line="${line%$'\r'}"
     if [ -z "$line" ]; then
       break
     fi
+    case "$line" in
+      [Cc][Oo][Nn][Tt][Ee][Nn][Tt]-[Ll][Ee][Nn][Gg][Tt][Hh]:*)
+        content_length="${line#*:}"
+        content_length="${content_length//[[:space:]]/}"
+        # A malformed length must be rejected, not digit-stripped into a
+        # different valid number that would truncate or garble the body.
+        case "$content_length" in
+          '' | *[!0-9]*) content_length="" ;;
+        esac
+        ;;
+    esac
   done
   path_query="${request_line#* }"
   path_query="${path_query%% *}"
   case "$path_query" in
-    /callback\?*api_key=*)
-      case "&${path_query#*\?}&" in
-        *"&state=${state}&"*)
-          printf '%s' "${path_query#*\?}" >"$dir/query.tmp"
-          mv "$dir/query.tmp" "$dir/query"
-          gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+    /callback\?*)
+      local cb_query="${path_query#*\?}" creds=""
+      if [ "$method" = "POST" ]; then
+        # read -n, not -N: macOS ships bash 3.2, which lacks -N, and -n reads
+        # the exact count anyway because the urlencoded body is newline-free
+        # ASCII. The length-of-length guard keeps oversized values out of the
+        # arithmetic tests, and the size cap plus timeout keep a hostile
+        # local client from ballooning or stalling the capture.
+        if [ -n "$content_length" ] && [ "${#content_length}" -le 5 ] && [ "$content_length" -gt 0 ] && [ "$content_length" -le 16384 ]; then
+          IFS= read -r -t 10 -n "$content_length" creds || true
+        fi
+      else
+        creds="$cb_query"
+      fi
+      case "$creds" in
+        *api_key=*)
+          case "&${cb_query}&" in
+            *"&state=${state}&"*)
+              printf '%s' "$creds" >"$dir/query.tmp"
+              mv "$dir/query.tmp" "$dir/query"
+              gram_hooks_login_http_response 200 "$(gram_hooks_login_success_html)"
+              ;;
+            *)
+              gram_hooks_login_http_response 403 ""
+              ;;
+          esac
           ;;
         *)
-          gram_hooks_login_http_response 403 ""
+          gram_hooks_login_http_response 204 ""
           ;;
       esac
       ;;
@@ -1549,8 +1584,10 @@ gram_hooks_login() {
   fi
 
   # The callback URL carries the state token as its own query parameter; the
-  # dashboard preserves existing parameters when appending the credentials.
-  local auth_url="${server_url%/}/?from_cli=true&cli_callback_url=http%3A%2F%2F127.0.0.1%3A${port}%2Fcallback%3Fstate%3D${state}&key_scope=hooks"
+  # dashboard preserves it whether it appends the credentials to the query
+  # string (legacy) or, per callback_method=post, delivers them as a form
+  # body that keeps the API key out of URLs.
+  local auth_url="${server_url%/}/?from_cli=true&cli_callback_url=http%3A%2F%2F127.0.0.1%3A${port}%2Fcallback%3Fstate%3D${state}&key_scope=hooks&callback_method=post"
   # Project slugs are URL-safe by construction; anything else would need
   # percent-encoding, so it is dropped rather than corrupt the query string.
   case "$project_hint" in

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1294,7 +1294,7 @@ gram_hooks_login_http_response() {
 }
 
 gram_hooks_login_success_html() {
-  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. This tab will close itself; if it stays open, you can close it.</p><script>window.close()</script></body></html>'
+  printf '<!doctype html><html><head><title>Speakeasy hooks connected</title></head><body style="font-family:sans-serif;text-align:center;padding-top:4rem"><h1>Authentication successful</h1><p>Speakeasy hooks are connected. You can close this tab.</p><script>window.close()</script></body></html>'
 }
 
 # gram_hooks_login_handle_request reads one HTTP request from stdin (the nc

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -61,13 +61,25 @@ func TestSharedAuthScriptMatchesCheckedIn(t *testing.T) {
 		"hooks/plugin-claude/hooks/auth.sh has drifted from renderSharedAuthScript() — keep them identical")
 }
 
-// TestSharedAuthScriptBrowserLoginRoundtrip drives the interactive login flow
-// end to end against the real nc-based localhost listener: a stubbed browser
-// opener captures the dashboard URL, the test plays the dashboard's role by
-// requesting the localhost callback with an api_key, and the flow must cache
-// the credentials and clear the attempt cooldown marker.
-func TestSharedAuthScriptBrowserLoginRoundtrip(t *testing.T) {
-	t.Parallel()
+// authLoginHarness is a running gram_hooks_login invocation whose localhost
+// listener is ready to receive callback requests.
+type authLoginHarness struct {
+	ctx      context.Context
+	cmd      *exec.Cmd
+	output   *bytes.Buffer
+	authFile string
+	urlFile  string
+	port     string
+	state    string
+}
+
+// startSharedAuthScriptLogin drives the interactive login flow against the
+// real nc-based localhost listener: a stubbed browser opener captures the
+// dashboard URL, and the harness returns once the listener's port and
+// per-attempt state token are known so the test can play the dashboard's
+// role.
+func startSharedAuthScriptLogin(t *testing.T) *authLoginHarness {
+	t.Helper()
 	_, err := exec.LookPath("nc")
 	require.NoError(t, err, "netcat is required: the browser login flow depends on it and must stay covered")
 
@@ -109,19 +121,25 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 	)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 	cmd := exec.CommandContext(ctx, "bash", "-c", `. ./auth.sh; gram_hooks_login https://gram.test default`)
 	cmd.Dir = dir
 	cmd.Env = env
 	// The listener runs as a background child sharing stdout; WaitDelay keeps
 	// Wait from blocking on its pipe if a failure path leaks it.
 	cmd.WaitDelay = 5 * time.Second
-	var output bytes.Buffer
-	cmd.Stdout = &output
-	cmd.Stderr = &output
+	output := &bytes.Buffer{}
+	cmd.Stdout = output
+	cmd.Stderr = output
 	require.NoError(t, cmd.Start())
 
-	var port, state string
+	h := &authLoginHarness{
+		ctx:      ctx,
+		cmd:      cmd,
+		output:   output,
+		authFile: authFile,
+		urlFile:  urlFile,
+	}
 	portPattern := regexp.MustCompile(`127\.0\.0\.1%3A(\d+)%2Fcallback%3Fstate%3D([A-Za-z0-9-]+)`)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		raw, err := os.ReadFile(urlFile)
@@ -130,8 +148,8 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 		}
 		match := portPattern.FindStringSubmatch(string(raw))
 		if assert.NotNil(c, match, "auth URL missing callback port and state token: %s", string(raw)) {
-			port = match[1]
-			state = match[2]
+			h.port = match[1]
+			h.state = match[2]
 		}
 	}, 30*time.Second, 100*time.Millisecond, "browser opener was never invoked: %s", output.String())
 
@@ -140,12 +158,23 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 	argv := string(requireFileBytes(t, argvFile))
 	require.NotContains(t, argv, "state", "opener argv must not carry the state token")
 
+	return h
+}
+
+// TestSharedAuthScriptBrowserLoginRoundtrip plays a legacy dashboard that
+// ignores callback_method=post and returns the credentials in the callback
+// query string: the flow must still cache them and clear the attempt
+// cooldown marker.
+func TestSharedAuthScriptBrowserLoginRoundtrip(t *testing.T) {
+	t.Parallel()
+	h := startSharedAuthScriptLogin(t)
+
 	// A callback without the per-attempt state token is an injection attempt
 	// by something else on this machine: rejected, and the listener keeps
 	// waiting for the real redirect.
-	forged := "http://127.0.0.1:" + port + "/callback?api_key=attacker-key&project=evil"
+	forged := "http://127.0.0.1:" + h.port + "/callback?api_key=attacker-key&project=evil"
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, forged, nil)
+		req, err := http.NewRequestWithContext(h.ctx, http.MethodGet, forged, nil)
 		if !assert.NoError(c, err) {
 			return
 		}
@@ -155,11 +184,11 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 		}
 		assert.NoError(c, resp.Body.Close())
 		assert.Equal(c, http.StatusForbidden, resp.StatusCode)
-	}, 30*time.Second, 200*time.Millisecond, "forged callback was never rejected: %s", output.String())
+	}, 30*time.Second, 200*time.Millisecond, "forged callback was never rejected: %s", h.output.String())
 
-	callback := "http://127.0.0.1:" + port + "/callback?state=" + state + "&api_key=test-key-123&project=default&email=a%40b.c"
+	callback := "http://127.0.0.1:" + h.port + "/callback?state=" + h.state + "&api_key=test-key-123&project=default&email=a%40b.c"
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, callback, nil)
+		req, err := http.NewRequestWithContext(h.ctx, http.MethodGet, callback, nil)
 		if !assert.NoError(c, err) {
 			return
 		}
@@ -171,18 +200,79 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 		assert.NoError(c, err)
 		assert.NoError(c, resp.Body.Close())
 		assert.Equal(c, http.StatusOK, resp.StatusCode)
-		assert.Contains(c, string(body), "close this tab")
-	}, 30*time.Second, 200*time.Millisecond, "callback request never succeeded: %s", output.String())
+		assert.Contains(c, string(body), "window.close()")
+	}, 30*time.Second, 200*time.Millisecond, "callback request never succeeded: %s", h.output.String())
 
-	require.NoError(t, cmd.Wait(), output.String())
+	require.NoError(t, h.cmd.Wait(), h.output.String())
 
-	cached := string(requireFileBytes(t, authFile))
+	cached := string(requireFileBytes(t, h.authFile))
 	require.Contains(t, cached, "server_url=https://gram.test\n")
 	require.Contains(t, cached, "api_key=test-key-123\n")
 	require.NotContains(t, cached, "attacker-key")
 	require.Contains(t, cached, "project=default\n")
 	require.Contains(t, cached, "email=a@b.c\n")
-	require.NoFileExists(t, authFile+".login-attempt", "successful login must clear the attempt cooldown marker")
+	require.NoFileExists(t, h.authFile+".login-attempt", "successful login must clear the attempt cooldown marker")
+}
+
+// TestSharedAuthScriptBrowserLoginFormPost plays a dashboard that honors the
+// callback_method=post opt-in: the credentials arrive as a form POST body so
+// the API key never appears in a URL, while the state token stays in the
+// callback URL's query string and must still be echoed for the POST to be
+// accepted.
+func TestSharedAuthScriptBrowserLoginFormPost(t *testing.T) {
+	t.Parallel()
+	h := startSharedAuthScriptLogin(t)
+
+	require.Contains(t, string(requireFileBytes(t, h.urlFile)), "callback_method=post",
+		"auth URL must opt into the form POST token exchange")
+
+	// A POSTed body whose callback query lacks this attempt's state token is
+	// an injection attempt by something else on this machine: rejected, and
+	// the listener keeps waiting for the dashboard's real submission.
+	forged := "http://127.0.0.1:" + h.port + "/callback?state=wrong"
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		req, err := http.NewRequestWithContext(h.ctx, http.MethodPost, forged,
+			strings.NewReader("api_key=attacker-key&project=evil"))
+		if !assert.NoError(c, err) {
+			return
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := http.DefaultClient.Do(req)
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.NoError(c, resp.Body.Close())
+		assert.Equal(c, http.StatusForbidden, resp.StatusCode)
+	}, 30*time.Second, 200*time.Millisecond, "forged POST callback was never rejected: %s", h.output.String())
+
+	callback := "http://127.0.0.1:" + h.port + "/callback?state=" + h.state
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		req, err := http.NewRequestWithContext(h.ctx, http.MethodPost, callback,
+			strings.NewReader("api_key=test-key-456&project=default&email=a%40b.c&organization_id=org-123"))
+		if !assert.NoError(c, err) {
+			return
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := http.DefaultClient.Do(req)
+		if !assert.NoError(c, err) {
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(c, err)
+		assert.NoError(c, resp.Body.Close())
+		assert.Equal(c, http.StatusOK, resp.StatusCode)
+		assert.Contains(c, string(body), "window.close()")
+	}, 30*time.Second, 200*time.Millisecond, "POST callback request never succeeded: %s", h.output.String())
+
+	require.NoError(t, h.cmd.Wait(), h.output.String())
+
+	cached := string(requireFileBytes(t, h.authFile))
+	require.Contains(t, cached, "server_url=https://gram.test\n")
+	require.Contains(t, cached, "api_key=test-key-456\n")
+	require.NotContains(t, cached, "attacker-key")
+	require.Contains(t, cached, "project=default\n")
+	require.Contains(t, cached, "email=a@b.c\n")
+	require.Contains(t, cached, "org=org-123\n")
 }
 
 func TestGeneratePluginWithCustomDomainURL(t *testing.T) {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -64,7 +64,6 @@ func TestSharedAuthScriptMatchesCheckedIn(t *testing.T) {
 // authLoginHarness is a running gram_hooks_login invocation whose localhost
 // listener is ready to receive callback requests.
 type authLoginHarness struct {
-	ctx      context.Context
 	cmd      *exec.Cmd
 	output   *bytes.Buffer
 	authFile string
@@ -134,7 +133,6 @@ if [ -f "$1" ]; then cat "$1" > "$GRAM_TEST_URL_FILE"; else printf '%s' "$1" > "
 	require.NoError(t, cmd.Start())
 
 	h := &authLoginHarness{
-		ctx:      ctx,
 		cmd:      cmd,
 		output:   output,
 		authFile: authFile,
@@ -174,7 +172,7 @@ func TestSharedAuthScriptBrowserLoginRoundtrip(t *testing.T) {
 	// waiting for the real redirect.
 	forged := "http://127.0.0.1:" + h.port + "/callback?api_key=attacker-key&project=evil"
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		req, err := http.NewRequestWithContext(h.ctx, http.MethodGet, forged, nil)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, forged, nil)
 		if !assert.NoError(c, err) {
 			return
 		}
@@ -188,7 +186,7 @@ func TestSharedAuthScriptBrowserLoginRoundtrip(t *testing.T) {
 
 	callback := "http://127.0.0.1:" + h.port + "/callback?state=" + h.state + "&api_key=test-key-123&project=default&email=a%40b.c"
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		req, err := http.NewRequestWithContext(h.ctx, http.MethodGet, callback, nil)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, callback, nil)
 		if !assert.NoError(c, err) {
 			return
 		}
@@ -231,7 +229,7 @@ func TestSharedAuthScriptBrowserLoginFormPost(t *testing.T) {
 	// the listener keeps waiting for the dashboard's real submission.
 	forged := "http://127.0.0.1:" + h.port + "/callback?state=wrong"
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		req, err := http.NewRequestWithContext(h.ctx, http.MethodPost, forged,
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, forged,
 			strings.NewReader("api_key=attacker-key&project=evil"))
 		if !assert.NoError(c, err) {
 			return
@@ -247,7 +245,7 @@ func TestSharedAuthScriptBrowserLoginFormPost(t *testing.T) {
 
 	callback := "http://127.0.0.1:" + h.port + "/callback?state=" + h.state
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		req, err := http.NewRequestWithContext(h.ctx, http.MethodPost, callback,
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, callback,
 			strings.NewReader("api_key=test-key-456&project=default&email=a%40b.c&organization_id=org-123"))
 		if !assert.NoError(c, err) {
 			return


### PR DESCRIPTION
## Summary

- The hooks browser login returned the minted API key to the localhost listener in the callback URL's query string, exposing it in browser history and request logs. The auth URL now opts into an Apple-style `form_post` exchange via `callback_method=post`.
- Dashboard (`CliCallback`): when `callback_method=post` is requested, the credentials are delivered by an auto-submitted hidden form POST to the callback URL instead of a query-string redirect. A form navigation (not `fetch`) so the localhost listener needs no CORS/private-network-access preflight handling. Legacy clients that don't send the param keep the query-string redirect.
- Hook auth listener (`hooks/plugin-claude/hooks/auth.sh` + the embedded copy in `renderSharedAuthScript`, drift-test enforced): accepts the POST body (bounded, timeout-guarded read that works on macOS bash 3.2) while still accepting the legacy GET query string from older dashboards. The state-token guard is unchanged — it stays in the callback URL query and must be echoed on both paths.
- The success page now closes the tab when the browser allows it.
- New e2e test drives the full login flow through the real nc listener with a form POST dashboard; the existing roundtrip test now covers the legacy query-string dashboard.

Closes [DNO-419](https://linear.app/speakeasy/issue/DNO-419/bug-support-post-token-exchange-for-hook-auth-flow)

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the hook auth flow to return credentials via a form POST, keeping API keys out of URLs and logs. Backwards compatible with legacy GET; fixes DNO-419.

- **Bug Fixes**
  - Dashboard `CliCallback` supports `callback_method=post` and auto-submits a hidden form to the local callback; falls back to query-string redirect for older clients.
  - Local hook auth listener accepts form POST bodies and legacy GETs; enforces the state token from the callback URL; adds bounded, timeout-guarded body reads compatible with macOS bash 3.2.
  - Generated plugin auth script opts into `callback_method=post`; the success page now attempts `window.close()` and shows simpler copy; new tests cover both POST and legacy flows and enforce no drift between the checked-in and generated scripts.
  - Cleanup: `transmitKey` is synchronous (no floating promise), and tests use `t.Context()` directly.

<sup>Written for commit a9d359eba013ee221cea019c44018c3486b63232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

