### PR TITLE
feat(dashboard): manage identity providers on toolset MCP servers

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -771,9 +771,8 @@ function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
     const needsEnableDialog =
       status === "disabled" || currentStatus === "disabled";
     const needsPublicWarning = goingPublic && systemVarNames.length > 0;
-    // Guard on toolset.mcpIsPublic rather than currentStatus: a disabled
-    // server can still carry mcp_is_public=true, and selecting Private would
-    // flip it (and clear the OAuth config) all the same.
+    // Guard on mcpIsPublic, not currentStatus: a disabled server can still
+    // carry mcp_is_public=true, and Private would flip it (clearing OAuth).
     const needsConvertBlock =
       status === "private" &&
       mustConvertOAuthBeforePrivate({

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -56,6 +56,11 @@ import {
   EXCLUDED_TAG_KEY,
   MCPToolFilterScopesPanel,
 } from "@/pages/mcp/MCPToolFilterScopesPanel";
+import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
+import {
+  getOAuthParadigm,
+  mustConvertOAuthBeforePrivate,
+} from "./toolsetAuthSurface";
 import { useRoutes } from "@/routes";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
 import { useAddOAuthProxyServerMutation } from "@gram/client/react-query/addOAuthProxyServer.js";
@@ -664,6 +669,7 @@ function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
     target: ServerStatus;
     sourceStatus: ServerStatus;
   } | null>(null);
+  const [convertOAuthBlockOpen, setConvertOAuthBlockOpen] = useState(false);
   const updateToolsetMutation = useUpdateToolsetMutation();
   const telemetry = useTelemetry();
 
@@ -765,11 +771,27 @@ function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
     const needsEnableDialog =
       status === "disabled" || currentStatus === "disabled";
     const needsPublicWarning = goingPublic && systemVarNames.length > 0;
+    // Guard on toolset.mcpIsPublic rather than currentStatus: a disabled
+    // server can still carry mcp_is_public=true, and selecting Private would
+    // flip it (and clear the OAuth config) all the same.
+    const needsConvertBlock =
+      status === "private" &&
+      mustConvertOAuthBeforePrivate({
+        flagEnabled:
+          telemetry.isFeatureEnabled(
+            ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG,
+          ) ?? false,
+        mcpIsPublic: toolset.mcpIsPublic ?? false,
+        userSessionIssuerWired: Boolean(toolset.userSessionIssuerId),
+        oauthParadigm: getOAuthParadigm(toolset),
+      });
 
     // Defer state changes until after the dropdown has fully closed to avoid
     // Radix focus-trap conflicts (same pattern as before).
     setTimeout(() => {
-      if (needsPublicWarning) {
+      if (needsConvertBlock) {
+        setConvertOAuthBlockOpen(true);
+      } else if (needsPublicWarning) {
         // Show the system-vars warning first. If the user confirms, we chain to
         // ServerEnableDialog when the transition also requires enablement.
         setPublicWarningPending({
@@ -848,6 +870,26 @@ function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
+      <Dialog
+        open={convertOAuthBlockOpen}
+        onOpenChange={setConvertOAuthBlockOpen}
+      >
+        <Dialog.Content className="max-w-md">
+          <Dialog.Header>
+            <Dialog.Title>Convert OAuth configuration first</Dialog.Title>
+            <Dialog.Description>
+              The existing OAuth configuration must be converted to a session
+              issuer before this MCP server can be made private. You can convert
+              it from the Authentication section on this page.
+            </Dialog.Description>
+          </Dialog.Header>
+          <Dialog.Footer>
+            <Button onClick={() => setConvertOAuthBlockOpen(false)}>
+              Close
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
       <PublicMcpWarningDialog
         isOpen={publicWarningPending !== null}
         onClose={() => setPublicWarningPending(null)}

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -59,6 +59,7 @@ import {
 import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import {
   getOAuthParadigm,
+  isUserSessionIssuerWired,
   mustConvertOAuthBeforePrivate,
 } from "./toolsetAuthSurface";
 import { useRoutes } from "@/routes";
@@ -781,7 +782,7 @@ function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
             ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG,
           ) ?? false,
         mcpIsPublic: toolset.mcpIsPublic ?? false,
-        userSessionIssuerWired: Boolean(toolset.userSessionIssuerId),
+        userSessionIssuerWired: isUserSessionIssuerWired(toolset),
         oauthParadigm: getOAuthParadigm(toolset),
       });
 

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -52,6 +52,7 @@ import {
 } from "./ToolsetAuthenticationSection";
 import {
   getOAuthParadigm,
+  isUserSessionIssuerWired,
   type OAuthParadigm,
   toolsetAuthSurface,
   type ToolsetConvertAction,
@@ -911,8 +912,7 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
     flagEnabled:
       telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
       false,
-    userSessionIssuerWired:
-      !!toolset.userSessionIssuerId || !!toolset.userSessionIssuerSlug,
+    userSessionIssuerWired: isUserSessionIssuerWired(toolset),
     oauthParadigm,
   });
 

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -898,10 +898,12 @@ type OAuthSectionProps = {
   toolset: Toolset;
 };
 
-// Dispatches between the user-sessions authentication surface and the legacy
-// OAuth section based on the toolset's auth state (see toolsetAuthSurface).
-// A wired user_session_issuer or a clean slate gets the shared authentication
-// section; a legacy OAuth config keeps the old UI plus a convert path.
+/**
+ * Dispatches between the user-sessions surface and the legacy OAuth section
+ * by the toolset's auth state (see toolsetAuthSurface). A wired issuer or a
+ * clean slate gets the shared section; legacy OAuth keeps the old UI plus a
+ * convert path.
+ */
 function OAuthSection({ toolset }: OAuthSectionProps) {
   const telemetry = useTelemetry();
   const oauthParadigm = getOAuthParadigm(toolset);
@@ -931,7 +933,7 @@ function LegacyOAuthSection({
   toolset,
   convertAction,
 }: OAuthSectionProps & {
-  // The migration entry point to render, null when the feature flag is off.
+  /** Migration entry point to render; null when the flag is off. */
   convertAction: ToolsetConvertAction | null;
 }) {
   const [isOAuthModalOpen, setIsOAuthModalOpen] = useState(false);
@@ -979,19 +981,14 @@ function LegacyOAuthSection({
     ? "Enable the MCP server to configure OAuth"
     : "This MCP server does not require the OAuth authorization code flow";
 
-  // userSessionIssuerSlug is populated by the toolsets read path when the
-  // OAuth-Proxy → user-sessions migration has produced a user_session_issuer
-  // for this toolset. Flag holders with a wired issuer never reach this
-  // component (the dispatcher above sends them to the manage surface), but
-  // non-holders can land here wired, so the legacy display still handles it.
+  // Flag holders with a wired issuer never reach this component (the
+  // dispatcher sends them to the manage surface), but non-holders can land
+  // here wired, so the legacy display still handles it.
   const userSessionIssuerWired = !!toolset.userSessionIssuerSlug;
-  // The wire-modal migration applies to both OAuth Proxy paradigms (custom
-  // and gram-managed): both produce a user_session_issuer, even though
-  // gram-managed skips the remote_session_* pair.
+  // Wire-modal covers both OAuth Proxy paradigms (custom and gram-managed).
   const showWireUserSessionIssuer = convertAction === "wire-modal";
-  // Once the user_session_issuer is wired, the OAuth-proxy CLIENT_ID/SECRET
-  // it was cloned from is no longer the live credential — hide Configure to
-  // avoid steering operators back into the legacy paradigm.
+  // Once wired, the cloned CLIENT_ID/SECRET is no longer live — hide Configure
+  // so operators aren't steered back into the legacy paradigm.
   const hideConfigureButton = userSessionIssuerWired;
 
   return (

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -46,6 +46,17 @@ import {
   EnvironmentVariable,
   getValueForEnvironment,
 } from "./environmentVariableUtils";
+import {
+  ConvertToUserSessionsButton,
+  ToolsetAuthenticationSection,
+} from "./ToolsetAuthenticationSection";
+import {
+  getOAuthParadigm,
+  type OAuthParadigm,
+  toolsetAuthSurface,
+  type ToolsetConvertAction,
+  toolsetConvertAction,
+} from "./toolsetAuthSurface";
 import { useEnvironmentVariables } from "./useEnvironmentVariables";
 import { shouldRenderWireUserSessionIssuerModal } from "./wire-user-session-issuer/rendering";
 import { WireUserSessionIssuerModal } from "./wire-user-session-issuer/WireUserSessionIssuerModal";
@@ -883,22 +894,46 @@ export function MCPAuthenticationTab({
   );
 }
 
-type OAuthParadigm = "external" | "gram" | "proxy";
-
-function getOAuthParadigm(toolset: Toolset): OAuthParadigm | null {
-  if (toolset.externalOauthServer) return "external";
-  if (!toolset.oauthProxyServer) return null;
-  return toolset.oauthProxyServer.oauthProxyProviders?.[0]?.providerType ===
-    "gram"
-    ? "gram"
-    : "proxy";
-}
-
 type OAuthSectionProps = {
   toolset: Toolset;
 };
 
+// Dispatches between the user-sessions authentication surface and the legacy
+// OAuth section based on the toolset's auth state (see toolsetAuthSurface).
+// A wired user_session_issuer or a clean slate gets the shared authentication
+// section; a legacy OAuth config keeps the old UI plus a convert path.
 function OAuthSection({ toolset }: OAuthSectionProps) {
+  const telemetry = useTelemetry();
+  const oauthParadigm = getOAuthParadigm(toolset);
+  const surface = toolsetAuthSurface({
+    flagEnabled:
+      telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
+      false,
+    userSessionIssuerWired:
+      !!toolset.userSessionIssuerId || !!toolset.userSessionIssuerSlug,
+    oauthParadigm,
+  });
+
+  if (surface === "manage" || surface === "attach") {
+    return <ToolsetAuthenticationSection toolset={toolset} />;
+  }
+  return (
+    <LegacyOAuthSection
+      toolset={toolset}
+      convertAction={
+        surface === "legacy" ? toolsetConvertAction(oauthParadigm) : null
+      }
+    />
+  );
+}
+
+function LegacyOAuthSection({
+  toolset,
+  convertAction,
+}: OAuthSectionProps & {
+  // The migration entry point to render, null when the feature flag is off.
+  convertAction: ToolsetConvertAction | null;
+}) {
   const [isOAuthModalOpen, setIsOAuthModalOpen] = useState(false);
   const [isEditOAuthModalOpen, setIsEditOAuthModalOpen] = useState(false);
   const [isGramOAuthModalOpen, setIsGramOAuthModalOpen] = useState(false);
@@ -907,8 +942,6 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
     isWireUserSessionIssuerModalOpen,
     setIsWireUserSessionIssuerModalOpen,
   ] = useState(false);
-
-  const telemetry = useTelemetry();
 
   const { data: environmentsData } = useListEnvironments();
   const environments = environmentsData?.environments ?? [];
@@ -948,18 +981,14 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
 
   // userSessionIssuerSlug is populated by the toolsets read path when the
   // OAuth-Proxy → user-sessions migration has produced a user_session_issuer
-  // for this toolset.
+  // for this toolset. Flag holders with a wired issuer never reach this
+  // component (the dispatcher above sends them to the manage surface), but
+  // non-holders can land here wired, so the legacy display still handles it.
   const userSessionIssuerWired = !!toolset.userSessionIssuerSlug;
-  // The migration entry point appears for both OAuth Proxy paradigms (custom
+  // The wire-modal migration applies to both OAuth Proxy paradigms (custom
   // and gram-managed): both produce a user_session_issuer, even though
-  // gram-managed skips the remote_session_* pair. External-OAuth toolsets
-  // have nothing to port. Gated to feature-flag holders, and hidden once a
-  // user_session_issuer is already wired (nothing left to migrate).
-  const showWireUserSessionIssuer =
-    (telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
-      false) &&
-    !userSessionIssuerWired &&
-    (oauthParadigm === "proxy" || oauthParadigm === "gram");
+  // gram-managed skips the remote_session_* pair.
+  const showWireUserSessionIssuer = convertAction === "wire-modal";
   // Once the user_session_issuer is wired, the OAuth-proxy CLIENT_ID/SECRET
   // it was cloned from is no longer the live credential — hide Configure to
   // avoid steering operators back into the legacy paradigm.
@@ -987,6 +1016,9 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
             >
               <Button.Text>Wire User Session Issuer</Button.Text>
             </Button>
+          )}
+          {convertAction === "attach-sheet" && (
+            <ConvertToUserSessionsButton toolset={toolset} />
           )}
           {!hideConfigureButton && (
             <Tooltip>

--- a/client/dashboard/src/pages/mcp/ToolsetAuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/ToolsetAuthenticationSection.tsx
@@ -1,0 +1,74 @@
+import type { Toolset } from "@/lib/toolTypes";
+import { useRemoteSessionIssuers } from "@gram/client/react-query/remoteSessionIssuers.js";
+import { Button } from "@speakeasy-api/moonshine";
+import { useState } from "react";
+import { PageSection } from "./MCPDetails";
+import { AttachRemoteIdentityProviderSheet } from "./x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet";
+import { AuthenticationSectionBody } from "./x/tabs/settings/sections/authentication/AuthenticationSection";
+import { useToolsetAuthTarget } from "./x/tabs/settings/sections/authentication/authTarget";
+import { UserSessionsList } from "./x/tabs/settings/sections/authentication/McpServerSessionsPanel";
+import { externalOauthIssuerUrl } from "./toolsetAuthSurface";
+
+// The user-sessions authentication surface for toolset-backed MCP servers:
+// the same identity-provider configuration the remote server settings tab
+// renders, wrapped in this page's section chrome. Covers both the attach
+// state (no user_session_issuer yet) and the manage state.
+export function ToolsetAuthenticationSection({
+  toolset,
+}: {
+  toolset: Toolset;
+}): JSX.Element {
+  const target = useToolsetAuthTarget(toolset);
+
+  return (
+    <>
+      <PageSection
+        heading="Authentication"
+        description="Configure the upstream identity provider and user session settings for clients connecting to this server."
+      >
+        <AuthenticationSectionBody target={target} />
+      </PageSection>
+      {target.userSessionIssuerId && (
+        <PageSection
+          heading="User sessions"
+          description="Active sessions clients hold into this server, established via OAuth."
+        >
+          <UserSessionsList issuerId={target.userSessionIssuerId} />
+        </PageSection>
+      )}
+    </>
+  );
+}
+
+// Convert path for external-OAuth toolsets: opens the attach sheet seeded
+// with the external server's issuer URL. On success the sheet links the
+// created user_session_issuer to the toolset, which flips the page to the
+// manage surface; the external OAuth config stays in place but goes inert.
+export function ConvertToUserSessionsButton({
+  toolset,
+}: {
+  toolset: Toolset;
+}): JSX.Element {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const target = useToolsetAuthTarget(toolset);
+  // No user_session_issuer exists yet on this surface, so every issuer this
+  // project can see is selectable.
+  const { data: issuersResult } = useRemoteSessionIssuers();
+  const selectableIssuers = issuersResult?.result.items ?? [];
+
+  return (
+    <>
+      <Button variant="tertiary" onClick={() => setSheetOpen(true)}>
+        <Button.Text>Convert to User Sessions</Button.Text>
+      </Button>
+      <AttachRemoteIdentityProviderSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        target={target}
+        userSessionIssuer={null}
+        selectableIssuers={selectableIssuers}
+        initialIssuerUrl={externalOauthIssuerUrl(toolset)}
+      />
+    </>
+  );
+}

--- a/client/dashboard/src/pages/mcp/ToolsetAuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/ToolsetAuthenticationSection.tsx
@@ -9,10 +9,11 @@ import { useToolsetAuthTarget } from "./x/tabs/settings/sections/authentication/
 import { UserSessionsList } from "./x/tabs/settings/sections/authentication/McpServerSessionsPanel";
 import { externalOauthIssuerUrl } from "./toolsetAuthSurface";
 
-// The user-sessions authentication surface for toolset-backed MCP servers:
-// the same identity-provider configuration the remote server settings tab
-// renders, wrapped in this page's section chrome. Covers both the attach
-// state (no user_session_issuer yet) and the manage state.
+/**
+ * User-sessions auth surface for toolset-backed MCP servers: the remote
+ * server tab's identity-provider config wrapped in this page's section
+ * chrome. Covers both the attach state (no issuer yet) and the manage state.
+ */
 export function ToolsetAuthenticationSection({
   toolset,
 }: {
@@ -40,10 +41,12 @@ export function ToolsetAuthenticationSection({
   );
 }
 
-// Convert path for external-OAuth toolsets: opens the attach sheet seeded
-// with the external server's issuer URL. On success the sheet links the
-// created user_session_issuer to the toolset, which flips the page to the
-// manage surface; the external OAuth config stays in place but goes inert.
+/**
+ * Convert path for external-OAuth toolsets: opens the attach sheet seeded
+ * with the external server's issuer URL. On success the sheet links the new
+ * issuer to the toolset, flipping the page to the manage surface; the
+ * external OAuth config stays in place but goes inert.
+ */
 export function ConvertToUserSessionsButton({
   toolset,
 }: {
@@ -51,8 +54,7 @@ export function ConvertToUserSessionsButton({
 }): JSX.Element {
   const [sheetOpen, setSheetOpen] = useState(false);
   const target = useToolsetAuthTarget(toolset);
-  // No user_session_issuer exists yet on this surface, so every issuer this
-  // project can see is selectable.
+  // No issuer wired yet, so every issuer this project can see is selectable.
   const { data: issuersResult } = useRemoteSessionIssuers();
   const selectableIssuers = issuersResult?.result.items ?? [];
 

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.test.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.test.ts
@@ -4,6 +4,7 @@ import type { Toolset } from "@/lib/toolTypes";
 import {
   externalOauthIssuerUrl,
   getOAuthParadigm,
+  isUserSessionIssuerWired,
   mustConvertOAuthBeforePrivate,
   toolsetAuthSurface,
   toolsetConvertAction,
@@ -147,6 +148,31 @@ describe("mustConvertOAuthBeforePrivate", () => {
         oauthParadigm: "proxy",
       }),
     ).toBe(false);
+  });
+});
+
+describe("isUserSessionIssuerWired", () => {
+  it("treats either issuer field as wired", () => {
+    expect(
+      isUserSessionIssuerWired({
+        userSessionIssuerId: "usi_123",
+      } as unknown as Toolset),
+    ).toBe(true);
+    expect(
+      isUserSessionIssuerWired({
+        userSessionIssuerSlug: "my-issuer",
+      } as unknown as Toolset),
+    ).toBe(true);
+    expect(
+      isUserSessionIssuerWired({
+        userSessionIssuerId: "usi_123",
+        userSessionIssuerSlug: "my-issuer",
+      } as unknown as Toolset),
+    ).toBe(true);
+  });
+
+  it("is unwired when both fields are absent", () => {
+    expect(isUserSessionIssuerWired({} as Toolset)).toBe(false);
   });
 });
 

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.test.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import type { Toolset } from "@/lib/toolTypes";
+import {
+  externalOauthIssuerUrl,
+  getOAuthParadigm,
+  mustConvertOAuthBeforePrivate,
+  toolsetAuthSurface,
+  toolsetConvertAction,
+} from "./toolsetAuthSurface";
+
+describe("toolsetAuthSurface", () => {
+  it("shows the unchanged legacy UI when the flag is off, regardless of state", () => {
+    expect(
+      toolsetAuthSurface({
+        flagEnabled: false,
+        userSessionIssuerWired: true,
+        oauthParadigm: "proxy",
+      }),
+    ).toBe("legacy-only");
+    expect(
+      toolsetAuthSurface({
+        flagEnabled: false,
+        userSessionIssuerWired: false,
+        oauthParadigm: null,
+      }),
+    ).toBe("legacy-only");
+  });
+
+  it("shows the manage surface once a user_session_issuer is wired", () => {
+    expect(
+      toolsetAuthSurface({
+        flagEnabled: true,
+        userSessionIssuerWired: true,
+        oauthParadigm: null,
+      }),
+    ).toBe("manage");
+  });
+
+  it("prefers the manage surface over leftover legacy config", () => {
+    // Wire-migrated toolsets keep their inert oauth_proxy_server rows; the
+    // wired issuer is what gates the serve path, so it wins the tiebreak.
+    expect(
+      toolsetAuthSurface({
+        flagEnabled: true,
+        userSessionIssuerWired: true,
+        oauthParadigm: "proxy",
+      }),
+    ).toBe("manage");
+    expect(
+      toolsetAuthSurface({
+        flagEnabled: true,
+        userSessionIssuerWired: true,
+        oauthParadigm: "external",
+      }),
+    ).toBe("manage");
+  });
+
+  it("keeps the legacy surface while a legacy paradigm is configured unwired", () => {
+    for (const oauthParadigm of ["external", "gram", "proxy"] as const) {
+      expect(
+        toolsetAuthSurface({
+          flagEnabled: true,
+          userSessionIssuerWired: false,
+          oauthParadigm,
+        }),
+      ).toBe("legacy");
+    }
+  });
+
+  it("shows the attach surface when nothing is configured", () => {
+    expect(
+      toolsetAuthSurface({
+        flagEnabled: true,
+        userSessionIssuerWired: false,
+        oauthParadigm: null,
+      }),
+    ).toBe("attach");
+  });
+});
+
+describe("toolsetConvertAction", () => {
+  it("routes proxy paradigms through the wire modal", () => {
+    expect(toolsetConvertAction("proxy")).toBe("wire-modal");
+    expect(toolsetConvertAction("gram")).toBe("wire-modal");
+  });
+
+  it("routes external OAuth through the attach sheet", () => {
+    expect(toolsetConvertAction("external")).toBe("attach-sheet");
+  });
+
+  it("offers no convert path without a legacy paradigm", () => {
+    expect(toolsetConvertAction(null)).toBeNull();
+  });
+});
+
+describe("mustConvertOAuthBeforePrivate", () => {
+  it("blocks going private while legacy OAuth is configured unwired", () => {
+    for (const oauthParadigm of ["external", "gram", "proxy"] as const) {
+      expect(
+        mustConvertOAuthBeforePrivate({
+          flagEnabled: true,
+          mcpIsPublic: true,
+          userSessionIssuerWired: false,
+          oauthParadigm,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("keeps today's silent clear when the flag is off (no convert path)", () => {
+    expect(
+      mustConvertOAuthBeforePrivate({
+        flagEnabled: false,
+        mcpIsPublic: true,
+        userSessionIssuerWired: false,
+        oauthParadigm: "external",
+      }),
+    ).toBe(false);
+  });
+
+  it("allows the flip once a user session issuer is wired (leftover config is inert)", () => {
+    expect(
+      mustConvertOAuthBeforePrivate({
+        flagEnabled: true,
+        mcpIsPublic: true,
+        userSessionIssuerWired: true,
+        oauthParadigm: "external",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not block without OAuth config or when already private", () => {
+    expect(
+      mustConvertOAuthBeforePrivate({
+        flagEnabled: true,
+        mcpIsPublic: true,
+        userSessionIssuerWired: false,
+        oauthParadigm: null,
+      }),
+    ).toBe(false);
+    expect(
+      mustConvertOAuthBeforePrivate({
+        flagEnabled: true,
+        mcpIsPublic: false,
+        userSessionIssuerWired: false,
+        oauthParadigm: "proxy",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("getOAuthParadigm", () => {
+  it("prefers external OAuth over a proxy server", () => {
+    const toolset = {
+      externalOauthServer: { id: "ext" },
+      oauthProxyServer: { oauthProxyProviders: [{ providerType: "custom" }] },
+    } as unknown as Toolset;
+    expect(getOAuthParadigm(toolset)).toBe("external");
+  });
+
+  it("distinguishes gram-managed from custom proxy providers", () => {
+    const gram = {
+      oauthProxyServer: { oauthProxyProviders: [{ providerType: "gram" }] },
+    } as unknown as Toolset;
+    const custom = {
+      oauthProxyServer: { oauthProxyProviders: [{ providerType: "custom" }] },
+    } as unknown as Toolset;
+    expect(getOAuthParadigm(gram)).toBe("gram");
+    expect(getOAuthParadigm(custom)).toBe("proxy");
+  });
+
+  it("returns null when no legacy OAuth is configured", () => {
+    expect(getOAuthParadigm({} as Toolset)).toBeNull();
+  });
+});
+
+describe("externalOauthIssuerUrl", () => {
+  it("reads the RFC 8414 issuer claim from the stored metadata", () => {
+    const toolset = {
+      externalOauthServer: {
+        metadata: { issuer: "https://auth.example.com" },
+      },
+    } as unknown as Toolset;
+    expect(externalOauthIssuerUrl(toolset)).toBe("https://auth.example.com");
+  });
+
+  it("returns undefined for missing, blank, or non-string issuers", () => {
+    expect(externalOauthIssuerUrl({} as Toolset)).toBeUndefined();
+    expect(
+      externalOauthIssuerUrl({
+        externalOauthServer: { metadata: { issuer: "   " } },
+      } as unknown as Toolset),
+    ).toBeUndefined();
+    expect(
+      externalOauthIssuerUrl({
+        externalOauthServer: { metadata: { issuer: 42 } },
+      } as unknown as Toolset),
+    ).toBeUndefined();
+    expect(
+      externalOauthIssuerUrl({
+        externalOauthServer: { metadata: null },
+      } as unknown as Toolset),
+    ).toBeUndefined();
+  });
+});

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
@@ -1,0 +1,104 @@
+import type { Toolset } from "@/lib/toolTypes";
+
+// Pure decision logic for which authentication surface the toolset detail
+// page shows. Kept separate from React so the matrix stays unit testable
+// without rendering hooks.
+
+export type OAuthParadigm = "external" | "gram" | "proxy";
+
+export function getOAuthParadigm(toolset: Toolset): OAuthParadigm | null {
+  if (toolset.externalOauthServer) return "external";
+  if (!toolset.oauthProxyServer) return null;
+  return toolset.oauthProxyServer.oauthProxyProviders?.[0]?.providerType ===
+    "gram"
+    ? "gram"
+    : "proxy";
+}
+
+export type ToolsetAuthSurface =
+  // user_session_issuer wired → the shared authentication section (manage
+  // identity providers, session duration, active sessions).
+  | "manage"
+  // legacy OAuth (external / proxy / gram) configured and no
+  // user_session_issuer yet → the legacy OAuth UI plus a convert path.
+  | "legacy"
+  // nothing configured → the shared authentication section in its attach
+  // state; the legacy wizard is not reachable.
+  | "attach"
+  // feature flag off → the pre-user-sessions UI, unchanged.
+  | "legacy-only";
+
+export function toolsetAuthSurface({
+  flagEnabled,
+  userSessionIssuerWired,
+  oauthParadigm,
+}: {
+  flagEnabled: boolean;
+  userSessionIssuerWired: boolean;
+  oauthParadigm: OAuthParadigm | null;
+}): ToolsetAuthSurface {
+  if (!flagEnabled) return "legacy-only";
+  // A wired user_session_issuer always wins: once linked, the serve path
+  // gates on it and any leftover legacy OAuth config is inert.
+  if (userSessionIssuerWired) return "manage";
+  if (oauthParadigm) return "legacy";
+  return "attach";
+}
+
+// The convert path offered on the "legacy" surface. Proxy paradigms migrate
+// through the wire-user-session-issuer modal (it clones the proxy provider's
+// credentials); external OAuth has no credentials to clone, so it converts by
+// attaching a fresh identity provider through the attach sheet.
+export type ToolsetConvertAction = "wire-modal" | "attach-sheet";
+
+export function toolsetConvertAction(
+  oauthParadigm: OAuthParadigm | null,
+): ToolsetConvertAction | null {
+  switch (oauthParadigm) {
+    case "proxy":
+    case "gram":
+      return "wire-modal";
+    case "external":
+      return "attach-sheet";
+    case null:
+      return null;
+  }
+}
+
+// Whether switching the MCP server to private must be blocked until the
+// legacy OAuth config is converted to a user session issuer. The backend
+// silently clears external OAuth / OAuth proxy config on any mcp_is_public
+// flip (UpdateToolset in server/internal/toolsets/impl.go). Once a user
+// session issuer is wired the leftover legacy config is inert, so losing it
+// is harmless and the flip goes through. Flag off keeps today's silent
+// behavior since no convert path exists there.
+export function mustConvertOAuthBeforePrivate({
+  flagEnabled,
+  mcpIsPublic,
+  userSessionIssuerWired,
+  oauthParadigm,
+}: {
+  flagEnabled: boolean;
+  mcpIsPublic: boolean;
+  userSessionIssuerWired: boolean;
+  oauthParadigm: OAuthParadigm | null;
+}): boolean {
+  return (
+    flagEnabled &&
+    mcpIsPublic &&
+    !userSessionIssuerWired &&
+    oauthParadigm !== null
+  );
+}
+
+// Best-effort issuer URL to seed the attach sheet's discovery when converting
+// an external-OAuth toolset: the RFC 8414 `issuer` claim from the stored
+// metadata document, when present.
+export function externalOauthIssuerUrl(toolset: Toolset): string | undefined {
+  const metadata = toolset.externalOauthServer?.metadata as
+    | Record<string, unknown>
+    | undefined
+    | null;
+  const issuer = metadata?.["issuer"];
+  return typeof issuer === "string" && issuer.trim() ? issuer : undefined;
+}

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
@@ -1,8 +1,9 @@
 import type { Toolset } from "@/lib/toolTypes";
 
-// Pure decision logic for which authentication surface the toolset detail
-// page shows. Kept separate from React so the matrix stays unit testable
-// without rendering hooks.
+/**
+ * Pure decision logic for which authentication surface the toolset detail
+ * page shows. React-free so the matrix stays unit testable.
+ */
 
 export type OAuthParadigm = "external" | "gram" | "proxy";
 
@@ -16,16 +17,13 @@ export function getOAuthParadigm(toolset: Toolset): OAuthParadigm | null {
 }
 
 export type ToolsetAuthSurface =
-  // user_session_issuer wired → the shared authentication section (manage
-  // identity providers, session duration, active sessions).
+  // user_session_issuer wired → shared section, manage state.
   | "manage"
-  // legacy OAuth (external / proxy / gram) configured and no
-  // user_session_issuer yet → the legacy OAuth UI plus a convert path.
+  // legacy OAuth configured, unwired → legacy UI plus a convert path.
   | "legacy"
-  // nothing configured → the shared authentication section in its attach
-  // state; the legacy wizard is not reachable.
+  // nothing configured → shared section, attach state.
   | "attach"
-  // feature flag off → the pre-user-sessions UI, unchanged.
+  // flag off → pre-user-sessions UI, unchanged.
   | "legacy-only";
 
 export function toolsetAuthSurface({
@@ -38,17 +36,18 @@ export function toolsetAuthSurface({
   oauthParadigm: OAuthParadigm | null;
 }): ToolsetAuthSurface {
   if (!flagEnabled) return "legacy-only";
-  // A wired user_session_issuer always wins: once linked, the serve path
-  // gates on it and any leftover legacy OAuth config is inert.
+  // A wired issuer always wins: the serve path gates on it and any leftover
+  // legacy OAuth config is inert.
   if (userSessionIssuerWired) return "manage";
   if (oauthParadigm) return "legacy";
   return "attach";
 }
 
-// The convert path offered on the "legacy" surface. Proxy paradigms migrate
-// through the wire-user-session-issuer modal (it clones the proxy provider's
-// credentials); external OAuth has no credentials to clone, so it converts by
-// attaching a fresh identity provider through the attach sheet.
+/**
+ * Convert path offered on the "legacy" surface. Proxy paradigms migrate via
+ * the wire modal (it clones the proxy's credentials); external OAuth has none
+ * to clone, so it converts by attaching a fresh provider via the attach sheet.
+ */
 export type ToolsetConvertAction = "wire-modal" | "attach-sheet";
 
 export function toolsetConvertAction(
@@ -65,13 +64,13 @@ export function toolsetConvertAction(
   }
 }
 
-// Whether switching the MCP server to private must be blocked until the
-// legacy OAuth config is converted to a user session issuer. The backend
-// silently clears external OAuth / OAuth proxy config on any mcp_is_public
-// flip (UpdateToolset in server/internal/toolsets/impl.go). Once a user
-// session issuer is wired the leftover legacy config is inert, so losing it
-// is harmless and the flip goes through. Flag off keeps today's silent
-// behavior since no convert path exists there.
+/**
+ * Whether the public→private flip must be blocked pending OAuth conversion.
+ * The backend silently clears external OAuth / OAuth proxy config on any
+ * mcp_is_public flip (UpdateToolset in server/internal/toolsets/impl.go).
+ * A wired issuer makes leftover config inert, so the flip is safe. Flag off
+ * keeps today's silent behavior since no convert path exists there.
+ */
 export function mustConvertOAuthBeforePrivate({
   flagEnabled,
   mcpIsPublic,
@@ -91,9 +90,10 @@ export function mustConvertOAuthBeforePrivate({
   );
 }
 
-// Best-effort issuer URL to seed the attach sheet's discovery when converting
-// an external-OAuth toolset: the RFC 8414 `issuer` claim from the stored
-// metadata document, when present.
+/**
+ * Best-effort issuer URL to seed the attach sheet's discovery: the RFC 8414
+ * `issuer` claim from the external server's stored metadata, when present.
+ */
 export function externalOauthIssuerUrl(toolset: Toolset): string | undefined {
   const metadata = toolset.externalOauthServer?.metadata as
     | Record<string, unknown>

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
@@ -16,6 +16,17 @@ export function getOAuthParadigm(toolset: Toolset): OAuthParadigm | null {
     : "proxy";
 }
 
+/**
+ * Whether a user_session_issuer is wired to the toolset. The read path
+ * populates userSessionIssuerSlug together with userSessionIssuerId, but both
+ * fields are independently optional in the SDK type, so accepting either
+ * keeps every consumer (surface dispatch, private-flip guard) agreeing on
+ * wiredness rather than diverging on which field it happens to check.
+ */
+export function isUserSessionIssuerWired(toolset: Toolset): boolean {
+  return !!toolset.userSessionIssuerId || !!toolset.userSessionIssuerSlug;
+}
+
 export type ToolsetAuthSurface =
   // user_session_issuer wired → shared section, manage state.
   | "manage"

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -24,13 +24,10 @@ import {
 import { proxyRegisterUpstreamClient } from "@/lib/proxyRegisterUpstreamClient";
 import { deriveRemoteSessionIssuerNameFromUrl } from "@/lib/sources";
 import { remoteSessionClientDisplayName } from "@/pages/remote-identity-providers/clientDisplay";
-import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { RemoteSessionClient } from "@gram/client/models/components/remotesessionclient.js";
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
 import type { UserSessionIssuer } from "@gram/client/models/components/usersessionissuer.js";
 import { CreateRemoteSessionClientFormTokenEndpointAuthMethod } from "@gram/client/models/components/createremotesessionclientform.js";
-import { invalidateAllGetMcpServer } from "@gram/client/react-query/getMcpServer.js";
-import { invalidateAllMcpServers } from "@gram/client/react-query/mcpServers.js";
 import { invalidateAllRemoteSessionClients } from "@gram/client/react-query/remoteSessionClients.js";
 import { invalidateAllRemoteSessionIssuers } from "@gram/client/react-query/remoteSessionIssuers.js";
 import { invalidateAllUserSessionIssuers } from "@gram/client/react-query/userSessionIssuers.js";
@@ -38,6 +35,7 @@ import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import type { AuthTarget } from "./authTarget";
 import {
   ClientTypeFields,
   EndpointsFields,
@@ -60,16 +58,17 @@ type Mode = "select" | "new";
 export function AttachRemoteIdentityProviderSheet({
   open,
   onOpenChange,
-  mcpServer,
+  target,
   userSessionIssuer,
   selectableIssuers,
   initialIssuerUrl,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mcpServer: McpServer;
-  // null when the MCP server has no user_session_issuer linked yet — the
-  // first add also creates one and links it via updateMcpServer.
+  // The MCP server or toolset the user_session_issuer gets linked to.
+  target: AuthTarget;
+  // null when the target has no user_session_issuer linked yet — the first
+  // add also creates one and links it via target.linkUserSessionIssuer.
   userSessionIssuer: UserSessionIssuer | null;
   // remote_session_issuers (organization-level and same-project) that are not
   // already associated with userSessionIssuer. Empty list hides the issuer
@@ -226,7 +225,7 @@ export function AttachRemoteIdentityProviderSheet({
       if (!issuerId) {
         const created = await client.userSessionIssuers.create({
           createUserSessionIssuerForm: {
-            slug: buildUserSessionResourceSlug(mcpServer.slug ?? "mcp"),
+            slug: buildUserSessionResourceSlug(target.slug),
             authnChallengeMode: "interactive",
             sessionDurationHours: DEFAULT_USER_SESSION_DURATION_HOURS,
           },
@@ -366,23 +365,11 @@ export function AttachRemoteIdentityProviderSheet({
         });
       }
 
-      // Step 4: on first-add, point the MCP server at the freshly-created
-      // user_session_issuer and set visibility to private so the server
-      // begins serving traffic. updateMcpServer is a full-record replace,
-      // so re-send the existing UUID references alongside the update.
+      // Step 4: on first-add, link the target to the freshly-created
+      // user_session_issuer. How the link is stored (and any side effects
+      // like flipping a remote server private) is the target's business.
       if (!userSessionIssuer) {
-        await client.mcpServers.update({
-          updateMcpServerForm: {
-            id: mcpServer.id,
-            name: mcpServer.name ?? undefined,
-            remoteMcpServerId: mcpServer.remoteMcpServerId ?? undefined,
-            tunneledMcpServerId: mcpServer.tunneledMcpServerId ?? undefined,
-            toolsetId: mcpServer.toolsetId ?? undefined,
-            environmentId: mcpServer.environmentId ?? undefined,
-            visibility: "private",
-            userSessionIssuerId: issuerId,
-          },
-        });
+        await target.linkUserSessionIssuer(issuerId);
       }
 
       return { unsupportedDcrAuthMethod };
@@ -392,8 +379,7 @@ export function AttachRemoteIdentityProviderSheet({
         invalidateAllUserSessionIssuers(queryClient, { refetchType: "all" }),
         invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
         invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
-        invalidateAllGetMcpServer(queryClient, { refetchType: "all" }),
-        invalidateAllMcpServers(queryClient, { refetchType: "all" }),
+        target.invalidate(queryClient),
       ]);
 
       toast.success("Identity provider attached");
@@ -422,7 +408,7 @@ export function AttachRemoteIdentityProviderSheet({
     : null;
   const { reset: resetAttachMutation } = attachMutation;
 
-  // Reset transient state whenever the sheet is reopened. The mcpServer slug
+  // Reset transient state whenever the sheet is reopened. The target slug
   // seeds the default new-issuer slug so most operators can submit without
   // touching the field, but we still allow editing.
   useEffect(() => {
@@ -431,11 +417,11 @@ export function AttachRemoteIdentityProviderSheet({
     setSelectedIssuerId("");
     // Seed the slug from the Issuer URL when we have one (the "Start With
     // Discovered Configuration" path). Otherwise fall back to the
-    // mcpServer-based default. Either way slugDirty resets to false so the
+    // target-based default. Either way slugDirty resets to false so the
     // operator's first keystroke in the field starts locking it in.
     setSlug(
       deriveSlugFromUrl(initialIssuerUrl ?? "") ??
-        buildUserSessionResourceSlug(mcpServer.slug ?? "mcp"),
+        buildUserSessionResourceSlug(target.slug),
     );
     setSlugDirty(false);
     setName(deriveRemoteSessionIssuerNameFromUrl(initialIssuerUrl ?? "") ?? "");
@@ -453,7 +439,7 @@ export function AttachRemoteIdentityProviderSheet({
     resetAttachMutation();
   }, [
     open,
-    mcpServer.slug,
+    target.slug,
     initialIssuerUrl,
     hasSelectable,
     setIssuerUrl,

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -65,10 +65,10 @@ export function AttachRemoteIdentityProviderSheet({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  // The MCP server or toolset the user_session_issuer gets linked to.
+  // The MCP server or toolset the issuer gets linked to.
   target: AuthTarget;
-  // null when the target has no user_session_issuer linked yet — the first
-  // add also creates one and links it via target.linkUserSessionIssuer.
+  // null when the target has no issuer yet — the first add creates one and
+  // links it via target.linkUserSessionIssuer.
   userSessionIssuer: UserSessionIssuer | null;
   // remote_session_issuers (organization-level and same-project) that are not
   // already associated with userSessionIssuer. Empty list hides the issuer
@@ -365,9 +365,9 @@ export function AttachRemoteIdentityProviderSheet({
         });
       }
 
-      // Step 4: on first-add, link the target to the freshly-created
-      // user_session_issuer. How the link is stored (and any side effects
-      // like flipping a remote server private) is the target's business.
+      // Step 4: on first-add, link the target to the new issuer. How the link
+      // is stored (and side effects like flipping a server private) is the
+      // target's business.
       if (!userSessionIssuer) {
         await target.linkUserSessionIssuer(issuerId);
       }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
@@ -15,6 +15,7 @@ import { SettingsInlineEmptyState } from "../../SettingsInlineEmptyState";
 import { SettingsSection } from "../../SettingsSection";
 import { AttachRemoteIdentityProviderSheet } from "./AttachRemoteIdentityProviderSheet";
 import { AuthenticationSetupActions } from "./AuthenticationSetupActions";
+import { type AuthTarget, useMcpServerAuthTarget } from "./authTarget";
 import { DeleteRemoteIdentityProviderDialog } from "./DeleteRemoteIdentityProviderDialog";
 import { McpServerSessionsPanel } from "./McpServerSessionsPanel";
 import { ModifyRemoteIdentityProviderSheet } from "./ModifyRemoteIdentityProviderSheet";
@@ -28,12 +29,51 @@ import {
 
 export const MCP_AUTHENTICATION_SECTION_ID = "authentication";
 
+// Chrome wrapper for the remote/tunneled MCP server settings tab. The
+// target-agnostic body below also mounts on the toolset detail page inside
+// that page's own section chrome.
 export function AuthenticationSection({
   mcpServer,
 }: {
   mcpServer: McpServer;
 }): JSX.Element {
-  const userSessionIssuerId = mcpServer.userSessionIssuerId;
+  const target = useMcpServerAuthTarget(mcpServer);
+
+  return (
+    <>
+      <SettingsSection id={MCP_AUTHENTICATION_SECTION_ID}>
+        <SettingsSection.Header>
+          <SettingsSection.Title>Authentication</SettingsSection.Title>
+          <SettingsSection.Description>
+            Configure the upstream identity provider and user session settings
+            for clients connecting to this server.
+          </SettingsSection.Description>
+        </SettingsSection.Header>
+        <SettingsSection.Panel>
+          <SettingsSection.Body>
+            <AuthenticationSectionBody target={target} />
+          </SettingsSection.Body>
+          <SettingsSection.Footer>
+            <SettingsSection.FooterHint>
+              Authentication changes apply to new client connections.
+            </SettingsSection.FooterHint>
+          </SettingsSection.Footer>
+        </SettingsSection.Panel>
+      </SettingsSection>
+      <McpServerSessionsPanel mcpServer={mcpServer} />
+    </>
+  );
+}
+
+// The authentication configuration surface: identity-provider setup or the
+// manage fields, plus the attach/modify/delete overlays. Chrome-free so both
+// the remote server settings tab and the toolset detail page can mount it.
+export function AuthenticationSectionBody({
+  target,
+}: {
+  target: AuthTarget;
+}): JSX.Element {
+  const userSessionIssuerId = target.userSessionIssuerId ?? undefined;
   const issuerConfigured = !!userSessionIssuerId;
 
   const {
@@ -45,12 +85,10 @@ export function AuthenticationSection({
   });
 
   // Probe the remote MCP server's protected-resource metadata so setup can
-  // offer discovery when the server advertises OAuth metadata.
+  // offer discovery when the server advertises OAuth metadata. Targets with
+  // no probeable upstream (tunneled, toolset-backed) leave this idle.
   const { status: probeStatus, metadata: protectedResourceMetadata } =
-    useProtectedResourceMetadata(
-      mcpServer.remoteMcpServerId,
-      !issuerConfigured,
-    );
+    useProtectedResourceMetadata(target.remoteMcpServerId, !issuerConfigured);
   const authorizationServer =
     protectedResourceMetadata?.authorizationServers?.[0];
 
@@ -145,53 +183,34 @@ export function AuthenticationSection({
 
   return (
     <>
-      <SettingsSection id={MCP_AUTHENTICATION_SECTION_ID}>
-        <SettingsSection.Header>
-          <SettingsSection.Title>Authentication</SettingsSection.Title>
-          <SettingsSection.Description>
-            Configure the upstream identity provider and user session settings
-            for clients connecting to this server.
-          </SettingsSection.Description>
-        </SettingsSection.Header>
-        <SettingsSection.Panel>
-          <SettingsSection.Body>
-            <FieldGroup className="gap-6">{authenticationFields}</FieldGroup>
-          </SettingsSection.Body>
-          <SettingsSection.Footer>
-            <SettingsSection.FooterHint>
-              Authentication changes apply to new client connections.
-            </SettingsSection.FooterHint>
-          </SettingsSection.Footer>
-        </SettingsSection.Panel>
+      <FieldGroup className="gap-6">{authenticationFields}</FieldGroup>
 
-        <AttachRemoteIdentityProviderSheet
-          open={sheetOpen}
-          onOpenChange={setSheetOpen}
-          mcpServer={mcpServer}
-          userSessionIssuer={userSessionIssuer ?? null}
-          selectableIssuers={selectableIssuers}
-          initialIssuerUrl={sheetInitialUrl}
+      <AttachRemoteIdentityProviderSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        target={target}
+        userSessionIssuer={userSessionIssuer ?? null}
+        selectableIssuers={selectableIssuers}
+        initialIssuerUrl={sheetInitialUrl}
+      />
+
+      {deleteTarget && userSessionIssuerId && (
+        <DeleteRemoteIdentityProviderDialog
+          open={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          userSessionIssuerId={userSessionIssuerId}
+          issuer={deleteTarget}
         />
+      )}
 
-        {deleteTarget && userSessionIssuerId && (
-          <DeleteRemoteIdentityProviderDialog
-            open={deleteOpen}
-            onOpenChange={setDeleteOpen}
-            userSessionIssuerId={userSessionIssuerId}
-            issuer={deleteTarget}
-          />
-        )}
-
-        {modifyTarget && userSessionIssuer && (
-          <ModifyRemoteIdentityProviderSheet
-            open={modifyOpen}
-            onOpenChange={setModifyOpen}
-            userSessionIssuer={userSessionIssuer}
-            issuer={modifyTarget}
-          />
-        )}
-      </SettingsSection>
-      <McpServerSessionsPanel mcpServer={mcpServer} />
+      {modifyTarget && userSessionIssuer && (
+        <ModifyRemoteIdentityProviderSheet
+          open={modifyOpen}
+          onOpenChange={setModifyOpen}
+          userSessionIssuer={userSessionIssuer}
+          issuer={modifyTarget}
+        />
+      )}
     </>
   );
 }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
@@ -29,9 +29,11 @@ import {
 
 export const MCP_AUTHENTICATION_SECTION_ID = "authentication";
 
-// Chrome wrapper for the remote/tunneled MCP server settings tab. The
-// target-agnostic body below also mounts on the toolset detail page inside
-// that page's own section chrome.
+/**
+ * Chrome wrapper for the remote/tunneled MCP server settings tab. The
+ * target-agnostic body below also mounts on the toolset detail page inside
+ * that page's own section chrome.
+ */
 export function AuthenticationSection({
   mcpServer,
 }: {
@@ -65,9 +67,11 @@ export function AuthenticationSection({
   );
 }
 
-// The authentication configuration surface: identity-provider setup or the
-// manage fields, plus the attach/modify/delete overlays. Chrome-free so both
-// the remote server settings tab and the toolset detail page can mount it.
+/**
+ * The auth configuration surface: identity-provider setup or the manage
+ * fields, plus the attach/modify/delete overlays. Chrome-free so both the
+ * remote server settings tab and the toolset detail page can mount it.
+ */
 export function AuthenticationSectionBody({
   target,
 }: {
@@ -84,9 +88,9 @@ export function AuthenticationSectionBody({
     enabled: issuerConfigured,
   });
 
-  // Probe the remote MCP server's protected-resource metadata so setup can
-  // offer discovery when the server advertises OAuth metadata. Targets with
-  // no probeable upstream (tunneled, toolset-backed) leave this idle.
+  // Probe protected-resource metadata so setup can offer discovery when the
+  // server advertises OAuth metadata. Idle for targets with no probeable
+  // upstream (tunneled, toolset-backed).
   const { status: probeStatus, metadata: protectedResourceMetadata } =
     useProtectedResourceMetadata(target.remoteMcpServerId, !issuerConfigured);
   const authorizationServer =

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/McpServerSessionsPanel.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/McpServerSessionsPanel.tsx
@@ -6,7 +6,10 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SettingsSection } from "../../SettingsSection";
 
-function McpServerSessionsPanelInner({
+// Chrome-free list of a user_session_issuer's active sessions. Mounted in
+// the remote server settings tab (wrapped in SettingsSection below) and on
+// the toolset detail page inside that page's own section chrome.
+export function UserSessionsList({
   issuerId,
 }: {
   issuerId: string;
@@ -26,7 +29,7 @@ function McpServerSessionsPanelInner({
   const sessions = data?.pages.flatMap((p) => p.result.items) ?? [];
 
   return (
-    <SettingsSection.Body>
+    <>
       {isPending ? (
         <div className="space-y-2">
           {Array.from({ length: 3 }).map((_, i) => (
@@ -67,7 +70,7 @@ function McpServerSessionsPanelInner({
           </Button>
         </div>
       )}
-    </SettingsSection.Body>
+    </>
   );
 }
 
@@ -87,15 +90,15 @@ export function McpServerSessionsPanel({
         </SettingsSection.Description>
       </SettingsSection.Header>
       <SettingsSection.Panel>
-        {issuerId ? (
-          <McpServerSessionsPanelInner issuerId={issuerId} />
-        ) : (
-          <SettingsSection.Body>
+        <SettingsSection.Body>
+          {issuerId ? (
+            <UserSessionsList issuerId={issuerId} />
+          ) : (
             <p className="text-muted-foreground text-sm">
               This server isn&apos;t gated by a session issuer.
             </p>
-          </SettingsSection.Body>
-        )}
+          )}
+        </SettingsSection.Body>
       </SettingsSection.Panel>
     </SettingsSection>
   );

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/McpServerSessionsPanel.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/McpServerSessionsPanel.tsx
@@ -6,9 +6,11 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SettingsSection } from "../../SettingsSection";
 
-// Chrome-free list of a user_session_issuer's active sessions. Mounted in
-// the remote server settings tab (wrapped in SettingsSection below) and on
-// the toolset detail page inside that page's own section chrome.
+/**
+ * Chrome-free list of an issuer's active sessions. Mounted in the remote
+ * server settings tab (wrapped in SettingsSection below) and on the toolset
+ * detail page inside that page's own section chrome.
+ */
 export function UserSessionsList({
   issuerId,
 }: {

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
@@ -8,24 +8,25 @@ import { invalidateAllToolset } from "@gram/client/react-query/toolset.js";
 import type { QueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-// AuthTarget abstracts the resource a user_session_issuer gets linked to. The
-// authentication components (section body, attach sheet, sessions list) only
-// ever talk to this interface; the two implementations below know whether the
-// link lives on mcp_servers.user_session_issuer_id or
-// toolsets.user_session_issuer_id.
+/**
+ * Abstracts the resource a user_session_issuer links to. The auth components
+ * (section body, attach sheet, sessions list) only talk to this interface;
+ * the implementations below know whether the link lives on
+ * mcp_servers.user_session_issuer_id or toolsets.user_session_issuer_id.
+ */
 export type AuthTarget = {
-  // Slug seeding auto-derived user_session_issuer / remote_session_issuer
-  // slugs on first add.
+  /** Seeds auto-derived issuer slugs on first add. */
   slug: string;
-  // Current user_session_issuer link; null when the target has none yet.
+  /** Current issuer link; null when the target has none yet. */
   userSessionIssuerId: string | null;
-  // Remote MCP server id for the RFC 9728 protected-resource probe. Undefined
-  // when the target has no probeable upstream (tunneled and toolset-backed
-  // servers), which leaves the probe idle.
+  /**
+   * Remote MCP server id for the RFC 9728 probe. Undefined for targets with
+   * no probeable upstream (tunneled, toolset-backed), leaving the probe idle.
+   */
   remoteMcpServerId?: string;
-  // Link a freshly created user_session_issuer to the target (first add).
+  /** Link a freshly created issuer to the target (first add). */
   linkUserSessionIssuer: (userSessionIssuerId: string) => Promise<void>;
-  // Invalidate the target-specific queries that embed the link.
+  /** Invalidate the target-specific queries that embed the link. */
   invalidate: (queryClient: QueryClient) => Promise<void>;
 };
 
@@ -38,10 +39,9 @@ export function useMcpServerAuthTarget(mcpServer: McpServer): AuthTarget {
       userSessionIssuerId: mcpServer.userSessionIssuerId ?? null,
       remoteMcpServerId: mcpServer.remoteMcpServerId,
       linkUserSessionIssuer: async (userSessionIssuerId: string) => {
-        // Point the MCP server at the user_session_issuer and set visibility
-        // to private so the server begins serving traffic. updateMcpServer is
-        // a full-record replace, so re-send the existing UUID references
-        // alongside the update.
+        // Point the server at the issuer and set visibility private so it
+        // serves traffic. update is a full-record replace, so re-send the
+        // existing UUID references alongside.
         await client.mcpServers.update({
           updateMcpServerForm: {
             id: mcpServer.id,
@@ -74,8 +74,8 @@ export function useToolsetAuthTarget(toolset: Toolset): AuthTarget {
       slug: toolset.slug,
       userSessionIssuerId: toolset.userSessionIssuerId ?? null,
       linkUserSessionIssuer: async (userSessionIssuerId: string) => {
-        // Toolset-backed servers are already live, so linking only flips auth
-        // gating — mcpEnabled / mcpIsPublic stay untouched.
+        // Toolsets are already live, so linking only flips auth gating —
+        // mcpEnabled / mcpIsPublic stay untouched.
         await client.toolsets.setUserSessionIssuer({
           slug: toolset.slug,
           setUserSessionIssuerRequestBody: { userSessionIssuerId },

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
@@ -50,6 +50,7 @@ export function useMcpServerAuthTarget(mcpServer: McpServer): AuthTarget {
             tunneledMcpServerId: mcpServer.tunneledMcpServerId ?? undefined,
             toolsetId: mcpServer.toolsetId ?? undefined,
             environmentId: mcpServer.environmentId ?? undefined,
+            toolVariationsGroupId: mcpServer.toolVariationsGroupId ?? undefined,
             visibility: "private",
             userSessionIssuerId,
           },

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
@@ -1,0 +1,93 @@
+import { useSdkClient } from "@/contexts/Sdk";
+import type { Toolset } from "@/lib/toolTypes";
+import type { McpServer } from "@gram/client/models/components/mcpserver.js";
+import { invalidateAllGetMcpServer } from "@gram/client/react-query/getMcpServer.js";
+import { invalidateAllListToolsets } from "@gram/client/react-query/listToolsets.js";
+import { invalidateAllMcpServers } from "@gram/client/react-query/mcpServers.js";
+import { invalidateAllToolset } from "@gram/client/react-query/toolset.js";
+import type { QueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+// AuthTarget abstracts the resource a user_session_issuer gets linked to. The
+// authentication components (section body, attach sheet, sessions list) only
+// ever talk to this interface; the two implementations below know whether the
+// link lives on mcp_servers.user_session_issuer_id or
+// toolsets.user_session_issuer_id.
+export type AuthTarget = {
+  // Slug seeding auto-derived user_session_issuer / remote_session_issuer
+  // slugs on first add.
+  slug: string;
+  // Current user_session_issuer link; null when the target has none yet.
+  userSessionIssuerId: string | null;
+  // Remote MCP server id for the RFC 9728 protected-resource probe. Undefined
+  // when the target has no probeable upstream (tunneled and toolset-backed
+  // servers), which leaves the probe idle.
+  remoteMcpServerId?: string;
+  // Link a freshly created user_session_issuer to the target (first add).
+  linkUserSessionIssuer: (userSessionIssuerId: string) => Promise<void>;
+  // Invalidate the target-specific queries that embed the link.
+  invalidate: (queryClient: QueryClient) => Promise<void>;
+};
+
+export function useMcpServerAuthTarget(mcpServer: McpServer): AuthTarget {
+  const client = useSdkClient();
+
+  return useMemo(
+    () => ({
+      slug: mcpServer.slug ?? "mcp",
+      userSessionIssuerId: mcpServer.userSessionIssuerId ?? null,
+      remoteMcpServerId: mcpServer.remoteMcpServerId,
+      linkUserSessionIssuer: async (userSessionIssuerId: string) => {
+        // Point the MCP server at the user_session_issuer and set visibility
+        // to private so the server begins serving traffic. updateMcpServer is
+        // a full-record replace, so re-send the existing UUID references
+        // alongside the update.
+        await client.mcpServers.update({
+          updateMcpServerForm: {
+            id: mcpServer.id,
+            name: mcpServer.name ?? undefined,
+            remoteMcpServerId: mcpServer.remoteMcpServerId ?? undefined,
+            tunneledMcpServerId: mcpServer.tunneledMcpServerId ?? undefined,
+            toolsetId: mcpServer.toolsetId ?? undefined,
+            environmentId: mcpServer.environmentId ?? undefined,
+            visibility: "private",
+            userSessionIssuerId,
+          },
+        });
+      },
+      invalidate: async (queryClient: QueryClient) => {
+        await Promise.all([
+          invalidateAllGetMcpServer(queryClient, { refetchType: "all" }),
+          invalidateAllMcpServers(queryClient, { refetchType: "all" }),
+        ]);
+      },
+    }),
+    [client, mcpServer],
+  );
+}
+
+export function useToolsetAuthTarget(toolset: Toolset): AuthTarget {
+  const client = useSdkClient();
+
+  return useMemo(
+    () => ({
+      slug: toolset.slug,
+      userSessionIssuerId: toolset.userSessionIssuerId ?? null,
+      linkUserSessionIssuer: async (userSessionIssuerId: string) => {
+        // Toolset-backed servers are already live, so linking only flips auth
+        // gating — mcpEnabled / mcpIsPublic stay untouched.
+        await client.toolsets.setUserSessionIssuer({
+          slug: toolset.slug,
+          setUserSessionIssuerRequestBody: { userSessionIssuerId },
+        });
+      },
+      invalidate: async (queryClient: QueryClient) => {
+        await Promise.all([
+          invalidateAllToolset(queryClient, { refetchType: "all" }),
+          invalidateAllListToolsets(queryClient, { refetchType: "all" }),
+        ]);
+      },
+    }),
+    [client, toolset],
+  );
+}

--- a/docs/toolset-remote-session-config.md
+++ b/docs/toolset-remote-session-config.md
@@ -1,0 +1,61 @@
+# Handover: RSI/RSC configuration for toolset-based MCP servers
+
+Branch: `walker/toolset-remote-session-config` (off `origin/main`, uncommitted working tree).
+Status: implementation complete, all checks green, manual browser verification done except one edge (see "Remaining work").
+
+## Goal
+
+Bring the remote-MCP-server identity-provider configuration (user session issuer + remote session issuer/client, the "sheet" flow) to toolset/catalog-based MCP servers on the old toolset detail page. Motivation: USI/RSI/RSC is the target auth direction for all server kinds, and today a toolset that gets a USI wired via the one-shot `WireUserSessionIssuerModal` has no UI to tweak or manage it afterwards.
+
+## Agreed design decisions (from spec interview, 2026-07-08)
+
+1. Frontend-only, single PR. Backend already type-agnostic: the serve path gates on `toolsets.user_session_issuer_id`, and when it is set the issuer gate wins and the legacy OAuth chain is skipped entirely (`server/internal/mcp/impl.go`, ~line 642, `runInToolsetGate`).
+2. Shared components parameterized by an `AuthTarget` interface (state-context composition pattern). Remote target links via `mcpServers.update` (keeps its visibility-private side effect); toolset target links via `toolsets.setUserSessionIssuer` and touches nothing else (no `mcpEnabled`/`mcpIsPublic` changes).
+3. State matrix on the toolset Authentication tab, USI-first tiebreak:
+   - Flag off: today's UI, byte-for-byte (`legacy-only`).
+   - USI wired: shared manage surface only, even if inert legacy config remains (`manage`).
+   - Legacy OAuth configured, unwired: legacy UI plus a convert path (`legacy`). Proxy/gram paradigms convert via the existing wire modal; external OAuth converts via the attach sheet with the issuer URL prefilled from the stored RFC 8414 metadata.
+   - Nothing configured: shared attach surface only, legacy wizard unreachable (`attach`).
+4. No full USI unlink anywhere. Once wired, the link is permanent; only the RSI/RSC layer is tweakable (add/edit/remove identity providers).
+5. Convert leaves legacy config in the DB inert (wire-modal precedent). No `removeOAuthServer` call.
+6. Whole matrix gated behind the existing `ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG` PostHog flag. In local dev, `devTelemetry` returns true for every flag, so the new surfaces always show locally.
+
+## What changed (all in `client/dashboard/src/pages/mcp/`)
+
+New files:
+
+- `x/tabs/settings/sections/authentication/authTarget.ts`: `AuthTarget` type plus `useMcpServerAuthTarget` and `useToolsetAuthTarget` hooks. Each supplies `slug`, `userSessionIssuerId`, optional `remoteMcpServerId` (probe seed, undefined for toolsets so the RFC 9728 probe stays idle), `linkUserSessionIssuer`, and `invalidate`.
+- `toolsetAuthSurface.ts`: pure matrix logic. `getOAuthParadigm` (moved out of MCPEnvironmentSettings), `toolsetAuthSurface`, `toolsetConvertAction`, `externalOauthIssuerUrl`. Note: `toolsetConvertAction` uses `case null` because oxlint enforces switch exhaustiveness.
+- `toolsetAuthSurface.test.ts`: 13 unit tests, all passing.
+- `ToolsetAuthenticationSection.tsx`: toolset-page chrome. `ToolsetAuthenticationSection` renders a PageSection "Authentication" wrapping `AuthenticationSectionBody`, plus a PageSection "User sessions" wrapping `UserSessionsList` when wired. `ConvertToUserSessionsButton` is the external-OAuth convert entry (opens the attach sheet with `userSessionIssuer={null}` and all project issuers selectable).
+
+Modified files:
+
+- `x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx`: prop `mcpServer: McpServer` replaced by `target: AuthTarget`. Slug seeding uses `target.slug`, step 4 first-add link is `target.linkUserSessionIssuer(issuerId)`, and target-specific invalidations go through `target.invalidate(queryClient)` alongside the common USI/RSI/RSC ones.
+- `x/tabs/settings/sections/authentication/AuthenticationSection.tsx`: split into chrome-free exported `AuthenticationSectionBody({ target })` (all queries, fields, and the attach/modify/delete overlays) and the thin `AuthenticationSection({ mcpServer })` wrapper that keeps the SettingsSection chrome and sessions panel. Remote page output unchanged. Gotcha: body converts `target.userSessionIssuerId` (string | null) to undefined for the SDK hooks.
+- `x/tabs/settings/sections/authentication/McpServerSessionsPanel.tsx`: inner list extracted as exported chrome-free `UserSessionsList({ issuerId })`; the panel wrapper is unchanged.
+- `MCPDetails.tsx`: `MCPStatusDropdown` now blocks the public→private flip while legacy OAuth is configured unwired. Backend (`UpdateToolset`, `server/internal/toolsets/impl.go` ~line 413) silently clears external OAuth / OAuth proxy config on any `mcp_is_public` flip; the new `mustConvertOAuthBeforePrivate` guard (in `toolsetAuthSurface.ts`, unit tested) shows a blocking inform-only dialog ("The existing OAuth configuration must be converted to a session issuer before this MCP server can be made private") instead of applying the update. Flag-gated like the rest of the matrix (flag off keeps today's silent clear); once a USI is wired the flip is allowed since leftover config is inert. Guards on `toolset.mcpIsPublic`, not the dropdown's current status, so a disabled-but-still-public server is covered too.
+- `MCPEnvironmentSettings.tsx`: `OAuthSection` is now a small dispatcher (computes paradigm + surface, routes to `ToolsetAuthenticationSection` or legacy). The old body is renamed `LegacyOAuthSection` and takes `convertAction: ToolsetConvertAction | null`; `showWireUserSessionIssuer` is now just `convertAction === "wire-modal"`, and an `attach-sheet` convertAction renders `ConvertToUserSessionsButton` next to it. Everything else in the legacy component (modals, status display, badges) is untouched.
+
+Untouched on purpose: `WireUserSessionIssuerModal` and its machine, `ModifyRemoteIdentityProviderSheet`, `DeleteRemoteIdentityProviderDialog` (both already target-agnostic, keyed by USI/RSI ids only), all backend code.
+
+## Verification done
+
+- `pnpm -F dashboard type-check`, `pnpm -F dashboard lint`: green.
+- `pnpm -F dashboard test toolsetAuthSurface`: 13/13 pass. The full suite has 53 failures in 7 files, but the identical failures exist on clean main (verified by stashing and rerunning), so they are pre-existing.
+- Browser against local stack (dashboard at https://localhost:5173, note HTTPS):
+  - Remote server regression: `/mcp/x/r-linear-9e27/settings#authentication` renders exactly as before (session duration, issuer row with Edit/Delete, user sessions panel).
+  - Manage surface: `/mcp/linear#authentication` (toolset with USI wired) shows Authentication + User sessions sections, attach sheet opens.
+  - Attach surface: `/mcp/jamf#authentication` (unconfigured toolset) shows the "No authentication configured" empty state with Configure Manually (Use Discovered disabled since no probe), no sessions section, no legacy wizard.
+  - No console errors.
+
+## Remaining work
+
+1. Not manually verified: the `legacy` surface (legacy OAuth configured, unwired) with its convert buttons. No local toolset has an OAuth proxy or external OAuth configured. Options: seed one locally for a visual check, or rely on unit tests plus the untouched wire modal. Walker had not chosen when this doc was written.
+2. Commit + PR (use the `pr` skill; remember the `env -u GH_TOKEN -u GITHUB_TOKEN` prefix for gh writes). Suggested demo: pr-demo-gif of the toolset attach flow.
+3. Possible reviewer question: `ConvertToUserSessionsButton` mounts its own `useRemoteSessionIssuers()`; fine per React Query dedup.
+
+## Related context
+
+- Memory file: `project_toolset_rsi_rsc_sheet.md` in the project memory dir holds the same decisions in short form.
+- Related future work: remove-oauth-proxy spec (`docs/remove-oauth-proxy-for-user-session-issuer.md`) eventually kills the legacy wizard; AGE-1902 unifies toolset servers into `/mcp/x`, at which point the same `AuthenticationSectionBody` remounts there.


### PR DESCRIPTION
## What

Brings the remote-MCP-server identity-provider configuration (user session issuer + remote session issuer/client "sheet" flow) to toolset/catalog-based MCP servers on the toolset detail page, and adds a guard that blocks switching a public MCP server to private while unconverted legacy OAuth config would be silently cleared.

Frontend-only. The backend serve path is already type-agnostic: when `toolsets.user_session_issuer_id` is set, the issuer gate wins and the legacy OAuth chain is skipped.

## Why

USI/RSI/RSC is the target auth direction for all server kinds. Today a toolset that gets a USI wired via the one-shot `WireUserSessionIssuerModal` has no UI to manage it afterwards. Separately, `UpdateToolset` silently clears external OAuth / OAuth proxy config on any `mcp_is_public` flip, so a user toggling a public server to private loses their OAuth setup with no warning.

## How

- **`AuthTarget` abstraction** (`authTarget.ts`): shared components are parameterized by a small interface (`slug`, `userSessionIssuerId`, optional probe seed, `linkUserSessionIssuer`, `invalidate`). Remote servers link via `mcpServers.update`; toolsets link via `toolsets.setUserSessionIssuer` and touch nothing else.
- **Auth surface matrix** (`toolsetAuthSurface.ts`, unit tested): flag off → today's UI unchanged; USI wired → shared manage surface; legacy OAuth configured unwired → legacy UI plus a convert path; nothing configured → shared attach surface (legacy wizard unreachable).
- **Shared components split chrome-free**: `AuthenticationSectionBody`, `UserSessionsList`, and `AttachRemoteIdentityProviderSheet` now take a `target` instead of an `McpServer`; the remote `/mcp/x` page output is unchanged.
- **Public→private guard** (`mustConvertOAuthBeforePrivate` + blocking dialog in `MCPStatusDropdown`): "The existing OAuth configuration must be converted to a session issuer before this MCP server can be made private." Once a USI is wired the flip is allowed (leftover legacy config is inert). Guards on `toolset.mcpIsPublic`, not dropdown status, so a disabled-but-still-public server is covered.

Everything is gated behind the existing `ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG` PostHog flag; flag off is byte-for-byte today's behavior, including the silent clear (no convert path exists there).

## Notes for reviewers

- No full USI unlink anywhere; once wired, only the RSI/RSC layer is manageable. Convert leaves legacy config in the DB inert (wire-modal precedent).
- `WireUserSessionIssuerModal`, `ModifyRemoteIdentityProviderSheet`, `DeleteRemoteIdentityProviderDialog`, and all backend code are untouched.
- Verified in browser against the local stack: remote-server page regression, manage/attach/legacy surfaces, and the private-flip block (config intact after a blocked flip; the unguarded flip was reproduced first and does clear the DB columns).
- `docs/toolset-remote-session-config.md` carries the design decisions and verification log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds identity provider management to toolset-based MCP servers using the same attach/manage UI as remote servers. Blocks public→private flips until legacy OAuth is converted to a session issuer.

- **New Features**
  - Toolset detail page shows Authentication and User sessions with the shared UI.
  - `AuthTarget` enables attach/manage flows for both remote servers and toolsets; `toolsetAuthSurface` selects attach/manage/legacy with conversion paths: proxy/gram via wire modal, external OAuth via attach sheet seeded from RFC 8414 `issuer`.
  - Behind `ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG`; flag off keeps today’s legacy UI; remote MCP settings unchanged.
  - Unit tests cover the surface matrix; added `docs/toolset-remote-session-config.md`.

- **Bug Fixes**
  - Preserves `toolVariationsGroupId` when wiring a user session issuer on remote MCP servers.
  - Unifies wired-state detection via shared `isUserSessionIssuerWired` used by both the surface dispatcher and the private-flip guard.

<sup>Written for commit a62f39b23095921b86957882b1b4792aa3afbbaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

