### PR TITLE
fix: merge email-less telemetry rows into employee usage summaries (DNO-468)

### DIFF
--- a/.changeset/dno-468-employee-usage-identity-merge.md
+++ b/.changeset/dno-468-employee-usage-identity-merge.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+The enrollment page no longer shows 0 tokens and a stale last activity for employees whose telemetry rows split across identity keys: usage rows carrying a user id but no email now merge into the employee's email-keyed summary, linked AI accounts attach to that merged summary, and role breakdowns resolve those users instead of bucketing them as Unassigned. The employees and agents tables also render their pagination footer flush against the table instead of floating below a gap.

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -1294,8 +1294,8 @@ function EmployeeCostTable({
   );
 
   return (
-    <section className="bg-card flex flex-col gap-4">
-      <div className="flex items-center justify-between">
+    <section className="bg-card flex flex-col">
+      <div className="mb-4 flex items-center justify-between">
         <div>
           <h3 className="font-semibold">
             {isCost ? "Cost" : "Usage"} by {isRoleView ? "Role" : "Employee"}

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -792,7 +792,7 @@ function EmployeeTable({
   };
 
   return (
-    <section className="bg-card flex flex-col gap-4">
+    <section className="bg-card flex flex-col">
       <Table
         columns={columns}
         data={pageEmployees}

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -433,7 +433,9 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 	}
 
 	users := make([]*telem_gen.UserSummary, len(items))
+	rawUserIDsByKey := make(map[string][]string, len(items))
 	for i, item := range items {
+		rawUserIDsByKey[item.UserID] = item.RawUserIDs
 		// Build per-tool breakdown from the 3 maps
 		tools := make([]*telem_gen.ToolUsage, 0, len(item.ToolCounts))
 		for urn, count := range item.ToolCounts {
@@ -486,7 +488,7 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 	// user_id — external ids don't map to a directory owner.
 	if payload.UserType != "external" {
 		if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
-			s.attachUserAccounts(ctx, authCtx.ActiveOrganizationID, users)
+			s.attachUserAccounts(ctx, authCtx.ActiveOrganizationID, users, rawUserIDsByKey)
 		}
 	}
 
@@ -498,13 +500,24 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 }
 
 // attachUserAccounts populates UserSummary.Accounts from the user_accounts
-// directory for the given internal user ids. Best-effort: a lookup failure
-// leaves accounts empty rather than failing the listing.
-func (s *Service) attachUserAccounts(ctx context.Context, orgID string, users []*telem_gen.UserSummary) {
+// directory. The directory is keyed by raw gram user id while summaries are
+// keyed email-first, so each summary is looked up under its group key plus every
+// raw user_id folded into it (rawUserIDsByKey, keyed by summary group key).
+// Best-effort: a lookup failure leaves accounts empty rather than failing the
+// listing.
+func (s *Service) attachUserAccounts(ctx context.Context, orgID string, users []*telem_gen.UserSummary, rawUserIDsByKey map[string][]string) {
+	summaryByID := make(map[string]*telem_gen.UserSummary, len(users))
 	userIDs := make([]string, 0, len(users))
 	for _, u := range users {
-		if u.UserID != "" {
-			userIDs = append(userIDs, u.UserID)
+		for _, id := range append([]string{u.UserID}, rawUserIDsByKey[u.UserID]...) {
+			if id == "" {
+				continue
+			}
+			if _, ok := summaryByID[id]; ok {
+				continue
+			}
+			summaryByID[id] = u
+			userIDs = append(userIDs, id)
 		}
 	}
 	if len(userIDs) == 0 {
@@ -520,9 +533,12 @@ func (s *Service) attachUserAccounts(ctx context.Context, orgID string, users []
 		return
 	}
 
-	byUser := make(map[string][]*telem_gen.UserAccount, len(rows))
 	for _, row := range rows {
 		if !row.UserID.Valid || row.UserID.String == "" {
+			continue
+		}
+		summary, ok := summaryByID[row.UserID.String]
+		if !ok {
 			continue
 		}
 		var lastSeen *string
@@ -531,7 +547,7 @@ func (s *Service) attachUserAccounts(ctx context.Context, orgID string, users []
 			lastSeen = &ns
 		}
 		idStr := row.ID.String()
-		byUser[row.UserID.String] = append(byUser[row.UserID.String], &telem_gen.UserAccount{
+		summary.Accounts = append(summary.Accounts, &telem_gen.UserAccount{
 			ID:               &idStr,
 			Provider:         row.Provider,
 			Email:            conv.FromPGText[string](row.Email),
@@ -539,12 +555,6 @@ func (s *Service) attachUserAccounts(ctx context.Context, orgID string, users []
 			ExternalOrgID:    conv.FromPGText[string](row.ExternalOrgID),
 			LastSeenUnixNano: lastSeen,
 		})
-	}
-
-	for _, u := range users {
-		if accts, ok := byUser[u.UserID]; ok {
-			u.Accounts = accts
-		}
 	}
 }
 
@@ -641,9 +651,18 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 
 	const unassignedRoleID = "unassigned"
 	for _, item := range items {
+		// Role assignments are keyed by raw gram user id while summaries are keyed
+		// email-first, so fall back to the raw ids folded into the summary.
 		ri := roleInfo{id: unassignedRoleID, name: "Unassigned"}
 		if r, ok := userToRole[item.UserID]; ok {
 			ri = r
+		} else {
+			for _, rawID := range item.RawUserIDs {
+				if r, ok := userToRole[rawID]; ok {
+					ri = r
+					break
+				}
+			}
 		}
 		agg, exists := aggByRole[ri.id]
 		if !exists {

--- a/server/internal/telemetry/repo/models.go
+++ b/server/internal/telemetry/repo/models.go
@@ -234,6 +234,11 @@ type UserSummary struct {
 
 	// Distinct AI account types observed for this user ('team', 'personal').
 	AccountTypes []string `ch:"account_types"`
+
+	// Raw user_id values folded into this summary. The internal group key is
+	// email-first, so these are needed to join the summary back to user_id-keyed
+	// stores (user_accounts, role assignments).
+	RawUserIDs []string `ch:"raw_user_ids"`
 }
 
 // EmployeeDataFlowRow represents an aggregated call-path tuple for an employee.

--- a/server/internal/telemetry/repo/pagination.go
+++ b/server/internal/telemetry/repo/pagination.go
@@ -56,17 +56,28 @@ func withHavingPagination(sb squirrel.SelectBuilder, cursor, sortOrder, projectI
 // withHavingTuplePagination adds cursor-based HAVING conditions with tuple comparison for tie-breaking.
 // Used for queries like ListChats where multiple records might have the same start time.
 // The tuple comparison includes both the time expression and the group column for stable ordering.
-func withHavingTuplePagination(sb squirrel.SelectBuilder, cursor, sortOrder, projectID, groupColumn, timeExpr string) squirrel.SelectBuilder {
+// leftJoin/joinArgs, when non-empty, add a LEFT JOIN to the cursor-lookup subquery so
+// group expressions that reference a join alias (e.g. SearchUsers' known_emails)
+// stay valid inside it; pass "" and nil when the group column is a plain column.
+func withHavingTuplePagination(sb squirrel.SelectBuilder, cursor, sortOrder, projectID, groupColumn, timeExpr, leftJoin string, joinArgs []any) squirrel.SelectBuilder {
 	if cursor == "" {
 		return sb
 	}
 
-	subquery := "(SELECT " + timeExpr + " FROM telemetry_logs WHERE gram_project_id = ? AND " + groupColumn + " = ? GROUP BY " + groupColumn + " LIMIT 1)"
+	join := ""
+	if leftJoin != "" {
+		join = " LEFT JOIN " + leftJoin
+	}
+	subquery := "(SELECT " + timeExpr + " FROM telemetry_logs" + join + " WHERE gram_project_id = ? AND " + groupColumn + " = ? GROUP BY " + groupColumn + " LIMIT 1)"
+
+	args := make([]any, 0, len(joinArgs)+3)
+	args = append(args, joinArgs...)
+	args = append(args, projectID, cursor, cursor)
 
 	if sortOrder == "asc" {
-		return sb.Having("("+timeExpr+", "+groupColumn+") > ("+subquery+", ?)", projectID, cursor, cursor)
+		return sb.Having("("+timeExpr+", "+groupColumn+") > ("+subquery+", ?)", args...)
 	}
-	return sb.Having("("+timeExpr+", "+groupColumn+") < ("+subquery+", ?)", projectID, cursor, cursor)
+	return sb.Having("("+timeExpr+", "+groupColumn+") < ("+subquery+", ?)", args...)
 }
 
 // withOrdering adds ORDER BY clauses based on sort direction.

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -54,12 +54,28 @@ func withAccountTypeFilter(sb squirrel.SelectBuilder, accountType string) squirr
 
 // SearchUsers powers employee enrollment lists, so internal users are grouped by
 // email first to collapse rows that mix email-only and opaque user.id identity.
+// Rows that carry a user_id but no email resolve an email through the
+// known_emails join (see SearchUsers) so a person's email-less rows (e.g. tool
+// calls attributed by id only) merge into their email-keyed summary instead of
+// splitting into a second, token-less one.
 func searchUsersGroupExpr(groupBy string) string {
 	if groupBy == "external_user_id" {
 		return userIdentifierExpr("external_user_id")
 	}
-	return "if(telemetry_logs.user_email != '', telemetry_logs.user_email, telemetry_logs.user_id)"
+	return "multiIf(" +
+		"telemetry_logs.user_email != '', telemetry_logs.user_email, " +
+		"known_emails.known_email != '', known_emails.known_email, " +
+		"telemetry_logs.user_id)"
 }
+
+// searchUsersKnownEmailsJoin maps each user_id to an email observed alongside it
+// anywhere in the search window, for use as a LEFT JOIN on telemetry_logs. It
+// backs the email fallback in searchUsersGroupExpr and takes three args:
+// project id, time start, time end.
+const searchUsersKnownEmailsJoin = "(SELECT user_id, any(user_email) AS known_email" +
+	" FROM telemetry_logs" +
+	" WHERE gram_project_id = ? AND time_unix_nano >= ? AND time_unix_nano <= ? AND user_id != '' AND user_email != ''" +
+	" GROUP BY user_id) AS known_emails ON telemetry_logs.user_id = known_emails.user_id"
 
 // totalTokensExpr is a grouped-aggregate expression that yields a reliable total
 // token count. AI-coding providers like Claude Code report
@@ -1163,7 +1179,7 @@ func (q *Queries) ListChats(ctx context.Context, arg ListChatsParams) ([]ChatSum
 	sb = sb.GroupBy("gram_chat_id")
 
 	// HAVING clause for cursor pagination with tuple comparison for tie-breaking
-	sb = withHavingTuplePagination(sb, arg.Cursor, arg.SortOrder, arg.GramProjectID, "gram_chat_id", "min(time_unix_nano)")
+	sb = withHavingTuplePagination(sb, arg.Cursor, arg.SortOrder, arg.GramProjectID, "gram_chat_id", "min(time_unix_nano)", "", nil)
 
 	// Ordering - include gram_chat_id as secondary for stable ordering
 	sb = withOrdering(sb, arg.SortOrder, "start_time_unix_nano", "gram_chat_id")
@@ -1568,12 +1584,29 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 
 		// Distinct account types observed (powers the employees personal-account indicator)
 		"groupUniqArrayIf(account_type, account_type != '') AS account_types",
+
+		// Raw user_id values folded into this summary. The group key is email-first,
+		// so callers joining against user_id-keyed stores (user_accounts, role
+		// assignments) need these to find the summary's underlying ids.
+		"groupUniqArrayIf(telemetry_logs.user_id, telemetry_logs.user_id != '') AS raw_user_ids",
 	).
 		From("telemetry_logs").
 		Where("gram_project_id = ?", arg.GramProjectID).
 		Where("time_unix_nano >= ?", arg.TimeStart).
 		Where("time_unix_nano <= ?", arg.TimeEnd).
 		Where(groupExpr + " != ''")
+
+	// Internal grouping keys on email, so rows missing user_email look up the
+	// email observed alongside their user_id elsewhere in the window. Without
+	// this, a person's email-less rows surface as a separate summary keyed by
+	// their raw user_id that carries none of their token usage.
+	var joinClause string
+	var joinArgs []any
+	if arg.GroupBy != "external_user_id" {
+		joinClause = searchUsersKnownEmailsJoin
+		joinArgs = []any{arg.GramProjectID, arg.TimeStart, arg.TimeEnd}
+		sb = sb.LeftJoin(joinClause, joinArgs...)
+	}
 
 	// Optional deployment filter
 	if arg.GramDeploymentID != "" {
@@ -1603,7 +1636,7 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 	sb = sb.GroupBy(groupExpr)
 
 	// Cursor pagination using last_seen + group column for stable ordering
-	sb = withHavingTuplePagination(sb, arg.Cursor, arg.SortOrder, arg.GramProjectID, groupExpr, "max(time_unix_nano)")
+	sb = withHavingTuplePagination(sb, arg.Cursor, arg.SortOrder, arg.GramProjectID, groupExpr, "max(time_unix_nano)", joinClause, joinArgs)
 
 	// Order by last_seen with group column as tie-breaker
 	sb = withOrdering(sb, arg.SortOrder, "last_seen_unix_nano", "user_id")

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -3,12 +3,15 @@ package telemetry_test
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	hooksRepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -389,6 +392,128 @@ func TestSearchUsers_MergesInternalUsersByEmail(t *testing.T) {
 	require.Len(t, filtered.Users, 1)
 	require.Equal(t, email, filtered.Users[0].UserID)
 	require.Equal(t, int64(450), filtered.Users[0].TotalTokens)
+}
+
+// TestSearchUsers_MergesEmaillessRowsByKnownUserID guards the enrollment page
+// token counts: a person's rows that carry a user_id but no email (e.g. tool
+// calls attributed by id only) must fold into their email-keyed summary instead
+// of surfacing as a separate zero-token summary keyed by the raw user_id.
+func TestSearchUsers_MergesEmaillessRowsByKnownUserID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	userID := "gram-user-" + uuid.New().String()
+	email := "merged-emailless-" + uuid.New().String() + "@example.com"
+
+	// Token usage reported with both id and email; a later tool call carries the
+	// id only.
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), userID, email, 200, 100, 2.5)
+	toolCallAt := now.Add(-5 * time.Minute)
+	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, toolCallAt, "tools:http:petstore:listPets", 200, 0.5, userID, "")
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.Len(c, res.Users, 1) {
+			return
+		}
+
+		user := res.Users[0]
+		assert.Equal(c, email, user.UserID)
+		assert.Equal(c, email, user.UserEmail)
+		assert.Equal(c, int64(200), user.TotalInputTokens)
+		assert.Equal(c, int64(100), user.TotalOutputTokens)
+		assert.Equal(c, int64(1), user.TotalToolCalls)
+		assert.Equal(c, strconv.FormatInt(toolCallAt.UnixNano(), 10), user.LastSeenUnixNano)
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+// TestSearchUsers_AttachesAccountsToEmailKeyedSummary guards the accounts
+// breakdown on the employees list: the user_accounts directory is keyed by raw
+// gram user id while summaries are keyed email-first, so a summary must pick up
+// accounts through the user_id values folded into it.
+func TestSearchUsers_AttachesAccountsToEmailKeyedSummary(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	// user_accounts.user_id has a FK to users, so reuse the seeded session user.
+	userID := authCtx.UserID
+	email := "account-holder-" + uuid.New().String() + "@example.com"
+
+	hooksQueries := hooksRepo.New(ti.conn)
+	_, err := hooksQueries.UpsertUserAccount(ctx, hooksRepo.UpsertUserAccountParams{
+		OrganizationID:      authCtx.ActiveOrganizationID,
+		Provider:            "anthropic",
+		ExternalAccountUuid: uuid.New().String(),
+		UserID:              conv.ToPGTextEmpty(userID),
+		ExternalOrgID:       conv.ToPGTextEmpty("ext-org-" + uuid.New().String()),
+		ExternalAccountID:   conv.ToPGTextEmpty(""),
+		Email:               conv.ToPGTextEmpty(email),
+		AccountType:         conv.ToPGTextEmpty("team"),
+	})
+	require.NoError(t, err)
+
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), userID, email, 100, 50, 1.0)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.Len(c, res.Users, 1) {
+			return
+		}
+
+		user := res.Users[0]
+		assert.Equal(c, email, user.UserID)
+		if !assert.Len(c, user.Accounts, 1) {
+			return
+		}
+		account := user.Accounts[0]
+		assert.Equal(c, "anthropic", account.Provider)
+		if assert.NotNil(c, account.AccountType) {
+			assert.Equal(c, "team", *account.AccountType)
+		}
+		if assert.NotNil(c, account.Email) {
+			assert.Equal(c, email, *account.Email)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func TestSearchUsers_Pagination(t *testing.T) {


### PR DESCRIPTION
## Summary

On the enrollment page, employees with a linked account showed **0 tokens** and a stale Last Activity, while heavy users showed correct tokens but **no accounts** ("—") despite having linked accounts.

Fixes [DNO-468](https://linear.app/speakeasy/issue/DNO-468/enrollment-page-shows-0-tokens-for-employees-whose-telemetry)

## Root cause

`telemetry.SearchUsers` groups ClickHouse rows email-first (`if(user_email != '', user_email, user_id)`). Rows that carry a `user_id` but no `user_email` (e.g. tool calls attributed by id only) split into a second, token-less summary keyed by the raw user id. Two bugs then compound:

1. The dashboard matches a member by user id first, so it picks the degenerate raw-id summary (0 tokens, stale last-seen); the email-keyed summary with the real usage leaks into "Unknown users".
2. `attachUserAccounts` looks up `user_accounts` by the summary group key. Raw-id summaries match the directory (hence "1 account" on exactly the broken rows); email-keyed summaries never match (hence "—" despite linked accounts).

Verified against prod: one affected user had ~80k rows with email (3.3M tokens, active today) plus 61 email-less tool-call rows whose last-seen matched the stale timestamp on the page exactly.

## Changes

- `SearchUsers` LEFT JOINs a per-`user_id` known-email mapping over the search window, so email-less rows fold into the person's email-keyed summary (tokens, last activity, and tool calls merge correctly).
- Summaries expose `raw_user_ids`; `attachUserAccounts` looks up the accounts directory by group key **plus** raw user ids, so accounts attach to email-keyed summaries too.
- Same raw-id fallback in `searchUsersByRole`, so role aggregation resolves email-keyed users instead of bucketing them as "Unassigned".
- `withHavingTuplePagination` accepts the join so the cursor-lookup subquery stays valid with the new group expression.

No API surface or frontend data changes needed — the dashboard's existing email fallback matching picks up the merged summary.

Also folds in a small UI polish on the same page: the employees and agents tables wrapped the table and its `border-t` pagination bar in a `gap-4` flex column, floating the footer 16px below the table content. The gap is removed so the footer sits flush (matching `Team.tsx`), with the agents header spacing preserved via a margin.

## Testing

- New: `TestSearchUsers_MergesEmaillessRowsByKnownUserID`, `TestSearchUsers_AttachesAccountsToEmailKeyedSummary`
- Full `internal/telemetry` suite and `mise lint:server` pass
- New query shape validated directly against prod ClickHouse: affected users collapse to a single email-keyed summary with correct totals and their gram user id in `raw_user_ids`

## Follow-up

The user detail page (`GetUserMetricsSummary`) still filters rows with the old per-row identity expression, so a merged employee's detail view may undercount their email-less rows (tracked in DNO-468 as a note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
