### PR TITLE
fix(dashboard): pass key directly to ProjectCard/ProjectRow in OrgHome

### DIFF
--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -215,7 +215,6 @@ function OrgHomeInner() {
 
   const renderProjectItem = (project: OrgProject) => {
     const props = {
-      key: project.id,
       project,
       latestLog: latestActionByProjectSlug.get(project.slug),
       facepile: getFacepileMembers(project.slug),
@@ -223,9 +222,9 @@ function OrgHomeInner() {
       onToggleFavorite: () => toggleFavorite(project.id),
     };
     return viewMode === "grid" ? (
-      <ProjectCard {...props} />
+      <ProjectCard key={project.id} {...props} />
     ) : (
-      <ProjectRow {...props} />
+      <ProjectRow key={project.id} {...props} />
     );
   };
 


### PR DESCRIPTION
The org home render logged a React warning because `key` was included in the shared `props` object and spread into `ProjectCard`/`ProjectRow` (`OrgHome.tsx:232`). React doesn't allow `key` to be spread via JSX.

Removed `key` from the props object and pass it explicitly on each element instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AGE-2736 by removing `key` from the shared props in `OrgHome` and passing `key={project.id}` directly to `ProjectCard` and `ProjectRow` to stop the React warning. No UI or behavior changes; this just removes console noise during org home render.

<sup>Written for commit 4b663ce693cc586fc8095d7329faf1dc160a37e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

