### PR TITLE
feat: filter tombstoned rows from billing TUM reads

### DIFF
--- a/.changeset/billing-tum-tombstone-filter.md
+++ b/.changeset/billing-tum-tombstone-filter.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Billing tokens-under-management reads over attribute_metrics_summaries now filter tombstoned rows (is_active = 1), matching the costs page reads, so generations soft-deleted by the backfill runbook are excluded from billed totals and breakdowns.

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -5864,6 +5864,9 @@ const tumMeasureExpr = "toInt64(sumIfMerge(total_input_tokens) + sumIfMerge(tota
 func tumObservedBase(sb squirrel.SelectBuilder, arg GetTokensUnderManagementParams) squirrel.SelectBuilder {
 	sb = sb.
 		From("attribute_metrics_summaries").
+		// Exclude tombstoned rows (soft-deleted backfill data; see the
+		// is_active column comment in server/clickhouse/schema.sql).
+		Where("is_active = 1").
 		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
 		Where("time_bucket >= toStartOfDay(fromUnixTimestamp64Nano(?))", arg.StartUnixNano).
 		Where("time_bucket < fromUnixTimestamp64Nano(?)", arg.EndUnixNano)


### PR DESCRIPTION
## Summary

Follow-up to #4162. The billing tokens-under-management reads over `attribute_metrics_summaries` (`tumObservedBase`, shared by `GetTokensUnderManagementByDay`, `GetTumBreakdownTotalsByDay`, and `GetTumBreakdownDimByDay`) were missing the tombstone filter that the costs page reads gained in #4162. They now require `is_active = 1`, so generations soft-deleted by the backfill runbook's tombstone flips are excluded from billed totals, the hourly cycle snapshots, and the billing page breakdowns. Live MV ingestion (which defaults to active) is unaffected.

## Test plan

- [x] `mise test:server ./internal/usage/...` — 21 tests pass
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter tombstoned rows from billing Tokens Under Management (TUM) reads by requiring is_active = 1 on `attribute_metrics_summaries`. This matches the costs page and excludes soft-deleted backfill generations from billed totals, hourly snapshots, and billing page breakdowns.

<sup>Written for commit 4dfbc773544cc99fa98b3774fe3bca2acc357b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

