### PR TITLE
chore: enforce clickhouse memory cap in server config, not cgroups

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -99,8 +99,6 @@ services:
       CLICKHOUSE_USER: gram
       CLICKHOUSE_PASSWORD: gram
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-    mem_limit: 2g
-    memswap_limit: 2g
     volumes:
       - clickhouse_data:/var/lib/clickhouse
     ulimits:

--- a/local/clickhouse/config.d/limits.xml
+++ b/local/clickhouse/config.d/limits.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0"?>
 <!-- Server-level limits for low-memory development -->
 <clickhouse>
-    <!-- Hard total server memory cap (bytes) -->
-    <max_server_memory_usage>0</max_server_memory_usage> <!-- 0 = auto (90% of container RAM) -->
+    <!-- Hard total server memory cap (bytes). Set explicitly rather than relying on the
+         auto ratio (90% of visible RAM) or a compose cgroup limit: cgroup limits are not
+         enforced in every environment, in which case ClickHouse sees the whole host's RAM. -->
+    <max_server_memory_usage>2147483648</max_server_memory_usage> <!-- 2 GiB -->
 
     <!-- Reduce cache sizes relative to available RAM -->
     <cache_size_to_ram_max_ratio>0.20</cache_size_to_ram_max_ratio>


### PR DESCRIPTION
## Summary

Moves the local ClickHouse memory cap from a Docker cgroup limit (`mem_limit: 2g` in `compose.yml`) into ClickHouse's own server config (`max_server_memory_usage: 2 GiB` in `local/clickhouse/config.d/limits.xml`).

## Why

The compose `mem_limit` relies on the cgroup memory controller, which is not available in every environment we run the dev stack in. #4166 hit this on the Cursor Cloud VM: the cgroup can't delegate the memory controller, so bringing up infra required a local, untracked `compose.override.yaml` just to clear ClickHouse's `mem_limit`.

Worse, when the cgroup limit is absent, ClickHouse's previous auto cap (`max_server_memory_usage = 0`, i.e. 90% of visible RAM) is computed against the whole host — so ClickHouse was effectively unbounded exactly in the environments where the container limit didn't apply.

An explicit `max_server_memory_usage` is enforced by ClickHouse itself and behaves identically everywhere, with no per-environment compose overrides needed.

## Testing

- Rebuilt and recreated the container; `system.server_settings` reports `max_server_memory_usage = 2147483648`.
- `docker inspect` confirms no container memory limit remains (`Memory: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce the ClickHouse memory cap in the server config instead of Docker cgroups. Sets `max_server_memory_usage` to 2 GiB and removes `mem_limit`/`memswap_limit` so memory is consistently bounded even when cgroups aren’t enforced.

- **Migration**
  - Recreate the ClickHouse container to apply the new config (e.g., docker compose up -d --force-recreate clickhouse).

<sup>Written for commit a77803acc72396457591a575fef4bec759a04cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

