### PR TITLE
mig(clickhouse): add shadow server name override

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260714200951_shadow-mcp-server-name-override.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260714200951_shadow-mcp-server-name-override.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `shadow_mcp_inventory_urls` DROP COLUMN `server_name_override`;

--- a/server/clickhouse/local/golang_migrate/20260714200951_shadow-mcp-server-name-override.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260714200951_shadow-mcp-server-name-override.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `shadow_mcp_inventory_urls` ADD COLUMN `server_name_override` String DEFAULT '' AFTER `server_name`;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:Hg5O+/gb1lwLm+MZw+wdP9Iwtno11ldzFIHJAgx21OQ=
+h1:GUtsMQUeIWRtPOUUUe6Qkq7qsMAbC8WrTqPXYQikwS4=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -61,3 +61,4 @@ h1:Hg5O+/gb1lwLm+MZw+wdP9Iwtno11ldzFIHJAgx21OQ=
 20260714115000_chat-token-summaries-hook-source.up.sql h1:imvQVMa/2Ceuy6tnFmkld537Wr2CwzNsi3qs9DysDA4=
 20260714115010_tum-breakdown-summaries.up.sql h1:TcimH9EEZmoeVZixI3x6kGInFlHcGY4Vl00cgZDKWYM=
 20260714173525_drop-tum-breakdown-summaries.up.sql h1:bN2z1+CUm9cttkIMubc0en+gp7viCi4ojcCACI8rhtU=
+20260714200951_shadow-mcp-server-name-override.up.sql h1:O6ZXprNwT+7pVXUmO6pkPoy+SFpCh4+zSH3E61ODGnQ=

--- a/server/clickhouse/migrations/20260714200946_shadow-mcp-server-name-override.sql
+++ b/server/clickhouse/migrations/20260714200946_shadow-mcp-server-name-override.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `shadow_mcp_inventory_urls` ADD COLUMN `server_name_override` String DEFAULT '' AFTER `server_name`;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:td+gck5j62Je7cBaeKWY89zi8IWEu6fGAr2Q8Pjj5rY=
+h1:Beq/KEH80GXTZkfSqhQhsId5C3uo/curjvpCdaYLMks=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -66,3 +66,4 @@ h1:td+gck5j62Je7cBaeKWY89zi8IWEu6fGAr2Q8Pjj5rY=
 20260714002931_shadow-mcp-inventory-slug-hash-index.sql h1:ADB3UFfaTz1mFPB48773RbSxvK9BzKhgckcQK6Qpkcs=
 20260714104103_remove-semicolons-from-comments.sql h1:rmLVYmzQHSaEFOpdgNm8kVycsC9IenURpFjFa4ZI6PY=
 20260714173521_drop-tum-breakdown-summaries.sql h1:La2w4JzKmjNoWbI1cZXtZKwXYCbFSkNUHwgVACpS0IY=
+20260714200946_shadow-mcp-server-name-override.sql h1:FjftHYJ4Mqv4G1R1n0LoyA4M5pVgXcRwhz6ZUiebLd8=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -268,6 +268,7 @@ CREATE TABLE IF NOT EXISTS shadow_mcp_inventory_urls (
     canonical_server_url String,
     url_host String,
     server_name String,
+    server_name_override String DEFAULT '',
     first_seen DateTime64(9, 'UTC'),
     last_seen DateTime64(9, 'UTC'),
     updated_at DateTime64(9, 'UTC')


### PR DESCRIPTION
## Summary

- add a dedicated `server_name_override` column to the Shadow MCP inventory URL table
- keep the production Atlas migration and local golang-migrate files synchronized
- default existing and newly observed rows to an empty override for backward compatibility

## Stack

This is the migration-only prerequisite for AGE-2994. The dependent feature PR will target this branch so application and UI changes remain isolated.

## Verification

- `mise run clickhouse:hash`
- `mise run test:server ./internal/telemetry -count=1` — 260 tests passed
- `git diff --check`

Part of AGE-2994.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server_name_override column to the Shadow MCP inventory URLs table in ClickHouse so server names can be edited. Migration-only prereq for AGE-2994; defaults to '' for backward compatibility.

- **Migration**
  - Adds server_name_override String DEFAULT '' to shadow_mcp_inventory_urls (after server_name); updates schema.sql.
  - Adds Atlas migration and local golang-migrate up/down scripts; updates atlas.sum in both.
  - No app/UI changes; run DB migrations only.

<sup>Written for commit 842b1da5dde23c38fab7bd359ab627b920eb206e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

