### PR TITLE
feat: operator-gated tenant backfill for attribute_metrics_summaries

### DIFF
--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -114,6 +114,7 @@ type Activities struct {
 	outboxRelay                     *outbox_relay.Relay
 	outboxGC                        *outbox_relay.GC
 	pluginPublisher                 *activities.PluginPublisher
+	backfillAttributeMetrics        *activities.BackfillAttributeMetricsSummaries
 }
 
 func NewActivities(
@@ -215,6 +216,7 @@ func NewActivities(
 		outboxRelay:                     outbox_relay.New(logger, tracerProvider, db, svixClient, productFeatures),
 		outboxGC:                        outbox_relay.NewGC(logger, meterProvider, db),
 		pluginPublisher:                 activities.NewPluginPublisher(logger, db, pluginPublisher),
+		backfillAttributeMetrics:        activities.NewBackfillAttributeMetricsSummaries(logger, chConn),
 	}
 }
 
@@ -501,4 +503,50 @@ func (a *Activities) PublishPluginProject(ctx context.Context, input plugins.Pub
 		return nil, fmt.Errorf("publish plugin project: %w", err)
 	}
 	return result, nil
+}
+
+func (a *Activities) PrepareAttributeMetricsBackfill(ctx context.Context, params activities.PrepareAttributeMetricsBackfillParams) (*activities.PrepareAttributeMetricsBackfillResult, error) {
+	result, err := a.backfillAttributeMetrics.Prepare(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("prepare attribute metrics backfill: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) StageAttributeMetricsBackfillChunk(ctx context.Context, params activities.StageAttributeMetricsBackfillChunkParams) error {
+	if err := a.backfillAttributeMetrics.StageChunk(ctx, params); err != nil {
+		return fmt.Errorf("stage attribute metrics backfill chunk: %w", err)
+	}
+	return nil
+}
+
+func (a *Activities) ValidateAttributeMetricsBackfill(ctx context.Context, params activities.ValidateAttributeMetricsBackfillParams) (*activities.ValidateAttributeMetricsBackfillResult, error) {
+	result, err := a.backfillAttributeMetrics.Validate(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("validate attribute metrics backfill: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) ArchiveAttributeMetricsBackfill(ctx context.Context, params activities.ArchiveAttributeMetricsBackfillParams) (*activities.ArchiveAttributeMetricsBackfillResult, error) {
+	result, err := a.backfillAttributeMetrics.Archive(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("archive attribute metrics backfill: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) CommitAttributeMetricsBackfill(ctx context.Context, params activities.CommitAttributeMetricsBackfillParams) (*activities.CommitAttributeMetricsBackfillResult, error) {
+	result, err := a.backfillAttributeMetrics.Commit(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("commit attribute metrics backfill: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) CleanupAttributeMetricsBackfill(ctx context.Context, params activities.CleanupAttributeMetricsBackfillParams) error {
+	if err := a.backfillAttributeMetrics.Cleanup(ctx, params); err != nil {
+		return fmt.Errorf("cleanup attribute metrics backfill: %w", err)
+	}
+	return nil
 }

--- a/server/internal/background/activities/backfill_attribute_metrics_summaries.go
+++ b/server/internal/background/activities/backfill_attribute_metrics_summaries.go
@@ -1,0 +1,349 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mvbackfill"
+)
+
+// Tenant-scoped rebuild of attribute_metrics_summaries from raw
+// telemetry_logs. The staging/commit mechanics live in the generic
+// mvbackfill driver; this file holds only what is specific to this MV — the
+// table wiring (Spec) and the validation stats over its aggregate columns.
+
+// attributeMetricsSummaryColumns is the full column list shared by the live,
+// staging, and archive tables (the archive prefixes backfill_run_id).
+// Explicit lists keep the INSERT ... SELECTs immune to column order drift.
+const attributeMetricsSummaryColumns = "gram_project_id, time_bucket, " +
+	"department_name, job_title, employee_type, division_name, cost_center_name, user_email, " +
+	"model, hook_source, roles, groups, " +
+	"total_chats, total_input_tokens, total_output_tokens, total_tokens, " +
+	"cache_read_input_tokens, cache_creation_input_tokens, total_cost, total_tool_calls, unique_tool_calls, " +
+	"account_type, provider, billing_mode, " +
+	"query_source, skill_name, agent_name, mcp_server_name, mcp_tool_name"
+
+// telemetryLogsSourceColumns is the ordinary (non-materialized) column list
+// shared by telemetry_logs and telemetry_logs_backfill_feed. Keep in sync
+// with both table definitions in server/clickhouse/schema.sql.
+const telemetryLogsSourceColumns = "id, time_unix_nano, observed_time_unix_nano, observed_timestamp, " +
+	"severity_text, body, trace_id, span_id, attributes, resource_attributes, " +
+	"gram_project_id, gram_deployment_id, gram_function_id, gram_urn, " +
+	"service_name, service_version, gram_chat_id"
+
+// attributeMetricsBackfillSpec wires the attribute_metrics_summaries rebuild
+// into the generic driver. The backfill DDL for the feed, staging, and
+// archive tables lives in server/clickhouse/schema.sql.
+var attributeMetricsBackfillSpec = mvbackfill.Spec{
+	SourceTable:      "telemetry_logs",
+	SourceTimeColumn: "time_unix_nano",
+	SourceColumns:    telemetryLogsSourceColumns,
+	FeedTable:        "telemetry_logs_backfill_feed",
+	LiveTable:        "attribute_metrics_summaries",
+	StagingTable:     "attribute_metrics_summaries_backfill",
+	ArchiveTable:     "attribute_metrics_summaries_backfill_archive",
+	TenantColumn:     "gram_project_id",
+	BucketColumn:     "time_bucket",
+	Columns:          attributeMetricsSummaryColumns,
+}
+
+type BackfillAttributeMetricsSummaries struct {
+	logger *slog.Logger
+	conn   clickhouse.Conn
+	driver *mvbackfill.Driver
+}
+
+func NewBackfillAttributeMetricsSummaries(logger *slog.Logger, conn clickhouse.Conn) *BackfillAttributeMetricsSummaries {
+	return &BackfillAttributeMetricsSummaries{
+		logger: logger.With(attr.SlogComponent("backfill_attribute_metrics_summaries")),
+		conn:   conn,
+		driver: mvbackfill.NewDriver(conn, attributeMetricsBackfillSpec),
+	}
+}
+
+type PrepareAttributeMetricsBackfillParams struct {
+	ProjectID        string `json:"project_id"`
+	BoundaryUnixNano int64  `json:"boundary_unix_nano"`
+}
+
+type PrepareAttributeMetricsBackfillResult struct {
+	// RawRowCount is the number of raw telemetry_logs rows in the rebuild
+	// window. Zero means there is nothing to backfill.
+	RawRowCount     uint64 `json:"raw_row_count"`
+	MinTimeUnixNano int64  `json:"min_time_unix_nano"`
+	MaxTimeUnixNano int64  `json:"max_time_unix_nano"`
+}
+
+// Prepare clears any staging leftovers for the tenant (from an earlier
+// aborted or crashed run) and measures the tenant's raw-log window below the
+// boundary. The window bounds drive the workflow's day-chunked staging loop.
+func (b *BackfillAttributeMetricsSummaries) Prepare(ctx context.Context, params PrepareAttributeMetricsBackfillParams) (*PrepareAttributeMetricsBackfillResult, error) {
+	projectID, err := uuid.Parse(params.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("parse project ID: %w", err)
+	}
+
+	stop := startActivityHeartbeat(ctx)
+	defer stop()
+
+	window, err := b.driver.Prepare(ctx, projectID.String(), time.Unix(0, params.BoundaryUnixNano).UTC())
+	if err != nil {
+		return nil, fmt.Errorf("prepare backfill: %w", err)
+	}
+
+	b.logger.InfoContext(ctx, "prepared attribute metrics backfill",
+		attr.SlogProjectID(projectID.String()),
+	)
+
+	return &PrepareAttributeMetricsBackfillResult{
+		RawRowCount:     window.RowCount,
+		MinTimeUnixNano: window.MinTime.UnixNano(),
+		MaxTimeUnixNano: window.MaxTime.UnixNano(),
+	}, nil
+}
+
+type StageAttributeMetricsBackfillChunkParams struct {
+	ProjectID    string `json:"project_id"`
+	FromUnixNano int64  `json:"from_unix_nano"`
+	ToUnixNano   int64  `json:"to_unix_nano"`
+}
+
+// StageChunk replays one time slice of the tenant's raw logs through the
+// Null-engine feed; the attached backfill MV performs the rollup into the
+// staging table.
+func (b *BackfillAttributeMetricsSummaries) StageChunk(ctx context.Context, params StageAttributeMetricsBackfillChunkParams) error {
+	projectID, err := uuid.Parse(params.ProjectID)
+	if err != nil {
+		return fmt.Errorf("parse project ID: %w", err)
+	}
+
+	stop := startActivityHeartbeat(ctx)
+	defer stop()
+
+	if err := b.driver.StageChunk(ctx, projectID.String(),
+		time.Unix(0, params.FromUnixNano).UTC(),
+		time.Unix(0, params.ToUnixNano).UTC(),
+	); err != nil {
+		return fmt.Errorf("stage raw log chunk: %w", err)
+	}
+	return nil
+}
+
+type ValidateAttributeMetricsBackfillParams struct {
+	ProjectID        string `json:"project_id"`
+	BoundaryUnixNano int64  `json:"boundary_unix_nano"`
+}
+
+// AttributeMetricsBackfillTableStats summarizes one side (staging or live) of
+// the pending swap so the operator can compare conserved invariants — totals
+// only move where the MV logic intentionally changed.
+type AttributeMetricsBackfillTableStats struct {
+	RowCount                 uint64  `json:"row_count"`
+	MinTimeBucketUnixSec     int64   `json:"min_time_bucket_unix_sec"`
+	MaxTimeBucketUnixSec     int64   `json:"max_time_bucket_unix_sec"`
+	TotalCost                float64 `json:"total_cost"`
+	TotalInputTokens         int64   `json:"total_input_tokens"`
+	TotalOutputTokens        int64   `json:"total_output_tokens"`
+	TotalTokens              int64   `json:"total_tokens"`
+	CacheReadInputTokens     int64   `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64   `json:"cache_creation_input_tokens"`
+	// TotalToolCalls counts tool rows (legacy column, kept warm during the
+	// expand-contract transition); UniqueToolCalls dedups by call identity and
+	// is what readers consume. Live rows written before the provenance-first
+	// MV have empty unique_tool_calls states, so a staging-vs-live gap here is
+	// expected on first rebuild.
+	TotalToolCalls  uint64 `json:"total_tool_calls"`
+	UniqueToolCalls uint64 `json:"unique_tool_calls"`
+	TotalChats      uint64 `json:"total_chats"`
+}
+
+type ValidateAttributeMetricsBackfillResult struct {
+	// Staging covers everything the backfill rebuilt for the tenant.
+	Staging AttributeMetricsBackfillTableStats `json:"staging"`
+	// Live covers the delete window [staging min bucket, boundary) — exactly
+	// the live rows the commit step will replace.
+	Live AttributeMetricsBackfillTableStats `json:"live"`
+}
+
+// Validate produces side-by-side stats of the staged rebuild and the live
+// rows it would replace. This is deliberately MV-specific (it aggregates this
+// MV's -State columns), so it lives here rather than in the driver. The
+// workflow surfaces the result via a query handler and then blocks on the
+// operator's approve/abort signal.
+func (b *BackfillAttributeMetricsSummaries) Validate(ctx context.Context, params ValidateAttributeMetricsBackfillParams) (*ValidateAttributeMetricsBackfillResult, error) {
+	projectID, err := uuid.Parse(params.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("parse project ID: %w", err)
+	}
+
+	staging, err := b.tableStats(ctx, attributeMetricsBackfillSpec.StagingTable, projectID.String(), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("summarize staging table: %w", err)
+	}
+
+	boundary := time.Unix(0, params.BoundaryUnixNano).UTC()
+	windowStart := time.Unix(staging.MinTimeBucketUnixSec, 0).UTC()
+	live, err := b.tableStats(ctx, attributeMetricsBackfillSpec.LiveTable, projectID.String(), &windowStart, &boundary)
+	if err != nil {
+		return nil, fmt.Errorf("summarize live table: %w", err)
+	}
+
+	return &ValidateAttributeMetricsBackfillResult{
+		Staging: *staging,
+		Live:    *live,
+	}, nil
+}
+
+func (b *BackfillAttributeMetricsSummaries) tableStats(ctx context.Context, table string, projectID string, from *time.Time, to *time.Time) (*AttributeMetricsBackfillTableStats, error) {
+	query := "SELECT count(), " +
+		"toInt64(toUnixTimestamp(coalesce(min(time_bucket), toDateTime(0, 'UTC')))), " +
+		"toInt64(toUnixTimestamp(coalesce(max(time_bucket), toDateTime(0, 'UTC')))), " +
+		"sumIfMerge(total_cost), " +
+		"sumIfMerge(total_input_tokens), " +
+		"sumIfMerge(total_output_tokens), " +
+		"sumIfMerge(total_tokens), " +
+		"sumIfMerge(cache_read_input_tokens), " +
+		"sumIfMerge(cache_creation_input_tokens), " +
+		"countIfMerge(total_tool_calls), " +
+		"uniqExactIfMerge(unique_tool_calls), " +
+		"uniqExactIfMerge(total_chats) " +
+		"FROM " + table + " WHERE gram_project_id = ?"
+	args := []any{projectID}
+	if from != nil {
+		query += " AND time_bucket >= ?"
+		args = append(args, *from)
+	}
+	if to != nil {
+		query += " AND time_bucket < ?"
+		args = append(args, *to)
+	}
+
+	var stats AttributeMetricsBackfillTableStats
+	if err := b.conn.QueryRow(ctx, query, args...).Scan(
+		&stats.RowCount,
+		&stats.MinTimeBucketUnixSec,
+		&stats.MaxTimeBucketUnixSec,
+		&stats.TotalCost,
+		&stats.TotalInputTokens,
+		&stats.TotalOutputTokens,
+		&stats.TotalTokens,
+		&stats.CacheReadInputTokens,
+		&stats.CacheCreationInputTokens,
+		&stats.TotalToolCalls,
+		&stats.UniqueToolCalls,
+		&stats.TotalChats,
+	); err != nil {
+		return nil, fmt.Errorf("query %s stats: %w", table, err)
+	}
+	return &stats, nil
+}
+
+type ArchiveAttributeMetricsBackfillParams struct {
+	ProjectID        string `json:"project_id"`
+	BoundaryUnixNano int64  `json:"boundary_unix_nano"`
+	// BackfillRunID scopes the archived rows to this workflow run so repeated
+	// backfills of the same tenant stay distinguishable for a restore.
+	BackfillRunID string `json:"backfill_run_id"`
+}
+
+type ArchiveAttributeMetricsBackfillResult struct {
+	ArchivedRowCount uint64 `json:"archived_row_count"`
+	// DeleteWindowStartUnixSec is min(time_bucket) of the staged rebuild — the
+	// commit deletes live rows in [this, boundary). Live buckets older than the
+	// staged coverage are never touched (the raw-retention clamp: summaries
+	// whose raw logs already expired cannot be rebuilt, so they are not
+	// deleted).
+	DeleteWindowStartUnixSec int64 `json:"delete_window_start_unix_sec"`
+}
+
+// Archive snapshots the tenant's live rows in the delete window into the
+// archive table. It must fully succeed before Commit runs so the snapshot is
+// taken from untouched live data.
+func (b *BackfillAttributeMetricsSummaries) Archive(ctx context.Context, params ArchiveAttributeMetricsBackfillParams) (*ArchiveAttributeMetricsBackfillResult, error) {
+	projectID, err := uuid.Parse(params.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("parse project ID: %w", err)
+	}
+
+	stop := startActivityHeartbeat(ctx)
+	defer stop()
+
+	archive, err := b.driver.Archive(ctx, projectID.String(), time.Unix(0, params.BoundaryUnixNano).UTC(), params.BackfillRunID)
+	if err != nil {
+		return nil, fmt.Errorf("archive live rows: %w", err)
+	}
+
+	b.logger.InfoContext(ctx, "archived live attribute metrics rows",
+		attr.SlogProjectID(projectID.String()),
+	)
+
+	return &ArchiveAttributeMetricsBackfillResult{
+		ArchivedRowCount:         archive.ArchivedRowCount,
+		DeleteWindowStartUnixSec: archive.DeleteWindowStart.Unix(),
+	}, nil
+}
+
+type CommitAttributeMetricsBackfillParams struct {
+	ProjectID        string `json:"project_id"`
+	BoundaryUnixNano int64  `json:"boundary_unix_nano"`
+}
+
+type CommitAttributeMetricsBackfillResult struct {
+	DeleteWindowStartUnixSec int64 `json:"delete_window_start_unix_sec"`
+	// InsertedRowCount is the tenant's live row count inside the swapped window
+	// right after the insert (pre-merge, so it roughly matches staging's count).
+	InsertedRowCount uint64 `json:"inserted_row_count"`
+}
+
+// Commit swaps the staged rebuild into the live table: delete the tenant's
+// live rows in [staging min bucket, boundary), then insert the staged rows.
+func (b *BackfillAttributeMetricsSummaries) Commit(ctx context.Context, params CommitAttributeMetricsBackfillParams) (*CommitAttributeMetricsBackfillResult, error) {
+	projectID, err := uuid.Parse(params.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("parse project ID: %w", err)
+	}
+
+	stop := startActivityHeartbeat(ctx)
+	defer stop()
+
+	commit, err := b.driver.Commit(ctx, projectID.String(), time.Unix(0, params.BoundaryUnixNano).UTC())
+	if err != nil {
+		return nil, fmt.Errorf("commit backfill: %w", err)
+	}
+
+	b.logger.InfoContext(ctx, "committed attribute metrics backfill",
+		attr.SlogProjectID(projectID.String()),
+	)
+
+	return &CommitAttributeMetricsBackfillResult{
+		DeleteWindowStartUnixSec: commit.DeleteWindowStart.Unix(),
+		InsertedRowCount:         commit.InsertedRowCount,
+	}, nil
+}
+
+type CleanupAttributeMetricsBackfillParams struct {
+	ProjectID string `json:"project_id"`
+}
+
+// Cleanup clears the tenant's staged rows. Runs after a commit and after an
+// operator abort; a failure here never invalidates a committed swap.
+func (b *BackfillAttributeMetricsSummaries) Cleanup(ctx context.Context, params CleanupAttributeMetricsBackfillParams) error {
+	projectID, err := uuid.Parse(params.ProjectID)
+	if err != nil {
+		return fmt.Errorf("parse project ID: %w", err)
+	}
+
+	stop := startActivityHeartbeat(ctx)
+	defer stop()
+
+	if err := b.driver.Cleanup(ctx, projectID.String()); err != nil {
+		return fmt.Errorf("clean up staging rows: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/activities/backfill_attribute_metrics_summaries_integration_test.go
+++ b/server/internal/background/activities/backfill_attribute_metrics_summaries_integration_test.go
@@ -1,0 +1,340 @@
+package activities_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// TestBackfillAttributeMetricsSummaries_FullLifecycle drives the real
+// activities against ClickHouse through the whole staging flow: raw Claude
+// logs (including pre-cutoff history and legacy hook_source spellings) are
+// replayed through the Null-engine feed, validated, archived, and swapped
+// into the live table. All operations are tenant-scoped, so the shared test
+// database is safe.
+func TestBackfillAttributeMetricsSummaries_FullLifecycle(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	projectID := uuid.NewString()
+	boundary := time.Now().UTC().Truncate(time.Hour)
+
+	// Raw history for the tenant. The live MV only ingests rows at/after its
+	// 2026-06-20 cutoff, so preCutoff exists only in raw logs until the
+	// backfill extends live history backwards. postCutoff rows flow through
+	// the live MV at insert time as well.
+	preCutoff := time.Date(2026, time.June, 10, 12, 30, 0, 0, time.UTC)
+	postCutoff := time.Date(2026, time.June, 25, 9, 15, 0, 0, time.UTC)
+
+	// Legacy spelling: the row is admitted as Claude by provenance (the OTEL
+	// URN) while hook_source passes through as the stamped "claude".
+	insertBackfillClaudeAPIRequestLog(t, ctx, chConn, projectID, preCutoff, "session-pre", 0.25, 100, "claude")
+	// Empty hook_source: provenance still admits the row; the dimension stays
+	// empty.
+	insertBackfillClaudeAPIRequestLog(t, ctx, chConn, projectID, postCutoff, "session-post", 0.50, 200, "")
+	// Non-Claude row: classified as cursor by its usage URN.
+	insertBackfillCursorUsageLog(t, ctx, chConn, projectID, postCutoff.Add(5*time.Minute), "session-cursor", 0.10, 40)
+	// Claude tool call via OTEL tool_result, re-emitted with the same
+	// tool_use_id: total_tool_calls counts both rows, unique_tool_calls dedups
+	// to one call.
+	toolUseID := uuid.NewString()
+	insertBackfillClaudeToolResultLog(t, ctx, chConn, projectID, postCutoff.Add(10*time.Minute), "session-post", toolUseID, "Bash")
+	insertBackfillClaudeToolResultLog(t, ctx, chConn, projectID, postCutoff.Add(11*time.Minute), "session-post", toolUseID, "Bash")
+
+	// A stale live aggregate inside the rebuild window (e.g. produced by old
+	// MV logic under the legacy "claude" bucket). The commit must delete it
+	// and the archive must preserve it.
+	staleBucket := postCutoff.Truncate(time.Hour)
+	insertBackfillStaleLiveSummary(t, ctx, chConn, projectID, staleBucket, "claude", 999.0)
+
+	// Inserts become visible to reads with a small delay in the test
+	// container; wait for the fixture rows (raw + MV-ingested + stale) before
+	// running the activities. Production backfills read history ingested long
+	// ago, so the activities themselves need no such wait.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var rawRows uint64
+		assert.NoError(c, chConn.QueryRow(ctx,
+			"SELECT count() FROM telemetry_logs WHERE gram_project_id = ?", projectID,
+		).Scan(&rawRows))
+		assert.Equal(c, uint64(5), rawRows)
+
+		var liveBuckets uint64
+		assert.NoError(c, chConn.QueryRow(ctx,
+			"SELECT count() FROM attribute_metrics_summaries WHERE gram_project_id = ?", projectID,
+		).Scan(&liveBuckets))
+		assert.NotZero(c, liveBuckets)
+	}, 15*time.Second, 250*time.Millisecond)
+
+	act := activities.NewBackfillAttributeMetricsSummaries(logger, chConn)
+
+	prep, err := act.Prepare(ctx, activities.PrepareAttributeMetricsBackfillParams{
+		ProjectID:        projectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), prep.RawRowCount)
+	require.Equal(t, preCutoff.UnixNano(), prep.MinTimeUnixNano)
+
+	// Stage the whole window in one chunk; chunking is a workflow concern.
+	require.NoError(t, act.StageChunk(ctx, activities.StageAttributeMetricsBackfillChunkParams{
+		ProjectID:    projectID,
+		FromUnixNano: prep.MinTimeUnixNano,
+		ToUnixNano:   boundary.UnixNano(),
+	}))
+
+	// Poll for the same read-visibility delay as above on the staged rows.
+	var report *activities.ValidateAttributeMetricsBackfillResult
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		r, err := act.Validate(ctx, activities.ValidateAttributeMetricsBackfillParams{
+			ProjectID:        projectID,
+			BoundaryUnixNano: boundary.UnixNano(),
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		report = r
+		assert.InDelta(c, 0.85, r.Staging.TotalCost, 1e-9)
+	}, 15*time.Second, 250*time.Millisecond)
+	require.NotZero(t, report.Staging.RowCount)
+	// 100+20 (pre-cutoff Claude) + 200+20 (post-cutoff Claude) + 40 (cursor).
+	require.Equal(t, int64(380), report.Staging.TotalTokens)
+	// Two tool_result rows staged, but they share one tool_use_id: the legacy
+	// row count sees both, the deduped count collapses them to one call.
+	require.Equal(t, uint64(2), report.Staging.TotalToolCalls)
+	require.Equal(t, uint64(1), report.Staging.UniqueToolCalls)
+	require.Equal(t, uint64(3), report.Staging.TotalChats)
+	require.Equal(t, preCutoff.Truncate(time.Hour).Unix(), report.Staging.MinTimeBucketUnixSec)
+	// Live already holds the MV-ingested post-cutoff rows plus the stale row.
+	require.InDelta(t, 999.0+0.60, report.Live.TotalCost, 1e-9)
+
+	runID := uuid.NewString()
+	archive, err := act.Archive(ctx, activities.ArchiveAttributeMetricsBackfillParams{
+		ProjectID:        projectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+		BackfillRunID:    runID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, preCutoff.Truncate(time.Hour).Unix(), archive.DeleteWindowStartUnixSec)
+
+	commit, err := act.Commit(ctx, activities.CommitAttributeMetricsBackfillParams{
+		ProjectID:        projectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, preCutoff.Truncate(time.Hour).Unix(), commit.DeleteWindowStartUnixSec)
+
+	// The live table now reflects only the rebuild: pre-cutoff history
+	// restored, the stale 999.0 aggregate replaced, hook_source preserved as
+	// stamped on the raw rows.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		costBySource := queryBackfillLiveCostByHookSource(t, ctx, chConn, projectID)
+		assert.InDelta(c, 0.25, costBySource["claude"], 1e-9)
+		assert.InDelta(c, 0.50, costBySource[""], 1e-9)
+		assert.InDelta(c, 0.10, costBySource["cursor"], 1e-9)
+
+		var preCutoffRows uint64
+		assert.NoError(c, chConn.QueryRow(ctx,
+			"SELECT count() FROM attribute_metrics_summaries WHERE gram_project_id = ? AND time_bucket = ?",
+			projectID, preCutoff.Truncate(time.Hour),
+		).Scan(&preCutoffRows))
+		assert.NotZero(c, preCutoffRows, "backfill should extend live history before the MV cutoff")
+	}, 15*time.Second, 250*time.Millisecond)
+
+	// The archive preserved the replaced rows (including the stale one) under
+	// this run id.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var archivedStale uint64
+		assert.NoError(c, chConn.QueryRow(ctx,
+			"SELECT count() FROM attribute_metrics_summaries_backfill_archive WHERE backfill_run_id = ? AND hook_source = 'claude'",
+			runID,
+		).Scan(&archivedStale))
+		assert.Equal(c, uint64(1), archivedStale)
+	}, 15*time.Second, 250*time.Millisecond)
+
+	require.NoError(t, act.Cleanup(ctx, activities.CleanupAttributeMetricsBackfillParams{ProjectID: projectID}))
+	var stagingRows uint64
+	require.NoError(t, chConn.QueryRow(ctx,
+		"SELECT count() FROM attribute_metrics_summaries_backfill WHERE gram_project_id = ?",
+		projectID,
+	).Scan(&stagingRows))
+	require.Zero(t, stagingRows)
+}
+
+// TestBackfillAttributeMetricsSummaries_CommitRequiresStagedRows guards the
+// raw-retention clamp: with nothing staged, Archive and Commit must refuse to
+// touch the live table rather than derive an unbounded delete window.
+func TestBackfillAttributeMetricsSummaries_CommitRequiresStagedRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	act := activities.NewBackfillAttributeMetricsSummaries(logger, chConn)
+	projectID := uuid.NewString()
+	boundary := time.Now().UTC().Truncate(time.Hour)
+
+	_, err = act.Archive(ctx, activities.ArchiveAttributeMetricsBackfillParams{
+		ProjectID:        projectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+		BackfillRunID:    uuid.NewString(),
+	})
+	require.ErrorContains(t, err, "staging table has no rows")
+
+	_, err = act.Commit(ctx, activities.CommitAttributeMetricsBackfillParams{
+		ProjectID:        projectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+	})
+	require.ErrorContains(t, err, "staging table has no rows")
+}
+
+func insertBackfillClaudeAPIRequestLog(t *testing.T, ctx context.Context, chConn clickhouse.Conn, projectID string, timestamp time.Time, sessionID string, cost float64, inputTokens int, hookSource string) {
+	t.Helper()
+
+	attributes := map[string]any{
+		"event.name":             "api_request",
+		"prompt.id":              uuid.NewString(),
+		"gen_ai.conversation.id": sessionID,
+		"input_tokens":           inputTokens,
+		"output_tokens":          20,
+		"cache_read_tokens":      0,
+		"cache_creation_tokens":  0,
+		"cost_usd":               cost,
+		"model":                  "claude-sonnet-4-5",
+		"user.email":             "user@example.com",
+	}
+	if hookSource != "" {
+		attributes["gram.hook.source"] = hookSource
+	}
+	insertBackfillTelemetryLog(t, ctx, chConn, projectID, timestamp, "claude_code.api_request", "claude-code:otel:logs", "claude-code", sessionID, attributes)
+}
+
+func insertBackfillCursorUsageLog(t *testing.T, ctx context.Context, chConn clickhouse.Conn, projectID string, timestamp time.Time, sessionID string, cost float64, totalTokens int) {
+	t.Helper()
+
+	attributes := map[string]any{
+		"gen_ai.conversation.id":    sessionID,
+		"gen_ai.usage.input_tokens": totalTokens,
+		"gen_ai.usage.total_tokens": totalTokens,
+		"gen_ai.usage.cost":         cost,
+		"gen_ai.response.model":     "gpt-5",
+		"gram.hook.source":          "cursor",
+		"user.email":                "user@example.com",
+	}
+	insertBackfillTelemetryLog(t, ctx, chConn, projectID, timestamp, "cursor usage", "cursor:usage:metrics", "gram-server", sessionID, attributes)
+}
+
+func insertBackfillClaudeToolResultLog(t *testing.T, ctx context.Context, chConn clickhouse.Conn, projectID string, timestamp time.Time, sessionID string, toolUseID string, toolName string) {
+	t.Helper()
+
+	attributes := map[string]any{
+		"event.name":             "tool_result",
+		"tool_use_id":            toolUseID,
+		"tool_name":              toolName,
+		"success":                "true",
+		"gen_ai.conversation.id": sessionID,
+		"user.email":             "user@example.com",
+	}
+	insertBackfillTelemetryLog(t, ctx, chConn, projectID, timestamp, "claude_code.tool_result", "claude-code:otel:logs", "claude-code", sessionID, attributes)
+}
+
+func insertBackfillTelemetryLog(t *testing.T, ctx context.Context, chConn clickhouse.Conn, projectID string, timestamp time.Time, body string, gramURN string, serviceName string, sessionID string, attributes map[string]any) {
+	t.Helper()
+
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	err = telemetryrepo.New(chConn).InsertTelemetryLog(ctx, telemetryrepo.InsertTelemetryLogParams{
+		ID:                   uuid.NewString(),
+		TimeUnixNano:         timestamp.UnixNano(),
+		ObservedTimeUnixNano: timestamp.UnixNano(),
+		SeverityText:         nil,
+		Body:                 body,
+		TraceID:              nil,
+		SpanID:               nil,
+		Attributes:           string(attrsJSON),
+		ResourceAttributes:   "{}",
+		GramProjectID:        projectID,
+		GramDeploymentID:     nil,
+		GramFunctionID:       nil,
+		GramURN:              gramURN,
+		ServiceName:          serviceName,
+		ServiceVersion:       nil,
+		GramChatID:           &sessionID,
+	})
+	require.NoError(t, err)
+}
+
+// insertBackfillStaleLiveSummary plants a live aggregate row directly (as old
+// MV logic would have written it) so the test can prove the commit replaces
+// stale data.
+func insertBackfillStaleLiveSummary(t *testing.T, ctx context.Context, chConn clickhouse.Conn, projectID string, bucket time.Time, hookSource string, cost float64) {
+	t.Helper()
+
+	err := chConn.Exec(ctx,
+		`INSERT INTO attribute_metrics_summaries (
+			gram_project_id, time_bucket,
+			department_name, job_title, employee_type, division_name, cost_center_name, user_email,
+			model, hook_source, roles, groups,
+			total_chats, total_input_tokens, total_output_tokens, total_tokens,
+			cache_read_input_tokens, cache_creation_input_tokens, total_cost, total_tool_calls,
+			account_type, provider, billing_mode,
+			query_source, skill_name, agent_name, mcp_server_name, mcp_tool_name
+		)
+		SELECT
+			toUUID(?), toDateTime(?, 'UTC'),
+			'', '', '', '', '', 'user@example.com',
+			'claude-sonnet-4-5', ?, [], [],
+			uniqExactIfState('stale-chat', toUInt8(1)),
+			sumIfState(toInt64(1), toUInt8(1)),
+			sumIfState(toInt64(1), toUInt8(1)),
+			sumIfState(toInt64(2), toUInt8(1)),
+			sumIfState(toInt64(0), toUInt8(1)),
+			sumIfState(toInt64(0), toUInt8(1)),
+			sumIfState(toFloat64(?), toUInt8(1)),
+			countIfState(toUInt8(0)),
+			'', '', '',
+			'', '', '', '', ''
+		FROM system.one`,
+		projectID, bucket.Unix(), hookSource, cost,
+	)
+	require.NoError(t, err)
+}
+
+func queryBackfillLiveCostByHookSource(t *testing.T, ctx context.Context, chConn clickhouse.Conn, projectID string) map[string]float64 {
+	t.Helper()
+
+	rows, err := chConn.Query(ctx,
+		"SELECT hook_source, sumIfMerge(total_cost) FROM attribute_metrics_summaries WHERE gram_project_id = ? GROUP BY hook_source",
+		projectID,
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	out := make(map[string]float64)
+	for rows.Next() {
+		var source string
+		var cost float64
+		require.NoError(t, rows.Scan(&source, &cost))
+		out[source] = cost
+	}
+	require.NoError(t, rows.Err())
+	return out
+}

--- a/server/internal/background/backfill_attribute_metrics_summaries.go
+++ b/server/internal/background/backfill_attribute_metrics_summaries.go
@@ -1,0 +1,240 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+// Tenant-scoped attribute_metrics_summaries backfill (Null-table staging
+// pattern; the table mechanics live in the internal/mvbackfill driver, the
+// MV-specific wiring in the activities package). The workflow is a
+// two-phase, operator-gated rebuild:
+//
+// Phase 1 (automatic): pick an hour-aligned boundary, clear staging, replay
+// the tenant's raw telemetry_logs in day chunks through the Null-engine feed
+// (the deployed backfill MV performs the rollup into staging), then produce a
+// staging-vs-live validation report.
+//
+// Gate: the workflow parks on SignalBackfillAttributeMetricsDecision until an
+// operator has manually verified the invariants (the report is exposed via
+// the QueryBackfillAttributeMetricsValidationReport query handler and in the
+// Validate activity result in workflow history).
+//
+// Phase 2 (on approval): archive the live rows in the delete window, swap
+// staging into live (synchronous delete + insert), clear staging. On
+// rejection: clear staging and finish without touching the live table.
+//
+// Operate it with the Temporal CLI:
+//
+//	temporal workflow start --type BackfillAttributeMetricsSummariesWorkflow \
+//	  --task-queue <queue> --workflow-id 'v1:backfill-attribute-metrics-summaries:<project-id>' \
+//	  --input '{"project_id": "<project-id>"}'
+//	temporal workflow query --workflow-id ... --type backfill-validation-report
+//	temporal workflow signal --workflow-id ... \
+//	  --name backfill-attribute-metrics-decision --input '{"approve": true}'
+const (
+	// SignalBackfillAttributeMetricsDecision carries the operator's
+	// approve/abort verdict after manual validation of the staged rebuild.
+	SignalBackfillAttributeMetricsDecision = "backfill-attribute-metrics-decision"
+
+	// QueryBackfillAttributeMetricsValidationReport returns the
+	// staging-vs-live validation stats (zero value until staging completes).
+	QueryBackfillAttributeMetricsValidationReport = "backfill-validation-report"
+
+	// backfillAttributeMetricsChunk is the staging chunk width. Day-sized
+	// chunks keep single INSERT ... SELECTs bounded and make the loop
+	// resumable at day granularity; raw retention is 90 days, so a full
+	// rebuild is at most ~91 activities.
+	backfillAttributeMetricsChunk = 24 * time.Hour
+)
+
+type BackfillAttributeMetricsSummariesParams struct {
+	// ProjectID is the tenant (gram_project_id) whose summaries are rebuilt.
+	ProjectID string `json:"project_id"`
+}
+
+type BackfillAttributeMetricsSummariesResult struct {
+	ProjectID        string `json:"project_id"`
+	BoundaryUnixNano int64  `json:"boundary_unix_nano"`
+	RawRowCount      uint64 `json:"raw_row_count"`
+	StagedChunks     int    `json:"staged_chunks"`
+
+	Report *activities.ValidateAttributeMetricsBackfillResult `json:"report,omitempty"`
+
+	// Committed reports whether the staged data was swapped into the live
+	// table. False means the run finished without modifying live data (nothing
+	// to backfill, or the operator aborted).
+	Committed        bool   `json:"committed"`
+	AbortReason      string `json:"abort_reason,omitempty"`
+	ArchivedRowCount uint64 `json:"archived_row_count"`
+	InsertedRowCount uint64 `json:"inserted_row_count"`
+}
+
+// BackfillAttributeMetricsDecision is the operator signal payload.
+type BackfillAttributeMetricsDecision struct {
+	Approve bool   `json:"approve"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+func ExecuteBackfillAttributeMetricsSummariesWorkflow(ctx context.Context, env *tenv.Environment, params BackfillAttributeMetricsSummariesParams) (client.WorkflowRun, error) {
+	// One workflow ID per tenant: Temporal rejects a second concurrent run for
+	// the same project while allowing re-runs once the previous one closed.
+	id := fmt.Sprintf("v1:backfill-attribute-metrics-summaries:%s", params.ProjectID)
+	return env.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    id,
+		TaskQueue:             string(env.Queue()),
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+	}, BackfillAttributeMetricsSummariesWorkflow, params)
+}
+
+// SignalBackfillAttributeMetricsSummariesDecision delivers the operator's
+// approve/abort verdict to a waiting backfill workflow.
+func SignalBackfillAttributeMetricsSummariesDecision(ctx context.Context, env *tenv.Environment, projectID string, decision BackfillAttributeMetricsDecision) error {
+	id := fmt.Sprintf("v1:backfill-attribute-metrics-summaries:%s", projectID)
+	if err := env.Client().SignalWorkflow(ctx, id, "", SignalBackfillAttributeMetricsDecision, decision); err != nil {
+		return fmt.Errorf("signal backfill decision: %w", err)
+	}
+	return nil
+}
+
+func BackfillAttributeMetricsSummariesWorkflow(ctx workflow.Context, params BackfillAttributeMetricsSummariesParams) (*BackfillAttributeMetricsSummariesResult, error) {
+	// Hour-aligned boundary: summary buckets are hourly, so everything below
+	// the boundary is rebuilt from staging while buckets at/after it keep
+	// being written by the live MV during the run — no gap, no double count.
+	boundary := workflow.Now(ctx).UTC().Truncate(time.Hour)
+
+	result := &BackfillAttributeMetricsSummariesResult{
+		ProjectID:        params.ProjectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+		RawRowCount:      0,
+		StagedChunks:     0,
+		Report:           nil,
+		Committed:        false,
+		AbortReason:      "",
+		ArchivedRowCount: 0,
+		InsertedRowCount: 0,
+	}
+
+	// Expose the validation report to `temporal workflow query` for the
+	// operator gate; empty until the Validate activity completes.
+	if err := workflow.SetQueryHandler(ctx, QueryBackfillAttributeMetricsValidationReport, func() (*activities.ValidateAttributeMetricsBackfillResult, error) {
+		return result.Report, nil
+	}); err != nil {
+		return nil, fmt.Errorf("register validation report query handler: %w", err)
+	}
+
+	// Staging chunks and the commit mutation rewrite large parts; give each
+	// call a wide budget and rely on heartbeats for liveness.
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Minute,
+		HeartbeatTimeout:    2 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    time.Minute,
+			MaximumAttempts:    5,
+		},
+	})
+
+	var a *Activities
+
+	var prep activities.PrepareAttributeMetricsBackfillResult
+	if err := workflow.ExecuteActivity(ctx, a.PrepareAttributeMetricsBackfill, activities.PrepareAttributeMetricsBackfillParams{
+		ProjectID:        params.ProjectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+	}).Get(ctx, &prep); err != nil {
+		return nil, fmt.Errorf("prepare backfill: %w", err)
+	}
+	result.RawRowCount = prep.RawRowCount
+	if prep.RawRowCount == 0 {
+		result.AbortReason = "no raw telemetry logs to rebuild from"
+		return result, nil
+	}
+
+	// Replay oldest-first so a long run loses nothing to the rolling raw-log
+	// TTL: the oldest (most at-risk) rows are staged first.
+	for start := time.Unix(0, prep.MinTimeUnixNano).UTC().Truncate(backfillAttributeMetricsChunk); start.Before(boundary); start = start.Add(backfillAttributeMetricsChunk) {
+		end := start.Add(backfillAttributeMetricsChunk)
+		if end.After(boundary) {
+			end = boundary
+		}
+		if err := workflow.ExecuteActivity(ctx, a.StageAttributeMetricsBackfillChunk, activities.StageAttributeMetricsBackfillChunkParams{
+			ProjectID:    params.ProjectID,
+			FromUnixNano: start.UnixNano(),
+			ToUnixNano:   end.UnixNano(),
+		}).Get(ctx, nil); err != nil {
+			return nil, fmt.Errorf("stage chunk starting %s: %w", start.Format(time.RFC3339), err)
+		}
+		result.StagedChunks++
+	}
+
+	var report activities.ValidateAttributeMetricsBackfillResult
+	if err := workflow.ExecuteActivity(ctx, a.ValidateAttributeMetricsBackfill, activities.ValidateAttributeMetricsBackfillParams{
+		ProjectID:        params.ProjectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+	}).Get(ctx, &report); err != nil {
+		return nil, fmt.Errorf("validate backfill: %w", err)
+	}
+	result.Report = &report
+
+	// Operator gate: park until a human has compared the staging and live
+	// stats (and run any ad-hoc queries against the staging table) and signals
+	// the verdict. The workflow ID is stable per tenant, so the signal needs
+	// only the project ID.
+	var decision BackfillAttributeMetricsDecision
+	workflow.GetSignalChannel(ctx, SignalBackfillAttributeMetricsDecision).Receive(ctx, &decision)
+
+	if !decision.Approve {
+		result.AbortReason = decision.Reason
+		if result.AbortReason == "" {
+			result.AbortReason = "operator rejected the staged backfill"
+		}
+		if err := workflow.ExecuteActivity(ctx, a.CleanupAttributeMetricsBackfill, activities.CleanupAttributeMetricsBackfillParams{
+			ProjectID: params.ProjectID,
+		}).Get(ctx, nil); err != nil {
+			return nil, fmt.Errorf("clean up staging after abort: %w", err)
+		}
+		return result, nil
+	}
+
+	// Archive completes before Commit starts, so the snapshot is taken from
+	// untouched live rows even if Commit later retries mid-swap.
+	var archive activities.ArchiveAttributeMetricsBackfillResult
+	if err := workflow.ExecuteActivity(ctx, a.ArchiveAttributeMetricsBackfill, activities.ArchiveAttributeMetricsBackfillParams{
+		ProjectID:        params.ProjectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+		BackfillRunID:    workflow.GetInfo(ctx).WorkflowExecution.RunID,
+	}).Get(ctx, &archive); err != nil {
+		return nil, fmt.Errorf("archive live rows: %w", err)
+	}
+	result.ArchivedRowCount = archive.ArchivedRowCount
+
+	var commit activities.CommitAttributeMetricsBackfillResult
+	if err := workflow.ExecuteActivity(ctx, a.CommitAttributeMetricsBackfill, activities.CommitAttributeMetricsBackfillParams{
+		ProjectID:        params.ProjectID,
+		BoundaryUnixNano: boundary.UnixNano(),
+	}).Get(ctx, &commit); err != nil {
+		return nil, fmt.Errorf("commit backfill: %w", err)
+	}
+	result.Committed = true
+	result.InsertedRowCount = commit.InsertedRowCount
+
+	// Best-effort: staged rows are transient and Prepare re-clears them on the
+	// next run, so a cleanup failure must not fail a committed backfill.
+	if err := workflow.ExecuteActivity(ctx, a.CleanupAttributeMetricsBackfill, activities.CleanupAttributeMetricsBackfillParams{
+		ProjectID: params.ProjectID,
+	}).Get(ctx, nil); err != nil {
+		workflow.GetLogger(ctx).Warn("failed to clean up staging after commit", "error", err)
+	}
+
+	return result, nil
+}

--- a/server/internal/background/backfill_attribute_metrics_summaries_test.go
+++ b/server/internal/background/backfill_attribute_metrics_summaries_test.go
@@ -1,0 +1,245 @@
+package background
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+)
+
+const testBackfillProjectID = "0f9d5a3f-6a2f-4a4b-9c3e-2b1a0d8e7c6d"
+
+// registerBackfillActivityStubs wires happy-path stubs for every backfill
+// activity and returns a recorder of the invocation order plus the staged
+// chunk windows.
+type backfillActivityRecorder struct {
+	calls         []string
+	stagedWindows [][2]int64
+	cleanupCount  int
+}
+
+func registerBackfillActivityStubs(env *testsuite.TestWorkflowEnvironment, rec *backfillActivityRecorder, rawWindow [2]int64, rawRowCount uint64) {
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, params activities.PrepareAttributeMetricsBackfillParams) (*activities.PrepareAttributeMetricsBackfillResult, error) {
+			rec.calls = append(rec.calls, "prepare")
+			return &activities.PrepareAttributeMetricsBackfillResult{
+				RawRowCount:     rawRowCount,
+				MinTimeUnixNano: rawWindow[0],
+				MaxTimeUnixNano: rawWindow[1],
+			}, nil
+		},
+		activity.RegisterOptions{Name: "PrepareAttributeMetricsBackfill"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, params activities.StageAttributeMetricsBackfillChunkParams) error {
+			rec.calls = append(rec.calls, "stage")
+			rec.stagedWindows = append(rec.stagedWindows, [2]int64{params.FromUnixNano, params.ToUnixNano})
+			return nil
+		},
+		activity.RegisterOptions{Name: "StageAttributeMetricsBackfillChunk"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, params activities.ValidateAttributeMetricsBackfillParams) (*activities.ValidateAttributeMetricsBackfillResult, error) {
+			rec.calls = append(rec.calls, "validate")
+			return &activities.ValidateAttributeMetricsBackfillResult{
+				Staging: activities.AttributeMetricsBackfillTableStats{
+					RowCount:                 10,
+					MinTimeBucketUnixSec:     rawWindow[0] / int64(time.Second),
+					MaxTimeBucketUnixSec:     rawWindow[1] / int64(time.Second),
+					TotalCost:                12.5,
+					TotalInputTokens:         100,
+					TotalOutputTokens:        50,
+					TotalTokens:              150,
+					CacheReadInputTokens:     0,
+					CacheCreationInputTokens: 0,
+					TotalToolCalls:           3,
+					UniqueToolCalls:          3,
+					TotalChats:               2,
+				},
+				Live: activities.AttributeMetricsBackfillTableStats{
+					RowCount:                 8,
+					MinTimeBucketUnixSec:     rawWindow[0] / int64(time.Second),
+					MaxTimeBucketUnixSec:     rawWindow[1] / int64(time.Second),
+					TotalCost:                12.5,
+					TotalInputTokens:         100,
+					TotalOutputTokens:        50,
+					TotalTokens:              150,
+					CacheReadInputTokens:     0,
+					CacheCreationInputTokens: 0,
+					TotalToolCalls:           3,
+					UniqueToolCalls:          3,
+					TotalChats:               2,
+				},
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ValidateAttributeMetricsBackfill"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, params activities.ArchiveAttributeMetricsBackfillParams) (*activities.ArchiveAttributeMetricsBackfillResult, error) {
+			rec.calls = append(rec.calls, "archive")
+			return &activities.ArchiveAttributeMetricsBackfillResult{
+				ArchivedRowCount:         8,
+				DeleteWindowStartUnixSec: rawWindow[0] / int64(time.Second),
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ArchiveAttributeMetricsBackfill"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, params activities.CommitAttributeMetricsBackfillParams) (*activities.CommitAttributeMetricsBackfillResult, error) {
+			rec.calls = append(rec.calls, "commit")
+			return &activities.CommitAttributeMetricsBackfillResult{
+				DeleteWindowStartUnixSec: rawWindow[0] / int64(time.Second),
+				InsertedRowCount:         10,
+			}, nil
+		},
+		activity.RegisterOptions{Name: "CommitAttributeMetricsBackfill"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, params activities.CleanupAttributeMetricsBackfillParams) error {
+			rec.calls = append(rec.calls, "cleanup")
+			rec.cleanupCount++
+			return nil
+		},
+		activity.RegisterOptions{Name: "CleanupAttributeMetricsBackfill"},
+	)
+}
+
+func TestBackfillAttributeMetricsSummariesWorkflow_CommitsOnApproval(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	now := env.Now().UTC()
+	rawStart := now.Add(-36 * time.Hour)
+	rec := &backfillActivityRecorder{calls: nil, stagedWindows: nil, cleanupCount: 0}
+	registerBackfillActivityStubs(env, rec, [2]int64{rawStart.UnixNano(), now.Add(-time.Hour).UnixNano()}, 500)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalBackfillAttributeMetricsDecision, BackfillAttributeMetricsDecision{
+			Approve: true,
+			Reason:  "",
+		})
+	}, time.Minute)
+
+	env.ExecuteWorkflow(BackfillAttributeMetricsSummariesWorkflow, BackfillAttributeMetricsSummariesParams{
+		ProjectID: testBackfillProjectID,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result BackfillAttributeMetricsSummariesResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.True(t, result.Committed)
+	require.Equal(t, uint64(500), result.RawRowCount)
+	require.Equal(t, uint64(8), result.ArchivedRowCount)
+	require.Equal(t, uint64(10), result.InsertedRowCount)
+	require.NotNil(t, result.Report)
+
+	// Prepare first, staging chunks, validate, then the gated commit sequence.
+	require.Equal(t, "prepare", rec.calls[0])
+	require.Equal(t, []string{"validate", "archive", "commit", "cleanup"}, rec.calls[len(rec.calls)-4:])
+
+	// A ~36h window staged in day chunks: 2-3 chunks depending on alignment,
+	// contiguous, ending exactly at the hour-aligned boundary.
+	require.NotEmpty(t, rec.stagedWindows)
+	boundary := result.BoundaryUnixNano
+	require.Equal(t, boundary, rec.stagedWindows[len(rec.stagedWindows)-1][1])
+	require.LessOrEqual(t, rec.stagedWindows[0][0], rawStart.UnixNano())
+	for i := 1; i < len(rec.stagedWindows); i++ {
+		require.Equal(t, rec.stagedWindows[i-1][1], rec.stagedWindows[i][0])
+	}
+}
+
+func TestBackfillAttributeMetricsSummariesWorkflow_AbortsOnRejection(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	now := env.Now().UTC()
+	rec := &backfillActivityRecorder{calls: nil, stagedWindows: nil, cleanupCount: 0}
+	registerBackfillActivityStubs(env, rec, [2]int64{now.Add(-6 * time.Hour).UnixNano(), now.Add(-time.Hour).UnixNano()}, 42)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalBackfillAttributeMetricsDecision, BackfillAttributeMetricsDecision{
+			Approve: false,
+			Reason:  "staging totals diverged",
+		})
+	}, time.Minute)
+
+	env.ExecuteWorkflow(BackfillAttributeMetricsSummariesWorkflow, BackfillAttributeMetricsSummariesParams{
+		ProjectID: testBackfillProjectID,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result BackfillAttributeMetricsSummariesResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.False(t, result.Committed)
+	require.Equal(t, "staging totals diverged", result.AbortReason)
+	require.NotContains(t, rec.calls, "archive")
+	require.NotContains(t, rec.calls, "commit")
+	require.Equal(t, 1, rec.cleanupCount)
+}
+
+func TestBackfillAttributeMetricsSummariesWorkflow_NoRawLogs(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	rec := &backfillActivityRecorder{calls: nil, stagedWindows: nil, cleanupCount: 0}
+	registerBackfillActivityStubs(env, rec, [2]int64{0, 0}, 0)
+
+	env.ExecuteWorkflow(BackfillAttributeMetricsSummariesWorkflow, BackfillAttributeMetricsSummariesParams{
+		ProjectID: testBackfillProjectID,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result BackfillAttributeMetricsSummariesResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.False(t, result.Committed)
+	require.Equal(t, []string{"prepare"}, rec.calls)
+}
+
+func TestBackfillAttributeMetricsSummariesWorkflow_ExposesValidationReportQuery(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	now := env.Now().UTC()
+	rec := &backfillActivityRecorder{calls: nil, stagedWindows: nil, cleanupCount: 0}
+	registerBackfillActivityStubs(env, rec, [2]int64{now.Add(-2 * time.Hour).UnixNano(), now.Add(-time.Hour).UnixNano()}, 42)
+
+	env.RegisterDelayedCallback(func() {
+		value, err := env.QueryWorkflow(QueryBackfillAttributeMetricsValidationReport)
+		require.NoError(t, err)
+		var report *activities.ValidateAttributeMetricsBackfillResult
+		require.NoError(t, value.Get(&report))
+		require.NotNil(t, report)
+		require.Equal(t, uint64(10), report.Staging.RowCount)
+
+		env.SignalWorkflow(SignalBackfillAttributeMetricsDecision, BackfillAttributeMetricsDecision{
+			Approve: true,
+			Reason:  "",
+		})
+	}, time.Minute)
+
+	env.ExecuteWorkflow(BackfillAttributeMetricsSummariesWorkflow, BackfillAttributeMetricsSummariesParams{
+		ProjectID: testBackfillProjectID,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -379,6 +379,13 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.GCOutboxProcessedRows)
 	temporalWorker.RegisterActivity(activities.ListPluginPublishCandidates)
 	temporalWorker.RegisterActivity(activities.PublishPluginProject)
+	// Attribute metrics backfill activities
+	temporalWorker.RegisterActivity(activities.PrepareAttributeMetricsBackfill)
+	temporalWorker.RegisterActivity(activities.StageAttributeMetricsBackfillChunk)
+	temporalWorker.RegisterActivity(activities.ValidateAttributeMetricsBackfill)
+	temporalWorker.RegisterActivity(activities.ArchiveAttributeMetricsBackfill)
+	temporalWorker.RegisterActivity(activities.CommitAttributeMetricsBackfill)
+	temporalWorker.RegisterActivity(activities.CleanupAttributeMetricsBackfill)
 
 	// AI integration usage syncing runs on its own worker and task queue.
 	aiUsageWorker.RegisterActivity(activities.PollAIData)
@@ -432,6 +439,8 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(ProcessOutboxWorkflow)
 	temporalWorker.RegisterWorkflow(OutboxGCWorkflow)
 	temporalWorker.RegisterWorkflow(PluginGeneratorRolloutWorkflow)
+	// Operator-gated tenant backfill for attribute_metrics_summaries
+	temporalWorker.RegisterWorkflow(BackfillAttributeMetricsSummariesWorkflow)
 
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {

--- a/server/internal/mvbackfill/mvbackfill.go
+++ b/server/internal/mvbackfill/mvbackfill.go
@@ -1,0 +1,304 @@
+// Package mvbackfill rebuilds tenant-scoped slices of a ClickHouse
+// materialized-view target from its raw source table using the Null-table
+// staging pattern.
+//
+// The pattern needs four tables wired up in the schema (see the
+// attribute_metrics_summaries backfill DDL in server/clickhouse/schema.sql
+// for the reference layout):
+//
+//   - a Null-engine clone of the source table (the feed),
+//   - a staging table with the live target's exact schema,
+//   - a materialized view from the feed into staging repeating the live MV's
+//     SELECT (minus any ingest-time cutoff), so the transform is always the
+//     deployed MV SQL — never a copy that can drift,
+//   - an archive table with the live schema plus a leading backfill_run_id
+//     column, for pre-delete snapshots.
+//
+// The Driver runs the per-tenant lifecycle against those tables:
+//
+//  1. Prepare    — clear the tenant's staging leftovers, measure the raw
+//     source window below the boundary.
+//  2. StageChunk — replay one time slice of raw rows through the feed; the
+//     staging MV rebuilds the aggregates into the staging table.
+//  3. Archive    — snapshot the live rows the commit will delete.
+//  4. Commit     — delete the live window, insert the staged rows.
+//  5. Cleanup    — clear the tenant's staging rows.
+//
+// Validation between staging and live sits between steps 2 and 3 and is left
+// to the caller: the invariants worth checking are specific to each MV's
+// aggregate columns.
+//
+// All steps are idempotent so callers (Temporal activities) can retry safely:
+// Prepare and Cleanup are deletes, StageChunk re-runs are absorbed by
+// Prepare's staging clear on a fresh run, Archive clears its run's rows
+// before re-inserting, and Commit's synchronous delete also clears any
+// partial insert from a failed prior attempt.
+package mvbackfill
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// Spec wires one materialized-view backfill into the driver. All identifiers
+// are interpolated into SQL, so they must be compile-time constants — only
+// tenant IDs and time bounds are bound as query parameters.
+type Spec struct {
+	// SourceTable is the raw table the rebuild replays (e.g. telemetry_logs).
+	SourceTable string
+
+	// SourceTimeColumn is the Int64 unix-nano event-time column on
+	// SourceTable that windows the replay.
+	SourceTimeColumn string
+
+	// SourceColumns is the explicit list of SourceTable's ordinary
+	// (non-materialized) columns, shared with FeedTable. A positional
+	// SELECT * would break when the physical column order of the migrated
+	// source table differs from the freshly created feed table (columns
+	// added via ALTER land at the end of the source but in declared order
+	// on the feed).
+	SourceColumns string
+
+	// FeedTable is the Null-engine clone of SourceTable that the staging MV
+	// reads from.
+	FeedTable string
+
+	// LiveTable is the materialized view's target table being rebuilt.
+	LiveTable string
+
+	// StagingTable receives the rebuilt rows from the staging MV. Identical
+	// schema to LiveTable.
+	StagingTable string
+
+	// ArchiveTable receives pre-delete snapshots of live rows. Schema is
+	// LiveTable's columns prefixed with a backfill_run_id column.
+	ArchiveTable string
+
+	// TenantColumn scopes every statement to one tenant
+	// (e.g. gram_project_id).
+	TenantColumn string
+
+	// BucketColumn is the DateTime aggregation bucket column on the live,
+	// staging, and archive tables.
+	BucketColumn string
+
+	// Columns is the explicit shared column list of the live, staging, and
+	// archive tables, keeping the INSERT ... SELECTs immune to column order
+	// drift.
+	Columns string
+}
+
+// Driver executes the staging lifecycle for a single Spec. It is stateless
+// beyond the connection and safe for concurrent use across tenants.
+type Driver struct {
+	conn clickhouse.Conn
+	spec Spec
+}
+
+func NewDriver(conn clickhouse.Conn, spec Spec) *Driver {
+	return &Driver{conn: conn, spec: spec}
+}
+
+// mutationCtx makes ALTER ... DELETE block until the mutation has been
+// applied on the server, so a returned nil error means the rows are actually
+// gone and a follow-up INSERT cannot race the delete.
+func mutationCtx(ctx context.Context) context.Context {
+	return clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"mutations_sync": 1,
+	}))
+}
+
+// SourceWindow measures the tenant's raw source rows below the boundary.
+// RowCount zero means there is nothing to backfill (MinTime/MaxTime are the
+// unix epoch in that case).
+type SourceWindow struct {
+	RowCount uint64
+	MinTime  time.Time
+	MaxTime  time.Time
+}
+
+// Prepare clears any staging leftovers for the tenant (from an earlier
+// aborted or crashed run) and measures the tenant's raw source window below
+// the boundary. The window bounds drive the caller's chunked staging loop.
+func (d *Driver) Prepare(ctx context.Context, tenant string, boundary time.Time) (*SourceWindow, error) {
+	if err := d.conn.Exec(mutationCtx(ctx),
+		"ALTER TABLE "+d.spec.StagingTable+" DELETE WHERE "+d.spec.TenantColumn+" = ?",
+		tenant,
+	); err != nil {
+		return nil, fmt.Errorf("clear staging rows: %w", err)
+	}
+
+	var count uint64
+	var minNano, maxNano int64
+	if err := d.conn.QueryRow(ctx,
+		"SELECT count(), coalesce(min("+d.spec.SourceTimeColumn+"), 0), coalesce(max("+d.spec.SourceTimeColumn+"), 0) "+
+			"FROM "+d.spec.SourceTable+" WHERE "+d.spec.TenantColumn+" = ? AND "+d.spec.SourceTimeColumn+" < ?",
+		tenant, boundary.UnixNano(),
+	).Scan(&count, &minNano, &maxNano); err != nil {
+		return nil, fmt.Errorf("measure source window: %w", err)
+	}
+
+	return &SourceWindow{
+		RowCount: count,
+		MinTime:  time.Unix(0, minNano).UTC(),
+		MaxTime:  time.Unix(0, maxNano).UTC(),
+	}, nil
+}
+
+// StageChunk replays the tenant's raw source rows in [from, to) through the
+// Null-engine feed. The attached staging MV performs the actual rollup into
+// the staging table. Only the ordinary columns are carried by name (never
+// positionally — the migrated source table's physical order differs from the
+// feed's declared order); the feed table recomputes the materialized columns
+// the MV reads.
+func (d *Driver) StageChunk(ctx context.Context, tenant string, from time.Time, to time.Time) error {
+	if err := d.conn.Exec(ctx,
+		"INSERT INTO "+d.spec.FeedTable+" ("+d.spec.SourceColumns+") "+
+			"SELECT "+d.spec.SourceColumns+" FROM "+d.spec.SourceTable+
+			" WHERE "+d.spec.TenantColumn+" = ? AND "+d.spec.SourceTimeColumn+" >= ? AND "+d.spec.SourceTimeColumn+" < ?",
+		tenant, from.UnixNano(), to.UnixNano(),
+	); err != nil {
+		return fmt.Errorf("stage source chunk: %w", err)
+	}
+	return nil
+}
+
+// ArchiveResult reports the pre-commit snapshot. DeleteWindowStart is
+// min(bucket) of the staged rebuild — the commit deletes live rows in
+// [DeleteWindowStart, boundary). Live buckets older than the staged coverage
+// are never touched (the raw-retention clamp: summaries whose raw rows
+// already expired cannot be rebuilt, so they are not deleted).
+type ArchiveResult struct {
+	ArchivedRowCount  uint64
+	DeleteWindowStart time.Time
+}
+
+// Archive snapshots the tenant's live rows in the delete window into the
+// archive table, keyed by runID for post-commit restores. It must fully
+// succeed before Commit runs so the snapshot is taken from untouched live
+// data; re-runs first clear this run's rows, making it idempotent.
+func (d *Driver) Archive(ctx context.Context, tenant string, boundary time.Time, runID string) (*ArchiveResult, error) {
+	if runID == "" {
+		return nil, fmt.Errorf("backfill run ID is required")
+	}
+
+	windowStart, err := d.stagingWindowStart(ctx, tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.conn.Exec(mutationCtx(ctx),
+		"ALTER TABLE "+d.spec.ArchiveTable+" DELETE WHERE backfill_run_id = ?",
+		runID,
+	); err != nil {
+		return nil, fmt.Errorf("clear prior archive attempt: %w", err)
+	}
+
+	if err := d.conn.Exec(ctx,
+		"INSERT INTO "+d.spec.ArchiveTable+" (backfill_run_id, "+d.spec.Columns+") "+
+			"SELECT ?, "+d.spec.Columns+" FROM "+d.spec.LiveTable+
+			" WHERE "+d.spec.TenantColumn+" = ? AND "+d.spec.BucketColumn+" >= ? AND "+d.spec.BucketColumn+" < ?",
+		runID, tenant, windowStart, boundary,
+	); err != nil {
+		return nil, fmt.Errorf("archive live rows: %w", err)
+	}
+
+	var archived uint64
+	if err := d.conn.QueryRow(ctx,
+		"SELECT count() FROM "+d.spec.ArchiveTable+" WHERE backfill_run_id = ?",
+		runID,
+	).Scan(&archived); err != nil {
+		return nil, fmt.Errorf("count archived rows: %w", err)
+	}
+
+	return &ArchiveResult{
+		ArchivedRowCount:  archived,
+		DeleteWindowStart: windowStart,
+	}, nil
+}
+
+// CommitResult reports the swap. InsertedRowCount is the tenant's live row
+// count inside the swapped window right after the insert (pre-merge, so it
+// roughly matches the staging count).
+type CommitResult struct {
+	DeleteWindowStart time.Time
+	InsertedRowCount  uint64
+}
+
+// Commit swaps the staged rebuild into the live table: delete the tenant's
+// live rows in [staging min bucket, boundary), then insert the staged rows.
+// The synchronous delete also clears any partial insert left by a failed
+// earlier attempt, so retrying the whole operation is safe. Buckets at or
+// after the boundary were written by the live MV during the run and are
+// untouched — no gap, no double count.
+func (d *Driver) Commit(ctx context.Context, tenant string, boundary time.Time) (*CommitResult, error) {
+	windowStart, err := d.stagingWindowStart(ctx, tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.conn.Exec(mutationCtx(ctx),
+		"ALTER TABLE "+d.spec.LiveTable+" DELETE WHERE "+d.spec.TenantColumn+" = ? AND "+d.spec.BucketColumn+" >= ? AND "+d.spec.BucketColumn+" < ?",
+		tenant, windowStart, boundary,
+	); err != nil {
+		return nil, fmt.Errorf("delete live window: %w", err)
+	}
+
+	if err := d.conn.Exec(ctx,
+		"INSERT INTO "+d.spec.LiveTable+" ("+d.spec.Columns+") "+
+			"SELECT "+d.spec.Columns+" FROM "+d.spec.StagingTable+
+			" WHERE "+d.spec.TenantColumn+" = ? AND "+d.spec.BucketColumn+" < ?",
+		tenant, boundary,
+	); err != nil {
+		return nil, fmt.Errorf("insert staged rows into live table: %w", err)
+	}
+
+	var inserted uint64
+	if err := d.conn.QueryRow(ctx,
+		"SELECT count() FROM "+d.spec.LiveTable+
+			" WHERE "+d.spec.TenantColumn+" = ? AND "+d.spec.BucketColumn+" >= ? AND "+d.spec.BucketColumn+" < ?",
+		tenant, windowStart, boundary,
+	).Scan(&inserted); err != nil {
+		return nil, fmt.Errorf("count swapped live rows: %w", err)
+	}
+
+	return &CommitResult{
+		DeleteWindowStart: windowStart,
+		InsertedRowCount:  inserted,
+	}, nil
+}
+
+// stagingWindowStart returns min(bucket) of the tenant's staged rows — the
+// lower bound of the live delete window. Erroring on an empty staging table
+// protects against ever deleting live rows that nothing would replace.
+func (d *Driver) stagingWindowStart(ctx context.Context, tenant string) (time.Time, error) {
+	var count uint64
+	var minBucket time.Time
+	if err := d.conn.QueryRow(ctx,
+		"SELECT count(), coalesce(min("+d.spec.BucketColumn+"), toDateTime(0, 'UTC')) FROM "+d.spec.StagingTable+
+			" WHERE "+d.spec.TenantColumn+" = ?",
+		tenant,
+	).Scan(&count, &minBucket); err != nil {
+		return time.Time{}, fmt.Errorf("query staging window: %w", err)
+	}
+	if count == 0 {
+		return time.Time{}, fmt.Errorf("staging table has no rows for tenant %s", tenant)
+	}
+	return minBucket.UTC(), nil
+}
+
+// Cleanup clears the tenant's staged rows. Safe to run after a commit and
+// after an abort; a failure here never invalidates a committed swap (Prepare
+// re-clears on the next run anyway).
+func (d *Driver) Cleanup(ctx context.Context, tenant string) error {
+	if err := d.conn.Exec(mutationCtx(ctx),
+		"ALTER TABLE "+d.spec.StagingTable+" DELETE WHERE "+d.spec.TenantColumn+" = ?",
+		tenant,
+	); err != nil {
+		return fmt.Errorf("clear staging rows: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

> Stacked on #4058 (backfill staging DDL), which stacks on #4026 (provenance-first attribute metrics) — merge in that order; GitHub retargets automatically as each base merges.

- Adds a tenant-scoped backfiller that rebuilds `attribute_metrics_summaries` from raw `telemetry_logs` using the Null-table staging pattern: raw rows are replayed through a Null-engine feed so the deployed backfill MV performs the rollup into a staging table — the transform can never drift from the schema. The staging MV (DDL in #4058) mirrors the provenance-first live MV from #4026 (Claude OTEL `api_request`/`tool_result` rows, Codex/Cursor usage and completed tool-call hook rows, everything else excluded), so a rebuild is exactly how historical data adopts the new rules — including deduped `unique_tool_calls`.
- The staging/archive/commit mechanics live in a generic `server/internal/mvbackfill` driver (spec-wired, reusable for other MVs later); everything specific to this MV — table wiring and the validation stats over its aggregate columns — stays in the activities package.
- A Temporal workflow (`BackfillAttributeMetricsSummariesWorkflow`) orchestrates the run in two operator-gated phases: stage + validate automatically, then park on a signal until an operator reviews the staging-vs-live report (exposed via a query handler) and approves or aborts. On approval the live window is archived, then swapped (synchronous delete + insert); on abort staging is cleared and live data is untouched.
- The validation report surfaces both the legacy row-counted and deduped tool-call totals, plus a staging-vs-live comparison of every conserved measure, so the operator can verify that totals only move where the MV logic intentionally changed (tool counting, excluded sources).

## Safety properties

- Hour-aligned boundary: buckets at/after the boundary keep being written by the live MV during the run — no gap, no double count.
- Raw-retention clamp: the commit only deletes live buckets the staged rebuild actually covers, so summaries whose raw logs already expired are never deleted.
- Archive-before-commit snapshot keyed by run ID for post-commit restores.
- All activities are idempotent so Temporal retries are safe; mutations run with `mutations_sync=1`.

## Operating it

```
temporal workflow start --type BackfillAttributeMetricsSummariesWorkflow \
  --task-queue <queue> --workflow-id 'v1:backfill-attribute-metrics-summaries:<project-id>' \
  --input '{"project_id": "<project-id>"}'
temporal workflow query --workflow-id ... --type backfill-validation-report
temporal workflow signal --workflow-id ... \
  --name backfill-attribute-metrics-decision --input '{"approve": true}'
```

## Test plan

- [x] Workflow unit tests: commit on approval, abort on rejection, no-raw-logs short circuit, validation report query
- [x] ClickHouse integration test driving the real activities end to end: provenance classification of legacy/empty hook_source rows, tool_result dedup (re-emitted tool_use_id counts once), pre-cutoff history restored, stale live rows replaced and archived
- [x] `mise build:server`, `mise lint:server`
- [x] End-to-end local run: workflow staged, validated, parked on the operator signal, and committed after approval against a seeded local ClickHouse