### PR TITLE
chore: fix telemetry testing guidance on async insert visibility

### DIFF
--- a/server/internal/telemetry/README.md
+++ b/server/internal/telemetry/README.md
@@ -370,7 +370,8 @@ Key testing patterns:
 - Use `testenv.Launch()` in `TestMain` to set up infrastructure
 - Create helper functions for inserting test data
 - Use table-driven tests with descriptive names
-- After inserts, wait for ClickHouse eventual consistency by polling with `require.EventuallyWithT`, never `time.Sleep` (see the `golang` skill for the repo-wide convention and its `forbidigo` enforcement).
+- After inserts, call `testenv.FlushClickHouseAsyncInserts(t, conn)` (`server/internal/testenv/clickhouse.go`) before querying. Telemetry writes use ClickHouse [async inserts](https://clickhouse.com/docs/optimize/asynchronous-inserts), so rows only become visible after the async insert queue flushes — this helper drains it synchronously (`SYSTEM FLUSH ASYNC INSERT QUEUE`), making the data deterministically visible.
+- **Never wait for visibility non-deterministically** — no `time.Sleep` (enforced repo-wide via `forbidigo`; see the `golang` skill) and no `require.EventuallyWithT` polling for async-insert visibility. Polling masks the real synchronization point, slows tests, and still flakes under load. Reserve `require.EventuallyWithT` for conditions that are genuinely eventually consistent with no explicit flush mechanism.
 
 ## Data Models
 


### PR DESCRIPTION
## Summary

The telemetry README's testing section told test authors to wait for ClickHouse "eventual consistency" after inserts by polling with `require.EventuallyWithT`. That guidance is misleading: telemetry writes use ClickHouse async inserts, and there is an explicit, deterministic synchronization point — `testenv.FlushClickHouseAsyncInserts` (`server/internal/testenv/clickhouse.go`), which drains the async insert queue via `SYSTEM FLUSH ASYNC INSERT QUEUE`.

## Changes

- Replace the "poll with `require.EventuallyWithT`" bullet with guidance to call `testenv.FlushClickHouseAsyncInserts(t, conn)` after inserts, before querying.
- Add an explicit caution against non-deterministic waits for async-insert visibility (`time.Sleep` remains forbidden via `forbidigo`; `EventuallyWithT` polling masks the real sync point, slows tests, and can still flake under load). `EventuallyWithT` stays reserved for conditions that are genuinely eventually consistent with no flush mechanism.

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update telemetry testing docs to flush ClickHouse async inserts with `testenv.FlushClickHouseAsyncInserts(t, conn)` before querying instead of polling with `require.EventuallyWithT`. Clarifies that `time.Sleep` and polling must not be used for async-insert visibility to keep tests deterministic and faster.

<sup>Written for commit 009671ea0f8ded7fd5a6469491f301bcab6cfe87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

