### PR TITLE
mig: risk_policy_id dimension on tum_breakdown_summaries (DNO-488)

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260713161846_tum-breakdown-risk-policy-id.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260713161846_tum-breakdown-risk-policy-id.down.sql
@@ -1,0 +1,20 @@
+-- reverse: create "tum_breakdown_summaries_mv" view
+DROP VIEW `tum_breakdown_summaries_mv`;
+-- reverse: create "chat_token_summaries_mv" view
+DROP VIEW `chat_token_summaries_mv`;
+-- reverse: drop "chat_token_summaries_mv" view
+CREATE MATERIALIZED VIEW `chat_token_summaries_mv` TO `chat_token_summaries` AS SELECT gram_project_id, chat_id, toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano, 'UTC')) AS time_bucket, sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens, toUInt64(countIf(startsWith(gram_urn, 'tools:') OR (urn != '') OR (event_source != '') OR (toString(attributes.gen_ai.usage.total_tokens) = ''))) AS stored_event_count FROM telemetry_logs WHERE chat_id != '' GROUP BY gram_project_id, chat_id, time_bucket;
+-- reverse: create "tum_breakdown_summaries" table
+DROP TABLE `tum_breakdown_summaries`;
+-- reverse: create "chat_token_summaries" table
+DROP TABLE `chat_token_summaries`;
+-- reverse: drop "chat_token_summaries" table
+CREATE TABLE `chat_token_summaries` (
+  `gram_project_id` UUID,
+  `chat_id` String,
+  `time_bucket` DateTime('UTC'),
+  `hook_source` String,
+  `total_tokens` SimpleAggregateFunction(sum, Int64),
+  `stored_event_count` SimpleAggregateFunction(sum, UInt64)
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`gram_project_id`, `chat_id`, `time_bucket`) ORDER BY (`gram_project_id`, `chat_id`, `time_bucket`, `hook_source`) TTL time_bucket + toIntervalDay(730) SETTINGS index_granularity = 8192 COMMENT 'Per-chat daily token usage and stored-session evidence, retained beyond the raw telemetry TTL to support tokens-under-management billing across historical billing cycles';

--- a/server/clickhouse/local/golang_migrate/20260713161846_tum-breakdown-risk-policy-id.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260713161846_tum-breakdown-risk-policy-id.up.sql
@@ -1,0 +1,34 @@
+-- drop "chat_token_summaries" table
+DROP TABLE `chat_token_summaries`;
+-- create "chat_token_summaries" table
+CREATE TABLE `chat_token_summaries` (
+  `gram_project_id` UUID,
+  `chat_id` String,
+  `time_bucket` DateTime('UTC'),
+  `hook_source` String,
+  `total_tokens` SimpleAggregateFunction(sum, Int64),
+  `stored_event_count` SimpleAggregateFunction(sum, UInt64)
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`gram_project_id`, `chat_id`, `time_bucket`) ORDER BY (`gram_project_id`, `chat_id`, `time_bucket`, `hook_source`) TTL time_bucket + toIntervalDay(730) SETTINGS index_granularity = 8192 COMMENT 'Per-chat daily token usage and stored-session evidence, retained beyond the raw telemetry TTL to support tokens-under-management billing across historical billing cycles';
+-- create "tum_breakdown_summaries" table
+CREATE TABLE `tum_breakdown_summaries` (
+  `gram_project_id` UUID,
+  `chat_id` String,
+  `time_bucket` DateTime('UTC'),
+  `hook_source` String,
+  `model` String,
+  `user_email` String,
+  `division_name` String,
+  `roles` Array(String),
+  `risk_policy_id` String,
+  `input_tokens` SimpleAggregateFunction(sum, Int64),
+  `output_tokens` SimpleAggregateFunction(sum, Int64),
+  `total_tokens` SimpleAggregateFunction(sum, Int64)
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`gram_project_id`, `time_bucket`, `chat_id`, `hook_source`, `model`, `user_email`, `division_name`, `roles`) ORDER BY (`gram_project_id`, `time_bucket`, `chat_id`, `hook_source`, `model`, `user_email`, `division_name`, `roles`, `risk_policy_id`) TTL time_bucket + toIntervalDay(730) SETTINGS index_granularity = 8192 COMMENT 'Per-chat daily billed token usage broken down by consuming surface and user identity, retained beyond the raw telemetry TTL to power the billing page breakdowns across historical billing cycles';
+-- drop "chat_token_summaries_mv" view
+DROP VIEW `chat_token_summaries_mv`;
+-- create "chat_token_summaries_mv" view
+CREATE MATERIALIZED VIEW `chat_token_summaries_mv` TO `chat_token_summaries` AS SELECT gram_project_id, chat_id, toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano, 'UTC')) AS time_bucket, hook_source, sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS total_tokens, toUInt64(countIf(startsWith(gram_urn, 'tools:') OR (urn != '') OR (event_source != '') OR (toString(attributes.gen_ai.usage.total_tokens) = ''))) AS stored_event_count FROM telemetry_logs WHERE chat_id != '' GROUP BY gram_project_id, chat_id, time_bucket, hook_source;
+-- create "tum_breakdown_summaries_mv" view
+CREATE MATERIALIZED VIEW `tum_breakdown_summaries_mv` TO `tum_breakdown_summaries` AS SELECT gram_project_id, chat_id, toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano, 'UTC')) AS time_bucket, hook_source, toString(attributes.gen_ai.response.model) AS model, user_email, toString(attributes.user.attributes.division_name) AS division_name, arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)')) AS roles, toString(attributes.gram.risk.policy_id) AS risk_policy_id, sum(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens))) AS input_tokens, sum(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens))) AS output_tokens, sum(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens))) AS total_tokens FROM telemetry_logs WHERE (chat_id != '') AND (toString(attributes.gen_ai.usage.total_tokens) != '') GROUP BY gram_project_id, chat_id, time_bucket, hook_source, model, user_email, division_name, roles, risk_policy_id;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:5hXiuTkKpHtBsjHFhweY7/ZRhKYc2QK8rEfE/iPyaww=
+h1:GNhFPldp4M6pySNJ7S59ZO6FfCBUnkjkEI4thQHWjkE=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -54,3 +54,4 @@ h1:5hXiuTkKpHtBsjHFhweY7/ZRhKYc2QK8rEfE/iPyaww=
 20260709000641_provenance-first-attribute-metrics.up.sql h1:RXfFCI+1CjRTnNDikG52cqoa4+WSNenq4KgCjW5nv0w=
 20260710150001_shadow-mcp-inventory-urls.up.sql h1:/dMAeHWkPSnMHkNsTUle08RA2tXUex7qqGcLxgGk7Fk=
 20260713031549_telemetry-logs-staging.up.sql h1:OXRCOTGmSJhLDkRFxOodnXuf1COxVtzglHF9lNvjclk=
+20260713161846_tum-breakdown-risk-policy-id.up.sql h1:dzXZV3aoPg/1tGOYj04prdu+k4ii4LtEqSr7Zl/yVIk=

--- a/server/clickhouse/migrations/20260713161517_tum-breakdown-risk-policy-id.sql
+++ b/server/clickhouse/migrations/20260713161517_tum-breakdown-risk-policy-id.sql
@@ -1,0 +1,39 @@
+-- Hand-edited (not atlas's DROP+recreate): add risk_policy_id as a sort-key
+-- dimension to "tum_breakdown_summaries" NON-destructively, so the billing
+-- page can break Risk Policy Analysis tokens down by the specific risk
+-- policy whose scan produced them (attributes.gram.risk.policy_id, stamped
+-- on judge completions by the scanners). ADD COLUMN and MODIFY ORDER BY must
+-- be one ALTER statement — ClickHouse only lets MODIFY ORDER BY extend the
+-- key with columns added in the same ALTER. Existing aggregates are
+-- preserved (no DROP TABLE).
+--
+-- No backfill: the attribute was never emitted before the companion code
+-- change, so pre-existing rows correctly keep risk_policy_id '' and read as
+-- "(unset)". That also means no DELETE/re-derive passes here (contrast the
+-- hook_source migration): the only write gap is the seconds between DROP
+-- VIEW and CREATE VIEW below, a bounded UNDERCOUNT — the safe direction for
+-- a billing record.
+ALTER TABLE `tum_breakdown_summaries`
+  ADD COLUMN `risk_policy_id` String,
+  MODIFY ORDER BY (`gram_project_id`, `time_bucket`, `chat_id`, `hook_source`, `model`, `user_email`, `division_name`, `roles`, `risk_policy_id`);
+-- Swap the MV to the new grouping key. Kept adjacent to minimize the
+-- ingestion gap.
+DROP VIEW `tum_breakdown_summaries_mv`;
+CREATE MATERIALIZED VIEW `tum_breakdown_summaries_mv` TO `tum_breakdown_summaries` AS
+SELECT
+    gram_project_id,
+    chat_id,
+    toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano, 'UTC')) AS time_bucket,
+    hook_source,
+    toString(attributes.gen_ai.response.model) AS model,
+    user_email,
+    toString(attributes.user.attributes.division_name) AS division_name,
+    arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)')) AS roles,
+    toString(attributes.gram.risk.policy_id) AS risk_policy_id,
+    sum(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens))) AS input_tokens,
+    sum(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens))) AS output_tokens,
+    sum(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens))) AS total_tokens
+FROM telemetry_logs
+WHERE chat_id != ''
+  AND toString(attributes.gen_ai.usage.total_tokens) != ''
+GROUP BY gram_project_id, chat_id, time_bucket, hook_source, model, user_email, division_name, roles, risk_policy_id;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:3Uf+pN59IX5hHBnNH8IsDOCbtDjKpoLGoJ7NuFst18Y=
+h1:LutKU8yt8rPlHqLsZIQ4ITjnpQy8BO4wd6rVNaXEm7Y=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -61,3 +61,4 @@ h1:3Uf+pN59IX5hHBnNH8IsDOCbtDjKpoLGoJ7NuFst18Y=
 20260709200000_tum-breakdown-summaries.sql h1:fIWUArHikvB7GodDCiFBQi4AfkU8MlTbUXiM1dgPz7A=
 20260710150000_shadow-mcp-inventory-urls.sql h1:B3xXOhFpxCoOvOqwVXZUVezjbky75EwEw3ePfSLI4z8=
 20260713031544_telemetry-logs-staging.sql h1:ibENGxmwC3z6XqbovQWCeoSOMQkR55OVIsdy/mcJuCg=
+20260713161517_tum-breakdown-risk-policy-id.sql h1:PxYo2e5Rz3sE+57pDiAkSoASDt6z2fHprpXEOa1I9zI=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -706,6 +706,11 @@ CREATE TABLE IF NOT EXISTS tum_breakdown_summaries (
     user_email String,
     division_name String,
     roles Array(String),
+    -- The risk policy whose scan produced a risk-analysis judge completion
+    -- (attributes.gram.risk.policy_id, stamped by the scanners). '' for
+    -- non-scanning rows and for judge rows ingested before the dimension
+    -- existed — no backfill is possible, the attribute was never emitted.
+    risk_policy_id String,
 
     -- Billed token split for the slice (input + output = total for
     -- completion rows; they carry no cache attributes).
@@ -713,7 +718,11 @@ CREATE TABLE IF NOT EXISTS tum_breakdown_summaries (
     output_tokens SimpleAggregateFunction(sum, Int64),
     total_tokens SimpleAggregateFunction(sum, Int64)
 ) ENGINE = AggregatingMergeTree
-ORDER BY (gram_project_id, time_bucket, chat_id, hook_source, model, user_email, division_name, roles)
+-- PRIMARY KEY is the pre-risk_policy_id sort key: ALTER MODIFY ORDER BY can
+-- only extend the sort key, never the primary key, so the split must be
+-- explicit here to match the live table.
+PRIMARY KEY (gram_project_id, time_bucket, chat_id, hook_source, model, user_email, division_name, roles)
+ORDER BY (gram_project_id, time_bucket, chat_id, hook_source, model, user_email, division_name, roles, risk_policy_id)
 TTL time_bucket + INTERVAL 730 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Per-chat daily billed token usage broken down by consuming surface and user identity, retained beyond the raw telemetry TTL to power the billing page breakdowns across historical billing cycles';
@@ -730,13 +739,14 @@ SELECT
     user_email,
     toString(attributes.user.attributes.division_name) AS division_name,
     arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)')) AS roles,
+    toString(attributes.gram.risk.policy_id) AS risk_policy_id,
     sum(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens))) AS input_tokens,
     sum(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens))) AS output_tokens,
     sum(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens))) AS total_tokens
 FROM telemetry_logs
 WHERE chat_id != ''
   AND toString(attributes.gen_ai.usage.total_tokens) != ''
-GROUP BY gram_project_id, chat_id, time_bucket, hook_source, model, user_email, division_name, roles;
+GROUP BY gram_project_id, chat_id, time_bucket, hook_source, model, user_email, division_name, roles, risk_policy_id;
 
 CREATE TABLE IF NOT EXISTS attribute_keys (
     gram_project_id UUID,


### PR DESCRIPTION
Part of [DNO-488](https://linear.app/speakeasy/issue/DNO-488/tum-risk-policy-usage-breakdown). Migration-only PR; the companion code PR (scanner threading + billing page section) follows.

Adds `risk_policy_id` as a sort-key dimension to `tum_breakdown_summaries`, so the billing page can break Risk Policy Analysis tokens down by the specific risk policy whose scan produced them (`attributes.gram.risk.policy_id`, stamped on judge completions by the follow-up PR).

## Approach

- **Non-destructive hand-written ALTER** — `ADD COLUMN` + `MODIFY ORDER BY` in one statement (ClickHouse only extends the sort key with columns added in the same ALTER), then a tight `DROP VIEW`/`CREATE VIEW` swap. Same protocol as the `chat_token_summaries` hook_source migration (#4062); Atlas's generated diff would DROP + recreate the table and lose the billing aggregates.
- **`PRIMARY KEY` split from `ORDER BY` in schema.sql** — `MODIFY ORDER BY` extends the sort key but never the primary key, so the declared schema pins the primary key to the pre-migration prefix to avoid drift.
- **No backfill, by construction** — the attribute has never been emitted, so pre-existing rows (and judge rows until the code PR deploys) correctly carry `''` and read as "(unset)". That also means no DELETE/re-derive passes: the only ingestion gap is the seconds between the MV drop and recreate, a bounded undercount (the safe direction for a billing record).
- **golang-migrate local mirror catch-up** — the generated `local/golang_migrate` pair also syncs the two Jul 9 atlas-only hand-written migrations that never got mirrored (`chat_token_summaries` hook_source, `tum_breakdown_summaries` creation). That stream is a local-dev fallback (prod applies `clickhouse/migrations/`), so its DROP+recreate is acceptable there.

## Verification

- Applied to local ClickHouse (`mise clickhouse:migrate`), then `mise clickhouse:diff drift-check` produced no atlas delta — the migrated table matches schema.sql exactly.
- `materialized_columns_gen.go` unchanged (no new telemetry_logs materialized columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `risk_policy_id` to ClickHouse `tum_breakdown_summaries` and updates its MV to enable per-policy breakdown of Risk Policy Analysis tokens on the billing page. Supports DNO-488; the threading and UI changes ship in a follow-up PR.

- **Migration**
  - Non-destructive ALTER: add `risk_policy_id` and extend ORDER BY in one statement to preserve aggregates.
  - Swapped `tum_breakdown_summaries_mv` to group by `risk_policy_id` from `attributes.gram.risk.policy_id`; no backfill (older rows stay '').
  - Kept PRIMARY KEY unchanged in `schema.sql` and extended ORDER BY to include `risk_policy_id`; synced `local/golang_migrate` (safe local drops/recreates, including missed Jul 9 migrations).

<sup>Written for commit a61f156c1a6a04cd6b290f06da4450e1cc0f7892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

