### PR TITLE
fix: address OpenRouter model refresh review feedback

### DIFF
--- a/.changeset/openrouter-model-feedback.md
+++ b/.changeset/openrouter-model-feedback.md
@@ -1,0 +1,7 @@
+---
+"server": patch
+"dashboard": patch
+"@gram-ai/elements": patch
+---
+
+Address review feedback from the OpenRouter model refresh: pin explicit per-provider fallback models in ResolveModel so de-listed or unknown models never silently resolve to a premium model (previously anthropic/\* fell back alphabetically to Claude Fable 5), give elements an explicit DEFAULT_MODEL (Claude Sonnet 5) instead of MODELS[0], and remove Gemini 3.5 Flash from the prompt-policy judge picker (the judge disables reasoning, which that model rejects).

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -130,9 +130,11 @@ import { formatUsageCost } from "@/pages/chatLogs/claudeUsage";
 // empty-string item value, so "" is mapped through this and back on change.
 const DEFAULT_MODEL_VALUE = "__default__";
 
+// Gemini 3.5 Flash is deliberately absent: the judge disables reasoning
+// (`reasoning.effort: "none"`), which the Gemini 3.5 generation rejects with a
+// 400 — every evaluation on it would fail into the policy's error mode.
 const JUDGE_MODELS: { value: string; label: string }[] = [
   { value: "", label: "Default (Gemini 3.1 Flash Lite)" },
-  { value: "google/gemini-3.5-flash", label: "Gemini 3.5 Flash" },
   { value: "anthropic/claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
   { value: "anthropic/claude-haiku-4.5", label: "Claude Haiku 4.5" },
 ];

--- a/elements/src/components/Replay.tsx
+++ b/elements/src/components/Replay.tsx
@@ -29,7 +29,7 @@ import {
   type Cassette,
   type ReplayOptions,
 } from "@/lib/cassette";
-import { MODELS } from "@/lib/models";
+import { DEFAULT_MODEL } from "@/lib/models";
 import { cn } from "@/lib/utils";
 import { recommended } from "@/plugins";
 import type { ElementsConfig } from "@/types";
@@ -104,7 +104,7 @@ export const Replay = ({
     () => ({
       config,
       setModel: () => {},
-      model: MODELS[0],
+      model: DEFAULT_MODEL,
       isExpanded: false,
       setIsExpanded: () => {},
       isOpen: true,

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -8,7 +8,7 @@ import { useMCPTools } from "@/hooks/useMCPTools";
 import { useToolApproval } from "@/hooks/useToolApproval";
 import { getApiUrl } from "@/lib/api";
 import { initErrorTracking, trackError } from "@/lib/errorTracking";
-import { MODELS } from "@/lib/models";
+import { DEFAULT_MODEL } from "@/lib/models";
 import {
   clearFrontendToolApprovalConfig,
   getEnabledTools,
@@ -201,7 +201,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
   const toolApproval = useToolApproval();
 
   const [model, setModel] = useState<Model>(
-    config.model?.defaultModel ?? MODELS[0],
+    config.model?.defaultModel ?? DEFAULT_MODEL,
   );
   const [isExpanded, setIsExpanded] = useState(
     config.modal?.defaultExpanded ?? false,

--- a/elements/src/lib/models.ts
+++ b/elements/src/lib/models.ts
@@ -39,3 +39,10 @@ export const MODELS = [
   "mistralai/devstral-2512",
   "mistralai/mistral-medium-3.1",
 ] as const;
+
+// Default model for chat surfaces when the host app doesn't pin one via
+// config.model.defaultModel. Kept explicit (rather than MODELS[0]) so
+// reordering MODELS — e.g. listing a premium model first — can never
+// silently change what unconfigured embeds run on.
+export const DEFAULT_MODEL: (typeof MODELS)[number] =
+  "anthropic/claude-sonnet-5";

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -126,9 +126,27 @@ func IsModelAllowed(model string) bool {
 	return allowList[model]
 }
 
-// ResolveModel returns the model as-is if it's in the allowlist.
-// Otherwise, it returns the first allowed model (sorted alphabetically)
-// from the same provider. Returns empty string if no fallback is found.
+// providerFallbacks pins the model an unknown or de-listed model resolves to,
+// per provider. Without this, ResolveModel's alphabetical fallback silently
+// upgrades callers to whatever sorts first — for Anthropic that is the
+// premium-priced claude-fable-5. Each entry names the provider's
+// standard-cost workhorse; keep it allowlisted (enforced by tests).
+var providerFallbacks = map[string]string{
+	"anthropic":  "anthropic/claude-sonnet-5",
+	"openai":     "openai/gpt-5.6-terra",
+	"google":     "google/gemini-3.5-flash",
+	"deepseek":   "deepseek/deepseek-v4-flash",
+	"meta-llama": "meta-llama/llama-4-maverick",
+	"x-ai":       "x-ai/grok-4.3",
+	"qwen":       "qwen/qwen3.7-max",
+	"moonshotai": "moonshotai/kimi-k2.6",
+	"mistralai":  "mistralai/mistral-medium-3-5",
+}
+
+// ResolveModel returns the model as-is if it's in the allowlist. Otherwise, it
+// returns the provider's pinned fallback from providerFallbacks, or — for
+// providers without a pin — the first allowed model sorted alphabetically.
+// Returns empty string if no fallback is found.
 func ResolveModel(model string) string {
 	if allowList[model] {
 		return model
@@ -137,6 +155,10 @@ func ResolveModel(model string) string {
 	provider, _, ok := strings.Cut(model, "/")
 	if !ok || provider == "" {
 		return ""
+	}
+
+	if fallback := providerFallbacks[provider]; fallback != "" && allowList[fallback] {
+		return fallback
 	}
 
 	prefix := provider + "/"

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -1589,17 +1588,6 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 		"response_format should not be set when JSONSchema is nil")
 }
 
-func firstAllowedModelForProvider(prefix string) string {
-	var models []string
-	for m := range allowList {
-		if strings.HasPrefix(m, prefix) {
-			models = append(models, m)
-		}
-	}
-	sort.Strings(models)
-	return models[0]
-}
-
 func TestResolveModel_AllowedModelReturnedAsIs(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, "openai/gpt-5.4", ResolveModel("openai/gpt-5.4"))
@@ -1607,14 +1595,33 @@ func TestResolveModel_AllowedModelReturnedAsIs(t *testing.T) {
 
 func TestResolveModel_UnsupportedOpenAIFallback(t *testing.T) {
 	t.Parallel()
-	expected := firstAllowedModelForProvider("openai/")
-	require.Equal(t, expected, ResolveModel("openai/gpt-4"))
+	require.Equal(t, "openai/gpt-5.6-terra", ResolveModel("openai/gpt-4"))
 }
 
 func TestResolveModel_UnsupportedAnthropicFallback(t *testing.T) {
 	t.Parallel()
-	expected := firstAllowedModelForProvider("anthropic/")
-	require.Equal(t, expected, ResolveModel("anthropic/claude-2"))
+	require.Equal(t, "anthropic/claude-sonnet-5", ResolveModel("anthropic/claude-2"))
+}
+
+func TestResolveModel_FallbacksAreAllowlisted(t *testing.T) {
+	t.Parallel()
+	for provider, fallback := range providerFallbacks {
+		require.True(t, allowList[fallback],
+			"providerFallbacks[%q] = %q is not in the allowlist", provider, fallback)
+	}
+}
+
+func TestResolveModel_EveryProviderHasPinnedFallback(t *testing.T) {
+	t.Parallel()
+	// Every provider in the allowlist must have an explicit fallback pin, so
+	// de-listing a model can never silently route callers to whichever model
+	// sorts first alphabetically (e.g. a premium-priced one).
+	for m := range allowList {
+		provider, _, ok := strings.Cut(m, "/")
+		require.True(t, ok, "allowlist entry %q has no provider prefix", m)
+		require.NotEmpty(t, providerFallbacks[provider],
+			"provider %q (from allowlist entry %q) has no pinned fallback", provider, m)
+	}
 }
 
 func TestResolveModel_UnknownProviderReturnsEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses the three unresolved cubic findings on #4128 (merged with feedback outstanding):

### 1. P1 — `ResolveModel` silently upgraded callers to Claude Fable 5
`ResolveModel`'s fallback for unknown/de-listed models picked the alphabetically first allowlisted model per provider — and `anthropic/claude-fable-5` now sorts first, so pinned deprecated Anthropic models (e.g. `claude-sonnet-4` policies) were silently routed to the most expensive model.

Fix: an explicit `providerFallbacks` map pins each provider's standard-cost workhorse (anthropic → sonnet-5, openai → gpt-5.6-terra, google → gemini-3.5-flash, …); alphabetical ordering remains only as a backstop for unpinned providers. Two new invariant tests enforce that every fallback is allowlisted **and** every provider in the allowlist has a pin — so a future de-listing can't reintroduce this bug class.

### 2. P1 — Gemini 3.5 Flash breaks the prompt-policy judge
The judge path (`GetObjectCompletion`) hard-codes `reasoning.effort: "none"`, which the Gemini 3.5 generation rejects with a 400 — every evaluation pinned to it would fail into the policy's error mode. Removed it from the `JUDGE_MODELS` picker with a comment explaining why (default judge `gemini-3.1-flash-lite` is unaffected).

### 3. P2 — Elements embeds defaulted to premium Fable 5
`ElementsProvider` and `Replay` used `MODELS[0]` as the implicit default, and Fable 5 is now first in the list. Added an explicit `DEFAULT_MODEL = "anthropic/claude-sonnet-5"` in `elements/src/lib/models.ts` and switched both call sites to it, so list ordering can never change what unconfigured embeds run on.

## Verification
- `go build ./...` + openrouter tests incl. new invariant tests (8/8 ResolveModel tests pass) ✅
- elements: build, 103 tests, lint ✅
- dashboard: `tsc -b --noEmit --force`, lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins per‑provider fallbacks in OpenRouter model resolution to stop silent upgrades to premium models, removes `google/gemini-3.5-flash` from the judge picker, and sets an explicit Elements default model for stable behavior.

- **Bug Fixes**
  - Model resolution: `ResolveModel` now uses a `providerFallbacks` map (e.g., Anthropic → `anthropic/claude-sonnet-5`) before the alphabetical backstop; tests enforce all fallbacks are allowlisted and every provider has a pin.
  - Judge picker: Removed `google/gemini-3.5-flash` because the judge sets `reasoning.effort: "none"`, which that model rejects; default remains Gemini 3.1 Flash Lite.
  - Elements defaults: Added `DEFAULT_MODEL = "anthropic/claude-sonnet-5"` and use it in `Replay` and `ElementsProvider` instead of `MODELS[0]` to avoid list ordering changing behavior.

<sup>Written for commit 85cdc3d83de6167e9d352876d9f3fe0a6750a18f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

