### PR TITLE
fix: stop env var save persisting masked placeholder as real value

### DIFF
--- a/.changeset/env-var-save-mask-guard.md
+++ b/.changeset/env-var-save-mask-guard.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the MCP server Authentication tab persisting the server-redacted placeholder (e.g. `sup*****`) as the real environment variable value. Saving now only writes a value the user actually typed, removes on an intentional clear, and otherwise leaves the stored secret untouched — covering both the state-toggle path and untouched saves that swept in unmapped required variables.

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -44,6 +44,7 @@ import {
 import {
   EnvVarState,
   EnvironmentVariable,
+  getSystemValueSaveOp,
   getValueForEnvironment,
 } from "./environmentVariableUtils";
 import {
@@ -591,11 +592,13 @@ export function MCPAuthenticationTab({
 
       // Collect environment variable values for system state
       if (envVar.state === "system") {
-        const value = getEditingValue(envVar);
-        if (value) {
-          entriesToUpdate.push({ name: envVar.key, value });
-        } else {
-          // Value was cleared - remove from environment
+        const saveOp = getSystemValueSaveOp(
+          editing?.value,
+          getValueForEnvironment(envVar, selectedEnvironmentView),
+        );
+        if (saveOp.kind === "update") {
+          entriesToUpdate.push({ name: envVar.key, value: saveOp.value });
+        } else if (saveOp.kind === "remove") {
           entriesToRemove.push(envVar.key);
         }
       }

--- a/client/dashboard/src/pages/mcp/environmentVariableUtils.test.ts
+++ b/client/dashboard/src/pages/mcp/environmentVariableUtils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { EnvironmentVariable } from "./environmentVariableUtils";
-import { getSystemProvidedVariables } from "./environmentVariableUtils";
+import {
+  getSystemProvidedVariables,
+  getSystemValueSaveOp,
+} from "./environmentVariableUtils";
 
 const mkVar = (
   overrides: Partial<EnvironmentVariable> &
@@ -68,5 +71,44 @@ describe("getSystemProvidedVariables", () => {
       }),
     ];
     expect(getSystemProvidedVariables(vars, "prod")).toEqual(["CUSTOM_SECRET"]);
+  });
+});
+
+describe("getSystemValueSaveOp", () => {
+  it("skips when the variable was never edited", () => {
+    expect(getSystemValueSaveOp(undefined, "sup*****")).toEqual({
+      kind: "skip",
+    });
+    expect(getSystemValueSaveOp(undefined, "")).toEqual({ kind: "skip" });
+  });
+
+  it("skips when the editing value is the loaded redacted value", () => {
+    // State toggles seed editing state with the redacted display value;
+    // saving must not write the mask back over the real secret.
+    expect(getSystemValueSaveOp("sup*****", "sup*****")).toEqual({
+      kind: "skip",
+    });
+  });
+
+  it("updates when the user typed a new value", () => {
+    expect(getSystemValueSaveOp("new-secret", "sup*****")).toEqual({
+      kind: "update",
+      value: "new-secret",
+    });
+  });
+
+  it("updates when a value is typed for a variable with no stored value", () => {
+    expect(getSystemValueSaveOp("first-value", "")).toEqual({
+      kind: "update",
+      value: "first-value",
+    });
+  });
+
+  it("removes when the user cleared a previously stored value", () => {
+    expect(getSystemValueSaveOp("", "sup*****")).toEqual({ kind: "remove" });
+  });
+
+  it("skips when cleared and no value was stored", () => {
+    expect(getSystemValueSaveOp("", "")).toEqual({ kind: "skip" });
   });
 });

--- a/client/dashboard/src/pages/mcp/environmentVariableUtils.ts
+++ b/client/dashboard/src/pages/mcp/environmentVariableUtils.ts
@@ -82,6 +82,28 @@ export const getEditingValue = (
   return getValueForEnvironment(envVar, selectedEnvironmentView);
 };
 
+// Decide what to persist for a system-state variable on save. Loaded values
+// are server-redacted (e.g. "sup*****"), so writing one back would replace the
+// stored secret with the mask. Only a value the user actually typed (one that
+// differs from the loaded redacted value) is an update; clearing a previously
+// set value is a removal; anything else must not touch the stored value.
+export type SystemValueSaveOp =
+  | { kind: "update"; value: string }
+  | { kind: "remove" }
+  | { kind: "skip" };
+
+export const getSystemValueSaveOp = (
+  editingValue: string | undefined,
+  loadedValue: string,
+): SystemValueSaveOp => {
+  if (editingValue === undefined) return { kind: "skip" };
+  if (!editingValue) {
+    return loadedValue ? { kind: "remove" } : { kind: "skip" };
+  }
+  if (editingValue === loadedValue) return { kind: "skip" };
+  return { kind: "update", value: editingValue };
+};
+
 // Check if an environment has all required variables configured
 export const environmentHasAllRequiredVariables = (
   environmentSlug: string,


### PR DESCRIPTION
## What

Fixes [AGE-2983](https://linear.app/speakeasy/issue/AGE-2983/bug-env-var-save-persists-the-masked-placeholder-as-the-value): saving environment variables on the MCP server Authentication tab could persist the server-redacted display value (for example `sup*****`) as the real stored secret, silently destroying it. Reported by Fermatcommerce via Pylon #11730.

## Why it happened

`handleSaveAll` in `MCPEnvironmentSettings.tsx` collected values for every system-state variable swept into a save via `getEditingValue`, which falls back to the redacted display value when the user never typed anything. Two paths triggered it with zero value input from the user:

1. Toggling a variable's state (System to Omit to System) seeds editing state with the redacted value, so the next save wrote the mask.
2. A required variable whose value lives in the environment but has no `mcp_environment_configs` row makes `hasUnsavedChanges` return true on page load. A single click of the Save button (or any unrelated edit) swept it into the save and wrote the mask over the real value.

The corruption is undetectable afterwards because the mask redacts to itself.

## Change

- New pure helper `getSystemValueSaveOp(editingValue, loadedValue)` in `environmentVariableUtils.ts` decides what a save may do per system-state variable: write only a value the user actually typed (differs from the loaded redacted value), remove only on an intentional clear of a stored value, otherwise skip the value write entirely. Config entries (provided-by state, header display name) still save as before.
- `handleSaveAll` uses the helper instead of echoing the display value.
- Unit tests covering all helper branches, including the two repro paths.

## Verification

Both repro scenarios from the Linear ticket were replayed against the local stack with the fix applied, using ciphertext length in `environment_entries` as ground truth (AES-GCM ciphertext length reveals plaintext length):

- Scenario 1 (state toggle dance, never typing): 24-char secret stayed at 72 base64 chars with an untouched `updated_at`. Before the fix it became 48 chars (`sup*****`).
- Scenario 2 (untouched Save Configuration on a toolset with an unmapped required variable): 47-char URL stayed at 100 base64 chars, and the save still created the expected `provided_by=system` config row. Before the fix the URL was wiped to `htt*****`.

## Notes for reviewers

- Deliberate trade-off: a user literally typing a value identical to the current value's own mask is treated as a no-op. That input is exactly the ambiguity the mask creates and cannot be distinguished from an echo.
- The `environments.update` API still accepts mask-shaped values verbatim from raw API clients. A server-side backstop was considered and dropped to keep this change frontend-only; can be revisited as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that saved the redacted placeholder (e.g., "sup*****") as the real secret when saving MCP Authentication env vars, causing silent data loss (AGE-2983). Now we only write values the user typed; clears remove; everything else is skipped.

- **Bug Fixes**
  - Added `getSystemValueSaveOp` to choose update/remove/skip per system-state variable.
  - Updated `handleSaveAll` to use the helper instead of echoing the display value.
  - Added tests for all branches, including the two repro cases from AGE-2983; added a changeset for release.

<sup>Written for commit e72623954c1405784b29cac2a13ffb2787095f27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

