### PR TITLE
mig: add mcp_servers remote-no-environment check constraint

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2994,6 +2994,9 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_tool_variations_group_id_fkey FOREIGN KEY (tool_variations_group_id) REFERENCES tool_variations_groups (id) ON DELETE SET NULL,
   -- Exactly one backend must be set.
   CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunneled_mcp_server_id, toolset_id) = 1),
+  -- environment_id is inert for remote-backed servers (the remote serve path
+  -- never reads it); remote-backed servers must not carry one.
+  CONSTRAINT mcp_servers_remote_no_environment_check CHECK (environment_id IS NULL OR remote_mcp_server_id IS NULL),
   -- Remote and tunneled servers carry a Gram-as-AS issuer attached at create
   -- time for the server's lifetime, regardless of visibility. Toolset-backed
   -- servers are exempt (their auth lives on toolsets.user_session_issuer_id).

--- a/server/migrations/20260714214014_mcp-servers-remote-no-environment-check.sql
+++ b/server/migrations/20260714214014_mcp-servers-remote-no-environment-check.sql
@@ -1,0 +1,7 @@
+-- atlas:txmode none
+
+-- Add the remote-no-environment constraint without validating existing rows
+-- while holding the table lock, then validate it separately without
+-- blocking writes. Mirrors the mcp_servers_issuer_required_check migration.
+ALTER TABLE "mcp_servers" ADD CONSTRAINT "mcp_servers_remote_no_environment_check" CHECK ((environment_id IS NULL) OR (remote_mcp_server_id IS NULL)) NOT VALID;
+ALTER TABLE "mcp_servers" VALIDATE CONSTRAINT "mcp_servers_remote_no_environment_check";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zoSbTJvxkqmkEu7W1XZ7OeUQnf2fz6xfDtx7DOC4ok0=
+h1:q242O6F3FgspU3jEyJIS5JCeP+Kq3GFJwsdI0AiMeD0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -264,3 +264,4 @@ h1:zoSbTJvxkqmkEu7W1XZ7OeUQnf2fz6xfDtx7DOC4ok0=
 20260713202859_environment-entries-add-is-secret.sql h1:6lQFy0k5gSthCic6INJDuaD/40n4jg54Swrjo9q/38M=
 20260714022021_mcp-server-tool-metadata.sql h1:1sKmFfyHXtx8MK988nYVkuKhlwoTi7/phABFHhl3WPw=
 20260714202057_chat-messages-listing-probe-indexes.sql h1:raNxlqK5jljXe4Z+JVp5dyx4R/uR9WmziXphoRoTG6w=
+20260714214014_mcp-servers-remote-no-environment-check.sql h1:1NGdnHtR7X+lL/Jf9dZ/ijl/P+LVYJanfkU+9eTIB0I=


### PR DESCRIPTION
## What

Add a DB CHECK constraint so a remote-backed `mcp_server` can never carry an environment association:

```sql
CHECK ((environment_id IS NULL) OR (remote_mcp_server_id IS NULL))
```

Remote MCP servers already have a dedicated model for supplying (secret) header values — `remote_mcp_server_headers` — which is what the live proxy path consumes. The `environment_id` association is a redundant second config model for remote servers (never read at runtime), so this enforces "one data model, not two" at the storage layer. The column stays fully supported for toolset- and tunneled-backed servers.

## How

Added `NOT VALID` first, then `VALIDATE CONSTRAINT` in a separate statement (`atlas:txmode none`) so existing rows are scanned without holding the table lock — mirrors `mcp_servers_issuer_required_check`.

## ⚠️ Deploy note

The `VALIDATE CONSTRAINT` step will **fail if any existing `mcp_servers` row has both `remote_mcp_server_id` and `environment_id` non-null**. Confirm production has no such rows before rollout:

```sql
SELECT count(*) FROM mcp_servers WHERE remote_mcp_server_id IS NOT NULL AND environment_id IS NOT NULL;
```

If any exist, a data-cleanup step (null out `environment_id`) is required first.

## Related

Write-time API guard enforcing the same invariant: https://github.com/speakeasy-api/gram/pull/4194

🤖 Generated with [Claude Code](https://claude.com/claude-code)
