### PR TITLE
fix: apply typed date ranges when picker presets are hidden

### DIFF
--- a/.changeset/time-range-picker-preset-fallback.md
+++ b/.changeset/time-range-picker-preset-fallback.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+TimeRangePicker: natural-language input that the AI parser normalizes to a preset (e.g. "last week" → 7d) now applies as the preset's concrete date range when that preset isn't offered via `availablePresets`, instead of silently doing nothing. Fixes typed date ranges on the billing page, which passes `availablePresets={[]}`.

--- a/elements/src/components/ui/time-range-picker.test.ts
+++ b/elements/src/components/ui/time-range-picker.test.ts
@@ -24,7 +24,11 @@ vi.mock("ai", () => ({
 // Avoid pulling Datadog RUM (and its window access) into the Node test env.
 vi.mock("@/lib/errorTracking", () => ({ trackError: vi.fn() }));
 
-import { parseWithAI } from "./time-range-picker";
+import {
+  getPresetRange,
+  parseWithAI,
+  resolveParsedRange,
+} from "./time-range-picker";
 
 describe("parseWithAI request auth", () => {
   beforeEach(() => {
@@ -53,5 +57,44 @@ describe("parseWithAI request auth", () => {
     const opts = createOpenRouterMock.mock.calls[0]![0];
     expect(opts.headers["Gram-Project"]).toBe("proj-slug");
     expect(opts.headers["Gram-Session"]).toBeUndefined();
+  });
+});
+
+describe("resolveParsedRange", () => {
+  beforeEach(() => {
+    // Freeze time so two getPresetRange calls produce identical ranges.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T12:00:00"));
+    return () => vi.useRealTimers();
+  });
+
+  it("returns a preset unchanged when the preset is offered", () => {
+    const parsed = { type: "preset", preset: "7d" } as const;
+    expect(resolveParsedRange(parsed, () => true)).toBe(parsed);
+  });
+
+  it("passes custom ranges through untouched", () => {
+    const parsed = {
+      type: "custom",
+      range: { from: new Date("2026-01-05"), to: new Date("2026-01-10") },
+      label: "1/5-1/10",
+    } as const;
+    expect(resolveParsedRange(parsed, () => false)).toBe(parsed);
+  });
+
+  // Regression test: the billing page passes availablePresets={[]} to hide
+  // the quick-pick options, but the AI parser normalizes common phrases
+  // ("last week") to presets. Before the fix, such input was silently
+  // discarded; it must instead apply as the preset's concrete range.
+  it("falls back to the preset's concrete range when the preset is not offered", () => {
+    const resolved = resolveParsedRange(
+      { type: "preset", preset: "7d" },
+      () => false,
+    );
+    expect(resolved).toEqual({
+      type: "custom",
+      range: getPresetRange("7d"),
+      label: "1w",
+    });
   });
 });

--- a/elements/src/components/ui/time-range-picker.tsx
+++ b/elements/src/components/ui/time-range-picker.tsx
@@ -171,6 +171,26 @@ type ParseResult =
   | { type: "custom"; range: TimeRange; label?: string }
   | null;
 
+// Exported for unit testing. Decides how a successful parse is applied given
+// the picker's available presets: `availablePresets` only limits the
+// quick-pick options, so typed input that the AI normalizes to a preset
+// (e.g. "last week" -> 7d) must still apply when that preset isn't offered —
+// as the preset's concrete date range. Otherwise Enter silently no-ops
+// (the billing page passes availablePresets={[]}).
+export function resolveParsedRange(
+  parsed: NonNullable<ParseResult>,
+  isPresetAvailable: (preset: DateRangePreset) => boolean,
+): NonNullable<ParseResult> {
+  if (parsed.type === "preset" && !isPresetAvailable(parsed.preset)) {
+    return {
+      type: "custom",
+      range: getPresetRange(parsed.preset),
+      label: getPresetByValue(parsed.preset)?.shortLabel,
+    };
+  }
+  return parsed;
+}
+
 const timeRangeSchema = z.object({
   from: z.string().describe("ISO8601 start date/time"),
   to: z.string().describe("ISO8601 end date/time"),
@@ -442,13 +462,13 @@ function TimeRangePicker({
 
   const applyParseResult = (parsed: ParseResult) => {
     if (parsed) {
-      if (parsed.type === "preset") {
-        if (!isPresetAvailable(parsed.preset)) return false;
-        onPresetChange?.(parsed.preset);
+      const resolved = resolveParsedRange(parsed, isPresetAvailable);
+      if (resolved.type === "preset") {
+        onPresetChange?.(resolved.preset);
         setCustomLabel(null);
       } else {
-        const label = parsed.label || undefined;
-        onCustomRangeChange?.(parsed.range.from, parsed.range.to, label);
+        const label = resolved.label || undefined;
+        onCustomRangeChange?.(resolved.range.from, resolved.range.to, label);
         setCustomLabel(label || null);
       }
       setInputValue("");


### PR DESCRIPTION
# Summary

On the **/billing** page, typing a natural-language date range (e.g. "last week", "past 7 days") into the time-range picker and pressing Enter silently did nothing.

## Root cause

The billing page (PR #3973, DNO-404) passes `availablePresets={[]}` to the shared `TimeRangePicker` to hide the relative quick-pick presets in favor of the billing-cycle dropdown. But the AI parser deliberately normalizes common phrases to preset labels ("last week" → `7d`), and `applyParseResult` rejected any parse whose preset wasn't in `availablePresets` — with no feedback. So exactly the most natural inputs were the ones silently discarded, while explicit ranges ("jan 5 to jan 10") still worked.

## Fix

`availablePresets` now only limits the quick-pick options, not what typed input can resolve to. A new pure helper `resolveParsedRange` converts a parse that lands on an unavailable preset into the preset's concrete date range (with its short label, e.g. `1w`), which then applies through the existing custom-range path. Pickers that do offer the preset are unchanged.

- `elements/src/components/ui/time-range-picker.tsx`: extract `resolveParsedRange` (exported for unit testing, same pattern as `parseWithAI`); `applyParseResult` routes through it.
- `elements/src/components/ui/time-range-picker.test.ts`: 3 new tests — preset passthrough when offered, custom-range passthrough, and the fallback regression case.
- Patch changeset for `@gram-ai/elements`.

## Verification

- `pnpm -F @gram-ai/elements test` — 106 passed (14 files), including the new regression tests
- `pnpm -F @gram-ai/elements type-check` — clean
- `pnpm -F @gram-ai/elements lint` — clean (oxfmt, oxlint --type-aware, tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfbVW8MPTHZ1vocYmjtbeH


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the time-range picker so typed natural-language ranges (e.g., "last week") apply even when presets are hidden, restoring expected behavior on the `/billing` page. Aligns with DNO-404 by hiding quick-pick presets while keeping typed input working.

- **Bug Fixes**
  - `availablePresets` now only limits quick-pick UI; typed input that normalizes to a preset is converted to its concrete date range and applied.
  - Added `resolveParsedRange` with unit tests for offered-preset passthrough, custom passthrough, and hidden-preset fallback.
  - Patch changeset published for `@gram-ai/elements`.

<sup>Written for commit a7e4899c01893c318cffe1ddbc0eed2045d27c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

