### PR TITLE
chore: activate mise in bash/zsh during agent-mode onboarding

### DIFF
--- a/zero
+++ b/zero
@@ -95,9 +95,10 @@ if $agent_mode && ! command -v mise &> /dev/null; then
         echo "✅ Added mise activation in $bashrc"
     fi
 
-    zshrc="${ZDOTDIR-$HOME}/.zshrc"
+    # :- so a set-but-empty ZDOTDIR falls back to HOME too
+    zshrc="${ZDOTDIR:-$HOME}/.zshrc"
     if [ ! -f "$zshrc" ] || ! grep -Eq '^[^#]*mise activate zsh' "$zshrc"; then
-        mkdir -p "${ZDOTDIR-$HOME}"
+        mkdir -p "${ZDOTDIR:-$HOME}"
         echo "eval \"\$($mise_bin activate zsh)\"" >> "$zshrc"
         echo "✅ Added mise activation in $zshrc"
     fi

--- a/zero
+++ b/zero
@@ -82,10 +82,32 @@ if $agent_mode && ! command -v mise &> /dev/null; then
     curl -fsSL https://mise.run | sh
     export PATH="$HOME/.local/bin:$PATH"
     mise trust
+
+    mise_bin="$HOME/.local/bin/mise"
+
+    bashrc="$HOME/.bashrc"
+    if [ ! -f "$bashrc" ] || ! grep -qF "mise activate bash" "$bashrc"; then
+        echo "eval \"\$($mise_bin activate bash)\"" >> "$bashrc"
+        echo "✅ Added mise activation in $bashrc"
+    fi
+
+    zshrc="${ZDOTDIR-$HOME}/.zshrc"
+    if [ ! -f "$zshrc" ] || ! grep -qF "mise activate zsh" "$zshrc"; then
+        echo "eval \"\$($mise_bin activate zsh)\"" >> "$zshrc"
+        echo "✅ Added mise activation in $zshrc"
+    fi
+
+    # mise activate exports MISE_SHELL; if it's unset, the current shell
+    # hasn't been activated yet.
+    if [ -z "${MISE_SHELL:-}" ]; then
+        echo "ℹ️ To take effect in your current shell, run:"
+        echo "   eval \"\$($mise_bin activate bash)\"   # bash"
+        echo "   eval \"\$($mise_bin activate zsh)\"    # zsh"
+    fi
 else
     check_command "mise" "
     Install it from here: https://mise.jdx.dev/
-    - Make sure to update your .zprofile (zsh), .profile (bash), ...
+    - Make sure to update your .zshrc (zsh), .bashrc (bash), ...
     - Additionaly enable completions for better DX: https://mise.jdx.dev/installing-mise.html#autocompletion
     "
 fi

--- a/zero
+++ b/zero
@@ -83,16 +83,21 @@ if $agent_mode && ! command -v mise &> /dev/null; then
     export PATH="$HOME/.local/bin:$PATH"
     mise trust
 
-    mise_bin="$HOME/.local/bin/mise"
+    # printf %q shell-quotes the path (valid in bash and zsh) so the rc
+    # entry survives a $HOME containing spaces.
+    mise_bin=$(printf '%q' "$HOME/.local/bin/mise")
 
+    # The grep only matches uncommented activation lines, so a
+    # commented-out one doesn't suppress installing a working one.
     bashrc="$HOME/.bashrc"
-    if [ ! -f "$bashrc" ] || ! grep -qF "mise activate bash" "$bashrc"; then
+    if [ ! -f "$bashrc" ] || ! grep -Eq '^[^#]*mise activate bash' "$bashrc"; then
         echo "eval \"\$($mise_bin activate bash)\"" >> "$bashrc"
         echo "✅ Added mise activation in $bashrc"
     fi
 
     zshrc="${ZDOTDIR-$HOME}/.zshrc"
-    if [ ! -f "$zshrc" ] || ! grep -qF "mise activate zsh" "$zshrc"; then
+    if [ ! -f "$zshrc" ] || ! grep -Eq '^[^#]*mise activate zsh' "$zshrc"; then
+        mkdir -p "${ZDOTDIR-$HOME}"
         echo "eval \"\$($mise_bin activate zsh)\"" >> "$zshrc"
         echo "✅ Added mise activation in $zshrc"
     fi


### PR DESCRIPTION
## Summary

Makes onboarding for sandboxed coding agents more seamless. When `./zero --agent` installs mise into a fresh sandbox, the binary landed in `~/.local/bin` but no shell was ever hooked up, so agents had to figure out how to use mise correctly (activation, PATH shims, env loading) before any `mise` task would work. Now the script sets that up for them.

## Changes

- After the agent-mode mise install, append `eval "$(mise activate ...)"` to `~/.bashrc` and `${ZDOTDIR-$HOME}/.zshrc` — idempotently, guarded by a `grep` so re-running `./zero --agent` never duplicates the lines (missing rc files are created).
- Print copy-pasteable activation commands for the current shell, gated on `MISE_SHELL` being unset so the hint only appears when the running shell hasn't already been activated.
- Non-agent (interactive) onboarding path is unchanged.

## Testing

- `bash -n zero` passes.
- Verified the append logic in a sandbox `$HOME`: first run writes the expanded activation line, second run is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically activates `mise` for agent sandboxes so tasks work right after running `./zero --agent`. Non-agent onboarding is unchanged.

- **New Features**
  - Idempotently add `eval "$($HOME/.local/bin/mise activate bash|zsh)"` to `~/.bashrc` and `${ZDOTDIR:-$HOME}/.zshrc`, with hardening: shell-quote the path to handle spaces, ignore commented lines, create missing rc files/dirs, and treat empty `ZDOTDIR` as unset.
  - When `MISE_SHELL` is unset, print copy‑paste activation commands for the current shell; update help text to reference `.zshrc`/`.bashrc`.

<sup>Written for commit 4aa00fa1bc200b1f7a1240cffbe5dc9e253a17da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

