### PR TITLE
mig: index Shadow MCP inventory URL slugs

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260714002937_shadow-mcp-inventory-slug-hash-index.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260714002937_shadow-mcp-inventory-slug-hash-index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `shadow_mcp_inventory_urls` DROP INDEX `idx_shadow_mcp_inventory_urls_slug_hash`;

--- a/server/clickhouse/local/golang_migrate/20260714002937_shadow-mcp-inventory-slug-hash-index.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260714002937_shadow-mcp-inventory-slug-hash-index.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `shadow_mcp_inventory_urls` ADD INDEX `idx_shadow_mcp_inventory_urls_slug_hash` ((substring(lower(hex(SHA256(canonical_server_url))), 1, 8))) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE `shadow_mcp_inventory_urls` MATERIALIZE INDEX `idx_shadow_mcp_inventory_urls_slug_hash`;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:/nOQMb/d0L2Uotg/wszCSMuh2k+WX8LIfEmOQ1+K5mk=
+h1:TnJ+pN/jcGICgs45Ue/B6gE1G6p0eYrI1Jt74tee4j8=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -56,3 +56,4 @@ h1:/nOQMb/d0L2Uotg/wszCSMuh2k+WX8LIfEmOQ1+K5mk=
 20260713031549_telemetry-logs-staging.up.sql h1:OXRCOTGmSJhLDkRFxOodnXuf1COxVtzglHF9lNvjclk=
 20260713200607_attribute-metrics-tombstone-rollback.up.sql h1:novQH2dH347ntmWv9cKExXgXP9OXhxcsVs7gnnIWFJk=
 20260713204907_staging-attribution-org-id.up.sql h1:MBHfGI2HcHd4OXbPFQI4ORrkotmtTW+v81pypZ2/8KA=
+20260714002937_shadow-mcp-inventory-slug-hash-index.up.sql h1:3sBIskKg2s4QeSrlO8X2vRyQriwhn+WG083ix1m77jM=

--- a/server/clickhouse/migrations/20260714002931_shadow-mcp-inventory-slug-hash-index.sql
+++ b/server/clickhouse/migrations/20260714002931_shadow-mcp-inventory-slug-hash-index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `shadow_mcp_inventory_urls` ADD INDEX `idx_shadow_mcp_inventory_urls_slug_hash` ((substring(lower(hex(SHA256(canonical_server_url))), 1, 8))) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE `shadow_mcp_inventory_urls` MATERIALIZE INDEX `idx_shadow_mcp_inventory_urls_slug_hash`;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:CYc0VjNZhLzprtG5B5wN8ob3WbRpJGOXZuuy2bTBI9s=
+h1:vfPVq3eCWTO/u2rHlNVTvVwF/LMIJ/CwnhLlBxYfDTE=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -63,3 +63,4 @@ h1:CYc0VjNZhLzprtG5B5wN8ob3WbRpJGOXZuuy2bTBI9s=
 20260713031544_telemetry-logs-staging.sql h1:ibENGxmwC3z6XqbovQWCeoSOMQkR55OVIsdy/mcJuCg=
 20260713200247_staging-attribution-org-id.sql h1:Ve6kZtHIOJOeuy/GIsTvy+mcxyaThDKmn+G5oF3QfyA=
 20260713200603_attribute-metrics-tombstone-rollback.sql h1:Ta0W3cE0k5O93hxh6BMYZuRpVfPJGY7drzG3bW/HBqI=
+20260714002931_shadow-mcp-inventory-slug-hash-index.sql h1:ADB3UFfaTz1mFPB48773RbSxvK9BzKhgckcQK6Qpkcs=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -276,6 +276,10 @@ ORDER BY (gram_project_id, canonical_server_url)
 SETTINGS index_granularity = 8192
 COMMENT 'Project-scoped Shadow MCP inventory URLs and display metadata';
 
+CREATE INDEX IF NOT EXISTS idx_shadow_mcp_inventory_urls_slug_hash
+ON shadow_mcp_inventory_urls (substring(lower(hex(SHA256(canonical_server_url))), 1, 8))
+TYPE bloom_filter(0.01) GRANULARITY 1;
+
 CREATE TABLE IF NOT EXISTS metrics_summaries (
     -- Key columns
     gram_project_id UUID,


### PR DESCRIPTION
## What changes

- Adds a ClickHouse bloom-filter index for the Shadow MCP canonical URL slug-hash expression.
- Adds matching production and local migrations, including local rollback support.
- Materializes the index for existing Shadow MCP inventory rows.
- Regenerates both Atlas migration manifests.

## Why

The Shadow MCP server detail lookup filters inventory URLs by the hash suffix used in route slugs. This migration keeps that lookup efficient while isolating all database migration files in their own PR.

## Stack

1. This migration PR
2. #4065 — Shadow MCP server detail page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a ClickHouse bloom-filter index on the Shadow MCP inventory slug hash to speed up server detail lookups. Supports Linear DNO-459 by keeping slug-based URL filtering fast.

- **Migration**
  - Adds and materializes `idx_shadow_mcp_inventory_urls_slug_hash` (8-char SHA256 of `canonical_server_url`) on `shadow_mcp_inventory_urls`.
  - Includes prod and local migrations with rollback; updates `atlas.sum` and `schema.sql`.

<sup>Written for commit 60f038d3c865fc9225b619c6c1022f4e073590f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

