### PR TITLE
mig: openrouter_api_keys key_type column for a second per-org key (DNO-400)

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1254,6 +1254,14 @@ ON http_security (type, scheme);
 CREATE TABLE IF NOT EXISTS openrouter_api_keys (
   organization_id TEXT NOT NULL,
 
+  -- Which upstream OpenRouter key this row provisions: 'chat' pays for
+  -- customer-facing completion surfaces (playground, elements, assistants,
+  -- /chat/completions proxy); 'internal' pays for platform-initiated LLM
+  -- usage (risk judges, title generation, chat resolutions, memory), so a
+  -- burst of scanning inference can never exhaust the chat key's monthly cap
+  -- and 402 the customer's chat surface.
+  key_type TEXT NOT NULL DEFAULT 'chat',
+
   key TEXT NOT NULL,
   key_hash TEXT NOT NULL,
   monthly_credits BIGINT NOT NULL DEFAULT 0,
@@ -1264,7 +1272,7 @@ CREATE TABLE IF NOT EXISTS openrouter_api_keys (
   deleted_at timestamptz,
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
 
-  CONSTRAINT openrouter_api_keys_pkey PRIMARY KEY (organization_id)
+  CONSTRAINT openrouter_api_keys_pkey PRIMARY KEY (organization_id, key_type)
 );
 
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1002,6 +1002,7 @@ type OauthProxyServer struct {
 
 type OpenrouterApiKey struct {
 	OrganizationID string
+	KeyType        string
 	Key            string
 	KeyHash        string
 	MonthlyCredits int64

--- a/server/internal/thirdparty/openrouter/repo/models.go
+++ b/server/internal/thirdparty/openrouter/repo/models.go
@@ -10,6 +10,7 @@ import (
 
 type OpenrouterApiKey struct {
 	OrganizationID string
+	KeyType        string
 	Key            string
 	KeyHash        string
 	MonthlyCredits int64

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -21,7 +21,7 @@ INSERT INTO openrouter_api_keys (
   , $3
   , $4
 )
-RETURNING organization_id, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+RETURNING organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateOpenRouterAPIKeyParams struct {
@@ -41,6 +41,7 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 	var i OpenrouterApiKey
 	err := row.Scan(
 		&i.OrganizationID,
+		&i.KeyType,
 		&i.Key,
 		&i.KeyHash,
 		&i.MonthlyCredits,
@@ -54,7 +55,7 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 }
 
 const getOpenRouterAPIKey = `-- name: GetOpenRouterAPIKey :one
-SELECT organization_id, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+SELECT organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 FROM openrouter_api_keys
 WHERE organization_id = $1
   AND deleted IS FALSE
@@ -65,6 +66,7 @@ func (q *Queries) GetOpenRouterAPIKey(ctx context.Context, organizationID string
 	var i OpenrouterApiKey
 	err := row.Scan(
 		&i.OrganizationID,
+		&i.KeyType,
 		&i.Key,
 		&i.KeyHash,
 		&i.MonthlyCredits,
@@ -82,7 +84,7 @@ UPDATE openrouter_api_keys
 SET monthly_credits = $1, key_hash = $2, key = $3
 WHERE organization_id = $4
   AND deleted IS FALSE
-RETURNING organization_id, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+RETURNING organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateOpenRouterKeyParams struct {
@@ -102,6 +104,7 @@ func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterK
 	var i OpenrouterApiKey
 	err := row.Scan(
 		&i.OrganizationID,
+		&i.KeyType,
 		&i.Key,
 		&i.KeyHash,
 		&i.MonthlyCredits,

--- a/server/migrations/20260709233126_openrouter-api-keys-key-type.sql
+++ b/server/migrations/20260709233126_openrouter-api-keys-key-type.sql
@@ -1,0 +1,2 @@
+-- Modify "openrouter_api_keys" table
+ALTER TABLE "openrouter_api_keys" DROP CONSTRAINT "openrouter_api_keys_pkey", ADD COLUMN "key_type" text NOT NULL DEFAULT 'chat', ADD PRIMARY KEY ("organization_id", "key_type");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:K2K88fOWZ0ZO9e7Fdo+jT2TDKJtllLlrSFI2g/AfKjg=
+h1:oupHBHvBta7DKnOw6mnibTNqjdZFASPfNDLzw1+1M6k=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -256,3 +256,4 @@ h1:K2K88fOWZ0ZO9e7Fdo+jT2TDKJtllLlrSFI2g/AfKjg=
 20260709124627_add-remote-session-issuer-documentation-urls.sql h1:xnKvDYXMQkyBCJIRGe+XZHJfq8sI1y+EgQfHsea3zO4=
 20260709172736_device-agent-syncs.sql h1:GZQ/O5LcdX5dtVYE4ADV6y4pOFGoaTYv4maGmzw1mUw=
 20260709213047_plugin-connections-split-fingerprint.sql h1:zwCQg6wRiUD27gtUHufcNFPPHRwzsL0XDM1gDGl60o0=
+20260709233126_openrouter-api-keys-key-type.sql h1:StwicFRLrgGzCpkGnK+0ta9YTOwZP7vN9yOVJIvoDhE=


### PR DESCRIPTION
Part of [DNO-400](https://linear.app/speakeasy/issue/DNO-400) (fixes AIS-232's cost-isolation problem). **Ships alone, merge before the code PRs** — migrations carry no application logic per convention.

Each org currently has ONE OpenRouter key with a monthly cap, shared by customer-facing chat surfaces and the platform's own LLM-as-a-judge scanning. A prompt-based risk policy burning ~$10/day nearly exhausted an org's entire cap, which would have 402'd their whole chat surface (playground, elements, assistants, `/chat/completions`).

## Change

`openrouter_api_keys` gains `key_type TEXT NOT NULL DEFAULT 'chat'` and the primary key widens to `(organization_id, key_type)`, making room for a second `internal` key per org that pays for platform-initiated inference (risk judges, title generation, chat resolutions, memory) with its own independently tracked and capped budget.

- Fast metadata-only column default; the PK drop/re-add takes an `ACCESS EXCLUSIVE` lock on a table with one row per org — negligible.
- **Backward compatible during rollout**: no data migration, and old code's un-filtered `WHERE organization_id = $1 … :one` lookup keeps returning exactly one row until the follow-up code PR starts creating `internal` rows.
- Regenerated sqlc models included per convention (`models.go` + the `SELECT *` expansions in `queries.sql.go`).

The `KeyType` plumbing (provisioning, key selection, refresh workflow, metrics) follows in a separate code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `key_type` to `openrouter_api_keys` and widen the primary key to `(organization_id, key_type)` to support a second per‑org OpenRouter key. This separates platform-initiated LLM spend from customer chat caps and addresses DNO-400.

- **Migration**
  - Schema: add `key_type TEXT NOT NULL DEFAULT 'chat'`; primary key is now `(organization_id, key_type)` to enable an `internal` key alongside `chat`.
  - Behavior: backward compatible; existing `organization_id` lookups still return one row until `internal` keys exist; no data migration.
  - Ops: metadata-only default; brief `ACCESS EXCLUSIVE` lock for the PK rebuild on a small table.
  - Codegen: regenerated sqlc models and queries to include `key_type` and return it from create/get/update.

<sup>Written for commit 538af14b26630914f67125629897c3d61e3ca7c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

