### PR TITLE
fix(dashboard): clear multi-select announcement timers on unmount

### DIFF
--- a/client/dashboard/src/components/ui/multi-select.tsx
+++ b/client/dashboard/src/components/ui/multi-select.tsx
@@ -356,18 +356,35 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
     const prevIsOpen = React.useRef(isPopoverOpen);
     const prevSearchValue = React.useRef(searchValue);
 
+    const politeTimerRef =
+      React.useRef<ReturnType<typeof setTimeout>>(undefined);
+    const assertiveTimerRef =
+      React.useRef<ReturnType<typeof setTimeout>>(undefined);
+
     const announce = React.useCallback(
       (message: string, priority: "polite" | "assertive" = "polite") => {
         if (priority === "assertive") {
           setAssertiveMessage(message);
-          setTimeout(() => setAssertiveMessage(""), 100);
+          clearTimeout(assertiveTimerRef.current);
+          assertiveTimerRef.current = setTimeout(
+            () => setAssertiveMessage(""),
+            100,
+          );
         } else {
           setPoliteMessage(message);
-          setTimeout(() => setPoliteMessage(""), 100);
+          clearTimeout(politeTimerRef.current);
+          politeTimerRef.current = setTimeout(() => setPoliteMessage(""), 100);
         }
       },
       [],
     );
+
+    React.useEffect(() => {
+      return () => {
+        clearTimeout(politeTimerRef.current);
+        clearTimeout(assertiveTimerRef.current);
+      };
+    }, []);
 
     const multiSelectId = React.useId();
     const listboxId = `${multiSelectId}-listbox`;


### PR DESCRIPTION
## Summary

Fixes a CI test flake in the dashboard test suite ([example failing run](https://github.com/speakeasy-api/gram/actions/runs/29330808899/job/87078096690?pr=4185)) where all tests pass but vitest reports an unhandled error:

```
ReferenceError: window is not defined
 ❯ Timeout._onTimeout src/components/ui/multi-select.tsx:366:28
```

## Cause

`MultiSelect`'s screen-reader `announce` helper scheduled `setTimeout(() => setPoliteMessage(""), 100)` (and the assertive equivalent) without ever clearing the timers. When a test finished within that 100ms window, the timer fired after vitest tore down the jsdom environment, and React's `setState` crashed on the missing `window`. Outside of tests this is the same leak in milder form: a state update on an unmounted component.

## Fix

- Keep the polite/assertive announcement timer IDs in refs.
- Clear any pending timer before scheduling a new one, so rapid announcements no longer truncate each other's clear delay.
- Clear both timers in an unmount cleanup effect.

## Verification

- `pnpm -F dashboard test src/components/ui/multi-select.test.tsx` — passes with no unhandled errors.
- `pnpm -F dashboard type-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unhandled errors in dashboard tests by clearing `MultiSelect` screen reader announcement timers after unmount. Fixes a flaky jsdom “window is not defined” error and stops setState on unmounted components.

- **Bug Fixes**
  - Store polite/assertive timeout IDs in refs.
  - Clear pending timeouts before scheduling new ones.
  - Clean up both timers on unmount.

<sup>Written for commit 1facad15791d5db8075998545b6a0d6fce95398a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

