### PR TITLE
feat: autoclose OAuth screen after handshake

### DIFF
--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -82,9 +82,13 @@ type consentTemplateData struct {
 	// completed (a card is Connected). Cancel is always available.
 	ConsentEnabled bool
 	// FirstParty swaps the approve/deny client-grant footer for a terminal
-	// "you can close this tab" message: a first-party challenge has no MCP
-	// client to grant to, so linking the cards is the whole job.
+	// completion message: a first-party challenge has no MCP client to grant
+	// to, so linking the cards is the whole job.
 	FirstParty bool
+	// AutoClose marks a completed first-party connection. The consent script
+	// closes only this terminal state; incomplete connections and MCP client
+	// consent remain open.
+	AutoClose bool
 }
 
 // remoteSessionCard is the per-remote view rendered by the {{range}} block
@@ -214,13 +218,14 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		return oops.E(oops.CodeUnexpected, err, "build remote session cards").LogError(ctx, logger)
 	}
 
-	consentEnabled := len(cards) == 0
+	hasConnectedCard := false
 	for _, c := range cards {
 		if c.Connected {
-			consentEnabled = true
+			hasConnectedCard = true
 			break
 		}
 	}
+	consentEnabled := len(cards) == 0 || hasConnectedCard
 
 	data := consentTemplateData{
 		ClientName:         clientName,
@@ -234,6 +239,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		RemoteSessionCards: cards,
 		ConsentEnabled:     consentEnabled,
 		FirstParty:         challengeState.FirstParty,
+		AutoClose:          challengeState.FirstParty && hasConnectedCard,
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -85,9 +85,10 @@ type consentTemplateData struct {
 	// completion message: a first-party challenge has no MCP client to grant
 	// to, so linking the cards is the whole job.
 	FirstParty bool
-	// AutoClose marks a completed first-party connection. The consent script
-	// closes only this terminal state; incomplete connections and MCP client
-	// consent remain open.
+	// AutoClose marks a fully completed first-party connection: every bound
+	// remote_session_client is connected. The consent script closes only this
+	// terminal state; partially-linked connections (some cards still
+	// disconnected) and MCP client consent remain open.
 	AutoClose bool
 }
 
@@ -239,7 +240,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		RemoteSessionCards: cards,
 		ConsentEnabled:     consentEnabled,
 		FirstParty:         challengeState.FirstParty,
-		AutoClose:          challengeState.FirstParty && hasConnectedCard,
+		AutoClose:          shouldAutoCloseFirstParty(challengeState.FirstParty, cards),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -440,6 +441,24 @@ func buildClientRedirect(redirectURI, code, originalState, errCode, errDescripti
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// shouldAutoCloseFirstParty reports whether a first-party connect tab is fully
+// terminal and safe to auto-close: every bound remote_session_client is
+// connected. The runtime gate (remotesessions.ResolveAccessTokens) fails the
+// request unless all bound clients have a usable token, so closing after only
+// the first of several providers is linked would strand the user mid-flow. A
+// challenge with no cards is never auto-closed — there is nothing to complete.
+func shouldAutoCloseFirstParty(firstParty bool, cards []remoteSessionCard) bool {
+	if !firstParty || len(cards) == 0 {
+		return false
+	}
+	for _, c := range cards {
+		if !c.Connected {
+			return false
+		}
+	}
+	return true
 }
 
 // buildRemoteSessionCards loads every remote_session_client linked to the

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -69,6 +69,34 @@ func TestConsentTemplateIncompleteFirstPartyConnectionStaysOpen(t *testing.T) {
 	require.NotContains(t, page.String(), "Connection complete")
 }
 
+func TestShouldAutoCloseFirstParty(t *testing.T) {
+	t.Parallel()
+
+	connected := remoteSessionCard{Connected: true}
+	disconnected := remoteSessionCard{Connected: false}
+
+	tests := []struct {
+		name       string
+		firstParty bool
+		cards      []remoteSessionCard
+		want       bool
+	}{
+		{name: "not first party", firstParty: false, cards: []remoteSessionCard{connected}, want: false},
+		{name: "no cards", firstParty: true, cards: nil, want: false},
+		{name: "single connected", firstParty: true, cards: []remoteSessionCard{connected}, want: true},
+		{name: "single disconnected", firstParty: true, cards: []remoteSessionCard{disconnected}, want: false},
+		{name: "all connected", firstParty: true, cards: []remoteSessionCard{connected, connected}, want: true},
+		{name: "one still disconnected", firstParty: true, cards: []remoteSessionCard{connected, disconnected}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, shouldAutoCloseFirstParty(tt.firstParty, tt.cards))
+		})
+	}
+}
+
 func TestConsentScriptClosesOnlyMarkedPages(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -1,0 +1,78 @@
+package mcp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsentTemplateCompletedFirstPartyConnectionAutoCloses(t *testing.T) {
+	t.Parallel()
+
+	var page bytes.Buffer
+	err := consentTemplate.Execute(&page, consentTemplateData{
+		ClientName:     "Gram",
+		MCPSlug:        "example",
+		MCPRouteBase:   "x/mcp",
+		State:          "state",
+		CSRFToken:      "csrf",
+		SubjectDisplay: "user@example.com",
+		RedirectURI:    "",
+		ScriptURL:      "/mcp/consent-page-test.js",
+		RemoteSessionCards: []remoteSessionCard{{
+			ClientID:     "client-id",
+			IssuerSlug:   "example-issuer",
+			Connected:    true,
+			Expired:      false,
+			ChallengeURL: "https://issuer.example.com/authorize",
+		}},
+		ConsentEnabled: true,
+		FirstParty:     true,
+		AutoClose:      true,
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, page.String(), "<body data-auto-close>")
+	require.Contains(t, page.String(), "Connection complete. This tab will close automatically.")
+	require.NotContains(t, page.String(), "When you've connected the services above")
+}
+
+func TestConsentTemplateIncompleteFirstPartyConnectionStaysOpen(t *testing.T) {
+	t.Parallel()
+
+	var page bytes.Buffer
+	err := consentTemplate.Execute(&page, consentTemplateData{
+		ClientName:     "Gram",
+		MCPSlug:        "example",
+		MCPRouteBase:   "x/mcp",
+		State:          "state",
+		CSRFToken:      "csrf",
+		SubjectDisplay: "user@example.com",
+		RedirectURI:    "",
+		ScriptURL:      "/mcp/consent-page-test.js",
+		RemoteSessionCards: []remoteSessionCard{{
+			ClientID:     "client-id",
+			IssuerSlug:   "example-issuer",
+			Connected:    false,
+			Expired:      false,
+			ChallengeURL: "https://issuer.example.com/authorize",
+		}},
+		ConsentEnabled: false,
+		FirstParty:     true,
+		AutoClose:      false,
+	})
+	require.NoError(t, err)
+
+	require.NotContains(t, page.String(), "data-auto-close")
+	require.Contains(t, page.String(), "When you've connected the services above, you can close this tab.")
+	require.NotContains(t, page.String(), "Connection complete")
+}
+
+func TestConsentScriptClosesOnlyMarkedPages(t *testing.T) {
+	t.Parallel()
+
+	script := string(consentScriptData)
+	require.Contains(t, script, `document.body.hasAttribute("data-auto-close")`)
+	require.Contains(t, script, "window.close();")
+}

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -74,27 +74,16 @@ func TestShouldAutoCloseFirstParty(t *testing.T) {
 
 	connected := remoteSessionCard{Connected: true}
 	disconnected := remoteSessionCard{Connected: false}
+	expired := remoteSessionCard{Connected: false, Expired: true}
 
-	tests := []struct {
-		name       string
-		firstParty bool
-		cards      []remoteSessionCard
-		want       bool
-	}{
-		{name: "not first party", firstParty: false, cards: []remoteSessionCard{connected}, want: false},
-		{name: "no cards", firstParty: true, cards: nil, want: false},
-		{name: "single connected", firstParty: true, cards: []remoteSessionCard{connected}, want: true},
-		{name: "single disconnected", firstParty: true, cards: []remoteSessionCard{disconnected}, want: false},
-		{name: "all connected", firstParty: true, cards: []remoteSessionCard{connected, connected}, want: true},
-		{name: "one still disconnected", firstParty: true, cards: []remoteSessionCard{connected, disconnected}, want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tt.want, shouldAutoCloseFirstParty(tt.firstParty, tt.cards))
-		})
-	}
+	require.False(t, shouldAutoCloseFirstParty(false, []remoteSessionCard{connected}), "client consent must stay open")
+	require.False(t, shouldAutoCloseFirstParty(true, nil), "a connection with no cards must stay open")
+	require.True(t, shouldAutoCloseFirstParty(true, []remoteSessionCard{connected}))
+	require.False(t, shouldAutoCloseFirstParty(true, []remoteSessionCard{disconnected}))
+	require.False(t, shouldAutoCloseFirstParty(true, []remoteSessionCard{expired}))
+	require.True(t, shouldAutoCloseFirstParty(true, []remoteSessionCard{connected, connected}))
+	require.False(t, shouldAutoCloseFirstParty(true, []remoteSessionCard{connected, disconnected}), "partially connected flows must stay open")
+	require.False(t, shouldAutoCloseFirstParty(true, []remoteSessionCard{connected, expired}), "flows with expired sessions must stay open")
 }
 
 func TestConsentScriptClosesOnlyMarkedPages(t *testing.T) {

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -75,4 +75,5 @@ func TestConsentScriptClosesOnlyMarkedPages(t *testing.T) {
 	script := string(consentScriptData)
 	require.Contains(t, script, `document.body.hasAttribute("data-auto-close")`)
 	require.Contains(t, script, "window.close();")
+	require.Contains(t, script, "}, 3000);")
 }

--- a/server/internal/mcp/authnchallenge_firstparty.go
+++ b/server/internal/mcp/authnchallenge_firstparty.go
@@ -25,8 +25,8 @@ import (
 // HandleIDPCallback enforces access once the IDP identifies the user).
 //
 // No ClientID/RedirectURI: a first-party challenge has no MCP client to grant
-// to or redirect back to. Once the user links a card on the consent page, the
-// flow is terminal and the page closes its dashboard-opened tab.
+// to or redirect back to. Once the user links every card on the consent page,
+// the flow is terminal and the page closes its dashboard-opened tab.
 func (s *Service) ServeFirstPartyConnect(w http.ResponseWriter, r *http.Request, endpoint *ResolvedMcpEndpoint) error {
 	ctx := r.Context()
 	logger := endpoint.LogWith(s.logger)

--- a/server/internal/mcp/authnchallenge_firstparty.go
+++ b/server/internal/mcp/authnchallenge_firstparty.go
@@ -25,8 +25,8 @@ import (
 // HandleIDPCallback enforces access once the IDP identifies the user).
 //
 // No ClientID/RedirectURI: a first-party challenge has no MCP client to grant
-// to or redirect back to. Once the user links the cards on the consent page,
-// the flow is terminal (they close the tab).
+// to or redirect back to. Once the user links a card on the consent page, the
+// flow is terminal and the page closes its dashboard-opened tab.
 func (s *Service) ServeFirstPartyConnect(w http.ResponseWriter, r *http.Request, endpoint *ResolvedMcpEndpoint) error {
 	ctx := r.Context()
 	logger := endpoint.LogWith(s.logger)

--- a/server/internal/mcp/consent_script.js
+++ b/server/internal/mcp/consent_script.js
@@ -17,7 +17,7 @@
   if (document.body.hasAttribute("data-auto-close")) {
     window.setTimeout(function () {
       window.close();
-    }, 1500);
+    }, 3000);
   }
 
   // Replace an element's contents with a spinner + label.

--- a/server/internal/mcp/consent_script.js
+++ b/server/internal/mcp/consent_script.js
@@ -11,6 +11,15 @@
 (function () {
   "use strict";
 
+  // A connected first-party flow has no remaining consent step. Briefly show
+  // confirmation, then close the tab opened by the dashboard. If the browser
+  // declines window.close(), the completion message remains as a fallback.
+  if (document.body.hasAttribute("data-auto-close")) {
+    window.setTimeout(function () {
+      window.close();
+    }, 1500);
+  }
+
   // Replace an element's contents with a spinner + label.
   function showPending(el, label) {
     el.textContent = "";

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -325,7 +325,7 @@
       }
     </style>
   </head>
-  <body>
+  <body{{if .AutoClose}} data-auto-close{{end}}>
     <main class="main">
       <div class="auth-consent-container">
         <div class="header">
@@ -377,7 +377,11 @@
           </div>
           {{end}}
         </div>
-        {{end}} {{if .FirstParty}}
+        {{end}} {{if .AutoClose}}
+        <p class="info">
+          Connection complete. This tab will close automatically.
+        </p>
+        {{else if .FirstParty}}
         <p class="info">
           When you've connected the services above, you can close this tab.
         </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- mark completed first-party MCP connection pages as terminal only when every required remote session is connected
- keep partially connected, expired-session, empty, and MCP client consent flows open
- automatically close completed dashboard-opened OAuth tabs after a 3-second confirmation
- cover single-card, multi-card, disconnected, and expired-session close behavior

## Testing
- `mise run test:server ./internal/mcp/...` (339 tests; initial implementation)
- `mise run test:server ./internal/xmcp/...` (53 tests; initial implementation)
- multi-card review update verification pending

[oauth_completion_tab_measured_three_second_autoclose.mp4](https://cursor.com/agents/bc-6207b73d-384e-4e02-aff4-2dde01f23aeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foauth_completion_tab_measured_three_second_autoclose.mp4)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-298](https://linear.app/speakeasy/issue/AIS-298/feat-autoclose-oauth-screen-at-end-of-handshake)

<div><a href="https://cursor.com/agents/bc-6207b73d-384e-4e02-aff4-2dde01f23aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6207b73d-384e-4e02-aff4-2dde01f23aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-close the OAuth screen after a first-party handshake completes to reduce stray tabs. The tab only closes once every required card is connected; incomplete connections and MCP client consent pages stay open (Linear AIS-298).

- **New Features**
  - Marks terminal first-party connections with `AutoClose` only when all cards are connected; template adds `data-auto-close` and a “Connection complete...” message.
  - Consent script waits 3s, then closes only `data-auto-close` pages (message remains if close is blocked).
  - Server enables consent when any card is connected; adds `shouldAutoCloseFirstParty` to require all cards for auto-close. Tests cover completed/incomplete templates, the all-cards check, and the 3s close.

<sup>Written for commit 6f71e4063b1faea493711afa318fae4339a29879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

