### PR TITLE
fix: return toolset env vars in stable sorted order

### DIFF
--- a/.changeset/stable-env-vars-sort-order.md
+++ b/.changeset/stable-env-vars-sort-order.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the environment variables table on the MCP server page reordering its rows on every page refresh and tab focus change. The toolset API now returns security, server, and function environment variables in a stable sorted order.

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -1789,8 +1789,6 @@ func AssembleEnvironmentVariablesForToolset(
 		})
 	}
 
-	// Sort by security key so variables come back in a stable order across
-	// requests — map iteration order is randomized per call.
 	securityVars := make([]*types.SecurityVariable, 0, len(securityVarsMap))
 	for _, key := range slices.Sorted(maps.Keys(securityVarsMap)) {
 		securityVars = append(securityVars, securityVarsMap[key])

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -1785,11 +1785,18 @@ func AssembleEnvironmentVariablesForToolset(
 	if len(serverEnvVarsMap) > 0 {
 		serverVars = append(serverVars, &types.ServerVariable{
 			Description:  "",
-			EnvVariables: slices.Collect(maps.Keys(serverEnvVarsMap)),
+			EnvVariables: slices.Sorted(maps.Keys(serverEnvVarsMap)),
 		})
 	}
 
-	return slices.Collect(maps.Values(securityVarsMap)), serverVars
+	// Sort by security key so variables come back in a stable order across
+	// requests — map iteration order is randomized per call.
+	securityVars := make([]*types.SecurityVariable, 0, len(securityVarsMap))
+	for _, key := range slices.Sorted(maps.Keys(securityVarsMap)) {
+		securityVars = append(securityVars, securityVarsMap[key])
+	}
+
+	return securityVars, serverVars
 }
 
 func environmentVariablesForTools(ctx context.Context, tx DBTX, toolsetID uuid.UUID, tools []ToolEnvLookupParams) ([]*types.SecurityVariable, []*types.ServerVariable, error) {
@@ -1834,7 +1841,11 @@ func dedupeFunctionEnvVars(vars []*types.FunctionEnvironmentVariable) []*types.F
 		deduped[envVar.Name] = envVar
 	}
 
-	return slices.Collect(maps.Values(deduped))
+	result := make([]*types.FunctionEnvironmentVariable, 0, len(deduped))
+	for _, name := range slices.Sorted(maps.Keys(deduped)) {
+		result = append(result, deduped[name])
+	}
+	return result
 }
 
 func extractExternalMCPHeaderDefinitions(ctx context.Context, logger *slog.Logger, headerData []byte, sourceSlug string) ([]*types.ExternalMCPHeaderDefinition, error) {

--- a/server/internal/mv/toolset_env_vars_test.go
+++ b/server/internal/mv/toolset_env_vars_test.go
@@ -102,9 +102,8 @@ func TestAssembleEnvironmentVariablesForToolset_DisambiguatesSameKeyAcrossDocume
 func TestAssembleEnvironmentVariablesForToolset_StableSortedOrder(t *testing.T) {
 	t.Parallel()
 
-	// Ordering previously fell out of Go map iteration, which is randomized
-	// per call, so the API shuffled variables on every request and the
-	// dashboard env vars table reordered on each refresh (AGE-2985).
+	// Regression test for AGE-2985: ordering previously fell out of randomized
+	// Go map iteration, so the API shuffled variables on every request.
 	securityEntriesByKey := map[mv.SecurityDefinitionKey]tsr.HttpSecurity{
 		{Key: "zulu"}:  {ID: uuid.New(), Key: "zulu", EnvVariables: []string{"ZULU_KEY"}},
 		{Key: "mike"}:  {ID: uuid.New(), Key: "mike", EnvVariables: []string{"MIKE_KEY"}},

--- a/server/internal/mv/toolset_env_vars_test.go
+++ b/server/internal/mv/toolset_env_vars_test.go
@@ -98,3 +98,33 @@ func TestAssembleEnvironmentVariablesForToolset_DisambiguatesSameKeyAcrossDocume
 	require.Len(t, vars, 1)
 	require.Equal(t, []string{"DOC_A_API_KEY"}, vars[0].EnvVariables, "tool from doc A must resolve doc A's entry, never doc B's")
 }
+
+func TestAssembleEnvironmentVariablesForToolset_StableSortedOrder(t *testing.T) {
+	t.Parallel()
+
+	// Ordering previously fell out of Go map iteration, which is randomized
+	// per call, so the API shuffled variables on every request and the
+	// dashboard env vars table reordered on each refresh (AGE-2985).
+	securityEntriesByKey := map[mv.SecurityDefinitionKey]tsr.HttpSecurity{
+		{Key: "zulu"}:  {ID: uuid.New(), Key: "zulu", EnvVariables: []string{"ZULU_KEY"}},
+		{Key: "mike"}:  {ID: uuid.New(), Key: "mike", EnvVariables: []string{"MIKE_KEY"}},
+		{Key: "alpha"}: {ID: uuid.New(), Key: "alpha", EnvVariables: []string{"ALPHA_KEY"}},
+	}
+
+	tools := []mv.ToolEnvLookupParams{
+		{Security: []byte(`[{"zulu":[]},{"mike":[]}]`), ServerEnvVar: "SERVER_URL_B"},
+		{Security: []byte(`[{"alpha":[]}]`), ServerEnvVar: "SERVER_URL_A"},
+	}
+
+	for range 20 {
+		securityVars, serverVars := mv.AssembleEnvironmentVariablesForToolset(tools, securityEntriesByKey, nil)
+
+		require.Len(t, securityVars, 3)
+		require.Equal(t, []string{"ALPHA_KEY"}, securityVars[0].EnvVariables)
+		require.Equal(t, []string{"MIKE_KEY"}, securityVars[1].EnvVariables)
+		require.Equal(t, []string{"ZULU_KEY"}, securityVars[2].EnvVariables)
+
+		require.Len(t, serverVars, 1)
+		require.Equal(t, []string{"SERVER_URL_A", "SERVER_URL_B"}, serverVars[0].EnvVariables)
+	}
+}


### PR DESCRIPTION
Fixes [AGE-2985](https://linear.app/speakeasy/issue/AGE-2985/bug-env-vars-table-has-no-stable-sort-order-reorders-on-refresh-and).

## Problem

The environment variables table on the MCP server page reordered on every page refresh, and even when switching browser tabs (react-query refetches on window focus, and each response came back in a new order).

The rows in that table are built from the toolset API's `securityVariables`, `serverVariables`, and `functionEnvironmentVariables`. All three were collected from Go maps in `server/internal/mv/toolset.go` via `slices.Collect(maps.Values(...))` / `maps.Keys(...)`, and Go randomizes map iteration order on every call — so every API response shuffled the variables.

## Fix

Sort each collection deterministically at assembly time:

- Security variables: sorted by security key in `AssembleEnvironmentVariablesForToolset`
- Server variable names: `slices.Sorted(maps.Keys(...))`
- Function env vars: sorted by name in `dedupeFunctionEnvVars`

Both toolset view paths (list entries and full describe) funnel through these functions, so all clients get a stable order. The environments page itself was never affected — `ListEnvironmentEntries` has had `ORDER BY ee.name` since the schema was introduced.

## Testing

- New regression test `TestAssembleEnvironmentVariablesForToolset_StableSortedOrder` asserts the sorted order holds across 20 consecutive assemblies (map randomization made the old behavior fail within a few iterations).
- `go test ./internal/mv/... ./internal/toolsets/...` green, `mise lint:server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return toolset environment variables in a deterministic, stable order so the MCP server env vars table stops reordering on refresh and tab focus. Fixes Linear AGE-2985.

- **Bug Fixes**
  - Sort security vars by key in `AssembleEnvironmentVariablesForToolset`, server var names via `slices.Sorted(maps.Keys(...))`, and function env vars by name in `dedupeFunctionEnvVars`.
  - Add regression test `TestAssembleEnvironmentVariablesForToolset_StableSortedOrder` to verify stable ordering across calls, and a changeset for a dashboard patch.

<sup>Written for commit c5c1d4fc9bf45f7b0ebe2d5f531d608471cc4f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

