### PR TITLE
fix: stop chats.list and listSources from aggregating whole project per page

### DIFF
--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -257,7 +257,11 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 		return nil, err
 	}
 
-	baseParams := repo.CountChatsParams{
+	pinned := conv.PtrValOr(payload.Pinned, "")
+	sources := parseSourceFilter(conv.PtrValOr(payload.Source, ""))
+	accountType := conv.PtrValOr(payload.AccountType, "")
+
+	rows, err := s.repo.ListChats(ctx, repo.ListChatsParams{
 		ProjectID:         *authCtx.ProjectID,
 		ExternalUserID:    externalUserID,
 		UserID:            userID,
@@ -269,31 +273,9 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 		ExcludeSourceKind: excludeSourceKind,
 		HasRiskFilter:     hasRiskFilter,
 		MinRiskScore:      minRiskScore,
-		Pinned:            conv.PtrValOr(payload.Pinned, ""),
-		Sources:           parseSourceFilter(conv.PtrValOr(payload.Source, "")),
-		AccountType:       conv.PtrValOr(payload.AccountType, ""),
-	}
-
-	total, err := s.repo.CountChats(ctx, baseParams)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "count chats").LogError(ctx, s.logger)
-	}
-
-	rows, err := s.repo.ListChats(ctx, repo.ListChatsParams{
-		ProjectID:         baseParams.ProjectID,
-		ExternalUserID:    baseParams.ExternalUserID,
-		UserID:            baseParams.UserID,
-		FromTime:          baseParams.FromTime,
-		ToTime:            baseParams.ToTime,
-		Search:            baseParams.Search,
-		AssistantID:       baseParams.AssistantID,
-		SourceKind:        baseParams.SourceKind,
-		ExcludeSourceKind: baseParams.ExcludeSourceKind,
-		HasRiskFilter:     baseParams.HasRiskFilter,
-		MinRiskScore:      baseParams.MinRiskScore,
-		Pinned:            baseParams.Pinned,
-		Sources:           baseParams.Sources,
-		AccountType:       baseParams.AccountType,
+		Pinned:            pinned,
+		Sources:           sources,
+		AccountType:       accountType,
 		SortBy:            payload.SortBy,
 		SortOrder:         payload.SortOrder,
 		PageLimit:         conv.SafeInt32(payload.Limit),
@@ -301,6 +283,35 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list chats").LogError(ctx, s.logger)
+	}
+
+	// Every page row carries the pre-LIMIT total via a window count. A separate
+	// count query is only needed when the requested offset is past the end of
+	// the result set, so there are no rows to read it from.
+	var total int64
+	switch {
+	case len(rows) > 0:
+		total = rows[0].TotalCount
+	case payload.Offset > 0:
+		total, err = s.repo.CountChats(ctx, repo.CountChatsParams{
+			ProjectID:         *authCtx.ProjectID,
+			ExternalUserID:    externalUserID,
+			UserID:            userID,
+			FromTime:          fromTime,
+			ToTime:            toTime,
+			Search:            search,
+			AssistantID:       assistantID,
+			SourceKind:        sourceKind,
+			ExcludeSourceKind: excludeSourceKind,
+			HasRiskFilter:     hasRiskFilter,
+			MinRiskScore:      minRiskScore,
+			Pinned:            pinned,
+			Sources:           sources,
+			AccountType:       accountType,
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "count chats").LogError(ctx, s.logger)
+		}
 	}
 
 	result := make([]*gen.ChatOverview, 0, len(rows))

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -261,7 +261,32 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 	sources := parseSourceFilter(conv.PtrValOr(payload.Source, ""))
 	accountType := conv.PtrValOr(payload.AccountType, "")
 
-	rows, err := s.repo.ListChats(ctx, repo.ListChatsParams{
+	// When the requested offset is past the end of the result set, the page
+	// query returns no rows to carry the window total, and the fallback count
+	// below runs as a second statement. Share one repeatable-read snapshot
+	// between the two so the total can't come from a different point in time
+	// than the empty page (e.g. an empty page whose total implies the page
+	// exists). Offset-zero requests can't hit the fallback, so they skip the
+	// transaction.
+	querier := s.repo
+	var listTx pgx.Tx
+	if payload.Offset > 0 {
+		tx, err := s.db.BeginTx(ctx, pgx.TxOptions{
+			IsoLevel:       pgx.RepeatableRead,
+			AccessMode:     pgx.ReadOnly,
+			DeferrableMode: "",
+			BeginQuery:     "",
+			CommitQuery:    "",
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "list chats").LogError(ctx, s.logger)
+		}
+		defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+		listTx = tx
+		querier = s.repo.WithTx(tx)
+	}
+
+	rows, err := querier.ListChats(ctx, repo.ListChatsParams{
 		ProjectID:         *authCtx.ProjectID,
 		ExternalUserID:    externalUserID,
 		UserID:            userID,
@@ -293,7 +318,7 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 	case len(rows) > 0:
 		total = rows[0].TotalCount
 	case payload.Offset > 0:
-		total, err = s.repo.CountChats(ctx, repo.CountChatsParams{
+		total, err = querier.CountChats(ctx, repo.CountChatsParams{
 			ProjectID:         *authCtx.ProjectID,
 			ExternalUserID:    externalUserID,
 			UserID:            userID,
@@ -311,6 +336,12 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "count chats").LogError(ctx, s.logger)
+		}
+	}
+
+	if listTx != nil {
+		if err := listTx.Commit(ctx); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "list chats").LogError(ctx, s.logger)
 		}
 	}
 

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -263,7 +263,9 @@ DO NOTHING;
 -- name: CountChats :one
 -- Fallback for chats.list pagination: ListChats returns the total alongside
 -- each page via a window count, so this only runs when a requested page is
--- past the end of the result set (no rows to carry the total).
+-- past the end of the result set (no rows to carry the total). The handler
+-- runs it in the same repeatable-read transaction as the ListChats page read,
+-- so the total reflects the same snapshot the empty page came from.
 --
 -- risk_counts pre-aggregates active findings per chat once for the whole
 -- project (one pass over risk_results), so the risk presence + threshold

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -261,9 +261,15 @@ ON CONFLICT (chat_id, external_message_id) WHERE external_message_id IS NOT NULL
 DO NOTHING;
 
 -- name: CountChats :one
+-- Fallback for chats.list pagination: ListChats returns the total alongside
+-- each page via a window count, so this only runs when a requested page is
+-- past the end of the result set (no rows to carry the total).
+--
 -- risk_counts pre-aggregates active findings per chat once for the whole
 -- project (one pass over risk_results), so the risk presence + threshold
--- filters become a cheap join instead of a correlated subquery per chat.
+-- filters become a cheap join instead of a correlated subquery per chat. The
+-- parameter-only gate makes it a one-time filter that skips the scan entirely
+-- when neither risk filter is active.
 WITH risk_counts AS (
   SELECT cm.chat_id, COUNT(*)::integer AS cnt
   FROM risk_results rr
@@ -272,7 +278,8 @@ WITH risk_counts AS (
   -- disabling/deleting a policy retires its findings everywhere (keeps this
   -- count in sync with the risk.results.list detail view).
   JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
-  WHERE rr.project_id = @project_id
+  WHERE (@has_risk_filter::text <> '' OR @min_risk_score::int >= 0)
+    AND rr.project_id = @project_id
     AND rr.found IS TRUE
     AND rr.excluded_at IS NULL
     AND rr.false_positive_at IS NULL
@@ -347,12 +354,17 @@ candidate_chats AS (
     )
 ),
 chat_activity AS (
+  -- Per-chat backward probe on chat_messages_chat_id_created_at_idx instead of
+  -- aggregating every candidate chat's full message history.
   SELECT
     cc.id,
-    COALESCE(MAX(cm.created_at), cc.created_at) AS last_message_timestamp
+    COALESCE(last_msg.ts, cc.created_at) AS last_message_timestamp
   FROM candidate_chats cc
-  LEFT JOIN chat_messages cm ON cm.chat_id = cc.id
-  GROUP BY cc.id, cc.created_at
+  CROSS JOIN LATERAL (
+    SELECT MAX(cm.created_at) AS ts
+    FROM chat_messages cm
+    WHERE cm.chat_id = cc.id
+  ) last_msg
 )
 SELECT COUNT(*) AS total
 FROM chat_activity ca
@@ -360,10 +372,15 @@ WHERE (@from_time::timestamptz IS NULL OR ca.last_message_timestamp >= @from_tim
   AND (@to_time::timestamptz IS NULL OR ca.last_message_timestamp <= @to_time);
 
 -- name: ListChats :many
+-- Returns the page plus the pre-LIMIT total (total_count window column), so the
+-- handler only needs a separate CountChats round trip when the requested page
+-- is past the end of the result set.
+--
 -- risk_counts pre-aggregates active findings per chat once for the whole
--- project (one pass over risk_results). It feeds both the risk presence +
--- threshold filters and the risk_findings_count column below, replacing what
--- were two correlated subqueries per candidate chat.
+-- project (one pass over risk_results) to serve the risk presence + threshold
+-- filters. The parameter-only gate makes it a one-time filter that skips the
+-- scan entirely when neither risk filter is active; the displayed
+-- risk_findings_count is computed per returned page row in the final SELECT.
 WITH risk_counts AS (
   SELECT cm.chat_id, COUNT(*)::integer AS cnt
   FROM risk_results rr
@@ -372,7 +389,8 @@ WITH risk_counts AS (
   -- disabling/deleting a policy retires its findings everywhere (keeps this
   -- count in sync with the risk.results.list detail view).
   JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
-  WHERE rr.project_id = @project_id
+  WHERE (@has_risk_filter::text <> '' OR @min_risk_score::int >= 0)
+    AND rr.project_id = @project_id
     AND rr.found IS TRUE
     AND rr.excluded_at IS NULL
     AND rr.false_positive_at IS NULL
@@ -386,7 +404,6 @@ candidate_chats AS (
     c.external_user_id,
     c.created_at,
     c.updated_at,
-    COALESCE(rc.cnt, 0) AS risk_findings_count,
     COALESCE(ua.account_type, '')::text AS account_type,
     COALESCE(ua.email, '')::text AS account_email
   FROM chats c
@@ -458,13 +475,21 @@ candidate_chats AS (
     )
 ),
 chat_stats AS (
+  -- Per-chat probe on chat_messages_chat_id_created_at_idx (index-only count +
+  -- max) instead of aggregating every candidate chat's full message history.
   SELECT
     cc.id,
-    COUNT(cm.id)::integer AS num_messages,
-    COALESCE(MAX(cm.created_at), cc.created_at) AS last_message_timestamp
+    stats.num_messages,
+    COALESCE(stats.max_created_at, cc.created_at)::timestamptz AS last_message_timestamp
   FROM candidate_chats cc
-  LEFT JOIN chat_messages cm ON cm.chat_id = cc.id
-  GROUP BY cc.id, cc.created_at
+  CROSS JOIN LATERAL (
+    -- COUNT(*) rather than COUNT(cm.id) so the probe stays index-only.
+    SELECT
+      COUNT(*)::integer AS num_messages,
+      MAX(cm.created_at) AS max_created_at
+    FROM chat_messages cm
+    WHERE cm.chat_id = cc.id
+  ) stats
 ),
 filtered_chats AS (
   SELECT
@@ -476,7 +501,6 @@ filtered_chats AS (
     cc.updated_at,
     cs.num_messages,
     cs.last_message_timestamp,
-    cc.risk_findings_count,
     cc.account_type,
     cc.account_email
   FROM candidate_chats cc
@@ -495,9 +519,11 @@ limited_chats AS (
     fc.num_messages,
     (SELECT source FROM chat_messages WHERE chat_id = fc.id AND source IS NOT NULL AND source <> '' ORDER BY created_at DESC LIMIT 1) AS source,
     fc.last_message_timestamp,
-    fc.risk_findings_count,
     fc.account_type,
-    fc.account_email
+    fc.account_email,
+    -- Window count runs before LIMIT/OFFSET, so every returned row carries the
+    -- total number of filtered chats.
+    COUNT(*) OVER ()::bigint AS total_count
   FROM filtered_chats fc
   ORDER BY
     CASE WHEN @sort_by = 'last_message_timestamp' AND @sort_order = 'desc' THEN fc.last_message_timestamp END DESC NULLS LAST,
@@ -519,9 +545,22 @@ SELECT
   lc.updated_at,
   lc.num_messages,
   lc.last_message_timestamp,
-  lc.risk_findings_count,
+  -- Active findings for the returned page rows only; must stay in sync with
+  -- the risk_counts predicate above (and the risk.results.list detail view).
+  (
+    SELECT COUNT(*)::integer
+    FROM risk_results rr
+    JOIN chat_messages cm ON cm.id = rr.chat_message_id
+    JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
+    WHERE rr.project_id = @project_id
+      AND cm.chat_id = lc.id
+      AND rr.found IS TRUE
+      AND rr.excluded_at IS NULL
+      AND rr.false_positive_at IS NULL
+  ) AS risk_findings_count,
   lc.account_type,
-  lc.account_email
+  lc.account_email,
+  lc.total_count
 FROM limited_chats lc;
 
 -- name: ListChatSources :many
@@ -529,22 +568,27 @@ FROM limited_chats lc;
 -- project's chats, honoring the same visibility scoping as ListChats. Feeds the
 -- agent-type filter options on the Agent Sessions page so the list reflects the
 -- sources actually present in the data rather than a hardcoded catalog.
-WITH latest_sources AS (
-  SELECT DISTINCT ON (cm.chat_id) cm.source AS source
-  FROM chats c
-  JOIN chat_messages cm ON cm.chat_id = c.id
-  WHERE c.project_id = @project_id
-    AND c.deleted IS FALSE
-    AND (@external_user_id::text = '' OR c.external_user_id = @external_user_id::text)
-    AND (@user_id::text = '' OR c.user_id = @user_id::text)
+-- Driven from chats with a per-chat probe on
+-- chat_messages_chat_id_created_at_source_idx for the latest non-empty source,
+-- instead of sorting the project's entire message history. The lateral join
+-- drops chats with no sourced messages, matching the previous inner-join
+-- semantics.
+SELECT DISTINCT latest.source
+FROM chats c
+CROSS JOIN LATERAL (
+  SELECT cm.source
+  FROM chat_messages cm
+  WHERE cm.chat_id = c.id
     AND cm.source IS NOT NULL
     AND cm.source <> ''
-  ORDER BY cm.chat_id, cm.created_at DESC
-)
-SELECT DISTINCT source
-FROM latest_sources
-WHERE source IS NOT NULL
-ORDER BY source;
+  ORDER BY cm.created_at DESC
+  LIMIT 1
+) latest
+WHERE c.project_id = @project_id
+  AND c.deleted IS FALSE
+  AND (@external_user_id::text = '' OR c.external_user_id = @external_user_id::text)
+  AND (@user_id::text = '' OR c.user_id = @user_id::text)
+ORDER BY latest.source;
 
 -- name: GetChat :one
 -- Loads a chat plus the team/personal classification of the AI account that

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -83,7 +83,8 @@ WITH risk_counts AS (
   -- disabling/deleting a policy retires its findings everywhere (keeps this
   -- count in sync with the risk.results.list detail view).
   JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
-  WHERE rr.project_id = $3
+  WHERE ($3::text <> '' OR $4::int >= 0)
+    AND rr.project_id = $5
     AND rr.found IS TRUE
     AND rr.excluded_at IS NULL
     AND rr.false_positive_at IS NULL
@@ -94,55 +95,55 @@ candidate_chats AS (
   FROM chats c
   LEFT JOIN risk_counts rc ON rc.chat_id = c.id
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
-  WHERE c.project_id = $3
+  WHERE c.project_id = $5
     AND c.deleted IS FALSE
-    AND ($4 = '' OR c.external_user_id = $4)
-    AND ($5 = '' OR c.user_id = $5)
+    AND ($6 = '' OR c.external_user_id = $6)
+    AND ($7 = '' OR c.user_id = $7)
     AND (
-      $6::text = ''
-      OR ($6::text = 'true' AND c.pinned_at IS NOT NULL)
-      OR ($6::text = 'false' AND c.pinned_at IS NULL)
+      $8::text = ''
+      OR ($8::text = 'true' AND c.pinned_at IS NOT NULL)
+      OR ($8::text = 'false' AND c.pinned_at IS NULL)
     )
     AND (
-      $7 = ''
-      OR c.id::text ILIKE '%' || $7 || '%'
-      OR c.external_user_id ILIKE '%' || $7 || '%'
-      OR c.title ILIKE '%' || $7 || '%'
+      $9 = ''
+      OR c.id::text ILIKE '%' || $9 || '%'
+      OR c.external_user_id ILIKE '%' || $9 || '%'
+      OR c.title ILIKE '%' || $9 || '%'
     )
     AND (
-      $8 = ''
+      $10 = ''
       OR EXISTS (
         SELECT 1 FROM assistant_threads at
         WHERE at.chat_id = c.id
-          AND at.assistant_id = $8::uuid
+          AND at.assistant_id = $10::uuid
           AND at.deleted IS FALSE
           -- Optional source-kind dimension so setup/onboarding and runtime
           -- threads for the same assistant don't pollute each other's listing.
           -- @source_kind keeps only threads of that kind (onboarding passes
           -- 'setup'); @exclude_source_kind drops threads of that kind (runtime
           -- views pass 'setup'). Empty string on either disables that side.
-          AND ($9::text = '' OR at.source_kind = $9::text)
-          AND ($10::text = '' OR at.source_kind <> $10::text)
+          AND ($11::text = '' OR at.source_kind = $11::text)
+          AND ($12::text = '' OR at.source_kind <> $12::text)
       )
     )
     AND (
-      $11::text = ''
-      OR ($11::text = 'true' AND COALESCE(rc.cnt, 0) > 0)
-      OR ($11::text = 'false' AND COALESCE(rc.cnt, 0) = 0)
+      $3::text = ''
+      OR ($3::text = 'true' AND COALESCE(rc.cnt, 0) > 0)
+      OR ($3::text = 'false' AND COALESCE(rc.cnt, 0) = 0)
     )
     AND (
-      $12::text = ''
-      OR ua.account_type = $12::text
+      $13::text = ''
+      OR ua.account_type = $13::text
       -- Rows without a classified account type are treated as 'team' so the
       -- team filter stays backwards-compatible with pre-classification chats.
       OR (
-        $12::text = 'team'
+        $13::text = 'team'
         AND (ua.account_type IS NULL OR ua.account_type = '')
       )
     )
     AND (
-      $13::int < 0
-      OR COALESCE(rc.cnt, 0) >= $13::int
+      $4::int < 0
+      OR COALESCE(rc.cnt, 0) >= $4::int
     )
     AND (
       coalesce(cardinality($14::text[]), 0) = 0
@@ -158,12 +159,17 @@ candidate_chats AS (
     )
 ),
 chat_activity AS (
+  -- Per-chat backward probe on chat_messages_chat_id_created_at_idx instead of
+  -- aggregating every candidate chat's full message history.
   SELECT
     cc.id,
-    COALESCE(MAX(cm.created_at), cc.created_at) AS last_message_timestamp
+    COALESCE(last_msg.ts, cc.created_at) AS last_message_timestamp
   FROM candidate_chats cc
-  LEFT JOIN chat_messages cm ON cm.chat_id = cc.id
-  GROUP BY cc.id, cc.created_at
+  CROSS JOIN LATERAL (
+    SELECT MAX(cm.created_at) AS ts
+    FROM chat_messages cm
+    WHERE cm.chat_id = cc.id
+  ) last_msg
 )
 SELECT COUNT(*) AS total
 FROM chat_activity ca
@@ -174,6 +180,8 @@ WHERE ($1::timestamptz IS NULL OR ca.last_message_timestamp >= $1)
 type CountChatsParams struct {
 	FromTime          pgtype.Timestamptz
 	ToTime            pgtype.Timestamptz
+	HasRiskFilter     string
+	MinRiskScore      int32
 	ProjectID         uuid.UUID
 	ExternalUserID    interface{}
 	UserID            interface{}
@@ -182,19 +190,25 @@ type CountChatsParams struct {
 	AssistantID       interface{}
 	SourceKind        string
 	ExcludeSourceKind string
-	HasRiskFilter     string
 	AccountType       string
-	MinRiskScore      int32
 	Sources           []string
 }
 
+// Fallback for chats.list pagination: ListChats returns the total alongside
+// each page via a window count, so this only runs when a requested page is
+// past the end of the result set (no rows to carry the total).
+//
 // risk_counts pre-aggregates active findings per chat once for the whole
 // project (one pass over risk_results), so the risk presence + threshold
-// filters become a cheap join instead of a correlated subquery per chat.
+// filters become a cheap join instead of a correlated subquery per chat. The
+// parameter-only gate makes it a one-time filter that skips the scan entirely
+// when neither risk filter is active.
 func (q *Queries) CountChats(ctx context.Context, arg CountChatsParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countChats,
 		arg.FromTime,
 		arg.ToTime,
+		arg.HasRiskFilter,
+		arg.MinRiskScore,
 		arg.ProjectID,
 		arg.ExternalUserID,
 		arg.UserID,
@@ -203,9 +217,7 @@ func (q *Queries) CountChats(ctx context.Context, arg CountChatsParams) (int64, 
 		arg.AssistantID,
 		arg.SourceKind,
 		arg.ExcludeSourceKind,
-		arg.HasRiskFilter,
 		arg.AccountType,
-		arg.MinRiskScore,
 		arg.Sources,
 	)
 	var total int64
@@ -1548,22 +1560,22 @@ func (q *Queries) ListChatResolutions(ctx context.Context, chatID uuid.UUID) ([]
 }
 
 const listChatSources = `-- name: ListChatSources :many
-WITH latest_sources AS (
-  SELECT DISTINCT ON (cm.chat_id) cm.source AS source
-  FROM chats c
-  JOIN chat_messages cm ON cm.chat_id = c.id
-  WHERE c.project_id = $1
-    AND c.deleted IS FALSE
-    AND ($2::text = '' OR c.external_user_id = $2::text)
-    AND ($3::text = '' OR c.user_id = $3::text)
+SELECT DISTINCT latest.source
+FROM chats c
+CROSS JOIN LATERAL (
+  SELECT cm.source
+  FROM chat_messages cm
+  WHERE cm.chat_id = c.id
     AND cm.source IS NOT NULL
     AND cm.source <> ''
-  ORDER BY cm.chat_id, cm.created_at DESC
-)
-SELECT DISTINCT source
-FROM latest_sources
-WHERE source IS NOT NULL
-ORDER BY source
+  ORDER BY cm.created_at DESC
+  LIMIT 1
+) latest
+WHERE c.project_id = $1
+  AND c.deleted IS FALSE
+  AND ($2::text = '' OR c.external_user_id = $2::text)
+  AND ($3::text = '' OR c.user_id = $3::text)
+ORDER BY latest.source
 `
 
 type ListChatSourcesParams struct {
@@ -1576,6 +1588,11 @@ type ListChatSourcesParams struct {
 // project's chats, honoring the same visibility scoping as ListChats. Feeds the
 // agent-type filter options on the Agent Sessions page so the list reflects the
 // sources actually present in the data rather than a hardcoded catalog.
+// Driven from chats with a per-chat probe on
+// chat_messages_chat_id_created_at_source_idx for the latest non-empty source,
+// instead of sorting the project's entire message history. The lateral join
+// drops chats with no sourced messages, matching the previous inner-join
+// semantics.
 func (q *Queries) ListChatSources(ctx context.Context, arg ListChatSourcesParams) ([]pgtype.Text, error) {
 	rows, err := q.db.Query(ctx, listChatSources, arg.ProjectID, arg.ExternalUserID, arg.UserID)
 	if err != nil {
@@ -1605,7 +1622,8 @@ WITH risk_counts AS (
   -- disabling/deleting a policy retires its findings everywhere (keeps this
   -- count in sync with the risk.results.list detail view).
   JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
-  WHERE rr.project_id = $1
+  WHERE ($2::text <> '' OR $3::int >= 0)
+    AND rr.project_id = $1
     AND rr.found IS TRUE
     AND rr.excluded_at IS NULL
     AND rr.false_positive_at IS NULL
@@ -1619,7 +1637,6 @@ candidate_chats AS (
     c.external_user_id,
     c.created_at,
     c.updated_at,
-    COALESCE(rc.cnt, 0) AS risk_findings_count,
     COALESCE(ua.account_type, '')::text AS account_type,
     COALESCE(ua.email, '')::text AS account_email
   FROM chats c
@@ -1629,53 +1646,53 @@ candidate_chats AS (
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
   WHERE c.project_id = $1
     AND c.deleted IS FALSE
-    AND ($2 = '' OR c.external_user_id = $2)
-    AND ($3 = '' OR c.user_id = $3)
+    AND ($4 = '' OR c.external_user_id = $4)
+    AND ($5 = '' OR c.user_id = $5)
     AND (
-      $4::text = ''
-      OR ($4::text = 'true' AND c.pinned_at IS NOT NULL)
-      OR ($4::text = 'false' AND c.pinned_at IS NULL)
+      $6::text = ''
+      OR ($6::text = 'true' AND c.pinned_at IS NOT NULL)
+      OR ($6::text = 'false' AND c.pinned_at IS NULL)
     )
     AND (
-      $5 = ''
-      OR c.id::text ILIKE '%' || $5 || '%'
-      OR c.external_user_id ILIKE '%' || $5 || '%'
-      OR c.title ILIKE '%' || $5 || '%'
+      $7 = ''
+      OR c.id::text ILIKE '%' || $7 || '%'
+      OR c.external_user_id ILIKE '%' || $7 || '%'
+      OR c.title ILIKE '%' || $7 || '%'
     )
     AND (
-      $6 = ''
+      $8 = ''
       OR EXISTS (
         SELECT 1 FROM assistant_threads at
         WHERE at.chat_id = c.id
-          AND at.assistant_id = $6::uuid
+          AND at.assistant_id = $8::uuid
           AND at.deleted IS FALSE
           -- Optional source-kind dimension so setup/onboarding and runtime
           -- threads for the same assistant don't pollute each other's listing.
           -- @source_kind keeps only threads of that kind (onboarding passes
           -- 'setup'); @exclude_source_kind drops threads of that kind (runtime
           -- views pass 'setup'). Empty string on either disables that side.
-          AND ($7::text = '' OR at.source_kind = $7::text)
-          AND ($8::text = '' OR at.source_kind <> $8::text)
+          AND ($9::text = '' OR at.source_kind = $9::text)
+          AND ($10::text = '' OR at.source_kind <> $10::text)
       )
     )
     AND (
-      $9::text = ''
-      OR ($9::text = 'true' AND COALESCE(rc.cnt, 0) > 0)
-      OR ($9::text = 'false' AND COALESCE(rc.cnt, 0) = 0)
+      $2::text = ''
+      OR ($2::text = 'true' AND COALESCE(rc.cnt, 0) > 0)
+      OR ($2::text = 'false' AND COALESCE(rc.cnt, 0) = 0)
     )
     AND (
-      $10::text = ''
-      OR ua.account_type = $10::text
+      $11::text = ''
+      OR ua.account_type = $11::text
       -- Rows without a classified account type are treated as 'team' so the
       -- team filter stays backwards-compatible with pre-classification chats.
       OR (
-        $10::text = 'team'
+        $11::text = 'team'
         AND (ua.account_type IS NULL OR ua.account_type = '')
       )
     )
     AND (
-      $11::int < 0
-      OR COALESCE(rc.cnt, 0) >= $11::int
+      $3::int < 0
+      OR COALESCE(rc.cnt, 0) >= $3::int
     )
     AND (
       coalesce(cardinality($12::text[]), 0) = 0
@@ -1691,13 +1708,21 @@ candidate_chats AS (
     )
 ),
 chat_stats AS (
+  -- Per-chat probe on chat_messages_chat_id_created_at_idx (index-only count +
+  -- max) instead of aggregating every candidate chat's full message history.
   SELECT
     cc.id,
-    COUNT(cm.id)::integer AS num_messages,
-    COALESCE(MAX(cm.created_at), cc.created_at) AS last_message_timestamp
+    stats.num_messages,
+    COALESCE(stats.max_created_at, cc.created_at)::timestamptz AS last_message_timestamp
   FROM candidate_chats cc
-  LEFT JOIN chat_messages cm ON cm.chat_id = cc.id
-  GROUP BY cc.id, cc.created_at
+  CROSS JOIN LATERAL (
+    -- COUNT(*) rather than COUNT(cm.id) so the probe stays index-only.
+    SELECT
+      COUNT(*)::integer AS num_messages,
+      MAX(cm.created_at) AS max_created_at
+    FROM chat_messages cm
+    WHERE cm.chat_id = cc.id
+  ) stats
 ),
 filtered_chats AS (
   SELECT
@@ -1709,7 +1734,6 @@ filtered_chats AS (
     cc.updated_at,
     cs.num_messages,
     cs.last_message_timestamp,
-    cc.risk_findings_count,
     cc.account_type,
     cc.account_email
   FROM candidate_chats cc
@@ -1728,9 +1752,11 @@ limited_chats AS (
     fc.num_messages,
     (SELECT source FROM chat_messages WHERE chat_id = fc.id AND source IS NOT NULL AND source <> '' ORDER BY created_at DESC LIMIT 1) AS source,
     fc.last_message_timestamp,
-    fc.risk_findings_count,
     fc.account_type,
-    fc.account_email
+    fc.account_email,
+    -- Window count runs before LIMIT/OFFSET, so every returned row carries the
+    -- total number of filtered chats.
+    COUNT(*) OVER ()::bigint AS total_count
   FROM filtered_chats fc
   ORDER BY
     CASE WHEN $15 = 'last_message_timestamp' AND $16 = 'desc' THEN fc.last_message_timestamp END DESC NULLS LAST,
@@ -1752,14 +1778,29 @@ SELECT
   lc.updated_at,
   lc.num_messages,
   lc.last_message_timestamp,
-  lc.risk_findings_count,
+  -- Active findings for the returned page rows only; must stay in sync with
+  -- the risk_counts predicate above (and the risk.results.list detail view).
+  (
+    SELECT COUNT(*)::integer
+    FROM risk_results rr
+    JOIN chat_messages cm ON cm.id = rr.chat_message_id
+    JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
+    WHERE rr.project_id = $1
+      AND cm.chat_id = lc.id
+      AND rr.found IS TRUE
+      AND rr.excluded_at IS NULL
+      AND rr.false_positive_at IS NULL
+  ) AS risk_findings_count,
   lc.account_type,
-  lc.account_email
+  lc.account_email,
+  lc.total_count
 FROM limited_chats lc
 `
 
 type ListChatsParams struct {
 	ProjectID         uuid.UUID
+	HasRiskFilter     string
+	MinRiskScore      int32
 	ExternalUserID    interface{}
 	UserID            interface{}
 	Pinned            string
@@ -1767,9 +1808,7 @@ type ListChatsParams struct {
 	AssistantID       interface{}
 	SourceKind        string
 	ExcludeSourceKind string
-	HasRiskFilter     string
 	AccountType       string
-	MinRiskScore      int32
 	Sources           []string
 	FromTime          pgtype.Timestamptz
 	ToTime            pgtype.Timestamptz
@@ -1792,15 +1831,23 @@ type ListChatsRow struct {
 	RiskFindingsCount    int32
 	AccountType          string
 	AccountEmail         string
+	TotalCount           int64
 }
 
+// Returns the page plus the pre-LIMIT total (total_count window column), so the
+// handler only needs a separate CountChats round trip when the requested page
+// is past the end of the result set.
+//
 // risk_counts pre-aggregates active findings per chat once for the whole
-// project (one pass over risk_results). It feeds both the risk presence +
-// threshold filters and the risk_findings_count column below, replacing what
-// were two correlated subqueries per candidate chat.
+// project (one pass over risk_results) to serve the risk presence + threshold
+// filters. The parameter-only gate makes it a one-time filter that skips the
+// scan entirely when neither risk filter is active; the displayed
+// risk_findings_count is computed per returned page row in the final SELECT.
 func (q *Queries) ListChats(ctx context.Context, arg ListChatsParams) ([]ListChatsRow, error) {
 	rows, err := q.db.Query(ctx, listChats,
 		arg.ProjectID,
+		arg.HasRiskFilter,
+		arg.MinRiskScore,
 		arg.ExternalUserID,
 		arg.UserID,
 		arg.Pinned,
@@ -1808,9 +1855,7 @@ func (q *Queries) ListChats(ctx context.Context, arg ListChatsParams) ([]ListCha
 		arg.AssistantID,
 		arg.SourceKind,
 		arg.ExcludeSourceKind,
-		arg.HasRiskFilter,
 		arg.AccountType,
-		arg.MinRiskScore,
 		arg.Sources,
 		arg.FromTime,
 		arg.ToTime,
@@ -1839,6 +1884,7 @@ func (q *Queries) ListChats(ctx context.Context, arg ListChatsParams) ([]ListCha
 			&i.RiskFindingsCount,
 			&i.AccountType,
 			&i.AccountEmail,
+			&i.TotalCount,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -196,7 +196,9 @@ type CountChatsParams struct {
 
 // Fallback for chats.list pagination: ListChats returns the total alongside
 // each page via a window count, so this only runs when a requested page is
-// past the end of the result set (no rows to carry the total).
+// past the end of the result set (no rows to carry the total). The handler
+// runs it in the same repeatable-read transaction as the ListChats page read,
+// so the total reflects the same snapshot the empty page came from.
 //
 // risk_counts pre-aggregates active findings per chat once for the whole
 // project (one pass over risk_results), so the risk presence + threshold


### PR DESCRIPTION
# fix: stop chats.list and listSources from aggregating whole project per page

`chats.list` and `chats.listSources` were taking seconds on the dashboard. Both derived per-chat facts (message count, last-message time, latest source, risk findings) by aggregating the project's **entire** `chat_messages` / `risk_results` history on every request — and `chats.list` did most of that work twice (once for `CountChats`, once for `ListChats`).

## Changes

**`ListChats` / `CountChats`**
- The whole-table `chat_messages` LEFT JOIN + GROUP BY becomes a per-chat `LATERAL` probe (index-only `COUNT(*)` + `MAX(created_at)` on `chat_messages_chat_id_created_at_idx`).
- The `risk_counts` CTE (one pass over the project's `risk_results`) is gated behind a parameter-only condition, so it only runs when a risk filter is actually active. Verified via `EXPLAIN`: it plans as a `One-Time Filter` with the scans `(never executed)` when inactive. The displayed `risk_findings_count` moves to a per-page-row subquery with identical predicates.
- `ListChats` now returns the pre-LIMIT total via `COUNT(*) OVER ()`, so the handler only calls `CountChats` when the requested offset is past the end of the result set (no rows to carry the total). This halves the remaining work and makes the total exactly consistent with the page.

**`ListChatSources`**
- `DISTINCT ON` over the join of all project chats × all their messages (full scan + sort per dropdown load) becomes one index-only backward probe per chat on the partial `chat_messages_chat_id_created_at_source_idx`.

## Behavior

No user-visible change: identical filters, values, ordering, and API surface. The one nuance is an improvement — `total` now comes from the same statement as the page, so it can no longer disagree with the page contents under concurrent inserts.

## Dependencies

The supporting indexes ship separately in #4197 (migrations-in-their-own-PR rule) and should land first. These queries are correct without them, just slower.

## Testing

- Full `server/internal/chat` test suite passes.
- `EXPLAIN` on all three rewritten paths confirms the intended plans (one-time filter gate, index-only lateral probes).
- `lint:server` clean.
