### PR TITLE
fix: synthesize JSON-RPC error when a remote MCP returns a non-JSON-RPC 2xx body

### DIFF
--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -562,12 +562,38 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 	switch {
 	case errors.Is(err, ErrUndecodableJSONRPCBody):
 		// The remote returned a non-SSE body that isn't a single JSON-RPC
-		// message (observed in prod as a bare heartbeat scalar from a
-		// non-spec-compliant upstream). Mirror the SSE relay path, which skips
-		// interception for undecodable events and forwards them verbatim:
-		// relay the upstream bytes and status to the client unchanged rather
-		// than manufacturing a 5xx. msg is nil, so interceptors are skipped and
-		// bodyBytes is written through below.
+		// message. Two sub-cases, split by whether the client's request
+		// expects a reply:
+		//
+		//   - The client sent a request (valid id) and upstream answered 2xx
+		//     with a non-JSON-RPC body. Observed with upstreams that reply to
+		//     an authenticated request with their backing API's raw envelope
+		//     (e.g. {"Output":…,"Version":…}) instead of a JSON-RPC result
+		//     (AIS-267). Relaying that verbatim hands the client a payload its
+		//     JSON-RPC layer can neither parse nor correlate to its outstanding
+		//     call, so the connection fails opaquely. Synthesize a JSON-RPC
+		//     error carrying the originating id so the client surfaces a clean,
+		//     correlatable failure with the upstream's actual body for
+		//     debugging.
+		//
+		//   - Everything else (no id — a notification with no reply slot; or a
+		//     non-2xx status that already signals the error) keeps the verbatim
+		//     relay, mirroring the SSE relay path's treatment of undecodable
+		//     events. This preserves the bare-heartbeat-scalar behavior. msg is
+		//     nil, so interceptors are skipped and bodyBytes is written through
+		//     below.
+		if userReqID.IsValid() && upstreamStatus >= 200 && upstreamStatus < 300 {
+			p.Logger.WarnContext(ctx, "remote mcp server returned non-json-rpc 2xx body; synthesizing json-rpc error for client",
+				attr.SlogError(err),
+				attr.SlogComponent("remotemcp.proxy"),
+				attr.SlogHTTPResponseStatusCode(upstreamStatus))
+			responseBytes = p.writeRejection(ctx, w, span, userReqID, &RejectError{
+				Code:    RejectCodeInternalError,
+				Message: "remote MCP server returned a non-JSON-RPC response",
+				Data:    nonJSONRPCUpstreamData(upstreamResp, bodyBytes),
+			})
+			return nil
+		}
 		p.Logger.WarnContext(ctx, "relaying undecodable remote mcp response to client verbatim", attr.SlogError(err))
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "invalid jsonrpc response from remote mcp server").LogError(ctx, p.Logger)
@@ -1289,6 +1315,39 @@ func (p *Proxy) dispatchInterceptorError(
 	}
 	*responseBytes = p.writeRejection(ctx, w, span, id, err)
 	return nil
+}
+
+// maxNonJSONRPCEchoBytes bounds how much of a non-JSON-RPC upstream body is
+// echoed back in the synthesized error's "data" field. Enough to show the
+// upstream's actual response shape for debugging without relaying an
+// unbounded payload into a JSON-RPC error envelope.
+const maxNonJSONRPCEchoBytes = 2048
+
+// nonJSONRPCUpstreamData builds the JSON-RPC error "data" payload for a
+// synthesized rejection when the upstream answered a client request with a
+// non-JSON-RPC body. It echoes the upstream status, content type, and a
+// bounded snippet of the raw body — the same bytes the client would have
+// received verbatim before this synthesis, so nothing new is exposed — so
+// operators and clients can diagnose the non-conformant upstream.
+func nonJSONRPCUpstreamData(resp *http.Response, body []byte) map[string]any {
+	snippet := body
+	truncated := false
+	if len(snippet) > maxNonJSONRPCEchoBytes {
+		snippet = snippet[:maxNonJSONRPCEchoBytes]
+		truncated = true
+	}
+
+	data := map[string]any{
+		"upstream_status": resp.StatusCode,
+		"upstream_body":   string(snippet),
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		data["upstream_content_type"] = ct
+	}
+	if truncated {
+		data["upstream_body_truncated"] = true
+	}
+	return data
 }
 
 // writeResponse relays status, headers, and body from the upstream response

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -786,17 +786,20 @@ func TestProxy_Post_OversizedUpstreamBodyReturnsError(t *testing.T) {
 	require.ErrorIs(t, err, proxy.ErrBodyTooLarge)
 }
 
-func TestProxy_Post_UndecodableUpstreamBodyRelaysVerbatim(t *testing.T) {
+func TestProxy_Post_NonJSONRPC2xxBodyForRequestSynthesizesJSONRPCError(t *testing.T) {
 	t.Parallel()
 
-	// A non-spec-compliant remote returned a non-SSE body that isn't a single
-	// JSON-RPC message (observed in prod as a bare heartbeat scalar). The proxy
-	// must relay it verbatim with the upstream status rather than surfacing a
-	// 5xx — mirroring the SSE relay path's treatment of undecodable events.
+	// AIS-267: an upstream answered an authenticated request with its backing
+	// API's raw envelope ({"Output":…,"Version":…}) on HTTP 200 instead of a
+	// JSON-RPC result. Relaying that verbatim hands the client a payload it
+	// cannot parse or correlate. The proxy must synthesize a JSON-RPC error
+	// carrying the originating request id so the client surfaces a clean,
+	// correlatable failure, with the upstream body echoed in "data".
+	const upstreamBody = `{"Output":"result-payload","Version":"1"}`
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("3"))
+		_, _ = w.Write([]byte(upstreamBody))
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -807,9 +810,75 @@ func TestProxy_Post_UndecodableUpstreamBodyRelaysVerbatim(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code, "a synthesized JSON-RPC error is delivered with HTTP 200")
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &envelope))
+	require.Equal(t, "2.0", envelope["jsonrpc"], "synthesized response must be valid JSON-RPC 2.0")
+	require.EqualValues(t, 1, envelope["id"], "synthesized error must carry the originating request id")
+	rpcErr, ok := envelope["error"].(map[string]any)
+	require.True(t, ok, "synthesized response must be a JSON-RPC error")
+	require.EqualValues(t, proxy.RejectCodeInternalError, rpcErr["code"])
+	data, ok := rpcErr["data"].(map[string]any)
+	require.True(t, ok, "error data must carry upstream diagnostics")
+	require.EqualValues(t, http.StatusOK, data["upstream_status"])
+	echoedBody, ok := data["upstream_body"].(string)
+	require.True(t, ok, "upstream body must be echoed as a string")
+	require.JSONEq(t, upstreamBody, echoedBody, "upstream body must be echoed for debugging")
+}
+
+func TestProxy_Post_UndecodableUpstreamBodyForNotificationRelaysVerbatim(t *testing.T) {
+	t.Parallel()
+
+	// A non-spec-compliant remote returned a non-JSON-RPC body (observed in
+	// prod as a bare heartbeat scalar) in response to a notification, which
+	// carries no id and no reply slot. There is nothing to correlate a
+	// synthesized error against, so the proxy relays the body verbatim with the
+	// upstream status rather than surfacing a 5xx.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("3"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+
+	const notificationBody = `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(notificationBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
 	require.Equal(t, http.StatusOK, rr.Code, "undecodable upstream body must not surface as a 5xx")
 	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 	require.Equal(t, "3", rr.Body.String(), "undecodable upstream body must reach the client unmangled")
+}
+
+func TestProxy_Post_NonJSONRPCNon2xxBodyForRequestRelaysVerbatim(t *testing.T) {
+	t.Parallel()
+
+	// When the upstream body isn't JSON-RPC but the status is non-2xx, the
+	// status itself already signals the error. The proxy relays the body and
+	// status verbatim rather than masking the status behind a synthesized
+	// HTTP 200 JSON-RPC error.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusBadGateway, rr.Code, "non-2xx status must be relayed verbatim")
+	require.Equal(t, "upstream unavailable", rr.Body.String(), "non-2xx body must reach the client unmangled")
 }
 
 func TestProxy_Post_GzipEncodedUpstreamBodyIsDecodedAndIntercepted(t *testing.T) {


### PR DESCRIPTION
## Problem

Connecting to the `Finance - Navan` remote MCP server failed right after OAuth. The upstream (`mcp.navan.com`) answered the authenticated `initialize` reconnect with `HTTP 200` and its backing API's raw envelope — `{"Output": …, "Version": …}` — instead of a JSON-RPC result.

The `/x/mcp` proxy relays remote-backed responses verbatim. Its buffered POST path treats any body that fails JSON-RPC decode (`ErrUndecodableJSONRPCBody`) as a heartbeat-style scalar and forwards it unchanged. So the client received a `200` whose body had no `jsonrpc`/`id`/`method`/`result`, and its JSON-RPC validator rejected it with `unrecognized_keys: ["Output","Version"]` — the reconnect broke with no correlatable error.

## Fix

In the proxy's POST path, when the upstream returns a **2xx** body that isn't a JSON-RPC message **and the client's request carried a valid id** (i.e. it's awaiting a reply), synthesize a JSON-RPC error response carrying that id instead of relaying the raw body. The upstream status, content-type, and a bounded snippet of the body are echoed in `error.data` for debugging (the same bytes the client would otherwise have received — nothing new is exposed).

Verbatim relay is preserved for:
- **notifications** (no id → no reply slot to fill), and
- **non-2xx** responses (the status already signals the error),

so the existing bare-heartbeat-scalar behavior is unchanged.

This guarantees that a response to a request over `/x/mcp` is always a well-formed, correlatable JSON-RPC message. It does not make a non-conformant upstream work — the underlying `{Output, Version}` shape is Navan's — but it converts an opaque client-side parse failure into a clean, actionable JSON-RPC error.

## Note for reviewers

This intentionally reverses the prior "relay verbatim even for id-bearing requests" decision (previously covered by `TestProxy_Post_UndecodableUpstreamBodyRelaysVerbatim`), narrowing verbatim relay to the notification / non-2xx cases. That test is replaced by three focused tests covering the synthesized-error path and both preserved verbatim paths.

## Testing

- `mise test:server ./internal/remotemcp/proxy/` — 123 passing
- `mise lint:server` — clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes opaque failures when a remote MCP returns HTTP 200 with a non-JSON-RPC body by synthesizing a JSON-RPC error for id-bearing requests. Ensures replies over `/x/mcp` are always correlatable and addresses AIS-267 (Navan’s `{"Output","Version"}` envelope after OAuth).

- **Bug Fixes**
  - For 2xx responses that aren’t JSON-RPC and the request had a valid id, return a JSON-RPC error with the same id.
  - Include upstream status, content type, and up to 2048 bytes of the body in `error.data` for debugging.
  - Preserve verbatim relay for notifications (no id) and non-2xx responses; added tests for all three paths.

<sup>Written for commit aa0fcd9e1442f3957f5e48f0ce6af0970be5886e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

