### PR TITLE
fix(pystreams): keep presidio backlog from starving the scan pool

### DIFF
--- a/infra/gram_infra/pubsub/subscriber.py
+++ b/infra/gram_infra/pubsub/subscriber.py
@@ -46,6 +46,7 @@ import asyncer
 import structlog
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from google.cloud.pubsub_v1.subscriber.scheduler import Scheduler
+from google.cloud.pubsub_v1.types import FlowControl
 from google.protobuf.message import Message
 
 from .broker import SubscriberBroker, SubscriberHandle
@@ -77,12 +78,14 @@ def _unwrap_single(eg: BaseExceptionGroup) -> BaseException:
     return exc
 
 
-# Default ceiling on concurrently-executing handler tasks. The library's own
-# flow control admits up to ~1000 outstanding messages by default; without an
-# app-level cap a backlog of slow handlers would spawn that many concurrent
-# tasks. A modest default keeps fan-out bounded while leaving plenty of
-# parallelism for typical I/O-bound handlers. A value <= 0 disables the bound
-# entirely (handlers limited only by the library's flow control).
+# Default ceiling on concurrently-executing handler tasks. ``receive`` also
+# sizes the client's flow-control window from this bound (2x, one executing
+# generation plus one ready) so it limits in-process *retention*, not just
+# execution: without that coupling the library would still lease up to its own
+# default (~1000) messages into the process, where they'd wait invisible to the
+# broker instead of staying undelivered and redeliverable. A value <= 0
+# disables the bound entirely (handlers and prefetch limited only by the
+# library's default flow control).
 _DEFAULT_MAX_CONCURRENCY = 50
 
 
@@ -323,8 +326,14 @@ class Subscriber[M: Message]:
     @asynccontextmanager
     async def _session(
         self,
+        *,
+        max_outstanding: int | None = None,
     ) -> AsyncGenerator[tuple[_PortalScheduler, Any, MemoryObjectReceiveStream]]:
         """Portal + scheduler + streaming-pull plumbing shared by receive/stream.
+
+        ``max_outstanding`` caps the client's flow-control window — how many
+        leased, un-acked messages the streaming pull holds in this process at
+        once. ``None`` keeps the library default (~1000).
 
         Teardown is fully synchronous (checkpoint-free), so it runs to completion
         even when the surrounding task is being cancelled — the Ctrl-C path needs
@@ -344,6 +353,13 @@ class Subscriber[M: Message]:
                 # The stub types this as ThreadScheduler, but subscribe accepts
                 # any Scheduler subclass (per its own docstring).
                 scheduler=scheduler,  # pyrefly: ignore[bad-argument-type]
+                # Only max_messages is overridden; () is subscribe's own default
+                # sentinel and yields the stock FlowControl.
+                flow_control=(
+                    FlowControl(max_messages=max_outstanding)
+                    if max_outstanding is not None
+                    else ()
+                ),
                 await_callbacks_on_shutdown=True,
             )
             try:
@@ -372,6 +388,15 @@ class Subscriber[M: Message]:
         handlers run at once; ``max_concurrency`` overrides the subscriber's
         default for this call, and a value <= 0 disables the bound.
 
+        The bound governs admission, not just execution: the client's
+        flow-control window is sized to 2x the bound (one executing generation
+        plus one ready), so a backlog past that stays *undelivered at the
+        broker* — visible and immediately redeliverable — rather than leased
+        into this process. The limiter alone couldn't do that: this loop drains
+        the stream and spawns a task per message, so without the window every
+        prefetched message (library default ~1000) would sit here leased and
+        invisible, waiting on the limiter.
+
         A terminal subscription failure (subscription deleted, permission
         revoked, ...) is raised out of this call, mirroring how the Go library's
         ``Receive`` returns the error.
@@ -387,7 +412,9 @@ class Subscriber[M: Message]:
         limiter = anyio.CapacityLimiter(limit) if limit > 0 else None
 
         try:
-            async with self._session() as (scheduler, future, receive_stream):
+            async with self._session(
+                max_outstanding=2 * limit if limit > 0 else None
+            ) as (scheduler, future, receive_stream):
                 with anyio.move_on_after(timeout):  # None => no deadline
                     async with anyio.create_task_group() as tg:
 

--- a/infra/tests/conftest.py
+++ b/infra/tests/conftest.py
@@ -125,9 +125,13 @@ class FakeSubscriberClient:
         # The _PortalScheduler handed to subscribe(); Any because tests poke
         # library-side entry points (schedule/shutdown) on it directly.
         self.scheduler: Any = None
+        # Extra keyword arguments subscribe() received (flow_control, ...), so
+        # tests can assert on the plumbing the Subscriber configures.
+        self.subscribe_kwargs: dict[str, Any] | None = None
 
     def subscribe(self, subscription_path, callback, *, scheduler, **kwargs):
         self.scheduler = scheduler
+        self.subscribe_kwargs = kwargs
 
         def pump() -> None:
             for message in self._messages:

--- a/infra/tests/test_backends.py
+++ b/infra/tests/test_backends.py
@@ -298,6 +298,69 @@ def test_publish_raises_publish_error(backend) -> None:
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
+def test_receive_sizes_flow_control_from_concurrency_bound(backend) -> None:
+    # The concurrency bound must govern admission, not just execution: receive
+    # sizes the client's flow-control window to 2x the bound so a backlog past
+    # it stays undelivered at the broker instead of leased into the process
+    # (the library default admits ~1000).
+    client = FakeSubscriberClient([])
+    subscriber = Subscriber(
+        SubscriberHandle(cast(Any, client), "subscriptions/test"),
+        ping_pb2.Message,
+        logger=structlog.get_logger("gram_infra.test"),
+        topic_proto_name=TOPIC_PROTO,
+        subscription_proto_name=SUB_PROTO,
+    )
+
+    async def callback(message, meta) -> None:
+        return None
+
+    async def scenario() -> None:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(lambda: subscriber.receive(callback, max_concurrency=8))
+            with anyio.fail_after(5):
+                while client.subscribe_kwargs is None:
+                    await anyio.lowlevel.checkpoint()
+            tg.cancel_scope.cancel()
+
+    anyio.run(scenario, backend=backend)
+
+    assert client.subscribe_kwargs is not None
+    assert client.subscribe_kwargs["flow_control"].max_messages == 16
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_receive_keeps_default_flow_control_when_unbounded(backend) -> None:
+    # <=0 disables the app-level bound; the client keeps its stock flow control
+    # rather than a window derived from a non-positive limit.
+    client = FakeSubscriberClient([])
+    subscriber = Subscriber(
+        SubscriberHandle(cast(Any, client), "subscriptions/test"),
+        ping_pb2.Message,
+        logger=structlog.get_logger("gram_infra.test"),
+        topic_proto_name=TOPIC_PROTO,
+        subscription_proto_name=SUB_PROTO,
+    )
+
+    async def callback(message, meta) -> None:
+        return None
+
+    async def scenario() -> None:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(lambda: subscriber.receive(callback, max_concurrency=0))
+            with anyio.fail_after(5):
+                while client.subscribe_kwargs is None:
+                    await anyio.lowlevel.checkpoint()
+            tg.cancel_scope.cancel()
+
+    anyio.run(scenario, backend=backend)
+
+    assert client.subscribe_kwargs is not None
+    # () is subscribe's default sentinel for "stock FlowControl".
+    assert client.subscribe_kwargs["flow_control"] == ()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_receive_acks_messages_on_backend(backend) -> None:
     messages = [
         FakeMessage(ping_pb2.Message(id="one").SerializeToString(), message_id="one"),

--- a/pystreams/src/pystreams/cmd/flags_presidio.py
+++ b/pystreams/src/pystreams/cmd/flags_presidio.py
@@ -1,6 +1,23 @@
+import math
 from collections.abc import Sequence
 
 import click
+
+
+def _finite_float(
+    ctx: click.Context, param: click.Parameter, value: float | None
+) -> float | None:
+    """Reject non-finite timeout values at parse time.
+
+    ``float`` parsing accepts ``nan`` and ``inf``, and NaN fails every
+    comparison — so it would slip past the scanners' ``<= 0`` disable checks
+    and *silently* turn a timeout off, reverting queued scans to unbounded
+    waits. A misconfigured bound should fail loudly here, where the error
+    names the flag; ``<= 0`` remains the one documented way to disable one.
+    """
+    if value is not None and not math.isfinite(value):
+        raise click.BadParameter("must be a finite number (use <=0 to disable)")
+    return value
 
 
 def presidio_options() -> Sequence[click.Option]:
@@ -45,6 +62,7 @@ def presidio_options() -> Sequence[click.Option]:
             ["--scan-timeout"],
             type=float,
             default=300.0,
+            callback=_finite_float,
             envvar="GRAM_PYSTREAMS_SCAN_TIMEOUT",
             help=(
                 "Seconds a single scan may execute before it is treated as a "
@@ -56,6 +74,7 @@ def presidio_options() -> Sequence[click.Option]:
             ["--scan-slot-timeout"],
             type=float,
             default=60.0,
+            callback=_finite_float,
             envvar="GRAM_PYSTREAMS_SCAN_SLOT_TIMEOUT",
             help=(
                 "Seconds a scan may wait for a free pool worker before the "

--- a/pystreams/src/pystreams/cmd/flags_presidio.py
+++ b/pystreams/src/pystreams/cmd/flags_presidio.py
@@ -31,12 +31,14 @@ def presidio_options() -> Sequence[click.Option]:
         click.Option(
             ["--scan-max-tasks-per-child"],
             type=int,
-            default=1000,
+            default=10_000,
             envvar="GRAM_PYSTREAMS_SCAN_MAX_TASKS_PER_CHILD",
             help=(
                 "Recycle a scan-pool worker after this many scans to bound memory "
-                "drift (like gunicorn --max-requests). <=0 disables recycling. "
-                "Only applies when --scan-workers > 0."
+                "drift (like gunicorn --max-requests). Each recycle costs a full "
+                "spaCy model reload on the replacement worker, so size it in "
+                "hours of traffic. <=0 disables recycling. Only applies when "
+                "--scan-workers > 0."
             ),
         ),
         click.Option(
@@ -45,9 +47,34 @@ def presidio_options() -> Sequence[click.Option]:
             default=300.0,
             envvar="GRAM_PYSTREAMS_SCAN_TIMEOUT",
             help=(
-                "Seconds a single scan may run before it is treated as a failure "
-                "(like gunicorn --timeout). <=0 disables the bound. Only applies "
-                "when --scan-workers > 0."
+                "Seconds a single scan may execute before it is treated as a "
+                "failure (like gunicorn --timeout). <=0 disables the bound. Only "
+                "applies when --scan-workers > 0."
+            ),
+        ),
+        click.Option(
+            ["--scan-slot-timeout"],
+            type=float,
+            default=60.0,
+            envvar="GRAM_PYSTREAMS_SCAN_SLOT_TIMEOUT",
+            help=(
+                "Seconds a scan may wait for a free pool worker before the "
+                "message is requeued (nacked for redelivery) instead of burning "
+                "the execution budget on queue wait. <=0 disables the bound. "
+                "Only applies when --scan-workers > 0."
+            ),
+        ),
+        click.Option(
+            ["--max-inflight"],
+            type=int,
+            default=None,
+            envvar="GRAM_PYSTREAMS_MAX_INFLIGHT",
+            help=(
+                "Cap on PresidioAnalysis messages processed concurrently by this "
+                "process. Excess backlog then waits at the broker (visible and "
+                "redeliverable) rather than in-process where it spends the scan "
+                "slot budget. Unset derives from scan capacity (2 handlers per "
+                "scan slot, minimum 4); <=0 disables the cap."
             ),
         ),
     ]

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -62,6 +62,8 @@ async def multi(
     scan_workers: int,
     scan_max_tasks_per_child: int,
     scan_timeout: float,
+    scan_slot_timeout: float,
+    max_inflight: int | None,
 ):
     logging.configure_logging(
         pretty_log=pretty_log,
@@ -125,6 +127,7 @@ async def multi(
                 scan_workers=scan_workers,
                 scan_max_tasks_per_child=scan_max_tasks_per_child,
                 scan_timeout=scan_timeout,
+                scan_slot_timeout=scan_slot_timeout,
                 max_scan_concurrency=max_scan_concurrency,
                 logger=logger,
             )
@@ -163,10 +166,21 @@ async def multi(
                     processor_pb2.PyProcessor,
                     PingHandler(logger, ping_log_level).handle,
                 )
+                # Admit only as many messages as the scan pool can plausibly
+                # serve: 2 handlers per scan slot keeps the pool fed while one
+                # message's findings publish, and everything past the cap waits
+                # at the broker — visible as subscription backlog and
+                # redeliverable — instead of in-process, where 50 handlers
+                # racing 2 workers spent whole slot budgets queued (the
+                # process_duration >> scan_duration gap).
+                if max_inflight is None:
+                    scan_slots = scan_workers if scan_workers > 0 else 2
+                    max_inflight = max(4, 2 * scan_slots)
                 await receivers.receive(
                     presidio_analysis_pb2.PresidioAnalysis,
                     presidio_analyzer_pb2.PresidioAnalyzer,
                     presidio_handler.handle,
+                    max_concurrency=max_inflight,
                 )
 
                 health_state.set_ready()

--- a/pystreams/src/pystreams/cmd/receiver.py
+++ b/pystreams/src/pystreams/cmd/receiver.py
@@ -10,6 +10,7 @@ not repeated at the call site.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import partial
 from typing import TypeVar
 
 import anyio.abc
@@ -36,14 +37,20 @@ class ReceiverGroup:
         message_type: type[M],
         subscription_type: type[Message],
         handler: MessageCallback[M],
+        *,
+        max_concurrency: int | None = None,
     ) -> None:
         """Resolve a subscriber for ``message_type`` and start consuming it.
 
         The handler is wrapped so every delivered message runs inside a
         ``stream.handleMessage`` span tagged with the topic and subscription
-        proto names. Async because resolving the subscriber may reconcile the
-        topic/subscription against the local emulator, which is offloaded off the
-        event loop rather than blocking it.
+        proto names. ``max_concurrency`` caps how many handlers run at once for
+        this subscription (None keeps the subscriber's default; <=0 disables
+        the bound) — size it to the handler's real downstream capacity, since
+        undelivered messages wait at the broker but admitted ones wait
+        in-process. Async because resolving the subscriber may reconcile the
+        topic/subscription against the local emulator, which is offloaded off
+        the event loop rather than blocking it.
         """
         subscriber = await pubsub_subscriber_for_message_async(
             self.broker,
@@ -52,10 +59,13 @@ class ReceiverGroup:
             logger=self.logger,
         )
         self.task_group.start_soon(
-            subscriber.receive,
-            traced(
-                handler,
-                topic_proto_name=message_type.DESCRIPTOR.full_name,
-                subscription_proto_name=subscription_type.DESCRIPTOR.full_name,
-            ),
+            partial(
+                subscriber.receive,
+                traced(
+                    handler,
+                    topic_proto_name=message_type.DESCRIPTOR.full_name,
+                    subscription_proto_name=subscription_type.DESCRIPTOR.full_name,
+                ),
+                max_concurrency=max_concurrency,
+            )
         )

--- a/pystreams/src/pystreams/cmd/receiver.py
+++ b/pystreams/src/pystreams/cmd/receiver.py
@@ -46,9 +46,11 @@ class ReceiverGroup:
         ``stream.handleMessage`` span tagged with the topic and subscription
         proto names. ``max_concurrency`` caps how many handlers run at once for
         this subscription (None keeps the subscriber's default; <=0 disables
-        the bound) — size it to the handler's real downstream capacity, since
-        undelivered messages wait at the broker but admitted ones wait
-        in-process. Async because resolving the subscriber may reconcile the
+        the bound), and also sizes the pubsub client's flow-control window (2x
+        the bound), so backlog past it stays undelivered at the broker rather
+        than leased into this process — size it to the handler's real
+        downstream capacity. Async because resolving the subscriber may
+        reconcile the
         topic/subscription against the local emulator, which is offloaded off
         the event loop rather than blocking it.
         """

--- a/pystreams/src/pystreams/deps/scanner.py
+++ b/pystreams/src/pystreams/deps/scanner.py
@@ -24,6 +24,7 @@ async def build_presidio_scanner(
     scan_workers: int,
     scan_max_tasks_per_child: int,
     scan_timeout: float,
+    scan_slot_timeout: float,
     max_scan_concurrency: int | None,
     logger: structlog.stdlib.BoundLogger,
 ) -> Scanner:
@@ -41,11 +42,13 @@ async def build_presidio_scanner(
             workers=scan_workers,
             max_tasks_per_child=scan_max_tasks_per_child,
             scan_timeout=scan_timeout,
+            scan_slot_timeout=scan_slot_timeout,
         )
         return await ProcessPoolScanner.create(
             max_workers=scan_workers,
             max_tasks_per_child=scan_max_tasks_per_child,
             scan_timeout=scan_timeout,
+            slot_timeout=scan_slot_timeout,
         )
 
     analyzer = await build_default_analyzer()

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -14,7 +14,12 @@ from opentelemetry import trace
 
 from pystreams import attr
 from pystreams.risk import metrics
-from pystreams.risk.scanner import DEFAULT_SCORE_THRESHOLD, Detection, Scanner
+from pystreams.risk.scanner import (
+    DEFAULT_SCORE_THRESHOLD,
+    Detection,
+    Scanner,
+    ScanSlotTimeout,
+)
 
 # Source label stamped on every finding this handler emits, so all findings
 # from the Presidio path are attributed identically downstream.
@@ -94,6 +99,19 @@ class PresidioHandler:
                     message.content, requested, score_threshold
                 )
                 scan_ms = (time.perf_counter() - scan_started) * 1000
+            except ScanSlotTimeout:
+                # The scan never started: the pool was backlogged for the whole
+                # slot budget and the content was never touched. Unlike the
+                # swallowed failures below this is not a property of the
+                # message, so re-raising to nack is safe (nothing scanned,
+                # nothing published — redelivery duplicates no work) and
+                # correct: the subscription's retry policy backs the message
+                # off (10s..600s) and it lands back here once capacity clears,
+                # instead of being silently dropped unscanned. No log line:
+                # backlog requeues fire in bursts, and the ``requeued`` outcome
+                # recorded in the ``finally`` already carries the signal.
+                outcome = metrics.OUTCOME_REQUEUED
+                raise
             except Exception as exc:
                 # This is best-effort shadow processing, and the PresidioAnalyzer
                 # subscription declares no dead-letter policy. Letting a scan

--- a/pystreams/src/pystreams/risk/metrics.py
+++ b/pystreams/src/pystreams/risk/metrics.py
@@ -37,6 +37,10 @@ from opentelemetry import metrics
 OUTCOME_DETECTED: Final = "detected"  # findings were published
 OUTCOME_CLEAN: Final = "clean"  # scan succeeded, nothing detected
 OUTCOME_ERROR: Final = "error"  # scan failed and was swallowed
+# The scan never reached a pool worker within the slot budget; the message was
+# nacked for redelivery. This delivery's wall clock still records (it is real
+# latency), but split out so backlog requeues don't read as scan failures.
+OUTCOME_REQUEUED: Final = "requeued"
 
 _OUTCOME_ATTR: Final = "outcome"
 

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -237,10 +237,14 @@ class ProcessPoolScanner(_AsyncCloseable):
     Everything that touches the executor is bridged through anyio's threading and
     cancellation primitives (``to_thread.run_sync`` + ``fail_after``) rather than
     the asyncio loop directly, so the scanner runs unchanged on either anyio
-    backend (asyncio or trio). The bridge uses a dedicated thread limiter sized to
-    the worker count, so blocking on pool results never draws down anyio's shared
-    default thread pool (used by the publish hop and the in-process scanner) — only
-    ``max_workers`` scans run at once, so that many result-waits is the ceiling.
+    backend (asyncio or trio). The bridge uses two dedicated thread limiters,
+    each sized to the worker count, so blocking on the pool never draws down
+    anyio's shared default thread pool (used by the publish hop and the
+    in-process scanner). Result-waits get one (only ``max_workers`` scans run at
+    once, so that many is the ceiling) and submits get their own: result-wait
+    tokens are held for a whole scan, and a submit queued behind them would
+    stall un-metered — the slot clock only starts once the future exists — so
+    submits must never share their capacity.
     """
 
     def __init__(
@@ -250,14 +254,19 @@ class ProcessPoolScanner(_AsyncCloseable):
         scan_timeout: float | None = 300.0,
         slot_timeout: float | None = 60.0,
         wait_limiter: anyio.CapacityLimiter | None = None,
+        submit_limiter: anyio.CapacityLimiter | None = None,
     ):
         self._executor = executor
         self._scan_timeout = scan_timeout if scan_timeout and scan_timeout > 0 else None
         self._slot_timeout = slot_timeout if slot_timeout and slot_timeout > 0 else None
-        # Dedicated limiter for the result-wait threads (see class docstring). None
-        # falls back to anyio's default limiter — fine for the single-scan tests,
-        # but ``create`` always supplies one for the real, concurrent path.
+        # Dedicated limiters for the result-wait and submit threads (see class
+        # docstring); they must be distinct — sharing one lets result-waits,
+        # which hold a token per running scan, starve submissions and delay the
+        # slot clock. None falls back to anyio's default limiter — fine for the
+        # single-scan tests, but ``create`` always supplies both for the real,
+        # concurrent path.
         self._wait_limiter = wait_limiter
+        self._submit_limiter = submit_limiter
 
     @classmethod
     async def create(
@@ -298,6 +307,7 @@ class ProcessPoolScanner(_AsyncCloseable):
             scan_timeout=scan_timeout,
             slot_timeout=slot_timeout,
             wait_limiter=anyio.CapacityLimiter(max_workers),
+            submit_limiter=anyio.CapacityLimiter(max_workers),
         )
         # One warmup task per worker, run concurrently; each does a real scan and
         # then briefly sleeps so the tasks can't all be served by one worker —
@@ -378,11 +388,16 @@ class ProcessPoolScanner(_AsyncCloseable):
         # ``max_tasks_per_child`` recycles a worker. That spawn is real blocking
         # I/O (hundreds of ms at warmup), so bridge it through a worker thread like
         # the result wait below; the executor is never touched from the loop.
+        # Submits get their own limiter, never the result-waits': those tokens
+        # are held for a running scan's whole duration, and a submit queued
+        # behind them would wait un-metered — the slot deadline can't start
+        # until the future exists. Submit tokens are only ever held for the
+        # brief call itself, so this wait stays small and bounded.
         def submit() -> Future[_T]:
             return self._executor.submit(fn, *args)
 
         return await asyncify(
-            submit, abandon_on_cancel=True, limiter=self._wait_limiter
+            submit, abandon_on_cancel=True, limiter=self._submit_limiter
         )()
 
     async def _await_result(self, future: Future[_T]) -> _T:

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -73,6 +73,18 @@ _FINDING_LEVEL_DROP = frozenset({"US_DRIVER_LICENSE"})
 _T = TypeVar("_T")
 
 
+class ScanSlotTimeout(Exception):
+    """A scan spent its whole slot budget queued, never reaching a pool worker.
+
+    Raised only when the pool future was still pending at the slot deadline and
+    could be cancelled: the content was never scanned, no work was duplicated,
+    so the caller can safely requeue the message (nack for redelivery) instead
+    of burning the much larger execution budget on pure queue wait. A scan that
+    times out *while executing* raises ``TimeoutError`` instead — that signals
+    a pathological input, where a retry would just tie up another worker.
+    """
+
+
 @dataclass(frozen=True)
 class Detection:
     """A real (non-false-positive) PII match found in scanned content.
@@ -195,20 +207,32 @@ class ProcessPoolScanner(_AsyncCloseable):
     false-positive-filtered, byte offsets resolved), which is small and picklable;
     the heavy text and the analyzer never cross the process boundary per message.
 
-    Two lifecycle knobs borrow from gunicorn's pre-fork model (the same shape the
-    official Presidio image uses to scale):
+    Three lifecycle knobs; the first two borrow from gunicorn's pre-fork model
+    (the same shape the official Presidio image uses to scale):
 
     - ``max_tasks_per_child`` recycles a worker after it has run that many scans
       (gunicorn's ``--max-requests``), bounding spaCy/numpy memory drift over a
-      long-lived worker. ``None``/<=0 disables recycling.
-    - ``scan_timeout`` bounds how long a single scan may take before it is treated
-      as a failure (gunicorn's ``--timeout``). The worker cannot be interrupted
-      mid-scan: the timed-out scan keeps running on its worker to completion, but
-      the caller stops waiting and that worker is simply unavailable (not serving
-      other scans) until it finishes, at which point ``max_tasks_per_child`` may
-      recycle it. Meanwhile the other workers keep serving — a single pathological
-      message ties up at most one worker rather than stalling the consumer.
-      ``None``/<=0 disables the bound.
+      long-lived worker. Each recycle costs a full spaCy model load on the
+      replacement worker, so size it in hours of traffic, not minutes.
+      ``None``/<=0 disables recycling.
+    - ``scan_timeout`` bounds how long a single scan may *execute* before it is
+      treated as a failure (gunicorn's ``--timeout``). The worker cannot be
+      interrupted mid-scan: the timed-out scan keeps running on its worker to
+      completion, but the caller stops waiting and that worker is simply
+      unavailable (not serving other scans) until it finishes, at which point
+      ``max_tasks_per_child`` may recycle it. Meanwhile the other workers keep
+      serving — a single pathological message ties up at most one worker rather
+      than stalling the consumer. ``None``/<=0 disables the bound.
+    - ``slot_timeout`` bounds how long a scan may sit *queued* before a worker
+      picks it up. Queue wait and execution are different failure modes: a scan
+      that never started is pure capacity backlog — its content was never
+      touched, so it is safe to hand back for redelivery once the backlog
+      clears — whereas an execution timeout signals a pathological input.
+      Without the split, a backlog deep enough to outlast ``scan_timeout`` made
+      millisecond scans of small payloads "fail" after the full execution
+      budget and get dropped. Past the deadline the still-pending future is
+      cancelled and :class:`ScanSlotTimeout` is raised; the caller decides the
+      requeue. ``None``/<=0 disables the bound.
 
     Everything that touches the executor is bridged through anyio's threading and
     cancellation primitives (``to_thread.run_sync`` + ``fail_after``) rather than
@@ -224,10 +248,12 @@ class ProcessPoolScanner(_AsyncCloseable):
         executor: ProcessPoolExecutor,
         *,
         scan_timeout: float | None = 300.0,
+        slot_timeout: float | None = 60.0,
         wait_limiter: anyio.CapacityLimiter | None = None,
     ):
         self._executor = executor
         self._scan_timeout = scan_timeout if scan_timeout and scan_timeout > 0 else None
+        self._slot_timeout = slot_timeout if slot_timeout and slot_timeout > 0 else None
         # Dedicated limiter for the result-wait threads (see class docstring). None
         # falls back to anyio's default limiter — fine for the single-scan tests,
         # but ``create`` always supplies one for the real, concurrent path.
@@ -238,8 +264,9 @@ class ProcessPoolScanner(_AsyncCloseable):
         cls,
         *,
         max_workers: int = 4,
-        max_tasks_per_child: int | None = 1000,
+        max_tasks_per_child: int | None = 10_000,
         scan_timeout: float | None = 300.0,
+        slot_timeout: float | None = 60.0,
     ) -> ProcessPoolScanner:
         """Build the pool and eagerly warm every worker's analyzer.
 
@@ -269,6 +296,7 @@ class ProcessPoolScanner(_AsyncCloseable):
         scanner = cls(
             executor,
             scan_timeout=scan_timeout,
+            slot_timeout=slot_timeout,
             wait_limiter=anyio.CapacityLimiter(max_workers),
         )
         # One warmup task per worker, run concurrently; each does a real scan and
@@ -289,6 +317,12 @@ class ProcessPoolScanner(_AsyncCloseable):
         self, content: str, entities: list[str] | None, score_threshold: float
     ) -> list[Detection]:
         future = await self._submit(_worker_scan, content, entities, score_threshold)
+        # Queue wait and execution are bounded separately: waiting for a worker
+        # is a capacity signal (raises ScanSlotTimeout, message safely
+        # requeueable), so the execution budget below is spent on execution and
+        # a backlog can't "fail" cheap scans that never ran. Neither timed-out
+        # path records a scan_duration — see record_scan_duration.
+        await self._wait_for_start(future)
         if self._scan_timeout is None:
             detections, scan_seconds = await self._await_result(future)
         else:
@@ -296,17 +330,44 @@ class ProcessPoolScanner(_AsyncCloseable):
                 with anyio.fail_after(self._scan_timeout):
                     detections, scan_seconds = await self._await_result(future)
             except TimeoutError:
-                # Pull it from the executor queue if it hasn't started; a no-op
-                # once a worker has picked it up (the scan can't be interrupted,
-                # but the wait is over and the worker will be recycled per
-                # max_tasks_per_child). A timed-out scan records no scan_duration
-                # — see record_scan_duration.
+                # The scan started (``_wait_for_start`` returned), so this
+                # cancel is a no-op — the scan can't be interrupted, but the
+                # wait is over and the worker will be recycled per
+                # max_tasks_per_child.
                 future.cancel()
                 raise
         metrics.record_scan_duration(
             scan_seconds, metrics.size_bucket_for(len(content))
         )
         return detections
+
+    async def _wait_for_start(self, future: Future[_T]) -> None:
+        """Wait (bounded by ``slot_timeout``) until a worker picks the scan up.
+
+        Polls the future's state instead of parking a worker thread: a queued
+        scan holds no thread and no ``wait_limiter`` slot while it waits, so a
+        deep backlog can't pin the limiter that running scans' result-waits
+        need. Past the deadline the still-pending future is cancelled and
+        :class:`ScanSlotTimeout` raised; if a worker won the race and picked it
+        up just as the deadline fired (``cancel`` fails), the scan proceeds and
+        is bounded by ``scan_timeout`` like any other.
+        """
+        deadline = (
+            None
+            if self._slot_timeout is None
+            else anyio.current_time() + self._slot_timeout
+        )
+        delay = 0.005
+        while not future.running() and not future.done():
+            if deadline is not None and anyio.current_time() >= deadline:
+                if future.cancel():
+                    raise ScanSlotTimeout(
+                        f"scan queued for {self._slot_timeout:g}s without being "
+                        "picked up by a pool worker"
+                    )
+                return
+            await anyio.sleep(delay)
+            delay = min(delay * 2, 0.1)
 
     async def _warm_one(self) -> None:
         await self._await_result(await self._submit(_worker_warm))

--- a/pystreams/tests/test_flags_presidio.py
+++ b/pystreams/tests/test_flags_presidio.py
@@ -1,0 +1,67 @@
+"""Parse-time validation of the presidio timeout flags.
+
+NaN is the dangerous input: ``float("nan")`` parses fine and fails every
+comparison, so without the ``_finite_float`` callback it would slip past the
+scanners' ``<= 0`` disable checks and silently turn a timeout off — reverting
+queued scans to the unbounded waits the slot timeout exists to prevent.
+"""
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from pystreams.cmd.flags_presidio import presidio_options
+
+
+@pytest.fixture
+def parse():
+    """Parse argv/env through a command carrying only the presidio options.
+
+    Returns the parsed params dict on success; raises ``UsageError`` (via
+    ``standalone_mode=False``) so tests assert on the failure directly instead
+    of on exit codes.
+    """
+
+    def _parse(args: list[str], env: dict[str, str] | None = None) -> dict:
+        captured: dict = {}
+
+        def _record(**kwargs) -> None:
+            captured.update(kwargs)
+
+        command = click.Command(
+            "probe", params=list(presidio_options()), callback=_record
+        )
+        CliRunner().invoke(
+            command, args, env=env, standalone_mode=False, catch_exceptions=False
+        )
+        return captured
+
+    return _parse
+
+
+@pytest.mark.parametrize("flag", ["--scan-timeout", "--scan-slot-timeout"])
+@pytest.mark.parametrize("bad", ["nan", "inf", "-inf"])
+def test_non_finite_timeouts_are_rejected_at_parse(parse, flag, bad):
+    with pytest.raises(click.UsageError, match="finite"):
+        parse([flag, bad])
+
+
+def test_non_finite_timeout_from_env_is_rejected(parse):
+    # The env var path goes through the same conversion + callback as the flag.
+    with pytest.raises(click.UsageError, match="finite"):
+        parse([], env={"GRAM_PYSTREAMS_SCAN_SLOT_TIMEOUT": "nan"})
+
+
+def test_zero_still_means_disabled(parse):
+    # <=0 is the documented disable switch and must keep parsing cleanly.
+    params = parse(["--scan-timeout", "0", "--scan-slot-timeout", "-1"])
+
+    assert params["scan_timeout"] == 0.0
+    assert params["scan_slot_timeout"] == -1.0
+
+
+def test_finite_timeouts_pass_through(parse):
+    params = parse(["--scan-timeout", "120.5", "--scan-slot-timeout", "30"])
+
+    assert params["scan_timeout"] == 120.5
+    assert params["scan_slot_timeout"] == 30.0

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -10,7 +10,12 @@ from structlog.testing import capture_logs
 from pystreams.risk import handler as handler_mod
 from pystreams.risk import metrics
 from pystreams.risk.handler import PresidioHandler
-from pystreams.risk.scanner import DEFAULT_SCORE_THRESHOLD, Detection, _AsyncCloseable
+from pystreams.risk.scanner import (
+    DEFAULT_SCORE_THRESHOLD,
+    Detection,
+    ScanSlotTimeout,
+    _AsyncCloseable,
+)
 
 # Matches the RFC3339 UTC form the handler stamps on a finding's created_at.
 _RFC3339_UTC = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
@@ -274,6 +279,40 @@ async def test_scan_failure_is_swallowed_and_logged():
     # carried it.
     assert secret not in repr(entry)
     assert "123-45-6789" not in repr(entry)
+
+
+async def test_slot_timeout_is_reraised_for_redelivery():
+    scanner = FakeScanner(error=ScanSlotTimeout("scan queued for 60s"))
+    publisher = FakePublisher()
+    handler = _handler(scanner, publisher)
+    msg = _message("my ssn is 123-45-6789", request_id="req-1")
+
+    # A slot timeout means the content was never scanned: unlike other scan
+    # failures it must propagate, so the message nacks and Pub/Sub redelivers
+    # it (with the subscription's retry backoff) once capacity clears, instead
+    # of being acked away unscanned.
+    with capture_logs() as logs, pytest.raises(ScanSlotTimeout):
+        await handler.handle(msg, _meta(delivery_attempt=4))
+
+    # Nothing was scanned, so nothing is published — redelivery duplicates no
+    # findings.
+    assert publisher.published == []
+    # Deliberately silent: requeues fire in bursts under backlog, and the
+    # ``requeued`` outcome on process_duration already carries the signal, so
+    # the handler emits no per-message log line (it must not be mislabeled as
+    # a "presidio scan failed" swallow either).
+    assert logs == []
+
+
+async def test_slot_timeout_records_requeued_outcome(recorded_durations):
+    handler = _handler(FakeScanner(error=ScanSlotTimeout("scan queued for 60s")))
+
+    with pytest.raises(ScanSlotTimeout):
+        await handler.handle(_message("a@b.com", request_id="req-1"), _meta())
+
+    (seconds, outcome, _) = recorded_durations[-1]
+    assert outcome == metrics.OUTCOME_REQUEUED
+    assert seconds >= 0.0
 
 
 class _BoomResult:

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -312,6 +312,59 @@ async def test_pool_scan_execution_times_out_via_anyio_deadline():
     assert not future.cancelled()
 
 
+class _FirstRunningExecutor:
+    """Executor stand-in where only the first future starts; the rest queue.
+
+    Models a saturated pool: the first scan is picked up by "the worker" and
+    never completes, while every later submission stays pending forever.
+    """
+
+    def __init__(self):
+        self.submitted: list[Future] = []
+
+    def submit(self, fn, *args):
+        future: Future = Future()
+        if not self.submitted:
+            future.set_running_or_notify_cancel()
+        self.submitted.append(future)
+        return future
+
+
+async def test_submit_is_not_starved_by_result_waits():
+    # Regression: submits must not share the result-wait limiter. A result-wait
+    # holds its token for the whole running scan, so a shared limiter would
+    # block a new message inside _submit — before the slot deadline even starts
+    # — until an earlier scan finished, exactly the unbounded wait the slot
+    # timeout exists to prevent.
+    executor = _FirstRunningExecutor()
+    wait_limiter = anyio.CapacityLimiter(1)
+    scanner = ProcessPoolScanner(
+        cast(ProcessPoolExecutor, executor),
+        scan_timeout=None,
+        slot_timeout=0.1,
+        wait_limiter=wait_limiter,
+    )
+
+    async with anyio.create_task_group() as tg:
+        # The first scan runs forever, parking a result-wait thread that holds
+        # the only wait_limiter token.
+        tg.start_soon(scanner.scan, "first", None, 0.75)
+        # Poll, not an Event: the awaited condition is a worker *thread*
+        # borrowing the limiter token inside the scanner, which exposes no
+        # hook to signal from.
+        while wait_limiter.statistics().borrowed_tokens == 0:  # noqa: ASYNC110
+            await anyio.sleep(0.01)
+
+        # The second scan must still submit immediately and requeue at its slot
+        # deadline; under a shared limiter it would hang here past fail_after.
+        with anyio.fail_after(2):
+            with pytest.raises(ScanSlotTimeout):
+                await scanner.scan("second", None, 0.75)
+
+        assert len(executor.submitted) == 2
+        tg.cancel_scope.cancel()
+
+
 async def test_pool_scan_slot_deadline_defers_to_execution_bound_once_started():
     executor = _RunningStuckExecutor()
     scanner = ProcessPoolScanner(

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -11,6 +11,7 @@ from pystreams.risk.scanner import (
     Detection,
     ProcessPoolScanner,
     Recognized,
+    ScanSlotTimeout,
     ThreadScanner,
     _AsyncCloseable,
 )
@@ -228,11 +229,11 @@ async def test_context_manager_exit_closes_scanner():
 
 
 class _StuckExecutor:
-    """Executor stand-in whose submitted futures never complete.
+    """Executor stand-in whose futures are never picked up by a worker.
 
-    Lets the ProcessPoolScanner timeout path be tested without spawning real
-    worker processes or loading the spaCy model: ``scan`` submits, then waits on a
-    future that is never resolved, so the anyio ``fail_after`` deadline must fire.
+    Lets the ProcessPoolScanner slot-timeout path be tested without spawning
+    real worker processes or loading the spaCy model: ``scan`` submits a future
+    that stays pending forever, so the slot deadline must fire.
     """
 
     def __init__(self):
@@ -240,6 +241,24 @@ class _StuckExecutor:
 
     def submit(self, fn, *args):
         future: Future = Future()
+        self.submitted.append(future)
+        return future
+
+
+class _RunningStuckExecutor:
+    """Executor stand-in whose futures start executing but never complete.
+
+    The future is marked running at submit, standing in for a worker that
+    picked the scan up and wedged: the slot wait passes instantly and the
+    execution deadline (``scan_timeout``) must fire.
+    """
+
+    def __init__(self):
+        self.submitted: list[Future] = []
+
+    def submit(self, fn, *args):
+        future: Future = Future()
+        future.set_running_or_notify_cancel()
         self.submitted.append(future)
         return future
 
@@ -260,18 +279,49 @@ class _ImmediateExecutor:
         return future
 
 
-async def test_pool_scan_times_out_via_anyio_deadline():
+async def test_pool_scan_slot_timeout_raises_when_never_picked_up():
     executor = _StuckExecutor()
-    scanner = ProcessPoolScanner(cast(ProcessPoolExecutor, executor), scan_timeout=0.05)
+    scanner = ProcessPoolScanner(
+        cast(ProcessPoolExecutor, executor), scan_timeout=None, slot_timeout=0.05
+    )
 
-    # The scan never completes, so the anyio fail_after deadline must raise.
+    # No worker ever picks the scan up, so the slot deadline raises the
+    # requeueable ScanSlotTimeout — not the execution TimeoutError.
+    with pytest.raises(ScanSlotTimeout):
+        await scanner.scan("anything", None, 0.75)
+
+    # The still-queued scan is pulled from the executor queue rather than left
+    # to run with nobody awaiting it.
+    (future,) = executor.submitted
+    assert future.cancelled()
+
+
+async def test_pool_scan_execution_times_out_via_anyio_deadline():
+    executor = _RunningStuckExecutor()
+    scanner = ProcessPoolScanner(
+        cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=None
+    )
+
+    # A worker picked the scan up (slot wait passes) but it never completes, so
+    # the execution deadline must raise plain TimeoutError.
     with pytest.raises(TimeoutError):
         await scanner.scan("anything", None, 0.75)
 
-    # On timeout the future is cancelled, so a still-queued scan is pulled rather
-    # than left to run with nobody awaiting it (and the abandoned wait unblocks).
+    # A running scan cannot be interrupted; the cancel attempt is a no-op.
     (future,) = executor.submitted
-    assert future.cancelled()
+    assert not future.cancelled()
+
+
+async def test_pool_scan_slot_deadline_defers_to_execution_bound_once_started():
+    executor = _RunningStuckExecutor()
+    scanner = ProcessPoolScanner(
+        cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=0.05
+    )
+
+    # The scan started, so even with a slot bound configured the failure is the
+    # execution timeout — slot expiry never misclassifies a running scan.
+    with pytest.raises(TimeoutError):
+        await scanner.scan("anything", None, 0.75)
 
 
 async def test_pool_scan_without_timeout_returns_result():
@@ -336,12 +386,28 @@ async def test_pool_scan_records_worker_reported_duration(recorded_scan_duration
 
 
 async def test_pool_scan_timeout_records_no_duration(recorded_scan_durations):
-    executor = _StuckExecutor()
-    scanner = ProcessPoolScanner(cast(ProcessPoolExecutor, executor), scan_timeout=0.05)
+    executor = _RunningStuckExecutor()
+    scanner = ProcessPoolScanner(
+        cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=None
+    )
 
     # A timed-out scan reports nothing: scan_duration stays a clean read of what
     # completed scans cost.
     with pytest.raises(TimeoutError):
+        await scanner.scan("anything", None, 0.75)
+
+    assert recorded_scan_durations == []
+
+
+async def test_pool_scan_slot_timeout_records_no_duration(recorded_scan_durations):
+    scanner = ProcessPoolScanner(
+        cast(ProcessPoolExecutor, _StuckExecutor()),
+        scan_timeout=None,
+        slot_timeout=0.05,
+    )
+
+    # A scan that never ran has no execution cost to report either.
+    with pytest.raises(ScanSlotTimeout):
         await scanner.scan("anything", None, 0.75)
 
     assert recorded_scan_durations == []

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -245,16 +245,38 @@ class _StuckExecutor:
         return future
 
 
-class _RunningStuckExecutor:
+class _StuckRunningBase:
+    """Base for executor fakes whose futures start running but never resolve.
+
+    A context manager by necessity, not convenience: a running future can't be
+    cancelled, so a timed-out scan's abandoned result-wait thread stays parked
+    in ``future.result()``. anyio worker threads are non-daemon, and one that
+    never finishes blocks interpreter shutdown — pytest prints its summary and
+    then hangs forever. Leaving the ``with`` block resolves every still-pending
+    future so those threads can exit. (The real executor resolves its futures
+    on shutdown/kill, so production teardown has no equivalent leak; it is
+    purely a property of these fakes.)
+    """
+
+    def __init__(self):
+        self.submitted: list[Future] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        for future in self.submitted:
+            if not future.done():
+                future.set_result(([], 0.0))
+
+
+class _RunningStuckExecutor(_StuckRunningBase):
     """Executor stand-in whose futures start executing but never complete.
 
     The future is marked running at submit, standing in for a worker that
     picked the scan up and wedged: the slot wait passes instantly and the
     execution deadline (``scan_timeout``) must fire.
     """
-
-    def __init__(self):
-        self.submitted: list[Future] = []
 
     def submit(self, fn, *args):
         future: Future = Future()
@@ -297,30 +319,27 @@ async def test_pool_scan_slot_timeout_raises_when_never_picked_up():
 
 
 async def test_pool_scan_execution_times_out_via_anyio_deadline():
-    executor = _RunningStuckExecutor()
-    scanner = ProcessPoolScanner(
-        cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=None
-    )
+    with _RunningStuckExecutor() as executor:
+        scanner = ProcessPoolScanner(
+            cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=None
+        )
 
-    # A worker picked the scan up (slot wait passes) but it never completes, so
-    # the execution deadline must raise plain TimeoutError.
-    with pytest.raises(TimeoutError):
-        await scanner.scan("anything", None, 0.75)
+        # A worker picked the scan up (slot wait passes) but it never
+        # completes, so the execution deadline must raise plain TimeoutError.
+        with pytest.raises(TimeoutError):
+            await scanner.scan("anything", None, 0.75)
 
-    # A running scan cannot be interrupted; the cancel attempt is a no-op.
-    (future,) = executor.submitted
-    assert not future.cancelled()
+        # A running scan cannot be interrupted; the cancel attempt is a no-op.
+        (future,) = executor.submitted
+        assert not future.cancelled()
 
 
-class _FirstRunningExecutor:
+class _FirstRunningExecutor(_StuckRunningBase):
     """Executor stand-in where only the first future starts; the rest queue.
 
     Models a saturated pool: the first scan is picked up by "the worker" and
     never completes, while every later submission stays pending forever.
     """
-
-    def __init__(self):
-        self.submitted: list[Future] = []
 
     def submit(self, fn, *args):
         future: Future = Future()
@@ -336,45 +355,47 @@ async def test_submit_is_not_starved_by_result_waits():
     # block a new message inside _submit — before the slot deadline even starts
     # — until an earlier scan finished, exactly the unbounded wait the slot
     # timeout exists to prevent.
-    executor = _FirstRunningExecutor()
     wait_limiter = anyio.CapacityLimiter(1)
-    scanner = ProcessPoolScanner(
-        cast(ProcessPoolExecutor, executor),
-        scan_timeout=None,
-        slot_timeout=0.1,
-        wait_limiter=wait_limiter,
-    )
+    with _FirstRunningExecutor() as executor:
+        scanner = ProcessPoolScanner(
+            cast(ProcessPoolExecutor, executor),
+            scan_timeout=None,
+            slot_timeout=0.1,
+            wait_limiter=wait_limiter,
+        )
 
-    async with anyio.create_task_group() as tg:
-        # The first scan runs forever, parking a result-wait thread that holds
-        # the only wait_limiter token.
-        tg.start_soon(scanner.scan, "first", None, 0.75)
-        # Poll, not an Event: the awaited condition is a worker *thread*
-        # borrowing the limiter token inside the scanner, which exposes no
-        # hook to signal from.
-        while wait_limiter.statistics().borrowed_tokens == 0:  # noqa: ASYNC110
-            await anyio.sleep(0.01)
+        async with anyio.create_task_group() as tg:
+            # The first scan runs forever, parking a result-wait thread that
+            # holds the only wait_limiter token.
+            tg.start_soon(scanner.scan, "first", None, 0.75)
+            # Poll, not an Event: the awaited condition is a worker *thread*
+            # borrowing the limiter token inside the scanner, which exposes no
+            # hook to signal from.
+            while wait_limiter.statistics().borrowed_tokens == 0:  # noqa: ASYNC110
+                await anyio.sleep(0.01)
 
-        # The second scan must still submit immediately and requeue at its slot
-        # deadline; under a shared limiter it would hang here past fail_after.
-        with anyio.fail_after(2):
-            with pytest.raises(ScanSlotTimeout):
-                await scanner.scan("second", None, 0.75)
+            # The second scan must still submit immediately and requeue at its
+            # slot deadline; under a shared limiter it would hang here past
+            # fail_after.
+            with anyio.fail_after(2):
+                with pytest.raises(ScanSlotTimeout):
+                    await scanner.scan("second", None, 0.75)
 
-        assert len(executor.submitted) == 2
-        tg.cancel_scope.cancel()
+            assert len(executor.submitted) == 2
+            tg.cancel_scope.cancel()
 
 
 async def test_pool_scan_slot_deadline_defers_to_execution_bound_once_started():
-    executor = _RunningStuckExecutor()
-    scanner = ProcessPoolScanner(
-        cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=0.05
-    )
+    with _RunningStuckExecutor() as executor:
+        scanner = ProcessPoolScanner(
+            cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=0.05
+        )
 
-    # The scan started, so even with a slot bound configured the failure is the
-    # execution timeout — slot expiry never misclassifies a running scan.
-    with pytest.raises(TimeoutError):
-        await scanner.scan("anything", None, 0.75)
+        # The scan started, so even with a slot bound configured the failure is
+        # the execution timeout — slot expiry never misclassifies a running
+        # scan.
+        with pytest.raises(TimeoutError):
+            await scanner.scan("anything", None, 0.75)
 
 
 async def test_pool_scan_without_timeout_returns_result():
@@ -439,17 +460,17 @@ async def test_pool_scan_records_worker_reported_duration(recorded_scan_duration
 
 
 async def test_pool_scan_timeout_records_no_duration(recorded_scan_durations):
-    executor = _RunningStuckExecutor()
-    scanner = ProcessPoolScanner(
-        cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=None
-    )
+    with _RunningStuckExecutor() as executor:
+        scanner = ProcessPoolScanner(
+            cast(ProcessPoolExecutor, executor), scan_timeout=0.05, slot_timeout=None
+        )
 
-    # A timed-out scan reports nothing: scan_duration stays a clean read of what
-    # completed scans cost.
-    with pytest.raises(TimeoutError):
-        await scanner.scan("anything", None, 0.75)
+        # A timed-out scan reports nothing: scan_duration stays a clean read of
+        # what completed scans cost.
+        with pytest.raises(TimeoutError):
+            await scanner.scan("anything", None, 0.75)
 
-    assert recorded_scan_durations == []
+        assert recorded_scan_durations == []
 
 
 async def test_pool_scan_slot_timeout_records_no_duration(recorded_scan_durations):


### PR DESCRIPTION
Fixes AIS-307

## Why

The Presidio consumer's end-to-end `process_duration` metric runs orders of magnitude above `scan_duration`: the subscriber admits many more concurrent messages (default 50 per pod) than the scan pool has workers, so bursty fan-out traffic (one request publishing many `PresidioAnalysis` messages) piles queue wait onto every message. Worse, the single `scan_timeout` covered queue wait _and_ execution, so under a deep enough backlog even small payloads whose scans cost milliseconds could burn the whole timeout without ever reaching a worker — and were then acked away unscanned.

Two amplifiers: the low `max_tasks_per_child` default forced a full spaCy model reload every few minutes of traffic per worker, and each timed-out wait left an abandoned thread pinning a `wait_limiter` slot.

## What

- **Cap in-flight messages near scan capacity.** `ReceiverGroup.receive` now takes `max_concurrency`; the Presidio receiver caps at `--max-inflight` (env `GRAM_PYSTREAMS_MAX_INFLIGHT`), deriving `max(4, 2 x scan workers)` when unset. The bound governs admission, not just execution: `gram_infra`'s subscriber sizes the pubsub client's flow-control window to 2x the bound (one generation executing, one ready), so backlog past it stays undelivered at the broker — visible and redeliverable — instead of leased into the process (the library default admits ~1000).
- **Split queue wait from execution timeout.** New `--scan-slot-timeout` (default 60s) bounds how long a scan may sit queued. A scan that never reached a worker raises `ScanSlotTimeout`, which the handler re-raises: the message nacks and redelivers with the subscription's existing retry backoff, recorded as a new `requeued` outcome on `process_duration` (no log line — the metric is the signal). Execution keeps the existing `scan_timeout` and the swallow-and-ack poison protection. The slot wait polls future state instead of parking a thread, so queued scans no longer pin `wait_limiter` slots — and pool submits get their own thread limiter, so result-waits holding tokens for a running scan's whole duration can't stall a submission before its slot clock starts.
- **Recycle workers 10x less often.** `--scan-max-tasks-per-child` default 1000 -> 10,000, so the per-worker model reload happens on the scale of hours of traffic rather than minutes.
- **Fail loudly on non-finite timeouts.** `--scan-timeout`/`--scan-slot-timeout` reject `nan`/`inf` at flag parse: NaN fails every comparison, so it would slip past the `<=0` disable checks and silently turn a bound off. `<=0` remains the documented disable switch.

## Notes for reviewers

- Requeue-on-slot-timeout is safe without a DLQ: the condition is capacity, not a poison message, so redelivery clears once the backlog drains; nothing was scanned or published, so no duplicated findings.
- No deploy config changes required — the new flags derive sensible values from the configured worker count.
- After deploy, `process_duration` split by `outcome` should show the timeout-driven `error` tail collapse into `requeued` samples capped near the slot budget, and subscription backlog metrics become the honest queue-depth signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Presidio backlog from starving the scan pool by capping leased messages based on scan capacity and separating queue wait from execution, so overflow stays at the broker and timed‑out waits are requeued instead of dropped.

- **Bug Fixes**
  - Admission bound governs leasing: receiver now takes `max_concurrency`; Presidio uses `--max-inflight` (env `GRAM_PYSTREAMS_MAX_INFLIGHT`), default `max(4, 2× scan workers)`. The Pub/Sub client’s flow-control window is sized to `2×` that bound so only that many messages are leased; excess stays at the broker. `<=0` keeps the library’s default.
  - Split timeouts: new `--scan-slot-timeout` (env `GRAM_PYSTREAMS_SCAN_SLOT_TIMEOUT`) bounds queue wait and raises `ScanSlotTimeout` to nack/redeliver; `--scan-timeout` still covers execution. Records `requeued` outcome in `process_duration`.
  - Start slot timers promptly: pool submits use a dedicated thread limiter so they aren’t blocked by result waits; queued scans poll future state and don’t pin the wait limiter.
  - Reject non‑finite timeouts: `--scan-timeout` and `--scan-slot-timeout` fail on `NaN`/`±inf` at parse time; `<=0` remains the disable switch.
  - Fewer worker reloads: default `--scan-max-tasks-per-child` raised to `10_000` to cut spaCy reload churn.
  - Test stability: resolve stuck executor fakes so pytest can exit cleanly (no runtime impact).

- **Migration**
  - No action needed. Defaults derive from configured scan workers.

<sup>Written for commit 331390cad923d6adf0f3eddfbd693bf5dc87b4bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

