### PR TITLE
fix(remotemcp): stop forwarding browser Origin/Referer/Cookie to upstream MCP servers

### DIFF
--- a/.changeset/remote-mcp-strip-browser-headers.md
+++ b/.changeset/remote-mcp-strip-browser-headers.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Stop forwarding browser-only headers (`Origin`, `Referer`, `Cookie`) from the inbound request to remote MCP upstreams. When the dashboard drove a remote MCP server, its `Origin` was relayed verbatim and upstreams enforcing the MCP spec's DNS-rebinding protection (e.g. Langfuse) rejected the request with 403 "Access forbidden", surfacing as "Something went wrong loading tools" in the Tools tab. Dropping these headers makes dashboard-proxied requests match those from a headless MCP client and prevents the dashboard session cookie from leaking upstream.

--- a/server/internal/remotemcp/proxy/headers.go
+++ b/server/internal/remotemcp/proxy/headers.go
@@ -25,6 +25,15 @@ const (
 // that fails JSON-RPC decode and bypasses response interception. Letting the
 // transport add and unwind its own encoding keeps the buffered body decodable.
 //
+// Origin, Referer, and Cookie are browser-only headers that carry the
+// dashboard's own origin and session, not the caller's intent toward the
+// upstream. They are meaningless upstream and actively harmful: MCP servers
+// that implement the spec's DNS-rebinding protection validate Origin and
+// reject a request whose Origin isn't their own (e.g. Langfuse 403s a
+// forwarded "Origin: https://<dashboard>"), and forwarding Cookie would leak
+// the gram_session to an arbitrary upstream. Drop them so requests proxied
+// from the dashboard match those from a headless MCP client.
+//
 // Authorization is end-to-end and is handled separately by
 // [Proxy.applyRequestHeaders] based on [Proxy.AuthorizationOverride].
 func isSkippedRequestHeader(name string) bool {
@@ -34,10 +43,13 @@ func isSkippedRequestHeader(name string) bool {
 		"authorization",
 		"connection",
 		"content-length",
+		"cookie",
 		"host",
 		"keep-alive",
+		"origin",
 		"proxy-authenticate",
 		"proxy-authorization",
+		"referer",
 		"te",
 		"trailer",
 		"transfer-encoding",

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -189,6 +189,42 @@ func TestProxy_Post_StripsAuthorizationHeader(t *testing.T) {
 	require.Empty(t, gotAuth, "Gram API key must never be forwarded to the remote MCP server")
 }
 
+func TestProxy_Post_StripsBrowserHeaders(t *testing.T) {
+	t.Parallel()
+
+	var gotOrigin, gotReferer, gotCookie, gotAccept string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotOrigin = r.Header.Get("Origin")
+		gotReferer = r.Header.Get("Referer")
+		gotCookie = r.Header.Get("Cookie")
+		gotAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+	// Headers a browser attaches when the dashboard drives the proxy. Origin
+	// trips upstream DNS-rebinding checks and Cookie would leak the dashboard
+	// session, so neither may reach the upstream MCP server.
+	req.Header.Set("Origin", "https://app.getgram.ai")
+	req.Header.Set("Referer", "https://app.getgram.ai/mcp/x/some-server/tools")
+	req.Header.Set("Cookie", "gram_session=super-secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	require.Empty(t, gotOrigin, "browser Origin must not be forwarded to the remote MCP server")
+	require.Empty(t, gotReferer, "browser Referer must not be forwarded to the remote MCP server")
+	require.Empty(t, gotCookie, "dashboard session cookie must not leak to the remote MCP server")
+	// Forward-safe headers still pass through untouched.
+	require.Equal(t, "application/json, text/event-stream", gotAccept)
+}
+
 func TestProxy_Post_AppliesStaticHeader(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Loading tools for a remote MCP server from the dashboard **Tools tab** failed with *"Something went wrong loading tools."* Server logs showed the upstream returning **403**:

```
WARN  remote mcp server rejected upstream credentials   proxy.go:758   http.response.status_code: 403
WARN  relaying undecodable remote mcp response to client verbatim
      error.message: upstream response is not a json-rpc message: ... "MCP error -32600: Access forbid..."
```

The credentials were fine — a direct `curl` to the upstream (Langfuse) with the exact same configured `Authorization: Basic …` header returned `200` and a full `tools/list`. The only difference was the **`Origin`** header:

| `Origin` sent to Langfuse | Result |
|---|---|
| `https://localhost:5173` (dashboard) | **403** `Access forbidden` |
| upstream's own origin / none | `200` ✅ |

## Root cause

`isSkippedRequestHeader` (`server/internal/remotemcp/proxy/headers.go`) stripped hop-by-hop headers + `Authorization`, but **not** `Origin`/`Referer`/`Cookie`. `applyRequestHeaders` copies all non-skipped inbound headers to the upstream, so when the request originated in the browser, the dashboard's `Origin` was relayed verbatim. Upstreams that implement the MCP Streamable-HTTP spec's DNS-rebinding protection validate `Origin` and reject a foreign one with 403. A headless MCP client (Claude Desktop, Inspector CLI) sends no `Origin`, so only the browser-proxied path was affected.

## Fix

Add `origin`, `referer`, and `cookie` to `isSkippedRequestHeader` so dashboard-proxied requests match headless ones. Dropping `Cookie` also prevents the `gram_session` cookie from leaking to an arbitrary upstream.

## Testing

- New `TestProxy_Post_StripsBrowserHeaders` asserts `Origin`/`Referer`/`Cookie` never reach the upstream while forward-safe headers (`Accept`) still pass through.
- `mise lint:server` clean; existing proxy header tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)