### PR TITLE
chore: optimize project overview performance

### DIFF
--- a/.changeset/parallelize-project-overview-clickhouse.md
+++ b/.changeset/parallelize-project-overview-clickhouse.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Reduce project overview latency by running independent ClickHouse aggregations concurrently, tracing each query, and computing chat resolutions in a single PostgreSQL pass.

--- a/server/internal/chat/get_chat_metrics_summary_test.go
+++ b/server/internal/chat/get_chat_metrics_summary_test.go
@@ -1,0 +1,64 @@
+package chat_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+)
+
+func TestGetChatMetricsSummaryUsesLatestResolution(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	ti := newTestChatService(t)
+	queries := repo.New(ti.conn)
+	chatID := seedChat(t, ctx, ti, "user-1", "", "resolved chat")
+
+	for _, role := range []string{"user", "assistant"} {
+		err := queries.CreateChatMessageWithToolCalls(ctx, repo.CreateChatMessageWithToolCallsParams{
+			ChatID:     chatID,
+			ProjectID:  uuid.NullUUID{UUID: ti.projectID, Valid: true},
+			Role:       role,
+			Content:    role + " message",
+			ToolCalls:  nil,
+			ToolCallID: pgtype.Text{},
+			Generation: 0,
+		})
+		require.NoError(t, err)
+	}
+
+	_, err := queries.InsertChatResolution(ctx, repo.InsertChatResolutionParams{
+		ProjectID:       ti.projectID,
+		ChatID:          chatID,
+		UserGoal:        "test",
+		Resolution:      "failure",
+		ResolutionNotes: "first result",
+		Score:           0,
+	})
+	require.NoError(t, err)
+	_, err = queries.InsertChatResolution(ctx, repo.InsertChatResolutionParams{
+		ProjectID:       ti.projectID,
+		ChatID:          chatID,
+		UserGoal:        "test",
+		Resolution:      "success",
+		ResolutionNotes: "latest result",
+		Score:           100,
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	result, err := queries.GetChatMetricsSummary(ctx, repo.GetChatMetricsSummaryParams{
+		ProjectID: ti.projectID,
+		TimeStart: pgtype.Timestamptz{Time: now.Add(-time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+		TimeEnd:   pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), result.TotalChats)
+	require.Equal(t, int64(1), result.ResolvedChats)
+	require.Zero(t, result.FailedChats)
+}

--- a/server/internal/chat/get_chat_metrics_summary_test.go
+++ b/server/internal/chat/get_chat_metrics_summary_test.go
@@ -61,4 +61,16 @@ func TestGetChatMetricsSummaryUsesLatestResolution(t *testing.T) {
 	require.Equal(t, int64(1), result.TotalChats)
 	require.Equal(t, int64(1), result.ResolvedChats)
 	require.Zero(t, result.FailedChats)
+
+	emptyResult, err := queries.GetChatMetricsSummary(ctx, repo.GetChatMetricsSummaryParams{
+		ProjectID: ti.projectID,
+		TimeStart: pgtype.Timestamptz{Time: now.Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+		TimeEnd:   pgtype.Timestamptz{Time: now.Add(2 * time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+	require.Zero(t, emptyResult.TotalChats)
+	require.Zero(t, emptyResult.ResolvedChats)
+	require.Zero(t, emptyResult.FailedChats)
+	require.Zero(t, emptyResult.AvgSessionDurationMs)
+	require.Zero(t, emptyResult.AvgResolutionTimeMs)
 }

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -1113,37 +1113,37 @@ WHERE c.project_id = @project_id
   AND m.created_at <= @time_end;
 
 -- name: GetChatMetricsSummary :one
-WITH latest_resolutions AS MATERIALIZED (
-  SELECT DISTINCT ON (cr.chat_id)
-    cr.chat_id,
-    cr.resolution
-  FROM chat_resolutions cr
-  WHERE cr.project_id = @project_id
-  ORDER BY cr.chat_id, cr.created_at DESC
-),
-chat_stats AS (
+-- Aggregate the requested chat window first so resolution selection does not
+-- sort unrelated project history for empty or narrow windows.
+WITH chat_stats AS MATERIALIZED (
   SELECT
     c.id as chat_id,
-    MIN(m.created_at) as first_message_at,
-    MAX(m.created_at) as last_message_at,
-    EXTRACT(EPOCH FROM (MAX(m.created_at) - MIN(m.created_at))) * 1000 as duration_ms,
-    COALESCE(latest_resolutions.resolution, '') as resolution_status
+    EXTRACT(EPOCH FROM (MAX(m.created_at) - MIN(m.created_at))) * 1000 as duration_ms
   FROM chats c
   INNER JOIN chat_messages m ON m.chat_id = c.id
-  LEFT JOIN latest_resolutions ON latest_resolutions.chat_id = c.id
   WHERE c.project_id = @project_id
     AND c.deleted IS FALSE
     AND m.created_at >= @time_start
     AND m.created_at <= @time_end
-  GROUP BY c.id, latest_resolutions.resolution
+  GROUP BY c.id
+),
+latest_resolutions AS (
+  SELECT DISTINCT ON (cr.chat_id)
+    cr.chat_id,
+    cr.resolution
+  FROM chat_resolutions cr
+  INNER JOIN chat_stats cs ON cs.chat_id = cr.chat_id
+  WHERE cr.project_id = @project_id
+  ORDER BY cr.chat_id, cr.created_at DESC
 )
 SELECT
   COUNT(*)::bigint as total_chats,
-  COALESCE(SUM(CASE WHEN resolution_status = 'success' THEN 1 ELSE 0 END), 0)::bigint as resolved_chats,
-  COALESCE(SUM(CASE WHEN resolution_status = 'failure' THEN 1 ELSE 0 END), 0)::bigint as failed_chats,
-  COALESCE(AVG(duration_ms), 0)::double precision as avg_session_duration_ms,
-  COALESCE(AVG(CASE WHEN resolution_status != '' THEN duration_ms END), 0)::double precision as avg_resolution_time_ms
-FROM chat_stats;
+  COALESCE(SUM(CASE WHEN COALESCE(latest_resolutions.resolution, '') = 'success' THEN 1 ELSE 0 END), 0)::bigint as resolved_chats,
+  COALESCE(SUM(CASE WHEN COALESCE(latest_resolutions.resolution, '') = 'failure' THEN 1 ELSE 0 END), 0)::bigint as failed_chats,
+  COALESCE(AVG(chat_stats.duration_ms), 0)::double precision as avg_session_duration_ms,
+  COALESCE(AVG(CASE WHEN COALESCE(latest_resolutions.resolution, '') != '' THEN chat_stats.duration_ms END), 0)::double precision as avg_resolution_time_ms
+FROM chat_stats
+LEFT JOIN latest_resolutions ON latest_resolutions.chat_id = chat_stats.chat_id;
 
 -- name: CreateChatMessageWithToolCalls :exec
 -- Inserts a single chat_messages row with optional tool_calls JSON,

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -1113,23 +1113,29 @@ WHERE c.project_id = @project_id
   AND m.created_at <= @time_end;
 
 -- name: GetChatMetricsSummary :one
-WITH chat_stats AS (
+WITH latest_resolutions AS MATERIALIZED (
+  SELECT DISTINCT ON (cr.chat_id)
+    cr.chat_id,
+    cr.resolution
+  FROM chat_resolutions cr
+  WHERE cr.project_id = @project_id
+  ORDER BY cr.chat_id, cr.created_at DESC
+),
+chat_stats AS (
   SELECT
     c.id as chat_id,
     MIN(m.created_at) as first_message_at,
     MAX(m.created_at) as last_message_at,
     EXTRACT(EPOCH FROM (MAX(m.created_at) - MIN(m.created_at))) * 1000 as duration_ms,
-    COALESCE(
-      (SELECT resolution FROM chat_resolutions WHERE chat_id = c.id ORDER BY created_at DESC LIMIT 1),
-      ''
-    ) as resolution_status
+    COALESCE(latest_resolutions.resolution, '') as resolution_status
   FROM chats c
   INNER JOIN chat_messages m ON m.chat_id = c.id
+  LEFT JOIN latest_resolutions ON latest_resolutions.chat_id = c.id
   WHERE c.project_id = @project_id
     AND c.deleted IS FALSE
     AND m.created_at >= @time_start
     AND m.created_at <= @time_end
-  GROUP BY c.id
+  GROUP BY c.id, latest_resolutions.resolution
 )
 SELECT
   COUNT(*)::bigint as total_chats,

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -731,37 +731,35 @@ func (q *Queries) GetChatMessageStats(ctx context.Context, arg GetChatMessageSta
 }
 
 const getChatMetricsSummary = `-- name: GetChatMetricsSummary :one
-WITH latest_resolutions AS MATERIALIZED (
-  SELECT DISTINCT ON (cr.chat_id)
-    cr.chat_id,
-    cr.resolution
-  FROM chat_resolutions cr
-  WHERE cr.project_id = $1
-  ORDER BY cr.chat_id, cr.created_at DESC
-),
-chat_stats AS (
+WITH chat_stats AS MATERIALIZED (
   SELECT
     c.id as chat_id,
-    MIN(m.created_at) as first_message_at,
-    MAX(m.created_at) as last_message_at,
-    EXTRACT(EPOCH FROM (MAX(m.created_at) - MIN(m.created_at))) * 1000 as duration_ms,
-    COALESCE(latest_resolutions.resolution, '') as resolution_status
+    EXTRACT(EPOCH FROM (MAX(m.created_at) - MIN(m.created_at))) * 1000 as duration_ms
   FROM chats c
   INNER JOIN chat_messages m ON m.chat_id = c.id
-  LEFT JOIN latest_resolutions ON latest_resolutions.chat_id = c.id
   WHERE c.project_id = $1
     AND c.deleted IS FALSE
     AND m.created_at >= $2
     AND m.created_at <= $3
-  GROUP BY c.id, latest_resolutions.resolution
+  GROUP BY c.id
+),
+latest_resolutions AS (
+  SELECT DISTINCT ON (cr.chat_id)
+    cr.chat_id,
+    cr.resolution
+  FROM chat_resolutions cr
+  INNER JOIN chat_stats cs ON cs.chat_id = cr.chat_id
+  WHERE cr.project_id = $1
+  ORDER BY cr.chat_id, cr.created_at DESC
 )
 SELECT
   COUNT(*)::bigint as total_chats,
-  COALESCE(SUM(CASE WHEN resolution_status = 'success' THEN 1 ELSE 0 END), 0)::bigint as resolved_chats,
-  COALESCE(SUM(CASE WHEN resolution_status = 'failure' THEN 1 ELSE 0 END), 0)::bigint as failed_chats,
-  COALESCE(AVG(duration_ms), 0)::double precision as avg_session_duration_ms,
-  COALESCE(AVG(CASE WHEN resolution_status != '' THEN duration_ms END), 0)::double precision as avg_resolution_time_ms
+  COALESCE(SUM(CASE WHEN COALESCE(latest_resolutions.resolution, '') = 'success' THEN 1 ELSE 0 END), 0)::bigint as resolved_chats,
+  COALESCE(SUM(CASE WHEN COALESCE(latest_resolutions.resolution, '') = 'failure' THEN 1 ELSE 0 END), 0)::bigint as failed_chats,
+  COALESCE(AVG(chat_stats.duration_ms), 0)::double precision as avg_session_duration_ms,
+  COALESCE(AVG(CASE WHEN COALESCE(latest_resolutions.resolution, '') != '' THEN chat_stats.duration_ms END), 0)::double precision as avg_resolution_time_ms
 FROM chat_stats
+LEFT JOIN latest_resolutions ON latest_resolutions.chat_id = chat_stats.chat_id
 `
 
 type GetChatMetricsSummaryParams struct {
@@ -778,6 +776,8 @@ type GetChatMetricsSummaryRow struct {
 	AvgResolutionTimeMs  float64
 }
 
+// Aggregate the requested chat window first so resolution selection does not
+// sort unrelated project history for empty or narrow windows.
 func (q *Queries) GetChatMetricsSummary(ctx context.Context, arg GetChatMetricsSummaryParams) (GetChatMetricsSummaryRow, error) {
 	row := q.db.QueryRow(ctx, getChatMetricsSummary, arg.ProjectID, arg.TimeStart, arg.TimeEnd)
 	var i GetChatMetricsSummaryRow

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -731,23 +731,29 @@ func (q *Queries) GetChatMessageStats(ctx context.Context, arg GetChatMessageSta
 }
 
 const getChatMetricsSummary = `-- name: GetChatMetricsSummary :one
-WITH chat_stats AS (
+WITH latest_resolutions AS MATERIALIZED (
+  SELECT DISTINCT ON (cr.chat_id)
+    cr.chat_id,
+    cr.resolution
+  FROM chat_resolutions cr
+  WHERE cr.project_id = $1
+  ORDER BY cr.chat_id, cr.created_at DESC
+),
+chat_stats AS (
   SELECT
     c.id as chat_id,
     MIN(m.created_at) as first_message_at,
     MAX(m.created_at) as last_message_at,
     EXTRACT(EPOCH FROM (MAX(m.created_at) - MIN(m.created_at))) * 1000 as duration_ms,
-    COALESCE(
-      (SELECT resolution FROM chat_resolutions WHERE chat_id = c.id ORDER BY created_at DESC LIMIT 1),
-      ''
-    ) as resolution_status
+    COALESCE(latest_resolutions.resolution, '') as resolution_status
   FROM chats c
   INNER JOIN chat_messages m ON m.chat_id = c.id
+  LEFT JOIN latest_resolutions ON latest_resolutions.chat_id = c.id
   WHERE c.project_id = $1
     AND c.deleted IS FALSE
     AND m.created_at >= $2
     AND m.created_at <= $3
-  GROUP BY c.id
+  GROUP BY c.id, latest_resolutions.resolution
 )
 SELECT
   COUNT(*)::bigint as total_chats,

--- a/server/internal/telemetry/get_project_overview_test.go
+++ b/server/internal/telemetry/get_project_overview_test.go
@@ -1,0 +1,54 @@
+package telemetry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
+)
+
+func TestGetProjectOverviewSessionMode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsServiceWithSessionCapture(t, true)
+	to := time.Now().UTC().Truncate(time.Second)
+
+	result, err := ti.service.GetProjectOverview(ctx, &gen.GetProjectOverviewPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		From:             to.Add(-24 * time.Hour).Format(time.RFC3339),
+		To:               to.Format(time.RFC3339),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "session", result.MetricsMode)
+	require.NotNil(t, result.Summary)
+	require.NotNil(t, result.Comparison)
+	require.Empty(t, result.Summary.TopUsers)
+	require.Empty(t, result.Summary.TopServers)
+	require.Empty(t, result.Summary.LlmClientBreakdown)
+}
+
+func TestGetProjectOverviewToolCallMode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsServiceWithSessionCapture(t, false)
+	to := time.Now().UTC().Truncate(time.Second)
+
+	result, err := ti.service.GetProjectOverview(ctx, &gen.GetProjectOverviewPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		From:             to.Add(-24 * time.Hour).Format(time.RFC3339),
+		To:               to.Format(time.RFC3339),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "tool_call", result.MetricsMode)
+	require.NotNil(t, result.Summary)
+	require.NotNil(t, result.Comparison)
+	require.Empty(t, result.Summary.TopUsers)
+	require.Empty(t, result.Summary.TopServers)
+	require.Empty(t, result.Summary.LlmClientBreakdown)
+}

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -1558,139 +1558,34 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 		metricsMode = "session"
 	}
 
-	// These queries hit two databases. The PostgreSQL pool is safe for concurrent
-	// use, so each PG query runs in its own goroutine. The shared ClickHouse
-	// connection races when queried concurrently with itself, so every ClickHouse
-	// query runs sequentially in a single lane. Total latency is the slower of
-	// (serial ClickHouse total) and (slowest PostgreSQL query) rather than the sum
-	// of every query.
+	// These queries hit two database pools. Each pool is safe for concurrent use,
+	// so independent queries run concurrently. The ClickHouse helper keeps its
+	// orchestration and query-level tracing together.
 	var (
 		chatMetrics           chatRepo.GetChatMetricsSummaryRow
-		toolMetrics           *repo.OverviewSummary
 		chatMetricsComparison chatRepo.GetChatMetricsSummaryRow
-		toolMetricsComparison *repo.OverviewSummary
-		activeServersRaw      *repo.ActiveCounts
-		topServers            []repo.TopServer
+		clickHouseResult      projectOverviewClickHouseResult
 		serverNameOverrides   []hooksRepo.ListHooksServerNameOverridesRow
 
 		// Session-mode (PostgreSQL) results; only populated when sessionMode is true.
 		activeUsersCountPG int64
 		topUsersPG         []chatRepo.GetTopUsersByMessagesRow
 		llmClientsPG       []chatRepo.GetLLMClientBreakdownByMessagesRow
-
-		// Tool-call-mode (ClickHouse) results; only populated when sessionMode is false.
-		topUsersCH   []repo.TopUser
-		llmClientsCH []repo.LLMClientUsage
 	)
 
 	eg, egCtx := errgroup.WithContext(ctx)
 
-	// ClickHouse lane: a single goroutine runs every ClickHouse query in sequence.
-	// The shared clickhouse.Conn does not tolerate concurrent queries against
-	// itself, so these must not be split across goroutines.
 	eg.Go(func() error {
 		var fetchErr error
-
-		// Tool call metrics (no filters): current and comparison periods.
-		toolMetrics, fetchErr = s.chRepo.GetOverviewSummary(egCtx, repo.GetOverviewSummaryParams{
-			GramProjectID:     projectID,
-			TimeStart:         timeStart,
-			TimeEnd:           timeEnd,
-			UserID:            "",
-			ExternalUserID:    "",
-			APIKeyID:          "",
-			ToolsetSlug:       "",
-			RemoteMCPServerID: "",
-			MCPServerID:       "",
-			EventSource:       "",
-			HookSource:        "",
-			AccountType:       "",
-			ExternalOrgID:     "",
+		clickHouseResult, fetchErr = fetchProjectOverviewClickHouse(egCtx, s.tracer, s.chRepo, projectOverviewClickHouseParams{
+			projectID:       projectID,
+			timeStart:       timeStart,
+			timeEnd:         timeEnd,
+			comparisonStart: comparisonStart,
+			comparisonEnd:   comparisonEnd,
+			sessionMode:     sessionMode,
 		})
-		if fetchErr != nil {
-			return oops.E(oops.CodeUnexpected, fetchErr, "error retrieving tool call metrics")
-		}
-
-		toolMetricsComparison, fetchErr = s.chRepo.GetOverviewSummary(egCtx, repo.GetOverviewSummaryParams{
-			GramProjectID:     projectID,
-			TimeStart:         comparisonStart,
-			TimeEnd:           comparisonEnd,
-			UserID:            "",
-			ExternalUserID:    "",
-			APIKeyID:          "",
-			ToolsetSlug:       "",
-			RemoteMCPServerID: "",
-			MCPServerID:       "",
-			EventSource:       "",
-			HookSource:        "",
-			AccountType:       "",
-			ExternalOrgID:     "",
-		})
-		if fetchErr != nil {
-			return oops.E(oops.CodeUnexpected, fetchErr, "error retrieving comparison tool call metrics")
-		}
-
-		// Active server count from hooks data. In tool-call mode this same row also
-		// yields the active user count (resolved after Wait).
-		activeServersRaw, fetchErr = s.chRepo.GetActiveCounts(egCtx, repo.GetActiveCountsParams{
-			GramProjectID:  projectID,
-			TimeStart:      timeStart,
-			TimeEnd:        timeEnd,
-			ExternalUserID: "",
-			APIKeyID:       "",
-			ToolsetSlug:    "",
-			SessionMode:    sessionMode,
-		})
-		if fetchErr != nil {
-			return oops.E(oops.CodeUnexpected, fetchErr, "error retrieving active server counts")
-		}
-
-		// Top servers from hooks data.
-		topServers, fetchErr = s.chRepo.GetTopServers(egCtx, repo.GetTopServersParams{
-			GramProjectID:  projectID,
-			TimeStart:      timeStart,
-			TimeEnd:        timeEnd,
-			ExternalUserID: "",
-			APIKeyID:       "",
-			ToolsetSlug:    "",
-			Limit:          10,
-		})
-		if fetchErr != nil {
-			return oops.E(oops.CodeUnexpected, fetchErr, "error retrieving top servers")
-		}
-
-		// In tool-call mode, top users and the LLM client breakdown also come from
-		// ClickHouse. In session mode they come from PostgreSQL (separate lanes).
-		if !sessionMode {
-			topUsersCH, fetchErr = s.chRepo.GetTopUsers(egCtx, repo.GetTopUsersParams{
-				GramProjectID:  projectID,
-				TimeStart:      timeStart,
-				TimeEnd:        timeEnd,
-				ExternalUserID: "",
-				APIKeyID:       "",
-				ToolsetSlug:    "",
-				Limit:          10,
-				SessionMode:    false,
-			})
-			if fetchErr != nil {
-				return oops.E(oops.CodeUnexpected, fetchErr, "error retrieving top users from CH")
-			}
-
-			llmClientsCH, fetchErr = s.chRepo.GetLLMClientBreakdown(egCtx, repo.GetLLMClientBreakdownParams{
-				GramProjectID:  projectID,
-				TimeStart:      timeStart,
-				TimeEnd:        timeEnd,
-				ExternalUserID: "",
-				APIKeyID:       "",
-				ToolsetSlug:    "",
-				SessionMode:    false,
-			})
-			if fetchErr != nil {
-				return oops.E(oops.CodeUnexpected, fetchErr, "error retrieving LLM client breakdown from CH")
-			}
-		}
-
-		return nil
+		return fetchErr
 	})
 
 	// PostgreSQL lanes: the pgxpool is safe for concurrent use, so fan these out.
@@ -1777,7 +1672,7 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 	}
 
 	// Resolve active counts and top lists now that every query has returned.
-	activeServersCount := int64(activeServersRaw.ActiveServersCount) //nolint:gosec // Bounded count that won't overflow int64
+	activeServersCount := int64(clickHouseResult.activeCounts.ActiveServersCount) //nolint:gosec // Bounded count that won't overflow int64
 	var activeUsersCount int64
 	var topUsers []*telem_gen.TopUser
 	var llmClientBreakdown []*telem_gen.LLMClientUsage
@@ -1786,9 +1681,9 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 		topUsers = toTopUsersFromPG(topUsersPG)
 		llmClientBreakdown = toLLMClientUsageFromPG(llmClientsPG)
 	} else {
-		activeUsersCount = int64(activeServersRaw.ActiveUsersCount) //nolint:gosec // Bounded count that won't overflow int64
-		topUsers = toTopUsers(topUsersCH)
-		llmClientBreakdown = toLLMClientUsage(llmClientsCH)
+		activeUsersCount = int64(clickHouseResult.activeCounts.ActiveUsersCount) //nolint:gosec // Bounded count that won't overflow int64
+		topUsers = toTopUsers(clickHouseResult.topUsers)
+		llmClientBreakdown = toLLMClientUsage(clickHouseResult.llmClients)
 	}
 
 	// Build a map for quick lookup: raw_server_name -> display_name
@@ -1798,13 +1693,13 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 	}
 
 	// Apply overrides to top servers
-	topServersWithOverrides := applyServerNameOverrides(topServers, overrideMap)
+	topServersWithOverrides := applyServerNameOverrides(clickHouseResult.topServers, overrideMap)
 
 	// Convert to API types - build summaries with nested fields
 	return &telem_gen.GetProjectOverviewResult{
 		Summary: buildProjectOverviewSummary(
 			chatMetrics,
-			toolMetrics,
+			clickHouseResult.toolMetrics,
 			activeServersCount,
 			activeUsersCount,
 			topUsers,
@@ -1813,7 +1708,7 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 		),
 		Comparison: buildProjectOverviewSummary(
 			chatMetricsComparison,
-			toolMetricsComparison,
+			clickHouseResult.toolMetricsComparison,
 			0, // Don't need active counts for comparison
 			0,
 			nil, // Don't need top lists for comparison

--- a/server/internal/telemetry/project_overview.go
+++ b/server/internal/telemetry/project_overview.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )
@@ -190,6 +191,7 @@ func traceProjectOverviewQuery(ctx context.Context, tracer trace.Tracer, name st
 	err := query(queryCtx)
 	if err != nil {
 		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 	}
 
 	return err

--- a/server/internal/telemetry/project_overview.go
+++ b/server/internal/telemetry/project_overview.go
@@ -1,0 +1,196 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
+)
+
+type projectOverviewClickHouseReader interface {
+	GetOverviewSummary(context.Context, repo.GetOverviewSummaryParams) (*repo.OverviewSummary, error)
+	GetActiveCounts(context.Context, repo.GetActiveCountsParams) (*repo.ActiveCounts, error)
+	GetTopServers(context.Context, repo.GetTopServersParams) ([]repo.TopServer, error)
+	GetTopUsers(context.Context, repo.GetTopUsersParams) ([]repo.TopUser, error)
+	GetLLMClientBreakdown(context.Context, repo.GetLLMClientBreakdownParams) ([]repo.LLMClientUsage, error)
+}
+
+type projectOverviewClickHouseParams struct {
+	projectID       string
+	timeStart       int64
+	timeEnd         int64
+	comparisonStart int64
+	comparisonEnd   int64
+	sessionMode     bool
+}
+
+type projectOverviewClickHouseResult struct {
+	toolMetrics           *repo.OverviewSummary
+	toolMetricsComparison *repo.OverviewSummary
+	activeCounts          *repo.ActiveCounts
+	topServers            []repo.TopServer
+	topUsers              []repo.TopUser
+	llmClients            []repo.LLMClientUsage
+}
+
+func fetchProjectOverviewClickHouse(
+	ctx context.Context,
+	tracer trace.Tracer,
+	reader projectOverviewClickHouseReader,
+	params projectOverviewClickHouseParams,
+) (projectOverviewClickHouseResult, error) {
+	var result projectOverviewClickHouseResult
+	// clickhouse.Conn is a connection pool: concurrent queries acquire separate
+	// transports and remain bounded by the pool's MaxOpenConns setting.
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		return traceProjectOverviewQuery(egCtx, tracer, "telemetry.getProjectOverview.clickhouse.overview.current", func(queryCtx context.Context) error {
+			var queryErr error
+			result.toolMetrics, queryErr = reader.GetOverviewSummary(queryCtx, repo.GetOverviewSummaryParams{
+				GramProjectID:     params.projectID,
+				TimeStart:         params.timeStart,
+				TimeEnd:           params.timeEnd,
+				UserID:            "",
+				ExternalUserID:    "",
+				APIKeyID:          "",
+				ToolsetSlug:       "",
+				RemoteMCPServerID: "",
+				MCPServerID:       "",
+				EventSource:       "",
+				HookSource:        "",
+				AccountType:       "",
+				ExternalOrgID:     "",
+			})
+			if queryErr != nil {
+				return oops.E(oops.CodeUnexpected, queryErr, "error retrieving tool call metrics")
+			}
+			return nil
+		})
+	})
+
+	eg.Go(func() error {
+		return traceProjectOverviewQuery(egCtx, tracer, "telemetry.getProjectOverview.clickhouse.overview.comparison", func(queryCtx context.Context) error {
+			var queryErr error
+			result.toolMetricsComparison, queryErr = reader.GetOverviewSummary(queryCtx, repo.GetOverviewSummaryParams{
+				GramProjectID:     params.projectID,
+				TimeStart:         params.comparisonStart,
+				TimeEnd:           params.comparisonEnd,
+				UserID:            "",
+				ExternalUserID:    "",
+				APIKeyID:          "",
+				ToolsetSlug:       "",
+				RemoteMCPServerID: "",
+				MCPServerID:       "",
+				EventSource:       "",
+				HookSource:        "",
+				AccountType:       "",
+				ExternalOrgID:     "",
+			})
+			if queryErr != nil {
+				return oops.E(oops.CodeUnexpected, queryErr, "error retrieving comparison tool call metrics")
+			}
+			return nil
+		})
+	})
+
+	eg.Go(func() error {
+		return traceProjectOverviewQuery(egCtx, tracer, "telemetry.getProjectOverview.clickhouse.activeCounts", func(queryCtx context.Context) error {
+			var queryErr error
+			result.activeCounts, queryErr = reader.GetActiveCounts(queryCtx, repo.GetActiveCountsParams{
+				GramProjectID:  params.projectID,
+				TimeStart:      params.timeStart,
+				TimeEnd:        params.timeEnd,
+				ExternalUserID: "",
+				APIKeyID:       "",
+				ToolsetSlug:    "",
+				SessionMode:    params.sessionMode,
+			})
+			if queryErr != nil {
+				return oops.E(oops.CodeUnexpected, queryErr, "error retrieving active server counts")
+			}
+			return nil
+		})
+	})
+
+	eg.Go(func() error {
+		return traceProjectOverviewQuery(egCtx, tracer, "telemetry.getProjectOverview.clickhouse.topServers", func(queryCtx context.Context) error {
+			var queryErr error
+			result.topServers, queryErr = reader.GetTopServers(queryCtx, repo.GetTopServersParams{
+				GramProjectID:  params.projectID,
+				TimeStart:      params.timeStart,
+				TimeEnd:        params.timeEnd,
+				ExternalUserID: "",
+				APIKeyID:       "",
+				ToolsetSlug:    "",
+				Limit:          10,
+			})
+			if queryErr != nil {
+				return oops.E(oops.CodeUnexpected, queryErr, "error retrieving top servers")
+			}
+			return nil
+		})
+	})
+
+	if !params.sessionMode {
+		eg.Go(func() error {
+			return traceProjectOverviewQuery(egCtx, tracer, "telemetry.getProjectOverview.clickhouse.topUsers", func(queryCtx context.Context) error {
+				var queryErr error
+				result.topUsers, queryErr = reader.GetTopUsers(queryCtx, repo.GetTopUsersParams{
+					GramProjectID:  params.projectID,
+					TimeStart:      params.timeStart,
+					TimeEnd:        params.timeEnd,
+					ExternalUserID: "",
+					APIKeyID:       "",
+					ToolsetSlug:    "",
+					Limit:          10,
+					SessionMode:    false,
+				})
+				if queryErr != nil {
+					return oops.E(oops.CodeUnexpected, queryErr, "error retrieving top users from CH")
+				}
+				return nil
+			})
+		})
+
+		eg.Go(func() error {
+			return traceProjectOverviewQuery(egCtx, tracer, "telemetry.getProjectOverview.clickhouse.llmClientBreakdown", func(queryCtx context.Context) error {
+				var queryErr error
+				result.llmClients, queryErr = reader.GetLLMClientBreakdown(queryCtx, repo.GetLLMClientBreakdownParams{
+					GramProjectID:  params.projectID,
+					TimeStart:      params.timeStart,
+					TimeEnd:        params.timeEnd,
+					ExternalUserID: "",
+					APIKeyID:       "",
+					ToolsetSlug:    "",
+					SessionMode:    false,
+				})
+				if queryErr != nil {
+					return oops.E(oops.CodeUnexpected, queryErr, "error retrieving LLM client breakdown from CH")
+				}
+				return nil
+			})
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return projectOverviewClickHouseResult{}, fmt.Errorf("fetch project overview ClickHouse data: %w", err)
+	}
+
+	return result, nil
+}
+
+func traceProjectOverviewQuery(ctx context.Context, tracer trace.Tracer, name string, query func(context.Context) error) error {
+	queryCtx, span := tracer.Start(ctx, name)
+	defer span.End()
+
+	err := query(queryCtx)
+	if err != nil {
+		span.RecordError(err)
+	}
+
+	return err
+}

--- a/server/internal/telemetry/project_overview_internal_test.go
+++ b/server/internal/telemetry/project_overview_internal_test.go
@@ -1,0 +1,174 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+func TestFetchProjectOverviewClickHouseRunsSessionQueriesConcurrently(t *testing.T) {
+	t.Parallel()
+
+	reader := newBarrierProjectOverviewReader(4)
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	tracer, recorder := newProjectOverviewTestTracer(t)
+
+	result, err := fetchProjectOverviewClickHouse(ctx, tracer, reader, projectOverviewClickHouseParams{
+		projectID:       "00000000-0000-0000-0000-000000000001",
+		timeStart:       200,
+		timeEnd:         300,
+		comparisonStart: 100,
+		comparisonEnd:   200,
+		sessionMode:     true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), result.toolMetrics.TotalToolCalls)
+	require.Equal(t, uint64(7), result.toolMetricsComparison.TotalToolCalls)
+	require.Equal(t, uint64(3), result.activeCounts.ActiveServersCount)
+	require.Equal(t, uint64(4), result.activeCounts.ActiveUsersCount)
+	require.Equal(t, []repo.TopServer{{ServerName: "server", ToolCallCount: 5}}, result.topServers)
+	require.Empty(t, result.topUsers)
+	require.Empty(t, result.llmClients)
+	require.Equal(t, int32(4), reader.started.Load())
+	require.Equal(t, int32(2), reader.overviewCalls.Load())
+	require.Equal(t, int32(1), reader.activeCountCalls.Load())
+	require.Equal(t, int32(1), reader.topServerCalls.Load())
+	require.Zero(t, reader.topUserCalls.Load())
+	require.Zero(t, reader.llmClientCalls.Load())
+	require.Len(t, recorder.Ended(), 4)
+}
+
+func TestFetchProjectOverviewClickHouseRunsToolCallQueriesConcurrently(t *testing.T) {
+	t.Parallel()
+
+	reader := newBarrierProjectOverviewReader(6)
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	tracer, recorder := newProjectOverviewTestTracer(t)
+
+	result, err := fetchProjectOverviewClickHouse(ctx, tracer, reader, projectOverviewClickHouseParams{
+		projectID:       "00000000-0000-0000-0000-000000000001",
+		timeStart:       200,
+		timeEnd:         300,
+		comparisonStart: 100,
+		comparisonEnd:   200,
+		sessionMode:     false,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), result.toolMetrics.TotalToolCalls)
+	require.Equal(t, uint64(7), result.toolMetricsComparison.TotalToolCalls)
+	require.Equal(t, uint64(3), result.activeCounts.ActiveServersCount)
+	require.Equal(t, uint64(4), result.activeCounts.ActiveUsersCount)
+	require.Equal(t, []repo.TopServer{{ServerName: "server", ToolCallCount: 5}}, result.topServers)
+	require.Equal(t, []repo.TopUser{{UserID: "user", UserType: "external", ActivityCount: 6}}, result.topUsers)
+	require.Equal(t, []repo.LLMClientUsage{{ClientName: "client", ActivityCount: 8}}, result.llmClients)
+	require.Equal(t, int32(6), reader.started.Load())
+	require.Equal(t, int32(2), reader.overviewCalls.Load())
+	require.Equal(t, int32(1), reader.activeCountCalls.Load())
+	require.Equal(t, int32(1), reader.topServerCalls.Load())
+	require.Equal(t, int32(1), reader.topUserCalls.Load())
+	require.Equal(t, int32(1), reader.llmClientCalls.Load())
+	require.Len(t, recorder.Ended(), 6)
+}
+
+func newProjectOverviewTestTracer(t *testing.T) (trace.Tracer, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	return provider.Tracer("project-overview-test"), recorder
+}
+
+type barrierProjectOverviewReader struct {
+	expected         int32
+	started          atomic.Int32
+	overviewCalls    atomic.Int32
+	activeCountCalls atomic.Int32
+	topServerCalls   atomic.Int32
+	topUserCalls     atomic.Int32
+	llmClientCalls   atomic.Int32
+	allStarted       chan struct{}
+	closeOnce        sync.Once
+}
+
+func newBarrierProjectOverviewReader(expected int32) *barrierProjectOverviewReader {
+	return &barrierProjectOverviewReader{
+		expected:   expected,
+		allStarted: make(chan struct{}),
+	}
+}
+
+func (r *barrierProjectOverviewReader) GetOverviewSummary(ctx context.Context, params repo.GetOverviewSummaryParams) (*repo.OverviewSummary, error) {
+	r.overviewCalls.Add(1)
+	if err := r.waitForQueries(ctx); err != nil {
+		return nil, err
+	}
+
+	summary := &repo.OverviewSummary{}
+	if params.TimeStart == 200 {
+		summary.TotalToolCalls = 11
+	} else {
+		summary.TotalToolCalls = 7
+	}
+	return summary, nil
+}
+
+func (r *barrierProjectOverviewReader) GetActiveCounts(ctx context.Context, _ repo.GetActiveCountsParams) (*repo.ActiveCounts, error) {
+	r.activeCountCalls.Add(1)
+	if err := r.waitForQueries(ctx); err != nil {
+		return nil, err
+	}
+	return &repo.ActiveCounts{ActiveServersCount: 3, ActiveUsersCount: 4}, nil
+}
+
+func (r *barrierProjectOverviewReader) GetTopServers(ctx context.Context, _ repo.GetTopServersParams) ([]repo.TopServer, error) {
+	r.topServerCalls.Add(1)
+	if err := r.waitForQueries(ctx); err != nil {
+		return nil, err
+	}
+	return []repo.TopServer{{ServerName: "server", ToolCallCount: 5}}, nil
+}
+
+func (r *barrierProjectOverviewReader) GetTopUsers(ctx context.Context, _ repo.GetTopUsersParams) ([]repo.TopUser, error) {
+	r.topUserCalls.Add(1)
+	if err := r.waitForQueries(ctx); err != nil {
+		return nil, err
+	}
+	return []repo.TopUser{{UserID: "user", UserType: "external", ActivityCount: 6}}, nil
+}
+
+func (r *barrierProjectOverviewReader) GetLLMClientBreakdown(ctx context.Context, _ repo.GetLLMClientBreakdownParams) ([]repo.LLMClientUsage, error) {
+	r.llmClientCalls.Add(1)
+	if err := r.waitForQueries(ctx); err != nil {
+		return nil, err
+	}
+	return []repo.LLMClientUsage{{ClientName: "client", ActivityCount: 8}}, nil
+}
+
+func (r *barrierProjectOverviewReader) waitForQueries(ctx context.Context) error {
+	if r.started.Add(1) == r.expected {
+		r.closeOnce.Do(func() {
+			close(r.allStarted)
+		})
+	}
+
+	select {
+	case <-r.allStarted:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for concurrent project overview queries: %w", ctx.Err())
+	}
+}

--- a/server/internal/telemetry/project_overview_internal_test.go
+++ b/server/internal/telemetry/project_overview_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -80,6 +81,41 @@ func TestFetchProjectOverviewClickHouseRunsToolCallQueriesConcurrently(t *testin
 	require.Equal(t, int32(1), reader.topUserCalls.Load())
 	require.Equal(t, int32(1), reader.llmClientCalls.Load())
 	require.Len(t, recorder.Ended(), 6)
+}
+
+func TestTraceProjectOverviewQueryMarksFailedSpanAsError(t *testing.T) {
+	t.Parallel()
+
+	tracer, recorder := newProjectOverviewTestTracer(t)
+	queryErr := fmt.Errorf("query failed")
+
+	err := traceProjectOverviewQuery(t.Context(), tracer, "project-overview-query", func(context.Context) error {
+		return queryErr
+	})
+	require.ErrorIs(t, err, queryErr)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Equal(t, queryErr.Error(), spans[0].Status().Description)
+	require.Len(t, spans[0].Events(), 1)
+	require.Equal(t, "exception", spans[0].Events()[0].Name)
+}
+
+func TestTraceProjectOverviewQueryLeavesSuccessfulSpanUnset(t *testing.T) {
+	t.Parallel()
+
+	tracer, recorder := newProjectOverviewTestTracer(t)
+
+	err := traceProjectOverviewQuery(t.Context(), tracer, "project-overview-query", func(context.Context) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code)
+	require.Empty(t, spans[0].Events())
 }
 
 func newProjectOverviewTestTracer(t *testing.T) (trace.Tracer, *tracetest.SpanRecorder) {

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -64,6 +64,12 @@ type testInstance struct {
 func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
+	return newTestLogsServiceWithSessionCapture(t, true)
+}
+
+func newTestLogsServiceWithSessionCapture(t *testing.T, sessionCapture bool) (context.Context, *testInstance) {
+	t.Helper()
+
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
@@ -107,8 +113,8 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 		return false, nil
 	}
 
-	sessionCaptureEnabled := func(_ context.Context, orgID string) (bool, error) {
-		return true, nil
+	sessionCaptureEnabled := func(_ context.Context, _ string) (bool, error) {
+		return sessionCapture, nil
 	}
 
 	posthogClient := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")


### PR DESCRIPTION
## Summary

- run the four session-mode or six tool-call-mode ClickHouse aggregations concurrently through the existing connection pool
- add named child spans for every project-overview ClickHouse query and mark failed queries with error status
- compute each chat's latest resolution once instead of rescanning `chat_resolutions` for every chat
- preserve current/comparison boundaries, metrics-mode selection, top lists, server-name overrides, authorization, and feature gating
- add focused endpoint, concurrency, query-semantics, race, and changeset coverage

## Root cause

`telemetry.getProjectOverview` deliberately serialized all ClickHouse work because the shared `clickhouse.Conn` was assumed to be unsafe for concurrent queries. The driver object is actually a connection pool, defaults to ten open connections, and other Gram endpoints already run multiple queries through it concurrently. The endpoint therefore paid for four to six independent ClickHouse queries as a sum instead of a maximum.

Session-mode requests had a second bottleneck in `GetChatMetricsSummary`: its correlated latest-resolution subquery scanned `chat_resolutions` once per chat because that table has no supporting `(chat_id, created_at)` index.

The refreshed production baseline over 24 hours measured:

- 3.93s sampled p50
- 7.15s sampled p95
- 3.54s sampled mean across 31 indexed spans
- 4.02s unsampled mean across 35 APM hits

A representative 3.56s session-mode trace spent 3.42s in `GetChatMetricsSummary`. A 7.69s trace also spent 4.20s in the top-user query and 3.74s in the client breakdown, which remain explicit residual bottlenecks.

For 10,000 chats, 40,000 messages, and 10,000 resolutions, the pre-fix synthetic PostgreSQL plan measured:

- 1.745s execution
- 980,195 buffer hits
- 10,000 scans of `chat_resolutions`

The final time-window-scoped plan measures:

- 15.9ms execution for the dense 10,000-chat case
- 532 buffer hits
- one scan of `chat_resolutions`
- identical aggregate results to the unscoped optimized query

A follow-up sparse-window benchmark with 50,001 project resolutions measured:

- one relevant chat: 12.8ms unscoped → 3.4ms scoped
- zero relevant chats: 11.7ms unscoped → 0.019ms scoped, with `chat_resolutions` never scanned

## Impact

Users opening the project home page or changing its date range should spend substantially less time waiting for overview cards and rankings to load. The only HTTP API route whose execution changes is `POST /rpc/telemetry.getProjectOverview`.

| User-visible surface | Affected route | Expected outcome | Who benefits |
| --- | --- | --- | --- |
| Project home dashboard | `/:orgSlug/projects/:projectSlug` → `POST /rpc/telemetry.getProjectOverview` | **High** improvement for loading Active Servers, Tool Calls, Failed Tool Calls, Top Servers, and current-vs-previous-period values | All projects with logging enabled; the improvement applies on initial page load and whenever the date range changes. |
| MCP/tool-call project overview | `POST /rpc/telemetry.getProjectOverview` when `metrics_mode=tool_call` | **High** expected latency reduction | Projects without session capture. Six independent reads now overlap, so users wait approximately for the slowest read rather than all six in sequence. |
| Session-based project overview | `POST /rpc/telemetry.getProjectOverview` when `metrics_mode=session` | **Medium–High** expected latency reduction, especially for projects with many resolved chats | Projects with session capture. Four independent reads overlap, and chat/session totals no longer repeatedly rescan resolution history. Very large projects may still wait on Top Users or client-breakdown calculations. |
| Direct management API consumers | `POST /rpc/telemetry.getProjectOverview`, authenticated with either a project API key or dashboard session | Same response returned sooner; no request or response changes required | SDK, API-key, and session-authenticated callers of this route. |
| Other dashboard and management API surfaces | Including `POST /rpc/telemetry.getObservabilityOverview`, telemetry search/list routes, and chat list/detail routes | **No change** | They do not use the project-overview orchestration changed here. |

Ratings describe expected **end-to-end** improvement. The synthetic PostgreSQL plan isolates the pathological resolution lookup and therefore represents the upper bound, not a production latency guarantee. Production p50/p95 must be verified after deployment using the new `telemetry.getProjectOverview.clickhouse.*` spans.

No response schemas, authorization behavior, feature gates, database schema, migrations, time-period semantics, aggregation definitions, top-list behavior, or server-name overrides change.

## Validation

- `mise run gen:sqlc-server`
- `mise run test:server ./internal/chat ./internal/telemetry/...` (393 tests)
- 40 repeated focused span-status tests
- 20 race-detector span-status tests
- rollback-only sparse/dense PostgreSQL differential and `EXPLAIN (ANALYZE, BUFFERS)` benchmarks
- `mise lint:server`
- `mise build:server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce project overview latency by running ClickHouse queries in parallel and computing latest chat resolutions in one PostgreSQL pass, with per-query tracing and error-marked spans. No API or response changes.

- **Refactors**
  - Run ClickHouse reads concurrently (4 in session mode, 6 in tool-call) via the pool; add spans `telemetry.getProjectOverview.clickhouse.*`.
  - Replace the latest-resolution lookup with a MATERIALIZED CTE and scoped join; extract a small ClickHouse helper and add focused tests for concurrency and race safety.

- **Bug Fixes**
  - Scope resolution selection to chats in the requested window to avoid sorting unrelated history and to return correct results for empty or narrow ranges.
  - Mark failed overview query spans as errors to improve trace visibility.

<sup>Written for commit 607cb3f6b760657d2b2502aa67eccac77a3c879c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

