### PR TITLE
mig: add chats(project_id) index to fix chat.list statement timeouts

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1273,6 +1273,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS chats_org_external_chat_id_key
 ON chats (organization_id, external_chat_id)
 WHERE external_chat_id IS NOT NULL;
 
+-- Every chat listing (chat.list) drives off project_id + the not-deleted
+-- predicate; without this the planner seq-scans the whole (cross-project) chats
+-- table, which pushes large orgs' listings past statement_timeout.
+CREATE INDEX IF NOT EXISTS chats_project_id_idx
+ON chats (project_id)
+WHERE deleted IS FALSE;
+
 CREATE TABLE IF NOT EXISTS assistants (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1275,10 +1275,12 @@ WHERE external_chat_id IS NOT NULL;
 
 -- Every chat listing (chat.list) drives off project_id + the not-deleted
 -- predicate; without this the planner seq-scans the whole (cross-project) chats
--- table, which pushes large orgs' listings past statement_timeout.
+-- table, which pushes large orgs' listings past statement_timeout. Kept
+-- non-partial so it also backs the ON DELETE CASCADE from projects, whose
+-- internal lookup spans all rows (including soft-deleted) and a
+-- deleted-IS-FALSE partial index could not serve.
 CREATE INDEX IF NOT EXISTS chats_project_id_idx
-ON chats (project_id)
-WHERE deleted IS FALSE;
+ON chats (project_id);
 
 CREATE TABLE IF NOT EXISTS assistants (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/migrations/20260708200902_chats-add-project-id-index.sql
+++ b/server/migrations/20260708200902_chats-add-project-id-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "chats_project_id_idx" to table: "chats"
+CREATE INDEX CONCURRENTLY "chats_project_id_idx" ON "chats" ("project_id") WHERE (deleted IS FALSE);

--- a/server/migrations/20260708200902_chats-add-project-id-index.sql
+++ b/server/migrations/20260708200902_chats-add-project-id-index.sql
@@ -1,4 +1,0 @@
--- atlas:txmode none
-
--- Create index "chats_project_id_idx" to table: "chats"
-CREATE INDEX CONCURRENTLY "chats_project_id_idx" ON "chats" ("project_id") WHERE (deleted IS FALSE);

--- a/server/migrations/20260708203242_chats-add-project-id-index.sql
+++ b/server/migrations/20260708203242_chats-add-project-id-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "chats_project_id_idx" to table: "chats"
+CREATE INDEX CONCURRENTLY "chats_project_id_idx" ON "chats" ("project_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:hOnslQhI0AHl+8Wx88W8VrvIDk/ylYfbjzH+9F86JH8=
+h1:GCbKb3KeM5a1z54Tty2s5ByOaSUkxgDRaZs7ZtmADRU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -249,4 +249,4 @@ h1:hOnslQhI0AHl+8Wx88W8VrvIDk/ylYfbjzH+9F86JH8=
 20260707120239_assistant-mcp-servers.sql h1:bDNWbd/16MXwFmJBGKVMmnLcxgdiDCCpizKI/ftevrY=
 20260707200235_add-billing-cycle-usage.sql h1:Oma/fS74ZRIZnopKrTdKwxYxtoEO+fPYATfmqeDiudc=
 20260707204416_billing-cycle-usage-tum-tokens-check.sql h1:e0oVX1jZavibZRbsR6pHqmhApLYK0fLjohgqx/kN65g=
-20260708200902_chats-add-project-id-index.sql h1:TrKHMNPXTqsutZqhJPsdH2YMXy3VCYb6vlAB4gYLHhw=
+20260708203242_chats-add-project-id-index.sql h1:6mzOm6Z7RUHSx94M5JH93IOTSM5MmtVdgcCbM//86Io=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Uodszq0ITn1QQZq1qg2xR5vP5lb9O2ymmlivpk6WD+U=
+h1:hOnslQhI0AHl+8Wx88W8VrvIDk/ylYfbjzH+9F86JH8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -249,3 +249,4 @@ h1:Uodszq0ITn1QQZq1qg2xR5vP5lb9O2ymmlivpk6WD+U=
 20260707120239_assistant-mcp-servers.sql h1:bDNWbd/16MXwFmJBGKVMmnLcxgdiDCCpizKI/ftevrY=
 20260707200235_add-billing-cycle-usage.sql h1:Oma/fS74ZRIZnopKrTdKwxYxtoEO+fPYATfmqeDiudc=
 20260707204416_billing-cycle-usage-tum-tokens-check.sql h1:e0oVX1jZavibZRbsR6pHqmhApLYK0fLjohgqx/kN65g=
+20260708200902_chats-add-project-id-index.sql h1:TrKHMNPXTqsutZqhJPsdH2YMXy3VCYb6vlAB4gYLHhw=


### PR DESCRIPTION
## What

Adds a partial index `chats_project_id_idx ON chats (project_id) WHERE deleted IS FALSE`.

## Why

Production `chat.list` requests for large orgs were returning **500s** — nginx-ingress logged `@http.status_code:500` with ~60s upstream duration, and `gram-server` logged:

```
list chats: ERROR: canceling statement due to statement timeout (SQLSTATE 57014)
```

Root cause: every branch of the `ListChats`/`CountChats` query drives off `WHERE c.project_id = @project_id AND c.deleted IS FALSE`, but `chats` had **no index on `project_id`** (only the PK and a partial `(organization_id, external_chat_id)` unique index). The FK on `project_id` does not create one. So Postgres seq-scanned the entire cross-project `chats` table, then aggregated `chat_messages` across every candidate chat to compute `last_message_timestamp` — blowing past `statement_timeout` for heavy orgs.

## Change

- SDL: partial index on `chats (project_id) WHERE deleted IS FALSE`.
- Atlas-generated migration builds it `CONCURRENTLY` (`-- atlas:txmode none`), so the rollout takes no `ACCESS EXCLUSIVE` lock and `chats` keeps serving during the build.

Migration-only PR (no business logic), per the migration-PR convention.

## Verification

- `mise db:diff` generated the migration (not hand-edited).
- `mise db:migrate` applied it cleanly on a fresh local DB.

## Follow-up (not in this PR)

For orgs that keep growing, the full `chat_messages` aggregation before `LIMIT` won't scale even with this index. Recommend denormalizing `last_message_timestamp` / `num_messages` onto the `chats` row (maintained by ingest) as a separate change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a non-partial index on `chats(project_id)` to stop `chat.list` statement timeouts and avoid 500s on large orgs. This enables index scans and also supports `ON DELETE CASCADE` for project deletions.

- **Migration**
  - Creates `chats_project_id_idx` concurrently to avoid blocking locks or downtime.

<sup>Written for commit bb61443958f6c6dd7f2d847310297335b9692990. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

