### PR TITLE
feat: tag assistant runner spans with gram identity

### DIFF
--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -25,6 +25,7 @@ use futures::FutureExt;
 use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{OnceCell, oneshot};
+use tracing::Instrument;
 
 use agentkit_compaction::{AgentBuilderCompactorExt, CompactionReason, Compactor};
 
@@ -64,6 +65,10 @@ pub struct RuntimeHost {
     /// stamped by the first turn that carries one (GKE warm-pool sandbox).
     /// Set-once: boot env wins.
     pub assistant_id: OnceLock<String>,
+    /// Project the assistant belongs to, stamped by the first turn that
+    /// carries one (same set-once discipline as assistant_id). Only used to
+    /// tag exported trace spans; never drives behavior.
+    pub project_id: OnceLock<String>,
     pub started_at: Instant,
     /// Per-idempotency-key admission slot. The bool tracks whether the
     /// keyed turn has actually been enqueued: holding the mutex covers
@@ -156,6 +161,7 @@ pub async fn build_host(
     }
     let host = Arc::new(RuntimeHost {
         assistant_id: assistant_id_cell,
+        project_id: OnceLock::new(),
         started_at: Instant::now(),
         seen: DashMap::new(),
         threads: DashMap::new(),
@@ -452,11 +458,20 @@ async fn spawn_thread(
     let log_thread_id = thread_id.clone();
     let host_for_eviction = Arc::clone(host);
     let evict_thread_id = thread_id.clone();
+    let loop_host = Arc::clone(host);
+    let loop_thread_id = thread_id.clone();
 
     let task_handle = tokio::spawn(async move {
-        let outcome = AssertUnwindSafe(run_loop(driver, inbox_rx, loop_idle, turn_end_compactor))
-            .catch_unwind()
-            .await;
+        let outcome = AssertUnwindSafe(run_loop(
+            driver,
+            inbox_rx,
+            loop_idle,
+            turn_end_compactor,
+            loop_host,
+            loop_thread_id,
+        ))
+        .catch_unwind()
+        .await;
         match outcome {
             Ok(Ok(reason)) => {
                 tracing::info!(thread_id = %log_thread_id, reason = %reason, "thread loop exited")
@@ -809,12 +824,32 @@ async fn run_loop<S>(
     mut inbox: UnboundedReceiver<String>,
     idle_since: Arc<Mutex<Option<Instant>>>,
     turn_end_compactor: Option<PersistingCompactor>,
+    host: Arc<RuntimeHost>,
+    thread_id: String,
 ) -> Result<&'static str, RunnerError>
 where
     S: ModelSession,
 {
     loop {
-        match driver.next().await? {
+        // A fresh root span per driver step (one model call plus its tool
+        // executions) keeps traces bounded while stamping every agentkit span
+        // exported underneath it with gram identity — the attributes the fly
+        // adapter used to bake into OTEL_RESOURCE_ATTRIBUTES per machine.
+        // Identity is re-read each step because a warm-pool runner learns its
+        // assistant from the first /turn, after this loop is already running.
+        let step_span = tracing::info_span!(
+            "agent.step",
+            thread_id = %thread_id,
+            gram.assistant.id = tracing::field::Empty,
+            gram.project.id = tracing::field::Empty,
+        );
+        if let Some(id) = host.assistant_id.get() {
+            step_span.record("gram.assistant.id", tracing::field::display(id));
+        }
+        if let Some(id) = host.project_id.get() {
+            step_span.record("gram.project.id", tracing::field::display(id));
+        }
+        match driver.next().instrument(step_span).await? {
             LoopStep::Finished(_turn) => {
                 if let Some(compactor) = &turn_end_compactor {
                     compact_at_turn_end(compactor, &driver).await;
@@ -970,6 +1005,7 @@ mod tests {
         let _ = assistant_id.set("asst".to_string());
         Arc::new(RuntimeHost {
             assistant_id,
+            project_id: OnceLock::new(),
             started_at: Instant::now(),
             seen: DashMap::new(),
             threads: DashMap::new(),

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -70,6 +70,15 @@ async fn state_handler(State(host): State<AppState>) -> Json<RunnerStateResponse
     })
 }
 
+#[tracing::instrument(
+    name = "thread_turn",
+    skip_all,
+    fields(
+        thread_id = %thread_id,
+        gram.assistant.id = tracing::field::Empty,
+        gram.project.id = tracing::field::Empty,
+    )
+)]
 async fn thread_turn(
     State(host): State<AppState>,
     Path(thread_id): Path<String>,
@@ -124,6 +133,24 @@ async fn thread_turn(
         .filter(|id| !id.is_empty())
     {
         let _ = host.assistant_id.set(assistant_id.to_string());
+    }
+    // Same set-once discipline for the project id; it only feeds trace
+    // attributes, so a turn that omits it just leaves the cell for the next.
+    if let Some(project_id) = request
+        .project_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        let _ = host.project_id.set(project_id.to_string());
+    }
+
+    let span = tracing::Span::current();
+    if let Some(id) = host.assistant_id.get() {
+        span.record("gram.assistant.id", tracing::field::display(id));
+    }
+    if let Some(id) = host.project_id.get() {
+        span.record("gram.project.id", tracing::field::display(id));
     }
 
     // Hand reconcile to the actor and proceed to enqueue. The actor runs

--- a/agents/runner/src/wire.rs
+++ b/agents/runner/src/wire.rs
@@ -30,6 +30,10 @@ pub struct ThreadTurnRequest {
     /// the first turn. Ignored once the boot env has set it (env wins).
     #[serde(default)]
     pub assistant_id: Option<String>,
+    /// Project the assistant belongs to. Set-once like `assistant_id`; only
+    /// used to stamp exported trace spans so traces filter per project.
+    #[serde(default)]
+    pub project_id: Option<String>,
 }
 
 /// 202-style ack returned by `/threads/{thread_id}/turn`. The actual turn

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -93,6 +93,10 @@ type runtimeTurnRequest struct {
 	// from the turn. Boot env wins when present, so it is harmless and unused
 	// on Fly.
 	AssistantID string `json:"assistant_id,omitempty"`
+	// ProjectID travels with AssistantID under the same set-once discipline.
+	// The runner stamps it on exported trace spans so traces filter per
+	// project; it never drives runner behavior.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 type runtimeHTTPRequest struct {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -849,6 +849,7 @@ func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 		AuthToken:   authToken,
 		MCPServers:  mcpServers,
 		AssistantID: runtime.AssistantID.String(),
+		ProjectID:   runtime.ProjectID.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal assistant fly runtime turn request: %w", err)

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -396,6 +396,7 @@ func (g *GKERuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 		AuthToken:   authToken,
 		MCPServers:  mcpServers,
 		AssistantID: runtime.AssistantID.String(),
+		ProjectID:   runtime.ProjectID.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal gke runtime turn request: %w", err)


### PR DESCRIPTION
Follow-up to speakeasy-api/gram-infra#1844, which restored OTLP trace export from the GKE assistant runtime. One parity gap remained: the fly adapter stamped `gram.assistant.id` / `gram.project.id` as OTEL resource attributes on each machine, but GKE runners boot generic from the warm pool, so identity can't come from env — and the runner never tagged spans with it. Exported traces were filterable by service/env/cluster but not by assistant or project.

## Changes

**Runner (`agents/runner`)**
- `run_loop` wraps each `driver.next()` step (one model call + its tool executions) in an `agent.step` span carrying `thread_id`, `gram.assistant.id`, and `gram.project.id` — all agentkit spans exported under it inherit the trace. Identity is re-read each step because a warm-pool runner learns its assistant after the loop starts.
- `thread_turn` gets an `#[instrument]` span with the same fields for enqueue/bootstrap visibility.
- `RuntimeHost` gains a `project_id` cell with the same set-once, bind-after-bootstrap discipline as `assistant_id`.

**Server (`internal/assistants`)**
- `runtimeTurnRequest` carries `project_id` alongside `assistant_id`; both the GKE and Fly backends populate it. It only feeds trace attributes, never runner behavior.

`cargo check` + clippy clean; `go build` clean. Local `cargo test` / `go test` couldn't run on my machine (unrelated toolchain/disk issues) — relying on CI here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tags all runner spans with `gram.assistant.id` and `gram.project.id` so traces can be filtered by assistant and project on both GKE and Fly. Adds a per-step `agent.step` span to bound traces and ensure identity is attached to all downstream spans.

- **New Features**
  - Runner: Wrap each model step in an `agent.step` span that records `thread_id`, `gram.assistant.id`, and `gram.project.id`. Identity is read each step for warm-pool GKE runners; `thread_turn` is instrumented; `RuntimeHost` adds set-once `project_id`.
  - Server: `runtimeTurnRequest` now includes `project_id`, populated by both Fly and GKE backends. It only feeds trace attributes and does not change behavior.

<sup>Written for commit a5501e77d911b7c15a6fec5aa5ef381996ac4ad2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

