### PR TITLE
fix(server): return 401 instead of 500 on invalid chat session token (AGE-2982)

### DIFF
--- a/server/internal/auth/chatsessions/jwt.go
+++ b/server/internal/auth/chatsessions/jwt.go
@@ -55,8 +55,12 @@ func (m *Manager) GenerateToken(ctx context.Context, claims ChatSessionClaims, e
 	return signed, jti, nil
 }
 
-// ValidateToken validates a JWT token and returns the claims
-func (m *Manager) ValidateToken(ctx context.Context, tokenString string) (*ChatSessionClaims, error) {
+// ValidateToken validates a JWT token and returns the claims. invalidToken
+// reports that the token itself was rejected (malformed, bad signature,
+// expired, or revoked) and the caller should be treated as unauthenticated;
+// an error without invalidToken is a server fault, such as a failed
+// revocation lookup.
+func (m *Manager) ValidateToken(ctx context.Context, tokenString string) (claims *ChatSessionClaims, invalidToken bool, err error) {
 	//nolint:exhaustruct // no point in setting all the claims fields
 	token, err := jwt.ParseWithClaims(tokenString, &ChatSessionClaims{}, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -66,19 +70,21 @@ func (m *Manager) ValidateToken(ctx context.Context, tokenString string) (*ChatS
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("parse token: %w", err)
+		return nil, true, fmt.Errorf("parse token: %w", err)
 	}
 
 	claims, ok := token.Claims.(*ChatSessionClaims)
 	if !ok || !token.Valid {
-		return nil, fmt.Errorf("invalid token")
+		return nil, true, fmt.Errorf("invalid token")
 	}
 
-	// Check if token is revoked
-	isRevoked, _ := m.IsTokenRevoked(ctx, claims.ID)
+	isRevoked, err := m.IsTokenRevoked(ctx, claims.ID)
+	if err != nil {
+		return nil, false, fmt.Errorf("check token revocation: %w", err)
+	}
 	if isRevoked {
-		return nil, fmt.Errorf("token has been revoked")
+		return nil, true, fmt.Errorf("token has been revoked")
 	}
 
-	return claims, nil
+	return claims, false, nil
 }

--- a/server/internal/auth/chatsessions/manager.go
+++ b/server/internal/auth/chatsessions/manager.go
@@ -89,10 +89,6 @@ func (m *Manager) IsTokenRevoked(ctx context.Context, jti string) (bool, error) 
 }
 
 func (m *Manager) Authorize(ctx context.Context, token string) (context.Context, error) {
-	// ValidateToken only returns token-validity errors (malformed, bad
-	// signature, expired, revoked); revocation-check infra errors are
-	// currently discarded. If that changes, this mapping must distinguish
-	// server faults from unauthorized callers.
 	claims, invalidToken, err := m.ValidateToken(ctx, token)
 	if invalidToken {
 		return ctx, oops.E(oops.CodeUnauthorized, err, "unauthorized access")
@@ -100,7 +96,7 @@ func (m *Manager) Authorize(ctx context.Context, token string) (context.Context,
 	if err != nil {
 		// Not a verdict on the token — surface as a server fault rather than
 		// telling the caller to re-authenticate.
-		return ctx, fmt.Errorf("validate chat session token: %w", err)
+		return ctx, oops.E(oops.CodeUnexpected, err, "validate chat session token").LogError(ctx, m.logger)
 	}
 
 	// Parse project ID from string to UUID

--- a/server/internal/auth/chatsessions/manager.go
+++ b/server/internal/auth/chatsessions/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
 // Manager handles chat session token lifecycle
@@ -88,9 +89,18 @@ func (m *Manager) IsTokenRevoked(ctx context.Context, jti string) (bool, error) 
 }
 
 func (m *Manager) Authorize(ctx context.Context, token string) (context.Context, error) {
-	claims, err := m.ValidateToken(ctx, token)
+	// ValidateToken only returns token-validity errors (malformed, bad
+	// signature, expired, revoked); revocation-check infra errors are
+	// currently discarded. If that changes, this mapping must distinguish
+	// server faults from unauthorized callers.
+	claims, invalidToken, err := m.ValidateToken(ctx, token)
+	if invalidToken {
+		return ctx, oops.E(oops.CodeUnauthorized, err, "unauthorized access")
+	}
 	if err != nil {
-		return ctx, err
+		// Not a verdict on the token — surface as a server fault rather than
+		// telling the caller to re-authenticate.
+		return ctx, fmt.Errorf("validate chat session token: %w", err)
 	}
 
 	// Parse project ID from string to UUID

--- a/server/internal/auth/chatsessions/manager_test.go
+++ b/server/internal/auth/chatsessions/manager_test.go
@@ -1,0 +1,126 @@
+package chatsessions_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func testClaims() chatsessions.ChatSessionClaims {
+	return chatsessions.ChatSessionClaims{
+		OrgID:            "org-123",
+		ProjectID:        uuid.NewString(),
+		OrganizationSlug: "test-org",
+		ProjectSlug:      "test-project",
+		UserID:           "user-123",
+	}
+}
+
+func requireUnauthorized(t *testing.T, err error) {
+	t.Helper()
+
+	require.Error(t, err)
+	var se *oops.ShareableError
+	require.ErrorAs(t, err, &se)
+	require.Equal(t, oops.CodeUnauthorized, se.Code)
+}
+
+func TestManagerAuthorize_EmptyToken(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestManager(t)
+
+	_, err := mgr.Authorize(t.Context(), "")
+	requireUnauthorized(t, err)
+}
+
+func TestManagerAuthorize_MalformedToken(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestManager(t)
+
+	_, err := mgr.Authorize(t.Context(), "not-a-jwt")
+	requireUnauthorized(t, err)
+}
+
+func TestManagerAuthorize_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mgr := newTestManager(t)
+
+	token, _, err := mgr.GenerateToken(ctx, testClaims(), "https://example.com", -60)
+	require.NoError(t, err)
+
+	_, err = mgr.Authorize(ctx, token)
+	requireUnauthorized(t, err)
+}
+
+func TestManagerAuthorize_RevokedToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mgr := newTestManager(t)
+
+	token, jti, err := mgr.GenerateToken(ctx, testClaims(), "https://example.com", 3600)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.RevokeToken(ctx, jti))
+
+	_, err = mgr.Authorize(ctx, token)
+	requireUnauthorized(t, err)
+}
+
+func TestManagerAuthorize_RevocationCheckUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Point the revocation cache at a dead address so the lookup fails with an
+	// infrastructure error rather than a token-validity verdict.
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:        "127.0.0.1:1",
+		DialTimeout: 100 * time.Millisecond,
+	})
+	t.Cleanup(func() {
+		_ = redisClient.Close()
+	})
+	mgr := chatsessions.NewManager(testenv.NewLogger(t), redisClient, "test-jwt-secret")
+
+	token, _, err := mgr.GenerateToken(ctx, testClaims(), "https://example.com", 3600)
+	require.NoError(t, err)
+
+	_, err = mgr.Authorize(ctx, token)
+	require.Error(t, err)
+	var se *oops.ShareableError
+	require.NotErrorAs(t, err, &se, "revocation-check failures must surface as server faults, not unauthorized")
+}
+
+func TestManagerAuthorize_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mgr := newTestManager(t)
+
+	claims := testClaims()
+	token, _, err := mgr.GenerateToken(ctx, claims, "https://example.com", 3600)
+	require.NoError(t, err)
+
+	authorizedCtx, err := mgr.Authorize(ctx, token)
+	require.NoError(t, err)
+
+	authCtx, ok := contextvalues.GetAuthContext(authorizedCtx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	require.Equal(t, claims.OrgID, authCtx.ActiveOrganizationID)
+	require.Equal(t, claims.ProjectID, authCtx.ProjectID.String())
+	require.Equal(t, claims.UserID, authCtx.UserID)
+}

--- a/server/internal/auth/chatsessions/manager_test.go
+++ b/server/internal/auth/chatsessions/manager_test.go
@@ -101,7 +101,8 @@ func TestManagerAuthorize_RevocationCheckUnavailable(t *testing.T) {
 	_, err = mgr.Authorize(ctx, token)
 	require.Error(t, err)
 	var se *oops.ShareableError
-	require.NotErrorAs(t, err, &se, "revocation-check failures must surface as server faults, not unauthorized")
+	require.ErrorAs(t, err, &se)
+	require.Equal(t, oops.CodeUnexpected, se.Code, "revocation-check failures must surface as server faults, not unauthorized")
 }
 
 func TestManagerAuthorize_ValidToken(t *testing.T) {

--- a/server/internal/auth/chatsessions/setup_test.go
+++ b/server/internal/auth/chatsessions/setup_test.go
@@ -1,0 +1,40 @@
+package chatsessions_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Redis: true})
+	if err != nil {
+		log.Fatalf("Failed to launch test infrastructure: %v", err)
+	}
+
+	infra = res
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("Failed to cleanup test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}
+
+func newTestManager(t *testing.T) *chatsessions.Manager {
+	t.Helper()
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	return chatsessions.NewManager(testenv.NewLogger(t), redisClient, "test-jwt-secret")
+}

--- a/server/internal/chatsessions/impl.go
+++ b/server/internal/chatsessions/impl.go
@@ -135,9 +135,12 @@ func (s *Service) Revoke(ctx context.Context, p *gen.RevokePayload) error {
 	}
 
 	// Validate the token and extract JTI
-	claims, err := s.chatSessionsManager.ValidateToken(ctx, p.Token)
-	if err != nil {
+	claims, invalidToken, err := s.chatSessionsManager.ValidateToken(ctx, p.Token)
+	if invalidToken {
 		return oops.E(oops.CodeBadRequest, err, "invalid token").LogError(ctx, s.logger)
+	}
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to validate token").LogError(ctx, s.logger)
 	}
 
 	// Verify the token belongs to the same org/project

--- a/server/internal/middleware/chat_session_cors.go
+++ b/server/internal/middleware/chat_session_cors.go
@@ -44,9 +44,13 @@ func chatSessionsCORS(chatSessionsManager *chatsessions.Manager) func(next http.
 				return
 			}
 
-			claims, err := chatSessionsManager.ValidateToken(r.Context(), chatSession)
-			if err != nil {
+			claims, invalidToken, err := chatSessionsManager.ValidateToken(r.Context(), chatSession)
+			if invalidToken {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			if err != nil {
+				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
 


### PR DESCRIPTION
Fixes [DNO-485](https://linear.app/speakeasy/issue/DNO-485/chatlist-returns-500-instead-of-401-on-expired-dashboard-session): `GET /rpc/chat.list` returned a **500** when chat-session JWT validation failed, flapping the "High 5XX rate" and "Elevated 5XX on nginx ingress" Datadog monitors. The common trigger is a dashboard tab with an expired session cookie — the session scheme fails, Goa falls through to the chat-session JWT scheme with an empty token, and the raw `parse token: token is malformed` error was treated as an unexpected fault.

## Changes

* `chatsessions.Manager.ValidateToken` now returns an explicit `invalidToken bool` alongside the error, distinguishing a rejected token (malformed, bad signature, expired, revoked) from a server fault. No sentinel-error type assertions at call sites.
* `Manager.Authorize` maps `invalidToken` to `oops.CodeUnauthorized` → **401**. This is the shared Goa security seam for `chat`, `instances`, `assets`, and `telemetry`, so all four services are fixed at once.
* The revocation-lookup error was previously discarded (`isRevoked, _ := m.IsTokenRevoked(...)`), silently failing **open** on Redis outages. It now surfaces as a server fault (500) instead of a false "unauthorized" — matching the intent already documented on `IsTokenRevoked`.
* Callers updated for the new signature: the chat-session CORS middleware (401 vs 500 split) and `chatSessions.Revoke` (400 for an invalid token, 500 for a failed lookup).

## Tests

New `chatsessions` package tests cover: empty/malformed/expired/revoked tokens → `oops.CodeUnauthorized`, a valid token populating the auth context, and a dead Redis making `Authorize` fail as a server fault rather than unauthorized.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

## Summary by cubic

Return 401 instead of 500 when the chat-session JWT is missing, malformed, expired, or revoked, and treat revocation lookup failures as coded server faults. Addresses Linear [DNO-485](https://linear.app/speakeasy/issue/DNO-485/bug-chatlist-returns-500-instead-of-401-on-expired-dashboard-session) by fixing `/rpc/chat.list` behavior and aligning auth responses across chat, instances, assets, and telemetry.

* **Bug Fixes**
  * `chatsessions.Manager.ValidateToken` now returns `(claims, invalidToken bool, err)`; `invalidToken` maps to `oops.CodeUnauthorized` in `Manager.Authorize` → 401 at the Goa security seam for all four services.
  * Revocation lookup failures now return `oops.CodeUnexpected` with logging → 500, removing the fail-open on Redis outages.
  * Updated `server/internal/middleware/chat_session_cors.go` and `server/internal/chatsessions/impl.go` to split invalid-token (401/400) from infra errors (500).
  * Added tests for empty/malformed/expired/revoked tokens, valid tokens populating auth context, and dead Redis behavior.

Written for commit 06a6d3e481021bfaefd391d00d39328ff74dd94d. Summary will update on new commits.

[![Review in cubic](https://uploads.linear.app/49865655-68fb-4c55-83c8-f488bdc5a356/b1dce02b-8dc4-434e-b462-53cd0d3cc8cc/baa4c0ba-bc92-49dc-9a10-11ab48abd79f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzQ5ODY1NjU1LTY4ZmItNGM1NS04M2M4LWY0ODhiZGM1YTM1Ni9iMWRjZTAyYi04ZGM0LTQzNGUtYjQ2Mi01M2NkMGQzY2M4Y2MvYmFhNGMwYmEtYmM5Mi00OWRjLTlhMTAtMTFhYjQ4YWJkNzlmIiwiaWF0IjoxNzg0MjM1MzA5LCJleHAiOjE4MTU4MDU4Njl9.Ex4NVlj61i6zysDT0Zb-jLRUW4yac7s2o33_30UmBho)](<https://cubic.dev/pr/speakeasy-api/gram/pull/4132?utm_source=github>)