### PR TITLE
feat(dashboard): show created and updated dates in risk policies table

### DIFF
--- a/.changeset/policy-table-created-updated.md
+++ b/.changeset/policy-table-created-updated.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The risk policies table now shows Created and Updated columns with compact relative dates; hovering either reveals the exact timestamp.

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -85,6 +85,7 @@ import {
   type PolicyMessageType,
 } from "./policy-data";
 import { cn } from "@/lib/utils";
+import { dateTimeFormatters, HumanizeDateTime } from "@/lib/dates";
 import { useDetectionRulesStore } from "./detection-rules-data";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useRoutes } from "@/routes";
@@ -588,6 +589,18 @@ function isPromptPolicy(policy: RiskPolicy): boolean {
   return policy.policyType === "prompt_based";
 }
 
+/** Compact relative date for the policy table's Created/Updated columns, with
+ *  the exact timestamp on hover. */
+function PolicyDateCell({ date }: { date: Date }): JSX.Element {
+  return (
+    <SimpleTooltip tooltip={dateTimeFormatters.full.format(date)}>
+      <span className="text-muted-foreground text-sm whitespace-nowrap">
+        <HumanizeDateTime date={date} includeTime={false} />
+      </span>
+    </SimpleTooltip>
+  );
+}
+
 export default function PolicyCenter(): JSX.Element {
   return (
     <RequireScope scope="org:admin" level="page">
@@ -856,6 +869,18 @@ function PolicyCenterContent() {
           {policyAudienceSummary(row)}
         </span>
       ),
+    },
+    {
+      key: "createdAt",
+      header: "Created",
+      width: "0.8fr",
+      render: (row) => <PolicyDateCell date={row.policy.createdAt} />,
+    },
+    {
+      key: "updatedAt",
+      header: "Updated",
+      width: "0.8fr",
+      render: (row) => <PolicyDateCell date={row.policy.updatedAt} />,
     },
     {
       key: "actions",


### PR DESCRIPTION
## Summary

Adds **Created** and **Updated** columns to the Policy Center policies table. Both fields were already returned by `riskListPolicies` (the table was already sorting by `createdAt`) — they just weren't displayed.

- Compact relative dates (`HumanizeDateTime` with `includeTime={false}`, same pattern as the Triggers table), so cells stay narrow in an already-dense table
- Hovering a date shows the exact timestamp in a tooltip
- Shared `PolicyDateCell` helper so both columns render identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mXQiLSpuJoZTGm2zzu8Lf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Created and Updated columns to the risk policies table with compact relative dates; hover shows the exact timestamp. Both columns use a shared PolicyDateCell for consistent rendering and minimal width.

<sup>Written for commit 1f3feb762157f3df2a653452529e300447d14667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

