### PR TITLE
chore: stop auto-adding preview label to PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2018,25 +2018,6 @@ jobs:
 
           echo "✅ All CI checks passed or were skipped."
 
-  add-preview-label:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    needs: [changes, docker-build-server, docker-build-client]
-    if: |
-      github.event_name == 'pull_request' &&
-      !cancelled() &&
-      needs.docker-build-server.result == 'success' &&
-      needs.docker-build-client.result == 'success'
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Add preview label
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --add-label preview
-
   svix-sync-webhooks:
     name: Sync webhook event types to Svix
     runs-on: blacksmith-2vcpu-ubuntu-2404


### PR DESCRIPTION
## What

Removes the `add-preview-label` job from the PR workflow. This job automatically added the `preview` label to every pull request once the server and client docker builds succeeded, which spun up a preview environment for every PR by default.

## Why

Preview environments should be opt-in. Anyone who wants one can still add the `preview` label manually — all of the label-consuming logic (`preview-image-tags`, preview environment deploys) is unchanged.

## Changes

- Deleted the `add-preview-label` job from `.github/workflows/pr.yaml`. No other jobs depended on it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-adding the `preview` label in PR CI so preview environments are opt-in. Removed the `add-preview-label` job from `.github/workflows/pr.yaml`; manual `preview` labels still trigger existing preview deploy logic.

<sup>Written for commit 02af9072338896a547f3c2fe5e9c4d67997529b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

