### PR TITLE
fix: persist compliance activities cursor incrementally during sync

### DIFF
--- a/server/internal/aiintegrations/compliance_import.go
+++ b/server/internal/aiintegrations/compliance_import.go
@@ -50,6 +50,11 @@ type discoveredActivity struct {
 	// every activity up to the page's pagination token is fully imported
 	// and the token may be persisted as the global activities cursor.
 	activitiesCursor string
+	// cursorOnly marks a sentinel for a page with no importable activities.
+	// It carries just the page's pagination token; the import stage forwards
+	// it to the writer without fetching anything so the cursor still
+	// advances past fully-filtered pages.
+	cursorOnly bool
 }
 
 // messagePageBatch is one fetched page of chat messages ready to write.
@@ -65,6 +70,9 @@ type messagePageBatch struct {
 	// the last completed activities page instead of the stored cursor from
 	// the previous successful sync.
 	activitiesCursor string
+	// cursorOnly marks a sentinel batch that carries just an activities
+	// cursor for a fully-filtered page; there is nothing to write.
+	cursorOnly bool
 }
 
 type ComplianceImportService struct {
@@ -167,6 +175,18 @@ func (s *ComplianceImportService) SyncAnthropicCompliance(ctx context.Context, c
 func (s *ComplianceImportService) importChatActivities(ctx context.Context, client *anthropicapi.Client, cfg Config, in <-chan discoveredActivity, out chan<- messagePageBatch, progress *ComplianceSyncProgress) error {
 	users := newConnectedUserResolver(s.db, cfg.OrganizationID)
 	for discovered := range in {
+		if discovered.cursorOnly {
+			// A fully-filtered page has no chats to import; forward its
+			// cursor straight to the writer so it still becomes durable
+			// after all previously discovered work is written.
+			select {
+			case <-ctx.Done():
+				return ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
+			case out <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: discovered.activitiesCursor, cursorOnly: true}:
+			}
+			continue
+		}
+
 		activity := discovered.activity
 		s.heartbeat(ctx, "chat_import", progress.ChatsImported)
 		chatID, messagesCursor, err := s.upsertActivityChat(ctx, cfg, activity, users)
@@ -193,21 +213,23 @@ func (s *ComplianceImportService) importChatActivities(ctx context.Context, clie
 // cursor is advanced so retries resume from the last completed page.
 func (s *ComplianceImportService) writeMessagePages(ctx context.Context, cfg Config, in <-chan messagePageBatch, progress *ComplianceSyncProgress) error {
 	for batch := range in {
-		s.heartbeat(ctx, "message_write", progress.MessagePagesWritten+1)
+		if !batch.cursorOnly {
+			s.heartbeat(ctx, "message_write", progress.MessagePagesWritten+1)
 
-		if _, err := s.writer.WriteExternal(ctx, cfg.ProjectID, batch.rows); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "write anthropic compliance chat messages")
-		}
-
-		if batch.lastID != "" {
-			if err := chatrepo.New(s.db).UpdateAIIntegrationConfigChatCursor(ctx, chatrepo.UpdateAIIntegrationConfigChatCursorParams{
-				LastCursorID: conv.ToPGText(batch.lastID),
-				ChatID:       batch.chatID,
-			}); err != nil {
-				return oops.E(oops.CodeUnexpected, err, "record anthropic compliance chat cursor")
+			if _, err := s.writer.WriteExternal(ctx, cfg.ProjectID, batch.rows); err != nil {
+				return oops.E(oops.CodeUnexpected, err, "write anthropic compliance chat messages")
 			}
+
+			if batch.lastID != "" {
+				if err := chatrepo.New(s.db).UpdateAIIntegrationConfigChatCursor(ctx, chatrepo.UpdateAIIntegrationConfigChatCursorParams{
+					LastCursorID: conv.ToPGText(batch.lastID),
+					ChatID:       batch.chatID,
+				}); err != nil {
+					return oops.E(oops.CodeUnexpected, err, "record anthropic compliance chat cursor")
+				}
+			}
+			progress.MessagePagesWritten++
 		}
-		progress.MessagePagesWritten++
 
 		// Batches arrive in feed order, so once the last batch of an
 		// activities page is written, everything discovered up to that
@@ -270,7 +292,7 @@ func (s *ComplianceImportService) streamChatActivities(ctx context.Context, clie
 		}
 
 		for i, activity := range importable {
-			discovered := discoveredActivity{activity: activity, activitiesCursor: ""}
+			discovered := discoveredActivity{activity: activity, activitiesCursor: "", cursorOnly: false}
 			if i == len(importable)-1 && page.LastID != "" {
 				discovered.activitiesCursor = page.LastID
 			}
@@ -279,6 +301,20 @@ func (s *ComplianceImportService) streamChatActivities(ctx context.Context, clie
 				return nextCursor, ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
 			case out <- discovered:
 				progress.ChatActivities++
+			}
+		}
+
+		if len(importable) == 0 && page.LastID != "" {
+			// A page with no importable activities still advances the feed.
+			// Emit a cursor-only sentinel so the writer persists the page's
+			// token once all previously discovered work is durably written;
+			// otherwise retries would re-fetch fully-filtered pages forever
+			// on feeds dominated by non-user activities.
+			var none anthropicapi.Activity
+			select {
+			case <-ctx.Done():
+				return nextCursor, ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
+			case out <- discoveredActivity{activity: none, activitiesCursor: page.LastID, cursorOnly: true}:
 			}
 		}
 
@@ -369,7 +405,7 @@ func (s *ComplianceImportService) fetchChatMessages(ctx context.Context, client 
 			return err
 		}
 
-		batch := messagePageBatch{chatID: chatID, rows: rows, lastID: page.LastID, activitiesCursor: ""}
+		batch := messagePageBatch{chatID: chatID, rows: rows, lastID: page.LastID, activitiesCursor: "", cursorOnly: false}
 		finalPage := !page.HasMore || page.LastID == ""
 		if finalPage {
 			// The chat's last message page closes out the activity; if the

--- a/server/internal/aiintegrations/compliance_import.go
+++ b/server/internal/aiintegrations/compliance_import.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
@@ -41,6 +42,16 @@ const (
 	anthropicComplianceMessagePageBufferSize = 2
 )
 
+// discoveredActivity is one importable chat activity from the feed.
+type discoveredActivity struct {
+	activity anthropicapi.Activity
+	// activitiesCursor is set on the final importable activity of an
+	// activities page: once that activity's messages are durably written,
+	// every activity up to the page's pagination token is fully imported
+	// and the token may be persisted as the global activities cursor.
+	activitiesCursor string
+}
+
 // messagePageBatch is one fetched page of chat messages ready to write.
 type messagePageBatch struct {
 	chatID uuid.UUID
@@ -48,6 +59,12 @@ type messagePageBatch struct {
 	// lastID is the page's pagination token; it advances the per-chat
 	// message cursor only after the page's rows are durably written.
 	lastID string
+	// activitiesCursor, when set, marks this batch as the last one produced
+	// by an activities page; the writer persists it as the global activities
+	// cursor once the batch is durably written, so a failed run resumes from
+	// the last completed activities page instead of the stored cursor from
+	// the previous successful sync.
+	activitiesCursor string
 }
 
 type ComplianceImportService struct {
@@ -71,7 +88,11 @@ func NewComplianceImportService(logger *slog.Logger, db *pgxpool.Pool, guardianP
 // SyncAnthropicCompliance imports new compliance activity and chat messages.
 // It returns the activities pagination cursor reached by this run; callers
 // must persist it on success so the next run resumes after the last imported
-// activity instead of re-discovering by time window.
+// activity instead of re-discovering by time window. The cursor is also
+// persisted incrementally during the run — after each activities page whose
+// chats are fully written — so retries of a failed or timed-out run resume
+// from the last completed page rather than repaying the whole discovery
+// cost.
 //
 // The sync is a three-stage pipeline: a producer goroutine streams chat
 // activities from the feed page by page, a fetch goroutine resolves each chat
@@ -93,7 +114,7 @@ func (s *ComplianceImportService) SyncAnthropicCompliance(ctx context.Context, c
 	client := anthropicapi.New(s.guardianPolicy, anthropicapi.WithAPIKey(cfg.APIKey))
 
 	g, gctx := errgroup.WithContext(ctx)
-	chatActivities := make(chan anthropicapi.Activity, anthropicComplianceActivityBufferSize)
+	chatActivities := make(chan discoveredActivity, anthropicComplianceActivityBufferSize)
 	messagePages := make(chan messagePageBatch, anthropicComplianceMessagePageBufferSize)
 
 	// Each stage writes only its own progress fields and error variable;
@@ -106,6 +127,7 @@ func (s *ComplianceImportService) SyncAnthropicCompliance(ctx context.Context, c
 		MessagePagesFetched: 0,
 		MessagePagesWritten: 0,
 		CursorReached:       "",
+		CursorPersisted:     "",
 	}
 	var nextCursor string
 	var discoverErr, importErr, writeErr error
@@ -142,9 +164,10 @@ func (s *ComplianceImportService) SyncAnthropicCompliance(ctx context.Context, c
 // rows, and pages each chat's messages into row batches for the writer
 // stage. It doesn't matter if a chat is imported more than once per run,
 // because chat inserts are idempotent.
-func (s *ComplianceImportService) importChatActivities(ctx context.Context, client *anthropicapi.Client, cfg Config, in <-chan anthropicapi.Activity, out chan<- messagePageBatch, progress *ComplianceSyncProgress) error {
+func (s *ComplianceImportService) importChatActivities(ctx context.Context, client *anthropicapi.Client, cfg Config, in <-chan discoveredActivity, out chan<- messagePageBatch, progress *ComplianceSyncProgress) error {
 	users := newConnectedUserResolver(s.db, cfg.OrganizationID)
-	for activity := range in {
+	for discovered := range in {
+		activity := discovered.activity
 		s.heartbeat(ctx, "chat_import", progress.ChatsImported)
 		chatID, messagesCursor, err := s.upsertActivityChat(ctx, cfg, activity, users)
 		if err != nil {
@@ -156,7 +179,7 @@ func (s *ComplianceImportService) importChatActivities(ctx context.Context, clie
 		// chat is first seen via its created activity; it doesn't change
 		// on later claude_chat_updated activities.
 		enrichChat := activity.Type == anthropicComplianceActivityCreated
-		if err := s.fetchChatMessages(ctx, client, cfg, chatID, activity, messagesCursor, enrichChat, users, out, progress); err != nil {
+		if err := s.fetchChatMessages(ctx, client, cfg, chatID, activity, messagesCursor, enrichChat, discovered.activitiesCursor, users, out, progress); err != nil {
 			return err
 		}
 	}
@@ -166,7 +189,8 @@ func (s *ComplianceImportService) importChatActivities(ctx context.Context, clie
 // writeMessagePages persists fetched message pages. It must remain a single
 // goroutine: the per-chat message cursor may only advance after that page's
 // rows are durably written, and pages of one chat must be written in feed
-// order.
+// order. When a batch closes out an activities page, the global activities
+// cursor is advanced so retries resume from the last completed page.
 func (s *ComplianceImportService) writeMessagePages(ctx context.Context, cfg Config, in <-chan messagePageBatch, progress *ComplianceSyncProgress) error {
 	for batch := range in {
 		s.heartbeat(ctx, "message_write", progress.MessagePagesWritten+1)
@@ -184,6 +208,20 @@ func (s *ComplianceImportService) writeMessagePages(ctx context.Context, cfg Con
 			}
 		}
 		progress.MessagePagesWritten++
+
+		// Batches arrive in feed order, so once the last batch of an
+		// activities page is written, everything discovered up to that
+		// page's pagination token is durable and the token is a safe
+		// resume point.
+		if batch.activitiesCursor != "" {
+			if err := repo.New(s.db).AdvanceUsagePollCursor(ctx, repo.AdvanceUsagePollCursorParams{
+				LastCursorID:          conv.ToPGText(batch.activitiesCursor),
+				AiIntegrationConfigID: cfg.ID,
+			}); err != nil {
+				return oops.E(oops.CodeUnexpected, err, "advance anthropic compliance activities cursor")
+			}
+			progress.CursorPersisted = batch.activitiesCursor
+		}
 	}
 	return nil
 }
@@ -192,7 +230,11 @@ func (s *ComplianceImportService) writeMessagePages(ctx context.Context, cfg Con
 // persisted cursor and sends chat activities to out as they are discovered.
 // It returns the cursor reached by this run: the verbatim last_id pagination
 // token from the final page, not an id derived from imported rows.
-func (s *ComplianceImportService) streamChatActivities(ctx context.Context, client *anthropicapi.Client, cfg Config, out chan<- anthropicapi.Activity, progress *ComplianceSyncProgress) (string, error) {
+//
+// The final importable activity of each page carries the page's pagination
+// token so the writer stage can persist the global cursor once that
+// activity's messages are durably written.
+func (s *ComplianceImportService) streamChatActivities(ctx context.Context, client *anthropicapi.Client, cfg Config, out chan<- discoveredActivity, progress *ComplianceSyncProgress) (string, error) {
 	// First sync has no cursor yet; bound the initial backfill with a time
 	// window around the watermark. Every later sync resumes from the cursor.
 	createdAtGTE := time.Time{}
@@ -219,14 +261,23 @@ func (s *ComplianceImportService) streamChatActivities(ctx context.Context, clie
 		}
 		progress.ActivityPages++
 
+		importable := make([]anthropicapi.Activity, 0, len(page.Data))
 		for _, activity := range page.Data {
 			if activity.Actor.Type != "user_actor" || activity.ClaudeChatID == "" {
 				continue
 			}
+			importable = append(importable, activity)
+		}
+
+		for i, activity := range importable {
+			discovered := discoveredActivity{activity: activity, activitiesCursor: ""}
+			if i == len(importable)-1 && page.LastID != "" {
+				discovered.activitiesCursor = page.LastID
+			}
 			select {
 			case <-ctx.Done():
 				return nextCursor, ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
-			case out <- activity:
+			case out <- discovered:
 				progress.ChatActivities++
 			}
 		}
@@ -293,7 +344,7 @@ func (s *ComplianceImportService) upsertActivityChat(ctx context.Context, cfg Co
 // When enrichChat is set, the first page's chat-level metadata (title,
 // owner, timestamps) is upserted onto the chat row; the metadata is
 // identical on every page, so once is enough.
-func (s *ComplianceImportService) fetchChatMessages(ctx context.Context, client *anthropicapi.Client, cfg Config, chatID uuid.UUID, activity anthropicapi.Activity, afterID string, enrichChat bool, users *connectedUserResolver, out chan<- messagePageBatch, progress *ComplianceSyncProgress) error {
+func (s *ComplianceImportService) fetchChatMessages(ctx context.Context, client *anthropicapi.Client, cfg Config, chatID uuid.UUID, activity anthropicapi.Activity, afterID string, enrichChat bool, activitiesCursor string, users *connectedUserResolver, out chan<- messagePageBatch, progress *ComplianceSyncProgress) error {
 	for pageNum := 1; ; pageNum++ {
 		s.heartbeat(ctx, "message_import", pageNum)
 		page, err := client.GetChatMessages(ctx, anthropicapi.GetChatMessagesParams{
@@ -318,13 +369,22 @@ func (s *ComplianceImportService) fetchChatMessages(ctx context.Context, client 
 			return err
 		}
 
+		batch := messagePageBatch{chatID: chatID, rows: rows, lastID: page.LastID, activitiesCursor: ""}
+		finalPage := !page.HasMore || page.LastID == ""
+		if finalPage {
+			// The chat's last message page closes out the activity; if the
+			// activity closes out an activities page, tell the writer the
+			// global cursor is safe to persist after this batch.
+			batch.activitiesCursor = activitiesCursor
+		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
-		case out <- messagePageBatch{chatID: chatID, rows: rows, lastID: page.LastID}:
+		case out <- batch:
 		}
 
-		if !page.HasMore || page.LastID == "" {
+		if finalPage {
 			break
 		}
 		afterID = page.LastID

--- a/server/internal/aiintegrations/compliance_import_test.go
+++ b/server/internal/aiintegrations/compliance_import_test.go
@@ -1,0 +1,173 @@
+package aiintegrations
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	anthropicapi "github.com/speakeasy-api/gram/server/internal/thirdparty/anthropic"
+)
+
+func TestStreamChatActivitiesMarksLastImportableActivityPerPage(t *testing.T) {
+	t.Parallel()
+
+	userActivity := func(id, chatID string) anthropicapi.Activity {
+		return anthropicapi.Activity{
+			ID:               id,
+			Type:             anthropicComplianceActivityCreated,
+			CreatedAt:        "2026-07-14T10:00:00Z",
+			OrganizationID:   "ext-org",
+			OrganizationUUID: "",
+			Actor:            anthropicapi.Actor{Type: "user_actor", EmailAddress: "dev@example.com", UserID: "user_1", IPAddress: "", UserAgent: ""},
+			ClaudeChatID:     chatID,
+			ClaudeProjectID:  "",
+		}
+	}
+	systemActivity := anthropicapi.Activity{
+		ID:               "act_2",
+		Type:             anthropicComplianceActivityUpdated,
+		CreatedAt:        "2026-07-14T10:00:01Z",
+		OrganizationID:   "ext-org",
+		OrganizationUUID: "",
+		Actor:            anthropicapi.Actor{Type: "api_actor", EmailAddress: "", UserID: "", IPAddress: "", UserAgent: ""},
+		ClaudeChatID:     "chat_ignored",
+		ClaudeProjectID:  "",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("after_id") {
+		case "":
+			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
+				Data:    []anthropicapi.Activity{userActivity("act_1", "chat_1"), systemActivity, userActivity("act_3", "chat_2")},
+				HasMore: true,
+				FirstID: "act_1",
+				LastID:  "act_3",
+			})
+		case "act_3":
+			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
+				Data:    []anthropicapi.Activity{userActivity("act_4", "chat_3")},
+				HasMore: false,
+				FirstID: "act_4",
+				LastID:  "act_4",
+			})
+		default:
+			t.Errorf("unexpected after_id %q", r.URL.Query().Get("after_id"))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	client := anthropicapi.New(policy, anthropicapi.WithBaseURL(server.URL), anthropicapi.WithAPIKey("anthropic-key"))
+
+	svc := NewComplianceImportService(testenv.NewLogger(t), nil, policy, nil, func(context.Context, string, int) {})
+	extOrgID := "ext-org"
+	cfg := Config{
+		ID:                     uuid.New(),
+		OrganizationID:         "org_test",
+		Provider:               ProviderAnthropicCompliance,
+		ProjectID:              uuid.New(),
+		ExternalOrganizationID: &extOrgID,
+		BillingMode:            "",
+		APIKey:                 "anthropic-key",
+		Enabled:                true,
+		PollWatermarkAt:        time.Date(2026, 7, 14, 9, 0, 0, 0, time.UTC),
+		NextPollAfter:          time.Time{},
+		LastPollError:          "",
+		LastPollFailedAt:       time.Time{},
+		LastPollSuccessAt:      time.Time{},
+		ConsecutiveFailures:    0,
+		LastCursor:             "",
+		CreatedAt:              time.Time{},
+		UpdatedAt:              time.Time{},
+	}
+
+	out := make(chan discoveredActivity, 16)
+	progress := &ComplianceSyncProgress{
+		FirstSync:           true,
+		ActivityPages:       0,
+		ChatActivities:      0,
+		ChatsImported:       0,
+		MessagePagesFetched: 0,
+		MessagePagesWritten: 0,
+		CursorReached:       "",
+		CursorPersisted:     "",
+	}
+
+	cursor, err := svc.streamChatActivities(t.Context(), client, cfg, out, progress)
+	require.NoError(t, err)
+	close(out)
+
+	require.Equal(t, "act_4", cursor)
+	require.Equal(t, 2, progress.ActivityPages)
+	require.Equal(t, 3, progress.ChatActivities)
+
+	var discovered []discoveredActivity
+	for d := range out {
+		discovered = append(discovered, d)
+	}
+	require.Len(t, discovered, 3)
+
+	// The api_actor activity is filtered, so the last importable activity of
+	// page one (act_3) carries the page's cursor; mid-page activities carry
+	// none; the final page's last activity carries its cursor too.
+	require.Equal(t, "act_1", discovered[0].activity.ID)
+	require.Empty(t, discovered[0].activitiesCursor)
+	require.Equal(t, "act_3", discovered[1].activity.ID)
+	require.Equal(t, "act_3", discovered[1].activitiesCursor)
+	require.Equal(t, "act_4", discovered[2].activity.ID)
+	require.Equal(t, "act_4", discovered[2].activitiesCursor)
+}
+
+func TestWriteMessagePagesAdvancesActivitiesCursor(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	extOrgID := "ext-org"
+	watermark := time.Now().UTC().Add(-initialUsagePollLookback)
+	created := upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderAnthropicCompliance, "anthropic-key", true, true, &extOrgID, &watermark)
+	cfg := created.Config
+
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, nil)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	svc := NewComplianceImportService(testenv.NewLogger(t), conn, nil, writer, func(context.Context, string, int) {})
+
+	in := make(chan messagePageBatch, 3)
+	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: ""}
+	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: "act_100"}
+	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: "act_200"}
+	close(in)
+
+	progress := &ComplianceSyncProgress{
+		FirstSync:           true,
+		ActivityPages:       0,
+		ChatActivities:      0,
+		ChatsImported:       0,
+		MessagePagesFetched: 0,
+		MessagePagesWritten: 0,
+		CursorReached:       "",
+		CursorPersisted:     "",
+	}
+	require.NoError(t, svc.writeMessagePages(ctx, cfg, in, progress))
+
+	require.Equal(t, 3, progress.MessagePagesWritten)
+	require.Equal(t, "act_200", progress.CursorPersisted)
+
+	// The persisted cursor must be visible through the same read PollAIData
+	// performs at the start of each retry attempt, so a failed run resumes
+	// from the last completed activities page.
+	reloaded, err := store.GetUsagePollConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.Equal(t, "act_200", reloaded.LastCursor)
+}

--- a/server/internal/aiintegrations/compliance_import_test.go
+++ b/server/internal/aiintegrations/compliance_import_test.go
@@ -32,32 +32,43 @@ func TestStreamChatActivitiesMarksLastImportableActivityPerPage(t *testing.T) {
 			ClaudeProjectID:  "",
 		}
 	}
-	systemActivity := anthropicapi.Activity{
-		ID:               "act_2",
-		Type:             anthropicComplianceActivityUpdated,
-		CreatedAt:        "2026-07-14T10:00:01Z",
-		OrganizationID:   "ext-org",
-		OrganizationUUID: "",
-		Actor:            anthropicapi.Actor{Type: "api_actor", EmailAddress: "", UserID: "", IPAddress: "", UserAgent: ""},
-		ClaudeChatID:     "chat_ignored",
-		ClaudeProjectID:  "",
+	systemActivity := func(id string) anthropicapi.Activity {
+		return anthropicapi.Activity{
+			ID:               id,
+			Type:             anthropicComplianceActivityUpdated,
+			CreatedAt:        "2026-07-14T10:00:01Z",
+			OrganizationID:   "ext-org",
+			OrganizationUUID: "",
+			Actor:            anthropicapi.Actor{Type: "api_actor", EmailAddress: "", UserID: "", IPAddress: "", UserAgent: ""},
+			ClaudeChatID:     "chat_ignored",
+			ClaudeProjectID:  "",
+		}
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Query().Get("after_id") {
 		case "":
 			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
-				Data:    []anthropicapi.Activity{userActivity("act_1", "chat_1"), systemActivity, userActivity("act_3", "chat_2")},
+				Data:    []anthropicapi.Activity{userActivity("act_1", "chat_1"), systemActivity("act_2"), userActivity("act_3", "chat_2")},
 				HasMore: true,
 				FirstID: "act_1",
 				LastID:  "act_3",
 			})
 		case "act_3":
+			// A fully-filtered page: nothing importable, but the feed still
+			// advances past it.
 			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
-				Data:    []anthropicapi.Activity{userActivity("act_4", "chat_3")},
-				HasMore: false,
+				Data:    []anthropicapi.Activity{systemActivity("act_4"), systemActivity("act_5")},
+				HasMore: true,
 				FirstID: "act_4",
-				LastID:  "act_4",
+				LastID:  "act_5",
+			})
+		case "act_5":
+			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
+				Data:    []anthropicapi.Activity{userActivity("act_6", "chat_3")},
+				HasMore: false,
+				FirstID: "act_6",
+				LastID:  "act_6",
 			})
 		default:
 			t.Errorf("unexpected after_id %q", r.URL.Query().Get("after_id"))
@@ -107,25 +118,31 @@ func TestStreamChatActivitiesMarksLastImportableActivityPerPage(t *testing.T) {
 	require.NoError(t, err)
 	close(out)
 
-	require.Equal(t, "act_4", cursor)
-	require.Equal(t, 2, progress.ActivityPages)
+	require.Equal(t, "act_6", cursor)
+	require.Equal(t, 3, progress.ActivityPages)
 	require.Equal(t, 3, progress.ChatActivities)
 
 	var discovered []discoveredActivity
 	for d := range out {
 		discovered = append(discovered, d)
 	}
-	require.Len(t, discovered, 3)
+	require.Len(t, discovered, 4)
 
 	// The api_actor activity is filtered, so the last importable activity of
 	// page one (act_3) carries the page's cursor; mid-page activities carry
-	// none; the final page's last activity carries its cursor too.
+	// none. The fully-filtered second page yields a cursor-only sentinel so
+	// its token still becomes durable. The final page's last activity
+	// carries its cursor too.
 	require.Equal(t, "act_1", discovered[0].activity.ID)
 	require.Empty(t, discovered[0].activitiesCursor)
+	require.False(t, discovered[0].cursorOnly)
 	require.Equal(t, "act_3", discovered[1].activity.ID)
 	require.Equal(t, "act_3", discovered[1].activitiesCursor)
-	require.Equal(t, "act_4", discovered[2].activity.ID)
-	require.Equal(t, "act_4", discovered[2].activitiesCursor)
+	require.True(t, discovered[2].cursorOnly)
+	require.Equal(t, "act_5", discovered[2].activitiesCursor)
+	require.Empty(t, discovered[2].activity.ID)
+	require.Equal(t, "act_6", discovered[3].activity.ID)
+	require.Equal(t, "act_6", discovered[3].activitiesCursor)
 }
 
 func TestWriteMessagePagesAdvancesActivitiesCursor(t *testing.T) {
@@ -143,10 +160,13 @@ func TestWriteMessagePagesAdvancesActivitiesCursor(t *testing.T) {
 
 	svc := NewComplianceImportService(testenv.NewLogger(t), conn, nil, writer, func(context.Context, string, int) {})
 
-	in := make(chan messagePageBatch, 3)
-	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: ""}
-	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: "act_100"}
-	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: "act_200"}
+	in := make(chan messagePageBatch, 4)
+	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: "", cursorOnly: false}
+	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: "act_100", cursorOnly: false}
+	// A cursor-only sentinel from a fully-filtered activities page: advances
+	// the cursor without counting as a written message page.
+	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: "act_150", cursorOnly: true}
+	in <- messagePageBatch{chatID: uuid.Nil, rows: nil, lastID: "", activitiesCursor: "act_200", cursorOnly: false}
 	close(in)
 
 	progress := &ComplianceSyncProgress{

--- a/server/internal/aiintegrations/queries.sql
+++ b/server/internal/aiintegrations/queries.sql
@@ -169,6 +169,12 @@ SET poll_watermark_at = @poll_watermark_at,
     updated_at = clock_timestamp()
 WHERE ai_integration_config_id = @ai_integration_config_id;
 
+-- name: AdvanceUsagePollCursor :exec
+UPDATE ai_integration_syncs
+SET last_cursor_id = @last_cursor_id,
+    updated_at = clock_timestamp()
+WHERE ai_integration_config_id = @ai_integration_config_id;
+
 -- name: RecordUsagePollFailure :exec
 UPDATE ai_integration_syncs
 SET next_poll_after = @next_poll_after,

--- a/server/internal/aiintegrations/repo/queries.sql.go
+++ b/server/internal/aiintegrations/repo/queries.sql.go
@@ -12,6 +12,23 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const advanceUsagePollCursor = `-- name: AdvanceUsagePollCursor :exec
+UPDATE ai_integration_syncs
+SET last_cursor_id = $1,
+    updated_at = clock_timestamp()
+WHERE ai_integration_config_id = $2
+`
+
+type AdvanceUsagePollCursorParams struct {
+	LastCursorID          pgtype.Text
+	AiIntegrationConfigID uuid.UUID
+}
+
+func (q *Queries) AdvanceUsagePollCursor(ctx context.Context, arg AdvanceUsagePollCursorParams) error {
+	_, err := q.db.Exec(ctx, advanceUsagePollCursor, arg.LastCursorID, arg.AiIntegrationConfigID)
+	return err
+}
+
 const countConfigsByOrganization = `-- name: CountConfigsByOrganization :one
 SELECT count(*)
 FROM ai_integration_configs

--- a/server/internal/aiintegrations/sync_error.go
+++ b/server/internal/aiintegrations/sync_error.go
@@ -101,16 +101,18 @@ type ComplianceSyncProgress struct {
 	ChatsImported       int  `json:"chats_imported"`
 	MessagePagesFetched int  `json:"message_pages_fetched"`
 	MessagePagesWritten int  `json:"message_pages_written"`
-	// CursorReached is the activities pagination token the run got to. It is
-	// not persisted on failure, so the next run resumes from the stored
-	// cursor; the value shows how far discovery progressed regardless.
+	// CursorReached is the activities pagination token discovery got to; it
+	// shows how far the feed walk progressed regardless of durability.
 	CursorReached string `json:"cursor_reached,omitempty"`
+	// CursorPersisted is the last activities pagination token durably
+	// written to the sync state during the run; retries resume from it.
+	CursorPersisted string `json:"cursor_persisted,omitempty"`
 }
 
 func (p ComplianceSyncProgress) String() string {
 	return fmt.Sprintf(
-		"first_sync=%t activity_pages=%d chat_activities=%d chats_imported=%d message_pages_fetched=%d message_pages_written=%d cursor_reached=%q",
-		p.FirstSync, p.ActivityPages, p.ChatActivities, p.ChatsImported, p.MessagePagesFetched, p.MessagePagesWritten, p.CursorReached,
+		"first_sync=%t activity_pages=%d chat_activities=%d chats_imported=%d message_pages_fetched=%d message_pages_written=%d cursor_reached=%q cursor_persisted=%q",
+		p.FirstSync, p.ActivityPages, p.ChatActivities, p.ChatsImported, p.MessagePagesFetched, p.MessagePagesWritten, p.CursorReached, p.CursorPersisted,
 	)
 }
 

--- a/server/internal/aiintegrations/sync_error_test.go
+++ b/server/internal/aiintegrations/sync_error_test.go
@@ -27,6 +27,7 @@ func TestNewSyncErrorAccumulatesAllStageFailures(t *testing.T) {
 		MessagePagesFetched: 210,
 		MessagePagesWritten: 208,
 		CursorReached:       "activity_9",
+		CursorPersisted:     "activity_5",
 	},
 		SyncStageError{Stage: "discover_activities", Err: discoverErr},
 		SyncStageError{Stage: "import_chats", Err: nil},
@@ -45,6 +46,7 @@ func TestNewSyncErrorAccumulatesAllStageFailures(t *testing.T) {
 	require.Contains(t, msg, "activity_pages=4")
 	require.Contains(t, msg, "chats_imported=57")
 	require.Contains(t, msg, `cursor_reached="activity_9"`)
+	require.Contains(t, msg, `cursor_persisted="activity_5"`)
 
 	require.ErrorIs(t, err, discoverErr)
 	require.ErrorIs(t, err, writeErr)
@@ -104,6 +106,7 @@ func TestSyncErrorExposesTypedCausesThroughUnwrap(t *testing.T) {
 		MessagePagesFetched: 0,
 		MessagePagesWritten: 0,
 		CursorReached:       "",
+		CursorPersisted:     "",
 	},
 		SyncStageError{Stage: "discover_activities", Err: fmt.Errorf("list anthropic compliance activities: %w", httpErr)},
 	)
@@ -124,6 +127,7 @@ func TestComplianceSyncProgressMarshalsToJSON(t *testing.T) {
 		MessagePagesFetched: 4,
 		MessagePagesWritten: 5,
 		CursorReached:       "activity_1",
+		CursorPersisted:     "activity_0",
 	})
 	require.NoError(t, err)
 	require.JSONEq(t, `{
@@ -133,6 +137,7 @@ func TestComplianceSyncProgressMarshalsToJSON(t *testing.T) {
 		"chats_imported": 3,
 		"message_pages_fetched": 4,
 		"message_pages_written": 5,
-		"cursor_reached": "activity_1"
+		"cursor_reached": "activity_1",
+		"cursor_persisted": "activity_0"
 	}`, string(raw))
 }

--- a/server/internal/background/activities/poll_ai_data_test.go
+++ b/server/internal/background/activities/poll_ai_data_test.go
@@ -46,6 +46,7 @@ func TestPollAPIKeyRejectedSeesThroughWrappedSyncErrors(t *testing.T) {
 			MessagePagesFetched: 0,
 			MessagePagesWritten: 0,
 			CursorReached:       "",
+			CursorPersisted:     "",
 		},
 	}
 	wrapped := oops.E(oops.CodeUnauthorized, syncErr, "anthropic compliance rejected the configured api key")
@@ -72,6 +73,7 @@ func TestNewPollFailureErrorCarriesStageAndProgressDetails(t *testing.T) {
 			MessagePagesFetched: 210,
 			MessagePagesWritten: 208,
 			CursorReached:       "activity_9",
+			CursorPersisted:     "activity_5",
 		},
 	}
 	cause := oops.E(oops.CodeUnexpected, syncErr, "sync anthropic compliance data")


### PR DESCRIPTION
## Summary

Follow-up to #4090, addressing the `PollAIData` attempts observed timing out in prod (DNO-461): the Anthropic compliance import only persisted its global activities cursor after a *fully successful* run, so every 2-hour Start-To-Close timeout forced the next attempt to re-walk the entire activities backlog from scratch — one `GetChatMessages` call per activity. When the backlog's fixed discovery cost exceeds one attempt's budget, retries can never converge.

This makes the global cursor durable incrementally, at activities-page granularity, while preserving the invariant that the cursor only advances past a page once every chat discovered in it is fully written:

- **Discovery** tags the last importable activity of each activities page with the page's pagination token.
- **Import** forwards the tag onto the final message batch of that activity, so it only reaches the writer after all of the chat's message pages are fetched.
- **Writer** (single goroutine, feed order) persists the token via a new `AdvanceUsagePollCursor` query after the marked batch is durably written. The query touches only `last_cursor_id` on `ai_integration_syncs` — watermark, `next_poll_after`, and failure counters remain owned by `RecordUsagePollSuccess`/`Failure`.

Retry attempts re-read the config at start, so after a timeout the next attempt resumes discovery from the last *completed* page instead of repaying the whole discovery toll. This also means a first sync that persists any page no longer re-triggers the 24-hour time-window backfill on retry.

`ComplianceSyncProgress` gains a `cursor_persisted` field (alongside `cursor_reached`), so failure reports in the Temporal UI now show how far durability got, not just discovery.

## Test plan

- [x] New test: `streamChatActivities` against an httptest activities feed — marker lands on the last importable activity per page, skipping filtered non-user actors
- [x] New test: `writeMessagePages` against a real test database — cursor advances in order and is visible through `GetUsagePollConfig`, the exact read a retry attempt performs
- [x] `go test ./internal/aiintegrations/... ./internal/background/...` (484 tests pass)
- [x] `mise lint:server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the Anthropic compliance activities cursor incrementally during sync so retries resume from the last completed page instead of re-walking the entire backlog. Addresses stalled PollAIData attempts and timeouts in prod (DNO-461).

- Bug Fixes
  - Tag the last importable activity per page with the page token; for fully filtered pages, emit a cursor-only marker so the writer still advances the global cursor.
  - Carry the token with the final message batch and persist it after durable write via `AdvanceUsagePollCursor`; expose `cursor_persisted` alongside `cursor_reached` in progress.
  - Advance cursors in feed order so retries start from the last persisted page, avoiding repeated full discovery and the 24-hour backfill on partial runs.

<sup>Written for commit 4beda314b6b1e8ccf3fcfbe24badf98b7f23ac57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

