### PR TITLE
mig: introduces nonblocking warning policy type

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3651,6 +3651,11 @@ CREATE TABLE IF NOT EXISTS risk_policy_challenges (
   entity TEXT,
   rule_id TEXT,
 
+  -- SHA-256 (hex) of the exact scanned call input. Scopes an acknowledgement to
+  -- one concrete call, so an ack clears only an identical retry — not every call
+  -- of the same tool under the same policy. NULL for non-call-scoped rows.
+  call_fingerprint TEXT,
+
   challenged_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   acknowledged_at timestamptz,
   -- When an acknowledgement stops suppressing re-challenge (the "remember" window).
@@ -3671,7 +3676,7 @@ CREATE TABLE IF NOT EXISTS risk_policy_challenges (
 COMMENT ON TABLE risk_policy_challenges IS 'Interactive warn/challenge lifecycle for warn-action policies: a warn match records a challenged row; the user self-service acknowledges to proceed on retry. Never stores the raw matched value.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS risk_policy_challenges_current_key
-ON risk_policy_challenges (project_id, user_id, risk_policy_id, tool_name) NULLS NOT DISTINCT
+ON risk_policy_challenges (project_id, user_id, risk_policy_id, tool_name, call_fingerprint) NULLS NOT DISTINCT
 WHERE deleted IS FALSE;
 
 CREATE INDEX IF NOT EXISTS risk_policy_challenges_project_status_updated_idx
@@ -3679,7 +3684,7 @@ ON risk_policy_challenges (project_id, status, updated_at DESC)
 WHERE deleted IS FALSE;
 
 CREATE INDEX IF NOT EXISTS risk_policy_challenges_active_ack_idx
-ON risk_policy_challenges (project_id, user_id, risk_policy_id, tool_name, expires_at)
+ON risk_policy_challenges (project_id, user_id, risk_policy_id, tool_name, call_fingerprint, expires_at)
 WHERE deleted IS FALSE AND status = 'acknowledged';
 
 -- Non-partial indexes backing the ON DELETE CASCADE foreign keys. The RI

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1518,23 +1518,24 @@ type RiskPolicyBypassRequest struct {
 
 // Interactive warn/challenge lifecycle for warn-action policies: a warn match records a challenged row; the user self-service acknowledges to proceed on retry. Never stores the raw matched value.
 type RiskPolicyChallenge struct {
-	ID             uuid.UUID
-	OrganizationID string
-	ProjectID      uuid.UUID
-	RiskPolicyID   uuid.UUID
-	UserID         string
-	ToolName       pgtype.Text
-	Status         string
-	PolicyName     pgtype.Text
-	Entity         pgtype.Text
-	RuleID         pgtype.Text
-	ChallengedAt   pgtype.Timestamptz
-	AcknowledgedAt pgtype.Timestamptz
-	ExpiresAt      pgtype.Timestamptz
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
-	DeletedAt      pgtype.Timestamptz
-	Deleted        bool
+	ID              uuid.UUID
+	OrganizationID  string
+	ProjectID       uuid.UUID
+	RiskPolicyID    uuid.UUID
+	UserID          string
+	ToolName        pgtype.Text
+	Status          string
+	PolicyName      pgtype.Text
+	Entity          pgtype.Text
+	RuleID          pgtype.Text
+	CallFingerprint pgtype.Text
+	ChallengedAt    pgtype.Timestamptz
+	AcknowledgedAt  pgtype.Timestamptz
+	ExpiresAt       pgtype.Timestamptz
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+	DeletedAt       pgtype.Timestamptz
+	Deleted         bool
 }
 
 type RiskPolicyEvalReview struct {

--- a/server/migrations/20260709083351_risk-policy-challenge-call-fingerprint.sql
+++ b/server/migrations/20260709083351_risk-policy-challenge-call-fingerprint.sql
@@ -1,0 +1,12 @@
+-- atlas:txmode none
+
+-- Drop index "risk_policy_challenges_active_ack_idx" from table: "risk_policy_challenges"
+DROP INDEX CONCURRENTLY "risk_policy_challenges_active_ack_idx";
+-- Drop index "risk_policy_challenges_current_key" from table: "risk_policy_challenges"
+DROP INDEX CONCURRENTLY "risk_policy_challenges_current_key";
+-- Modify "risk_policy_challenges" table
+ALTER TABLE "risk_policy_challenges" ADD COLUMN "call_fingerprint" text NULL;
+-- Create index "risk_policy_challenges_active_ack_idx" to table: "risk_policy_challenges"
+CREATE INDEX CONCURRENTLY "risk_policy_challenges_active_ack_idx" ON "risk_policy_challenges" ("project_id", "user_id", "risk_policy_id", "tool_name", "call_fingerprint", "expires_at") WHERE ((deleted IS FALSE) AND (status = 'acknowledged'::text));
+-- Create index "risk_policy_challenges_current_key" to table: "risk_policy_challenges"
+CREATE UNIQUE INDEX CONCURRENTLY "risk_policy_challenges_current_key" ON "risk_policy_challenges" ("project_id", "user_id", "risk_policy_id", "tool_name", "call_fingerprint") NULLS NOT DISTINCT WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:gYOFuZrjCAtkYrSAxvC9uYCSluDdobVO/Jpj6eXy7p8=
+h1:Jp8LOPvMBdpALdutn9SnDX33BjhqoqyzH7yHOVupZZA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -252,3 +252,4 @@ h1:gYOFuZrjCAtkYrSAxvC9uYCSluDdobVO/Jpj6eXy7p8=
 20260708203242_chats-add-project-id-index.sql h1:6mzOm6Z7RUHSx94M5JH93IOTSM5MmtVdgcCbM//86Io=
 20260708221138_comment-users-admin-platform-admin.sql h1:OWKP0Byie6YS9Ji7I3NlK7ik2b6NF6C9T2HyUH/5p7k=
 20260708232901_add-user-session-issuer-classification.sql h1:vs+5d/Qj35hGa90mEysuL1tFakAUOWmuqTUDUVuz118=
+20260709083351_risk-policy-challenge-call-fingerprint.sql h1:jIIXDWLontE+WT4GeA17OSO3rojBf76ZLETT9i2bubA=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/3875 so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes risk policy challenge acknowledgements to a single tool call by adding a `call_fingerprint` to `risk_policy_challenges`. Prevents an ack from suppressing future, non-identical calls; updates indexes and the Go model.

- **New Features**
  - Added `call_fingerprint` (SHA-256 hex of call input) to `risk_policy_challenges` so acknowledgements only clear identical retries.
  - Updated unique and active-ack indexes to include `call_fingerprint`. Updated `RiskPolicyChallenge` with `CallFingerprint`.

- **Migration**
  - Adds a nullable column and rebuilds indexes concurrently. No backfill required; existing rows remain valid.

<sup>Written for commit 8ee66988d9daeeac61144c9a2f44e1ca61a4e997. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

