### PR TITLE
fix(dashboard): align model key table actions

### DIFF
--- a/.changeset/align-model-key-table.md
+++ b/.changeset/align-model-key-table.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Improve model provider key table alignment and make disabled keys easier to identify.

--- a/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
@@ -127,16 +127,16 @@ function ModelProviderKeysTable({
     {
       key: "key",
       header: "Key",
-      width: "200px",
+      width: "260px",
       render: (slot) => {
         const key = keysBySlot.get(slot.slot);
         return (
           <Stack direction="horizontal" gap={2} align="center">
             <KeySourceBadge source={keySourceForSlot(slot.slot, keysBySlot)} />
             {key && !key.enabled ? (
-              <Type muted small>
-                Key disabled
-              </Type>
+              <Badge variant="warning" background className="shrink-0">
+                <Badge.Text>Disabled</Badge.Text>
+              </Badge>
             ) : null}
           </Stack>
         );
@@ -145,7 +145,7 @@ function ModelProviderKeysTable({
     {
       key: "updated",
       header: "Updated",
-      width: "140px",
+      width: "170px",
       render: (slot) => {
         const key = keysBySlot.get(slot.slot);
         if (!key) {
@@ -156,7 +156,7 @@ function ModelProviderKeysTable({
           );
         }
         return (
-          <Type muted small>
+          <Type muted small className="whitespace-nowrap">
             <HumanizeDateTime date={key.updatedAt} />
           </Type>
         );
@@ -165,40 +165,45 @@ function ModelProviderKeysTable({
     {
       key: "actions",
       header: "",
-      width: "300px",
+      width: "220px",
       render: (slot) => {
         const key = keysBySlot.get(slot.slot);
         return (
-          <Stack direction="horizontal" gap={2} justify="end">
+          <Stack direction="horizontal" gap={2} align="center" justify="end">
             <Button
               variant="secondary"
               size="sm"
+              className="w-28"
               onClick={() => setDialogSlot(slot)}
               disabled={isMutating || !customModelKeysEnabled}
             >
               {key ? "Replace key" : "Set key"}
             </Button>
-            {key ? (
-              <Switch
-                checked={key.enabled}
-                onCheckedChange={(enabled) => handleSetEnabled(key, enabled)}
-                disabled={
-                  isMutating || (!key.enabled && !customModelKeysEnabled)
-                }
-                aria-label={`${slot.name} key enabled`}
-              />
-            ) : null}
-            {key ? (
-              <Button
-                variant="destructiveGhost"
-                size="sm"
-                onClick={() => handleRemove(slot, key)}
-                disabled={isMutating}
-                aria-label={`Remove ${slot.name} key`}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            ) : null}
+            <div className="flex w-9 shrink-0 justify-center">
+              {key ? (
+                <Switch
+                  checked={key.enabled}
+                  onCheckedChange={(enabled) => handleSetEnabled(key, enabled)}
+                  disabled={
+                    isMutating || (!key.enabled && !customModelKeysEnabled)
+                  }
+                  aria-label={`${slot.name} key enabled`}
+                />
+              ) : null}
+            </div>
+            <div className="flex w-9 shrink-0 justify-center">
+              {key ? (
+                <Button
+                  variant="destructiveGhost"
+                  size="sm"
+                  onClick={() => handleRemove(slot, key)}
+                  disabled={isMutating}
+                  aria-label={`Remove ${slot.name} key`}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              ) : null}
+            </div>
           </Stack>
         );
       },


### PR DESCRIPTION
## Summary

- render disabled model provider keys with a warning badge
- stabilize key, timestamp, and action column widths so controls align across rows
- keep timestamps on one line and reserve consistent space for optional actions

Follow-up to #4182.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the model provider keys table so actions and timestamps line up across rows, and make disabled keys easy to spot with a warning badge. This improves scanability and reduces UI jitter.

- **Bug Fixes**
  - Show a warning "Disabled" `Badge` instead of muted text.
  - Stabilize layout: key column 260px, updated 170px with nowrap, actions 220px with fixed-width slots for switch/delete.
  - Use a fixed-width "Set/Replace key" button to keep actions aligned.

<sup>Written for commit 105cef29bc5d48b252ba8e3e8b7ea0f5992fc2ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

