### PR TITLE
fix: harden ai usage polling

### DIFF
--- a/server/internal/background/activities/claude_prompt_correlation.go
+++ b/server/internal/background/activities/claude_prompt_correlation.go
@@ -182,6 +182,13 @@ func (c *CorrelateClaudePrompts) findClaudeUserPromptMatch(
 	if messagePrompt == "" {
 		return noMatch, false, nil
 	}
+	if len(messagePrompt) > telemetryrepo.MaxClaudePromptCorrelationEditDistanceBytes {
+		c.logger.WarnContext(ctx, "skipping Claude prompt correlation for oversized prompt",
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogChatID(chatID.String()),
+		)
+		return noMatch, false, nil
+	}
 
 	queryCtx, cancel := context.WithTimeout(ctx, c.matchTimeout)
 	defer cancel()

--- a/server/internal/background/activities/claude_prompt_correlation_test.go
+++ b/server/internal/background/activities/claude_prompt_correlation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -154,6 +155,29 @@ func TestCorrelateClaudePromptsAdvancesMessageCursorWithoutMatches(t *testing.T)
 	require.Equal(t, int32(claudePromptCorrelationMessageBatchSize+1), store.lastListParams.LimitCount)
 }
 
+func TestCorrelateClaudePromptsSkipsOversizedMessagePrompt(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeClaudePromptStore{
+		rows: []activitiesrepo.ListUnlinkedClaudeUserMessagesForCorrelationRow{{
+			ID:        uuid.New(),
+			Seq:       1,
+			Content:   strings.Repeat("a", telemetryrepo.MaxClaudePromptCorrelationEditDistanceBytes+1),
+			CreatedAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true},
+		}},
+	}
+	telemetry := &fakeClaudePromptTelemetry{}
+	act := newTestCorrelateClaudePrompts(t, store, telemetry)
+
+	result, err := act.Do(t.Context(), fakeCorrelateClaudePromptsArgs())
+
+	require.NoError(t, err)
+	require.False(t, result.HasMore)
+	require.Equal(t, int64(1), result.AfterMessageSeq)
+	require.Equal(t, 0, telemetry.calls)
+	require.False(t, store.backfilled)
+}
+
 func TestCorrelateClaudePromptsCarriesInputCursors(t *testing.T) {
 	t.Parallel()
 
@@ -244,10 +268,12 @@ type fakeClaudePromptTelemetry struct {
 	candidates          []telemetryrepo.ClaudeUserPromptCandidate
 	err                 error
 	waitForContextDone  bool
+	calls               int
 	lastCandidateParams telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams
 }
 
 func (f *fakeClaudePromptTelemetry) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Context, params telemetryrepo.ListClaudeUserPromptCandidatesForCorrelationParams) ([]telemetryrepo.ClaudeUserPromptCandidate, error) {
+	f.calls++
 	f.lastCandidateParams = params
 	if f.waitForContextDone {
 		<-ctx.Done()

--- a/server/internal/background/activities/poll_cursor_usage_metrics.go
+++ b/server/internal/background/activities/poll_cursor_usage_metrics.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	PollUsageMaxAttempts = 3
+	PollUsageMaxAttempts = 5
 )
 
 type PollCursorUsageMetrics struct {

--- a/server/internal/background/ai_integration_usage_poller.go
+++ b/server/internal/background/ai_integration_usage_poller.go
@@ -39,7 +39,7 @@ const (
 
 	// aiUsagePollerActivityScheduleToCloseTimeout bounds the full
 	// provider/config usage poll across all Temporal retries.
-	aiUsagePollerActivityScheduleToCloseTimeout = 6 * time.Hour
+	aiUsagePollerActivityScheduleToCloseTimeout = 12 * time.Hour
 
 	// aiUsagePollerCoordinatorChildConcurrency limits how many
 	// provider/config child workflows a coordinator starts per batch.

--- a/server/internal/background/ai_integration_usage_poller.go
+++ b/server/internal/background/ai_integration_usage_poller.go
@@ -27,15 +27,19 @@ const (
 
 	// aiUsagePollerCoordinatorRunTimeout is the total budgeted
 	// time for each scheduled coordinator run.
-	aiUsagePollerCoordinatorRunTimeout = 45 * time.Minute
+	aiUsagePollerCoordinatorRunTimeout = 8 * time.Hour
 
 	// aiUsagePollerCoordinatorActivityTimeout is the budget for
 	// short coordinator activities like candidate listing.
 	aiUsagePollerCoordinatorActivityTimeout = 30 * time.Second
 
 	// aiUsagePollerActivityTimeout is the budget for
-	// one provider/config usage poll activity.
-	aiUsagePollerActivityTimeout = 50 * time.Minute
+	// one provider/config usage poll attempt.
+	aiUsagePollerActivityTimeout = 2 * time.Hour
+
+	// aiUsagePollerActivityScheduleToCloseTimeout bounds the full
+	// provider/config usage poll across all Temporal retries.
+	aiUsagePollerActivityScheduleToCloseTimeout = 6 * time.Hour
 
 	// aiUsagePollerCoordinatorChildConcurrency limits how many
 	// provider/config child workflows a coordinator starts per batch.
@@ -44,6 +48,14 @@ const (
 	// aiUsagePollerCoordinatorRetryInitialInterval is the first
 	// backoff delay for short coordinator activity retries.
 	aiUsagePollerCoordinatorRetryInitialInterval = 5 * time.Second
+
+	// aiUsagePollerActivityRetryInitialInterval is the first backoff delay
+	// for provider/config usage poll activity retries.
+	aiUsagePollerActivityRetryInitialInterval = time.Minute
+
+	// aiUsagePollerActivityRetryMaximumInterval caps backoff between
+	// provider/config usage poll activity retries.
+	aiUsagePollerActivityRetryMaximumInterval = 15 * time.Minute
 )
 
 func AIUsagePollerCoordinatorWorkflow(ctx workflow.Context) error {
@@ -120,11 +132,15 @@ func AIUsagePollerCoordinatorWorkflow(ctx workflow.Context) error {
 func AIUsagePollerWorkflow(ctx workflow.Context, configID string) error {
 	taskQueue := AIUsagePollerTaskQueue(tenv.TaskQueueName(workflow.GetInfo(ctx).TaskQueueName))
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		TaskQueue:           taskQueue,
-		StartToCloseTimeout: aiUsagePollerActivityTimeout,
-		HeartbeatTimeout:    time.Minute,
+		TaskQueue:              taskQueue,
+		StartToCloseTimeout:    aiUsagePollerActivityTimeout,
+		ScheduleToCloseTimeout: aiUsagePollerActivityScheduleToCloseTimeout,
+		HeartbeatTimeout:       time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
-			MaximumAttempts: activities.PollUsageMaxAttempts,
+			MaximumAttempts:    activities.PollUsageMaxAttempts,
+			InitialInterval:    aiUsagePollerActivityRetryInitialInterval,
+			BackoffCoefficient: 2,
+			MaximumInterval:    aiUsagePollerActivityRetryMaximumInterval,
 		},
 	})
 

--- a/server/internal/background/ai_integration_usage_poller_test.go
+++ b/server/internal/background/ai_integration_usage_poller_test.go
@@ -25,9 +25,11 @@ func TestAIUsagePollerCadenceAndRetryConfig(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, 5*time.Minute, aiUsagePollerCoordinatorInterval)
-	require.Equal(t, 50*time.Minute, aiUsagePollerActivityTimeout)
+	require.Equal(t, 8*time.Hour, aiUsagePollerCoordinatorRunTimeout)
+	require.Equal(t, 2*time.Hour, aiUsagePollerActivityTimeout)
+	require.Equal(t, 6*time.Hour, aiUsagePollerActivityScheduleToCloseTimeout)
 	require.Equal(t, 5, aiUsagePollerCoordinatorChildConcurrency)
-	require.Equal(t, 3, activities.PollUsageMaxAttempts)
+	require.Equal(t, 5, activities.PollUsageMaxAttempts)
 }
 
 func TestAIUsagePollerCoordinatorWorkflowListsCandidatesAndStartsChildren(t *testing.T) {

--- a/server/internal/background/ai_integration_usage_poller_test.go
+++ b/server/internal/background/ai_integration_usage_poller_test.go
@@ -27,7 +27,7 @@ func TestAIUsagePollerCadenceAndRetryConfig(t *testing.T) {
 	require.Equal(t, 5*time.Minute, aiUsagePollerCoordinatorInterval)
 	require.Equal(t, 8*time.Hour, aiUsagePollerCoordinatorRunTimeout)
 	require.Equal(t, 2*time.Hour, aiUsagePollerActivityTimeout)
-	require.Equal(t, 6*time.Hour, aiUsagePollerActivityScheduleToCloseTimeout)
+	require.Equal(t, 12*time.Hour, aiUsagePollerActivityScheduleToCloseTimeout)
 	require.Equal(t, 5, aiUsagePollerCoordinatorChildConcurrency)
 	require.Equal(t, 5, activities.PollUsageMaxAttempts)
 }

--- a/server/internal/telemetry/claude_prompt_correlation_test.go
+++ b/server/internal/telemetry/claude_prompt_correlation_test.go
@@ -91,6 +91,45 @@ func TestListClaudeUserPromptCandidatesForCorrelationBindsLargePrompt(t *testing
 	require.Empty(t, candidates)
 }
 
+func TestListClaudeUserPromptCandidatesForCorrelationSkipsOversizedStoredPrompt(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	projectID := uuid.New().String()
+	chatID := uuid.New().String()
+	sessionID := uuid.New().String()
+	now := time.Now().UTC()
+
+	insertClaudeUserPromptEvent(t, ctx, ti.chClient, claudeUserPromptEventFixture{
+		projectID:     projectID,
+		chatID:        chatID,
+		sessionID:     sessionID,
+		promptID:      "prompt-oversized",
+		prompt:        strings.Repeat("a", telemetryRepo.MaxClaudePromptCorrelationEditDistanceBytes+1),
+		eventSequence: 1,
+		timestamp:     now,
+	})
+
+	var candidates []telemetryRepo.ClaudeUserPromptCandidate
+	require.Eventually(t, func() bool {
+		var err error
+		candidates, err = ti.chClient.ListClaudeUserPromptCandidatesForCorrelation(ctx, telemetryRepo.ListClaudeUserPromptCandidatesForCorrelationParams{
+			GramProjectID:          projectID,
+			GramChatID:             chatID,
+			SessionID:              sessionID,
+			MessagePrompt:          strings.Repeat("a", telemetryRepo.MaxClaudePromptCorrelationEditDistanceBytes),
+			MessageTimeUnixNano:    now.UnixNano(),
+			AfterEventSequence:     0,
+			AfterEventTimeUnixNano: 0,
+			MinFuzzyLength:         40,
+			MaxTimeDeltaNanos:      (10 * time.Minute).Nanoseconds(),
+		})
+		return err == nil
+	}, 2*time.Second, 50*time.Millisecond)
+	require.Empty(t, candidates)
+}
+
 func TestListClaudeUserPromptCandidatesForCorrelationMatchesEscapedPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -27,6 +27,8 @@ import (
 // Rejects: "1bad", ".leading.dot", "path with spaces", "semi;colon", "@@double", "trailing.", "double..dot"
 var validJSONPath = regexp.MustCompile(`^@?[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$`)
 
+const MaxClaudePromptCorrelationEditDistanceBytes = 65536
+
 func userIdentifierExpr(col string) string {
 	return "if(telemetry_logs." + col + " != '', telemetry_logs." + col + ", telemetry_logs.user_email)"
 }
@@ -4533,12 +4535,16 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 	if arg.MessagePrompt == "" {
 		return nil, nil
 	}
+	if len(arg.MessagePrompt) > MaxClaudePromptCorrelationEditDistanceBytes {
+		return nil, nil
+	}
 
 	ctx = clickhouse.Context(ctx, clickhouse.WithParameters(clickhouse.Parameters{
 		"gram_project_id":               arg.GramProjectID,
 		"gram_chat_id":                  arg.GramChatID,
 		"session_id":                    arg.SessionID,
 		"message_prompt_b64":            base64.StdEncoding.EncodeToString([]byte(arg.MessagePrompt)),
+		"max_edit_distance_bytes":       strconv.Itoa(MaxClaudePromptCorrelationEditDistanceBytes),
 		"message_time_unix_nano":        strconv.FormatInt(arg.MessageTimeUnixNano, 10),
 		"after_event_sequence":          strconv.FormatInt(arg.AfterEventSequence, 10),
 		"after_event_time_unix_nano":    strconv.FormatInt(arg.AfterEventTimeUnixNano, 10),
@@ -4547,9 +4553,10 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 		"negative_max_time_delta_nanos": strconv.FormatInt(-arg.MaxTimeDeltaNanos, 10),
 	}))
 
+	normalizedPromptExpr := "replaceRegexpAll(trimBoth(toString(attributes.prompt)), '\\\\s+', ' ')"
 	rawEvents := sq.Select(
 		"toString(attributes.prompt.id) AS prompt_id",
-		"replaceRegexpAll(trimBoth(toString(attributes.prompt)), '\\\\s+', ' ') AS prompt",
+		normalizedPromptExpr+" AS prompt",
 		"toInt64OrZero(toString(attributes.event.sequence)) AS event_sequence",
 		"time_unix_nano",
 	).
@@ -4560,6 +4567,7 @@ func (q *Queries) ListClaudeUserPromptCandidatesForCorrelation(ctx context.Conte
 		Where("toString(attributes.event.name) = 'user_prompt'").
 		Where("toString(attributes.prompt.id) != ''").
 		Where("toString(attributes.prompt) != ''").
+		Where("length(" + normalizedPromptExpr + ") <= {max_edit_distance_bytes:UInt64}").
 		Where(squirrel.Or{
 			squirrel.Expr("event_sequence > {after_event_sequence:Int64}"),
 			squirrel.Expr(`(

--- a/server/internal/thirdparty/anthropic/client.go
+++ b/server/internal/thirdparty/anthropic/client.go
@@ -53,7 +53,7 @@ func New(guardianPolicy *guardian.Policy, opts ...Option) *Client {
 		panic("anthropic client requires guardian policy")
 	}
 	c := &Client{
-		httpClient: guardianPolicy.PooledClient(),
+		httpClient: guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig()),
 		baseURL:    defaultBaseURL,
 		apiKey:     "",
 	}


### PR DESCRIPTION
## Summary
- Increase AI usage poller timeouts and retries for more resilient provider ingestion.
- Add HTTP retries for Anthropic compliance requests.
- Skip oversized Claude prompt correlation inputs before ClickHouse edit-distance scoring.

## Test plan
- `go test ./server/internal/background -run 'TestAIUsagePoller'`
- `go test ./server/internal/background/activities -run 'TestCorrelateClaudePrompts'`
- `go test ./server/internal/telemetry -run 'TestListClaudeUserPromptCandidatesForCorrelation'`
- `go test ./server/internal/thirdparty/anthropic`
- `git diff --check`

Fixes DNO-461 and DNO-462


Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens usage polling by extending Temporal timeouts and enabling exponential backoff retries; adds HTTP retries to the `anthropic` client. Skips oversized Claude prompts during correlation to avoid expensive edit-distance work and reduce false positives.

- **Bug Fixes**
  - Coordinator run timeout set to 8h; activity timeout 2h; schedule-to-close 12h.
  - Activity retries: 5 attempts, 1m initial backoff, 2x factor, 15m max interval.
  - Usage metrics polling attempts increased to 5.
  - `anthropic` client now uses default HTTP retry configuration.
  - Correlation skips prompts > 65,536 bytes and enforces the limit in ClickHouse.

<sup>Written for commit 418b2a23862cbc0c6dd8228ed472ea377b189677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



