### PR TITLE
feat: add an on-demand local assistant runtime backend

### DIFF
--- a/.changeset/local-assistant-runtime-backend.md
+++ b/.changeset/local-assistant-runtime-backend.md
@@ -1,0 +1,9 @@
+---
+"server": minor
+---
+
+Assistant runtimes can now run locally: the new `local` runtime provider (the
+local-development default) starts one Docker container per assistant on demand,
+reuses it across turns, and automatically replaces idle containers when the
+runtime image is rebuilt — no Fly.io credentials or registry pushes needed for
+local image development.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,10 @@
 {
   "mcpServers": {
+    "assistants-dev": {
+      "type": "stdio",
+      "command": "mise",
+      "args": ["x", "--", "go", "run", "./server/cmd/dev-mcp"]
+    },
     "madprocs": {
       "type": "http",
       "url": "https://localhost:35294/mcp"

--- a/.mise-tasks/assistants/local-clean.sh
+++ b/.mise-tasks/assistants/local-clean.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+#MISE description="Remove all local assistant runtime containers and their workspace volumes"
+#MISE confirm="Remove all local assistant runtime containers and workspace volumes?"
+
+set -euo pipefail
+
+filter="label=gram.speakeasy.com/role=assistant_runtime"
+
+containers="$(docker ps --all --quiet --filter "$filter")"
+if [ -n "$containers" ]; then
+  echo "Removing containers:"
+  # shellcheck disable=SC2086
+  docker rm --force $containers
+else
+  echo "No local assistant runtime containers found."
+fi
+
+volumes="$(docker volume ls --format '{{.Name}}' | grep '^gram-asst-work-' || true)"
+if [ -n "$volumes" ]; then
+  echo "Removing workspace volumes:"
+  # shellcheck disable=SC2086
+  docker volume rm $volumes
+else
+  echo "No workspace volumes found."
+fi
+
+echo ""
+echo "Note: the corresponding assistant_runtimes rows will self-heal — the next"
+echo "turn re-admits and relaunches a fresh container."

--- a/.mise-tasks/assistants/local-status.sh
+++ b/.mise-tasks/assistants/local-status.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#MISE description="Show local assistant runtime containers, their state, published ports and images"
+
+set -euo pipefail
+
+filter="label=gram.speakeasy.com/role=assistant_runtime"
+
+echo "Local assistant runtime containers:"
+docker ps --all --filter "$filter" \
+  --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}\t{{.Image}}"
+
+echo ""
+echo "Workspace volumes:"
+docker volume ls --format "{{.Name}}" | grep '^gram-asst-work-' || echo "(none)"

--- a/.mise-tasks/build/assistants-runtime-image.sh
+++ b/.mise-tasks/build/assistants-runtime-image.sh
@@ -15,21 +15,13 @@ fi
 arch="${arch/aarch64/arm64}"
 arch="${arch/x86_64/amd64}"
 
-image="gram-assistant-runtime:dev"
+image="${GRAM_ASSISTANT_RUNTIME_OCI_IMAGE:-gram-assistant-runtime}:dev"
 
 echo "Building assistant runtime image for architecture(s): $arch"
 docker build --platform "linux/${arch}" -f ./agents/runtime-image/Dockerfile -t "${image}" .
 
-if [ -n "${GRAM_ASSISTANT_RUNTIME_OCI_IMAGE:-}" ] && [ "$arch" = "amd64" ]; then
-  fly_image="${GRAM_ASSISTANT_RUNTIME_OCI_IMAGE}:dev"
-  docker rmi "$fly_image" || true
-  docker tag "${image}" "$fly_image"
-  docker push "$fly_image"
-  echo ""
-  echo "Pushed image to Fly.io registry as:"
-  echo "$fly_image"
-  echo ""
-fi
-
 echo "Image available locally as:"
 echo "${image}"
+echo ""
+echo "The local assistant runtime provider picks it up on the next admission"
+echo "or recycle — no registry push needed."

--- a/.mise-tasks/start/assistant-runtime.mts
+++ b/.mise-tasks/start/assistant-runtime.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node
 
-//MISE description="Stream assistant runtime logs from Fly.io runtimes"
+//MISE description="Stream assistant runtime logs from local Docker and Fly.io runtimes"
 //MISE hide=true
 //USAGE flag "--poll-seconds <seconds>" default="3" help="How often to poll for active assistant runtimes."
 
@@ -15,6 +15,7 @@ type RuntimeRow = {
   state: string;
   app_name: string;
   machine_id: string;
+  container_name: string;
 };
 
 type LogStreamProcess = ChildProcessByStdio<null, Readable, Readable>;
@@ -70,7 +71,11 @@ function psqlConnection() {
 }
 
 function linePrefix(runtime: RuntimeRow): string {
-  return runtime.app_name || `assistant-${runtime.thread_id.split("-")[0]}`;
+  return (
+    runtime.container_name ||
+    runtime.app_name ||
+    `assistant-${runtime.thread_id.split("-")[0]}`
+  );
 }
 
 function flyAppName(runtime: RuntimeRow): string {
@@ -122,7 +127,8 @@ function sameTarget(left: RuntimeRow, right: RuntimeRow): boolean {
     left.backend === right.backend &&
     left.thread_id === right.thread_id &&
     left.app_name === right.app_name &&
-    left.machine_id === right.machine_id
+    left.machine_id === right.machine_id &&
+    left.container_name === right.container_name
   );
 }
 
@@ -141,10 +147,23 @@ function spawnFlySubscriber(runtime: RuntimeRow): LogStreamProcess {
   });
 }
 
+function spawnDockerSubscriber(runtime: RuntimeRow): LogStreamProcess {
+  return spawn(
+    "docker",
+    ["logs", "--follow", "--tail", "25", runtime.container_name],
+    {
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+}
+
 function spawnSubscriber(runtime: RuntimeRow): LogStreamProcess {
   switch (runtime.backend) {
     case "flyio":
       return spawnFlySubscriber(runtime);
+    case "local":
+      return spawnDockerSubscriber(runtime);
     default:
       return spawn(
         "bash",
@@ -184,7 +203,9 @@ function startSubscriber(runtime: RuntimeRow) {
 
   writeLine(
     linePrefix(runtime),
-    `attached fly logs for ${flyAppName(runtime)}`,
+    runtime.backend === "local"
+      ? `attached docker logs for ${runtime.container_name}`
+      : `attached fly logs for ${flyAppName(runtime)}`,
   );
 
   proc.on("close", (code, signal) => {
@@ -225,7 +246,8 @@ WITH runtimes AS (
     r.backend,
     r.state,
     COALESCE(r.backend_metadata_json->>'app_name', '') AS app_name,
-    COALESCE(r.backend_metadata_json->>'machine_id', '') AS machine_id
+    COALESCE(r.backend_metadata_json->>'machine_id', '') AS machine_id,
+    COALESCE(r.backend_metadata_json->>'container_name', '') AS container_name
   FROM assistant_runtimes r
   WHERE r.deleted IS FALSE
     AND r.state IN ('starting', 'active')
@@ -280,7 +302,7 @@ FROM runtimes;
 
 async function reconcileOnce() {
   const runtimes = (await loadRuntimes()).filter(
-    (runtime) => runtime.backend === "flyio",
+    (runtime) => runtime.backend === "flyio" || runtime.backend === "local",
   );
   desiredRuntimes.clear();
   for (const runtime of runtimes) {
@@ -297,11 +319,15 @@ async function reconcileOnce() {
   }
 
   for (const [runtimeID, runtime] of desiredRuntimes) {
-    // Flyio rows start with empty backend metadata and get populated after
-    // Ensure. Wait for app_name so we spawn a single `flyctl logs -a <app>`
-    // instead of the generic fallback, then reattach — avoids the duplicate
-    // log stream we were getting while the old fallback subscriber dies.
+    // Runtime rows start with empty backend metadata and get populated after
+    // Ensure. Wait for the backend's identity field so we attach a single
+    // targeted stream instead of the generic fallback, then reattach — avoids
+    // the duplicate log stream we were getting while the old fallback
+    // subscriber dies.
     if (runtime.backend === "flyio" && !runtime.app_name) {
+      continue;
+    }
+    if (runtime.backend === "local" && !runtime.container_name) {
       continue;
     }
     const existing = subscribers.get(runtimeID);

--- a/.mise-tasks/start/assistant-runtime.mts
+++ b/.mise-tasks/start/assistant-runtime.mts
@@ -208,7 +208,7 @@ function startSubscriber(runtime: RuntimeRow) {
       : `attached fly logs for ${flyAppName(runtime)}`,
   );
 
-  proc.on("close", (code, signal) => {
+  const scheduleRetry = (reason: string) => {
     const current = subscribers.get(runtime.runtime_id);
     if (current !== sub) {
       return;
@@ -217,10 +217,7 @@ function startSubscriber(runtime: RuntimeRow) {
       subscribers.delete(runtime.runtime_id);
       return;
     }
-    writeLine(
-      linePrefix(runtime),
-      `log stream exited (${signal ?? code ?? "unknown"}), retrying...`,
-    );
+    writeLine(linePrefix(runtime), reason);
     subscribers.delete(runtime.runtime_id);
     setTimeout(() => {
       if (shuttingDown) {
@@ -232,6 +229,18 @@ function startSubscriber(runtime: RuntimeRow) {
       }
       startSubscriber(desired);
     }, 2000);
+  };
+
+  // A missing/broken CLI (docker, flyctl) surfaces as a spawn "error" with no
+  // "close"; without a handler it would crash the whole watcher.
+  proc.on("error", (err) => {
+    scheduleRetry(`log stream failed to start (${err.message}), retrying...`);
+  });
+
+  proc.on("close", (code, signal) => {
+    scheduleRetry(
+      `log stream exited (${signal ?? code ?? "unknown"}), retrying...`,
+    );
   });
 }
 

--- a/.mise-tasks/zero/fly.mts
+++ b/.mise-tasks/zero/fly.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node
 
-//MISE description="Setup Gram Functions to use Fly.io during development."
+//MISE description="Setup Gram Functions to use Fly.io during development. Assistant runtimes run locally and need no Fly.io setup."
 //MISE dir="{{ config_root }}"
 //USAGE flag "--restart" default="false" help="Force the onboarding even if configuration already exists."
 
@@ -49,11 +49,9 @@ function isExistingConfigComplete(): boolean {
   const content = readFileSync(configPath, "utf-8");
   const functionsProvider = configValue(content, "GRAM_FUNCTIONS_PROVIDER");
 
-  // Skip was chosen previously — local provider with assistant runtime placeholders
+  // Skip was chosen previously — local functions provider needs nothing else.
   if (functionsProvider === "local") {
-    return (
-      configValue(content, "GRAM_ASSISTANT_RUNTIME_PROVIDER") !== undefined
-    );
+    return true;
   }
 
   const requiredKeys = [
@@ -63,11 +61,6 @@ function isExistingConfigComplete(): boolean {
     "GRAM_FUNCTIONS_RUNNER_OCI_IMAGE",
     "GRAM_FUNCTIONS_RUNNER_VERSION",
     "GRAM_FUNCTIONS_FLYIO_REGION",
-    "GRAM_ASSISTANT_RUNTIME_PROVIDER",
-    "GRAM_ASSISTANT_RUNTIME_FLYIO_API_TOKEN",
-    "GRAM_ASSISTANT_RUNTIME_FLYIO_ORG",
-    "GRAM_ASSISTANT_RUNTIME_FLYIO_REGION",
-    "GRAM_ASSISTANT_RUNTIME_OCI_IMAGE",
     "GRAM_FUNCTIONS_TIGRIS_BUCKET_URI",
     "GRAM_FUNCTIONS_TIGRIS_KEY",
     "GRAM_FUNCTIONS_TIGRIS_SECRET",
@@ -77,10 +70,7 @@ function isExistingConfigComplete(): boolean {
     return false;
   }
 
-  return (
-    configValue(content, "GRAM_FUNCTIONS_PROVIDER") === "flyio" &&
-    configValue(content, "GRAM_ASSISTANT_RUNTIME_PROVIDER") === "flyio"
-  );
+  return configValue(content, "GRAM_FUNCTIONS_PROVIDER") === "flyio";
 }
 
 function getExisting(...keys: string[]): string | undefined {
@@ -106,14 +96,9 @@ async function saveConfigs(values: Record<string, string>): Promise<void> {
 async function fallbackToMockFlyio() {
   await saveConfigs({
     GRAM_FUNCTIONS_PROVIDER: "local",
-    GRAM_ASSISTANT_RUNTIME_PROVIDER: "flyio",
-    GRAM_ASSISTANT_RUNTIME_FLYIO_ORG: "TODO",
-    GRAM_ASSISTANT_RUNTIME_FLYIO_API_TOKEN: "TODO",
-    GRAM_ASSISTANT_RUNTIME_FLYIO_REGION: "us",
-    GRAM_ASSISTANT_RUNTIME_OCI_IMAGE: "gram-assistant-runtime",
   });
   outro(
-    "Defaulted Gram Functions to the local provider and wrote TODO assistant runtime Fly.io placeholders. To configure real Fly.io credentials later, run `mise run zero:fly --restart`.",
+    "Defaulted Gram Functions to the local provider. Assistant runtimes run locally by default and need no Fly.io setup. To configure real Fly.io credentials later, run `mise run zero:fly --restart`.",
   );
   process.exit(0);
 }
@@ -474,7 +459,7 @@ async function run() {
 
   note(
     `
-To deploy Gram Functions and assistant runtimes to Fly.io, you'll need:
+To deploy Gram Functions to Fly.io, you'll need:
     - A Fly.io account
     - A Fly.io organization-scoped token
     - A Fly.io app namespace for runner images
@@ -498,14 +483,8 @@ To deploy Gram Functions and assistant runtimes to Fly.io, you'll need:
   }
 
   const s = spinner();
-  const existingToken = getExisting(
-    "GRAM_FUNCTIONS_FLYIO_API_TOKEN",
-    "GRAM_ASSISTANT_RUNTIME_FLYIO_API_TOKEN",
-  );
-  const existingOrg = getExisting(
-    "GRAM_FUNCTIONS_FLYIO_ORG",
-    "GRAM_ASSISTANT_RUNTIME_FLYIO_ORG",
-  );
+  const existingToken = getExisting("GRAM_FUNCTIONS_FLYIO_API_TOKEN");
+  const existingOrg = getExisting("GRAM_FUNCTIONS_FLYIO_ORG");
 
   let token: string;
   let org: string;
@@ -530,7 +509,6 @@ To deploy Gram Functions and assistant runtimes to Fly.io, you'll need:
 
   const initialApp =
     registryAppName(getExisting("GRAM_FUNCTIONS_RUNNER_OCI_IMAGE")) ??
-    registryAppName(getExisting("GRAM_ASSISTANT_RUNTIME_OCI_IMAGE")) ??
     randomAppName();
   const app = await text({
     message:
@@ -558,18 +536,13 @@ To deploy Gram Functions and assistant runtimes to Fly.io, you'll need:
     GRAM_FUNCTIONS_RUNNER_OCI_IMAGE: `registry.fly.io/${app}`,
     GRAM_FUNCTIONS_RUNNER_VERSION: "main",
     GRAM_FUNCTIONS_FLYIO_REGION: "us",
-    GRAM_ASSISTANT_RUNTIME_PROVIDER: "flyio",
-    GRAM_ASSISTANT_RUNTIME_FLYIO_ORG: org,
-    GRAM_ASSISTANT_RUNTIME_FLYIO_API_TOKEN: token,
-    GRAM_ASSISTANT_RUNTIME_FLYIO_REGION: "us",
-    GRAM_ASSISTANT_RUNTIME_OCI_IMAGE: `registry.fly.io/${app}`,
     GRAM_FUNCTIONS_TIGRIS_BUCKET_URI: `s3://${bucket}`,
     GRAM_FUNCTIONS_TIGRIS_KEY: tigrisKey,
     GRAM_FUNCTIONS_TIGRIS_SECRET: tigrisSecret,
   });
 
   outro(
-    "Updated mise.local.toml. You're ready to deploy Gram Functions and assistant runtimes to Fly.io.",
+    "Updated mise.local.toml. You're ready to deploy Gram Functions to Fly.io.",
   );
 }
 

--- a/.mise-tasks/zero/tls.sh
+++ b/.mise-tasks/zero/tls.sh
@@ -188,10 +188,13 @@ cert_names() {
   site_host="$(extract_hostname "$GRAM_SITE_URL")"
   server_host="$(extract_hostname "$GRAM_SERVER_URL")"
 
+  # host.docker.internal lets local assistant runtime containers dial the
+  # server over TLS through Docker's host gateway alias.
   printf "%s\n" \
     "$site_host" \
     "$server_host" \
     "localhost" \
+    "host.docker.internal" \
     "127.0.0.1" \
     "::1" \
     | awk 'NF && !seen[$0]++'
@@ -215,6 +218,9 @@ gen_keypair() {
     echo "WARN: root CA not found at $root_ca" >&2
   else
     mise set --file mise.local.toml NODE_EXTRA_CA_CERTS="$root_ca"
+    # Mounted into local assistant runtime containers so runners trust the
+    # local server certificate.
+    mise set --file mise.local.toml GRAM_ASSISTANT_RUNTIME_LOCAL_CA_FILE="$root_ca"
   fi
 
   echo "  cert => $CERT_PATH"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,10 @@ The main frontend application lives in `client/dashboard/` (not `client/` direct
 
 </commands>
 
+### Testing assistants locally
+
+`.mcp.json` registers the `assistants-dev` MCP server (`server/cmd/dev-mcp`), which drives the local management API without the dashboard UI. It logs into the local stack on its own (dev-idp auto-approves), so no setup is needed beyond a running dev stack. Use its tools — assistant CRUD, `run_turn` (send a message and wait for the assistant's reply), `load_chat`, and trigger CRUD — to exercise assistant runtime changes end to end. `whoami` lists the available project slugs.
+
 ### Database Migrations
 
 Migration rules live in the `postgresql` skill (`.agents/skills/postgresql/SKILL.md`, "Database migrations" section). Activate that skill any time you touch `server/migrations/`, `atlas.sum`, or `server/database/schema.sql`.

--- a/agents/runner/src/tools/bun_run.rs
+++ b/agents/runner/src/tools/bun_run.rs
@@ -44,7 +44,9 @@ required. \
 (lightpanda) is available — prefer `import { withContext } from './browser'` \
 and run page work inside the callback so each invocation gets a fresh, \
 auto-disposed BrowserContext. Use `getBrowser()` from the same module only \
-when you need the raw Browser handle. For LLM-friendly page reading, \
+when you need the raw Browser handle; each call opens a dedicated \
+connection that supports exactly one BrowserContext — never call \
+`newContext()` twice on one handle, and `close()` the handle when done. For LLM-friendly page reading, \
 `import { markdown } from './browser'` and call `markdown(page)` to get \
 `{ title, byline, markdown }`; it runs Readability over the page HTML and \
 serializes to Markdown. Pass `{ readable: false }` for non-article pages \

--- a/agents/runtime-image/README.md
+++ b/agents/runtime-image/README.md
@@ -1,0 +1,70 @@
+# Gram Assistant Runtime Image
+
+The container image assistant runtimes run in: the Rust runner
+(`agents/runner`), the bun-based sandbox, and a lightpanda browser.
+
+## Local development
+
+Local development uses the `local` assistant runtime provider (the default,
+`GRAM_ASSISTANT_RUNTIME_PROVIDER=local`): the Gram server starts one runtime
+container per assistant on your machine's Docker daemon, on demand. No Fly.io
+credentials, apps, or registry pushes are involved.
+
+### Workflow
+
+1. Build the image:
+
+   ```sh
+   mise run build:assistants-runtime-image
+   ```
+
+2. Start Gram normally (e.g. `madprocs`, or `mise start:server
+--dev-single-process`).
+
+3. Send a turn to an assistant (for example from the dashboard). The server
+   launches the matching `gram-asst-<assistant-id>` container automatically,
+   publishes the runner port on an ephemeral loopback port, and reuses the
+   container on later turns.
+
+4. Iterate: rebuild the image with the same command. The next admission or
+   recycle detects the image ID change and replaces idle containers with the
+   new image — a container with a turn in flight is never interrupted, it
+   rolls over on the next safe opportunity.
+
+Each assistant gets a `gram-asst-work-<assistant-id>` Docker volume as its
+workspace. It survives container stops and replacements, and is removed when
+the assistant runtime is reaped.
+
+### TLS
+
+Runtime containers reach the server at `https://host.docker.internal:<port>`.
+`mise run zero:tls` includes that hostname in the local certificate and writes
+`GRAM_ASSISTANT_RUNTIME_LOCAL_CA_FILE` (the mkcert root CA) to
+`mise.local.toml`; the server mounts that CA into runtime containers so the
+runner trusts the local certificate. If you set up TLS before this hostname
+was added, re-run `mise run zero:tls`.
+
+### Inspecting and cleaning up
+
+```sh
+mise run assistants:local-status   # containers, ports, images, volumes
+mise run start:assistant-runtime   # stream runtime logs (also part of madprocs)
+docker logs -f gram-asst-<assistant-id>
+mise run assistants:local-clean    # remove all runtime containers + volumes
+```
+
+### Smoke test
+
+1. `mise run build:assistants-runtime-image`
+2. Start the stack and send a turn to any assistant.
+3. `mise run assistants:local-status` — the assistant's container is `Up` with
+   a `127.0.0.1:<port>->8081/tcp` publish, and the turn produces a reply.
+4. `mise run assistants:local-clean` — containers and volumes are gone; the
+   next turn relaunches from scratch.
+
+### Migrating from the Fly.io workflow
+
+If your `mise.local.toml` still pins `GRAM_ASSISTANT_RUNTIME_PROVIDER=flyio`
+(or a `registry.fly.io/...` value for `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE`),
+remove those keys along with `GRAM_ASSISTANT_RUNTIME_FLYIO_*` to pick up the
+local defaults.

--- a/agents/runtime-image/init.sh
+++ b/agents/runtime-image/init.sh
@@ -8,17 +8,15 @@ mkdir -p "$workdir"
 
 # The platform may mount an extra CA bundle (e.g. the mkcert root CA during
 # local development) so the runner and its sandbox children trust the Gram
-# server's TLS certificate. Append it to the system trust store once per
-# container; the sentinel survives restarts on the writable layer.
+# server's TLS certificate. Build a combined bundle in /tmp rather than
+# mutating the system trust store, which must stay pristine (and may sit on a
+# read-only root filesystem).
 extra_ca=/usr/local/share/gram/extra-ca.pem
-extra_ca_sentinel=/etc/ssl/certs/.gram-extra-ca-appended
 if [ -f "$extra_ca" ]; then
-  if [ ! -f "$extra_ca_sentinel" ]; then
-    cat "$extra_ca" >> /etc/ssl/certs/ca-certificates.crt
-    : > "$extra_ca_sentinel"
-  fi
+  ca_bundle=/tmp/gram-ca-bundle.pem
+  cat /etc/ssl/certs/ca-certificates.crt "$extra_ca" > "$ca_bundle"
+  export SSL_CERT_FILE="$ca_bundle"
   export NODE_EXTRA_CA_CERTS="$extra_ca"
-  export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 fi
 
 # Size-capped tmpfs + read-only bind-mounted deps where mount(2) is permitted;

--- a/agents/runtime-image/init.sh
+++ b/agents/runtime-image/init.sh
@@ -6,6 +6,21 @@ workdir=/var/lib/gram-assistant/work
 sandbox_src=/usr/share/gram/sandbox
 mkdir -p "$workdir"
 
+# The platform may mount an extra CA bundle (e.g. the mkcert root CA during
+# local development) so the runner and its sandbox children trust the Gram
+# server's TLS certificate. Append it to the system trust store once per
+# container; the sentinel survives restarts on the writable layer.
+extra_ca=/usr/local/share/gram/extra-ca.pem
+extra_ca_sentinel=/etc/ssl/certs/.gram-extra-ca-appended
+if [ -f "$extra_ca" ]; then
+  if [ ! -f "$extra_ca_sentinel" ]; then
+    cat "$extra_ca" >> /etc/ssl/certs/ca-certificates.crt
+    : > "$extra_ca_sentinel"
+  fi
+  export NODE_EXTRA_CA_CERTS="$extra_ca"
+  export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+fi
+
 # Size-capped tmpfs + read-only bind-mounted deps where mount(2) is permitted;
 # symlink the deps where it is not (the platform supplies the writable workdir).
 if mount -t tmpfs -o size=256m,mode=0755 tmpfs "$workdir" 2>/dev/null; then

--- a/agents/runtime-image/sandbox/browser.ts
+++ b/agents/runtime-image/sandbox/browser.ts
@@ -12,25 +12,40 @@ import { gfm } from "turndown-plugin-gfm";
 
 const CDP_ENDPOINT = "http://127.0.0.1:9222";
 
-let cached: Browser | null = null;
-
+// Lightpanda reuses frame IDs across contexts, so a single CDP connection can
+// only ever host one BrowserContext — a second newContext() on the same
+// connection corrupts Playwright's target registry in a way that poisons the
+// whole handle. Every Browser handle is therefore a dedicated connection that
+// refuses a second context up front, and callers must close it when done.
 export async function getBrowser(): Promise<Browser> {
-  if (cached?.isConnected()) {
-    return cached;
-  }
-  cached = await chromium.connectOverCDP(CDP_ENDPOINT);
-  return cached;
+  const browser = await chromium.connectOverCDP(CDP_ENDPOINT);
+  const newContext = browser.newContext.bind(browser);
+  let hasContext = false;
+  browser.newContext = async (options) => {
+    if (hasContext) {
+      throw new Error(
+        "this browser handle already hosts a BrowserContext and the sandbox browser supports exactly one per handle; call getBrowser() again (or use withContext) for the next context",
+      );
+    }
+    hasContext = true;
+    return await newContext(options);
+  };
+  return browser;
 }
 
 export async function withContext<T>(
   fn: (ctx: BrowserContext) => Promise<T>,
 ): Promise<T> {
   const browser = await getBrowser();
-  const ctx = await browser.newContext();
   try {
-    return await fn(ctx);
+    const ctx = await browser.newContext();
+    try {
+      return await fn(ctx);
+    } finally {
+      await ctx.close();
+    }
   } finally {
-    await ctx.close();
+    await browser.close();
   }
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -230,7 +230,12 @@ GRAM_FUNCTIONS_LOCAL_RUNNER_ROOT = "{{config_root}}/local/functions"
 ########################################
 ## Gram Assistant runtime settings ##
 ########################################
-GRAM_ASSISTANT_RUNTIME_PROVIDER = "flyio"
+## Where assistant runtimes run.
+## Allowed values: local, flyio, gke.
+## The local provider starts runtime containers on demand on this machine's
+## Docker daemon. Build the image with `mise run build:assistants-runtime-image`.
+GRAM_ASSISTANT_RUNTIME_PROVIDER = "local"
+GRAM_ASSISTANT_RUNTIME_OCI_IMAGE = "gram-assistant-runtime"
 
 ##################
 ## MCP Registry ##

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -61,11 +61,11 @@ linters:
       - path: cmd/|internal/dns/
         linters:
           - forbidigo
-      # riskjudgebench is a developer/benchmark CLI (not part of the server
-      # binary). Like test files, it favors terse partial structs and direct
-      # error returns over production-grade hardening, so exempt it from the
+      # riskjudgebench and dev-mcp are developer CLIs (not part of the server
+      # binary). Like test files, they favor terse partial structs and direct
+      # error returns over production-grade hardening, so exempt them from the
       # same dev-tooling linters we exempt tests from.
-      - path: cmd/riskjudgebench/
+      - path: cmd/riskjudgebench/|cmd/dev-mcp/
         linters:
           - exhaustruct
           - wrapcheck

--- a/server/cmd/dev-mcp/client.go
+++ b/server/cmd/dev-mcp/client.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"sync"
+)
+
+const sessionCookieName = "gram_session"
+
+// apiClient is a session-authenticated client for the local server's
+// management API. Sessions are minted lazily by walking the dashboard's OIDC
+// login flow — the local dev-idp auto-approves, so the whole redirect chain
+// completes without interaction — and the resulting cookie lives in the
+// client's jar for the life of the process.
+type apiClient struct {
+	base   *url.URL
+	hc     *http.Client
+	logger *slog.Logger
+
+	mu        sync.Mutex
+	sessionOK bool
+}
+
+func newAPIClient(base *url.URL, insecure bool, logger *slog.Logger) *apiClient {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		// cookiejar.New with nil options never errors; keep the compiler honest.
+		panic(err)
+	}
+
+	var transport http.RoundTripper
+	if insecure {
+		transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // opt-in flag for local self-signed certs
+		}
+	}
+
+	return &apiClient{
+		base:   base,
+		logger: logger,
+		hc: &http.Client{
+			Jar:       jar,
+			Transport: transport,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				// The login chain ends at /rpc/auth.callback, which sets the
+				// session cookie and then redirects to the dashboard. The
+				// dashboard may not be running, so stop there.
+				if len(via) > 0 && via[len(via)-1].URL.Path == "/rpc/auth.callback" {
+					return http.ErrUseLastResponse
+				}
+				if len(via) >= 10 {
+					return fmt.Errorf("stopped after 10 redirects")
+				}
+				return nil
+			},
+		},
+	}
+}
+
+func (c *apiClient) hasSessionCookie() bool {
+	for _, ck := range c.hc.Jar.Cookies(c.base) {
+		if ck.Name == sessionCookieName && ck.Value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// login walks GET /rpc/auth.login through the IDP and back to the auth
+// callback, leaving a session cookie in the jar.
+func (c *apiClient) login(ctx context.Context) error {
+	loginURL := c.base.JoinPath("/rpc/auth.login").String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, loginURL, nil)
+	if err != nil {
+		return fmt.Errorf("build login request: %w", err)
+	}
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("walk login flow: %w", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	if !c.hasSessionCookie() {
+		return fmt.Errorf("login flow finished with status %d but no %s cookie; is the local stack (server + dev-idp) running?", resp.StatusCode, sessionCookieName)
+	}
+
+	c.logger.InfoContext(ctx, "logged in to local server")
+	return nil
+}
+
+func (c *apiClient) ensureSession(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sessionOK {
+		return nil
+	}
+	if err := c.login(ctx); err != nil {
+		return err
+	}
+	c.sessionOK = true
+	return nil
+}
+
+// call performs an authenticated JSON API call and returns the raw response
+// body. A 401 invalidates the cached session and retries once with a fresh
+// login. project sets the Gram-Project header when non-empty; when omitted
+// the server falls back to the organization's only project.
+func (c *apiClient) call(ctx context.Context, method, path string, query url.Values, project string, body any) (json.RawMessage, error) {
+	if err := c.ensureSession(ctx); err != nil {
+		return nil, err
+	}
+
+	raw, status, err := c.doOnce(ctx, method, path, query, project, body)
+	if status == http.StatusUnauthorized {
+		c.mu.Lock()
+		c.sessionOK = false
+		c.mu.Unlock()
+		if err := c.ensureSession(ctx); err != nil {
+			return nil, err
+		}
+		raw, status, err = c.doOnce(ctx, method, path, query, project, body)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if status < 200 || status > 299 {
+		return nil, fmt.Errorf("%s %s: status %d: %s", method, path, status, string(raw))
+	}
+	return raw, nil
+}
+
+func (c *apiClient) doOnce(ctx context.Context, method, path string, query url.Values, project string, body any) (json.RawMessage, int, error) {
+	u := c.base.JoinPath(path)
+	if query != nil {
+		u.RawQuery = query.Encode()
+	}
+
+	var reqBody io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, fmt.Errorf("encode request body: %w", err)
+		}
+		reqBody = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), reqBody)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if project != "" {
+		req.Header.Set("Gram-Project", project)
+	}
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read response body: %w", err)
+	}
+	return raw, resp.StatusCode, nil
+}

--- a/server/cmd/dev-mcp/main.go
+++ b/server/cmd/dev-mcp/main.go
@@ -1,0 +1,60 @@
+// Command dev-mcp is a local-development MCP server that exposes assistant
+// management operations (CRUD, running turns, triggers) over stdio. It lets
+// coding agents exercise the assistant runtime against a locally running
+// server without driving the dashboard UI.
+//
+// It authenticates by walking the same OIDC login flow the dashboard uses;
+// the local dev-idp auto-approves, so no interaction is needed.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"os/signal"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+func main() {
+	serverURL := flag.String("server-url", "https://localhost:8080", "Base URL of the locally running server")
+	insecure := flag.Bool("insecure", false, "Skip TLS certificate verification for the server URL")
+	flag.Parse()
+
+	// stdout carries the MCP protocol; all logging goes to stderr.
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	if err := run(*serverURL, *insecure, logger); err != nil {
+		logger.Error("dev-mcp exited", attr.SlogError(err))
+		os.Exit(1)
+	}
+}
+
+func run(serverURL string, insecure bool, logger *slog.Logger) error {
+	base, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("parse server url: %w", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	api := newAPIClient(base, insecure, logger)
+
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "assistants-dev",
+		Title:   "Assistant local dev tools",
+		Version: "0.1.0",
+	}, nil)
+	registerTools(server, api)
+
+	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
+		return fmt.Errorf("run mcp server: %w", err)
+	}
+	return nil
+}

--- a/server/cmd/dev-mcp/tools.go
+++ b/server/cmd/dev-mcp/tools.go
@@ -1,0 +1,485 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	defaultAssistantModel = "anthropic/claude-sonnet-5"
+	defaultTurnTimeout    = 300 * time.Second
+	maxTurnTimeout        = 900 * time.Second
+	turnPollInterval      = 2 * time.Second
+)
+
+func textResult(raw json.RawMessage) *mcp.CallToolResult {
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(raw)}}}
+}
+
+// projectInput is embedded by every project-scoped tool input.
+type projectInput struct {
+	Project string `json:"project,omitempty" jsonschema:"Project slug to scope the call to. Omit to use the organization's only project."`
+}
+
+type toolsetRef struct {
+	ToolsetSlug     string `json:"toolset_slug" jsonschema:"The toolset slug exposed to the assistant."`
+	EnvironmentSlug string `json:"environment_slug,omitempty" jsonschema:"Optional environment slug used when invoking the toolset."`
+}
+
+type mcpServerRef struct {
+	MCPServerSlug   string `json:"mcp_server_slug" jsonschema:"The MCP server slug attached to the assistant."`
+	EnvironmentSlug string `json:"environment_slug,omitempty" jsonschema:"Optional environment slug used when connecting to the MCP server."`
+}
+
+type idInput struct {
+	projectInput
+	ID string `json:"id" jsonschema:"The resource ID (UUID)."`
+}
+
+type createAssistantInput struct {
+	projectInput
+	Name           string         `json:"name" jsonschema:"The assistant name."`
+	Model          string         `json:"model,omitempty" jsonschema:"OpenRouter model identifier. Defaults to anthropic/claude-sonnet-5."`
+	Instructions   string         `json:"instructions" jsonschema:"System instructions for the assistant."`
+	Toolsets       []toolsetRef   `json:"toolsets,omitempty" jsonschema:"Toolsets available to the assistant. Defaults to none."`
+	MCPServers     []mcpServerRef `json:"mcp_servers,omitempty" jsonschema:"MCP servers attached directly to the assistant."`
+	WarmTTLSeconds int            `json:"warm_ttl_seconds,omitempty" jsonschema:"Warm runtime TTL in seconds."`
+	MaxConcurrency int            `json:"max_concurrency,omitempty" jsonschema:"Maximum active warm runtimes."`
+	Status         string         `json:"status,omitempty" jsonschema:"Initial status: active or paused. Defaults to active."`
+}
+
+type updateAssistantInput struct {
+	projectInput
+	ID             string         `json:"id" jsonschema:"The assistant ID."`
+	Name           string         `json:"name,omitempty" jsonschema:"New assistant name."`
+	Model          string         `json:"model,omitempty" jsonschema:"New OpenRouter model identifier."`
+	Instructions   string         `json:"instructions,omitempty" jsonschema:"New system instructions."`
+	Toolsets       []toolsetRef   `json:"toolsets,omitempty" jsonschema:"Replacement toolset list."`
+	MCPServers     []mcpServerRef `json:"mcp_servers,omitempty" jsonschema:"Replacement MCP server list."`
+	WarmTTLSeconds int            `json:"warm_ttl_seconds,omitempty" jsonschema:"Warm runtime TTL in seconds."`
+	MaxConcurrency int            `json:"max_concurrency,omitempty" jsonschema:"Maximum active warm runtimes."`
+	Status         string         `json:"status,omitempty" jsonschema:"New status: active or paused."`
+}
+
+type runTurnInput struct {
+	projectInput
+	AssistantID    string `json:"assistant_id" jsonschema:"The assistant to send the message to."`
+	Message        string `json:"message" jsonschema:"The user message text."`
+	ChatID         string `json:"chat_id,omitempty" jsonschema:"Existing chat to continue. Omit to start a new conversation."`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty" jsonschema:"How long to wait for the reply before giving up. Defaults to 300, capped at 900."`
+}
+
+type loadChatInput struct {
+	projectInput
+	ChatID     string `json:"chat_id" jsonschema:"The chat ID to load."`
+	Generation int    `json:"generation,omitempty" jsonschema:"Generation to load; omit for the latest."`
+	FromStart  bool   `json:"from_start,omitempty" jsonschema:"Return the oldest page instead of the newest."`
+	Limit      int    `json:"limit,omitempty" jsonschema:"Maximum messages per page (1-200)."`
+}
+
+type listChatsInput struct {
+	projectInput
+	AssistantID string `json:"assistant_id,omitempty" jsonschema:"Filter to chats produced by this assistant."`
+}
+
+type createTriggerInput struct {
+	projectInput
+	DefinitionSlug string         `json:"definition_slug" jsonschema:"Trigger definition slug, e.g. cron. Use list_trigger_definitions to discover the options and their config schemas."`
+	Name           string         `json:"name" jsonschema:"The trigger instance name."`
+	AssistantID    string         `json:"assistant_id" jsonschema:"The assistant the trigger dispatches to."`
+	TargetDisplay  string         `json:"target_display,omitempty" jsonschema:"User-facing target label. Defaults to the assistant ID."`
+	Config         map[string]any `json:"config" jsonschema:"Definition-specific config payload, e.g. {\"schedule\": \"*/5 * * * *\"} for cron."`
+	Status         string         `json:"status,omitempty" jsonschema:"Initial status."`
+}
+
+// chatMessage is the subset of the chat service's message shape run_turn
+// needs for terminal detection and reporting.
+type chatMessage struct {
+	ID  string `json:"id"`
+	Seq int64  `json:"seq"`
+	// Role and Content mirror the chat service's message shape; Content is
+	// usually a JSON string but can be an array of structured parts.
+	Content      json.RawMessage `json:"content"`
+	Role         string          `json:"role"`
+	ToolCalls    *string         `json:"tool_calls"`
+	FinishReason *string         `json:"finish_reason"`
+	CreatedAt    string          `json:"created_at"`
+}
+
+// contentText renders a message's content for the turn result: plain text
+// when the content is a JSON string, the raw JSON otherwise.
+func contentText(content json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(content, &s); err == nil {
+		return s
+	}
+	return string(content)
+}
+
+type chatPage struct {
+	Messages      []chatMessage `json:"messages"`
+	Generation    int           `json:"generation"`
+	MaxGeneration int           `json:"max_generation"`
+}
+
+func registerTools(server *mcp.Server, api *apiClient) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "whoami",
+		Description: "Show the authenticated local user and their organizations/projects. Use this to discover project slugs.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		raw, err := api.call(ctx, http.MethodGet, "/rpc/auth.info", nil, "", nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		var info map[string]any
+		if err := json.Unmarshal(raw, &info); err != nil {
+			return nil, nil, fmt.Errorf("decode auth info: %w", err)
+		}
+		delete(info, "session_token")
+		delete(info, "session_cookie")
+		out, err := json.Marshal(info)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode auth info: %w", err)
+		}
+		return textResult(out), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_assistants",
+		Description: "List assistants in the project.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in projectInput) (*mcp.CallToolResult, any, error) {
+		raw, err := api.call(ctx, http.MethodGet, "/rpc/assistants.list", nil, in.Project, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "get_assistant",
+		Description: "Get an assistant by ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in idInput) (*mcp.CallToolResult, any, error) {
+		raw, err := api.call(ctx, http.MethodGet, "/rpc/assistants.get", url.Values{"id": {in.ID}}, in.Project, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "create_assistant",
+		Description: "Create an assistant. Toolsets and MCP servers are optional; a bare assistant with instructions is enough to exercise the runtime.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in createAssistantInput) (*mcp.CallToolResult, any, error) {
+		body := map[string]any{
+			"name":         in.Name,
+			"model":        in.Model,
+			"instructions": in.Instructions,
+			"toolsets":     in.Toolsets,
+		}
+		if in.Model == "" {
+			body["model"] = defaultAssistantModel
+		}
+		if in.Toolsets == nil {
+			body["toolsets"] = []toolsetRef{}
+		}
+		if in.MCPServers != nil {
+			body["mcp_servers"] = in.MCPServers
+		}
+		if in.WarmTTLSeconds > 0 {
+			body["warm_ttl_seconds"] = in.WarmTTLSeconds
+		}
+		if in.MaxConcurrency > 0 {
+			body["max_concurrency"] = in.MaxConcurrency
+		}
+		if in.Status != "" {
+			body["status"] = in.Status
+		}
+		raw, err := api.call(ctx, http.MethodPost, "/rpc/assistants.create", nil, in.Project, body)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "update_assistant",
+		Description: "Update an assistant. Only the provided fields change.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in updateAssistantInput) (*mcp.CallToolResult, any, error) {
+		body := map[string]any{"id": in.ID}
+		if in.Name != "" {
+			body["name"] = in.Name
+		}
+		if in.Model != "" {
+			body["model"] = in.Model
+		}
+		if in.Instructions != "" {
+			body["instructions"] = in.Instructions
+		}
+		if in.Toolsets != nil {
+			body["toolsets"] = in.Toolsets
+		}
+		if in.MCPServers != nil {
+			body["mcp_servers"] = in.MCPServers
+		}
+		if in.WarmTTLSeconds > 0 {
+			body["warm_ttl_seconds"] = in.WarmTTLSeconds
+		}
+		if in.MaxConcurrency > 0 {
+			body["max_concurrency"] = in.MaxConcurrency
+		}
+		if in.Status != "" {
+			body["status"] = in.Status
+		}
+		raw, err := api.call(ctx, http.MethodPost, "/rpc/assistants.update", nil, in.Project, body)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_assistant",
+		Description: "Delete an assistant by ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in idInput) (*mcp.CallToolResult, any, error) {
+		if _, err := api.call(ctx, http.MethodDelete, "/rpc/assistants.delete", url.Values{"id": {in.ID}}, in.Project, nil); err != nil {
+			return nil, nil, err
+		}
+		return textResult(json.RawMessage(`{"deleted": true}`)), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "run_turn",
+		Description: "Send a message to an assistant and wait for the reply. Starts a new chat unless chat_id is given. Returns the chat ID, the assistant's final reply, and every message the turn produced (tool calls included). This drives the full runtime path: trigger ingest, Temporal, and the runtime container.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runTurnInput) (*mcp.CallToolResult, any, error) {
+		out, err := runTurn(ctx, api, in)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(out), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "load_chat",
+		Description: "Load a chat transcript page. Useful for inspecting a turn's tool calls or polling a chat manually.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in loadChatInput) (*mcp.CallToolResult, any, error) {
+		q := url.Values{"id": {in.ChatID}}
+		if in.Generation > 0 {
+			q.Set("generation", strconv.Itoa(in.Generation))
+		}
+		if in.FromStart {
+			q.Set("from_start", "true")
+		}
+		if in.Limit > 0 {
+			q.Set("limit", strconv.Itoa(in.Limit))
+		}
+		raw, err := api.call(ctx, http.MethodGet, "/rpc/chat.load", q, in.Project, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_chats",
+		Description: "List chats in the project, optionally filtered to one assistant's threads.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in listChatsInput) (*mcp.CallToolResult, any, error) {
+		q := url.Values{}
+		if in.AssistantID != "" {
+			q.Set("assistant_id", in.AssistantID)
+		}
+		raw, err := api.call(ctx, http.MethodGet, "/rpc/chat.list", q, in.Project, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_trigger_definitions",
+		Description: "List available trigger definitions and their config schemas.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in projectInput) (*mcp.CallToolResult, any, error) {
+		raw, err := api.call(ctx, http.MethodGet, "/rpc/triggers.listDefinitions", nil, in.Project, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_triggers",
+		Description: "List trigger instances in the project.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in projectInput) (*mcp.CallToolResult, any, error) {
+		raw, err := api.call(ctx, http.MethodGet, "/rpc/triggers.list", nil, in.Project, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "create_trigger",
+		Description: "Create a trigger instance that dispatches to an assistant. For quick end-to-end runtime tests, a cron trigger with a tight schedule works well; pause or delete it when done.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in createTriggerInput) (*mcp.CallToolResult, any, error) {
+		body := map[string]any{
+			"definition_slug": in.DefinitionSlug,
+			"name":            in.Name,
+			"target_kind":     "assistant",
+			"target_ref":      in.AssistantID,
+			"target_display":  in.TargetDisplay,
+			"config":          in.Config,
+		}
+		if in.TargetDisplay == "" {
+			body["target_display"] = in.AssistantID
+		}
+		if in.Status != "" {
+			body["status"] = in.Status
+		}
+		raw, err := api.call(ctx, http.MethodPost, "/rpc/triggers.create", nil, in.Project, body)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "delete_trigger",
+		Description: "Delete a trigger instance by ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in idInput) (*mcp.CallToolResult, any, error) {
+		if _, err := api.call(ctx, http.MethodDelete, "/rpc/triggers.delete", url.Values{"id": {in.ID}}, in.Project, nil); err != nil {
+			return nil, nil, err
+		}
+		return textResult(json.RawMessage(`{"deleted": true}`)), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "pause_trigger",
+		Description: "Pause a trigger instance by ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in idInput) (*mcp.CallToolResult, any, error) {
+		raw, err := api.call(ctx, http.MethodPost, "/rpc/triggers.pause", url.Values{"id": {in.ID}}, in.Project, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "resume_trigger",
+		Description: "Resume a paused trigger instance by ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in idInput) (*mcp.CallToolResult, any, error) {
+		raw, err := api.call(ctx, http.MethodPost, "/rpc/triggers.resume", url.Values{"id": {in.ID}}, in.Project, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		return textResult(raw), nil, nil
+	})
+}
+
+func loadChatPage(ctx context.Context, api *apiClient, project, chatID string) (chatPage, error) {
+	raw, err := api.call(ctx, http.MethodGet, "/rpc/chat.load", url.Values{"id": {chatID}}, project, nil)
+	if err != nil {
+		return chatPage{}, err
+	}
+	var page chatPage
+	if err := json.Unmarshal(raw, &page); err != nil {
+		return chatPage{}, fmt.Errorf("decode chat page: %w", err)
+	}
+	return page, nil
+}
+
+func emptyToolCalls(tc *string) bool {
+	return tc == nil || *tc == "" || *tc == "[]" || *tc == "null"
+}
+
+func runTurn(ctx context.Context, api *apiClient, in runTurnInput) (json.RawMessage, error) {
+	timeout := defaultTurnTimeout
+	if in.TimeoutSeconds > 0 {
+		timeout = min(time.Duration(in.TimeoutSeconds)*time.Second, maxTurnTimeout)
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Baseline the newest message so only this turn's output is reported.
+	var baselineSeq int64
+	if in.ChatID != "" {
+		page, err := loadChatPage(ctx, api, in.Project, in.ChatID)
+		if err != nil {
+			return nil, fmt.Errorf("baseline chat before send: %w", err)
+		}
+		for _, msg := range page.Messages {
+			baselineSeq = max(baselineSeq, msg.Seq)
+		}
+	}
+
+	sendBody := map[string]any{
+		"assistant_id": in.AssistantID,
+		"message":      in.Message,
+	}
+	if in.ChatID != "" {
+		sendBody["chat_id"] = in.ChatID
+	}
+	raw, err := api.call(ctx, http.MethodPost, "/rpc/assistants.sendMessage", nil, in.Project, sendBody)
+	if err != nil {
+		return nil, err
+	}
+	var sent struct {
+		ChatID   string `json:"chat_id"`
+		Accepted bool   `json:"accepted"`
+	}
+	if err := json.Unmarshal(raw, &sent); err != nil {
+		return nil, fmt.Errorf("decode sendMessage result: %w", err)
+	}
+	if !sent.Accepted {
+		return nil, fmt.Errorf("message was not accepted for chat %s", sent.ChatID)
+	}
+
+	ticker := time.NewTicker(turnPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for reply on chat %s (the turn may still complete; poll with load_chat): %w", sent.ChatID, ctx.Err())
+		case <-ticker.C:
+		}
+
+		page, err := loadChatPage(ctx, api, in.Project, sent.ChatID)
+		if err != nil {
+			return nil, fmt.Errorf("poll chat: %w", err)
+		}
+		if len(page.Messages) == 0 {
+			continue
+		}
+
+		last := page.Messages[len(page.Messages)-1]
+		terminal := last.Seq > baselineSeq &&
+			last.Role == "assistant" &&
+			last.FinishReason != nil && *last.FinishReason == "stop" &&
+			emptyToolCalls(last.ToolCalls)
+		if !terminal {
+			continue
+		}
+
+		var newMessages []chatMessage
+		for _, msg := range page.Messages {
+			if msg.Seq > baselineSeq {
+				newMessages = append(newMessages, msg)
+			}
+		}
+		reply := contentText(last.Content)
+		out, err := json.Marshal(map[string]any{
+			"chat_id":      sent.ChatID,
+			"reply":        reply,
+			"new_messages": newMessages,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("encode turn result: %w", err)
+		}
+		return out, nil
+	}
+}

--- a/server/cmd/dev-mcp/tools.go
+++ b/server/cmd/dev-mcp/tools.go
@@ -50,7 +50,7 @@ type createAssistantInput struct {
 	Instructions   string         `json:"instructions" jsonschema:"System instructions for the assistant."`
 	Toolsets       []toolsetRef   `json:"toolsets,omitempty" jsonschema:"Toolsets available to the assistant. Defaults to none."`
 	MCPServers     []mcpServerRef `json:"mcp_servers,omitempty" jsonschema:"MCP servers attached directly to the assistant."`
-	WarmTTLSeconds int            `json:"warm_ttl_seconds,omitempty" jsonschema:"Warm runtime TTL in seconds."`
+	WarmTTLSeconds *int           `json:"warm_ttl_seconds,omitempty" jsonschema:"Warm runtime TTL in seconds. Zero disables the warm window."`
 	MaxConcurrency int            `json:"max_concurrency,omitempty" jsonschema:"Maximum active warm runtimes."`
 	Status         string         `json:"status,omitempty" jsonschema:"Initial status: active or paused. Defaults to active."`
 }
@@ -63,7 +63,7 @@ type updateAssistantInput struct {
 	Instructions   string         `json:"instructions,omitempty" jsonschema:"New system instructions."`
 	Toolsets       []toolsetRef   `json:"toolsets,omitempty" jsonschema:"Replacement toolset list."`
 	MCPServers     []mcpServerRef `json:"mcp_servers,omitempty" jsonschema:"Replacement MCP server list."`
-	WarmTTLSeconds int            `json:"warm_ttl_seconds,omitempty" jsonschema:"Warm runtime TTL in seconds."`
+	WarmTTLSeconds *int           `json:"warm_ttl_seconds,omitempty" jsonschema:"Warm runtime TTL in seconds. Zero disables the warm window."`
 	MaxConcurrency int            `json:"max_concurrency,omitempty" jsonschema:"Maximum active warm runtimes."`
 	Status         string         `json:"status,omitempty" jsonschema:"New status: active or paused."`
 }
@@ -192,8 +192,8 @@ func registerTools(server *mcp.Server, api *apiClient) {
 		if in.MCPServers != nil {
 			body["mcp_servers"] = in.MCPServers
 		}
-		if in.WarmTTLSeconds > 0 {
-			body["warm_ttl_seconds"] = in.WarmTTLSeconds
+		if in.WarmTTLSeconds != nil {
+			body["warm_ttl_seconds"] = *in.WarmTTLSeconds
 		}
 		if in.MaxConcurrency > 0 {
 			body["max_concurrency"] = in.MaxConcurrency
@@ -228,8 +228,8 @@ func registerTools(server *mcp.Server, api *apiClient) {
 		if in.MCPServers != nil {
 			body["mcp_servers"] = in.MCPServers
 		}
-		if in.WarmTTLSeconds > 0 {
-			body["warm_ttl_seconds"] = in.WarmTTLSeconds
+		if in.WarmTTLSeconds != nil {
+			body["warm_ttl_seconds"] = *in.WarmTTLSeconds
 		}
 		if in.MaxConcurrency > 0 {
 			body["max_concurrency"] = in.MaxConcurrency
@@ -393,6 +393,38 @@ func loadChatPage(ctx context.Context, api *apiClient, project, chatID string) (
 	return page, nil
 }
 
+// collectMessagesAfter pages forward through the chat with `after_seq` keyset
+// cursors so a turn that produced more than one page is reported in full.
+func collectMessagesAfter(ctx context.Context, api *apiClient, project, chatID string, baselineSeq int64) ([]chatMessage, error) {
+	const pageLimit = 200
+	var out []chatMessage
+	cursor := baselineSeq
+	for {
+		q := url.Values{"id": {chatID}, "limit": {strconv.Itoa(pageLimit)}}
+		if cursor > 0 {
+			q.Set("after_seq", strconv.FormatInt(cursor, 10))
+		} else {
+			q.Set("from_start", "true")
+		}
+		raw, err := api.call(ctx, http.MethodGet, "/rpc/chat.load", q, project, nil)
+		if err != nil {
+			return nil, err
+		}
+		var page chatPage
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return nil, fmt.Errorf("decode chat page: %w", err)
+		}
+		if len(page.Messages) == 0 {
+			return out, nil
+		}
+		out = append(out, page.Messages...)
+		cursor = page.Messages[len(page.Messages)-1].Seq
+		if len(page.Messages) < pageLimit {
+			return out, nil
+		}
+	}
+}
+
 func emptyToolCalls(tc *string) bool {
 	return tc == nil || *tc == "" || *tc == "[]" || *tc == "null"
 }
@@ -465,11 +497,9 @@ func runTurn(ctx context.Context, api *apiClient, in runTurnInput) (json.RawMess
 			continue
 		}
 
-		var newMessages []chatMessage
-		for _, msg := range page.Messages {
-			if msg.Seq > baselineSeq {
-				newMessages = append(newMessages, msg)
-			}
+		newMessages, err := collectMessagesAfter(ctx, api, in.Project, sent.ChatID, baselineSeq)
+		if err != nil {
+			return nil, fmt.Errorf("collect turn messages: %w", err)
 		}
 		reply := contentText(last.Content)
 		out, err := json.Marshal(map[string]any{

--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -20,17 +21,22 @@ import (
 var assistantRuntimeFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "assistant-runtime-provider",
-		Usage:   "Assistant runtime provider. Allowed values: flyio, gke.",
+		Usage:   "Assistant runtime provider. Allowed values: flyio, gke, local.",
 		Value:   assistants.RuntimeProviderFlyIO,
 		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_PROVIDER"},
 		Action: func(_ *cli.Context, val string) error {
 			switch val {
-			case "", assistants.RuntimeProviderFlyIO, assistants.RuntimeProviderGKE:
+			case "", assistants.RuntimeProviderFlyIO, assistants.RuntimeProviderGKE, assistants.RuntimeProviderLocal:
 				return nil
 			default:
 				return fmt.Errorf("invalid assistant runtime provider: %s", val)
 			}
 		},
+	},
+	&cli.StringFlag{
+		Name:    "assistant-runtime-local-ca-file",
+		Usage:   "PEM CA bundle mounted into local assistant runtime containers and appended to their trust store, so runners trust the local server's TLS certificate. Typically the mkcert root CA.",
+		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_LOCAL_CA_FILE"},
 	},
 	&cli.StringFlag{
 		Name:    "assistant-runtime-gke-namespace",
@@ -127,9 +133,25 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 	switch provider {
 	case "", assistants.RuntimeProviderFlyIO:
 		provider = assistants.RuntimeProviderFlyIO
-	case assistants.RuntimeProviderGKE:
+	case assistants.RuntimeProviderGKE, assistants.RuntimeProviderLocal:
 	default:
 		return assistants.RuntimeBackendConfig{}, fmt.Errorf("invalid assistant runtime provider: %s", provider)
+	}
+
+	environment := c.String("environment")
+
+	// Containers cannot reach the host's loopback URL, so unless a runtime
+	// server URL was set explicitly, the local backend rewrites the host to
+	// Docker's host gateway alias (the port and scheme are preserved; the
+	// local TLS certificate covers the alias via zero:tls).
+	localRuntimeServerURL := resolvedServerURL
+	if c.String("assistant-runtime-server-url") == "" && resolvedServerURL != nil {
+		rewritten := *resolvedServerURL
+		rewritten.Host = assistants.LocalRuntimeHostGatewayAlias
+		if port := resolvedServerURL.Port(); port != "" {
+			rewritten.Host = net.JoinHostPort(rewritten.Host, port)
+		}
+		localRuntimeServerURL = &rewritten
 	}
 
 	gkeNamespace := c.String("assistant-runtime-gke-namespace")
@@ -177,6 +199,18 @@ func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistan
 			ServerURL:        resolvedServerURL,
 			RunnerCIDRBlocks: c.StringSlice("assistant-runtime-gke-runner-cidr"),
 		},
+		// Enabled whenever the process runs in the local environment (not only
+		// when local is the target) so locally created runtime rows stay
+		// routable for cleanup while experimenting with other targets.
+		Local: assistants.LocalRuntimeConfig{
+			Enabled:         provider == assistants.RuntimeProviderLocal || environment == "local",
+			Environment:     environment,
+			OCIImage:        c.String("assistant-runtime-oci-image"),
+			ImageTag:        AssistantRuntimeImageHash,
+			GuestPort:       0,
+			ServerURL:       localRuntimeServerURL,
+			ExtraCACertFile: c.String("assistant-runtime-local-ca-file"),
+		},
 	}, nil
 }
 
@@ -213,8 +247,12 @@ func newAssistantRuntime(
 	}
 
 	// Fly and GKE call back to the server at the same URL; validate it once.
-	if err := guardianPolicy.ValidateHost(ctx, cfg.Fly.ServerURL.Hostname()); err != nil {
-		return nil, fmt.Errorf("assistant runtime requires a public --assistant-runtime-server-url or --server-url; got %q: %w", cfg.Fly.ServerURL.String(), err)
+	// The local backend's URL is exempt: its host gateway alias only resolves
+	// inside containers, never from the host.
+	if cfg.Provider != assistants.RuntimeProviderLocal {
+		if err := guardianPolicy.ValidateHost(ctx, cfg.Fly.ServerURL.Hostname()); err != nil {
+			return nil, fmt.Errorf("assistant runtime requires a public --assistant-runtime-server-url or --server-url; got %q: %w", cfg.Fly.ServerURL.String(), err)
+		}
 	}
 
 	backend, err := assistants.NewRuntimeBackend(logger, tracerProvider, guardianPolicy, cfg)

--- a/server/cmd/gram/flags_assistants_test.go
+++ b/server/cmd/gram/flags_assistants_test.go
@@ -63,11 +63,60 @@ func TestAssistantRuntimeConfigFromCLIFallsBackToServerURL(t *testing.T) {
 	require.Equal(t, serverURL, cfg.Fly.ServerURL)
 }
 
+func TestAssistantRuntimeConfigFromCLIAcceptsLocalProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := newAssistantRuntimeCLIContext(t, map[string]string{
+		"assistant-runtime-provider": assistants.RuntimeProviderLocal,
+		"environment":                "local",
+	})
+
+	serverURL := &url.URL{Scheme: "https", Host: "localhost:8080"}
+	cfg, err := assistantRuntimeConfigFromCLI(ctx, serverURL)
+	require.NoError(t, err)
+	require.Equal(t, assistants.RuntimeProviderLocal, cfg.Provider)
+	require.True(t, cfg.Local.Enabled)
+	// The container-facing URL swaps the host for Docker's host gateway alias
+	// while preserving scheme and port.
+	require.Equal(t, "https://host.docker.internal:8080", cfg.Local.ServerURL.String())
+}
+
+func TestAssistantRuntimeConfigFromCLILocalHonorsOverrideURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := newAssistantRuntimeCLIContext(t, map[string]string{
+		"assistant-runtime-provider":   assistants.RuntimeProviderLocal,
+		"assistant-runtime-server-url": "https://runtime.example.com",
+		"environment":                  "local",
+	})
+
+	cfg, err := assistantRuntimeConfigFromCLI(ctx, &url.URL{Scheme: "https", Host: "localhost:8080"})
+	require.NoError(t, err)
+	require.Equal(t, "https://runtime.example.com", cfg.Local.ServerURL.String())
+}
+
+func TestAssistantRuntimeConfigFromCLIEnablesLocalInLocalEnvironment(t *testing.T) {
+	t.Parallel()
+
+	ctx := newAssistantRuntimeCLIContext(t, map[string]string{
+		"assistant-runtime-provider": assistants.RuntimeProviderFlyIO,
+		"environment":                "local",
+	})
+
+	cfg, err := assistantRuntimeConfigFromCLI(ctx, &url.URL{Scheme: "https", Host: "localhost:8080"})
+	require.NoError(t, err)
+	require.Equal(t, assistants.RuntimeProviderFlyIO, cfg.Provider)
+	// Locally created rows stay routable for cleanup even when targeting
+	// another backend.
+	require.True(t, cfg.Local.Enabled)
+}
+
 func newAssistantRuntimeCLIContext(t *testing.T, values map[string]string) *cli.Context {
 	t.Helper()
 
 	set := flag.NewFlagSet("test", flag.ContinueOnError)
 	require.NoError(t, (&cli.StringFlag{Name: "server-url"}).Apply(set))
+	require.NoError(t, (&cli.StringFlag{Name: "environment"}).Apply(set))
 	for _, item := range functionsFlags {
 		require.NoError(t, item.Apply(set))
 	}

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -909,14 +909,12 @@ WHERE id = @runtime_id
   AND state = @active_state
   AND deleted IS FALSE;
 
--- name: ListActiveAssistantRuntimesForImageRecycle :many
--- Returns live v2 runtime rows that carry backend metadata so a deploy-time
--- sweep can roll their machines onto the current runtime image. Only `active`
--- rows qualify: `starting` rows are mid-boot and already pull the current
--- image, while expiring/stopped rows are torn down or recycled lazily on the
--- next admission. Rows orphaned by a deleted assistant are excluded: they
--- belong to the deleted-assistant janitor, and recycling them would bump
--- updated_at and postpone the inactivity-based reap.
+-- name: ListActiveAssistantRuntimes :many
+-- Returns live v2 runtime rows that carry backend metadata for runtime
+-- reconciliation sweeps. Only `active` rows qualify: `starting` rows are
+-- mid-boot, while expiring/stopped rows are already being torn down or await
+-- re-admission. Rows orphaned by a deleted assistant belong to the
+-- deleted-assistant janitor and are excluded here.
 SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
 FROM assistant_runtimes r
 WHERE r.state = @active_state

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1148,7 +1148,7 @@ func (q *Queries) InsertAssistantThreadEvent(ctx context.Context, arg InsertAssi
 	return id, err
 }
 
-const listActiveAssistantRuntimesForImageRecycle = `-- name: ListActiveAssistantRuntimesForImageRecycle :many
+const listActiveAssistantRuntimes = `-- name: ListActiveAssistantRuntimes :many
 SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
 FROM assistant_runtimes r
 WHERE r.state = $1
@@ -1166,7 +1166,7 @@ WHERE r.state = $1
 ORDER BY r.updated_at ASC
 `
 
-type ListActiveAssistantRuntimesForImageRecycleRow struct {
+type ListActiveAssistantRuntimesRow struct {
 	ID                  uuid.UUID
 	AssistantThreadID   uuid.UUID
 	AssistantID         uuid.UUID
@@ -1177,22 +1177,20 @@ type ListActiveAssistantRuntimesForImageRecycleRow struct {
 	WarmUntil           pgtype.Timestamptz
 }
 
-// Returns live v2 runtime rows that carry backend metadata so a deploy-time
-// sweep can roll their machines onto the current runtime image. Only `active`
-// rows qualify: `starting` rows are mid-boot and already pull the current
-// image, while expiring/stopped rows are torn down or recycled lazily on the
-// next admission. Rows orphaned by a deleted assistant are excluded: they
-// belong to the deleted-assistant janitor, and recycling them would bump
-// updated_at and postpone the inactivity-based reap.
-func (q *Queries) ListActiveAssistantRuntimesForImageRecycle(ctx context.Context, activeState string) ([]ListActiveAssistantRuntimesForImageRecycleRow, error) {
-	rows, err := q.db.Query(ctx, listActiveAssistantRuntimesForImageRecycle, activeState)
+// Returns live v2 runtime rows that carry backend metadata for runtime
+// reconciliation sweeps. Only `active` rows qualify: `starting` rows are
+// mid-boot, while expiring/stopped rows are already being torn down or await
+// re-admission. Rows orphaned by a deleted assistant belong to the
+// deleted-assistant janitor and are excluded here.
+func (q *Queries) ListActiveAssistantRuntimes(ctx context.Context, activeState string) ([]ListActiveAssistantRuntimesRow, error) {
+	rows, err := q.db.Query(ctx, listActiveAssistantRuntimes, activeState)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListActiveAssistantRuntimesForImageRecycleRow
+	var items []ListActiveAssistantRuntimesRow
 	for rows.Next() {
-		var i ListActiveAssistantRuntimesForImageRecycleRow
+		var i ListActiveAssistantRuntimesRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.AssistantThreadID,

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -107,19 +107,22 @@ func (c runnerClient) request(ctx context.Context, baseURL string, r runtimeHTTP
 }
 
 // health polls /healthz until it answers, the timeout elapses, or ctx ends.
+// The whole loop runs under a timeout-scoped context so an in-flight probe
+// cannot overshoot the budget.
 func (c runnerClient) health(ctx context.Context, baseURL string, timeout, poll time.Duration) error {
-	deadline := time.Now().Add(timeout)
+	healthCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	for {
 		probe := runtimeHTTPRequest{Method: http.MethodGet, Path: "/healthz", ContentType: "", Body: nil, MaxTimeSeconds: runnerHealthProbeTimeoutSeconds, IdempotencyKey: ""}
-		if _, err := c.request(ctx, baseURL, probe); err == nil {
+		if _, err := c.request(healthCtx, baseURL, probe); err == nil {
 			return nil
 		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("%w: %s runtime health check timed out", ErrRuntimeUnhealthy, c.backend)
-		}
 		select {
-		case <-ctx.Done():
-			return fmt.Errorf("wait for %s runtime health: %w", c.backend, ctx.Err())
+		case <-healthCtx.Done():
+			if ctx.Err() != nil {
+				return fmt.Errorf("wait for %s runtime health: %w", c.backend, ctx.Err())
+			}
+			return fmt.Errorf("%w: %s runtime health check timed out", ErrRuntimeUnhealthy, c.backend)
 		case <-time.After(poll):
 		}
 	}

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -1,13 +1,17 @@
 package assistants
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/speakeasy-api/gram/server/internal/chat"
 )
@@ -23,6 +27,142 @@ type runtimeHTTPDoer interface {
 // guest VM. Backends use it when wiring service ports on freshly launched
 // machines.
 const defaultRuntimeGuestPort = 8081
+
+const (
+	// runnerDefaultReqTimeout bounds runner HTTP calls that do not carry
+	// their own timeout (state reads and other short requests).
+	runnerDefaultReqTimeout = 2 * time.Minute
+	// runnerHealthProbeTimeoutSeconds caps a single /healthz probe so one
+	// stalled probe cannot overshoot a backend's overall health budget.
+	runnerHealthProbeTimeoutSeconds = 2
+	// runnerMaxResponseBytes bounds runner response reads so a misbehaving
+	// runner cannot exhaust server memory.
+	runnerMaxResponseBytes = 4 << 20
+)
+
+// runtimeResourcePrefix names runner resources across backends (GKE claims,
+// local containers and volumes).
+const runtimeResourcePrefix = "gram-asst"
+
+// Runner workloads are labelled with assistant/project identity across
+// backends (GKE claim labels, local container labels) so owned resources can
+// be rediscovered and filtered uniformly.
+const (
+	runtimeLabelAssistantID          = "gram.speakeasy.com/assistant-id"
+	runtimeLabelProjectID            = "gram.speakeasy.com/project-id"
+	runtimeLabelRole                 = "gram.speakeasy.com/role"
+	runtimeLabelRoleAssistantRuntime = "assistant_runtime"
+)
+
+// runtimeImageRef joins an image repository and tag into the "<repo>[:<tag>]"
+// reference form backends launch machines with and compare against.
+func runtimeImageRef(image, tag string) string {
+	if tag == "" {
+		return image
+	}
+	return image + ":" + tag
+}
+
+// runnerClient speaks the runner HTTP protocol for backends that dial the
+// runner directly by base URL (GKE pod IPs, local containers). Fly keeps its
+// own request layer for machine pinning and response-size limits.
+type runnerClient struct {
+	do      runtimeHTTPDoer
+	backend string
+}
+
+func (c runnerClient) request(ctx context.Context, baseURL string, r runtimeHTTPRequest) ([]byte, error) {
+	reqCtx, cancel := runtimeRequestContext(ctx, r.MaxTimeSeconds, runnerDefaultReqTimeout)
+	defer cancel()
+
+	var reader io.Reader
+	if r.Body != nil {
+		reader = bytes.NewReader(r.Body)
+	}
+	req, err := http.NewRequestWithContext(reqCtx, r.Method, baseURL+r.Path, reader)
+	if err != nil {
+		return nil, fmt.Errorf("build %s runtime request: %w", c.backend, err)
+	}
+	if r.ContentType != "" {
+		req.Header.Set("Content-Type", r.ContentType)
+	}
+	if r.IdempotencyKey != "" {
+		req.Header.Set("X-Idempotency-Key", r.IdempotencyKey)
+	}
+
+	resp, err := c.do.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute %s runtime request: %w", c.backend, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, runnerMaxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read %s runtime response: %w", c.backend, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &runtimeResponseError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(respBody))}
+	}
+	return respBody, nil
+}
+
+// health polls /healthz until it answers, the timeout elapses, or ctx ends.
+func (c runnerClient) health(ctx context.Context, baseURL string, timeout, poll time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		probe := runtimeHTTPRequest{Method: http.MethodGet, Path: "/healthz", ContentType: "", Body: nil, MaxTimeSeconds: runnerHealthProbeTimeoutSeconds, IdempotencyKey: ""}
+		if _, err := c.request(ctx, baseURL, probe); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w: %s runtime health check timed out", ErrRuntimeUnhealthy, c.backend)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for %s runtime health: %w", c.backend, ctx.Err())
+		case <-time.After(poll):
+		}
+	}
+}
+
+func (c runnerClient) state(ctx context.Context, baseURL string) (runnerStateResponse, error) {
+	body, err := c.request(ctx, baseURL, runtimeHTTPRequest{Method: http.MethodGet, Path: "/state", ContentType: "", Body: nil, MaxTimeSeconds: 0, IdempotencyKey: ""})
+	if err != nil {
+		return runnerStateResponse{}, err
+	}
+	var state runnerStateResponse
+	if err := json.Unmarshal(body, &state); err != nil {
+		return runnerStateResponse{}, fmt.Errorf("decode %s runtime state: %w", c.backend, err)
+	}
+	return state, nil
+}
+
+// turn delivers a turn to /threads/{threadID}/turn, wrapping failures with
+// the classifyTurnError sentinel the service dispatches on.
+func (c runnerClient) turn(ctx context.Context, baseURL string, runtime assistantRuntimeRecord, threadID uuid.UUID, idempotencyKey, authToken, prompt string, mcpServers []runtimeMCPServer, timeout time.Duration) error {
+	reqBody, err := json.Marshal(runtimeTurnRequest{
+		Input:       prompt,
+		AuthToken:   authToken,
+		MCPServers:  mcpServers,
+		AssistantID: runtime.AssistantID.String(),
+		ProjectID:   runtime.ProjectID.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s runtime turn request: %w", c.backend, err)
+	}
+	req := runtimeHTTPRequest{
+		Method:         http.MethodPost,
+		Path:           "/threads/" + threadID.String() + "/turn",
+		ContentType:    "application/json",
+		Body:           reqBody,
+		MaxTimeSeconds: int(timeout / time.Second),
+		IdempotencyKey: idempotencyKey,
+	}
+	if _, err := c.request(ctx, baseURL, req); err != nil {
+		return fmt.Errorf("%w: execute %s turn request: %w", classifyTurnError(err), c.backend, err)
+	}
+	return nil
+}
 
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -52,6 +52,7 @@ const (
 	runtimeLabelProjectID            = "gram.speakeasy.com/project-id"
 	runtimeLabelRole                 = "gram.speakeasy.com/role"
 	runtimeLabelRoleAssistantRuntime = "assistant_runtime"
+	runtimeLabelSpecHash             = "gram.speakeasy.com/spec-hash"
 )
 
 // runtimeImageRef joins an image repository and tag into the "<repo>[:<tag>]"

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -63,6 +63,14 @@ type RuntimeBackend interface {
 	ReapStoppedMachine(ctx context.Context, runtime assistantRuntimeRecord) error
 }
 
+// runtimeLivenessChecker is implemented by backends that can cheaply and
+// authoritatively determine whether a runtime's backing resource still
+// exists. The stuck-runtime janitor uses it to reconcile resources removed
+// outside Gram without imposing provider API scans on every backend.
+type runtimeLivenessChecker interface {
+	RuntimeExists(ctx context.Context, runtime assistantRuntimeRecord) (bool, error)
+}
+
 type RuntimeBackendEnsureResult struct {
 	ColdStart           bool
 	BackendMetadataJSON []byte

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -705,7 +705,7 @@ func (f *FlyRuntimeBackend) RecycleImage(ctx context.Context, runtime assistantR
 // desiredImageRef returns the configured runtime image reference in the same
 // "<repo>:<tag>" form fly's MachineImageRef serialises into.
 func (f *FlyRuntimeBackend) desiredImageRef() string {
-	return fmt.Sprintf("%s:%s", f.config.OCIImage, f.config.ImageTag)
+	return runtimeImageRef(f.config.OCIImage, f.config.ImageTag)
 }
 
 // machineImageRef rebuilds the "<registry>/<repo>:<tag>" form from a fly

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -1,14 +1,11 @@
 package assistants
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -39,16 +36,10 @@ const (
 	gkeRuntimePollInterval  = time.Second
 	// gkeRuntimeReapCallTimeout caps a single delete during reap so one wedged
 	// row cannot consume the parent activity's deadline.
-	gkeRuntimeReapCallTimeout   = 30 * time.Second
-	gkeRuntimeDefaultReqTimeout = 2 * time.Minute
-	gkeRuntimeTurnTimeout       = 30 * time.Minute
+	gkeRuntimeReapCallTimeout = 30 * time.Second
+	gkeRuntimeTurnTimeout     = 30 * time.Minute
 
 	gkeSandboxReadyConditionType = "Ready"
-
-	gkeMetadataAssistantID = "gram.speakeasy.com/assistant-id"
-	gkeMetadataProjectID   = "gram.speakeasy.com/project-id"
-	gkeMetadataRole        = "gram.speakeasy.com/role"
-	gkeMetadataRoleValue   = "assistant_runtime"
 
 	// gkeClaimUIDLabel is injected by the SandboxClaim controller onto the pod,
 	// carrying the owning claim's UID. We resolve the runner pod (for its IP) by
@@ -135,10 +126,10 @@ type gkeRuntimeMetadata struct {
 }
 
 type GKERuntimeBackend struct {
-	logger     *slog.Logger
-	tracer     trace.Tracer
-	config     GKERuntimeConfig
-	httpClient runtimeHTTPDoer
+	logger *slog.Logger
+	tracer trace.Tracer
+	config GKERuntimeConfig
+	runner runnerClient
 }
 
 func NewGKERuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider, httpClient runtimeHTTPDoer, config GKERuntimeConfig) *GKERuntimeBackend {
@@ -146,10 +137,10 @@ func NewGKERuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvid
 		config.GuestPort = defaultRuntimeGuestPort
 	}
 	return &GKERuntimeBackend{
-		logger:     logger.With(attr.SlogComponent("assistants_gke")),
-		tracer:     tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/assistants"),
-		config:     config,
-		httpClient: httpClient,
+		logger: logger.With(attr.SlogComponent("assistants_gke")),
+		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/assistants"),
+		config: config,
+		runner: runnerClient{do: httpClient, backend: runtimeBackendGKE},
 	}
 }
 
@@ -170,14 +161,11 @@ func (g *GKERuntimeBackend) ImageRef() string { return g.desiredImageRef() }
 func (g *GKERuntimeBackend) ReusesIdleRuntimes() bool { return false }
 
 func (g *GKERuntimeBackend) desiredImageRef() string {
-	if g.config.ImageTag == "" {
-		return g.config.OCIImage
-	}
-	return g.config.OCIImage + ":" + g.config.ImageTag
+	return runtimeImageRef(g.config.OCIImage, g.config.ImageTag)
 }
 
 func (g *GKERuntimeBackend) claimName(runtime assistantRuntimeRecord) string {
-	return "gram-asst-" + strings.ToLower(runtime.AssistantID.String())
+	return runtimeResourcePrefix + "-" + strings.ToLower(runtime.AssistantID.String())
 }
 
 func (g *GKERuntimeBackend) claims() dynamic.ResourceInterface {
@@ -240,7 +228,7 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 	}
 	metadata.Image = g.desiredImageRef()
 
-	if err := g.waitForHealth(ctx, metadata); err != nil {
+	if err := g.runner.health(ctx, g.endpoint(metadata), gkeRuntimeHealthTimeout, 500*time.Millisecond); err != nil {
 		return RuntimeBackendEnsureResult{}, err
 	}
 
@@ -253,9 +241,9 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 
 func (g *GKERuntimeBackend) buildClaim(name string, runtime assistantRuntimeRecord) *unstructured.Unstructured {
 	labels := map[string]any{
-		gkeMetadataAssistantID: strings.ToLower(runtime.AssistantID.String()),
-		gkeMetadataProjectID:   strings.ToLower(runtime.ProjectID.String()),
-		gkeMetadataRole:        gkeMetadataRoleValue,
+		runtimeLabelAssistantID: strings.ToLower(runtime.AssistantID.String()),
+		runtimeLabelProjectID:   strings.ToLower(runtime.ProjectID.String()),
+		runtimeLabelRole:        runtimeLabelRoleAssistantRuntime,
 	}
 	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": gkeSandboxClaimGVR.Group + "/" + gkeSandboxClaimGVR.Version,
@@ -362,23 +350,6 @@ func (g *GKERuntimeBackend) endpoint(metadata gkeRuntimeMetadata) string {
 	return fmt.Sprintf("http://%s:%d", metadata.PodIP, g.config.GuestPort)
 }
 
-func (g *GKERuntimeBackend) waitForHealth(ctx context.Context, metadata gkeRuntimeMetadata) error {
-	deadline := time.Now().Add(gkeRuntimeHealthTimeout)
-	for {
-		if _, err := g.doRequest(ctx, metadata, http.MethodGet, "/healthz", nil, "", "", 0); err == nil {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("%w: gke runtime health check timed out", ErrRuntimeUnhealthy)
-		}
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("wait for gke runtime health: %w", ctx.Err())
-		case <-time.After(500 * time.Millisecond):
-		}
-	}
-}
-
 func (g *GKERuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntimeRecord, threadID uuid.UUID, idempotencyKey string, authToken string, prompt string, mcpServers []runtimeMCPServer) error {
 	if err := validateRuntimeBackend(g, runtime.Backend); err != nil {
 		return err
@@ -391,20 +362,7 @@ func (g *GKERuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 		return fmt.Errorf("%w: gke runtime pod ip is not available", ErrRuntimeUnhealthy)
 	}
 
-	reqBody, err := json.Marshal(runtimeTurnRequest{
-		Input:       prompt,
-		AuthToken:   authToken,
-		MCPServers:  mcpServers,
-		AssistantID: runtime.AssistantID.String(),
-		ProjectID:   runtime.ProjectID.String(),
-	})
-	if err != nil {
-		return fmt.Errorf("marshal gke runtime turn request: %w", err)
-	}
-	if _, err := g.doRequest(ctx, metadata, http.MethodPost, "/threads/"+threadID.String()+"/turn", reqBody, "application/json", idempotencyKey, gkeRuntimeTurnTimeout); err != nil {
-		return fmt.Errorf("%w: execute gke turn request: %w", classifyTurnError(err), err)
-	}
-	return nil
+	return g.runner.turn(ctx, g.endpoint(metadata), runtime, threadID, idempotencyKey, authToken, prompt, mcpServers, gkeRuntimeTurnTimeout)
 }
 
 func (g *GKERuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
@@ -418,13 +376,9 @@ func (g *GKERuntimeBackend) Status(ctx context.Context, runtime assistantRuntime
 	if metadata.PodIP == "" {
 		return RuntimeBackendStatus{}, fmt.Errorf("%w: gke runtime pod ip is not available", ErrRuntimeUnhealthy)
 	}
-	body, err := g.doRequest(ctx, metadata, http.MethodGet, "/state", nil, "", "", 0)
+	state, err := g.runner.state(ctx, g.endpoint(metadata))
 	if err != nil {
 		return RuntimeBackendStatus{}, fmt.Errorf("load gke runtime state: %w", err)
-	}
-	var state runnerStateResponse
-	if err := json.Unmarshal(body, &state); err != nil {
-		return RuntimeBackendStatus{}, fmt.Errorf("decode gke runtime state: %w", err)
 	}
 	return RuntimeBackendStatus{Configured: true, IdleSeconds: state.minThreadIdle()}, nil
 }
@@ -481,45 +435,6 @@ func (g *GKERuntimeBackend) RecycleImage(ctx context.Context, runtime assistantR
 		return RuntimeBackendRecycleResult{}, err
 	}
 	return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
-}
-
-func (g *GKERuntimeBackend) doRequest(ctx context.Context, metadata gkeRuntimeMetadata, method, path string, body []byte, contentType, idempotencyKey string, maxTimeout time.Duration) ([]byte, error) {
-	fallback := gkeRuntimeDefaultReqTimeout
-	if maxTimeout > 0 {
-		fallback = maxTimeout
-	}
-	reqCtx, cancel := context.WithTimeout(ctx, fallback)
-	defer cancel()
-
-	var reader io.Reader
-	if body != nil {
-		reader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(reqCtx, method, g.endpoint(metadata)+path, reader)
-	if err != nil {
-		return nil, fmt.Errorf("build gke runtime request: %w", err)
-	}
-	if contentType != "" {
-		req.Header.Set("Content-Type", contentType)
-	}
-	if idempotencyKey != "" {
-		req.Header.Set("X-Idempotency-Key", idempotencyKey)
-	}
-
-	resp, err := g.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("execute gke runtime request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read gke runtime response: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &runtimeResponseError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(respBody))}
-	}
-	return respBody, nil
 }
 
 func decodeGKERuntimeMetadata(raw []byte) (gkeRuntimeMetadata, error) {

--- a/server/internal/assistants/runtime_local.go
+++ b/server/internal/assistants/runtime_local.go
@@ -2,11 +2,15 @@ package assistants
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -86,6 +90,9 @@ type localContainerInfo struct {
 	ID      string
 	Running bool
 	ImageID string
+	// SpecHash is the runtimeLabelSpecHash label stamped at creation. Empty
+	// for containers created before the label existed.
+	SpecHash string
 	// HostPort is the loopback port the runner guest port is published on.
 	// Zero when the container is not running (ephemeral publishes are
 	// re-assigned on every start).
@@ -254,13 +261,16 @@ func (l *LocalRuntimeBackend) Ensure(ctx context.Context, runtime assistantRunti
 		return RuntimeBackendEnsureResult{}, fmt.Errorf("inspect local runtime container %s: %w", name, err)
 	}
 
-	// A rebuilt image changes the image ID under the same tag. Replace the
-	// container when it is safe: a busy runner (a turn in flight) keeps its
-	// current container and a later admission picks the new image up. The
-	// workspace volume always survives replacement. Removal targets the
-	// inspected incarnation's ID, not the name, so a racing Ensure can never
-	// tear down a replacement it did not examine.
-	if exists && info.ImageID != desiredImageID && !l.runnerBusy(ctx, info) {
+	// A rebuilt image changes the image ID under the same tag, and a config
+	// change (server URL, CA file) changes the spec hash — both are frozen
+	// into the container at creation, so drift on either means replace, not
+	// warm-restart. Replacement only happens when it is safe: a busy runner
+	// (a turn in flight) keeps its current container and a later admission
+	// picks the change up. The workspace volume always survives replacement.
+	// Removal targets the inspected incarnation's ID, not the name, so a
+	// racing Ensure can never tear down a replacement it did not examine.
+	desiredSpecHash := l.containerSpec(runtime, name).Labels[runtimeLabelSpecHash]
+	if exists && (info.ImageID != desiredImageID || info.SpecHash != desiredSpecHash) && !l.runnerBusy(ctx, info) {
 		if err := l.engine.Remove(ctx, info.ID); err != nil {
 			return RuntimeBackendEnsureResult{}, fmt.Errorf("remove drifted local runtime container %s: %w", name, err)
 		}
@@ -268,7 +278,7 @@ func (l *LocalRuntimeBackend) Ensure(ctx context.Context, runtime assistantRunti
 	}
 
 	if !exists {
-		info = localContainerInfo{ID: "", Running: false, ImageID: "", HostPort: 0}
+		info = localContainerInfo{ID: "", Running: false, ImageID: "", SpecHash: "", HostPort: 0}
 	}
 	coldStart := !info.Running
 	payload, err := l.startContainer(ctx, runtime, name, info, exists)
@@ -375,7 +385,7 @@ func (l *LocalRuntimeBackend) startContainer(ctx context.Context, runtime assist
 }
 
 func (l *LocalRuntimeBackend) containerSpec(runtime assistantRuntimeRecord, name string) localContainerSpec {
-	return localContainerSpec{
+	spec := localContainerSpec{
 		Name:  name,
 		Image: l.desiredImageRef(),
 		Labels: map[string]string{
@@ -391,12 +401,28 @@ func (l *LocalRuntimeBackend) containerSpec(runtime assistantRuntimeRecord, name
 		VolumeName:      localVolumeName(runtime),
 		ExtraCACertFile: l.config.ExtraCACertFile,
 	}
+	spec.Labels[runtimeLabelSpecHash] = localContainerSpecHash(spec)
+	return spec
 }
 
-// RecycleImage replaces an idle container whose image ID drifted from the
-// currently built image, without launching anything for rows that have no
-// container. Busy runners are skipped — the next admission's Ensure picks the
-// new image up lazily.
+// localContainerSpecHash fingerprints the parts of a container spec that are
+// frozen at creation (env, image reference, mounts) and cannot be changed on
+// an existing container. Stamped as a label so Ensure and RecycleImage detect
+// config drift and replace the container instead of warm-restarting a stale
+// incarnation.
+func localContainerSpecHash(spec localContainerSpec) string {
+	parts := []string{"image=" + spec.Image, "volume=" + spec.VolumeName, "ca=" + spec.ExtraCACertFile}
+	for _, key := range slices.Sorted(maps.Keys(spec.Env)) {
+		parts = append(parts, "env."+key+"="+spec.Env[key])
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return hex.EncodeToString(sum[:8])
+}
+
+// RecycleImage replaces an idle container whose image ID or creation-time
+// config drifted from the current spec, without launching anything for rows
+// that have no container. Busy runners are skipped — the next admission's
+// Ensure picks the change up lazily.
 func (l *LocalRuntimeBackend) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
 	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
 		return RuntimeBackendRecycleResult{}, err
@@ -418,14 +444,15 @@ func (l *LocalRuntimeBackend) RecycleImage(ctx context.Context, runtime assistan
 	// A stopped container is never resurrected here — its row may be expired
 	// or stopped on purpose, and the next admission's Ensure picks the new
 	// image up anyway.
-	if !info.Running || info.ImageID == desiredImageID || l.runnerBusy(ctx, info) {
+	desiredSpecHash := l.containerSpec(runtime, name).Labels[runtimeLabelSpecHash]
+	if !info.Running || (info.ImageID == desiredImageID && info.SpecHash == desiredSpecHash) || l.runnerBusy(ctx, info) {
 		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
 	}
 
 	if err := l.engine.Remove(ctx, info.ID); err != nil {
 		return RuntimeBackendRecycleResult{}, fmt.Errorf("remove drifted local runtime container %s: %w", name, err)
 	}
-	payload, err := l.startContainer(ctx, runtime, name, localContainerInfo{ID: "", Running: false, ImageID: "", HostPort: 0}, false)
+	payload, err := l.startContainer(ctx, runtime, name, localContainerInfo{ID: "", Running: false, ImageID: "", SpecHash: "", HostPort: 0}, false)
 	if err != nil {
 		return RuntimeBackendRecycleResult{}, err
 	}

--- a/server/internal/assistants/runtime_local.go
+++ b/server/internal/assistants/runtime_local.go
@@ -1,0 +1,519 @@
+package assistants
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const runtimeBackendLocal = "local"
+
+// LocalRuntimeHostGatewayAlias is the hostname containers reach the host on.
+// Docker Desktop resolves it natively; on native Linux engines the backend
+// adds a host-gateway alias for it on every container.
+const LocalRuntimeHostGatewayAlias = "host.docker.internal"
+
+const (
+	// localRuntimeHealthTimeout bounds the runner /healthz wait after a
+	// container (re)start. The image is already present on the local daemon,
+	// so there is no pull cost — this only covers the runner boot.
+	localRuntimeHealthTimeout   = 60 * time.Second
+	localRuntimeHealthPollDelay = 250 * time.Millisecond
+	localRuntimeTurnTimeout     = 30 * time.Minute
+
+	// localRuntimeWorkdirMountPath is where the per-assistant workspace volume
+	// mounts inside the container. It matches the runner init script's workdir:
+	// the unprivileged container cannot mount tmpfs over it, so init falls back
+	// to symlinking the sandbox deps into the (volume-backed) directory.
+	localRuntimeWorkdirMountPath = "/var/lib/gram-assistant/work"
+	// localRuntimeCACertMountPath is where the optional extra CA bundle is
+	// bind-mounted read-only. The runner init script appends it to the system
+	// trust store so the runner (and its sandbox children) trust the local
+	// mkcert-issued server certificate.
+	localRuntimeCACertMountPath = "/usr/local/share/gram/extra-ca.pem"
+)
+
+// localRuntimeLoopbackCIDRs is the narrowly scoped guardian allowlist for the
+// local backend's runner client: containers publish the runner guest port on a
+// loopback ephemeral port, which the default egress policy blocks as SSRF.
+// Only this one client is relaxed; the policy's global enforcement is unchanged.
+var localRuntimeLoopbackCIDRs = []string{"127.0.0.0/8", "::1/128"}
+
+var (
+	errLocalContainerNotFound  = errors.New("local runtime container not found")
+	errLocalContainerNameInUse = errors.New("local runtime container name in use")
+	errLocalImageNotFound      = errors.New("local runtime image not found")
+)
+
+// containerEngine is the narrow surface of a Docker-compatible engine the
+// local backend needs. Production shells out to the docker CLI
+// (dockerCLIEngine); tests use a fake.
+type containerEngine interface {
+	// ImageID resolves an image reference to its content-addressed ID.
+	// Returns errLocalImageNotFound when the image is absent.
+	ImageID(ctx context.Context, imageRef string) (string, error)
+	// Inspect returns the current state of a named container. Returns
+	// errLocalContainerNotFound when absent.
+	Inspect(ctx context.Context, name string) (localContainerInfo, error)
+	// Run creates and starts a container. Returns errLocalContainerNameInUse
+	// when a container with the spec's name already exists.
+	Run(ctx context.Context, spec localContainerSpec) (containerID string, err error)
+	// Start starts a stopped container.
+	Start(ctx context.Context, name string) error
+	// Stop stops a running container. Idempotent: a missing or already
+	// stopped container is success.
+	Stop(ctx context.Context, name string) error
+	// Remove force-removes a container (by name or ID) regardless of state.
+	// Idempotent.
+	Remove(ctx context.Context, nameOrID string) error
+	// RemoveVolume removes a named volume. Idempotent.
+	RemoveVolume(ctx context.Context, name string) error
+}
+
+type localContainerInfo struct {
+	ID      string
+	Running bool
+	ImageID string
+	// HostPort is the loopback port the runner guest port is published on.
+	// Zero when the container is not running (ephemeral publishes are
+	// re-assigned on every start).
+	HostPort int
+}
+
+type localContainerSpec struct {
+	Name   string
+	Image  string
+	Labels map[string]string
+	Env    map[string]string
+	// VolumeName is mounted at localRuntimeWorkdirMountPath.
+	VolumeName string
+	// ExtraCACertFile, when set, is a host path bind-mounted read-only at
+	// localRuntimeCACertMountPath.
+	ExtraCACertFile string
+}
+
+// LocalRuntimeConfig configures the local Docker-backed assistant runtime
+// backend used for image development on a developer machine.
+type LocalRuntimeConfig struct {
+	// Enabled controls whether the backend is constructed. It is on whenever
+	// the process runs in the local environment (so locally created rows stay
+	// routable even when targeting another backend) or when local is the
+	// target provider.
+	Enabled bool
+	// Environment must be "local": the backend launches containers on the
+	// host's Docker daemon and dials them over loopback, which has no place in
+	// a deployed process.
+	Environment string
+	OCIImage    string
+	ImageTag    string
+	GuestPort   int
+	// ServerURL is the management API base as reachable from inside a
+	// container — typically the --server-url with its host rewritten to
+	// host.docker.internal.
+	ServerURL *url.URL
+	// ExtraCACertFile optionally points at a PEM CA bundle (typically the
+	// mkcert root CA) mounted into containers so the runner trusts the local
+	// server's TLS certificate.
+	ExtraCACertFile string
+}
+
+func (c LocalRuntimeConfig) Validate() error {
+	if c.Environment != "local" {
+		return fmt.Errorf("assistant runtime provider %q is only supported when --environment=local; got %q", runtimeBackendLocal, c.Environment)
+	}
+	if c.OCIImage == "" {
+		return fmt.Errorf("--assistant-runtime-oci-image is required")
+	}
+	if c.ServerURL == nil || c.ServerURL.Hostname() == "" {
+		return fmt.Errorf("local assistant runtime requires a container-reachable --assistant-runtime-server-url or --server-url")
+	}
+	return nil
+}
+
+// localRuntimeMetadata is persisted opaquely in
+// assistant_runtimes.backend_metadata_json for local-backed rows. HostPort is
+// only valid for the container incarnation that Ensure observed: an
+// out-of-band restart re-assigns the ephemeral publish, which surfaces as
+// ErrRuntimeUnhealthy on the next turn and self-heals through re-admission.
+type localRuntimeMetadata struct {
+	ContainerID   string `json:"container_id"`
+	ContainerName string `json:"container_name"`
+	HostPort      int    `json:"host_port"`
+}
+
+// LocalRuntimeBackend runs one Docker container per assistant on the
+// developer's machine. Containers are named deterministically per assistant
+// and labelled with assistant/project identity, so Ensure is idempotent and a
+// restarted server rediscovers containers it launched before. The runner guest
+// port is published to an ephemeral loopback port that is re-resolved on every
+// (re)start.
+type LocalRuntimeBackend struct {
+	logger *slog.Logger
+	tracer trace.Tracer
+	config LocalRuntimeConfig
+	engine containerEngine
+	runner runnerClient
+	// healthTimeout is localRuntimeHealthTimeout; tests shrink it.
+	healthTimeout time.Duration
+}
+
+func NewLocalRuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider, httpClient runtimeHTTPDoer, engine containerEngine, config LocalRuntimeConfig) *LocalRuntimeBackend {
+	if config.GuestPort == 0 {
+		config.GuestPort = defaultRuntimeGuestPort
+	}
+	return &LocalRuntimeBackend{
+		logger:        logger.With(attr.SlogComponent("assistants_local")),
+		tracer:        tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/assistants"),
+		config:        config,
+		engine:        engine,
+		runner:        runnerClient{do: httpClient, backend: runtimeBackendLocal},
+		healthTimeout: localRuntimeHealthTimeout,
+	}
+}
+
+func (l *LocalRuntimeBackend) Backend() string { return runtimeBackendLocal }
+
+func (l *LocalRuntimeBackend) SupportsBackend(backend string) bool {
+	return backend == runtimeBackendLocal
+}
+
+func (l *LocalRuntimeBackend) ServerURL() *url.URL { return l.config.ServerURL }
+
+func (l *LocalRuntimeBackend) ImageRef() string { return l.desiredImageRef() }
+
+// ReusesIdleRuntimes is true: Stop leaves the container and its workspace
+// volume in place, and the next admission restarts the same container.
+func (l *LocalRuntimeBackend) ReusesIdleRuntimes() bool { return true }
+
+func (l *LocalRuntimeBackend) desiredImageRef() string {
+	return runtimeImageRef(l.config.OCIImage, l.config.ImageTag)
+}
+
+func localContainerName(runtime assistantRuntimeRecord) string {
+	return runtimeResourcePrefix + "-" + strings.ToLower(runtime.AssistantID.String())
+}
+
+func localVolumeName(runtime assistantRuntimeRecord) string {
+	return runtimeResourcePrefix + "-work-" + strings.ToLower(runtime.AssistantID.String())
+}
+
+func localRuntimeEndpoint(hostPort int) string {
+	return "http://127.0.0.1:" + strconv.Itoa(hostPort)
+}
+
+// resolveDesiredImageID resolves the configured image reference to its local
+// image ID. Image rebuilds keep the same tag (locally always :dev) while the
+// ID changes, so drift is detected by ID rather than by tag.
+func (l *LocalRuntimeBackend) resolveDesiredImageID(ctx context.Context) (string, error) {
+	imageID, err := l.engine.ImageID(ctx, l.desiredImageRef())
+	if errors.Is(err, errLocalImageNotFound) {
+		return "", fmt.Errorf("assistant runtime image %q is not available locally: build it with `mise run build:assistants-runtime-image`: %w", l.desiredImageRef(), err)
+	}
+	if err != nil {
+		return "", fmt.Errorf("resolve local runtime image id: %w", err)
+	}
+	return imageID, nil
+}
+
+func (l *LocalRuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntimeRecord) (result RuntimeBackendEnsureResult, err error) {
+	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+
+	ctx, span := l.tracer.Start(ctx, "assistants.runtime.local.ensure")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	desiredImageID, err := l.resolveDesiredImageID(ctx)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+
+	name := localContainerName(runtime)
+	info, err := l.engine.Inspect(ctx, name)
+	exists := true
+	if errors.Is(err, errLocalContainerNotFound) {
+		exists = false
+	} else if err != nil {
+		return RuntimeBackendEnsureResult{}, fmt.Errorf("inspect local runtime container %s: %w", name, err)
+	}
+
+	// A rebuilt image changes the image ID under the same tag. Replace the
+	// container when it is safe: a busy runner (a turn in flight) keeps its
+	// current container and a later admission picks the new image up. The
+	// workspace volume always survives replacement. Removal targets the
+	// inspected incarnation's ID, not the name, so a racing Ensure can never
+	// tear down a replacement it did not examine.
+	if exists && info.ImageID != desiredImageID && !l.runnerBusy(ctx, info) {
+		if err := l.engine.Remove(ctx, info.ID); err != nil {
+			return RuntimeBackendEnsureResult{}, fmt.Errorf("remove drifted local runtime container %s: %w", name, err)
+		}
+		exists = false
+	}
+
+	if !exists {
+		info = localContainerInfo{ID: "", Running: false, ImageID: "", HostPort: 0}
+	}
+	coldStart := !info.Running
+	payload, err := l.startContainer(ctx, runtime, name, info, exists)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+	return RuntimeBackendEnsureResult{ColdStart: coldStart, BackendMetadataJSON: payload}, nil
+}
+
+// runnerBusy reports whether the container's runner has a turn in flight. Any
+// probe failure counts as busy so a replace never races an unreachable-but-
+// live runner.
+func (l *LocalRuntimeBackend) runnerBusy(ctx context.Context, info localContainerInfo) bool {
+	if !info.Running {
+		return false
+	}
+	if info.HostPort == 0 {
+		return true
+	}
+	state, err := l.runner.state(ctx, localRuntimeEndpoint(info.HostPort))
+	if err != nil {
+		return true
+	}
+	idle := state.minThreadIdle()
+	return idle != nil && *idle == 0
+}
+
+// startContainer converges the named container onto a running, healthy state
+// and returns the encoded runtime metadata: it launches a fresh container when
+// none exists (adopting one a racing Ensure created), restarts a stopped one,
+// and waits for runner health. The caller passes its inspect result via
+// info/exists so the warm path costs no extra engine calls. A container this
+// call created is removed again on any subsequent failure, so the next
+// admission relaunches cleanly instead of adopting a wedged container; the
+// workspace volume is never part of that cleanup.
+func (l *LocalRuntimeBackend) startContainer(ctx context.Context, runtime assistantRuntimeRecord, name string, info localContainerInfo, exists bool) (payload []byte, err error) {
+	needInspect := false
+	if !exists {
+		_, runErr := l.engine.Run(ctx, l.containerSpec(runtime, name))
+		switch {
+		case runErr == nil:
+			needInspect = true
+			// Clean up the container this call created on every error exit,
+			// with a fresh context so cleanup still runs on ctx timeout.
+			defer func() {
+				if err == nil {
+					return
+				}
+				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+				defer cancel()
+				if removeErr := l.engine.Remove(cleanupCtx, name); removeErr != nil {
+					l.logger.WarnContext(ctx, "remove local runtime container after failed launch",
+						attr.SlogAssistantID(runtime.AssistantID.String()),
+						attr.SlogError(removeErr),
+					)
+				}
+			}()
+		case errors.Is(runErr, errLocalContainerNameInUse):
+			// A racing Ensure created the container between our inspect and
+			// run; adopt it.
+			needInspect = true
+		default:
+			return nil, fmt.Errorf("run local runtime container %s: %w", name, runErr)
+		}
+	} else if !info.Running {
+		if startErr := l.engine.Start(ctx, name); startErr != nil {
+			return nil, fmt.Errorf("start local runtime container %s: %w", name, startErr)
+		}
+		needInspect = true
+	}
+
+	// Re-inspect only after a launch or start: ephemeral loopback publishes
+	// are re-assigned on every container start, so the persisted port is only
+	// valid for the current incarnation. The warm path keeps the caller's
+	// inspect result.
+	if needInspect {
+		fresh, inspectErr := l.engine.Inspect(ctx, name)
+		if inspectErr != nil {
+			return nil, fmt.Errorf("inspect local runtime container %s after start: %w", name, inspectErr)
+		}
+		info = fresh
+	}
+	if !info.Running || info.HostPort == 0 {
+		return nil, fmt.Errorf("%w: local runtime container %s is not running with a published port", ErrRuntimeUnhealthy, name)
+	}
+
+	if err := l.runner.health(ctx, localRuntimeEndpoint(info.HostPort), l.healthTimeout, localRuntimeHealthPollDelay); err != nil {
+		return nil, err
+	}
+
+	metadata := localRuntimeMetadata{
+		ContainerID:   info.ID,
+		ContainerName: name,
+		HostPort:      info.HostPort,
+	}
+	payload, err = json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("encode local runtime metadata: %w", err)
+	}
+	return payload, nil
+}
+
+func (l *LocalRuntimeBackend) containerSpec(runtime assistantRuntimeRecord, name string) localContainerSpec {
+	return localContainerSpec{
+		Name:  name,
+		Image: l.desiredImageRef(),
+		Labels: map[string]string{
+			runtimeLabelAssistantID: strings.ToLower(runtime.AssistantID.String()),
+			runtimeLabelProjectID:   strings.ToLower(runtime.ProjectID.String()),
+			runtimeLabelRole:        runtimeLabelRoleAssistantRuntime,
+		},
+		Env: map[string]string{
+			"GRAM_ASSISTANT_ID":         runtime.AssistantID.String(),
+			"GRAM_ASSISTANT_PROJECT_ID": runtime.ProjectID.String(),
+			"GRAM_SERVER_URL":           l.config.ServerURL.String(),
+		},
+		VolumeName:      localVolumeName(runtime),
+		ExtraCACertFile: l.config.ExtraCACertFile,
+	}
+}
+
+// RecycleImage replaces an idle container whose image ID drifted from the
+// currently built image, without launching anything for rows that have no
+// container. Busy runners are skipped — the next admission's Ensure picks the
+// new image up lazily.
+func (l *LocalRuntimeBackend) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
+	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+
+	desiredImageID, err := l.resolveDesiredImageID(ctx)
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+
+	name := localContainerName(runtime)
+	info, err := l.engine.Inspect(ctx, name)
+	if errors.Is(err, errLocalContainerNotFound) {
+		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
+	}
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, fmt.Errorf("inspect local runtime container %s: %w", name, err)
+	}
+	// A stopped container is never resurrected here — its row may be expired
+	// or stopped on purpose, and the next admission's Ensure picks the new
+	// image up anyway.
+	if !info.Running || info.ImageID == desiredImageID || l.runnerBusy(ctx, info) {
+		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
+	}
+
+	if err := l.engine.Remove(ctx, info.ID); err != nil {
+		return RuntimeBackendRecycleResult{}, fmt.Errorf("remove drifted local runtime container %s: %w", name, err)
+	}
+	payload, err := l.startContainer(ctx, runtime, name, localContainerInfo{ID: "", Running: false, ImageID: "", HostPort: 0}, false)
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+	return RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: payload}, nil
+}
+
+func (l *LocalRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntimeRecord, threadID uuid.UUID, idempotencyKey string, authToken string, prompt string, mcpServers []runtimeMCPServer) error {
+	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
+		return err
+	}
+	metadata, err := decodeLocalRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return err
+	}
+	if metadata.HostPort == 0 {
+		return fmt.Errorf("%w: local runtime host port is not available", ErrRuntimeUnhealthy)
+	}
+
+	return l.runner.turn(ctx, localRuntimeEndpoint(metadata.HostPort), runtime, threadID, idempotencyKey, authToken, prompt, mcpServers, localRuntimeTurnTimeout)
+}
+
+func (l *LocalRuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
+	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
+		return RuntimeBackendStatus{}, err
+	}
+	metadata, err := decodeLocalRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return RuntimeBackendStatus{}, err
+	}
+	if metadata.HostPort == 0 {
+		return RuntimeBackendStatus{}, fmt.Errorf("%w: local runtime host port is not available", ErrRuntimeUnhealthy)
+	}
+	state, err := l.runner.state(ctx, localRuntimeEndpoint(metadata.HostPort))
+	if err != nil {
+		return RuntimeBackendStatus{}, fmt.Errorf("load local runtime state: %w", err)
+	}
+	return RuntimeBackendStatus{Configured: true, IdleSeconds: state.minThreadIdle()}, nil
+}
+
+// Stop halts the container while keeping it and its workspace volume in place
+// for warm restart on the next admission.
+func (l *LocalRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
+	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
+		return err
+	}
+	name := localContainerName(runtime)
+	if err := l.engine.Stop(ctx, name); err != nil {
+		return fmt.Errorf("stop local runtime container %s: %w", name, err)
+	}
+	return nil
+}
+
+// Reap permanently removes the container and its workspace volume. Idempotent.
+func (l *LocalRuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRecord) error {
+	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
+		return err
+	}
+	name := localContainerName(runtime)
+	if err := l.engine.Remove(ctx, name); err != nil {
+		return fmt.Errorf("remove local runtime container %s: %w", name, err)
+	}
+	volume := localVolumeName(runtime)
+	if err := l.engine.RemoveVolume(ctx, volume); err != nil {
+		return fmt.Errorf("remove local runtime volume %s: %w", volume, err)
+	}
+	return nil
+}
+
+// ReapStoppedMachine removes only the container, preserving the workspace
+// volume so the next admission for this assistant cold-launches into the same
+// workspace. Idempotent.
+func (l *LocalRuntimeBackend) ReapStoppedMachine(ctx context.Context, runtime assistantRuntimeRecord) error {
+	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
+		return err
+	}
+	name := localContainerName(runtime)
+	if err := l.engine.Remove(ctx, name); err != nil {
+		return fmt.Errorf("remove stopped local runtime container %s: %w", name, err)
+	}
+	return nil
+}
+
+func decodeLocalRuntimeMetadata(raw []byte) (localRuntimeMetadata, error) {
+	if len(raw) == 0 {
+		return localRuntimeMetadata{}, fmt.Errorf("local runtime metadata is empty")
+	}
+	var metadata localRuntimeMetadata
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return localRuntimeMetadata{}, fmt.Errorf("decode local runtime metadata: %w", err)
+	}
+	return metadata, nil
+}
+
+var _ RuntimeBackend = (*LocalRuntimeBackend)(nil)

--- a/server/internal/assistants/runtime_local.go
+++ b/server/internal/assistants/runtime_local.go
@@ -492,6 +492,24 @@ func (l *LocalRuntimeBackend) Status(ctx context.Context, runtime assistantRunti
 	return RuntimeBackendStatus{Configured: true, IdleSeconds: state.minThreadIdle()}, nil
 }
 
+// RuntimeExists checks the container resource itself rather than the runner
+// endpoint. A stopped container still exists and remains reusable; only a
+// definitive not-found result means an active database row is orphaned.
+func (l *LocalRuntimeBackend) RuntimeExists(ctx context.Context, runtime assistantRuntimeRecord) (bool, error) {
+	if err := validateRuntimeBackend(l, runtime.Backend); err != nil {
+		return false, err
+	}
+	name := localContainerName(runtime)
+	_, err := l.engine.Inspect(ctx, name)
+	if errors.Is(err, errLocalContainerNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect local runtime container %s: %w", name, err)
+	}
+	return true, nil
+}
+
 // Stop halts the container while keeping it and its workspace volume in place
 // for warm restart on the next admission.
 func (l *LocalRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
@@ -547,3 +565,4 @@ func decodeLocalRuntimeMetadata(raw []byte) (localRuntimeMetadata, error) {
 }
 
 var _ RuntimeBackend = (*LocalRuntimeBackend)(nil)
+var _ runtimeLivenessChecker = (*LocalRuntimeBackend)(nil)

--- a/server/internal/assistants/runtime_local.go
+++ b/server/internal/assistants/runtime_local.go
@@ -307,19 +307,22 @@ func (l *LocalRuntimeBackend) runnerBusy(ctx context.Context, info localContaine
 func (l *LocalRuntimeBackend) startContainer(ctx context.Context, runtime assistantRuntimeRecord, name string, info localContainerInfo, exists bool) (payload []byte, err error) {
 	needInspect := false
 	if !exists {
-		_, runErr := l.engine.Run(ctx, l.containerSpec(runtime, name))
+		createdID, runErr := l.engine.Run(ctx, l.containerSpec(runtime, name))
 		switch {
 		case runErr == nil:
 			needInspect = true
 			// Clean up the container this call created on every error exit,
 			// with a fresh context so cleanup still runs on ctx timeout.
+			// Removal targets the created ID, never the shared name, so a
+			// failed admission cannot tear down a replacement container a
+			// concurrent Ensure launched in the meantime.
 			defer func() {
 				if err == nil {
 					return
 				}
 				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 				defer cancel()
-				if removeErr := l.engine.Remove(cleanupCtx, name); removeErr != nil {
+				if removeErr := l.engine.Remove(cleanupCtx, createdID); removeErr != nil {
 					l.logger.WarnContext(ctx, "remove local runtime container after failed launch",
 						attr.SlogAssistantID(runtime.AssistantID.String()),
 						attr.SlogError(removeErr),

--- a/server/internal/assistants/runtime_local_docker.go
+++ b/server/internal/assistants/runtime_local_docker.go
@@ -1,0 +1,172 @@
+package assistants
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// dockerCLIEngine implements containerEngine by shelling out to the docker
+// CLI. It exists for local development only, so a contained CLI wrapper beats
+// pulling the Docker SDK into the server module.
+type dockerCLIEngine struct {
+	guestPort int
+}
+
+func newDockerCLIEngine(guestPort int) *dockerCLIEngine {
+	if guestPort == 0 {
+		guestPort = defaultRuntimeGuestPort
+	}
+	return &dockerCLIEngine{guestPort: guestPort}
+}
+
+var _ containerEngine = (*dockerCLIEngine)(nil)
+
+func (d *dockerCLIEngine) exec(ctx context.Context, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, "docker", args...).Output() //nolint:gosec // fixed docker binary; args are engine-constructed, never raw user input
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("docker %s: %w: %s", args[0], err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", fmt.Errorf("docker %s: %w", args[0], err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// isNotFoundOutput matches the docker CLI's not-found errors across object
+// types and CLI versions ("No such container: ...", "no such volume", "No
+// such image", "no such object").
+func isNotFoundOutput(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no such")
+}
+
+func (d *dockerCLIEngine) ImageID(ctx context.Context, imageRef string) (string, error) {
+	out, err := d.exec(ctx, "image", "inspect", "--format", "{{.Id}}", imageRef)
+	if isNotFoundOutput(err) {
+		return "", errLocalImageNotFound
+	}
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+// dockerContainerInspect is the subset of `docker container inspect` output
+// the backend needs.
+type dockerContainerInspect struct {
+	ID    string `json:"Id"`
+	State struct {
+		Running bool `json:"Running"`
+	} `json:"State"`
+	Image           string `json:"Image"`
+	NetworkSettings struct {
+		Ports map[string][]struct {
+			HostIP   string `json:"HostIp"`
+			HostPort string `json:"HostPort"`
+		} `json:"Ports"`
+	} `json:"NetworkSettings"`
+}
+
+func (d *dockerCLIEngine) Inspect(ctx context.Context, name string) (localContainerInfo, error) {
+	out, err := d.exec(ctx, "container", "inspect", "--format", "{{json .}}", name)
+	if isNotFoundOutput(err) {
+		return localContainerInfo{}, errLocalContainerNotFound
+	}
+	if err != nil {
+		return localContainerInfo{}, err
+	}
+
+	var inspect dockerContainerInspect
+	if err := json.Unmarshal([]byte(out), &inspect); err != nil {
+		return localContainerInfo{}, fmt.Errorf("decode docker inspect output for %s: %w", name, err)
+	}
+
+	hostPort := 0
+	for _, binding := range inspect.NetworkSettings.Ports[strconv.Itoa(d.guestPort)+"/tcp"] {
+		port, err := strconv.Atoi(binding.HostPort)
+		if err != nil {
+			continue
+		}
+		hostPort = port
+		break
+	}
+
+	return localContainerInfo{
+		ID:       inspect.ID,
+		Running:  inspect.State.Running,
+		ImageID:  inspect.Image,
+		HostPort: hostPort,
+	}, nil
+}
+
+func (d *dockerCLIEngine) Run(ctx context.Context, spec localContainerSpec) (string, error) {
+	args := []string{
+		"run", "--detach",
+		"--name", spec.Name,
+		// Publish the guest port to an ephemeral loopback port; the exact port
+		// is re-resolved via Inspect after every start.
+		"--publish", "127.0.0.1::" + strconv.Itoa(d.guestPort),
+		// Docker Desktop resolves the alias natively; on native Linux engines
+		// the host-gateway mapping provides the same name.
+		"--add-host", LocalRuntimeHostGatewayAlias + ":host-gateway",
+		"--volume", spec.VolumeName + ":" + localRuntimeWorkdirMountPath,
+	}
+	if spec.ExtraCACertFile != "" {
+		args = append(args, "--volume", spec.ExtraCACertFile+":"+localRuntimeCACertMountPath+":ro")
+	}
+	for _, key := range slices.Sorted(maps.Keys(spec.Labels)) {
+		args = append(args, "--label", key+"="+spec.Labels[key])
+	}
+	for _, key := range slices.Sorted(maps.Keys(spec.Env)) {
+		args = append(args, "--env", key+"="+spec.Env[key])
+	}
+	args = append(args, spec.Image)
+
+	out, err := d.exec(ctx, args...)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "already in use") {
+			return "", errLocalContainerNameInUse
+		}
+		return "", err
+	}
+	return out, nil
+}
+
+func (d *dockerCLIEngine) Start(ctx context.Context, name string) error {
+	if _, err := d.exec(ctx, "start", name); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *dockerCLIEngine) Stop(ctx context.Context, name string) error {
+	if _, err := d.exec(ctx, "stop", name); err != nil && !isNotFoundOutput(err) {
+		return err
+	}
+	return nil
+}
+
+func (d *dockerCLIEngine) Remove(ctx context.Context, name string) error {
+	if _, err := d.exec(ctx, "rm", "--force", name); err != nil && !isNotFoundOutput(err) {
+		return err
+	}
+	return nil
+}
+
+func (d *dockerCLIEngine) RemoveVolume(ctx context.Context, name string) error {
+	if _, err := d.exec(ctx, "volume", "rm", name); err != nil && !isNotFoundOutput(err) {
+		return err
+	}
+	return nil
+}

--- a/server/internal/assistants/runtime_local_docker.go
+++ b/server/internal/assistants/runtime_local_docker.go
@@ -69,7 +69,10 @@ type dockerContainerInspect struct {
 	State struct {
 		Running bool `json:"Running"`
 	} `json:"State"`
-	Image           string `json:"Image"`
+	Image  string `json:"Image"`
+	Config struct {
+		Labels map[string]string `json:"Labels"`
+	} `json:"Config"`
 	NetworkSettings struct {
 		Ports map[string][]struct {
 			HostIP   string `json:"HostIp"`
@@ -106,6 +109,7 @@ func (d *dockerCLIEngine) Inspect(ctx context.Context, name string) (localContai
 		ID:       inspect.ID,
 		Running:  inspect.State.Running,
 		ImageID:  inspect.Image,
+		SpecHash: inspect.Config.Labels[runtimeLabelSpecHash],
 		HostPort: hostPort,
 	}, nil
 }

--- a/server/internal/assistants/runtime_local_test.go
+++ b/server/internal/assistants/runtime_local_test.go
@@ -1,0 +1,532 @@
+package assistants
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type fakeContainer struct {
+	id      string
+	imageID string
+	running bool
+	spec    localContainerSpec
+	starts  int
+}
+
+type fakeContainerEngine struct {
+	mu         sync.Mutex
+	imageIDs   map[string]string
+	containers map[string]*fakeContainer
+	volumes    map[string]bool
+	hostPort   int
+	runCalls   int
+	runErr     error
+	nextID     int
+}
+
+func newFakeContainerEngine(imageRef, imageID string, hostPort int) *fakeContainerEngine {
+	return &fakeContainerEngine{
+		mu:         sync.Mutex{},
+		imageIDs:   map[string]string{imageRef: imageID},
+		containers: map[string]*fakeContainer{},
+		volumes:    map[string]bool{},
+		hostPort:   hostPort,
+		runCalls:   0,
+		runErr:     nil,
+		nextID:     0,
+	}
+}
+
+func (f *fakeContainerEngine) ImageID(_ context.Context, imageRef string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	id, ok := f.imageIDs[imageRef]
+	if !ok {
+		return "", errLocalImageNotFound
+	}
+	return id, nil
+}
+
+func (f *fakeContainerEngine) Inspect(_ context.Context, name string) (localContainerInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	container, ok := f.containers[name]
+	if !ok {
+		return localContainerInfo{}, errLocalContainerNotFound
+	}
+	hostPort := 0
+	if container.running {
+		hostPort = f.hostPort
+	}
+	return localContainerInfo{
+		ID:       container.id,
+		Running:  container.running,
+		ImageID:  container.imageID,
+		HostPort: hostPort,
+	}, nil
+}
+
+func (f *fakeContainerEngine) Run(_ context.Context, spec localContainerSpec) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.runCalls++
+	if f.runErr != nil {
+		return "", f.runErr
+	}
+	if _, ok := f.containers[spec.Name]; ok {
+		return "", errLocalContainerNameInUse
+	}
+	f.nextID++
+	id := fmt.Sprintf("container-%d", f.nextID)
+	f.containers[spec.Name] = &fakeContainer{
+		id:      id,
+		imageID: f.imageIDs[spec.Image],
+		running: true,
+		spec:    spec,
+		starts:  1,
+	}
+	f.volumes[spec.VolumeName] = true
+	return id, nil
+}
+
+func (f *fakeContainerEngine) Start(_ context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	container, ok := f.containers[name]
+	if !ok {
+		return errLocalContainerNotFound
+	}
+	container.running = true
+	container.starts++
+	return nil
+}
+
+func (f *fakeContainerEngine) Stop(_ context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if container, ok := f.containers[name]; ok {
+		container.running = false
+	}
+	return nil
+}
+
+func (f *fakeContainerEngine) Remove(_ context.Context, nameOrID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for name, container := range f.containers {
+		if name == nameOrID || container.id == nameOrID {
+			delete(f.containers, name)
+		}
+	}
+	return nil
+}
+
+func (f *fakeContainerEngine) RemoveVolume(_ context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.volumes, name)
+	return nil
+}
+
+func (f *fakeContainerEngine) container(t *testing.T, name string) *fakeContainer {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	container, ok := f.containers[name]
+	require.True(t, ok, "expected container %s to exist", name)
+	return container
+}
+
+const (
+	testLocalImageRef = "gram-assistant-runtime:dev"
+	testLocalImageID  = "sha256:image-1"
+)
+
+func healthyRunnerHandler(idleSeconds uint64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/state":
+			_ = json.NewEncoder(w).Encode(runnerStateResponse{
+				AssistantID:   "a",
+				UptimeSeconds: 1,
+				Threads:       []runnerThreadState{{ThreadID: "t1", ChatID: "c1", IdleSeconds: idleSeconds}},
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}
+
+func newTestLocalBackend(t *testing.T, engine containerEngine, doer runtimeHTTPDoer) *LocalRuntimeBackend {
+	t.Helper()
+	return NewLocalRuntimeBackend(testenv.NewLogger(t), testenv.NewTracerProvider(t), doer, engine, LocalRuntimeConfig{
+		Enabled:         true,
+		Environment:     "local",
+		OCIImage:        "gram-assistant-runtime",
+		ImageTag:        "dev",
+		GuestPort:       defaultRuntimeGuestPort,
+		ServerURL:       &url.URL{Scheme: "https", Host: "host.docker.internal:8080"},
+		ExtraCACertFile: "",
+	})
+}
+
+func localRecord(assistantID uuid.UUID, metadata []byte) assistantRuntimeRecord {
+	return assistantRuntimeRecord{
+		ID:                  uuid.New(),
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendLocal,
+		BackendMetadataJSON: metadata,
+		State:               runtimeStateStarting,
+		WarmUntil:           pgtype.Timestamptz{},
+	}
+}
+
+func decodeLocalMetadata(t *testing.T, raw []byte) localRuntimeMetadata {
+	t.Helper()
+	metadata, err := decodeLocalRuntimeMetadata(raw)
+	require.NoError(t, err)
+	return metadata
+}
+
+func TestLocalEnsureLaunchesAndReuses(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	assistantID := uuid.New()
+	record := localRecord(assistantID, nil)
+
+	result, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	require.True(t, result.ColdStart)
+	metadata := decodeLocalMetadata(t, result.BackendMetadataJSON)
+	require.Equal(t, "gram-asst-"+strings.ToLower(assistantID.String()), metadata.ContainerName)
+	require.Equal(t, port, metadata.HostPort)
+	require.Equal(t, 1, engine.runCalls)
+
+	container := engine.container(t, metadata.ContainerName)
+	require.Equal(t, "https://host.docker.internal:8080", container.spec.Env["GRAM_SERVER_URL"])
+	require.Equal(t, assistantID.String(), container.spec.Env["GRAM_ASSISTANT_ID"])
+
+	// A second Ensure adopts the running container without launching another.
+	result, err = backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	require.False(t, result.ColdStart)
+	require.Equal(t, 1, engine.runCalls)
+}
+
+func TestLocalEnsureRestartsStoppedContainer(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+
+	_, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	name := localContainerName(record)
+	require.NoError(t, backend.Stop(t.Context(), record))
+	require.False(t, engine.container(t, name).running)
+
+	// The stopped container is rediscovered by name and restarted — no new
+	// launch, even with no persisted metadata (e.g. after a server restart).
+	result, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	require.True(t, result.ColdStart)
+	require.Equal(t, 1, engine.runCalls)
+	require.Equal(t, 2, engine.container(t, name).starts)
+}
+
+func TestLocalEnsureReplacesDriftedIdleContainer(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+
+	_, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	firstID := engine.container(t, localContainerName(record)).id
+
+	// Rebuild: same tag, new image ID.
+	engine.mu.Lock()
+	engine.imageIDs[testLocalImageRef] = "sha256:image-2"
+	engine.mu.Unlock()
+
+	result, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	require.True(t, result.ColdStart)
+	metadata := decodeLocalMetadata(t, result.BackendMetadataJSON)
+	replacement := engine.container(t, metadata.ContainerName)
+	require.NotEqual(t, firstID, replacement.id)
+	require.Equal(t, "sha256:image-2", replacement.imageID)
+	// The workspace volume survives the replacement.
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	require.True(t, engine.volumes[localVolumeName(record)])
+}
+
+func TestLocalEnsureKeepsDriftedBusyContainer(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(0)) // idle 0 = turn in flight
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+
+	_, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	firstID := engine.container(t, localContainerName(record)).id
+
+	engine.mu.Lock()
+	engine.imageIDs[testLocalImageRef] = "sha256:image-2"
+	engine.mu.Unlock()
+
+	// The runner reports a turn in flight, so the drifted container is kept.
+	result, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	require.False(t, result.ColdStart)
+	require.Equal(t, firstID, engine.container(t, localContainerName(record)).id)
+	require.Equal(t, 1, engine.runCalls)
+}
+
+func TestLocalEnsureMissingImageFails(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine("other-image:dev", testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+
+	_, err := backend.Ensure(t.Context(), localRecord(uuid.New(), nil))
+	require.ErrorIs(t, err, errLocalImageNotFound)
+	require.ErrorContains(t, err, "build:assistants-runtime-image")
+}
+
+func TestLocalEnsureCleansUpUnhealthyLaunch(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	backend.healthTimeout = 50 * time.Millisecond
+	record := localRecord(uuid.New(), nil)
+
+	_, err := backend.Ensure(t.Context(), record)
+	require.ErrorIs(t, err, ErrRuntimeUnhealthy)
+
+	// The container this call created was removed so the next admission
+	// relaunches cleanly; the workspace volume is preserved.
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	require.Empty(t, engine.containers)
+	require.True(t, engine.volumes[localVolumeName(record)])
+}
+
+func TestLocalEnsureAdoptsRacingLaunch(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+	name := localContainerName(record)
+
+	// Simulate a racing Ensure creating the container between this call's
+	// inspect and run: the engine reports the name in use, and the container
+	// appears (running) for the follow-up inspect.
+	engine.mu.Lock()
+	engine.runErr = errLocalContainerNameInUse
+	engine.containers[name] = &fakeContainer{
+		id:      "container-racer",
+		imageID: testLocalImageID,
+		running: true,
+		spec:    localContainerSpec{Name: name, Image: testLocalImageRef, Labels: nil, Env: nil, VolumeName: localVolumeName(record), ExtraCACertFile: ""},
+		starts:  1,
+	}
+	engine.mu.Unlock()
+
+	result, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	metadata := decodeLocalMetadata(t, result.BackendMetadataJSON)
+	require.Equal(t, "container-racer", metadata.ContainerID)
+}
+
+func TestLocalRunTurnPostsToRunner(t *testing.T) {
+	t.Parallel()
+
+	threadID := uuid.New()
+	var gotPath, gotIdem string
+	var gotBody runtimeTurnRequest
+	doer, _, port := testRunner(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotIdem = r.Header.Get("X-Idempotency-Key")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	})
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+
+	metadata, err := json.Marshal(localRuntimeMetadata{
+		ContainerID:   "container-1",
+		ContainerName: "gram-asst-x",
+		HostPort:      port,
+	})
+	require.NoError(t, err)
+	record := localRecord(uuid.New(), metadata)
+
+	err = backend.RunTurn(t.Context(), record, threadID, "event-1", "jwt-token", "hello", nil)
+	require.NoError(t, err)
+	require.Equal(t, "/threads/"+threadID.String()+"/turn", gotPath)
+	require.Equal(t, "event-1", gotIdem)
+	require.Equal(t, "hello", gotBody.Input)
+	require.Equal(t, "jwt-token", gotBody.AuthToken)
+}
+
+func TestLocalStatusReadsRunnerState(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(7))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+
+	metadata, err := json.Marshal(localRuntimeMetadata{
+		ContainerID:   "container-1",
+		ContainerName: "gram-asst-x",
+		HostPort:      port,
+	})
+	require.NoError(t, err)
+
+	status, err := backend.Status(t.Context(), localRecord(uuid.New(), metadata))
+	require.NoError(t, err)
+	require.True(t, status.Configured)
+	require.NotNil(t, status.IdleSeconds)
+	require.Equal(t, uint64(7), *status.IdleSeconds)
+}
+
+func TestLocalStopAndReapLifecycle(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+	name := localContainerName(record)
+	volume := localVolumeName(record)
+
+	_, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+
+	// Stop keeps the container and volume; it is idempotent.
+	require.NoError(t, backend.Stop(t.Context(), record))
+	require.NoError(t, backend.Stop(t.Context(), record))
+	require.False(t, engine.container(t, name).running)
+
+	// ReapStoppedMachine removes the container, preserving the workspace.
+	require.NoError(t, backend.ReapStoppedMachine(t.Context(), record))
+	require.NoError(t, backend.ReapStoppedMachine(t.Context(), record))
+	engine.mu.Lock()
+	_, containerExists := engine.containers[name]
+	volumeExists := engine.volumes[volume]
+	engine.mu.Unlock()
+	require.False(t, containerExists)
+	require.True(t, volumeExists)
+
+	// Reap removes everything and is idempotent when already gone.
+	require.NoError(t, backend.Reap(t.Context(), record))
+	require.NoError(t, backend.Reap(t.Context(), record))
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	require.False(t, engine.volumes[volume])
+}
+
+func TestLocalRecycleImageReplacesDriftedIdleContainer(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+
+	// No container yet: nothing to recycle, nothing launched.
+	result, err := backend.RecycleImage(t.Context(), record)
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
+	require.Equal(t, 0, engine.runCalls)
+
+	_, err = backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+
+	// Image current: skip.
+	result, err = backend.RecycleImage(t.Context(), record)
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
+
+	engine.mu.Lock()
+	engine.imageIDs[testLocalImageRef] = "sha256:image-2"
+	engine.mu.Unlock()
+
+	result, err = backend.RecycleImage(t.Context(), record)
+	require.NoError(t, err)
+	require.True(t, result.Recycled)
+	metadata := decodeLocalMetadata(t, result.BackendMetadataJSON)
+	require.Equal(t, "sha256:image-2", engine.container(t, metadata.ContainerName).imageID)
+
+	// A stopped drifted container is never resurrected by the sweep.
+	require.NoError(t, backend.Stop(t.Context(), record))
+	engine.mu.Lock()
+	engine.imageIDs[testLocalImageRef] = "sha256:image-3"
+	engine.mu.Unlock()
+	result, err = backend.RecycleImage(t.Context(), record)
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
+	require.False(t, engine.container(t, localContainerName(record)).running)
+}
+
+func TestLocalConcurrentEnsureCreatesOneContainer(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Go(func() {
+			_, errs[i] = backend.Ensure(t.Context(), record)
+		})
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	require.Len(t, engine.containers, 1)
+}

--- a/server/internal/assistants/runtime_local_test.go
+++ b/server/internal/assistants/runtime_local_test.go
@@ -235,6 +235,30 @@ func TestLocalEnsureLaunchesAndReuses(t *testing.T) {
 	require.Equal(t, 1, engine.runCalls)
 }
 
+func TestLocalRuntimeExistsDistinguishesMissingAndStoppedContainers(t *testing.T) {
+	t.Parallel()
+
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, 18081)
+	backend := newTestLocalBackend(t, engine, nil)
+	record := localRecord(uuid.New(), []byte(`{"container_id":"old"}`))
+
+	exists, err := backend.RuntimeExists(t.Context(), record)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	name := localContainerName(record)
+	engine.containers[name] = &fakeContainer{
+		id:      "container-stopped",
+		imageID: testLocalImageID,
+		running: false,
+		spec:    backend.containerSpec(record, name),
+		starts:  0,
+	}
+	exists, err = backend.RuntimeExists(t.Context(), record)
+	require.NoError(t, err)
+	require.True(t, exists, "a stopped container still exists for warm reuse")
+}
+
 func TestLocalEnsureRestartsStoppedContainer(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/runtime_local_test.go
+++ b/server/internal/assistants/runtime_local_test.go
@@ -354,6 +354,10 @@ func TestLocalRecycleImageReplacesConfigDriftedIdleContainer(t *testing.T) {
 	replacement := engine.container(t, metadata.ContainerName)
 	require.NotEqual(t, firstID, replacement.id)
 	require.Equal(t, "https://host.docker.internal:9443", replacement.spec.Env["GRAM_SERVER_URL"])
+	// The workspace volume survives the replacement.
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	require.True(t, engine.volumes[localVolumeName(record)])
 }
 
 func TestLocalEnsureKeepsDriftedBusyContainer(t *testing.T) {

--- a/server/internal/assistants/runtime_local_test.go
+++ b/server/internal/assistants/runtime_local_test.go
@@ -76,6 +76,7 @@ func (f *fakeContainerEngine) Inspect(_ context.Context, name string) (localCont
 		ID:       container.id,
 		Running:  container.running,
 		ImageID:  container.imageID,
+		SpecHash: container.spec.Labels[runtimeLabelSpecHash],
 		HostPort: hostPort,
 	}, nil
 }
@@ -287,6 +288,74 @@ func TestLocalEnsureReplacesDriftedIdleContainer(t *testing.T) {
 	require.True(t, engine.volumes[localVolumeName(record)])
 }
 
+func TestLocalEnsureReplacesConfigDriftedIdleContainer(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+
+	_, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	firstID := engine.container(t, localContainerName(record)).id
+
+	// Same image, changed backend config: the server URL frozen into the
+	// container's env no longer matches.
+	drifted := NewLocalRuntimeBackend(testenv.NewLogger(t), testenv.NewTracerProvider(t), doer, engine, LocalRuntimeConfig{
+		Enabled:         true,
+		Environment:     "local",
+		OCIImage:        "gram-assistant-runtime",
+		ImageTag:        "dev",
+		GuestPort:       defaultRuntimeGuestPort,
+		ServerURL:       &url.URL{Scheme: "https", Host: "host.docker.internal:9443"},
+		ExtraCACertFile: "",
+	})
+
+	result, err := drifted.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	require.True(t, result.ColdStart)
+	metadata := decodeLocalMetadata(t, result.BackendMetadataJSON)
+	replacement := engine.container(t, metadata.ContainerName)
+	require.NotEqual(t, firstID, replacement.id)
+	require.Equal(t, "https://host.docker.internal:9443", replacement.spec.Env["GRAM_SERVER_URL"])
+	// The workspace volume survives the replacement.
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	require.True(t, engine.volumes[localVolumeName(record)])
+}
+
+func TestLocalRecycleImageReplacesConfigDriftedIdleContainer(t *testing.T) {
+	t.Parallel()
+
+	doer, _, port := testRunner(t, healthyRunnerHandler(5))
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, port)
+	backend := newTestLocalBackend(t, engine, doer)
+	record := localRecord(uuid.New(), nil)
+
+	_, err := backend.Ensure(t.Context(), record)
+	require.NoError(t, err)
+	firstID := engine.container(t, localContainerName(record)).id
+
+	drifted := NewLocalRuntimeBackend(testenv.NewLogger(t), testenv.NewTracerProvider(t), doer, engine, LocalRuntimeConfig{
+		Enabled:         true,
+		Environment:     "local",
+		OCIImage:        "gram-assistant-runtime",
+		ImageTag:        "dev",
+		GuestPort:       defaultRuntimeGuestPort,
+		ServerURL:       &url.URL{Scheme: "https", Host: "host.docker.internal:9443"},
+		ExtraCACertFile: "",
+	})
+
+	result, err := drifted.RecycleImage(t.Context(), record)
+	require.NoError(t, err)
+	require.True(t, result.Recycled)
+	metadata := decodeLocalMetadata(t, result.BackendMetadataJSON)
+	replacement := engine.container(t, metadata.ContainerName)
+	require.NotEqual(t, firstID, replacement.id)
+	require.Equal(t, "https://host.docker.internal:9443", replacement.spec.Env["GRAM_SERVER_URL"])
+}
+
 func TestLocalEnsureKeepsDriftedBusyContainer(t *testing.T) {
 	t.Parallel()
 
@@ -363,7 +432,7 @@ func TestLocalEnsureAdoptsRacingLaunch(t *testing.T) {
 		id:      "container-racer",
 		imageID: testLocalImageID,
 		running: true,
-		spec:    localContainerSpec{Name: name, Image: testLocalImageRef, Labels: nil, Env: nil, VolumeName: localVolumeName(record), ExtraCACertFile: ""},
+		spec:    backend.containerSpec(record, name),
 		starts:  1,
 	}
 	engine.mu.Unlock()

--- a/server/internal/assistants/runtime_provider.go
+++ b/server/internal/assistants/runtime_provider.go
@@ -14,6 +14,7 @@ import (
 const (
 	RuntimeProviderFlyIO = runtimeBackendFlyIO
 	RuntimeProviderGKE   = runtimeBackendGKE
+	RuntimeProviderLocal = runtimeBackendLocal
 
 	defaultFlyRuntimeRegion = "us"
 	defaultFlyRuntimePrefix = "gram-asst"
@@ -23,6 +24,7 @@ type RuntimeBackendConfig struct {
 	Provider string
 	Fly      FlyRuntimeConfig
 	GKE      GKERuntimeConfig
+	Local    LocalRuntimeConfig
 }
 
 type FlyRuntimeConfig struct {
@@ -76,9 +78,9 @@ func (c FlyRuntimeConfig) Validate() error {
 // NewRuntimeBackend assembles a runtimeRouter over every configured backend and
 // targets config.Provider for new admissions. A backend is constructed when its
 // config is present — Fly when an API token is set, GKE when an in-cluster
-// kubernetes client is injected — so the two can run side by side (e.g. target
-// GKE while still tearing down Fly-backed rows). The target backend must be
-// among those constructed.
+// kubernetes client is injected, local when running in the local environment —
+// so several can run side by side (e.g. target GKE while still tearing down
+// Fly-backed rows). The target backend must be among those constructed.
 func NewRuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider, httpPolicy *guardian.Policy, config RuntimeBackendConfig) (RuntimeBackend, error) {
 	backends := map[string]RuntimeBackend{}
 
@@ -102,6 +104,20 @@ func NewRuntimeBackend(logger *slog.Logger, tracerProvider trace.TracerProvider,
 			guardian.WithAllowedCIDRBlocks(config.GKE.RunnerCIDRBlocks...),
 		)
 		backends[runtimeBackendGKE] = NewGKERuntimeBackend(logger, tracerProvider, gkeClient, config.GKE)
+	}
+
+	if config.Local.Enabled {
+		if err := config.Local.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid local assistant runtime config: %w", err)
+		}
+		// Containers publish the runner guest port on a loopback ephemeral
+		// port, which the default egress policy blocks. Allowlist loopback for
+		// this one client only — the policy's global enforcement is unchanged.
+		localClient := httpPolicy.PooledClient(
+			guardian.WithDefaultRetryConfig(),
+			guardian.WithAllowedCIDRBlocks(localRuntimeLoopbackCIDRs...),
+		)
+		backends[runtimeBackendLocal] = NewLocalRuntimeBackend(logger, tracerProvider, localClient, newDockerCLIEngine(config.Local.GuestPort), config.Local)
 	}
 
 	router, err := newRuntimeRouter(config.Provider, backends)

--- a/server/internal/assistants/runtime_router.go
+++ b/server/internal/assistants/runtime_router.go
@@ -107,6 +107,22 @@ func (r *runtimeRouter) Status(ctx context.Context, runtime assistantRuntimeReco
 	return status, nil
 }
 
+func (r *runtimeRouter) RuntimeExists(ctx context.Context, runtime assistantRuntimeRecord) (bool, error) {
+	b, err := r.route(runtime.Backend)
+	if err != nil {
+		return false, err
+	}
+	checker, ok := b.(runtimeLivenessChecker)
+	if !ok {
+		return true, nil
+	}
+	exists, err := checker.RuntimeExists(ctx, runtime)
+	if err != nil {
+		return false, fmt.Errorf("check %s runtime existence: %w", runtime.Backend, err)
+	}
+	return exists, nil
+}
+
 func (r *runtimeRouter) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
 	b, err := r.route(runtime.Backend)
 	if err != nil {
@@ -141,3 +157,4 @@ func (r *runtimeRouter) ReapStoppedMachine(ctx context.Context, runtime assistan
 }
 
 var _ RuntimeBackend = (*runtimeRouter)(nil)
+var _ runtimeLivenessChecker = (*runtimeRouter)(nil)

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -164,6 +164,18 @@ func (t *telemetryRuntimeBackend) Status(ctx context.Context, runtime assistantR
 	return status, nil
 }
 
+func (t *telemetryRuntimeBackend) RuntimeExists(ctx context.Context, runtime assistantRuntimeRecord) (bool, error) {
+	checker, ok := t.inner.(runtimeLivenessChecker)
+	if !ok {
+		return true, nil
+	}
+	exists, err := checker.RuntimeExists(ctx, runtime)
+	if err != nil {
+		return false, fmt.Errorf("runtime existence check: %w", err)
+	}
+	return exists, nil
+}
+
 func (t *telemetryRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
 	err := t.inner.Stop(ctx, runtime)
 	if err != nil {
@@ -253,3 +265,5 @@ func (t *telemetryRuntimeBackend) emit(
 		Attributes: attrs,
 	})
 }
+
+var _ runtimeLivenessChecker = (*telemetryRuntimeBackend)(nil)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -559,9 +559,62 @@ func (s *ServiceCore) ReapStuckRuntimes(ctx context.Context) (ReapStuckRuntimesR
 	//     attempts after CAS active->expiring without reaching Stop or
 	//     Revert. Without this the row blocks the partial unique index
 	//     ReserveAssistantRuntime depends on.
-	// 'active' rows are never reaped: an idle runtime keeps its VM until the
-	// assistant is deleted.
+	// Healthy 'active' rows are never reaped: an idle runtime keeps its VM
+	// until the assistant is deleted. The local reconciliation below is the
+	// narrow exception for a row whose container no longer exists.
 	queries := assistantrepo.New(s.db)
+	// Local containers can be removed outside Gram (docker rm, daemon reset,
+	// pruning). Reconcile those rows before the age-based SQL sweep: unlike a
+	// healthy idle runtime, a definitively missing container can never make
+	// progress. Stop only the row; the next admission recreates the container
+	// against the preserved workspace volume.
+	if checker, ok := s.runtime.(runtimeLivenessChecker); ok && s.runtime.SupportsBackend(runtimeBackendLocal) {
+		rows, err := queries.ListActiveAssistantRuntimes(ctx, runtimeStateActive)
+		if err != nil {
+			return out, fmt.Errorf("list active assistant runtimes for liveness reconciliation: %w", err)
+		}
+		for _, row := range rows {
+			if row.Backend != runtimeBackendLocal {
+				continue
+			}
+			record := assistantRuntimeRecord{
+				ID:                  row.ID,
+				AssistantThreadID:   row.AssistantThreadID,
+				AssistantID:         row.AssistantID,
+				ProjectID:           row.ProjectID,
+				Backend:             row.Backend,
+				BackendMetadataJSON: row.BackendMetadataJson,
+				State:               row.State,
+				WarmUntil:           row.WarmUntil,
+			}
+			exists, err := checker.RuntimeExists(ctx, record)
+			if err != nil {
+				s.logger.WarnContext(ctx, "check assistant runtime existence failed",
+					attr.SlogAssistantID(row.AssistantID.String()),
+					attr.SlogProjectID(row.ProjectID.String()),
+					attr.SlogAssistantRuntimeID(row.ID.String()),
+					attr.SlogError(err),
+				)
+				continue
+			}
+			if exists {
+				continue
+			}
+			if err := queries.StopAssistantRuntime(ctx, assistantrepo.StopAssistantRuntimeParams{
+				State:         runtimeStateStopped,
+				ProjectID:     row.ProjectID,
+				RuntimeID:     row.ID,
+				StartingState: runtimeStateStarting,
+				ActiveState:   runtimeStateActive,
+				ExpiringState: runtimeStateExpiring,
+			}); err != nil {
+				return out, fmt.Errorf("stop vanished local assistant runtime: %w", err)
+			}
+			affected[row.AssistantID] = struct{}{}
+			out.StaleRuntimesStopped++
+		}
+	}
+
 	runtimeAssistantIDs, err := queries.ReapStuckAssistantRuntimes(ctx, assistantrepo.ReapStuckAssistantRuntimesParams{
 		StoppedState:   runtimeStateStopped,
 		StartingState:  runtimeStateStarting,
@@ -1480,7 +1533,7 @@ func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params Rec
 	}
 
 	queries := assistantrepo.New(s.db)
-	rows, err := queries.ListActiveAssistantRuntimesForImageRecycle(ctx, runtimeStateActive)
+	rows, err := queries.ListActiveAssistantRuntimes(ctx, runtimeStateActive)
 	if err != nil {
 		return RecycleAssistantRuntimeImagesResult{}, fmt.Errorf("list active assistant runtimes for image recycle: %w", err)
 	}

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -743,6 +743,75 @@ func TestServiceCoreReapStuckRuntimesLeavesIdleActiveRuntime(t *testing.T) {
 	require.Equal(t, eventStatusPending, event.Status)
 }
 
+func TestServiceCoreReapStuckRuntimesStopsLocalRowsWithMissingContainers(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "reap_missing_local_runtime")
+	require.NoError(t, err)
+
+	missingProjectID, missingAssistantID, missingThreadID := insertReapableProject(t, conn, "missing-local-runtime")
+	missingRuntimeID := insertActiveV2RuntimeRow(
+		t,
+		conn,
+		missingProjectID,
+		missingAssistantID,
+		missingThreadID,
+		runtimeBackendLocal,
+		runtimeStateActive,
+		`{"container_id":"missing","container_name":"gram-asst-missing","host_port":18081}`,
+	)
+
+	presentProjectID, presentAssistantID, presentThreadID := insertReapableProject(t, conn, "present-local-runtime")
+	presentRuntimeID := insertActiveV2RuntimeRow(
+		t,
+		conn,
+		presentProjectID,
+		presentAssistantID,
+		presentThreadID,
+		runtimeBackendLocal,
+		runtimeStateActive,
+		`{"container_id":"present","container_name":"gram-asst-present","host_port":18082}`,
+	)
+
+	engine := newFakeContainerEngine(testLocalImageRef, testLocalImageID, 18082)
+	backend := newTestLocalBackend(t, engine, nil)
+	presentRecord := assistantRuntimeRecord{
+		ID:                  presentRuntimeID,
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         presentAssistantID,
+		ProjectID:           presentProjectID,
+		Backend:             runtimeBackendLocal,
+		BackendMetadataJSON: []byte(`{"container_id":"present"}`),
+		State:               runtimeStateActive,
+		WarmUntil:           pgtype.Timestamptz{},
+	}
+	presentName := localContainerName(presentRecord)
+	engine.containers[presentName] = &fakeContainer{
+		id:      "present",
+		imageID: testLocalImageID,
+		running: false,
+		spec:    backend.containerSpec(presentRecord, presentName),
+		starts:  0,
+	}
+
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
+	result, err := core.ReapStuckRuntimes(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, result.StaleRuntimesStopped)
+	require.Contains(t, result.AffectedAssistantIDs, missingAssistantID)
+	require.NotContains(t, result.AffectedAssistantIDs, presentAssistantID)
+
+	missingRuntime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: missingRuntimeID, ProjectID: missingProjectID})
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateStopped, missingRuntime.State)
+	require.True(t, missingRuntime.DeletedAt.Valid)
+
+	presentRuntime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: presentRuntimeID, ProjectID: presentProjectID})
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateActive, presentRuntime.State)
+	require.False(t, presentRuntime.DeletedAt.Valid)
+}
+
 func insertAssistantFixture(t *testing.T, conn *pgxpool.Pool) (projectID, assistantID, chatID, threadID uuid.UUID) {
 	t.Helper()
 	ctx := t.Context()


### PR DESCRIPTION
## Summary

- Adds a `local` assistant runtime provider (`GRAM_ASSISTANT_RUNTIME_PROVIDER=local`, now the local-development default) that starts one Docker container per assistant on demand from the locally built `gram-assistant-runtime:dev` image — no Fly.io credentials, apps, or registry pushes in the local loop anymore.
- Containers are named/labelled deterministically per assistant so `Ensure` is idempotent, concurrent admissions converge on one container, and a restarted server rediscovers containers it launched. Each assistant gets a persistent workspace volume that survives stops and image swaps and is removed on reap.
- Image rebuilds are detected by image ID (the tag stays `dev`) and configuration changes (server URL, CA mount) by a spec-hash label stamped at creation; idle containers with either kind of drift are replaced automatically on the next admission or recycle sweep, so a changed config propagates instead of being frozen into a warm-restarted container. A runner with a turn in flight is never interrupted.
- The server dials runners on an ephemeral loopback publish through a guardian client with a narrowly scoped loopback allowlist — the global egress policy is unchanged, and the `local` provider refuses to start outside `--environment=local`.
- Containers reach the server via `host.docker.internal`; `zero:tls` adds that hostname to the local certificate and hands the mkcert root CA to the server for mounting into runtime containers.
- Docker interactions sit behind a narrow `containerEngine` interface (docker CLI implementation) so lifecycle tests run against a fake; the runner HTTP layer shared by GKE and local moves into a common `runnerClient`.
- Dev tooling follows: `zero:fly` is functions-only now, the image build task no longer pushes to Fly, runtime log streaming supports `docker logs`, and new `assistants:local-status` / `assistants:local-clean` tasks cover inspection and cleanup. Local workflow docs live in `agents/runtime-image/README.md`.

## Drive-by fix: sandbox browser broke after the first context

Dogfooding the local runtime surfaced a runtime-image bug affecting all backends: lightpanda reuses frame IDs across browser contexts, so the second `newContext()` on a shared Playwright CDP connection tripped `Duplicate target FID-…` and poisoned the handle — only the first navigation of a `bun_run` process ever worked. `withContext` now opens and closes a dedicated CDP connection per call, `getBrowser()` rejects a second context with a descriptive error instead of the cryptic protocol assert, and the `bun_run` tool prompt states the one-context-per-handle rule.

## Local dev MCP server for assistant operations

Testing runtime changes previously meant driving the dashboard UI by hand. `server/cmd/dev-mcp` (registered in `.mcp.json` as `assistants-dev`) is a stdio MCP server that lets coding agents do it directly: it walks the dashboard's OIDC login flow against the local dev-idp (which auto-approves, so no interaction or credentials), then exposes assistant CRUD, `run_turn` (send a message and poll the chat until the terminal assistant reply), chat inspection, and trigger CRUD over the management API. Verified end to end against the local stack: create assistant → `run_turn` on a fresh chat and a follow-up on the same chat (replies arrive through trigger ingest → Temporal → the local Docker runtime) → cron trigger create/pause/resume/delete → cleanup.

Closes [DNO-480](https://linear.app/speakeasy/issue/DNO-480)

