### PR TITLE
fix: repair mise run seed after SDK barrel removal and make it traceable

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -3,11 +3,12 @@
 //MISE description="Seed the local database with data"
 
 import assert from "node:assert";
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { intro, log, outro } from "@clack/prompts";
+import { intro, log as clackLog, outro } from "@clack/prompts";
 import { GramCore } from "@gram/client/core.js";
 import { accessEnableRBAC } from "@gram/client/funcs/accessEnableRBAC.js";
 import { assetsUploadFunctions } from "@gram/client/funcs/assetsUploadFunctions.js";
@@ -27,9 +28,51 @@ import { toolsetsCreate } from "@gram/client/funcs/toolsetsCreate.js";
 import { toolsetsUpdateBySlug } from "@gram/client/funcs/toolsetsUpdateBySlug.js";
 import { environmentsCreate } from "@gram/client/funcs/environmentsCreate.js";
 import { environmentsList } from "@gram/client/funcs/environmentsList.js";
-import { ServiceError } from "@gram/client/models/errors";
-import { $ } from "zx";
+import { $, chalk } from "zx";
 import { seedTunnel } from "./seed/tunnel.mts";
+
+function isConflictError(error: unknown): boolean {
+  const data = (error as { data$?: { name?: unknown } } | null)?.data$;
+  return data?.name === "conflict";
+}
+
+const seedStartedAt = performance.now();
+let lastLogAt = seedStartedAt;
+
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+function lap(): string {
+  const now = performance.now();
+  const elapsed = now - lastLogAt;
+  lastLogAt = now;
+  return chalk.dim(`[+${formatDuration(elapsed)}]`);
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Timed out after ${ms}ms: ${label}`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() =>
+    clearTimeout(timer),
+  ) as Promise<T>;
+}
+
+/** clack log with time-since-previous-statement appended, to surface slow seed steps. */
+const log = {
+  info: (message: string) => clackLog.info(`${message} ${lap()}`),
+  warn: (message: string) => clackLog.warn(`${message} ${lap()}`),
+  error: (message: string) => clackLog.error(`${message} ${lap()}`),
+};
 
 type Asset = {
   slug: string;
@@ -129,7 +172,12 @@ async function seed() {
   intro("Seeding local development environment...");
   using _ = {
     [Symbol.dispose]() {
-      outro(success ? "Seeding complete!" : "Seeding failed.");
+      const total = formatDuration(performance.now() - seedStartedAt);
+      outro(
+        success
+          ? `Seeding complete in ${total}!`
+          : `Seeding failed after ${total}.`,
+      );
     },
   };
   const serverURL = process.env["GRAM_SERVER_URL"];
@@ -640,9 +688,7 @@ async function getOrCreateProject(init: {
     },
   );
   switch (true) {
-    case !res.ok &&
-      res.error instanceof ServiceError &&
-      res.error.data$.name === "conflict":
+    case !res.ok && isConflictError(res.error):
       const getRes = await projectsRead(
         gram,
         { slug },
@@ -690,7 +736,10 @@ async function deployAssets(init: {
       let contentType: string;
 
       if ("url" in asset) {
-        const response = await fetch(asset.url);
+        log.info(`Fetching OpenAPI spec from ${asset.url}...`);
+        const response = await fetch(asset.url, {
+          signal: AbortSignal.timeout(30_000),
+        });
         if (!response.ok) {
           abort(
             `Failed to fetch OpenAPI spec from ${asset.url}`,
@@ -699,15 +748,56 @@ async function deployAssets(init: {
         }
         spec = await response.text();
         contentType = "application/json";
+        log.info(`Fetched OpenAPI spec '${asset.slug}' (${spec.length} bytes)`);
       } else {
         spec = await fs.readFile(asset.filename, "utf-8");
         contentType = asset.filename.endsWith(".yaml")
           ? "application/x-yaml"
           : "application/json";
+        log.info(`Read OpenAPI spec '${asset.slug}' (${spec.length} bytes)`);
       }
 
       const requestBody = new Blob([spec], { type: contentType });
-      const res = await assetsUploadOpenAPIv3(
+      const res = await withTimeout(
+        assetsUploadOpenAPIv3(
+          init.gram,
+          {
+            contentLength: requestBody.size,
+            requestBody,
+          },
+          {
+            option2: {
+              projectSlugHeaderGramProject: projectSlug,
+              sessionHeaderGramSession: sessionId,
+            },
+          },
+        ),
+        60_000,
+        `upload OpenAPI asset '${asset.slug}'`,
+      );
+
+      if (!res.ok) {
+        const source = "url" in asset ? asset.url : asset.filename;
+        abort(`Failed to upload asset \`${source}\``, res.error);
+      }
+
+      const { id: assetId } = await res.value.asset;
+      log.info(
+        `Uploaded OpenAPI asset '${asset.slug}' (asset_id = ${assetId})`,
+      );
+      oapi.push({ assetId, name: asset.slug, slug: asset.slug });
+      continue;
+    }
+
+    const archive = await buildSeedFunctionArchive(asset);
+    log.info(
+      `Built functions archive '${asset.slug}' (${archive.length} bytes)`,
+    );
+    const requestBody = new Blob([new Uint8Array(archive)], {
+      type: "application/zip",
+    });
+    const res = await withTimeout(
+      assetsUploadFunctions(
         init.gram,
         {
           contentLength: requestBody.size,
@@ -719,34 +809,9 @@ async function deployAssets(init: {
             sessionHeaderGramSession: sessionId,
           },
         },
-      );
-
-      if (!res.ok) {
-        const source = "url" in asset ? asset.url : asset.filename;
-        abort(`Failed to upload asset \`${source}\``, res.error);
-      }
-
-      const { id: assetId } = await res.value.asset;
-      oapi.push({ assetId, name: asset.slug, slug: asset.slug });
-      continue;
-    }
-
-    const archive = await buildSeedFunctionArchive(asset);
-    const requestBody = new Blob([new Uint8Array(archive)], {
-      type: "application/zip",
-    });
-    const res = await assetsUploadFunctions(
-      init.gram,
-      {
-        contentLength: requestBody.size,
-        requestBody,
-      },
-      {
-        option2: {
-          projectSlugHeaderGramProject: projectSlug,
-          sessionHeaderGramSession: sessionId,
-        },
-      },
+      ),
+      60_000,
+      `upload functions asset '${asset.slug}'`,
     );
 
     if (!res.ok) {
@@ -754,6 +819,9 @@ async function deployAssets(init: {
     }
 
     const { id: assetId } = await res.value.asset;
+    log.info(
+      `Uploaded functions asset '${asset.slug}' (asset_id = ${assetId})`,
+    );
     functions.push({
       assetId,
       name: asset.slug,
@@ -762,20 +830,25 @@ async function deployAssets(init: {
     });
   }
 
-  const evolveRes = await deploymentsEvolveDeployment(
-    init.gram,
-    {
-      evolveForm: {
-        upsertOpenapiv3Assets: oapi,
-        upsertFunctions: functions,
+  log.info(`Evolving deployment for '${projectSlug}'...`);
+  const evolveRes = await withTimeout(
+    deploymentsEvolveDeployment(
+      init.gram,
+      {
+        evolveForm: {
+          upsertOpenapiv3Assets: oapi,
+          upsertFunctions: functions,
+        },
       },
-    },
-    {
-      option2: {
-        projectSlugHeaderGramProject: projectSlug,
-        sessionHeaderGramSession: sessionId,
+      {
+        option2: {
+          projectSlugHeaderGramProject: projectSlug,
+          sessionHeaderGramSession: sessionId,
+        },
       },
-    },
+    ),
+    60_000,
+    `evolve deployment for '${projectSlug}'`,
   );
 
   if (!evolveRes.ok) {
@@ -787,6 +860,7 @@ async function deployAssets(init: {
     abort("Deployment ID not found", evolveRes.value);
   }
 
+  log.info(`Waiting for deployment ${deploymentId} to complete...`);
   await waitForDeploymentCompletion({
     deploymentId,
     gram: init.gram,
@@ -1427,9 +1501,7 @@ async function upsertToolset(init: {
     },
   );
   switch (true) {
-    case !createRes.ok &&
-      createRes.error instanceof ServiceError &&
-      createRes.error.data$.name === "conflict":
+    case !createRes.ok && isConflictError(createRes.error):
       const updateRes = await toolsetsUpdateBySlug(
         gram,
         {
@@ -1589,9 +1661,7 @@ async function upsertMcpLogsToolset(init: {
 
   let toolset: Toolset;
   switch (true) {
-    case !createRes.ok &&
-      createRes.error instanceof ServiceError &&
-      createRes.error.data$.name === "conflict":
+    case !createRes.ok && isConflictError(createRes.error):
       const updateRes = await toolsetsUpdateBySlug(
         gram,
         {

--- a/.mise-tasks/seed/tunnel.mts
+++ b/.mise-tasks/seed/tunnel.mts
@@ -24,6 +24,23 @@ export async function seedTunnel() {
   const dbUser = process.env.DB_USER || "gram";
   const dbName = process.env.DB_NAME || "gram";
   const sql = `
+-- The seed key is a well-known constant, so any live row holding its hash under
+-- another project is a stale fixture from a previous seed run; retire it so the
+-- global key_hash unique index does not reject the upsert below.
+UPDATE tunneled_mcp_servers
+SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
+WHERE key_hash = :'key_hash'
+  AND deleted IS FALSE
+  AND NOT (
+    name = :'source_name'
+    AND project_id = (
+      SELECT id FROM projects
+      WHERE slug = :'project_slug' AND deleted IS FALSE
+      ORDER BY created_at DESC
+      LIMIT 1
+    )
+  );
+
 WITH project AS (
   SELECT id, slug
   FROM projects
@@ -102,7 +119,7 @@ FROM source, endpoint, mcp_server;
 
   const result = await $({
     input: sql,
-  })`docker compose exec -T gram-db psql -U ${dbUser} -d ${dbName} -v ON_ERROR_STOP=1 -v project_slug=${SEEDED_PROJECT_SLUG} -v source_name=${SEEDED_TUNNEL_SOURCE_NAME} -v key_hash=${SEEDED_TUNNEL_KEY_HASH} -v key_prefix=${SEEDED_TUNNEL_KEY_PREFIX} -tA -f -`.quiet();
+  })`docker compose exec -T gram-db psql -q -U ${dbUser} -d ${dbName} -v ON_ERROR_STOP=1 -v project_slug=${SEEDED_PROJECT_SLUG} -v source_name=${SEEDED_TUNNEL_SOURCE_NAME} -v key_hash=${SEEDED_TUNNEL_KEY_HASH} -v key_prefix=${SEEDED_TUNNEL_KEY_PREFIX} -tA -f -`.quiet();
 
   const output = result.stdout.trim();
   if (!output) {


### PR DESCRIPTION
## Summary

Repairs `mise run seed`, which was broken by the SDK barrel-file removal (#3945), and makes it traceable so future hangs are diagnosable. Four stacked issues fixed:

1. **`ERR_MODULE_NOT_FOUND` on startup** — `seed.mts` imported the now-removed `@gram/client/models/errors` barrel. Replaced the `instanceof ServiceError` checks with a structural `isConflictError(error: unknown)` so the task no longer couples to SDK error models at all.
2. **Silent indefinite hang at `deployments.evolve`** — the server blocks on the Temporal `ProcessDeployment` workflow, so seeding hangs forever when the worker isn't running. Added strict timeouts (30s abort on the external spec fetch, 60s on uploads/evolve) and trace logs so this fails loudly in ~60s with a labelled error instead.
3. **`tunneled_mcp_servers_key_hash_key` duplicate on re-run** — the tunnel upsert arbiters on `(project_id, name)`, but the global `key_hash` unique index can be held by a stale fixture row under another project (e.g. a re-created `ecommerce-api`). Since the seed key is a well-known constant, any live row holding its hash that isn't the target row is retired before the upsert. Also runs `psql -q` so the `UPDATE` command tag doesn't corrupt the JSON the task parses.
4. **`crypto.createHash is not a function`** — `seedObservabilityData` used the global WebCrypto `crypto`; added the `node:crypto` import.

Also adds per-step elapsed timings (`[+1.6s]`) to every seed log line and a total duration in the outro, to support optimizing the slow steps (toolset visibility change ~5s, ClickHouse inserts ~5s).

## Testing

- `mise run seed` completes in ~19s against a fully running local stack (exit 0)
- Re-running is idempotent: second run updates existing fixtures and passes, including the tunnel fixture that previously hit the duplicate-key error
- Verified the timeout path: with the Temporal worker stopped, seed exits after 60s with `Timed out after 60000ms: evolve deployment for 'ecommerce-api'` instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs `mise run seed` after removal of `@gram/client/models/errors` and makes the seed task observable with strict timeouts and step timings to avoid silent hangs.

- **Bug Fixes**
  - Replaced the removed `@gram/client/models/errors` import with a structural `isConflictError(...)` check (no SDK error-model coupling).
  - Prevents indefinite hang at deployment evolve with timeouts: 30s for external spec fetch, 60s for uploads/evolve, with clear error labels.
  - Fixes `tunneled_mcp_servers_key_hash_key` duplicate on reruns by retiring stale rows before upsert; runs `psql -q` to keep JSON output parseable.
  - Resolves `crypto.createHash is not a function` by importing `node:crypto`.

- **New Features**
  - Adds per-step elapsed timings on seed logs and a total duration summary.
  - Adds trace logs for fetching specs, uploading assets, evolving deployments, and waiting for completion.

<sup>Written for commit 9dcbb8803a42484d269706f2bfd9871d82a7273f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

