### PR TITLE
fix: bind Temporal metrics to configured OTel meter (AGE-2952)

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -331,7 +331,7 @@ type temporalClientOptions struct {
 	taskQueue    string
 }
 
-func newTemporalClient(logger *slog.Logger, opts temporalClientOptions) (*temporal.Environment, func(context.Context) error, error) {
+func newTemporalClient(logger *slog.Logger, meterProvider metric.MeterProvider, opts temporalClientOptions) (*temporal.Environment, func(context.Context) error, error) {
 	var nilShutdownFunc = noopShutdown
 	if opts.address == "" || opts.namespace == "" {
 		return nil, nilShutdownFunc, nil
@@ -364,7 +364,11 @@ func newTemporalClient(logger *slog.Logger, opts temporalClientOptions) (*tempor
 	}
 
 	interceptors = append(interceptors, tracingInterceptor)
-	clientOptions.MetricsHandler = opentelemetry.NewMetricsHandler(opentelemetry.MetricsHandlerOptions{})
+	clientOptions.MetricsHandler = opentelemetry.NewMetricsHandler(opentelemetry.MetricsHandlerOptions{
+		// Bind Temporal to the post-SetupOTelSDK meter so counters export as delta counts.
+		// Otherwise Datadog .as_rate() monitors can stick until the worker restarts.
+		Meter: meterProvider.Meter("temporal-sdk-go"),
+	})
 
 	clientOptions.Interceptors = interceptors
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -453,8 +453,6 @@ func newStartCommand() *cli.Command {
 				attr.SlogServiceVersion(shortGitSHA()),
 				attr.SlogServiceEnv(serviceEnv),
 			)
-			tracerProvider := otel.GetTracerProvider()
-			meterProvider := otel.GetMeterProvider()
 			slog.SetDefault(logger)
 
 			if serviceEnv == "local" {
@@ -475,6 +473,9 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("setup opentelemetry sdk: %w", err)
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
+
+			tracerProvider := otel.GetTracerProvider()
+			meterProvider := otel.GetMeterProvider()
 
 			guardianPolicy, err := newGuardianPolicy(c, tracerProvider)
 			if err != nil {
@@ -596,7 +597,7 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to create kubernetes client: %w", err)
 			}
 
-			temporalEnv, shutdown, err := newTemporalClient(logger, temporalClientOptions{
+			temporalEnv, shutdown, err := newTemporalClient(logger, meterProvider, temporalClientOptions{
 				address:      c.String("temporal-address"),
 				namespace:    c.String("temporal-namespace"),
 				taskQueue:    c.String("temporal-task-queue"),

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -326,8 +326,6 @@ func newWorkerCommand() *cli.Command {
 				attr.SlogServiceVersion(shortGitSHA()),
 				attr.SlogServiceEnv(serviceEnv),
 			)
-			tracerProvider := otel.GetTracerProvider()
-			meterProvider := otel.GetMeterProvider()
 			slog.SetDefault(logger)
 
 			if serviceEnv == "local" {
@@ -337,7 +335,22 @@ func newWorkerCommand() *cli.Command {
 			ctx, cancel := context.WithCancel(c.Context)
 			defer cancel()
 
-			temporalEnv, shutdown, err := newTemporalClient(logger, temporalClientOptions{
+			shutdown, err := o11y.SetupOTelSDK(ctx, logger, o11y.SetupOTelSDKOptions{
+				ServiceName:    serviceName,
+				ServiceVersion: shortGitSHA(),
+				GitSHA:         GitSHA,
+				EnableTracing:  c.Bool("with-otel-tracing"),
+				EnableMetrics:  c.Bool("with-otel-metrics"),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to setup opentelemetry sdk: %w", err)
+			}
+			shutdownFuncs = append(shutdownFuncs, shutdown)
+
+			tracerProvider := otel.GetTracerProvider()
+			meterProvider := otel.GetMeterProvider()
+
+			temporalEnv, shutdown, err := newTemporalClient(logger, meterProvider, temporalClientOptions{
 				address:      c.String("temporal-address"),
 				namespace:    c.String("temporal-namespace"),
 				taskQueue:    c.String("temporal-task-queue"),
@@ -349,18 +362,6 @@ func newWorkerCommand() *cli.Command {
 			}
 			if temporalEnv == nil {
 				return errors.New("insufficient options to create temporal client")
-			}
-			shutdownFuncs = append(shutdownFuncs, shutdown)
-
-			shutdown, err = o11y.SetupOTelSDK(ctx, logger, o11y.SetupOTelSDKOptions{
-				ServiceName:    serviceName,
-				ServiceVersion: shortGitSHA(),
-				GitSHA:         GitSHA,
-				EnableTracing:  c.Bool("with-otel-tracing"),
-				EnableMetrics:  c.Bool("with-otel-metrics"),
-			})
-			if err != nil {
-				return fmt.Errorf("failed to setup opentelemetry sdk: %w", err)
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Temporal OpenTelemetry metrics by binding the Temporal client to the app’s Meter so counters export as delta. Prevents stuck Datadog .as_rate() monitors and aligns initialization order with OTel setup.

- **Bug Fixes**
  - Pass `metric.MeterProvider` to `newTemporalClient` and set `opentelemetry.NewMetricsHandler` with `Meter: meterProvider.Meter("temporal-sdk-go")`.
  - Initialize OTel SDK before creating the Temporal client in the worker; in start, get providers after setup.
  - Counters now export as delta instead of cumulative, unblocking Datadog rate monitors.

<sup>Written for commit fba940001b6af9eedf4abc2280438abb9c2bb7c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->