### PR TITLE
mig(clickhouse): add telemetry_logs_staging holding table

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260713031549_telemetry-logs-staging.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260713031549_telemetry-logs-staging.down.sql
@@ -1,0 +1,2 @@
+-- reverse: create "telemetry_logs_staging" table
+DROP TABLE `telemetry_logs_staging`;

--- a/server/clickhouse/local/golang_migrate/20260713031549_telemetry-logs-staging.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260713031549_telemetry-logs-staging.up.sql
@@ -1,0 +1,25 @@
+-- create "telemetry_logs_staging" table
+CREATE TABLE `telemetry_logs_staging` (
+  `id` UUID DEFAULT generateUUIDv7() COMMENT 'Unique identifier for the log entry, preserved when the row is promoted to telemetry_logs.',
+  `time_unix_nano` Int64 COMMENT 'Unix time (ns) when the event occurred measured by the origin clock.' CODEC(Delta(8), ZSTD(1)),
+  `observed_time_unix_nano` Int64 COMMENT 'Unix time (ns) when the event was observed by the collection system.' CODEC(Delta(8), ZSTD(1)),
+  `observed_timestamp` DateTime64(9) DEFAULT fromUnixTimestamp64Nano(observed_time_unix_nano) COMMENT 'Human-readable timestamp derived from observed_time_unix_nano.',
+  `severity_text` LowCardinality(Nullable(String)) COMMENT 'Text representation of severity (DEBUG, INFO, WARN, ERROR, FATAL).',
+  `body` String COMMENT 'The primary log message extracted from the log record.' CODEC(ZSTD(1)),
+  `trace_id` Nullable(FixedString(32)) COMMENT 'W3C trace ID linking related logs across services.',
+  `span_id` Nullable(FixedString(16)) COMMENT 'W3C span ID for specific operation within a trace.',
+  `attributes` JSON COMMENT 'Additional attributes about the specific event occurrence.' CODEC(ZSTD(1)),
+  `resource_attributes` JSON COMMENT 'Attributes describing the resource that generated this log.' CODEC(ZSTD(1)),
+  `gram_project_id` UUID COMMENT 'Project ID (denormalized from resource_attributes).',
+  `gram_deployment_id` Nullable(UUID) COMMENT 'Deployment ID (denormalized from resource_attributes).',
+  `gram_function_id` Nullable(UUID) COMMENT 'Function ID that generated the log (null for HTTP logs).',
+  `gram_urn` String COMMENT 'The Gram URN (e.g. claude-code:otel:logs).',
+  `service_name` LowCardinality(String) COMMENT 'Logical service name.',
+  `service_version` Nullable(String) COMMENT 'Service version.',
+  `gram_chat_id` Nullable(String) COMMENT 'The Chat ID (Claude session id) associated with the log.',
+  `chat_id` String MATERIALIZED toString(attributes.gen_ai.conversation.id) COMMENT 'Chat ID (materialized from attributes.gen_ai.conversation.id) — the promotion worker scopes by this.',
+  `request_id` String MATERIALIZED toString(attributes.request_id) COMMENT 'Claude API request id (materialized from attributes.request_id) — the attribution join key.'
+) ENGINE = MergeTree
+PRIMARY KEY (`gram_project_id`, `time_unix_nano`, `id`) ORDER BY (`gram_project_id`, `time_unix_nano`, `id`) PARTITION BY (toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))) TTL fromUnixTimestamp64Nano(observed_time_unix_nano) + toIntervalDay(2) SETTINGS index_granularity = 8192 COMMENT 'Holding pen for Claude OTEL api_request rows with redacted (custom) MCP attribution, awaiting transcript-derived attribution before promotion into telemetry_logs.';
+-- create index "idx_telemetry_logs_staging_chat_id" to table: "telemetry_logs_staging"
+ALTER TABLE `telemetry_logs_staging` ADD INDEX `idx_telemetry_logs_staging_chat_id` ((chat_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:E2eV8IWu597v52/pQ4NeGHi+MgTIxwwj2F5T+K/7SrQ=
+h1:5hXiuTkKpHtBsjHFhweY7/ZRhKYc2QK8rEfE/iPyaww=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -53,3 +53,4 @@ h1:E2eV8IWu597v52/pQ4NeGHi+MgTIxwwj2F5T+K/7SrQ=
 20260707200146_attribute-metrics-summaries-ttl-730d.up.sql h1:KDvIau/nvNDnU1rbICJ0A2GqmR2hOiK2AGLeLHBMA3s=
 20260709000641_provenance-first-attribute-metrics.up.sql h1:RXfFCI+1CjRTnNDikG52cqoa4+WSNenq4KgCjW5nv0w=
 20260710150001_shadow-mcp-inventory-urls.up.sql h1:/dMAeHWkPSnMHkNsTUle08RA2tXUex7qqGcLxgGk7Fk=
+20260713031549_telemetry-logs-staging.up.sql h1:OXRCOTGmSJhLDkRFxOodnXuf1COxVtzglHF9lNvjclk=

--- a/server/clickhouse/migrations/20260713031544_telemetry-logs-staging.sql
+++ b/server/clickhouse/migrations/20260713031544_telemetry-logs-staging.sql
@@ -1,0 +1,25 @@
+-- Create "telemetry_logs_staging" table
+CREATE TABLE `telemetry_logs_staging` (
+  `id` UUID DEFAULT generateUUIDv7() COMMENT 'Unique identifier for the log entry, preserved when the row is promoted to telemetry_logs.',
+  `time_unix_nano` Int64 COMMENT 'Unix time (ns) when the event occurred measured by the origin clock.' CODEC(Delta(8), ZSTD(1)),
+  `observed_time_unix_nano` Int64 COMMENT 'Unix time (ns) when the event was observed by the collection system.' CODEC(Delta(8), ZSTD(1)),
+  `observed_timestamp` DateTime64(9) DEFAULT fromUnixTimestamp64Nano(observed_time_unix_nano) COMMENT 'Human-readable timestamp derived from observed_time_unix_nano.',
+  `severity_text` LowCardinality(Nullable(String)) COMMENT 'Text representation of severity (DEBUG, INFO, WARN, ERROR, FATAL).',
+  `body` String COMMENT 'The primary log message extracted from the log record.' CODEC(ZSTD(1)),
+  `trace_id` Nullable(FixedString(32)) COMMENT 'W3C trace ID linking related logs across services.',
+  `span_id` Nullable(FixedString(16)) COMMENT 'W3C span ID for specific operation within a trace.',
+  `attributes` JSON COMMENT 'Additional attributes about the specific event occurrence.' CODEC(ZSTD(1)),
+  `resource_attributes` JSON COMMENT 'Attributes describing the resource that generated this log.' CODEC(ZSTD(1)),
+  `gram_project_id` UUID COMMENT 'Project ID (denormalized from resource_attributes).',
+  `gram_deployment_id` Nullable(UUID) COMMENT 'Deployment ID (denormalized from resource_attributes).',
+  `gram_function_id` Nullable(UUID) COMMENT 'Function ID that generated the log (null for HTTP logs).',
+  `gram_urn` String COMMENT 'The Gram URN (e.g. claude-code:otel:logs).',
+  `service_name` LowCardinality(String) COMMENT 'Logical service name.',
+  `service_version` Nullable(String) COMMENT 'Service version.',
+  `gram_chat_id` Nullable(String) COMMENT 'The Chat ID (Claude session id) associated with the log.',
+  `chat_id` String MATERIALIZED toString(attributes.gen_ai.conversation.id) COMMENT 'Chat ID (materialized from attributes.gen_ai.conversation.id) — the promotion worker scopes by this.',
+  `request_id` String MATERIALIZED toString(attributes.request_id) COMMENT 'Claude API request id (materialized from attributes.request_id) — the attribution join key.'
+) ENGINE = MergeTree
+PRIMARY KEY (`gram_project_id`, `time_unix_nano`, `id`) ORDER BY (`gram_project_id`, `time_unix_nano`, `id`) PARTITION BY (toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))) TTL fromUnixTimestamp64Nano(observed_time_unix_nano) + toIntervalDay(2) SETTINGS index_granularity = 8192 COMMENT 'Holding pen for Claude OTEL api_request rows with redacted (custom) MCP attribution, awaiting transcript-derived attribution before promotion into telemetry_logs.';
+-- Create index "idx_telemetry_logs_staging_chat_id" to table: "telemetry_logs_staging"
+ALTER TABLE `telemetry_logs_staging` ADD INDEX `idx_telemetry_logs_staging_chat_id` ((chat_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:r7Q53bi+T+oleLHG9HYZdAeMU/VBwTJQf1OeXg3DL3k=
+h1:3Uf+pN59IX5hHBnNH8IsDOCbtDjKpoLGoJ7NuFst18Y=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -60,3 +60,4 @@ h1:r7Q53bi+T+oleLHG9HYZdAeMU/VBwTJQf1OeXg3DL3k=
 20260709191016_chat-token-summaries-hook-source.sql h1:LcKVoSg09ZBP2c1LPJe7yMtnL8MoHn8mnrYin0nOthk=
 20260709200000_tum-breakdown-summaries.sql h1:fIWUArHikvB7GodDCiFBQi4AfkU8MlTbUXiM1dgPz7A=
 20260710150000_shadow-mcp-inventory-urls.sql h1:B3xXOhFpxCoOvOqwVXZUVezjbky75EwEw3ePfSLI4z8=
+20260713031544_telemetry-logs-staging.sql h1:ibENGxmwC3z6XqbovQWCeoSOMQkR55OVIsdy/mcJuCg=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -101,6 +101,51 @@ CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_account_type ON telemetry_logs
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_provider ON telemetry_logs (provider) TYPE set(0) GRANULARITY 4;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_billing_mode ON telemetry_logs (billing_mode) TYPE set(0) GRANULARITY 4;
 
+-- telemetry_logs_staging parks Claude OTEL api_request rows whose inline MCP
+-- attribution was redacted (mcp_server.name = 'custom') until the
+-- transcript-derived attribution for the request arrives via hooks (or a
+-- timeout passes). Its physical columns match telemetry_logs so rows can be
+-- re-inserted verbatim, but it deliberately carries only the two materialized
+-- columns promotion needs (chat_id, request_id) — telemetry_logs' other
+-- materialized columns are recomputed at insert time when the row is
+-- promoted. The promotion worker rewrites attributes.mcp_server.name /
+-- attributes.mcp_tool.name and inserts the row into telemetry_logs — the
+-- moment attribute_metrics_summaries_mv fires — then deletes it here. Rows
+-- keep their id across promotion, so telemetry_logs itself is the
+-- exactly-once ledger. The short TTL is a cleanup backstop only (measured
+-- from observation time, since the promotion timeout is too): the 30-minute
+-- timeout sweep promotes stragglers verbatim long before it.
+CREATE TABLE IF NOT EXISTS telemetry_logs_staging (
+    id UUID DEFAULT generateUUIDv7() COMMENT 'Unique identifier for the log entry, preserved when the row is promoted to telemetry_logs.',
+    time_unix_nano Int64 COMMENT 'Unix time (ns) when the event occurred measured by the origin clock.' CODEC(Delta, ZSTD),
+    observed_time_unix_nano Int64 COMMENT 'Unix time (ns) when the event was observed by the collection system.' CODEC(Delta, ZSTD),
+    observed_timestamp DateTime64(9) DEFAULT fromUnixTimestamp64Nano(observed_time_unix_nano) COMMENT 'Human-readable timestamp derived from observed_time_unix_nano.',
+    severity_text LowCardinality(Nullable(String)) COMMENT 'Text representation of severity (DEBUG, INFO, WARN, ERROR, FATAL).',
+    body String COMMENT 'The primary log message extracted from the log record.' CODEC(ZSTD),
+    trace_id Nullable(FixedString(32)) COMMENT 'W3C trace ID linking related logs across services.',
+    span_id Nullable(FixedString(16)) COMMENT 'W3C span ID for specific operation within a trace.',
+    attributes JSON COMMENT 'Additional attributes about the specific event occurrence.' CODEC(ZSTD),
+    resource_attributes JSON COMMENT 'Attributes describing the resource that generated this log.' CODEC(ZSTD),
+    gram_project_id UUID COMMENT 'Project ID (denormalized from resource_attributes).',
+    gram_deployment_id Nullable(UUID) COMMENT 'Deployment ID (denormalized from resource_attributes).',
+    gram_function_id Nullable(UUID) COMMENT 'Function ID that generated the log (null for HTTP logs).',
+    gram_urn String COMMENT 'The Gram URN (e.g. claude-code:otel:logs).',
+    service_name LowCardinality(String) COMMENT 'Logical service name.',
+    service_version Nullable(String) COMMENT 'Service version.',
+    gram_chat_id Nullable(String) COMMENT 'The Chat ID (Claude session id) associated with the log.',
+    chat_id String MATERIALIZED toString(attributes.gen_ai.conversation.id) COMMENT 'Chat ID (materialized from attributes.gen_ai.conversation.id) — the promotion worker scopes by this.',
+    request_id String MATERIALIZED toString(attributes.request_id) COMMENT 'Claude API request id (materialized from attributes.request_id) — the attribution join key.'
+) ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))
+ORDER BY (gram_project_id, time_unix_nano, id)
+TTL fromUnixTimestamp64Nano(observed_time_unix_nano) + INTERVAL 2 DAY
+SETTINGS index_granularity = 8192
+COMMENT 'Holding pen for Claude OTEL api_request rows with redacted (custom) MCP attribution, awaiting transcript-derived attribution before promotion into telemetry_logs.';
+
+-- The promotion worker scopes every read by session, so chat_id needs the
+-- same bloom-filter treatment it gets on telemetry_logs.
+CREATE INDEX IF NOT EXISTS idx_telemetry_logs_staging_chat_id ON telemetry_logs_staging (chat_id) TYPE bloom_filter(0.01) GRANULARITY 1;
+
 CREATE TABLE IF NOT EXISTS trace_summaries (
     -- Key cols
     trace_id FixedString(32),


### PR DESCRIPTION
## Summary

Migration-only PR, split out of #4122 (stacked: #4122 now targets this branch).

Adds the `telemetry_logs_staging` ClickHouse table: a holding pen for Claude OTEL `api_request` rows whose MCP attribution Claude redacted to `custom`. Rows wait here until the transcript-derived attribution for their `request_id` arrives via hooks (or a 30-minute timeout passes), then the promotion worker rewrites the attribution and inserts them into `telemetry_logs` — the moment `attribute_metrics_summaries_mv` fires.

- Physical columns match `telemetry_logs` so rows re-insert verbatim; only the two materialized columns promotion needs (`chat_id`, `request_id`) are carried.
- TTL is a 2-day cleanup backstop measured from observation time (same clock as the promotion timeout, so late OTEL exports can't expire unpromoted).
- Bloom-filter index on `chat_id` for the per-session promotion reads.

No code reads or writes this table until #4122 lands.

## Test plan

- [ ] Atlas lint green
- [ ] #4122 (staging/promotion code + tests) validates the table end-to-end


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ClickHouse `telemetry_logs_staging`, a holding table for Claude OTEL `api_request` rows with redacted MCP attribution. This delays insert into `telemetry_logs` until transcript-derived attribution arrives.

- **Migration**
  - Create `telemetry_logs_staging` with physical columns matching `telemetry_logs`; only `chat_id` and `request_id` are materialized.
  - `MergeTree` with PK `(gram_project_id, time_unix_nano, id)`, partition by event day, TTL 2 days from `observed_time_unix_nano`.
  - Add bloom-filter index on `chat_id` for session-scoped promotion reads.

<sup>Written for commit 0aafb656fefdcf5db05fe38f0bf2821af398c065. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

