### PR TITLE
mig: drop tum_breakdown_summaries and its MV (zero readers after DNO-491)

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260714173525_drop-tum-breakdown-summaries.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260714173525_drop-tum-breakdown-summaries.down.sql
@@ -1,0 +1,17 @@
+-- reverse: drop "tum_breakdown_summaries" table
+CREATE TABLE `tum_breakdown_summaries` (
+  `gram_project_id` UUID,
+  `chat_id` String,
+  `time_bucket` DateTime('UTC'),
+  `hook_source` String,
+  `model` String,
+  `user_email` String,
+  `division_name` String,
+  `roles` Array(String),
+  `input_tokens` SimpleAggregateFunction(sum, Int64),
+  `output_tokens` SimpleAggregateFunction(sum, Int64),
+  `total_tokens` SimpleAggregateFunction(sum, Int64)
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`gram_project_id`, `time_bucket`, `chat_id`, `hook_source`, `model`, `user_email`, `division_name`, `roles`) ORDER BY (`gram_project_id`, `time_bucket`, `chat_id`, `hook_source`, `model`, `user_email`, `division_name`, `roles`) TTL time_bucket + toIntervalDay(730) SETTINGS index_granularity = 8192 COMMENT 'Per-chat daily billed token usage broken down by consuming surface and user identity, retained beyond the raw telemetry TTL to power the billing page breakdowns across historical billing cycles';
+-- reverse: drop "tum_breakdown_summaries_mv" view
+CREATE MATERIALIZED VIEW `tum_breakdown_summaries_mv` TO `tum_breakdown_summaries` AS SELECT gram_project_id, chat_id, toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano, 'UTC')) AS time_bucket, hook_source, toString(attributes.gen_ai.response.model) AS model, user_email, toString(attributes.user.attributes.division_name) AS division_name, arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)')) AS roles, sum(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens))) AS input_tokens, sum(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens))) AS output_tokens, sum(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens))) AS total_tokens FROM telemetry_logs WHERE (chat_id != '') AND (toString(attributes.gen_ai.usage.total_tokens) != '') GROUP BY gram_project_id, chat_id, time_bucket, hook_source, model, user_email, division_name, roles;

--- a/server/clickhouse/local/golang_migrate/20260714173525_drop-tum-breakdown-summaries.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260714173525_drop-tum-breakdown-summaries.up.sql
@@ -1,0 +1,5 @@
+-- drop "tum_breakdown_summaries_mv" view (IF EXISTS: local golang-migrate
+-- lineages that ran an earlier revision of this drop may lack the objects)
+DROP VIEW IF EXISTS `tum_breakdown_summaries_mv`;
+-- drop "tum_breakdown_summaries" table
+DROP TABLE IF EXISTS `tum_breakdown_summaries`;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:KdzLKgkbCTnPkKzzCjQ5BB6By/UCkBcvxIAb5OxQhBs=
+h1:Hg5O+/gb1lwLm+MZw+wdP9Iwtno11ldzFIHJAgx21OQ=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -60,3 +60,4 @@ h1:KdzLKgkbCTnPkKzzCjQ5BB6By/UCkBcvxIAb5OxQhBs=
 20260714104107_remove-semicolons-from-comments.up.sql h1:CQMvFncxlzgu0sdoeGZwZ2myd7qathbX0VgfMxopi9U=
 20260714115000_chat-token-summaries-hook-source.up.sql h1:imvQVMa/2Ceuy6tnFmkld537Wr2CwzNsi3qs9DysDA4=
 20260714115010_tum-breakdown-summaries.up.sql h1:TcimH9EEZmoeVZixI3x6kGInFlHcGY4Vl00cgZDKWYM=
+20260714173525_drop-tum-breakdown-summaries.up.sql h1:bN2z1+CUm9cttkIMubc0en+gp7viCi4ojcCACI8rhtU=

--- a/server/clickhouse/migrations/20260714173521_drop-tum-breakdown-summaries.sql
+++ b/server/clickhouse/migrations/20260714173521_drop-tum-breakdown-summaries.sql
@@ -1,0 +1,6 @@
+-- atlas:nolint destructive
+
+-- Drop "tum_breakdown_summaries_mv" view
+DROP VIEW `tum_breakdown_summaries_mv`;
+-- Drop "tum_breakdown_summaries" table
+DROP TABLE `tum_breakdown_summaries`;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:NywZy1Jej+HMbdAlE0bdVh2x8qm4DihJypndvX7g+sU=
+h1:td+gck5j62Je7cBaeKWY89zi8IWEu6fGAr2Q8Pjj5rY=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -65,3 +65,4 @@ h1:NywZy1Jej+HMbdAlE0bdVh2x8qm4DihJypndvX7g+sU=
 20260713200603_attribute-metrics-tombstone-rollback.sql h1:Ta0W3cE0k5O93hxh6BMYZuRpVfPJGY7drzG3bW/HBqI=
 20260714002931_shadow-mcp-inventory-slug-hash-index.sql h1:ADB3UFfaTz1mFPB48773RbSxvK9BzKhgckcQK6Qpkcs=
 20260714104103_remove-semicolons-from-comments.sql h1:rmLVYmzQHSaEFOpdgNm8kVycsC9IenURpFjFa4ZI6PY=
+20260714173521_drop-tum-breakdown-summaries.sql h1:La2w4JzKmjNoWbI1cZXtZKwXYCbFSkNUHwgVACpS0IY=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -742,57 +742,6 @@ FROM telemetry_logs
 WHERE chat_id != ''
 GROUP BY gram_project_id, chat_id, time_bucket, hook_source;
 
--- tum_breakdown_summaries is the DIMENSIONED billing aggregate: the same
--- gen_ai completion rows chat_token_summaries (the billing record) sums,
--- broken down by consuming surface and user identity so the billing page's
--- breakdowns can report the billed population exactly. Reads apply the same
--- read-time stored-session qualification (via chat_token_summaries) and
--- registry-driven source scoping (billing.ModelUsageSources). Identity
--- dimensions are stamped on completion rows at emit time by the telemetry
--- logger's directory snapshot. attribute_metrics_summaries is provenance-
--- first (agent-fleet surfaces only) and no longer carries these rows.
-CREATE TABLE IF NOT EXISTS tum_breakdown_summaries (
-    -- Key columns
-    gram_project_id UUID,
-    chat_id String,
-    time_bucket DateTime('UTC'),
-    hook_source String,
-    model String,
-    user_email String,
-    division_name String,
-    roles Array(String),
-
-    -- Billed token split for the slice (input + output = total for
-    -- completion rows; they carry no cache attributes).
-    input_tokens SimpleAggregateFunction(sum, Int64),
-    output_tokens SimpleAggregateFunction(sum, Int64),
-    total_tokens SimpleAggregateFunction(sum, Int64)
-) ENGINE = AggregatingMergeTree
-ORDER BY (gram_project_id, time_bucket, chat_id, hook_source, model, user_email, division_name, roles)
-TTL time_bucket + INTERVAL 730 DAY
-SETTINGS index_granularity = 8192
-COMMENT 'Per-chat daily billed token usage broken down by consuming surface and user identity, retained beyond the raw telemetry TTL to power the billing page breakdowns across historical billing cycles';
-
-CREATE MATERIALIZED VIEW IF NOT EXISTS tum_breakdown_summaries_mv TO tum_breakdown_summaries AS
-SELECT
-    gram_project_id,
-    chat_id,
-    -- Force UTC so the daily billing bucket boundary never shifts with the
-    -- server timezone (fromUnixTimestamp64Nano defaults to the server tz).
-    toStartOfDay(fromUnixTimestamp64Nano(time_unix_nano, 'UTC')) AS time_bucket,
-    hook_source,
-    toString(attributes.gen_ai.response.model) AS model,
-    user_email,
-    toString(attributes.user.attributes.division_name) AS division_name,
-    arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)')) AS roles,
-    sum(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens))) AS input_tokens,
-    sum(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens))) AS output_tokens,
-    sum(toInt64OrZero(toString(attributes.gen_ai.usage.total_tokens))) AS total_tokens
-FROM telemetry_logs
-WHERE chat_id != ''
-  AND toString(attributes.gen_ai.usage.total_tokens) != ''
-GROUP BY gram_project_id, chat_id, time_bucket, hook_source, model, user_email, division_name, roles;
-
 CREATE TABLE IF NOT EXISTS attribute_keys (
     gram_project_id UUID,
     attribute_key String,


### PR DESCRIPTION
Follow-up to #4146 (DNO-491) — **merge after #4158**.

Drops `tum_breakdown_summaries` and `tum_breakdown_summaries_mv`. The observed-traffic redefinition moved every billing read to `attribute_metrics_summaries`, leaving this aggregate with **zero readers** while its MV kept ingesting on every telemetry insert. Verified exhaustively before dropping: no Go readers/writers, no cascading MVs, no dashboard/elements/CLI/functions/seed references, nothing in gram-infra or device-agent — the only mentions anywhere are its own schema/migration definitions and prose.

**`chat_token_summaries` and its MV are deliberately kept** — they remain the historical pre-redefinition billing record (the dormant endpoint that read them is removed in #4158; the data keeps accumulating).

Destructive and not expand-contract by design: the table held only a derived aggregate (rebuildable from `telemetry_logs` within its 90-day TTL if ever needed), and the invoiced record lives in Postgres `billing_cycle_usage` snapshots.

Verified locally: `mise run clickhouse:migrate` applies cleanly (MV dropped before its target table); the objects are gone from the local instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `tum_breakdown_summaries` and `tum_breakdown_summaries_mv` now that DNO-491 moved all TUM/billing reads to `attribute_metrics_summaries`. This stops an unused MV from ingesting and reduces write load; `chat_token_summaries` stays as the historical record.

- **Migration**
  - Drops the MV then table via Atlas (`-- atlas:nolint destructive`); removes both from `schema.sql`.
  - Local `golang_migrate`: up uses `DROP VIEW/TABLE IF EXISTS`; down recreates the table and MV.
  - Safe drop of a derived aggregate; invoiced totals remain in Postgres `billing_cycle_usage`.

<sup>Written for commit ba0dc059f8d469ff199b7ac33040ed79a7a5262d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

