### PR TITLE
fix(dashboard): externalize theme bootstrap

### DIFF
--- a/client/dashboard/index.html
+++ b/client/dashboard/index.html
@@ -8,29 +8,7 @@
     <!-- Apply the theme class before first paint to avoid a flash of the
          wrong theme on load. Mirrors App.tsx (key: "preferred-theme",
          default: light). Keep these in sync. -->
-    <script>
-      (function () {
-        try {
-          var theme =
-            localStorage.getItem("preferred-theme") === "dark"
-              ? "dark"
-              : "light";
-          var root = document.documentElement;
-          root.classList.remove("light", "dark");
-          root.classList.add(theme);
-          var favicon = document.getElementById("favicon");
-          var faviconAlt = document.getElementById("favicon-alt");
-          if (favicon)
-            favicon.href =
-              theme === "dark" ? "/favicon-dark.png" : "/favicon.png";
-          if (faviconAlt)
-            faviconAlt.href =
-              theme === "dark" ? "/favicon-dark.ico" : "/favicon.ico";
-        } catch (e) {
-          /* localStorage unavailable — fall back to CSS defaults */
-        }
-      })();
-    </script>
+    <script src="/src/theme-init.ts" vite-ignore></script>
 
     <meta property="og:title" content="Speakeasy AI Control Plane" />
     <meta

--- a/client/dashboard/knip.config.ts
+++ b/client/dashboard/knip.config.ts
@@ -2,6 +2,8 @@ import type { KnipConfig } from "knip";
 
 const config: KnipConfig = {
   // Vite entry (index.html → src/main.tsx) is auto-detected.
+  // Emitted programmatically by themeInitPlugin, which Knip cannot infer.
+  entry: ["src/theme-init.ts"],
   // Vitest, ESLint, Tailwind, and TypeScript plugins are auto-enabled.
   ignoreBinaries: [
     // Invoked from the lint:format script; not on the dep tree.

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -46,7 +46,7 @@ import { AppRoute, useRoutes, useOrgRoutes } from "./routes";
 
 export default function App(): JSX.Element {
   // Initialize from storage so React/Moonshine match the theme the pre-paint
-  // inline script (in index.html) already applied to <html> — avoids a flash.
+  // script (loaded from index.html) already applied to <html> — avoids a flash.
   const [theme, setTheme] = useState<"light" | "dark">(() => {
     try {
       return localStorage.getItem(PREFERRED_THEME_STORAGE_KEY) === "dark"

--- a/client/dashboard/src/theme-init.test.ts
+++ b/client/dashboard/src/theme-init.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const indexHtml = fs.readFileSync("index.html", "utf8");
+
+describe("theme bootstrap", () => {
+  it("loads from an external script without executable inline scripts", () => {
+    const scriptTags = [
+      ...indexHtml.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g),
+    ];
+    const executableInlineBodies = scriptTags
+      .filter(([, attributes]) => !/\bsrc=/.test(attributes ?? ""))
+      .map(([, , body]) => body?.trim())
+      .filter(Boolean);
+
+    expect(executableInlineBodies).toEqual([]);
+    expect(indexHtml).toContain(
+      '<script src="/src/theme-init.ts" vite-ignore></script>',
+    );
+  });
+});

--- a/client/dashboard/src/theme-init.test.ts
+++ b/client/dashboard/src/theme-init.test.ts
@@ -3,20 +3,32 @@ import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const indexHtml = fs.readFileSync("index.html", "utf8");
+const scriptTagPattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/g;
+const scriptSrcAttributePattern = /(?:^|\s)src\s*=/i;
+
+function getExecutableInlineBodies(html: string) {
+  return [...html.matchAll(scriptTagPattern)]
+    .filter(
+      ([, attributes]) => !scriptSrcAttributePattern.test(attributes ?? ""),
+    )
+    .map(([, , body]) => body?.trim())
+    .filter(Boolean);
+}
 
 describe("theme bootstrap", () => {
   it("loads from an external script without executable inline scripts", () => {
-    const scriptTags = [
-      ...indexHtml.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g),
-    ];
-    const executableInlineBodies = scriptTags
-      .filter(([, attributes]) => !/\bsrc=/.test(attributes ?? ""))
-      .map(([, , body]) => body?.trim())
-      .filter(Boolean);
-
-    expect(executableInlineBodies).toEqual([]);
+    expect(getExecutableInlineBodies(indexHtml)).toEqual([]);
     expect(indexHtml).toContain(
       '<script src="/src/theme-init.ts" vite-ignore></script>',
     );
+  });
+
+  it("does not treat data-src as an external script source", () => {
+    const html =
+      '<script data-src="/example.js">window.inlineRan = true;</script>';
+
+    expect(getExecutableInlineBodies(html)).toEqual([
+      "window.inlineRan = true;",
+    ]);
   });
 });

--- a/client/dashboard/src/theme-init.ts
+++ b/client/dashboard/src/theme-init.ts
@@ -1,0 +1,26 @@
+(function () {
+  try {
+    const theme =
+      localStorage.getItem("preferred-theme") === "dark" ? "dark" : "light";
+    const root = document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+
+    const favicon = document.getElementById(
+      "favicon",
+    ) as HTMLLinkElement | null;
+    const faviconAlt = document.getElementById(
+      "favicon-alt",
+    ) as HTMLLinkElement | null;
+
+    if (favicon) {
+      favicon.href = theme === "dark" ? "/favicon-dark.png" : "/favicon.png";
+    }
+
+    if (faviconAlt) {
+      faviconAlt.href = theme === "dark" ? "/favicon-dark.ico" : "/favicon.ico";
+    }
+  } catch {
+    // localStorage unavailable — fall back to CSS defaults.
+  }
+})();

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 import process from "node:process";
 
-import { defineConfig } from "vite";
+import { defineConfig, normalizePath, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -38,6 +38,51 @@ const manualChunkGroups: [string, string[]][] = [
     ],
   ],
 ];
+
+const themeInitPath = path.resolve(__dirname, "src/theme-init.ts");
+const themeInitScriptPattern =
+  /<script src="\/src\/theme-init\.ts"\s*><\/script>/;
+
+function themeInitPlugin(): Plugin {
+  return {
+    name: "theme-init",
+    apply: "build",
+    buildStart() {
+      this.emitFile({
+        type: "chunk",
+        id: themeInitPath,
+        name: "theme-init",
+      });
+    },
+    transformIndexHtml: {
+      order: "post",
+      handler(html, context) {
+        if (!context.bundle) {
+          this.error("Theme bootstrap output bundle is unavailable");
+        }
+
+        const normalizedThemeInitPath = normalizePath(themeInitPath);
+        const themeInitChunk = Object.values(context.bundle).find(
+          (output) =>
+            output.type === "chunk" &&
+            output.facadeModuleId !== null &&
+            normalizePath(output.facadeModuleId) === normalizedThemeInitPath,
+        );
+        if (!themeInitChunk) {
+          this.error("Could not find the emitted theme bootstrap chunk");
+        }
+        if (!themeInitScriptPattern.test(html)) {
+          this.error("Could not find the theme bootstrap script in index.html");
+        }
+
+        return html.replace(
+          themeInitScriptPattern,
+          `<script src="/${themeInitChunk.fileName}"></script>`,
+        );
+      },
+    },
+  };
+}
 
 function packagePathRegex(packages: string[]): RegExp {
   const alternatives = packages.map((pkg) =>
@@ -175,7 +220,7 @@ export default defineConfig(({ command }) => {
           }
         : undefined,
     },
-    plugins: [react(), tailwindcss()],
+    plugins: [themeInitPlugin(), react(), tailwindcss()],
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Why

The dashboard applies the saved light or dark theme and matching favicon before React mounts. This prevents the page from briefly rendering with the wrong theme on a hard load.

That bootstrap previously lived in an inline script in index.html. The deployed CSP allows external scripts from 'self', but it does not allow inline scripts, so Chrome blocked the bootstrap and emitted CSP violations and reports. React eventually reapplied the theme, but only after the initial paint.

## What changed

The bootstrap now lives in src/theme-init.ts as a small dependency-free script. It only:

- reads preferred-theme from localStorage
- applies the light or dark class to the document root
- selects the matching PNG and ICO favicons

index.html still loads it synchronously near the top of head, with no async or defer attribute, so it runs before first paint. React remains responsible for subsequent theme changes after the app mounts.

## How the Vite plugin works

The source HTML references /src/theme-init.ts with vite-ignore. This leaves the development path usable without asking Vite's normal HTML pipeline to bundle the classic script tag.

For production builds, the theme-init plugin:

1. Emits src/theme-init.ts as its own Vite/Rollup chunk during buildStart.
2. Lets the bundler generate the normal content-hashed filename.
3. Runs a post transformIndexHtml hook after the output bundle exists.
4. Finds the emitted chunk by its facade module path and replaces the source tag with the generated URL, such as /assets/theme-init-B9Ga4Llv.js.

The plugin fails the build if the output bundle, emitted chunk, or expected HTML tag is missing. That prevents a configuration change from silently shipping an unhashed or broken bootstrap reference.

## Why use a generated asset URL

Dashboard JavaScript is served with a one-year immutable cache policy. A fixed public filename such as /theme-init.js could therefore leave clients running stale bootstrap code after a deployment.

Emitting a Vite chunk gives every content change a new URL while keeping the script same-origin. The existing CSP can authorize it through 'self' without adding unsafe-inline, maintaining a byte-sensitive CSP hash, or coordinating per-response nonces.

## Regression coverage

The new test verifies that index.html contains no executable inline script bodies and continues to reference the external bootstrap.

Verified with:

- pnpm -F dashboard test src/theme-init.test.ts
- pnpm -F dashboard lint
- pnpm -F dashboard build
- inspection of the built HTML and emitted theme-init asset