### PR TITLE
mig: split plugin_github_connections fingerprint into per-plugin MCP map + hooks version

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3266,13 +3266,27 @@ CREATE TABLE IF NOT EXISTS plugin_github_connections (
   -- existing connections (and any future connection without the marketplace
   -- surface enabled) are unconstrained.
   marketplace_token TEXT,
-  -- Stable content hash of the plugin packages last published to this repo,
-  -- independent of per-publish values (manifest version, injected API keys).
-  -- The automated generator rollout compares the current fingerprint against
-  -- this value and skips republishing when nothing has changed. Nullable so
-  -- connections published before fingerprinting existed re-publish once to
-  -- backfill it.
+  -- DEPRECATED: superseded by published_mcp_fingerprint + published_hooks_version
+  -- when hooks and MCP plugin generation were decoupled. No longer written or
+  -- read; retained per expand-contract and dropped in a later contract migration.
   published_fingerprint TEXT,
+  -- Per-plugin content fingerprints of the MCP (feature) plugins last published
+  -- to this repo: a JSON object mapping plugin slug -> stable hash (plus a
+  -- reserved "__shared__" key for the marketplace/README files), independent of
+  -- per-publish values (manifest version, injected API key). The automated
+  -- rollout compares the current fingerprints against this value to skip no-op
+  -- MCP republishes. JSON (rather than a single hash) so a future per-plugin
+  -- publish flow can decide independently which plugins have unpublished changes
+  -- without another migration. Excludes the hooks subtree, which rolls out on
+  -- published_hooks_version instead. Nullable so connections predating the split
+  -- republish once to backfill it.
+  published_mcp_fingerprints JSONB,
+  -- The hooksGeneratorVersion stamped into the observability (hooks) plugin last
+  -- published to this repo. The rollout regenerates the hooks subtree only when
+  -- the current hooksGeneratorVersion differs from this value, so an MCP-only
+  -- publish leaves the hooks plugin untouched. Nullable so connections predating
+  -- the split republish the hooks plugin once to backfill it.
+  published_hooks_version TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1233,15 +1233,17 @@ type PluginAssignment struct {
 }
 
 type PluginGithubConnection struct {
-	ID                   uuid.UUID
-	ProjectID            uuid.UUID
-	InstallationID       int64
-	RepoOwner            string
-	RepoName             string
-	MarketplaceToken     pgtype.Text
-	PublishedFingerprint pgtype.Text
-	CreatedAt            pgtype.Timestamptz
-	UpdatedAt            pgtype.Timestamptz
+	ID                       uuid.UUID
+	ProjectID                uuid.UUID
+	InstallationID           int64
+	RepoOwner                string
+	RepoName                 string
+	MarketplaceToken         pgtype.Text
+	PublishedFingerprint     pgtype.Text
+	PublishedMcpFingerprints []byte
+	PublishedHooksVersion    pgtype.Text
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
 }
 
 type PluginServer struct {

--- a/server/internal/plugins/repo/models.go
+++ b/server/internal/plugins/repo/models.go
@@ -34,15 +34,17 @@ type PluginAssignment struct {
 }
 
 type PluginGithubConnection struct {
-	ID                   uuid.UUID
-	ProjectID            uuid.UUID
-	InstallationID       int64
-	RepoOwner            string
-	RepoName             string
-	MarketplaceToken     pgtype.Text
-	PublishedFingerprint pgtype.Text
-	CreatedAt            pgtype.Timestamptz
-	UpdatedAt            pgtype.Timestamptz
+	ID                       uuid.UUID
+	ProjectID                uuid.UUID
+	InstallationID           int64
+	RepoOwner                string
+	RepoName                 string
+	MarketplaceToken         pgtype.Text
+	PublishedFingerprint     pgtype.Text
+	PublishedMcpFingerprints []byte
+	PublishedHooksVersion    pgtype.Text
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
 }
 
 type PluginServer struct {

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -155,7 +155,7 @@ func (q *Queries) DeletePlugin(ctx context.Context, arg DeletePluginParams) erro
 }
 
 const getGitHubConnection = `-- name: GetGitHubConnection :one
-SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, created_at, updated_at
+SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, published_mcp_fingerprints, published_hooks_version, created_at, updated_at
 FROM plugin_github_connections
 WHERE project_id = $1
 `
@@ -171,6 +171,8 @@ func (q *Queries) GetGitHubConnection(ctx context.Context, projectID uuid.UUID) 
 		&i.RepoName,
 		&i.MarketplaceToken,
 		&i.PublishedFingerprint,
+		&i.PublishedMcpFingerprints,
+		&i.PublishedHooksVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -178,7 +180,7 @@ func (q *Queries) GetGitHubConnection(ctx context.Context, projectID uuid.UUID) 
 }
 
 const getGitHubConnectionByMarketplaceToken = `-- name: GetGitHubConnectionByMarketplaceToken :one
-SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, created_at, updated_at
+SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, published_mcp_fingerprints, published_hooks_version, created_at, updated_at
 FROM plugin_github_connections
 WHERE marketplace_token = $1
 `
@@ -196,6 +198,8 @@ func (q *Queries) GetGitHubConnectionByMarketplaceToken(ctx context.Context, mar
 		&i.RepoName,
 		&i.MarketplaceToken,
 		&i.PublishedFingerprint,
+		&i.PublishedMcpFingerprints,
+		&i.PublishedHooksVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -897,7 +901,7 @@ ON CONFLICT (project_id) DO UPDATE
       marketplace_token = COALESCE(plugin_github_connections.marketplace_token, EXCLUDED.marketplace_token),
       published_fingerprint = EXCLUDED.published_fingerprint,
       updated_at = clock_timestamp()
-RETURNING id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, created_at, updated_at
+RETURNING id, project_id, installation_id, repo_owner, repo_name, marketplace_token, published_fingerprint, published_mcp_fingerprints, published_hooks_version, created_at, updated_at
 `
 
 type UpsertGitHubConnectionParams struct {
@@ -934,6 +938,8 @@ func (q *Queries) UpsertGitHubConnection(ctx context.Context, arg UpsertGitHubCo
 		&i.RepoName,
 		&i.MarketplaceToken,
 		&i.PublishedFingerprint,
+		&i.PublishedMcpFingerprints,
+		&i.PublishedHooksVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/migrations/20260709213047_plugin-connections-split-fingerprint.sql
+++ b/server/migrations/20260709213047_plugin-connections-split-fingerprint.sql
@@ -1,0 +1,2 @@
+-- Modify "plugin_github_connections" table
+ALTER TABLE "plugin_github_connections" ADD COLUMN "published_mcp_fingerprints" jsonb NULL, ADD COLUMN "published_hooks_version" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Vls2e48N0t4EUIvo2j5r5ambLMjOMElPmvYsCinqS9M=
+h1:K2K88fOWZ0ZO9e7Fdo+jT2TDKJtllLlrSFI2g/AfKjg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -255,3 +255,4 @@ h1:Vls2e48N0t4EUIvo2j5r5ambLMjOMElPmvYsCinqS9M=
 20260709083351_risk-policy-challenge-call-fingerprint.sql h1:jIIXDWLontE+WT4GeA17OSO3rojBf76ZLETT9i2bubA=
 20260709124627_add-remote-session-issuer-documentation-urls.sql h1:xnKvDYXMQkyBCJIRGe+XZHJfq8sI1y+EgQfHsea3zO4=
 20260709172736_device-agent-syncs.sql h1:GZQ/O5LcdX5dtVYE4ADV6y4pOFGoaTYv4maGmzw1mUw=
+20260709213047_plugin-connections-split-fingerprint.sql h1:zwCQg6wRiUD27gtUHufcNFPPHRwzsL0XDM1gDGl60o0=


### PR DESCRIPTION
Adds published_mcp_fingerprints (JSONB per-plugin map slug->hash) and published_hooks_version (TEXT) so the hooks and MCP plugin components can roll out independently. Kept the old published_fingerprint column as deprecated per expand-contract; it is dropped in a later contract migration. JSONB (rather than a single hash) so a future per-plugin publish flow needs no further migration.

Prerequisite for doing hooks release channels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the plugin publish fingerprint into per-plugin MCP fingerprints and a separate hooks generator version so MCP and hooks can roll out independently. Added `published_mcp_fingerprints` (JSONB map slug->hash, supports `__shared__`) and `published_hooks_version` (TEXT); kept `published_fingerprint` as deprecated for expand-contract.

- **Migration**
  - Added columns to `plugin_github_connections` and regenerated models/queries to surface them; keep `published_fingerprint` temporarily.
  - Nulls trigger a one-time backfill: MCP uses the per-plugin map (supports `__shared__`); hooks uses the generator version.

<sup>Written for commit 32782985493ce5a51e727996d6f408385cb9968a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

