### PR TITLE
feat: configure WorkOS API rate limiting

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -517,9 +517,8 @@ func newBillingProvider(
 // the dev-idp's mock-workos emulator without changing any wiring.
 func workosClientOpts(c *cli.Context) workos.ClientOpts {
 	return workos.ClientOpts{
-		Endpoint:   c.String("workos-endpoint"),
-		HTTPClient: nil,
-		ClientID:   c.String("idp-client-id"),
+		Endpoint: c.String("workos-endpoint"),
+		ClientID: c.String("idp-client-id"),
 	}
 }
 

--- a/server/internal/thirdparty/workos/client.go
+++ b/server/internal/thirdparty/workos/client.go
@@ -3,6 +3,7 @@ package workos
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -73,8 +74,6 @@ type Client struct {
 type ClientOpts struct {
 	// Endpoint overrides the WorkOS base URL for both raw HTTP and SDK calls.
 	Endpoint string
-	// HTTPClient overrides the default retryable HTTP client.
-	HTTPClient *guardian.HTTPClient
 	// ClientID is the IDP client ID (GRAM_IDP_CLIENT_ID), needed for SSO code exchange.
 	ClientID string
 }
@@ -90,12 +89,16 @@ func NewClient(guardianPolicy *guardian.Policy, apiKey string, opts ...ClientOpt
 		endpoint = opt.Endpoint
 	}
 
-	httpClient := opt.HTTPClient
-	if httpClient == nil {
-		retryCfg := guardian.DefaultRetryConfig()
-		retryCfg.WaitMax = 10 * time.Second
-		httpClient = guardianPolicy.PooledClient(guardian.WithRetryConfig(retryCfg))
-	}
+	retryCfg := guardian.DefaultRetryConfig()
+	retryCfg.WaitMax = 10 * time.Second
+	httpClient := guardianPolicy.PooledClient(
+		guardian.WithRetryConfig(retryCfg),
+		guardian.WithResilience("workos", guardian.ResilienceConfig{
+			Partition: partitionByHostAndAPIKey(apiKey),
+			Limit:     guardian.PerMinute(6000),
+			Breaker:   guardian.NoBreaker(),
+		}),
+	)
 
 	um := usermanagement.NewClient(apiKey)
 	um.HTTPClient = httpClient
@@ -113,6 +116,18 @@ func NewClient(guardianPolicy *guardian.Policy, apiKey string, opts ...ClientOpt
 		events:     &events.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint},
 		sso:        &sso.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint, JSONEncode: nil, ClientID: opt.ClientID},
 		dsync:      &directorysync.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint},
+	}
+}
+
+// partitionByHostAndAPIKey fingerprints the credential because guardian exports
+// partition segments as OTel attributes.
+func partitionByHostAndAPIKey(apiKey string) guardian.PartitionStrategy {
+	byHost := guardian.PartitionByHost()
+	fingerprint := sha256.Sum256([]byte(apiKey))
+	keySegment := fmt.Sprintf("key-sha256-%x", fingerprint)
+
+	return func(req *http.Request) []string {
+		return append(byHost(req), keySegment)
 	}
 }
 

--- a/server/internal/thirdparty/workos/client_partition_test.go
+++ b/server/internal/thirdparty/workos/client_partition_test.go
@@ -1,0 +1,24 @@
+package workos
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionByHostAndAPIKey(t *testing.T) {
+	t.Parallel()
+
+	const apiKey = "sk_test_do-not-expose"
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://API.WORKOS.COM/users", nil)
+	require.NoError(t, err)
+
+	partition := partitionByHostAndAPIKey(apiKey)(req)
+	require.Len(t, partition, 3)
+	require.Equal(t, []string{"api.workos.com", "443"}, partition[:2])
+	require.NotContains(t, strings.Join(partition, ":"), apiKey)
+	require.Equal(t, partition, partitionByHostAndAPIKey(apiKey)(req))
+	require.NotEqual(t, partition, partitionByHostAndAPIKey("sk_test_other")(req))
+}

--- a/server/internal/thirdparty/workos/client_test.go
+++ b/server/internal/thirdparty/workos/client_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -430,9 +429,8 @@ func newTestClient(t *testing.T, fake *fakeWorkOS) (*workos.Client, *fakeWorkOS)
 	require.NoError(t, err)
 
 	client := workos.NewClient(guardianPolicy, "test-api-key", workos.ClientOpts{
-		Endpoint:   srv.URL,
-		HTTPClient: &http.Client{Timeout: 10 * time.Second},
-		ClientID:   "test-client-id",
+		Endpoint: srv.URL,
+		ClientID: "test-client-id",
 	})
 	return client, fake
 }

--- a/server/internal/thirdparty/workos/connection_test.go
+++ b/server/internal/thirdparty/workos/connection_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,9 +26,8 @@ func newClientWithHandler(t *testing.T, handler http.Handler) *workos.Client {
 	require.NoError(t, err)
 
 	return workos.NewClient(guardianPolicy, "test-api-key", workos.ClientOpts{
-		Endpoint:   srv.URL,
-		HTTPClient: &http.Client{Timeout: 10 * time.Second},
-		ClientID:   "test-client-id",
+		Endpoint: srv.URL,
+		ClientID: "test-client-id",
 	})
 }
 


### PR DESCRIPTION
## Summary

- route WorkOS SDK and raw HTTP requests through Guardian resilience
- configure the WorkOS quota at 6,000 requests per minute
- partition resilience state by host, port, and a full SHA-256 API-key fingerprint
- keep the raw API key out of OTel partition attributes
- remove the test-only HTTP client override so tests exercise the production client construction path

## Why

WorkOS applies its request quota per API key. Host-only partitioning would combine independent credentials, while using the raw credential as a partition segment would expose it through `gram.resilience.partition` telemetry.

The stable SHA-256 fingerprint separates keys without publishing credential material. The current shared Guardian policy uses `NewNoopLimiter`, so this change establishes the intended partitioning and telemetry now; enforcement begins when a real shared limiter is enabled.

## Validation

- `go test ./server/internal/thirdparty/workos`
- `go vet ./server/internal/thirdparty/workos`
- commit hooks: `go mod tidy`, `gofmt`, and `go:fix`

`mise lint:server` was attempted but golangci-lint failed during package discovery with `context loading failed: no go files to analyze`; it produced no code diagnostics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all WorkOS SDK and HTTP calls through `guardian` resilience with a 6,000 req/min quota to prepare for enforcement and prevent key cross-talk. Partition limits by host, port, and a SHA‑256 API key fingerprint to isolate credentials and keep raw keys out of telemetry.

- **New Features**
  - Apply `guardian` limiter at 6,000 rpm; breaker disabled.
  - Partition by host, port, and `key-sha256-…` fingerprint; no raw keys in `gram.resilience.partition`.
  - Use the same pooled client for SDK and raw HTTP; deterministic partitioning covered by tests.

- **Refactors**
  - Remove test-only HTTP client override so tests exercise the production client path.

<sup>Written for commit d5cd8f2e2bc8f1a453a87c351950f9521e43d4f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

