### PR TITLE
fix(seed): avoid hardcoded ClickHouse container

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -74,6 +74,12 @@ const log = {
   error: (message: string) => clackLog.error(`${message} ${lap()}`),
 };
 
+async function runClickHouseSQL(sql: string): Promise<void> {
+  await $({
+    input: sql,
+  })`docker compose exec -T clickhouse clickhouse-client --multiquery`.quiet();
+}
+
 type Asset = {
   slug: string;
 } & (
@@ -548,14 +554,7 @@ async function seedShadowMCPInventoryData(init: {
   `;
 
   try {
-    const tmpFile = path.join(process.cwd(), ".seed-shadow-mcp.sql");
-    await fs.writeFile(tmpFile, sql, "utf-8");
-    try {
-      await $`docker cp ${tmpFile} gram-clickhouse-1:/tmp/seed-shadow-mcp.sql`.quiet();
-      await $`docker exec gram-clickhouse-1 clickhouse-client --multiquery --queries-file /tmp/seed-shadow-mcp.sql`.quiet();
-    } finally {
-      await fs.unlink(tmpFile).catch(() => {});
-    }
+    await runClickHouseSQL(sql);
     log.info(
       `Seeded ${servers.length} Shadow MCP servers with ${telemetryRows.length} calls into '${SEED_PROJECTS[0].slug}'.`,
     );
@@ -2820,14 +2819,7 @@ async function seedPersonalAccounts(init: {
   `;
 
   try {
-    const tmpFile = path.join(process.cwd(), ".seed-personal-accounts-ch.sql");
-    await fs.writeFile(tmpFile, chSQL, "utf-8");
-    try {
-      await $`docker cp ${tmpFile} gram-clickhouse-1:/tmp/seed-personal-accounts-ch.sql`.quiet();
-      await $`docker exec gram-clickhouse-1 clickhouse-client --multiquery --queries-file /tmp/seed-personal-accounts-ch.sql`.quiet();
-    } finally {
-      await fs.unlink(tmpFile).catch(() => {});
-    }
+    await runClickHouseSQL(chSQL);
     log.info(
       `Seeded ${chRows.length} usage rows + ${toolRows.length / 2} tool-call traces (team/personal) into ClickHouse.`,
     );
@@ -4345,15 +4337,7 @@ async function seedObservabilityData(init: {
   `;
 
   try {
-    // Write to temp file and execute via docker
-    const tmpFile = `/tmp/seed_clickhouse_${Date.now()}.sql`;
-    await fs.writeFile(tmpFile, chSQL);
-
-    // Use docker exec to run clickhouse-client inside the container
-    // Copy the file into the container, then execute using --queries-file
-    await $`docker cp ${tmpFile} gram-clickhouse-1:/tmp/seed.sql`.quiet();
-    await $`docker exec gram-clickhouse-1 clickhouse-client --multiquery --queries-file /tmp/seed.sql`.quiet();
-    await fs.unlink(tmpFile);
+    await runClickHouseSQL(chSQL);
     log.info(`Inserted ${chInserts.length} telemetry events into ClickHouse`);
   } catch (e) {
     log.warn(`Failed to seed ClickHouse: ${e}`);


### PR DESCRIPTION
## Summary

- resolve ClickHouse through the Docker Compose service instead of the hardcoded `gram-clickhouse-1` container name
- stream SQL directly to `clickhouse-client` over stdin, removing temporary file and copy cleanup
- share the execution path across Shadow MCP, personal-account, and observability seed data

## Verification

- `pnpm exec oxfmt --check .mise-tasks/seed.mts`
- `node --import tsx --check .mise-tasks/seed.mts`
- `git diff --check`
- `mise run seed` could not complete because the local server on port 8080 was not running

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve ClickHouse via the Docker Compose `clickhouse` service and stream SQL to `clickhouse-client` over stdin to make seeding reliable across environments and remove temp file handling.

- **Bug Fixes**
  - Use `docker compose exec -T clickhouse` instead of the hardcoded `gram-clickhouse-1` container.

- **Refactors**
  - Added `runClickHouseSQL(sql)` and reused it in Shadow MCP, personal-account, and observability seed paths.

<sup>Written for commit 09a006aa01128e2b8febd6458bb8f7419d4b33e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

