### PR TITLE
chore(ci): run dashboard tests in CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1480,6 +1480,48 @@ jobs:
         if: success()
         run: pnpm store prune
 
+  client-test:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [changes, sdk-gen-check]
+    if: |
+      !cancelled() &&
+      needs.sdk-gen-check.result != 'failure' &&
+      needs.changes.outputs.client == 'true'
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Prepare GitHub Actions environment
+        run: mise run github
+
+      - name: Cache PNPM
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ env.GH_CACHE_PNPM_KEY }}
+          restore-keys: |
+            ${{ env.GH_CACHE_PNPM_KEY }}
+            ${{ env.GH_CACHE_PNPM_KEY_PARTIAL }}
+          path: |
+            ${{ env.PNPM_STORE_PATH }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test
+        working-directory: client/dashboard
+
+      - name: Prune PNPM store
+        if: success()
+        run: pnpm store prune
+
   sdk-gen-check:
     name: Check SDK is up-to-date
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -1919,6 +1961,7 @@ jobs:
       - docker-build-client
       - docker-build-pystreams
       - client-build-lint
+      - client-test
       - sdk-gen-check
       - cli-build-lint
       - hooks-build-test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1514,6 +1514,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build Elements dependency
+        run: pnpm build
+        working-directory: elements
+
       - name: Test
         run: pnpm test
         working-directory: client/dashboard

--- a/client/dashboard/src/components/observe/useObserveFilters.test.tsx
+++ b/client/dashboard/src/components/observe/useObserveFilters.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@gram/client/react-query/members.js", () => ({
 vi.mock("@gram/client/react-query/roles.js", () => ({
   useRoles: vi.fn(),
 }));
-vi.mock("@gram/client/react-query", () => ({
+vi.mock("@gram/client/react-query/_context.js", () => ({
   useGramContext: () => ({}),
 }));
 vi.mock("@gram/client/funcs/telemetryGetHooksSummary", () => ({

--- a/client/dashboard/src/components/page-header.test.tsx
+++ b/client/dashboard/src/components/page-header.test.tsx
@@ -7,6 +7,9 @@ vi.mock("@/components/ui/sidebar", () => ({
 vi.mock("@/components/ui/separator", () => ({
   Separator: () => <hr data-testid="separator" />,
 }));
+vi.mock("./onboarding-banner.tsx", () => ({
+  OnboardingBanner: () => null,
+}));
 // Stub context/hook modules imported at the top of page-header.tsx (used only
 // in PageHeaderBreadcrumbs, not PageHeaderComponent, but they execute on import)
 vi.mock("@/contexts/Sdk.tsx", () => ({ useSlugs: () => ({}) }));

--- a/client/dashboard/src/components/sources/useFailedDeploymentSources.test.ts
+++ b/client/dashboard/src/components/sources/useFailedDeploymentSources.test.ts
@@ -4,10 +4,16 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@gram/client/react-query/index.js", () => ({
+vi.mock("@gram/client/react-query/deployment.js", () => ({
   useDeployment: vi.fn(() => ({ data: undefined, isLoading: false })),
+}));
+vi.mock("@gram/client/react-query/deploymentLogs.js", () => ({
   useDeploymentLogs: vi.fn(() => ({ data: undefined, isLoading: false })),
+}));
+vi.mock("@gram/client/react-query/latestDeployment.js", () => ({
   useLatestDeployment: vi.fn(() => ({ data: undefined, isLoading: false })),
+}));
+vi.mock("@gram/client/react-query/listToolsets.js", () => ({
   useListToolsets: vi.fn(() => ({ data: undefined })),
 }));
 

--- a/client/dashboard/src/components/workspace-switcher.test.tsx
+++ b/client/dashboard/src/components/workspace-switcher.test.tsx
@@ -11,6 +11,7 @@ vi.mock("@/contexts/Auth", () => ({
     projects: [{ id: "p1", slug: "proj", name: "Proj" }],
   }),
   useProject: () => ({ id: "p1", slug: "proj", name: "Proj", switchProject }),
+  useSession: () => ({ organizations: [{ id: "org_1" }] }),
 }));
 vi.mock("@/contexts/Sdk", () => ({
   useSlugs: () => ({ orgSlug: "acme", projectSlug: "proj" }),
@@ -21,6 +22,7 @@ vi.mock("@/hooks/useRBAC", () => ({
 }));
 vi.mock("react-router", () => ({
   Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
 }));
 vi.mock("./project-menu", () => ({
   ProjectAvatar: () => <span data-testid="project-avatar" />,

--- a/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.test.ts
+++ b/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.test.ts
@@ -41,10 +41,16 @@ vi.mock("@/contexts/Fetcher", () => ({
   useFetcher: () => ({ fetch: mockAuthedFetch }),
 }));
 
-vi.mock("@gram/client/react-query", () => ({
+vi.mock("@gram/client/react-query/deployment.js", () => ({
   useDeployment: vi.fn(() => ({ data: undefined })),
+}));
+vi.mock("@gram/client/react-query/deploymentLogs.js", () => ({
   useDeploymentLogs: vi.fn(() => ({ data: undefined })),
+}));
+vi.mock("@gram/client/react-query/latestDeployment.js", () => ({
   useLatestDeployment: vi.fn(() => ({ data: undefined })),
+}));
+vi.mock("@gram/client/react-query/listToolsets.js", () => ({
   useListToolsets: vi.fn(() => ({ data: undefined })),
 }));
 
@@ -1122,7 +1128,7 @@ describe("useExternalMcpReleaseWorkflow", () => {
         {
           createRemoteSessionClientForm: expect.objectContaining({
             remoteSessionIssuerId: "rsi-1",
-            userSessionIssuerId: "usi-1",
+            userSessionIssuerIds: ["usi-1"],
             clientId: "dcr-client-id",
             clientSecret: "dcr-client-secret",
             tokenEndpointAuthMethod: "client_secret_basic",

--- a/client/dashboard/src/pages/mcp/oauth-wizard/EditOAuthProxyModal.test.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/EditOAuthProxyModal.test.tsx
@@ -16,8 +16,11 @@ const mocks = vi.hoisted(() => ({
   invalidateAllToolset: vi.fn(),
 }));
 
-vi.mock("@gram/client/react-query", () => ({
+vi.mock("@gram/client/react-query/toolset.js", () => ({
   invalidateAllToolset: mocks.invalidateAllToolset,
+}));
+
+vi.mock("@gram/client/react-query/updateOAuthProxyServer.js", () => ({
   useUpdateOAuthProxyServerMutation: (options: {
     onSuccess?: () => void;
     onError?: (e: Error) => void;

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
@@ -22,49 +22,55 @@ const mocks = vi.hoisted(() => {
       .fn()
       .mockResolvedValue({ slug: "env-new", name: "Toolset OAuth" }),
     deleteEnvironment: vi.fn().mockResolvedValue(undefined),
-    updateOAuthProxy: vi.fn().mockResolvedValue(undefined),
     capture: vi.fn(),
     invalidateAllToolset: vi.fn(),
     invalidateAllGetMcpMetadata: vi.fn(),
     invalidateAllListEnvironments: vi.fn(),
-    invalidateAllRemoteSessionIssuers: vi.fn(),
-    invalidateAllRemoteSessionClients: vi.fn(),
-    invalidateAllUserSessionIssuers: vi.fn(),
     isFeatureEnabled: vi.fn(() => false),
   };
 });
 
-vi.mock("@gram/client/react-query", () => ({
-  useGramContext: () => ({}),
+vi.mock("@gram/client/react-query/toolset.js", () => ({
   invalidateAllToolset: mocks.invalidateAllToolset,
+}));
+
+vi.mock("@gram/client/react-query/getMcpMetadata.js", () => ({
   invalidateAllGetMcpMetadata: mocks.invalidateAllGetMcpMetadata,
+}));
+
+vi.mock("@gram/client/react-query/listEnvironments.js", () => ({
   invalidateAllListEnvironments: mocks.invalidateAllListEnvironments,
-  invalidateAllRemoteSessionIssuers: mocks.invalidateAllRemoteSessionIssuers,
-  invalidateAllRemoteSessionClients: mocks.invalidateAllRemoteSessionClients,
-  invalidateAllUserSessionIssuers: mocks.invalidateAllUserSessionIssuers,
-  buildAddExternalOAuthServerMutation: () => ({
-    mutationKey: [],
-    mutationFn: mocks.addExternalOAuth,
-  }),
-  buildAddOAuthProxyServerMutation: () => ({
-    mutationKey: [],
-    mutationFn: mocks.addOAuthProxy,
-  }),
-  buildCreateEnvironmentMutation: () => ({
-    mutationKey: [],
-    mutationFn: mocks.createEnvironment,
-  }),
-  buildDeleteEnvironmentMutation: () => ({
-    mutationKey: [],
-    mutationFn: mocks.deleteEnvironment,
-  }),
   buildListEnvironmentsQuery: () => ({
     queryKey: ["@gram/client", "environments", "list", {}],
     queryFn: () => Promise.resolve({ environments: [] }),
   }),
-  buildUpdateOAuthProxyServerMutation: () => ({
+}));
+
+vi.mock("@gram/client/react-query/addExternalOAuthServer.js", () => ({
+  buildAddExternalOAuthServerMutation: () => ({
     mutationKey: [],
-    mutationFn: mocks.updateOAuthProxy,
+    mutationFn: mocks.addExternalOAuth,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/addOAuthProxyServer.js", () => ({
+  buildAddOAuthProxyServerMutation: () => ({
+    mutationKey: [],
+    mutationFn: mocks.addOAuthProxy,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/createEnvironment.js", () => ({
+  buildCreateEnvironmentMutation: () => ({
+    mutationKey: [],
+    mutationFn: mocks.createEnvironment,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/deleteEnvironment.js", () => ({
+  buildDeleteEnvironmentMutation: () => ({
+    mutationKey: [],
+    mutationFn: mocks.deleteEnvironment,
   }),
 }));
 


### PR DESCRIPTION
## Why

The dashboard Vitest suite was not running in CI, so failures introduced by SDK and component changes could remain unnoticed. The suite had accumulated failures after generated React Query barrel modules were removed and several component dependencies changed.

This PR restores the suite and makes future dashboard test regressions fail the required CI gate.

## What changed

### Add dashboard tests to CI

Adds a separate `client-test` job that:

- runs when the existing `client` path filter detects relevant changes
- uses the same checkout, Mise, PNPM cache, and install setup as `client-build-lint`
- builds the `@gram-ai/elements` workspace dependency so its `dist` exports exist on clean runners
- waits for `sdk-gen-check` and does not proceed when SDK generation fails
- runs `pnpm test` from `client/dashboard`
- reports into `CI Gate`, so a test failure blocks the aggregate required check

Keeping tests separate from `client-build-lint` makes the result and failure mode visible as its own CI check.

### Repair the currently failing dashboard tests

The test-only changes fall into three groups:

1. **Generated React Query imports**
   - Replace mocks of removed `@gram/client/react-query` barrel modules with mocks of the leaf modules used by production code.
   - Applies to observe filters, failed deployment sources, the external MCP release workflow, and OAuth wizard tests.

2. **Component isolation**
   - Stub `OnboardingBanner` in the page-header test so unrelated WebGL/canvas initialization does not run.
   - Add the current `useSession` and `useNavigate` dependencies to the workspace-switcher test harness.

3. **Current API contract**
   - Update the external MCP release workflow assertion from singular `userSessionIssuerId` to `userSessionIssuerIds: ["usi-1"]`.

No production dashboard behavior or dependencies are changed; this PR updates CI configuration and test fixtures only.

## Verification

- `pnpm -F dashboard test` — 69 files, 659 tests passed
- `pnpm -F dashboard lint`
- `pnpm -F dashboard type-check`
- workflow formatting and Git diff checks

Linear: AGE-2989
