### PR TITLE
feat: forward per-org TUM token usage to PostHog (AGE-2289)

### DIFF
--- a/.changeset/age-2289-posthog-token-usage.md
+++ b/.changeset/age-2289-posthog-token-usage.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Forward each organization's tokens-under-management usage to PostHog (AGE-2289): hourly group properties on the organization group (current/previous cycle tokens, contracted allowance, utilization) plus a once-per-day organization_token_usage event, emitted from the billing usage refresh workflow.

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -78,6 +78,7 @@ type Activities struct {
 	reapFlyApps                     *activities.ReapFlyApps
 	refreshBillingUsage             *activities.RefreshBillingUsage
 	snapshotBillingCycleUsage       *activities.SnapshotBillingCycleUsage
+	forwardTokenUsageToPostHog      *activities.ForwardTokenUsageToPostHog
 	refreshOpenRouterKey            *activities.RefreshOpenRouterKey
 	transitionDeployment            *activities.TransitionDeployment
 	validateDeployment              *activities.ValidateDeployment
@@ -180,6 +181,7 @@ func NewActivities(
 		reapFlyApps:                     activities.NewReapFlyApps(logger, meterProvider, db, functionsDeployer, 1),
 		refreshBillingUsage:             activities.NewRefreshBillingUsage(logger, db, billingRepo),
 		snapshotBillingCycleUsage:       activities.NewSnapshotBillingCycleUsage(logger, db, chConn, cacheAdapter, emailService),
+		forwardTokenUsageToPostHog:      activities.NewForwardTokenUsageToPostHog(logger, db, posthogClient, cacheAdapter),
 		refreshOpenRouterKey:            activities.NewRefreshOpenRouterKey(logger, db, openrouterProvisioner),
 		transitionDeployment:            activities.NewTransitionDeployment(logger, db),
 		validateDeployment:              activities.NewValidateDeployment(logger, db, billingRepo),
@@ -298,6 +300,10 @@ func (a *Activities) RefreshBillingUsage(ctx context.Context, orgIDs []string) e
 
 func (a *Activities) SnapshotBillingCycleUsage(ctx context.Context, orgIDs []string) error {
 	return a.snapshotBillingCycleUsage.Do(ctx, orgIDs)
+}
+
+func (a *Activities) ForwardTokenUsageToPostHog(ctx context.Context, orgIDs []string) error {
+	return a.forwardTokenUsageToPostHog.Do(ctx, orgIDs)
 }
 
 func (a *Activities) GetAllOrganizations(ctx context.Context) ([]string, error) {

--- a/server/internal/background/activities/forward_token_usage_posthog.go
+++ b/server/internal/background/activities/forward_token_usage_posthog.go
@@ -109,6 +109,13 @@ func (f *ForwardTokenUsageToPostHog) forwardOrganization(ctx context.Context, qu
 	if len(rows) >= 2 {
 		properties["tum_tokens_previous_cycle"] = rows[len(rows)-2].TumTokens
 	}
+	// Group properties merge (last write wins per key), so the limit keys are
+	// written on EVERY refresh: an org whose contracted limit was removed
+	// would otherwise keep its stale allowance and ratio on the PostHog group
+	// and GTM cohorts would keep treating it as limited. nil overwrites the
+	// old value for unlimited orgs.
+	properties["tum_monthly_token_limit"] = nil
+	properties["tum_allowance_used_ratio"] = nil
 	if meta.TumMonthlyTokenLimit.Valid && meta.TumMonthlyTokenLimit.Int64 > 0 {
 		limit := meta.TumMonthlyTokenLimit.Int64
 		properties["tum_monthly_token_limit"] = limit

--- a/server/internal/background/activities/forward_token_usage_posthog.go
+++ b/server/internal/background/activities/forward_token_usage_posthog.go
@@ -143,6 +143,14 @@ func (f *ForwardTokenUsageToPostHog) forwardOrganization(ctx context.Context, qu
 
 	if err := f.posthog.CaptureGroupEvent(ctx, organizationTokenUsageEvent, orgID,
 		map[string]string{"organization": org.Slug}, properties); err != nil {
+		// Release the day's claim so the activity retry (or the next hourly
+		// run) can re-emit the point — otherwise a transient enqueue failure
+		// silently drops this org's trend point for the whole day. If the
+		// delete itself fails the point is lost; log so the gap is traceable.
+		if delErr := f.cache.Delete(ctx, dedupeKey); delErr != nil {
+			f.logger.ErrorContext(ctx, "failed to release token usage event dedupe claim",
+				attr.SlogOrganizationID(orgID), attr.SlogError(delErr))
+		}
 		return fmt.Errorf("capture token usage event: %w", err)
 	}
 

--- a/server/internal/background/activities/forward_token_usage_posthog.go
+++ b/server/internal/background/activities/forward_token_usage_posthog.go
@@ -1,0 +1,143 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+// tokenUsagePosthog is the slice of the PostHog client this activity needs,
+// kept as an interface so tests can capture the forwarded payloads.
+type tokenUsagePosthog interface {
+	GroupIdentify(ctx context.Context, groupType string, groupKey string, groupProperties map[string]any) error
+	CaptureGroupEvent(ctx context.Context, eventName string, distinctID string, groups map[string]string, eventProperties map[string]any) error
+}
+
+// organizationTokenUsageEvent is the daily per-organization usage event GTM
+// charts trends on; the group properties set alongside it are what cohorts
+// and dashboards filter on.
+const organizationTokenUsageEvent = "organization_token_usage"
+
+// tokenUsageEventDedupeTTL keeps the once-a-day event marker alive well past
+// the day it guards, then lets Redis reclaim it.
+const tokenUsageEventDedupeTTL = 48 * time.Hour
+
+// ForwardTokenUsageToPostHog publishes each organization's tokens-under-
+// management usage to PostHog (AGE-2289) so GTM can price as a function of
+// token use. It reads the durable billing_cycle_usage snapshots the
+// SnapshotBillingCycleUsage activity just refreshed — never ClickHouse — and
+// forwards two shapes per org: group properties on the "organization" group
+// (idempotent, refreshed every run) and a once-per-UTC-day
+// organization_token_usage event (the time series).
+type ForwardTokenUsageToPostHog struct {
+	logger  *slog.Logger
+	db      *pgxpool.Pool
+	posthog tokenUsagePosthog
+	cache   cache.Cache
+}
+
+func NewForwardTokenUsageToPostHog(logger *slog.Logger, db *pgxpool.Pool, posthogClient tokenUsagePosthog, cacheAdapter cache.Cache) *ForwardTokenUsageToPostHog {
+	return &ForwardTokenUsageToPostHog{
+		logger:  logger,
+		db:      db,
+		posthog: posthogClient,
+		cache:   cacheAdapter,
+	}
+}
+
+func (f *ForwardTokenUsageToPostHog) Do(ctx context.Context, orgIDs []string) error {
+	queries := usagerepo.New(f.db)
+	orgs := orgRepo.New(f.db)
+	now := time.Now().UTC()
+
+	var errs []error
+	for _, orgID := range orgIDs {
+		if err := f.forwardOrganization(ctx, queries, orgs, orgID, now); err != nil {
+			f.logger.ErrorContext(ctx, "failed to forward token usage to posthog",
+				attr.SlogOrganizationID(orgID), attr.SlogError(err))
+			errs = append(errs, fmt.Errorf("forward org %s: %w", orgID, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (f *ForwardTokenUsageToPostHog) forwardOrganization(ctx context.Context, queries *usagerepo.Queries, orgs *orgRepo.Queries, orgID string, now time.Time) error {
+	rows, err := queries.ListBillingCycleUsage(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("list billing cycle usage: %w", err)
+	}
+	// No snapshots means no billed usage yet — don't mint empty PostHog
+	// groups for every dormant org.
+	if len(rows) == 0 {
+		return nil
+	}
+
+	org, err := orgs.GetOrganizationMetadata(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("get organization metadata: %w", err)
+	}
+
+	meta, err := queries.GetBillingMetadata(ctx, orgID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get billing metadata: %w", err)
+	}
+	// On pgx.ErrNoRows the zero-value row stands in for an unconfigured
+	// contract, same as the snapshot activity.
+
+	// Rows are ordered by cycle_start, so the last row is the active cycle.
+	current := rows[len(rows)-1]
+	properties := map[string]any{
+		"organization_id":          orgID,
+		"organization_slug":        org.Slug,
+		"gram_account_type":        org.GramAccountType,
+		"tum_tokens_current_cycle": current.TumTokens,
+		"tum_cycle_start":          current.CycleStart.Time.UTC().Format(time.RFC3339),
+		"tum_cycle_end":            current.CycleEnd.Time.UTC().Format(time.RFC3339),
+	}
+	if len(rows) >= 2 {
+		properties["tum_tokens_previous_cycle"] = rows[len(rows)-2].TumTokens
+	}
+	if meta.TumMonthlyTokenLimit.Valid && meta.TumMonthlyTokenLimit.Int64 > 0 {
+		limit := meta.TumMonthlyTokenLimit.Int64
+		properties["tum_monthly_token_limit"] = limit
+		properties["tum_allowance_used_ratio"] = math.Round(float64(current.TumTokens)/float64(limit)*10_000) / 10_000
+	}
+
+	// The organization group is keyed by SLUG across every PostHog capture
+	// path (dashboard posthog-js and the server's CaptureEvent alike); an id
+	// key here would fork the group into a second identity.
+	if err := f.posthog.GroupIdentify(ctx, "organization", org.Slug, properties); err != nil {
+		return fmt.Errorf("group identify: %w", err)
+	}
+
+	// The workflow runs hourly but the trend series wants one point per day:
+	// a SET NX marker elects exactly one run per UTC day to emit the event. A
+	// lost marker (Redis flush) costs at most one duplicate point.
+	dedupeKey := fmt.Sprintf("posthog:org-token-usage:%s:%s", orgID, now.Format("2006-01-02"))
+	won, err := f.cache.Add(ctx, dedupeKey, tokenUsageEventDedupeTTL)
+	if err != nil {
+		return fmt.Errorf("token usage event dedupe: %w", err)
+	}
+	if !won {
+		return nil
+	}
+
+	if err := f.posthog.CaptureGroupEvent(ctx, organizationTokenUsageEvent, orgID,
+		map[string]string{"organization": org.Slug}, properties); err != nil {
+		return fmt.Errorf("capture token usage event: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/background/activities/forward_token_usage_posthog.go
+++ b/server/internal/background/activities/forward_token_usage_posthog.go
@@ -145,10 +145,16 @@ func (f *ForwardTokenUsageToPostHog) forwardOrganization(ctx context.Context, qu
 		map[string]string{"organization": org.Slug}, properties); err != nil {
 		// Release the day's claim so the activity retry (or the next hourly
 		// run) can re-emit the point — otherwise a transient enqueue failure
-		// silently drops this org's trend point for the whole day. If the
-		// delete itself fails the point is lost; log so the gap is traceable.
-		if delErr := f.cache.Delete(ctx, dedupeKey); delErr != nil {
-			f.logger.ErrorContext(ctx, "failed to release token usage event dedupe claim",
+		// silently drops this org's trend point for the whole day. The
+		// release runs on a bounded non-cancelable context (same pattern as
+		// tum_usage_alerts.go): the capture may have failed BECAUSE the
+		// parent ctx was cancelled, and a release on that same ctx would fail
+		// with it, stranding the marker. If the delete still fails the point
+		// is lost; log so the gap is traceable.
+		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		if delErr := f.cache.Delete(releaseCtx, dedupeKey); delErr != nil {
+			f.logger.ErrorContext(releaseCtx, "failed to release token usage event dedupe claim",
 				attr.SlogOrganizationID(orgID), attr.SlogError(delErr))
 		}
 		return fmt.Errorf("capture token usage event: %w", err)

--- a/server/internal/background/activities/forward_token_usage_posthog_test.go
+++ b/server/internal/background/activities/forward_token_usage_posthog_test.go
@@ -1,0 +1,175 @@
+package activities_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+type groupIdentifyCall struct {
+	groupType  string
+	groupKey   string
+	properties map[string]any
+}
+
+type groupEventCall struct {
+	event      string
+	distinctID string
+	groups     map[string]string
+	properties map[string]any
+}
+
+// capturePosthogClient records the forwarded payloads so tests can assert on
+// exactly what would reach PostHog.
+type capturePosthogClient struct {
+	mu         sync.Mutex
+	identifies []groupIdentifyCall
+	events     []groupEventCall
+}
+
+func (c *capturePosthogClient) GroupIdentify(_ context.Context, groupType string, groupKey string, groupProperties map[string]any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.identifies = append(c.identifies, groupIdentifyCall{groupType: groupType, groupKey: groupKey, properties: groupProperties})
+	return nil
+}
+
+func (c *capturePosthogClient) CaptureGroupEvent(_ context.Context, eventName string, distinctID string, groups map[string]string, eventProperties map[string]any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, groupEventCall{event: eventName, distinctID: distinctID, groups: groups, properties: eventProperties})
+	return nil
+}
+
+func setupForwardTokenUsageTest(t *testing.T, dbName string) (*activities.ForwardTokenUsageToPostHog, *pgxpool.Pool, *capturePosthogClient, string) {
+	t.Helper()
+	ctx := t.Context()
+
+	conn, err := infra.CloneTestDatabase(t, dbName)
+	require.NoError(t, err)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	orgID := "org-" + uuid.NewString()[:8]
+	_, err = orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Token Usage Org",
+		Slug:        orgID,
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	captured := &capturePosthogClient{}
+	act := activities.NewForwardTokenUsageToPostHog(
+		testenv.NewLogger(t),
+		conn,
+		captured,
+		cache.NewRedisCacheAdapter(redisClient),
+	)
+	return act, conn, captured, orgID
+}
+
+func upsertCycleUsage(t *testing.T, conn *pgxpool.Pool, orgID string, start, end time.Time, tokens int64) {
+	t.Helper()
+	err := usagerepo.New(conn).UpsertBillingCycleUsage(t.Context(), usagerepo.UpsertBillingCycleUsageParams{
+		OrganizationID: orgID,
+		CycleStart:     pgtype.Timestamptz{Time: start, Valid: true},
+		CycleEnd:       pgtype.Timestamptz{Time: end, Valid: true},
+		TumTokens:      tokens,
+		FinalizedAt:    pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+}
+
+// TestForwardTokenUsageToPostHog_ForwardsGroupAndDailyEvent pins the payload
+// shape (AGE-2289): group properties on the slug-keyed organization group
+// carrying the current/previous cycle TUM tokens and allowance utilization,
+// plus a once-per-UTC-day organization_token_usage event with the same
+// numbers.
+func TestForwardTokenUsageToPostHog_ForwardsGroupAndDailyEvent(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	act, conn, captured, orgID := setupForwardTokenUsageTest(t, "posthogtum")
+
+	_, err := usagerepo.New(conn).UpsertBillingMetadata(ctx, usagerepo.UpsertBillingMetadataParams{
+		OrganizationID:         orgID,
+		TumMonthlyTokenLimit:   pgtype.Int8{Int64: 1_000, Valid: true},
+		AlertEmail:             pgtype.Text{},
+		BillingCycleAnchorDay:  1,
+		TunneledMcpServerLimit: pgtype.Int4{},
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	cycleStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	prevStart := cycleStart.AddDate(0, -1, 0)
+	upsertCycleUsage(t, conn, orgID, prevStart, cycleStart, 400)
+	upsertCycleUsage(t, conn, orgID, cycleStart, cycleStart.AddDate(0, 1, 0), 250)
+
+	require.NoError(t, act.Do(ctx, []string{orgID}))
+
+	require.Len(t, captured.identifies, 1)
+	identify := captured.identifies[0]
+	require.Equal(t, "organization", identify.groupType)
+	require.Equal(t, orgID, identify.groupKey, "the organization group is keyed by slug (the seeded slug equals the org id)")
+	require.Equal(t, int64(250), identify.properties["tum_tokens_current_cycle"])
+	require.Equal(t, int64(400), identify.properties["tum_tokens_previous_cycle"])
+	require.Equal(t, int64(1_000), identify.properties["tum_monthly_token_limit"])
+	require.InDelta(t, 0.25, identify.properties["tum_allowance_used_ratio"], 1e-9)
+	require.Equal(t, orgID, identify.properties["organization_id"])
+
+	require.Len(t, captured.events, 1)
+	event := captured.events[0]
+	require.Equal(t, "organization_token_usage", event.event)
+	require.Equal(t, orgID, event.distinctID)
+	require.Equal(t, map[string]string{"organization": orgID}, event.groups)
+	require.Equal(t, int64(250), event.properties["tum_tokens_current_cycle"])
+}
+
+// TestForwardTokenUsageToPostHog_EventOncePerDay pins the hourly-refresh
+// behavior: group properties re-forward on every run (last write wins), but
+// the trend event is elected once per UTC day via the SET NX marker.
+func TestForwardTokenUsageToPostHog_EventOncePerDay(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	act, conn, captured, orgID := setupForwardTokenUsageTest(t, "posthogtumdaily")
+
+	now := time.Now().UTC()
+	cycleStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	upsertCycleUsage(t, conn, orgID, cycleStart, cycleStart.AddDate(0, 1, 0), 100)
+
+	require.NoError(t, act.Do(ctx, []string{orgID}))
+	require.NoError(t, act.Do(ctx, []string{orgID}))
+
+	require.Len(t, captured.identifies, 2, "group properties refresh on every run")
+	require.Len(t, captured.events, 1, "the usage event is emitted once per day")
+}
+
+// TestForwardTokenUsageToPostHog_SkipsOrgsWithoutSnapshots pins that dormant
+// orgs (no billed usage snapshots) mint no PostHog groups or events.
+func TestForwardTokenUsageToPostHog_SkipsOrgsWithoutSnapshots(t *testing.T) {
+	t.Parallel()
+
+	act, _, captured, orgID := setupForwardTokenUsageTest(t, "posthogtumempty")
+
+	require.NoError(t, act.Do(t.Context(), []string{orgID}))
+
+	require.Empty(t, captured.identifies)
+	require.Empty(t, captured.events)
+}

--- a/server/internal/background/activities/forward_token_usage_posthog_test.go
+++ b/server/internal/background/activities/forward_token_usage_posthog_test.go
@@ -2,6 +2,7 @@ package activities_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -37,6 +38,9 @@ type capturePosthogClient struct {
 	mu         sync.Mutex
 	identifies []groupIdentifyCall
 	events     []groupEventCall
+	// failNextCaptures makes that many CaptureGroupEvent calls fail without
+	// recording, simulating transient PostHog enqueue failures.
+	failNextCaptures int
 }
 
 func (c *capturePosthogClient) GroupIdentify(_ context.Context, groupType string, groupKey string, groupProperties map[string]any) error {
@@ -49,6 +53,10 @@ func (c *capturePosthogClient) GroupIdentify(_ context.Context, groupType string
 func (c *capturePosthogClient) CaptureGroupEvent(_ context.Context, eventName string, distinctID string, groups map[string]string, eventProperties map[string]any) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.failNextCaptures > 0 {
+		c.failNextCaptures--
+		return errors.New("posthog enqueue failed")
+	}
 	c.events = append(c.events, groupEventCall{event: eventName, distinctID: distinctID, groups: groups, properties: eventProperties})
 	return nil
 }
@@ -168,6 +176,28 @@ func TestForwardTokenUsageToPostHog_EventOncePerDay(t *testing.T) {
 	require.Nil(t, props["tum_monthly_token_limit"])
 	require.Contains(t, props, "tum_allowance_used_ratio")
 	require.Nil(t, props["tum_allowance_used_ratio"])
+}
+
+// TestForwardTokenUsageToPostHog_CaptureFailureReleasesDailyClaim pins the
+// dedupe-vs-delivery ordering: a failed capture must release the day's SET NX
+// claim so a retry can still emit the point, instead of the whole day's trend
+// point silently dropping.
+func TestForwardTokenUsageToPostHog_CaptureFailureReleasesDailyClaim(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	act, conn, captured, orgID := setupForwardTokenUsageTest(t, "posthogtumretry")
+
+	now := time.Now().UTC()
+	cycleStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	upsertCycleUsage(t, conn, orgID, cycleStart, cycleStart.AddDate(0, 1, 0), 100)
+
+	captured.failNextCaptures = 1
+	require.Error(t, act.Do(ctx, []string{orgID}), "the failed capture surfaces so the activity retries")
+	require.Empty(t, captured.events)
+
+	require.NoError(t, act.Do(ctx, []string{orgID}))
+	require.Len(t, captured.events, 1, "the retry re-claims the released marker and emits the point")
 }
 
 // TestForwardTokenUsageToPostHog_SkipsOrgsWithoutSnapshots pins that dormant

--- a/server/internal/background/activities/forward_token_usage_posthog_test.go
+++ b/server/internal/background/activities/forward_token_usage_posthog_test.go
@@ -159,6 +159,15 @@ func TestForwardTokenUsageToPostHog_EventOncePerDay(t *testing.T) {
 
 	require.Len(t, captured.identifies, 2, "group properties refresh on every run")
 	require.Len(t, captured.events, 1, "the usage event is emitted once per day")
+
+	// This org has no contracted limit: the limit keys must still be written
+	// (as nil) so a removed contract clears stale values off the group
+	// instead of leaving GTM cohorts treating the org as limited.
+	props := captured.identifies[0].properties
+	require.Contains(t, props, "tum_monthly_token_limit")
+	require.Nil(t, props["tum_monthly_token_limit"])
+	require.Contains(t, props, "tum_allowance_used_ratio")
+	require.Nil(t, props["tum_allowance_used_ratio"])
 }
 
 // TestForwardTokenUsageToPostHog_SkipsOrgsWithoutSnapshots pins that dormant

--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -135,6 +135,16 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 			failedOrgCount += len(batch)
 		}
 
+		// Forward the freshly snapshotted TUM usage to PostHog for GTM
+		// pricing analysis (AGE-2289). Reads only the durable snapshots, so
+		// it is cheap and safe even when the snapshot batch above partially
+		// failed — stale rows just re-forward the last known usage.
+		if err := workflow.ExecuteActivity(ctx, a.ForwardTokenUsageToPostHog, batch).Get(ctx, nil); err != nil {
+			logger.Error("Failed to forward token usage batch to posthog", "error", err, "batch_start", i)
+			failedBatchCount++
+			failedOrgCount += len(batch)
+		}
+
 		batchesProcessed++
 		if end < len(orgIDs) {
 			// Polar's usage endpoints are rate-limited, so keep a deterministic

--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -23,9 +23,10 @@ const (
 	snapshotBillingCycleUsageStartToCloseTimeout = 5 * time.Minute
 	refreshBillingUsageActivityMaximumAttempts   = 3
 	// Reserve more than the worst-case retry path for one batch: the Polar
-	// refresh (3 attempts × 60s) plus the cycle snapshot (3 attempts × 5m),
-	// each with 10s/15s retry backoffs and Temporal jitter.
-	refreshBillingUsageBatchWorstCaseRetryWindow = 20 * time.Minute
+	// refresh (3 attempts × 60s), the cycle snapshot (3 attempts × 5m), and
+	// the PostHog usage forward (3 attempts × 60s), each with 10s/15s retry
+	// backoffs and Temporal jitter.
+	refreshBillingUsageBatchWorstCaseRetryWindow = 24 * time.Minute
 	refreshBillingUsageWorkflowRunTimeout        = 30 * time.Minute
 	refreshBillingUsagesWaitInterval             = 10 * time.Second
 )

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -56,6 +56,17 @@ func TestRefreshBillingUsageWorkflow_ContinuesAsNewNearRunTimeout(t *testing.T) 
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
 	)
 
+	forwardCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, batch []string) error {
+			forwardCallCount++
+			require.NotEmpty(t, batch)
+			require.LessOrEqual(t, len(batch), refreshBillingUsageBatchSize)
+			return nil
+		},
+		activity.RegisterOptions{Name: "ForwardTokenUsageToPostHog"},
+	)
+
 	env.ExecuteWorkflow(RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
 		OrgIDs:           nil,
 		StartIndex:       0,
@@ -70,6 +81,7 @@ func TestRefreshBillingUsageWorkflow_ContinuesAsNewNearRunTimeout(t *testing.T) 
 	require.Equal(t, 1, getAllCallCount)
 	require.Equal(t, billingUsagePauseEveryBatches, refreshCallCount)
 	require.Equal(t, refreshCallCount, snapshotCallCount, "every batch gets a snapshot activity")
+	require.Equal(t, refreshCallCount, forwardCallCount, "every batch forwards token usage to posthog")
 
 	var nextInput RefreshBillingUsageInput
 	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(continueAsNewErr.Input, &nextInput))
@@ -122,6 +134,12 @@ func TestRefreshBillingUsageWorkflow_FailingBatchDoesNotAbortRun(t *testing.T) {
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
 	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, batch []string) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "ForwardTokenUsageToPostHog"},
+	)
 
 	env.ExecuteWorkflow(RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
 		OrgIDs:           orgIDs,
@@ -170,6 +188,12 @@ func TestRefreshBillingUsageWorkflow_SleepCancellationFailsRun(t *testing.T) {
 			return nil
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, batch []string) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "ForwardTokenUsageToPostHog"},
 	)
 	env.RegisterDelayedCallback(func() {
 		env.CancelWorkflow()

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -193,8 +193,11 @@ func TestRefreshBillingUsageWorkflow_SleepCancellationFailsRun(t *testing.T) {
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
 	)
+	forwardCallCount := 0
 	env.RegisterActivityWithOptions(
 		func(_ context.Context, batch []string) error {
+			forwardCallCount++
+			require.NotEmpty(t, batch)
 			return nil
 		},
 		activity.RegisterOptions{Name: "ForwardTokenUsageToPostHog"},
@@ -213,4 +216,5 @@ func TestRefreshBillingUsageWorkflow_SleepCancellationFailsRun(t *testing.T) {
 	require.True(t, env.IsWorkflowCompleted())
 	require.Error(t, env.GetWorkflowError())
 	require.Equal(t, billingUsagePauseEveryBatches, refreshCallCount)
+	require.Equal(t, refreshCallCount, forwardCallCount, "every completed batch forwarded token usage before the cancellation")
 }

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -134,8 +134,11 @@ func TestRefreshBillingUsageWorkflow_FailingBatchDoesNotAbortRun(t *testing.T) {
 		},
 		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
 	)
+	forwardCallCount := 0
 	env.RegisterActivityWithOptions(
 		func(_ context.Context, batch []string) error {
+			forwardCallCount++
+			require.NotEmpty(t, batch)
 			return nil
 		},
 		activity.RegisterOptions{Name: "ForwardTokenUsageToPostHog"},
@@ -152,6 +155,7 @@ func TestRefreshBillingUsageWorkflow_FailingBatchDoesNotAbortRun(t *testing.T) {
 	require.NoError(t, env.GetWorkflowError())
 	require.Equal(t, 2, refreshCallCount)
 	require.Equal(t, 2, snapshotCallCount, "snapshots still run when the Polar refresh batch fails")
+	require.Equal(t, 2, forwardCallCount, "posthog forwarding still runs when the Polar refresh batch fails")
 }
 
 func TestRefreshBillingUsageWorkflow_SleepCancellationFailsRun(t *testing.T) {

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -340,6 +340,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.GetAIIntegrationsCandidates)
 	temporalWorker.RegisterActivity(activities.RefreshBillingUsage)
 	temporalWorker.RegisterActivity(activities.SnapshotBillingCycleUsage)
+	temporalWorker.RegisterActivity(activities.ForwardTokenUsageToPostHog)
 	temporalWorker.RegisterActivity(activities.GetAllOrganizations)
 	temporalWorker.RegisterActivity(activities.ValidateDeployment)
 	temporalWorker.RegisterActivity(activities.GenerateToolsetEmbeddings)

--- a/server/internal/thirdparty/posthog/posthog.go
+++ b/server/internal/thirdparty/posthog/posthog.go
@@ -129,6 +129,69 @@ func (p *Posthog) IdentifyUser(ctx context.Context, distinctID string, personPro
 	return nil
 }
 
+// GroupIdentify sets properties on a PostHog group (e.g. the "organization"
+// group), enabling group-based cohorts and dashboards. Last write wins per
+// property, so callers can refresh values idempotently. The group key must
+// match the convention the capture paths use — the organization group is
+// keyed by org SLUG (see CaptureEvent), so a mismatched key would fork the
+// group into two identities.
+func (p *Posthog) GroupIdentify(ctx context.Context, groupType string, groupKey string, groupProperties map[string]any) error {
+	if p.disabled {
+		p.logger.InfoContext(ctx, "posthog is disabled, dropping group identify")
+		return nil
+	}
+
+	properties := posthog.NewProperties()
+	for k, v := range groupProperties {
+		properties.Set(k, v)
+	}
+
+	if err := p.client.Enqueue(posthog.GroupIdentify{
+		Type:       groupType,
+		Key:        groupKey,
+		Properties: properties,
+	}); err != nil {
+		return fmt.Errorf("failed to enqueue group identify: %w", err)
+	}
+
+	return nil
+}
+
+// CaptureGroupEvent captures an event with explicit group memberships, for
+// server-initiated events emitted outside any request auth context (e.g.
+// background workers reporting per-organization metrics). No person profile
+// is created for the distinct id — these events describe the group, not a
+// user.
+func (p *Posthog) CaptureGroupEvent(ctx context.Context, eventName string, distinctID string, groups map[string]string, eventProperties map[string]any) error {
+	if p.disabled {
+		p.logger.InfoContext(ctx, "posthog is disabled, dropping event")
+		return nil
+	}
+
+	phGroups := map[string]any{}
+	for groupType, groupKey := range groups {
+		phGroups[groupType] = groupKey
+	}
+
+	properties := posthog.NewProperties().
+		Set("is_gram", true).
+		Set("$process_person_profile", false)
+	for k, v := range eventProperties {
+		properties.Set(k, v)
+	}
+
+	if err := p.client.Enqueue(posthog.Capture{
+		DistinctId: distinctID,
+		Event:      eventName,
+		Properties: properties,
+		Groups:     phGroups,
+	}); err != nil {
+		return fmt.Errorf("failed to enqueue event: %w", err)
+	}
+
+	return nil
+}
+
 func (p *Posthog) CaptureEvent(ctx context.Context, eventName string, distinctID string, eventProperties map[string]any) error {
 	// If posthog is disabled, we return true so we don't block the user from using the product
 	if p.disabled {


### PR DESCRIPTION
## Summary

Forwards each organization's tokens-under-management usage to PostHog so GTM can price as a function of company token use (AGE-2289).

## What GTM gets

- **Group properties** on the `organization` group, refreshed hourly: `tum_tokens_current_cycle`, `tum_tokens_previous_cycle`, `tum_monthly_token_limit`, `tum_allowance_used_ratio`, plus org id/slug/account type and cycle boundaries. Powers cohorts and dashboards like "orgs above 80% of allowance."
- **A daily `organization_token_usage` event** per org with the same properties and `$groups: {organization: <slug>}` — the time series for trend charts. The hourly workflow elects one run per UTC day via a Redis SET NX marker (a lost marker costs at most one duplicate point). No person profiles are created for these server events.

## How

- New `ForwardTokenUsageToPostHog` activity reads only the durable `billing_cycle_usage` snapshots (never ClickHouse) plus org/billing metadata. Orgs with no snapshots are skipped so dormant orgs mint no PostHog groups.
- Runs as its own step in the hourly `RefreshBillingUsageWorkflow`, right after `SnapshotBillingCycleUsage`, with the same per-batch failure tolerance as its siblings.
- The `posthog` wrapper gains `GroupIdentify` and `CaptureGroupEvent` (explicit groups for background contexts with no auth). The organization group is keyed by **slug**, matching the convention every existing capture path uses — an id key would fork each org into a second group identity.

## Notes

- `RefreshBillingUsage`'s doc comment has said "Send usage data to posthog for tracking purposes" since it landed; this PR is the code that comment promised.
- TUM only, per product decision — fleet-observed analytics tokens are deliberately not forwarded.

## Testing

- New activity tests pin the payload shape, the once-per-day event vs every-run group refresh, and the dormant-org skip (Postgres + Redis via testenv, capture PostHog fake).
- Workflow tests now assert every batch forwards to PostHog.
- `go test ./internal/background/... ./internal/thirdparty/posthog`, `mise lint:server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards each org’s tokens-under-management usage to PostHog so GTM can price by token use (AGE-2289). Adds hourly org group updates and one `organization_token_usage` event per org per UTC day.

- New Features
  - New `ForwardTokenUsageToPostHog` activity reads durable `billing_cycle_usage` snapshots; skips orgs without snapshots.
  - Runs after `SnapshotBillingCycleUsage` in the hourly `RefreshBillingUsageWorkflow`.
  - Hourly `organization` group properties (keyed by slug): current/previous cycle tokens, monthly limit, utilization ratio, and cycle bounds; always writes limit/ratio (nil if unconfigured) to clear stale values.
  - Daily `organization_token_usage` with `$groups: {organization: <slug>}`; deduped via Redis SET NX (48h TTL); no person profiles. Extends `posthog` with `GroupIdentify` and `CaptureGroupEvent`.

- Bug Fixes
  - Increased the workflow’s retry reserve to 24m to include the PostHog forward step.
  - On capture failure, release the daily-event dedupe claim so retries can re-emit the point; the release runs on a bounded non-cancelable context to avoid stranding the marker on cancellation.

<sup>Written for commit b8aa9787b15b178e54542885503adcae6a84cc1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

