### PR TITLE
feat: tag assistant runner spans with gram identity

### DIFF
--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -5,12 +5,14 @@ mod gram_client;
 mod http_layer;
 mod runtime;
 mod server;
+mod telemetry;
 mod tools;
 mod wire;
 mod workdir;
 
 use std::net::SocketAddr;
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use opentelemetry::trace::TracerProvider as _;
@@ -22,6 +24,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::server::ServeConfig;
+use crate::telemetry::{IdentityStampProcessor, SpanIdentity};
 
 #[derive(Parser, Debug)]
 #[command(name = "gram-assistant-runner", version)]
@@ -96,12 +99,17 @@ async fn main() -> ExitCode {
             with_otel_tracing,
             otel_protocol,
         } => {
-            let tracer_provider = init_tracing(with_otel_tracing.then_some(otel_protocol));
+            let identity = Arc::new(SpanIdentity::default());
+            SpanIdentity::bind(&identity.assistant_id, assistant_id.as_deref());
+            let tracer_provider = init_tracing(
+                with_otel_tracing.then_some(otel_protocol),
+                Arc::clone(&identity),
+            );
             let result = server::serve(ServeConfig {
                 addr,
-                assistant_id,
                 server_url,
                 initial_token,
+                identity,
             })
             .await
             .map_err(|e| e.to_string());
@@ -130,7 +138,13 @@ async fn main() -> ExitCode {
 /// An exporter that fails to build degrades to log-only tracing rather than
 /// failing the process: the runner serves user traffic and a misconfigured
 /// collector endpoint should not take it down.
-fn init_tracing(otel_protocol: Option<OtlpProtocol>) -> Option<SdkTracerProvider> {
+///
+/// `identity` feeds an [`IdentityStampProcessor`] that stamps gram identity
+/// onto every exported span; the same cells are shared with the runtime host.
+fn init_tracing(
+    otel_protocol: Option<OtlpProtocol>,
+    identity: Arc<SpanIdentity>,
+) -> Option<SdkTracerProvider> {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         tracing_subscriber::EnvFilter::new(
             "info,agentkit=trace,agentkit_loop=trace,agentkit_reporting=trace,agentkit_mcp=trace",
@@ -153,6 +167,7 @@ fn init_tracing(otel_protocol: Option<OtlpProtocol>) -> Option<SdkTracerProvider
             Some(
                 SdkTracerProvider::builder()
                     .with_resource(resource)
+                    .with_span_processor(IdentityStampProcessor::new(identity))
                     .with_batch_exporter(exporter)
                     .build(),
             )

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -48,6 +48,12 @@ enum Mode {
         #[arg(long, env = "GRAM_ASSISTANT_ID")]
         assistant_id: Option<String>,
 
+        /// The project the assistant belongs to, used only to tag exported
+        /// trace spans. Optional like --assistant-id: a warm-pool sandbox
+        /// learns it from the first turn instead.
+        #[arg(long, env = "GRAM_ASSISTANT_PROJECT_ID")]
+        assistant_project_id: Option<String>,
+
         /// Base URL of the management API the runner calls back into for
         /// bootstrap, completions, and MCP traffic.
         #[arg(long, env = "GRAM_SERVER_URL")]
@@ -94,6 +100,7 @@ async fn main() -> ExitCode {
         Mode::Serve {
             addr,
             assistant_id,
+            assistant_project_id,
             server_url,
             initial_token,
             with_otel_tracing,
@@ -101,6 +108,7 @@ async fn main() -> ExitCode {
         } => {
             let identity = Arc::new(SpanIdentity::default());
             SpanIdentity::bind(&identity.assistant_id, assistant_id.as_deref());
+            SpanIdentity::bind(&identity.project_id, assistant_project_id.as_deref());
             let tracer_provider = init_tracing(
                 with_otel_tracing.then_some(otel_protocol),
                 Arc::clone(&identity),

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use agentkit_adapter_completions::CompletionsAdapter;
@@ -34,6 +34,7 @@ use crate::compaction::{Compaction, PersistingCompactor, PrimaryCompaction, buil
 use crate::errors::RunnerError;
 use crate::gram_client::GramBootstrapClient;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_bootstrap_client, build_http};
+use crate::telemetry::SpanIdentity;
 use crate::tools;
 use crate::wire::{McpServer, RunnerMessage, ThreadBootstrap};
 use crate::workdir::ASSISTANT_WORKDIR;
@@ -60,15 +61,9 @@ pub type AppState = Arc<RuntimeHost>;
 
 /// Singleton host shared by every per-thread task on the VM.
 pub struct RuntimeHost {
-    /// The assistant this VM serves, surfaced in /state. Set from the
-    /// GRAM_ASSISTANT_ID boot env when present (Fly, GKE cold-start), or
-    /// stamped by the first turn that carries one (GKE warm-pool sandbox).
-    /// Set-once: boot env wins.
-    pub assistant_id: OnceLock<String>,
-    /// Project the assistant belongs to, stamped by the first turn that
-    /// carries one (same set-once discipline as assistant_id). Only used to
-    /// tag exported trace spans; never drives behavior.
-    pub project_id: OnceLock<String>,
+    /// Gram identity shared with the span processor registered in
+    /// `init_tracing`; see [`SpanIdentity`] for the set-once discipline.
+    pub identity: Arc<SpanIdentity>,
     pub started_at: Instant,
     /// Per-idempotency-key admission slot. The bool tracks whether the
     /// keyed turn has actually been enqueued: holding the mutex covers
@@ -133,7 +128,7 @@ impl ConfiguredThread {
 }
 
 pub async fn build_host(
-    assistant_id: Option<String>,
+    identity: Arc<SpanIdentity>,
     server_url: String,
     initial_token: String,
     thread_idle_ttl: Duration,
@@ -153,15 +148,8 @@ pub async fn build_host(
 
     let gram_client =
         GramBootstrapClient::new(server_url, build_bootstrap_client(http_client.clone()));
-    let assistant_id_cell = OnceLock::new();
-    // Ignore an empty/whitespace boot env so warm-pool pods stay unbound and
-    // can learn their assistant from the first turn.
-    if let Some(id) = assistant_id.filter(|id| !id.trim().is_empty()) {
-        let _ = assistant_id_cell.set(id);
-    }
     let host = Arc::new(RuntimeHost {
-        assistant_id: assistant_id_cell,
-        project_id: OnceLock::new(),
+        identity,
         started_at: Instant::now(),
         seen: DashMap::new(),
         threads: DashMap::new(),
@@ -458,7 +446,6 @@ async fn spawn_thread(
     let log_thread_id = thread_id.clone();
     let host_for_eviction = Arc::clone(host);
     let evict_thread_id = thread_id.clone();
-    let loop_host = Arc::clone(host);
     let loop_thread_id = thread_id.clone();
 
     let task_handle = tokio::spawn(async move {
@@ -467,7 +454,6 @@ async fn spawn_thread(
             inbox_rx,
             loop_idle,
             turn_end_compactor,
-            loop_host,
             loop_thread_id,
         ))
         .catch_unwind()
@@ -824,7 +810,6 @@ async fn run_loop<S>(
     mut inbox: UnboundedReceiver<String>,
     idle_since: Arc<Mutex<Option<Instant>>>,
     turn_end_compactor: Option<PersistingCompactor>,
-    host: Arc<RuntimeHost>,
     thread_id: String,
 ) -> Result<&'static str, RunnerError>
 where
@@ -832,23 +817,10 @@ where
 {
     loop {
         // A fresh root span per driver step (one model call plus its tool
-        // executions) keeps traces bounded while stamping every agentkit span
-        // exported underneath it with gram identity — the attributes the fly
-        // adapter used to bake into OTEL_RESOURCE_ATTRIBUTES per machine.
-        // Identity is re-read each step because a warm-pool runner learns its
-        // assistant from the first /turn, after this loop is already running.
-        let step_span = tracing::info_span!(
-            "agent.step",
-            thread_id = %thread_id,
-            gram.assistant.id = tracing::field::Empty,
-            gram.project.id = tracing::field::Empty,
-        );
-        if let Some(id) = host.assistant_id.get() {
-            step_span.record("gram.assistant.id", tracing::field::display(id));
-        }
-        if let Some(id) = host.project_id.get() {
-            step_span.record("gram.project.id", tracing::field::display(id));
-        }
+        // executions) bounds traces and carries the thread id. Gram identity
+        // rides the span processor registered on the tracer provider, which
+        // stamps every exported span.
+        let step_span = tracing::info_span!("agent.step", thread_id = %thread_id);
         match driver.next().instrument(step_span).await? {
             LoopStep::Finished(_turn) => {
                 if let Some(compactor) = &turn_end_compactor {
@@ -1001,11 +973,10 @@ mod tests {
             "http://localhost".to_string(),
             build_bootstrap_client(http_client.clone()),
         );
-        let assistant_id = OnceLock::new();
-        let _ = assistant_id.set("asst".to_string());
+        let identity = Arc::new(SpanIdentity::default());
+        let _ = identity.assistant_id.set("asst".to_string());
         Arc::new(RuntimeHost {
-            assistant_id,
-            project_id: OnceLock::new(),
+            identity,
             started_at: Instant::now(),
             seen: DashMap::new(),
             threads: DashMap::new(),

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -25,6 +25,7 @@ use futures::FutureExt;
 use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{OnceCell, oneshot};
+use tracing::Instrument;
 
 use agentkit_compaction::{AgentBuilderCompactorExt, CompactionReason, Compactor};
 
@@ -64,6 +65,10 @@ pub struct RuntimeHost {
     /// stamped by the first turn that carries one (GKE warm-pool sandbox).
     /// Set-once: boot env wins.
     pub assistant_id: OnceLock<String>,
+    /// Project the assistant belongs to, stamped by the first turn that
+    /// carries one (same set-once discipline as assistant_id). Only used to
+    /// tag exported trace spans; never drives behavior.
+    pub project_id: OnceLock<String>,
     pub started_at: Instant,
     /// Per-idempotency-key admission slot. The bool tracks whether the
     /// keyed turn has actually been enqueued: holding the mutex covers
@@ -156,6 +161,7 @@ pub async fn build_host(
     }
     let host = Arc::new(RuntimeHost {
         assistant_id: assistant_id_cell,
+        project_id: OnceLock::new(),
         started_at: Instant::now(),
         seen: DashMap::new(),
         threads: DashMap::new(),
@@ -452,11 +458,20 @@ async fn spawn_thread(
     let log_thread_id = thread_id.clone();
     let host_for_eviction = Arc::clone(host);
     let evict_thread_id = thread_id.clone();
+    let loop_host = Arc::clone(host);
+    let loop_thread_id = thread_id.clone();
 
     let task_handle = tokio::spawn(async move {
-        let outcome = AssertUnwindSafe(run_loop(driver, inbox_rx, loop_idle, turn_end_compactor))
-            .catch_unwind()
-            .await;
+        let outcome = AssertUnwindSafe(run_loop(
+            driver,
+            inbox_rx,
+            loop_idle,
+            turn_end_compactor,
+            loop_host,
+            loop_thread_id,
+        ))
+        .catch_unwind()
+        .await;
         match outcome {
             Ok(Ok(reason)) => {
                 tracing::info!(thread_id = %log_thread_id, reason = %reason, "thread loop exited")
@@ -809,12 +824,32 @@ async fn run_loop<S>(
     mut inbox: UnboundedReceiver<String>,
     idle_since: Arc<Mutex<Option<Instant>>>,
     turn_end_compactor: Option<PersistingCompactor>,
+    host: Arc<RuntimeHost>,
+    thread_id: String,
 ) -> Result<&'static str, RunnerError>
 where
     S: ModelSession,
 {
     loop {
-        match driver.next().await? {
+        // A fresh root span per driver step (one model call plus its tool
+        // executions) keeps traces bounded while stamping every agentkit span
+        // exported underneath it with gram identity — the attributes the fly
+        // adapter used to bake into OTEL_RESOURCE_ATTRIBUTES per machine.
+        // Identity is re-read each step because a warm-pool runner learns its
+        // assistant from the first /turn, after this loop is already running.
+        let step_span = tracing::info_span!(
+            "agent.step",
+            thread_id = %thread_id,
+            gram.assistant.id = tracing::field::Empty,
+            gram.project.id = tracing::field::Empty,
+        );
+        if let Some(id) = host.assistant_id.get() {
+            step_span.record("gram.assistant.id", tracing::field::display(id));
+        }
+        if let Some(id) = host.project_id.get() {
+            step_span.record("gram.project.id", tracing::field::display(id));
+        }
+        match driver.next().instrument(step_span).await? {
             LoopStep::Finished(_turn) => {
                 if let Some(compactor) = &turn_end_compactor {
                     compact_at_turn_end(compactor, &driver).await;
@@ -970,6 +1005,7 @@ mod tests {
         let _ = assistant_id.set("asst".to_string());
         Arc::new(RuntimeHost {
             assistant_id,
+            project_id: OnceLock::new(),
             started_at: Instant::now(),
             seen: DashMap::new(),
             threads: DashMap::new(),

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -11,21 +11,24 @@ use tokio::sync::{Mutex, Notify};
 use crate::runtime::{
     AppState, DEFAULT_THREAD_IDLE_TTL, McpCmd, build_host, ensure_thread, snapshot_threads,
 };
+use crate::telemetry::SpanIdentity;
 
 const IDEMPOTENCY_HEADER: &str = "x-idempotency-key";
 use crate::wire::{RunnerStateResponse, ThreadStateView, ThreadTurnRequest, ThreadTurnResponse};
 
 pub struct ServeConfig {
     pub addr: SocketAddr,
-    pub assistant_id: Option<String>,
     pub server_url: String,
     pub initial_token: String,
+    /// Shared with the span processor registered in `init_tracing` so spans
+    /// pick up the identity as soon as the host learns it.
+    pub identity: Arc<SpanIdentity>,
 }
 
 pub async fn serve(config: ServeConfig) -> Result<(), std::io::Error> {
     let shutdown = Arc::new(Notify::new());
     let host = build_host(
-        config.assistant_id,
+        config.identity,
         config.server_url,
         config.initial_token,
         DEFAULT_THREAD_IDLE_TTL,
@@ -57,7 +60,12 @@ async fn healthz() -> &'static str {
 async fn state_handler(State(host): State<AppState>) -> Json<RunnerStateResponse> {
     let snapshot = snapshot_threads(&host);
     Json(RunnerStateResponse {
-        assistant_id: host.assistant_id.get().cloned().unwrap_or_default(),
+        assistant_id: host
+            .identity
+            .assistant_id
+            .get()
+            .cloned()
+            .unwrap_or_default(),
         uptime_seconds: host.started_at.elapsed().as_secs(),
         threads: snapshot
             .into_iter()
@@ -70,15 +78,7 @@ async fn state_handler(State(host): State<AppState>) -> Json<RunnerStateResponse
     })
 }
 
-#[tracing::instrument(
-    name = "thread_turn",
-    skip_all,
-    fields(
-        thread_id = %thread_id,
-        gram.assistant.id = tracing::field::Empty,
-        gram.project.id = tracing::field::Empty,
-    )
-)]
+#[tracing::instrument(name = "thread_turn", skip_all, fields(thread_id = %thread_id))]
 async fn thread_turn(
     State(host): State<AppState>,
     Path(thread_id): Path<String>,
@@ -123,35 +123,10 @@ async fn thread_turn(
         .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
 
     // A warm-pool sandbox boots without GRAM_ASSISTANT_ID and learns its
-    // assistant from the first turn that carries one. Bind it only after
-    // bootstrap succeeds (so a failed turn can't poison the pod's identity) and
-    // never from an empty/whitespace id. Set-once: a boot env value wins.
-    if let Some(assistant_id) = request
-        .assistant_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-    {
-        let _ = host.assistant_id.set(assistant_id.to_string());
-    }
-    // Same set-once discipline for the project id; it only feeds trace
-    // attributes, so a turn that omits it just leaves the cell for the next.
-    if let Some(project_id) = request
-        .project_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-    {
-        let _ = host.project_id.set(project_id.to_string());
-    }
-
-    let span = tracing::Span::current();
-    if let Some(id) = host.assistant_id.get() {
-        span.record("gram.assistant.id", tracing::field::display(id));
-    }
-    if let Some(id) = host.project_id.get() {
-        span.record("gram.project.id", tracing::field::display(id));
-    }
+    // identity from the first turn that carries it. Bind only after bootstrap
+    // succeeds so a failed turn can't poison the pod's identity.
+    SpanIdentity::bind(&host.identity.assistant_id, request.assistant_id.as_deref());
+    SpanIdentity::bind(&host.identity.project_id, request.project_id.as_deref());
 
     // Hand reconcile to the actor and proceed to enqueue. The actor runs
     // concurrently with the agent loop, so a server added by this /turn

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -7,6 +7,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, Notify};
+use tracing::Instrument;
 
 use crate::runtime::{
     AppState, DEFAULT_THREAD_IDLE_TTL, McpCmd, build_host, ensure_thread, snapshot_threads,
@@ -78,12 +79,31 @@ async fn state_handler(State(host): State<AppState>) -> Json<RunnerStateResponse
     })
 }
 
-#[tracing::instrument(name = "thread_turn", skip_all, fields(thread_id = %thread_id))]
 async fn thread_turn(
     State(host): State<AppState>,
     Path(thread_id): Path<String>,
     headers: HeaderMap,
     Json(request): Json<ThreadTurnRequest>,
+) -> Result<Json<ThreadTurnResponse>, (StatusCode, String)> {
+    // Bind identity from the request before opening the span so the span
+    // processor stamps this turn's own spans too — a warm-pool sandbox
+    // learns its identity from the first turn that carries it. Binding
+    // before validation and bootstrap is safe: the backend routes a pod to
+    // exactly one assistant, so even a turn that goes on to fail carries
+    // this pod's real identity.
+    SpanIdentity::bind(&host.identity.assistant_id, request.assistant_id.as_deref());
+    SpanIdentity::bind(&host.identity.project_id, request.project_id.as_deref());
+    let span = tracing::info_span!("thread_turn", thread_id = %thread_id);
+    thread_turn_inner(host, thread_id, headers, request)
+        .instrument(span)
+        .await
+}
+
+async fn thread_turn_inner(
+    host: AppState,
+    thread_id: String,
+    headers: HeaderMap,
+    request: ThreadTurnRequest,
 ) -> Result<Json<ThreadTurnResponse>, (StatusCode, String)> {
     if thread_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "missing thread_id".to_string()));
@@ -121,12 +141,6 @@ async fn thread_turn(
     let thread = ensure_thread(&host, &thread_id, request.auth_token)
         .await
         .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, e.to_string()))?;
-
-    // A warm-pool sandbox boots without GRAM_ASSISTANT_ID and learns its
-    // identity from the first turn that carries it. Bind only after bootstrap
-    // succeeds so a failed turn can't poison the pod's identity.
-    SpanIdentity::bind(&host.identity.assistant_id, request.assistant_id.as_deref());
-    SpanIdentity::bind(&host.identity.project_id, request.project_id.as_deref());
 
     // Hand reconcile to the actor and proceed to enqueue. The actor runs
     // concurrently with the agent loop, so a server added by this /turn

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -87,12 +87,12 @@ async fn thread_turn(
 ) -> Result<Json<ThreadTurnResponse>, (StatusCode, String)> {
     // Bind identity from the request before opening the span so the span
     // processor stamps this turn's own spans too — a warm-pool sandbox
-    // learns its identity from the first turn that carries it. Binding
-    // before validation and bootstrap is safe: the backend routes a pod to
-    // exactly one assistant, so even a turn that goes on to fail carries
-    // this pod's real identity.
-    SpanIdentity::bind(&host.identity.assistant_id, request.assistant_id.as_deref());
-    SpanIdentity::bind(&host.identity.project_id, request.project_id.as_deref());
+    // learns its identity from the first turn that carries it. Nothing is
+    // authenticated yet, so bind_request commits only well-formed UUIDs to
+    // the permanent cells; a stray malformed POST leaves them open for the
+    // real first turn.
+    SpanIdentity::bind_request(&host.identity.assistant_id, request.assistant_id.as_deref());
+    SpanIdentity::bind_request(&host.identity.project_id, request.project_id.as_deref());
     let span = tracing::info_span!("thread_turn", thread_id = %thread_id);
     thread_turn_inner(host, thread_id, headers, request)
         .instrument(span)

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -70,6 +70,15 @@ async fn state_handler(State(host): State<AppState>) -> Json<RunnerStateResponse
     })
 }
 
+#[tracing::instrument(
+    name = "thread_turn",
+    skip_all,
+    fields(
+        thread_id = %thread_id,
+        gram.assistant.id = tracing::field::Empty,
+        gram.project.id = tracing::field::Empty,
+    )
+)]
 async fn thread_turn(
     State(host): State<AppState>,
     Path(thread_id): Path<String>,
@@ -124,6 +133,24 @@ async fn thread_turn(
         .filter(|id| !id.is_empty())
     {
         let _ = host.assistant_id.set(assistant_id.to_string());
+    }
+    // Same set-once discipline for the project id; it only feeds trace
+    // attributes, so a turn that omits it just leaves the cell for the next.
+    if let Some(project_id) = request
+        .project_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        let _ = host.project_id.set(project_id.to_string());
+    }
+
+    let span = tracing::Span::current();
+    if let Some(id) = host.assistant_id.get() {
+        span.record("gram.assistant.id", tracing::field::display(id));
+    }
+    if let Some(id) = host.project_id.get() {
+        span.record("gram.project.id", tracing::field::display(id));
     }
 
     // Hand reconcile to the actor and proceed to enqueue. The actor runs

--- a/agents/runner/src/telemetry.rs
+++ b/agents/runner/src/telemetry.rs
@@ -22,6 +22,9 @@ impl SpanIdentity {
     /// Set-once with blank input ignored: an empty boot env or a turn that
     /// omits the id leaves the cell open for a later, real value.
     pub fn bind(cell: &OnceLock<String>, raw: Option<&str>) {
+        if cell.get().is_some() {
+            return;
+        }
         if let Some(id) = raw.map(str::trim).filter(|id| !id.is_empty()) {
             let _ = cell.set(id.to_string());
         }

--- a/agents/runner/src/telemetry.rs
+++ b/agents/runner/src/telemetry.rs
@@ -7,11 +7,12 @@ use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{Span, SpanData, SpanProcessor};
 
 /// Gram identity shared between the runtime host and the span processor
-/// that stamps it onto exported spans. The assistant id comes from the
-/// GRAM_ASSISTANT_ID boot env when present, or from the first /turn that
-/// carries one (GKE warm-pool sandbox); the project id comes from the first
-/// /turn only. Set-once cells — the boot env wins because it is seeded
-/// first, and a sandbox binds to one assistant and project for its lifetime.
+/// that stamps it onto exported spans. Both ids come from the
+/// GRAM_ASSISTANT_ID / GRAM_ASSISTANT_PROJECT_ID boot envs when present
+/// (Fly, GKE cold-start), or from the first /turn that carries them (GKE
+/// warm-pool sandbox). Set-once cells — the boot env wins because it is
+/// seeded first, and a sandbox binds to one assistant and project for its
+/// lifetime.
 #[derive(Debug, Default)]
 pub struct SpanIdentity {
     pub assistant_id: OnceLock<String>,
@@ -20,7 +21,9 @@ pub struct SpanIdentity {
 
 impl SpanIdentity {
     /// Set-once with blank input ignored: an empty boot env or a turn that
-    /// omits the id leaves the cell open for a later, real value.
+    /// omits the id leaves the cell open for a later, real value. Only for
+    /// trusted sources (the boot env); request-borne ids go through
+    /// [`SpanIdentity::bind_request`].
     pub fn bind(cell: &OnceLock<String>, raw: Option<&str>) {
         if cell.get().is_some() {
             return;
@@ -29,6 +32,24 @@ impl SpanIdentity {
             let _ = cell.set(id.to_string());
         }
     }
+
+    /// [`SpanIdentity::bind`] for ids arriving on unauthenticated requests:
+    /// the cells are permanent once set, so a stray or malformed POST must
+    /// not get to misattribute the pod's spans. The backend only ever sends
+    /// UUIDs, so anything else is rejected and leaves the cell open for the
+    /// real first turn.
+    pub fn bind_request(cell: &OnceLock<String>, raw: Option<&str>) {
+        Self::bind(cell, raw.map(str::trim).filter(|id| is_uuid(id)));
+    }
+}
+
+fn is_uuid(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() == 36
+        && bytes.iter().enumerate().all(|(i, b)| match i {
+            8 | 13 | 18 | 23 => *b == b'-',
+            _ => b.is_ascii_hexdigit(),
+        })
 }
 
 /// Appends `gram.assistant.id` / `gram.project.id` to every span at start,
@@ -67,5 +88,41 @@ impl SpanProcessor for IdentityStampProcessor {
 
     fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_request_only_accepts_uuids() {
+        let cell = OnceLock::new();
+        for rejected in [
+            None,
+            Some(""),
+            Some("   "),
+            Some("not-a-uuid"),
+            Some("12345678-1234-1234-1234-12345678901"),
+            Some("12345678-1234-1234-1234-1234567890123"),
+            Some("12345678x1234-1234-1234-123456789012"),
+            Some("gggggggg-gggg-gggg-gggg-gggggggggggg"),
+        ] {
+            SpanIdentity::bind_request(&cell, rejected);
+            assert_eq!(cell.get(), None, "should reject {rejected:?}");
+        }
+
+        SpanIdentity::bind_request(&cell, Some(" 0198a7c2-1234-7bcd-8ef0-A0b1c2d3e4f5 "));
+        assert_eq!(
+            cell.get().map(String::as_str),
+            Some("0198a7c2-1234-7bcd-8ef0-A0b1c2d3e4f5")
+        );
+
+        SpanIdentity::bind_request(&cell, Some("11111111-2222-3333-4444-555555555555"));
+        assert_eq!(
+            cell.get().map(String::as_str),
+            Some("0198a7c2-1234-7bcd-8ef0-A0b1c2d3e4f5"),
+            "set-once: a later value must not overwrite"
+        );
     }
 }

--- a/agents/runner/src/telemetry.rs
+++ b/agents/runner/src/telemetry.rs
@@ -1,0 +1,68 @@
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use opentelemetry::trace::Span as _;
+use opentelemetry::{Context, KeyValue};
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::trace::{Span, SpanData, SpanProcessor};
+
+/// Gram identity shared between the runtime host and the span processor
+/// that stamps it onto exported spans. The assistant id comes from the
+/// GRAM_ASSISTANT_ID boot env when present, or from the first /turn that
+/// carries one (GKE warm-pool sandbox); the project id comes from the first
+/// /turn only. Set-once cells — the boot env wins because it is seeded
+/// first, and a sandbox binds to one assistant and project for its lifetime.
+#[derive(Debug, Default)]
+pub struct SpanIdentity {
+    pub assistant_id: OnceLock<String>,
+    pub project_id: OnceLock<String>,
+}
+
+impl SpanIdentity {
+    /// Set-once with blank input ignored: an empty boot env or a turn that
+    /// omits the id leaves the cell open for a later, real value.
+    pub fn bind(cell: &OnceLock<String>, raw: Option<&str>) {
+        if let Some(id) = raw.map(str::trim).filter(|id| !id.is_empty()) {
+            let _ = cell.set(id.to_string());
+        }
+    }
+}
+
+/// Appends `gram.assistant.id` / `gram.project.id` to every span at start,
+/// once known, so per-span filtering in the backend works. Resource
+/// attributes can't carry them because a warm-pool runner learns its
+/// identity from the first /turn, after the tracer provider is built.
+///
+/// The keys mirror `server/internal/attr`'s `AssistantIDKey`/`ProjectIDKey`,
+/// which the telemetry backend filters on — keep them in sync.
+#[derive(Debug)]
+pub struct IdentityStampProcessor {
+    identity: Arc<SpanIdentity>,
+}
+
+impl IdentityStampProcessor {
+    pub fn new(identity: Arc<SpanIdentity>) -> Self {
+        Self { identity }
+    }
+}
+
+impl SpanProcessor for IdentityStampProcessor {
+    fn on_start(&self, span: &mut Span, _cx: &Context) {
+        if let Some(id) = self.identity.assistant_id.get() {
+            span.set_attribute(KeyValue::new("gram.assistant.id", id.clone()));
+        }
+        if let Some(id) = self.identity.project_id.get() {
+            span.set_attribute(KeyValue::new("gram.project.id", id.clone()));
+        }
+    }
+
+    fn on_end(&self, _span: SpanData) {}
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+        Ok(())
+    }
+}

--- a/agents/runner/src/wire.rs
+++ b/agents/runner/src/wire.rs
@@ -30,6 +30,10 @@ pub struct ThreadTurnRequest {
     /// the first turn. Ignored once the boot env has set it (env wins).
     #[serde(default)]
     pub assistant_id: Option<String>,
+    /// Project the assistant belongs to. Set-once like `assistant_id`; only
+    /// used to stamp exported trace spans so traces filter per project.
+    #[serde(default)]
+    pub project_id: Option<String>,
 }
 
 /// 202-style ack returned by `/threads/{thread_id}/turn`. The actual turn

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -93,6 +93,10 @@ type runtimeTurnRequest struct {
 	// from the turn. Boot env wins when present, so it is harmless and unused
 	// on Fly.
 	AssistantID string `json:"assistant_id,omitempty"`
+	// ProjectID travels with AssistantID under the same set-once discipline.
+	// The runner stamps it on exported trace spans so traces filter per
+	// project; it never drives runner behavior.
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 type runtimeHTTPRequest struct {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -849,6 +849,7 @@ func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 		AuthToken:   authToken,
 		MCPServers:  mcpServers,
 		AssistantID: runtime.AssistantID.String(),
+		ProjectID:   runtime.ProjectID.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal assistant fly runtime turn request: %w", err)

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -396,6 +396,7 @@ func (g *GKERuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 		AuthToken:   authToken,
 		MCPServers:  mcpServers,
 		AssistantID: runtime.AssistantID.String(),
+		ProjectID:   runtime.ProjectID.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("marshal gke runtime turn request: %w", err)


### PR DESCRIPTION
Follow-up to speakeasy-api/gram-infra#1844, which restored OTLP trace export from the GKE assistant runtime. One parity gap remained: the fly adapter stamped `gram.assistant.id` / `gram.project.id` as OTEL resource attributes on each machine, but GKE runners boot generic from the warm pool, so identity can't come from env — and the runner never tagged spans with it. Exported traces were filterable by service/env/cluster but not by assistant or project.

## Changes

**Runner (`agents/runner`)**
- `run_loop` wraps each `driver.next()` step (one model call + its tool executions) in an `agent.step` span carrying `thread_id`, `gram.assistant.id`, and `gram.project.id` — all agentkit spans exported under it inherit the trace. Identity is re-read each step because a warm-pool runner learns its assistant after the loop starts.
- `thread_turn` gets an `#[instrument]` span with the same fields for enqueue/bootstrap visibility.
- `RuntimeHost` gains a `project_id` cell with the same set-once, bind-after-bootstrap discipline as `assistant_id`.

**Server (`internal/assistants`)**
- `runtimeTurnRequest` carries `project_id` alongside `assistant_id`; both the GKE and Fly backends populate it. It only feeds trace attributes, never runner behavior.

Compatible in both directions: old runners ignore the unknown `project_id` field; new runners treat a missing one as unset.

(Supersedes #4100, which was accidentally raised from a fork.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stamp gram identity on all exported runner spans so traces filter by assistant and project. Warm‑pool GKE runners learn identity from boot env or the first `/turn`; we validate UUIDs and bind before the `thread_turn` span opens.

- **New Features**
  - Add a span processor that stamps `gram.assistant.id` and `gram.project.id` on every span; identity is set-once from env or the first `/turn`, validated (UUID-only), and bound before `thread_turn`.
  - Wrap each driver step in an `agent.step` span with `thread_id`; instrument `thread_turn` with `thread_id`.
  - Add `project_id` to `runtimeTurnRequest`; propagate in Fly and GKE; runner also accepts `--assistant-project-id`/`GRAM_ASSISTANT_PROJECT_ID`; `RuntimeHost` shares identity with the processor.

- **Migration**
  - Backward compatible: old runners ignore `project_id`; missing `project_id` is treated as unset.

<sup>Written for commit 7c006c4267ac56a1284e7f251086e6d543c60991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

