### PR TITLE
fix(risk): honor rule_id and other filters when policy_id is set

### DIFF
--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1065,13 +1065,13 @@ func (s *Service) listRiskResultsRaw(ctx context.Context, payload *gen.ListRiskR
 	// policy_id + rule_id are honored. When set, the count is scoped to that
 	// policy (and includes disabled policies for historical findings) to match
 	// the list query's semantics.
-	var policyID uuid.NullUUID
+	var policyIDInput *string
 	if payload.PolicyID != nil && *payload.PolicyID != "" {
-		parsed, err := uuid.Parse(*payload.PolicyID)
-		if err != nil {
-			return nil, oops.C(oops.CodeInvalid)
-		}
-		policyID = uuid.NullUUID{UUID: parsed, Valid: true}
+		policyIDInput = payload.PolicyID
+	}
+	policyID, err := conv.PtrToNullUUID(policyIDInput)
+	if err != nil {
+		return nil, oops.E(oops.CodeInvalid, err, "invalid policy ID")
 	}
 
 	category := ""

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1060,11 +1060,18 @@ func (s *Service) listRiskResultsRaw(ctx context.Context, payload *gen.ListRiskR
 		}
 		return s.listResultsByChat(ctx, *authCtx.ProjectID, *payload.ChatID, cursor, pageSize, totalCount)
 	}
-	// The by-policy listing includes disabled policies (historical findings),
-	// so its count is computed inside listResultsByPolicy with the same
-	// semantics rather than from the enabled-only project aggregate.
+	// A policy filter is applied alongside the other filters rather than
+	// short-circuiting to a separate listing, so combinations like
+	// policy_id + rule_id are honored. When set, the count is scoped to that
+	// policy (and includes disabled policies for historical findings) to match
+	// the list query's semantics.
+	var policyID uuid.NullUUID
 	if payload.PolicyID != nil && *payload.PolicyID != "" {
-		return s.listResultsByPolicy(ctx, *authCtx.ProjectID, *payload.PolicyID, cursor, pageSize)
+		parsed, err := uuid.Parse(*payload.PolicyID)
+		if err != nil {
+			return nil, oops.C(oops.CodeInvalid)
+		}
+		policyID = uuid.NullUUID{UUID: parsed, Valid: true}
 	}
 
 	category := ""
@@ -1091,11 +1098,20 @@ func (s *Service) listRiskResultsRaw(ctx context.Context, payload *gen.ListRiskR
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid to").LogError(ctx, s.logger)
 	}
-	totalCount, err := s.repo.CountAllFindings(ctx, *authCtx.ProjectID)
+
+	var totalCount int64
+	if policyID.Valid {
+		totalCount, err = s.repo.CountRiskResultsByProjectAndPolicy(ctx, repo.CountRiskResultsByProjectAndPolicyParams{
+			ProjectID:    *authCtx.ProjectID,
+			RiskPolicyID: policyID.UUID,
+		})
+	} else {
+		totalCount, err = s.repo.CountAllFindings(ctx, *authCtx.ProjectID)
+	}
 	if err != nil {
 		totalCount = 0
 	}
-	return s.listResultsByProject(ctx, *authCtx.ProjectID, cursor, pageSize, totalCount, category, ruleID, userID, uniqueMatch, fromTime, toTime)
+	return s.listResultsByProject(ctx, *authCtx.ProjectID, cursor, pageSize, totalCount, policyID, category, ruleID, userID, uniqueMatch, fromTime, toTime)
 }
 
 func parseOptionalTimestamptz(raw *string) (pgtype.Timestamptz, error) {
@@ -1549,45 +1565,11 @@ func (s *Service) listResultsByChat(ctx context.Context, projectID uuid.UUID, ra
 	return s.paginateResults(results, nextCursor, pageSize, totalCount), nil
 }
 
-func (s *Service) listResultsByPolicy(ctx context.Context, projectID uuid.UUID, rawPolicyID string, cursor *riskResultsCursor, pageSize int) (*gen.ListRiskResultsResult, error) {
-	policyID, err := uuid.Parse(rawPolicyID)
-	if err != nil {
-		return nil, oops.C(oops.CodeInvalid)
-	}
-	totalCount, err := s.repo.CountRiskResultsByProjectAndPolicy(ctx, repo.CountRiskResultsByProjectAndPolicyParams{
-		ProjectID:    projectID,
-		RiskPolicyID: policyID,
-	})
-	if err != nil {
-		totalCount = 0
-	}
-	cursorCreatedAt, cursorID := cursorToParams(cursor)
-	rows, err := s.repo.ListRiskResultsByProjectAndPolicy(ctx, repo.ListRiskResultsByProjectAndPolicyParams{
-		ProjectID:              projectID,
-		RiskPolicyID:           policyID,
-		CursorMessageCreatedAt: cursorCreatedAt,
-		CursorID:               cursorID,
-		PageLimit:              conv.SafeInt32(pageSize + 1),
-	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk results by policy").LogError(ctx, s.logger)
-	}
-	results := make([]*types.RiskResult, 0, len(rows))
-	var nextCursor *riskResultsCursor
-	for i, row := range rows {
-		chatID := row.ChatID.String()
-		results = append(results, foundRowToResult(row.ID, row.RiskPolicyID, row.RiskPolicyVersion, row.BlockID, row.ChatMessageID, &chatID, row.ChatTitle, row.ChatUserID, row.Source, row.RuleID, row.Description, row.Match, row.StartPos, row.EndPos, row.Confidence, row.Tags, row.Spans, row.MessageCreatedAt))
-		if i == pageSize {
-			nextCursor = &riskResultsCursor{MessageCreatedAt: row.MessageCreatedAt.Time, ID: row.ID}
-		}
-	}
-	return s.paginateResults(results, nextCursor, pageSize, totalCount), nil
-}
-
-func (s *Service) listResultsByProject(ctx context.Context, projectID uuid.UUID, cursor *riskResultsCursor, pageSize int, totalCount int64, category string, ruleID string, userID string, uniqueMatch bool, fromTime, toTime pgtype.Timestamptz) (*gen.ListRiskResultsResult, error) {
+func (s *Service) listResultsByProject(ctx context.Context, projectID uuid.UUID, cursor *riskResultsCursor, pageSize int, totalCount int64, policyID uuid.NullUUID, category string, ruleID string, userID string, uniqueMatch bool, fromTime, toTime pgtype.Timestamptz) (*gen.ListRiskResultsResult, error) {
 	cursorCreatedAt, cursorID := cursorToParams(cursor)
 	rows, err := s.repo.ListRiskResultsByProjectFound(ctx, repo.ListRiskResultsByProjectFoundParams{
 		ProjectID:              projectID,
+		PolicyID:               policyID,
 		FromTime:               fromTime,
 		ToTime:                 toTime,
 		Category:               category,

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -815,6 +815,11 @@ WHERE rr.id = @id
 -- (risk_policy_id, rule_id, match), choosing the most recent occurrence. Done
 -- inside a subquery so pagination over the deduped stream stays correct
 -- (client-side dedup over paged data broke "Load more").
+--
+-- @policy_id is optional. When NULL only enabled policies are considered (the
+-- default project-wide view). When set the results are scoped to that policy
+-- AND disabled-but-not-deleted policies are included, so explicitly filtering
+-- to a policy still surfaces its historical findings after it was turned off.
 SELECT
     sub.id, sub.project_id, sub.organization_id, sub.risk_policy_id,
     sub.risk_policy_version, sub.chat_message_id, sub.source, sub.found,
@@ -841,7 +846,8 @@ FROM (
   FROM risk_results rr
   JOIN chat_messages cm ON cm.id = rr.chat_message_id
   LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
-  JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
+  JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE
+    AND (rp.enabled IS TRUE OR rr.risk_policy_id = sqlc.narg(policy_id)::uuid)
   LEFT JOIN LATERAL (
     SELECT tcb.id AS block_id FROM tool_call_blocks tcb
     WHERE tcb.project_id = rr.project_id
@@ -851,6 +857,7 @@ FROM (
   ) blk ON TRUE
   WHERE rr.project_id = @project_id
     AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
+    AND (sqlc.narg(policy_id)::uuid IS NULL OR rr.risk_policy_id = sqlc.narg(policy_id)::uuid)
     AND (sqlc.narg(from_time)::timestamptz IS NULL OR cm.created_at >= sqlc.narg(from_time)::timestamptz)
     AND (sqlc.narg(to_time)::timestamptz IS NULL OR cm.created_at < sqlc.narg(to_time)::timestamptz)
     AND (@rule_id::text = '' OR rr.rule_id ILIKE '%' || @rule_id::text || '%')

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -2519,7 +2519,8 @@ FROM (
   FROM risk_results rr
   JOIN chat_messages cm ON cm.id = rr.chat_message_id
   LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
-  JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
+  JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE
+    AND (rp.enabled IS TRUE OR rr.risk_policy_id = $2::uuid)
   LEFT JOIN LATERAL (
     SELECT tcb.id AS block_id FROM tool_call_blocks tcb
     WHERE tcb.project_id = rr.project_id
@@ -2527,13 +2528,14 @@ FROM (
       AND tcb.deleted IS FALSE
     ORDER BY tcb.created_at DESC LIMIT 1
   ) blk ON TRUE
-  WHERE rr.project_id = $2
+  WHERE rr.project_id = $3
     AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
-    AND ($3::timestamptz IS NULL OR cm.created_at >= $3::timestamptz)
-    AND ($4::timestamptz IS NULL OR cm.created_at < $4::timestamptz)
-    AND ($5::text = '' OR rr.rule_id ILIKE '%' || $5::text || '%')
-    AND ($6::text = '' OR c.external_user_id ILIKE '%' || $6::text || '%')
-    AND ($7::text = '' OR (
+    AND ($2::uuid IS NULL OR rr.risk_policy_id = $2::uuid)
+    AND ($4::timestamptz IS NULL OR cm.created_at >= $4::timestamptz)
+    AND ($5::timestamptz IS NULL OR cm.created_at < $5::timestamptz)
+    AND ($6::text = '' OR rr.rule_id ILIKE '%' || $6::text || '%')
+    AND ($7::text = '' OR c.external_user_id ILIKE '%' || $7::text || '%')
+    AND ($8::text = '' OR (
     CASE
       WHEN rr.source = 'llm_judge' THEN 'prompt_policy'
       WHEN rr.source IN ('shadow_mcp', 'destructive_tool', 'cli_destructive', 'prompt_injection') THEN rr.source
@@ -2579,19 +2581,20 @@ FROM (
       WHEN rr.source = 'presidio' THEN 'pii'
       ELSE 'custom'
     END
-  ) = $7::text)
+  ) = $8::text)
 ) sub
 WHERE sub.dedup_rank = 1
   AND (
-    $8::timestamptz IS NULL
-    OR (sub.message_created_at, sub.id) < ($8::timestamptz, $9::uuid)
+    $9::timestamptz IS NULL
+    OR (sub.message_created_at, sub.id) < ($9::timestamptz, $10::uuid)
   )
 ORDER BY sub.message_created_at DESC, sub.id DESC
-LIMIT $10
+LIMIT $11
 `
 
 type ListRiskResultsByProjectFoundParams struct {
 	UniqueMatch            bool
+	PolicyID               uuid.NullUUID
 	ProjectID              uuid.UUID
 	FromTime               pgtype.Timestamptz
 	ToTime                 pgtype.Timestamptz
@@ -2643,9 +2646,15 @@ type ListRiskResultsByProjectFoundRow struct {
 // (risk_policy_id, rule_id, match), choosing the most recent occurrence. Done
 // inside a subquery so pagination over the deduped stream stays correct
 // (client-side dedup over paged data broke "Load more").
+//
+// @policy_id is optional. When NULL only enabled policies are considered (the
+// default project-wide view). When set the results are scoped to that policy
+// AND disabled-but-not-deleted policies are included, so explicitly filtering
+// to a policy still surfaces its historical findings after it was turned off.
 func (q *Queries) ListRiskResultsByProjectFound(ctx context.Context, arg ListRiskResultsByProjectFoundParams) ([]ListRiskResultsByProjectFoundRow, error) {
 	rows, err := q.db.Query(ctx, listRiskResultsByProjectFound,
 		arg.UniqueMatch,
+		arg.PolicyID,
 		arg.ProjectID,
 		arg.FromTime,
 		arg.ToTime,

--- a/server/internal/risk/results_test.go
+++ b/server/internal/risk/results_test.go
@@ -150,6 +150,38 @@ func TestListRiskResults_ByPolicy_DisabledPolicyShowsHistoricalFindings(t *testi
 	require.Equal(t, int64(0), unfiltered.TotalCount, "unfiltered total count should not include disabled-policy findings")
 }
 
+// A policy filter must not swallow the other filters. Selecting a policy and a
+// rule id together has to honor both, otherwise (as reported in FDE-32) picking
+// a policy causes rule_id/user_id/category/time filters to be silently ignored.
+func TestListRiskResults_ByPolicyAndRuleID(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Policy+Rule Filter")})
+	require.NoError(t, err)
+	policyID, _ := uuid.Parse(policy.ID)
+
+	_, injMsg := seedChatMessage(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID)
+	seedRiskResultWith(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, policyID, injMsg, "prompt_injection", "prompt_injection", "ignore previous instructions")
+
+	_, emailMsg := seedChatMessage(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID)
+	seedRiskResultWith(t, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, policyID, emailMsg, "presidio", "pii.email_address", "a@b.com")
+
+	ruleID := "prompt_injection"
+	result, err := ti.service.ListRiskResults(ctx, &gen.ListRiskResultsPayload{
+		PolicyID: &policy.ID,
+		RuleID:   &ruleID,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Results, 1, "policy + rule_id filter should return only the matching rule")
+	require.Equal(t, "prompt_injection", *result.Results[0].RuleID)
+}
+
 func TestListRiskResults_ByChatID(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestRiskService(t)


### PR DESCRIPTION
`/rpc/risk.listResults` short-circuited to a policy-only listing whenever a `policy_id` was provided, silently dropping the `rule_id`, `user_id`, `category`, time-range and `unique_match` filters. So a request like `policy_id=…&rule_id=prompt_injection` returned findings from every rule (e.g. `Telephone number`, `Email address`), as reported by SmartNews.

The fix applies the policy filter *alongside* the other filters via the unified project-found query rather than routing to a separate query. An optional `policy_id` narg scopes results to that policy and relaxes the enabled-only join so an explicitly selected disabled policy still surfaces its historical findings — preserving the existing behavior for that case, plus now honoring the date range and unique-match toggle there too.

Added a test asserting that `policy_id` + `rule_id` returns only the matching rule.

Note: `ListRiskResultsByProjectAndPolicy` (and its count) are kept as they're still used elsewhere in tests; only the listing path in `listRiskResultsRaw` was rerouted.

---

## Summary by cubic

Fixes risk results filtering so `policy_id` works with `rule_id`, `user_id`, `category`, time range, and `unique_match`, and counts scope correctly. Resolves Linear [AIS-288](https://linear.app/speakeasy/issue/AIS-288/bug-rpcrisklistresults-does-not-respect-rule-id-filter) by aligning `/rpc/risk.listResults` with expected behavior, including historical findings for explicitly selected disabled policies.

* **Bug Fixes**
  * Apply `policy_id` alongside other filters in the unified project query; explicitly selected disabled policies still return historical findings.
  * When `policy_id` is set, count is scoped to that policy; otherwise use project-wide count.
  * Parse `policy_id` with `conv.PtrToNullUUID`; normalize empty string to no filter; return `oops.E(oops.CodeInvalid, err, "invalid policy ID")` for invalid IDs.
  * Removed the policy-only listing path and added a test asserting `policy_id` + `rule_id` returns only the matching rule.

Written for commit 65723d1653e8dec7a39d6d23d3ea8b86228f03e3. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)