### PR TITLE
chore: bump hooksGeneratorVersion to validate phased hooks rollout

### DIFF
--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -330,7 +330,7 @@ const mcpGeneratorVersion = "9"
 //
 // The Plugin Generate Check CI workflow requires the relevant one of these two
 // constants to change whenever generate.go does.
-const hooksGeneratorVersion = "13"
+const hooksGeneratorVersion = "14"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits


### PR DESCRIPTION
## What

Bumps `hooksGeneratorVersion` from `13` to `14` with no other changes. The only rendered-output difference is the hooks plugin manifest version (`0.13.0` → `0.14.0`) across all three platforms — hook behavior is unchanged.

## Why

This is a deliberately ineffectual release to validate the new phased hooks rollout (#4086) end to end:

1. On merge, the next rollout tick should republish hooks **only to canary orgs** (`speakeasy-team`): their connected repos get a `0.14.0` hooks commit, a fresh `plugins-hooks-*` API key, and `published_hooks_version = "14"`.
2. All other orgs stay carried at version `13` (the PostHog `hooks-rollout` payload pin is below 14, so the gate fails closed for them).
3. Once verified, raising the [PostHog payload pin](https://us.posthog.com/project/10122/feature_flags/755549) to `{"version": 14}` should roll the bump out to everyone.

## Verification

Rendered the published hooks tree (`export-hook-plugin -published`) from `main` and this branch and diffed: the only change is the `version` field in the 12 `plugin.json` manifests (4 config modes × Claude/Cursor/Codex). Build, `internal/plugins` + `internal/productfeatures` tests, and `mise lint:server` all pass.
