### PR TITLE
fix: self-heal default plugin creation on slug conflict

### DIFF
--- a/server/internal/plugins/default_plugin.go
+++ b/server/internal/plugins/default_plugin.go
@@ -28,9 +28,10 @@ type EnsureDefaultPluginResult struct {
 // missing — covers projects that predate this feature (created before
 // CreateProject started provisioning one). Concurrent callers racing to
 // create it are resolved by re-fetching on the is_default unique-index
-// violation; any other unique violation (e.g. a pre-existing plugin already
-// named/slugged "Default"/"default") is a real conflict and surfaces as an
-// error rather than masking it.
+// violation. A project that already has a plugin sitting on the reserved
+// "default" slug (e.g. one created manually before this feature shipped) is
+// healed by promoting that plugin to is_default instead, since the slug
+// collision means CreateDefaultPlugin can never succeed for that project.
 //
 // Takes the raw transaction (not just *repo.Queries) because the insert
 // attempt runs inside a SAVEPOINT: a Postgres transaction is aborted after
@@ -63,18 +64,33 @@ func EnsureDefaultPlugin(ctx context.Context, tx pgx.Tx, organizationID string, 
 	})
 	if err != nil {
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == "plugins_project_id_is_default_key" {
-			if _, err := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+savepoint); err != nil {
-				return nil, fmt.Errorf("rollback savepoint after race: %w", err)
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+			switch pgErr.ConstraintName {
+			case "plugins_project_id_is_default_key":
+				if _, err := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+savepoint); err != nil {
+					return nil, fmt.Errorf("rollback savepoint after race: %w", err)
+				}
+				plugin, err := q.GetDefaultPlugin(ctx, repo.GetDefaultPluginParams{
+					OrganizationID: organizationID,
+					ProjectID:      projectID,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("get default plugin after race: %w", err)
+				}
+				return &EnsureDefaultPluginResult{Plugin: plugin, Created: false}, nil
+			case "plugins_organization_id_project_id_slug_key":
+				if _, err := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+savepoint); err != nil {
+					return nil, fmt.Errorf("rollback savepoint after slug conflict: %w", err)
+				}
+				plugin, err := q.PromoteToDefaultPlugin(ctx, repo.PromoteToDefaultPluginParams{
+					OrganizationID: organizationID,
+					ProjectID:      projectID,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("promote existing default-slug plugin: %w", err)
+				}
+				return &EnsureDefaultPluginResult{Plugin: plugin, Created: false}, nil
 			}
-			plugin, err := q.GetDefaultPlugin(ctx, repo.GetDefaultPluginParams{
-				OrganizationID: organizationID,
-				ProjectID:      projectID,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("get default plugin after race: %w", err)
-			}
-			return &EnsureDefaultPluginResult{Plugin: plugin, Created: false}, nil
 		}
 		return nil, fmt.Errorf("create default plugin: %w", err)
 	}

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -56,7 +56,7 @@ func TestEnsureDefaultPlugin_ReturnsExistingWhenPresent(t *testing.T) {
 	require.Equal(t, first.Plugin.ID, second.Plugin.ID)
 }
 
-func TestEnsureDefaultPlugin_ConflictWithExistingNonDefaultPlugin(t *testing.T) {
+func TestEnsureDefaultPlugin_PromotesExistingDefaultSlugPlugin(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestPluginsService(t)
@@ -66,10 +66,12 @@ func TestEnsureDefaultPlugin_ConflictWithExistingNonDefaultPlugin(t *testing.T) 
 
 	queries := pluginsrepo.New(ti.conn)
 
-	// A plugin already occupies the "Default"/"default" name+slug, but isn't
-	// marked is_default — a real conflict, not a race with another Ensure
-	// call, so it must surface as an error rather than being masked.
-	_, err := queries.CreatePlugin(ctx, pluginsrepo.CreatePluginParams{
+	// A plugin already occupies the "Default"/"default" name+slug (e.g.
+	// created manually before this feature shipped) but isn't marked
+	// is_default. CreateDefaultPlugin can never succeed for this project, so
+	// EnsureDefaultPlugin must heal by promoting the existing plugin instead
+	// of failing forever.
+	existing, err := queries.CreatePlugin(ctx, pluginsrepo.CreatePluginParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
 		Name:           "Default",
@@ -79,8 +81,11 @@ func TestEnsureDefaultPlugin_ConflictWithExistingNonDefaultPlugin(t *testing.T) 
 	require.NoError(t, err)
 
 	tx := testenv.BeginTx(t, ctx, ti.conn)
-	_, err = plugins.EnsureDefaultPlugin(ctx, tx, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
-	require.Error(t, err)
+	result, err := plugins.EnsureDefaultPlugin(ctx, tx, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
+	require.NoError(t, err)
+	require.False(t, result.Created)
+	require.Equal(t, existing.ID, result.Plugin.ID)
+	require.Equal(t, pgtype.Bool{Bool: true, Valid: true}, result.Plugin.IsDefault)
 }
 
 func TestAttachToDefaultPlugin_DisplayNameCollision_ReturnsError(t *testing.T) {

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -25,6 +25,21 @@ WHERE organization_id = @organization_id
   AND is_default IS TRUE
   AND deleted IS FALSE;
 
+-- name: PromoteToDefaultPlugin :one
+-- Self-heals projects that already have a plugin sitting on the reserved
+-- "default" slug (e.g. created manually before this feature shipped) by
+-- flagging it as the project's is_default plugin. Called by
+-- EnsureDefaultPlugin when CreateDefaultPlugin loses to
+-- plugins_organization_id_project_id_slug_key instead of the is_default race.
+UPDATE plugins
+SET is_default = TRUE,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND project_id = @project_id
+  AND slug = 'default'
+  AND deleted IS FALSE
+RETURNING *;
+
 -- name: GetPlugin :one
 SELECT *
 FROM plugins

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -908,6 +908,46 @@ func (q *Queries) ListPluginsWithServersForProject(ctx context.Context, projectI
 	return items, nil
 }
 
+const promoteToDefaultPlugin = `-- name: PromoteToDefaultPlugin :one
+UPDATE plugins
+SET is_default = TRUE,
+    updated_at = clock_timestamp()
+WHERE organization_id = $1
+  AND project_id = $2
+  AND slug = 'default'
+  AND deleted IS FALSE
+RETURNING id, organization_id, project_id, name, slug, description, is_default, created_at, updated_at, deleted_at, deleted
+`
+
+type PromoteToDefaultPluginParams struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+}
+
+// Self-heals projects that already have a plugin sitting on the reserved
+// "default" slug (e.g. created manually before this feature shipped) by
+// flagging it as the project's is_default plugin. Called by
+// EnsureDefaultPlugin when CreateDefaultPlugin loses to
+// plugins_organization_id_project_id_slug_key instead of the is_default race.
+func (q *Queries) PromoteToDefaultPlugin(ctx context.Context, arg PromoteToDefaultPluginParams) (Plugin, error) {
+	row := q.db.QueryRow(ctx, promoteToDefaultPlugin, arg.OrganizationID, arg.ProjectID)
+	var i Plugin
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.IsDefault,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const removeAllPluginAssignments = `-- name: RemoveAllPluginAssignments :execrows
 DELETE FROM plugin_assignments
 WHERE plugin_id = $1


### PR DESCRIPTION
## Summary

Fixes prod 500s on the Plugins page and MCP detail Overview tab reported in speakeasy-team's org (`ServiceError: ensure default plugin` at `/rpc/plugins.listPlugins`, confirmed via Datadog RUM + backend logs).

`EnsureDefaultPlugin` runs lazily on every `plugins.listPlugins` call to backfill the Default plugin for projects that predate it (#3869). It only handled a race on the `plugins_project_id_is_default_key` unique index — not a project that already has a plugin sitting on the reserved `default` slug (e.g. one created manually before this feature shipped, which is exactly what happened on speakeasy-team's project). That case hit `plugins_organization_id_project_id_slug_key` instead, which wasn't caught, so the insert failed and the whole request 500'd — on every single request, forever.

## Changes

- New `PromoteToDefaultPlugin` query: flags an existing `default`-slugged plugin as `is_default` instead of inserting a new one.
- `EnsureDefaultPlugin` now catches the slug-conflict constraint violation and self-heals by promoting the existing plugin, instead of surfacing a hard error.
- Updated `TestEnsureDefaultPlugin_ConflictWithExistingNonDefaultPlugin` → `TestEnsureDefaultPlugin_PromotesExistingDefaultSlugPlugin` to assert the new healing behavior.

## Test plan

- [x] `go test ./internal/plugins/...` — full suite (180 tests) passes
- [x] `mise lint:server` — clean
- [x] Confirmed root cause against prod Datadog RUM error + `gram-server` logs showing the `plugins_organization_id_project_id_slug_key` violation repeating on every request


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repeated 500s on the Plugins page and MCP Overview by self-healing default plugin creation when a project already has a `default`-slug plugin. On slug conflict, `EnsureDefaultPlugin` now promotes the existing plugin to default instead of erroring.

- **Bug Fixes**
  - Added `PromoteToDefaultPlugin` to set an existing `default`-slug plugin as `is_default`.
  - Updated `EnsureDefaultPlugin` to catch `plugins_organization_id_project_id_slug_key` and promote; still resolves the `plugins_project_id_is_default_key` race.
  - Updated test to `TestEnsureDefaultPlugin_PromotesExistingDefaultSlugPlugin` to assert the healing behavior.

<sup>Written for commit 58c6a8c27e7e40d48d59a5e38aae1c28df8a766c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

