### PR TITLE
feat: manage model provider keys from project settings

### DIFF
--- a/.changeset/byok-dashboard-key-management.md
+++ b/.changeset/byok-dashboard-key-management.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Manage bring-your-own model provider keys from project settings: set a project default OpenRouter key, override individual surfaces, and see which surfaces run on your key versus the platform key.

--- a/client/dashboard/src/components/platform-admin-panel.tsx
+++ b/client/dashboard/src/components/platform-admin-panel.tsx
@@ -16,6 +16,7 @@ import {
   Building2,
   FileSearch,
   FolderSync,
+  Key,
   KeyRound,
   Loader2,
   Mail,
@@ -310,6 +311,21 @@ function ProductFeaturesSection(): ReactElement {
         onToggle={handleToggle}
         error={
           pendingFeature === FeatureName.Webhooks
+            ? mutError?.message
+            : undefined
+        }
+      />
+
+      <FeatureToggle
+        label="Custom Model Provider Keys"
+        description="Allows projects in this organization to store OpenRouter API keys for model completions."
+        icon={Key}
+        featureName={FeatureName.CustomModelKeys}
+        enabled={features.customModelKeysEnabled}
+        isPending={isPending && pendingFeature === FeatureName.CustomModelKeys}
+        onToggle={handleToggle}
+        error={
+          pendingFeature === FeatureName.CustomModelKeys
             ? mutError?.message
             : undefined
         }

--- a/client/dashboard/src/pages/settings/ModelProviderKeyDialog.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeyDialog.tsx
@@ -1,0 +1,100 @@
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Type } from "@/components/ui/type";
+import { invalidateAllModelProviderKeys } from "@gram/client/react-query/modelProviderKeys.js";
+import { useUpsertModelProviderKeyMutation } from "@gram/client/react-query/upsertModelProviderKey.js";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { MODEL_KEY_PROVIDER, type ModelKeySlot } from "./model-key-slots";
+
+export function ModelProviderKeyDialog({
+  slot,
+  hasExistingKey,
+  onClose,
+}: {
+  slot: ModelKeySlot;
+  hasExistingKey: boolean;
+  onClose: () => void;
+}): JSX.Element {
+  const queryClient = useQueryClient();
+  const [apiKey, setApiKey] = useState("");
+  const fieldId = `model-key-${slot.slot}`;
+
+  const { mutate: upsert, isPending: isMutating } =
+    useUpsertModelProviderKeyMutation({
+      onSuccess: () => {
+        toast.success(`${slot.name} key saved`);
+        void invalidateAllModelProviderKeys(queryClient);
+        onClose();
+      },
+      onError: (err) => {
+        toast.error(`Failed to save key: ${err.message}`);
+      },
+    });
+
+  const canSave = apiKey.trim() !== "" && !isMutating;
+
+  const save = () => {
+    if (!canSave) return;
+    upsert({
+      request: {
+        upsertKeyRequestBody: {
+          slot: slot.slot,
+          provider: MODEL_KEY_PROVIDER,
+          apiKey: apiKey.trim(),
+          enabled: true,
+        },
+      },
+    });
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>
+            {hasExistingKey
+              ? `Replace ${slot.name} key`
+              : `Set ${slot.name} key`}
+          </Dialog.Title>
+          <Dialog.Description>{slot.description}</Dialog.Description>
+        </Dialog.Header>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor={fieldId}>OpenRouter API key</Label>
+          <Input
+            id={fieldId}
+            type="password"
+            placeholder={
+              hasExistingKey ? "•••••• (saved)" : "OpenRouter API key"
+            }
+            value={apiKey}
+            onChange={setApiKey}
+            onEnter={save}
+            disabled={isMutating}
+            autoFocus
+          />
+          <Type muted small>
+            The key is validated with the provider and stored encrypted. It is
+            never displayed again.
+          </Type>
+        </div>
+        <Dialog.Footer>
+          <Button variant="secondary" onClick={onClose} disabled={isMutating}>
+            Cancel
+          </Button>
+          <Button onClick={save} disabled={!canSave}>
+            {isMutating ? "Validating..." : "Save"}
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Heading } from "@/components/ui/heading";
 import { SkeletonTable } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
-import { useProject } from "@/contexts/Auth";
+import { useProjectSlugForRequests } from "@/contexts/Sdk";
 import { HumanizeDateTime } from "@/lib/dates";
 import type { ModelProviderKey } from "@gram/client/models/components/modelproviderkey.js";
 import { useDeleteModelProviderKeyMutation } from "@gram/client/react-query/deleteModelProviderKey.js";
@@ -27,9 +27,9 @@ import { ModelProviderKeyDialog } from "./ModelProviderKeyDialog";
 
 export function ModelProviderKeysSection(): JSX.Element {
   const queryClient = useQueryClient();
-  const project = useProject();
+  const gramProject = useProjectSlugForRequests();
   const { data, isLoading, isError, refetch } = useModelProviderKeys({
-    gramProject: project.slug,
+    gramProject,
   });
   const { data: features } = useProductFeatures();
   const [dialogSlot, setDialogSlot] = useState<ModelKeySlot | null>(null);

--- a/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
@@ -28,9 +28,11 @@ import { ModelProviderKeyDialog } from "./ModelProviderKeyDialog";
 export function ModelProviderKeysSection(): JSX.Element {
   const queryClient = useQueryClient();
   const gramProject = useProjectSlugForRequests();
-  const { data, isLoading, isError, refetch } = useModelProviderKeys({
-    gramProject,
-  });
+  const { data, isLoading, isError, refetch } = useModelProviderKeys(
+    { gramProject },
+    undefined,
+    { throwOnError: false },
+  );
   const { data: features } = useProductFeatures();
   const [dialogSlot, setDialogSlot] = useState<ModelKeySlot | null>(null);
 

--- a/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Heading } from "@/components/ui/heading";
 import { SkeletonTable } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
+import { useProject } from "@/contexts/Auth";
 import { HumanizeDateTime } from "@/lib/dates";
 import type { ModelProviderKey } from "@gram/client/models/components/modelproviderkey.js";
 import { useDeleteModelProviderKeyMutation } from "@gram/client/react-query/deleteModelProviderKey.js";
@@ -26,7 +27,10 @@ import { ModelProviderKeyDialog } from "./ModelProviderKeyDialog";
 
 export function ModelProviderKeysSection(): JSX.Element {
   const queryClient = useQueryClient();
-  const { data, isLoading } = useModelProviderKeys();
+  const project = useProject();
+  const { data, isLoading, isError, refetch } = useModelProviderKeys({
+    gramProject: project.slug,
+  });
   const { data: features } = useProductFeatures();
   const [dialogSlot, setDialogSlot] = useState<ModelKeySlot | null>(null);
 
@@ -133,6 +137,30 @@ export function ModelProviderKeysSection(): JSX.Element {
     },
   ];
 
+  let keyList: JSX.Element;
+  if (isLoading) {
+    keyList = <SkeletonTable />;
+  } else if (isError) {
+    keyList = (
+      <Stack direction="horizontal" gap={2} align="center">
+        <Type muted small>
+          Failed to load provider keys.
+        </Type>
+        <Button variant="secondary" size="sm" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </Stack>
+    );
+  } else {
+    keyList = (
+      <Table
+        columns={columns}
+        data={MODEL_KEY_SLOTS}
+        rowKey={(row) => row.slot}
+      />
+    );
+  }
+
   return (
     <Stack gap={4}>
       <div>
@@ -153,15 +181,7 @@ export function ModelProviderKeysSection(): JSX.Element {
         )}
       </div>
 
-      {isLoading ? (
-        <SkeletonTable />
-      ) : (
-        <Table
-          columns={columns}
-          data={MODEL_KEY_SLOTS}
-          rowKey={(row) => row.slot}
-        />
-      )}
+      {keyList}
 
       {dialogSlot ? (
         <ModelProviderKeyDialog

--- a/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
@@ -1,0 +1,193 @@
+import { ReleaseStageBadge } from "@/components/release-stage-badge";
+import { Button } from "@/components/ui/button";
+import { Heading } from "@/components/ui/heading";
+import { SkeletonTable } from "@/components/ui/skeleton";
+import { Type } from "@/components/ui/type";
+import { HumanizeDateTime } from "@/lib/dates";
+import type { ModelProviderKey } from "@gram/client/models/components/modelproviderkey.js";
+import { useDeleteModelProviderKeyMutation } from "@gram/client/react-query/deleteModelProviderKey.js";
+import {
+  invalidateAllModelProviderKeys,
+  useModelProviderKeys,
+} from "@gram/client/react-query/modelProviderKeys.js";
+import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
+import { useQueryClient } from "@tanstack/react-query";
+import { Badge, Column, Stack, Table } from "@speakeasy-api/moonshine";
+import { Trash2 } from "lucide-react";
+import { type ComponentProps, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  keySourceForSlot,
+  MODEL_KEY_SLOTS,
+  type KeySource,
+  type ModelKeySlot,
+} from "./model-key-slots";
+import { ModelProviderKeyDialog } from "./ModelProviderKeyDialog";
+
+export function ModelProviderKeysSection(): JSX.Element {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useModelProviderKeys();
+  const { data: features } = useProductFeatures();
+  const [dialogSlot, setDialogSlot] = useState<ModelKeySlot | null>(null);
+
+  const canWrite = features?.customModelKeysEnabled ?? false;
+
+  const keysBySlot = useMemo(
+    () => new Map((data?.keys ?? []).map((key) => [key.slot, key] as const)),
+    [data],
+  );
+
+  const { mutate: deleteKey, isPending: isDeleting } =
+    useDeleteModelProviderKeyMutation({
+      onSuccess: () => {
+        toast.success("Provider key removed");
+        void invalidateAllModelProviderKeys(queryClient);
+      },
+      onError: (err) => {
+        toast.error(`Failed to remove key: ${err.message}`);
+      },
+    });
+
+  const handleRemove = (slot: ModelKeySlot, key: ModelProviderKey) => {
+    if (!window.confirm(`Remove the ${slot.name} provider key?`)) return;
+    deleteKey({ request: { id: key.id } });
+  };
+
+  const columns: Column<ModelKeySlot>[] = [
+    {
+      key: "surface",
+      header: "Surface",
+      render: (slot) => (
+        <Stack gap={1}>
+          <Type variant="body" className="font-medium">
+            {slot.name}
+          </Type>
+          <Type muted small>
+            {slot.description}
+          </Type>
+        </Stack>
+      ),
+    },
+    {
+      key: "key",
+      header: "Key",
+      width: "200px",
+      render: (slot) => {
+        const key = keysBySlot.get(slot.slot);
+        return (
+          <Stack direction="horizontal" gap={2} align="center">
+            <KeySourceBadge source={keySourceForSlot(slot.slot, keysBySlot)} />
+            {key && !key.enabled ? (
+              <Type muted small>
+                Key disabled
+              </Type>
+            ) : null}
+          </Stack>
+        );
+      },
+    },
+    {
+      key: "updated",
+      header: "Updated",
+      width: "140px",
+      render: (slot) => {
+        const key = keysBySlot.get(slot.slot);
+        if (!key) return null;
+        return (
+          <Type muted small>
+            <HumanizeDateTime date={key.updatedAt} />
+          </Type>
+        );
+      },
+    },
+    {
+      key: "actions",
+      header: "",
+      width: "220px",
+      render: (slot) => {
+        const key = keysBySlot.get(slot.slot);
+        return (
+          <Stack direction="horizontal" gap={2} justify="end">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setDialogSlot(slot)}
+              disabled={!canWrite || isDeleting}
+            >
+              {key ? "Replace key" : "Set key"}
+            </Button>
+            {key ? (
+              <Button
+                variant="destructiveGhost"
+                size="sm"
+                onClick={() => handleRemove(slot, key)}
+                disabled={isDeleting}
+                aria-label={`Remove ${slot.name} key`}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            ) : null}
+          </Stack>
+        );
+      },
+    },
+  ];
+
+  return (
+    <Stack gap={4}>
+      <div>
+        <Stack direction="horizontal" gap={2} align="center" className="mb-2">
+          <Heading variant="h4">Model Provider Keys</Heading>
+          <ReleaseStageBadge stage="preview" />
+        </Stack>
+        <Type muted small>
+          Bring your own OpenRouter API key for model completions. Set a project
+          default for all surfaces, or override individual surfaces. Keys are
+          write-only and never displayed after saving.
+        </Type>
+        {features && !features.customModelKeysEnabled && (
+          <Type muted small className="mt-2">
+            Custom model provider keys are not enabled for your organization.
+            Contact Speakeasy to enable them.
+          </Type>
+        )}
+      </div>
+
+      {isLoading ? (
+        <SkeletonTable />
+      ) : (
+        <Table
+          columns={columns}
+          data={MODEL_KEY_SLOTS}
+          rowKey={(row) => row.slot}
+        />
+      )}
+
+      {dialogSlot ? (
+        <ModelProviderKeyDialog
+          slot={dialogSlot}
+          hasExistingKey={keysBySlot.has(dialogSlot.slot)}
+          onClose={() => setDialogSlot(null)}
+        />
+      ) : null}
+    </Stack>
+  );
+}
+
+const KEY_SOURCE_BADGE: Record<
+  KeySource,
+  { variant: ComponentProps<typeof Badge>["variant"]; label: string }
+> = {
+  custom: { variant: "success", label: "Custom key" },
+  inherited: { variant: "information", label: "Project default" },
+  platform: { variant: "neutral", label: "Platform key" },
+};
+
+function KeySourceBadge({ source }: { source: KeySource }): JSX.Element {
+  const badge = KEY_SOURCE_BADGE[source];
+  return (
+    <Badge variant={badge.variant} background className="shrink-0">
+      <Badge.Text>{badge.label}</Badge.Text>
+    </Badge>
+  );
+}

--- a/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
@@ -25,7 +25,17 @@ import {
 } from "./model-key-slots";
 import { ModelProviderKeyDialog } from "./ModelProviderKeyDialog";
 
-export function ModelProviderKeysSection(): JSX.Element {
+export function ModelProviderKeysSection(): JSX.Element | null {
+  const { data: features } = useProductFeatures();
+
+  if (!features?.customModelKeysEnabled) {
+    return null;
+  }
+
+  return <EnabledModelProviderKeysSection />;
+}
+
+function EnabledModelProviderKeysSection(): JSX.Element {
   const queryClient = useQueryClient();
   const gramProject = useProjectSlugForRequests();
   const { data, isLoading, isError, refetch } = useModelProviderKeys(
@@ -33,10 +43,7 @@ export function ModelProviderKeysSection(): JSX.Element {
     undefined,
     { throwOnError: false },
   );
-  const { data: features } = useProductFeatures();
   const [dialogSlot, setDialogSlot] = useState<ModelKeySlot | null>(null);
-
-  const canWrite = features?.customModelKeysEnabled ?? false;
 
   const keysBySlot = useMemo(
     () => new Map((data?.keys ?? []).map((key) => [key.slot, key] as const)),
@@ -98,7 +105,13 @@ export function ModelProviderKeysSection(): JSX.Element {
       width: "140px",
       render: (slot) => {
         const key = keysBySlot.get(slot.slot);
-        if (!key) return null;
+        if (!key) {
+          return (
+            <Type muted small>
+              —
+            </Type>
+          );
+        }
         return (
           <Type muted small>
             <HumanizeDateTime date={key.updatedAt} />
@@ -118,7 +131,7 @@ export function ModelProviderKeysSection(): JSX.Element {
               variant="secondary"
               size="sm"
               onClick={() => setDialogSlot(slot)}
-              disabled={!canWrite || isDeleting}
+              disabled={isDeleting}
             >
               {key ? "Replace key" : "Set key"}
             </Button>
@@ -175,12 +188,6 @@ export function ModelProviderKeysSection(): JSX.Element {
           default for all surfaces, or override individual surfaces. Keys are
           write-only and never displayed after saving.
         </Type>
-        {features && !features.customModelKeysEnabled && (
-          <Type muted small className="mt-2">
-            Custom model provider keys are not enabled for your organization.
-            Contact Speakeasy to enable them.
-          </Type>
-        )}
       </div>
 
       {keyList}

--- a/client/dashboard/src/pages/settings/Settings.tsx
+++ b/client/dashboard/src/pages/settings/Settings.tsx
@@ -11,6 +11,7 @@ import { ShieldAlert } from "lucide-react";
 import { Stack } from "@speakeasy-api/moonshine";
 import { SettingsDangerZone } from "./SettingsDangerZone";
 import { RegistryCacheSection } from "./RegistryCacheSection";
+import { ModelProviderKeysSection } from "./ModelProviderKeysSection";
 
 export default function Settings(): JSX.Element {
   const isAdmin = useIsPlatformAdmin();
@@ -31,6 +32,10 @@ export default function Settings(): JSX.Element {
             Manage your project configuration and perform administrative
             actions.
           </Type>
+          <div className="mb-8">
+            <ModelProviderKeysSection />
+          </div>
+
           <div>
             <SettingsDangerZone />
           </div>

--- a/client/dashboard/src/pages/settings/model-key-slots.ts
+++ b/client/dashboard/src/pages/settings/model-key-slots.ts
@@ -29,16 +29,6 @@ export const MODEL_KEY_SLOTS: ModelKeySlot[] = [
     description: "Chat completions served through Elements embeds.",
   },
   {
-    slot: "gram",
-    name: "Chat",
-    description: "Completions from the hosted MCP chat surface.",
-  },
-  {
-    slot: "slack",
-    name: "Slack",
-    description: "Completions from the Slack integration.",
-  },
-  {
     slot: "assistants",
     name: "Assistants",
     description: "Completions from assistant runs and triggers.",

--- a/client/dashboard/src/pages/settings/model-key-slots.ts
+++ b/client/dashboard/src/pages/settings/model-key-slots.ts
@@ -1,0 +1,65 @@
+import type { ModelProviderKey } from "@gram/client/models/components/modelproviderkey.js";
+
+export const PROJECT_DEFAULT_SLOT = "default";
+export const MODEL_KEY_PROVIDER = "openrouter";
+
+export type ModelKeySlot = {
+  slot: string;
+  name: string;
+  description: string;
+};
+
+// The completion surfaces a customer key can cover. The 'default' slot covers
+// every other slot that has no dedicated override; the server rejects slots
+// outside this list.
+export const MODEL_KEY_SLOTS: ModelKeySlot[] = [
+  {
+    slot: PROJECT_DEFAULT_SLOT,
+    name: "Project default",
+    description: "Covers every surface below without a dedicated key.",
+  },
+  {
+    slot: "playground",
+    name: "Playground",
+    description: "Completions from the dashboard playground.",
+  },
+  {
+    slot: "elements",
+    name: "Elements",
+    description: "Chat completions served through Elements embeds.",
+  },
+  {
+    slot: "gram",
+    name: "Chat",
+    description: "Completions from the hosted MCP chat surface.",
+  },
+  {
+    slot: "slack",
+    name: "Slack",
+    description: "Completions from the Slack integration.",
+  },
+  {
+    slot: "assistants",
+    name: "Assistants",
+    description: "Completions from assistant runs and triggers.",
+  },
+];
+
+export type KeySource = "custom" | "inherited" | "platform";
+
+// Mirrors the server's resolution order: an enabled slot override wins, then
+// an enabled project-default key, then the platform-provisioned key.
+export function keySourceForSlot(
+  slot: string,
+  keysBySlot: Map<string, ModelProviderKey>,
+): KeySource {
+  const own = keysBySlot.get(slot);
+  if (own?.enabled) return "custom";
+  if (
+    slot !== PROJECT_DEFAULT_SLOT &&
+    keysBySlot.get(PROJECT_DEFAULT_SLOT)?.enabled
+  ) {
+    return "inherited";
+  }
+  return "platform";
+}

--- a/client/dashboard/src/pages/settings/model-key-slots.ts
+++ b/client/dashboard/src/pages/settings/model-key-slots.ts
@@ -1,6 +1,6 @@
 import type { ModelProviderKey } from "@gram/client/models/components/modelproviderkey.js";
 
-export const PROJECT_DEFAULT_SLOT = "default";
+const PROJECT_DEFAULT_SLOT = "default";
 export const MODEL_KEY_PROVIDER = "openrouter";
 
 export type ModelKeySlot = {


### PR DESCRIPTION
## Summary

- Adds a **Model Provider Keys** section (preview) to project settings for bring-your-own OpenRouter keys.
- Users set a project-default key that every completion surface inherits, or override individual surfaces (playground, Elements, assistants).
- Each surface shows whether it resolves to a custom key, the project default, or the platform key, mirroring the server's resolution order; disabled keys are called out.
- Keys are write-only: entered in a dialog, validated by the provider on save, and never rendered back.
- Write actions are gated on the custom model keys product feature; removal stays available so stale keys can always be cleaned up.

Closes [DNO-474](https://linear.app/speakeasy/issue/DNO-474)

✻ Clauded with care