### PR TITLE
chore: include Codex in dashboard example agent copy

### DIFF
--- a/.changeset/codex-in-dashboard-copy.md
+++ b/.changeset/codex-in-dashboard-copy.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Include Codex alongside Claude Code and Cursor in example agent lists across risk policies, logging, insights, and the connect-server dialog.

--- a/client/dashboard/src/lib/insights-suggestions.ts
+++ b/client/dashboard/src/lib/insights-suggestions.ts
@@ -627,7 +627,7 @@ export const INSIGHTS_SUGGESTIONS = {
       label: "Compare clients",
       icon: "bot",
       prompt:
-        "Compare usage across different AI coding clients (Claude Code, Cursor, etc). Which is most popular?",
+        "Compare usage across different AI coding clients (Claude Code, Cursor, Codex, etc). Which is most popular?",
     },
   ],
 

--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -1332,7 +1332,7 @@ function SingleServerNextSteps({
             </div>
             <div className="flex-1">
               <Type className="text-sm font-medium no-underline">
-                Connect via Claude, Cursor
+                Connect via Claude, Cursor, Codex
               </Type>
             </div>
             <ArrowRight className="text-muted-foreground h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100" />

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -208,8 +208,8 @@ function OrgLogsInner() {
                 className="text-muted-foreground ml-6 text-sm"
               >
                 Capture user prompts and assistant responses from agents like
-                Cursor, Claude Code, and more. Sessions appear in the Agent
-                Sessions tab.
+                Cursor, Claude Code, Codex, and more. Sessions appear in the
+                Agent Sessions tab.
               </Type>
             </Stack>
             {!featuresLoading && (

--- a/client/dashboard/src/pages/security/detection-rules-data.ts
+++ b/client/dashboard/src/pages/security/detection-rules-data.ts
@@ -60,7 +60,7 @@ const CATEGORY_RULE_DESCRIPTION: Record<RuleCategory, string> = {
   off_policy:
     "Classifier-backed detector for requests that fall outside the organization's acceptable-use policy.",
   shadow_mcp:
-    "Detects MCP tool calls in Cursor and Claude Code that didn't originate from a Speakeasy-issued MCP server. Requires Speakeasy hooks on the agent.",
+    "Detects MCP tool calls in Cursor, Claude Code, and Codex that didn't originate from a Speakeasy-issued MCP server. Requires Speakeasy hooks on the agent.",
   destructive_tool:
     "Flags tool calls whose Gram tool definition is annotated as destructive. Requires Speakeasy hooks and Gram-issued tool metadata.",
   cli_destructive:

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -91,7 +91,7 @@ export const RULE_CATEGORY_META: Record<
   shadow_mcp: {
     label: "Shadow MCP",
     description:
-      "Tool calls in Cursor and Claude Code that don't come from a Speakeasy-issued MCP server. Requires Speakeasy hooks to be installed on the agent.",
+      "Tool calls in Cursor, Claude Code, and Codex that don't come from a Speakeasy-issued MCP server. Requires Speakeasy hooks to be installed on the agent.",
     icon: "shield-off",
   },
   destructive_tool: {


### PR DESCRIPTION
## Summary

Several dashboard example lists name only Claude Code and Cursor when referring to supported AI coding agents. Codex is now supported everywhere those examples apply, so add it alongside them:

- **Risk policies** — Shadow MCP policy + detection-rule descriptions
- **Logging** — org logging page session-capture copy
- **Insights** — client-comparison suggested prompt
- **Catalog** — "Connect via…" server dialog card

Copy-only; setup/observability-hooks flow already listed Codex.

Closes [DNO-397](https://linear.app/speakeasy/issue/DNO-397)

✻ Clauded...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Codex alongside Claude Code and Cursor in dashboard example agent lists to reflect current support. Updates copy in risk policies, org logging session capture, insights client-comparison prompt, and the catalog connect-server dialog to satisfy DNO-397.

<sup>Written for commit 8af10ad04b2c25412aa16c93eee5bc62a6a90d09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

