### PR TITLE
mig: show device agent active users in dashboard

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -352,6 +352,26 @@ CREATE UNIQUE INDEX IF NOT EXISTS api_keys_organization_id_name_key
 ON api_keys (organization_id, name)
 WHERE deleted IS FALSE;
 
+-- Tracks which users are actively running the Speakeasy device agent. The agent
+-- polls agent.getPlugins every ~60s carrying the enrolled user's email; that
+-- email is the only per-user signal (the org-scoped API key is shared across the
+-- fleet), so we key last-seen on (organization_id, email).
+CREATE TABLE IF NOT EXISTS device_agent_syncs (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+
+  organization_id TEXT NOT NULL,
+  email TEXT NOT NULL,
+
+  first_seen_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  last_seen_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT device_agent_syncs_pkey PRIMARY KEY (id),
+  CONSTRAINT device_agent_syncs_org_email_key UNIQUE (organization_id, email),
+  CONSTRAINT device_agent_syncs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS deployments_openapiv3_assets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   deployment_id uuid NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -480,6 +480,16 @@ type DeploymentsPackage struct {
 	VersionID    uuid.UUID
 }
 
+type DeviceAgentSync struct {
+	ID             uuid.UUID
+	OrganizationID string
+	Email          string
+	FirstSeenAt    pgtype.Timestamptz
+	LastSeenAt     pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
 type DeviceOwner struct {
 	ID             uuid.UUID
 	OrganizationID string

--- a/server/migrations/20260709172736_device-agent-syncs.sql
+++ b/server/migrations/20260709172736_device-agent-syncs.sql
@@ -1,0 +1,13 @@
+-- Create "device_agent_syncs" table
+CREATE TABLE "device_agent_syncs" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "email" text NOT NULL,
+  "first_seen_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "last_seen_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "device_agent_syncs_org_email_key" UNIQUE ("organization_id", "email"),
+  CONSTRAINT "device_agent_syncs_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:q3JOOhY7bI+GRSs1jo+X5xb5nw1+oq6Gj2ibTkYBPEY=
+h1:Vls2e48N0t4EUIvo2j5r5ambLMjOMElPmvYsCinqS9M=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -254,3 +254,4 @@ h1:q3JOOhY7bI+GRSs1jo+X5xb5nw1+oq6Gj2ibTkYBPEY=
 20260708232901_add-user-session-issuer-classification.sql h1:vs+5d/Qj35hGa90mEysuL1tFakAUOWmuqTUDUVuz118=
 20260709083351_risk-policy-challenge-call-fingerprint.sql h1:jIIXDWLontE+WT4GeA17OSO3rojBf76ZLETT9i2bubA=
 20260709124627_add-remote-session-issuer-documentation-urls.sql h1:xnKvDYXMQkyBCJIRGe+XZHJfq8sI1y+EgQfHsea3zO4=
+20260709172736_device-agent-syncs.sql h1:GZQ/O5LcdX5dtVYE4ADV6y4pOFGoaTYv4maGmzw1mUw=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/4052 so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds database support to track device agent active users in the dashboard. Stores first/last seen per organization and email for accurate active-user counts.

- **Migration**
  - Create `device_agent_syncs` table keyed by `(organization_id, email)` with timestamp defaults and FK to `organization_metadata` (ON DELETE CASCADE).
  - Add `DeviceAgentSync` model.
  - Include migration `20260709172736_device-agent-syncs.sql` and update `atlas.sum`.

<sup>Written for commit 3cecd1f2855a3fa4f26217b0fb9cfe49135c2ad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

