### PR TITLE
chore: move mcp/skill/subagent out of cost breakdown selector

### DIFF
--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -158,7 +158,26 @@ export function CostsExplorer(): JSX.Element {
   // full-project `all` view. It scopes both the breakdown options and, via the
   // attribution empty-row handling below, which rows count.
   const datasetParam = searchParams.get(DATASET_PARAM);
-  const dataset: Dataset = isDataset(datasetParam) ? datasetParam : "all";
+  // Backward compat: shared/bookmarked links from before the dataset selector
+  // pointed `?by=` straight at an attribution dim (e.g. `?by=mcp_server_name`)
+  // with no `?dataset=`. Infer the owning dataset from such a `?by=` so the link
+  // still lands on the intended attribution view rather than silently falling
+  // back to the org default (BASE_PIVOTS excludes attribution dims).
+  const dataset: Dataset = isDataset(datasetParam)
+    ? datasetParam
+    : isDimension(byParam) && isAttributionDim(byParam)
+      ? datasetForDim(byParam)
+      : "all";
+  // Within a non-`all` dataset the slice is enforced only by dropping the empty
+  // attribution group from the *grouped* table. The un-groupable views — the
+  // session list, the "Most costly sessions" widget, and cross-cut cards over a
+  // non-attribution dim — can't express that "attribute present" predicate with
+  // the IN-only filter API, so on their own they'd show whole-project numbers
+  // under a dataset label. They only become correct once the drill path pins an
+  // attribution value (which inherently restricts rows to the slice); until
+  // then, suppress them rather than mislead.
+  const sliceScoped =
+    dataset === "all" || path.some((c) => isAttributionDim(c.dim));
   // The deepest filter crumb is the entity in view. Agent/Model are leaves —
   // once you're on one, individual sessions are the only meaningful view, so we
   // lock to them: force sessions mode and offer no further dimension breakdown.
@@ -166,11 +185,18 @@ export function CostsExplorer(): JSX.Element {
   const deepestCrumb = path.length ? path[path.length - 1]! : null;
   const atSessionLeaf = deepestCrumb != null && isSessionLeaf(deepestCrumb.dim);
   // The sessions sentinel swaps the table for the per-session list; the rest of
-  // the page (filters, widgets, header stats) is unchanged.
-  const sessionsMode = isSessionsAxis(byParam) || atSessionLeaf;
+  // the page (filters, widgets, header stats) is unchanged. In an unscoped
+  // dataset view the list can't be restricted to the slice, so the sentinel is
+  // ignored there (a session leaf always pins an attribution value, so it stays
+  // scoped and is still honored).
+  const sessionsMode =
+    atSessionLeaf || (isSessionsAxis(byParam) && sliceScoped);
   // The "Most costly sessions" widget shows on org/division/department/user
-  // (not Agent/Model, which already render the full session table).
-  const showSessionsWidget = showsTopSessionsWidget(deepestCrumb);
+  // (not Agent/Model, which already render the full session table), and only
+  // where the slice is scoped — at an unscoped dataset root it would list
+  // whole-project sessions.
+  const showSessionsWidget =
+    showsTopSessionsWidget(deepestCrumb) && sliceScoped;
 
   // Navigate to a node: encode its filter path into the URL and pin the
   // breakdown axis in `?by=`. `replace` for view-only changes (re-pivoting)
@@ -238,8 +264,19 @@ export function CostsExplorer(): JSX.Element {
     () => new Set(datasetPivots(dataset).map((p) => p.dim)),
     [dataset],
   );
+  // A dataset's nested breakdown dim (MCP Tool under MCP Server, Skill under
+  // Subagent) is only valid once its parent is pinned in the drill path. Guard
+  // the raw `?by=` against this too — otherwise a deep/stale link like
+  // `?dataset=subagents&by=skill_name` would render the child cut at the dataset
+  // root while the selector reads "Subagents". Fall back to the dataset default
+  // when the required parent is missing.
+  const byParamParent = isDimension(byParam)
+    ? datasetPivotParent(dataset, byParam)
+    : null;
   const groupBy =
-    isDimension(byParam) && datasetDimSet.has(byParam)
+    isDimension(byParam) &&
+    datasetDimSet.has(byParam) &&
+    (byParamParent === null || path.some((c) => c.dim === byParamParent))
       ? byParam
       : datasetDefaultGroupBy(dataset, path, availableDims);
 
@@ -548,6 +585,9 @@ export function CostsExplorer(): JSX.Element {
       d !== groupBy &&
       !path.some((c) => c.dim === d) &&
       (!availableDims || availableDims.has(d)) &&
+      // In an unscoped dataset view only the dataset's own attribution dims are
+      // correctly scoped; a cross-cut like Model would sum whole-project spend.
+      (sliceScoped || datasetDimSet.has(d)) &&
       (!attributes || (attributes[d]?.length ?? 0) > 1),
   );
   const mixDimA = mixDims[0];
@@ -810,12 +850,17 @@ export function CostsExplorer(): JSX.Element {
     : pivotOptions.map((p) => ({ value: p.dim as string, label: p.label }));
   const axisOptions: { value: string; label: string }[] = [
     ...dimensionAxisOptions,
-    { value: SESSIONS_AXIS, label: LABELS[SESSIONS_AXIS]! },
+    // The per-session list is only offered where the slice is scoped — at an
+    // unscoped dataset root it can't be filtered to the slice (see sliceScoped).
+    ...(sliceScoped
+      ? [{ value: SESSIONS_AXIS, label: LABELS[SESSIONS_AXIS]! }]
+      : []),
   ];
   const axisValue: string = sessionsMode ? SESSIONS_AXIS : groupBy;
-  const onViewSessions = sessionsMode
-    ? undefined
-    : () => changeGroupBy(SESSIONS_AXIS);
+  const onViewSessions =
+    sessionsMode || !sliceScoped
+      ? undefined
+      : () => changeGroupBy(SESSIONS_AXIS);
 
   // The root Skill breakdown is scoped to agent-less spend (skill-only branch of
   // the Subagent → Skill tree). Rather than relabel the axis "Skill (only)",

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -40,10 +40,18 @@ import {
   BREAKDOWN_PARAM,
   collectionLabel,
   type Crumb,
+  type Dataset,
+  DATASET_OPTIONS,
+  DATASET_PARAM,
+  datasetDefaultGroupBy,
+  datasetForDim,
+  datasetPivotParent,
+  datasetPivots,
   defaultGroupBy,
   displayName,
   encodeCrumb,
   isAttributionDim,
+  isDataset,
   isDimension,
   isSessionLeaf,
   isSessionsAxis,
@@ -51,8 +59,6 @@ import {
   type Measures,
   nextAvailableDimension,
   parseDrillPath,
-  PIVOTS,
-  pivotParent,
   SESSIONS_AXIS,
   showsTopSessionsWidget,
 } from "./taxonomy";
@@ -148,6 +154,11 @@ export function CostsExplorer(): JSX.Element {
   }, [location.pathname, costsBase]);
 
   const byParam = searchParams.get(BREAKDOWN_PARAM);
+  // The active dataset (spend slice) rides in `?dataset=`; absent/invalid → the
+  // full-project `all` view. It scopes both the breakdown options and, via the
+  // attribution empty-row handling below, which rows count.
+  const datasetParam = searchParams.get(DATASET_PARAM);
+  const dataset: Dataset = isDataset(datasetParam) ? datasetParam : "all";
   // The deepest filter crumb is the entity in view. Agent/Model are leaves —
   // once you're on one, individual sessions are the only meaningful view, so we
   // lock to them: force sessions mode and offer no further dimension breakdown.
@@ -163,13 +174,24 @@ export function CostsExplorer(): JSX.Element {
 
   // Navigate to a node: encode its filter path into the URL and pin the
   // breakdown axis in `?by=`. `replace` for view-only changes (re-pivoting)
-  // that shouldn't add a back-button step.
-  const goToNode = (nextPath: Crumb[], by: Axis, replace = false) => {
+  // that shouldn't add a back-button step. `ds` overrides the dataset param
+  // (e.g. drilling from `all` into an attribution cut promotes to its dataset);
+  // omitted, the current dataset is preserved.
+  const goToNode = (
+    nextPath: Crumb[],
+    by: Axis,
+    replace = false,
+    ds?: Dataset,
+  ) => {
     const tail = nextPath.map(encodeCrumb).join("/");
     // Preserve the rest of the query (the date-range filter lives here too) and
-    // only override the breakdown axis.
+    // only override the breakdown axis (and dataset, when given).
     const params = new URLSearchParams(searchParams);
     params.set(BREAKDOWN_PARAM, by);
+    if (ds !== undefined) {
+      if (ds === "all") params.delete(DATASET_PARAM);
+      else params.set(DATASET_PARAM, ds);
+    }
     const url = `${tail ? `${costsBase}/${tail}` : costsBase}?${params.toString()}`;
     void navigate(url, { replace });
   };
@@ -209,9 +231,17 @@ export function CostsExplorer(): JSX.Element {
     [attrKeysData],
   );
 
-  const groupBy = isDimension(byParam)
-    ? byParam
-    : defaultGroupBy(path, availableDims);
+  // The breakdown axis must belong to the active dataset — a `?by=` left over
+  // from another dataset (or an org dim while in an attribution slice) falls
+  // back to the dataset's default axis.
+  const datasetDimSet = useMemo(
+    () => new Set(datasetPivots(dataset).map((p) => p.dim)),
+    [dataset],
+  );
+  const groupBy =
+    isDimension(byParam) && datasetDimSet.has(byParam)
+      ? byParam
+      : datasetDefaultGroupBy(dataset, path, availableDims);
 
   // Every cost query is scoped to the current project via a project_id filter
   // (the endpoints are org-scoped, but project_id is an allowlisted dimension),
@@ -695,10 +725,17 @@ export function CostsExplorer(): JSX.Element {
     // chains (e.g. the same user/agent twice). The pivot list already hides
     // filtered dims; this guards the mix-card + fallback-chain paths too.
     if (path.some((c) => c.dim === dim)) return;
+    // Drilling from `all` into an attribution cut (e.g. a "Spend by MCP server"
+    // mix-card row) promotes the view into that dataset. Within a dataset the
+    // drill never switches datasets — undefined preserves the current one.
+    const ds =
+      dataset === "all" && isAttributionDim(dim)
+        ? datasetForDim(dim)
+        : undefined;
     // Agent/Model are leaves: drilling a row shows that slice's individual
     // sessions instead of pivoting to another dimension.
     if (isSessionLeaf(dim)) {
-      goToNode([...path, { dim, value }], SESSIONS_AXIS);
+      goToNode([...path, { dim, value }], SESSIONS_AXIS, false, ds);
       return;
     }
     // Otherwise land on the next chain axis that actually has data, skipping
@@ -708,7 +745,7 @@ export function CostsExplorer(): JSX.Element {
     // drilling stays enabled and never blocks prematurely.)
     const next = nextAvailableDimension(dim, availableDims);
     if (next === null) return;
-    goToNode([...path, { dim, value }], next);
+    goToNode([...path, { dim, value }], next, false, ds);
   };
 
   // Drill into a main-table row: use the current breakdown axis.
@@ -729,11 +766,19 @@ export function CostsExplorer(): JSX.Element {
     goToNode(path.slice(0, -1), removed.dim);
   };
 
-  // Jump straight back to the org root (clear all filters).
-  const goHome = () => goToNode([], defaultGroupBy([], availableDims));
+  // Jump straight back to the org root (clear all filters) and reset to the full
+  // `all` dataset — Home always lands on the project-wide overview.
+  const goHome = () =>
+    goToNode([], defaultGroupBy([], availableDims), false, "all");
 
   // Re-pivot the current node's breakdown axis without drilling (view-only).
   const changeGroupBy = (axis: Axis) => goToNode(path, axis, true);
+
+  // Switch datasets: start a fresh drill at that slice's root grouped by its
+  // default axis. A drill path from another dataset (e.g. a division filter)
+  // doesn't carry over, so clear it.
+  const changeDataset = (ds: Dataset) =>
+    goToNode([], datasetDefaultGroupBy(ds, [], availableDims), false, ds);
 
   // Offer a breakdown axis only if it can actually partition the current slice
   // into >1 row. `attributes` (the entity's distinct dimension values) tells us:
@@ -741,12 +786,13 @@ export function CostsExplorer(): JSX.Element {
   // Profile grid instead. Always keep the active axis; show everything at the
   // org root, where there's no slice to measure against yet.
   const filteredDims = new Set(path.map((c) => c.dim));
-  const pivotOptions = PIVOTS.filter((p) => {
+  const pivotOptions = datasetPivots(dataset).filter((p) => {
     if (filteredDims.has(p.dim)) return false;
     if (p.dim === groupBy) return true;
-    // A nested attribution cut (MCP Tool) is only meaningful under its parent
-    // (MCP Server) — offer it as a breakdown axis only once the parent is pinned.
-    const parent = pivotParent(p.dim);
+    // A nested attribution cut (MCP Tool under MCP Server, Skill under Subagent)
+    // is only meaningful once its parent is pinned in the drill path — offer it
+    // as a breakdown axis only then.
+    const parent = datasetPivotParent(dataset, p.dim);
     if (parent && !filteredDims.has(parent)) return false;
     // Hide dimensions the org has no data for at all (IDP doesn't populate them).
     if (availableDims && !availableDims.has(p.dim)) return false;
@@ -959,6 +1005,9 @@ export function CostsExplorer(): JSX.Element {
         }
         onViewSessions={onViewSessions}
         seriesByGroup={seriesByGroup}
+        datasetValue={dataset}
+        datasetOptions={DATASET_OPTIONS}
+        onDatasetChange={(value) => changeDataset(value as Dataset)}
         rangePicker={rangePicker}
         rangeLabel={formatDateRange(from, to)}
         isLoading={loadingSlice}

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -286,6 +286,12 @@ export type EntityProfileProps = {
   onViewSessions?: () => void;
   // Per-group daily cost series for the row sparklines.
   seriesByGroup: Map<string, number[]>;
+  // The active dataset (spend slice) and its options, rendered as a selector at
+  // the top-right beside the date picker. `all` is the full project spend; the
+  // others narrow to a Claude attribution lens (MCP / Subagents / Skills).
+  datasetValue: string;
+  datasetOptions: { value: string; label: string }[];
+  onDatasetChange: (value: string) => void;
   // The date-range picker control, rendered in the header above the stats.
   rangePicker: ReactNode;
   // Human date-range label (e.g. "June 15–19") for the CSV export filename.
@@ -324,6 +330,9 @@ export function EntityProfile({
   tableOverride,
   onViewSessions,
   seriesByGroup,
+  datasetValue,
+  datasetOptions,
+  onDatasetChange,
   rangePicker,
   rangeLabel,
   widgets,
@@ -432,9 +441,24 @@ export function EntityProfile({
               </span>
             </button>
           </div>
-          {/* Date-range picker pinned to the top-right of the header, in line
-              with the back controls on the left — it scopes every number below. */}
-          <div className="absolute top-5 right-8 z-10">{rangePicker}</div>
+          {/* Dataset selector + date-range picker pinned to the top-right of the
+              header, in line with the back controls on the left. The dataset
+              narrows to a spend slice; the range scopes every number below. */}
+          <div className="absolute top-5 right-8 z-10 flex items-stretch gap-2">
+            <Select value={datasetValue} onValueChange={onDatasetChange}>
+              <SelectTrigger className="border-border bg-background hover:bg-muted data-[state=open]:bg-muted !h-auto w-auto cursor-pointer gap-1.5 rounded-md border py-1 pr-2.5 pl-3 text-sm font-medium shadow-none transition-colors focus-visible:ring-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="end">
+                {datasetOptions.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {rangePicker}
+          </div>
           <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex min-w-0 items-start gap-4">
               <div className="border-border bg-background flex size-16 shrink-0 items-center justify-center rounded-2xl border">

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -445,18 +445,25 @@ export function EntityProfile({
               header, in line with the back controls on the left. The dataset
               narrows to a spend slice; the range scopes every number below. */}
           <div className="absolute top-5 right-8 z-10 flex items-stretch gap-2">
-            <Select value={datasetValue} onValueChange={onDatasetChange}>
-              <SelectTrigger className="border-border bg-background hover:bg-muted data-[state=open]:bg-muted !h-auto w-auto cursor-pointer gap-1.5 rounded-md border py-1 pr-2.5 pl-3 text-sm font-medium shadow-none transition-colors focus-visible:ring-0">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent align="end">
-                {datasetOptions.map((o) => (
-                  <SelectItem key={o.value} value={o.value}>
-                    {o.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            {/* Grey "Dataset" label box wrapping the selector; stretches to the
+                same height as the date picker via the row's items-stretch. */}
+            <div className="border-border bg-muted flex items-stretch overflow-hidden rounded-md border text-sm">
+              <span className="text-muted-foreground flex items-center pr-2 pl-3 font-medium">
+                Dataset
+              </span>
+              <Select value={datasetValue} onValueChange={onDatasetChange}>
+                <SelectTrigger className="border-border bg-background hover:bg-muted data-[state=open]:bg-muted !h-full w-auto cursor-pointer gap-1.5 rounded-none border-0 border-l py-1 pr-2.5 pl-3 font-medium shadow-none transition-colors">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  {datasetOptions.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
             {rangePicker}
           </div>
           <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">

--- a/client/dashboard/src/pages/costs/taxonomy.ts
+++ b/client/dashboard/src/pages/costs/taxonomy.ts
@@ -127,6 +127,94 @@ export function pivotParent(dim: Dimension): Dimension | null {
   return PIVOT_PARENT[dim] ?? null;
 }
 
+// ── Datasets ────────────────────────────────────────────────────────────────
+// A "dataset" is a narrow slice of the overall spend rather than a breakdown of
+// it: the Claude attribution lenses (MCP calls, Subagent runs, Skill runs), each
+// isolating a subset of turns. They live in their own top-right selector instead
+// of the breakdown dropdown because they aren't true breakdown axes. `all` — the
+// full project spend — is the default and keeps the org/attribute breakdowns.
+export const DATASET_PARAM = "dataset";
+export const DATASETS = ["all", "mcp", "subagents", "skills"] as const;
+export type Dataset = (typeof DATASETS)[number];
+
+export function isDataset(value: string | null | undefined): value is Dataset {
+  return value != null && (DATASETS as readonly string[]).includes(value);
+}
+
+// Per-dataset config: the selector label, the attribution dimensions you can
+// break the slice down by (the first is the default axis on entry), and any
+// parent a nested dim must sit under before it's offered as a breakdown. The
+// `parent` map mirrors PIVOT_PARENT but is dataset-scoped: a Skill is a child of
+// a Subagent here (Subagent → Skill), yet a valid root cut in the standalone
+// Skills dataset.
+type DatasetMeta = {
+  label: string;
+  dims: Dimension[];
+  parent: Partial<Record<Dimension, Dimension>>;
+};
+const DATASET_META: Record<Dataset, DatasetMeta> = {
+  all: { label: "All spend", dims: [], parent: {} },
+  mcp: {
+    label: "MCP",
+    dims: [Dimension.McpServerName, Dimension.McpToolName],
+    parent: { [Dimension.McpToolName]: Dimension.McpServerName },
+  },
+  subagents: {
+    label: "Subagents",
+    dims: [Dimension.AgentName, Dimension.SkillName],
+    parent: { [Dimension.SkillName]: Dimension.AgentName },
+  },
+  skills: { label: "Skills", dims: [Dimension.SkillName], parent: {} },
+};
+
+export const DATASET_OPTIONS: { value: Dataset; label: string }[] =
+  DATASETS.map((ds) => ({ value: ds, label: DATASET_META[ds].label }));
+
+export function datasetLabel(ds: Dataset): string {
+  return DATASET_META[ds].label;
+}
+
+// The dataset an attribution dimension belongs to — used to promote the `all`
+// view into the right dataset when a drill lands on an attribution cut (e.g. a
+// "Spend by MCP server" mix-card row). Non-attribution dims stay in `all`.
+export function datasetForDim(dim: Dimension): Dataset {
+  switch (dim) {
+    case Dimension.McpServerName:
+    case Dimension.McpToolName:
+      return "mcp";
+    case Dimension.AgentName:
+      return "subagents";
+    case Dimension.SkillName:
+      return "skills";
+    default:
+      return "all";
+  }
+}
+
+// The non-attribution breakdown axes — the `all` dataset's pivots. Attribution
+// dims are excluded here; they're only reachable inside their own dataset.
+export const BASE_PIVOTS: DimMeta[] = PIVOTS.filter(
+  (p) => !isAttributionDim(p.dim),
+);
+
+// The breakdown axes offered inside a dataset: the base org/attribute pivots for
+// `all`, or the dataset's own attribution dims otherwise.
+export function datasetPivots(ds: Dataset): DimMeta[] {
+  if (ds === "all") return BASE_PIVOTS;
+  const dims = new Set(DATASET_META[ds].dims);
+  return PIVOTS.filter((p) => dims.has(p.dim));
+}
+
+// The parent a nested breakdown dim must sit under within a dataset (so MCP Tool
+// only appears once MCP Server is pinned, Skill once its Subagent is). Null when
+// the dim is a valid root cut for the dataset.
+export function datasetPivotParent(
+  ds: Dataset,
+  dim: Dimension,
+): Dimension | null {
+  return DATASET_META[ds].parent[dim] ?? null;
+}
+
 // Levels that surface the "Most costly sessions" widget: the org root and the
 // org-structure rollups down to the individual user. Agent/Model already render
 // the full session table, so they don't repeat it as a widget.
@@ -268,10 +356,25 @@ export function defaultGroupBy(
   const last = path[path.length - 1];
   if (last) return nextDimension(last.dim) ?? last.dim;
   if (available && available.size > 0) {
-    const hit = PIVOTS.find((p) => available.has(p.dim));
+    // Attribution cuts are excluded here — they belong to their own dataset, so
+    // the `all` root never defaults to one.
+    const hit = BASE_PIVOTS.find((p) => available.has(p.dim));
     if (hit) return hit.dim;
   }
   return CHAIN[0]!.dim;
+}
+
+// The breakdown axis a node defaults to within a dataset: the dataset's primary
+// dim at its root, otherwise the natural drill child (same as `all`).
+export function datasetDefaultGroupBy(
+  ds: Dataset,
+  path: Crumb[],
+  available?: Set<Dimension>,
+): Dimension {
+  if (ds === "all") return defaultGroupBy(path, available);
+  const last = path[path.length - 1];
+  if (last) return nextDimension(last.dim) ?? last.dim;
+  return DATASET_META[ds].dims[0]!;
 }
 
 // Human label for an entity value: title-cased name for emails, the raw value

--- a/client/dashboard/src/pages/costs/taxonomy.ts
+++ b/client/dashboard/src/pages/costs/taxonomy.ts
@@ -177,18 +177,14 @@ export function datasetLabel(ds: Dataset): string {
 // The dataset an attribution dimension belongs to — used to promote the `all`
 // view into the right dataset when a drill lands on an attribution cut (e.g. a
 // "Spend by MCP server" mix-card row). Non-attribution dims stay in `all`.
+const DIM_DATASET: Partial<Record<Dimension, Dataset>> = {
+  [Dimension.McpServerName]: "mcp",
+  [Dimension.McpToolName]: "mcp",
+  [Dimension.AgentName]: "subagents",
+  [Dimension.SkillName]: "skills",
+};
 export function datasetForDim(dim: Dimension): Dataset {
-  switch (dim) {
-    case Dimension.McpServerName:
-    case Dimension.McpToolName:
-      return "mcp";
-    case Dimension.AgentName:
-      return "subagents";
-    case Dimension.SkillName:
-      return "skills";
-    default:
-      return "all";
-  }
+  return DIM_DATASET[dim] ?? "all";
 }
 
 // The non-attribution breakdown axes — the `all` dataset's pivots. Attribution

--- a/client/dashboard/src/pages/costs/taxonomy.ts
+++ b/client/dashboard/src/pages/costs/taxonomy.ts
@@ -172,9 +172,7 @@ export function datasetForDim(dim: Dimension): Dataset {
 
 // The non-attribution breakdown axes — the `all` dataset's pivots. Attribution
 // dims are excluded here; they're only reachable inside their own dataset.
-const BASE_PIVOTS: DimMeta[] = PIVOTS.filter(
-  (p) => !isAttributionDim(p.dim),
-);
+const BASE_PIVOTS: DimMeta[] = PIVOTS.filter((p) => !isAttributionDim(p.dim));
 
 // The breakdown axes offered inside a dataset: the base org/attribute pivots for
 // `all`, or the dataset's own attribution dims otherwise.

--- a/client/dashboard/src/pages/costs/taxonomy.ts
+++ b/client/dashboard/src/pages/costs/taxonomy.ts
@@ -47,7 +47,7 @@ const CHAIN: DimMeta[] = [
 // Every axis the user can pivot to at any level (dynamic taxonomy). The Claude
 // attribution cuts (MCP Server/Tool, Skill, Subagent) are appended last so they
 // never preempt the org-hierarchy default at the root (see defaultGroupBy).
-export const PIVOTS: DimMeta[] = [
+const PIVOTS: DimMeta[] = [
   ...CHAIN,
   { dim: Dimension.JobTitle, label: "Job Title" },
   { dim: Dimension.EmployeeType, label: "Employment Type" },
@@ -115,18 +115,6 @@ export function isAttributionDim(dim: Dimension): boolean {
   return ATTRIBUTION_DIMS.has(dim);
 }
 
-// A nested attribution cut and the parent it must sit under. MCP Tool only makes
-// sense scoped to an MCP Server (a tool call always belongs to a server), so it
-// is offered as a breakdown axis only once its parent is pinned in the drill
-// path. Skill, by contrast, is a valid root cut ("skills run outside a
-// subagent") so it has no required parent.
-const PIVOT_PARENT: Partial<Record<Dimension, Dimension>> = {
-  [Dimension.McpToolName]: Dimension.McpServerName,
-};
-export function pivotParent(dim: Dimension): Dimension | null {
-  return PIVOT_PARENT[dim] ?? null;
-}
-
 // ── Datasets ────────────────────────────────────────────────────────────────
 // A "dataset" is a narrow slice of the overall spend rather than a breakdown of
 // it: the Claude attribution lenses (MCP calls, Subagent runs, Skill runs), each
@@ -134,7 +122,7 @@ export function pivotParent(dim: Dimension): Dimension | null {
 // of the breakdown dropdown because they aren't true breakdown axes. `all` — the
 // full project spend — is the default and keeps the org/attribute breakdowns.
 export const DATASET_PARAM = "dataset";
-export const DATASETS = ["all", "mcp", "subagents", "skills"] as const;
+const DATASETS = ["all", "mcp", "subagents", "skills"] as const;
 export type Dataset = (typeof DATASETS)[number];
 
 export function isDataset(value: string | null | undefined): value is Dataset {
@@ -144,9 +132,8 @@ export function isDataset(value: string | null | undefined): value is Dataset {
 // Per-dataset config: the selector label, the attribution dimensions you can
 // break the slice down by (the first is the default axis on entry), and any
 // parent a nested dim must sit under before it's offered as a breakdown. The
-// `parent` map mirrors PIVOT_PARENT but is dataset-scoped: a Skill is a child of
-// a Subagent here (Subagent → Skill), yet a valid root cut in the standalone
-// Skills dataset.
+// `parent` map is dataset-scoped: a Skill is a child of a Subagent here
+// (Subagent → Skill), yet a valid root cut in the standalone Skills dataset.
 type DatasetMeta = {
   label: string;
   dims: Dimension[];
@@ -170,10 +157,6 @@ const DATASET_META: Record<Dataset, DatasetMeta> = {
 export const DATASET_OPTIONS: { value: Dataset; label: string }[] =
   DATASETS.map((ds) => ({ value: ds, label: DATASET_META[ds].label }));
 
-export function datasetLabel(ds: Dataset): string {
-  return DATASET_META[ds].label;
-}
-
 // The dataset an attribution dimension belongs to — used to promote the `all`
 // view into the right dataset when a drill lands on an attribution cut (e.g. a
 // "Spend by MCP server" mix-card row). Non-attribution dims stay in `all`.
@@ -189,7 +172,7 @@ export function datasetForDim(dim: Dimension): Dataset {
 
 // The non-attribution breakdown axes — the `all` dataset's pivots. Attribution
 // dims are excluded here; they're only reachable inside their own dataset.
-export const BASE_PIVOTS: DimMeta[] = PIVOTS.filter(
+const BASE_PIVOTS: DimMeta[] = PIVOTS.filter(
   (p) => !isAttributionDim(p.dim),
 );
 


### PR DESCRIPTION
Moves MCP, skills, and subagents out of the breakdowns menu and puts them in a new "datasets" dropdown next to the time range picker

<img width="2776" height="2238" alt="CleanShot 2026-07-07 at 16 13 29@2x" src="https://github.com/user-attachments/assets/a4a9535e-4d00-4ecf-9f61-89114dcd23ed" />
<img width="2868" height="2250" alt="CleanShot 2026-07-07 at 16 13 57@2x" src="https://github.com/user-attachments/assets/d72380cc-d85d-4e10-a698-5c06762db979" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved MCP, Subagents, and Skills attribution views into a new Datasets dropdown beside the date range picker. Adds a `?dataset=` URL param and scopes pivots, drills, and defaults to the active dataset while preventing unscoped views from showing project-wide numbers.

- **New Features**
  - Dataset selector: All spend, MCP, Subagents, Skills; persists via `?dataset=`; labeled “Dataset” control next to the date picker.
  - Dataset-aware behavior: breakdowns are scoped with parent gating; drilling from All into an attribution auto-switches datasets; switching datasets resets to its default axis; Home resets to `all`.

- **Bug Fixes**
  - Guard unscoped dataset roots: hide the session list, “Most costly sessions” widget, and non-attribution cross-cuts until an attribution value is pinned.
  - URL/back-compat: infer dataset from an attribution `?by=` when `?dataset=` is missing; require a dataset dim’s parent to be pinned before honoring it; fall back to the dataset’s default when `?by=` is invalid; replace `datasetForDim` switch with a lookup map.
  - CI: remove unused taxonomy exports/helpers to satisfy knip; format `taxonomy.ts` to satisfy `oxfmt --check` and fix the client-build-lint job.

<sup>Written for commit b351bb464d2dfe634fd0e8d87dcd3461ca2e328d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

