### PR TITLE
mig: add is_secret column to environment_entries

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -672,6 +672,7 @@ WHERE definition_slug = 'dashboard' AND status = 'active' AND deleted IS FALSE;
 CREATE TABLE IF NOT EXISTS environment_entries (
   name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 60),
   value TEXT NOT NULL CHECK (value <> '' AND CHAR_LENGTH(value) <= 4000),
+  is_secret BOOLEAN NOT NULL DEFAULT TRUE,
   environment_id uuid NOT NULL,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -568,6 +568,7 @@ type Environment struct {
 type EnvironmentEntry struct {
 	Name          string
 	Value         string
+	IsSecret      bool
 	EnvironmentID uuid.UUID
 	CreatedAt     pgtype.Timestamptz
 	UpdatedAt     pgtype.Timestamptz

--- a/server/internal/environments/repo/models.go
+++ b/server/internal/environments/repo/models.go
@@ -25,6 +25,7 @@ type Environment struct {
 type EnvironmentEntry struct {
 	Name          string
 	Value         string
+	IsSecret      bool
 	EnvironmentID uuid.UUID
 	CreatedAt     pgtype.Timestamptz
 	UpdatedAt     pgtype.Timestamptz

--- a/server/internal/environments/repo/queries.sql.go
+++ b/server/internal/environments/repo/queries.sql.go
@@ -130,7 +130,7 @@ VALUES (
     unnest($2::text[]),
     unnest($3::text[])
 )
-RETURNING name, value, environment_id, created_at, updated_at
+RETURNING name, value, is_secret, environment_id, created_at, updated_at
 `
 
 type CreateEnvironmentEntriesParams struct {
@@ -151,6 +151,7 @@ func (q *Queries) CreateEnvironmentEntries(ctx context.Context, arg CreateEnviro
 		if err := rows.Scan(
 			&i.Name,
 			&i.Value,
+			&i.IsSecret,
 			&i.EnvironmentID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -378,7 +379,7 @@ func (q *Queries) GetEnvironmentForToolset(ctx context.Context, arg GetEnvironme
 }
 
 const listEnvironmentEntries = `-- name: ListEnvironmentEntries :many
-SELECT ee.name, ee.value, ee.environment_id, ee.created_at, ee.updated_at
+SELECT ee.name, ee.value, ee.is_secret, ee.environment_id, ee.created_at, ee.updated_at
 FROM environment_entries ee
 INNER JOIN environments e ON ee.environment_id = e.id
 WHERE
@@ -404,6 +405,7 @@ func (q *Queries) ListEnvironmentEntries(ctx context.Context, arg ListEnvironmen
 		if err := rows.Scan(
 			&i.Name,
 			&i.Value,
+			&i.IsSecret,
 			&i.EnvironmentID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -586,7 +588,7 @@ ON CONFLICT (environment_id, name)
 DO UPDATE SET
     value = EXCLUDED.value,
     updated_at = now()
-RETURNING name, value, environment_id, created_at, updated_at
+RETURNING name, value, is_secret, environment_id, created_at, updated_at
 `
 
 type UpsertEnvironmentEntryParams struct {
@@ -601,6 +603,7 @@ func (q *Queries) UpsertEnvironmentEntry(ctx context.Context, arg UpsertEnvironm
 	err := row.Scan(
 		&i.Name,
 		&i.Value,
+		&i.IsSecret,
 		&i.EnvironmentID,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/internal/environments/shared.go
+++ b/server/internal/environments/shared.go
@@ -227,6 +227,7 @@ func (e *EnvironmentEntries) ListEnvironmentEntries(ctx context.Context, project
 		decryptedEntries[i] = repo.EnvironmentEntry{
 			Name:          entry.Name,
 			Value:         value,
+			IsSecret:      entry.IsSecret,
 			EnvironmentID: entry.EnvironmentID,
 			CreatedAt:     entry.CreatedAt,
 			UpdatedAt:     entry.UpdatedAt,
@@ -260,6 +261,7 @@ func (e *EnvironmentEntries) CreateEnvironmentEntries(ctx context.Context, param
 		decryptedEntries[i] = repo.EnvironmentEntry{
 			Name:          entry.Name,
 			Value:         redactedEnvironment(originalValues[entry.Name]), // avoid having to needlessly decrypt the value
+			IsSecret:      entry.IsSecret,
 			EnvironmentID: entry.EnvironmentID,
 			CreatedAt:     entry.CreatedAt,
 			UpdatedAt:     entry.UpdatedAt,

--- a/server/migrations/20260713202859_environment-entries-add-is-secret.sql
+++ b/server/migrations/20260713202859_environment-entries-add-is-secret.sql
@@ -1,0 +1,2 @@
+-- Modify "environment_entries" table
+ALTER TABLE "environment_entries" ADD COLUMN "is_secret" boolean NOT NULL DEFAULT true;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:S2UfD1hLyteBHSHsfVwykPspbHcv3hyp1f6bSxkQ7rA=
+h1:POEfxMYXnr1AShw986O3XDScx6ZQHtKCdPVDU3B4s4g=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -261,3 +261,4 @@ h1:S2UfD1hLyteBHSHsfVwykPspbHcv3hyp1f6bSxkQ7rA=
 20260710142212_plugin-connections-hooks-config.sql h1:i5v1a+00vugROm0s9hoPjea9F9Mx2QvGj2gN77nhQWo=
 20260713113216_mcp_server_requires_user_session_issuer.sql h1:zurTJ5thZI6HfBkNBqo+kpDekeok7fuQx2wbfrQ1WTY=
 20260713200058_model-provider-keys.sql h1:+Ke7rD4wY8spaHYGs5bXmar7aepllAALdaiVUsmXf7A=
+20260713202859_environment-entries-add-is-secret.sql h1:6lQFy0k5gSthCic6INJDuaD/40n4jg54Swrjo9q/38M=


### PR DESCRIPTION
## Summary

Adds an `is_secret` boolean column (`NOT NULL DEFAULT true`) to `environment_entries`.

This is the schema half of AGE-2986 (allow viewing/revealing non-secret environment variable values after save, prompted by Pylon #11730). The application code that reads and writes the column ships in #4157, stacked on this PR.

Beyond the migration itself, this PR carries the sqlc regeneration (CI's dirty-files check requires generated models to match the schema) and, because the regenerated `EnvironmentEntry` struct gains a field, two one-line `IsSecret: entry.IsSecret` passthroughs in `shared.go` to satisfy exhaustruct. Both are behaviorally inert: nothing reads the field until #4157.

## Notes for reviewers

- The `DEFAULT true` doubles as the backfill: on Postgres 11+ this is a metadata-only change (no table rewrite), and every pre-existing row reads as secret, which preserves today's encrypt-and-redact behavior exactly. Nothing changes for any caller until the follow-up PR lands.
- The default stays `true` permanently (the analogous `remote_mcp_server_headers.is_secret` defaults to `false`, but that column existed from table creation). The application always sets the flag explicitly on insert, so the DB default only ever matters for the backfill.
- Migration generated with `mise db:diff`; no hand edits.

Linear: AGE-2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)
