### PR TITLE
feat: list the risk-policy and prompt-injection key slots in project settings

### DIFF
--- a/.changeset/dashboard-risk-judge-slots.md
+++ b/.changeset/dashboard-risk-judge-slots.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Model provider key settings list the risk policy judge and prompt injection classifier slots.

--- a/client/dashboard/src/pages/settings/model-key-slots.ts
+++ b/client/dashboard/src/pages/settings/model-key-slots.ts
@@ -33,6 +33,17 @@ export const MODEL_KEY_SLOTS: ModelKeySlot[] = [
     name: "Assistants",
     description: "Completions from assistant runs and triggers.",
   },
+  {
+    slot: "risk-policy",
+    name: "Risk policy judge",
+    description:
+      "Prompt-based risk policy evaluations of observed agent traffic.",
+  },
+  {
+    slot: "prompt-injection",
+    name: "Prompt injection classifier",
+    description: "Prompt injection scanning of observed agent traffic.",
+  },
 ];
 
 export type KeySource = "custom" | "inherited" | "platform";


### PR DESCRIPTION
## Summary

- Adds the `risk-policy` and `prompt-injection` rows to the model provider key slot list, so projects can set dedicated keys for the risk-policy judge and the prompt-injection classifier from settings.
- UI-only companion to #4116 (backend slots); based on #4115 because the slot list module is introduced there. Merge after both.

Part of [DNO-475](https://linear.app/speakeasy/issue/DNO-475)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `risk-policy` and `prompt-injection` key slots in Project Settings so projects can assign BYOK keys for the risk policy judge and the prompt injection classifier. Supports Linear DNO-475 by enabling per-slot overrides from the dashboard.

<sup>Written for commit fd5c16eb21f0cd0f81d064943e349e8d25f70c5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

