### PR TITLE
fix: retry marketplace upload-pack requests

### DIFF
--- a/server/internal/marketplace/handler.go
+++ b/server/internal/marketplace/handler.go
@@ -1,6 +1,7 @@
 package marketplace
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -20,6 +21,11 @@ import (
 // out one namespace, and so the dispatch logic stays here rather than leaking
 // into the server bootstrap.
 const RoutePrefix = "/marketplace/"
+
+// Upload-pack requests contain ref negotiation data rather than packfiles.
+// Bounding and buffering them lets net/http replay the read-only POST if an
+// idle upstream connection disappears while the request is being sent.
+const maxUploadPackRequestBytes = 1 << 20
 
 // Server hosts the git Smart HTTP proxy for plugin source clones. Streams
 // directly from GitHub against an installation token minted by the resolver —
@@ -117,8 +123,8 @@ func (s *Server) handleInfoRefs(w http.ResponseWriter, r *http.Request) {
 	s.proxyToGitHub(w, r, http.MethodGet, upstreamURL, up.AccessToken, nil)
 }
 
-// handleUploadPack streams the packfile by piping the client's wants/haves to
-// github.com and the resulting packfile back.
+// handleUploadPack buffers the client's small wants/haves request so it can be
+// replayed, then streams the resulting packfile back from GitHub.
 func (s *Server) handleUploadPack(w http.ResponseWriter, r *http.Request) {
 	token := tokenFromSlug(r.PathValue("slug"))
 	if token == "" {
@@ -132,16 +138,27 @@ func (s *Server) handleUploadPack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxUploadPackRequestBytes))
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
 	upstreamURL := fmt.Sprintf(
 		"https://github.com/%s/%s.git/git-upload-pack",
 		url.PathEscape(up.Owner), url.PathEscape(up.Repo),
 	)
-	s.proxyToGitHub(w, r, http.MethodPost, upstreamURL, up.AccessToken, r.Body)
+	s.proxyToGitHub(w, r, http.MethodPost, upstreamURL, up.AccessToken, bytes.NewReader(body))
 }
 
 // proxyToGitHub forwards a Smart HTTP request to github.com with installation-
-// token basic auth and streams the response back. Body and headers are
-// streamed without buffering so packfiles flow through in chunks.
+// token basic auth and streams the response back so packfiles flow through in
+// chunks.
 func (s *Server) proxyToGitHub(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -159,6 +176,11 @@ func (s *Server) proxyToGitHub(
 		return
 	}
 	upstreamReq.SetBasicAuth("x-access-token", accessToken)
+	if method == http.MethodPost {
+		// git-upload-pack is read-only. An empty value marks the POST as
+		// idempotent to net/http without sending the header to GitHub.
+		upstreamReq.Header["Idempotency-Key"] = []string{}
+	}
 	if ct := r.Header.Get("Content-Type"); ct != "" {
 		upstreamReq.Header.Set("Content-Type", ct)
 	}

--- a/server/internal/marketplace/handler_test.go
+++ b/server/internal/marketplace/handler_test.go
@@ -1,9 +1,12 @@
 package marketplace
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,6 +23,23 @@ type spyResolver struct {
 func (r *spyResolver) Resolve(_ context.Context, _ string) (Upstream, error) {
 	r.called = true
 	return Upstream{}, ErrNotFound
+}
+
+type fixedResolver struct{}
+
+func (*fixedResolver) Resolve(_ context.Context, token string) (Upstream, error) {
+	return Upstream{
+		Token:       token,
+		Owner:       "speakeasy-plugins",
+		Repo:        "test-plugins",
+		AccessToken: "github-token",
+	}, nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 // Token-format check is a cheap pre-filter that keeps the resolver's DB
@@ -53,4 +73,88 @@ func TestMalformedTokensSkipResolver(t *testing.T) {
 			require.False(t, spy.called, "resolver must not be called for malformed tokens")
 		})
 	}
+}
+
+func TestUploadPackRequestIsReplayable(t *testing.T) {
+	t.Parallel()
+
+	wantBody := []byte("0032want 0123456789012345678901234567890123456789\n0000")
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			gotBody, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			require.Equal(t, wantBody, gotBody)
+			require.NotNil(t, req.GetBody)
+
+			replayedBody, err := req.GetBody()
+			require.NoError(t, err)
+			defer func() { require.NoError(t, replayedBody.Close()) }()
+			gotReplayedBody, err := io.ReadAll(replayedBody)
+			require.NoError(t, err)
+			require.Equal(t, wantBody, gotReplayedBody)
+			_, markedIdempotent := req.Header["Idempotency-Key"]
+			require.True(t, markedIdempotent)
+
+			return &http.Response{
+				Status:           "200 OK",
+				StatusCode:       http.StatusOK,
+				Proto:            "HTTP/1.1",
+				ProtoMajor:       1,
+				ProtoMinor:       1,
+				Header:           make(http.Header),
+				Body:             io.NopCloser(strings.NewReader("packfile")),
+				ContentLength:    8,
+				TransferEncoding: nil,
+				Close:            false,
+				Uncompressed:     false,
+				Trailer:          nil,
+				Request:          req,
+				TLS:              nil,
+			}, nil
+		}),
+		CheckRedirect: nil,
+		Jar:           nil,
+		Timeout:       0,
+	}
+	server := NewServer(&fixedResolver{}, client, testenv.NewLogger(t))
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/marketplace/"+strings.Repeat("a", 43)+".git/git-upload-pack",
+		bytes.NewReader(wantBody),
+	)
+	// Incoming server requests do not provide GetBody.
+	req.GetBody = nil
+	rec := httptest.NewRecorder()
+
+	server.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "packfile", rec.Body.String())
+}
+
+func TestUploadPackRejectsLargeRequestBody(t *testing.T) {
+	t.Parallel()
+
+	clientCalled := false
+	client := &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			clientCalled = true
+			return nil, nil
+		}),
+		CheckRedirect: nil,
+		Jar:           nil,
+		Timeout:       0,
+	}
+	server := NewServer(&fixedResolver{}, client, testenv.NewLogger(t))
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/marketplace/"+strings.Repeat("a", 43)+".git/git-upload-pack",
+		bytes.NewReader(make([]byte, maxUploadPackRequestBytes+1)),
+	)
+	rec := httptest.NewRecorder()
+
+	server.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	require.False(t, clientCalled)
 }


### PR DESCRIPTION
## Root cause

The marketplace proxy forwarded the incoming server request body directly into an outbound `git-upload-pack` POST. Because that body was only an `io.Reader`, `http.NewRequestWithContext` could not populate `Request.GetBody`. When GitHub closed a reused connection while the request was being sent, Go attempted to retry but could not recreate the body, returning `net/http: cannot rewind body after connection loss`. The proxy then returned a customer-facing 502.
## Solution

- Read the small upload-pack negotiation payload into a bounded buffer and build the upstream request from a `bytes.Reader`, allowing Go to populate `GetBody` and replay the payload.
- Mark the read-only `git-upload-pack` POST as idempotent using an empty `Idempotency-Key` header value. Go uses this to enable safe transport retries but does not send the empty header to GitHub.
- Continue streaming the potentially large packfile response without buffering.
- Return 413 for negotiation payloads exceeding the limit and add regression tests for replayability and size enforcement.

## Why 1 MiB

Upload-pack request bodies contain only Git ref negotiation data; the large packfile travels in the response and remains streamed. Over the last 30 days, production handled 1,308,804 matching requests with an average ingress request size of about 436 bytes and a maximum of 1,354 bytes. A 1 MiB limit is more than 770 times the observed maximum, leaving substantial headroom while preventing unbounded per-request memory use.

## Verification

- `go test ./internal/marketplace`
- `mise lint:server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make marketplace `git-upload-pack` POSTs replayable so Go can auto-retry on dropped connections, eliminating intermittent 502s. Buffer small negotiation payloads (<= 1 MiB) and keep packfile responses streamed.

- **Bug Fixes**
  - Buffer upload-pack negotiation bodies and send via `bytes.Reader` so `GetBody` is available for retries.
  - Mark read-only POSTs as idempotent with an empty `Idempotency-Key` to enable safe transport retries (not forwarded to GitHub).
  - Stream packfile responses as before; no response buffering.
  - Return 413 for oversized bodies and add tests for replayability and size limits.

<sup>Written for commit eb419a100d07234f482963c8061a3b14b171ef3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

