### PR TITLE
chore: reduce risk overview latency

### DIFF
--- a/.changeset/speed-up-risk-overview.md
+++ b/.changeset/speed-up-risk-overview.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Reduce risk overview latency by overlapping its independent database aggregations.

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
@@ -1358,48 +1359,71 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 	}
 
 	window := riskOverviewWindowParams(from, to)
-	counts, err := s.repo.GetRiskOverviewCounts(ctx, repo.GetRiskOverviewCountsParams{
-		ProjectID: *authCtx.ProjectID,
-		FromTime:  window.from,
-		ToTime:    window.to,
-	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "get risk overview counts").LogError(ctx, s.logger)
-	}
+	// Keep the production-dominant counts query off the critical path of the
+	// findings queries while capping each request at three database connections.
+	var (
+		counts         repo.GetRiskOverviewCountsRow
+		countsErr      error
+		userRows       []repo.ListRiskOverviewTopUsersRow
+		usersErr       error
+		timeSeriesRows []repo.ListRiskOverviewTimeSeriesFindingsRow
+		timeSeriesErr  error
+		ruleRows       []repo.ListRiskOverviewTopRulesRow
+		rulesErr       error
+		queries        sync.WaitGroup
+	)
 
-	userRows, err := s.repo.ListRiskOverviewTopUsers(ctx, repo.ListRiskOverviewTopUsersParams{
-		ProjectID: *authCtx.ProjectID,
-		FromTime:  window.from,
-		ToTime:    window.to,
-		// Returns enough rows for the "view all users" page to show the full
-		// long-tail without pagination. The main /risk-overview widget only
-		// renders the top 10 of these.
-		RowLimit: 200,
+	queries.Go(func() {
+		counts, countsErr = s.repo.GetRiskOverviewCounts(ctx, repo.GetRiskOverviewCountsParams{
+			ProjectID: *authCtx.ProjectID,
+			FromTime:  window.from,
+			ToTime:    window.to,
+		})
 	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top users").LogError(ctx, s.logger)
-	}
+	queries.Go(func() {
+		userRows, usersErr = s.repo.ListRiskOverviewTopUsers(ctx, repo.ListRiskOverviewTopUsersParams{
+			ProjectID: *authCtx.ProjectID,
+			FromTime:  window.from,
+			ToTime:    window.to,
+			// Returns enough rows for the "view all users" page to show the full
+			// long-tail without pagination. The main /risk-overview widget only
+			// renders the top 10 of these.
+			RowLimit: 200,
+		})
+	})
+	queries.Go(func() {
+		timeSeriesRows, timeSeriesErr = s.repo.ListRiskOverviewTimeSeriesFindings(ctx, repo.ListRiskOverviewTimeSeriesFindingsParams{
+			ProjectID: *authCtx.ProjectID,
+			FromTime:  window.from,
+			ToTime:    window.to,
+		})
+		if timeSeriesErr != nil {
+			return
+		}
 
-	timeSeriesRows, err := s.repo.ListRiskOverviewTimeSeriesFindings(ctx, repo.ListRiskOverviewTimeSeriesFindingsParams{
-		ProjectID: *authCtx.ProjectID,
-		FromTime:  window.from,
-		ToTime:    window.to,
+		ruleRows, rulesErr = s.repo.ListRiskOverviewTopRules(ctx, repo.ListRiskOverviewTopRulesParams{
+			ProjectID: *authCtx.ProjectID,
+			FromTime:  window.from,
+			ToTime:    window.to,
+			// Returns enough rows for the "view all rules" page to show the long
+			// tail without pagination. The main /risk-overview widget only renders
+			// the top 10 of these.
+			RowLimit: 200,
+		})
 	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview time series findings").LogError(ctx, s.logger)
-	}
+	queries.Wait()
 
-	ruleRows, err := s.repo.ListRiskOverviewTopRules(ctx, repo.ListRiskOverviewTopRulesParams{
-		ProjectID: *authCtx.ProjectID,
-		FromTime:  window.from,
-		ToTime:    window.to,
-		// Returns enough rows for the "view all rules" page to show the long
-		// tail without pagination. The main /risk-overview widget only renders
-		// the top 10 of these.
-		RowLimit: 200,
-	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top rules").LogError(ctx, s.logger)
+	if countsErr != nil {
+		return nil, oops.E(oops.CodeUnexpected, countsErr, "get risk overview counts").LogError(ctx, s.logger)
+	}
+	if usersErr != nil {
+		return nil, oops.E(oops.CodeUnexpected, usersErr, "list risk overview top users").LogError(ctx, s.logger)
+	}
+	if timeSeriesErr != nil {
+		return nil, oops.E(oops.CodeUnexpected, timeSeriesErr, "list risk overview time series findings").LogError(ctx, s.logger)
+	}
+	if rulesErr != nil {
+		return nil, oops.E(oops.CodeUnexpected, rulesErr, "list risk overview top rules").LogError(ctx, s.logger)
 	}
 
 	topCategories := riskOverviewTopCategories(timeSeriesRows, 10)


### PR DESCRIPTION
## Summary

- overlap the independent `risk.getOverview` database aggregations in three bounded execution lanes
- keep the production-dominant counts query off the critical path of the findings queries
- preserve authorization, window handling, query semantics, ordering, row limits, and response construction
- cap each request at three database connections instead of dispatching all four queries simultaneously
- add a server patch changeset

## Root cause

`GET /rpc/risk.getOverview` ran four independent PostgreSQL aggregations sequentially after authorization and window resolution. Production traces show that these SQL calls account for virtually all request latency, so the endpoint paid the sum of counts, top-users, time-series, and top-rules latency even though none depends on another query's result.

Current indexed production APM spans measured:

- last 24 hours: 9.09s p50, 17.95s p95 (14 sampled spans)
- last 7 days: 3.77s p50, 17.59s p95 (99 sampled spans)

A representative 11.65s trace spent nearly all of its time in the four sequential SQL calls. Authorization completed in milliseconds; counts was the longest query, while the findings-only queries each took roughly 1.5–1.9s.

On a representative local dataset with 2 million risk results and a 10% finding rate, the same query work measured:

- serialized standalone query time: 811.5ms total
- optimized handler wall time: 462.5ms
- representative wall-time reduction: 43%

This is a local critical-path measurement, not a claim that production p50 has improved before deployment.

## Impact

| Surface | Expected improvement | Notes |
| --- | --- | --- |
| `GET /rpc/risk.getOverview` | **High** when multiple aggregations are slow | Wall time moves from the sum of all four queries toward the slowest of three bounded lanes. |
| PostgreSQL connection/CPU pressure | **Moderate increase per request** | Total SQL work is unchanged, but up to three queries may execute concurrently. Time-series and top-rules remain serial to cap fan-out. |
| Other risk management endpoints | **None** | No shared SQL, schema, or repository methods change. |

A covering range-index experiment was rejected: PostgreSQL still selected a parallel sequential scan for a broad representative window, while the proposed index consumed 263MB against a 364MB table. No schema or migration changes are included.

If counts remains multi-second after deployment, the next structural optimization is pre-aggregated project/hour summaries rather than another broad raw-table index.

No response schemas, authorization behavior, supported windows, database queries, persistence, category classification, ordering, row limits, or time-series zero filling change.

## Validation

- `mise test:server ./internal/risk/... -run '^TestGetRiskOverview_' -count=1 -race` (4 tests)
- `mise test:server ./internal/risk/... -count=1` (331 tests)
- `mise build:server`
- `mise lint:server`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce latency for `GET /rpc/risk.getOverview` by overlapping its independent aggregations with bounded concurrency. Wall time moves toward the slowest lane, and all behavior and results remain the same.

- **Refactors**
  - Run counts, top-users, and time-series/top-rules in three lanes using `sync.WaitGroup`; keep counts off the findings critical path.
  - Cap each request to 3 DB connections; keep time-series and top-rules serial within a lane to limit fan-out.
  - Add a server patch changeset; no schema, API, or query semantics changed.

<sup>Written for commit 7d1b350b0c51a05cdb8a73e1bac5f1670903e47f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

