### PR TITLE
chore(ci): notify github-prs slack channel on review-bypass merges

### DIFF
--- a/.github/workflows/review-bypass.yml
+++ b/.github/workflows/review-bypass.yml
@@ -138,8 +138,22 @@ jobs:
             | tail -1)
           labeled_by="${labeled_by:-unknown}"
 
+          # Escape Slack mrkdwn control characters so PR metadata (title,
+          # branch name) can't inject formatting or special mentions like
+          # <!channel> into the audit post. The title also stays outside the
+          # <url|label> link so a literal "|" can't corrupt the link syntax.
+          escape_mrkdwn() {
+            local s=$1
+            s=${s//&/&amp;}
+            s=${s//</&lt;}
+            s=${s//>/&gt;}
+            printf '%s' "$s"
+          }
+          title_esc=$(escape_mrkdwn "$PR_TITLE")
+          branch_esc=$(escape_mrkdwn "$BASE_BRANCH")
+
           payload=$(jq -n \
-            --arg text ":warning: *Review bypass merge* — <${PR_URL}|#${PR_NUMBER}: ${PR_TITLE}> by \`${PR_AUTHOR}\` merged to \`${BASE_BRANCH}\` without independent review. Bypass authorized by \`${labeled_by}\` via the \`review:bypass\` label. All required status checks passed." \
+            --arg text ":warning: *Review bypass merge* — <${PR_URL}|#${PR_NUMBER}> ${title_esc} by \`${PR_AUTHOR}\` merged to \`${branch_esc}\` without independent review. Bypass authorized by \`${labeled_by}\` via the \`review:bypass\` label. All required status checks passed." \
             '{text: $text}')
 
           curl -sf -X POST -H 'Content-Type: application/json' -d "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/review-bypass.yml
+++ b/.github/workflows/review-bypass.yml
@@ -28,26 +28,30 @@ name: Review Bypass
 # that window fires no run. Running the same reconciliation on
 # `synchronize` (the push that resolves the conflict) repairs any state
 # that drifted while runs were suppressed.
+#
+# When a PR merges with the bypass label still applied, the notify job
+# posts an audit notification to the #github-prs Slack channel.
 
 on:
   pull_request:
-    types: [labeled, unlabeled, synchronize]
+    types: [labeled, unlabeled, synchronize, closed]
 
 permissions: {}
-
-# Serialize runs per PR so rapid label churn can't interleave; each run
-# reconciles from freshly-read state, so the last run always converges.
-concurrency:
-  group: review-bypass-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   reconcile:
     name: Reconcile bypass approval with label
     if: >
+      github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.action == 'synchronize' || github.event.label.name == 'review:bypass')
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    # Serialize runs per PR so rapid label churn can't interleave; each run
+    # reconciles from freshly-read state, so the last run always converges.
+    # Job-level (not workflow-level) so notify runs are never cancelled.
+    concurrency:
+      group: review-bypass-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Generate gram-bot token
         id: generate-token
@@ -99,3 +103,44 @@ jobs:
           else
             echo "State already consistent (label present: ${has_label}); nothing to do."
           fi
+
+  notify:
+    name: Notify Slack of bypass merge
+    if: >
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'review:bypass') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      issues: read # timeline lookup of who applied the bypass label
+    steps:
+      - name: Post to #github-prs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_PRS_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$SLACK_WEBHOOK_URL" ]]; then
+            echo "SLACK_GITHUB_PRS_WEBHOOK_URL secret is not set; skipping notification."
+            exit 0
+          fi
+
+          labeled_by=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/events" --paginate \
+            --jq '[.[] | select(.event == "labeled" and .label.name == "review:bypass") | .actor.login] | last // empty' \
+            | tail -1)
+          labeled_by="${labeled_by:-unknown}"
+
+          payload=$(jq -n \
+            --arg text ":warning: *Review bypass merge* — <${PR_URL}|#${PR_NUMBER}: ${PR_TITLE}> by \`${PR_AUTHOR}\` merged to \`${BASE_BRANCH}\` without independent review. Bypass authorized by \`${labeled_by}\` via the \`review:bypass\` label. All required status checks passed." \
+            '{text: $text}')
+
+          curl -sf -X POST -H 'Content-Type: application/json' -d "$payload" "$SLACK_WEBHOOK_URL"
+          echo "Posted bypass-merge notification for PR #${PR_NUMBER} (authorized by ${labeled_by})."


### PR DESCRIPTION
Follow-up to [AGE-2901](https://linear.app/speakeasy/issue/AGE-2901/feat-implement-pr-review-bypass-label-for-gram-repo): post an audit notification to **#github-prs** whenever a PR merges with the `review:bypass` label applied.

## Change

- `review-bypass.yml` now also triggers on `closed`; a new `notify` job fires only when `merged == true` **and** the label is still on the PR at merge time (label removed before merge → approval was dismissed → no ping, correctly).
- Message names the PR, author, base branch, and **who authorized the bypass** (resolved from the label timeline, same as the reconcile job), e.g.:
  > ⚠️ **Review bypass merge** — #3975: fix: Tool Logs status filtering by `simplesagar` merged to `main` without independent review. Bypass authorized by `simplesagar` via the `review:bypass` label. All required status checks passed.
- Posts via a Slack **incoming webhook** secret; the job logs and exits cleanly if the secret isn't configured yet, so this can merge before the webhook exists.
- Concurrency moved from workflow-level to the reconcile job so an in-flight notification can't be cancelled by label churn. Trigger remains `pull_request` (never `pull_request_target`).

## Setup required (one-time, after merge)

1. In Slack: create an **Incoming Webhook** targeting `#github-prs` (api.slack.com/apps → your workspace app → Incoming Webhooks → Add New Webhook → pick #github-prs).
2. `gh secret set SLACK_GITHUB_PRS_WEBHOOK_URL --repo speakeasy-api/gram` and paste the webhook URL.

## Testing

After merge + secret setup: apply `review:bypass` to a test PR, merge it, and confirm the message lands in #github-prs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrDheXXpBVn2WkiSZekvdT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Post an audit message to #github-prs when a PR merges with the `review:bypass` label, including who authorized the bypass. Aligns with Linear AGE-2901.

- **New Features**
  - Add `notify` job on `pull_request.closed` to send Slack webhook when `merged == true` and `review:bypass` is present.
  - Message includes PR number/title, author, base branch, and the user who applied the label (from timeline). Escapes Slack mrkdwn characters and avoids link-title injection.
  - Move concurrency to the reconcile job so notifications aren’t cancelled by label churn; still uses `pull_request` (not `pull_request_target`).
  - Gracefully skips if `SLACK_GITHUB_PRS_WEBHOOK_URL` is not set.

- **Migration**
  - Create a Slack Incoming Webhook for #github-prs.
  - Add repo secret `SLACK_GITHUB_PRS_WEBHOOK_URL` with the webhook URL.

<sup>Written for commit 38b9e8ab24ca9ee31e83699638898514aa186189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

