### PR TITLE
fix: blank dashboard from moonshine chunk-group await deadlock

### DIFF
--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -6,9 +6,16 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
+// Manually grouped vendor chunks. CAUTION: never group a package whose dist
+// contains a top-level `await import(...)` (check before adding). Grouping
+// pulls the package's shared internals into the group chunk, so the awaited
+// sub-module ends up statically importing the very chunk that is suspended
+// awaiting it — a silent module-evaluation deadlock that blank-screens the
+// app. This took prod down for @speakeasy-api/moonshine (its dist top-level
+// awaits ./speakeasy-logo-*.mjs), which is why it is absent from this list;
+// Rolldown's automatic chunking handles it without creating the cycle.
 const manualChunkGroups: [string, string[]][] = [
   ["lucide-react", ["lucide-react"]],
-  ["moonshine", ["@speakeasy-api/moonshine"]],
   [
     "three",
     [


### PR DESCRIPTION
**Production hotfix** for the blank dashboard after #4008 deployed.

## Symptom

https://dev.getgram.ai renders a blank page. No JS console errors, all assets load with 200s, no API calls fire — the entry module simply never finishes evaluating (`import(main)` hangs forever).

## Root cause

`@speakeasy-api/moonshine`'s dist contains a **top-level `await import("./speakeasy-logo-*.mjs")`** (moonshine.es.js:971). The manual `codeSplitting` group for moonshine pulled the package's shared internals into the `moonshine` chunk, which created a fatal cycle through the awaiting module:

1. The `moonshine` chunk starts evaluating and suspends on the top-level `await import()` of the logo sub-module.
2. The emitted `speakeasy-logo-*.js` chunk **statically imports the `moonshine` chunk** (for the shared internals the group captured).
3. The logo module can't begin until the moonshine chunk finishes evaluating; the moonshine chunk can't finish until the logo module evaluates. Deadlock — silent, per ES module semantics, so nothing is logged.

Every chunk that imports `moonshine` (including `main`) then hangs. My pre-merge cycle check missed it because one edge of the cycle is a _dynamic_ import.

## Fix

Drop `@speakeasy-api/moonshine` from `manualChunkGroups`. Rolldown's automatic chunking places the shared internals so no cycle passes through the awaiting module. The remaining groups (`lucide-react`, `three`, `externals`) are safe — none of those packages contain top-level await. A comment on the group list warns against re-adding such packages.

Longer-term follow-up (not this PR): remove the top-level `await import()` from moonshine's build output — it's a hazard for any consumer bundler configuration.

## Verification

Reproduced the hang locally with `vite preview` + Playwright (importing the entry module times out; importing the `moonshine` chunk alone hangs). After the fix: app boots to the login screen, `#root` renders, and every `modulepreload` chunk evaluates with no timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix blank dashboard by removing `@speakeasy-api/moonshine` from Vite manual chunk groups to resolve a top‑level await import cycle that deadlocked module evaluation. The app now boots normally.

- **Bug Fixes**
  - Dropped `@speakeasy-api/moonshine` from `manualChunkGroups` and added a cautionary comment; Rolldown’s automatic chunking avoids the cycle while keeping `lucide-react`, `three`, and `externals`.
  - Verified with `vite preview` + Playwright: login renders and all `modulepreload` chunks evaluate.

<sup>Written for commit 13d0bb1dbb0c8fdabf20f691f608e92f21f572ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

