### PR TITLE
fix: hide Elements model key row

### DIFF
--- a/client/dashboard/src/pages/settings/model-key-slots.ts
+++ b/client/dashboard/src/pages/settings/model-key-slots.ts
@@ -24,11 +24,6 @@ export const MODEL_KEY_SLOTS: ModelKeySlot[] = [
     description: "Completions from the dashboard playground.",
   },
   {
-    slot: "elements",
-    name: "Elements",
-    description: "Chat completions served through Elements embeds.",
-  },
-  {
     slot: "assistants",
     name: "Assistants",
     description: "Completions from assistant runs and triggers.",


### PR DESCRIPTION
## Summary

Remove the Elements entry from the Model Provider Keys table in project settings. This is a visual-only change; existing Elements keys and backend behavior remain unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Elements row in Project Settings > Model Provider Keys. UI-only change; existing Elements keys still work and backend behavior is unchanged.

<sup>Written for commit 6b2065a78684f6a35941bb956c8b2e12b98ed4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

