### PR TITLE
chore: allow any lowercase qualifier in PR title hygiene check

### DIFF
--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -24,11 +24,11 @@ jobs:
             exit 0
           fi
 
-          if [[ "$PR_TITLE" =~ ^(chore|fix|feat|mig)(\([a-zA-Z0-9_-]+\))?!?:\ [a-zA-Z] ]]; then
+          if [[ "$PR_TITLE" =~ ^[a-z0-9_-]+(\([a-zA-Z0-9_-]+\))?!?:\ [a-zA-Z] ]]; then
             echo "PR title format is valid."
           else
             echo "PR title must:"
-            echo '- Start with one of: "chore", "fix", "feat", "mig"'
+            echo '- Start with a lowercase qualifier (e.g. "chore", "fix", "feat", "mig") - alphanumeric, dashes, and underscores only'
             echo "- ... optionally followed by a scope in parentheses - alphanumeric, dashes, and underscores only"
             echo "- ... optionally followed by an exclamation mark (!) to indicate a breaking change"
             echo "- ... followed by a colon and a space"


### PR DESCRIPTION
## Summary

The PR title check in `hygiene.yaml` hardcoded the qualifiers `chore|fix|feat|mig`, so titles using any other conventional-commit qualifier (e.g. `perf:`, `docs(scope):`) failed even when well-formed.

This generalizes the regex to accept any `<qualifier>: <message>` or `<qualifier>(<scope>): <message>`:

- qualifier: lowercase letters, numbers, underscores, dashes (`[a-z0-9_-]+`)
- scope: letters, numbers, underscores, dashes (optional)
- optional `!` breaking-change marker retained

The error message's first bullet is updated to match.

Downstream steps that key off specific qualifiers are unchanged and still enforce their own patterns: `mig:` required for migration PRs, and `chore`/`mig` skipping changeset lint.

## Testing

Regex verified in bash against sample titles:

- ✅ `feat(server): add thing`, `feat: add thing`, `feat!: breaking`, `perf: speed up`, `docs2(my-scope_1)!: breaking`
- ❌ `Feat: nope` (uppercase), `feat(bad scope): nope` (space in scope), `feat:nospace` (missing space)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalized the PR title hygiene check to accept any lowercase conventional-commit qualifier (alphanumeric, dashes, underscores), with optional scope and optional !. Updated the error message to match; qualifier-specific steps (e.g., requiring `mig` for migrations and skipping changeset lint for `chore`/`mig`) are unchanged.

<sup>Written for commit 35c98e2c3435c2cafb37f9e96cbdc6fc3c9bc401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

