### PR TITLE
chore: optimize platform tool lookup performance

### DIFF
--- a/.changeset/optimize-toolset-list.md
+++ b/.changeset/optimize-toolset-list.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Avoid rebuilding every platform tool descriptor for each tool returned by `toolsets.list`, significantly reducing latency for projects with large toolsets.

--- a/server/internal/platformtools/registry.go
+++ b/server/internal/platformtools/registry.go
@@ -338,46 +338,65 @@ func FindToolDescriptor(toolURN urn.Tool, extras ...ExternalTool) (ToolDescripto
 	return zero, false
 }
 
-func FindToolEntries(toolURNs []string, extras ...ExternalTool) []*types.ToolEntry {
-	entries := make([]*types.ToolEntry, 0, len(toolURNs))
-	seen := make(map[string]struct{}, len(toolURNs))
+func indexToolDescriptors(extras ...ExternalTool) map[string]ToolDescriptor {
+	all := ListPlatformTools(extras...)
+	descriptorsByURN := make(map[string]ToolDescriptor, len(all))
+	for _, descriptor := range all {
+		toolURN := descriptor.ToolURN().String()
+		if _, exists := descriptorsByURN[toolURN]; exists {
+			continue
+		}
+		descriptorsByURN[toolURN] = descriptor
+	}
+	return descriptorsByURN
+}
+
+func findToolDescriptors(toolURNs []string, extras ...ExternalTool) []ToolDescriptor {
+	var found []ToolDescriptor
+	var seen map[string]struct{}
+	var descriptorsByURN map[string]ToolDescriptor
 	for _, rawURN := range toolURNs {
 		var toolURN urn.Tool
 		if err := toolURN.UnmarshalText([]byte(rawURN)); err != nil {
 			continue
 		}
-		descriptor, ok := FindToolDescriptor(toolURN, extras...)
+		if toolURN.Kind != urn.ToolKindPlatform {
+			continue
+		}
+		if descriptorsByURN == nil {
+			descriptorsByURN = indexToolDescriptors(extras...)
+		}
+		descriptor, ok := descriptorsByURN[toolURN.String()]
 		if !ok {
 			continue
 		}
-		if _, ok := seen[descriptor.ToolURN().String()]; ok {
+		descriptorURN := descriptor.ToolURN().String()
+		if _, ok := seen[descriptorURN]; ok {
 			continue
 		}
-		seen[descriptor.ToolURN().String()] = struct{}{}
+		if seen == nil {
+			seen = make(map[string]struct{}, len(descriptorsByURN))
+		}
+		seen[descriptorURN] = struct{}{}
+		found = append(found, descriptor)
+	}
+	return found
+}
+
+func FindToolEntries(toolURNs []string, extras ...ExternalTool) []*types.ToolEntry {
+	descriptors := findToolDescriptors(toolURNs, extras...)
+	entries := make([]*types.ToolEntry, 0, len(descriptors))
+	for _, descriptor := range descriptors {
 		entries = append(entries, descriptor.ToToolEntry())
 	}
-
 	return entries
 }
 
 func FindTypedTools(projectID uuid.UUID, toolURNs []string, extras ...ExternalTool) []*types.Tool {
-	tools := make([]*types.Tool, 0, len(toolURNs))
-	seen := make(map[string]struct{}, len(toolURNs))
-	for _, rawURN := range toolURNs {
-		var toolURN urn.Tool
-		if err := toolURN.UnmarshalText([]byte(rawURN)); err != nil {
-			continue
-		}
-		descriptor, ok := FindToolDescriptor(toolURN, extras...)
-		if !ok {
-			continue
-		}
-		if _, ok := seen[descriptor.ToolURN().String()]; ok {
-			continue
-		}
-		seen[descriptor.ToolURN().String()] = struct{}{}
+	descriptors := findToolDescriptors(toolURNs, extras...)
+	tools := make([]*types.Tool, 0, len(descriptors))
+	for _, descriptor := range descriptors {
 		tools = append(tools, descriptor.ToTool(projectID))
 	}
-
 	return tools
 }

--- a/server/internal/platformtools/registry_test.go
+++ b/server/internal/platformtools/registry_test.go
@@ -1,0 +1,100 @@
+package platformtools
+
+import (
+	"context"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/platformtools/logs"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type fixedDescriptorExecutor struct {
+	descriptor ToolDescriptor
+}
+
+func (e *fixedDescriptorExecutor) Descriptor() ToolDescriptor {
+	return e.descriptor
+}
+
+func (e *fixedDescriptorExecutor) Call(_ context.Context, _ toolconfig.ToolCallEnv, _ io.Reader, _ io.Writer) error {
+	return nil
+}
+
+func TestFindToolEntries(t *testing.T) {
+	t.Parallel()
+
+	searchLogsURN := urn.NewTool(urn.ToolKindPlatform, "logs", "search_logs").String()
+	httpToolURN := urn.NewTool(urn.ToolKindHTTP, "petstore", "list_pets").String()
+
+	entries := FindToolEntries([]string{
+		httpToolURN,
+		"not-a-tool-urn",
+		searchLogsURN,
+		searchLogsURN,
+	})
+
+	require.Len(t, entries, 1)
+	require.Equal(t, searchLogsURN, entries[0].ToolUrn)
+	require.Equal(t, "platform_search_logs", entries[0].Name)
+}
+
+func TestFindTypedTools(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	searchLogsURN := urn.NewTool(urn.ToolKindPlatform, "logs", "search_logs").String()
+	httpToolURN := urn.NewTool(urn.ToolKindHTTP, "petstore", "list_pets").String()
+
+	tools := FindTypedTools(projectID, []string{
+		httpToolURN,
+		"not-a-tool-urn",
+		searchLogsURN,
+		searchLogsURN,
+	})
+
+	require.Len(t, tools, 1)
+	require.NotNil(t, tools[0].PlatformToolDefinition)
+	require.Equal(t, searchLogsURN, tools[0].PlatformToolDefinition.ToolUrn)
+	require.Equal(t, projectID.String(), tools[0].PlatformToolDefinition.ProjectID)
+}
+
+func TestFindToolEntries_PreservesBuiltInPrecedence(t *testing.T) {
+	t.Parallel()
+
+	builtIn := logs.NewSearchLogsTool(nil).Descriptor()
+	override := builtIn
+	override.Name = "external_override"
+
+	entries := FindToolEntries(
+		[]string{builtIn.ToolURN().String()},
+		ExternalTool{
+			Executor:        &fixedDescriptorExecutor{descriptor: override},
+			RequiredFeature: "",
+		},
+	)
+
+	require.Len(t, entries, 1)
+	require.Equal(t, builtIn.Name, entries[0].Name)
+}
+
+func BenchmarkFindToolEntriesWithHTTPTools(b *testing.B) {
+	toolURNs := make([]string, 1000)
+	for i := range toolURNs {
+		toolURNs[i] = urn.NewTool(urn.ToolKindHTTP, "benchmark", "tool_"+strconv.Itoa(i)).String()
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		entries := FindToolEntries(toolURNs)
+		if len(entries) != 0 {
+			b.Fatalf("expected no platform tools, got %d", len(entries))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- build the platform-tool descriptor index at most once per lookup
- skip descriptor construction entirely when a toolset contains no platform URNs
- share ordered matching and deduplication between entry and typed-tool results
- preserve first-match precedence for colliding built-in and external descriptors
- add functional coverage, a scale benchmark, and a server patch changeset

## Root cause

`toolsets.list` calls `FindToolEntries` for each toolset. That function previously called `FindToolDescriptor` for every tool URN, and each lookup rebuilt all 73 platform-tool descriptors. Large HTTP-only toolsets therefore paid for thousands of unnecessary schema/descriptor constructions.

For 1,000 HTTP URNs, the pre-fix benchmark measured:

- 1.899s/op
- 1.93GB allocated/op
- 12.36M allocations/op

The optimized benchmark measures:

- 0.302ms/op
- 96KB allocated/op
- 2,000 allocations/op

## Impact

Projects with large toolsets should see substantially lower `toolsets.list` latency and memory usage without an API or schema change. Because the optimized lookup is shared by both lightweight toolset entries and full toolset descriptions, several secondary paths also benefit.

| Surface | Affected paths / branch | Expected end-to-end improvement | Notes |
| --- | --- | --- | --- |
| Toolset listing | `GET /rpc/toolsets.list` | **High** for projects with many or large toolsets | Primary target. Runs the lightweight lookup once per returned toolset without the full toolset cache; HTTP-only toolsets avoid platform descriptor construction entirely. |
| Full toolset management views | `toolsets.create`, `update`, `get`, `listToolFilters`, `clone`; OAuth server/proxy mutations; `setUserSessionIssuer`; `setToolVariationsGroup` | **Low–Medium** normally; **High** for very large uncached toolsets | These use `DescribeToolset`. Cache hits see no change; mutations using `SkipCache` always exercise the optimized path. |
| Other management APIs | `instances.get`; conditional `instances.invoke/tool`; `mcpServers.listToolFilters`; `mcpMetadata.export` | **Low–Medium** | These also build a full toolset view, but descriptor lookup is only one part of the request. |
| Toolset-backed MCP and install routes | `POST /mcp/{mcpSlug}` and HTML/install routes below `/mcp/{mcpSlug}` | **Low–Medium** | Benefits cold/uncached toolset loading. Within a request, the toolset cache generally prevents duplicate work; tool execution and upstream calls may dominate total latency. |
| Toolset embedding workflow | `IndexToolsetWorkflow` → `GenerateToolsetEmbeddings` | **Medium** for large toolsets | The activity calls `DescribeToolset`; embedding generation itself may remain the dominant cost. Workflow structure, inputs, retries, and timeouts are unchanged. |
| Shadow MCP risk analysis | `RiskAnalysisCoordinatorWorkflow` → `AnalyzeBatch` → Shadow MCP validation | **Low** overall | Only the conditional Shadow MCP scanner branch uses this path, and scanning work is likely to dominate. Workflow semantics are unchanged. |
| Unrelated/single-tool paths | `toolsets.listForOrg`, `toolsets.delete`, `toolsets.checkMCPSlugAvailability`, and single-tool `FindToolDescriptor` callers | **None** | These do not call the optimized bulk lookup. |

Ratings describe expected **end-to-end** improvement. The local microbenchmark isolates the pathological descriptor lookup and therefore represents the upper bound, not a latency guarantee for every endpoint.

No response schemas, authorization behavior, database queries, persistence, tool selection semantics, workflow payloads, or serialization change.

## Validation

- `mise run test:server ./internal/platformtools`
- `mise run test:server ./internal/toolsets -run '^TestToolsetsService_ListToolsets'` (16 tests)
- focused benchmark with `-benchtime=1x -benchmem`
- `mise run lint:server`
- two-axis standards/spec review: no remaining findings

The complete `mise run test:server` suite was attempted but stopped after the local environment hit memory pressure, which made ClickHouse unavailable and interrupted unrelated integration packages. Focused affected-package tests passed before and after that attempt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up platform tool lookups by indexing platform descriptors once per call and skipping non-platform URNs, cutting latency and memory for large toolsets. In a 1,000-HTTP-URN benchmark: 1.899s/op → 0.302ms/op and 1.93GB → 96KB.

- **Refactors**
  - Build a descriptor index once per lookup (`indexToolDescriptors`).
  - Skip descriptor work when a toolset has no platform URNs.
  - Share ordered matching and dedup across `FindToolEntries` and `FindTypedTools`.
  - Keep first-match precedence for built-in over external descriptors.
  - Add focused tests and a scale benchmark; include a `server` patch changeset.

<sup>Written for commit 8633ea4e10f13e24312fc14f59510abc66c43277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
