### PR TITLE
fix: attach employee linked accounts by directory ownership (DNO-509)

### DIFF
--- a/.changeset/employees-linked-accounts-ownership.md
+++ b/.changeset/employees-linked-accounts-ownership.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Employees list linked accounts now attach by directory ownership (summary email resolved to the org user, or the account's own email) instead of by the raw telemetry user_ids folded into a summary. Stray telemetry rows that pair one person's email with another person's user id could previously hand an account — and the role bucket in the by-role view — to the wrong employee (DNO-509).

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -34,6 +34,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/telemetryerrs"
 	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	usersRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
@@ -499,24 +500,103 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 	}, nil
 }
 
+// resolveSummaryOwnerIDs maps summary group keys to the Gram user id each key
+// authoritatively identifies. SearchUsers keys internal summaries email-first,
+// so an email-shaped key is resolved through the org's user directory; a
+// non-email key is already a raw gram user id and identifies itself. Keys that
+// resolve to no connected user are absent from the result. Best-effort: on a
+// directory lookup failure only the id-shaped keys are returned.
+func (s *Service) resolveSummaryOwnerIDs(ctx context.Context, orgID string, keys []string) map[string]string {
+	ownerByKey := make(map[string]string, len(keys))
+	emails := make([]string, 0, len(keys))
+	seen := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if !strings.Contains(key, "@") {
+			ownerByKey[key] = key
+			continue
+		}
+		email := conv.NormalizeEmail(key)
+		if _, ok := seen[email]; ok {
+			continue
+		}
+		seen[email] = struct{}{}
+		emails = append(emails, email)
+	}
+	if len(emails) == 0 {
+		return ownerByKey
+	}
+
+	rows, err := usersRepo.New(s.db).GetConnectedUsersByEmails(ctx, usersRepo.GetConnectedUsersByEmailsParams{
+		Emails:         emails,
+		OrganizationID: orgID,
+	})
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to resolve summary emails to org users", attr.SlogError(err))
+		return ownerByKey
+	}
+	idByEmail := make(map[string]string, len(rows))
+	for _, row := range rows {
+		idByEmail[conv.NormalizeEmail(row.Email)] = row.ID
+	}
+	for _, key := range keys {
+		if !strings.Contains(key, "@") {
+			continue
+		}
+		if id, ok := idByEmail[conv.NormalizeEmail(key)]; ok {
+			ownerByKey[key] = id
+		}
+	}
+	return ownerByKey
+}
+
 // attachUserAccounts populates UserSummary.Accounts from the user_accounts
-// directory. The directory is keyed by raw gram user id while summaries are
-// keyed email-first, so each summary is looked up under its group key plus every
-// raw user_id folded into it (rawUserIDsByKey, keyed by summary group key).
-// Best-effort: a lookup failure leaves accounts empty rather than failing the
-// listing.
+// directory. Ownership comes from the directory itself, never from telemetry
+// row identity: an account row attaches to the summary whose resolved owner
+// (email group key resolved through the user directory, or an id-shaped group
+// key) matches the row's user_id, else to the summary keyed by the account's
+// own email (its own usage rows, e.g. an unprovisioned member or a personal
+// identity). The raw telemetry user_ids folded into a summary (rawUserIDsByKey)
+// only widen the candidate fetch — attaching through them would let a stray row
+// pairing one person's email with another person's user id hand the second
+// person's accounts to the first summary (DNO-509). Best-effort: a lookup
+// failure leaves accounts empty rather than failing the listing.
 func (s *Service) attachUserAccounts(ctx context.Context, orgID string, users []*telem_gen.UserSummary, rawUserIDsByKey map[string][]string) {
-	summaryByID := make(map[string]*telem_gen.UserSummary, len(users))
-	userIDs := make([]string, 0, len(users))
+	if len(users) == 0 {
+		return
+	}
+
+	keys := make([]string, 0, len(users))
 	for _, u := range users {
-		for _, id := range append([]string{u.UserID}, rawUserIDsByKey[u.UserID]...) {
+		keys = append(keys, u.UserID)
+	}
+	ownerByKey := s.resolveSummaryOwnerIDs(ctx, orgID, keys)
+
+	summaryByOwner := make(map[string]*telem_gen.UserSummary, len(users))
+	summaryByEmailKey := make(map[string]*telem_gen.UserSummary, len(users))
+	userIDs := make([]string, 0, len(users))
+	seenIDs := make(map[string]struct{}, len(users))
+	for _, u := range users {
+		// Group keys are distinct, but two case-variant email keys can resolve to
+		// the same user; the earlier summary in list order keeps the claim.
+		if owner := ownerByKey[u.UserID]; owner != "" {
+			if _, claimed := summaryByOwner[owner]; !claimed {
+				summaryByOwner[owner] = u
+			}
+		}
+		if strings.Contains(u.UserID, "@") {
+			emailKey := conv.NormalizeEmail(u.UserID)
+			if _, claimed := summaryByEmailKey[emailKey]; !claimed {
+				summaryByEmailKey[emailKey] = u
+			}
+		}
+		for _, id := range append([]string{ownerByKey[u.UserID]}, rawUserIDsByKey[u.UserID]...) {
 			if id == "" {
 				continue
 			}
-			if _, ok := summaryByID[id]; ok {
+			if _, ok := seenIDs[id]; ok {
 				continue
 			}
-			summaryByID[id] = u
+			seenIDs[id] = struct{}{}
 			userIDs = append(userIDs, id)
 		}
 	}
@@ -537,8 +617,13 @@ func (s *Service) attachUserAccounts(ctx context.Context, orgID string, users []
 		if !row.UserID.Valid || row.UserID.String == "" {
 			continue
 		}
-		summary, ok := summaryByID[row.UserID.String]
-		if !ok {
+		summary := summaryByOwner[row.UserID.String]
+		if summary == nil {
+			if email := conv.NormalizeEmail(conv.FromPGTextOrEmpty[string](row.Email)); email != "" {
+				summary = summaryByEmailKey[email]
+			}
+		}
+		if summary == nil {
 			continue
 		}
 		var lastSeen *string
@@ -643,6 +728,17 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 		}
 	}
 
+	// Role assignments are keyed by raw gram user id while summaries are keyed
+	// email-first, so resolve each summary's owner through the user directory.
+	// The raw ids folded into a summary are only a fallback for keys that do not
+	// resolve: a stray row pairing one person's email with another person's user
+	// id would otherwise bucket the summary under the wrong role (DNO-509).
+	keys := make([]string, 0, len(items))
+	for _, item := range items {
+		keys = append(keys, item.UserID)
+	}
+	ownerByKey := s.resolveSummaryOwnerIDs(ctx, params.organizationID, keys)
+
 	// Single pass: aggregate per-user costs by role and build the response.
 	type roleAgg struct {
 		summary *telem_gen.RoleSummary
@@ -651,11 +747,13 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 
 	const unassignedRoleID = "unassigned"
 	for _, item := range items {
-		// Role assignments are keyed by raw gram user id while summaries are keyed
-		// email-first, so fall back to the raw ids folded into the summary.
 		ri := roleInfo{id: unassignedRoleID, name: "Unassigned"}
-		if r, ok := userToRole[item.UserID]; ok {
-			ri = r
+		if owner, ok := ownerByKey[item.UserID]; ok {
+			// A resolved member without an assignment stays Unassigned rather than
+			// borrowing a role through raw telemetry ids.
+			if r, ok := userToRole[owner]; ok {
+				ri = r
+			}
 		} else {
 			for _, rawID := range item.RawUserIDs {
 				if r, ok := userToRole[rawID]; ok {

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	hooksRepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
+	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -514,6 +516,193 @@ func TestSearchUsers_AttachesAccountsToEmailKeyedSummary(t *testing.T) {
 			assert.Equal(c, email, *account.Email)
 		}
 	}, 10*time.Second, 200*time.Millisecond)
+}
+
+// TestSearchUsers_ForeignRawUserIDsDoNotStealAccounts reproduces DNO-509: a
+// stray telemetry row pairing one employee's email with another employee's
+// user_id folds the second employee's id into the first summary's raw_user_ids.
+// Accounts must still attach by directory ownership — the first summary must
+// not pick up the second employee's account, and the second employee must keep
+// it.
+func TestSearchUsers_ForeignRawUserIDsDoNotStealAccounts(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	userA, emailA := seedConnectedOrgUser(t, ctx, ti, "alice")
+	userB, emailB := seedConnectedOrgUser(t, ctx, ti, "bob")
+
+	hooksQueries := hooksRepo.New(ti.conn)
+	accountEmailByOwner := map[string]string{userA: emailA, userB: emailB}
+	for owner, accountEmail := range accountEmailByOwner {
+		_, err := hooksQueries.UpsertUserAccount(ctx, hooksRepo.UpsertUserAccountParams{
+			OrganizationID:      authCtx.ActiveOrganizationID,
+			Provider:            "anthropic",
+			ExternalAccountUuid: uuid.New().String(),
+			UserID:              conv.ToPGTextEmpty(owner),
+			ExternalOrgID:       conv.ToPGTextEmpty("ext-org-" + uuid.New().String()),
+			ExternalAccountID:   conv.ToPGTextEmpty(""),
+			Email:               conv.ToPGTextEmpty(accountEmail),
+			AccountType:         conv.ToPGTextEmpty("team"),
+		})
+		require.NoError(t, err)
+	}
+
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-30*time.Minute), userB, emailB, 100, 50, 1.0)
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-20*time.Minute), userA, emailA, 100, 50, 1.0)
+	// The poisoned row: A's email with B's user_id, most recent so A's summary
+	// sorts first and would claim B's id under raw-id attachment.
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), userB, emailA, 10, 5, 0.1)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.Len(c, res.Users, 2) {
+			return
+		}
+
+		byKey := make(map[string]*gen.UserSummary, len(res.Users))
+		for _, u := range res.Users {
+			byKey[u.UserID] = u
+		}
+		summaryA := byKey[emailA]
+		summaryB := byKey[emailB]
+		if !assert.NotNil(c, summaryA) || !assert.NotNil(c, summaryB) {
+			return
+		}
+		if assert.Len(c, summaryA.Accounts, 1) && assert.NotNil(c, summaryA.Accounts[0].Email) {
+			assert.Equal(c, emailA, *summaryA.Accounts[0].Email)
+		}
+		if assert.Len(c, summaryB.Accounts, 1) && assert.NotNil(c, summaryB.Accounts[0].Email) {
+			assert.Equal(c, emailB, *summaryB.Accounts[0].Email)
+		}
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+// TestSearchUsers_PersonalAccountAttachesToOwnerSummary covers the
+// device-bridge shape: a personal session's rows carry the employee's user_id
+// under the personal email, producing a personal-email summary whose
+// raw_user_ids hold the employee's id. Both of the employee's accounts must
+// attach to the employee's own summary, not to the personal-email usage row —
+// even when the personal-email summary sorts first.
+func TestSearchUsers_PersonalAccountAttachesToOwnerSummary(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	userID, workEmail := seedConnectedOrgUser(t, ctx, ti, "carol")
+	personalEmail := "carol-personal-" + uuid.New().String() + "@gmail.com"
+
+	hooksQueries := hooksRepo.New(ti.conn)
+	accountTypeByEmail := map[string]string{workEmail: "team", personalEmail: "personal"}
+	for accountEmail, accountType := range accountTypeByEmail {
+		_, err := hooksQueries.UpsertUserAccount(ctx, hooksRepo.UpsertUserAccountParams{
+			OrganizationID:      authCtx.ActiveOrganizationID,
+			Provider:            "anthropic",
+			ExternalAccountUuid: uuid.New().String(),
+			UserID:              conv.ToPGTextEmpty(userID),
+			ExternalOrgID:       conv.ToPGTextEmpty("ext-org-" + uuid.New().String()),
+			ExternalAccountID:   conv.ToPGTextEmpty(""),
+			Email:               conv.ToPGTextEmpty(accountEmail),
+			AccountType:         conv.ToPGTextEmpty(accountType),
+		})
+		require.NoError(t, err)
+	}
+
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-20*time.Minute), userID, workEmail, 100, 50, 1.0)
+	insertPollingLogWithUserAndEmail(t, ctx, projectID, deploymentID, now.Add(-5*time.Minute), userID, personalEmail, 10, 5, 0.1)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.Len(c, res.Users, 2) {
+			return
+		}
+
+		byKey := make(map[string]*gen.UserSummary, len(res.Users))
+		for _, u := range res.Users {
+			byKey[u.UserID] = u
+		}
+		workSummary := byKey[workEmail]
+		personalSummary := byKey[personalEmail]
+		if !assert.NotNil(c, workSummary) || !assert.NotNil(c, personalSummary) {
+			return
+		}
+		if assert.Len(c, workSummary.Accounts, 2) {
+			gotEmails := make([]string, 0, 2)
+			for _, account := range workSummary.Accounts {
+				if assert.NotNil(c, account.Email) {
+					gotEmails = append(gotEmails, *account.Email)
+				}
+			}
+			assert.ElementsMatch(c, []string{workEmail, personalEmail}, gotEmails)
+		}
+		assert.Empty(c, personalSummary.Accounts)
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+// seedConnectedOrgUser creates a user connected to the test org and returns
+// its id and directory email, satisfying the user_accounts FK and the email
+// resolution that account attachment relies on.
+func seedConnectedOrgUser(t *testing.T, ctx context.Context, ti *testInstance, name string) (string, string) {
+	t.Helper()
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	userID := uuid.New().String()
+	email := name + "-" + uuid.New().String() + "@example.com"
+
+	_, err := userrepo.New(ti.conn).UpsertUser(ctx, userrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: name,
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+
+	return userID, email
 }
 
 func TestSearchUsers_Pagination(t *testing.T) {


### PR DESCRIPTION
Fixes [DNO-509](https://linear.app/speakeasy/issue/DNO-509/bug-personal-account-tracking-misattribution-in-linked-accounts): linked accounts on the Employees page rendering under the wrong employee (e.g. walker's account under Adam, Adam's under Nolan; same pattern at MoonPay).

## Root cause

The `user_accounts` directory in Postgres is **correct** — verified in prod for both affected orgs. The misattribution is read-side:

- Hook telemetry written **before #3492 (June 18)** stamped `user_id` from the shared API-key owner instead of the payload email, leaving rows that pair one person's email with another person's user id (e.g. 627 rows `nolan@… + adam's id`, 5,616 rows `aferguson@… + ecorella's id`, all June 15–18).
- `SearchUsers` folds every `user_id` seen in an email group into that summary's `raw_user_ids` over the query window; with the default 30-day window still covering June 16–18, summaries carry other people's ids.
- `attachUserAccounts` claimed those raw ids first-summary-wins and attached directory rows through them — handing an account to whichever summary sorted first and stealing it from its real owner. `searchUsersByRole` used the same fallback to pick a summary's role bucket.

The same shape is also produced today, benignly, by device-bridged personal sessions (employee's user id under the personal email), which could hand an employee's whole account list to an anonymous "unknown user" row.

## Fix

Attach accounts by directory ownership, never by telemetry row identity:

1. Resolve each summary's email group key to its connected org user (`GetConnectedUsersByEmails`); an id-shaped key identifies itself. An account row attaches to the summary whose resolved owner matches `user_accounts.user_id`.
2. Otherwise attach to the summary keyed by the account's own email (unprovisioned members, identities whose directory email differs from the telemetry email).
3. Otherwise don't attach. Raw `user_ids` now only widen the candidate fetch.

`searchUsersByRole` uses the same resolution; a resolved member without an assignment stays Unassigned instead of borrowing a role through raw ids.

Deliberate behavior change: personal accounts now surface only under the owning employee row (which drives the personal-account filter), no longer duplicated under the personal-email unknown-user row.

## Testing

- `TestSearchUsers_ForeignRawUserIDsDoNotStealAccounts` — exact DNO-509 repro (poisoned row makes the wrong summary sort first carrying the other user's id); fails on the old code.
- `TestSearchUsers_PersonalAccountAttachesToOwnerSummary` — device-bridge shape; both accounts land on the employee row.
- Existing `TestSearchUsers_AttachesAccountsToEmailKeyedSummary` passes unchanged via the self-match rule.
- Full `internal/telemetry` suite green against real PG+CH; `mise lint:server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes linked account misattribution on the Employees page by attaching accounts using directory ownership instead of raw telemetry user_ids. Also fixes role bucketing so summaries don’t borrow roles via stray user_ids (DNO-509).

- **Bug Fixes**
  - Resolve each summary’s email key to the connected org user; id-shaped keys identify themselves.
  - Attach accounts when the summary’s resolved owner matches `user_accounts.user_id`; else attach by the account’s email; otherwise skip.
  - Use raw telemetry user_ids only to widen the fetch, not for attachment or role bucketing.
  - Personal accounts now show only under the owning employee (not duplicated under the personal-email row).
  - Added tests for misattribution and device-bridged personal sessions.

<sup>Written for commit 2246f21a563b47f375c3e1931e477f96de1e4038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

