### PR TITLE
feat: replace MCP environment tabs with a searchable selector

### DIFF
--- a/client/dashboard/src/pages/mcp/EnvironmentSwitcher.tsx
+++ b/client/dashboard/src/pages/mcp/EnvironmentSwitcher.tsx
@@ -131,7 +131,9 @@ export function EnvironmentSwitcher({
             >
               <span className="flex items-center gap-2 truncate">
                 {selectedIsAttached && (
-                  <Link className="text-foreground h-3 w-3 shrink-0" />
+                  <SimpleTooltip tooltip="Attached">
+                    <Link className="text-foreground h-3 w-3 shrink-0" />
+                  </SimpleTooltip>
                 )}
                 <span className="truncate">{selectedLabel}</span>
               </span>

--- a/client/dashboard/src/pages/mcp/EnvironmentSwitcher.tsx
+++ b/client/dashboard/src/pages/mcp/EnvironmentSwitcher.tsx
@@ -88,8 +88,7 @@ export function EnvironmentSwitcher({
 
   // Dropdown row indicator: a chain-link icon (with an "Attached" tooltip) on
   // the attached env, transparent spacer of the same size on the rest so
-  // labels stay aligned. Blue matches the "Attached" badge (Moonshine
-  // information variant).
+  // labels stay aligned.
   const renderAttachedIndicator = (env: Environment) => {
     const isAttachedEnv =
       mcpAttachedEnvironmentSlug != null &&

--- a/client/dashboard/src/pages/mcp/EnvironmentSwitcher.tsx
+++ b/client/dashboard/src/pages/mcp/EnvironmentSwitcher.tsx
@@ -1,7 +1,22 @@
+import { Button as UIButton } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { Button } from "@speakeasy-api/moonshine";
-import { Plus, Unlink } from "lucide-react";
+import { Check, ChevronsUpDown, Link, Plus, Unlink } from "lucide-react";
+import { useState } from "react";
 import {
   EnvironmentVariable,
   environmentHasAllRequiredVariables,
@@ -44,6 +59,8 @@ export function EnvironmentSwitcher({
   onDetachEnvironment,
   onCreateEnvironment,
 }: EnvironmentSwitcherProps): JSX.Element | null {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
   // Sort environments with attached environment first, falling back to default for sort order only
   const sortSlug =
     mcpAttachedEnvironmentSlug || defaultEnvironmentSlug || "default";
@@ -69,49 +86,102 @@ export function EnvironmentSwitcher({
       )
     : false;
 
+  // Dropdown row indicator: a chain-link icon (with an "Attached" tooltip) on
+  // the attached env, transparent spacer of the same size on the rest so
+  // labels stay aligned. Blue matches the "Attached" badge (Moonshine
+  // information variant).
+  const renderAttachedIndicator = (env: Environment) => {
+    const isAttachedEnv =
+      mcpAttachedEnvironmentSlug != null &&
+      env.slug === mcpAttachedEnvironmentSlug;
+    if (!isAttachedEnv) {
+      return <div className="h-3 w-3 shrink-0" />;
+    }
+    return (
+      <SimpleTooltip tooltip="Attached">
+        <Link className="text-foreground h-3 w-3 shrink-0" />
+      </SimpleTooltip>
+    );
+  };
+
+  const selectedEnv = sortedEnvironments.find(
+    (env) => env.slug === selectedEnvironmentView,
+  );
+  const selectedLabel = selectedEnv
+    ? getEnvironmentDisplayName(selectedEnv)
+    : selectedEnvironmentView;
+  const selectedIsAttached =
+    mcpAttachedEnvironmentSlug != null &&
+    selectedEnvironmentView === mcpAttachedEnvironmentSlug;
+
   if (environments.length === 0) {
     return null;
   }
 
   return (
     <div className="flex items-center gap-1 border-b">
-      {/* Environment tabs */}
-      {sortedEnvironments.map((env) => {
-        const isSelected = selectedEnvironmentView === env.slug;
-        const isAttachedEnv =
-          mcpAttachedEnvironmentSlug != null &&
-          env.slug === mcpAttachedEnvironmentSlug;
-        const envHasAllRequired = environmentHasAllRequiredVariables(
-          env.slug,
-          requiredVars,
-        );
-
-        return (
-          <button
-            key={env.slug}
-            onClick={() => onEnvironmentSelect(env.slug)}
-            className={cn(
-              "relative flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors",
-              isSelected
-                ? "text-foreground"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            {isAttachedEnv && (
-              <div
-                className={cn(
-                  "h-2 w-2 rounded-full",
-                  envHasAllRequired ? "bg-green-500" : "bg-yellow-500",
+      {/* Environment selector */}
+      <div className="py-2 pl-3">
+        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+          <PopoverTrigger asChild>
+            <UIButton
+              variant="outline"
+              role="combobox"
+              aria-expanded={pickerOpen}
+              className="min-w-[200px] justify-between gap-2 px-3"
+            >
+              <span className="flex items-center gap-2 truncate">
+                {selectedIsAttached && (
+                  <Link className="text-foreground h-3 w-3 shrink-0" />
                 )}
-              />
-            )}
-            {getEnvironmentDisplayName(env)}
-            {isSelected && (
-              <div className="bg-primary absolute right-0 bottom-0 left-0 h-0.5" />
-            )}
-          </button>
-        );
-      })}
+                <span className="truncate">{selectedLabel}</span>
+              </span>
+              <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+            </UIButton>
+          </PopoverTrigger>
+          <PopoverContent className="w-[280px] p-0" align="start">
+            <Command>
+              {sortedEnvironments.length > 4 && (
+                <CommandInput
+                  placeholder="Search environments..."
+                  className="h-9"
+                />
+              )}
+              <CommandList>
+                <CommandEmpty>No environments found.</CommandEmpty>
+                <CommandGroup>
+                  {sortedEnvironments.map((env) => {
+                    const isSelected = selectedEnvironmentView === env.slug;
+                    return (
+                      <CommandItem
+                        key={env.slug}
+                        value={env.slug}
+                        keywords={[getEnvironmentDisplayName(env)]}
+                        className="cursor-pointer gap-2"
+                        onSelect={(slug) => {
+                          onEnvironmentSelect(slug);
+                          setPickerOpen(false);
+                        }}
+                      >
+                        {renderAttachedIndicator(env)}
+                        <span className="truncate">
+                          {getEnvironmentDisplayName(env)}
+                        </span>
+                        <Check
+                          className={cn(
+                            "ml-auto h-4 w-4 shrink-0",
+                            isSelected ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
 
       {/* Right side actions */}
       <div className="ml-auto flex items-center gap-3 py-1.5 pr-3">


### PR DESCRIPTION
## What

On the MCP server detail page (**Authentication → Environment Variables**), the environment picker rendered one tab per environment. With many attached environments the tab strip overflowed the container horizontally. This replaces the tab strip with a searchable dropdown selector.

## Changes

- Swapped the horizontal `<button>` tab strip in `EnvironmentSwitcher` for a dropdown composed from the existing `Popover` + `Command` primitives (no changes to any `components/ui/*` file).
- Search box appears automatically when there are more than 4 environments; matches on the visible display name (via `keywords`), not just the slug.
- The attached environment is marked with a small chain-link icon (`text-foreground`) plus an "Attached" tooltip, in the trigger and in its dropdown row. Non-attached rows use a matching-size spacer so labels stay aligned.
- Preserved existing behavior: attached-environment-first sort, `"default"` → "Default" display name, empty-state handling, and all save/cancel/attach/detach actions.

## Testing

- `pnpm -F dashboard type-check` — clean
- ESLint + oxfmt — clean
- Verified locally on `/mcp/jamf#authentication` (closed selector + open dropdown).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the overflowing environment tabs on Authentication → Environment Variables with a searchable dropdown, making large environment lists easier to navigate and preventing horizontal overflow.

- **New Features**
  - Replaced the tab strip with a dropdown built from existing `Popover` and `Command` primitives.
  - Search appears when there are more than 4 environments; matches display name, not just slug.
  - Marks the attached environment with a chain-link icon in both the trigger and list; keeps labels aligned.
  - Preserves existing behavior: attached-first sort, `default` → “Default,” empty state, and all attach/detach/save/cancel actions.

- **Bug Fixes**
  - Added the "Attached" tooltip to the selector trigger icon so the closed selector icon isn’t ambiguous.

<sup>Written for commit 7d68fa4ea77078c3f8eee9053fb31544c52b5559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

