### PR TITLE
feat: consume Elements source directly in dashboard

### DIFF
--- a/.changeset/quick-elements-source.md
+++ b/.changeset/quick-elements-source.md
@@ -1,0 +1,6 @@
+---
+"@gram-ai/elements": patch
+"dashboard": patch
+---
+
+Consume Elements source directly in dashboard development and production builds while preserving built package exports for external consumers.

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -8,6 +8,7 @@ server:
 client:
   - ".github/**"
   - "client/**"
+  - "elements/**"
   - "package.json"
   - "pnpm-lock.yaml"
   - "pnpm-workspace.yaml"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1325,7 +1325,7 @@ jobs:
       - name: Build
         env:
           NODE_ENV: production
-        run: mise exec --env viteprod -- pnpm build
+        run: mise exec --env viteprod -- pnpm -F dashboard build
 
       - name: Upload source maps to DataDog
         env:
@@ -1412,7 +1412,7 @@ jobs:
       - name: Build
         env:
           NODE_ENV: production
-        run: mise exec --env viteprod -- pnpm build
+        run: mise exec --env viteprod -- pnpm -F dashboard build
 
       - name: Lint
         run: pnpm lint
@@ -1799,6 +1799,10 @@ jobs:
 
       - name: Build
         run: pnpm build
+        working-directory: elements
+
+      - name: Check package contracts
+        run: pnpm test:package
         working-directory: elements
 
       - name: Lint

--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -42,10 +42,6 @@ if ! mise run install:pnpm --offline; then
   mise run install:pnpm
 fi
 
-# Build the workspace packages the dashboard's type-check depends on since these
-# are gitignored and not carried over to new worktrees.
-mise run build:elements
-
 suffix=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
 compose_project="gram-infra-${suffix}"
 mise set --file mise.local.toml "COMPOSE_PROJECT_NAME=${compose_project}"

--- a/.mise-tasks/start/dashboard.sh
+++ b/.mise-tasks/start/dashboard.sh
@@ -3,7 +3,4 @@
 
 set -e
 
-# Elements is a dependency of the dashboard and must be built first
-pnpm --filter ./elements build
-
 exec pnpm --filter ./client/dashboard dev

--- a/client/dashboard/src/App.css
+++ b/client/dashboard/src/App.css
@@ -2,9 +2,9 @@
 @import "tw-animate-css";
 @import "tw-shimmer";
 /* Scan the elements package so Tailwind generates the utility classes its
- * compiled components use (e.g. the dark slate JSON viewer) — they live in
- * node_modules and aren't picked up by the default dashboard-src scan. */
-@source "../node_modules/@gram-ai/elements/dist";
+ * source components use (e.g. the dark slate JSON viewer) — they live outside
+ * the dashboard and aren't picked up by the default dashboard-src scan. */
+@source "../../../elements/src";
 @reference "../node_modules/@speakeasy-api/moonshine/src/global.css";
 
 @custom-variant dark (&:where(.dark, .dark *));

--- a/client/dashboard/tsconfig.app.json
+++ b/client/dashboard/tsconfig.app.json
@@ -10,6 +10,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "customConditions": ["gram-source"],
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 import process from "node:process";
 
-import { defineConfig } from "vite";
+import { defaultClientConditions, defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -177,6 +177,7 @@ export default defineConfig(({ command }) => {
     },
     plugins: [react(), tailwindcss()],
     resolve: {
+      conditions: ["gram-source", ...defaultClientConditions],
       alias: {
         "@": path.resolve(__dirname, "./src"),
         "@gram/client": path.resolve(__dirname, "./src/sdk/src"),

--- a/client/dashboard/vitest.config.ts
+++ b/client/dashboard/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
       "@gram/client": path.resolve(__dirname, "./src/sdk/src"),
     },
-    conditions: ["source"],
+    conditions: ["gram-source", "source"],
   },
   define: {
     __GRAM_SERVER_URL__: JSON.stringify(""),

--- a/elements/.storybook/vite.config.mts
+++ b/elements/.storybook/vite.config.mts
@@ -1,13 +1,9 @@
 import { defineConfig, loadEnv, Plugin, ViteDevServer } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createNetServer, Socket } from "node:net";
 import { createElementsServerHandlers } from "../src/server";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Protocol-sniffing proxy that detects HTTP vs HTTPS and routes accordingly.
@@ -131,11 +127,6 @@ export default defineConfig(({ mode }) => {
         parseInt(process.env.ELEMENTS_STORYBOOK_PORT ?? "6007") - 1,
       ),
     ],
-    resolve: {
-      alias: {
-        "@": resolve(__dirname, "../src"),
-      },
-    },
     // define the process.env variable for the browser env and attach the .env values (used for storybook stories that rely on external provider keys, namely google)
     define: {
       __GRAM_API_URL__: JSON.stringify(process.env["GRAM_API_URL"] || ""),

--- a/elements/components.json
+++ b/elements/components.json
@@ -12,11 +12,11 @@
   },
   "iconLibrary": "lucide",
   "aliases": {
-    "components": "@/components",
-    "utils": "@/lib/utils",
-    "ui": "@/components/ui",
-    "lib": "@/lib",
-    "hooks": "@/hooks"
+    "components": "#elements/components",
+    "utils": "#elements/lib/utils",
+    "ui": "#elements/components/ui",
+    "lib": "#elements/lib",
+    "hooks": "#elements/hooks"
   },
   "registries": {
     "@assistant-ui": "https://r.assistant-ui.com/{name}.json"

--- a/elements/package.json
+++ b/elements/package.json
@@ -4,52 +4,91 @@
   "type": "module",
   "version": "1.42.0",
   "main": "dist/index.js",
+  "imports": {
+    "#elements/components/activeChatTitle.helpers": "./src/components/activeChatTitle.helpers.ts",
+    "#elements/components/Chat": "./src/components/Chat/index.tsx",
+    "#elements/components/FrontendTools": "./src/components/FrontendTools/index.tsx",
+    "#elements/components/ShareButton": "./src/components/ShareButton/index.tsx",
+    "#elements/components/*": "./src/components/*.tsx",
+    "#elements/constants/*": "./src/constants/*.ts",
+    "#elements/contexts/contexts": "./src/contexts/contexts.ts",
+    "#elements/contexts/ReplayContext": "./src/contexts/ReplayContext.ts",
+    "#elements/contexts/ThreadMetaContext": "./src/contexts/ThreadMetaContext.ts",
+    "#elements/contexts/portal-container-context": "./src/contexts/portal-container-context.ts",
+    "#elements/contexts/*": "./src/contexts/*.tsx",
+    "#elements/hooks/useGramThreadListAdapter": "./src/hooks/useGramThreadListAdapter.tsx",
+    "#elements/hooks/*": "./src/hooks/*.ts",
+    "#elements/lib/*": "./src/lib/*.ts",
+    "#elements/plugins": "./src/plugins/index.ts",
+    "#elements/plugins/chart": "./src/plugins/chart/index.ts",
+    "#elements/plugins/chart/ui": "./src/plugins/chart/ui/index.ts",
+    "#elements/plugins/generative-ui": "./src/plugins/generative-ui/index.ts",
+    "#elements/plugins/generative-ui/ui": "./src/plugins/generative-ui/ui/index.ts",
+    "#elements/types": "./src/types/index.ts",
+    "#elements/types/*": "./src/types/*.ts",
+    "#elements/index": "./src/index.ts",
+    "#elements/global.css": "./src/global.css"
+  },
   "exports": {
     ".": {
+      "gram-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/elements.js"
     },
     "./server": {
+      "gram-source": "./src/server.ts",
       "types": "./dist/server.d.ts",
       "default": "./dist/server.js"
     },
     "./server/core": {
+      "gram-source": "./src/server/core.ts",
       "types": "./dist/server/core.d.ts",
       "default": "./dist/server/core.js"
     },
     "./server/express": {
+      "gram-source": "./src/server/express.ts",
       "types": "./dist/server/express.d.ts",
       "default": "./dist/server/express.js"
     },
     "./server/nextjs": {
+      "gram-source": "./src/server/nextjs.ts",
       "types": "./dist/server/nextjs.d.ts",
       "default": "./dist/server/nextjs.js"
     },
     "./server/fastify": {
+      "gram-source": "./src/server/fastify.ts",
       "types": "./dist/server/fastify.d.ts",
       "default": "./dist/server/fastify.js"
     },
     "./server/hono": {
+      "gram-source": "./src/server/hono.ts",
       "types": "./dist/server/hono.d.ts",
       "default": "./dist/server/hono.js"
     },
     "./server/bun": {
+      "gram-source": "./src/server/bun.ts",
       "types": "./dist/server/bun.d.ts",
       "default": "./dist/server/bun.js"
     },
     "./server/tanstack-start": {
+      "gram-source": "./src/server/tanstack-start.ts",
       "types": "./dist/server/tanstack-start.d.ts",
       "default": "./dist/server/tanstack-start.js"
     },
     "./plugins": {
+      "gram-source": "./src/plugins/index.ts",
       "types": "./dist/plugins/index.d.ts",
       "default": "./dist/plugins.js"
     },
     "./compat": {
+      "gram-source": "./src/compat-plugin.ts",
       "types": "./dist/compat-plugin.d.ts",
       "default": "./dist/compat-plugin.js"
     },
-    "./elements.css": "./dist/elements.css"
+    "./elements.css": {
+      "gram-source": "./src/global.css",
+      "default": "./dist/elements.css"
+    }
   },
   "bin": {
     "elements": "./bin/cli.js"
@@ -69,6 +108,7 @@
   "scripts": {
     "build": "vite build",
     "test": "vitest run",
+    "test:package": "node scripts/check-package-contract.mjs",
     "test:watch": "vitest",
     "lint": "pnpm lint:format && pnpm lint:no-barrels && pnpm lint:oxlint && pnpm type-check",
     "lint:oxlint": "oxlint --type-aware",

--- a/elements/scripts/check-package-contract.mjs
+++ b/elements/scripts/check-package-contract.mjs
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = realpathSync(fileURLToPath(new URL("..", import.meta.url)));
+const workspaceDir = dirname(packageDir);
+
+const exportContracts = [
+  {
+    specifier: "@gram-ai/elements",
+    source: "src/index.ts",
+    defaultTarget: "dist/elements.js",
+    types: "dist/index.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/server",
+    source: "src/server.ts",
+    defaultTarget: "dist/server.js",
+    types: "dist/server.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/server/core",
+    source: "src/server/core.ts",
+    defaultTarget: "dist/server/core.js",
+    types: "dist/server/core.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/server/express",
+    source: "src/server/express.ts",
+    defaultTarget: "dist/server/express.js",
+    types: "dist/server/express.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/server/nextjs",
+    source: "src/server/nextjs.ts",
+    defaultTarget: "dist/server/nextjs.js",
+    types: "dist/server/nextjs.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/server/fastify",
+    source: "src/server/fastify.ts",
+    defaultTarget: "dist/server/fastify.js",
+    types: "dist/server/fastify.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/server/hono",
+    source: "src/server/hono.ts",
+    defaultTarget: "dist/server/hono.js",
+    types: "dist/server/hono.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/server/bun",
+    source: "src/server/bun.ts",
+    defaultTarget: "dist/server/bun.js",
+    types: "dist/server/bun.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/server/tanstack-start",
+    source: "src/server/tanstack-start.ts",
+    defaultTarget: "dist/server/tanstack-start.js",
+    types: "dist/server/tanstack-start.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/plugins",
+    source: "src/plugins/index.ts",
+    defaultTarget: "dist/plugins.js",
+    types: "dist/plugins/index.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/compat",
+    source: "src/compat-plugin.ts",
+    defaultTarget: "dist/compat-plugin.js",
+    types: "dist/compat-plugin.d.ts",
+  },
+  {
+    specifier: "@gram-ai/elements/elements.css",
+    source: "src/global.css",
+    defaultTarget: "dist/elements.css",
+  },
+];
+
+const tempDir = mkdtempSync(join(tmpdir(), "gram-elements-contract-"));
+
+try {
+  const tarball = join(tempDir, "gram-ai-elements.tgz");
+  execFileSync(
+    "pnpm",
+    ["--config.ignore-scripts=true", "pack", "--out", tarball],
+    { cwd: packageDir, stdio: "pipe" },
+  );
+
+  const unpackedDir = join(tempDir, "unpacked");
+  mkdirSync(unpackedDir);
+  execFileSync("tar", ["-xzf", tarball, "-C", unpackedDir]);
+  const packedPackageDir = join(unpackedDir, "package");
+
+  for (const contract of exportContracts) {
+    for (const target of [
+      contract.source,
+      contract.defaultTarget,
+      contract.types,
+    ]) {
+      if (target) {
+        assert.ok(
+          existsSync(join(packedPackageDir, target)),
+          `packed artifact is missing ${target}`,
+        );
+      }
+    }
+  }
+  assert.ok(
+    existsSync(join(packedPackageDir, "bin/cli.js")),
+    "packed artifact is missing bin/cli.js",
+  );
+  const builtCss = readFileSync(
+    join(packedPackageDir, "dist/elements.css"),
+    "utf8",
+  );
+  assert.match(builtCss, /\.gram-elements/, "built CSS is missing its scope");
+  assert.match(
+    builtCss,
+    /--shimmer-track-height/,
+    "built CSS is missing Elements theme styles",
+  );
+  for (const declarationPath of listFiles(
+    join(packedPackageDir, "dist"),
+  ).filter((filePath) => filePath.endsWith(".d.ts"))) {
+    const declarationContent = readFileSync(declarationPath, "utf8");
+    assert.doesNotMatch(
+      declarationContent,
+      /#elements\//,
+      `${relative(packedPackageDir, declarationPath)} exposes a private package import`,
+    );
+    assertRelativeDeclarationImports(declarationPath, declarationContent);
+  }
+
+  const consumerDir = join(tempDir, "consumer");
+  const packageScopeDir = join(consumerDir, "node_modules", "@gram-ai");
+  mkdirSync(packageScopeDir, { recursive: true });
+  symlinkSync(packedPackageDir, join(packageScopeDir, "elements"), "dir");
+  writeFileSync(
+    join(consumerDir, "package.json"),
+    JSON.stringify({ private: true, type: "module" }),
+  );
+
+  const defaultResolutions = resolveExports(consumerDir);
+  assertResolutions(defaultResolutions, "defaultTarget", packedPackageDir);
+
+  writeFileSync(
+    join(consumerDir, "contract.ts"),
+    [
+      'import type { ElementsConfig } from "@gram-ai/elements";',
+      'import { createChatSession, type SessionHandlerOptions } from "@gram-ai/elements/server/core";',
+      'const config: ElementsConfig = { projectSlug: "contract-test" };',
+      'const options: SessionHandlerOptions = { embedOrigin: "https://example.com", userIdentifier: "contract-test" };',
+      "void createChatSession;",
+      "void config;",
+      "void options;",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(consumerDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "Bundler",
+        noEmit: true,
+        skipLibCheck: true,
+        strict: true,
+        target: "ES2024",
+      },
+      files: ["contract.ts"],
+    }),
+  );
+  execFileSync(resolve(workspaceDir, "node_modules/.bin/tsc"), ["-p", "."], {
+    cwd: consumerDir,
+    stdio: "pipe",
+  });
+  const defaultDeclarationFiles = execFileSync(
+    resolve(workspaceDir, "node_modules/.bin/tsc"),
+    ["-p", ".", "--listFilesOnly"],
+    { cwd: consumerDir, encoding: "utf8" },
+  );
+  assert.match(
+    defaultDeclarationFiles,
+    /\/dist\/index\.d\.ts/,
+    "default type resolution did not use dist/index.d.ts",
+  );
+  assert.match(
+    defaultDeclarationFiles,
+    /\/dist\/server\/core\.d\.ts/,
+    "default type resolution did not use dist/server/core.d.ts",
+  );
+  assert.doesNotMatch(
+    defaultDeclarationFiles,
+    /\/unpacked\/package\/src\//,
+    "default type resolution unexpectedly used package source",
+  );
+
+  execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      'const module = await import("@gram-ai/elements/server/core"); if (typeof module.createChatSession !== "function") process.exit(1);',
+    ],
+    { cwd: consumerDir, stdio: "pipe" },
+  );
+
+  rmSync(join(packedPackageDir, "dist"), { recursive: true });
+  const sourceResolutions = resolveExports(consumerDir, ["gram-source"]);
+  assertResolutions(sourceResolutions, "source", packedPackageDir);
+
+  console.log("Elements package contracts passed");
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+function resolveExports(consumerDir, conditions = []) {
+  const script = `
+    const specifiers = ${JSON.stringify(
+      exportContracts.map(({ specifier }) => specifier),
+    )};
+    console.log(JSON.stringify(Object.fromEntries(
+      specifiers.map((specifier) => [specifier, import.meta.resolve(specifier)]),
+    )));
+  `;
+  const output = execFileSync(
+    process.execPath,
+    [
+      ...conditions.map((condition) => `--conditions=${condition}`),
+      "--input-type=module",
+      "--eval",
+      script,
+    ],
+    { cwd: consumerDir, encoding: "utf8" },
+  );
+  return JSON.parse(output);
+}
+
+function assertResolutions(resolutions, targetKind, packedPackageDir) {
+  for (const contract of exportContracts) {
+    const resolvedUrl = resolutions[contract.specifier];
+    assert.ok(resolvedUrl, `did not resolve ${contract.specifier}`);
+    const resolvedPath = realpathSync(fileURLToPath(resolvedUrl));
+    const expectedPath = realpathSync(
+      join(packedPackageDir, contract[targetKind]),
+    );
+    assert.equal(
+      resolvedPath,
+      expectedPath,
+      `${contract.specifier} did not resolve to ${contract[targetKind]}`,
+    );
+  }
+}
+
+function listFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name);
+    return entry.isDirectory() ? listFiles(entryPath) : entryPath;
+  });
+}
+
+function assertRelativeDeclarationImports(declarationPath, content) {
+  const code = content
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+
+  for (const match of code.matchAll(/(["'])(\.\.?\/[^"']+)\1/g)) {
+    const specifier = match[2];
+    const target = resolve(dirname(declarationPath), specifier);
+    const withoutJavaScriptExtension = target.replace(/\.(?:c|m)?js$/, "");
+    const candidates = [
+      target,
+      `${withoutJavaScriptExtension}.d.ts`,
+      `${withoutJavaScriptExtension}.d.mts`,
+      `${withoutJavaScriptExtension}.d.cts`,
+      join(target, "index.d.ts"),
+      join(target, "index.d.mts"),
+      join(target, "index.d.cts"),
+    ];
+    assert.ok(
+      candidates.some(
+        (candidate) => existsSync(candidate) && statSync(candidate).isFile(),
+      ),
+      `${declarationPath} imports missing declaration ${specifier}`,
+    );
+  }
+}

--- a/elements/src/components/ActiveChatTitle.tsx
+++ b/elements/src/components/ActiveChatTitle.tsx
@@ -1,12 +1,12 @@
 import { useAssistantApi, useAssistantState } from "@assistant-ui/react";
 import { PencilIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import {
   FALLBACK_TITLE,
   MAX_TITLE_LENGTH,
   resolveTitleEdit,
-} from "@/components/activeChatTitle.helpers";
+} from "#elements/components/activeChatTitle.helpers";
 
 export interface ActiveChatTitleProps {
   className?: string;

--- a/elements/src/components/Chat/index.tsx
+++ b/elements/src/components/Chat/index.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import * as React from "react";
-import { useElements } from "@/hooks/useElements";
+import { useElements } from "#elements/hooks/useElements";
 import { AssistantModal } from "../assistant-ui/assistant-modal";
 import { AssistantSidecar } from "../assistant-ui/assistant-sidecar";
 import { ErrorBoundary } from "../assistant-ui/error-boundary";
 import { Thread } from "../assistant-ui/thread";
-import { ShadowRoot } from "@/components/ShadowRoot";
+import { ShadowRoot } from "#elements/components/ShadowRoot";
 
 interface ChatProps {
   className?: string;

--- a/elements/src/components/Chat/stories/ConnectionConfiguration.stories.tsx
+++ b/elements/src/components/Chat/stories/ConnectionConfiguration.stories.tsx
@@ -1,4 +1,5 @@
-import { GetSessionFn } from "@/types";
+import { GetSessionFn } from "#elements/types";
+import type { ElementsImportMetaEnv } from "#elements/types/env";
 import { google } from "@ai-sdk/google";
 import type { Meta, StoryFn } from "@storybook/react-vite";
 import { Chat } from "..";
@@ -42,7 +43,8 @@ const session: GetSessionFn = async () => {
     method: "POST",
     headers: {
       "Gram-Project":
-        import.meta.env.VITE_GRAM_ELEMENTS_STORYBOOK_PROJECT_SLUG ?? "",
+        (import.meta.env as ElementsImportMetaEnv)
+          .VITE_GRAM_ELEMENTS_STORYBOOK_PROJECT_SLUG ?? "",
     },
   });
   const data = await response.json();

--- a/elements/src/components/Chat/stories/CustomComponents.stories.tsx
+++ b/elements/src/components/Chat/stories/CustomComponents.stories.tsx
@@ -1,4 +1,4 @@
-import { Chat, ComponentOverrides } from "@/index";
+import { Chat, ComponentOverrides } from "#elements/index";
 import { useAssistantState } from "@assistant-ui/react";
 import { Meta, StoryFn } from "@storybook/react-vite";
 

--- a/elements/src/components/Chat/stories/MessageFeedback.stories.tsx
+++ b/elements/src/components/Chat/stories/MessageFeedback.stories.tsx
@@ -1,4 +1,4 @@
-import { MessageFeedback } from "@/components/assistant-ui/message-feedback";
+import { MessageFeedback } from "#elements/components/assistant-ui/message-feedback";
 import type { Meta, StoryFn } from "@storybook/react-vite";
 import { LazyMotion, domAnimation } from "motion/react";
 import { Chat } from "..";

--- a/elements/src/components/Chat/stories/Variants.stories.tsx
+++ b/elements/src/components/Chat/stories/Variants.stories.tsx
@@ -1,7 +1,7 @@
 import { Chat } from "..";
 import type { Meta, StoryFn, StoryObj } from "@storybook/react-vite";
-import { ThreadList } from "@/components/assistant-ui/thread-list";
-import { ROOT_SELECTOR } from "@/constants/tailwind";
+import { ThreadList } from "#elements/components/assistant-ui/thread-list";
+import { ROOT_SELECTOR } from "#elements/constants/tailwind";
 
 const meta: Meta<typeof Chat> = {
   title: "Chat/Variants",

--- a/elements/src/components/ChatHistory.tsx
+++ b/elements/src/components/ChatHistory.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { ThreadList } from "@/components/assistant-ui/thread-list";
-import { ShadowRoot } from "@/components/ShadowRoot";
+import { ThreadList } from "#elements/components/assistant-ui/thread-list";
+import { ShadowRoot } from "#elements/components/ShadowRoot";
 
 interface ChatHistoryProps {
   className?: string;

--- a/elements/src/components/FrontendTools/index.tsx
+++ b/elements/src/components/FrontendTools/index.tsx
@@ -1,5 +1,5 @@
 import { AssistantTool } from "@assistant-ui/react";
-import type { FrontendTools } from "@/types";
+import type { FrontendTools } from "#elements/types";
 
 export function FrontendTools({
   tools: frontendTools,

--- a/elements/src/components/Markdown.tsx
+++ b/elements/src/components/Markdown.tsx
@@ -5,10 +5,10 @@ import ReactMarkdown, {
 } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import { MarkdownLinkProvider } from "@/contexts/MarkdownLinkContext";
-import { MarkdownAnchor } from "@/components/markdown-anchor";
-import { cn } from "@/lib/utils";
-import type { LinkResolver, MarkdownLinkComponent } from "@/types";
+import { MarkdownLinkProvider } from "#elements/contexts/MarkdownLinkContext";
+import { MarkdownAnchor } from "#elements/components/markdown-anchor";
+import { cn } from "#elements/lib/utils";
+import type { LinkResolver, MarkdownLinkComponent } from "#elements/types";
 
 export interface MarkdownProps {
   /** Raw markdown text. */

--- a/elements/src/components/MessageContent.tsx
+++ b/elements/src/components/MessageContent.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { FC, useMemo } from "react";
-import { ElementsContext } from "@/contexts/contexts";
-import { ToolExecutionProvider } from "@/contexts/ToolExecutionContext";
+import { ElementsContext } from "#elements/contexts/contexts";
+import { ToolExecutionProvider } from "#elements/contexts/ToolExecutionContext";
 import type {
   ElementsContextType,
   LinkResolver,
   MarkdownLinkComponent,
   Model,
-} from "@/types";
-import { recommended } from "@/plugins";
-import { chart } from "@/plugins/chart";
-import { generativeUI } from "@/plugins/generative-ui";
+} from "#elements/types";
+import { recommended } from "#elements/plugins";
+import { chart } from "#elements/plugins/chart";
+import { generativeUI } from "#elements/plugins/generative-ui";
 import { parseSegments } from "./MessageContent.parser";
 import { Markdown } from "./Markdown";
 

--- a/elements/src/components/Replay.stories.tsx
+++ b/elements/src/components/Replay.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react-vite";
-import { Chat } from "@/components/Chat";
-import { Replay } from "@/components/Replay";
-import type { Cassette } from "@/lib/cassette";
+import { Chat } from "#elements/components/Chat";
+import { Replay } from "#elements/components/Replay";
+import type { Cassette } from "#elements/lib/cassette";
 
 const meta: Meta<typeof Replay> = {
   title: "Misc/Replay",

--- a/elements/src/components/Replay.tsx
+++ b/elements/src/components/Replay.tsx
@@ -19,20 +19,20 @@
  * ```
  */
 
-import { ROOT_SELECTOR } from "@/constants/tailwind";
-import { ChatIdContext } from "@/contexts/ChatIdContext";
-import { ElementsContext } from "@/contexts/contexts";
-import { ReplayContext } from "@/contexts/ReplayContext";
-import { ToolApprovalProvider } from "@/contexts/ToolApprovalContext";
+import { ROOT_SELECTOR } from "#elements/constants/tailwind";
+import { ChatIdContext } from "#elements/contexts/ChatIdContext";
+import { ElementsContext } from "#elements/contexts/contexts";
+import { ReplayContext } from "#elements/contexts/ReplayContext";
+import { ToolApprovalProvider } from "#elements/contexts/ToolApprovalContext";
 import {
   createReplayTransport,
   type Cassette,
   type ReplayOptions,
-} from "@/lib/cassette";
-import { MODELS } from "@/lib/models";
-import { cn } from "@/lib/utils";
-import { recommended } from "@/plugins";
-import type { ElementsConfig } from "@/types";
+} from "#elements/lib/cassette";
+import { MODELS } from "#elements/lib/models";
+import { cn } from "#elements/lib/utils";
+import { recommended } from "#elements/plugins";
+import type { ElementsConfig } from "#elements/types";
 import {
   AssistantRuntimeProvider,
   useThreadRuntime,

--- a/elements/src/components/ShadowRoot.tsx
+++ b/elements/src/components/ShadowRoot.tsx
@@ -9,12 +9,12 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { PortalContainerProvider } from "@/contexts/portal-container";
-import { useElements } from "@/hooks/useElements";
-import { useThemeProps } from "@/hooks/useThemeProps";
-import { cn } from "@/lib/utils";
-import { ROOT_SELECTOR } from "@/constants/tailwind";
-import elementsStyles from "@/global.css?inline";
+import { PortalContainerProvider } from "#elements/contexts/portal-container";
+import { useElements } from "#elements/hooks/useElements";
+import { useThemeProps } from "#elements/hooks/useThemeProps";
+import { cn } from "#elements/lib/utils";
+import { ROOT_SELECTOR } from "#elements/constants/tailwind";
+import elementsStyles from "#elements/global.css?inline";
 
 interface ShadowRootProps {
   children: ReactNode;

--- a/elements/src/components/ShareButton/index.tsx
+++ b/elements/src/components/ShareButton/index.tsx
@@ -3,14 +3,14 @@
 import { Link } from "lucide-react";
 import { useCallback } from "react";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "#elements/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { useThreadId } from "@/hooks/useThreadId";
-import { cn } from "@/lib/utils";
+} from "#elements/components/ui/tooltip";
+import { useThreadId } from "#elements/hooks/useThreadId";
+import { cn } from "#elements/lib/utils";
 
 export interface ShareButtonProps {
   /**

--- a/elements/src/components/assistant-ui/assistant-modal.tsx
+++ b/elements/src/components/assistant-ui/assistant-modal.tsx
@@ -16,16 +16,16 @@ import {
 } from "motion/react";
 import * as m from "motion/react-m";
 
-import { ErrorBoundary } from "@/components/assistant-ui/error-boundary";
-import { Thread } from "@/components/assistant-ui/thread";
-import { ThreadList } from "@/components/assistant-ui/thread-list";
-import { useThemeProps } from "@/hooks/useThemeProps";
-import { useRadius } from "@/hooks/useRadius";
-import { useDensity } from "@/hooks/useDensity";
-import { assertNever, cn } from "@/lib/utils";
-import { useElements } from "@/hooks/useElements";
-import { useExpanded } from "@/hooks/useExpanded";
-import { EASE_OUT_QUINT } from "@/lib/easing";
+import { ErrorBoundary } from "#elements/components/assistant-ui/error-boundary";
+import { Thread } from "#elements/components/assistant-ui/thread";
+import { ThreadList } from "#elements/components/assistant-ui/thread-list";
+import { useThemeProps } from "#elements/hooks/useThemeProps";
+import { useRadius } from "#elements/hooks/useRadius";
+import { useDensity } from "#elements/hooks/useDensity";
+import { assertNever, cn } from "#elements/lib/utils";
+import { useElements } from "#elements/hooks/useElements";
+import { useExpanded } from "#elements/hooks/useExpanded";
+import { EASE_OUT_QUINT } from "#elements/lib/easing";
 import { useAssistantState } from "@assistant-ui/react";
 
 const LAYOUT_TRANSITION = {

--- a/elements/src/components/assistant-ui/assistant-sidecar.tsx
+++ b/elements/src/components/assistant-ui/assistant-sidecar.tsx
@@ -2,17 +2,17 @@
 
 import { type FC } from "react";
 import { Loader, PanelRightClose, PanelRightOpen } from "lucide-react";
-import { ErrorBoundary } from "@/components/assistant-ui/error-boundary";
-import { Thread } from "@/components/assistant-ui/thread";
-import { ThreadList } from "@/components/assistant-ui/thread-list";
-import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
-import { useThemeProps } from "@/hooks/useThemeProps";
-import { useElements } from "@/hooks/useElements";
-import { cn } from "@/lib/utils";
-import { useExpanded } from "@/hooks/useExpanded";
+import { ErrorBoundary } from "#elements/components/assistant-ui/error-boundary";
+import { Thread } from "#elements/components/assistant-ui/thread";
+import { ThreadList } from "#elements/components/assistant-ui/thread-list";
+import { TooltipIconButton } from "#elements/components/assistant-ui/tooltip-icon-button";
+import { useThemeProps } from "#elements/hooks/useThemeProps";
+import { useElements } from "#elements/hooks/useElements";
+import { cn } from "#elements/lib/utils";
+import { useExpanded } from "#elements/hooks/useExpanded";
 import { LazyMotion, domMax } from "motion/react";
 import * as m from "motion/react-m";
-import { EASE_OUT_QUINT } from "@/lib/easing";
+import { EASE_OUT_QUINT } from "#elements/lib/easing";
 import { useAssistantState } from "@assistant-ui/react";
 
 interface AssistantSidecarProps {

--- a/elements/src/components/assistant-ui/attachment.tsx
+++ b/elements/src/components/assistant-ui/attachment.tsx
@@ -14,16 +14,20 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@/components/ui/tooltip";
+} from "#elements/components/ui/tooltip";
 import {
   Dialog,
   DialogTitle,
   DialogContent,
   DialogTrigger,
-} from "@/components/ui/dialog";
-import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
-import { cn } from "@/lib/utils";
+} from "#elements/components/ui/dialog";
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+} from "#elements/components/ui/avatar";
+import { TooltipIconButton } from "#elements/components/assistant-ui/tooltip-icon-button";
+import { cn } from "#elements/lib/utils";
 
 const useFileSrc = (file: File | undefined) => {
   const [src, setSrc] = useState<string | undefined>(undefined);

--- a/elements/src/components/assistant-ui/connection-status-indicator.tsx
+++ b/elements/src/components/assistant-ui/connection-status-indicator.tsx
@@ -4,8 +4,8 @@ import {
   useConnectionStatus,
   useConnectionStatusOptional,
   type ConnectionState,
-} from "@/contexts/ConnectionStatusContext";
-import { cn } from "@/lib/utils";
+} from "#elements/contexts/ConnectionStatusContext";
+import { cn } from "#elements/lib/utils";
 import { Loader2Icon, WifiOffIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { FC } from "react";

--- a/elements/src/components/assistant-ui/error-boundary.tsx
+++ b/elements/src/components/assistant-ui/error-boundary.tsx
@@ -2,8 +2,8 @@
 
 import { AlertCircle } from "lucide-react";
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { trackError } from "@/lib/errorTracking";
-import { cn } from "@/lib/utils";
+import { trackError } from "#elements/lib/errorTracking";
+import { cn } from "#elements/lib/utils";
 import { Button } from "../ui/button";
 
 interface ErrorBoundaryProps {

--- a/elements/src/components/assistant-ui/follow-on-suggestions.tsx
+++ b/elements/src/components/assistant-ui/follow-on-suggestions.tsx
@@ -3,12 +3,12 @@ import { AnimatePresence } from "motion/react";
 import * as m from "motion/react-m";
 import { FC } from "react";
 
-import { Button } from "@/components/ui/button";
-import { useDensity } from "@/hooks/useDensity";
-import { useFollowOnSuggestions } from "@/hooks/useFollowOnSuggestions";
-import { useRadius } from "@/hooks/useRadius";
-import { EASE_OUT_QUINT } from "@/lib/easing";
-import { cn } from "@/lib/utils";
+import { Button } from "#elements/components/ui/button";
+import { useDensity } from "#elements/hooks/useDensity";
+import { useFollowOnSuggestions } from "#elements/hooks/useFollowOnSuggestions";
+import { useRadius } from "#elements/hooks/useRadius";
+import { EASE_OUT_QUINT } from "#elements/lib/easing";
+import { cn } from "#elements/lib/utils";
 
 const suggestionVariants = {
   hidden: {

--- a/elements/src/components/assistant-ui/markdown-text.tsx
+++ b/elements/src/components/assistant-ui/markdown-text.tsx
@@ -11,12 +11,12 @@ import { type FC, memo, useCallback, useState } from "react";
 import { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import { MarkdownAnchor } from "@/components/markdown-anchor";
-import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
-import { useMarkdownLink } from "@/contexts/MarkdownLinkContext";
-import { cn } from "@/lib/utils";
-import { useElements } from "@/hooks/useElements";
-import { useComponentsByLanguage } from "@/hooks/usePluginComponents";
+import { MarkdownAnchor } from "#elements/components/markdown-anchor";
+import { TooltipIconButton } from "#elements/components/assistant-ui/tooltip-icon-button";
+import { useMarkdownLink } from "#elements/contexts/MarkdownLinkContext";
+import { cn } from "#elements/lib/utils";
+import { useElements } from "#elements/hooks/useElements";
+import { useComponentsByLanguage } from "#elements/hooks/usePluginComponents";
 import { useAssistantState } from "@assistant-ui/react";
 
 const MarkdownTextImpl = () => {

--- a/elements/src/components/assistant-ui/mentioned-tools-badges.tsx
+++ b/elements/src/components/assistant-ui/mentioned-tools-badges.tsx
@@ -3,11 +3,11 @@ import { Wrench, X } from "lucide-react";
 import { AnimatePresence } from "motion/react";
 import * as m from "motion/react-m";
 
-import { cn } from "@/lib/utils";
-import { useDensity } from "@/hooks/useDensity";
-import { useRadius } from "@/hooks/useRadius";
-import { EASE_OUT_QUINT } from "@/lib/easing";
-import { MentionableTool } from "@/lib/tool-mentions";
+import { cn } from "#elements/lib/utils";
+import { useDensity } from "#elements/hooks/useDensity";
+import { useRadius } from "#elements/hooks/useRadius";
+import { EASE_OUT_QUINT } from "#elements/lib/easing";
+import { MentionableTool } from "#elements/lib/tool-mentions";
 
 export interface MentionedToolsBadgesProps {
   mentionedToolIds: string[];

--- a/elements/src/components/assistant-ui/message-feedback.tsx
+++ b/elements/src/components/assistant-ui/message-feedback.tsx
@@ -3,9 +3,9 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { EASE_OUT_QUINT } from "@/lib/easing";
-import { cn } from "@/lib/utils";
+} from "#elements/components/ui/tooltip";
+import { EASE_OUT_QUINT } from "#elements/lib/easing";
+import { cn } from "#elements/lib/utils";
 import { Heart, X } from "lucide-react";
 import { AnimatePresence } from "motion/react";
 import * as m from "motion/react-m";

--- a/elements/src/components/assistant-ui/reasoning.tsx
+++ b/elements/src/components/assistant-ui/reasoning.tsx
@@ -17,13 +17,13 @@ import {
   type ReasoningMessagePartComponent,
 } from "@assistant-ui/react";
 
-import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { MarkdownText } from "#elements/components/assistant-ui/markdown-text";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { cn } from "@/lib/utils";
+} from "#elements/components/ui/collapsible";
+import { cn } from "#elements/lib/utils";
 
 const ANIMATION_DURATION = 200;
 

--- a/elements/src/components/assistant-ui/thinking-indicator.tsx
+++ b/elements/src/components/assistant-ui/thinking-indicator.tsx
@@ -3,7 +3,7 @@
 import { useAssistantState } from "@assistant-ui/react";
 import { type FC, useEffect, useMemo, useState } from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 /**
  * Whimsical verbs cycled while the assistant is "thinking" — i.e. the message

--- a/elements/src/components/assistant-ui/thread-list.tsx
+++ b/elements/src/components/assistant-ui/thread-list.tsx
@@ -6,13 +6,17 @@ import {
 } from "@assistant-ui/react";
 import { MessageSquareTextIcon, PlusIcon } from "lucide-react";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { useRadius } from "@/hooks/useRadius";
-import { cn, initialsOf } from "@/lib/utils";
-import { useDensity } from "@/hooks/useDensity";
-import { useThreadMeta } from "@/contexts/ThreadMetaContext";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "#elements/components/ui/avatar";
+import { Button } from "#elements/components/ui/button";
+import { Skeleton } from "#elements/components/ui/skeleton";
+import { useRadius } from "#elements/hooks/useRadius";
+import { cn, initialsOf } from "#elements/lib/utils";
+import { useDensity } from "#elements/hooks/useDensity";
+import { useThreadMeta } from "#elements/contexts/ThreadMetaContext";
 
 /**
  * Formats a chat's creation date for the list row: "Jun 14" within the current

--- a/elements/src/components/assistant-ui/thread.tsx
+++ b/elements/src/components/assistant-ui/thread.tsx
@@ -49,38 +49,46 @@ import {
   ComposerAddAttachment,
   ComposerAttachments,
   UserMessageAttachments,
-} from "@/components/assistant-ui/attachment";
-import { FollowOnSuggestions } from "@/components/assistant-ui/follow-on-suggestions";
-import { MarkdownText } from "@/components/assistant-ui/markdown-text";
-import { MentionedToolsBadges } from "@/components/assistant-ui/mentioned-tools-badges";
-import { MessageFeedback } from "@/components/assistant-ui/message-feedback";
-import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning";
-import { ThinkingIndicator } from "@/components/assistant-ui/thinking-indicator";
-import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
-import { UserMessageText } from "@/components/assistant-ui/user-message-text";
-import { ToolMentionAutocomplete } from "@/components/assistant-ui/tool-mention-autocomplete";
-import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
-import { useChatId } from "@/contexts/ChatIdContext";
-import { useReplayContext } from "@/contexts/ReplayContext";
-import { useThreadMeta } from "@/contexts/ThreadMetaContext";
-import { useAuth } from "@/hooks/useAuth";
-import { useDensity } from "@/hooks/useDensity";
-import { useElements } from "@/hooks/useElements";
-import { isLocalThreadId } from "@/hooks/useGramThreadListAdapter";
-import { useRadius } from "@/hooks/useRadius";
-import { useRecordCassette } from "@/hooks/useRecordCassette";
-import { useThemeProps } from "@/hooks/useThemeProps";
-import { useToolMentions } from "@/hooks/useToolMentions";
-import { getApiUrl } from "@/lib/api";
-import { EASE_OUT_QUINT } from "@/lib/easing";
-import { MODELS } from "@/lib/models";
+} from "#elements/components/assistant-ui/attachment";
+import { FollowOnSuggestions } from "#elements/components/assistant-ui/follow-on-suggestions";
+import { MarkdownText } from "#elements/components/assistant-ui/markdown-text";
+import { MentionedToolsBadges } from "#elements/components/assistant-ui/mentioned-tools-badges";
+import { MessageFeedback } from "#elements/components/assistant-ui/message-feedback";
+import {
+  Reasoning,
+  ReasoningGroup,
+} from "#elements/components/assistant-ui/reasoning";
+import { ThinkingIndicator } from "#elements/components/assistant-ui/thinking-indicator";
+import { ToolFallback } from "#elements/components/assistant-ui/tool-fallback";
+import { UserMessageText } from "#elements/components/assistant-ui/user-message-text";
+import { ToolMentionAutocomplete } from "#elements/components/assistant-ui/tool-mention-autocomplete";
+import { TooltipIconButton } from "#elements/components/assistant-ui/tooltip-icon-button";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "#elements/components/ui/avatar";
+import { Button } from "#elements/components/ui/button";
+import { useChatId } from "#elements/contexts/ChatIdContext";
+import { useReplayContext } from "#elements/contexts/ReplayContext";
+import { useThreadMeta } from "#elements/contexts/ThreadMetaContext";
+import { useAuth } from "#elements/hooks/useAuth";
+import { useDensity } from "#elements/hooks/useDensity";
+import { useElements } from "#elements/hooks/useElements";
+import { isLocalThreadId } from "#elements/hooks/useGramThreadListAdapter";
+import { useRadius } from "#elements/hooks/useRadius";
+import { useRecordCassette } from "#elements/hooks/useRecordCassette";
+import { useThemeProps } from "#elements/hooks/useThemeProps";
+import { useToolMentions } from "#elements/hooks/useToolMentions";
+import { getApiUrl } from "#elements/lib/api";
+import { EASE_OUT_QUINT } from "#elements/lib/easing";
+import { MODELS } from "#elements/lib/models";
 import {
   type MentionableTool,
   toolSetToMentionableTools,
-} from "@/lib/tool-mentions";
-import { cn, initialsOf } from "@/lib/utils";
+} from "#elements/lib/tool-mentions";
+import { cn, initialsOf } from "#elements/lib/utils";
+import type { ElementsImportMetaEnv } from "#elements/types/env";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import {
   Tooltip,
@@ -749,7 +757,8 @@ const ComposerModelPicker: FC = () => {
 };
 
 const CASSETTE_RECORDING_ENABLED =
-  import.meta.env.VITE_ELEMENTS_ENABLE_CASSETTE_RECORDING === "true";
+  (import.meta.env as ElementsImportMetaEnv)
+    .VITE_ELEMENTS_ENABLE_CASSETTE_RECORDING === "true";
 
 const ComposerCassetteRecorder: FC = () => {
   const [popoverOpen, setPopoverOpen] = useState(false);

--- a/elements/src/components/assistant-ui/tool-fallback.tsx
+++ b/elements/src/components/assistant-ui/tool-fallback.tsx
@@ -1,14 +1,14 @@
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import {
   useAssistantState,
   type ToolCallMessagePartComponent,
 } from "@assistant-ui/react";
-import { useToolApproval } from "@/hooks/useToolApproval";
+import { useToolApproval } from "#elements/hooks/useToolApproval";
 import {
   ToolUI,
   type ToolStatus,
   type ContentItem,
-} from "@/components/ui/tool-ui";
+} from "#elements/components/ui/tool-ui";
 
 export const ToolFallback: ToolCallMessagePartComponent = ({
   toolName,

--- a/elements/src/components/assistant-ui/tool-group.tsx
+++ b/elements/src/components/assistant-ui/tool-group.tsx
@@ -1,8 +1,8 @@
 import { useAssistantState } from "@assistant-ui/react";
 import { useMemo, type FC, type PropsWithChildren } from "react";
-import { useElements } from "@/hooks/useElements";
-import { humanizeToolName } from "@/lib/humanize";
-import { ToolUIGroup } from "@/components/ui/tool-ui";
+import { useElements } from "#elements/hooks/useElements";
+import { humanizeToolName } from "#elements/lib/humanize";
+import { ToolUIGroup } from "#elements/components/ui/tool-ui";
 
 export const ToolGroup: FC<
   PropsWithChildren<{ startIndex: number; endIndex: number }>

--- a/elements/src/components/assistant-ui/tool-mention-autocomplete.tsx
+++ b/elements/src/components/assistant-ui/tool-mention-autocomplete.tsx
@@ -2,16 +2,16 @@ import { FC, useCallback, useEffect, useRef, useState } from "react";
 import { Wrench } from "lucide-react";
 import * as m from "motion/react-m";
 
-import { cn } from "@/lib/utils";
-import { useDensity } from "@/hooks/useDensity";
-import { useRadius } from "@/hooks/useRadius";
-import { EASE_OUT_QUINT } from "@/lib/easing";
+import { cn } from "#elements/lib/utils";
+import { useDensity } from "#elements/hooks/useDensity";
+import { useRadius } from "#elements/hooks/useRadius";
+import { EASE_OUT_QUINT } from "#elements/lib/easing";
 import {
   MentionableTool,
   detectMentionContext,
   filterToolsByQuery,
   insertToolMention,
-} from "@/lib/tool-mentions";
+} from "#elements/lib/tool-mentions";
 
 export interface ToolMentionAutocompleteProps {
   tools: MentionableTool[];

--- a/elements/src/components/assistant-ui/tooltip-icon-button.tsx
+++ b/elements/src/components/assistant-ui/tooltip-icon-button.tsx
@@ -7,9 +7,9 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+} from "#elements/components/ui/tooltip";
+import { Button } from "#elements/components/ui/button";
+import { cn } from "#elements/lib/utils";
 
 type TooltipIconButtonProps = ComponentPropsWithRef<typeof Button> & {
   tooltip: string;

--- a/elements/src/components/assistant-ui/user-message-text.tsx
+++ b/elements/src/components/assistant-ui/user-message-text.tsx
@@ -9,8 +9,8 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { cn } from "@/lib/utils";
+} from "#elements/components/ui/collapsible";
+import { cn } from "#elements/lib/utils";
 
 import {
   splitContextBlocks,

--- a/elements/src/components/markdown-anchor.tsx
+++ b/elements/src/components/markdown-anchor.tsx
@@ -1,7 +1,7 @@
 import { type ComponentPropsWithoutRef, memo } from "react";
 
-import { useMarkdownLink } from "@/contexts/MarkdownLinkContext";
-import { cn } from "@/lib/utils";
+import { useMarkdownLink } from "#elements/contexts/MarkdownLinkContext";
+import { cn } from "#elements/lib/utils";
 
 const ANCHOR_CLASS =
   "aui-md-a font-medium text-primary underline underline-offset-4";

--- a/elements/src/components/ui/avatar.tsx
+++ b/elements/src/components/ui/avatar.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Avatar({
   className,

--- a/elements/src/components/ui/button.tsx
+++ b/elements/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { buttonVariants } from "./buttonVariants";
 
 const Button = React.forwardRef<

--- a/elements/src/components/ui/calendar.tsx
+++ b/elements/src/components/ui/calendar.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface CalendarProps {
   /** Selected date range */

--- a/elements/src/components/ui/charts.stories.tsx
+++ b/elements/src/components/ui/charts.stories.tsx
@@ -7,7 +7,7 @@ import {
   DonutChart,
   RadarChart,
   ScatterChart,
-} from "@/plugins/chart/ui";
+} from "#elements/plugins/chart/ui";
 
 // Wrapper component to render different chart types
 const ChartWrapper = ({ children }: { children: React.ReactNode }) => (

--- a/elements/src/components/ui/dialog.tsx
+++ b/elements/src/components/ui/dialog.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
 
-import { cn } from "@/lib/utils";
-import { usePortalContainer } from "@/hooks/usePortalContainer";
+import { cn } from "#elements/lib/utils";
+import { usePortalContainer } from "#elements/hooks/usePortalContainer";
 
 function Dialog({
   ...props

--- a/elements/src/components/ui/generative-ui.tsx
+++ b/elements/src/components/ui/generative-ui.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useDensity } from "@/hooks/useDensity";
-import { cn } from "@/lib/utils";
-import { isJsonRenderTree, type JsonRenderNode } from "@/lib/generative-ui";
+import { useDensity } from "#elements/hooks/useDensity";
+import { cn } from "#elements/lib/utils";
+import {
+  isJsonRenderTree,
+  type JsonRenderNode,
+} from "#elements/lib/generative-ui";
 import { AlertCircleIcon } from "lucide-react";
-import { ElementType, FC, useMemo } from "react";
+import { type ComponentType, type FC, type ReactNode, useMemo } from "react";
 
 // Import all components from the generative-ui plugin ui directory
 import {
@@ -30,7 +33,7 @@ import {
   TabsWrapper,
   TabContentWrapper,
   Text,
-} from "@/plugins/generative-ui/ui";
+} from "#elements/plugins/generative-ui/ui";
 
 interface GenerativeUIProps {
   /** The JSON content to render - can be a json-render tree or raw object */
@@ -43,9 +46,13 @@ interface GenerativeUIProps {
  * Built-in components for rendering json-render trees.
  * These provide a default set of UI primitives for tool results.
  * Each entry has its own prop shape; the registry erases those generics via
- * `ElementType` so heterogeneous components can coexist under one map.
+ * `ComponentType` so heterogeneous components can coexist under one map.
  */
-const components: Record<string, ElementType> = {
+type DynamicComponentProps = Record<string, unknown> & {
+  children?: ReactNode;
+};
+
+const components = {
   // Layout
   Card: CardWrapper,
   Grid,
@@ -77,7 +84,7 @@ const components: Record<string, ElementType> = {
   Input: InputWrapper,
   Checkbox: CheckboxWrapper,
   Select: SelectWrapper,
-};
+} as unknown as Record<string, ComponentType<DynamicComponentProps>>;
 
 /**
  * Recursively render a json-render tree node

--- a/elements/src/components/ui/popover.tsx
+++ b/elements/src/components/ui/popover.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import { cn } from "@/lib/utils";
-import { usePortalContainer } from "@/hooks/usePortalContainer";
+import { cn } from "#elements/lib/utils";
+import { usePortalContainer } from "#elements/hooks/usePortalContainer";
 
 function Popover({
   ...props

--- a/elements/src/components/ui/skeleton.tsx
+++ b/elements/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Skeleton({
   className,

--- a/elements/src/components/ui/time-range-picker.test.ts
+++ b/elements/src/components/ui/time-range-picker.test.ts
@@ -22,7 +22,7 @@ vi.mock("ai", () => ({
 }));
 
 // Avoid pulling Datadog RUM (and its window access) into the Node test env.
-vi.mock("@/lib/errorTracking", () => ({ trackError: vi.fn() }));
+vi.mock("#elements/lib/errorTracking", () => ({ trackError: vi.fn() }));
 
 import { parseWithAI } from "./time-range-picker";
 

--- a/elements/src/components/ui/time-range-picker.tsx
+++ b/elements/src/components/ui/time-range-picker.tsx
@@ -5,8 +5,8 @@ import { generateObject, LanguageModel } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { z } from "zod";
 
-import { cn } from "@/lib/utils";
-import { trackError } from "@/lib/errorTracking";
+import { cn } from "#elements/lib/utils";
+import { trackError } from "#elements/lib/errorTracking";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import { Calendar } from "./calendar";
 

--- a/elements/src/components/ui/tool-ui.tsx
+++ b/elements/src/components/ui/tool-ui.tsx
@@ -14,7 +14,7 @@ import {
   TriangleAlertIcon,
   XIcon,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { codeToHtml, BundledLanguage } from "shiki";
 import { Button } from "./button";
 import { Popover, PopoverAnchor, PopoverContent } from "./popover";

--- a/elements/src/components/ui/tooltip.tsx
+++ b/elements/src/components/ui/tooltip.tsx
@@ -3,8 +3,8 @@
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
-import { cn } from "@/lib/utils";
-import { usePortalContainer } from "@/hooks/usePortalContainer";
+import { cn } from "#elements/lib/utils";
+import { usePortalContainer } from "#elements/hooks/usePortalContainer";
 
 function TooltipProvider({
   delayDuration = 0,

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -1,14 +1,14 @@
-import { FrontendTools } from "@/components/FrontendTools";
-import { ROOT_SELECTOR } from "@/constants/tailwind";
+import { FrontendTools } from "#elements/components/FrontendTools";
+import { ROOT_SELECTOR } from "#elements/constants/tailwind";
 import {
   isLocalThreadId,
   useGramThreadListAdapter,
-} from "@/hooks/useGramThreadListAdapter";
-import { useMCPTools } from "@/hooks/useMCPTools";
-import { useToolApproval } from "@/hooks/useToolApproval";
-import { getApiUrl } from "@/lib/api";
-import { initErrorTracking, trackError } from "@/lib/errorTracking";
-import { MODELS } from "@/lib/models";
+} from "#elements/hooks/useGramThreadListAdapter";
+import { useMCPTools } from "#elements/hooks/useMCPTools";
+import { useToolApproval } from "#elements/hooks/useToolApproval";
+import { getApiUrl } from "#elements/lib/api";
+import { initErrorTracking, trackError } from "#elements/lib/errorTracking";
+import { MODELS } from "#elements/lib/models";
 import {
   clearFrontendToolApprovalConfig,
   getEnabledTools,
@@ -17,13 +17,13 @@ import {
   wrapToolsWithApproval,
   wrapToolsWithByteCap,
   type ApprovalHelpers,
-} from "@/lib/tools";
-import { compactForModel } from "@/lib/contextCompaction";
-import { describeStreamError } from "@/lib/streamErrorMessage";
-import { cn } from "@/lib/utils";
-import { recommended } from "@/plugins";
-import { ElementsConfig, Model } from "@/types";
-import { Plugin } from "@/types/plugins";
+} from "#elements/lib/tools";
+import { compactForModel } from "#elements/lib/contextCompaction";
+import { describeStreamError } from "#elements/lib/streamErrorMessage";
+import { cn } from "#elements/lib/utils";
+import { recommended } from "#elements/plugins";
+import { ElementsConfig, Model } from "#elements/types";
+import { Plugin } from "#elements/types/plugins";
 import {
   AssistantRuntimeProvider,
   AssistantTool,

--- a/elements/src/contexts/MarkdownLinkContext.tsx
+++ b/elements/src/contexts/MarkdownLinkContext.tsx
@@ -5,7 +5,7 @@ import {
   useContext,
 } from "react";
 
-import type { LinkResolver, MarkdownLinkComponent } from "@/types";
+import type { LinkResolver, MarkdownLinkComponent } from "#elements/types";
 
 /**
  * Host-supplied hooks for rendering links inside assistant markdown.

--- a/elements/src/contexts/contexts.ts
+++ b/elements/src/contexts/contexts.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import type { ElementsContextType } from "@/types";
+import type { ElementsContextType } from "#elements/types";
 import { ToolApprovalContextType } from "./ToolApprovalContext";
 
 export const ElementsContext = createContext<ElementsContextType | undefined>(

--- a/elements/src/hooks/useAuth.ts
+++ b/elements/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useReplayContext } from "@/contexts/ReplayContext";
+import { useReplayContext } from "#elements/contexts/ReplayContext";
 import {
   hasExplicitSessionAuth,
   isAnyStaticSession,
@@ -6,8 +6,8 @@ import {
   isStaticSessionAuth,
   isUnifiedFunctionSession,
   isUnifiedStaticSession,
-} from "@/lib/auth";
-import { getTokenExpiry } from "@/lib/token";
+} from "#elements/lib/auth";
+import { getTokenExpiry } from "#elements/lib/token";
 import { useCallback, useMemo } from "react";
 import { ApiConfig, GetSessionFn } from "../types";
 import { getChatSessionQueryKey, useSession } from "./useSession";

--- a/elements/src/hooks/useElements.ts
+++ b/elements/src/hooks/useElements.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
-import { ElementsContext } from "@/contexts/contexts";
-import type { ElementsContextType } from "@/types";
+import { ElementsContext } from "#elements/contexts/contexts";
+import type { ElementsContextType } from "#elements/types";
 
 /**
  * @private Internal hook to access the ElementsContext

--- a/elements/src/hooks/useFollowOnSuggestions.ts
+++ b/elements/src/hooks/useFollowOnSuggestions.ts
@@ -1,4 +1,4 @@
-import { useReplayContext } from "@/contexts/ReplayContext";
+import { useReplayContext } from "#elements/contexts/ReplayContext";
 import { useAssistantState } from "@assistant-ui/react";
 import { generateObject } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";

--- a/elements/src/hooks/useGramThreadListAdapter.tsx
+++ b/elements/src/hooks/useGramThreadListAdapter.tsx
@@ -13,13 +13,13 @@ import {
   GramChatMessage,
   convertGramMessagesToExported,
   convertGramMessagesToUIMessages,
-} from "@/lib/messageConverter";
-import { sleep } from "@/lib/utils";
-import { trackError } from "@/lib/errorTracking";
+} from "#elements/lib/messageConverter";
+import { sleep } from "#elements/lib/utils";
+import { trackError } from "#elements/lib/errorTracking";
 import {
   ThreadMetaContext,
   type ThreadMeta,
-} from "@/contexts/ThreadMetaContext";
+} from "#elements/contexts/ThreadMetaContext";
 import {
   useCallback,
   useEffect,

--- a/elements/src/hooks/useMCPTools.ts
+++ b/elements/src/hooks/useMCPTools.ts
@@ -1,10 +1,10 @@
-import { assert } from "@/lib/utils";
-import type { MCPServerEntry } from "@/types";
-import { ToolsFilter } from "@/types";
+import { assert } from "#elements/lib/utils";
+import type { MCPServerEntry } from "#elements/types";
+import { ToolsFilter } from "#elements/types";
 import { createMCPClient } from "@ai-sdk/mcp";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useMemo, useRef } from "react";
-import { trackError } from "@/lib/errorTracking";
+import { trackError } from "#elements/lib/errorTracking";
 import { Auth } from "./useAuth";
 
 type MCPToolsResult = Awaited<

--- a/elements/src/hooks/useModel.ts
+++ b/elements/src/hooks/useModel.ts
@@ -1,4 +1,4 @@
-import { getApiUrl } from "@/lib/api";
+import { getApiUrl } from "#elements/lib/api";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { LanguageModel } from "ai";
 import { useAuth } from "./useAuth";

--- a/elements/src/hooks/usePluginComponents.ts
+++ b/elements/src/hooks/usePluginComponents.ts
@@ -3,7 +3,7 @@ import {
   SyntaxHighlighterProps,
 } from "@assistant-ui/react-markdown";
 import { ComponentType, useMemo } from "react";
-import { Plugin } from "@/types/plugins";
+import { Plugin } from "#elements/types/plugins";
 
 type ComponentsByLanguage =
   | Record<

--- a/elements/src/hooks/usePortalContainer.ts
+++ b/elements/src/hooks/usePortalContainer.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useContext } from "react";
-import { PortalContainerContext } from "@/contexts/portal-container-context";
+import { PortalContainerContext } from "#elements/contexts/portal-container-context";
 
 /**
  * Because we do not want Tailwind to leak from the Elements library, and

--- a/elements/src/hooks/useRadius.ts
+++ b/elements/src/hooks/useRadius.ts
@@ -1,4 +1,4 @@
-import { Radius } from "@/types";
+import { Radius } from "#elements/types";
 import { useElements } from "./useElements";
 
 /**

--- a/elements/src/hooks/useRecordCassette.ts
+++ b/elements/src/hooks/useRecordCassette.ts
@@ -21,7 +21,7 @@
 
 import { useThreadRuntime } from "@assistant-ui/react";
 import { useCallback, useRef, useState, useSyncExternalStore } from "react";
-import { recordCassette } from "@/lib/cassette";
+import { recordCassette } from "#elements/lib/cassette";
 
 export function useRecordCassette(): {
   /** Whether recording is currently active. */

--- a/elements/src/hooks/useSession.ts
+++ b/elements/src/hooks/useSession.ts
@@ -1,4 +1,4 @@
-import { GetSessionFn } from "@/types";
+import { GetSessionFn } from "#elements/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export function getChatSessionQueryKey(

--- a/elements/src/hooks/useToolApproval.ts
+++ b/elements/src/hooks/useToolApproval.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
-import { ToolApprovalContext } from "@/contexts/contexts";
-import type { ToolApprovalContextType } from "@/contexts/ToolApprovalContext";
+import { ToolApprovalContext } from "#elements/contexts/contexts";
+import type { ToolApprovalContextType } from "#elements/contexts/ToolApprovalContext";
 
 /**
  * Hook to access the tool approval context for managing human-in-the-loop

--- a/elements/src/hooks/useToolMentions.ts
+++ b/elements/src/hooks/useToolMentions.ts
@@ -5,7 +5,7 @@ import {
   parseMentionedTools,
   removeToolMention,
   toolSetToMentionableTools,
-} from "@/lib/tool-mentions";
+} from "#elements/lib/tool-mentions";
 
 export interface UseToolMentionsOptions {
   tools: Record<string, unknown> | undefined;

--- a/elements/src/index.ts
+++ b/elements/src/index.ts
@@ -1,9 +1,6 @@
 // Polyfill React 18 APIs for older React versions — must be the first import
 import "./compat";
 
-// Side-effect import to include CSS in build (consumers import via @gram-ai/elements/elements.css)
-import "./global.css";
-
 // Context Providers
 export { ElementsProvider as GramElementsProvider } from "./contexts/ElementsProvider";
 export { ElementsProvider } from "./contexts/ElementsProvider";
@@ -18,16 +15,16 @@ export {
 export type { MarkdownLinkValue } from "./contexts/MarkdownLinkContext";
 
 // Core Components
-export { Chat } from "@/components/Chat";
-export { ChatHistory } from "@/components/ChatHistory";
-export { ActiveChatTitle } from "@/components/ActiveChatTitle";
-export { ShareButton } from "@/components/ShareButton";
-export type { ShareButtonProps } from "@/components/ShareButton";
-export { ToolFallback } from "@/components/assistant-ui/tool-fallback";
-export { MessageContent } from "@/components/MessageContent";
-export type { MessageContentProps } from "@/components/MessageContent";
-export { Markdown } from "@/components/Markdown";
-export type { MarkdownProps } from "@/components/Markdown";
+export { Chat } from "#elements/components/Chat";
+export { ChatHistory } from "#elements/components/ChatHistory";
+export { ActiveChatTitle } from "#elements/components/ActiveChatTitle";
+export { ShareButton } from "#elements/components/ShareButton";
+export type { ShareButtonProps } from "#elements/components/ShareButton";
+export { ToolFallback } from "#elements/components/assistant-ui/tool-fallback";
+export { MessageContent } from "#elements/components/MessageContent";
+export type { MessageContentProps } from "#elements/components/MessageContent";
+export { Markdown } from "#elements/components/Markdown";
+export type { MarkdownProps } from "#elements/components/Markdown";
 
 // Static presentation primitives — render with no ElementsProvider/runtime, so
 // the dashboard's chat detail panel can reuse the elements tool UI directly.
@@ -35,7 +32,7 @@ export {
   ToolUI,
   ToolUISection,
   SyntaxHighlightedCode,
-} from "@/components/ui/tool-ui";
+} from "#elements/components/ui/tool-ui";
 export type {
   ToolUIProps,
   ToolUISectionProps,
@@ -43,17 +40,17 @@ export type {
   ContentItem,
   SectionHighlight,
   SectionMatch,
-} from "@/components/ui/tool-ui";
+} from "#elements/components/ui/tool-ui";
 
 // Replay
-export { Replay } from "@/components/Replay";
-export { useRecordCassette } from "@/hooks/useRecordCassette";
+export { Replay } from "#elements/components/Replay";
+export { useRecordCassette } from "#elements/hooks/useRecordCassette";
 export type {
   Cassette,
   CassetteMessage,
   CassettePart,
   ReplayOptions,
-} from "@/lib/cassette";
+} from "#elements/lib/cassette";
 
 // Frontend Tools
 export { defineFrontendTool } from "./lib/tools";
@@ -114,14 +111,14 @@ export { MODELS } from "./lib/models";
 export {
   convertGramMessagesToUIMessages,
   convertGramMessagesToExported,
-} from "@/lib/messageConverter";
+} from "#elements/lib/messageConverter";
 
-export { sleep } from "@/lib/utils";
+export { sleep } from "#elements/lib/utils";
 export type {
   GramChat,
   GramChatMessage,
   GramChatOverview,
-} from "@/lib/messageConverter";
+} from "#elements/lib/messageConverter";
 
 export type { Plugin } from "./types/plugins";
 
@@ -130,12 +127,12 @@ export {
   TimeRangePicker,
   getPresetRange,
   PRESETS,
-} from "@/components/ui/time-range-picker";
+} from "#elements/components/ui/time-range-picker";
 export type {
   TimeRange,
   TimeRangePreset,
   TimeRangePickerProps,
   DateRangePreset,
-} from "@/components/ui/time-range-picker";
-export { Calendar } from "@/components/ui/calendar";
-export type { CalendarProps } from "@/components/ui/calendar";
+} from "#elements/components/ui/time-range-picker";
+export { Calendar } from "#elements/components/ui/calendar";
+export type { CalendarProps } from "#elements/components/ui/calendar";

--- a/elements/src/lib/api.test.ts
+++ b/elements/src/lib/api.test.ts
@@ -1,4 +1,4 @@
-import type { ElementsConfig } from "@/types";
+import type { ElementsConfig } from "#elements/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("getApiUrl", () => {

--- a/elements/src/lib/api.ts
+++ b/elements/src/lib/api.ts
@@ -1,9 +1,13 @@
-import { ElementsConfig } from "@/types";
+import { ElementsConfig } from "#elements/types";
+
+declare const __GRAM_API_URL__: string | undefined;
 
 export function getApiUrl(config: ElementsConfig): string {
   // The api.url in the config should take precedence over the __GRAM_API_URL__ environment variable
   // because it is a user-defined override
+  const configuredApiUrl =
+    typeof __GRAM_API_URL__ !== "undefined" ? __GRAM_API_URL__ : undefined;
   const apiURL =
-    config.api?.url || __GRAM_API_URL__ || "https://app.getgram.ai";
+    config.api?.url || configuredApiUrl || "https://app.getgram.ai";
   return apiURL.replace(/\/+$/, ""); // Remove trailing slashes
 }

--- a/elements/src/lib/auth.ts
+++ b/elements/src/lib/auth.ts
@@ -6,7 +6,7 @@ import {
   SessionAuthConfig,
   StaticSessionAuthConfig,
   UnifiedSessionAuthConfig,
-} from "@/types";
+} from "#elements/types";
 
 export function isDangerousApiKeyAuth(
   auth: ApiConfig | undefined,

--- a/elements/src/lib/cassette.ts
+++ b/elements/src/lib/cassette.ts
@@ -17,7 +17,7 @@ import {
   type UIMessageStreamWriter,
 } from "ai";
 import type { ThreadMessage } from "@assistant-ui/react";
-import { sleep } from "@/lib/utils";
+import { sleep } from "#elements/lib/utils";
 
 // ---------------------------------------------------------------------------
 // Cassette types

--- a/elements/src/lib/errorTracking.config.ts
+++ b/elements/src/lib/errorTracking.config.ts
@@ -9,10 +9,17 @@
  * - VITE_DATADOG_SITE (optional, defaults to datadoghq.com)
  * - VITE_DATADOG_ENV (optional, defaults to prod)
  */
+import type { ElementsImportMetaEnv } from "#elements/types/env";
+
 export const DATADOG_CONFIG = {
-  applicationId: import.meta.env.VITE_DATADOG_APPLICATION_ID ?? "",
-  clientToken: import.meta.env.VITE_DATADOG_CLIENT_TOKEN ?? "",
-  site: import.meta.env.VITE_DATADOG_SITE ?? "datadoghq.com",
-  env: import.meta.env.VITE_DATADOG_ENV ?? "prod",
+  applicationId:
+    (import.meta.env as ElementsImportMetaEnv).VITE_DATADOG_APPLICATION_ID ??
+    "",
+  clientToken:
+    (import.meta.env as ElementsImportMetaEnv).VITE_DATADOG_CLIENT_TOKEN ?? "",
+  site:
+    (import.meta.env as ElementsImportMetaEnv).VITE_DATADOG_SITE ??
+    "datadoghq.com",
+  env: (import.meta.env as ElementsImportMetaEnv).VITE_DATADOG_ENV ?? "prod",
   service: "gram-elements",
 } as const;

--- a/elements/src/lib/tools.ts
+++ b/elements/src/lib/tools.ts
@@ -1,4 +1,4 @@
-import type { ToolsFilter } from "@/types";
+import type { ToolsFilter } from "#elements/types";
 import {
   AssistantToolProps,
   Tool,

--- a/elements/src/plugins/chart/component.tsx
+++ b/elements/src/plugins/chart/component.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useDensity } from "@/hooks/useDensity";
-import { cn } from "@/lib/utils";
-import { isJsonRenderTree, type JsonRenderNode } from "@/lib/generative-ui";
+import { useDensity } from "#elements/hooks/useDensity";
+import { cn } from "#elements/lib/utils";
+import {
+  isJsonRenderTree,
+  type JsonRenderNode,
+} from "#elements/lib/generative-ui";
 import { SyntaxHighlighterProps } from "@assistant-ui/react-markdown";
 import { AlertCircleIcon } from "lucide-react";
-import { ElementType, FC, useMemo } from "react";
+import { type ComponentType, type FC, useMemo } from "react";
 import { MacOSWindowFrame } from "../components/MacOSWindowFrame";
 import { PluginLoadingState } from "../components/PluginLoadingState";
 
@@ -33,10 +36,10 @@ function getRandomLoadingMessage(): string {
 
 /**
  * Chart components registry. Each entry accepts the chart-specific prop shape
- * declared in `./ui`, but the registry erases those generics via `ElementType`
+ * declared in `./ui`, but the registry erases those generics via `ComponentType`
  * so heterogeneous components can coexist under one key-indexed map.
  */
-const chartComponents: Record<string, ElementType> = {
+const chartComponents = {
   BarChart,
   LineChart,
   AreaChart,
@@ -44,7 +47,7 @@ const chartComponents: Record<string, ElementType> = {
   DonutChart,
   ScatterChart,
   RadarChart,
-};
+} as unknown as Record<string, ComponentType<Record<string, unknown>>>;
 
 /**
  * Render a chart node from json-render tree

--- a/elements/src/plugins/chart/index.ts
+++ b/elements/src/plugins/chart/index.ts
@@ -1,4 +1,4 @@
-import { Plugin } from "@/types/plugins";
+import { Plugin } from "#elements/types/plugins";
 import { ChartRenderer } from "./component";
 
 /**

--- a/elements/src/plugins/chart/ui/area-chart.tsx
+++ b/elements/src/plugins/chart/ui/area-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { FC, useMemo } from "react";
 import {
   AreaChart as RechartsAreaChart,

--- a/elements/src/plugins/chart/ui/bar-chart.tsx
+++ b/elements/src/plugins/chart/ui/bar-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { FC } from "react";
 import {
   BarChart as RechartsBarChart,

--- a/elements/src/plugins/chart/ui/donut-chart.tsx
+++ b/elements/src/plugins/chart/ui/donut-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { FC } from "react";
 import {
   PieChart as RechartsPieChart,

--- a/elements/src/plugins/chart/ui/line-chart.tsx
+++ b/elements/src/plugins/chart/ui/line-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { FC, useMemo } from "react";
 import {
   LineChart as RechartsLineChart,

--- a/elements/src/plugins/chart/ui/pie-chart.tsx
+++ b/elements/src/plugins/chart/ui/pie-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { FC } from "react";
 import {
   PieChart as RechartsPieChart,

--- a/elements/src/plugins/chart/ui/radar-chart.tsx
+++ b/elements/src/plugins/chart/ui/radar-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { FC } from "react";
 import {
   RadarChart as RechartsRadarChart,

--- a/elements/src/plugins/chart/ui/scatter-chart.tsx
+++ b/elements/src/plugins/chart/ui/scatter-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { FC } from "react";
 import {
   ScatterChart as RechartsScatterChart,

--- a/elements/src/plugins/components/MacOSWindowFrame.tsx
+++ b/elements/src/plugins/components/MacOSWindowFrame.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRadius } from "@/hooks/useRadius";
-import { cn } from "@/lib/utils";
+import { useRadius } from "#elements/hooks/useRadius";
+import { cn } from "#elements/lib/utils";
 import { FC, ReactNode } from "react";
 
 interface MacOSWindowFrameProps {

--- a/elements/src/plugins/components/PluginLoadingState.tsx
+++ b/elements/src/plugins/components/PluginLoadingState.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { FC } from "react";
 import { MacOSWindowFrame } from "./MacOSWindowFrame";
 

--- a/elements/src/plugins/generative-ui/component.tsx
+++ b/elements/src/plugins/generative-ui/component.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { GenerativeUI } from "@/components/ui/generative-ui";
-import { cn } from "@/lib/utils";
+import { GenerativeUI } from "#elements/components/ui/generative-ui";
+import { cn } from "#elements/lib/utils";
 import { SyntaxHighlighterProps } from "@assistant-ui/react-markdown";
 import { FC, useEffect, useMemo, useState } from "react";
 import { MacOSWindowFrame } from "../components/MacOSWindowFrame";

--- a/elements/src/plugins/generative-ui/index.ts
+++ b/elements/src/plugins/generative-ui/index.ts
@@ -1,4 +1,4 @@
-import { Plugin } from "@/types/plugins";
+import { Plugin } from "#elements/types/plugins";
 import { GenerativeUIRenderer } from "./component";
 
 /**

--- a/elements/src/plugins/generative-ui/ui/accordion.tsx
+++ b/elements/src/plugins/generative-ui/ui/accordion.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { ChevronDownIcon } from "lucide-react";
 import { Accordion as AccordionPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Accordion({
   ...props

--- a/elements/src/plugins/generative-ui/ui/action-button.tsx
+++ b/elements/src/plugins/generative-ui/ui/action-button.tsx
@@ -3,8 +3,8 @@
 import * as React from "react";
 import { Button, buttonVariants } from "./button";
 import type { VariantProps } from "class-variance-authority";
-import { cn } from "@/lib/utils";
-import { useToolExecution } from "@/contexts/ToolExecutionContext";
+import { cn } from "#elements/lib/utils";
+import { useToolExecution } from "#elements/contexts/ToolExecutionContext";
 
 export interface ActionButtonProps
   extends

--- a/elements/src/plugins/generative-ui/ui/alert.tsx
+++ b/elements/src/plugins/generative-ui/ui/alert.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",

--- a/elements/src/plugins/generative-ui/ui/avatar.tsx
+++ b/elements/src/plugins/generative-ui/ui/avatar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Avatar as AvatarPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Avatar({
   className,

--- a/elements/src/plugins/generative-ui/ui/badge.tsx
+++ b/elements/src/plugins/generative-ui/ui/badge.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",

--- a/elements/src/plugins/generative-ui/ui/button.tsx
+++ b/elements/src/plugins/generative-ui/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/elements/src/plugins/generative-ui/ui/card-wrapper.tsx
+++ b/elements/src/plugins/generative-ui/ui/card-wrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface CardWrapperProps extends React.ComponentProps<"div"> {
   title?: string;

--- a/elements/src/plugins/generative-ui/ui/card.tsx
+++ b/elements/src/plugins/generative-ui/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Card({
   className,

--- a/elements/src/plugins/generative-ui/ui/checkbox.tsx
+++ b/elements/src/plugins/generative-ui/ui/checkbox.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { CheckIcon } from "lucide-react";
 import { Checkbox as CheckboxPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Checkbox({
   className,

--- a/elements/src/plugins/generative-ui/ui/data-table.tsx
+++ b/elements/src/plugins/generative-ui/ui/data-table.tsx
@@ -9,7 +9,7 @@ import {
   TableRow,
   TableCell,
 } from "./table";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface DataTableProps extends React.ComponentProps<"div"> {
   headers?: string[];

--- a/elements/src/plugins/generative-ui/ui/dialog.tsx
+++ b/elements/src/plugins/generative-ui/ui/dialog.tsx
@@ -4,8 +4,8 @@ import * as React from "react";
 import { XIcon } from "lucide-react";
 import { Dialog as DialogPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import { cn } from "#elements/lib/utils";
+import { Button } from "#elements/components/ui/button";
 
 function Dialog({
   ...props

--- a/elements/src/plugins/generative-ui/ui/dropdown-menu.tsx
+++ b/elements/src/plugins/generative-ui/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function DropdownMenu({
   ...props

--- a/elements/src/plugins/generative-ui/ui/grid.tsx
+++ b/elements/src/plugins/generative-ui/ui/grid.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface GridProps extends React.ComponentProps<"div"> {
   columns?: number;

--- a/elements/src/plugins/generative-ui/ui/input.tsx
+++ b/elements/src/plugins/generative-ui/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Input({
   className,

--- a/elements/src/plugins/generative-ui/ui/label.tsx
+++ b/elements/src/plugins/generative-ui/ui/label.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Label as LabelPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Label({
   className,

--- a/elements/src/plugins/generative-ui/ui/list.tsx
+++ b/elements/src/plugins/generative-ui/ui/list.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface ListProps {
   items: string[];

--- a/elements/src/plugins/generative-ui/ui/metric.tsx
+++ b/elements/src/plugins/generative-ui/ui/metric.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface MetricProps extends React.ComponentProps<"div"> {
   label: string;

--- a/elements/src/plugins/generative-ui/ui/pagination.tsx
+++ b/elements/src/plugins/generative-ui/ui/pagination.tsx
@@ -5,7 +5,7 @@ import {
   MoreHorizontalIcon,
 } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 import { buttonVariants, Button } from "./button";
 
 function Pagination({

--- a/elements/src/plugins/generative-ui/ui/popover.tsx
+++ b/elements/src/plugins/generative-ui/ui/popover.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Popover as PopoverPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Popover({
   ...props

--- a/elements/src/plugins/generative-ui/ui/progress.tsx
+++ b/elements/src/plugins/generative-ui/ui/progress.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Progress as ProgressPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 interface ProgressProps extends Omit<
   React.ComponentProps<typeof ProgressPrimitive.Root>,

--- a/elements/src/plugins/generative-ui/ui/radio-group.tsx
+++ b/elements/src/plugins/generative-ui/ui/radio-group.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { CircleIcon } from "lucide-react";
 import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function RadioGroup({
   className,

--- a/elements/src/plugins/generative-ui/ui/select.tsx
+++ b/elements/src/plugins/generative-ui/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Select({
   ...props

--- a/elements/src/plugins/generative-ui/ui/separator.tsx
+++ b/elements/src/plugins/generative-ui/ui/separator.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Separator as SeparatorPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Separator({
   className,

--- a/elements/src/plugins/generative-ui/ui/skeleton-wrapper.tsx
+++ b/elements/src/plugins/generative-ui/ui/skeleton-wrapper.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { Skeleton } from "./skeleton";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface SkeletonWrapperProps {
   width?: string;

--- a/elements/src/plugins/generative-ui/ui/skeleton.tsx
+++ b/elements/src/plugins/generative-ui/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Skeleton({
   className,

--- a/elements/src/plugins/generative-ui/ui/stack.tsx
+++ b/elements/src/plugins/generative-ui/ui/stack.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface StackProps extends React.ComponentProps<"div"> {
   direction?: "horizontal" | "vertical";

--- a/elements/src/plugins/generative-ui/ui/switch.tsx
+++ b/elements/src/plugins/generative-ui/ui/switch.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Switch as SwitchPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Switch({
   className,

--- a/elements/src/plugins/generative-ui/ui/table.tsx
+++ b/elements/src/plugins/generative-ui/ui/table.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Table({
   className,

--- a/elements/src/plugins/generative-ui/ui/tabs.tsx
+++ b/elements/src/plugins/generative-ui/ui/tabs.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Tabs as TabsPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Tabs({
   className,

--- a/elements/src/plugins/generative-ui/ui/text.tsx
+++ b/elements/src/plugins/generative-ui/ui/text.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 export interface TextProps extends React.ComponentProps<"span"> {
   content?: string;

--- a/elements/src/plugins/generative-ui/ui/textarea.tsx
+++ b/elements/src/plugins/generative-ui/ui/textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function Textarea({
   className,

--- a/elements/src/plugins/generative-ui/ui/tooltip.tsx
+++ b/elements/src/plugins/generative-ui/ui/tooltip.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils";
+import { cn } from "#elements/lib/utils";
 
 function TooltipProvider({
   delayDuration = 0,

--- a/elements/src/plugins/index.ts
+++ b/elements/src/plugins/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "@/types/plugins";
+import type { Plugin } from "#elements/types/plugins";
 import { chart } from "./chart";
 import { generativeUI } from "./generative-ui";
 
@@ -19,4 +19,4 @@ export const recommended: PluginList = createPluginList([chart, generativeUI]);
 export { chart } from "./chart";
 export { generativeUI } from "./generative-ui";
 
-export type { Plugin } from "@/types/plugins";
+export type { Plugin } from "#elements/types/plugins";

--- a/elements/src/types/env.ts
+++ b/elements/src/types/env.ts
@@ -1,0 +1,9 @@
+export interface ElementsImportMetaEnv {
+  readonly VITE_GRAM_ELEMENTS_STORYBOOK_PROJECT_SLUG?: string | undefined;
+  readonly VITE_GRAM_ELEMENTS_STORYBOOK_MCP_URL?: string | undefined;
+  readonly VITE_DATADOG_APPLICATION_ID?: string | undefined;
+  readonly VITE_DATADOG_CLIENT_TOKEN?: string | undefined;
+  readonly VITE_DATADOG_SITE?: string | undefined;
+  readonly VITE_DATADOG_ENV?: string | undefined;
+  readonly VITE_ELEMENTS_ENABLE_CASSETTE_RECORDING?: string | undefined;
+}

--- a/elements/src/types/index.ts
+++ b/elements/src/types/index.ts
@@ -1,5 +1,5 @@
-import type { GramChatMessage } from "@/lib/messageConverter";
-import { MODELS } from "@/lib/models";
+import type { GramChatMessage } from "#elements/lib/messageConverter";
+import { MODELS } from "#elements/lib/models";
 import {
   AssistantTool,
   ImageMessagePartComponent,
@@ -1014,12 +1014,11 @@ export interface ModalConfig extends ExpandableConfig {
    * @example
    * ```ts
    * import { MessageCircleIcon } from 'lucide-react'
-   * import { cn } from '@/lib/utils'
    *
    * const config: ElementsConfig = {
    *   modal: {
    *     icon: (state) => {
-   *       return <div className={cn('size-6', state === 'open' ? 'rotate-90' : 'rotate-0')}>
+   *       return <div className={`size-6 ${state === 'open' ? 'rotate-90' : 'rotate-0'}`}>
    *         <MessageCircleIcon className="size-6" />
    *       </div>
    *     },

--- a/elements/src/vite-env.d.ts
+++ b/elements/src/vite-env.d.ts
@@ -2,19 +2,6 @@
 declare const __GRAM_API_URL__: string | undefined;
 declare const __GRAM_GIT_SHA__: string | undefined;
 
-interface ImportMetaEnv {
-  readonly VITE_GRAM_ELEMENTS_STORYBOOK_PROJECT_SLUG?: string | undefined;
-  readonly VITE_GRAM_ELEMENTS_STORYBOOK_MCP_URL?: string | undefined;
-  readonly VITE_DATADOG_APPLICATION_ID?: string | undefined;
-  readonly VITE_DATADOG_CLIENT_TOKEN?: string | undefined;
-  readonly VITE_DATADOG_SITE?: string | undefined;
-  readonly VITE_ELEMENTS_ENABLE_CASSETTE_RECORDING?: string | undefined;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
-
 declare module "*.css?inline" {
   const content: string;
   export default content;

--- a/elements/tsconfig.json
+++ b/elements/tsconfig.json
@@ -16,9 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "types": ["node", "vite/client"]
   },
   "include": ["src"],

--- a/elements/vite.config.ts
+++ b/elements/vite.config.ts
@@ -1,17 +1,76 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { dirname, resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import { externalizeDeps } from "vite-plugin-externalize-deps";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const declarationOutputDir = resolve(__dirname, "dist");
+const packageImports = (
+  JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf8")) as {
+    imports: Record<string, string>;
+  }
+).imports;
+
+function resolvePackageImport(specifier: string): string {
+  const exactTarget = packageImports[specifier];
+  if (exactTarget) {
+    return exactTarget;
+  }
+
+  for (const [pattern, target] of Object.entries(packageImports)) {
+    const wildcardIndex = pattern.indexOf("*");
+    if (wildcardIndex === -1) {
+      continue;
+    }
+
+    const prefix = pattern.slice(0, wildcardIndex);
+    const suffix = pattern.slice(wildcardIndex + 1);
+    if (specifier.startsWith(prefix) && specifier.endsWith(suffix)) {
+      const wildcard = specifier.slice(
+        prefix.length,
+        -suffix.length || undefined,
+      );
+      return target.replace("*", wildcard);
+    }
+  }
+
+  throw new Error(`Unknown package import in declaration output: ${specifier}`);
+}
+
+function rewritePackageImports(filePath: string, content: string): string {
+  return content.replace(
+    /(['"])(#elements\/[^'"]+)\1/g,
+    (_match, quote: string, specifier: string) => {
+      const sourceTarget = resolvePackageImport(specifier);
+      const declarationTarget = resolve(
+        declarationOutputDir,
+        sourceTarget.replace(/^\.\/src\//, "").replace(/\.(?:ts|tsx|css)$/, ""),
+      );
+      let relativeTarget = relative(
+        dirname(filePath),
+        declarationTarget,
+      ).replaceAll("\\", "/");
+      if (!relativeTarget.startsWith(".")) {
+        relativeTarget = `./${relativeTarget}`;
+      }
+
+      return `${quote}${relativeTarget}${quote}`;
+    },
+  );
+}
 
 export default defineConfig({
   plugins: [
     react(),
-    dts(),
+    dts({
+      beforeWriteFile(filePath, content) {
+        return { content: rewritePackageImports(filePath, content) };
+      },
+    }),
     tailwindcss(),
 
     // Automatically keep peerDependencies as they are defined in the package.json in sync
@@ -30,10 +89,12 @@ export default defineConfig({
     }),
   ],
   build: {
+    cssCodeSplit: true,
     sourcemap: true,
     lib: {
       entry: {
         elements: resolve(__dirname, "src/index.ts"),
+        "elements.css": resolve(__dirname, "src/global.css"),
         server: resolve(__dirname, "src/server.ts"),
         "server/core": resolve(__dirname, "src/server/core.ts"),
         "server/express": resolve(__dirname, "src/server/express.ts"),
@@ -68,11 +129,6 @@ export default defineConfig({
 
         sourcemapExcludeSources: true,
       },
-    },
-  },
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "src"),
     },
   },
   define: {


### PR DESCRIPTION
## Summary

- make the dashboard resolve `@gram-ai/elements` directly to Elements TypeScript through a private `gram-source` export condition
- replace Elements' colliding `@/*` imports with package-private `#elements/*` imports while preserving built npm declarations
- keep Elements CSS scoped and publishable, while having dashboard Tailwind scan Elements source
- remove redundant Elements prebuilds from dashboard startup, worktree initialization, and dashboard-specific CI
- add packed-package contracts for default and source export resolution, declarations, CSS, and CLI artifacts
- add patch changesets for `dashboard` and `@gram-ai/elements`

## Why

Dashboard startup previously waited roughly 6.9 seconds for a full Elements package build, primarily to generate declarations. The dashboard can now consume live Elements source and types without `elements/dist`, while Elements remains the canonical independently publishable package.

Linear: [AGE-2951](https://linear.app/speakeasy/issue/AGE-2951/feat-move-elements-into-gram-dashboard-codebase)

## Validation

- `pnpm -F @gram-ai/elements build`
- `pnpm -F @gram-ai/elements lint`
- `pnpm -F @gram-ai/elements test` — 14 files / 103 tests passed
- `pnpm -F @gram-ai/elements test:package`
- `pnpm -F @gram-ai/elements build-storybook`
- `pnpm -F dashboard type-check` with `elements/dist` absent
- `pnpm -F dashboard lint` with `elements/dist` absent
- `pnpm -F dashboard build` with `elements/dist` absent
- verified dashboard production sourcemaps reference `elements/src`
- verified Elements source edits trigger dashboard Vite reload without an Elements rebuild
- compared emitted Elements CSS with the baseline payload and verified dashboard CSS includes Elements utilities without importing the Elements global theme block

## Existing baseline failures

The full dashboard test suite remains baseline-red with the same 7 failing files / 62 failing tests under the original Vitest resolution conditions. Root type-check/lint also retain unrelated existing dev-IDP routing and mise-task failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consume `@gram-ai/elements` source directly in the `dashboard` via a new `gram-source` export condition, removing the Elements prebuild and speeding up startup while keeping Elements publishable for external consumers. Addresses Linear AGE-2951 by moving Elements into the dashboard codebase without changing the public package API or CSS scope.

- **New Features**
  - Added `gram-source` export condition and `#elements/*` imports map in `@gram-ai/elements`.
  - Dashboard resolves Elements TS via Vite `resolve.conditions` and TS `customConditions`.
  - Tailwind scans `elements/src`; CSS remains scoped and package still exports `@gram-ai/elements/elements.css`.
  - CI runs `elements` `test:package` to validate exports, types, CSS scope, and CLI; production builds target `dashboard`.

- **Migration**
  - No Elements build needed for `dashboard` dev or prod; use `pnpm -F dashboard dev` and `pnpm -F dashboard build`.
  - External consumers continue using built exports and `@gram-ai/elements/elements.css`; no changes required.

<sup>Written for commit d2eaad34b60f5f4c4b8cd9f21e43cc2a81c36b49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

