### PR TITLE
chore: deflake shadow MCP inventory tests with async insert flush

### DIFF
--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -283,8 +283,10 @@ func (q *Queries) InsertTelemetryLog(ctx context.Context, arg InsertTelemetryLog
 	return q.InsertTelemetryLogs(ctx, []InsertTelemetryLogParams{arg})
 }
 
-// InsertTelemetryLogs inserts telemetry log records into ClickHouse in a single
-// synchronous statement.
+// InsertTelemetryLogs inserts telemetry log records using a server-side async
+// insert (async_insert=1, wait_for_async_insert=0). The call is fire-and-forget
+// from CH's perspective: it acks once the rows are queued in CH's async insert
+// buffer, not once they are committed to disk.
 func (q *Queries) InsertTelemetryLogs(ctx context.Context, args []InsertTelemetryLogParams) error {
 	if len(args) == 0 {
 		return nil
@@ -415,6 +417,9 @@ type shadowMCPInventoryURLUpsert struct {
 	UpdatedAt          time.Time
 }
 
+// UpsertShadowMCPInventoryURLs merges the given rows with any existing
+// inventory rows and writes them using a server-side async insert
+// (fire-and-forget), same as InsertTelemetryLogs.
 func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []UpsertShadowMCPInventoryURLParams) error {
 	if len(args) == 0 {
 		return nil

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -54,6 +55,7 @@ type testInstance struct {
 	service            *telemetry.Service
 	logger             *slog.Logger
 	conn               *pgxpool.Pool
+	chConn             clickhouse.Conn
 	chClient           *repo.Queries
 	sessionManager     *sessions.Manager
 	orgID              string
@@ -129,6 +131,7 @@ func newTestLogsServiceWithSessionCapture(t *testing.T, sessionCapture bool) (co
 		telemLogger:        telemLogger,
 		logger:             logger,
 		conn:               conn,
+		chConn:             chConn,
 		chClient:           chClient,
 		sessionManager:     sessionManager,
 		orgID:              authCtx.ActiveOrganizationID,

--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryRepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestShadowMCPInventoryURLs_UpsertAndList(t *testing.T) {
@@ -51,17 +51,19 @@ func TestShadowMCPInventoryURLs_UpsertAndList(t *testing.T) {
 		},
 	}))
 
-	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
-	}, 1)
-
+	})
+	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
-	assert.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
-	assert.Equal(t, "Speakeasy", rows[0].ServerName)
-	assert.Equal(t, firstSeen, rows[0].FirstSeen)
-	assert.Equal(t, lastSeen, rows[0].LastSeen)
+	require.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
+	require.Equal(t, "Speakeasy", rows[0].ServerName)
+	require.Equal(t, firstSeen, rows[0].FirstSeen)
+	require.Equal(t, lastSeen, rows[0].LastSeen)
 }
 
 func TestShadowMCPInventoryUsage_FromTelemetry(t *testing.T) {
@@ -101,26 +103,20 @@ func TestShadowMCPInventoryUsage_FromTelemetry(t *testing.T) {
 		ObservedAt: base.Add(3 * time.Minute),
 	})
 
-	// All three calls collapse into one canonical URL, so waiting on the row
-	// count alone would pass as soon as the first async insert flushes. Wait
-	// for the full call count so the assertions below see complete data.
-	var usage []telemetryRepo.ShadowMCPInventoryUsageRow
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var err error
-		usage, err = ti.chClient.ListShadowMCPInventoryUsage(ctx, telemetryRepo.ListShadowMCPInventoryUsageParams{
-			GramProjectID: projectID,
-			Limit:         50,
-		})
-		require.NoError(c, err)
-		require.Len(c, usage, 1)
-		require.EqualValues(c, 3, usage[0].CallCount)
-	}, 5*time.Second, 100*time.Millisecond)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
-	assert.Equal(t, "https://mcp.speakeasy.com/mcp", usage[0].CanonicalServerURL)
+	usage, err := ti.chClient.ListShadowMCPInventoryUsage(ctx, telemetryRepo.ListShadowMCPInventoryUsageParams{
+		GramProjectID: projectID,
+		Limit:         50,
+	})
+	require.NoError(t, err)
+	require.Len(t, usage, 1)
+	require.EqualValues(t, 3, usage[0].CallCount)
+	require.Equal(t, "https://mcp.speakeasy.com/mcp", usage[0].CanonicalServerURL)
 	require.NotNil(t, usage[0].LastCalled)
-	assert.Equal(t, base.Add(2*time.Minute), *usage[0].LastCalled)
-	assert.EqualValues(t, 2, usage[0].UserCount)
-	assert.Equal(t, []string{"ada@example.com", "grace@example.com"}, usage[0].TopUsers)
+	require.Equal(t, base.Add(2*time.Minute), *usage[0].LastCalled)
+	require.EqualValues(t, 2, usage[0].UserCount)
+	require.Equal(t, []string{"ada@example.com", "grace@example.com"}, usage[0].TopUsers)
 }
 
 func TestListShadowMCPInventoryUsers_FromTelemetry(t *testing.T) {
@@ -152,19 +148,21 @@ func TestListShadowMCPInventoryUsers_FromTelemetry(t *testing.T) {
 		ObservedAt: base.Add(2 * time.Minute),
 	})
 
-	users := requireShadowMCPInventoryUsersEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryUsersParams{
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	users, err := ti.chClient.ListShadowMCPInventoryUsers(ctx, telemetryRepo.ListShadowMCPInventoryUsersParams{
 		GramProjectID:      projectID,
 		CanonicalServerURL: "https://mcp.speakeasy.com/mcp",
 		Limit:              50,
-	}, 2)
-
+	})
+	require.NoError(t, err)
 	require.Len(t, users, 2)
-	assert.Equal(t, "ada@example.com", users[0].UserKey)
-	assert.EqualValues(t, 2, users[0].CallCount)
-	assert.Equal(t, base.Add(time.Minute), users[0].LastCalled)
-	assert.Equal(t, "grace@example.com", users[1].UserKey)
-	assert.EqualValues(t, 1, users[1].CallCount)
-	assert.Equal(t, base.Add(2*time.Minute), users[1].LastCalled)
+	require.Equal(t, "ada@example.com", users[0].UserKey)
+	require.EqualValues(t, 2, users[0].CallCount)
+	require.Equal(t, base.Add(time.Minute), users[0].LastCalled)
+	require.Equal(t, "grace@example.com", users[1].UserKey)
+	require.EqualValues(t, 1, users[1].CallCount)
+	require.Equal(t, base.Add(2*time.Minute), users[1].LastCalled)
 }
 
 func TestLoggerUpsertShadowMCPInventoryURLs(t *testing.T) {
@@ -185,15 +183,17 @@ func TestLoggerUpsertShadowMCPInventoryURLs(t *testing.T) {
 		},
 	}))
 
-	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
-	}, 1)
-
+	})
+	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
-	assert.Equal(t, "Speakeasy", rows[0].ServerName)
-	assert.Equal(t, seenAt, rows[0].LastSeen)
+	require.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "Speakeasy", rows[0].ServerName)
+	require.Equal(t, seenAt, rows[0].LastSeen)
 }
 
 func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
@@ -226,15 +226,7 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 		ObservedAt: observedAt.Add(time.Hour),
 	})
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
-			GramProjectID:      projectID,
-			Limit:              50,
-			HostedMCPHostnames: nil,
-		})
-		require.NoError(c, err)
-		require.Equal(c, 1, result.InventoryURLCount)
-	}, 5*time.Second, 100*time.Millisecond)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
 		GramProjectID:      projectID,
@@ -244,16 +236,27 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, result.InventoryURLCount)
 
-	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+	// A second run sees the same usage and upserts the same single URL.
+	result, err = ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
+		GramProjectID:      projectID,
+		Limit:              50,
+		HostedMCPHostnames: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.InventoryURLCount)
+
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
-	}, 1)
-
+	})
+	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
-	assert.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
-	assert.Equal(t, observedAt, rows[0].FirstSeen)
-	assert.Equal(t, observedAt.Add(time.Minute), rows[0].LastSeen)
+	require.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
+	require.Equal(t, observedAt, rows[0].FirstSeen)
+	require.Equal(t, observedAt.Add(time.Minute), rows[0].LastSeen)
 }
 
 func TestBackfillShadowMCPInventoryURLs_ExcludesHostedHostnames(t *testing.T) {
@@ -296,23 +299,25 @@ func TestBackfillShadowMCPInventoryURLs_ExcludesHostedHostnames(t *testing.T) {
 		ObservedAt: observedAt.Add(2 * time.Minute),
 	})
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
-			GramProjectID:      projectID,
-			Limit:              50,
-			HostedMCPHostnames: []string{"https://app.getgram.ai"},
-		})
-		require.NoError(c, err)
-		require.Equal(c, 1, result.InventoryURLCount)
-	}, 5*time.Second, 100*time.Millisecond)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
-	rows := requireShadowMCPInventoryURLsEventually(ctx, t, ti, telemetryRepo.ListShadowMCPInventoryURLsParams{
+	result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
+		GramProjectID:      projectID,
+		Limit:              50,
+		HostedMCPHostnames: []string{"https://app.getgram.ai"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.InventoryURLCount)
+
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
 		Limit:         50,
-	}, 1)
-
+	})
+	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, "https://external.example.com/mcp", rows[0].CanonicalServerURL)
+	require.Equal(t, "https://external.example.com/mcp", rows[0].CanonicalServerURL)
 }
 
 type historicalShadowMCPCall struct {
@@ -358,44 +363,4 @@ func insertHistoricalShadowMCPCall(t *testing.T, ctx context.Context, ti *testIn
 		GramChatID:           nil,
 	})
 	require.NoError(t, err)
-}
-
-func requireShadowMCPInventoryURLsEventually(
-	ctx context.Context,
-	t *testing.T,
-	ti *testInstance,
-	params telemetryRepo.ListShadowMCPInventoryURLsParams,
-	wantLen int,
-) []telemetryRepo.ShadowMCPInventoryURLRow {
-	t.Helper()
-
-	var rows []telemetryRepo.ShadowMCPInventoryURLRow
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var err error
-		rows, err = ti.chClient.ListShadowMCPInventoryURLs(ctx, params)
-		require.NoError(c, err)
-		require.Len(c, rows, wantLen)
-	}, 5*time.Second, 100*time.Millisecond)
-
-	return rows
-}
-
-func requireShadowMCPInventoryUsersEventually(
-	ctx context.Context,
-	t *testing.T,
-	ti *testInstance,
-	params telemetryRepo.ListShadowMCPInventoryUsersParams,
-	wantLen int,
-) []telemetryRepo.ShadowMCPInventoryUserRow {
-	t.Helper()
-
-	var rows []telemetryRepo.ShadowMCPInventoryUserRow
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		var err error
-		rows, err = ti.chClient.ListShadowMCPInventoryUsers(ctx, params)
-		require.NoError(c, err)
-		require.Len(c, rows, wantLen)
-	}, 5*time.Second, 100*time.Millisecond)
-
-	return rows
 }

--- a/server/internal/testenv/clickhouse.go
+++ b/server/internal/testenv/clickhouse.go
@@ -2,7 +2,10 @@ package testenv
 
 import (
 	"context"
+	"testing"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
 	clickhousecontainer "github.com/testcontainers/testcontainers-go/modules/clickhouse"
 
 	"github.com/speakeasy-api/gram/server/internal/testinfra"
@@ -20,4 +23,15 @@ func NewTestClickhouse(ctx context.Context) (*clickhousecontainer.ClickHouseCont
 		return nil, nil, err
 	}
 	return container, clientFunc, nil
+}
+
+// FlushClickHouseAsyncInserts synchronously drains ClickHouse's async insert
+// queue. Some write paths (e.g. telemetry logs) use server-side async
+// fire-and-forget inserts, so rows only become visible to queries after a
+// buffer flush. Calling this after a write makes the data deterministically
+// visible without polling.
+func FlushClickHouseAsyncInserts(t *testing.T, conn clickhouse.Conn) {
+	t.Helper()
+
+	require.NoError(t, conn.Exec(t.Context(), "SYSTEM FLUSH ASYNC INSERT QUEUE"))
 }


### PR DESCRIPTION
## Summary

`TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts` flaked in CI: the backfill ran while only the first of two seeded telemetry logs was visible in ClickHouse, upserting a stale `last_seen`. #4119 patched a sibling test by polling on stronger conditions, but the underlying race remained.

**Root cause:** clickhouse-go's option is `WithAsync(wait bool)` — the bool is _wait_, not _async_. So `WithAsync(false)` in the telemetry repo **enables** server-side async insert with `wait_for_async_insert=0` (fire-and-forget), despite the code comment claiming a synchronous statement. It also overrides the test connection's `async_insert=0` setting, so rows become visible to test queries only after an async buffer flush, in unpredictable batches.

**Goal:** remove the non-determinism itself — and with it the need for `require.Eventually`-style assertions — rather than papering over it with more polling.

**Fix:** production write behavior is unchanged (async fire-and-forget is kept, and tests continue to exercise that same path). Tests instead get a deterministic synchronization barrier:

- New `testenv.FlushClickHouseAsyncInserts(t, conn)` runs `SYSTEM FLUSH ASYNC INSERT QUEUE`, which synchronously drains ClickHouse's async-insert buffers so subsequent queries see all prior writes.
- The shadow MCP inventory tests call it after each write phase (seeding and backfill upserts) and assert directly. All `EventuallyWithT` loops and the `require...Eventually` helpers are gone.
- Comment-only fix on `InsertTelemetryLogs`/`UpsertShadowMCPInventoryURLs` documenting that they are async fire-and-forget inserts, not synchronous ones.

## Testing

- `go test ./internal/telemetry/ -race -run 'ShadowMCP' -count=20` — passed (the flake previously reproduced within a few iterations per #4119).
- Full `go test ./internal/telemetry/ -race` — passed.
- `gcl` (golangci-lint custom) clean on the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflaked Shadow MCP inventory tests by flushing ClickHouse async inserts in tests, removing polling and making results deterministic. Production write behavior remains async and unchanged.

- **Bug Fixes**
  - Added `testenv.FlushClickHouseAsyncInserts(t, conn)` to run `SYSTEM FLUSH ASYNC INSERT QUEUE` and make async-inserted rows visible.
  - Updated Shadow MCP inventory tests to flush after seeding and backfill upserts; replaced `Eventually` loops with direct assertions.
  - Passed ClickHouse `chConn` through test setup to enable flushing.
  - Clarified comments in `InsertTelemetryLogs` and `UpsertShadowMCPInventoryURLs` that writes are async fire-and-forget (`clickhouse-go` `WithAsync(false)` = wait disabled).

<sup>Written for commit a5f5c5fbe239ab9f2e525c889007b45762334a5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

