### PR TITLE
feat: register assistants as a billed model-usage source (AGE-2850)

### DIFF
--- a/.changeset/age-2850-assistants-billed-source.md
+++ b/.changeset/age-2850-assistants-billed-source.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Register assistants as a billed model-usage source so assistant-runtime inference counts toward tokens under management and the billing page (AGE-2850). Polar ingestion and the completions credit gate already covered the source; registration scopes it into the TUM cycle snapshots and billing reads.

--- a/server/internal/billing/tracking.go
+++ b/server/internal/billing/tracking.go
@@ -56,16 +56,19 @@ var (
 	// convention-only because the completions proxy legitimately accepts a
 	// client-supplied gram source on the chat key (Elements).
 	ModelUsageSourceRiskAnalysis = registerModelUsageSource("risk-analysis")
-)
 
-// ModelUsageSourceAssistants tags assistants completions in telemetry but is
-// deliberately NOT registered above: Speakeasy covers assistants inference
-// today, so it must not count toward the billed population. Keeping the tag
-// (instead of dropping the constant) is what keeps those completions OUT —
-// an untagged completion normalizes to "gram" and would re-enter the billed
-// scope. Move it into the registered block when customers can BYOK
-// (see the "BYOK for Assistants" Linear project).
-const ModelUsageSourceAssistants ModelUsageSource = "assistants"
+	// ModelUsageSourceAssistants tags assistant-runtime completions (the
+	// runner sends X-Gram-Source: assistant on every /chat/completions call).
+	// Registered per AGE-2850: assistant inference runs on the org's
+	// OpenRouter chat key, so leaving it out of the billed population let
+	// orgs draw down their monthly key cap with usage TUM never captured.
+	// Polar ingestion and the completions credit gate always covered this
+	// source — registration is what scopes it into the TUM cycle snapshots
+	// and the billing page reads. If the Polar credits meter filters events
+	// by source metadata, "assistants" must be included there as well (Polar
+	// dashboard config, not in this repo).
+	ModelUsageSourceAssistants = registerModelUsageSource("assistants")
+)
 
 // ModelUsageSources lists every registered completion surface.
 func ModelUsageSources() []ModelUsageSource {

--- a/server/internal/telemetry/query_test.go
+++ b/server/internal/telemetry/query_test.go
@@ -823,11 +823,10 @@ func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
 	now := time.Date(2026, time.June, 20, 1, 0, 0, 0, time.UTC)
 	ts := now.Add(-10 * time.Minute)
 
-	// A billed completion (playground, a registered usage source) with stored
-	// evidence, next to two populations that must not appear anywhere in the
-	// billing details: an assistants completion (Speakeasy covers assistants
-	// inference until BYOK, so the surface is deliberately unregistered) and
-	// a Claude Code fleet api_request observed via OTEL (agent-native token
+	// Two billed completions with stored evidence — playground and an
+	// assistants-runtime completion (registered per AGE-2850) — next to a
+	// population that must not appear anywhere in the billing details: a
+	// Claude Code fleet api_request observed via OTEL (agent-native token
 	// attributes, never part of the billed population).
 	playgroundChat := uuid.NewString()
 	assistantsChat := uuid.NewString()
@@ -852,9 +851,9 @@ func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	// Wait until BOTH gram completions materialized in the billing aggregate
-	// (the assistants chat included) so the exclusion assertions below cannot
-	// pass vacuously against a half-ingested view.
+	// Wait until all gram completions materialized in the billing aggregate
+	// so the exclusion assertions below cannot pass vacuously against a
+	// half-ingested view.
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
@@ -881,17 +880,17 @@ func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
 		}
 		result = res
 		// The stored-evidence rows qualify the chats asynchronously too.
-		return res.Totals.TotalTokens == 1370
+		return res.Totals.TotalTokens == 1925
 	}, 10*time.Second, 200*time.Millisecond)
 
-	require.Equal(t, int64(1370), result.Totals.InputTokens, "the fixture reports all tokens as input")
+	require.Equal(t, int64(1925), result.Totals.InputTokens, "the fixture reports all tokens as input")
 	require.Equal(t, int64(0), result.Totals.OutputTokens)
 
 	var pointSum int64
 	for _, p := range result.Points {
 		pointSum += p.TotalTokens
 	}
-	require.Equal(t, int64(1370), pointSum, "daily points must only count the billed completions")
+	require.Equal(t, int64(1925), pointSum, "daily points must only count the billed completions")
 
 	rowsByKey := map[string]map[string]int64{}
 	for _, b := range result.Breakdowns {
@@ -900,12 +899,12 @@ func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
 			rowsByKey[b.Key][row.Value] = row.TotalTokens
 		}
 	}
-	require.Equal(t, map[string]int64{"playground": 1000, "risk-analysis": 300, "gram": 70}, rowsByKey["hook_source"],
+	require.Equal(t, map[string]int64{"playground": 1000, "assistants": 555, "risk-analysis": 300, "gram": 70}, rowsByKey["hook_source"],
 		"the source breakdown holds exactly the billed surfaces")
 	// The two model sections partition the billed population: user-facing
-	// completions vs the platform's scanning inference (declared tag and the
-	// grandfathered nil-chat gram row alike).
-	require.Equal(t, map[string]int64{"anthropic/claude-4.6": 1000}, rowsByKey["completion_model"])
+	// completions (assistants included) vs the platform's scanning inference
+	// (declared tag and the grandfathered nil-chat gram row alike).
+	require.Equal(t, map[string]int64{"anthropic/claude-4.6": 1000, "openai/gpt-5.4": 555}, rowsByKey["completion_model"])
 	require.Equal(t, map[string]int64{"google/gemini-3.1-flash-lite": 370}, rowsByKey["risk_analysis_model"])
 	// Scanned-user attribution flows into the billed rows, but a per-user
 	// (email) cut is deliberately not served to the billing page yet.
@@ -913,7 +912,7 @@ func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
 	require.Equal(t, map[string]int64{"dev": 1000}, rowsByKey["role"])
 	// The fixture carries no division attribute; the tokens land on the ''
 	// row (labeled by the frontend).
-	require.Equal(t, map[string]int64{"": 1370}, rowsByKey["division_name"])
+	require.Equal(t, map[string]int64{"": 1925}, rowsByKey["division_name"])
 }
 
 func TestQueryTumDetails_IncludesDeletedProjects(t *testing.T) {

--- a/server/internal/usage/tum_test.go
+++ b/server/internal/usage/tum_test.go
@@ -540,24 +540,31 @@ func TestGetTokensUnderManagementQuery_ExcludesUnregisteredSources(t *testing.T)
 
 	playgroundChat := uuid.New().String()
 	assistantsChat := uuid.New().String()
+	fleetChat := uuid.New().String()
 	untaggedChat := uuid.New().String()
 
 	// A registered billed surface: counted.
 	insertSourcedCompletionRow(t, chConn, projectID.String(), now, playgroundChat, 100, "playground")
 	insertToolCallRow(t, chConn, projectID.String(), now, playgroundChat)
 
-	// An unregistered surface (Speakeasy covers assistants inference until
-	// BYOK): excluded from the billed sum even though the chat qualifies.
+	// Assistant-runtime inference: registered per AGE-2850, counted toward
+	// the billed sum like any other completion surface.
 	insertSourcedCompletionRow(t, chConn, projectID.String(), now, assistantsChat, 5000, "assistants")
 	insertToolCallRow(t, chConn, projectID.String(), now, assistantsChat)
+
+	// An unregistered surface (fleet OTEL agents are analytics-only, never
+	// registered): excluded from the billed sum even though the chat
+	// qualifies.
+	insertSourcedCompletionRow(t, chConn, projectID.String(), now, fleetChat, 70000, "claude-code")
+	insertToolCallRow(t, chConn, projectID.String(), now, fleetChat)
 
 	// Rows without a hook source ('' — the shape of aggregates from before
 	// the dimension existed): grandfathered as billed.
 	insertTokenUsageRow(t, chConn, projectID.String(), now, untaggedChat, 40)
 	insertToolCallRow(t, chConn, projectID.String(), now, untaggedChat)
 
-	// Confirm all three chats materialized (unscoped read sees 5140), THEN
-	// assert the scoped read excludes exactly the assistants tokens — the
+	// Confirm all four chats materialized (unscoped read sees 75140), THEN
+	// assert the scoped read excludes exactly the fleet tokens — the
 	// exclusion cannot pass vacuously against a half-ingested view.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		res, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
@@ -569,7 +576,7 @@ func TestGetTokensUnderManagementQuery_ExcludesUnregisteredSources(t *testing.T)
 		if !assert.NoError(c, err) {
 			return
 		}
-		assert.Equal(c, int64(5140), sumTumBuckets(res))
+		assert.Equal(c, int64(75140), sumTumBuckets(res))
 	}, 10*time.Second, 200*time.Millisecond)
 
 	buckets, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
@@ -579,6 +586,6 @@ func TestGetTokensUnderManagementQuery_ExcludesUnregisteredSources(t *testing.T)
 		BilledHookSources: billing.ModelUsageSourceStrings(),
 	})
 	require.NoError(t, err)
-	require.Equal(t, int64(140), sumTumBuckets(buckets),
-		"billed sum counts registered sources plus grandfathered '' rows, never assistants")
+	require.Equal(t, int64(5140), sumTumBuckets(buckets),
+		"billed sum counts registered sources (assistants included) plus grandfathered '' rows, never fleet agents")
 }


### PR DESCRIPTION
## Summary

Registers `assistants` as a billed model-usage source so assistant-runtime inference counts toward Tokens Under Management (AGE-2850).

## Context

OpenRouter monthly-credit alerts fired for `speakeasy-team` because assistant inference was drawing down the org's per-key cap while TUM never captured it. Investigation showed most of the plumbing already existed:

- The assistant runner sends `X-Gram-Source: assistant` on every `/chat/completions` call (`agents/runner/src/runtime.rs`), so completions arrive tagged as `assistants`.
- Polar ingestion **already covered** this source — `polar.TrackModelUsage` only exempts `gram` and `risk-analysis`.
- The completions credit gate **already applied** (no source bypass).

The one real gap: `ModelUsageSourceAssistants` was deliberately unregistered ("until BYOK"), which excluded assistant tokens from everything scoping to the billed population — TUM cycle snapshots, `tum.history`, and the billing-page telemetry reads. AGE-2850 overrides the BYOK plan.

## Changes

- `billing/tracking.go` — move `ModelUsageSourceAssistants` into the registered source block (single point of declaration for the billed population).
- `usage/tum_test.go` — the exclusion test now pins assistants as billed; the exclusion mechanism itself stays pinned via a fleet OTEL source (`claude-code`), which is analytics-only and never registered.
- `telemetry/query_test.go` — `TumDetails` counts assistants in totals, the `hook_source` breakdown, and the user-facing `completion_model` section.

No frontend change: the billing page's Source breakdown is generic over `hook_source` values.

## Ops note

If the Polar credits meter filters events by `source` metadata, `assistants` must also be added there — that's Polar dashboard config, not version-controlled here.

## Testing

- `go test ./internal/billing ./internal/usage ./internal/telemetry ./internal/chat ./internal/background/activities`
- `mise lint:server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `assistants` as a billed model-usage source so assistant-runtime completions count toward TUM and billing views. Aligns TUM with OpenRouter credit consumption and satisfies AGE-2850 (track assistant credits in Polar).

- **New Features**
  - Registered `assistants` in `server/internal/billing/tracking.go` so TUM snapshots and billing queries include assistant tokens.
  - Updated tests to count `assistants` in totals, breakdowns, and `completion_model`; kept fleet OTEL `claude-code` excluded (analytics-only).
  - Added changeset `.changeset/age-2850-assistants-billed-source.md` marking `server` as a minor release.
  - No frontend changes; billing page already keys off `hook_source`.

- **Migration**
  - If the Polar credits meter filters by `source`, add `assistants` to the allowed list in the Polar dashboard config.

<sup>Written for commit 32785b02180b2fd390788beef7071cea7f71846b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

