### PR TITLE
chore: build elements and internal SDK during worktree/zero init

### DIFF
--- a/.mise-tasks/build/elements.sh
+++ b/.mise-tasks/build/elements.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+#MISE description="Build @gram-ai/elements that powers the dashboard"
+#MISE dir="{{ config_root }}/elements"
+#MISE depends=["install:pnpm"]
+#MISE sources=["src/**/*", "package.json", "tsconfig.json", "vite.config.ts"]
+#MISE outputs=["dist/**/*"]
+
+set -e
+
+exec pnpm --filter @gram-ai/elements build

--- a/.mise-tasks/build/internal-sdk.sh
+++ b/.mise-tasks/build/internal-sdk.sh
@@ -3,6 +3,8 @@
 #MISE description="Build the internal SDK that powers the dashboard"
 #MISE dir="{{ config_root }}/client/sdk"
 #MISE depends=["install:pnpm"]
+#MISE sources=["src/**/*", "package.json", "tsconfig.json"]
+#MISE outputs=["esm/**/*"]
 
 #USAGE flag "--readonly" help="Build with --frozen-lockfile"
 

--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -42,6 +42,13 @@ if ! mise run install:pnpm --offline; then
   mise run install:pnpm
 fi
 
+# Build the workspace packages the dashboard's type-check depends on. Both
+# @gram/client (esm/) and @gram-ai/elements (dist/) have gitignored build
+# output that nothing else in worktree init produces, so tsc can't resolve
+# their types until they're built.
+mise run build:internal-sdk
+mise run build:elements
+
 suffix=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
 compose_project="gram-infra-${suffix}"
 mise set --file mise.local.toml "COMPOSE_PROJECT_NAME=${compose_project}"

--- a/zero
+++ b/zero
@@ -122,6 +122,9 @@ mise run zero:tls
 echo -e "\n⏳ Building internal SDK"
 mise run build:internal-sdk
 
+echo -e "\n⏳ Building elements"
+mise run build:elements
+
 echo -e "\n⏳ Updating VS Code and Cursor editor settings"
 mise run install:vscode
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2920/chore-build-gram-aielements-during-worktreezero-init-to-fix-fresh

Fresh git worktrees (`mise git:worknew` -> `git:workinit`) and fresh `zero --agent` clones started with a dashboard that fails `pnpm -F dashboard type-check`, because the two buildable workspace packages it consumes have gitignored build output that nothing in init produces: `@gram-ai/elements` (`dist/`) and `@gram/client` (`esm/`).

Add a `build:elements` mise task mirroring `build:internal-sdk`, with `sources`/`outputs` fingerprinting so re-runs are no-ops. Call both `build:internal-sdk` and `build:elements` from `workinit.sh` (it built neither), and add `build:elements` to `zero` (which already built the SDK).

**Note:** the SDK's `source` export condition does not spare it from a build here, because the dashboard's tsconfig sets no `customConditions` and its Vite config no `resolve.conditions`, so `tsc` and Vite resolve `@gram/client` from `esm/`. Worktree init must therefore build the SDK too, not just elements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build `@gram-ai/elements` and the internal SDK during worktree and `zero` init so fresh clones pass the dashboard type-check. This addresses AGE-2920 by producing the gitignored `dist/` and `esm/` outputs the dashboard depends on.

- **Bug Fixes**
  - Added `build:elements` mise task with sources/outputs fingerprinting; mirrored the fingerprinting in `build:internal-sdk` to skip no-op builds.
  - `workinit.sh` and `zero` now run `build:internal-sdk` and `build:elements` so the dashboard resolves `@gram/client` from `esm/` and `@gram-ai/elements` from `dist/` without manual builds.

<sup>Written for commit fec8b172c1997b69b847ec6dec5e3415f73ceb10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

