### PR TITLE
fix: walk compliance activities feed forward with before_id

### DIFF
--- a/server/internal/aiintegrations/compliance_import.go
+++ b/server/internal/aiintegrations/compliance_import.go
@@ -46,9 +46,9 @@ const (
 type discoveredActivity struct {
 	activity anthropicapi.Activity
 	// activitiesCursor is set on the final importable activity of an
-	// activities page: once that activity's messages are durably written,
-	// every activity up to the page's pagination token is fully imported
-	// and the token may be persisted as the global activities cursor.
+	// activities page during forward walks: once that activity's messages
+	// are durably written, the whole page is fully imported and its first_id
+	// token may be persisted as the global activities cursor.
 	activitiesCursor string
 	// cursorOnly marks a sentinel for a page with no importable activities.
 	// It carries just the page's pagination token; the import stage forwards
@@ -94,13 +94,14 @@ func NewComplianceImportService(logger *slog.Logger, db *pgxpool.Pool, guardianP
 }
 
 // SyncAnthropicCompliance imports new compliance activity and chat messages.
-// It returns the activities pagination cursor reached by this run; callers
-// must persist it on success so the next run resumes after the last imported
-// activity instead of re-discovering by time window. The cursor is also
-// persisted incrementally during the run — after each activities page whose
-// chats are fully written — so retries of a failed or timed-out run resume
-// from the last completed page rather than repaying the whole discovery
-// cost.
+// It returns the activities feed position reached by this run: the newest
+// first_id token seen. Callers must persist it on success so the next run
+// walks forward (before_id) from that position — the feed is sorted newest
+// first, so this is the only direction that ever discovers new activity.
+// During forward walks the cursor is also persisted incrementally — after
+// each activities page whose chats are fully written — so retries of a
+// failed or timed-out run resume from the last completed page rather than
+// repaying the whole discovery cost.
 //
 // The sync is a three-stage pipeline: a producer goroutine streams chat
 // activities from the feed page by page, a fetch goroutine resolves each chat
@@ -248,24 +249,70 @@ func (s *ComplianceImportService) writeMessagePages(ctx context.Context, cfg Con
 	return nil
 }
 
-// streamChatActivities pages through the activities feed starting after the
-// persisted cursor and sends chat activities to out as they are discovered.
-// It returns the cursor reached by this run: the verbatim last_id pagination
-// token from the final page, not an id derived from imported rows.
+// streamChatActivities discovers importable chat activities and sends them
+// to out. The activities feed is always sorted newest first, so the walk
+// direction depends on cursor state:
 //
-// The final importable activity of each page carries the page's pagination
-// token so the writer stage can persist the global cursor once that
-// activity's messages are durably written.
+//   - First sync (no cursor): a bounded backfill pages OLDER via after_id
+//     down to the watermark window. It returns the newest edge seen so all
+//     later syncs walk forward from there.
+//   - Every later sync: pages NEWER via before_id from the stored cursor
+//     and returns the newest first_id reached.
+//
+// During forward walks the final importable activity of each page carries
+// the page's first_id so the writer stage persists the global cursor once
+// the page is durably written. Backfill pages carry no markers: an
+// interrupted first sync restarts its bounded window instead of risking a
+// forward resume that would skip the window's unimported older tail.
 func (s *ComplianceImportService) streamChatActivities(ctx context.Context, client *anthropicapi.Client, cfg Config, out chan<- discoveredActivity, progress *ComplianceSyncProgress) (string, error) {
-	// First sync has no cursor yet; bound the initial backfill with a time
-	// window around the watermark. Every later sync resumes from the cursor.
-	createdAtGTE := time.Time{}
 	if cfg.LastCursor == "" {
-		createdAtGTE = cfg.PollWatermarkAt.Add(-time.Hour * 24)
+		return s.backfillChatActivities(ctx, client, cfg, out, progress)
 	}
 
-	afterID := cfg.LastCursor
+	beforeID := cfg.LastCursor
 	nextCursor := cfg.LastCursor
+	for pageNum := 1; ; pageNum++ {
+		s.heartbeat(ctx, "activity_discovery", pageNum)
+		page, err := client.ListActivities(ctx, anthropicapi.ListActivitiesParams{
+			ActivityTypes: []string{
+				anthropicComplianceActivityCreated,
+				anthropicComplianceActivityUpdated,
+			},
+			OrganizationIDs: []string{*cfg.ExternalOrganizationID},
+			CreatedAtGTE:    time.Time{},
+			AfterID:         "",
+			BeforeID:        beforeID,
+			Limit:           anthropicComplianceActivityPageLimit,
+		})
+		if err != nil {
+			return nextCursor, oops.E(oops.CodeUnexpected, err, "list anthropic compliance activities")
+		}
+		progress.ActivityPages++
+
+		if err := s.emitPageActivities(ctx, page, page.FirstID, out, progress); err != nil {
+			return nextCursor, err
+		}
+
+		if page.FirstID != "" {
+			nextCursor = page.FirstID
+		}
+
+		if !page.HasMore || page.FirstID == "" {
+			return nextCursor, nil
+		}
+		beforeID = page.FirstID
+	}
+}
+
+// backfillChatActivities bootstraps a config that has no cursor yet by
+// paging OLDER via after_id, bounded to a time window around the watermark.
+// It returns the newest edge of the feed seen — the first page's first_id —
+// so the next sync walks forward from there with before_id.
+func (s *ComplianceImportService) backfillChatActivities(ctx context.Context, client *anthropicapi.Client, cfg Config, out chan<- discoveredActivity, progress *ComplianceSyncProgress) (string, error) {
+	createdAtGTE := cfg.PollWatermarkAt.Add(-time.Hour * 24)
+
+	afterID := ""
+	nextCursor := ""
 	for pageNum := 1; ; pageNum++ {
 		s.heartbeat(ctx, "activity_discovery", pageNum)
 		page, err := client.ListActivities(ctx, anthropicapi.ListActivitiesParams{
@@ -276,6 +323,7 @@ func (s *ComplianceImportService) streamChatActivities(ctx context.Context, clie
 			OrganizationIDs: []string{*cfg.ExternalOrganizationID},
 			CreatedAtGTE:    createdAtGTE,
 			AfterID:         afterID,
+			BeforeID:        "",
 			Limit:           anthropicComplianceActivityPageLimit,
 		})
 		if err != nil {
@@ -283,43 +331,18 @@ func (s *ComplianceImportService) streamChatActivities(ctx context.Context, clie
 		}
 		progress.ActivityPages++
 
-		importable := make([]anthropicapi.Activity, 0, len(page.Data))
-		for _, activity := range page.Data {
-			if activity.Actor.Type != "user_actor" || activity.ClaudeChatID == "" {
-				continue
-			}
-			importable = append(importable, activity)
+		// The feed is newest first, so the first page's first_id is the
+		// newest activity this run can see; it becomes the forward-walk
+		// cursor once the whole window is imported.
+		if pageNum == 1 && page.FirstID != "" {
+			nextCursor = page.FirstID
 		}
 
-		for i, activity := range importable {
-			discovered := discoveredActivity{activity: activity, activitiesCursor: "", cursorOnly: false}
-			if i == len(importable)-1 && page.LastID != "" {
-				discovered.activitiesCursor = page.LastID
-			}
-			select {
-			case <-ctx.Done():
-				return nextCursor, ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
-			case out <- discovered:
-				progress.ChatActivities++
-			}
-		}
-
-		if len(importable) == 0 && page.LastID != "" {
-			// A page with no importable activities still advances the feed.
-			// Emit a cursor-only sentinel so the writer persists the page's
-			// token once all previously discovered work is durably written;
-			// otherwise retries would re-fetch fully-filtered pages forever
-			// on feeds dominated by non-user activities.
-			var none anthropicapi.Activity
-			select {
-			case <-ctx.Done():
-				return nextCursor, ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
-			case out <- discoveredActivity{activity: none, activitiesCursor: page.LastID, cursorOnly: true}:
-			}
-		}
-
-		if page.LastID != "" {
-			nextCursor = page.LastID
+		// No checkpoint markers during a backfill: the walk moves toward
+		// older activities, so a mid-window token would make a resumed run
+		// skip the window's remaining older activities entirely.
+		if err := s.emitPageActivities(ctx, page, "", out, progress); err != nil {
+			return nextCursor, err
 		}
 
 		if !page.HasMore || page.LastID == "" {
@@ -327,6 +350,44 @@ func (s *ComplianceImportService) streamChatActivities(ctx context.Context, clie
 		}
 		afterID = page.LastID
 	}
+}
+
+// emitPageActivities filters one activities page down to importable chat
+// activities and sends them to out. When pageCursor is set, the final
+// importable activity carries it as the page's durable checkpoint marker —
+// or a cursor-only sentinel carries it when the whole page was filtered
+// out, so fully-filtered pages still advance the persisted cursor.
+func (s *ComplianceImportService) emitPageActivities(ctx context.Context, page *anthropicapi.ActivitiesPage, pageCursor string, out chan<- discoveredActivity, progress *ComplianceSyncProgress) error {
+	importable := make([]anthropicapi.Activity, 0, len(page.Data))
+	for _, activity := range page.Data {
+		if activity.Actor.Type != "user_actor" || activity.ClaudeChatID == "" {
+			continue
+		}
+		importable = append(importable, activity)
+	}
+
+	for i, activity := range importable {
+		discovered := discoveredActivity{activity: activity, activitiesCursor: "", cursorOnly: false}
+		if i == len(importable)-1 {
+			discovered.activitiesCursor = pageCursor
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
+		case out <- discovered:
+			progress.ChatActivities++
+		}
+	}
+
+	if len(importable) == 0 && pageCursor != "" {
+		var none anthropicapi.Activity
+		select {
+		case <-ctx.Done():
+			return ctx.Err() //nolint:wrapcheck // Preserve context cancellation sentinel errors for callers.
+		case out <- discoveredActivity{activity: none, activitiesCursor: pageCursor, cursorOnly: true}:
+		}
+	}
+	return nil
 }
 
 // upsertActivityChat resolves the chat row for an activity and returns its

--- a/server/internal/aiintegrations/compliance_import_test.go
+++ b/server/internal/aiintegrations/compliance_import_test.go
@@ -17,72 +17,45 @@ import (
 	anthropicapi "github.com/speakeasy-api/gram/server/internal/thirdparty/anthropic"
 )
 
-func TestStreamChatActivitiesMarksLastImportableActivityPerPage(t *testing.T) {
-	t.Parallel()
-
-	userActivity := func(id, chatID string) anthropicapi.Activity {
-		return anthropicapi.Activity{
-			ID:               id,
-			Type:             anthropicComplianceActivityCreated,
-			CreatedAt:        "2026-07-14T10:00:00Z",
-			OrganizationID:   "ext-org",
-			OrganizationUUID: "",
-			Actor:            anthropicapi.Actor{Type: "user_actor", EmailAddress: "dev@example.com", UserID: "user_1", IPAddress: "", UserAgent: ""},
-			ClaudeChatID:     chatID,
-			ClaudeProjectID:  "",
-		}
+func complianceUserActivity(id, chatID string) anthropicapi.Activity {
+	return anthropicapi.Activity{
+		ID:               id,
+		Type:             anthropicComplianceActivityCreated,
+		CreatedAt:        "2026-07-14T10:00:00Z",
+		OrganizationID:   "ext-org",
+		OrganizationUUID: "",
+		Actor:            anthropicapi.Actor{Type: "user_actor", EmailAddress: "dev@example.com", UserID: "user_1", IPAddress: "", UserAgent: ""},
+		ClaudeChatID:     chatID,
+		ClaudeProjectID:  "",
 	}
-	systemActivity := func(id string) anthropicapi.Activity {
-		return anthropicapi.Activity{
-			ID:               id,
-			Type:             anthropicComplianceActivityUpdated,
-			CreatedAt:        "2026-07-14T10:00:01Z",
-			OrganizationID:   "ext-org",
-			OrganizationUUID: "",
-			Actor:            anthropicapi.Actor{Type: "api_actor", EmailAddress: "", UserID: "", IPAddress: "", UserAgent: ""},
-			ClaudeChatID:     "chat_ignored",
-			ClaudeProjectID:  "",
-		}
-	}
+}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Query().Get("after_id") {
-		case "":
-			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
-				Data:    []anthropicapi.Activity{userActivity("act_1", "chat_1"), systemActivity("act_2"), userActivity("act_3", "chat_2")},
-				HasMore: true,
-				FirstID: "act_1",
-				LastID:  "act_3",
-			})
-		case "act_3":
-			// A fully-filtered page: nothing importable, but the feed still
-			// advances past it.
-			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
-				Data:    []anthropicapi.Activity{systemActivity("act_4"), systemActivity("act_5")},
-				HasMore: true,
-				FirstID: "act_4",
-				LastID:  "act_5",
-			})
-		case "act_5":
-			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
-				Data:    []anthropicapi.Activity{userActivity("act_6", "chat_3")},
-				HasMore: false,
-				FirstID: "act_6",
-				LastID:  "act_6",
-			})
-		default:
-			t.Errorf("unexpected after_id %q", r.URL.Query().Get("after_id"))
-		}
-	}))
-	t.Cleanup(server.Close)
+func complianceSystemActivity(id string) anthropicapi.Activity {
+	return anthropicapi.Activity{
+		ID:               id,
+		Type:             anthropicComplianceActivityUpdated,
+		CreatedAt:        "2026-07-14T10:00:01Z",
+		OrganizationID:   "ext-org",
+		OrganizationUUID: "",
+		Actor:            anthropicapi.Actor{Type: "api_actor", EmailAddress: "", UserID: "", IPAddress: "", UserAgent: ""},
+		ClaudeChatID:     "chat_ignored",
+		ClaudeProjectID:  "",
+	}
+}
+
+func complianceDiscoveryService(t *testing.T, serverURL string) (*ComplianceImportService, *anthropicapi.Client) {
+	t.Helper()
 
 	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
 	require.NoError(t, err)
-	client := anthropicapi.New(policy, anthropicapi.WithBaseURL(server.URL), anthropicapi.WithAPIKey("anthropic-key"))
-
+	client := anthropicapi.New(policy, anthropicapi.WithBaseURL(serverURL), anthropicapi.WithAPIKey("anthropic-key"))
 	svc := NewComplianceImportService(testenv.NewLogger(t), nil, policy, nil, func(context.Context, string, int) {})
+	return svc, client
+}
+
+func complianceDiscoveryConfig(lastCursor string) Config {
 	extOrgID := "ext-org"
-	cfg := Config{
+	return Config{
 		ID:                     uuid.New(),
 		OrganizationID:         "org_test",
 		Provider:               ProviderAnthropicCompliance,
@@ -97,14 +70,15 @@ func TestStreamChatActivitiesMarksLastImportableActivityPerPage(t *testing.T) {
 		LastPollFailedAt:       time.Time{},
 		LastPollSuccessAt:      time.Time{},
 		ConsecutiveFailures:    0,
-		LastCursor:             "",
+		LastCursor:             lastCursor,
 		CreatedAt:              time.Time{},
 		UpdatedAt:              time.Time{},
 	}
+}
 
-	out := make(chan discoveredActivity, 16)
-	progress := &ComplianceSyncProgress{
-		FirstSync:           true,
+func complianceDiscoveryProgress(firstSync bool) *ComplianceSyncProgress {
+	return &ComplianceSyncProgress{
+		FirstSync:           firstSync,
 		ActivityPages:       0,
 		ChatActivities:      0,
 		ChatsImported:       0,
@@ -113,7 +87,55 @@ func TestStreamChatActivitiesMarksLastImportableActivityPerPage(t *testing.T) {
 		CursorReached:       "",
 		CursorPersisted:     "",
 	}
+}
 
+func TestStreamChatActivitiesWalksForwardFromCursor(t *testing.T) {
+	t.Parallel()
+
+	// The feed is newest first; a forward walk pages with before_id and each
+	// page's newest edge is its first_id. Pages arrive oldest window first.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("after_id"); got != "" {
+			t.Errorf("forward walk must not send after_id, got %q", got)
+		}
+		if got := r.URL.Query().Get("created_at.gte"); got != "" {
+			t.Errorf("forward walk must not send created_at.gte, got %q", got)
+		}
+		switch r.URL.Query().Get("before_id") {
+		case "cur_start":
+			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
+				Data:    []anthropicapi.Activity{complianceUserActivity("act_3", "chat_2"), complianceSystemActivity("act_2"), complianceUserActivity("act_1", "chat_1")},
+				HasMore: true,
+				FirstID: "act_3",
+				LastID:  "act_1",
+			})
+		case "act_3":
+			// A fully-filtered page: nothing importable, but the feed still
+			// advances past it.
+			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
+				Data:    []anthropicapi.Activity{complianceSystemActivity("act_5"), complianceSystemActivity("act_4")},
+				HasMore: true,
+				FirstID: "act_5",
+				LastID:  "act_4",
+			})
+		case "act_5":
+			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
+				Data:    []anthropicapi.Activity{complianceUserActivity("act_6", "chat_3")},
+				HasMore: false,
+				FirstID: "act_6",
+				LastID:  "act_6",
+			})
+		default:
+			t.Errorf("unexpected before_id %q", r.URL.Query().Get("before_id"))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	svc, client := complianceDiscoveryService(t, server.URL)
+	cfg := complianceDiscoveryConfig("cur_start")
+	progress := complianceDiscoveryProgress(false)
+
+	out := make(chan discoveredActivity, 16)
 	cursor, err := svc.streamChatActivities(t.Context(), client, cfg, out, progress)
 	require.NoError(t, err)
 	close(out)
@@ -128,21 +150,81 @@ func TestStreamChatActivitiesMarksLastImportableActivityPerPage(t *testing.T) {
 	}
 	require.Len(t, discovered, 4)
 
-	// The api_actor activity is filtered, so the last importable activity of
-	// page one (act_3) carries the page's cursor; mid-page activities carry
-	// none. The fully-filtered second page yields a cursor-only sentinel so
-	// its token still becomes durable. The final page's last activity
-	// carries its cursor too.
-	require.Equal(t, "act_1", discovered[0].activity.ID)
+	// Page one sends newest first (act_3, act_1); the last importable
+	// activity carries the page's first_id checkpoint. The fully-filtered
+	// second page yields a cursor-only sentinel carrying its first_id. The
+	// final page's activity carries its own first_id.
+	require.Equal(t, "act_3", discovered[0].activity.ID)
 	require.Empty(t, discovered[0].activitiesCursor)
 	require.False(t, discovered[0].cursorOnly)
-	require.Equal(t, "act_3", discovered[1].activity.ID)
+	require.Equal(t, "act_1", discovered[1].activity.ID)
 	require.Equal(t, "act_3", discovered[1].activitiesCursor)
 	require.True(t, discovered[2].cursorOnly)
 	require.Equal(t, "act_5", discovered[2].activitiesCursor)
 	require.Empty(t, discovered[2].activity.ID)
 	require.Equal(t, "act_6", discovered[3].activity.ID)
 	require.Equal(t, "act_6", discovered[3].activitiesCursor)
+}
+
+func TestBackfillChatActivitiesReturnsNewestEdgeWithoutMarkers(t *testing.T) {
+	t.Parallel()
+
+	// First sync: no cursor stored. The backfill pages older with after_id
+	// inside the watermark window and hands off the newest edge (the first
+	// page's first_id) as the forward-walk cursor for every later sync.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("before_id"); got != "" {
+			t.Errorf("backfill must not send before_id, got %q", got)
+		}
+		if got := r.URL.Query().Get("created_at.gte"); got == "" {
+			t.Error("backfill must bound the window with created_at.gte")
+		}
+		switch r.URL.Query().Get("after_id") {
+		case "":
+			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
+				Data:    []anthropicapi.Activity{complianceUserActivity("act_9", "chat_9"), complianceUserActivity("act_8", "chat_8")},
+				HasMore: true,
+				FirstID: "act_9",
+				LastID:  "act_8",
+			})
+		case "act_8":
+			_ = json.NewEncoder(w).Encode(anthropicapi.ActivitiesPage{
+				Data:    []anthropicapi.Activity{complianceUserActivity("act_7", "chat_7")},
+				HasMore: false,
+				FirstID: "act_7",
+				LastID:  "act_7",
+			})
+		default:
+			t.Errorf("unexpected after_id %q", r.URL.Query().Get("after_id"))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	svc, client := complianceDiscoveryService(t, server.URL)
+	cfg := complianceDiscoveryConfig("")
+	progress := complianceDiscoveryProgress(true)
+
+	out := make(chan discoveredActivity, 16)
+	cursor, err := svc.streamChatActivities(t.Context(), client, cfg, out, progress)
+	require.NoError(t, err)
+	close(out)
+
+	// The handed-off cursor is the newest edge, not the backfill's deepest
+	// point — resuming forward from the oldest edge would walk backwards
+	// through history forever.
+	require.Equal(t, "act_9", cursor)
+	require.Equal(t, 2, progress.ActivityPages)
+	require.Equal(t, 3, progress.ChatActivities)
+
+	var discovered []discoveredActivity
+	for d := range out {
+		discovered = append(discovered, d)
+	}
+	require.Len(t, discovered, 3)
+	for _, d := range discovered {
+		require.False(t, d.cursorOnly)
+		require.Empty(t, d.activitiesCursor)
+	}
 }
 
 func TestWriteMessagePagesAdvancesActivitiesCursor(t *testing.T) {

--- a/server/internal/thirdparty/anthropic/client.go
+++ b/server/internal/thirdparty/anthropic/client.go
@@ -63,11 +63,16 @@ func New(guardianPolicy *guardian.Policy, opts ...Option) *Client {
 	return c
 }
 
+// ListActivitiesParams filters and paginates the activities feed. The feed
+// is always sorted newest first: AfterID pages toward OLDER activities (a
+// backfill) while BeforeID pages toward NEWER activities (an incremental
+// tail read). At most one of AfterID and BeforeID may be set.
 type ListActivitiesParams struct {
 	ActivityTypes   []string
 	OrganizationIDs []string
 	CreatedAtGTE    time.Time
 	AfterID         string
+	BeforeID        string
 	Limit           int
 }
 
@@ -125,6 +130,9 @@ func (c *Client) ListActivities(ctx context.Context, params ListActivitiesParams
 	}
 	if params.AfterID != "" {
 		q.Set("after_id", params.AfterID)
+	}
+	if params.BeforeID != "" {
+		q.Set("before_id", params.BeforeID)
 	}
 	if params.Limit > 0 {
 		q.Set("limit", strconv.Itoa(params.Limit))

--- a/server/internal/thirdparty/anthropic/client_test.go
+++ b/server/internal/thirdparty/anthropic/client_test.go
@@ -60,11 +60,44 @@ func TestListActivitiesSendsAuthAndFilters(t *testing.T) {
 		OrganizationIDs: []string{"91012d09-e48b-438e-a489-1bebfd8fa6f9"},
 		CreatedAtGTE:    time.Date(2026, 4, 10, 8, 9, 10, 0, time.UTC),
 		AfterID:         "activity_last",
+		BeforeID:        "",
 		Limit:           5000,
 	})
 	require.NoError(t, err)
 	require.True(t, page.HasMore)
 	require.Equal(t, "claude_chat_1", page.Data[0].ClaudeChatID)
+}
+
+func TestListActivitiesSendsBeforeID(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("before_id"); got != "activity_first" {
+			t.Errorf("expected before_id activity_first, got %q", got)
+		}
+		if got := r.URL.Query().Get("after_id"); got != "" {
+			t.Errorf("expected no after_id, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(ActivitiesPage{
+			Data:    nil,
+			HasMore: false,
+			FirstID: "",
+			LastID:  "",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(testGuardianPolicy(t), WithBaseURL(server.URL), WithAPIKey("anthropic-key"))
+	page, err := client.ListActivities(t.Context(), ListActivitiesParams{
+		ActivityTypes:   nil,
+		OrganizationIDs: nil,
+		CreatedAtGTE:    time.Time{},
+		AfterID:         "",
+		BeforeID:        "activity_first",
+		Limit:           100,
+	})
+	require.NoError(t, err)
+	require.False(t, page.HasMore)
 }
 
 func TestGetChatMessagesDecodesDocsShape(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the root cause behind DNO-461's stalled compliance syncs: the stored activities cursor was moving *backward* in time (observed in prod: June 26 → June 16) because incremental runs paged with `after_id`.

The Anthropic Activities feed is sorted **newest-first**, so `after_id` pages toward *older* entries. Using it with the stored cursor meant every incremental run re-walked history away from new data and never discovered new activity.

- **Incremental syncs** (cursor set) now page **forward** with `before_id` from the stored cursor. Each page's `first_id` becomes both the next `before_id` and the checkpoint token persisted incrementally (per #4216), so retries resume from the last fully-written page.
- **First syncs** (no cursor) keep the bounded `after_id` + `created_at.gte` backfill, but now hand off the **newest edge** (`first_id` of the first page) as the stored cursor instead of the oldest, so the next run walks forward from where the backfill started.
- Fully-filtered pages still advance the cursor via cursor-only sentinels.
- Existing configs need no migration: their stored cursor is simply reinterpreted as a `before_id` starting point, and the next run catches up forward from wherever the backward walk left the cursor.

The `anthropic` client gains a `BeforeID` param on `ListActivities`; exactly one of `after_id`/`before_id` is sent per request.

## Test plan

- [ ] `TestListActivitiesSendsBeforeID` verifies the client sends `before_id` and omits `after_id`
- [ ] `TestStreamChatActivitiesWalksForwardFromCursor` covers the incremental forward walk: `before_id` paging, no `created_at.gte`, `first_id` checkpoint markers, cursor-only sentinels for filtered pages
- [ ] `TestBackfillChatActivitiesReturnsNewestEdgeWithoutMarkers` covers first sync: `after_id` backfill, no checkpoint markers, newest edge handed off as cursor
- [ ] `go test ./internal/aiintegrations/... ./internal/thirdparty/anthropic/...` passes
- [ ] After deploy, confirm `last_cursor_id` embedded timestamps advance forward in prod

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNO-461 by walking the Anthropic activities feed forward with `before_id` so incremental syncs stop moving backward and start discovering new activity. First syncs still backfill but now store the newest edge as the cursor.

- **Bug Fixes**
  - Incremental syncs: page forward with `before_id` from the stored cursor and checkpoint each page’s `first_id` (fully filtered pages advance via cursor-only sentinels).
  - First syncs: bounded `after_id` + `created_at.gte` backfill, then hand off the newest edge (first page `first_id`) as the stored cursor; no mid-window markers.
  - `anthropic` client now supports `BeforeID` on `ListActivities` and sends only one of `after_id` or `before_id`.

- **Migration**
  - No migration needed; existing cursors are used as `before_id` starting points and the next run catches up forward.

<sup>Written for commit 882673132b59ea20d916a3a02cdcde4c6902921d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

