### PR TITLE
fix: globally rate limit WorkOS user event sync

### DIFF
--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -160,6 +160,7 @@ func NewActivities(
 	publishers *Publishers,
 	celEng *celenv.Engine,
 	judgeRateLimiter *ratelimit.Limiter,
+	workosRateLimiter activities.WorkOSRateLimiter,
 	builtinPresets *presetlib.Library,
 ) *Activities {
 	return &Activities{
@@ -212,7 +213,7 @@ func NewActivities(
 		backfillWorkOSGlobalRoles:       activities.NewBackfillWorkOSGlobalRoles(logger, db, workosClient),
 		processWorkOSOrganizationEvents: activities.NewProcessWorkOSOrganizationEvents(logger, db, workosClient),
 		processWorkOSGlobalRoleEvents:   activities.NewProcessWorkOSGlobalRoleEvents(logger, db, workosClient),
-		processWorkOSUserEvents:         activities.NewProcessWorkOSUserEvents(logger, db, workosClient),
+		processWorkOSUserEvents:         activities.NewProcessWorkOSUserEvents(logger, db, workosClient, workosRateLimiter),
 		cancelAssistantsSubscription:    activities.NewCancelAssistantsSubscription(logger, billingRepo),
 		outboxRelay:                     outbox_relay.New(logger, tracerProvider, db, svixClient, productFeatures),
 		outboxGC:                        outbox_relay.NewGC(logger, meterProvider, db),

--- a/server/internal/background/activities/process_workos_user_events.go
+++ b/server/internal/background/activities/process_workos_user_events.go
@@ -39,16 +39,28 @@ type ProcessWorkOSUserEventsResult struct {
 }
 
 type ProcessWorkOSUserEvents struct {
-	db           *pgxpool.Pool
-	logger       *slog.Logger
-	workosClient WorkOSClient
+	db                *pgxpool.Pool
+	logger            *slog.Logger
+	workosClient      WorkOSClient
+	workosRateLimiter WorkOSRateLimiter
 }
 
-func NewProcessWorkOSUserEvents(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSClient) *ProcessWorkOSUserEvents {
+// WorkOSRateLimiter waits for admission to the shared WorkOS API quota.
+type WorkOSRateLimiter interface {
+	Wait(ctx context.Context) error
+}
+
+func NewProcessWorkOSUserEvents(
+	logger *slog.Logger,
+	db *pgxpool.Pool,
+	workosClient WorkOSClient,
+	workosRateLimiter WorkOSRateLimiter,
+) *ProcessWorkOSUserEvents {
 	return &ProcessWorkOSUserEvents{
-		db:           db,
-		logger:       logger,
-		workosClient: workosClient,
+		db:                db,
+		logger:            logger,
+		workosClient:      workosClient,
+		workosRateLimiter: workosRateLimiter,
 	}
 }
 
@@ -68,6 +80,15 @@ func (p *ProcessWorkOSUserEvents) Do(ctx context.Context, params ProcessWorkOSUs
 		default:
 			sinceEventID = cursor
 		}
+	}
+
+	if err := p.workosRateLimiter.Wait(ctx); err != nil {
+		if ctx.Err() != nil {
+			return nil, oops.E(oops.CodeUnexpected, ctx.Err(), "wait for WorkOS API rate limit").LogError(ctx, logger)
+		}
+		// A Redis outage is not a WorkOS throttle. Fail open so limiter
+		// infrastructure cannot halt identity synchronization.
+		logger.WarnContext(ctx, "WorkOS API rate limiter unavailable, allowing request", attr.SlogError(err))
 	}
 
 	resp, err := p.workosClient.ListEvents(ctx, events.ListEventsOpts{

--- a/server/internal/background/activities/process_workos_user_events_test.go
+++ b/server/internal/background/activities/process_workos_user_events_test.go
@@ -3,6 +3,7 @@ package activities_test
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -29,6 +30,30 @@ func newUserEventsTestConn(t *testing.T, name string) *pgxpool.Pool {
 	conn, err := infra.CloneTestDatabase(t, name)
 	require.NoError(t, err)
 	return conn
+}
+
+type allowingWorkOSRateLimiter struct{}
+
+func (allowingWorkOSRateLimiter) Wait(context.Context) error { return nil }
+
+type failingWorkOSRateLimiter struct {
+	err   error
+	calls int
+}
+
+func (l *failingWorkOSRateLimiter) Wait(context.Context) error {
+	l.calls++
+	return l.err
+}
+
+func newProcessWorkOSUserEvents(
+	t *testing.T,
+	logger *slog.Logger,
+	conn *pgxpool.Pool,
+	workosClient activities.WorkOSClient,
+) *activities.ProcessWorkOSUserEvents {
+	t.Helper()
+	return activities.NewProcessWorkOSUserEvents(logger, conn, workosClient, allowingWorkOSRateLimiter{})
 }
 
 func userEventData(workosUserID, email, firstName, lastName, photoURL string) []byte {
@@ -99,7 +124,7 @@ func TestProcessWorkOSUserEvents_CreatesUser(t *testing.T) {
 		{ID: "event_user_create", Event: "user.created", CreatedAt: time.Now(), Data: userEventData(workosUserID, "ada@example.com", "Ada", "Lovelace", "https://example.com/ada.png")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_create", res.LastEventID)
@@ -164,7 +189,7 @@ func TestProcessWorkOSUserEvents_CreatesUserWithExistingExternalID(t *testing.T)
 		{ID: "event_user_create_external_id", Event: "user.created", CreatedAt: time.Now(), Data: userEventDataWithExternalID(workosUserID, externalID, "ada@example.com", "Ada", "Lovelace", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_create_external_id", res.LastEventID)
@@ -193,7 +218,7 @@ func TestProcessWorkOSUserEvents_LinksExistingLocalUserByExternalID(t *testing.T
 		{ID: "event_user_link_external_id", Event: "user.updated", CreatedAt: time.Now(), Data: userEventDataWithExternalID(workosUserID, externalID, "ada@example.com", "Ada", "Lovelace", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_link_external_id", res.LastEventID)
@@ -229,7 +254,7 @@ func TestProcessWorkOSUserEvents_UsesExistingWorkOSLinkBeforeExternalID(t *testi
 		{ID: "event_user_workos_first", Event: "user.updated", CreatedAt: time.Now(), Data: userEventDataWithExternalID(workosUserID, externalID, "new@example.com", "New", "Name", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_workos_first", res.LastEventID)
@@ -264,7 +289,7 @@ func TestProcessWorkOSUserEvents_ExternalIDLinkedToDifferentWorkOSUserStopsSync(
 		{ID: "event_user_external_id_conflict", Event: "user.updated", CreatedAt: time.Now(), Data: userEventDataWithExternalID(workosUserID, externalID, "new@example.com", "New", "User", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.Error(t, err)
 	require.Nil(t, res)
@@ -333,7 +358,7 @@ func TestProcessWorkOSUserEvents_LinksOptimisticRoleAssignments(t *testing.T) {
 		{ID: "event_user_role_assignment", Event: "user.created", CreatedAt: time.Now(), Data: userEventData(workosUserID, "role@example.com", "Role", "User", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_role_assignment", res.LastEventID)
@@ -417,7 +442,7 @@ func TestProcessWorkOSUserEvents_LinksMultipleOptimisticRoleAssignments(t *testi
 		{ID: "event_user_multi_role_link", Event: "user.created", CreatedAt: time.Now(), Data: userEventData(workosUserID, "multirole@example.com", "Multi", "Role", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_multi_role_link", res.LastEventID)
@@ -500,7 +525,7 @@ func TestProcessWorkOSUserEvents_LinksPendingRelationshipOverTombstone(t *testin
 		{ID: "event_user_relationship_tombstone", Event: "user.updated", CreatedAt: time.Now(), Data: userEventDataWithExternalID(workosUserID, gramUserID, "new@example.com", "Existing", "User", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_relationship_tombstone", res.LastEventID)
@@ -561,7 +586,7 @@ func TestProcessWorkOSUserEvents_LinksPendingRelationshipToExistingExternalID(t 
 		{ID: "event_user_relationship_external", Event: "user.updated", CreatedAt: time.Now(), Data: userEventDataWithExternalID(workosUserID, externalID, "new@example.com", "External", "User", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_relationship_external", res.LastEventID)
@@ -593,7 +618,7 @@ func TestProcessWorkOSUserEvents_UsesExistingUserIDWhenExternalIDMissing(t *test
 		{ID: "event_user_existing_id", Event: "user.updated", CreatedAt: time.Now(), Data: userEventData(workosUserID, "new@example.com", "New", "Name", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_user_existing_id", res.LastEventID)
@@ -624,7 +649,7 @@ func TestProcessWorkOSUserEvents_UpdatesExistingUserAndPreservesBlankFields(t *t
 		{ID: "event_user_update", Event: "user.updated", CreatedAt: time.Now(), Data: userEventData(workosUserID, "new@example.com", "New", "Name", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	_, err = activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 
@@ -652,7 +677,7 @@ func TestProcessWorkOSUserEvents_SoftDeletesUser(t *testing.T) {
 		{ID: "event_user_delete", Event: "user.deleted", CreatedAt: time.Now(), Data: userEventData(workosUserID, "delete@example.com", "", "", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	_, err = activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 
@@ -681,7 +706,7 @@ func TestProcessWorkOSUserEvents_AdvancesAndResumesCursor(t *testing.T) {
 		{ID: "event_next", Event: "user.created", CreatedAt: time.Now(), Data: userEventData(workosUserID, "cursor@example.com", "", "", "")},
 	}})
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Equal(t, "event_seed", res.SinceEventID)
@@ -705,7 +730,7 @@ func TestProcessWorkOSUserEvents_EmptyPageDoesNotAdvanceCursor(t *testing.T) {
 	const workosUserID = "user_empty"
 	workosClient := workos.NewStubClient()
 	workosClient.SetEventPages([][]events.Event{nil})
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
 	require.NoError(t, err)
 	require.Empty(t, res.LastEventID)
@@ -713,6 +738,22 @@ func TestProcessWorkOSUserEvents_EmptyPageDoesNotAdvanceCursor(t *testing.T) {
 
 	_, err = workosrepo.New(conn).GetUserSyncLastEventID(ctx, conv.ToPGText(workosUserID))
 	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestProcessWorkOSUserEvents_RateLimiterFailureFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newUserEventsTestConn(t, "workos_user_events_limiter_failure")
+	logger := testenv.NewLogger(t)
+	workosClient := workos.NewStubClient()
+	limiter := &failingWorkOSRateLimiter{err: errors.New("redis unavailable"), calls: 0}
+	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient, limiter)
+
+	_, err := activity.Do(ctx, processWorkOSUserEventsParams("user_limiter_failure"))
+	require.NoError(t, err)
+	require.Equal(t, 1, limiter.calls)
+	require.Len(t, workosClient.EventCalls(), 1)
 }
 
 func TestProcessWorkOSUserEvents_ExternalIDFailureDoesNotFail(t *testing.T) {
@@ -728,7 +769,7 @@ func TestProcessWorkOSUserEvents_ExternalIDFailureDoesNotFail(t *testing.T) {
 	}})
 	workosClient := &failingUpdateExternalIDWorkOSClient{StubClient: stub, err: errors.New("boom")}
 
-	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	activity := newProcessWorkOSUserEvents(t, logger, conn, workosClient)
 	res, err := activity.Do(ctx, processWorkOSUserEventsParams("user_external"))
 	require.NoError(t, err)
 	require.Equal(t, "event_external_id", res.LastEventID)

--- a/server/internal/background/activities/workos_rate_limiter.go
+++ b/server/internal/background/activities/workos_rate_limiter.go
@@ -1,0 +1,64 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+)
+
+const (
+	// WorkOS documents a general limit of 6,000 requests per 60 seconds per
+	// source IP. Keep headroom for WorkOS calls that have not yet been moved
+	// behind this limiter, and smooth webhook-driven bursts across worker pods.
+	workosAPIRateLimiterName = "workos-api"
+	workosAPIRateLimitKey    = "global"
+	workosAPIRequestsPerMin  = 5_400
+	workosAPIRequestBurst    = 20
+)
+
+type allowLimiter interface {
+	Allow(ctx context.Context, key string) (ratelimit.Result, error)
+}
+
+type redisWorkOSRateLimiter struct {
+	limiter allowLimiter
+}
+
+// NewWorkOSRateLimiter creates the shared WorkOS API limiter. Every caller
+// uses the same key because WorkOS applies its general quota across requests,
+// not per organization or user.
+func NewWorkOSRateLimiter(store ratelimit.Store) WorkOSRateLimiter {
+	return &redisWorkOSRateLimiter{
+		limiter: ratelimit.New(
+			store,
+			workosAPIRateLimiterName,
+			ratelimit.PerMinute(workosAPIRequestsPerMin).WithBurst(workosAPIRequestBurst),
+		),
+	}
+}
+
+// Wait blocks until this caller owns a token or the context is canceled.
+func (l *redisWorkOSRateLimiter) Wait(ctx context.Context) error {
+	for {
+		res, err := l.limiter.Allow(ctx, workosAPIRateLimitKey)
+		if err != nil {
+			return fmt.Errorf("check workos API rate limit: %w", err)
+		}
+		if res.Allowed {
+			return nil
+		}
+		if res.RetryAfter <= 0 {
+			return fmt.Errorf("workos API rate limit denied without a retry delay")
+		}
+
+		timer := time.NewTimer(res.RetryAfter)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("wait for workos API rate limit: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+}

--- a/server/internal/background/activities/workos_rate_limiter_test.go
+++ b/server/internal/background/activities/workos_rate_limiter_test.go
@@ -1,0 +1,70 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+)
+
+type scriptedLimiter struct {
+	results []ratelimit.Result
+	errs    []error
+	keys    []string
+}
+
+func (s *scriptedLimiter) Allow(_ context.Context, key string) (ratelimit.Result, error) {
+	s.keys = append(s.keys, key)
+	idx := len(s.keys) - 1
+	return s.results[idx], s.errs[idx]
+}
+
+func TestWorkOSRateLimiterWaitRetriesUntilAllowed(t *testing.T) {
+	t.Parallel()
+
+	limiter := &scriptedLimiter{
+		results: []ratelimit.Result{
+			{Allowed: false, Remaining: 0, RetryAfter: time.Nanosecond},
+			{Allowed: true, Remaining: 1, RetryAfter: 0},
+		},
+		errs: []error{nil, nil},
+		keys: nil,
+	}
+
+	err := (&redisWorkOSRateLimiter{limiter: limiter}).Wait(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []string{workosAPIRateLimitKey, workosAPIRateLimitKey}, limiter.keys)
+}
+
+func TestWorkOSRateLimiterWaitStopsWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	limiter := &scriptedLimiter{
+		results: []ratelimit.Result{{Allowed: false, Remaining: 0, RetryAfter: time.Hour}},
+		errs:    []error{nil},
+		keys:    nil,
+	}
+
+	err := (&redisWorkOSRateLimiter{limiter: limiter}).Wait(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWorkOSRateLimiterWaitReturnsStoreError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("redis unavailable")
+	limiter := &scriptedLimiter{
+		results: []ratelimit.Result{{Allowed: false, Remaining: 0, RetryAfter: 0}},
+		errs:    []error{wantErr},
+		keys:    nil,
+	}
+
+	err := (&redisWorkOSRateLimiter{limiter: limiter}).Wait(t.Context())
+	require.ErrorIs(t, err, wantErr)
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -278,6 +278,7 @@ func NewTemporalWorker(
 	}
 
 	judgeRateLimiter := openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(opts.RedisClient))
+	workosRateLimiter := activities.NewWorkOSRateLimiter(ratelimit.NewRedisStore(opts.RedisClient))
 
 	activities := NewActivities(
 		logger,
@@ -322,6 +323,7 @@ func NewTemporalWorker(
 		opts.Publishers,
 		celEng,
 		judgeRateLimiter,
+		workosRateLimiter,
 		opts.BuiltinPresets,
 	)
 

--- a/server/internal/thirdparty/workos/client_test.go
+++ b/server/internal/thirdparty/workos/client_test.go
@@ -8,12 +8,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/workos/workos-go/v6/pkg/common"
+	"github.com/workos/workos-go/v6/pkg/events"
 	"github.com/workos/workos-go/v6/pkg/organizations"
 	"github.com/workos/workos-go/v6/pkg/roles"
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
@@ -435,6 +437,48 @@ func newTestClient(t *testing.T, fake *fakeWorkOS) (*workos.Client, *fakeWorkOS)
 		ClientID:   "test-client-id",
 	})
 	return client, fake
+}
+
+func TestClientListEventsHonorsRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	requestTimes := make(chan time.Time, 2)
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestTimes <- time.Now()
+		if requests.Add(1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"data":          []any{},
+			"list_metadata": map[string]string{"before": "", "after": ""},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	client := workos.NewClient(guardianPolicy, "test-api-key", workos.ClientOpts{
+		Endpoint:   srv.URL,
+		HTTPClient: nil,
+		ClientID:   "test-client-id",
+	})
+
+	_, err = client.ListEvents(t.Context(), events.ListEventsOpts{
+		Events:         nil,
+		Limit:          1,
+		After:          "",
+		OrganizationId: "",
+		RangeStart:     "",
+		RangeEnd:       "",
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, requests.Load())
+	first, second := <-requestTimes, <-requestTimes
+	require.GreaterOrEqual(t, second.Sub(first), 900*time.Millisecond)
 }
 
 // --- tests ---


### PR DESCRIPTION
## Summary

- add a Redis-backed, fleet-wide admission limiter for WorkOS user-event polling
- cap polling at 5,400 requests/minute with burst 20, leaving headroom below WorkOS's documented 6,000 requests/60 seconds/IP quota
- wait contextually for Redis limiter `RetryAfter` before calling `ListEvents`, while failing open if Redis is unavailable
- add regression coverage confirming the WorkOS HTTP client honors server-provided `Retry-After`

## Why

Concurrent per-user Temporal workflows can independently call the WorkOS Events API, causing a fleet-wide burst that exhausts the HTTP client's five retry attempts. The existing HTTP retry layer already respects `Retry-After`, but it cannot prevent separate workflows and worker replicas from retrying into the same quota window.

Production event: https://app.datadoghq.com/logs?query=service%3Agram-worker%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ9KdmkV2NbUSAAAABhBWjlLZG5veUFBQldoX3Q1Qldnc1RRQ3kAAAAkMDE5ZjRhN2YtYWI5ZC00ZWQxLThkMWEtMzIyNzM2MzNkYjg2AAMxYw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1783655344187&to_ts=1783669744187&live=true

WorkOS quota documentation: https://workos.com/docs/reference/rate-limits

## Testing

- `go test ./server/internal/ratelimit ./server/internal/thirdparty/workos ./server/internal/background/activities ./server/internal/background`
- `mise lint:server`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Redis-backed, fleet-wide rate limiter for WorkOS user-event polling to prevent quota bursts across workers. Caps traffic at 5,400 req/min with burst 20 and fails open if Redis is down.

- **Bug Fixes**
  - Gate `ListEvents` behind a global `ratelimit` with a shared key to smooth cross-replica load; keeps headroom below WorkOS’s 6,000/60s per-IP limit.
  - Wait for limiter `RetryAfter` and honor server `Retry-After` before retrying.
  - Wire limiter into activities and worker; add tests for limiter waiting, fail-open behavior, and client retry timing.

<sup>Written for commit 4db0951e10e4e333959bb89fccc63d0640a2bc4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

