### PR TITLE
chore: make mock-oidc emulator port, issuer, and redirect worktree-aware

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -261,6 +261,23 @@ POLAR_METER_ID_TOOL_CALLS = "7ec16f6d-6189-4262-9898-c64bed7b8a91"
 POLAR_METER_ID_SERVERS = "af37f394-69c8-4d46-8308-9b92407ee52e"
 POLAR_METER_ID_CREDITS = "b96fda22-2147-4089-bedb-72c3304b17eb"
 
+########################
+## Mock OIDC emulator ##
+########################
+MOCK_OIDC_HOST = "localhost"
+MOCK_OIDC_PORT = "4000"
+MOCK_OIDC_ADDRESS = ":{{env.MOCK_OIDC_PORT}}"
+MOCK_OIDC_ISSUER = "http://{{env.MOCK_OIDC_HOST}}:{{env.MOCK_OIDC_PORT}}"
+## MOCK_OIDC_REDIRECT_URI depends on GRAM_ADMIN_SERVER_URL, so it is defined
+## below the Admin API Configuration section.
+## Transitional shim: worktrees created before mock-oidc owned its port captured
+## GRAM_ADMIN_OIDC_EMULATOR_URL into mise.local.toml as a dependent referencing
+## GRAM_ADMIN_OIDC_EMULATOR_HOST. Keep that name defined (pointing at the
+## mock-oidc host) so a stale mise.local.toml still resolves instead of
+## hard-failing mise. Safe to remove once worktrees have regenerated.
+GRAM_ADMIN_OIDC_EMULATOR_HOST = "{{env.MOCK_OIDC_HOST}}"
+GRAM_ADMIN_OIDC_EMULATOR_URL = "{{env.MOCK_OIDC_ISSUER}}"
+
 #############################
 ## Admin API Configuration ##
 #############################
@@ -271,12 +288,11 @@ GRAM_ADMIN_CONTROL_PORT = "8084"
 GRAM_ADMIN_CONTROL_ADDRESS = ":{{env.GRAM_ADMIN_CONTROL_PORT}}"
 GRAM_ADMIN_SERVER_URL = "https://{{env.GRAM_ADMIN_HOST}}:{{env.GRAM_ADMIN_PORT}}"
 GRAM_ADMIN_ENCRYPTION_KEY = "unset"
-GRAM_ADMIN_OIDC_EMULATOR_HOST = "localhost"
-GRAM_ADMIN_OIDC_EMULATOR_PORT = "4000"
-GRAM_ADMIN_OIDC_EMULATOR_URL = "http://{{env.GRAM_ADMIN_OIDC_EMULATOR_HOST}}:{{env.GRAM_ADMIN_OIDC_EMULATOR_PORT}}"
 GRAM_ADMIN_OIDC_CLIENT_ID = "gram-local.apps.googleusercontent.com"
 GRAM_ADMIN_OIDC_CLIENT_SECRET = "GOCSPX-example_secret"
 GRAM_ADMIN_ALLOWED_HDS = "speakeasyapi.dev,speakeasy.com"
+## Redirect URI the admin server sends and the mock-oidc emulator must allow.
+MOCK_OIDC_REDIRECT_URI = "{{env.GRAM_ADMIN_SERVER_URL}}/admin/auth.callback"
 
 ########################
 ## Svix configuration ##

--- a/mock-oidc/cli.go
+++ b/mock-oidc/cli.go
@@ -44,6 +44,11 @@ func NewApp() *cli.App {
 				Value:   "http://localhost:4000",
 				EnvVars: []string{"MOCK_OIDC_ISSUER"},
 			},
+			&cli.StringSliceFlag{
+				Name:    "redirect-uri",
+				Usage:   "Additional absolute redirect URI(s) to allow for every OAuth client, on top of those declared in the config file. Useful when the consumer's callback URL is assigned dynamically (e.g. a per-worktree remapped port).",
+				EnvVars: []string{"MOCK_OIDC_REDIRECT_URI"},
+			},
 			&cli.PathFlag{
 				Name:    "private-key",
 				Usage:   "Path to RSA private key (PEM). If absent, an ephemeral key is generated.",
@@ -117,6 +122,8 @@ func run(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+
+	cfg.AddRedirectURIs(c.StringSlice("redirect-uri")...)
 
 	privateKey, err := LoadOrGeneratePrivateKey(c.Path("private-key"), logger)
 	if err != nil {

--- a/mock-oidc/config.go
+++ b/mock-oidc/config.go
@@ -61,7 +61,7 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 // AddRedirectURIs appends the given absolute redirect URIs to every OAuth
-// client's allow-list, skipping any a client already declares.
+// client's allow-list, skipping any URI a client already declares.
 func (c *Config) AddRedirectURIs(uris ...string) {
 	for i := range c.Provider.OAuthClients {
 		client := &c.Provider.OAuthClients[i]

--- a/mock-oidc/config.go
+++ b/mock-oidc/config.go
@@ -60,6 +60,20 @@ func LoadConfig(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// AddRedirectURIs appends the given absolute redirect URIs to every OAuth
+// client's allow-list, skipping any a client already declares.
+func (c *Config) AddRedirectURIs(uris ...string) {
+	for i := range c.Provider.OAuthClients {
+		client := &c.Provider.OAuthClients[i]
+		for _, uri := range uris {
+			if uri == "" || slices.Contains(client.RedirectURIs, uri) {
+				continue
+			}
+			client.RedirectURIs = append(client.RedirectURIs, uri)
+		}
+	}
+}
+
 func (c *Config) FindUser(email string) (User, bool) {
 	for _, u := range c.Provider.Users {
 		if u.Email == email {

--- a/mock-oidc/config_test.go
+++ b/mock-oidc/config_test.go
@@ -1,0 +1,75 @@
+package mockoidc_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mockoidc "github.com/speakeasy-api/gram/mock-oidc"
+)
+
+func newRedirectConfig(clients ...mockoidc.OAuthClient) *mockoidc.Config {
+	return &mockoidc.Config{
+		Provider: mockoidc.ProviderConfig{
+			Users:        []mockoidc.User{{Email: "eng@speakeasyapi.dev"}},
+			OAuthClients: clients,
+		},
+	}
+}
+
+func TestAddRedirectURIsAppendsToEveryClient(t *testing.T) {
+	t.Parallel()
+
+	cfg := newRedirectConfig(
+		mockoidc.OAuthClient{ClientID: "a", RedirectURIs: []string{"https://localhost:8083/admin/auth.callback"}},
+		mockoidc.OAuthClient{ClientID: "b", RedirectURIs: []string{"https://localhost:8083/admin/auth.callback"}},
+	)
+
+	cfg.AddRedirectURIs("https://localhost:41234/admin/auth.callback")
+
+	for _, id := range []string{"a", "b"} {
+		client, ok := cfg.FindClient(id)
+		require.True(t, ok, "client %s should exist", id)
+		require.Equal(t, []string{
+			"https://localhost:8083/admin/auth.callback",
+			"https://localhost:41234/admin/auth.callback",
+		}, client.RedirectURIs)
+	}
+}
+
+func TestAddRedirectURIsSkipsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	cfg := newRedirectConfig(
+		mockoidc.OAuthClient{ClientID: "a", RedirectURIs: []string{"https://localhost:8083/admin/auth.callback"}},
+	)
+
+	// Same URI twice, and one that already exists, should not produce duplicates.
+	cfg.AddRedirectURIs(
+		"https://localhost:8083/admin/auth.callback",
+		"https://localhost:41234/admin/auth.callback",
+		"https://localhost:41234/admin/auth.callback",
+	)
+
+	client, ok := cfg.FindClient("a")
+	require.True(t, ok)
+	require.Equal(t, []string{
+		"https://localhost:8083/admin/auth.callback",
+		"https://localhost:41234/admin/auth.callback",
+	}, client.RedirectURIs)
+}
+
+func TestAddRedirectURIsIgnoresEmptyAndNoArgs(t *testing.T) {
+	t.Parallel()
+
+	cfg := newRedirectConfig(
+		mockoidc.OAuthClient{ClientID: "a", RedirectURIs: []string{"https://localhost:8083/admin/auth.callback"}},
+	)
+
+	cfg.AddRedirectURIs()
+	cfg.AddRedirectURIs("")
+
+	client, ok := cfg.FindClient("a")
+	require.True(t, ok)
+	require.Equal(t, []string{"https://localhost:8083/admin/auth.callback"}, client.RedirectURIs)
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-304/mock-oidc-emulator-port-and-redirect-uris-are-not-remapped-for

The mock OIDC emulator stayed on hardcoded defaults (port `4000`, issuer `http://localhost:4000`, redirect `https://localhost:8083/admin/auth.callback`) while `zero:remap-ports` moved the admin server and emulator to random per worktree ports. Admin login broke in any remapped worktree because the emulator listened on the wrong port, advertised the wrong issuer, and rejected the admin callback `redirect_uri`.

Following the existing `dev-idp` pattern (`GRAM_DEVIDP_PORT` owns the port and `GRAM_DEVIDP_ADDRESS` / `GRAM_DEVIDP_EXTERNAL_URL` derive from it), make `mock-oidc` own its port in `mise.toml` via `MOCK_OIDC_PORT`, with `MOCK_OIDC_ADDRESS` and `MOCK_OIDC_ISSUER` derived from it. The admin server references the emulator via `GRAM_ADMIN_OIDC_EMULATOR_URL = {{env.MOCK_OIDC_ISSUER}}`. A new `--redirect-uri` flag appends `MOCK_OIDC_REDIRECT_URI` (derived from `GRAM_ADMIN_SERVER_URL`) to every client allowlist, so the checked-in example config stays runnable standalone.

`GRAM_ADMIN_OIDC_EMULATOR_HOST` is kept as a transitional shim so existing worktrees whose `mise.local.toml` captured the old `GRAM_ADMIN_OIDC_EMULATOR_URL` template still load. Those worktrees should regenerate `mise.local.toml` for admin login to pick up the remapped values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `mock-oidc` emulator follow per-worktree remapped ports so admin login works again. Fixes AIS-304 by deriving its port, issuer, and redirect URIs from worktree values.

- **Bug Fixes**
  - `mise.toml`: add `MOCK_OIDC_HOST` and `MOCK_OIDC_PORT`; derive `MOCK_OIDC_ADDRESS` and `MOCK_OIDC_ISSUER`; set `MOCK_OIDC_REDIRECT_URI` from `GRAM_ADMIN_SERVER_URL`; map `GRAM_ADMIN_OIDC_EMULATOR_URL` to `MOCK_OIDC_ISSUER`.
  - `mock-oidc`: add `--redirect-uri` (env `MOCK_OIDC_REDIRECT_URI`) to append a callback URI to every OAuth client; add tests for redirect merging.

- **Migration**
  - Existing worktrees should regenerate `mise.local.toml` to pick up remapped values; `GRAM_ADMIN_OIDC_EMULATOR_HOST` remains as a temporary shim.

<sup>Written for commit 75a9895e67a8811cbec1bb5828692b7f29adb559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

