### PR TITLE
fix: deflake shadow MCP inventory usage test

### DIFF
--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -101,16 +101,24 @@ func TestShadowMCPInventoryUsage_FromTelemetry(t *testing.T) {
 		ObservedAt: base.Add(3 * time.Minute),
 	})
 
-	usage := requireShadowMCPInventoryUsageEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryUsageParams{
-		GramProjectID: projectID,
-		Limit:         50,
-	}, 1)
+	// All three calls collapse into one canonical URL, so waiting on the row
+	// count alone would pass as soon as the first async insert flushes. Wait
+	// for the full call count so the assertions below see complete data.
+	var usage []telemetryRepo.ShadowMCPInventoryUsageRow
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		usage, err = ti.chClient.ListShadowMCPInventoryUsage(ctx, telemetryRepo.ListShadowMCPInventoryUsageParams{
+			GramProjectID: projectID,
+			Limit:         50,
+		})
+		require.NoError(c, err)
+		require.Len(c, usage, 1)
+		require.EqualValues(c, 3, usage[0].CallCount)
+	}, 5*time.Second, 100*time.Millisecond)
 
-	require.Len(t, usage, 1)
 	assert.Equal(t, "https://mcp.speakeasy.com/mcp", usage[0].CanonicalServerURL)
 	require.NotNil(t, usage[0].LastCalled)
 	assert.Equal(t, base.Add(2*time.Minute), *usage[0].LastCalled)
-	assert.EqualValues(t, 3, usage[0].CallCount)
 	assert.EqualValues(t, 2, usage[0].UserCount)
 	assert.Equal(t, []string{"ada@example.com", "grace@example.com"}, usage[0].TopUsers)
 }
@@ -365,26 +373,6 @@ func requireShadowMCPInventoryURLsEventually(
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
 		rows, err = ti.chClient.ListShadowMCPInventoryURLs(ctx, params)
-		require.NoError(c, err)
-		require.Len(c, rows, wantLen)
-	}, 5*time.Second, 100*time.Millisecond)
-
-	return rows
-}
-
-func requireShadowMCPInventoryUsageEventually(
-	ctx context.Context,
-	t *testing.T,
-	ti *testInstance,
-	params telemetryRepo.ListShadowMCPInventoryUsageParams,
-	wantLen int,
-) []telemetryRepo.ShadowMCPInventoryUsageRow {
-	t.Helper()
-
-	var rows []telemetryRepo.ShadowMCPInventoryUsageRow
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var err error
-		rows, err = ti.chClient.ListShadowMCPInventoryUsage(ctx, params)
 		require.NoError(c, err)
 		require.Len(c, rows, wantLen)
 	}, 5*time.Second, 100*time.Millisecond)


### PR DESCRIPTION
## Summary

`TestShadowMCPInventoryUsage_FromTelemetry` fails intermittently on any branch (seen consistently on recent CI runs; reproduces locally within a few `-count` iterations).

Root cause: telemetry log inserts go through ClickHouse async inserts without waiting for the flush, so rows become visible eventually and in insert order. The test's three calls all canonicalize to the same inventory URL, so the `EventuallyWithT` condition — usage list length == 1 — is satisfied as soon as the *first* insert flushes. The follow-up assertions (call count 3, two users, last-called timestamp) then run against partial data and fail whenever the remaining rows land in a later flush batch.

Fix: wait for the full expected call count inside the eventually loop before asserting the rest. Verified with `-count=10` (previously failed within 5 iterations).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky Shadow MCP inventory usage test by waiting for complete usage data before asserting. Prevents failures from async ClickHouse inserts that expose partial data for a single canonical URL.

- **Bug Fixes**
  - In the eventually loop, wait until there is one row with CallCount == 3, then run assertions (URL, last-called, user count, top users).
  - Removed the helper that only waited on row count; verified stability with -count=10.

<sup>Written for commit c628b44148ad212d9aada86f136f5ab6395aeb0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

