### PR TITLE
mig: daniel/dno-472-byok-foundation-encrypted-provider-key-store-per-slot

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4071,3 +4071,27 @@ WHERE deleted IS FALSE;
 -- rows that the partial unique indexes above exclude.
 CREATE INDEX IF NOT EXISTS json_web_keys_set_tenant_idx
 ON json_web_keys (organization_id, json_web_key_set_id);
+
+-- Customer-supplied model provider API keys (BYOK), scoped per project and
+-- responsibility slot (completion surface). The 'default' slot applies to
+-- every surface that has no dedicated override row. Key material is
+-- AES-256-GCM encrypted at rest and never returned by the API.
+CREATE TABLE IF NOT EXISTS model_provider_keys (
+  id uuid PRIMARY KEY DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid NOT NULL,
+  slot TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  api_key_encrypted TEXT NOT NULL,
+  enabled boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT model_provider_keys_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS model_provider_keys_project_id_slot_key
+  ON model_provider_keys (project_id, slot)
+  WHERE deleted IS FALSE;

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4095,3 +4095,9 @@ CREATE TABLE IF NOT EXISTS model_provider_keys (
 CREATE UNIQUE INDEX IF NOT EXISTS model_provider_keys_project_id_slot_key
   ON model_provider_keys (project_id, slot)
   WHERE deleted IS FALSE;
+
+-- Non-partial index backing model_provider_keys_project_id_fkey (ON DELETE
+-- CASCADE): keeps project cascade deletes off a seq scan, including
+-- soft-deleted rows that the partial unique index above excludes.
+CREATE INDEX IF NOT EXISTS model_provider_keys_project_id_idx
+  ON model_provider_keys (project_id);

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4089,6 +4089,7 @@ CREATE TABLE IF NOT EXISTS model_provider_keys (
   deleted_at timestamptz,
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
 
+  CONSTRAINT model_provider_keys_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
   CONSTRAINT model_provider_keys_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
 );
 
@@ -4096,8 +4097,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS model_provider_keys_project_id_slot_key
   ON model_provider_keys (project_id, slot)
   WHERE deleted IS FALSE;
 
--- Non-partial index backing model_provider_keys_project_id_fkey (ON DELETE
--- CASCADE): keeps project cascade deletes off a seq scan, including
--- soft-deleted rows that the partial unique index above excludes.
+-- Non-partial indexes backing the cascade FKs: keep org/project cascade
+-- deletes off a seq scan, including soft-deleted rows that the partial
+-- unique index above excludes.
 CREATE INDEX IF NOT EXISTS model_provider_keys_project_id_idx
   ON model_provider_keys (project_id);
+
+CREATE INDEX IF NOT EXISTS model_provider_keys_organization_id_idx
+  ON model_provider_keys (organization_id);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -951,6 +951,20 @@ type McpServer struct {
 	Deleted               bool
 }
 
+type ModelProviderKey struct {
+	ID              uuid.UUID
+	OrganizationID  string
+	ProjectID       uuid.UUID
+	Slot            string
+	Provider        string
+	ApiKeyEncrypted string
+	Enabled         bool
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+	DeletedAt       pgtype.Timestamptz
+	Deleted         bool
+}
+
 type OauthProxyClientInfo struct {
 	McpSlug                 string
 	ClientID                string

--- a/server/migrations/20260713200058_model-provider-keys.sql
+++ b/server/migrations/20260713200058_model-provider-keys.sql
@@ -1,0 +1,23 @@
+-- Create "model_provider_keys" table
+CREATE TABLE "model_provider_keys" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NOT NULL,
+  "slot" text NOT NULL,
+  "provider" text NOT NULL,
+  "api_key_encrypted" text NOT NULL,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "model_provider_keys_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "model_provider_keys_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "model_provider_keys_organization_id_idx" to table: "model_provider_keys"
+CREATE INDEX "model_provider_keys_organization_id_idx" ON "model_provider_keys" ("organization_id");
+-- Create index "model_provider_keys_project_id_idx" to table: "model_provider_keys"
+CREATE INDEX "model_provider_keys_project_id_idx" ON "model_provider_keys" ("project_id");
+-- Create index "model_provider_keys_project_id_slot_key" to table: "model_provider_keys"
+CREATE UNIQUE INDEX "model_provider_keys_project_id_slot_key" ON "model_provider_keys" ("project_id", "slot") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:LnnTt1mK5jfnwFm6/sCTX+TmEXhipuNcu2Zb/9zgBaE=
+h1:S2UfD1hLyteBHSHsfVwykPspbHcv3hyp1f6bSxkQ7rA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -260,3 +260,4 @@ h1:LnnTt1mK5jfnwFm6/sCTX+TmEXhipuNcu2Zb/9zgBaE=
 20260710091948_risk-policies-add-score.sql h1:8HQa1NIJgn9NC86OtcVbwyPoatbngUtlfHzv2+ugHs4=
 20260710142212_plugin-connections-hooks-config.sql h1:i5v1a+00vugROm0s9hoPjea9F9Mx2QvGj2gN77nhQWo=
 20260713113216_mcp_server_requires_user_session_issuer.sql h1:zurTJ5thZI6HfBkNBqo+kpDekeok7fuQx2wbfrQ1WTY=
+20260713200058_model-provider-keys.sql h1:+Ke7rD4wY8spaHYGs5bXmar7aepllAALdaiVUsmXf7A=


### PR DESCRIPTION
Schema and migrations split off `daniel/dno-472-byok-foundation-encrypted-provider-key-store-per-slot` so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-project, per-slot encrypted store for BYOK model provider keys to support Linear DNO-472. Schema-only with a Go model; no behavior change.

- **New Features**
  - Created `model_provider_keys` table scoped by `(project_id, slot)` with soft-delete and a partial unique index; cascades on delete from `projects` and `organization_metadata`.
  - Added non-partial indexes on `project_id` and `organization_id` to keep cascade deletes and lookups fast.
  - Stores `api_key_encrypted` using AES-256-GCM at rest (never returned by the API); added `ModelProviderKey` in Go models.

<sup>Written for commit 44764e9c35382779c42fa8df00ac905de98d0958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

