### PR TITLE
feat: redefine tokens under management as observed agent traffic (DNO-491)

### DIFF
--- a/.changeset/tum-observed-traffic-definition.md
+++ b/.changeset/tum-observed-traffic-definition.md
@@ -1,0 +1,6 @@
+---
+"dashboard": minor
+"server": minor
+---
+
+Redefine tokens under management as observed agent traffic: the billing page now counts the tokens the platform observes coming from users' agent sessions (input and output — cache reads and writes excluded), never inference the platform spends itself (risk-policy analysis, hosted chat). Breakdowns now offer model, agent, provider, account type, project, user, division, department, and role; the project filter dropdown is replaced by the Project breakdown section.

--- a/.changeset/tum-observed-traffic-definition.md
+++ b/.changeset/tum-observed-traffic-definition.md
@@ -3,4 +3,4 @@
 "server": minor
 ---
 
-Redefine tokens under management as observed agent traffic: the billing page now counts the tokens the platform observes coming from users' agent sessions (input and output — cache reads and writes excluded), never inference the platform spends itself (risk-policy analysis, hosted chat). Breakdowns now offer model, agent, provider, account type, project, user, division, department, and role; the project filter dropdown is replaced by the Project breakdown section.
+Redefine tokens under management as observed agent traffic: the billing page now counts the tokens the platform observes coming from users' agent sessions (input, output, and cache writes — cache reads excluded), never inference the platform spends itself (risk-policy analysis, hosted chat). Breakdowns now offer model, agent, provider, account type, project, user, division, department, and role; the project filter dropdown is replaced by the Project breakdown section.

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -2794,14 +2794,11 @@ async function seedObservabilityData(init: {
   const GROUP_POOL = ["platform", "growth", "enterprise", "core"];
   // The consuming surface (gram.hook.source) for chat rows — the hook_source
   // dimension on telemetry.query. (The hooks seeding block below has its own
-  // HOOK_SOURCES list for hook events.) Mixes agent-fleet surfaces with
-  // billed gram surfaces (playground/gram) so the billing page — which
-  // scopes to registered billing.ModelUsageSources — has data locally.
-  // "assistants" is deliberately absent from the billed slots: it is
-  // unregistered (Speakeasy covers assistants inference until BYOK). Known
-  // seed gap vs prod: fleet sessions here emit gen_ai.usage rows (billed),
-  // while prod fleet telemetry reports tokens in agent-native namespaces
-  // only.
+  // HOOK_SOURCES list for hook events.) Mixes observed agent surfaces
+  // (claude-code, cowork, cursor, codex — the tokens-under-management
+  // population the billing page counts) with Gram-hosted surfaces
+  // (playground/gram — excluded from TUM, so the billing page's exclusion
+  // path has local data to prove itself against too).
   const CHAT_HOOK_SOURCES = [
     "claude-code",
     "cursor",
@@ -3664,43 +3661,50 @@ async function seedObservabilityData(init: {
 
       const sessionRows: string[] = [toolRow];
 
-      // A slice of anthropic-surface sessions re-emits its usage the way real
-      // Claude ingestion does: a claude-code:usage row carrying the session
-      // total (feeds chat_token_summaries / TUM but is excluded from the
-      // generic attribute_metrics path) plus api_request rows that split the
-      // tokens across attribution contexts (skill / MCP server + tool), so the
-      // skill and MCP breakdowns have real token data. Everything else keeps
-      // the single generic chat-completion usage row.
+      // Anthropic-surface sessions emit usage the way real Claude ingestion
+      // does: a claude-code:usage row carrying the session total (feeds
+      // chat_token_summaries but is excluded from attribute_metrics as a
+      // duplicate) plus api_request rows — the SOLE Claude usage source the
+      // provenance-first attribute_metrics MV admits (gram_urn must be the
+      // ingest-stamped claude-code:otel:logs). A slice of sessions splits its
+      // tokens across attribution contexts (skill / MCP server + tool) so the
+      // skill and MCP breakdowns have real token data.
       const claudeSurface =
         hookSource === "claude-code" || hookSource === "cowork";
       const attributed = claudeSurface && r() < 0.6;
-      if (attributed) {
+      if (claudeSurface) {
         const claudeModel =
           r() < 0.65 ? "claude-sonnet-4-6" : "claude-haiku-4-5";
-        const [mcpServer, mcpTools] =
-          MCP_ATTRIBUTIONS[Math.floor(r() * MCP_ATTRIBUTIONS.length)];
-        const mcpTool = mcpTools[Math.floor(r() * mcpTools.length)];
-        const skillName =
-          SKILL_ATTRIBUTIONS[Math.floor(r() * SKILL_ATTRIBUTIONS.length)];
 
         // Which attribution contexts this session used, and how the session's
         // tokens split across them (the plain turn always dominates).
-        const patternRoll = r();
         const attributions: string[] = [""];
-        if (patternRoll < 0.45) {
-          attributions.push(
-            `"mcp_server.name": "${mcpServer}", "mcp_tool.name": "${mcpTool}", `,
-          );
-        } else if (patternRoll < 0.75) {
-          attributions.push(`"skill.name": "${skillName}", `);
-        } else {
-          attributions.push(
-            `"mcp_server.name": "${mcpServer}", "mcp_tool.name": "${mcpTool}", `,
-            `"skill.name": "${skillName}", `,
-          );
+        if (attributed) {
+          const [mcpServer, mcpTools] =
+            MCP_ATTRIBUTIONS[Math.floor(r() * MCP_ATTRIBUTIONS.length)];
+          const mcpTool = mcpTools[Math.floor(r() * mcpTools.length)];
+          const skillName =
+            SKILL_ATTRIBUTIONS[Math.floor(r() * SKILL_ATTRIBUTIONS.length)];
+          const patternRoll = r();
+          if (patternRoll < 0.45) {
+            attributions.push(
+              `"mcp_server.name": "${mcpServer}", "mcp_tool.name": "${mcpTool}", `,
+            );
+          } else if (patternRoll < 0.75) {
+            attributions.push(`"skill.name": "${skillName}", `);
+          } else {
+            attributions.push(
+              `"mcp_server.name": "${mcpServer}", "mcp_tool.name": "${mcpTool}", `,
+              `"skill.name": "${skillName}", `,
+            );
+          }
         }
-        const fractions =
-          attributions.length === 2 ? [0.6, 0.4] : [0.5, 0.3, 0.2];
+        const FRACTIONS: Record<number, number[]> = {
+          1: [1],
+          2: [0.6, 0.4],
+          3: [0.5, 0.3, 0.2],
+        };
+        const fractions = FRACTIONS[attributions.length]!;
 
         sessionRows.push(
           `(${timeNano + BigInt(1_000_000_000)}, ${timeNano + BigInt(1_000_000_000)}, 'INFO', 'claude_code.usage', '${traceId}', '{"gen_ai.conversation.id": "${chatId}", "gen_ai.usage.total_tokens": ${totalTokens}, "gram.project.id": "${projectId}", "user.id": "${userId}", "gram.external_user.id": "${extUserId}", ${uaFrag}}', '{"service.name": "claude-code"}', '${projectId}', 'claude-code:usage/tokens', 'claude-code', '${chatId}')`,
@@ -3724,12 +3728,24 @@ async function seedObservabilityData(init: {
           ).toFixed(6);
           const rowNano = timeNano + BigInt((2 + i) * 1_000_000_000);
           sessionRows.push(
-            `(${rowNano}, ${rowNano}, 'INFO', 'claude_code.api_request', '${traceId}', '{${acctFrag}"event.name": "api_request", "prompt.id": "prompt-${dayNum}-${s}-${i}", "gen_ai.conversation.id": "${chatId}", "model": "${claudeModel}", "input_tokens": ${rowIn}, "output_tokens": ${rowOut}, "cache_read_tokens": ${rowRead}, "cache_creation_tokens": ${rowWrite}, "cost_usd": ${rowCost}, ${attrFrag}"gram.project.id": "${projectId}", "user.id": "${userId}", "gram.external_user.id": "${extUserId}", ${uaFrag}}', '{"service.name": "claude-code"}', '${projectId}', 'claude-code:api_request', 'claude-code', '${chatId}')`,
+            `(${rowNano}, ${rowNano}, 'INFO', 'claude_code.api_request', '${traceId}', '{${acctFrag}"event.name": "api_request", "prompt.id": "prompt-${dayNum}-${s}-${i}", "gen_ai.conversation.id": "${chatId}", "model": "${claudeModel}", "input_tokens": ${rowIn}, "output_tokens": ${rowOut}, "cache_read_tokens": ${rowRead}, "cache_creation_tokens": ${rowWrite}, "cost_usd": ${rowCost}, ${attrFrag}"gram.project.id": "${projectId}", "user.id": "${userId}", "gram.external_user.id": "${extUserId}", ${uaFrag}}', '{"service.name": "claude-code"}', '${projectId}', 'claude-code:otel:logs', 'claude-code', '${chatId}')`,
           );
         });
+      } else if (hookSource === "codex" || hookSource === "cursor") {
+        // Codex/Cursor usage-metrics row, matching real agent ingestion: the
+        // gram_urn's ${surface}:usage prefix is the provenance signal the
+        // attribute_metrics MV admits these rows on.
+        sessionRows.push(
+          `(${timeNano + BigInt(2_000_000_000)}, ${timeNano + BigInt(2_000_000_000)}, 'INFO', 'Agent usage', '${traceId}', '{${acctFrag}"gen_ai.operation.name": "chat", "gen_ai.conversation.id": "${chatId}", "gen_ai.usage.input_tokens": ${inputTokens}, "gen_ai.usage.output_tokens": ${outputTokens}, "gen_ai.usage.cache_read.input_tokens": ${cacheReadTokens}, "gen_ai.usage.cache_creation.input_tokens": ${cacheCreationTokens}, "gen_ai.usage.total_tokens": ${totalTokens}, "gen_ai.usage.cost": ${cost}, "gen_ai.response.model": "${model}", "gen_ai.provider.name": "${provider}", "gram.resource.urn": "${hookSource}:usage:metrics", "gram.project.id": "${projectId}", "user.id": "${userId}", "gram.external_user.id": "${extUserId}", ${uaFrag}}', '{"gram.deployment.id": "deployment-1"}', '${projectId}', '${hookSource}:usage:metrics', '${hookSource}', '${chatId}')`,
+        );
       } else {
-        // Token/cost usage row: feeds attribute_metrics_summaries (costs page)
-        // and chat_token_summaries (tokens under management).
+        // Gram-hosted surfaces (playground, gram): a generic completion row.
+        // Feeds chat_token_summaries; post-cutoff it is deliberately ABSENT
+        // from attribute_metrics_summaries (Gram-spent inference is not
+        // observed traffic), while pre-cutoff history reaches the aggregate
+        // via the old-rules backfill below — mirroring the retained Gram rows
+        // production carries from before the provenance-first cutover, which
+        // the billing reads must exclude.
         sessionRows.push(
           `(${timeNano + BigInt(2_000_000_000)}, ${timeNano + BigInt(2_000_000_000)}, 'INFO', 'Chat completion', '${traceId}', '{${acctFrag}"gen_ai.operation.name": "chat", "gen_ai.conversation.id": "${chatId}", "gen_ai.usage.input_tokens": ${inputTokens}, "gen_ai.usage.output_tokens": ${outputTokens}, "gen_ai.usage.cache_read.input_tokens": ${cacheReadTokens}, "gen_ai.usage.cache_creation.input_tokens": ${cacheCreationTokens}, "gen_ai.usage.total_tokens": ${totalTokens}, "gen_ai.usage.cost": ${cost}, "gen_ai.response.model": "${model}", "gen_ai.provider.name": "${provider}", "gram.resource.urn": "agents:chat:completion", "gram.project.id": "${projectId}", "user.id": "${userId}", "gram.external_user.id": "${extUserId}", "http.response.status_code": 200, ${uaFrag}}', '{"gram.deployment.id": "deployment-1"}', '${projectId}', 'agents:chat:completion', 'gram-mcp-gateway', '${chatId}')`,
         );
@@ -4242,12 +4258,17 @@ async function seedObservabilityData(init: {
 // MV's live-ingestion cutoff. attribute_metrics_summaries_mv skips rows before
 // 2026-06-20 (production data that old was backfilled once, out of band), so
 // seeded history from before the cutoff would never reach the costs page
-// without this. Mirrors the MV query in server/clickhouse/schema.sql
-// (attribute_metrics_summaries_mv) with the cutoff condition replaced by the
-// caller's time predicate and a project filter — keep the two in sync when
-// the MV changes. `sourceTable` must be telemetry_logs or a clone of it (the
-// query relies on its materialized columns); `timePredicate` may reference
-// attribute_metrics_cutoff_unix_nano from the WITH clause.
+// without this.
+//
+// DELIBERATELY mirrors the PRE-provenance-first MV rules (the ones
+// production's out-of-band backfill ran with), NOT the current MV: that is
+// how production's aggregate actually looks — pre-cutoff history includes
+// Gram-hosted completion rows (playground/gram hook_source) that the
+// tokens-under-management reads must exclude at read time. Seeding with the
+// same rules keeps local data an honest replica of that. `sourceTable` must
+// be telemetry_logs or a clone of it (the query relies on its materialized
+// columns); `timePredicate` may reference attribute_metrics_cutoff_unix_nano
+// from the WITH clause.
 function attributeMetricsBackfillSQL(
   projectId: string,
   sourceTable: string,

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -54588,7 +54588,7 @@ components:
           description: Gap-filled daily buckets in ascending time order
         totals:
           $ref: '#/components/schemas/TumDetailsTotals'
-      description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — matching the billed totals exactly.
+      description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
       required:
         - interval_seconds
         - points

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -31882,7 +31882,7 @@ paths:
         type: query
   /rpc/telemetry.queryTumDetails:
     post:
-      description: 'Org-scoped daily usage details for the billing page''s metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).'
+      description: 'Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.'
       operationId: queryTumDetails
       parameters:
         - allowEmptyValue: true
@@ -54514,7 +54514,7 @@ components:
       properties:
         key:
           type: string
-          description: 'The breakdown dimension key (hook_source, risk_analysis_model, completion_model, division_name, role). The two model keys partition the billed population: risk_analysis_model covers the platform''s risk-policy scanning inference, completion_model covers user-facing completion surfaces.'
+          description: The breakdown dimension key (model, hook_source, provider, account_type, email, division_name, department_name, role, project_id) — the public telemetry dimension identifiers, so the same keys work as telemetry.query filters. project_id rows carry project UUIDs; clients map them to names.
         rows:
           type: array
           items:
@@ -54553,15 +54553,15 @@ components:
           description: Bucket start time in Unix nanoseconds (string for JS precision)
         input_tokens:
           type: integer
-          description: Billed input tokens
+          description: Observed input tokens (cache reads and writes excluded)
           format: int64
         output_tokens:
           type: integer
-          description: Billed output tokens
+          description: Observed output tokens
           format: int64
         total_tokens:
           type: integer
-          description: Billed tokens under management
+          description: 'Tokens under management: input + output'
           format: int64
       description: One UTC day of billing usage details
       required:
@@ -54588,7 +54588,7 @@ components:
           description: Gap-filled daily buckets in ascending time order
         totals:
           $ref: '#/components/schemas/TumDetailsTotals'
-      description: Result of the billing usage details query. Everything derives from the billed population (registered completion surfaces), matching the invoiced totals exactly.
+      description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — matching the billed totals exactly.
       required:
         - interval_seconds
         - points
@@ -54599,15 +54599,15 @@ components:
       properties:
         input_tokens:
           type: integer
-          description: Billed input tokens
+          description: Observed input tokens (cache reads and writes excluded)
           format: int64
         output_tokens:
           type: integer
-          description: Billed output tokens
+          description: Observed output tokens
           format: int64
         total_tokens:
           type: integer
-          description: Billed tokens under management
+          description: 'Tokens under management: input + output'
           format: int64
       description: Whole-range totals for the billing usage details
       required:

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -31882,7 +31882,7 @@ paths:
         type: query
   /rpc/telemetry.queryTumDetails:
     post:
-      description: 'Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.'
+      description: 'Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.'
       operationId: queryTumDetails
       parameters:
         - allowEmptyValue: true
@@ -54551,9 +54551,13 @@ components:
         bucket_time_unix_nano:
           type: string
           description: Bucket start time in Unix nanoseconds (string for JS precision)
+        cache_creation_tokens:
+          type: integer
+          description: Observed cache-write tokens — prompt content entering the provider cache, counted once
+          format: int64
         input_tokens:
           type: integer
-          description: Observed input tokens (cache reads and writes excluded)
+          description: Observed input tokens (cache reads excluded)
           format: int64
         output_tokens:
           type: integer
@@ -54561,12 +54565,13 @@ components:
           format: int64
         total_tokens:
           type: integer
-          description: 'Tokens under management: input + output'
+          description: 'Tokens under management: input + output + cache writes'
           format: int64
       description: One UTC day of billing usage details
       required:
         - input_tokens
         - output_tokens
+        - cache_creation_tokens
         - total_tokens
         - bucket_time_unix_nano
     TumDetailsResult:
@@ -54588,7 +54593,7 @@ components:
           description: Gap-filled daily buckets in ascending time order
         totals:
           $ref: '#/components/schemas/TumDetailsTotals'
-      description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
+      description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache reads excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
       required:
         - interval_seconds
         - points
@@ -54597,9 +54602,13 @@ components:
     TumDetailsTotals:
       type: object
       properties:
+        cache_creation_tokens:
+          type: integer
+          description: Observed cache-write tokens — prompt content entering the provider cache, counted once
+          format: int64
         input_tokens:
           type: integer
-          description: Observed input tokens (cache reads and writes excluded)
+          description: Observed input tokens (cache reads excluded)
           format: int64
         output_tokens:
           type: integer
@@ -54607,12 +54616,13 @@ components:
           format: int64
         total_tokens:
           type: integer
-          description: 'Tokens under management: input + output'
+          description: 'Tokens under management: input + output + cache writes'
           format: int64
       description: Whole-range totals for the billing usage details
       required:
         - input_tokens
         - output_tokens
+        - cache_creation_tokens
         - total_tokens
     TunneledMcpConnection:
       type: object

--- a/client/dashboard/src/components/billing/breakdown-options.ts
+++ b/client/dashboard/src/components/billing/breakdown-options.ts
@@ -1,19 +1,23 @@
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
 import {
+  BadgeCheck,
   Bot,
+  Building2,
+  Cloud,
   Cpu,
+  FolderKanban,
   Layers,
   type LucideIcon,
   Network,
   Shield,
-  ShieldAlert,
   Sigma,
+  UserRound,
 } from "lucide-react";
 
 // The token-usage panel's breakdown catalog: every group-by dimension plus the
-// two special stackings (token type, risk), organized into scannable groups
-// for the picker. Kept in a non-component module so the picker component file
-// satisfies the react-refresh "only export components" rule.
+// special token-type stacking, organized into scannable groups for the picker.
+// Kept in a non-component module so the picker component file satisfies the
+// react-refresh "only export components" rule.
 
 // How the chart's bars stack: by the selected dimension's groups, by token
 // type, or as a single un-broken-down total. Lives here (not in the panel
@@ -26,12 +30,6 @@ export type StackMode = "group" | "tokenType" | "total";
 // series, so the billing page opens on the number that matches the usage card.
 export const BREAKDOWN_TOTAL = "total";
 const BREAKDOWN_TOKEN_TYPE = "tokenType";
-
-// The two halves of the billed population's model cut (see the server's
-// tumBreakdownDims): the platform's risk-policy scanning inference — the
-// metered unit of the TUM contracts — and user-facing completion surfaces.
-export const RISK_ANALYSIS_MODEL_DIM = "risk_analysis_model";
-export const COMPLETION_MODEL_DIM = "completion_model";
 
 // The chart series palette, shared with the usage details table so a metric's
 // dot color matches its chart legend color.
@@ -60,12 +58,12 @@ export type BreakdownGroup = {
   options: BreakdownOption[];
 };
 
-// Only dimensions billed completion rows genuinely carry: the model, the
-// identity snapshot hydrated at emit time (division, roles — a per-user cut
-// is deliberately not exposed on the billing page yet), and the consuming
-// surface. Fleet-only concepts (provider, account type, skill, MCP
-// server/tool, cache token types) live on the costs/insights pages, whose
-// analytics aggregate is scoped to agent-fleet provenance.
+// The dimensions the observed agent traffic — the tokens-under-management
+// population — genuinely carries (see the server's tumBreakdownDims): the
+// session's model and agent surface, the AI account's provider and
+// team/personal classification, and the user-identity snapshot hydrated at
+// emit time. Gram-hosted surfaces (playground, risk-analysis inference) are
+// not tokens under management and never appear here.
 export const BREAKDOWN_GROUPS: BreakdownGroup[] = [
   {
     // Ungrouped: the no-breakdown view leads the list, above every category.
@@ -73,38 +71,44 @@ export const BREAKDOWN_GROUPS: BreakdownGroup[] = [
     options: [{ value: BREAKDOWN_TOTAL, label: "Total", icon: Sigma }],
   },
   {
-    heading: "Model",
+    heading: "Usage",
     options: [
-      {
-        value: RISK_ANALYSIS_MODEL_DIM,
-        label: "Risk Policy Analysis Model",
-        icon: ShieldAlert,
-      },
-      { value: COMPLETION_MODEL_DIM, label: "Completion Model", icon: Cpu },
+      { value: Dimension.Model, label: "Model", icon: Cpu },
+      { value: BREAKDOWN_TOKEN_TYPE, label: "Token type", icon: Layers },
     ],
   },
   {
-    heading: "Usage",
+    heading: "Agents",
     options: [
-      { value: BREAKDOWN_TOKEN_TYPE, label: "Token type", icon: Layers },
+      // hook_source: the observed agent surface the session ran on
+      // (claude-code, cursor, codex, …).
+      { value: Dimension.HookSource, label: "Agent", icon: Bot },
+      { value: Dimension.Provider, label: "Provider", icon: Cloud },
+      {
+        value: Dimension.AccountType,
+        label: "Account type",
+        icon: BadgeCheck,
+      },
     ],
   },
   {
     heading: "Organization",
     options: [
+      // project_id values are project UUIDs; the section maps them to names.
+      { value: Dimension.ProjectId, label: "Project", icon: FolderKanban },
       { value: Dimension.DivisionName, label: "Division", icon: Network },
+      {
+        value: Dimension.DepartmentName,
+        label: "Department",
+        icon: Building2,
+      },
     ],
   },
   {
     heading: "People",
-    options: [{ value: Dimension.Role, label: "Role", icon: Shield }],
-  },
-  {
-    heading: "Surfaces",
     options: [
-      // hook_source: for billed completions this is the Gram surface the
-      // request ran through (playground, MCP chat, …).
-      { value: Dimension.HookSource, label: "Source", icon: Bot },
+      { value: Dimension.Email, label: "User", icon: UserRound },
+      { value: Dimension.Role, label: "Role", icon: Shield },
     ],
   },
 ];
@@ -120,24 +124,25 @@ export function stackModeFor(breakdown: string): StackMode {
   }
 }
 
-// The model cut is the one breakdown whose bars do NOT sum to the billed
-// total: each option charts only its half of the population. The panel shows
-// this note so lower bars read as a narrower scope, not less usage.
-export function scopeNoteFor(breakdown: string): string | null {
-  switch (breakdown) {
-    case RISK_ANALYSIS_MODEL_DIM:
-      return "Risk policy analysis inference only — one slice of the billed total";
-    case COMPLETION_MODEL_DIM:
-      return "Completion surfaces only — one slice of the billed total";
-    default:
-      return null;
-  }
-}
-
 export function breakdownLabel(value: string): string {
   for (const group of BREAKDOWN_GROUPS) {
     const hit = group.options.find((o) => o.value === value);
     if (hit) return hit.label;
+  }
+  return value;
+}
+
+// Display label for one breakdown row value: "" is observed traffic that
+// lacks the attribute, and project_id values are UUIDs mapped to project
+// names (a deleted project falls back to its raw id).
+export function breakdownValueLabel(
+  dimension: string,
+  value: string,
+  projectNames: Map<string, string>,
+): string {
+  if (value === "") return "(unset)";
+  if (dimension === Dimension.ProjectId) {
+    return projectNames.get(value) ?? value;
   }
   return value;
 }

--- a/client/dashboard/src/components/billing/token-usage-panel.tsx
+++ b/client/dashboard/src/components/billing/token-usage-panel.tsx
@@ -24,9 +24,14 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, ChartTooltip, Legend);
 // dimension or by token type, with client-side granularity roll-up (the
 // caller fetches daily buckets) and a cumulative view. Everything renders
 // from the billing details response (points + per-dimension rows, both
-// scoped server-side to the observed agent traffic, cache reads excluded) —
+// scoped server-side to the observed agent traffic, cache tokens excluded) —
 // plus, for the headline total, the billed per-day series the usage endpoint
-// already returns.
+// already returns. On a cycle finalized before a billing-definition change,
+// that sealed series is the invoiced record and can differ from the live
+// details data, so switching from the total view to a token-type or
+// dimension stacking can change the displayed sum — deliberate: the total
+// view shows what was billed, the breakdowns show the current population's
+// shape.
 
 // Pointer movement under this many pixels counts as a click, not a drag.
 const DRAG_THRESHOLD_PX = 5;
@@ -214,7 +219,7 @@ function ToggleButton({
 
 // The header info copy for the panel.
 function headerHint(): string {
-  return "Tokens under management — the agent traffic the platform observes from your users' sessions (Claude Code, Cursor, Codex): input and output tokens. Cache reads and writes are excluded (cached content isn't new traffic), and so is inference the platform itself runs (risk-policy analysis, hosted chat).";
+  return "Tokens under management — the agent traffic the platform observes from your users' sessions (including Claude Code, Cowork, Cursor, and Codex): input and output tokens. Cache reads and writes are excluded (cached content isn't new traffic), and so is inference the platform itself runs (risk-policy analysis, hosted chat).";
 }
 
 // The stacks for the modes fed by the details points.

--- a/client/dashboard/src/components/billing/token-usage-panel.tsx
+++ b/client/dashboard/src/components/billing/token-usage-panel.tsx
@@ -24,7 +24,7 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, ChartTooltip, Legend);
 // dimension or by token type, with client-side granularity roll-up (the
 // caller fetches daily buckets) and a cumulative view. Everything renders
 // from the billing details response (points + per-dimension rows, both
-// scoped server-side to the observed agent traffic, cache tokens excluded) —
+// scoped server-side to the observed agent traffic, cache reads excluded) —
 // plus, for the headline total, the billed per-day series the usage endpoint
 // already returns. On a cycle finalized before a billing-definition change,
 // that sealed series is the invoiced record and can differ from the live
@@ -44,16 +44,17 @@ const GRANULARITIES: { value: Granularity; label: string }[] = [
   { value: "month", label: "Monthly" },
 ];
 
-// The tokens-under-management token types: input + output sum to the total.
-// Cache tokens are excluded from the population entirely (a cache read
-// re-observes already-counted prompt content; a cache write is the provider
-// storing it), so they are not series here.
+// The tokens-under-management token types: input + output + cache writes
+// sum to the total. Cache READS are excluded from the population entirely
+// (a cache read re-observes already-counted prompt content), so they are
+// not a series here.
 const TOKEN_TYPES: {
   label: string;
   value: (p: TumDetailsPoint) => number;
 }[] = [
   { label: "Input", value: (p) => p.inputTokens },
   { label: "Output", value: (p) => p.outputTokens },
+  { label: "Cache write", value: (p) => p.cacheCreationTokens },
 ];
 
 const compactTokens = new Intl.NumberFormat("en-US", {
@@ -219,7 +220,7 @@ function ToggleButton({
 
 // The header info copy for the panel.
 function headerHint(): string {
-  return "Tokens under management — the agent traffic the platform observes from your users' sessions (including Claude Code, Cowork, Cursor, and Codex): input and output tokens. Cache reads and writes are excluded (cached content isn't new traffic), and so is inference the platform itself runs (risk-policy analysis, hosted chat).";
+  return "Tokens under management — the agent traffic the platform observes from your users' sessions (including Claude Code, Cowork, Cursor, and Codex): input, output, and cache-write tokens. Cache reads are excluded (re-read cached content isn't new traffic), and so is inference the platform itself runs (risk-policy analysis, hosted chat).";
 }
 
 // The stacks for the modes fed by the details points.

--- a/client/dashboard/src/components/billing/token-usage-panel.tsx
+++ b/client/dashboard/src/components/billing/token-usage-panel.tsx
@@ -21,12 +21,12 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, ChartTooltip, Legend);
 
 // Vercel-style consumption breakdown for tokens under management: a stacked
 // bar chart of tokens over the selected billing cycle, stacked by a chosen
-// dimension or by token type, with client-side
-// granularity roll-up (the caller fetches daily buckets) and a cumulative
-// view. Everything renders from the billing details response (points +
-// per-dimension rows, both scoped server-side to the billed completion
-// population) — plus, for the headline total, the billed per-day series the
-// usage endpoint already returns.
+// dimension or by token type, with client-side granularity roll-up (the
+// caller fetches daily buckets) and a cumulative view. Everything renders
+// from the billing details response (points + per-dimension rows, both
+// scoped server-side to the observed agent traffic, cache reads excluded) —
+// plus, for the headline total, the billed per-day series the usage endpoint
+// already returns.
 
 // Pointer movement under this many pixels counts as a click, not a drag.
 const DRAG_THRESHOLD_PX = 5;
@@ -39,8 +39,10 @@ const GRANULARITIES: { value: Granularity; label: string }[] = [
   { value: "month", label: "Monthly" },
 ];
 
-// Billed completions carry no cache attributes (input + output = total), so
-// the token-type view has exactly these two series.
+// The tokens-under-management token types: input + output sum to the total.
+// Cache tokens are excluded from the population entirely (a cache read
+// re-observes already-counted prompt content; a cache write is the provider
+// storing it), so they are not series here.
 const TOKEN_TYPES: {
   label: string;
   value: (p: TumDetailsPoint) => number;
@@ -212,7 +214,7 @@ function ToggleButton({
 
 // The header info copy for the panel.
 function headerHint(): string {
-  return "Tokens under management — what the platform bills: LLM completions that run through it, dominated by the platform's own risk-policy analysis of observed agent traffic (the metered unit). Agent telemetry observed via OTEL (Claude Code, Cursor, Codex) is not billed and not included here; see the Insights pages for it.";
+  return "Tokens under management — the agent traffic the platform observes from your users' sessions (Claude Code, Cursor, Codex): input and output tokens. Cache reads and writes are excluded (cached content isn't new traffic), and so is inference the platform itself runs (risk-policy analysis, hosted chat).";
 }
 
 // The stacks for the modes fed by the details points.
@@ -250,7 +252,6 @@ export function TokenUsagePanel({
   groups,
   billedSeries,
   stackBy,
-  scopeNote,
   breakdownPicker,
   loading,
   onSelectRange,
@@ -266,9 +267,6 @@ export function TokenUsagePanel({
   billedSeries: number[] | null;
   // How the bars stack — controlled by the caller's breakdown picker.
   stackBy: StackMode;
-  // Shown when the active breakdown charts only a slice of the billed
-  // population (the model cut), so lower bars aren't read as less usage.
-  scopeNote?: string | null;
   // The unified breakdown selector (dimensions + token type), rendered at
   // the head of the control row.
   breakdownPicker: ReactNode;
@@ -491,9 +489,6 @@ export function TokenUsagePanel({
             <Info className="text-muted-foreground size-3.5" />
           </SimpleTooltip>
         </div>
-        {scopeNote && (
-          <span className="text-muted-foreground text-xs">{scopeNote}</span>
-        )}
         <div className="ml-auto flex items-center gap-3">
           {breakdownPicker}
           <div className="bg-border h-4 w-px" />

--- a/client/dashboard/src/components/billing/tum-details-table.tsx
+++ b/client/dashboard/src/components/billing/tum-details-table.tsx
@@ -315,7 +315,11 @@ export function TumDetailsTable({
   const billedScale = useMemo(() => {
     if (!billedCycle) return 1;
     const analyticsTotal = data?.totals?.totalTokens ?? 0;
-    if (analyticsTotal === 0 || billedCycle.tokens === 0) return 1;
+    if (analyticsTotal === 0) return 1;
+    // A sealed zero-token cycle is a known zero: scale everything to 0 so
+    // the Total row matches the card even when live analytics recomputed
+    // nonzero tokens after the seal.
+    if (billedCycle.tokens === 0) return 0;
     return billedCycle.tokens / analyticsTotal;
   }, [data, billedCycle]);
 

--- a/client/dashboard/src/components/billing/tum-details-table.tsx
+++ b/client/dashboard/src/components/billing/tum-details-table.tsx
@@ -61,7 +61,7 @@ const TAIL_DIMENSION_SECTIONS: string[] = [
 ];
 
 // A measure carried by both the daily points and the whole-range totals.
-type MeasureField = "inputTokens" | "outputTokens";
+type MeasureField = "inputTokens" | "outputTokens" | "cacheCreationTokens";
 
 type MeasureRowSpec = {
   label: string;
@@ -69,11 +69,16 @@ type MeasureRowSpec = {
   field: MeasureField;
 };
 
-// Input + output sum to the TUM total; cache tokens (reads and writes) are
+// Input + output + cache writes sum to the TUM total; cache reads are
 // excluded from the population entirely.
 const TOKEN_TYPE_ROWS: MeasureRowSpec[] = [
   { label: "Input", color: CHART_COLORS[0]!, field: "inputTokens" },
   { label: "Output", color: CHART_COLORS[1]!, field: "outputTokens" },
+  {
+    label: "Cache write",
+    color: CHART_COLORS[2]!,
+    field: "cacheCreationTokens",
+  },
 ];
 
 // Row color for a dimension value — same palette walk as the chart's stacks,

--- a/client/dashboard/src/components/billing/tum-details-table.tsx
+++ b/client/dashboard/src/components/billing/tum-details-table.tsx
@@ -8,14 +8,12 @@ import { useMemo, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { isAttributionDim } from "@/pages/costs/taxonomy";
 import { type BillingPeriod, bucketDateKey } from "./billing-cycles";
 import {
   breakdownLabel,
+  breakdownValueLabel,
   CHART_COLORS,
-  COMPLETION_MODEL_DIM,
   OTHER_COLOR,
-  RISK_ANALYSIS_MODEL_DIM,
 } from "./breakdown-options";
 import { tumDetailsQuery } from "./tum-queries";
 
@@ -44,21 +42,22 @@ type DetailGroup = {
   rows: DetailRow[];
 };
 
-// The dimension sections, split so the headline model cuts sit directly
-// under Total and the rest follow the token-type group. Only dimensions
-// billed completion rows genuinely carry: the two model cuts (the platform's
-// risk-policy analysis inference vs user-facing completion surfaces), the
-// identity snapshot hydrated at emit time (division, roles — no per-user
-// section; that isn't exposed on the billing page yet), and the consuming
-// surface.
-const LEAD_DIMENSION_SECTIONS: string[] = [
-  RISK_ANALYSIS_MODEL_DIM,
-  COMPLETION_MODEL_DIM,
-];
+// The dimension sections, split so Model sits directly under Total and the
+// rest follow the token-type group, mirroring the chart's breakdown picker:
+// the observed session's model and agent surface, the AI account's provider
+// and team/personal classification, the project the traffic was recorded
+// under, and the emit-time identity snapshot (division, department, user,
+// roles).
+const LEAD_DIMENSION_SECTIONS: string[] = [Dimension.Model];
 const TAIL_DIMENSION_SECTIONS: string[] = [
-  Dimension.DivisionName,
-  Dimension.Role,
   Dimension.HookSource,
+  Dimension.Provider,
+  Dimension.AccountType,
+  Dimension.ProjectId,
+  Dimension.DivisionName,
+  Dimension.DepartmentName,
+  Dimension.Email,
+  Dimension.Role,
 ];
 
 // A measure carried by both the daily points and the whole-range totals.
@@ -70,7 +69,8 @@ type MeasureRowSpec = {
   field: MeasureField;
 };
 
-// Billed completions carry no cache attributes (input + output = total).
+// Input + output sum to the TUM total; cache tokens (reads and writes) are
+// excluded from the population entirely.
 const TOKEN_TYPE_ROWS: MeasureRowSpec[] = [
   { label: "Input", color: CHART_COLORS[0]!, field: "inputTokens" },
   { label: "Output", color: CHART_COLORS[1]!, field: "outputTokens" },
@@ -84,10 +84,12 @@ function valueColor(value: string, index: number): string {
 }
 
 // The dimension sections of the details table, mirroring the chart's group
-// stacks: same value order, "(unset)" labeling, attribution "" rows dropped.
+// stacks: same value order, "(unset)" labeling for unattributed traffic,
+// project UUIDs mapped to names.
 function dimensionGroups(
   data: TumDetailsResult | undefined,
   keys: string[],
+  projectNames: Map<string, string>,
 ): DetailGroup[] {
   const byKey = new Map(
     (data?.breakdowns ?? []).map((b) => [b.key, b.rows] as const),
@@ -96,13 +98,9 @@ function dimensionGroups(
   for (const key of keys) {
     const rows = byKey.get(key);
     if (!rows) continue;
-    // Attribution "" rows are not-applicable spend (same rule as the chart);
-    // zero-token rows (e.g. groups with only tool calls) are noise.
-    const visible = rows.filter(
-      (r) =>
-        r.totalTokens > 0 &&
-        (!isAttributionDim(key as Dimension) || r.value !== ""),
-    );
+    // "" rows are real observed traffic that lacks the attribute — shown as
+    // "(unset)". Zero-token rows are noise.
+    const visible = rows.filter((r) => r.totalTokens > 0);
     if (visible.length === 0) continue;
     groups.push({
       heading: breakdownLabel(key),
@@ -114,7 +112,7 @@ function dimensionGroups(
           ? "Users can hold multiple roles; rows overlap and can sum to more than the total token usage for the selected time period."
           : undefined,
       rows: visible.map((r, i) => ({
-        label: r.value === "" ? "(unset)" : r.value,
+        label: breakdownValueLabel(key, r.value, projectNames),
         color: valueColor(r.value, i),
         series: r.series,
         total: r.totalTokens,
@@ -274,22 +272,22 @@ function DetailGroupSection({
  */
 export function TumDetailsTable({
   period,
-  projectId,
+  projectNames,
   limit,
 }: {
   period: BillingPeriod;
-  // Optional project scope, matching the page-level project filter.
-  projectId: string | null;
+  // Project id → name, for labeling the Project section's UUID values.
+  projectNames: Map<string, string>;
   // Contracted monthly allowance; drives the per-metric overage share.
   limit: number | null;
 }): JSX.Element {
   const client = useGramContext();
   const organization = useOrganization();
-  const scope = { client, orgId: organization.id, period, projectId };
+  const scope = { client, orgId: organization.id, period };
   const { data, isFetching, isError } = useQuery(tumDetailsQuery(scope));
 
   // Sections collapsed via their header band, keyed by heading so the state
-  // survives period/project switches.
+  // survives period switches.
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const toggleGroup = (heading: string): void => {
     setCollapsed((prev) => {
@@ -304,9 +302,9 @@ export function TumDetailsTable({
   };
 
   // Billed normalization and overage attribution are organization-cycle
-  // concepts (the TUM contract has no per-project or sub-cycle split), so
-  // both switch off when a project filter or a custom range narrows the data.
-  const billedCycle = projectId == null ? period.cycle : null;
+  // concepts (the TUM contract has no sub-cycle split), so both switch off
+  // when a custom range narrows the data.
+  const billedCycle = period.cycle;
 
   // The table presents BILLED tokens: the analytics aggregate supplies the
   // distribution across metrics (it has the dimensions; billing's per-session
@@ -344,9 +342,9 @@ export function TumDetailsTable({
           },
         ],
       },
-      ...dimensionGroups(data, LEAD_DIMENSION_SECTIONS),
+      ...dimensionGroups(data, LEAD_DIMENSION_SECTIONS, projectNames),
       { heading: "Token type", rows: TOKEN_TYPE_ROWS.map(measureRow) },
-      ...dimensionGroups(data, TAIL_DIMENSION_SECTIONS),
+      ...dimensionGroups(data, TAIL_DIMENSION_SECTIONS, projectNames),
     ];
 
     // Convert every row into billed units (see billedScale).
@@ -358,31 +356,26 @@ export function TumDetailsTable({
         series: row.series.map((v) => v * billedScale),
       })),
     }));
-  }, [data, billedScale]);
+  }, [data, billedScale, projectNames]);
 
   // Time-based overage attribution: tokens count as overage from the moment
-  // the ORGANIZATION's cumulative usage crossed the included allowance. Days
+  // the organization's cumulative usage crossed the included allowance. Days
   // before the crossing weigh 0, days after weigh 1, and the crossing day is
   // prorated by how far into its tokens the allowance ran out (the data is
   // daily, so metrics are assumed to share the within-day distribution). The
-  // crossing point comes from the cycle's org-wide BILLED daily series — a
-  // project filter must not move it — so a project-scoped view shows that
-  // project's share of the overage: its tokens recorded after the org
-  // crossed.
+  // crossing point is walked on the cycle's BILLED daily series.
   //
   // Null when overage does not apply: no contracted allowance, or a custom
   // range (the allowance is an org-cycle number).
   const overageWeights = useMemo<number[] | null>(() => {
-    const cycle = period.cycle;
+    const cycle = billedCycle;
     if (limit == null || cycle == null) return null;
     const points = data?.points ?? [];
 
     // The daily series the crossing is walked on. Normally the cycle's
-    // org-wide billed days; when the TUM response didn't carry them (the
-    // synthesized active-cycle fallback has none), an all-zero walk would
-    // silently zero the whole column — instead org scope falls back to the
-    // billed-scaled analytics series, and project scope dashes out (its
-    // filtered series can't locate the org-wide crossing).
+    // billed days; when the TUM response didn't carry them (the synthesized
+    // active-cycle fallback has none), an all-zero walk would silently zero
+    // the whole column — fall back to the billed-scaled analytics series.
     let billed: number[];
     if (cycle.days.length > 0) {
       // The daily series is advisory: it recomputes live under the CURRENT
@@ -399,10 +392,8 @@ export function TumDetailsTable({
       billed = points.map(
         (p) => billedByDate.get(bucketDateKey(p.bucketTimeUnixNano)) ?? 0,
       );
-    } else if (billedCycle) {
-      billed = points.map((p) => p.totalTokens * billedScale);
     } else {
-      return null;
+      billed = points.map((p) => p.totalTokens * billedScale);
     }
 
     const weights = billed.map(() => 0);
@@ -414,14 +405,9 @@ export function TumDetailsTable({
       weights[i] =
         before >= limit ? 1 : (cumulative - limit) / (billed[i]! || 1);
     }
-    if (!billedCycle) {
-      // Project scope: the raw weights are exact against the billed series,
-      // and weighting the project's rows by them yields its true share.
-      return weights;
-    }
-    // Org scope: the rows are billed-scaled analytics, which track the billed
-    // series within a fraction of a percent but not to the token — pin the
-    // "Total tokens" row's overage to the usage card's number exactly.
+    // The rows are billed-scaled analytics, which track the billed series
+    // within a fraction of a percent but not to the token — pin the "Total
+    // tokens" row's overage to the usage card's number exactly.
     const billedOverage = Math.max(0, cycle.tokens - limit);
     const totals = points.map((p) => p.totalTokens * billedScale);
     const weightedTotal = totals.reduce(
@@ -431,25 +417,17 @@ export function TumDetailsTable({
     if (weightedTotal === 0) return weights.map(() => 0);
     const scale = billedOverage / weightedTotal;
     return weights.map((w) => w * scale);
-  }, [data, limit, period.cycle, billedCycle, billedScale]);
+  }, [data, limit, billedCycle, billedScale]);
 
   const loading = isFetching && !data;
   const failed = !loading && !data && isError;
 
   const totalTooltip = billedCycle
     ? "Billed tokens under management, attributed across metrics by the analytics distribution."
-    : "Tokens for the selected slice, from the analytics aggregates. Billed normalization applies to full organization billing cycles only.";
-  let overageTooltip: string;
-  if (billedCycle) {
-    overageTooltip =
-      "The billed overage (tokens beyond the included allowance), attributed to each metric by its tokens recorded after the allowance ran out. The crossing day is prorated.";
-  } else if (period.cycle) {
-    overageTooltip =
-      "This project's tokens recorded after the organization's usage crossed the included allowance (its share of the overage, measured in the project's analytics tokens). The crossing day is prorated.";
-  } else {
-    overageTooltip =
-      "The token allowance is an organization-per-cycle number; select a full billing cycle to see the overage.";
-  }
+    : "Tokens for the selected range, from the analytics aggregates. Billed normalization applies to full billing cycles only.";
+  const overageTooltip = billedCycle
+    ? "The billed overage (tokens beyond the included allowance), attributed to each metric by its tokens recorded after the allowance ran out. The crossing day is prorated."
+    : "The token allowance is an organization-per-cycle number; select a full billing cycle to see the overage.";
 
   return (
     <div className="border-border overflow-hidden rounded-lg border">

--- a/client/dashboard/src/components/billing/tum-details-table.tsx
+++ b/client/dashboard/src/components/billing/tum-details-table.tsx
@@ -316,10 +316,14 @@ export function TumDetailsTable({
     if (!billedCycle) return 1;
     const analyticsTotal = data?.totals?.totalTokens ?? 0;
     if (analyticsTotal === 0) return 1;
-    // A sealed zero-token cycle is a known zero: scale everything to 0 so
+    // A CLOSED zero-token cycle is a known zero: scale everything to 0 so
     // the Total row matches the card even when live analytics recomputed
-    // nonzero tokens after the seal.
-    if (billedCycle.tokens === 0) return 0;
+    // nonzero tokens after the seal. The active cycle is exempt — its card
+    // total is a live number that can trail the details query by a refetch,
+    // and a transient zero must not blank real traffic.
+    if (billedCycle.tokens === 0) {
+      return billedCycle.current ? 1 : 0;
+    }
     return billedCycle.tokens / analyticsTotal;
   }, [data, billedCycle]);
 

--- a/client/dashboard/src/components/billing/tum-queries.ts
+++ b/client/dashboard/src/components/billing/tum-queries.ts
@@ -5,7 +5,8 @@ import { unwrapAsync } from "@gram/client/types/fp";
 import { type BillingPeriod, periodStaleTime } from "./billing-cycles";
 
 // Shared query definitions for the TUM billing section, each scoped to one
-// period (a billing cycle or a custom range) and an optional project. Kept in
+// period (a billing cycle or a custom range), always org-wide — per-project
+// visibility comes from the Project breakdown, not a request filter. Kept in
 // a non-component module so the consuming component files satisfy the
 // react-refresh "only export components" rule. The generated SDK hooks key
 // their cache on gramSession only, so these definitions drive useQuery
@@ -13,9 +14,9 @@ import { type BillingPeriod, periodStaleTime } from "./billing-cycles";
 // telemetry is immutable) via periodStaleTime.
 //
 // The request lands on a billing-page-specific endpoint that scopes its
-// reads server-side to the billed completion population (see
-// billing.ModelUsageSources on the server) — the client carries no knowledge
-// of what is billed.
+// reads server-side to the tokens-under-management population (observed
+// agent traffic; see the server's QueryTumDetails) — the client carries no
+// knowledge of what is billed.
 
 export type PeriodScope = {
   client: GramCore;
@@ -24,8 +25,6 @@ export type PeriodScope = {
   // an org switch could serve another org's cached data for the same dates.
   orgId: string;
   period: BillingPeriod;
-  // Optional project scope; null spans the whole organization.
-  projectId: string | null;
 };
 
 export type PeriodQuery<T> = {
@@ -37,7 +36,7 @@ export type PeriodQuery<T> = {
 
 function periodQuery<T>(
   name: string,
-  { orgId, period, projectId }: PeriodScope,
+  { orgId, period }: PeriodScope,
   extraKeys: string[],
   queryFn: () => Promise<T>,
 ): PeriodQuery<T> {
@@ -48,7 +47,6 @@ function periodQuery<T>(
       period.start.toISOString(),
       period.end.toISOString(),
       ...extraKeys,
-      projectId ?? "all",
     ],
     staleTime: periodStaleTime(period),
     throwOnError: false,
@@ -66,7 +64,6 @@ export function tumDetailsQuery(
         telemetryWindowPayload: {
           from: scope.period.start,
           to: scope.period.end,
-          projectId: scope.projectId ?? undefined,
         },
       }),
     ),

--- a/client/dashboard/src/components/billing/tum-section.tsx
+++ b/client/dashboard/src/components/billing/tum-section.tsx
@@ -4,15 +4,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useOrganization } from "@/contexts/Auth";
-import { isAttributionDim } from "@/pages/costs/taxonomy";
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import {
@@ -39,7 +31,7 @@ import {
 } from "./billing-cycles";
 import {
   BREAKDOWN_TOTAL,
-  scopeNoteFor,
+  breakdownValueLabel,
   stackModeFor,
 } from "./breakdown-options";
 import { BreakdownPicker } from "./breakdown-picker";
@@ -49,23 +41,23 @@ import { tumDetailsQuery } from "./tum-queries";
 import { TumUsageCard } from "./tum-usage-card";
 
 // Org-wide token breakdown for one billing cycle: stacked daily tokens by a
-// selectable dimension, by token type, or by risk involvement — one unified
-// picker drives all three. Everything renders from the billing details
-// request shared with the details table (the server scopes it to the billed
-// completion population), except the headline total, which prefers the
-// billed per-day series the usage endpoint returns — the exact numbers on
-// the usage card. No data-availability pruning of the dimension list:
+// selectable dimension or by token type — one unified picker drives both.
+// Everything renders from the billing details request shared with the
+// details table (the server scopes it to the observed agent traffic, cache
+// reads excluded), except the headline total, which prefers the billed
+// per-day series the usage endpoint returns — the exact numbers on the
+// usage card. No data-availability pruning of the dimension list:
 // dimensions without data simply chart as "(unset)".
 function TumTokenBreakdown({
   period,
-  projectId,
+  projectNames,
   billedDays,
   onSelectRange,
 }: {
   period: BillingPeriod;
-  projectId: string | null;
+  // Project id → name, for labeling the Project breakdown's UUID values.
+  projectNames: Map<string, string>;
   // The billed per-day series and the cycle windows it fully describes.
-  // Org-wide — unusable under a project filter.
   billedDays: BilledDays;
   // Bar-click drill-down: narrows the page's period to the clicked bucket.
   onSelectRange: (start: Date, end: Date) => void;
@@ -79,24 +71,21 @@ function TumTokenBreakdown({
   const [dimension, setDimension] = useState<string>(Dimension.DivisionName);
   const stackBy = stackModeFor(breakdown);
 
-  const scope = { client, orgId: organization.id, period, projectId };
+  const scope = { client, orgId: organization.id, period };
   // Shared with the details table (same key — one request).
   const { data, isFetching } = useQuery(tumDetailsQuery(scope));
 
   const points = useMemo(() => data?.points ?? [], [data]);
 
-  // The selected dimension's rows. Attribution cuts hide the ""
-  // (not-applicable) row, same as the details table below.
+  // The selected dimension's rows. "" rows are real observed traffic that
+  // lacks the attribute — charted as "(unset)", same as the details table.
   const groups = useMemo<GroupSeries[]>(() => {
     const rows = data?.breakdowns.find((b) => b.key === dimension)?.rows ?? [];
-    const visible = isAttributionDim(dimension as Dimension)
-      ? rows.filter((r) => r.value !== "")
-      : rows;
-    return visible.map((r) => ({
-      label: r.value === "" ? "(unset)" : r.value,
+    return rows.map((r) => ({
+      label: breakdownValueLabel(dimension, r.value, projectNames),
       series: r.series,
     }));
-  }, [data, dimension]);
+  }, [data, dimension, projectNames]);
 
   // The billed series aligned to the points grid, used only when the billed
   // data COVERS every charted day — coverage, not positivity: a sealed
@@ -105,7 +94,7 @@ function TumTokenBreakdown({
   // synthesized active cycle without history) makes the whole view fall
   // back to the details totals rather than charting misleading zeros.
   const billedSeries = useMemo(() => {
-    if (projectId != null || points.length === 0) return null;
+    if (points.length === 0) return null;
     const series: number[] = [];
     for (const p of points) {
       const key = bucketDateKey(p.bucketTimeUnixNano);
@@ -119,7 +108,7 @@ function TumTokenBreakdown({
       series.push(billedDays.byDate.get(key) ?? 0);
     }
     return series;
-  }, [points, billedDays, projectId]);
+  }, [points, billedDays]);
 
   const breakdownPicker = (
     <BreakdownPicker
@@ -141,16 +130,12 @@ function TumTokenBreakdown({
       groups={groups}
       billedSeries={billedSeries}
       stackBy={stackBy}
-      scopeNote={scopeNoteFor(breakdown)}
       breakdownPicker={breakdownPicker}
       loading={isFetching && !data}
       onSelectRange={onSelectRange}
     />
   );
 }
-
-// All-projects sentinel for the project filter (Radix Select rejects "").
-const ALL_PROJECTS = "__all__";
 
 // The range picker's calendar hands back local midnights for both ends. The
 // page's data is bucketed by UTC day (matching the billing-cycle boundaries),
@@ -181,12 +166,19 @@ function customRangeFromPicker(
 export const TumUsageSection = (): JSX.Element => {
   const { data: tum } = useGetTokensUnderManagement();
   const organization = useOrganization();
+  // Projects are fetched only to label the Project breakdown's UUID values.
   const { data: projectsData } = useListProjects(
     { organizationId: organization.id },
     undefined,
     { throwOnError: false },
   );
-  const projects = projectsData?.projects ?? [];
+  const projectNames = useMemo(
+    () =>
+      new Map(
+        (projectsData?.projects ?? []).map((p) => [p.id, p.name] as const),
+      ),
+    [projectsData],
+  );
 
   // The selected billing cycle scopes the usage bar and the breakdown chart.
   // Derived (not synced) so the current cycle is the default once TUM loads.
@@ -206,17 +198,12 @@ export const TumUsageSection = (): JSX.Element => {
     label?: string;
   } | null>(null);
 
-  // Optional project scope for the chart and details table. The usage card
-  // stays org-wide — the TUM contract is an organization-level number.
-  const [projectId, setProjectId] = useState<string | null>(null);
-
   // Bumped by the Reset button; remounting the breakdown clears its internal
   // view state too (breakdown pick, granularity, cumulative, hidden series).
   const [viewNonce, setViewNonce] = useState(0);
   const handleReset = (): void => {
     setSelectedKey(null);
     setCustomRange(null);
-    setProjectId(null);
     setViewNonce((n) => n + 1);
   };
 
@@ -310,8 +297,9 @@ export const TumUsageSection = (): JSX.Element => {
     <Page.Section>
       <Page.Section.Title>Billing</Page.Section.Title>
       <Page.Section.Description>
-        The volume of agent traffic the platform has processed, stored, and run
-        security analysis on each billing cycle, measured in tokens.
+        The volume of agent traffic the platform observes from your users'
+        sessions each billing cycle, measured in tokens. Cache tokens are
+        excluded, as is inference the platform runs itself.
       </Page.Section.Description>
       <Page.Section.Body>
         {tum && period ? (
@@ -320,28 +308,10 @@ export const TumUsageSection = (): JSX.Element => {
               <Type variant="body" className="font-medium">
                 Tokens Under Management
               </Type>
-              <SimpleTooltip tooltip="Counts tokens from agent sessions the platform has stored chats or tool calls for during the selected billing cycle. Compared against your contracted monthly allowance.">
+              <SimpleTooltip tooltip="Counts the tokens observed in your users' agent sessions (input and output; cache reads and writes excluded) during the selected billing cycle. Compared against your contracted monthly allowance.">
                 <Info className="text-muted-foreground h-4 w-4" />
               </SimpleTooltip>
               <div className="ml-auto flex items-center gap-2">
-                <Select
-                  value={projectId ?? ALL_PROJECTS}
-                  onValueChange={(value) =>
-                    setProjectId(value === ALL_PROJECTS ? null : value)
-                  }
-                >
-                  <SelectTrigger className="bg-background h-auto w-auto gap-1.5 py-1.5 text-sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={ALL_PROJECTS}>All projects</SelectItem>
-                    {projects.map((p) => (
-                      <SelectItem key={p.id} value={p.id}>
-                        {p.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
                 <BillingCyclePicker
                   cycles={cycles}
                   selected={customRange ? null : selectedCycle}
@@ -397,7 +367,7 @@ export const TumUsageSection = (): JSX.Element => {
               <TumTokenBreakdown
                 key={viewNonce}
                 period={period}
-                projectId={projectId}
+                projectNames={projectNames}
                 billedDays={billedDays}
                 onSelectRange={handleBarSelect}
               />
@@ -406,7 +376,7 @@ export const TumUsageSection = (): JSX.Element => {
               <TumDetailsTable
                 key={viewNonce}
                 period={period}
-                projectId={projectId}
+                projectNames={projectNames}
                 limit={monthlyLimit}
               />
             </div>

--- a/client/dashboard/src/components/billing/tum-section.tsx
+++ b/client/dashboard/src/components/billing/tum-section.tsx
@@ -298,7 +298,7 @@ export const TumUsageSection = (): JSX.Element => {
       <Page.Section.Title>Billing</Page.Section.Title>
       <Page.Section.Description>
         The volume of agent traffic the platform observes from your users'
-        sessions each billing cycle, measured in tokens. Cache tokens are
+        sessions each billing cycle, measured in tokens. Cache reads are
         excluded, as is inference the platform runs itself.
       </Page.Section.Description>
       <Page.Section.Body>
@@ -308,7 +308,7 @@ export const TumUsageSection = (): JSX.Element => {
               <Type variant="body" className="font-medium">
                 Tokens Under Management
               </Type>
-              <SimpleTooltip tooltip="Counts the tokens observed in your users' agent sessions (input and output; cache reads and writes excluded) during the selected billing cycle. Compared against your contracted monthly allowance.">
+              <SimpleTooltip tooltip="Counts the tokens observed in your users' agent sessions (input, output, and cache writes; cache reads excluded) during the selected billing cycle. Compared against your contracted monthly allowance.">
                 <Info className="text-muted-foreground h-4 w-4" />
               </SimpleTooltip>
               <div className="ml-auto flex items-center gap-2">

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -5100,7 +5100,7 @@ examples:
         application/json: {"from": "2025-12-19T10:00:00Z", "to": "2025-12-26T10:00:00Z"}
       responses:
         "200":
-          application/json: {"breakdowns": [{"key": "<key>", "rows": []}], "interval_seconds": 788271, "points": [], "totals": {"input_tokens": 970099, "output_tokens": 419661, "total_tokens": 804391}}
+          application/json: {"breakdowns": [{"key": "<key>", "rows": []}], "interval_seconds": 788271, "points": [], "totals": {"cache_creation_tokens": 788271, "input_tokens": 970099, "output_tokens": 419661, "total_tokens": 804391}}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": false}
         "500":

--- a/client/dashboard/src/sdk/src/funcs/telemetryQueryTumDetails.ts
+++ b/client/dashboard/src/sdk/src/funcs/telemetryQueryTumDetails.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * queryTumDetails telemetry
  *
  * @remarks
- * Org-scoped daily usage details for the billing page's metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).
+ * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.
  */
 export function telemetryQueryTumDetails(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/funcs/telemetryQueryTumDetails.ts
+++ b/client/dashboard/src/sdk/src/funcs/telemetryQueryTumDetails.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * queryTumDetails telemetry
  *
  * @remarks
- * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.
+ * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.
  */
 export function telemetryQueryTumDetails(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/models/components/tumdetailsbreakdown.ts
+++ b/client/dashboard/src/sdk/src/models/components/tumdetailsbreakdown.ts
@@ -16,7 +16,7 @@ import {
  */
 export type TumDetailsBreakdown = {
   /**
-   * The breakdown dimension key (hook_source, risk_analysis_model, completion_model, division_name, role). The two model keys partition the billed population: risk_analysis_model covers the platform's risk-policy scanning inference, completion_model covers user-facing completion surfaces.
+   * The breakdown dimension key (model, hook_source, provider, account_type, email, division_name, department_name, role, project_id) — the public telemetry dimension identifiers, so the same keys work as telemetry.query filters. project_id rows carry project UUIDs; clients map them to names.
    */
   key: string;
   /**

--- a/client/dashboard/src/sdk/src/models/components/tumdetailspoint.ts
+++ b/client/dashboard/src/sdk/src/models/components/tumdetailspoint.ts
@@ -17,7 +17,11 @@ export type TumDetailsPoint = {
    */
   bucketTimeUnixNano: string;
   /**
-   * Observed input tokens (cache reads and writes excluded)
+   * Observed cache-write tokens — prompt content entering the provider cache, counted once
+   */
+  cacheCreationTokens: number;
+  /**
+   * Observed input tokens (cache reads excluded)
    */
   inputTokens: number;
   /**
@@ -25,7 +29,7 @@ export type TumDetailsPoint = {
    */
   outputTokens: number;
   /**
-   * Tokens under management: input + output
+   * Tokens under management: input + output + cache writes
    */
   totalTokens: number;
 };
@@ -37,6 +41,7 @@ export const TumDetailsPoint$inboundSchema: z.ZodMiniType<
 > = z.pipe(
   z.object({
     bucket_time_unix_nano: z.string(),
+    cache_creation_tokens: z.int(),
     input_tokens: z.int(),
     output_tokens: z.int(),
     total_tokens: z.int(),
@@ -44,6 +49,7 @@ export const TumDetailsPoint$inboundSchema: z.ZodMiniType<
   z.transform((v) => {
     return remap$(v, {
       "bucket_time_unix_nano": "bucketTimeUnixNano",
+      "cache_creation_tokens": "cacheCreationTokens",
       "input_tokens": "inputTokens",
       "output_tokens": "outputTokens",
       "total_tokens": "totalTokens",

--- a/client/dashboard/src/sdk/src/models/components/tumdetailspoint.ts
+++ b/client/dashboard/src/sdk/src/models/components/tumdetailspoint.ts
@@ -17,15 +17,15 @@ export type TumDetailsPoint = {
    */
   bucketTimeUnixNano: string;
   /**
-   * Billed input tokens
+   * Observed input tokens (cache reads and writes excluded)
    */
   inputTokens: number;
   /**
-   * Billed output tokens
+   * Observed output tokens
    */
   outputTokens: number;
   /**
-   * Billed tokens under management
+   * Tokens under management: input + output
    */
   totalTokens: number;
 };

--- a/client/dashboard/src/sdk/src/models/components/tumdetailsresult.ts
+++ b/client/dashboard/src/sdk/src/models/components/tumdetailsresult.ts
@@ -21,7 +21,7 @@ import {
 } from "./tumdetailstotals.js";
 
 /**
- * Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — matching the billed totals exactly.
+ * Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
  */
 export type TumDetailsResult = {
   /**

--- a/client/dashboard/src/sdk/src/models/components/tumdetailsresult.ts
+++ b/client/dashboard/src/sdk/src/models/components/tumdetailsresult.ts
@@ -21,7 +21,7 @@ import {
 } from "./tumdetailstotals.js";
 
 /**
- * Result of the billing usage details query. Everything derives from the billed population (registered completion surfaces), matching the invoiced totals exactly.
+ * Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — matching the billed totals exactly.
  */
 export type TumDetailsResult = {
   /**

--- a/client/dashboard/src/sdk/src/models/components/tumdetailsresult.ts
+++ b/client/dashboard/src/sdk/src/models/components/tumdetailsresult.ts
@@ -21,7 +21,7 @@ import {
 } from "./tumdetailstotals.js";
 
 /**
- * Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
+ * Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache reads excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
  */
 export type TumDetailsResult = {
   /**

--- a/client/dashboard/src/sdk/src/models/components/tumdetailstotals.ts
+++ b/client/dashboard/src/sdk/src/models/components/tumdetailstotals.ts
@@ -13,7 +13,11 @@ import { SDKValidationError } from "../errors/sdkvalidationerror.js";
  */
 export type TumDetailsTotals = {
   /**
-   * Observed input tokens (cache reads and writes excluded)
+   * Observed cache-write tokens — prompt content entering the provider cache, counted once
+   */
+  cacheCreationTokens: number;
+  /**
+   * Observed input tokens (cache reads excluded)
    */
   inputTokens: number;
   /**
@@ -21,7 +25,7 @@ export type TumDetailsTotals = {
    */
   outputTokens: number;
   /**
-   * Tokens under management: input + output
+   * Tokens under management: input + output + cache writes
    */
   totalTokens: number;
 };
@@ -32,12 +36,14 @@ export const TumDetailsTotals$inboundSchema: z.ZodMiniType<
   unknown
 > = z.pipe(
   z.object({
+    cache_creation_tokens: z.int(),
     input_tokens: z.int(),
     output_tokens: z.int(),
     total_tokens: z.int(),
   }),
   z.transform((v) => {
     return remap$(v, {
+      "cache_creation_tokens": "cacheCreationTokens",
       "input_tokens": "inputTokens",
       "output_tokens": "outputTokens",
       "total_tokens": "totalTokens",

--- a/client/dashboard/src/sdk/src/models/components/tumdetailstotals.ts
+++ b/client/dashboard/src/sdk/src/models/components/tumdetailstotals.ts
@@ -13,15 +13,15 @@ import { SDKValidationError } from "../errors/sdkvalidationerror.js";
  */
 export type TumDetailsTotals = {
   /**
-   * Billed input tokens
+   * Observed input tokens (cache reads and writes excluded)
    */
   inputTokens: number;
   /**
-   * Billed output tokens
+   * Observed output tokens
    */
   outputTokens: number;
   /**
-   * Billed tokens under management
+   * Tokens under management: input + output
    */
   totalTokens: number;
 };

--- a/client/dashboard/src/sdk/src/react-query/telemetryQueryTumDetails.ts
+++ b/client/dashboard/src/sdk/src/react-query/telemetryQueryTumDetails.ts
@@ -59,7 +59,7 @@ export type TelemetryQueryTumDetailsQueryError =
  * queryTumDetails telemetry
  *
  * @remarks
- * Org-scoped daily usage details for the billing page's metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).
+ * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.
  */
 export function useTelemetryQueryTumDetails(
   request: QueryTumDetailsRequest,
@@ -88,7 +88,7 @@ export function useTelemetryQueryTumDetails(
  * queryTumDetails telemetry
  *
  * @remarks
- * Org-scoped daily usage details for the billing page's metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).
+ * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.
  */
 export function useTelemetryQueryTumDetailsSuspense(
   request: QueryTumDetailsRequest,

--- a/client/dashboard/src/sdk/src/react-query/telemetryQueryTumDetails.ts
+++ b/client/dashboard/src/sdk/src/react-query/telemetryQueryTumDetails.ts
@@ -59,7 +59,7 @@ export type TelemetryQueryTumDetailsQueryError =
  * queryTumDetails telemetry
  *
  * @remarks
- * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.
+ * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.
  */
 export function useTelemetryQueryTumDetails(
   request: QueryTumDetailsRequest,
@@ -88,7 +88,7 @@ export function useTelemetryQueryTumDetails(
  * queryTumDetails telemetry
  *
  * @remarks
- * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.
+ * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.
  */
 export function useTelemetryQueryTumDetailsSuspense(
   request: QueryTumDetailsRequest,

--- a/client/dashboard/src/sdk/src/sdk/telemetry.ts
+++ b/client/dashboard/src/sdk/src/sdk/telemetry.ts
@@ -437,7 +437,7 @@ export class Telemetry extends ClientSDK {
    * queryTumDetails telemetry
    *
    * @remarks
-   * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.
+   * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.
    */
   async queryTumDetails(
     request: QueryTumDetailsRequest,

--- a/client/dashboard/src/sdk/src/sdk/telemetry.ts
+++ b/client/dashboard/src/sdk/src/sdk/telemetry.ts
@@ -437,7 +437,7 @@ export class Telemetry extends ClientSDK {
    * queryTumDetails telemetry
    *
    * @remarks
-   * Org-scoped daily usage details for the billing page's metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).
+   * Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.
    */
   async queryTumDetails(
     request: QueryTumDetailsRequest,

--- a/server/design/telemetry/design.go
+++ b/server/design/telemetry/design.go
@@ -358,7 +358,7 @@ var _ = Service("telemetry", func() {
 	})
 
 	Method("queryTumDetails", func() {
-		Description("Org-scoped daily usage details for the billing page's metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).")
+		Description("Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.")
 
 		// Org-scoped like queryRiskTokens; project_id optionally narrows the
 		// slice to one of the caller's projects.
@@ -1492,12 +1492,13 @@ var QueryRiskTokensResult = Type("QueryRiskTokensResult", func() {
 })
 
 // The per-metric fields shared by the daily points and the range totals.
-// Every measure comes from the dimensioned billing aggregate — never the
-// analytics aggregates — so the page reports exactly the billed population.
+// Every measure describes the observed agent traffic (the tokens-under-
+// management population) with cache tokens excluded on both sides, so
+// total_tokens = input + output.
 func tumDetailsMeasures() {
-	Attribute("input_tokens", Int64, "Billed input tokens")
-	Attribute("output_tokens", Int64, "Billed output tokens")
-	Attribute("total_tokens", Int64, "Billed tokens under management")
+	Attribute("input_tokens", Int64, "Observed input tokens (cache reads and writes excluded)")
+	Attribute("output_tokens", Int64, "Observed output tokens")
+	Attribute("total_tokens", Int64, "Tokens under management: input + output")
 	Required("input_tokens", "output_tokens", "total_tokens")
 }
 
@@ -1528,14 +1529,14 @@ var TumDetailsBreakdownRow = Type("TumDetailsBreakdownRow", func() {
 var TumDetailsBreakdown = Type("TumDetailsBreakdown", func() {
 	Description("Per-dimension billed token breakdown for the usage details table")
 
-	Attribute("key", String, "The breakdown dimension key (hook_source, risk_analysis_model, completion_model, division_name, role). The two model keys partition the billed population: risk_analysis_model covers the platform's risk-policy scanning inference, completion_model covers user-facing completion surfaces.")
+	Attribute("key", String, "The breakdown dimension key (model, hook_source, provider, account_type, email, division_name, department_name, role, project_id) — the public telemetry dimension identifiers, so the same keys work as telemetry.query filters. project_id rows carry project UUIDs; clients map them to names.")
 	Attribute("rows", ArrayOf(TumDetailsBreakdownRow), "Top values by tokens in descending order, with the remainder rolled into 'Other'")
 
 	Required("key", "rows")
 })
 
 var TumDetailsResult = Type("TumDetailsResult", func() {
-	Description("Result of the billing usage details query. Everything derives from the billed population (registered completion surfaces), matching the invoiced totals exactly.")
+	Description("Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — matching the billed totals exactly.")
 
 	Attribute("interval_seconds", Int64, "Timeseries bucket width in seconds. Always 86400 — the details are bucketed daily.")
 	Attribute("points", ArrayOf(TumDetailsPoint), "Gap-filled daily buckets in ascending time order")

--- a/server/design/telemetry/design.go
+++ b/server/design/telemetry/design.go
@@ -358,7 +358,7 @@ var _ = Service("telemetry", func() {
 	})
 
 	Method("queryTumDetails", func() {
-		Description("Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.")
+		Description("Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.")
 
 		// Org-scoped like queryRiskTokens; project_id optionally narrows the
 		// slice to one of the caller's projects.
@@ -1493,13 +1493,14 @@ var QueryRiskTokensResult = Type("QueryRiskTokensResult", func() {
 
 // The per-metric fields shared by the daily points and the range totals.
 // Every measure describes the observed agent traffic (the tokens-under-
-// management population) with cache tokens excluded on both sides, so
-// total_tokens = input + output.
+// management population) with cache reads excluded, so total_tokens =
+// input + output + cache_creation.
 func tumDetailsMeasures() {
-	Attribute("input_tokens", Int64, "Observed input tokens (cache reads and writes excluded)")
+	Attribute("input_tokens", Int64, "Observed input tokens (cache reads excluded)")
 	Attribute("output_tokens", Int64, "Observed output tokens")
-	Attribute("total_tokens", Int64, "Tokens under management: input + output")
-	Required("input_tokens", "output_tokens", "total_tokens")
+	Attribute("cache_creation_tokens", Int64, "Observed cache-write tokens — prompt content entering the provider cache, counted once")
+	Attribute("total_tokens", Int64, "Tokens under management: input + output + cache writes")
+	Required("input_tokens", "output_tokens", "cache_creation_tokens", "total_tokens")
 }
 
 var TumDetailsPoint = Type("TumDetailsPoint", func() {
@@ -1536,7 +1537,7 @@ var TumDetailsBreakdown = Type("TumDetailsBreakdown", func() {
 })
 
 var TumDetailsResult = Type("TumDetailsResult", func() {
-	Description("Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.")
+	Description("Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache reads excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.")
 
 	Attribute("interval_seconds", Int64, "Timeseries bucket width in seconds. Always 86400 — the details are bucketed daily.")
 	Attribute("points", ArrayOf(TumDetailsPoint), "Gap-filled daily buckets in ascending time order")

--- a/server/design/telemetry/design.go
+++ b/server/design/telemetry/design.go
@@ -1536,7 +1536,7 @@ var TumDetailsBreakdown = Type("TumDetailsBreakdown", func() {
 })
 
 var TumDetailsResult = Type("TumDetailsResult", func() {
-	Description("Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — matching the billed totals exactly.")
+	Description("Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.")
 
 	Attribute("interval_seconds", Int64, "Timeseries bucket width in seconds. Always 86400 — the details are bucketed daily.")
 	Attribute("points", ArrayOf(TumDetailsPoint), "Gap-filled daily buckets in ascending time order")

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -13817,7 +13817,7 @@ func telemetryUsage() {
 	fmt.Fprintln(os.Stderr, `    get-project-overview: Get project-level overview including total chats, tool calls, active servers/users, and top lists`)
 	fmt.Fprintln(os.Stderr, `    query: Generic, org-scoped analytics query over pre-aggregated usage metrics. Returns both a grouped table and a per-group hourly timeseries for the same slice of data, supporting arbitrary allowlisted group-by dimensions and filters (e.g. group by department_name, then drill in by filtering department_name and grouping by role).`)
 	fmt.Fprintln(os.Stderr, `    query-risk-tokens: Org-scoped daily token usage split by risk involvement: tokens from sessions with at least one active risk finding in the window versus all session tokens. Powers the token-usage panel's risk breakdown on the costs page.`)
-	fmt.Fprintln(os.Stderr, `    query-tum-details: Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.`)
+	fmt.Fprintln(os.Stderr, `    query-tum-details: Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.`)
 	fmt.Fprintln(os.Stderr, `    list-sessions: Org-scoped list of individual chat sessions for a slice of usage, filtered by the same allowlisted dimensions as telemetry.query. Returns per-session cost, token, and tool metrics with cursor pagination.`)
 	fmt.Fprintln(os.Stderr, `    list-filter-options: List available filter options (API keys or users) for the observability overview`)
 	fmt.Fprintln(os.Stderr, `    list-attribute-keys: List distinct attribute keys available for filtering`)
@@ -14121,7 +14121,7 @@ func telemetryQueryTumDetailsUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.`)
+	fmt.Fprintln(os.Stderr, `Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -13817,7 +13817,7 @@ func telemetryUsage() {
 	fmt.Fprintln(os.Stderr, `    get-project-overview: Get project-level overview including total chats, tool calls, active servers/users, and top lists`)
 	fmt.Fprintln(os.Stderr, `    query: Generic, org-scoped analytics query over pre-aggregated usage metrics. Returns both a grouped table and a per-group hourly timeseries for the same slice of data, supporting arbitrary allowlisted group-by dimensions and filters (e.g. group by department_name, then drill in by filtering department_name and grouping by role).`)
 	fmt.Fprintln(os.Stderr, `    query-risk-tokens: Org-scoped daily token usage split by risk involvement: tokens from sessions with at least one active risk finding in the window versus all session tokens. Powers the token-usage panel's risk breakdown on the costs page.`)
-	fmt.Fprintln(os.Stderr, `    query-tum-details: Org-scoped daily usage details for the billing page's metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).`)
+	fmt.Fprintln(os.Stderr, `    query-tum-details: Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.`)
 	fmt.Fprintln(os.Stderr, `    list-sessions: Org-scoped list of individual chat sessions for a slice of usage, filtered by the same allowlisted dimensions as telemetry.query. Returns per-session cost, token, and tool metrics with cursor pagination.`)
 	fmt.Fprintln(os.Stderr, `    list-filter-options: List available filter options (API keys or users) for the observability overview`)
 	fmt.Fprintln(os.Stderr, `    list-attribute-keys: List distinct attribute keys available for filtering`)
@@ -14121,7 +14121,7 @@ func telemetryQueryTumDetailsUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Org-scoped daily usage details for the billing page's metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).`)
+	fmt.Fprintln(os.Stderr, `Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -32331,7 +32331,7 @@ paths:
                 type: query
     /rpc/telemetry.queryTumDetails:
         post:
-            description: 'Org-scoped daily usage details for the billing page''s metrics table, computed in one pass: token type sums, session/tool-call/active-user counts, attribution slices (MCP tools, skills, unattributed users), and message-level stats (tokens in messages with active risk findings, tokens in tool-call messages).'
+            description: 'Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.'
             operationId: queryTumDetails
             parameters:
                 - allowEmptyValue: true
@@ -54893,7 +54893,7 @@ components:
             properties:
                 key:
                     type: string
-                    description: 'The breakdown dimension key (hook_source, risk_analysis_model, completion_model, division_name, role). The two model keys partition the billed population: risk_analysis_model covers the platform''s risk-policy scanning inference, completion_model covers user-facing completion surfaces.'
+                    description: The breakdown dimension key (model, hook_source, provider, account_type, email, division_name, department_name, role, project_id) — the public telemetry dimension identifiers, so the same keys work as telemetry.query filters. project_id rows carry project UUIDs; clients map them to names.
                 rows:
                     type: array
                     items:
@@ -54932,15 +54932,15 @@ components:
                     description: Bucket start time in Unix nanoseconds (string for JS precision)
                 input_tokens:
                     type: integer
-                    description: Billed input tokens
+                    description: Observed input tokens (cache reads and writes excluded)
                     format: int64
                 output_tokens:
                     type: integer
-                    description: Billed output tokens
+                    description: Observed output tokens
                     format: int64
                 total_tokens:
                     type: integer
-                    description: Billed tokens under management
+                    description: 'Tokens under management: input + output'
                     format: int64
             description: One UTC day of billing usage details
             required:
@@ -54967,7 +54967,7 @@ components:
                     description: Gap-filled daily buckets in ascending time order
                 totals:
                     $ref: '#/components/schemas/TumDetailsTotals'
-            description: Result of the billing usage details query. Everything derives from the billed population (registered completion surfaces), matching the invoiced totals exactly.
+            description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — matching the billed totals exactly.
             required:
                 - interval_seconds
                 - points
@@ -54978,15 +54978,15 @@ components:
             properties:
                 input_tokens:
                     type: integer
-                    description: Billed input tokens
+                    description: Observed input tokens (cache reads and writes excluded)
                     format: int64
                 output_tokens:
                     type: integer
-                    description: Billed output tokens
+                    description: Observed output tokens
                     format: int64
                 total_tokens:
                     type: integer
-                    description: Billed tokens under management
+                    description: 'Tokens under management: input + output'
                     format: int64
             description: Whole-range totals for the billing usage details
             required:

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -54967,7 +54967,7 @@ components:
                     description: Gap-filled daily buckets in ascending time order
                 totals:
                     $ref: '#/components/schemas/TumDetailsTotals'
-            description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — matching the billed totals exactly.
+            description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
             required:
                 - interval_seconds
                 - points

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -32331,7 +32331,7 @@ paths:
                 type: query
     /rpc/telemetry.queryTumDetails:
         post:
-            description: 'Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache tokens excluded) and per-dimension breakdowns over the same population.'
+            description: 'Org-scoped daily usage details for the billing page, computed in one pass: the tokens-under-management daily token-type split (observed agent traffic; cache reads excluded) and per-dimension breakdowns over the same population.'
             operationId: queryTumDetails
             parameters:
                 - allowEmptyValue: true
@@ -54930,9 +54930,13 @@ components:
                 bucket_time_unix_nano:
                     type: string
                     description: Bucket start time in Unix nanoseconds (string for JS precision)
+                cache_creation_tokens:
+                    type: integer
+                    description: Observed cache-write tokens — prompt content entering the provider cache, counted once
+                    format: int64
                 input_tokens:
                     type: integer
-                    description: Observed input tokens (cache reads and writes excluded)
+                    description: Observed input tokens (cache reads excluded)
                     format: int64
                 output_tokens:
                     type: integer
@@ -54940,12 +54944,13 @@ components:
                     format: int64
                 total_tokens:
                     type: integer
-                    description: 'Tokens under management: input + output'
+                    description: 'Tokens under management: input + output + cache writes'
                     format: int64
             description: One UTC day of billing usage details
             required:
                 - input_tokens
                 - output_tokens
+                - cache_creation_tokens
                 - total_tokens
                 - bucket_time_unix_nano
         TumDetailsResult:
@@ -54967,7 +54972,7 @@ components:
                     description: Gap-filled daily buckets in ascending time order
                 totals:
                     $ref: '#/components/schemas/TumDetailsTotals'
-            description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache tokens excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
+            description: Result of the billing usage details query. Everything derives from the tokens-under-management population — observed agent traffic with cache reads excluded — computed live from the telemetry aggregate. Matches the billed totals for cycles billed under this definition; cycles finalized before the observed-traffic redefinition serve immutable snapshot totals on the usage endpoint that can differ from this live compute.
             required:
                 - interval_seconds
                 - points
@@ -54976,9 +54981,13 @@ components:
         TumDetailsTotals:
             type: object
             properties:
+                cache_creation_tokens:
+                    type: integer
+                    description: Observed cache-write tokens — prompt content entering the provider cache, counted once
+                    format: int64
                 input_tokens:
                     type: integer
-                    description: Observed input tokens (cache reads and writes excluded)
+                    description: Observed input tokens (cache reads excluded)
                     format: int64
                 output_tokens:
                     type: integer
@@ -54986,12 +54995,13 @@ components:
                     format: int64
                 total_tokens:
                     type: integer
-                    description: 'Tokens under management: input + output'
+                    description: 'Tokens under management: input + output + cache writes'
                     format: int64
             description: Whole-range totals for the billing usage details
             required:
                 - input_tokens
                 - output_tokens
+                - cache_creation_tokens
                 - total_tokens
         TunneledMcpConnection:
             type: object

--- a/server/gen/http/telemetry/client/encode_decode.go
+++ b/server/gen/http/telemetry/client/encode_decode.go
@@ -5875,10 +5875,11 @@ func unmarshalRiskTokensPointResponseBodyToTelemetryRiskTokensPoint(v *RiskToken
 // *TumDetailsPointResponseBody.
 func unmarshalTumDetailsPointResponseBodyToTelemetryTumDetailsPoint(v *TumDetailsPointResponseBody) *telemetry.TumDetailsPoint {
 	res := &telemetry.TumDetailsPoint{
-		BucketTimeUnixNano: *v.BucketTimeUnixNano,
-		InputTokens:        *v.InputTokens,
-		OutputTokens:       *v.OutputTokens,
-		TotalTokens:        *v.TotalTokens,
+		BucketTimeUnixNano:  *v.BucketTimeUnixNano,
+		InputTokens:         *v.InputTokens,
+		OutputTokens:        *v.OutputTokens,
+		CacheCreationTokens: *v.CacheCreationTokens,
+		TotalTokens:         *v.TotalTokens,
 	}
 
 	return res
@@ -5889,9 +5890,10 @@ func unmarshalTumDetailsPointResponseBodyToTelemetryTumDetailsPoint(v *TumDetail
 // *TumDetailsTotalsResponseBody.
 func unmarshalTumDetailsTotalsResponseBodyToTelemetryTumDetailsTotals(v *TumDetailsTotalsResponseBody) *telemetry.TumDetailsTotals {
 	res := &telemetry.TumDetailsTotals{
-		InputTokens:  *v.InputTokens,
-		OutputTokens: *v.OutputTokens,
-		TotalTokens:  *v.TotalTokens,
+		InputTokens:         *v.InputTokens,
+		OutputTokens:        *v.OutputTokens,
+		CacheCreationTokens: *v.CacheCreationTokens,
+		TotalTokens:         *v.TotalTokens,
 	}
 
 	return res

--- a/server/gen/http/telemetry/client/types.go
+++ b/server/gen/http/telemetry/client/types.go
@@ -5103,21 +5103,27 @@ type RiskTokensPointResponseBody struct {
 type TumDetailsPointResponseBody struct {
 	// Bucket start time in Unix nanoseconds (string for JS precision)
 	BucketTimeUnixNano *string `form:"bucket_time_unix_nano,omitempty" json:"bucket_time_unix_nano,omitempty" xml:"bucket_time_unix_nano,omitempty"`
-	// Observed input tokens (cache reads and writes excluded)
+	// Observed input tokens (cache reads excluded)
 	InputTokens *int64 `form:"input_tokens,omitempty" json:"input_tokens,omitempty" xml:"input_tokens,omitempty"`
 	// Observed output tokens
 	OutputTokens *int64 `form:"output_tokens,omitempty" json:"output_tokens,omitempty" xml:"output_tokens,omitempty"`
-	// Tokens under management: input + output
+	// Observed cache-write tokens — prompt content entering the provider cache,
+	// counted once
+	CacheCreationTokens *int64 `form:"cache_creation_tokens,omitempty" json:"cache_creation_tokens,omitempty" xml:"cache_creation_tokens,omitempty"`
+	// Tokens under management: input + output + cache writes
 	TotalTokens *int64 `form:"total_tokens,omitempty" json:"total_tokens,omitempty" xml:"total_tokens,omitempty"`
 }
 
 // TumDetailsTotalsResponseBody is used to define fields on response body types.
 type TumDetailsTotalsResponseBody struct {
-	// Observed input tokens (cache reads and writes excluded)
+	// Observed input tokens (cache reads excluded)
 	InputTokens *int64 `form:"input_tokens,omitempty" json:"input_tokens,omitempty" xml:"input_tokens,omitempty"`
 	// Observed output tokens
 	OutputTokens *int64 `form:"output_tokens,omitempty" json:"output_tokens,omitempty" xml:"output_tokens,omitempty"`
-	// Tokens under management: input + output
+	// Observed cache-write tokens — prompt content entering the provider cache,
+	// counted once
+	CacheCreationTokens *int64 `form:"cache_creation_tokens,omitempty" json:"cache_creation_tokens,omitempty" xml:"cache_creation_tokens,omitempty"`
+	// Tokens under management: input + output + cache writes
 	TotalTokens *int64 `form:"total_tokens,omitempty" json:"total_tokens,omitempty" xml:"total_tokens,omitempty"`
 }
 
@@ -16234,6 +16240,9 @@ func ValidateTumDetailsPointResponseBody(body *TumDetailsPointResponseBody) (err
 	if body.OutputTokens == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("output_tokens", "body"))
 	}
+	if body.CacheCreationTokens == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("cache_creation_tokens", "body"))
+	}
 	if body.TotalTokens == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("total_tokens", "body"))
 	}
@@ -16251,6 +16260,9 @@ func ValidateTumDetailsTotalsResponseBody(body *TumDetailsTotalsResponseBody) (e
 	}
 	if body.OutputTokens == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("output_tokens", "body"))
+	}
+	if body.CacheCreationTokens == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("cache_creation_tokens", "body"))
 	}
 	if body.TotalTokens == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("total_tokens", "body"))

--- a/server/gen/http/telemetry/client/types.go
+++ b/server/gen/http/telemetry/client/types.go
@@ -5103,31 +5103,31 @@ type RiskTokensPointResponseBody struct {
 type TumDetailsPointResponseBody struct {
 	// Bucket start time in Unix nanoseconds (string for JS precision)
 	BucketTimeUnixNano *string `form:"bucket_time_unix_nano,omitempty" json:"bucket_time_unix_nano,omitempty" xml:"bucket_time_unix_nano,omitempty"`
-	// Billed input tokens
+	// Observed input tokens (cache reads and writes excluded)
 	InputTokens *int64 `form:"input_tokens,omitempty" json:"input_tokens,omitempty" xml:"input_tokens,omitempty"`
-	// Billed output tokens
+	// Observed output tokens
 	OutputTokens *int64 `form:"output_tokens,omitempty" json:"output_tokens,omitempty" xml:"output_tokens,omitempty"`
-	// Billed tokens under management
+	// Tokens under management: input + output
 	TotalTokens *int64 `form:"total_tokens,omitempty" json:"total_tokens,omitempty" xml:"total_tokens,omitempty"`
 }
 
 // TumDetailsTotalsResponseBody is used to define fields on response body types.
 type TumDetailsTotalsResponseBody struct {
-	// Billed input tokens
+	// Observed input tokens (cache reads and writes excluded)
 	InputTokens *int64 `form:"input_tokens,omitempty" json:"input_tokens,omitempty" xml:"input_tokens,omitempty"`
-	// Billed output tokens
+	// Observed output tokens
 	OutputTokens *int64 `form:"output_tokens,omitempty" json:"output_tokens,omitempty" xml:"output_tokens,omitempty"`
-	// Billed tokens under management
+	// Tokens under management: input + output
 	TotalTokens *int64 `form:"total_tokens,omitempty" json:"total_tokens,omitempty" xml:"total_tokens,omitempty"`
 }
 
 // TumDetailsBreakdownResponseBody is used to define fields on response body
 // types.
 type TumDetailsBreakdownResponseBody struct {
-	// The breakdown dimension key (hook_source, risk_analysis_model,
-	// completion_model, division_name, role). The two model keys partition the
-	// billed population: risk_analysis_model covers the platform's risk-policy
-	// scanning inference, completion_model covers user-facing completion surfaces.
+	// The breakdown dimension key (model, hook_source, provider, account_type,
+	// email, division_name, department_name, role, project_id) — the public
+	// telemetry dimension identifiers, so the same keys work as telemetry.query
+	// filters. project_id rows carry project UUIDs; clients map them to names.
 	Key *string `form:"key,omitempty" json:"key,omitempty" xml:"key,omitempty"`
 	// Top values by tokens in descending order, with the remainder rolled into
 	// 'Other'

--- a/server/gen/http/telemetry/server/encode_decode.go
+++ b/server/gen/http/telemetry/server/encode_decode.go
@@ -5600,10 +5600,11 @@ func marshalTelemetryRiskTokensPointToRiskTokensPointResponseBody(v *telemetry.R
 // *telemetry.TumDetailsPoint.
 func marshalTelemetryTumDetailsPointToTumDetailsPointResponseBody(v *telemetry.TumDetailsPoint) *TumDetailsPointResponseBody {
 	res := &TumDetailsPointResponseBody{
-		BucketTimeUnixNano: v.BucketTimeUnixNano,
-		InputTokens:        v.InputTokens,
-		OutputTokens:       v.OutputTokens,
-		TotalTokens:        v.TotalTokens,
+		BucketTimeUnixNano:  v.BucketTimeUnixNano,
+		InputTokens:         v.InputTokens,
+		OutputTokens:        v.OutputTokens,
+		CacheCreationTokens: v.CacheCreationTokens,
+		TotalTokens:         v.TotalTokens,
 	}
 
 	return res
@@ -5614,9 +5615,10 @@ func marshalTelemetryTumDetailsPointToTumDetailsPointResponseBody(v *telemetry.T
 // *telemetry.TumDetailsTotals.
 func marshalTelemetryTumDetailsTotalsToTumDetailsTotalsResponseBody(v *telemetry.TumDetailsTotals) *TumDetailsTotalsResponseBody {
 	res := &TumDetailsTotalsResponseBody{
-		InputTokens:  v.InputTokens,
-		OutputTokens: v.OutputTokens,
-		TotalTokens:  v.TotalTokens,
+		InputTokens:         v.InputTokens,
+		OutputTokens:        v.OutputTokens,
+		CacheCreationTokens: v.CacheCreationTokens,
+		TotalTokens:         v.TotalTokens,
 	}
 
 	return res

--- a/server/gen/http/telemetry/server/types.go
+++ b/server/gen/http/telemetry/server/types.go
@@ -4989,21 +4989,27 @@ type RiskTokensPointResponseBody struct {
 type TumDetailsPointResponseBody struct {
 	// Bucket start time in Unix nanoseconds (string for JS precision)
 	BucketTimeUnixNano string `form:"bucket_time_unix_nano" json:"bucket_time_unix_nano" xml:"bucket_time_unix_nano"`
-	// Observed input tokens (cache reads and writes excluded)
+	// Observed input tokens (cache reads excluded)
 	InputTokens int64 `form:"input_tokens" json:"input_tokens" xml:"input_tokens"`
 	// Observed output tokens
 	OutputTokens int64 `form:"output_tokens" json:"output_tokens" xml:"output_tokens"`
-	// Tokens under management: input + output
+	// Observed cache-write tokens — prompt content entering the provider cache,
+	// counted once
+	CacheCreationTokens int64 `form:"cache_creation_tokens" json:"cache_creation_tokens" xml:"cache_creation_tokens"`
+	// Tokens under management: input + output + cache writes
 	TotalTokens int64 `form:"total_tokens" json:"total_tokens" xml:"total_tokens"`
 }
 
 // TumDetailsTotalsResponseBody is used to define fields on response body types.
 type TumDetailsTotalsResponseBody struct {
-	// Observed input tokens (cache reads and writes excluded)
+	// Observed input tokens (cache reads excluded)
 	InputTokens int64 `form:"input_tokens" json:"input_tokens" xml:"input_tokens"`
 	// Observed output tokens
 	OutputTokens int64 `form:"output_tokens" json:"output_tokens" xml:"output_tokens"`
-	// Tokens under management: input + output
+	// Observed cache-write tokens — prompt content entering the provider cache,
+	// counted once
+	CacheCreationTokens int64 `form:"cache_creation_tokens" json:"cache_creation_tokens" xml:"cache_creation_tokens"`
+	// Tokens under management: input + output + cache writes
 	TotalTokens int64 `form:"total_tokens" json:"total_tokens" xml:"total_tokens"`
 }
 

--- a/server/gen/http/telemetry/server/types.go
+++ b/server/gen/http/telemetry/server/types.go
@@ -4989,31 +4989,31 @@ type RiskTokensPointResponseBody struct {
 type TumDetailsPointResponseBody struct {
 	// Bucket start time in Unix nanoseconds (string for JS precision)
 	BucketTimeUnixNano string `form:"bucket_time_unix_nano" json:"bucket_time_unix_nano" xml:"bucket_time_unix_nano"`
-	// Billed input tokens
+	// Observed input tokens (cache reads and writes excluded)
 	InputTokens int64 `form:"input_tokens" json:"input_tokens" xml:"input_tokens"`
-	// Billed output tokens
+	// Observed output tokens
 	OutputTokens int64 `form:"output_tokens" json:"output_tokens" xml:"output_tokens"`
-	// Billed tokens under management
+	// Tokens under management: input + output
 	TotalTokens int64 `form:"total_tokens" json:"total_tokens" xml:"total_tokens"`
 }
 
 // TumDetailsTotalsResponseBody is used to define fields on response body types.
 type TumDetailsTotalsResponseBody struct {
-	// Billed input tokens
+	// Observed input tokens (cache reads and writes excluded)
 	InputTokens int64 `form:"input_tokens" json:"input_tokens" xml:"input_tokens"`
-	// Billed output tokens
+	// Observed output tokens
 	OutputTokens int64 `form:"output_tokens" json:"output_tokens" xml:"output_tokens"`
-	// Billed tokens under management
+	// Tokens under management: input + output
 	TotalTokens int64 `form:"total_tokens" json:"total_tokens" xml:"total_tokens"`
 }
 
 // TumDetailsBreakdownResponseBody is used to define fields on response body
 // types.
 type TumDetailsBreakdownResponseBody struct {
-	// The breakdown dimension key (hook_source, risk_analysis_model,
-	// completion_model, division_name, role). The two model keys partition the
-	// billed population: risk_analysis_model covers the platform's risk-policy
-	// scanning inference, completion_model covers user-facing completion surfaces.
+	// The breakdown dimension key (model, hook_source, provider, account_type,
+	// email, division_name, department_name, role, project_id) — the public
+	// telemetry dimension identifiers, so the same keys work as telemetry.query
+	// filters. project_id rows carry project UUIDs; clients map them to names.
 	Key string `form:"key" json:"key" xml:"key"`
 	// Top values by tokens in descending order, with the remainder rolled into
 	// 'Other'

--- a/server/gen/telemetry/service.go
+++ b/server/gen/telemetry/service.go
@@ -51,7 +51,7 @@ type Service interface {
 	QueryRiskTokens(context.Context, *QueryRiskTokensPayload) (res *QueryRiskTokensResult, err error)
 	// Org-scoped daily usage details for the billing page, computed in one pass:
 	// the tokens-under-management daily token-type split (observed agent traffic;
-	// cache tokens excluded) and per-dimension breakdowns over the same population.
+	// cache reads excluded) and per-dimension breakdowns over the same population.
 	QueryTumDetails(context.Context, *QueryTumDetailsPayload) (res *TumDetailsResult, err error)
 	// Org-scoped list of individual chat sessions for a slice of usage, filtered
 	// by the same allowlisted dimensions as telemetry.query. Returns per-session
@@ -1695,11 +1695,14 @@ type TumDetailsBreakdownRow struct {
 type TumDetailsPoint struct {
 	// Bucket start time in Unix nanoseconds (string for JS precision)
 	BucketTimeUnixNano string
-	// Observed input tokens (cache reads and writes excluded)
+	// Observed input tokens (cache reads excluded)
 	InputTokens int64
 	// Observed output tokens
 	OutputTokens int64
-	// Tokens under management: input + output
+	// Observed cache-write tokens — prompt content entering the provider cache,
+	// counted once
+	CacheCreationTokens int64
+	// Tokens under management: input + output + cache writes
 	TotalTokens int64
 }
 
@@ -1719,11 +1722,14 @@ type TumDetailsResult struct {
 
 // Whole-range totals for the billing usage details
 type TumDetailsTotals struct {
-	// Observed input tokens (cache reads and writes excluded)
+	// Observed input tokens (cache reads excluded)
 	InputTokens int64
 	// Observed output tokens
 	OutputTokens int64
-	// Tokens under management: input + output
+	// Observed cache-write tokens — prompt content entering the provider cache,
+	// counted once
+	CacheCreationTokens int64
+	// Tokens under management: input + output + cache writes
 	TotalTokens int64
 }
 

--- a/server/gen/telemetry/service.go
+++ b/server/gen/telemetry/service.go
@@ -49,11 +49,9 @@ type Service interface {
 	// with at least one active risk finding in the window versus all session
 	// tokens. Powers the token-usage panel's risk breakdown on the costs page.
 	QueryRiskTokens(context.Context, *QueryRiskTokensPayload) (res *QueryRiskTokensResult, err error)
-	// Org-scoped daily usage details for the billing page's metrics table,
-	// computed in one pass: token type sums, session/tool-call/active-user counts,
-	// attribution slices (MCP tools, skills, unattributed users), and
-	// message-level stats (tokens in messages with active risk findings, tokens in
-	// tool-call messages).
+	// Org-scoped daily usage details for the billing page, computed in one pass:
+	// the tokens-under-management daily token-type split (observed agent traffic;
+	// cache tokens excluded) and per-dimension breakdowns over the same population.
 	QueryTumDetails(context.Context, *QueryTumDetailsPayload) (res *TumDetailsResult, err error)
 	// Org-scoped list of individual chat sessions for a slice of usage, filtered
 	// by the same allowlisted dimensions as telemetry.query. Returns per-session
@@ -1673,10 +1671,10 @@ type TopUser struct {
 
 // Per-dimension billed token breakdown for the usage details table
 type TumDetailsBreakdown struct {
-	// The breakdown dimension key (hook_source, risk_analysis_model,
-	// completion_model, division_name, role). The two model keys partition the
-	// billed population: risk_analysis_model covers the platform's risk-policy
-	// scanning inference, completion_model covers user-facing completion surfaces.
+	// The breakdown dimension key (model, hook_source, provider, account_type,
+	// email, division_name, department_name, role, project_id) — the public
+	// telemetry dimension identifiers, so the same keys work as telemetry.query
+	// filters. project_id rows carry project UUIDs; clients map them to names.
 	Key string
 	// Top values by tokens in descending order, with the remainder rolled into
 	// 'Other'
@@ -1697,11 +1695,11 @@ type TumDetailsBreakdownRow struct {
 type TumDetailsPoint struct {
 	// Bucket start time in Unix nanoseconds (string for JS precision)
 	BucketTimeUnixNano string
-	// Billed input tokens
+	// Observed input tokens (cache reads and writes excluded)
 	InputTokens int64
-	// Billed output tokens
+	// Observed output tokens
 	OutputTokens int64
-	// Billed tokens under management
+	// Tokens under management: input + output
 	TotalTokens int64
 }
 
@@ -1721,11 +1719,11 @@ type TumDetailsResult struct {
 
 // Whole-range totals for the billing usage details
 type TumDetailsTotals struct {
-	// Billed input tokens
+	// Observed input tokens (cache reads and writes excluded)
 	InputTokens int64
-	// Billed output tokens
+	// Observed output tokens
 	OutputTokens int64
-	// Billed tokens under management
+	// Tokens under management: input + output
 	TotalTokens int64
 }
 

--- a/server/internal/background/activities/snapshot_billing_cycle_usage.go
+++ b/server/internal/background/activities/snapshot_billing_cycle_usage.go
@@ -119,10 +119,10 @@ func (s *SnapshotBillingCycleUsage) snapshotOrganization(ctx context.Context, qu
 		}
 
 		days, err := s.telemetryRepo.GetTokensUnderManagementByDay(ctx, telemetryrepo.GetTokensUnderManagementParams{
-			ProjectIDs:        ids,
-			StartUnixNano:     cycle.Start.UnixNano(),
-			EndUnixNano:       cycle.End.UnixNano(),
-			BilledHookSources: billing.ModelUsageSourceStrings(),
+			ProjectIDs:          ids,
+			StartUnixNano:       cycle.Start.UnixNano(),
+			EndUnixNano:         cycle.End.UnixNano(),
+			ExcludedHookSources: billing.GramHostedHookSourceStrings(),
 		})
 		if err != nil {
 			return fmt.Errorf("compute tokens under management: %w", err)

--- a/server/internal/background/activities/snapshot_billing_cycle_usage.go
+++ b/server/internal/background/activities/snapshot_billing_cycle_usage.go
@@ -25,8 +25,10 @@ import (
 const (
 	// snapshotBillingCycles is how many trailing billing cycles (including the
 	// active one) are kept refreshed in Postgres. Matches the TUM endpoint's
-	// reporting window and is bounded by the 2-year retention of
-	// chat_token_summaries, so the first run backfills the full window.
+	// reporting window. The attribute_metrics_summaries retention (2 years)
+	// covers it, but coverage starts where the aggregate's data does — a
+	// first run seals cycles predating coverage at whatever (possibly zero)
+	// data exists.
 	snapshotBillingCycles = 12
 
 	// billingCycleFinalizeGrace is how long after a cycle closes its snapshot

--- a/server/internal/background/activities/snapshot_billing_cycle_usage_test.go
+++ b/server/internal/background/activities/snapshot_billing_cycle_usage_test.go
@@ -142,23 +142,22 @@ func insertTUMTelemetryRow(t *testing.T, ctx context.Context, queries *telemetry
 	require.NoError(t, err)
 }
 
-// insertStoredSession inserts token-usage rows plus a tool-call row for a chat
-// so the session qualifies as "stored" and counts toward TUM.
+// insertStoredSession inserts an observed Claude Code api_request row — the
+// tokens-under-management population (attribute_metrics_summaries). The
+// tokens land as input so the TUM measure counts exactly totalTokens.
 func insertStoredSession(t *testing.T, ctx context.Context, queries *telemetryrepo.Queries, projectID string, timestamp time.Time, totalTokens int) {
 	t.Helper()
 
-	chatID := uuid.NewString()
-	insertTUMTelemetryRow(t, ctx, queries, projectID, timestamp, "chat:completion", map[string]any{
-		"gen_ai.conversation.id":     chatID,
-		"gen_ai.usage.input_tokens":  totalTokens / 2,
-		"gen_ai.usage.output_tokens": totalTokens - totalTokens/2,
-		"gen_ai.usage.total_tokens":  totalTokens,
-		"gram.resource.urn":          "chat:completion",
-	})
-	insertTUMTelemetryRow(t, ctx, queries, projectID, timestamp, "tools:http:petstore:listPets", map[string]any{
-		"gen_ai.conversation.id":    chatID,
-		"gram.tool.urn":             "tools:http:petstore:listPets",
-		"http.response.status_code": 200,
+	insertTUMTelemetryRow(t, ctx, queries, projectID, timestamp, "claude-code:otel:logs", map[string]any{
+		"gen_ai.conversation.id": uuid.NewString(),
+		"prompt.id":              uuid.NewString(),
+		"event.name":             "api_request",
+		"input_tokens":           totalTokens,
+		"output_tokens":          0,
+		"cache_read_tokens":      0,
+		"cache_creation_tokens":  0,
+		"model":                  "claude-4.6",
+		"gram.hook.source":       "claude-code",
 	})
 }
 

--- a/server/internal/billing/tracking.go
+++ b/server/internal/billing/tracking.go
@@ -26,14 +26,16 @@ func registerModelUsageSource(s ModelUsageSource) ModelUsageSource {
 	return s
 }
 
-// The surfaces whose LLM completions run through Gram's server — the
-// population billed as tokens under management. Registering a source here is
-// its single point of declaration: it names the identifier AND adds it to
-// ModelUsageSources, which the billing page's telemetry reads iterate to
-// scope analytics to the billed population. Completion telemetry is tagged
-// with these values (gram.hook.source); agent-fleet telemetry observed via
-// OTEL (claude-code, cursor, codex, …) is not billed and is never registered
-// here.
+// The surfaces whose LLM completions run through Gram's server — inference
+// GRAM spends (from the org's OpenRouter keys), as opposed to the agent
+// traffic the platform merely observes. Registering a source here is its
+// single point of declaration: it names the identifier AND adds it to
+// ModelUsageSources. Tokens-under-management billing counts the OBSERVED
+// agent traffic (claude-code, cursor, codex sessions seen via OTEL/hooks)
+// and uses this registry as its EXCLUSION list (see
+// GramHostedHookSourceStrings): Gram-spent inference — whether reactive
+// (risk-policy judges) or user-initiated (playground, elements) — is never
+// tokens under management.
 var (
 	ModelUsageSourcePlayground = registerModelUsageSource("playground")
 	ModelUsageSourceElements   = registerModelUsageSource("elements")
@@ -41,12 +43,9 @@ var (
 	ModelUsageSourceSlack      = registerModelUsageSource("slack")
 
 	// ModelUsageSourceRiskAnalysis tags the platform's own risk-policy
-	// analysis inference (risk judge, prompt-injection scanner). Scanning is
-	// the metered unit of the enterprise TUM contracts — the act of securing
-	// observed agent traffic — so this source is registered (billed) even
-	// though no end user initiates the completions. The billing page reports
-	// it as its own "Risk policy analysis model" section, separate from
-	// user-facing completion surfaces.
+	// analysis inference (risk judge, prompt-injection scanner) — the
+	// textbook case of tokens Gram spends REACTING to observed traffic, so
+	// it must never count as tokens under management.
 	//
 	// Callers tagging gram or risk-analysis (platform-initiated inference)
 	// must also set openrouter.KeyTypeInternal on the completion request so
@@ -59,12 +58,11 @@ var (
 )
 
 // ModelUsageSourceAssistants tags assistants completions in telemetry but is
-// deliberately NOT registered above: Speakeasy covers assistants inference
-// today, so it must not count toward the billed population. Keeping the tag
-// (instead of dropping the constant) is what keeps those completions OUT —
-// an untagged completion normalizes to "gram" and would re-enter the billed
-// scope. Move it into the registered block when customers can BYOK
-// (see the "BYOK for Assistants" Linear project).
+// deliberately NOT registered above: registration drives OpenRouter key
+// conventions and Polar metering exemptions for Gram-run surfaces, and
+// assistants inference is Speakeasy-covered today. It is still Gram-spent
+// inference, so GramHostedHookSourceStrings appends it to the TUM exclusion
+// list explicitly.
 const ModelUsageSourceAssistants ModelUsageSource = "assistants"
 
 // ModelUsageSources lists every registered completion surface.
@@ -80,6 +78,18 @@ func ModelUsageSourceStrings() []string {
 		out[i] = string(s)
 	}
 	return out
+}
+
+// GramHostedHookSourceStrings lists every hook_source value Gram-server-run
+// completions are tagged with: the registered surfaces plus the unregistered
+// assistants tag, plus ” for rows recorded before Gram completions were
+// tagged (observed agent traffic is always tagged at ingest — claude-code,
+// cursor, codex — so an untagged row can only be Gram-era history). This is
+// the tokens-under-management EXCLUSION list — billing counts observed agent
+// traffic, and everything Gram itself spends (reactive scanning inference
+// and user-initiated hosted chat alike) is out of scope.
+func GramHostedHookSourceStrings() []string {
+	return append(ModelUsageSourceStrings(), string(ModelUsageSourceAssistants), "")
 }
 
 type ModelUsageEvent struct {

--- a/server/internal/billing/tracking.go
+++ b/server/internal/billing/tracking.go
@@ -82,8 +82,8 @@ func ModelUsageSourceStrings() []string {
 
 // GramHostedHookSourceStrings lists every hook_source value Gram-server-run
 // completions are tagged with: the registered surfaces plus the unregistered
-// assistants tag, plus ” for rows recorded before Gram completions were
-// tagged (observed agent traffic is always tagged at ingest — claude-code,
+// assistants tag, plus the empty string for rows recorded before Gram
+// completions were tagged (observed agent traffic is always tagged at ingest — claude-code,
 // cursor, codex — so an untagged row can only be Gram-era history). This is
 // the tokens-under-management EXCLUSION list — billing counts observed agent
 // traffic, and everything Gram itself spends (reactive scanning inference

--- a/server/internal/hooks/codex_usage.go
+++ b/server/internal/hooks/codex_usage.go
@@ -38,8 +38,10 @@ type codexUsageDataPoint struct {
 	OutputTokens    int64
 	CachedTokens    int64
 	ReasoningTokens int64
-	// ToolTokens is Codex's tool_token_count, stored verbatim for fidelity. It
-	// equals InputTokens + OutputTokens, so it never feeds a total downstream.
+	// ToolTokens is Codex's tool_token_count, stored verbatim for fidelity.
+	// It equals the RAW (cache-inclusive) input + output — NOT this struct's
+	// InputTokens, which is normalized to the uncached remainder — so it must
+	// never feed a total downstream.
 	ToolTokens    int64
 	TimestampNano int64
 }
@@ -125,7 +127,14 @@ func codexUsageFromRecord(rec *gen.OTELLogRecord) (codexUsageDataPoint, bool) {
 	// excludes cache reads, which land in cache_read.input_tokens). Normalize
 	// here so a codex row's input means the same thing as a Claude or Cursor
 	// row's everywhere downstream — tokens-under-management's cache exclusion
-	// depends on it.
+	// depends on it. Malformed counts are clamped into 0 <= cached <= input
+	// so bad client data can never INCREASE usage.
+	if input < 0 {
+		input = 0
+	}
+	if cached < 0 {
+		cached = 0
+	}
 	if cached > input {
 		cached = input
 	}

--- a/server/internal/hooks/codex_usage.go
+++ b/server/internal/hooks/codex_usage.go
@@ -119,6 +119,18 @@ func codexUsageFromRecord(rec *gen.OTELLogRecord) (codexUsageDataPoint, bool) {
 	reasoning, _ := logAttrInt64(attrs, "reasoning_token_count")
 	toolTokens, _ := logAttrInt64(attrs, "tool_token_count")
 
+	// Codex reports input_token_count INCLUSIVE of cached_token_count (OpenAI
+	// usage semantics: cached tokens are a subset of input), while the
+	// canonical gen_ai.usage.* shape is disjoint (Anthropic-style: input
+	// excludes cache reads, which land in cache_read.input_tokens). Normalize
+	// here so a codex row's input means the same thing as a Claude or Cursor
+	// row's everywhere downstream — tokens-under-management's cache exclusion
+	// depends on it.
+	if cached > input {
+		cached = input
+	}
+	input -= cached
+
 	return codexUsageDataPoint{
 		ConversationID:  logAttrString(attrs, "conversation.id"),
 		Model:           logAttrString(attrs, "model"),
@@ -183,6 +195,12 @@ func (s *Service) writeCodexUsageToClickHouse(ctx context.Context, payload *gen.
 		}
 		if p.CachedTokens > 0 {
 			attrs[attr.GenAIUsageCacheReadInputTokensKey] = p.CachedTokens
+		}
+		// The disjoint sum, matching Claude semantics (input + output + cache
+		// read; codex reports no cache writes). Without it codex rows count 0
+		// toward every total_tokens measure.
+		if total := p.InputTokens + p.OutputTokens + p.CachedTokens; total > 0 {
+			attrs[attr.GenAIUsageTotalTokensKey] = total
 		}
 		if p.ReasoningTokens > 0 {
 			// Saved for completeness; not surfaced on the dashboard yet.

--- a/server/internal/hooks/codex_usage_test.go
+++ b/server/internal/hooks/codex_usage_test.go
@@ -98,14 +98,38 @@ func TestExtractCodexUsage_TokenBearingEvent(t *testing.T) {
 	assert.Equal(t, "019e8c0e-740b-7113-b261-71fc14a82fb0", p.ConversationID)
 	assert.Equal(t, "gpt-5.4-mini", p.Model)
 	assert.Equal(t, "dev@example.com", p.UserEmail)
-	assert.Equal(t, int64(92728), p.InputTokens)
+	// Codex's input_token_count (92728) INCLUDES cached_token_count (68992);
+	// extraction normalizes to the disjoint gen_ai.usage shape, so InputTokens
+	// is the uncached remainder — matching what input means on Claude and
+	// Cursor rows.
+	assert.Equal(t, int64(92728-68992), p.InputTokens)
 	assert.Equal(t, int64(1441), p.OutputTokens)
 	assert.Equal(t, int64(68992), p.CachedTokens)
 	assert.Equal(t, int64(1170), p.ReasoningTokens)
-	// tool_token_count is captured verbatim and happens to equal input+output.
+	// tool_token_count is captured verbatim and happens to equal the raw
+	// (cache-inclusive) input + output.
 	assert.Equal(t, int64(94169), p.ToolTokens)
-	assert.Equal(t, p.InputTokens+p.OutputTokens, p.ToolTokens)
 	assert.Equal(t, int64(1780468942284000000), p.TimestampNano)
+}
+
+func TestExtractCodexUsage_CachedNeverExceedsInput(t *testing.T) {
+	t.Parallel()
+
+	// Defensive clamp: a malformed event reporting more cached than input
+	// tokens must not produce negative input.
+	rec := &gen.OTELLogRecord{
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", codexSSEEventName),
+			strAttr("event.kind", codexResponseCompletedKind),
+			strAttr("input_token_count", "100"),
+			strAttr("cached_token_count", "250"),
+			strAttr("conversation.id", "conv-clamp"),
+		},
+	}
+	points := extractCodexUsage(codexLogsPayload(rec))
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(0), points[0].InputTokens)
+	assert.Equal(t, int64(100), points[0].CachedTokens)
 }
 
 func TestExtractCodexUsage_SkipsRecordsWithoutUsage(t *testing.T) {

--- a/server/internal/hooks/tum_cache_exclusion_test.go
+++ b/server/internal/hooks/tum_cache_exclusion_test.go
@@ -15,11 +15,11 @@ import (
 // TestTumCacheExclusion_AllSurfaces drives all three REAL observed-traffic
 // ingest paths — the Claude OTEL logs endpoint, the Codex logs endpoint, and
 // the Cursor afterAgentResponse hook — with cache-heavy usage, then asserts
-// the tokens-under-management measure counts exactly the uncached input +
-// output for every surface. This pins the cross-surface semantic contract:
-// Claude and Cursor report input EXCLUSIVE of cache tokens, Codex reports it
-// INCLUSIVE (cached is a subset of input) and ingest normalizes it, so cache
-// reads and writes are excluded from billing uniformly.
+// the tokens-under-management measure counts exactly input + output + cache
+// WRITES for every surface, never cache READS. This pins the cross-surface
+// semantic contract: Claude and Cursor report input EXCLUSIVE of cache
+// tokens, Codex reports it INCLUSIVE (cached is a subset of input) and
+// ingest normalizes it, so cache reads are excluded from billing uniformly.
 func TestTumCacheExclusion_AllSurfaces(t *testing.T) {
 	t.Parallel()
 
@@ -30,7 +30,7 @@ func TestTumCacheExclusion_AllSurfaces(t *testing.T) {
 	now := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
 
 	// Claude: disjoint semantics at the source — input excludes the cache
-	// fields. TUM = 100 + 40 = 140.
+	// fields. TUM = 100 + 40 + 7000 (cache write) = 7140.
 	require.NoError(t, ti.service.Logs(ctx, claudeLogsPayload(
 		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
 		nil,
@@ -51,7 +51,8 @@ func TestTumCacheExclusion_AllSurfaces(t *testing.T) {
 	)))
 
 	// Codex: input_token_count is cache-INCLUSIVE (cached is a subset);
-	// ingest normalizes to the disjoint shape. TUM = (9000-8800) + 60 = 260.
+	// ingest normalizes to the disjoint shape; codex reports no cache
+	// writes. TUM = (9000-8800) + 60 = 260.
 	require.NoError(t, ti.service.Logs(ctx, codexLogsPayload(&gen.OTELLogRecord{
 		TimeUnixNano: new(nanoString(now)),
 		Attributes: []*gen.OTELAttribute{
@@ -66,7 +67,7 @@ func TestTumCacheExclusion_AllSurfaces(t *testing.T) {
 	})))
 
 	// Cursor: disjoint semantics at the source (Anthropic-style four-way
-	// split). TUM = 300 + 25 = 325.
+	// split). TUM = 300 + 25 + 3000 (cache write) = 3325.
 	email := "tum-cursor@example.com"
 	convID := "tum-cursor-conv"
 	inputTokens := 300
@@ -104,8 +105,8 @@ func TestTumCacheExclusion_AllSurfaces(t *testing.T) {
 		for _, b := range buckets {
 			total += b.Tokens
 		}
-		assert.Equal(c, int64(140+260+325), total,
-			"TUM must count uncached input + output only, on every surface")
+		assert.Equal(c, int64(7140+260+3325), total,
+			"TUM must count input + output + cache writes, never cache reads, on every surface")
 	}, 15*time.Second, 200*time.Millisecond)
 
 	rows, err := chQueries.GetTumBreakdownDimByDay(ctx, params, "hook_source")
@@ -115,8 +116,8 @@ func TestTumCacheExclusion_AllSurfaces(t *testing.T) {
 		bySurface[r.Value] += r.Tokens
 	}
 	require.Equal(t, map[string]int64{
-		"claude-code": 140,
+		"claude-code": 7140,
 		"codex":       260,
-		"cursor":      325,
+		"cursor":      3325,
 	}, bySurface)
 }

--- a/server/internal/hooks/tum_cache_exclusion_test.go
+++ b/server/internal/hooks/tum_cache_exclusion_test.go
@@ -1,0 +1,122 @@
+package hooks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+// TestTumCacheExclusion_AllSurfaces drives all three REAL observed-traffic
+// ingest paths — the Claude OTEL logs endpoint, the Codex logs endpoint, and
+// the Cursor afterAgentResponse hook — with cache-heavy usage, then asserts
+// the tokens-under-management measure counts exactly the uncached input +
+// output for every surface. This pins the cross-surface semantic contract:
+// Claude and Cursor report input EXCLUSIVE of cache tokens, Codex reports it
+// INCLUSIVE (cached is a subset of input) and ingest normalizes it, so cache
+// reads and writes are excluded from billing uniformly.
+func TestTumCacheExclusion_AllSurfaces(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chQueries := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+
+	// Claude: disjoint semantics at the source — input excludes the cache
+	// fields. TUM = 100 + 40 = 140.
+	require.NoError(t, ti.service.Logs(ctx, claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		nil,
+		&gen.OTELLogRecord{
+			TimeUnixNano: new(nanoString(now)),
+			Body:         &gen.OTELLogBody{StringValue: new("claude_code.api_request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("event.name", "api_request"),
+				strAttr("session.id", "tum-claude-session"),
+				strAttr("prompt.id", "tum-claude-prompt"),
+				strAttr("model", "claude-4.6"),
+				strAttr("input_tokens", "100"),
+				strAttr("output_tokens", "40"),
+				strAttr("cache_read_tokens", "50000"),
+				strAttr("cache_creation_tokens", "7000"),
+			},
+		},
+	)))
+
+	// Codex: input_token_count is cache-INCLUSIVE (cached is a subset);
+	// ingest normalizes to the disjoint shape. TUM = (9000-8800) + 60 = 260.
+	require.NoError(t, ti.service.Logs(ctx, codexLogsPayload(&gen.OTELLogRecord{
+		TimeUnixNano: new(nanoString(now)),
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", codexSSEEventName),
+			strAttr("event.kind", codexResponseCompletedKind),
+			strAttr("conversation.id", "tum-codex-conv"),
+			strAttr("model", "gpt-5.4-codex"),
+			strAttr("input_token_count", "9000"),
+			strAttr("cached_token_count", "8800"),
+			strAttr("output_token_count", "60"),
+		},
+	})))
+
+	// Cursor: disjoint semantics at the source (Anthropic-style four-way
+	// split). TUM = 300 + 25 = 325.
+	email := "tum-cursor@example.com"
+	convID := "tum-cursor-conv"
+	inputTokens := 300
+	outputTokens := 25
+	cacheReadTokens := 40000
+	cacheWriteTokens := 3000
+	_, err := ti.service.Cursor(ctx, &gen.CursorPayload{
+		HookEventName:    "afterAgentResponse",
+		UserEmail:        &email,
+		ConversationID:   &convID,
+		InputTokens:      &inputTokens,
+		OutputTokens:     &outputTokens,
+		CacheReadTokens:  &cacheReadTokens,
+		CacheWriteTokens: &cacheWriteTokens,
+	})
+	require.NoError(t, err)
+
+	dayStart := now.Truncate(24 * time.Hour)
+	params := telemetryrepo.GetTokensUnderManagementParams{
+		ProjectIDs:          []string{projectID},
+		StartUnixNano:       dayStart.UnixNano(),
+		EndUnixNano:         dayStart.Add(24 * time.Hour).UnixNano(),
+		ExcludedHookSources: billing.GramHostedHookSourceStrings(),
+	}
+
+	// The aggregate materializes asynchronously; converge on the exact
+	// cross-surface total, then pin each surface's slice. 100k+ cache tokens
+	// are in flight, so any leakage overshoots by orders of magnitude.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		buckets, err := chQueries.GetTokensUnderManagementByDay(ctx, params)
+		if !assert.NoError(c, err) {
+			return
+		}
+		var total int64
+		for _, b := range buckets {
+			total += b.Tokens
+		}
+		assert.Equal(c, int64(140+260+325), total,
+			"TUM must count uncached input + output only, on every surface")
+	}, 15*time.Second, 200*time.Millisecond)
+
+	rows, err := chQueries.GetTumBreakdownDimByDay(ctx, params, "hook_source")
+	require.NoError(t, err)
+	bySurface := map[string]int64{}
+	for _, r := range rows {
+		bySurface[r.Value] += r.Tokens
+	}
+	require.Equal(t, map[string]int64{
+		"claude-code": 140,
+		"codex":       260,
+		"cursor":      325,
+	}, bySurface)
+}

--- a/server/internal/telemetry/query.go
+++ b/server/internal/telemetry/query.go
@@ -251,28 +251,25 @@ func (s *Service) QueryRiskTokens(ctx context.Context, payload *telem_gen.QueryR
 }
 
 // tumBreakdownDims are the billing page's breakdown dimensions, in display
-// order. Each maps to a tum_breakdown_summaries expression (see
-// tumBreakdownDimExprs in the repo); the values match the telemetry
-// dimension identifiers the frontend picker uses. The model dimension is
-// split into the platform's risk-analysis inference (the metered unit of
-// the enterprise TUM contracts) versus user-facing completion surfaces.
-//
-// "email" is deliberately absent: scanned-user attribution now flows into
-// the billed rows (risk-analysis inference attributes to whose traffic was
-// scanned), and a per-user cut of that is not something we want to expose
-// on the billing page yet. The repo's dim expression stays plumbed —
-// re-adding the key here is the whole re-enable.
-var tumBreakdownDims = []string{"hook_source", "risk_analysis_model", "completion_model", "division_name", "role"}
+// order. Each maps to an attribute_metrics_summaries expression (see
+// tumBreakdownDimExprs in the repo); the values are the public telemetry
+// dimension identifiers the frontend picker uses. All the dimensions the
+// observed agent traffic genuinely carries are offered: the model and agent
+// surface of each session, the account's provider and team/personal
+// classification, the emit-time user-identity snapshot, and the project the
+// traffic was recorded under.
+var tumBreakdownDims = []string{"model", "hook_source", "provider", "account_type", "email", "division_name", "department_name", "role", "project_id"}
 
 // QueryTumDetails computes the billing page's usage details for a time range
-// in one request: the billed per-day token split and per-dimension
-// breakdowns. The backing queries run concurrently.
+// in one request: the tokens-under-management per-day token split and
+// per-dimension breakdowns. The backing queries run concurrently.
 //
-// Everything derives from billing-native sources — the dimensioned billing
-// aggregate (tum_breakdown_summaries) qualified and scoped exactly like
-// the billed totals (billing.ModelUsageSources), and chat message stats —
-// never the analytics aggregates, so the page reports the billed population
-// exactly.
+// Tokens under management are the agent traffic the platform OBSERVES from
+// the customer's users (Claude Code, Cursor, Codex sessions), excluding
+// cache reads — never the inference Gram itself spends (risk-policy judges,
+// hosted chat surfaces). Reads attribute_metrics_summaries scoped exactly
+// like the billed totals (same source exclusions and measure), so the page
+// reports the billed population exactly.
 func (s *Service) QueryTumDetails(ctx context.Context, payload *telem_gen.QueryTumDetailsPayload) (*telem_gen.TumDetailsResult, error) {
 	scope, err := s.resolveOrgQueryScope(ctx, payload.From, payload.To, payload.ProjectID)
 	if err != nil {
@@ -300,10 +297,10 @@ func (s *Service) QueryTumDetails(ctx context.Context, payload *telem_gen.QueryT
 	}
 
 	billedParams := repo.GetTokensUnderManagementParams{
-		ProjectIDs:        billedProjectIDs,
-		StartUnixNano:     timeStart,
-		EndUnixNano:       timeEnd,
-		BilledHookSources: billing.ModelUsageSourceStrings(),
+		ProjectIDs:          billedProjectIDs,
+		StartUnixNano:       timeStart,
+		EndUnixNano:         timeEnd,
+		ExcludedHookSources: billing.GramHostedHookSourceStrings(),
 	}
 
 	var (

--- a/server/internal/telemetry/query.go
+++ b/server/internal/telemetry/query.go
@@ -341,11 +341,12 @@ func (s *Service) QueryTumDetails(ctx context.Context, payload *telem_gen.QueryT
 	}
 
 	dayByBucket := make(map[int64]repo.TumBreakdownDayBucket, len(dayRows))
-	var totalInput, totalOutput, totalTokens int64
+	var totalInput, totalOutput, totalCacheCreation, totalTokens int64
 	for _, row := range dayRows {
 		dayByBucket[row.Day.UTC().UnixNano()] = row
 		totalInput += row.InputTokens
 		totalOutput += row.OutputTokens
+		totalCacheCreation += row.CacheCreationTokens
 		totalTokens += row.TotalTokens
 	}
 
@@ -419,10 +420,11 @@ func (s *Service) QueryTumDetails(ctx context.Context, payload *telem_gen.QueryT
 	for _, start := range starts {
 		day := dayByBucket[start]
 		points = append(points, &telem_gen.TumDetailsPoint{
-			BucketTimeUnixNano: strconv.FormatInt(start, 10),
-			InputTokens:        day.InputTokens,
-			OutputTokens:       day.OutputTokens,
-			TotalTokens:        day.TotalTokens,
+			BucketTimeUnixNano:  strconv.FormatInt(start, 10),
+			InputTokens:         day.InputTokens,
+			OutputTokens:        day.OutputTokens,
+			CacheCreationTokens: day.CacheCreationTokens,
+			TotalTokens:         day.TotalTokens,
 		})
 	}
 
@@ -431,9 +433,10 @@ func (s *Service) QueryTumDetails(ctx context.Context, payload *telem_gen.QueryT
 		Points:          points,
 		Breakdowns:      breakdowns,
 		Totals: &telem_gen.TumDetailsTotals{
-			InputTokens:  totalInput,
-			OutputTokens: totalOutput,
-			TotalTokens:  totalTokens,
+			InputTokens:         totalInput,
+			OutputTokens:        totalOutput,
+			CacheCreationTokens: totalCacheCreation,
+			TotalTokens:         totalTokens,
 		},
 	}, nil
 }

--- a/server/internal/telemetry/query_test.go
+++ b/server/internal/telemetry/query_test.go
@@ -891,7 +891,9 @@ func TestQueryTumDetails_CountsOnlyObservedTraffic(t *testing.T) {
 	// Observed traffic attributes to the session's user.
 	require.Equal(t, map[string]int64{"fleet@example.com": 1200, "codex@example.com": 400}, rowsByKey["email"])
 	require.Equal(t, map[string]int64{"Engineering": 1600}, rowsByKey["department_name"])
-	require.Equal(t, map[string]int64{"dev": 1200}, rowsByKey["role"])
+	// Role-less traffic (the codex row) lands on the '' row rather than
+	// vanishing from the section (arrayJoin on an empty array emits nothing).
+	require.Equal(t, map[string]int64{"dev": 1200, "": 400}, rowsByKey["role"])
 	// The fixtures carry no division attribute; the tokens land on the ''
 	// row (labeled by the frontend).
 	require.Equal(t, map[string]int64{"": 1600}, rowsByKey["division_name"])

--- a/server/internal/telemetry/query_test.go
+++ b/server/internal/telemetry/query_test.go
@@ -834,8 +834,8 @@ func TestQueryTumDetails_CountsOnlyObservedTraffic(t *testing.T) {
 	ts := now.Add(-10 * time.Minute)
 
 	// The tokens-under-management population: observed agent traffic. A
-	// Claude session with a huge cached prefix (only input + output count —
-	// cache reads and writes are excluded) and a Codex usage row.
+	// Claude session with a huge cached prefix (input, output, and cache
+	// writes count — cache reads are excluded) and a Codex usage row.
 	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, ts, uuid.NewString(), 1.5, 1000, 200, 50000, 300, "claude-4.6", "fleet@example.com", "Engineering", []string{"dev"}, "main", "", "", "", "")
 	insertAttributeUsageLog(t, ctx, projectID, ts, uuid.NewString(), 0.2, 400, "gpt-5.4-codex", "codex", "codex@example.com", "Engineering", nil)
 
@@ -864,17 +864,18 @@ func TestQueryTumDetails_CountsOnlyObservedTraffic(t *testing.T) {
 			return false
 		}
 		result = res
-		return res.Totals.TotalTokens == 1600
+		return res.Totals.TotalTokens == 1900
 	}, 10*time.Second, 200*time.Millisecond)
 
 	require.Equal(t, int64(1400), result.Totals.InputTokens)
 	require.Equal(t, int64(200), result.Totals.OutputTokens)
+	require.Equal(t, int64(300), result.Totals.CacheCreationTokens)
 
 	var pointSum int64
 	for _, p := range result.Points {
 		pointSum += p.TotalTokens
 	}
-	require.Equal(t, int64(1600), pointSum, "daily points must only count the observed traffic, minus cache tokens")
+	require.Equal(t, int64(1900), pointSum, "daily points must only count the observed traffic, minus cache reads")
 
 	rowsByKey := map[string]map[string]int64{}
 	for _, b := range result.Breakdowns {
@@ -883,22 +884,22 @@ func TestQueryTumDetails_CountsOnlyObservedTraffic(t *testing.T) {
 			rowsByKey[b.Key][row.Value] = row.TotalTokens
 		}
 	}
-	require.Equal(t, map[string]int64{"claude-code": 1200, "codex": 400}, rowsByKey["hook_source"],
+	require.Equal(t, map[string]int64{"claude-code": 1500, "codex": 400}, rowsByKey["hook_source"],
 		"the agent breakdown holds exactly the observed surfaces — no Gram-hosted rows")
-	require.Equal(t, map[string]int64{"claude-4.6": 1200, "gpt-5.4-codex": 400}, rowsByKey["model"])
-	require.Equal(t, map[string]int64{"anthropic": 1200, "": 400}, rowsByKey["provider"])
-	require.Equal(t, map[string]int64{"team": 1200, "": 400}, rowsByKey["account_type"])
+	require.Equal(t, map[string]int64{"claude-4.6": 1500, "gpt-5.4-codex": 400}, rowsByKey["model"])
+	require.Equal(t, map[string]int64{"anthropic": 1500, "": 400}, rowsByKey["provider"])
+	require.Equal(t, map[string]int64{"team": 1500, "": 400}, rowsByKey["account_type"])
 	// Observed traffic attributes to the session's user.
-	require.Equal(t, map[string]int64{"fleet@example.com": 1200, "codex@example.com": 400}, rowsByKey["email"])
-	require.Equal(t, map[string]int64{"Engineering": 1600}, rowsByKey["department_name"])
+	require.Equal(t, map[string]int64{"fleet@example.com": 1500, "codex@example.com": 400}, rowsByKey["email"])
+	require.Equal(t, map[string]int64{"Engineering": 1900}, rowsByKey["department_name"])
 	// Role-less traffic (the codex row) lands on the '' row rather than
 	// vanishing from the section (arrayJoin on an empty array emits nothing).
-	require.Equal(t, map[string]int64{"dev": 1200, "": 400}, rowsByKey["role"])
+	require.Equal(t, map[string]int64{"dev": 1500, "": 400}, rowsByKey["role"])
 	// The fixtures carry no division attribute; the tokens land on the ''
 	// row (labeled by the frontend).
-	require.Equal(t, map[string]int64{"": 1600}, rowsByKey["division_name"])
+	require.Equal(t, map[string]int64{"": 1900}, rowsByKey["division_name"])
 	// Project rows carry the project UUID; the frontend maps it to a name.
-	require.Equal(t, map[string]int64{projectID: 1600}, rowsByKey["project_id"])
+	require.Equal(t, map[string]int64{projectID: 1900}, rowsByKey["project_id"])
 }
 
 func TestQueryTumDetails_IncludesDeletedProjects(t *testing.T) {

--- a/server/internal/telemetry/query_test.go
+++ b/server/internal/telemetry/query_test.go
@@ -779,34 +779,44 @@ func TestQuery_TopNRollupIntoOther(t *testing.T) {
 	require.True(t, hasOther)
 }
 
-// insertChatEvidenceRow inserts a chat event row without token attributes —
-// the stored-session evidence the billed queries qualify chats on.
-func insertChatEvidenceRow(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, chatID string) {
+// insertRetainedGramAggregateRow seeds attribute_metrics_summaries directly
+// with a Gram-hosted completion row, the shape RETAINED from before the
+// provenance-first MV cutover stopped admitting Gram completions. The
+// tokens-under-management reads must exclude these at read time — that
+// exclusion is untestable through the MV (it no longer ingests such rows),
+// hence the direct aggregate-state insert.
+func insertRetainedGramAggregateRow(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, hookSource string, tokens int64) {
 	t.Helper()
 
 	conn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	id, err := uuid.NewV7()
-	require.NoError(t, err)
-
-	attributes := map[string]any{"gen_ai.conversation.id": chatID}
-	attrsJSON, err := json.Marshal(attributes)
-	require.NoError(t, err)
-
 	err = conn.Exec(ctx, `
-		INSERT INTO telemetry_logs (
-			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
-			trace_id, span_id, attributes, resource_attributes,
-			gram_project_id, gram_urn, service_name
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat message",
-		nil, nil, string(attrsJSON), "{}",
-		projectID, "chat:message", "gram-server")
+		INSERT INTO attribute_metrics_summaries
+		SELECT
+			toUUID(?) AS gram_project_id,
+			toStartOfHour(fromUnixTimestamp64Nano(?)) AS time_bucket,
+			'' AS department_name, '' AS job_title, '' AS employee_type,
+			'' AS division_name, '' AS cost_center_name,
+			'' AS user_email, 'gram-model' AS model, ? AS hook_source,
+			[]::Array(String) AS roles, []::Array(String) AS groups,
+			uniqExactIfState(toString('retained-chat'), toUInt8(1)) AS total_chats,
+			sumIfState(toInt64(?), toUInt8(1)) AS total_input_tokens,
+			sumIfState(toInt64(0), toUInt8(1)) AS total_output_tokens,
+			sumIfState(toInt64(?), toUInt8(1)) AS total_tokens,
+			sumIfState(toInt64(0), toUInt8(1)) AS cache_read_input_tokens,
+			sumIfState(toInt64(0), toUInt8(1)) AS cache_creation_input_tokens,
+			sumIfState(toFloat64(0), toUInt8(1)) AS total_cost,
+			countIfState(toUInt8(0)) AS total_tool_calls,
+			uniqExactIfState(toString(''), toUInt8(0)) AS unique_tool_calls,
+			'' AS account_type, '' AS provider, '' AS billing_mode,
+			'' AS query_source, '' AS skill_name, '' AS agent_name,
+			'' AS mcp_server_name, '' AS mcp_tool_name
+	`, projectID, timestamp.UnixNano(), hookSource, tokens, tokens)
 	require.NoError(t, err)
 }
 
-func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
+func TestQueryTumDetails_CountsOnlyObservedTraffic(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestLogsService(t)
@@ -823,51 +833,25 @@ func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
 	now := time.Date(2026, time.June, 20, 1, 0, 0, 0, time.UTC)
 	ts := now.Add(-10 * time.Minute)
 
-	// A billed completion (playground, a registered usage source) with stored
-	// evidence, next to two populations that must not appear anywhere in the
-	// billing details: an assistants completion (Speakeasy covers assistants
-	// inference until BYOK, so the surface is deliberately unregistered) and
-	// a Claude Code fleet api_request observed via OTEL (agent-native token
-	// attributes, never part of the billed population).
-	playgroundChat := uuid.NewString()
-	assistantsChat := uuid.NewString()
-	insertAttributeGramCompletionLog(t, ctx, projectID, ts, playgroundChat, 0.42, 1000, "anthropic/claude-4.6", "playground", "user@example.com", "Engineering", []string{"dev"})
-	insertChatEvidenceRow(t, ctx, projectID, ts, playgroundChat)
-	insertAttributeGramCompletionLog(t, ctx, projectID, ts, assistantsChat, 0.13, 555, "openai/gpt-5.4", "assistants", "assistant@example.com", "Engineering", nil)
-	insertChatEvidenceRow(t, ctx, projectID, ts, assistantsChat)
-	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, ts, uuid.NewString(), 1.5, 999999, 0, 0, 0, "claude-4.6", "fleet@example.com", "Engineering", nil, "main", "", "", "", "")
+	// The tokens-under-management population: observed agent traffic. A
+	// Claude session with a huge cached prefix (only input + output count —
+	// cache reads and writes are excluded) and a Codex usage row.
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, ts, uuid.NewString(), 1.5, 1000, 200, 50000, 300, "claude-4.6", "fleet@example.com", "Engineering", []string{"dev"}, "main", "", "", "", "")
+	insertAttributeUsageLog(t, ctx, projectID, ts, uuid.NewString(), 0.2, 400, "gpt-5.4-codex", "codex", "codex@example.com", "Engineering", nil)
 
-	// The platform's scanning inference, billed under its own model section:
-	// a judge completion carrying the dedicated risk-analysis source (and the
-	// scanned user's identity), plus a legacy internal row from before the
-	// source existed — gram-tagged with the nil chat id, classified by the
-	// grandfather fingerprint.
-	riskChat := uuid.NewString()
-	nilChat := "00000000-0000-0000-0000-000000000000"
-	insertAttributeGramCompletionLog(t, ctx, projectID, ts, riskChat, 0.01, 300, "google/gemini-3.1-flash-lite", "risk-analysis", "scanned@example.com", "Engineering", nil)
-	insertChatEvidenceRow(t, ctx, projectID, ts, riskChat)
-	insertAttributeGramCompletionLog(t, ctx, projectID, ts, nilChat, 0.01, 70, "google/gemini-3.1-flash-lite", "gram", "", "", nil)
-	insertChatEvidenceRow(t, ctx, projectID, ts, nilChat)
+	// Gram-hosted completion rows retained in the aggregate from before the
+	// provenance-first cutover: a user-facing playground chat and the
+	// platform's scanning inference. Both are Gram-spent inference — never
+	// tokens under management — and must not appear anywhere in the details.
+	insertRetainedGramAggregateRow(t, ctx, projectID, ts, "playground", 777)
+	insertRetainedGramAggregateRow(t, ctx, projectID, ts, "risk-analysis", 333)
 
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	// Wait until BOTH gram completions materialized in the billing aggregate
-	// (the assistants chat included) so the exclusion assertions below cannot
-	// pass vacuously against a half-ingested view.
-	chConn, err := infra.NewClickhouseClient(t)
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		row := chConn.QueryRow(ctx,
-			"SELECT count(DISTINCT chat_id) FROM tum_breakdown_summaries WHERE gram_project_id = ? AND chat_id IN (?, ?, ?, ?)",
-			projectID, playgroundChat, assistantsChat, riskChat, nilChat)
-		var chats uint64
-		if err := row.Scan(&chats); err != nil {
-			return false
-		}
-		return chats == 4
-	}, 10*time.Second, 200*time.Millisecond)
-
+	// The retained rows are direct aggregate inserts (visible immediately), so
+	// the totals below can only converge once BOTH observed rows materialized
+	// AND the exclusion holds — it cannot pass vacuously.
 	var result *gen.TumDetailsResult
 	require.Eventually(t, func() bool {
 		res, resErr := ti.service.QueryTumDetails(ctx, &gen.QueryTumDetailsPayload{
@@ -880,18 +864,17 @@ func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
 			return false
 		}
 		result = res
-		// The stored-evidence rows qualify the chats asynchronously too.
-		return res.Totals.TotalTokens == 1370
+		return res.Totals.TotalTokens == 1600
 	}, 10*time.Second, 200*time.Millisecond)
 
-	require.Equal(t, int64(1370), result.Totals.InputTokens, "the fixture reports all tokens as input")
-	require.Equal(t, int64(0), result.Totals.OutputTokens)
+	require.Equal(t, int64(1400), result.Totals.InputTokens)
+	require.Equal(t, int64(200), result.Totals.OutputTokens)
 
 	var pointSum int64
 	for _, p := range result.Points {
 		pointSum += p.TotalTokens
 	}
-	require.Equal(t, int64(1370), pointSum, "daily points must only count the billed completions")
+	require.Equal(t, int64(1600), pointSum, "daily points must only count the observed traffic, minus cache tokens")
 
 	rowsByKey := map[string]map[string]int64{}
 	for _, b := range result.Breakdowns {
@@ -900,20 +883,20 @@ func TestQueryTumDetails_CountsOnlyBilledCompletions(t *testing.T) {
 			rowsByKey[b.Key][row.Value] = row.TotalTokens
 		}
 	}
-	require.Equal(t, map[string]int64{"playground": 1000, "risk-analysis": 300, "gram": 70}, rowsByKey["hook_source"],
-		"the source breakdown holds exactly the billed surfaces")
-	// The two model sections partition the billed population: user-facing
-	// completions vs the platform's scanning inference (declared tag and the
-	// grandfathered nil-chat gram row alike).
-	require.Equal(t, map[string]int64{"anthropic/claude-4.6": 1000}, rowsByKey["completion_model"])
-	require.Equal(t, map[string]int64{"google/gemini-3.1-flash-lite": 370}, rowsByKey["risk_analysis_model"])
-	// Scanned-user attribution flows into the billed rows, but a per-user
-	// (email) cut is deliberately not served to the billing page yet.
-	require.NotContains(t, rowsByKey, "email")
-	require.Equal(t, map[string]int64{"dev": 1000}, rowsByKey["role"])
-	// The fixture carries no division attribute; the tokens land on the ''
+	require.Equal(t, map[string]int64{"claude-code": 1200, "codex": 400}, rowsByKey["hook_source"],
+		"the agent breakdown holds exactly the observed surfaces — no Gram-hosted rows")
+	require.Equal(t, map[string]int64{"claude-4.6": 1200, "gpt-5.4-codex": 400}, rowsByKey["model"])
+	require.Equal(t, map[string]int64{"anthropic": 1200, "": 400}, rowsByKey["provider"])
+	require.Equal(t, map[string]int64{"team": 1200, "": 400}, rowsByKey["account_type"])
+	// Observed traffic attributes to the session's user.
+	require.Equal(t, map[string]int64{"fleet@example.com": 1200, "codex@example.com": 400}, rowsByKey["email"])
+	require.Equal(t, map[string]int64{"Engineering": 1600}, rowsByKey["department_name"])
+	require.Equal(t, map[string]int64{"dev": 1200}, rowsByKey["role"])
+	// The fixtures carry no division attribute; the tokens land on the ''
 	// row (labeled by the frontend).
-	require.Equal(t, map[string]int64{"": 1370}, rowsByKey["division_name"])
+	require.Equal(t, map[string]int64{"": 1600}, rowsByKey["division_name"])
+	// Project rows carry the project UUID; the frontend maps it to a name.
+	require.Equal(t, map[string]int64{projectID: 1600}, rowsByKey["project_id"])
 }
 
 func TestQueryTumDetails_IncludesDeletedProjects(t *testing.T) {
@@ -943,12 +926,8 @@ func TestQueryTumDetails_IncludesDeletedProjects(t *testing.T) {
 	now := time.Date(2026, time.June, 20, 1, 0, 0, 0, time.UTC)
 	ts := now.Add(-10 * time.Minute)
 
-	liveChat := uuid.NewString()
-	doomedChat := uuid.NewString()
-	insertAttributeGramCompletionLog(t, ctx, projectID, ts, liveChat, 0.42, 1000, "anthropic/claude-4.6", "playground", "user@example.com", "Engineering", nil)
-	insertChatEvidenceRow(t, ctx, projectID, ts, liveChat)
-	insertAttributeGramCompletionLog(t, ctx, doomed.ID.String(), ts, doomedChat, 0.2, 250, "anthropic/claude-4.6", "playground", "user@example.com", "Engineering", nil)
-	insertChatEvidenceRow(t, ctx, doomed.ID.String(), ts, doomedChat)
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, ts, uuid.NewString(), 0.42, 1000, 0, 0, 0, "claude-4.6", "user@example.com", "Engineering", nil, "main", "", "", "", "")
+	insertAttributeClaudeAPIRequestLog(t, ctx, doomed.ID.String(), ts, uuid.NewString(), 0.2, 250, 0, 0, 0, "claude-4.6", "user@example.com", "Engineering", nil, "main", "", "", "", "")
 
 	_, err = projectsrepo.New(ti.conn).DeleteProject(ctx, doomed.ID)
 	require.NoError(t, err)

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -5653,12 +5653,13 @@ type GetTokensUnderManagementParams struct {
 }
 
 // tumMeasureExpr is the tokens-under-management measure over
-// attribute_metrics_summaries: input + output. Cache tokens are deliberately
-// excluded on both sides — a cache read re-observes prompt content that was
-// already counted (and dwarfs everything else: agent sessions re-read their
-// whole cached prefix on every turn), and a cache write is the provider's
-// storage of that same prompt content, not additional user traffic.
-const tumMeasureExpr = "toInt64(sumIfMerge(total_input_tokens) + sumIfMerge(total_output_tokens))"
+// attribute_metrics_summaries: input + output + cache WRITES. Cache reads
+// are deliberately excluded — a cache read re-observes prompt content that
+// was already counted when it entered the cache (and dwarfs everything else:
+// agent sessions re-read their whole cached prefix on every turn) — while a
+// cache write is new prompt content being observed for the first time, so it
+// counts.
+const tumMeasureExpr = "toInt64(sumIfMerge(total_input_tokens) + sumIfMerge(total_output_tokens) + sumIfMerge(cache_creation_input_tokens))"
 
 // tumObservedBase applies the shared window and observed-population scoping
 // for tokens-under-management reads over attribute_metrics_summaries. The
@@ -5694,9 +5695,10 @@ type TumDayBucket struct {
 }
 
 // GetTokensUnderManagementByDay sums the tokens-under-management measure per
-// UTC day for the billing window: the observed agent traffic's input and
-// output tokens (cache tokens excluded — see tumMeasureExpr), scoped to the
-// observed population (see ExcludedHookSources).
+// UTC day for the billing window: the observed agent traffic's input,
+// output, and cache-write tokens (cache reads excluded — see
+// tumMeasureExpr), scoped to the observed population (see
+// ExcludedHookSources).
 //
 // Reads the attribute_metrics_summaries aggregate — the provenance-first
 // fleet aggregate whose rows are, by construction, sessions the platform
@@ -5749,13 +5751,14 @@ func (q *Queries) GetTokensUnderManagementByDay(ctx context.Context, arg GetToke
 }
 
 // TumBreakdownDayBucket is one UTC day of tokens under management split by
-// type. TotalTokens is the TUM measure (input + output; cache tokens are
-// excluded from the population entirely).
+// type. TotalTokens is the TUM measure (input + output + cache writes;
+// cache reads are excluded from the population entirely).
 type TumBreakdownDayBucket struct {
-	Day          time.Time `ch:"day_bucket"`
-	InputTokens  int64     `ch:"sum_input_tokens"`
-	OutputTokens int64     `ch:"sum_output_tokens"`
-	TotalTokens  int64     `ch:"tum_tokens"`
+	Day                 time.Time `ch:"day_bucket"`
+	InputTokens         int64     `ch:"sum_input_tokens"`
+	OutputTokens        int64     `ch:"sum_output_tokens"`
+	CacheCreationTokens int64     `ch:"sum_cache_creation_tokens"`
+	TotalTokens         int64     `ch:"tum_tokens"`
 }
 
 // GetTumBreakdownTotalsByDay sums the tokens-under-management token-type
@@ -5774,6 +5777,7 @@ func (q *Queries) GetTumBreakdownTotalsByDay(ctx context.Context, arg GetTokensU
 		"toStartOfDay(time_bucket) AS day_bucket",
 		"toInt64(sumIfMerge(total_input_tokens)) AS sum_input_tokens",
 		"toInt64(sumIfMerge(total_output_tokens)) AS sum_output_tokens",
+		"toInt64(sumIfMerge(cache_creation_input_tokens)) AS sum_cache_creation_tokens",
 		tumMeasureExpr+" AS tum_tokens",
 	), arg).
 		GroupBy("day_bucket").

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -5640,12 +5640,39 @@ type GetTokensUnderManagementParams struct {
 	ProjectIDs    []string
 	StartUnixNano int64
 	EndUnixNano   int64
-	// BilledHookSources restricts the token sums to chats consumed through
-	// these surfaces (billing.ModelUsageSources). Rows aggregated before the
-	// hook_source dimension existed carry '' and are grandfathered as billed
-	// — sealed cycles beyond the migration's rewrite window keep their
-	// invoiced totals. Empty means no source scoping.
-	BilledHookSources []string
+	// ExcludedHookSources drops rows consumed through Gram-hosted completion
+	// surfaces (billing.GramHostedHookSourceStrings). Tokens under management
+	// are the agent traffic the platform OBSERVES coming from the customer's
+	// users (Claude Code, Cursor, Codex sessions) — never the inference Gram
+	// itself spends reacting to that traffic (risk-policy judges, playground
+	// and elements chats, title generation). The aggregate's provenance rules
+	// only admit observed traffic going forward; the exclusion also drops
+	// Gram completion rows retained from before that cutover. Empty means no
+	// exclusion.
+	ExcludedHookSources []string
+}
+
+// tumMeasureExpr is the tokens-under-management measure over
+// attribute_metrics_summaries: input + output. Cache tokens are deliberately
+// excluded on both sides — a cache read re-observes prompt content that was
+// already counted (and dwarfs everything else: agent sessions re-read their
+// whole cached prefix on every turn), and a cache write is the provider's
+// storage of that same prompt content, not additional user traffic.
+const tumMeasureExpr = "toInt64(sumIfMerge(total_input_tokens) + sumIfMerge(total_output_tokens))"
+
+// tumObservedBase applies the shared window and observed-population scoping
+// for tokens-under-management reads over attribute_metrics_summaries. The
+// aggregate is bucketed hourly; callers group to UTC days.
+func tumObservedBase(sb squirrel.SelectBuilder, arg GetTokensUnderManagementParams) squirrel.SelectBuilder {
+	sb = sb.
+		From("attribute_metrics_summaries").
+		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
+		Where("time_bucket >= toStartOfDay(fromUnixTimestamp64Nano(?))", arg.StartUnixNano).
+		Where("time_bucket < fromUnixTimestamp64Nano(?)", arg.EndUnixNano)
+	if len(arg.ExcludedHookSources) > 0 {
+		sb = sb.Where(squirrel.NotEq{"hook_source": arg.ExcludedHookSources})
+	}
+	return sb
 }
 
 // billedHookSourceFilter scopes a chat_token_summaries read to the billed
@@ -5662,22 +5689,23 @@ func billedHookSourceFilter(sb squirrel.SelectBuilder, sources []string) squirre
 
 // TumDayBucket is one UTC day's worth of tokens under management.
 type TumDayBucket struct {
-	Day    time.Time `ch:"time_bucket"`
+	Day    time.Time `ch:"day_bucket"`
 	Tokens int64     `ch:"tokens"`
 }
 
-// GetTokensUnderManagementByDay sums token usage per UTC day for the billing
-// window, counting only sessions Gram has stored non-metrics data for (chats,
-// tool calls). OTEL forwarding can report token usage for an entire customer
-// org while Gram is installed for a subset of users, so a chat's tokens only
-// count when at least one non-metrics row (a tool call, a hook event, or any
-// row without a token-usage attribute) was recorded for it inside the window.
+// GetTokensUnderManagementByDay sums the tokens-under-management measure per
+// UTC day for the billing window: the observed agent traffic's input and
+// output tokens (cache tokens excluded — see tumMeasureExpr), scoped to the
+// observed population (see ExcludedHookSources).
 //
-// Reads the chat_token_summaries aggregate, which buckets by day and is
-// retained well beyond the raw telemetry TTL, so historical billing cycles
-// stay computable. Window boundaries are day-granular: the start rounds down
-// to its UTC day and the end is expected to be a UTC day boundary, which
-// billing cycle boundaries always are. Days without usage are omitted.
+// Reads the attribute_metrics_summaries aggregate — the provenance-first
+// fleet aggregate whose rows are, by construction, sessions the platform
+// observed (Claude api_request rows require a session and prompt id;
+// Codex/Cursor usage rows are session usage) — retained well beyond the raw
+// telemetry TTL, so historical billing cycles stay computable. Window
+// boundaries are day-granular: the start rounds down to its UTC day and the
+// end is expected to be a UTC day boundary, which billing cycle boundaries
+// always are. Days without usage are omitted.
 //
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
 func (q *Queries) GetTokensUnderManagementByDay(ctx context.Context, arg GetTokensUnderManagementParams) ([]TumDayBucket, error) {
@@ -5685,34 +5713,14 @@ func (q *Queries) GetTokensUnderManagementByDay(ctx context.Context, arg GetToke
 		return nil, nil
 	}
 
-	storedChats := sq.Select("DISTINCT chat_id").
-		From("chat_token_summaries").
-		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
-		Where("time_bucket >= toStartOfDay(fromUnixTimestamp64Nano(?))", arg.StartUnixNano).
-		Where("time_bucket < fromUnixTimestamp64Nano(?)", arg.EndUnixNano).
-		Where("chat_id != ''").
-		Where("stored_event_count > 0")
-
-	storedChatsSQL, storedChatsArgs, err := storedChats.ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("building tum stored chats subquery: %w", err)
-	}
-
-	sb := sq.Select(
-		"time_bucket",
-		"sum(total_tokens) AS tokens",
-	).
-		From("chat_token_summaries").
-		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
-		Where("time_bucket >= toStartOfDay(fromUnixTimestamp64Nano(?))", arg.StartUnixNano).
-		Where("time_bucket < fromUnixTimestamp64Nano(?)", arg.EndUnixNano).
-		Where("chat_id != ''").
-		Where(squirrel.Expr("chat_id IN ("+storedChatsSQL+")", storedChatsArgs...)).
-		GroupBy("time_bucket").
-		OrderBy("time_bucket")
-	// The token sum is source-scoped; the stored-chats qualification above is
-	// not — stored evidence is chat-level, whatever surface recorded it.
-	sb = billedHookSourceFilter(sb, arg.BilledHookSources)
+	// The day alias must not shadow the hourly time_bucket source column
+	// (ILLEGAL_AGGREGATION — see the telemetry README gotcha).
+	sb := tumObservedBase(sq.Select(
+		"toStartOfDay(time_bucket) AS day_bucket",
+		tumMeasureExpr+" AS tokens",
+	), arg).
+		GroupBy("day_bucket").
+		OrderBy("day_bucket")
 
 	query, args, err := sb.ToSql()
 	if err != nil {
@@ -5740,52 +5748,19 @@ func (q *Queries) GetTokensUnderManagementByDay(ctx context.Context, arg GetToke
 	return buckets, nil
 }
 
-// billedStoredChatsSubquery builds the stored-session qualification subquery
-// on chat_token_summaries — the same rule the billed totals apply, so every
-// dimensioned read below describes exactly the billed population.
-func billedStoredChatsSubquery(arg GetTokensUnderManagementParams) (string, []any, error) {
-	sb := sq.Select("DISTINCT chat_id").
-		From("chat_token_summaries").
-		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
-		Where("time_bucket >= toStartOfDay(fromUnixTimestamp64Nano(?))", arg.StartUnixNano).
-		Where("time_bucket < fromUnixTimestamp64Nano(?)", arg.EndUnixNano).
-		Where("chat_id != ''").
-		Where("stored_event_count > 0")
-	sql, args, err := sb.ToSql()
-	if err != nil {
-		return "", nil, fmt.Errorf("building tum stored chats subquery: %w", err)
-	}
-	return sql, args, nil
-}
-
-// tumBreakdownBase applies the shared window, qualification, and source
-// scoping for reads over tum_breakdown_summaries.
-func tumBreakdownBase(sb squirrel.SelectBuilder, arg GetTokensUnderManagementParams) (squirrel.SelectBuilder, error) {
-	storedChatsSQL, storedChatsArgs, err := billedStoredChatsSubquery(arg)
-	if err != nil {
-		return sb, err
-	}
-	sb = sb.
-		From("tum_breakdown_summaries").
-		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
-		Where("time_bucket >= toStartOfDay(fromUnixTimestamp64Nano(?))", arg.StartUnixNano).
-		Where("time_bucket < fromUnixTimestamp64Nano(?)", arg.EndUnixNano).
-		Where(squirrel.Expr("chat_id IN ("+storedChatsSQL+")", storedChatsArgs...))
-	return billedHookSourceFilter(sb, arg.BilledHookSources), nil
-}
-
-// TumBreakdownDayBucket is one UTC day of billed tokens split
-// by type.
+// TumBreakdownDayBucket is one UTC day of tokens under management split by
+// type. TotalTokens is the TUM measure (input + output; cache tokens are
+// excluded from the population entirely).
 type TumBreakdownDayBucket struct {
-	Day          time.Time `ch:"time_bucket"`
-	InputTokens  int64     `ch:"input_tokens"`
-	OutputTokens int64     `ch:"output_tokens"`
-	TotalTokens  int64     `ch:"sum_total_tokens"`
+	Day          time.Time `ch:"day_bucket"`
+	InputTokens  int64     `ch:"sum_input_tokens"`
+	OutputTokens int64     `ch:"sum_output_tokens"`
+	TotalTokens  int64     `ch:"tum_tokens"`
 }
 
-// GetTumBreakdownTotalsByDay sums the billed completion token split per
-// UTC day, qualified and source-scoped identically to the billed totals.
-// Days without usage are omitted (callers gap-fill).
+// GetTumBreakdownTotalsByDay sums the tokens-under-management token-type
+// split per UTC day, scoped identically to the billed totals. Days without
+// usage are omitted (callers gap-fill).
 //
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
 func (q *Queries) GetTumBreakdownTotalsByDay(ctx context.Context, arg GetTokensUnderManagementParams) ([]TumBreakdownDayBucket, error) {
@@ -5793,18 +5768,16 @@ func (q *Queries) GetTumBreakdownTotalsByDay(ctx context.Context, arg GetTokensU
 		return nil, nil
 	}
 
-	// The total alias must NOT be "total_tokens": ClickHouse lets a SELECT
-	// alias shadow the source column (ILLEGAL_AGGREGATION).
-	sb, err := tumBreakdownBase(sq.Select(
-		"time_bucket",
-		"sum(input_tokens) AS input_tokens",
-		"sum(output_tokens) AS output_tokens",
-		"sum(total_tokens) AS sum_total_tokens",
-	), arg)
-	if err != nil {
-		return nil, err
-	}
-	sb = sb.GroupBy("time_bucket").OrderBy("time_bucket")
+	// Aliases must not shadow the source state columns (ILLEGAL_AGGREGATION —
+	// see the telemetry README gotcha).
+	sb := tumObservedBase(sq.Select(
+		"toStartOfDay(time_bucket) AS day_bucket",
+		"toInt64(sumIfMerge(total_input_tokens)) AS sum_input_tokens",
+		"toInt64(sumIfMerge(total_output_tokens)) AS sum_output_tokens",
+		tumMeasureExpr+" AS tum_tokens",
+	), arg).
+		GroupBy("day_bucket").
+		OrderBy("day_bucket")
 
 	query, args, err := sb.ToSql()
 	if err != nil {
@@ -5832,81 +5805,55 @@ func (q *Queries) GetTumBreakdownTotalsByDay(ctx context.Context, arg GetTokensU
 	return buckets, nil
 }
 
-// riskAnalysisRowPredicate classifies a billed row as the platform's own
-// risk-policy analysis inference — the metered unit of the enterprise TUM
-// contracts. Declared rows carry the dedicated source
-// (billing.ModelUsageSourceRiskAnalysis); the second clause grandfathers
-// rows emitted before that source existed, fingerprinted as internal
-// inference: gram/” source with the nil chat id (background workers run
-// completions outside any stored chat). Other internal nil-chat inference
-// (title generation, chat resolutions, memory) rides along under the same
-// clause — a deliberate simplification, it is a rounding error next to the
-// judges and is platform-side analysis either way.
-const riskAnalysisRowPredicate = "(hook_source = 'risk-analysis' OR (hook_source IN ('gram', '') AND chat_id = '00000000-0000-0000-0000-000000000000'))"
-
-// tumBreakdownDim describes one billing-page breakdown dimension: the
-// grouping expression over tum_breakdown_summaries, plus an optional row
-// filter for dimensions that slice the billed population (the two model
-// sections) rather than partition it by a column.
-type tumBreakdownDim struct {
-	expr   string
-	filter string
+// tumBreakdownDimExprs maps the billing page's breakdown dimensions to their
+// attribute_metrics_summaries grouping expressions. The keys are the public
+// telemetry dimension identifiers (see telemetryDimensionRegistry) so the
+// frontend picker and telemetry.query filters speak the same names. Roles
+// are multi-valued: a session's tokens count once under each held role, so
+// role rows overlap and can sum past the total.
+var tumBreakdownDimExprs = map[string]string{
+	"model":           "model",
+	"hook_source":     "hook_source",
+	"provider":        "provider",
+	"account_type":    "account_type",
+	"email":           "user_email",
+	"division_name":   "division_name",
+	"department_name": "department_name",
+	"role":            "arrayJoin(roles)",
+	// Values are project UUIDs; the dashboard maps them to project names.
+	"project_id": "toString(gram_project_id)",
 }
 
-// tumBreakdownDimExprs maps the billing page's breakdown dimensions to
-// their tum_breakdown_summaries expressions. Roles are multi-valued: a
-// session's tokens count once under each held role, so role rows overlap.
-// The model dimension is split in two: risk_analysis_model covers the
-// platform's scanning inference and completion_model covers user-facing
-// completion surfaces — together they partition the billed population.
-var tumBreakdownDimExprs = map[string]tumBreakdownDim{
-	"hook_source":         {expr: "hook_source", filter: ""},
-	"risk_analysis_model": {expr: "model", filter: riskAnalysisRowPredicate},
-	"completion_model":    {expr: "model", filter: "NOT " + riskAnalysisRowPredicate},
-	// email is plumbed but NOT in the service's tumBreakdownDims: a per-user
-	// cut of billed usage (which now includes scanned-user attribution of
-	// risk-analysis inference) is deliberately not exposed on the billing
-	// page yet.
-	"email":         {expr: "user_email", filter: ""},
-	"division_name": {expr: "division_name", filter: ""},
-	"role":          {expr: "arrayJoin(roles)", filter: ""},
-}
-
-// TumBreakdownDimDayBucket is one (UTC day, dimension value) slice of
-// billed tokens.
+// TumBreakdownDimDayBucket is one (UTC day, dimension value) slice of tokens
+// under management.
 type TumBreakdownDimDayBucket struct {
-	Day    time.Time `ch:"time_bucket"`
+	Day    time.Time `ch:"day_bucket"`
 	Value  string    `ch:"dim_value"`
 	Tokens int64     `ch:"tokens"`
 }
 
-// GetTumBreakdownDimByDay returns the billed daily token series per value
-// of one breakdown dimension, qualified and source-scoped identically to the
-// billed totals so the slices sum to them exactly (except the multi-valued
-// role dimension, whose rows overlap).
+// GetTumBreakdownDimByDay returns the daily tokens-under-management series
+// per value of one breakdown dimension, scoped identically to the billed
+// totals so the slices sum to them exactly (except the multi-valued role
+// dimension, whose rows overlap).
 //
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
 func (q *Queries) GetTumBreakdownDimByDay(ctx context.Context, arg GetTokensUnderManagementParams, dimension string) ([]TumBreakdownDimDayBucket, error) {
 	if len(arg.ProjectIDs) == 0 {
 		return nil, nil
 	}
-	dim, ok := tumBreakdownDimExprs[dimension]
+	expr, ok := tumBreakdownDimExprs[dimension]
 	if !ok {
 		return nil, fmt.Errorf("unsupported tum breakdown dimension: %q", dimension)
 	}
 
-	sb, err := tumBreakdownBase(sq.Select(
-		"time_bucket",
-		dim.expr+" AS dim_value",
-		"sum(total_tokens) AS tokens",
-	), arg)
-	if err != nil {
-		return nil, err
-	}
-	if dim.filter != "" {
-		sb = sb.Where(dim.filter)
-	}
-	sb = sb.GroupBy("time_bucket", "dim_value").OrderBy("time_bucket", "dim_value")
+	sb := tumObservedBase(sq.Select(
+		"toStartOfDay(time_bucket) AS day_bucket",
+		expr+" AS dim_value",
+		tumMeasureExpr+" AS tokens",
+	), arg).
+		GroupBy("day_bucket", "dim_value").
+		OrderBy("day_bucket", "dim_value")
 
 	query, args, err := sb.ToSql()
 	if err != nil {

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -5819,7 +5819,10 @@ var tumBreakdownDimExprs = map[string]string{
 	"email":           "user_email",
 	"division_name":   "division_name",
 	"department_name": "department_name",
-	"role":            "arrayJoin(roles)",
+	// arrayJoin([]) emits zero rows, which would silently DROP tokens from
+	// users with no roles — map the empty array to the '' row instead, so
+	// role-less traffic shows as "(unset)" like every other dimension.
+	"role": "arrayJoin(if(empty(roles), [''], roles))",
 	// Values are project UUIDs; the dashboard maps them to project names.
 	"project_id": "toString(gram_project_id)",
 }

--- a/server/internal/usage/tum.go
+++ b/server/internal/usage/tum.go
@@ -116,8 +116,11 @@ func (s *Service) SetBillingMetadata(ctx context.Context, payload *gen.SetBillin
 }
 
 // tumHistoryCycles is how many trailing billing cycles (including the active
-// one) the TUM endpoint reports. Bounded by the 2-year retention of
-// chat_token_summaries; older cycles simply come back empty.
+// one) the TUM endpoint reports. The 2-year retention of
+// attribute_metrics_summaries comfortably covers the window, but actual
+// COVERAGE starts where the aggregate's data does (its backfill was bounded
+// by the raw telemetry TTL) — cycles predating coverage recompute to zero
+// unless a finalized snapshot protects them.
 const tumHistoryCycles = 12
 const maxTunneledMcpServerLimit = 1<<31 - 1
 

--- a/server/internal/usage/tum.go
+++ b/server/internal/usage/tum.go
@@ -159,10 +159,10 @@ func (s *Service) buildTokensUnderManagement(ctx context.Context, authCtx *conte
 	history := make([]*gen.TUMPeriod, 0, len(cycles))
 	for _, cycle := range cycles {
 		days, err := s.telemetryRepo.GetTokensUnderManagementByDay(ctx, telemetryrepo.GetTokensUnderManagementParams{
-			ProjectIDs:        ids,
-			StartUnixNano:     cycle.Start.UnixNano(),
-			EndUnixNano:       cycle.End.UnixNano(),
-			BilledHookSources: billing.ModelUsageSourceStrings(),
+			ProjectIDs:          ids,
+			StartUnixNano:       cycle.Start.UnixNano(),
+			EndUnixNano:         cycle.End.UnixNano(),
+			ExcludedHookSources: billing.GramHostedHookSourceStrings(),
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to compute tokens under management").LogError(ctx, s.logger)

--- a/server/internal/usage/tum_test.go
+++ b/server/internal/usage/tum_test.go
@@ -181,7 +181,7 @@ func insertRetainedGramAggregateRow(t *testing.T, conn driver.Conn, projectID st
 	require.NoError(t, err)
 }
 
-func TestGetTokensUnderManagementQuery_ExcludesCacheTokens(t *testing.T) {
+func TestGetTokensUnderManagementQuery_ExcludesCacheReads(t *testing.T) {
 	t.Parallel()
 
 	_, _, chConn, projectID := newTUMTestService(t, "org-tum-query")
@@ -193,8 +193,8 @@ func TestGetTokensUnderManagementQuery_ExcludesCacheTokens(t *testing.T) {
 	windowStart := dayStart.Add(-2 * 24 * time.Hour)
 	windowEnd := dayStart.Add(24 * time.Hour)
 
-	// A Claude session whose turn re-read a huge cached prefix: only the
-	// input and output count — cache reads AND writes are excluded.
+	// A Claude session whose turn re-read a huge cached prefix: input,
+	// output, and the cache WRITE count — the cache READ is excluded.
 	insertObservedClaudeRow(t, chConn, projectID.String(), now, 100, 50, 100000, 25)
 
 	// A Codex usage row: observed traffic from the other admitted shape.
@@ -213,7 +213,7 @@ func TestGetTokensUnderManagementQuery_ExcludesCacheTokens(t *testing.T) {
 		if !assert.NoError(c, err) {
 			return
 		}
-		assert.Equal(c, int64(550), sumTumBuckets(res), "input + output only — no cache reads, no cache writes")
+		assert.Equal(c, int64(575), sumTumBuckets(res), "input + output + cache writes — never cache reads")
 		if !assert.Len(c, res, 1, "all in-window rows share one day bucket") {
 			return
 		}

--- a/server/internal/usage/tum_test.go
+++ b/server/internal/usage/tum_test.go
@@ -112,92 +112,108 @@ func insertTelemetryRow(t *testing.T, conn driver.Conn, projectID string, timest
 	require.NoError(t, err)
 }
 
-// insertTokenUsageRow inserts a token-usage (metrics) row, the kind produced
-// by OTEL forwarding. An empty chatID omits the conversation id attribute.
-func insertTokenUsageRow(t *testing.T, conn driver.Conn, projectID string, timestamp time.Time, chatID string, totalTokens int) {
+// insertObservedClaudeRow inserts the Claude Code api_request row the
+// provenance-first attribute_metrics_summaries MV admits — observed agent
+// traffic, the tokens-under-management population. The token-type split is
+// explicit so tests can pin the cache-read exclusion.
+func insertObservedClaudeRow(t *testing.T, conn driver.Conn, projectID string, timestamp time.Time, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int) {
 	t.Helper()
 
-	attributes := map[string]any{
-		"gen_ai.usage.input_tokens":  totalTokens / 2,
-		"gen_ai.usage.output_tokens": totalTokens - totalTokens/2,
-		"gen_ai.usage.total_tokens":  totalTokens,
-		"gram.resource.urn":          "chat:completion",
-	}
-	if chatID != "" {
-		attributes["gen_ai.conversation.id"] = chatID
-	}
-
-	insertTelemetryRow(t, conn, projectID, timestamp, "chat:completion", attributes)
-}
-
-// insertToolCallRow inserts a tool-call row tied to a chat — non-metrics
-// evidence that Gram stored the session.
-func insertToolCallRow(t *testing.T, conn driver.Conn, projectID string, timestamp time.Time, chatID string) {
-	t.Helper()
-
-	insertTelemetryRow(t, conn, projectID, timestamp, "tools:http:petstore:listPets", map[string]any{
-		"gen_ai.conversation.id":    chatID,
-		"gram.tool.urn":             "tools:http:petstore:listPets",
-		"http.response.status_code": 200,
+	insertTelemetryRow(t, conn, projectID, timestamp, "claude-code:otel:logs", map[string]any{
+		"gen_ai.conversation.id": uuid.NewString(),
+		"prompt.id":              uuid.NewString(),
+		"event.name":             "api_request",
+		"input_tokens":           inputTokens,
+		"output_tokens":          outputTokens,
+		"cache_read_tokens":      cacheReadTokens,
+		"cache_creation_tokens":  cacheCreationTokens,
+		"model":                  "claude-4.6",
+		"gram.hook.source":       "claude-code",
 	})
 }
 
-// insertChatEventRow inserts a chat event row without token-usage attributes
-// — non-metrics evidence that Gram stored the session.
-func insertChatEventRow(t *testing.T, conn driver.Conn, projectID string, timestamp time.Time, chatID string) {
+// insertObservedAgentUsageRow inserts a Codex/Cursor usage-metrics row — the
+// other observed-traffic shape the aggregate admits. The tokens land as
+// input, so the TUM measure counts exactly totalTokens.
+func insertObservedAgentUsageRow(t *testing.T, conn driver.Conn, projectID string, timestamp time.Time, provider string, totalTokens int) {
 	t.Helper()
 
-	insertTelemetryRow(t, conn, projectID, timestamp, "chat:message", map[string]any{
-		"gen_ai.conversation.id": chatID,
+	insertTelemetryRow(t, conn, projectID, timestamp, provider+":usage:metrics", map[string]any{
+		"gen_ai.conversation.id":    uuid.NewString(),
+		"gen_ai.usage.input_tokens": totalTokens,
+		"gen_ai.usage.total_tokens": totalTokens,
+		"gen_ai.response.model":     provider + "-model",
+		"gram.hook.source":          provider,
 	})
 }
 
-func TestGetTokensUnderManagementQuery_FiltersUnstoredSessions(t *testing.T) {
+// insertRetainedGramAggregateRow seeds attribute_metrics_summaries directly
+// with a Gram-hosted completion row, the shape RETAINED from before the
+// provenance-first MV cutover stopped admitting Gram completions. The
+// tokens-under-management reads must exclude these at read time — that
+// exclusion is untestable through the MV (it no longer ingests such rows),
+// hence the direct aggregate-state insert.
+func insertRetainedGramAggregateRow(t *testing.T, conn driver.Conn, projectID string, timestamp time.Time, hookSource string, tokens int64) {
+	t.Helper()
+
+	err := conn.Exec(t.Context(), `
+		INSERT INTO attribute_metrics_summaries
+		SELECT
+			toUUID(?) AS gram_project_id,
+			toStartOfHour(fromUnixTimestamp64Nano(?)) AS time_bucket,
+			'' AS department_name, '' AS job_title, '' AS employee_type,
+			'' AS division_name, '' AS cost_center_name,
+			'' AS user_email, 'gram-model' AS model, ? AS hook_source,
+			[]::Array(String) AS roles, []::Array(String) AS groups,
+			uniqExactIfState(toString('retained-chat'), toUInt8(1)) AS total_chats,
+			sumIfState(toInt64(?), toUInt8(1)) AS total_input_tokens,
+			sumIfState(toInt64(0), toUInt8(1)) AS total_output_tokens,
+			sumIfState(toInt64(?), toUInt8(1)) AS total_tokens,
+			sumIfState(toInt64(0), toUInt8(1)) AS cache_read_input_tokens,
+			sumIfState(toInt64(0), toUInt8(1)) AS cache_creation_input_tokens,
+			sumIfState(toFloat64(0), toUInt8(1)) AS total_cost,
+			countIfState(toUInt8(0)) AS total_tool_calls,
+			uniqExactIfState(toString(''), toUInt8(0)) AS unique_tool_calls,
+			'' AS account_type, '' AS provider, '' AS billing_mode,
+			'' AS query_source, '' AS skill_name, '' AS agent_name,
+			'' AS mcp_server_name, '' AS mcp_tool_name
+	`, projectID, timestamp.UnixNano(), hookSource, tokens, tokens)
+	require.NoError(t, err)
+}
+
+func TestGetTokensUnderManagementQuery_ExcludesCacheTokens(t *testing.T) {
 	t.Parallel()
 
 	_, _, chConn, projectID := newTUMTestService(t, "org-tum-query")
 
-	// The summary table buckets by UTC day, so the window is day-aligned and
-	// the out-of-window rows sit several days back.
+	// The read buckets by UTC day, so the window is day-aligned and the
+	// out-of-window rows sit several days back.
 	now := time.Now().UTC()
 	dayStart := now.Truncate(24 * time.Hour)
 	windowStart := dayStart.Add(-2 * 24 * time.Hour)
 	windowEnd := dayStart.Add(24 * time.Hour)
 
-	storedToolChat := uuid.New().String()
-	storedChatEventChat := uuid.New().String()
-	forwardedOnlyChat := uuid.New().String()
+	// A Claude session whose turn re-read a huge cached prefix: only the
+	// input and output count — cache reads AND writes are excluded.
+	insertObservedClaudeRow(t, chConn, projectID.String(), now, 100, 50, 100000, 25)
 
-	// Stored session: token rows plus a tool-call row. Counted.
-	insertTokenUsageRow(t, chConn, projectID.String(), now, storedToolChat, 100)
-	insertTokenUsageRow(t, chConn, projectID.String(), now, storedToolChat, 200)
-	insertToolCallRow(t, chConn, projectID.String(), now, storedToolChat)
+	// A Codex usage row: observed traffic from the other admitted shape.
+	insertObservedAgentUsageRow(t, chConn, projectID.String(), now, "codex", 400)
 
-	// Stored session: token row plus a chat event row without usage. Counted.
-	insertTokenUsageRow(t, chConn, projectID.String(), now, storedChatEventChat, 1000)
-	insertChatEventRow(t, chConn, projectID.String(), now, storedChatEventChat)
-
-	// OTEL-forwarded-only session: token rows with no stored chat or tool
-	// call data. Excluded.
-	insertTokenUsageRow(t, chConn, projectID.String(), now, forwardedOnlyChat, 5000)
-
-	// Token row with no chat id at all. Excluded.
-	insertTokenUsageRow(t, chConn, projectID.String(), now, "", 777)
-
-	// Stored session rows outside the window. Excluded.
-	insertTokenUsageRow(t, chConn, projectID.String(), now.Add(-5*24*time.Hour), storedToolChat, 9000)
+	// Observed rows outside the window. Excluded.
+	insertObservedClaudeRow(t, chConn, projectID.String(), now.Add(-5*24*time.Hour), 9000, 0, 0, 0)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		res, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-			ProjectIDs:        []string{projectID.String()},
-			StartUnixNano:     windowStart.UnixNano(),
-			EndUnixNano:       windowEnd.UnixNano(),
-			BilledHookSources: nil,
+			ProjectIDs:          []string{projectID.String()},
+			StartUnixNano:       windowStart.UnixNano(),
+			EndUnixNano:         windowEnd.UnixNano(),
+			ExcludedHookSources: nil,
 		})
 		if !assert.NoError(c, err) {
 			return
 		}
-		assert.Equal(c, int64(1300), sumTumBuckets(res), "should count only sessions with stored non-metrics data inside the window")
+		assert.Equal(c, int64(550), sumTumBuckets(res), "input + output only — no cache reads, no cache writes")
 		if !assert.Len(c, res, 1, "all in-window rows share one day bucket") {
 			return
 		}
@@ -223,20 +239,16 @@ func TestGetTokensUnderManagementQuery_DailyBreakdown(t *testing.T) {
 	windowStart := dayStart.Add(-2 * 24 * time.Hour)
 	windowEnd := dayStart.Add(24 * time.Hour)
 
-	chatID := uuid.New().String()
-
-	// Evidence on one day qualifies the chat for the whole window; token rows
-	// land in their own day buckets.
-	insertToolCallRow(t, chConn, projectID.String(), now, chatID)
-	insertTokenUsageRow(t, chConn, projectID.String(), now, chatID, 300)
-	insertTokenUsageRow(t, chConn, projectID.String(), now.Add(-24*time.Hour), chatID, 200)
+	// Observed rows land in their own day buckets.
+	insertObservedClaudeRow(t, chConn, projectID.String(), now, 200, 100, 0, 0)
+	insertObservedClaudeRow(t, chConn, projectID.String(), now.Add(-24*time.Hour), 200, 0, 0, 0)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		res, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-			ProjectIDs:        []string{projectID.String()},
-			StartUnixNano:     windowStart.UnixNano(),
-			EndUnixNano:       windowEnd.UnixNano(),
-			BilledHookSources: nil,
+			ProjectIDs:          []string{projectID.String()},
+			StartUnixNano:       windowStart.UnixNano(),
+			EndUnixNano:         windowEnd.UnixNano(),
+			ExcludedHookSources: nil,
 		})
 		if !assert.NoError(c, err) {
 			return
@@ -251,61 +263,16 @@ func TestGetTokensUnderManagementQuery_DailyBreakdown(t *testing.T) {
 	}, 10*time.Second, 200*time.Millisecond)
 }
 
-func TestGetTokensUnderManagementQuery_EvidenceOutsideWindowDoesNotCount(t *testing.T) {
-	t.Parallel()
-
-	_, _, chConn, projectID := newTUMTestService(t, "org-tum-stale-evidence")
-
-	now := time.Now().UTC()
-	dayStart := now.Truncate(24 * time.Hour)
-	windowStart := dayStart.Add(-2 * 24 * time.Hour)
-	windowEnd := dayStart.Add(24 * time.Hour)
-
-	chatID := uuid.New().String()
-
-	// Token usage inside the window, but the only stored evidence for the
-	// chat predates the window — the session does not count this cycle.
-	insertTokenUsageRow(t, chConn, projectID.String(), now, chatID, 4000)
-	insertToolCallRow(t, chConn, projectID.String(), now.Add(-5*24*time.Hour), chatID)
-
-	// Confirm the inserted rows have propagated using a wider window that
-	// includes the stale evidence, which qualifies the session and surfaces
-	// the in-window tokens. Once visible there, the narrow window below is a
-	// reliable negative.
-	widerStart := dayStart.Add(-7 * 24 * time.Hour)
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		res, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-			ProjectIDs:        []string{projectID.String()},
-			StartUnixNano:     widerStart.UnixNano(),
-			EndUnixNano:       windowEnd.UnixNano(),
-			BilledHookSources: nil,
-		})
-		if !assert.NoError(c, err) {
-			return
-		}
-		assert.Equal(c, int64(4000), sumTumBuckets(res))
-	}, 10*time.Second, 200*time.Millisecond)
-
-	buckets, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-		ProjectIDs:        []string{projectID.String()},
-		StartUnixNano:     windowStart.UnixNano(),
-		EndUnixNano:       windowEnd.UnixNano(),
-		BilledHookSources: nil,
-	})
-	require.NoError(t, err)
-	require.Empty(t, buckets)
-}
-
 func TestGetTokensUnderManagementQuery_NoProjects(t *testing.T) {
 	t.Parallel()
 
 	_, _, chConn, _ := newTUMTestService(t, "org-tum-no-projects")
 
 	buckets, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-		ProjectIDs:        nil,
-		StartUnixNano:     time.Now().Add(-1 * time.Hour).UnixNano(),
-		EndUnixNano:       time.Now().UnixNano(),
-		BilledHookSources: nil,
+		ProjectIDs:          nil,
+		StartUnixNano:       time.Now().Add(-1 * time.Hour).UnixNano(),
+		EndUnixNano:         time.Now().UnixNano(),
+		ExcludedHookSources: nil,
 	})
 	require.NoError(t, err)
 	require.Empty(t, buckets)
@@ -339,20 +306,21 @@ func TestGetTokensUnderManagement_Unconfigured(t *testing.T) {
 	require.True(t, end.After(now), "cycle end should be in the future")
 }
 
-func TestGetTokensUnderManagement_CountsStoredSessions(t *testing.T) {
+func TestGetTokensUnderManagement_CountsObservedTraffic(t *testing.T) {
 	t.Parallel()
 
 	orgID := "org-tum-counts"
 	svc, _, chConn, projectID := newTUMTestService(t, orgID)
 
-	now := time.Now().UTC()
-	storedChat := uuid.New().String()
-	forwardedChat := uuid.New().String()
-
 	// Timestamps sit at "now" so they always land inside the active cycle.
-	insertTokenUsageRow(t, chConn, projectID.String(), now, storedChat, 450)
-	insertToolCallRow(t, chConn, projectID.String(), now, storedChat)
-	insertTokenUsageRow(t, chConn, projectID.String(), now, forwardedChat, 9000)
+	now := time.Now().UTC()
+
+	// Observed agent traffic: counted. The retained Gram-hosted rows (a
+	// playground completion and pre-tagging '' history) must be excluded by
+	// the service's exclusion list.
+	insertObservedClaudeRow(t, chConn, projectID.String(), now, 450, 0, 0, 0)
+	insertRetainedGramAggregateRow(t, chConn, projectID.String(), now, "playground", 9000)
+	insertRetainedGramAggregateRow(t, chConn, projectID.String(), now, "", 7000)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		res, err := svc.GetTokensUnderManagement(testAuthContext(orgID), &gen.GetTokensUnderManagementPayload{})
@@ -512,23 +480,7 @@ func TestGetTokensUnderManagement_AlertEmailAdminOnly(t *testing.T) {
 	require.Equal(t, email, *result.AlertEmail)
 }
 
-// insertSourcedCompletionRow inserts a gram-server completion token row tagged
-// with a consuming surface (gram.hook.source), the shape emitted by
-// completionTelemetryIdentity.
-func insertSourcedCompletionRow(t *testing.T, conn driver.Conn, projectID string, timestamp time.Time, chatID string, totalTokens int, hookSource string) {
-	t.Helper()
-
-	insertTelemetryRow(t, conn, projectID, timestamp, "chat:completion", map[string]any{
-		"gen_ai.conversation.id":     chatID,
-		"gen_ai.usage.input_tokens":  totalTokens / 2,
-		"gen_ai.usage.output_tokens": totalTokens - totalTokens/2,
-		"gen_ai.usage.total_tokens":  totalTokens,
-		"gram.resource.urn":          "chat:completion",
-		"gram.hook.source":           hookSource,
-	})
-}
-
-func TestGetTokensUnderManagementQuery_ExcludesUnregisteredSources(t *testing.T) {
+func TestGetTokensUnderManagementQuery_ExcludesGramHostedSources(t *testing.T) {
 	t.Parallel()
 
 	_, _, chConn, projectID := newTUMTestService(t, "org-tum-billed-sources")
@@ -538,47 +490,41 @@ func TestGetTokensUnderManagementQuery_ExcludesUnregisteredSources(t *testing.T)
 	windowStart := dayStart.Add(-2 * 24 * time.Hour)
 	windowEnd := dayStart.Add(24 * time.Hour)
 
-	playgroundChat := uuid.New().String()
-	assistantsChat := uuid.New().String()
-	untaggedChat := uuid.New().String()
+	// Observed agent traffic: counted.
+	insertObservedClaudeRow(t, chConn, projectID.String(), now, 100, 0, 0, 0)
+	insertObservedAgentUsageRow(t, chConn, projectID.String(), now, "cursor", 40)
 
-	// A registered billed surface: counted.
-	insertSourcedCompletionRow(t, chConn, projectID.String(), now, playgroundChat, 100, "playground")
-	insertToolCallRow(t, chConn, projectID.String(), now, playgroundChat)
+	// Gram-hosted completion rows retained from before the provenance-first
+	// cutover: a user-facing surface, the platform's scanning inference, and
+	// a pre-tagging '' row. All excluded — Gram-spent inference is never
+	// tokens under management.
+	insertRetainedGramAggregateRow(t, chConn, projectID.String(), now, "playground", 5000)
+	insertRetainedGramAggregateRow(t, chConn, projectID.String(), now, "risk-analysis", 300)
+	insertRetainedGramAggregateRow(t, chConn, projectID.String(), now, "", 60)
 
-	// An unregistered surface (Speakeasy covers assistants inference until
-	// BYOK): excluded from the billed sum even though the chat qualifies.
-	insertSourcedCompletionRow(t, chConn, projectID.String(), now, assistantsChat, 5000, "assistants")
-	insertToolCallRow(t, chConn, projectID.String(), now, assistantsChat)
-
-	// Rows without a hook source ('' — the shape of aggregates from before
-	// the dimension existed): grandfathered as billed.
-	insertTokenUsageRow(t, chConn, projectID.String(), now, untaggedChat, 40)
-	insertToolCallRow(t, chConn, projectID.String(), now, untaggedChat)
-
-	// Confirm all three chats materialized (unscoped read sees 5140), THEN
-	// assert the scoped read excludes exactly the assistants tokens — the
-	// exclusion cannot pass vacuously against a half-ingested view.
+	// Confirm everything materialized (an unscoped read sees all five rows),
+	// THEN assert the scoped read excludes exactly the Gram-hosted tokens —
+	// the exclusion cannot pass vacuously against a half-ingested view.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		res, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-			ProjectIDs:        []string{projectID.String()},
-			StartUnixNano:     windowStart.UnixNano(),
-			EndUnixNano:       windowEnd.UnixNano(),
-			BilledHookSources: nil,
+			ProjectIDs:          []string{projectID.String()},
+			StartUnixNano:       windowStart.UnixNano(),
+			EndUnixNano:         windowEnd.UnixNano(),
+			ExcludedHookSources: nil,
 		})
 		if !assert.NoError(c, err) {
 			return
 		}
-		assert.Equal(c, int64(5140), sumTumBuckets(res))
+		assert.Equal(c, int64(5500), sumTumBuckets(res))
 	}, 10*time.Second, 200*time.Millisecond)
 
 	buckets, err := telemetryrepo.New(chConn).GetTokensUnderManagementByDay(t.Context(), telemetryrepo.GetTokensUnderManagementParams{
-		ProjectIDs:        []string{projectID.String()},
-		StartUnixNano:     windowStart.UnixNano(),
-		EndUnixNano:       windowEnd.UnixNano(),
-		BilledHookSources: billing.ModelUsageSourceStrings(),
+		ProjectIDs:          []string{projectID.String()},
+		StartUnixNano:       windowStart.UnixNano(),
+		EndUnixNano:         windowEnd.UnixNano(),
+		ExcludedHookSources: billing.GramHostedHookSourceStrings(),
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(140), sumTumBuckets(buckets),
-		"billed sum counts registered sources plus grandfathered '' rows, never assistants")
+		"the billed sum counts only observed agent traffic — never Gram-hosted surfaces, scanning inference, or untagged Gram-era rows")
 }


### PR DESCRIPTION
Fixes [DNO-491](https://linear.app/speakeasy/issue/DNO-491).

Redefines tokens under management: TUM is now the agent traffic the platform **observes** coming from a customer's users (Claude Code, cowork, Cursor, Codex sessions) — **input, output, and cache-write tokens — cache reads excluded** — never inference Gram itself spends, whether reactive (risk-policy judges) or user-initiated (playground, elements, slack, assistants).

## Server

- The three TUM reads (`GetTokensUnderManagementByDay`, `GetTumBreakdownTotalsByDay`, `GetTumBreakdownDimByDay`) move from `chat_token_summaries`/`tum_breakdown_summaries` to **`attribute_metrics_summaries`** — the provenance-first fleet aggregate, whose rows are by construction observed sessions. Measure: `sumIfMerge(input) + sumIfMerge(output) + sumIfMerge(cache_creation)` — a cache write is new prompt content observed for the first time and counts; a cache read re-observes already-counted content and does not.
- The source registry inverts roles: `billing.ModelUsageSources` is now the TUM **exclusion** list via `GramHostedHookSourceStrings()` (registry + assistants + `''` — observed rows are always tagged at ingest, so untagged rows can only be pre-tagging Gram history). The registry keeps driving OpenRouter key conventions and Polar exemptions.
- Retained pre-provenance-cutover Gram rows in the aggregate (playground/`''` hook_source) are excluded at read time — tested via direct aggregate-state INSERT fixtures, the only way to exercise this since the MV no longer ingests such rows.
- The stored-session qualification is gone with the old aggregate: `api_request` rows require a session + prompt id, so the population is inherently session-scoped.
- Card, cycle history, sealed snapshots, and the **threshold alert emails** (50/75/90/100/+50%) all flow through the same single query — verified end-to-end that alerts follow the new definition automatically (live compute of the in-progress cycle; never snapshots).

## Billing page

- Breakdowns become the dimensions observed traffic genuinely carries: **Model, Agent (hook_source), Provider, Account type, Project, User, Division, Department, Role**, plus the Input/Output/Cache write token-type view (no cache-read series — excluded from the population).
- The project filter dropdown is **replaced by a Project breakdown section**; requests are always org-wide, and project UUIDs map to names client-side (deleted projects fall back to the raw id).
- The risk/completion model split, scope notes, and `""`-row hiding are gone; unattributed observed traffic charts as `(unset)`.
- Copy updated everywhere to the observed-traffic framing.

## Seed

Fixes a real local-data regression: since the provenance-first MV (#4026), the seed's rows carried URNs the MV rejects, so nothing seeded after the Jun-20 cutoff reached `attribute_metrics_summaries`. Claude rows now carry `claude-code:otel:logs`, Codex/Cursor rows `{surface}:usage:metrics`; all Claude-surface sessions emit `api_request` rows (the sole admitted usage source). The pre-cutoff backfill deliberately keeps old-MV rules so local data mirrors production's retained Gram rows.

## Rollout notes

- **Sealed `billing_cycle_usage` snapshots are deliberately left as the invoiced record**: pre-deploy cycles keep old-definition totals (the page normalizes each closed cycle to its sealed number, so it stays internally consistent), producing a step change at the deploy boundary rather than a restated history. A cycle still inside the 72h finalize grace re-seals under the new definition. Judge-heavy orgs (e.g. MoonPay) will show larger old-definition history next to smaller new-definition cycles.
- Aggregate coverage starts ~mid-March 2026 (TTL-bounded backfill + Jun-20 cutoff); older cycles read 0.
- Redis alert-dedup keys persist per cycle, so thresholds already alerted this cycle stay suppressed until the new (typically larger) number crosses a higher one.
- `telemetry.queryRiskTokens` still reads the old population but has no dashboard consumer left — flagged for a cleanup PR.

## Verification

- Rewritten test suites: telemetry TUM details (fleet fixtures with cache splits, retained-Gram exclusion, all nine breakdown dims), usage TUM query/service tests, snapshot + alert activity tests — all green, plus `mise lint:server`, dashboard type-check + lint.
- Verified live against a fresh local seed: card 1,224,851 = table Total 1.22M, Input + Output sum exactly to it, Model shows fleet models only, Agent shows only observed surfaces, Project section maps `ecommerce-api`, no cache or Gram rows anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Pipeline audit (post-review)

A four-way deep-dive audit (ingest semantics per surface, aggregation math, frontend math, cycle/snapshot/alert math) verified the windowing, bucketing, rollup, rounding, overage, and cycle arithmetic end to end. Three correctness fixes shipped in this PR as a result:

- **Codex input was cache-inclusive** (OpenAI semantics: cached_tokens ⊂ input_tokens), so codex sessions were billing the cache reads the definition excludes — ingest now normalizes to the disjoint gen_ai.usage shape and sets total_tokens (codex previously counted 0 toward every total_tokens measure).
- **Role breakdown dropped role-less traffic** (`arrayJoin([])` emits nothing) — now lands on the `(unset)` row.
- **Sealed zero-token cycles** now scale the details table to 0, matching the card.

Known gaps flagged for follow-up (all pre-existing, none introduced here):

- **Hooks-only Claude devices contribute zero TUM**: the aggregate only admits OTEL `api_request` rows; devices running the plugin without the managed OTEL env are fully visible in sessions/logs but bill nothing. Cowork may fall entirely in this bucket, and counted cowork traffic is labeled `claude-code` (OTEL ingest hardcodes hook_source).
- **No idempotency on the OTLP token-ingest path**: at-least-once client retries can double-count (plain MergeTree, random row ids, no dedup token); conversely insert errors are swallowed so the client never retries a real failure.
- **Cursor double-count risk** if an org runs both the admin-API poller and device hooks (two writers emit `cursor:usage:metrics`).
- **Unified-ingest (hook.ingest.v1) usage payloads** carry no URN and never reach TUM.
- **Anchor-day change** can strand a sealed cycle forever (snapshot job keys the finalize-skip on cycle start only, while the API matches both boundaries) and confuses the PostHog forwarder's position-based cycle picks.
- **An overage crossed in a cycle's final hour is never alerted** (alerts only fire while `now` is inside the cycle).
