### PR TITLE
fix(dashboard): remove confusing hooks warning from detector cards

### DIFF
--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -103,14 +103,6 @@ import {
   getPolicyRuleGroupNamesForDeleteDialog,
 } from "./policy-delete-dialog";
 
-/** Built-in detector categories that only produce findings when Speakeasy hooks
- *  are installed on the agent (no rule list to customize). */
-const HOOK_REQUIRED_CATEGORIES: Set<RuleCategory> = new Set([
-  "shadow_mcp",
-  "destructive_tool",
-  "account_identity",
-]);
-
 /** One built-in detector as a toggleable card (Detect step). "Customize" opens
  *  a side-sheet to pick which rules in the category are active. */
 export function DetectorCard({
@@ -132,7 +124,6 @@ export function DetectorCard({
   const customizable = available && rules.length > 1;
   const enabledCount = rules.filter((r) => !disabledRules.has(r.id)).length;
   const customized = selected && enabledCount < rules.length;
-  const needsHook = HOOK_REQUIRED_CATEGORIES.has(category);
   return (
     <div
       className={cn(
@@ -157,21 +148,17 @@ export function DetectorCard({
           {meta.description}
         </p>
         <div className="mt-2 flex items-center gap-3 text-xs">
-          {needsHook ? (
-            <span className="text-warning">Requires Speakeasy hooks</span>
-          ) : (
-            rules.length > 0 && (
-              <span
-                className={cn(
-                  "bg-muted rounded-full px-2 py-0.5",
-                  customized ? "text-foreground" : "text-muted-foreground",
-                )}
-              >
-                {customized
-                  ? `${enabledCount} of ${rules.length} rules`
-                  : `${rules.length} rules`}
-              </span>
-            )
+          {rules.length > 0 && (
+            <span
+              className={cn(
+                "bg-muted rounded-full px-2 py-0.5",
+                customized ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {customized
+                ? `${enabledCount} of ${rules.length} rules`
+                : `${rules.length} rules`}
+            </span>
           )}
           {selected && customizable && (
             <button


### PR DESCRIPTION
## Why

PR #3835 removed the "Requires Speakeasy hooks" badge (and the now-unused `HOOK_REQUIRED_CATEGORIES` set) from the policy wizard's `DetectorCard`, because the warning was redundant and confusing — the hook requirement is already stated in each detector's own description text.

A bad merge resolution in #3924 (`feat: risk policy evals`, commit ad4e76d) inadvertently reintroduced the badge and the set. This restores the intended state from #3835.

## What changed

**Before:** `shadow_mcp`, `destructive_tool`, and `account_identity` detector cards rendered a `Requires Speakeasy hooks` warning label instead of their rule-count chip.

**After:** The warning label and the `HOOK_REQUIRED_CATEGORIES` set are removed. Detector cards show their rule-count chip like every other detector. Behaviour is otherwise unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the confusing "Requires Speakeasy hooks" badge from detector cards in the policy wizard and deleted the unused `HOOK_REQUIRED_CATEGORIES` set. Cards for `shadow_mcp`, `destructive_tool`, and `account_identity` now show the normal rule-count chip like other detectors; no behavior change.

<sup>Written for commit 1950e0c7d0e745caef4b08a2869b98e452e5ae28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

