### PR TITLE
feat: recommend FORCE_AUTOUPDATE_PLUGINS in Claude managed-settings snippets

### DIFF
--- a/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
+++ b/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
@@ -40,6 +40,9 @@ function ClaudeInstallContent({
     marketplaceUrl && marketplaceName
       ? JSON.stringify(
           {
+            env: {
+              FORCE_AUTOUPDATE_PLUGINS: "1",
+            },
             extraKnownMarketplaces: {
               [marketplaceName]: {
                 autoUpdate: true,

--- a/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
+++ b/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
@@ -168,6 +168,9 @@ function ClaudeCodeInstallContent({
     marketplaceUrl && marketplaceName
       ? JSON.stringify(
           {
+            env: {
+              FORCE_AUTOUPDATE_PLUGINS: "1",
+            },
             extraKnownMarketplaces: {
               [marketplaceName]: {
                 autoUpdate: true,

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -56,7 +56,8 @@ export const AGENT_PLATFORMS: AgentPlatform[] = [
     "OTEL_EXPORTER_OTLP_HEADERS": "Gram-Project=default,Gram-Key={{GRAM_API_KEY}}",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
     "OTEL_LOGS_EXPORTER": "otlp",
-    "OTEL_METRICS_EXPORTER": "otlp"
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "FORCE_AUTOUPDATE_PLUGINS": "1"
   },
   "extraKnownMarketplaces": {
     "{{GRAM_MARKETPLACE_NAME}}": {


### PR DESCRIPTION
## Summary

- Add `FORCE_AUTOUPDATE_PLUGINS: "1"` to the `env` block of every Claude Code managed-settings JSON snippet (onboarding wizard, plugins install dialog, hooks setup dialog) so org-wide plugin rollouts pick up updates automatically, regardless of a developer's local auto-update setting.

Closes [DNO-348](https://linear.app/speakeasy/issue/DNO-348/feat-add-force-autoupdate-plugins-to-claude-onboarding-steps).

## Test plan

- [x] `pnpm -F dashboard type-check` passes
- [ ] Visually confirm the new env var shows up in each of the 3 dialogs (onboarding wizard, plugins install dialog, hooks setup dialog)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force plugin auto-updates in Claude Code managed-settings by adding `FORCE_AUTOUPDATE_PLUGINS: "1"` to all snippets. Ensures org-wide plugin rollouts update even if a developer disabled auto-update (DNO-348).

- **New Features**
  - Added `FORCE_AUTOUPDATE_PLUGINS: "1"` under `env` in the JSON for the onboarding wizard, plugins install dialog, and hooks setup dialog.

<sup>Written for commit 4be748d4210ab355780aa2ae050c81125161e37d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

