### PR TITLE
chore: bump GoReleaser to v2.17

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,7 +124,7 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser-pro
-          version: "~> v2.14"
+          version: "~> v2.17"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
@@ -220,7 +220,7 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser-pro
-          version: "~> v2.14"
+          version: "~> v2.17"
           args: release --clean --config .goreleaser.hooks.yaml
         env:
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}


### PR DESCRIPTION
## Summary

- bump both GoReleaser Pro release jobs from the `v2.14` minor range to `v2.17`
- keep patch updates automatic within the `v2.17` minor range
- pick up GitHub API retry handling added after `v2.14`, preventing transient 5xx responses like the hooks `0.1.0` Homebrew publish failure from immediately failing a release

The GoReleaser GitHub Action wrapper is already at the latest release (`v7.2.3`). The legacy `brews` pipeline remains available in GoReleaser `v2.17`.

## Validation

- `hk fix`
- `git diff --check`
- parsed `.github/workflows/release.yaml` with `yq`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps GoReleaser Pro in the release workflows from v2.14 to v2.17 to pick up GitHub API retry handling and reduce transient release failures. Keeps patch updates within v2.17; no other workflow changes.

- **Dependencies**
  - Set `goreleaser-pro` to `~> v2.17` in both release jobs.
  - `goreleaser/goreleaser-action` remains at `v7.2.3`.
  - Legacy `brews` pipeline is still supported in `v2.17`.

<sup>Written for commit 771c7e6f26ef2a8b31f6b3002143c6920551c913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

