### PR TITLE
mig: reject environment_id on remote MCP servers

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -42683,7 +42683,7 @@ components:
       properties:
         environment_id:
           type: string
-          description: The ID of the environment to associate with the server
+          description: 'The ID of the environment to associate with the server. Not supported for remote MCP servers: the request is rejected when this is set alongside remote_mcp_server_id.'
           format: uuid
         name:
           type: string
@@ -56093,7 +56093,7 @@ components:
       properties:
         environment_id:
           type: string
-          description: The ID of the environment to associate with the server
+          description: 'The ID of the environment to associate with the server. Not supported for remote MCP servers: the request is rejected when this is set alongside remote_mcp_server_id.'
           format: uuid
         id:
           type: string

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -259,10 +259,14 @@ export function MCPServerStatusDropdown({
           remoteMcpServerId: server.remoteMcpServerId ?? undefined,
           tunneledMcpServerId: server.tunneledMcpServerId ?? undefined,
           toolsetId: server.toolsetId ?? undefined,
-          environmentId: server.environmentId ?? undefined,
           // updateMcpServer is a full-record replace for the optional UUID
           // references. Forwarding them keeps stored values intact across a
-          // visibility-only update.
+          // visibility-only update. Remote MCP servers cannot carry an
+          // environment (rejected by the API guard), so only forward it for
+          // toolset/tunneled backends.
+          environmentId: server.remoteMcpServerId
+            ? undefined
+            : (server.environmentId ?? undefined),
           toolVariationsGroupId: server.toolVariationsGroupId ?? undefined,
           visibility: next,
         },

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/BrandingSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/BrandingSection.tsx
@@ -60,7 +60,11 @@ export function BrandingSection({
             remoteMcpServerId: mcpServer.remoteMcpServerId ?? undefined,
             tunneledMcpServerId: mcpServer.tunneledMcpServerId ?? undefined,
             toolsetId: mcpServer.toolsetId ?? undefined,
-            environmentId: mcpServer.environmentId ?? undefined,
+            // Remote MCP servers cannot carry an environment (rejected by the
+            // API guard); only forward it for toolset/tunneled backends.
+            environmentId: mcpServer.remoteMcpServerId
+              ? undefined
+              : (mcpServer.environmentId ?? undefined),
             toolVariationsGroupId: mcpServer.toolVariationsGroupId ?? undefined,
             visibility: mcpServer.visibility,
           },

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/DangerZoneSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/DangerZoneSection.tsx
@@ -35,7 +35,11 @@ function mcpServerVisibilityUpdateForm(
     remoteMcpServerId: mcpServer.remoteMcpServerId ?? undefined,
     tunneledMcpServerId: mcpServer.tunneledMcpServerId ?? undefined,
     toolsetId: mcpServer.toolsetId ?? undefined,
-    environmentId: mcpServer.environmentId ?? undefined,
+    // Remote MCP servers cannot carry an environment (rejected by the API
+    // guard); only forward it for toolset/tunneled backends.
+    environmentId: mcpServer.remoteMcpServerId
+      ? undefined
+      : (mcpServer.environmentId ?? undefined),
     toolVariationsGroupId: mcpServer.toolVariationsGroupId ?? undefined,
     visibility,
   };

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/ToolFilteringSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/ToolFilteringSection.tsx
@@ -74,7 +74,11 @@ export function ToolFilteringSection({
           remoteMcpServerId: mcpServer.remoteMcpServerId ?? undefined,
           tunneledMcpServerId: mcpServer.tunneledMcpServerId ?? undefined,
           toolsetId: mcpServer.toolsetId ?? undefined,
-          environmentId: mcpServer.environmentId ?? undefined,
+          // Remote MCP servers cannot carry an environment (rejected by the
+          // API guard); only forward it for toolset/tunneled backends.
+          environmentId: mcpServer.remoteMcpServerId
+            ? undefined
+            : (mcpServer.environmentId ?? undefined),
           visibility: mcpServer.visibility,
           toolVariationsGroupId: groupId ?? undefined,
         },

--- a/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.ts
+++ b/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.ts
@@ -258,7 +258,8 @@ async function setMcpServerVisibility(
       name: mcpServer.name ?? undefined,
       remoteMcpServerId: mcpServer.remoteMcpServerId ?? undefined,
       toolsetId: mcpServer.toolsetId ?? undefined,
-      environmentId: mcpServer.environmentId ?? undefined,
+      // Remote MCP servers cannot carry an environment (rejected by the API
+      // guard). This is always a remote-backed server, so never forward it.
       toolVariationsGroupId: mcpServer.toolVariationsGroupId ?? undefined,
       visibility,
     },

--- a/client/dashboard/src/sdk/src/models/components/createmcpserverform.ts
+++ b/client/dashboard/src/sdk/src/models/components/createmcpserverform.ts
@@ -26,7 +26,7 @@ export type CreateMcpServerFormVisibility = ClosedEnum<
  */
 export type CreateMcpServerForm = {
   /**
-   * The ID of the environment to associate with the server
+   * The ID of the environment to associate with the server. Not supported for remote MCP servers: the request is rejected when this is set alongside remote_mcp_server_id.
    */
   environmentId?: string | undefined;
   /**

--- a/client/dashboard/src/sdk/src/models/components/updatemcpserverform.ts
+++ b/client/dashboard/src/sdk/src/models/components/updatemcpserverform.ts
@@ -26,7 +26,7 @@ export type UpdateMcpServerFormVisibility = ClosedEnum<
  */
 export type UpdateMcpServerForm = {
   /**
-   * The ID of the environment to associate with the server
+   * The ID of the environment to associate with the server. Not supported for remote MCP servers: the request is rejected when this is set alongside remote_mcp_server_id.
    */
   environmentId?: string | undefined;
   /**

--- a/server/design/mcpservers/design.go
+++ b/server/design/mcpservers/design.go
@@ -225,7 +225,7 @@ var CreateMcpServerForm = Type("CreateMcpServerForm", func() {
 	Description("Form for creating a new MCP server. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, or toolset_id must be provided.")
 
 	Attribute("name", String, "A human-readable display name for the server")
-	Attribute("environment_id", String, "The ID of the environment to associate with the server", func() {
+	Attribute("environment_id", String, "The ID of the environment to associate with the server. Not supported for remote MCP servers: the request is rejected when this is set alongside remote_mcp_server_id.", func() {
 		Format(FormatUUID)
 	})
 	Attribute("remote_mcp_server_id", String, "The ID of the remote MCP server to use as the backend", func() {
@@ -252,7 +252,7 @@ var UpdateMcpServerForm = Type("UpdateMcpServerForm", func() {
 		Format(FormatUUID)
 	})
 	Attribute("name", String, "A human-readable display name for the server. Omit to leave the existing name unchanged; if provided, must be non-empty.")
-	Attribute("environment_id", String, "The ID of the environment to associate with the server", func() {
+	Attribute("environment_id", String, "The ID of the environment to associate with the server. Not supported for remote MCP servers: the request is rejected when this is set alongside remote_mcp_server_id.", func() {
 		Format(FormatUUID)
 	})
 	Attribute("remote_mcp_server_id", String, "The ID of the remote MCP server to use as the backend", func() {

--- a/server/gen/http/mcp_servers/client/types.go
+++ b/server/gen/http/mcp_servers/client/types.go
@@ -18,7 +18,9 @@ import (
 type CreateMcpServerRequestBody struct {
 	// A human-readable display name for the server
 	Name string `form:"name" json:"name" xml:"name"`
-	// The ID of the environment to associate with the server
+	// The ID of the environment to associate with the server. Not supported for
+	// remote MCP servers: the request is rejected when this is set alongside
+	// remote_mcp_server_id.
 	EnvironmentID *string `form:"environment_id,omitempty" json:"environment_id,omitempty" xml:"environment_id,omitempty"`
 	// The ID of the remote MCP server to use as the backend
 	RemoteMcpServerID *string `form:"remote_mcp_server_id,omitempty" json:"remote_mcp_server_id,omitempty" xml:"remote_mcp_server_id,omitempty"`
@@ -41,7 +43,9 @@ type UpdateMcpServerRequestBody struct {
 	// A human-readable display name for the server. Omit to leave the existing
 	// name unchanged; if provided, must be non-empty.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// The ID of the environment to associate with the server
+	// The ID of the environment to associate with the server. Not supported for
+	// remote MCP servers: the request is rejected when this is set alongside
+	// remote_mcp_server_id.
 	EnvironmentID *string `form:"environment_id,omitempty" json:"environment_id,omitempty" xml:"environment_id,omitempty"`
 	// The ID of the remote MCP server to use as the backend
 	RemoteMcpServerID *string `form:"remote_mcp_server_id,omitempty" json:"remote_mcp_server_id,omitempty" xml:"remote_mcp_server_id,omitempty"`

--- a/server/gen/http/mcp_servers/server/types.go
+++ b/server/gen/http/mcp_servers/server/types.go
@@ -18,7 +18,9 @@ import (
 type CreateMcpServerRequestBody struct {
 	// A human-readable display name for the server
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// The ID of the environment to associate with the server
+	// The ID of the environment to associate with the server. Not supported for
+	// remote MCP servers: the request is rejected when this is set alongside
+	// remote_mcp_server_id.
 	EnvironmentID *string `form:"environment_id,omitempty" json:"environment_id,omitempty" xml:"environment_id,omitempty"`
 	// The ID of the remote MCP server to use as the backend
 	RemoteMcpServerID *string `form:"remote_mcp_server_id,omitempty" json:"remote_mcp_server_id,omitempty" xml:"remote_mcp_server_id,omitempty"`
@@ -41,7 +43,9 @@ type UpdateMcpServerRequestBody struct {
 	// A human-readable display name for the server. Omit to leave the existing
 	// name unchanged; if provided, must be non-empty.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// The ID of the environment to associate with the server
+	// The ID of the environment to associate with the server. Not supported for
+	// remote MCP servers: the request is rejected when this is set alongside
+	// remote_mcp_server_id.
 	EnvironmentID *string `form:"environment_id,omitempty" json:"environment_id,omitempty" xml:"environment_id,omitempty"`
 	// The ID of the remote MCP server to use as the backend
 	RemoteMcpServerID *string `form:"remote_mcp_server_id,omitempty" json:"remote_mcp_server_id,omitempty" xml:"remote_mcp_server_id,omitempty"`

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -43054,7 +43054,7 @@ components:
             properties:
                 environment_id:
                     type: string
-                    description: The ID of the environment to associate with the server
+                    description: 'The ID of the environment to associate with the server. Not supported for remote MCP servers: the request is rejected when this is set alongside remote_mcp_server_id.'
                     format: uuid
                 name:
                     type: string
@@ -56463,7 +56463,7 @@ components:
             properties:
                 environment_id:
                     type: string
-                    description: The ID of the environment to associate with the server
+                    description: 'The ID of the environment to associate with the server. Not supported for remote MCP servers: the request is rejected when this is set alongside remote_mcp_server_id.'
                     format: uuid
                 id:
                     type: string

--- a/server/gen/mcp_servers/service.go
+++ b/server/gen/mcp_servers/service.go
@@ -77,7 +77,9 @@ type CreateMcpServerPayload struct {
 	ProjectSlugInput *string
 	// A human-readable display name for the server
 	Name string
-	// The ID of the environment to associate with the server
+	// The ID of the environment to associate with the server. Not supported for
+	// remote MCP servers: the request is rejected when this is set alongside
+	// remote_mcp_server_id.
 	EnvironmentID *string
 	// The ID of the remote MCP server to use as the backend
 	RemoteMcpServerID *string
@@ -163,7 +165,9 @@ type UpdateMcpServerPayload struct {
 	// A human-readable display name for the server. Omit to leave the existing
 	// name unchanged; if provided, must be non-empty.
 	Name *string
-	// The ID of the environment to associate with the server
+	// The ID of the environment to associate with the server. Not supported for
+	// remote MCP servers: the request is rejected when this is set alongside
+	// remote_mcp_server_id.
 	EnvironmentID *string
 	// The ID of the remote MCP server to use as the backend
 	RemoteMcpServerID *string

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -130,6 +130,9 @@ func (s *Service) CreateMcpServer(ctx context.Context, payload *gen.CreateMcpSer
 	if err := validateTunneledMCPVisibility(ids, payload.Visibility); err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
 	}
+	if err := validateRemoteMcpEnvironmentExclusivity(ids); err != nil {
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
+	}
 
 	// Generate the server ID up front so the slug can include its suffix and
 	// the row can be inserted in a single statement (no insert-then-update).
@@ -440,6 +443,9 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogError(ctx, logger)
 	}
 	if err := validateTunneledMCPVisibility(ids, payload.Visibility); err != nil {
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
+	}
+	if err := validateRemoteMcpEnvironmentExclusivity(ids); err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
 	}
 
@@ -814,6 +820,18 @@ func validateServerBackendExclusivity(remoteMcpServerID, tunneledMcpServerID, to
 func validateTunneledMCPVisibility(ids serverIDs, visibility types.McpServerVisibility) error {
 	if ids.TunneledMcpServerID.Valid && string(visibility) == VisibilityPublic {
 		return fmt.Errorf("tunneled MCP servers cannot be public")
+	}
+	return nil
+}
+
+// validateRemoteMcpEnvironmentExclusivity rejects environment_id on
+// remote-backed servers. environment_id is inert at runtime for remote MCP
+// servers (the remote serve path never reads it) and only adds confusion, so
+// it is disallowed at write-time even though the column remains supported for
+// toolset- and tunneled-backed servers.
+func validateRemoteMcpEnvironmentExclusivity(ids serverIDs) error {
+	if ids.RemoteMcpServerID.Valid && ids.EnvironmentID.Valid {
+		return fmt.Errorf("environments are not supported for remote MCP servers")
 	}
 	return nil
 }

--- a/server/internal/mcpservers/remoteenvironmentguard_test.go
+++ b/server/internal/mcpservers/remoteenvironmentguard_test.go
@@ -1,0 +1,132 @@
+package mcpservers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/mcp_servers"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	environmentsrepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// seedEnvironment inserts an environment in the caller's project so it can be
+// referenced by environment_id in mcp_servers create/update payloads.
+func seedEnvironment(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, projectID uuid.UUID) environmentsrepo.Environment {
+	t.Helper()
+
+	slug := "env-" + uuid.New().String()[:8]
+	env, err := environmentsrepo.New(conn).CreateEnvironment(ctx, environmentsrepo.CreateEnvironmentParams{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+		Name:           slug,
+		Slug:           slug,
+		Description:    pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	return env
+}
+
+// AIS-308: environment_id is inert at runtime for remote-backed servers (the
+// remote serve path never reads it), so it is rejected at write-time. The
+// column stays supported for toolset- and tunneled-backed servers.
+
+func TestCreateMcpServer_RejectsEnvironmentWithRemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	serverID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+	envID := seedEnvironment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID).ID.String()
+
+	_, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "remote server with environment",
+		EnvironmentID:     &envID,
+		RemoteMcpServerID: &serverID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	requireOopsCode(t, err, oops.CodeInvalid)
+}
+
+func TestUpdateMcpServer_RejectsEnvironmentWithRemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	serverID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "remote server without environment",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &serverID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	require.NoError(t, err)
+
+	envID := seedEnvironment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID).ID.String()
+
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		EnvironmentID:     &envID,
+		RemoteMcpServerID: &serverID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	requireOopsCode(t, err, oops.CodeInvalid)
+}
+
+// TestCreateMcpServer_ToolsetWithEnvironmentSucceeds guards backward
+// compatibility: environment_id remains fully supported for toolset-backed
+// servers, so this combination must still succeed.
+func TestCreateMcpServer_ToolsetWithEnvironmentSucceeds(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := seedToolset(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
+	toolsetID := toolset.ID.String()
+	envID := seedEnvironment(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID).ID.String()
+
+	result, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "toolset server with environment",
+		EnvironmentID:     &envID,
+		RemoteMcpServerID: nil,
+		ToolsetID:         &toolsetID,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.EnvironmentID)
+	require.Equal(t, envID, *result.EnvironmentID)
+	require.NotNil(t, result.ToolsetID)
+	require.Equal(t, toolsetID, *result.ToolsetID)
+}


### PR DESCRIPTION
## What

Reject `environment_id` on remote-backed MCP servers.

Remote MCP servers already have a dedicated model for supplying (secret) header values: `remote_mcp_server_headers` (a stored `value`/secret, or `value_from_request_header` passthrough), which is what the live proxy path actually consumes. The `mcp_servers.environment_id` association is a **redundant second config model** for remote servers — it is never read by the remote serve path. This standardizes on the one model by rejecting the environment association at write time.

`environment_id` remains fully supported for toolset- and tunneled-backed servers.

## Changes

- **API guard** (`server/internal/mcpservers/impl.go`): new `validateRemoteMcpEnvironmentExclusivity` returning `CodeInvalid` ("environments are not supported for remote MCP servers"), wired into both `CreateMcpServer` and `UpdateMcpServer`.
- **Design/OpenAPI/SDK**: updated `environment_id` descriptions in the Goa design, regenerated `gen/**`, `openapi3.yaml`, `.speakeasy/out.openapi.yaml`, and the dashboard SDK models.
- **Dashboard UI**: the four `updateMcpServer` call-sites (`MCPServerDetails`, `BrandingSection`, `DangerZoneSection`, `ToolFilteringSection`) and `autoConfigureAuth.ts` no longer echo `environmentId` back for remote-backed servers, so partial updates (visibility, branding, tool-filtering) don't trip the new guard. No user-facing UI element changed.
- **Tests** (`remoteenvironmentguard_test.go`): create-reject, update-reject, and toolset-with-environment-still-succeeds.

Note: remote MCP's secret-header support (`remote_mcp_server_headers`) is unaffected — this change only removes the redundant environment association.

## Verification

- `go build` (mcpservers + gen) ✅
- dashboard `tsc -b` ✅
- guard tests ✅
- `mise lint:server` ✅

## Related

The backing DB CHECK constraint ships separately as a migration PR: https://github.com/speakeasy-api/gram/pull/4195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
