### PR TITLE
fix: unblock hooks browser sign-in for zero-grant members and slow callbacks

### DIFF
--- a/hooks/plugin-claude/hooks/auth.sh
+++ b/hooks/plugin-claude/hooks/auth.sh
@@ -191,7 +191,17 @@ gram_hooks_login_handle_request() {
   local state="$2"
   local probe="$3"
   local request_line="" line="" path_query="" method="" content_length=""
-  IFS= read -r -t 10 request_line || request_line=""
+  # This read is what waits for the browser to hit the callback. nc has already
+  # accepted a connection (or is about to on a reused socket), but the countdown
+  # starts the instant the serve loop iteration begins — before the user has
+  # clicked through the dashboard, minted the key, and been redirected back,
+  # which routinely takes far longer than a few seconds. A short timeout here
+  # fires first, the handler returns with no HTTP response, and the browser
+  # renders ERR_EMPTY_RESPONSE on the reused connection. Wait the full login
+  # window so the callback is actually caught. Once the first line arrives the
+  # rest of the request follows immediately, so the header/body reads below stay
+  # short.
+  IFS= read -r -t "${GRAM_HOOKS_LOGIN_TIMEOUT_SECONDS:-240}" request_line || request_line=""
   request_line="${request_line%$'\r'}"
   if [ -z "$request_line" ]; then
     return 0

--- a/server/internal/keys/impl.go
+++ b/server/internal/keys/impl.go
@@ -115,15 +115,16 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 	finalScopes := slices.Sorted(maps.Keys(scopes))
 
 	// A hooks key only attributes a developer's own coding-agent telemetry and
-	// carries no write powers, so any org member can mint one as part of the
-	// self-serve browser sign-in the hook plugins run. Every other scope (and
-	// any mix) stays admin-only.
-	requiredScope := authz.ScopeOrgAdmin
-	if slices.Equal(finalScopes, []string{auth.APIKeyScopeHooks.String()}) {
-		requiredScope = authz.ScopeOrgRead
-	}
-	if err := s.authz.Require(ctx, authz.Check{Scope: requiredScope, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
-		return nil, err
+	// carries no write powers, so any authenticated member of the org can mint
+	// one as part of the self-serve browser sign-in the hook plugins run — no
+	// role grant required. Directory-synced (SCIM) members frequently hold no
+	// scope grant at all, not even org:read, so gating this on any scope locks
+	// them out of hooks entirely. Every other scope (and any mix) stays
+	// admin-only.
+	if !slices.Equal(finalScopes, []string{auth.APIKeyScopeHooks.String()}) {
+		if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
+			return nil, err
+		}
 	}
 
 	token, err := s.generateToken()

--- a/server/internal/keys/rbac_test.go
+++ b/server/internal/keys/rbac_test.go
@@ -36,25 +36,28 @@ func TestKeysService_CreateKey_AllowsOrgAdminGrant(t *testing.T) {
 	require.Equal(t, "rbac-allow-create", key.Name)
 }
 
-func TestKeysService_CreateKey_AllowsHooksKeyWithOrgReadGrant(t *testing.T) {
+func TestKeysService_CreateKey_AllowsHooksKeyWithoutAnyGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestKeysService(t)
-	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{Scope: authz.ScopeOrgRead, Selector: authz.NewSelector(authz.ScopeOrgRead, testAuthContext(t, ctx).ActiveOrganizationID)})
+	// No grants at all — this is a directory-synced (SCIM) member who holds no
+	// role, not even org:read. They must still be able to self-serve a pure
+	// hooks key, since the hook plugins mint one during browser sign-in.
+	ctx = authztest.WithExactGrants(t, ctx)
 
 	key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-hooks-self-serve", Scopes: []string{"hooks"}})
 	require.NoError(t, err)
 	require.Equal(t, []string{"hooks"}, key.Scopes)
 }
 
-func TestKeysService_CreateKey_ForbidsMixedHooksKeyWithOrgReadGrant(t *testing.T) {
+func TestKeysService_CreateKey_ForbidsMixedHooksKeyWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestKeysService(t)
 	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{Scope: authz.ScopeOrgRead, Selector: authz.NewSelector(authz.ScopeOrgRead, testAuthContext(t, ctx).ActiveOrganizationID)})
 
-	// A non-admin member may only self-serve a pure hooks key; mixing in any
-	// other scope must still require org admin.
+	// The no-grant allowance is only for a pure hooks key; mixing in any other
+	// scope must still require org admin.
 	_, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-hooks-mixed", Scopes: []string{"hooks", "consumer"}})
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1315,7 +1315,17 @@ gram_hooks_login_handle_request() {
   local state="$2"
   local probe="$3"
   local request_line="" line="" path_query="" method="" content_length=""
-  IFS= read -r -t 10 request_line || request_line=""
+  # This read is what waits for the browser to hit the callback. nc has already
+  # accepted a connection (or is about to on a reused socket), but the countdown
+  # starts the instant the serve loop iteration begins — before the user has
+  # clicked through the dashboard, minted the key, and been redirected back,
+  # which routinely takes far longer than a few seconds. A short timeout here
+  # fires first, the handler returns with no HTTP response, and the browser
+  # renders ERR_EMPTY_RESPONSE on the reused connection. Wait the full login
+  # window so the callback is actually caught. Once the first line arrives the
+  # rest of the request follows immediately, so the header/body reads below stay
+  # short.
+  IFS= read -r -t "${GRAM_HOOKS_LOGIN_TIMEOUT_SECONDS:-240}" request_line || request_line=""
   request_line="${request_line%$'\r'}"
   if [ -z "$request_line" ]; then
     return 0


### PR DESCRIPTION
## Summary

Two independent failures could each break the hooks browser sign-in that the coding-agent plugins run during a session. In the wild we saw both at once at a customer: most members couldn't get a key at all, and the admins who could then hit an empty-response callback — so nobody's hooks connected and the login re-prompted every session.

### 1. `keys.create` locked out members with no role grant

Minting a pure `["hooks"]` key required `org:read`. Directory-synced (SCIM) members frequently hold **no role grant at all** — not even `org:read` — so they got a `403` and could never mint a hooks key. The plugin cached nothing and re-prompted the browser login on every new session.

A pure `["hooks"]` key now needs **no scope grant**: any authenticated member of the org can self-serve one (it carries no write powers and only attributes the developer's own telemetry). Any other scope, or any mix that includes `hooks`, still requires `org:admin`.

### 2. Localhost callback listener timed out before the browser arrived

The one-shot `nc` listener read the incoming HTTP request with a **10s timeout that starts when the serve-loop iteration begins** — before the user has clicked through the dashboard, minted the key, and been redirected back (routinely much longer than 10s). The read fired first, the handler returned with no HTTP response, and the browser rendered `net::ERR_EMPTY_RESPONSE` on the reused connection. The minted key was never delivered locally.

The request-line read now spans the full login window (`GRAM_HOOKS_LOGIN_TIMEOUT_SECONDS`, default 240s), matching the outer wait, so the handler stays parked on the socket until the callback actually lands. Header/body reads stay short since the rest of the request follows immediately once the first line arrives.

## Rollout

- Fix (1) is server-side and takes effect on deploy — affected members can retry sign-in immediately.
- Fix (2) ships in the generated plugin; the `auth.sh` change bumps the plugin fingerprint, so it rolls out on the next publish / fingerprint sweep.

## Tests

- `rbac_test.go`: a zero-grant member can mint a pure hooks key; a mixed hooks key still requires org admin.
- Existing `auth.sh` drift test keeps the generated script and the checked-in fixture in sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks hooks browser sign-in by allowing zero‑grant members to mint a pure `["hooks"]` key and by waiting for the full login window on the localhost callback to avoid empty responses.

- **Bug Fixes**
  - RBAC: A pure `["hooks"]` API key no longer requires `org:read`; any authenticated org member can create it. Mixed scopes still require `org:admin`. Updated in `server/internal/keys/impl.go` with tests in `server/internal/keys/rbac_test.go`.
  - Callback: The request-line read now waits up to `GRAM_HOOKS_LOGIN_TIMEOUT_SECONDS` (default `240s`) to catch the browser redirect, preventing `net::ERR_EMPTY_RESPONSE`. Implemented in `hooks/plugin-claude/hooks/auth.sh` and the generator `server/internal/plugins/generate.go`.

<sup>Written for commit 01969f39ee631a88239577a8243270dae4b41a16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

