### PR TITLE
feat: prefetch project overview from org home

### DIFF
--- a/client/dashboard/src/components/chart/MetricCard.tsx
+++ b/client/dashboard/src/components/chart/MetricCard.tsx
@@ -2,6 +2,7 @@ import { Icon, type IconName } from "@speakeasy-api/moonshine";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { formatCompact } from "@/lib/format";
 import { getValueColor, ThresholdConfig } from "./chartUtils";
+import { Loader2 } from "lucide-react";
 import { Link } from "react-router";
 
 type AccentColor = "red" | "orange" | "yellow" | "green" | "blue" | "purple";
@@ -14,6 +15,8 @@ export type MetricCardProps = {
   previousValue?: number;
   format?: "compact" | "number" | "currency" | "percent" | "ms" | "seconds";
   icon?: IconName;
+  /** Replaces the icon with a spinner while cached data refreshes in the background. */
+  isRefreshing?: boolean;
   invertDelta?: boolean;
   thresholds?: ThresholdConfig;
   comparisonLabel?: string;
@@ -32,6 +35,7 @@ export function MetricCard(props: MetricCardProps): JSX.Element {
     previousValue = 0,
     format = "compact",
     icon,
+    isRefreshing = false,
     invertDelta = false,
     thresholds,
     comparisonLabel,
@@ -94,7 +98,14 @@ export function MetricCard(props: MetricCardProps): JSX.Element {
         </div>
         {icon && (
           <div className="bg-muted/50 rounded-lg p-2">
-            <Icon name={icon} className="text-muted-foreground size-4" />
+            {isRefreshing ? (
+              <Loader2
+                aria-label={`Refreshing ${title}`}
+                className="text-muted-foreground size-4 animate-spin"
+              />
+            ) : (
+              <Icon name={icon} className="text-muted-foreground size-4" />
+            )}
           </div>
         )}
       </div>

--- a/client/dashboard/src/components/observe/useDateRangeFilter.ts
+++ b/client/dashboard/src/components/observe/useDateRangeFilter.ts
@@ -7,10 +7,10 @@ import {
   safeBase64Encode,
 } from "./observeFilterUtils";
 
-const DEFAULT_PRESET: DateRangePreset = "7d";
+export const DEFAULT_DATE_RANGE_PRESET: DateRangePreset = "7d";
 
 export function useDateRangeFilter(
-  defaultPreset: DateRangePreset = DEFAULT_PRESET,
+  defaultPreset: DateRangePreset = DEFAULT_DATE_RANGE_PRESET,
 ): {
   dateRange: DateRangePreset;
   customRange: { from: Date; to: Date } | null;

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -11,7 +11,6 @@ import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useAuditLogs } from "@gram/client/react-query/auditLogs.js";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
-import { telemetryGetProjectOverview } from "@gram/client/funcs/telemetryGetProjectOverview";
 import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
 import type { SearchUsersFilter } from "@gram/client/models/components/searchusersfilter.js";
 import type { UserSummary } from "@gram/client/models/components/usersummary.js";
@@ -33,9 +32,10 @@ import {
   useDateRangeFilter,
 } from "@/components/observe/useDateRangeFilter";
 import { ActivityTimelineCard } from "./ActivityTimelineCard";
+import { buildProjectOverviewQuery } from "./projectOverviewQuery";
 
 export function ProjectDashboard(): JSX.Element {
-  const { projectSlug } = useSlugs();
+  const { orgSlug, projectSlug } = useSlugs();
   const routes = useRoutes();
   const orgRoutes = useOrgRoutes();
 
@@ -63,21 +63,30 @@ export function ProjectDashboard(): JSX.Element {
   const logsEnabled = featuresData?.logsEnabled === true;
 
   // The SDK's useGetProjectOverview omits the request body from its query
-  // key, so changing the date range here would otherwise return cached data.
-  // Mirror the observe-page pattern: call useQuery directly with a key that
-  // includes the from/to ISO strings.
+  // key; the shared builder keys by org/project/range instead and is also
+  // used by the org-home prefetch.
   const client = useGramContext();
-  const { data: overview, isPending: isOverviewPending } = useQuery({
-    queryKey: ["project", "overview", from.toISOString(), to.toISOString()],
-    queryFn: () =>
-      unwrapAsync(
-        telemetryGetProjectOverview(client, {
-          getProjectMetricsSummaryPayload: { from, to },
-        }),
-      ),
-    enabled: logsEnabled,
+  const {
+    data: overview,
+    isPending: isOverviewPending,
+    isFetching: isOverviewFetching,
+  } = useQuery({
+    ...buildProjectOverviewQuery(client, {
+      organization: orgSlug ?? "",
+      project: projectSlug ?? "",
+      range: customRange
+        ? {
+            from: customRange.from.toISOString(),
+            to: customRange.to.toISOString(),
+          }
+        : { preset: dateRange },
+    }),
+    enabled: logsEnabled && !!orgSlug && !!projectSlug,
     placeholderData: keepPreviousData,
   });
+  // Cached (possibly stale or previous-range) data is on screen while a
+  // refetch runs; the overview cards swap their icon for a spinner.
+  const isOverviewRefreshing = isOverviewFetching && !isOverviewPending;
 
   const { data: membersData, isPending: isMembersPending } = useMembers();
   const members = useMemo(() => membersData?.members ?? [], [membersData]);
@@ -392,6 +401,7 @@ export function ProjectDashboard(): JSX.Element {
                     title="Active Servers"
                     value={overview?.summary.activeServersCount ?? 0}
                     icon="server"
+                    isRefreshing={isOverviewRefreshing}
                     tooltip="Unique MCP servers used by project members that received at least one tool call in the selected period. Servers with no activity in the window are not counted."
                   />
                 )}
@@ -402,6 +412,7 @@ export function ProjectDashboard(): JSX.Element {
                     title="Tool Calls"
                     value={overview?.summary.totalToolCalls ?? 0}
                     icon="wrench"
+                    isRefreshing={isOverviewRefreshing}
                     tooltip="Total tool invocations recorded across all servers and sources in the selected period."
                   />
                 )}
@@ -438,6 +449,7 @@ export function ProjectDashboard(): JSX.Element {
                     title="Failed Tool Calls"
                     value={overview?.summary.failedToolCalls ?? 0}
                     icon="circle-alert"
+                    isRefreshing={isOverviewRefreshing}
                     tooltip="MCP tool calls that returned an error (HTTP 4xx/5xx) in the selected period."
                   />
                 )}

--- a/client/dashboard/src/components/project/projectOverviewQuery.test.ts
+++ b/client/dashboard/src/components/project/projectOverviewQuery.test.ts
@@ -1,0 +1,240 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@gram/client/funcs/telemetryGetProjectOverview", () => ({
+  telemetryGetProjectOverview: vi.fn(),
+}));
+
+import { telemetryGetProjectOverview } from "@gram/client/funcs/telemetryGetProjectOverview";
+import {
+  PROJECT_OVERVIEW_STALE_TIME_MS,
+  buildProjectOverviewQuery,
+  isProjectOverviewQueryKey,
+  projectOverviewQueryKey,
+  type ProjectOverviewScope,
+} from "./projectOverviewQuery";
+
+const mockGetOverview = vi.mocked(telemetryGetProjectOverview);
+
+const client = {} as Parameters<typeof buildProjectOverviewQuery>[0];
+
+const baseScope: ProjectOverviewScope = {
+  organization: "org-a",
+  project: "proj-a",
+  range: { preset: "7d" },
+};
+
+type OverviewResult = Awaited<
+  ReturnType<
+    NonNullable<ReturnType<typeof buildProjectOverviewQuery>["queryFn"]>
+  >
+>;
+
+function overviewFixture(marker: string): OverviewResult {
+  return { summary: { marker } } as unknown as OverviewResult;
+}
+
+function okResult(value: OverviewResult) {
+  return Promise.resolve({ ok: true as const, value }) as ReturnType<
+    typeof telemetryGetProjectOverview
+  >;
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("projectOverviewQueryKey", () => {
+  it("differs across organization, project, preset, and custom range", () => {
+    const keys = [
+      projectOverviewQueryKey(baseScope),
+      projectOverviewQueryKey({ ...baseScope, organization: "org-b" }),
+      projectOverviewQueryKey({ ...baseScope, project: "proj-b" }),
+      projectOverviewQueryKey({ ...baseScope, range: { preset: "30d" } }),
+      projectOverviewQueryKey({
+        ...baseScope,
+        range: {
+          from: "2026-07-01T00:00:00.000Z",
+          to: "2026-07-08T00:00:00.000Z",
+        },
+      }),
+      projectOverviewQueryKey({
+        ...baseScope,
+        range: {
+          from: "2026-07-01T00:00:00.000Z",
+          to: "2026-07-09T00:00:00.000Z",
+        },
+      }),
+    ];
+    const serialized = keys.map((k) => JSON.stringify(k));
+    expect(new Set(serialized).size).toBe(keys.length);
+  });
+
+  it("produces the same key for the org-home prefetch and the project page default query", () => {
+    // Each call site constructs its own scope object; the cache must treat
+    // them as one entry.
+    const prefetch = buildProjectOverviewQuery(client, {
+      organization: "acme",
+      project: "analytics",
+      range: { preset: "7d" },
+    });
+    const page = buildProjectOverviewQuery(client, {
+      organization: "acme",
+      project: "analytics",
+      range: { preset: "7d" },
+    });
+    expect(page.queryKey).toEqual(prefetch.queryKey);
+
+    const queryClient = makeQueryClient();
+    const data = overviewFixture("shared");
+    queryClient.setQueryData(prefetch.queryKey, data);
+    expect(queryClient.getQueryData(page.queryKey)).toEqual(data);
+  });
+});
+
+describe("isProjectOverviewQueryKey", () => {
+  it("matches overview keys and nothing else", () => {
+    expect(isProjectOverviewQueryKey(projectOverviewQueryKey(baseScope))).toBe(
+      true,
+    );
+    expect(isProjectOverviewQueryKey(["project", "topUsers", "a", "b"])).toBe(
+      false,
+    );
+    expect(isProjectOverviewQueryKey(["@gram/client", "telemetry"])).toBe(
+      false,
+    );
+    expect(isProjectOverviewQueryKey([])).toBe(false);
+  });
+});
+
+describe("buildProjectOverviewQuery", () => {
+  it("sends the explicit target gramProject", async () => {
+    mockGetOverview.mockReturnValue(okResult(overviewFixture("a")));
+    const queryClient = makeQueryClient();
+
+    await queryClient.fetchQuery(
+      buildProjectOverviewQuery(client, {
+        organization: "acme",
+        project: "analytics",
+        range: { preset: "7d" },
+      }),
+    );
+
+    expect(mockGetOverview).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        gramProject: "analytics",
+        getProjectMetricsSummaryPayload: expect.objectContaining({
+          from: expect.any(Date),
+          to: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it("sends the exact bounds of a custom range", async () => {
+    mockGetOverview.mockReturnValue(okResult(overviewFixture("a")));
+    const queryClient = makeQueryClient();
+    const from = "2026-07-01T00:00:00.000Z";
+    const to = "2026-07-08T00:00:00.000Z";
+
+    await queryClient.fetchQuery(
+      buildProjectOverviewQuery(client, { ...baseScope, range: { from, to } }),
+    );
+
+    expect(mockGetOverview).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        getProjectMetricsSummaryPayload: {
+          from: new Date(from),
+          to: new Date(to),
+        },
+      }),
+    );
+  });
+
+  it("does not return cached project-A data for project B", async () => {
+    const queryClient = makeQueryClient();
+    const dataA = overviewFixture("project-a");
+    queryClient.setQueryData(projectOverviewQueryKey(baseScope), dataA);
+
+    const scopeB = { ...baseScope, project: "proj-b" };
+    const scopeOtherOrg = { ...baseScope, organization: "org-b" };
+    expect(
+      queryClient.getQueryData(projectOverviewQueryKey(scopeB)),
+    ).toBeUndefined();
+    expect(
+      queryClient.getQueryData(projectOverviewQueryKey(scopeOtherOrg)),
+    ).toBeUndefined();
+
+    // Fetching project B issues its own request instead of reusing A's data.
+    const dataB = overviewFixture("project-b");
+    mockGetOverview.mockReturnValue(okResult(dataB));
+    const result = await queryClient.fetchQuery(
+      buildProjectOverviewQuery(client, scopeB),
+    );
+    expect(result).toEqual(dataB);
+    expect(mockGetOverview).toHaveBeenCalledTimes(1);
+    expect(
+      queryClient.getQueryData(projectOverviewQueryKey(baseScope)),
+    ).toEqual(dataA);
+  });
+
+  it("reuses a prefetched result within the freshness window without a second request", async () => {
+    mockGetOverview.mockReturnValue(okResult(overviewFixture("prefetched")));
+    const queryClient = makeQueryClient();
+
+    await queryClient.prefetchQuery(
+      buildProjectOverviewQuery(client, baseScope),
+    );
+    // Navigation: the project page builds its own options object.
+    const data = await queryClient.fetchQuery(
+      buildProjectOverviewQuery(client, baseScope),
+    );
+
+    expect(data).toEqual(overviewFixture("prefetched"));
+    expect(mockGetOverview).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps serving stale data while a background refresh is in flight", async () => {
+    vi.useFakeTimers();
+    const queryClient = makeQueryClient();
+    const key = projectOverviewQueryKey(baseScope);
+    const v1 = overviewFixture("v1");
+    const v2 = overviewFixture("v2");
+
+    mockGetOverview.mockReturnValueOnce(okResult(v1));
+    await queryClient.prefetchQuery(
+      buildProjectOverviewQuery(client, baseScope),
+    );
+
+    vi.advanceTimersByTime(PROJECT_OVERVIEW_STALE_TIME_MS + 1_000);
+
+    let resolveRefetch!: (value: Awaited<ReturnType<typeof okResult>>) => void;
+    mockGetOverview.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefetch = resolve;
+      }) as ReturnType<typeof telemetryGetProjectOverview>,
+    );
+
+    const refetch = queryClient.prefetchQuery(
+      buildProjectOverviewQuery(client, baseScope),
+    );
+    await Promise.resolve();
+
+    // The stale entry is still readable while the refetch is pending.
+    expect(mockGetOverview).toHaveBeenCalledTimes(2);
+    expect(queryClient.getQueryData(key)).toEqual(v1);
+
+    resolveRefetch({ ok: true, value: v2 });
+    await refetch;
+    expect(queryClient.getQueryData(key)).toEqual(v2);
+  });
+});

--- a/client/dashboard/src/components/project/projectOverviewQuery.ts
+++ b/client/dashboard/src/components/project/projectOverviewQuery.ts
@@ -1,0 +1,80 @@
+import { getPresetRange, type DateRangePreset } from "@gram-ai/elements";
+import { telemetryGetProjectOverview } from "@gram/client/funcs/telemetryGetProjectOverview";
+import type { GetProjectOverviewResult } from "@gram/client/models/components/getprojectoverviewresult.js";
+import { unwrapAsync } from "@gram/client/types/fp";
+import type { QueryKey } from "@tanstack/react-query";
+
+/**
+ * Presets are keyed by name, not resolved timestamps: timestamp keys would
+ * never match across mounts. Custom ranges use their exact ISO bounds.
+ */
+export type ProjectOverviewRange =
+  | { preset: DateRangePreset }
+  | { from: string; to: string };
+
+export type ProjectOverviewScope = {
+  organization: string;
+  project: string;
+  range: ProjectOverviewRange;
+};
+
+// Product decision: an overview up to 30s old may render without a refetch,
+// so a prefetch from org home survives navigation.
+export const PROJECT_OVERVIEW_STALE_TIME_MS = 30_000;
+
+const KEY_PREFIX = ["project", "overview"] as const;
+
+export type ProjectOverviewQueryKey = readonly [
+  string,
+  string,
+  ProjectOverviewScope,
+];
+
+export function projectOverviewQueryKey(
+  scope: ProjectOverviewScope,
+): ProjectOverviewQueryKey {
+  return [...KEY_PREFIX, scope];
+}
+
+/**
+ * Overview keys are org/project-scoped, so SdkProvider's project-switch
+ * invalidation skips them; otherwise it would discard the prefetch.
+ */
+export function isProjectOverviewQueryKey(queryKey: QueryKey): boolean {
+  return queryKey[0] === KEY_PREFIX[0] && queryKey[1] === KEY_PREFIX[1];
+}
+
+function resolveRange(range: ProjectOverviewRange): { from: Date; to: Date } {
+  if ("preset" in range) {
+    return getPresetRange(range.preset);
+  }
+  return { from: new Date(range.from), to: new Date(range.to) };
+}
+
+type OverviewClient = Parameters<typeof telemetryGetProjectOverview>[0];
+
+/** Shared by the org-home prefetch and ProjectDashboard so keys never drift. */
+export function buildProjectOverviewQuery(
+  client: OverviewClient,
+  scope: ProjectOverviewScope,
+): {
+  queryKey: ProjectOverviewQueryKey;
+  queryFn: () => Promise<GetProjectOverviewResult>;
+  staleTime: number;
+} {
+  return {
+    queryKey: projectOverviewQueryKey(scope),
+    queryFn: () => {
+      const { from, to } = resolveRange(scope.range);
+      return unwrapAsync(
+        telemetryGetProjectOverview(client, {
+          // Explicit slug: org routes bind the SDK fetcher to `default`, and
+          // the request must match the project in the cache key.
+          gramProject: scope.project,
+          getProjectMetricsSummaryPayload: { from, to },
+        }),
+      );
+    },
+    staleTime: PROJECT_OVERVIEW_STALE_TIME_MS,
+  };
+}

--- a/client/dashboard/src/components/project/projectOverviewQuery.ts
+++ b/client/dashboard/src/components/project/projectOverviewQuery.ts
@@ -8,7 +8,7 @@ import type { QueryKey } from "@tanstack/react-query";
  * Presets are keyed by name, not resolved timestamps: timestamp keys would
  * never match across mounts. Custom ranges use their exact ISO bounds.
  */
-export type ProjectOverviewRange =
+type ProjectOverviewRange =
   | { preset: DateRangePreset }
   | { from: string; to: string };
 

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -1,4 +1,5 @@
 import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar-utils";
+import { isProjectOverviewQueryKey } from "@/components/project/projectOverviewQuery";
 import { clearStorageForLogout } from "@/lib/logout-storage";
 import { getServerURL } from "@/lib/utils";
 import { datadogRum } from "@datadog/browser-rum";
@@ -89,10 +90,14 @@ export const SdkProvider = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- telemetry is stable context value; including it would recreate the SDK client unnecessarily
   }, [projectSlug, pathProjectSlug]);
 
-  // Invalidate all queries when projectSlug changes
+  // Invalidate all queries when projectSlug changes; most keys are not
+  // project-aware. Overview keys are, and must survive so the org-home
+  // prefetch isn't discarded on navigation.
   useEffect(() => {
     if (previousProjectSlug.current !== projectSlug) {
-      void queryClient.invalidateQueries();
+      void queryClient.invalidateQueries({
+        predicate: (query) => !isProjectOverviewQueryKey(query.queryKey),
+      });
       previousProjectSlug.current = projectSlug;
     }
   }, [projectSlug]);

--- a/client/dashboard/src/lib/preferredProject.ts
+++ b/client/dashboard/src/lib/preferredProject.ts
@@ -1,6 +1,6 @@
 // Slug of the last-visited project, written by ProjectProvider. AuthProvider
 // and CliCallback still hold local copies of this key.
-export const PREFERRED_PROJECT_KEY = "preferredProject";
+const PREFERRED_PROJECT_KEY = "preferredProject";
 
 /**
  * The stored slug is global across organizations, so it only resolves when it

--- a/client/dashboard/src/lib/preferredProject.ts
+++ b/client/dashboard/src/lib/preferredProject.ts
@@ -1,0 +1,15 @@
+// Slug of the last-visited project, written by ProjectProvider. AuthProvider
+// and CliCallback still hold local copies of this key.
+export const PREFERRED_PROJECT_KEY = "preferredProject";
+
+/**
+ * The stored slug is global across organizations, so it only resolves when it
+ * exists in the given organization's projects.
+ */
+export function getPreferredProject<T extends { slug: string }>(
+  projects: readonly T[],
+): T | undefined {
+  const preferredSlug = localStorage.getItem(PREFERRED_PROJECT_KEY);
+  if (!preferredSlug) return undefined;
+  return projects.find((p) => p.slug === preferredSlug);
+}

--- a/client/dashboard/src/lib/preferredProject.ts
+++ b/client/dashboard/src/lib/preferredProject.ts
@@ -9,7 +9,12 @@ const PREFERRED_PROJECT_KEY = "preferredProject";
 export function getPreferredProject<T extends { slug: string }>(
   projects: readonly T[],
 ): T | undefined {
-  const preferredSlug = localStorage.getItem(PREFERRED_PROJECT_KEY);
+  let preferredSlug: string | null = null;
+  try {
+    preferredSlug = localStorage.getItem(PREFERRED_PROJECT_KEY);
+  } catch {
+    // localStorage unavailable
+  }
   if (!preferredSlug) return undefined;
   return projects.find((p) => p.slug === preferredSlug);
 }

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -2,6 +2,8 @@ import { InputDialog } from "@/components/input-dialog";
 import { Page } from "@/components/page-layout";
 import { MemberFacepile } from "@/components/member-facepile";
 import { ProjectAvatar } from "@/components/project-menu";
+import { DEFAULT_DATE_RANGE_PRESET } from "@/components/observe/useDateRangeFilter";
+import { buildProjectOverviewQuery } from "@/components/project/projectOverviewQuery";
 import { RequireScope } from "@/components/require-scope";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -20,6 +22,7 @@ import { useLocalStorageState } from "@/hooks/useLocalStorageState";
 import { useProjectFavorites } from "@/hooks/useProjectFavorites";
 import { useRBAC } from "@/hooks/useRBAC";
 import { dateTimeFormatters } from "@/lib/dates";
+import { getPreferredProject } from "@/lib/preferredProject";
 import { cn } from "@/lib/utils";
 import { ChallengesEmptyState } from "@/pages/access/ChallengesTab";
 import {
@@ -31,9 +34,12 @@ import type { AccessMember } from "@gram/client/models/components/accessmember.j
 import type { AuditLog } from "@gram/client/models/components/auditlog.js";
 import type { ChallengeBucket } from "@gram/client/models/components/challengebucket.js";
 import { Outcome } from "@gram/client/models/operations/listchallengebuckets.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useAuditLogs } from "@gram/client/react-query/auditLogs.js";
 import { useChallengeBuckets } from "@gram/client/react-query/challengeBuckets.js";
 import { useMembers } from "@gram/client/react-query/members.js";
+import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -55,7 +61,7 @@ import {
   Star,
   UserPlus,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 import { getActorLabel, renderVerb } from "@/lib/audit-log-format";
@@ -110,6 +116,37 @@ function OrgHomeInner() {
   const { favoriteSet, isFavorite, toggleFavorite } = useProjectFavorites(
     organization.id,
   );
+
+  // Warm the overview cache for the one project the user is most likely to
+  // open next (last visited, else `default`). Same feature gate as
+  // ProjectDashboard; staleTime dedupes re-runs and the fetch on navigation.
+  const gramClient = useGramContext();
+  const queryClient = useQueryClient();
+  const { data: featuresData } = useProductFeatures();
+  const logsEnabled = featuresData?.logsEnabled === true;
+  const prefetchProject =
+    getPreferredProject(organization.projects) ??
+    organization.projects.find((p) => p.slug === "default") ??
+    organization.projects[0];
+  const prefetchProjectSlug = prefetchProject?.slug;
+  const organizationSlug = organization.slug;
+
+  useEffect(() => {
+    if (!logsEnabled || !prefetchProjectSlug || !organizationSlug) return;
+    void queryClient.prefetchQuery(
+      buildProjectOverviewQuery(gramClient, {
+        organization: organizationSlug,
+        project: prefetchProjectSlug,
+        range: { preset: DEFAULT_DATE_RANGE_PRESET },
+      }),
+    );
+  }, [
+    logsEnabled,
+    prefetchProjectSlug,
+    organizationSlug,
+    gramClient,
+    queryClient,
+  ]);
 
   // Fetch org-wide audit log once. We use it to drive (a) the left rail
   // preview, (b) each project's "most recent action", and (c) the facepile


### PR DESCRIPTION
## What

Speculatively prefetches `telemetry.getProjectOverview` from org home for the single project the user is most likely to open next, so the project dashboard's overview cards render without skeletons. This is a perceived-latency improvement on top of #4104; it does not change endpoint performance.

- **New shared query-options builder** (`projectOverviewQuery.ts`), used by both org home and `ProjectDashboard` so cache keys can never drift. The key carries `{ organization, project, range }`; semantic presets are keyed by name (`7d`) rather than resolved timestamps, custom ranges by their exact ISO bounds. The request always sends an explicit `gramProject` header matching the key.
- **Org home prefetch**: one `prefetchQuery` for the user's last-visited project (validated against the active org), falling back to the `default` project. Gated on the same `logsEnabled` product feature as the dashboard. No hover/per-card prefetching.
- **30s freshness window** (`staleTime: 30_000`): opening the project within 30 seconds reuses the prefetched result without a duplicate request. Analytics being up to 30s old during navigation is an explicit product decision.
- **Invalidation carve-out**: `SdkProvider`'s global `invalidateQueries()` on project switch now skips the overview key family (those keys are fully org/project-scoped); everything else is still invalidated wholesale because legacy keys are not project-aware.
- **Refresh UX**: overview-backed metric cards (Active Servers, Tool Calls, Failed Tool Calls) show a spinner in place of their corner icon while cached data refreshes in the background. No cached data still renders the full skeleton.

## Safety

Cache entries cannot cross tenant boundaries: organization and project are part of every key, and the HTTP request pins the same project via an explicit header (the SDK fetcher only fills the header when absent). Tests cover key isolation across org/project/preset/custom range, prefetch/page key equality, the explicit header, cross-project cache isolation, request deduplication inside the freshness window, and stale-render-with-background-refresh.

## Reviewer notes

- The generated SDK hook (`useGetProjectOverview`) keys by headers but omits the request body, which is why the handwritten builder exists; no generated files were touched.
- `DEFAULT_DATE_RANGE_PRESET` is now exported from `useDateRangeFilter` so the prefetch preset and the dashboard default cannot drift.
- `preferredProject` localStorage access is centralized in `lib/preferredProject.ts`; `AuthProvider`/`CliCallback` still hold local copies of the key (follow-up candidate).
- Verified: `pnpm -F dashboard test` (new suite passes; the 7 pre-existing failing files fail identically on `main`), `type-check`, `lint`, `lint:format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefetches the project overview from org home for the project the user is most likely to open next, so the Project Dashboard renders its overview cards without skeletons. Adds a shared query builder, a 30s freshness window, and skips overview keys during project-switch invalidation to reuse results across navigation.

- **New Features**
  - Prefetch `telemetry.getProjectOverview` on org home for the last-visited project, falling back to `default` or the first project; gated by the logs feature.
  - Overview cards swap their corner icon for a spinner while cached data refreshes; skeletons only show when no cached data exists.
  - Results are fresh for 30s to avoid a second request during navigation.

- **Refactors**
  - Added `projectOverviewQuery.ts` with a shared query builder keyed by `{ organization, project, range }`; always sends an explicit `gramProject` header.
  - Project switch invalidation now skips overview keys so prefetched data survives navigation.
  - Exported `DEFAULT_DATE_RANGE_PRESET`; centralized `preferredProject` in `lib/preferredProject.ts` and tolerate unavailable `localStorage`.
  - Dropped unused exports flagged by knip; added tests for key isolation, org-home/page key equality, header pinning, cache safety, freshness reuse, and stale-while-revalidate behavior.

<sup>Written for commit 8ce7bdebe77f95e06170daad2efa39ab8462c8fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

