### PR TITLE
feat(risk): cache the PI judge system prompt

### DIFF
--- a/server/internal/scanners/promptinjection/openrouter/judge.go
+++ b/server/internal/scanners/promptinjection/openrouter/judge.go
@@ -12,6 +12,7 @@ import (
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -240,6 +241,21 @@ type judgeVerdict struct {
 	Rationale  string  `json:"rationale"`
 }
 
+// cachedSystemMessage renders SystemPrompt as a text part with an ephemeral
+// cache_control breakpoint. Providers only cache above their prefix minimum
+// (~1024 tokens on the Gemini judge model); below that it's a no-op.
+func cachedSystemMessage() or.ChatMessages {
+	return or.CreateChatMessagesSystem(or.ChatSystemMessage{
+		Role: or.ChatSystemMessageRoleSystem,
+		Content: or.CreateChatSystemMessageContentArrayOfChatContentText([]or.ChatContentText{{
+			Type:         or.ChatContentTextTypeText,
+			Text:         SystemPrompt,
+			CacheControl: &or.ChatContentCacheControl{Type: or.ChatContentCacheControlTypeEphemeral, TTL: nil},
+		}}),
+		Name: nil,
+	})
+}
+
 func (c *Engine) call(ctx context.Context, req promptinjection.Request, msg judgemessage.Message) (judgeVerdict, error) {
 	payload, err := json.Marshal(judgePayload{Message: riskjudge.RenderMessage(msg)})
 	if err != nil {
@@ -251,21 +267,41 @@ func (c *Engine) call(ctx context.Context, req promptinjection.Request, msg judg
 	callCtx, cancel := context.WithTimeout(ctx, judgeTimeout)
 	defer cancel()
 
-	response, err := c.client.GetObjectCompletion(callCtx, gramopenrouter.ObjectCompletionRequest{
-		OrgID:          req.OrgID,
-		ProjectID:      req.ProjectID,
-		Model:          c.model,
-		SystemPrompt:   SystemPrompt,
-		Prompt:         string(payload),
-		Temperature:    &c.temperature,
-		UsageSource:    billing.ModelUsageSourceGram,
-		UserID:         "",
-		ExternalUserID: "",
-		HTTPMetadata:   nil,
-		JSONSchema:     &c.schema,
+	// Build the request directly (not the GetObjectCompletion string helper) so
+	// the constant SystemPrompt carries a cache_control breakpoint, billing the
+	// resent prefix at the ~10x-cheaper cache-read rate without adding a
+	// non-schema field to the shared client.
+	messages := []or.ChatMessages{
+		cachedSystemMessage(),
+		or.CreateChatMessagesUser(or.ChatUserMessage{
+			Role:    or.ChatUserMessageRoleUser,
+			Content: or.CreateChatUserMessageContentStr(string(payload)),
+			Name:    nil,
+		}),
+	}
+
+	response, err := c.client.GetCompletion(callCtx, gramopenrouter.CompletionRequest{
+		OrgID:                     req.OrgID,
+		Messages:                  messages,
+		ProjectID:                 req.ProjectID,
+		Tools:                     nil,
+		Temperature:               &c.temperature,
+		Model:                     c.model,
+		Stream:                    false,
+		UsageSource:               billing.ModelUsageSourceGram,
+		ChatID:                    uuid.Nil,
+		UserID:                    "",
+		ExternalUserID:            "",
+		UserEmail:                 "",
+		HTTPMetadata:              nil,
+		APIKeyID:                  "",
+		JSONSchema:                &c.schema,
+		Reasoning:                 &gramopenrouter.Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
+		CacheControl:              nil,
+		NormalizeOutboundMessages: false,
 	})
 	if err != nil {
-		return judgeVerdict{}, fmt.Errorf("openrouter object completion: %w", err)
+		return judgeVerdict{}, fmt.Errorf("openrouter completion: %w", err)
 	}
 	if response == nil || response.Message == nil {
 		return judgeVerdict{}, fmt.Errorf("empty completion response")

--- a/server/internal/scanners/promptinjection/openrouter/judge_test.go
+++ b/server/internal/scanners/promptinjection/openrouter/judge_test.go
@@ -195,17 +195,22 @@ func (c *fakeCompletionClient) lastPrompt() string {
 	return c.prompts[len(c.prompts)-1]
 }
 
-func (c *fakeCompletionClient) GetObjectCompletion(_ context.Context, request openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
+func (c *fakeCompletionClient) GetCompletion(_ context.Context, request openrouter.CompletionRequest) (*openrouter.CompletionResponse, error) {
 	c.calls.Add(1)
+	// The judge sends [system, user]; the user message carries the payload JSON.
+	prompt := ""
+	if n := len(request.Messages); n > 0 {
+		prompt = openrouter.GetText(request.Messages[n-1])
+	}
 	c.mu.Lock()
-	c.prompts = append(c.prompts, request.Prompt)
+	c.prompts = append(c.prompts, prompt)
 	c.mu.Unlock()
 	if c.err != nil {
 		return nil, c.err
 	}
 
 	var p judgePayload
-	_ = json.Unmarshal([]byte(request.Prompt), &p)
+	_ = json.Unmarshal([]byte(prompt), &p)
 	resp := `{"is_attack":false,"confidence":0,"rationale":"ok"}`
 	if c.responder != nil {
 		resp = c.responder(p.Message.Body)
@@ -218,7 +223,7 @@ func (c *fakeCompletionClient) GetObjectCompletion(_ context.Context, request op
 	return &openrouter.CompletionResponse{Message: &msg}, nil
 }
 
-func (c *fakeCompletionClient) GetCompletion(_ context.Context, _ openrouter.CompletionRequest) (*openrouter.CompletionResponse, error) {
+func (c *fakeCompletionClient) GetObjectCompletion(_ context.Context, _ openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
 	return nil, errors.New("not implemented")
 }
 


### PR DESCRIPTION
## What
The prompt-injection judge resends an **identical ~1.4k-token system prompt on every call** (~3.85M/mo), re-billed as full-price input. This attaches an ephemeral `cache_control` breakpoint to the judge's system message — OpenRouter's native prompt caching — so the constant prefix bills at the ~10× cheaper cache-read rate.

Built at the **judge callsite** via `GetCompletion` (per review), so `thirdparty/openrouter` stays schema-faithful — no `CacheSystemPrompt` field on the shared request type — and caching is scoped to the judge, the only caller that needs it.

## Evidence
Verified end-to-end through gram's real client on `gemini-3.1-flash-lite`:
- **Implicit caching does not trigger** (0 cached tokens without the breakpoint).
- **With the breakpoint**, repeat calls cache **~1394/1420 tokens (~98%)**, cost ~4× lower per call.

## Important caveat
The provider only caches once the prefix clears its **~1024-token minimum**. Today's judge prompt is **~905 tokens → below the floor → this is a no-op on its own**. It takes effect once the tuned judge prompt (**#4057**, ~1.4k tokens) lands, which pushes the prefix over the threshold. So the two PRs are coupled for the cost win. Prerequisite for the judge-only simplification cost gate in **AIS-293**.

https://claude.ai/code/session_014mHf7MicPsfBAMHnxPZwVR