### PR TITLE
feat: byok slots for the risk-policy judge and prompt-injection classifier

### DIFF
--- a/.changeset/byok-risk-judge-slots.md
+++ b/.changeset/byok-risk-judge-slots.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Projects can now bring their own model provider key for the risk-policy judge and the prompt-injection classifier, each as an independent key slot. Unset slots fall back to the project default key, then the platform key.

--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -655,6 +655,7 @@ func judgeOne(ctx context.Context, client openrouter.CompletionClient, model str
 		Temperature:    &temp,
 		UsageSource:    billing.ModelUsageSourceGram,
 		KeyType:        openrouter.KeyTypeInternal,
+		KeySlot:        "",
 		UserID:         "",
 		ExternalUserID: "",
 		UserEmail:      "",

--- a/server/internal/background/activities/chat_resolutions/analyze_segment.go
+++ b/server/internal/background/activities/chat_resolutions/analyze_segment.go
@@ -326,6 +326,7 @@ If there are no tool calls, return an empty array.`, userPromptText)
 			JSONSchema:     &jsonSchemaConfig,
 			UsageSource:    billing.ModelUsageSourceGram,
 			KeyType:        openrouter.KeyTypeInternal,
+			KeySlot:        "",
 			UserID:         "",
 			ExternalUserID: "",
 			UserEmail:      "",

--- a/server/internal/background/activities/chat_resolutions/segment_chat.go
+++ b/server/internal/background/activities/chat_resolutions/segment_chat.go
@@ -187,6 +187,7 @@ There are %d messages total (indices 0-%d).%s`, conversationText, numMessages, n
 			JSONSchema:     &jsonSchemaConfig,
 			UsageSource:    billing.ModelUsageSourceGram,
 			KeyType:        openrouter.KeyTypeInternal,
+			KeySlot:        "",
 			UserID:         "",
 			ExternalUserID: "",
 			UserEmail:      "",

--- a/server/internal/billing/tracking.go
+++ b/server/internal/billing/tracking.go
@@ -65,6 +65,16 @@ var (
 // list explicitly.
 const ModelUsageSourceAssistants ModelUsageSource = "assistants"
 
+// The platform-initiated risk-analysis judges are likewise unregistered:
+// their completions are tagged and billed under ModelUsageSourceRiskAnalysis.
+// These values exist only as BYOK key slots, so a project can override the
+// key paying for the prompt-based risk-policy judge and the prompt-injection
+// classifier independently of each other and of the assistant.
+const (
+	ModelUsageSourceRiskPolicy      ModelUsageSource = "risk-policy"
+	ModelUsageSourcePromptInjection ModelUsageSource = "prompt-injection"
+)
+
 // ModelUsageSources lists every registered completion surface.
 func ModelUsageSources() []ModelUsageSource {
 	return slices.Clone(modelUsageSources)

--- a/server/internal/memory/contradiction.go
+++ b/server/internal/memory/contradiction.go
@@ -101,6 +101,7 @@ func (s *MemoryService) detectContradiction(ctx context.Context, orgID, projectI
 		JSONSchema:     &jsonSchemaConfig,
 		UsageSource:    billing.ModelUsageSourceGram,
 		KeyType:        openrouter.KeyTypeInternal,
+		KeySlot:        "",
 		UserID:         "",
 		ExternalUserID: "",
 		UserEmail:      "",

--- a/server/internal/modelkeys/resolver.go
+++ b/server/internal/modelkeys/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgerrcode"
@@ -32,17 +33,21 @@ const (
 func ValidSlots() []string {
 	slots := []string{SlotDefault}
 	for _, source := range billing.ModelUsageSources() {
-		// Risk-policy analysis is platform-initiated inference; its BYOK slot
-		// ships with the dedicated risk/PI phase, together with lifting the
-		// KeyTypeInternal short-circuit in ResolveKey.
+		// Risk-analysis completions resolve through the dedicated judge slots
+		// below, never through a slot named after their shared usage source.
 		if source == billing.ModelUsageSourceRiskAnalysis {
 			continue
 		}
 		slots = append(slots, string(source))
 	}
 	// Assistants is deliberately not a registered (billed) usage source while
-	// Speakeasy covers its inference, but it is a valid BYOK slot.
-	return append(slots, string(billing.ModelUsageSourceAssistants))
+	// Speakeasy covers its inference, but it is a valid BYOK slot; so is each
+	// platform-initiated judge slot.
+	slots = append(slots, string(billing.ModelUsageSourceAssistants))
+	for _, slot := range internalBYOKSlots {
+		slots = append(slots, string(slot))
+	}
+	return slots
 }
 
 // Resolver picks the OpenRouter API key a completion bills to. Precedence:
@@ -70,11 +75,12 @@ func NewResolver(db *pgxpool.Pool, enc *encryption.Client, provisioner openroute
 
 func (r *Resolver) ResolveKey(ctx context.Context, orgID string, projectID string, slot billing.ModelUsageSource, keyType openrouter.KeyType) (openrouter.ResolvedKey, error) {
 	// Callers without a project (e.g. embeddings) resolve straight to the
-	// platform key. So does KeyTypeInternal: it marks platform-initiated
-	// inference (risk judge, prompt-injection scanner), which stays on the
-	// platform's internal key until the dedicated risk/PI BYOK slots ship —
-	// a project default key must not capture it.
-	if projectID == "" || keyType.OrDefault() == openrouter.KeyTypeInternal {
+	// platform key. KeyTypeInternal marks platform-initiated inference; only
+	// the slots exposed for it (the risk-analysis judges) consult customer
+	// keys. Every other internal completion (chat titles, segment analysis,
+	// memory contradiction, naming helpers) stays on the platform's internal
+	// key — a project default key must not capture it.
+	if projectID == "" || (keyType.OrDefault() == openrouter.KeyTypeInternal && !internalSlotWithBYOK(slot)) {
 		resolved, err := r.platform.ResolveKey(ctx, orgID, projectID, slot, keyType)
 		if err != nil {
 			return openrouter.ResolvedKey{}, fmt.Errorf("resolve platform key: %w", err)
@@ -113,6 +119,20 @@ func (r *Resolver) ResolveKey(ctx context.Context, orgID string, projectID strin
 		return openrouter.ResolvedKey{}, fmt.Errorf("decrypt model provider key: %w", err)
 	}
 	return openrouter.ResolvedKey{Key: key, Customer: true}, nil
+}
+
+// internalBYOKSlots lists the platform-initiated (KeyTypeInternal) slots a
+// project may override with a customer key. Feeding both ValidSlots and the
+// ResolveKey gate from this one list keeps them from drifting: a slot
+// accepted by UpsertKey but absent from the gate would store keys that are
+// silently never consulted.
+var internalBYOKSlots = []billing.ModelUsageSource{
+	billing.ModelUsageSourceRiskPolicy,
+	billing.ModelUsageSourcePromptInjection,
+}
+
+func internalSlotWithBYOK(slot billing.ModelUsageSource) bool {
+	return slices.Contains(internalBYOKSlots, slot)
 }
 
 func isUndefinedTable(err error) bool {

--- a/server/internal/modelkeys/resolver_test.go
+++ b/server/internal/modelkeys/resolver_test.go
@@ -93,7 +93,46 @@ func TestResolveKey_InternalKeyTypeStaysOnPlatform(t *testing.T) {
 
 	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")
 
+	// Internal completions outside the exposed judge slots (chat titles,
+	// segment analysis, …) must not be captured by the project default key.
 	resolved, err := resolver.ResolveKey(ctx, orgID, projectID, billing.ModelUsageSourceRiskAnalysis, openrouter.KeyTypeInternal)
+	require.NoError(t, err)
+	require.Equal(t, "platform-key", resolved.Key)
+	require.False(t, resolved.Customer)
+}
+
+func TestResolveKey_JudgeSlotsResolveIndependently(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	enableCustomModelKeys(t, ctx, ti.conn)
+	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
+
+	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")
+	upsertTestKey(t, ctx, ti, string(billing.ModelUsageSourceRiskPolicy), "sk-or-risk-policy-override")
+
+	// The risk-policy judge resolves its dedicated override.
+	resolved, err := resolver.ResolveKey(ctx, orgID, projectID, billing.ModelUsageSourceRiskPolicy, openrouter.KeyTypeInternal)
+	require.NoError(t, err)
+	require.Equal(t, "sk-or-risk-policy-override", resolved.Key)
+	require.True(t, resolved.Customer)
+
+	// The prompt-injection classifier has no override and falls back to the
+	// project default key, not the risk-policy override.
+	resolved, err = resolver.ResolveKey(ctx, orgID, projectID, billing.ModelUsageSourcePromptInjection, openrouter.KeyTypeInternal)
+	require.NoError(t, err)
+	require.Equal(t, "sk-or-project-default", resolved.Key)
+	require.True(t, resolved.Customer)
+}
+
+func TestResolveKey_JudgeSlotsWithoutKeysStayOnPlatform(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	enableCustomModelKeys(t, ctx, ti.conn)
+	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
+
+	resolved, err := resolver.ResolveKey(ctx, orgID, projectID, billing.ModelUsageSourcePromptInjection, openrouter.KeyTypeInternal)
 	require.NoError(t, err)
 	require.Equal(t, "platform-key", resolved.Key)
 	require.False(t, resolved.Customer)

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -2475,6 +2475,7 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 		Temperature:  &temperature,
 		UsageSource:  billing.ModelUsageSourceGram,
 		KeyType:      openrouter.KeyTypeInternal,
+		KeySlot:      "",
 		// The admin who asked for the suggestion — this completion is
 		// user-initiated, so usage attributes to them, not "(unset)".
 		UserID:         userID,

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -2340,6 +2340,7 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 		Temperature:  &temperature,
 		UsageSource:  billing.ModelUsageSourceGram,
 		KeyType:      openrouter.KeyTypeInternal,
+		KeySlot:      "",
 		// The admin who asked for the suggestion — this completion is
 		// user-initiated, so usage attributes to them, not "(unset)". (cubic)
 		UserID:         userID,

--- a/server/internal/scanners/promptinjection/openrouter/judge.go
+++ b/server/internal/scanners/promptinjection/openrouter/judge.go
@@ -309,7 +309,7 @@ func (c *Engine) call(ctx context.Context, req promptinjection.Request, msg judg
 		Stream:                    false,
 		UsageSource:               billing.ModelUsageSourceRiskAnalysis,
 		KeyType:                   gramopenrouter.KeyTypeInternal,
-		KeySlot:                   "",
+		KeySlot:                   billing.ModelUsageSourcePromptInjection,
 		ChatID:                    uuid.Nil,
 		UserID:                    userID,
 		ExternalUserID:            "",

--- a/server/internal/scanners/promptpolicy/openrouter/judge.go
+++ b/server/internal/scanners/promptpolicy/openrouter/judge.go
@@ -216,6 +216,7 @@ func (j *Judge) call(ctx context.Context, in promptpolicy.Input) (judgeCallResul
 		Temperature:    &temperature,
 		UsageSource:    billing.ModelUsageSourceRiskAnalysis,
 		KeyType:        openrouter.KeyTypeInternal,
+		KeySlot:        billing.ModelUsageSourceRiskPolicy,
 		UserID:         in.UserID,
 		ExternalUserID: "",
 		UserEmail:      "",

--- a/server/internal/thirdparty/openrouter/completion_client.go
+++ b/server/internal/thirdparty/openrouter/completion_client.go
@@ -119,6 +119,9 @@ type ObjectCompletionRequest struct {
 	// KeyType selects which of the org's OpenRouter keys pays for the call;
 	// the zero value resolves to the chat key.
 	KeyType KeyType
+	// KeySlot selects the customer key slot the call resolves against; the
+	// zero value falls back to UsageSource.
+	KeySlot billing.ModelUsageSource
 }
 
 // CompletionResponse encapsulates the result of a completion call.

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -542,7 +542,7 @@ func (c *ChatClient) GetObjectCompletion(ctx context.Context, req ObjectCompleti
 		ExternalUserID:            req.ExternalUserID,
 		UserEmail:                 req.UserEmail,
 		KeyType:                   req.KeyType,
-		KeySlot:                   "",
+		KeySlot:                   req.KeySlot,
 		HTTPMetadata:              req.HTTPMetadata,
 		JSONSchema:                req.JSONSchema,
 		CacheControl:              nil,


### PR DESCRIPTION
## Summary

- Adds two BYOK key slots — `risk-policy` and `prompt-injection` — so a project can override the key paying for the prompt-based risk-policy judge and the prompt-injection classifier independently of each other and of the assistant slot.
- Lifts the resolver's `KeyTypeInternal` short-circuit for exactly these two slots: they resolve slot override → project default key → platform key. Every other platform-initiated completion (chat titles, segment analysis, memory contradiction, naming helpers) stays pinned to the platform key and cannot be captured by a project default key.
- Threads `KeySlot` through `ObjectCompletionRequest` so the risk-policy judge (which uses object completions) can name its slot; the PI classifier sets it on its completion request directly.
- Risk-analysis completions keep billing under the registered `risk-analysis` usage source — BYOK only changes which OpenRouter key pays.

The dashboard slot list lives in a file introduced by #4115, so the two UI rows ship as a small follow-up stacked on that branch rather than conflicting with it here.

Stacked on #4114 (DNO-473), parallel to #4115 (DNO-474).

Closes [DNO-475](https://linear.app/speakeasy/issue/DNO-475)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add BYOK per-slot overrides for the prompt-based risk-policy judge and the prompt-injection classifier. Other internal inference stays on the platform key. This fulfills DNO-475.

- **New Features**
  - New slots: `risk-policy` and `prompt-injection`. Resolution: slot override → project default → platform.
  - `KeyTypeInternal` only resolves customer keys for these two slots; all other internal surfaces stay on the platform key.
  - Threaded `KeySlot` through `ObjectCompletionRequest` and the `openrouter` unified client; judges set their slot, other internal calls pass an empty slot.
  - Billing unchanged: completions still report under `risk-analysis`; the new slots exist only for BYOK.

- **Bug Fixes**
  - Initialized empty `KeySlot` for risk exclusion suggestions to keep them on the platform key.

<sup>Written for commit adff6ba614251d7bfda242a7524197e5d51806ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

