### PR TITLE
feat: grow GKE assistant runtime workspaces

### DIFF
--- a/.changeset/grow-assistant-workspaces.md
+++ b/.changeset/grow-assistant-workspaces.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Grow GKE assistant runtime workspaces in bounded 10 GiB steps when disk usage reaches 80%, up to 60 GiB per ephemeral sandbox.

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -803,6 +803,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +996,7 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
+ "fs2",
  "futures",
  "http",
  "opentelemetry",
@@ -3278,6 +3289,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,6 +3312,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -56,6 +56,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive", "env"] }
 dashmap = "6"
 futures = "0.3"
+fs2 = "0.4"
 http = "1"
 reqwest = { version = "0.13.2", features = ["json"] }
 reqwest-middleware = { version = "0.5", features = ["json"] }

--- a/agents/runner/src/clip.rs
+++ b/agents/runner/src/clip.rs
@@ -36,10 +36,9 @@ use serde_json::Value;
 /// content-type discriminators).
 pub const MAX_TOOL_BYTES: usize = 150_000;
 
-/// 4 MiB. The assistant workdir is a fixed 256 MiB ext4 image
-/// (`agents/runtime-image/Dockerfile`), shared with `bun_run` temp files and
-/// any artifacts the agent writes itself. Bounding each spill keeps a single
-/// runaway MCP response from filling the image and breaking subsequent
+/// 4 MiB. The assistant workdir is shared with `bun_run` temp files and any
+/// artifacts the agent writes itself. Bounding each spill keeps a single
+/// runaway MCP response from filling the workspace and breaking subsequent
 /// filesystem-tool / `bun_run` / spill calls. Truncated spills still carry
 /// the leading body — enough for the agent to inspect with `head`/`grep`.
 pub const MAX_SPILL_BYTES: usize = 4 * 1024 * 1024;

--- a/agents/runner/src/gram_client.rs
+++ b/agents/runner/src/gram_client.rs
@@ -10,6 +10,7 @@ use crate::wire::{RunnerMessage, ThreadBootstrap};
 const BOOTSTRAP_PATH: &str = "/rpc/assistants.getThreadBootstrap";
 const CREATE_MCP_AUTH_FLOW_PATH: &str = "/rpc/assistantMcpAuth.create";
 const RECORD_COMPACTED_GENERATION_PATH: &str = "/rpc/assistants.recordCompactedGeneration";
+const GROW_WORKSPACE_PATH: &str = "/rpc/assistants.growWorkspace";
 const BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(15);
 // Compaction persistence runs off the loop's critical path, so a longer
 // budget is fine; the post-compaction call body can be sizable and the
@@ -68,6 +69,13 @@ pub struct CreateMcpAuthFlowResponse {
     pub server_id: String,
     pub mcp_slug: String,
     pub auth_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GrowWorkspaceResponse {
+    pub current_bytes: u64,
+    pub requested_bytes: u64,
+    pub expanded: bool,
 }
 
 impl GramBootstrapClient {
@@ -184,5 +192,37 @@ impl GramBootstrapClient {
             });
         }
         Ok(())
+    }
+
+    pub async fn grow_workspace(
+        &self,
+        tokens: &TokenRegistry,
+    ) -> Result<GrowWorkspaceResponse, GramClientError> {
+        let endpoint = format!(
+            "{}{}",
+            self.base_url.trim_end_matches('/'),
+            GROW_WORKSPACE_PATH
+        );
+        let bearer = tokens.current().map_err(|_| GramClientError::Token)?;
+        if bearer.is_empty() {
+            return Err(GramClientError::Token);
+        }
+
+        let resp = self
+            .http
+            .post(&endpoint)
+            .timeout(BOOTSTRAP_TIMEOUT)
+            .bearer_auth(&bearer)
+            .send()
+            .await?;
+        let status = resp.status();
+        let body = resp.text().await?;
+        if !status.is_success() {
+            return Err(GramClientError::Status {
+                status: status.as_u16(),
+                body,
+            });
+        }
+        Ok(serde_json::from_str(&body)?)
     }
 }

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -8,9 +8,12 @@ mod server;
 mod tools;
 mod wire;
 mod workdir;
+mod workspace;
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::process::ExitCode;
+use std::time::Duration;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use opentelemetry::trace::TracerProvider as _;
@@ -57,6 +60,27 @@ enum Mode {
         #[arg(long, env = "GRAM_INITIAL_TOKEN", default_value = "")]
         initial_token: String,
 
+        /// GKE disk-backed workspace mount to monitor. Unset on Fly and other
+        /// runtimes, which disables automatic storage growth.
+        #[arg(long, env = "GRAM_ASSISTANT_RUNTIME_GKE_WORKSPACE_PATH")]
+        workspace_path: Option<PathBuf>,
+
+        #[arg(
+            long,
+            env = "GRAM_ASSISTANT_RUNTIME_GKE_WORKSPACE_GROWTH_THRESHOLD_PERCENT",
+            default_value_t = 80,
+            value_parser = clap::value_parser!(u8).range(1..=100)
+        )]
+        workspace_growth_threshold_percent: u8,
+
+        #[arg(
+            long,
+            env = "GRAM_ASSISTANT_RUNTIME_GKE_WORKSPACE_CHECK_INTERVAL_SECONDS",
+            default_value_t = 30,
+            value_parser = clap::value_parser!(u64).range(1..)
+        )]
+        workspace_check_interval_seconds: u64,
+
         /// Export spans over OTLP. The exporter reads the standard
         /// OTEL_EXPORTER_OTLP_* environment variables (ENDPOINT, HEADERS,
         /// TIMEOUT, ...) for everything except transport selection, which
@@ -93,6 +117,9 @@ async fn main() -> ExitCode {
             assistant_id,
             server_url,
             initial_token,
+            workspace_path,
+            workspace_growth_threshold_percent,
+            workspace_check_interval_seconds,
             with_otel_tracing,
             otel_protocol,
         } => {
@@ -102,6 +129,11 @@ async fn main() -> ExitCode {
                 assistant_id,
                 server_url,
                 initial_token,
+                workspace_monitor: workspace_path.map(|path| workspace::WorkspaceMonitorConfig {
+                    path,
+                    threshold_percent: workspace_growth_threshold_percent,
+                    check_interval: Duration::from_secs(workspace_check_interval_seconds),
+                }),
             })
             .await
             .map_err(|e| e.to_string());

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -79,6 +79,9 @@ pub struct RuntimeHost {
     /// Fallback bearer used only when `/threads/turn` arrives with no
     /// `auth_token` so the bootstrap fetch still has a credential.
     pub initial_token: String,
+    /// Most recently delivered runtime bearer, used only by the workspace
+    /// growth callback. It never leaves the runner or enters a subprocess.
+    pub workspace_tokens: TokenRegistry,
 }
 
 /// Live per-thread state. Concurrent first-turn requests for the same
@@ -133,6 +136,7 @@ pub async fn build_host(
     initial_token: String,
     thread_idle_ttl: Duration,
 ) -> Result<Arc<RuntimeHost>, RunnerError> {
+    let workspace_tokens = TokenRegistry::new(initial_token.clone());
     let mut default_headers = http::HeaderMap::new();
     default_headers.insert(
         http::HeaderName::from_static("x-gram-source"),
@@ -164,6 +168,7 @@ pub async fn build_host(
         http_client,
         spill_root,
         initial_token,
+        workspace_tokens,
     });
 
     // Background eviction task: walks the threads map and drops any whose
@@ -268,6 +273,9 @@ pub async fn ensure_thread(
     let bearer = auth_token
         .filter(|t| !t.is_empty())
         .unwrap_or_else(|| host.initial_token.clone());
+    if !bearer.is_empty() {
+        host.workspace_tokens.rotate(&bearer)?;
+    }
 
     let mut initialized = false;
     let thread = cell
@@ -978,6 +986,7 @@ mod tests {
             http_client,
             spill_root: PathBuf::from("/tmp/runtime-test-spill"),
             initial_token: String::new(),
+            workspace_tokens: TokenRegistry::new(""),
         })
     }
 

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -14,12 +14,14 @@ use crate::runtime::{
 
 const IDEMPOTENCY_HEADER: &str = "x-idempotency-key";
 use crate::wire::{RunnerStateResponse, ThreadStateView, ThreadTurnRequest, ThreadTurnResponse};
+use crate::workspace::{self, WorkspaceMonitorConfig};
 
 pub struct ServeConfig {
     pub addr: SocketAddr,
     pub assistant_id: Option<String>,
     pub server_url: String,
     pub initial_token: String,
+    pub workspace_monitor: Option<WorkspaceMonitorConfig>,
 }
 
 pub async fn serve(config: ServeConfig) -> Result<(), std::io::Error> {
@@ -32,6 +34,13 @@ pub async fn serve(config: ServeConfig) -> Result<(), std::io::Error> {
     )
     .await
     .map_err(std::io::Error::other)?;
+    if let Some(workspace_config) = config.workspace_monitor {
+        workspace::spawn_monitor(
+            workspace_config,
+            host.gram_client.clone(),
+            host.workspace_tokens.clone(),
+        );
+    }
 
     let app = Router::new()
         .route("/healthz", get(healthz))

--- a/agents/runner/src/workdir.rs
+++ b/agents/runner/src/workdir.rs
@@ -3,8 +3,8 @@ use std::sync::OnceLock;
 
 use agentkit_tools_core::ToolError;
 
-/// Persistent working directory for the assistant inside the guest VM. Backed
-/// by a fixed-size loop-mounted ext4 image so disk usage is hard-capped.
+/// Runtime-scoped working directory for the assistant inside the guest VM.
+/// GKE backs it with a growable generic-ephemeral Persistent Disk.
 pub const ASSISTANT_WORKDIR: &str = "/var/lib/gram-assistant/work";
 
 /// Canonicalizes `path` and rejects anything that does not resolve to a

--- a/agents/runner/src/workspace.rs
+++ b/agents/runner/src/workspace.rs
@@ -1,0 +1,113 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::gram_client::GramBootstrapClient;
+use crate::http_layer::TokenRegistry;
+
+#[derive(Debug)]
+pub struct WorkspaceMonitorConfig {
+    pub path: PathBuf,
+    pub threshold_percent: u8,
+    pub check_interval: Duration,
+}
+
+pub fn spawn_monitor(
+    config: WorkspaceMonitorConfig,
+    gram_client: GramBootstrapClient,
+    tokens: TokenRegistry,
+) {
+    tokio::spawn(async move {
+        monitor(config, gram_client, tokens).await;
+    });
+}
+
+async fn monitor(
+    config: WorkspaceMonitorConfig,
+    gram_client: GramBootstrapClient,
+    tokens: TokenRegistry,
+) {
+    let mut interval = tokio::time::interval(config.check_interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut awaiting_growth_from = None;
+
+    loop {
+        interval.tick().await;
+        let path = config.path.clone();
+        let stats = tokio::task::spawn_blocking(move || disk_space(&path)).await;
+        let (total, available) = match stats {
+            Ok(Ok(stats)) => stats,
+            Ok(Err(error)) => {
+                tracing::warn!(path = %config.path.display(), error = %error, "read assistant workspace usage failed");
+                continue;
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "assistant workspace usage task failed");
+                continue;
+            }
+        };
+
+        if let Some(previous_total) = awaiting_growth_from {
+            if total <= previous_total {
+                continue;
+            }
+            awaiting_growth_from = None;
+        }
+        if !usage_at_or_above_threshold(total, available, config.threshold_percent) {
+            continue;
+        }
+
+        match gram_client.grow_workspace(&tokens).await {
+            Ok(result) if result.expanded => {
+                awaiting_growth_from = Some(total);
+                tracing::info!(
+                    current_bytes = result.current_bytes,
+                    requested_bytes = result.requested_bytes,
+                    "assistant workspace growth requested"
+                );
+            }
+            Ok(result) => {
+                tracing::info!(
+                    current_bytes = result.current_bytes,
+                    requested_bytes = result.requested_bytes,
+                    "assistant workspace reached its configured maximum"
+                );
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "assistant workspace growth request failed");
+            }
+        }
+    }
+}
+
+fn disk_space(path: &Path) -> Result<(u64, u64), std::io::Error> {
+    Ok((fs2::total_space(path)?, fs2::available_space(path)?))
+}
+
+fn usage_at_or_above_threshold(total: u64, available: u64, threshold_percent: u8) -> bool {
+    if total == 0 {
+        return false;
+    }
+    let used = total.saturating_sub(available);
+    u128::from(used) * 100 >= u128::from(total) * u128::from(threshold_percent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::usage_at_or_above_threshold;
+
+    #[test]
+    fn grows_at_threshold() {
+        assert!(usage_at_or_above_threshold(100, 20, 80));
+    }
+
+    #[test]
+    fn waits_below_threshold() {
+        assert!(!usage_at_or_above_threshold(100, 21, 80));
+    }
+
+    #[test]
+    fn ignores_zero_sized_filesystem() {
+        assert!(!usage_at_or_above_threshold(0, 0, 80));
+    }
+}

--- a/agents/runtime-image/init.sh
+++ b/agents/runtime-image/init.sh
@@ -7,8 +7,9 @@ sandbox_src=/usr/share/gram/sandbox
 mkdir -p "$workdir"
 
 # Size-capped tmpfs + read-only bind-mounted deps where mount(2) is permitted;
-# symlink the deps where it is not (the platform supplies the writable workdir).
-if mount -t tmpfs -o size=256m,mode=0755 tmpfs "$workdir" 2>/dev/null; then
+# symlink the deps where it is not or when GKE supplies a persistent workspace.
+# Never cover the generic-ephemeral PVC with the legacy tmpfs mount.
+if [[ -z "${GRAM_ASSISTANT_RUNTIME_GKE_WORKSPACE_PATH:-}" ]] && mount -t tmpfs -o size=256m,mode=0755 tmpfs "$workdir" 2>/dev/null; then
   for dep in browser.ts package.json node_modules; do
     src="$sandbox_src/$dep"
     dst="$workdir/$dep"

--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -58,6 +58,24 @@ var assistantRuntimeFlags = []cli.Flag{
 		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_RUNNER_CIDR"},
 	},
 	&cli.StringFlag{
+		Name:    "assistant-runtime-gke-workspace-volume-name",
+		Usage:   "Generic ephemeral volume name mounted as the GKE assistant workspace.",
+		Value:   "workspace",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_WORKSPACE_VOLUME_NAME"},
+	},
+	&cli.Int64Flag{
+		Name:    "assistant-runtime-gke-workspace-growth-increment-gib",
+		Usage:   "GiB added to a GKE assistant workspace for each authorized growth request.",
+		Value:   10,
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_WORKSPACE_GROWTH_INCREMENT_GIB"},
+	},
+	&cli.Int64Flag{
+		Name:    "assistant-runtime-gke-workspace-max-size-gib",
+		Usage:   "Maximum requested size in GiB for one GKE assistant workspace.",
+		Value:   60,
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_WORKSPACE_MAX_SIZE_GIB"},
+	},
+	&cli.StringFlag{
 		Name:    "assistant-runtime-server-url",
 		Usage:   "Optional host-reachable server base URL for assistant runtimes. Defaults to --server-url.",
 		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_SERVER_URL"},
@@ -168,14 +186,17 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 		// assistant cluster (k8s.NewRemoteDynamicClient); the egress-controlled
 		// HTTP client is built from the guardian policy in NewRuntimeBackend.
 		GKE: assistants.GKERuntimeConfig{
-			Dynamic:          nil,
-			Namespace:        gkeNamespace,
-			SandboxTemplate:  c.String("assistant-runtime-gke-sandbox-template"),
-			GuestPort:        0,
-			OCIImage:         c.String("assistant-runtime-oci-image"),
-			ImageTag:         AssistantRuntimeImageHash,
-			ServerURL:        resolvedServerURL,
-			RunnerCIDRBlocks: c.StringSlice("assistant-runtime-gke-runner-cidr"),
+			Dynamic:                     nil,
+			Namespace:                   gkeNamespace,
+			SandboxTemplate:             c.String("assistant-runtime-gke-sandbox-template"),
+			GuestPort:                   0,
+			OCIImage:                    c.String("assistant-runtime-oci-image"),
+			ImageTag:                    AssistantRuntimeImageHash,
+			ServerURL:                   resolvedServerURL,
+			RunnerCIDRBlocks:            c.StringSlice("assistant-runtime-gke-runner-cidr"),
+			WorkspaceVolumeName:         c.String("assistant-runtime-gke-workspace-volume-name"),
+			WorkspaceGrowthIncrementGiB: c.Int64("assistant-runtime-gke-workspace-growth-increment-gib"),
+			WorkspaceMaxSizeGiB:         c.Int64("assistant-runtime-gke-workspace-max-size-gib"),
 		},
 	}, nil
 }

--- a/server/cmd/gram/flags_assistants_test.go
+++ b/server/cmd/gram/flags_assistants_test.go
@@ -63,6 +63,19 @@ func TestAssistantRuntimeConfigFromCLIFallsBackToServerURL(t *testing.T) {
 	require.Equal(t, serverURL, cfg.Fly.ServerURL)
 }
 
+func TestAssistantRuntimeConfigFromCLIUsesBoundedWorkspaceGrowthDefaults(t *testing.T) {
+	t.Parallel()
+
+	ctx := newAssistantRuntimeCLIContext(t, map[string]string{
+		"assistant-runtime-provider": assistants.RuntimeProviderGKE,
+	})
+	cfg, err := assistantRuntimeConfigFromCLI(ctx, &url.URL{Scheme: "https", Host: "gram.example.com"})
+	require.NoError(t, err)
+	require.Equal(t, "workspace", cfg.GKE.WorkspaceVolumeName)
+	require.Equal(t, int64(10), cfg.GKE.WorkspaceGrowthIncrementGiB)
+	require.Equal(t, int64(60), cfg.GKE.WorkspaceMaxSizeGiB)
+}
+
 func newAssistantRuntimeCLIContext(t *testing.T, values map[string]string) *cli.Context {
 	t.Helper()
 

--- a/server/internal/assistants/impl.go
+++ b/server/internal/assistants/impl.go
@@ -31,13 +31,14 @@ import (
 )
 
 type Service struct {
-	tracer           trace.Tracer
-	logger           *slog.Logger
-	auth             *auth.Auth
-	authz            *authz.Engine
-	core             *ServiceCore
-	signaler         WorkflowSignaler
-	bootstrapLimiter *ratelimit.Limiter
+	tracer                 trace.Tracer
+	logger                 *slog.Logger
+	auth                   *auth.Auth
+	authz                  *authz.Engine
+	core                   *ServiceCore
+	signaler               WorkflowSignaler
+	bootstrapLimiter       *ratelimit.Limiter
+	workspaceGrowthLimiter *ratelimit.Limiter
 }
 
 var (
@@ -68,6 +69,9 @@ func NewService(
 		bootstrapLimiter: ratelimit.New(bootstrapStore, "assistant-bootstrap",
 			ratelimit.PerMinute(bootstrapRatePerMin).WithBurst(bootstrapRateBurst),
 			ratelimit.WithMetrics(meterProvider)),
+		workspaceGrowthLimiter: ratelimit.New(bootstrapStore, "assistant-workspace-growth",
+			ratelimit.PerMinute(workspaceGrowthRatePerMin).WithBurst(workspaceGrowthRateBurst),
+			ratelimit.WithMetrics(meterProvider)),
 	}
 }
 
@@ -81,6 +85,7 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	)
 	o11y.AttachHandler(mux, "POST", "/rpc/assistants.getThreadBootstrap", oops.ErrHandle(service.logger, service.handleGetThreadBootstrap).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/rpc/assistants.recordCompactedGeneration", oops.ErrHandle(service.logger, service.handleRecordCompactedGeneration).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", "/rpc/assistants.growWorkspace", oops.ErrHandle(service.logger, service.handleGrowWorkspace).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/rpc/assistantMcpAuth.create", oops.ErrHandle(service.logger, service.handleCreateMCPAuthFlow).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/rpc/assistantMcpAuth/{id}/oauth/callback", oops.ErrHandle(service.logger, service.handleMCPAuthCallback).ServeHTTP)
 }

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -2,6 +2,7 @@ package assistants
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -11,6 +12,8 @@ import (
 const (
 	runtimeBackendFlyIO = "flyio"
 )
+
+var ErrWorkspaceGrowthUnsupported = errors.New("assistant runtime workspace growth is not supported")
 
 type RuntimeBackend interface {
 	Backend() string
@@ -48,6 +51,10 @@ type RuntimeBackend interface {
 	// can reconcile newly attached or detached servers into a live
 	// thread without re-running the full thread bootstrap.
 	RunTurn(ctx context.Context, runtime assistantRuntimeRecord, threadID uuid.UUID, idempotencyKey string, authToken string, prompt string, mcpServers []runtimeMCPServer) error
+	// GrowWorkspace advances the runtime's workspace storage request by one
+	// backend-configured increment. Callers never select an absolute size; the
+	// backend enforces its own maximum.
+	GrowWorkspace(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendGrowWorkspaceResult, error)
 	Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error)
 	// Stop halts the active runtime so it can be re-admitted later. Backends
 	// may keep persisted state (e.g. Fly app + IP) intact for warm reuse.
@@ -87,6 +94,12 @@ type RuntimeBackendRecycleResult struct {
 type RuntimeBackendStatus struct {
 	Configured  bool
 	IdleSeconds *uint64
+}
+
+type RuntimeBackendGrowWorkspaceResult struct {
+	CurrentBytes   int64 `json:"current_bytes"`
+	RequestedBytes int64 `json:"requested_bytes"`
+	Expanded       bool  `json:"expanded"`
 }
 
 func validateRuntimeBackend(runtime RuntimeBackend, backend string) error {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -870,6 +870,10 @@ func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 	return nil
 }
 
+func (f *FlyRuntimeBackend) GrowWorkspace(_ context.Context, _ assistantRuntimeRecord) (RuntimeBackendGrowWorkspaceResult, error) {
+	return RuntimeBackendGrowWorkspaceResult{}, ErrWorkspaceGrowthUnsupported
+}
+
 func (f *FlyRuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
 	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
 		return RuntimeBackendStatus{}, err

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -17,10 +18,12 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 )
@@ -45,10 +48,14 @@ const (
 
 	gkeSandboxReadyConditionType = "Ready"
 
-	gkeMetadataAssistantID = "gram.speakeasy.com/assistant-id"
-	gkeMetadataProjectID   = "gram.speakeasy.com/project-id"
-	gkeMetadataRole        = "gram.speakeasy.com/role"
-	gkeMetadataRoleValue   = "assistant_runtime"
+	gkeMetadataAssistantID                      = "gram.speakeasy.com/assistant-id"
+	gkeMetadataProjectID                        = "gram.speakeasy.com/project-id"
+	gkeMetadataRole                             = "gram.speakeasy.com/role"
+	gkeMetadataRoleValue                        = "assistant_runtime"
+	gkeDefaultWorkspaceVolumeName               = "workspace"
+	gkeDefaultWorkspaceGrowthIncrementGiB int64 = 10
+	gkeDefaultWorkspaceMaxSizeGiB         int64 = 60
+	gkeBytesPerGiB                        int64 = 1024 * 1024 * 1024
 
 	// gkeClaimUIDLabel is injected by the SandboxClaim controller onto the pod,
 	// carrying the owning claim's UID. We resolve the runner pod (for its IP) by
@@ -62,6 +69,7 @@ var (
 	gkeSandboxClaimGVR = schema.GroupVersionResource{Group: "extensions.agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxclaims"}
 	gkeSandboxGVR      = schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1alpha1", Resource: "sandboxes"}
 	gkePodGVR          = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	gkePVCGVR          = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
 )
 
 // GKERuntimeConfig configures the GKE Agent Sandbox runtime backend. The dynamic
@@ -93,6 +101,11 @@ type GKERuntimeConfig struct {
 	// addresses the guardian egress policy blocks by default — so these blocks
 	// are allowlisted for the runner HTTP client only.
 	RunnerCIDRBlocks []string
+	// WorkspaceVolumeName is the generic ephemeral volume in the runner pod.
+	// Kubernetes names its generated PVC <pod-name>-<volume-name>.
+	WorkspaceVolumeName         string
+	WorkspaceGrowthIncrementGiB int64
+	WorkspaceMaxSizeGiB         int64
 }
 
 func (c GKERuntimeConfig) Validate() error {
@@ -119,6 +132,18 @@ func (c GKERuntimeConfig) Validate() error {
 			return fmt.Errorf("invalid --assistant-runtime-gke-runner-cidr %q: %w", cidr, err)
 		}
 	}
+	if c.WorkspaceVolumeName == "" {
+		return fmt.Errorf("--assistant-runtime-gke-workspace-volume-name is required")
+	}
+	if c.WorkspaceGrowthIncrementGiB <= 0 {
+		return fmt.Errorf("--assistant-runtime-gke-workspace-growth-increment-gib must be positive")
+	}
+	if c.WorkspaceMaxSizeGiB < c.WorkspaceGrowthIncrementGiB {
+		return fmt.Errorf("--assistant-runtime-gke-workspace-max-size-gib must be at least the growth increment")
+	}
+	if c.WorkspaceMaxSizeGiB > math.MaxInt64/gkeBytesPerGiB {
+		return fmt.Errorf("--assistant-runtime-gke-workspace-max-size-gib is too large")
+	}
 	return nil
 }
 
@@ -130,6 +155,7 @@ type gkeRuntimeMetadata struct {
 	Namespace   string `json:"namespace"`
 	ClaimName   string `json:"claim_name"`
 	SandboxName string `json:"sandbox_name"`
+	PodName     string `json:"pod_name,omitempty"`
 	PodIP       string `json:"pod_ip"`
 	Image       string `json:"image,omitempty"`
 }
@@ -144,6 +170,15 @@ type GKERuntimeBackend struct {
 func NewGKERuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider, httpClient runtimeHTTPDoer, config GKERuntimeConfig) *GKERuntimeBackend {
 	if config.GuestPort == 0 {
 		config.GuestPort = defaultRuntimeGuestPort
+	}
+	if config.WorkspaceVolumeName == "" {
+		config.WorkspaceVolumeName = gkeDefaultWorkspaceVolumeName
+	}
+	if config.WorkspaceGrowthIncrementGiB == 0 {
+		config.WorkspaceGrowthIncrementGiB = gkeDefaultWorkspaceGrowthIncrementGiB
+	}
+	if config.WorkspaceMaxSizeGiB == 0 {
+		config.WorkspaceMaxSizeGiB = gkeDefaultWorkspaceMaxSizeGiB
 	}
 	return &GKERuntimeBackend{
 		logger:     logger.With(attr.SlogComponent("assistants_gke")),
@@ -295,7 +330,7 @@ func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string
 				return gkeRuntimeMetadata{}, fmt.Errorf("get sandbox %s: %w", sandboxName, err)
 			}
 			if err == nil && sandboxReady(sandbox) {
-				podIP, err := g.resolvePodIP(ctx, string(claim.GetUID()))
+				podName, podIP, err := g.resolvePod(ctx, string(claim.GetUID()))
 				if err != nil {
 					return gkeRuntimeMetadata{}, err
 				}
@@ -304,6 +339,7 @@ func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string
 						Namespace:   g.config.Namespace,
 						ClaimName:   claimName,
 						SandboxName: sandboxName,
+						PodName:     podName,
 						PodIP:       podIP,
 						Image:       "",
 					}, nil
@@ -338,24 +374,24 @@ func sandboxReady(sandbox *unstructured.Unstructured) bool {
 	return false
 }
 
-// resolvePodIP finds the runner pod for a claim (by the controller-injected
-// claim-uid label) and returns its IP once the pod is Running. An empty string
-// means the pod is not scheduled/running yet, so the caller keeps polling.
-func (g *GKERuntimeBackend) resolvePodIP(ctx context.Context, claimUID string) (string, error) {
+// resolvePod finds the runner pod for a claim (by the controller-injected
+// claim-uid label) and returns its name and IP once the pod is Running. Empty
+// values mean the pod is not scheduled/running yet, so the caller keeps polling.
+func (g *GKERuntimeBackend) resolvePod(ctx context.Context, claimUID string) (string, string, error) {
 	pods, err := g.config.Dynamic.Resource(gkePodGVR).Namespace(g.config.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: gkeClaimUIDLabel + "=" + claimUID,
 	})
 	if err != nil {
-		return "", fmt.Errorf("list runner pods for claim %s: %w", claimUID, err)
+		return "", "", fmt.Errorf("list runner pods for claim %s: %w", claimUID, err)
 	}
 	for i := range pods.Items {
 		phase, _, _ := unstructured.NestedString(pods.Items[i].Object, "status", "phase")
 		ip, _, _ := unstructured.NestedString(pods.Items[i].Object, "status", "podIP")
 		if phase == "Running" && ip != "" {
-			return ip, nil
+			return pods.Items[i].GetName(), ip, nil
 		}
 	}
-	return "", nil
+	return "", "", nil
 }
 
 func (g *GKERuntimeBackend) endpoint(metadata gkeRuntimeMetadata) string {
@@ -404,6 +440,92 @@ func (g *GKERuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 		return fmt.Errorf("%w: execute gke turn request: %w", classifyTurnError(err), err)
 	}
 	return nil
+}
+
+func (g *GKERuntimeBackend) GrowWorkspace(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendGrowWorkspaceResult, error) {
+	if err := validateRuntimeBackend(g, runtime.Backend); err != nil {
+		return RuntimeBackendGrowWorkspaceResult{}, err
+	}
+	metadata, err := decodeGKERuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return RuntimeBackendGrowWorkspaceResult{}, err
+	}
+
+	podName := metadata.PodName
+	if podName == "" {
+		claimName := metadata.ClaimName
+		if claimName == "" {
+			claimName = g.claimName(runtime)
+		}
+		claim, err := g.claims().Get(ctx, claimName, metav1.GetOptions{})
+		if err != nil {
+			return RuntimeBackendGrowWorkspaceResult{}, fmt.Errorf("get sandbox claim %s for workspace growth: %w", claimName, err)
+		}
+		podName, _, err = g.resolvePod(ctx, string(claim.GetUID()))
+		if err != nil {
+			return RuntimeBackendGrowWorkspaceResult{}, err
+		}
+		if podName == "" {
+			return RuntimeBackendGrowWorkspaceResult{}, fmt.Errorf("%w: gke runtime pod is not available", ErrRuntimeUnhealthy)
+		}
+	}
+
+	pvcName := podName + "-" + g.config.WorkspaceVolumeName
+	pvcs := g.config.Dynamic.Resource(gkePVCGVR).Namespace(g.config.Namespace)
+	incrementBytes := g.config.WorkspaceGrowthIncrementGiB * gkeBytesPerGiB
+	maxBytes := g.config.WorkspaceMaxSizeGiB * gkeBytesPerGiB
+	result := RuntimeBackendGrowWorkspaceResult{
+		CurrentBytes:   0,
+		RequestedBytes: 0,
+		Expanded:       false,
+	}
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		pvc, err := pvcs.Get(ctx, pvcName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get workspace pvc %s: %w", pvcName, err)
+		}
+		rawSize, found, err := unstructured.NestedString(pvc.Object, "spec", "resources", "requests", "storage")
+		if err != nil {
+			return fmt.Errorf("read workspace pvc %s storage request: %w", pvcName, err)
+		}
+		if !found || rawSize == "" {
+			return fmt.Errorf("workspace pvc %s has no storage request", pvcName)
+		}
+		current, err := resource.ParseQuantity(rawSize)
+		if err != nil {
+			return fmt.Errorf("parse workspace pvc %s storage request %q: %w", pvcName, rawSize, err)
+		}
+		currentBytes := current.Value()
+		requestedBytes := currentBytes
+		if currentBytes < maxBytes {
+			requestedBytes = maxBytes
+			if incrementBytes < maxBytes-currentBytes {
+				requestedBytes = currentBytes + incrementBytes
+			}
+		}
+		result = RuntimeBackendGrowWorkspaceResult{
+			CurrentBytes:   currentBytes,
+			RequestedBytes: requestedBytes,
+			Expanded:       requestedBytes > currentBytes,
+		}
+		if !result.Expanded {
+			return nil
+		}
+
+		requested := resource.NewQuantity(requestedBytes, resource.BinarySI)
+		if err := unstructured.SetNestedField(pvc.Object, requested.String(), "spec", "resources", "requests", "storage"); err != nil {
+			return fmt.Errorf("set workspace pvc %s storage request: %w", pvcName, err)
+		}
+		_, err = pvcs.Update(ctx, pvc, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("update pvc resource: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return RuntimeBackendGrowWorkspaceResult{}, fmt.Errorf("update workspace pvc %s: %w", pvcName, err)
+	}
+	return result, nil
 }
 
 func (g *GKERuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {

--- a/server/internal/assistants/runtime_gke_test.go
+++ b/server/internal/assistants/runtime_gke_test.go
@@ -30,6 +30,7 @@ func newGKEFakeDynamic() *dynamicfake.FakeDynamicClient {
 		gkeSandboxClaimGVR: "SandboxClaimList",
 		gkeSandboxGVR:      "SandboxList",
 		gkePodGVR:          "PodList",
+		gkePVCGVR:          "PersistentVolumeClaimList",
 	})
 }
 
@@ -47,14 +48,17 @@ func seedUnstructured(t *testing.T, dyn dynamic.Interface, gvr schema.GroupVersi
 func newTestGKEBackend(t *testing.T, dyn dynamic.Interface, doer runtimeHTTPDoer, port int) *GKERuntimeBackend {
 	t.Helper()
 	return NewGKERuntimeBackend(testenv.NewLogger(t), testenv.NewTracerProvider(t), doer, GKERuntimeConfig{
-		Dynamic:          dyn,
-		Namespace:        "gram-test",
-		SandboxTemplate:  "gram-asst-pool",
-		GuestPort:        port,
-		OCIImage:         "registry.example.com/gram-assistant-runtime",
-		ImageTag:         "test",
-		ServerURL:        &url.URL{Scheme: "https", Host: "gram.example.com"},
-		RunnerCIDRBlocks: []string{"10.52.0.0/16"},
+		Dynamic:                     dyn,
+		Namespace:                   "gram-test",
+		SandboxTemplate:             "gram-asst-pool",
+		GuestPort:                   port,
+		OCIImage:                    "registry.example.com/gram-assistant-runtime",
+		ImageTag:                    "test",
+		ServerURL:                   &url.URL{Scheme: "https", Host: "gram.example.com"},
+		RunnerCIDRBlocks:            []string{"10.52.0.0/16"},
+		WorkspaceVolumeName:         "workspace",
+		WorkspaceGrowthIncrementGiB: 10,
+		WorkspaceMaxSizeGiB:         60,
 	})
 }
 
@@ -79,6 +83,7 @@ func gkeRecord(t *testing.T, backend *GKERuntimeBackend, assistantID uuid.UUID, 
 		Namespace:   "gram-test",
 		ClaimName:   "gram-asst-" + assistantID.String(),
 		SandboxName: "sb-1",
+		PodName:     "sb-1-pod",
 		PodIP:       podIP,
 		Image:       backend.desiredImageRef(),
 	}
@@ -158,6 +163,67 @@ func TestGKEStatusReadsRunnerState(t *testing.T) {
 	require.True(t, status.Configured)
 	require.NotNil(t, status.IdleSeconds)
 	require.Equal(t, uint64(7), *status.IdleSeconds)
+}
+
+func TestGKEGrowWorkspaceIncrementsPVC(t *testing.T) {
+	t.Parallel()
+
+	dyn := newGKEFakeDynamic()
+	pvc := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "PersistentVolumeClaim",
+		"metadata": map[string]any{
+			"name":      "sb-1-pod-workspace",
+			"namespace": "gram-test",
+		},
+		"spec": map[string]any{
+			"resources": map[string]any{
+				"requests": map[string]any{"storage": "20Gi"},
+			},
+		},
+	}}
+	seedUnstructured(t, dyn, gkePVCGVR, pvc)
+	backend := newTestGKEBackend(t, dyn, http.DefaultClient, defaultRuntimeGuestPort)
+
+	result, err := backend.GrowWorkspace(t.Context(), gkeRecord(t, backend, uuid.New(), "10.0.0.1"))
+	require.NoError(t, err)
+	require.Equal(t, int64(20)*gkeBytesPerGiB, result.CurrentBytes)
+	require.Equal(t, int64(30)*gkeBytesPerGiB, result.RequestedBytes)
+	require.True(t, result.Expanded)
+
+	updated, err := dyn.Resource(gkePVCGVR).Namespace("gram-test").Get(t.Context(), "sb-1-pod-workspace", metav1.GetOptions{})
+	require.NoError(t, err)
+	storage, found, err := unstructured.NestedString(updated.Object, "spec", "resources", "requests", "storage")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "30Gi", storage)
+}
+
+func TestGKEGrowWorkspaceStopsAtMaximum(t *testing.T) {
+	t.Parallel()
+
+	dyn := newGKEFakeDynamic()
+	pvc := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "PersistentVolumeClaim",
+		"metadata": map[string]any{
+			"name":      "sb-1-pod-workspace",
+			"namespace": "gram-test",
+		},
+		"spec": map[string]any{
+			"resources": map[string]any{
+				"requests": map[string]any{"storage": "60Gi"},
+			},
+		},
+	}}
+	seedUnstructured(t, dyn, gkePVCGVR, pvc)
+	backend := newTestGKEBackend(t, dyn, http.DefaultClient, defaultRuntimeGuestPort)
+
+	result, err := backend.GrowWorkspace(t.Context(), gkeRecord(t, backend, uuid.New(), "10.0.0.1"))
+	require.NoError(t, err)
+	require.Equal(t, int64(60)*gkeBytesPerGiB, result.CurrentBytes)
+	require.Equal(t, int64(60)*gkeBytesPerGiB, result.RequestedBytes)
+	require.False(t, result.Expanded)
 }
 
 func TestGKEEnsureWaitsForReadySandbox(t *testing.T) {

--- a/server/internal/assistants/runtime_router.go
+++ b/server/internal/assistants/runtime_router.go
@@ -95,6 +95,18 @@ func (r *runtimeRouter) RunTurn(ctx context.Context, runtime assistantRuntimeRec
 	return nil
 }
 
+func (r *runtimeRouter) GrowWorkspace(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendGrowWorkspaceResult, error) {
+	b, err := r.route(runtime.Backend)
+	if err != nil {
+		return RuntimeBackendGrowWorkspaceResult{}, err
+	}
+	result, err := b.GrowWorkspace(ctx, runtime)
+	if err != nil {
+		return result, fmt.Errorf("grow %s runtime workspace: %w", runtime.Backend, err)
+	}
+	return result, nil
+}
+
 func (r *runtimeRouter) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
 	b, err := r.route(runtime.Backend)
 	if err != nil {

--- a/server/internal/assistants/runtime_router_test.go
+++ b/server/internal/assistants/runtime_router_test.go
@@ -58,6 +58,10 @@ func (s *stubRuntimeBackend) RunTurn(_ context.Context, _ assistantRuntimeRecord
 	return nil
 }
 
+func (s *stubRuntimeBackend) GrowWorkspace(_ context.Context, _ assistantRuntimeRecord) (RuntimeBackendGrowWorkspaceResult, error) {
+	return RuntimeBackendGrowWorkspaceResult{CurrentBytes: 20, RequestedBytes: 30, Expanded: true}, nil
+}
+
 func (s *stubRuntimeBackend) Status(_ context.Context, _ assistantRuntimeRecord) (RuntimeBackendStatus, error) {
 	return RuntimeBackendStatus{Configured: true, IdleSeconds: nil}, nil
 }

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -153,6 +153,18 @@ func (t *telemetryRuntimeBackend) RunTurn(
 	return nil
 }
 
+func (t *telemetryRuntimeBackend) GrowWorkspace(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendGrowWorkspaceResult, error) {
+	result, err := t.inner.GrowWorkspace(ctx, runtime)
+	if err != nil {
+		t.emit(ctx, runtime, "runtime_workspace_grow", "runtime workspace growth failed", "ERROR", err)
+		return result, fmt.Errorf("runtime workspace growth: %w", err)
+	}
+	if result.Expanded {
+		t.emit(ctx, runtime, "runtime_workspace_grow", "runtime workspace growth requested", "INFO", nil)
+	}
+	return result, nil
+}
+
 func (t *telemetryRuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
 	status, err := t.inner.Status(ctx, runtime)
 	if err != nil {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1626,6 +1626,33 @@ func (s *ServiceCore) RuntimeImageRef() string {
 	return s.runtime.ImageRef()
 }
 
+func (s *ServiceCore) GrowRuntimeWorkspace(ctx context.Context, projectID, assistantID uuid.UUID) (RuntimeBackendGrowWorkspaceResult, error) {
+	row, err := assistantrepo.New(s.db).GetAssistantRuntimeV2(ctx, assistantrepo.GetAssistantRuntimeV2Params{
+		ProjectID:   projectID,
+		AssistantID: assistantID,
+	})
+	if err != nil {
+		return RuntimeBackendGrowWorkspaceResult{}, fmt.Errorf("load assistant runtime for workspace growth: %w", err)
+	}
+	if row.State != runtimeStateActive {
+		return RuntimeBackendGrowWorkspaceResult{}, fmt.Errorf("assistant runtime workspace cannot grow while state is %q", row.State)
+	}
+	result, err := s.runtime.GrowWorkspace(ctx, assistantRuntimeRecord{
+		ID:                  row.ID,
+		AssistantThreadID:   row.AssistantThreadID,
+		AssistantID:         row.AssistantID,
+		ProjectID:           row.ProjectID,
+		Backend:             row.Backend,
+		BackendMetadataJSON: row.BackendMetadataJson,
+		State:               row.State,
+		WarmUntil:           row.WarmUntil,
+	})
+	if err != nil {
+		return RuntimeBackendGrowWorkspaceResult{}, fmt.Errorf("grow assistant runtime workspace: %w", err)
+	}
+	return result, nil
+}
+
 // reapRuntimeRow tears down the backend resource for one row and records the
 // outcome in DB. Returns true on success (including idempotent no-op when
 // the resource was already gone). Errors are logged here so callers can

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -2119,6 +2119,10 @@ func (t testRuntimeBackend) RunTurn(_ context.Context, _ assistantRuntimeRecord,
 	return t.runTurnErr
 }
 
+func (t testRuntimeBackend) GrowWorkspace(_ context.Context, _ assistantRuntimeRecord) (RuntimeBackendGrowWorkspaceResult, error) {
+	return RuntimeBackendGrowWorkspaceResult{}, ErrWorkspaceGrowthUnsupported
+}
+
 func (t testRuntimeBackend) Status(context.Context, assistantRuntimeRecord) (RuntimeBackendStatus, error) {
 	if t.statusErr != nil {
 		return RuntimeBackendStatus{}, t.statusErr

--- a/server/internal/assistants/workspace_handler.go
+++ b/server/internal/assistants/workspace_handler.go
@@ -1,0 +1,76 @@
+package assistants
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+const (
+	workspaceGrowthRatePerMin = 1
+	workspaceGrowthRateBurst  = 1
+)
+
+func (s *Service) handleGrowWorkspace(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	token := r.Header.Get("Authorization")
+	if token == "" {
+		return oops.C(oops.CodeUnauthorized)
+	}
+
+	authedCtx, claims, err := s.core.assistantTokens.Authorize(ctx, token)
+	if err != nil {
+		return fmt.Errorf("authorize assistant runtime token: %w", err)
+	}
+	ctx = authedCtx
+	principal, ok := contextvalues.GetAssistantPrincipal(ctx)
+	if !ok {
+		return oops.C(oops.CodeUnauthorized)
+	}
+	projectID, err := uuid.Parse(claims.ProjectID)
+	if err != nil {
+		return oops.E(oops.CodeUnauthorized, err, "invalid token project")
+	}
+	rate, err := s.workspaceGrowthLimiter.Allow(ctx, principal.AssistantID.String())
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "check workspace growth rate limit").LogError(ctx, s.logger,
+			attr.SlogAssistantID(principal.AssistantID.String()),
+		)
+	}
+	if !rate.Allowed {
+		return oops.E(oops.CodeRateLimitExceeded, nil, "assistant workspace growth rate limit exceeded")
+	}
+
+	result, err := s.core.GrowRuntimeWorkspace(ctx, projectID, principal.AssistantID)
+	if err != nil {
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			return oops.E(oops.CodeNotFound, err, "active assistant runtime not found")
+		case errors.Is(err, ErrWorkspaceGrowthUnsupported):
+			return oops.E(oops.CodeConflict, err, "assistant runtime workspace cannot be expanded")
+		default:
+			return oops.E(oops.CodeUnexpected, err, "expand assistant runtime workspace").LogError(ctx, s.logger,
+				attr.SlogProjectID(projectID.String()),
+				attr.SlogAssistantID(principal.AssistantID.String()),
+			)
+		}
+	}
+
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "encode workspace growth response")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(payload); err != nil {
+		return fmt.Errorf("write workspace growth response: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- monitor the GKE assistant workspace every 30 seconds and request growth at 80% utilization
- add an authenticated internal RPC that expands only the calling assistant's generic-ephemeral PVC
- grow in server-controlled 10 GiB increments, capped at 60 GiB
- keep Fly runtimes unchanged and disable the legacy 256 MiB tmpfs overlay when GKE mounts the disk-backed workspace
- add telemetry, a per-assistant one-request-per-minute safety limit, and conflict-safe PVC updates

## Security and lifecycle

The runner never receives Kubernetes credentials. It calls `POST /rpc/assistants.growWorkspace` with its existing assistant runtime JWT. The server derives project and assistant identity from that token, loads the active runtime, resolves its own pod/PVC, and applies one bounded increment; callers cannot select a PVC or size.

After a successful request, the runner waits until the filesystem reports larger capacity before it can request another increment. The PVC remains generic-ephemeral and is deleted with the sandbox.

## Dependencies and rollout

Depends on:

- [gram-infra #1828](https://github.com/speakeasy-api/gram-infra/pull/1828) for the initial 20 GiB `standard-rwo` generic-ephemeral workspace, mount/env contract, quota, and PVC RBAC
- [gram-infra #1827](https://github.com/speakeasy-api/gram-infra/pull/1827) for the production assistant runtime move to GKE

Safe rollout order: merge/deploy this PR first (monitoring is disabled while the GKE workspace path env is absent), then apply #1828 after #1827. No database migration is required.

## Testing

- `go test ./server/internal/assistants ./server/cmd/gram`
- `cargo test --manifest-path agents/runner/Cargo.toml` (42 tests)
- `cargo clippy --manifest-path agents/runner/Cargo.toml --all-targets --all-features -- -D warnings`
- `mise lint:server`
- `mise exec -- hk fix`

Focused GKE tests cover a 20 GiB PVC growing to 30 GiB and a 60 GiB PVC remaining capped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically grows GKE assistant workspaces in 10 GiB steps when usage reaches 80%, capped at 60 GiB. Adds a secure RPC and a runner-side monitor; Fly runtimes are unchanged.

- **New Features**
  - Runner monitors the workspace every 30s (configurable) and calls `POST /rpc/assistants.growWorkspace` at 80% usage.
  - Server authenticates the runtime token, resolves the caller’s pod PVC, and increments storage by 10 GiB up to 60 GiB. Updates are conflict-safe and capped.
  - One growth request per assistant per minute, with telemetry. Runner waits for the filesystem to report the larger size before requesting again.
  - Disables the legacy 256 MiB tmpfs when `GRAM_ASSISTANT_RUNTIME_GKE_WORKSPACE_PATH` is set. Fly remains unchanged and returns “unsupported” for growth.
  - New flags: `--assistant-runtime-gke-workspace-volume-name` (default `workspace`), `--assistant-runtime-gke-workspace-growth-increment-gib` (default 10), `--assistant-runtime-gke-workspace-max-size-gib` (default 60).

- **Dependencies**
  - Requires infra support for the initial 20 GiB `standard-rwo` generic-ephemeral workspace, mount/env contract, quota, and PVC RBAC. Roll out this PR first, then infra changes afterward.

<sup>Written for commit 1a79de6edfa4e1ae40d62ac0e9e7ad0ece4d4a8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->