### PR TITLE
mig(spend-control): add spend rules storage

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260724165737_spend-rule-usage-summaries.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260724165737_spend-rule-usage-summaries.down.sql
@@ -1,0 +1,4 @@
+-- reverse: create "spend_rule_usage_summaries_mv" view
+DROP VIEW `spend_rule_usage_summaries_mv`;
+-- reverse: create "spend_rule_usage_summaries" table
+DROP TABLE `spend_rule_usage_summaries`;

--- a/server/clickhouse/local/golang_migrate/20260724165737_spend-rule-usage-summaries.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260724165737_spend-rule-usage-summaries.up.sql
@@ -1,0 +1,10 @@
+-- create "spend_rule_usage_summaries" table
+CREATE TABLE `spend_rule_usage_summaries` (
+  `gram_project_id` UUID,
+  `user_email` String,
+  `time_bucket` DateTime('UTC'),
+  `total_cost` Float64
+) ENGINE = SummingMergeTree
+PRIMARY KEY (`gram_project_id`, `user_email`, `time_bucket`) ORDER BY (`gram_project_id`, `user_email`, `time_bucket`) TTL time_bucket + toIntervalDay(400) SETTINGS index_granularity = 8192 COMMENT 'Minute-grained per-user LLM cost rollup for spend-rule evaluation.';
+-- create "spend_rule_usage_summaries_mv" view
+CREATE MATERIALIZED VIEW `spend_rule_usage_summaries_mv` TO `spend_rule_usage_summaries` AS WITH (gram_urn = 'claude-code:otel:logs') AND (chat_id != '') AND (toString(attributes.prompt.id) != '') AND ((toString(attributes.event.name) = 'api_request') OR (body = 'claude_code.api_request')) AS is_claude_api_request, startsWith(gram_urn, 'codex:usage') OR startsWith(gram_urn, 'cursor:usage') AS is_generic_usage_row SELECT gram_project_id, user_email, toStartOfMinute(fromUnixTimestamp64Nano(time_unix_nano)) AS time_bucket, sum(if(is_claude_api_request, multiIf(toString(attributes.cost_usd) != '', toFloat64OrZero(toString(attributes.cost_usd)), toString(attributes.cost_usd_micros) != '', toFloat64OrZero(toString(attributes.cost_usd_micros)) / 1000000, 0), toFloat64OrZero(toString(attributes.gen_ai.usage.cost)))) AS total_cost FROM telemetry_logs WHERE (user_email != '') AND (is_claude_api_request OR is_generic_usage_row) GROUP BY gram_project_id, user_email, time_bucket;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:yw0YFv59bZChUsWFsGdVjacR4zwjcifiTGsAvkSAtsI=
+h1:WmouPGNGILBfSDOT/o4hto14T1dmJnSRaZI1N/OQTFw=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -76,3 +76,4 @@ h1:yw0YFv59bZChUsWFsGdVjacR4zwjcifiTGsAvkSAtsI=
 20260723200913_chat-analysis-scores.up.sql h1:nDdYjmRJPmbxroG+ZYAxDf7R0f6Ak1CMYBvrkyE+3dM=
 20260723231517_work_delivered_efficiency.up.sql h1:+NibDX4zQXROmNmB3tVaLTZX8FQBHeIquu301CGGiY8=
 20260724083855_risk_findings_attribution.up.sql h1:1Tj5SJUC43cC2Lyh61nD+N5LVAROpQ9FyUxqEQjJYE4=
+20260724165737_spend-rule-usage-summaries.up.sql h1:0hpnDtMVkWrzc5CYJ9etO5fHvAH+M5OO+fu9943Yh8g=

--- a/server/clickhouse/migrations/20260724165732_spend-rule-usage-summaries.sql
+++ b/server/clickhouse/migrations/20260724165732_spend-rule-usage-summaries.sql
@@ -1,0 +1,10 @@
+-- Create "spend_rule_usage_summaries" table
+CREATE TABLE `spend_rule_usage_summaries` (
+  `gram_project_id` UUID,
+  `user_email` String,
+  `time_bucket` DateTime('UTC'),
+  `total_cost` Float64
+) ENGINE = SummingMergeTree
+PRIMARY KEY (`gram_project_id`, `user_email`, `time_bucket`) ORDER BY (`gram_project_id`, `user_email`, `time_bucket`) TTL time_bucket + toIntervalDay(400) SETTINGS index_granularity = 8192 COMMENT 'Minute-grained per-user LLM cost rollup for spend-rule evaluation.';
+-- Create "spend_rule_usage_summaries_mv" view
+CREATE MATERIALIZED VIEW `spend_rule_usage_summaries_mv` TO `spend_rule_usage_summaries` AS WITH (gram_urn = 'claude-code:otel:logs') AND (chat_id != '') AND (toString(attributes.prompt.id) != '') AND ((toString(attributes.event.name) = 'api_request') OR (body = 'claude_code.api_request')) AS is_claude_api_request, startsWith(gram_urn, 'codex:usage') OR startsWith(gram_urn, 'cursor:usage') AS is_generic_usage_row SELECT gram_project_id, user_email, toStartOfMinute(fromUnixTimestamp64Nano(time_unix_nano)) AS time_bucket, sum(if(is_claude_api_request, multiIf(toString(attributes.cost_usd) != '', toFloat64OrZero(toString(attributes.cost_usd)), toString(attributes.cost_usd_micros) != '', toFloat64OrZero(toString(attributes.cost_usd_micros)) / 1000000, 0), toFloat64OrZero(toString(attributes.gen_ai.usage.cost)))) AS total_cost FROM telemetry_logs WHERE (user_email != '') AND (is_claude_api_request OR is_generic_usage_row) GROUP BY gram_project_id, user_email, time_bucket;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:h7N1d9FCGIIIsUTUsULjn7uOs9EOQnDSo54CzgmR3KA=
+h1:A3gYMhWXHz36BwB/X9G1eQ2d40i+/SyOLcwl4hbr98s=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -81,3 +81,4 @@ h1:h7N1d9FCGIIIsUTUsULjn7uOs9EOQnDSo54CzgmR3KA=
 20260723200907_chat-analysis-scores.sql h1:y/Qvq/eB8xGDYyvPAre7ruYZ8V4DoV3GAwIrE6o3DTA=
 20260723231511_work_delivered_efficiency.sql h1:GQs/RUNtR094Hm48bWIIQk99QttL8jAPhq7+aLy2kWw=
 20260724083850_risk_findings_attribution.sql h1:1sev8sFRph7seEnkiDSHPiT7QA9keClkBC6lCVkQBVc=
+20260724165732_spend-rule-usage-summaries.sql h1:TF6wIYFW/QA6gcRNNlg0toN4y//Mw6bexZuywbuhuHU=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -793,6 +793,59 @@ GROUP BY
     mcp_tool_name,
     hook_hostname;
 
+-- spend_rule_usage_summaries is a narrow, enforcement-oriented rollup for
+-- spend controls. It intentionally avoids the analytics dimensions in
+-- attribute_metrics_summaries so rule evaluation can read exact per-actor spend
+-- at minute granularity without coupling to telemetry.query schema changes.
+CREATE TABLE IF NOT EXISTS spend_rule_usage_summaries (
+    gram_project_id UUID,
+    user_email String,
+    time_bucket DateTime('UTC'),
+    total_cost Float64
+) ENGINE = SummingMergeTree
+ORDER BY (gram_project_id, user_email, time_bucket)
+TTL time_bucket + INTERVAL 400 DAY
+SETTINGS index_granularity = 8192
+COMMENT 'Minute-grained per-user LLM cost rollup for spend-rule evaluation.';
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS spend_rule_usage_summaries_mv TO spend_rule_usage_summaries AS
+WITH
+    -- Keep these predicates aligned with attribute_metrics_summaries_mv's cost
+    -- source rows so spend controls reconcile with the cost dashboard.
+    -- Claude provenance is anchored on the OTEL log stream URN stamped at
+    -- ingest, mirroring is_claude_otel_row in attribute_metrics_summaries_mv:
+    -- service.name, body, and log attributes are writer-controlled, so
+    -- without the URN guard a Claude-formatted row arriving through any other
+    -- path would count toward enforcement but not the dashboard, warning or
+    -- blocking users on inflated spend.
+    (
+        gram_urn = 'claude-code:otel:logs'
+        AND chat_id != ''
+        AND toString(attributes.prompt.id) != ''
+        AND (toString(attributes.event.name) = 'api_request' OR body = 'claude_code.api_request')
+    ) AS is_claude_api_request,
+    -- Only Codex/Cursor usage-metric rows count. Generic gen_ai chat rows
+    -- (Gram-hosted completions and other sources) are deliberately excluded so
+    -- spend-rule enforcement reconciles with the cost dashboard's agent
+    -- surfaces. claude_chat:usage / claude_chat:cost rows (Claude web/desktop
+    -- spend polled from the Anthropic Admin API), which
+    -- attribute_metrics_summaries_mv does count, are also deliberately
+    -- excluded for now: spend rules govern agent/CLI spend until a product
+    -- decision includes Claude Chat in enforcement budgets.
+    (
+        startsWith(gram_urn, 'codex:usage')
+        OR startsWith(gram_urn, 'cursor:usage')
+    ) AS is_generic_usage_row
+SELECT
+    gram_project_id,
+    user_email,
+    toStartOfMinute(fromUnixTimestamp64Nano(time_unix_nano)) AS time_bucket,
+    sum(if(is_claude_api_request, multiIf(toString(attributes.cost_usd) != '', toFloat64OrZero(toString(attributes.cost_usd)), toString(attributes.cost_usd_micros) != '', toFloat64OrZero(toString(attributes.cost_usd_micros)) / 1000000, 0), toFloat64OrZero(toString(attributes.gen_ai.usage.cost)))) AS total_cost
+FROM telemetry_logs
+WHERE user_email != ''
+  AND (is_claude_api_request OR is_generic_usage_row)
+GROUP BY gram_project_id, user_email, time_bucket;
+
 CREATE TABLE IF NOT EXISTS chat_token_summaries (
     -- Key columns
     gram_project_id UUID,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2507,6 +2507,14 @@ CREATE INDEX IF NOT EXISTS directory_users_user_id_idx
 ON directory_users (user_id)
 WHERE user_id IS NOT NULL;
 
+-- Case-insensitive email lookup for resolving an org member to their directory
+-- profile (spend-rule evaluation's ListOrgActors matches on LOWER(email)); the
+-- user_id branch is served by directory_users_user_id_idx, so together the two
+-- keep that per-member lookup off a sequential scan of the org's directory rows.
+CREATE INDEX IF NOT EXISTS directory_users_organization_id_lower_email_idx
+ON directory_users (organization_id, LOWER(email))
+WHERE deleted IS FALSE AND workos_deleted IS FALSE;
+
 CREATE UNIQUE INDEX IF NOT EXISTS directory_users_workos_directory_user_id_key
 ON directory_users (workos_directory_user_id);
 
@@ -4670,3 +4678,142 @@ CREATE INDEX IF NOT EXISTS model_provider_keys_project_id_idx
 
 CREATE INDEX IF NOT EXISTS model_provider_keys_organization_id_idx
   ON model_provider_keys (organization_id);
+-- Org-scoped spend control rules. Each rule targets a set of actors via a CEL
+-- expression over org members' attributes (directory-synced attributes, group
+-- memberships, and org roles) and grants every matched actor a per-person USD
+-- budget for a UTC calendar window. A periodic evaluator compares each
+-- actor's spend against the limit and emits warning/breach events; rules with
+-- action = 'block' also open a circuit that denies the actor's Claude hook
+-- traffic until the window resets.
+--
+-- Rows are append-only version snapshots: editing a rule archives the current
+-- row (superseded_by points at its replacement) and inserts a new row with the
+-- same slug and version + 1. Config columns are never updated in place — only
+-- enabled (an operational toggle) and the archival columns change after
+-- insert — so events can join their exact rule row and always see the config
+-- that produced them. There is no hard delete; archiving ends a lineage while
+-- keeping its slug reserved and its history resolvable.
+CREATE TABLE IF NOT EXISTS spend_rules (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+
+  name TEXT NOT NULL,
+  -- URL-safe lineage identifier derived from the name at creation time and
+  -- shared by every version row of one rule. Immutable thereafter: the rule
+  -- URN ('spend_rule:<slug>:v<version>') embeds it, so renames must not
+  -- change it or historical events would detach from their rule. A slug is
+  -- never reused for a new rule, even after its lineage is archived (creation
+  -- checks the slug against all rows, archived included).
+  slug TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  -- CEL boolean expression over actor attributes (see
+  -- internal/spendrules/celenv). A rule applies to an actor when this
+  -- evaluates true.
+  target_expr TEXT NOT NULL,
+  -- Per-person budget in cents for one window. Must be positive; validated in
+  -- application code. External APIs and CEL still expose USD values.
+  limit_usd_cents BIGINT NOT NULL,
+  -- CEL boolean expression over the actor plus current-window usage. The
+  -- expression identifies budget breaches inside the target audience.
+  rule_expr TEXT NOT NULL DEFAULT 'spend_usd >= limit_usd',
+  -- UTC calendar window the budget covers ('daily', 'weekly' or 'monthly';
+  -- validated in application code). 'window' is a reserved keyword.
+  window_kind TEXT NOT NULL,
+  -- Percentage of the limit at which a warning event is emitted (1-100;
+  -- validated in application code).
+  warn_at_pct INT NOT NULL DEFAULT 80,
+  -- 'flag' or 'block'; validated in application code.
+  action TEXT NOT NULL DEFAULT 'flag',
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  -- Position of this row in its slug lineage; bumps by one on every edit.
+  version BIGINT NOT NULL DEFAULT 1,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  -- Set when the row stops being the live version of its lineage: either an
+  -- admin archived the rule, or an edit superseded this row.
+  archived_at timestamptz,
+  archived boolean NOT NULL GENERATED ALWAYS AS (archived_at IS NOT NULL) STORED,
+  -- The replacement row when this row was archived by an edit; NULL when an
+  -- admin archived the lineage outright (no successor).
+  superseded_by uuid,
+
+  CONSTRAINT spend_rules_pkey PRIMARY KEY (id),
+  -- Tenancy-pinning key: the superseded_by FK below and spend_rule_events
+  -- composite-FK (organization_id, id) here so neither can ever reference a
+  -- rule owned by another organization. A table-level constraint (not a
+  -- CREATE UNIQUE INDEX) because the self-referential FK must resolve inline;
+  -- the table is created in one migration so there is no online-index concern.
+  CONSTRAINT spend_rules_organization_id_id_key UNIQUE (organization_id, id),
+  CONSTRAINT spend_rules_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  -- Composite so the successor reference is pinned to the same organization —
+  -- a UUID-only FK would let a row point at another org's rule. No delete
+  -- action: rule rows are never hard-deleted individually (append-only,
+  -- archive-only), and the only delete path — the organization cascade —
+  -- removes referencer and referenced in one statement, which the
+  -- end-of-statement NO ACTION check accepts. ON DELETE SET NULL is not an
+  -- option here: on a composite key it would null organization_id (NOT NULL),
+  -- and Postgres 15's `SET NULL (column list)` form is not modeled by Atlas.
+  CONSTRAINT spend_rules_organization_id_superseded_by_fkey FOREIGN KEY (organization_id, superseded_by) REFERENCES spend_rules (organization_id, id)
+);
+
+-- URNs are unique because every (slug, version) pair maps to exactly one row.
+CREATE UNIQUE INDEX IF NOT EXISTS spend_rules_organization_id_slug_version_key
+ON spend_rules (organization_id, slug, version);
+
+-- At most one live (non-archived) version per lineage: an edit must archive
+-- the current row before inserting its replacement.
+CREATE UNIQUE INDEX IF NOT EXISTS spend_rules_organization_id_slug_live_key
+ON spend_rules (organization_id, slug)
+WHERE archived IS FALSE;
+
+-- Backs the self-referential (organization_id, superseded_by) foreign key's
+-- referencing side; without it every rule row delete (organization cascade)
+-- scans the table for referencing rows. superseded_by alone is selective
+-- enough — no need to widen it to the full key.
+CREATE INDEX IF NOT EXISTS spend_rules_superseded_by_idx
+ON spend_rules (superseded_by);
+
+-- Warning/breach events emitted by the spend rule evaluator. One row per
+-- (rule version row, actor, window, event type) — the unique index makes
+-- evaluator writes idempotent across its 5-minute cycles. spend_rule_id points
+-- at the exact (immutable) rule version row that fired, so every event
+-- resolves to the config that produced it; rule_urn carries the same identity
+-- in human-readable form. No soft delete: events are the audit trail shown in
+-- the dashboard events tab.
+CREATE TABLE IF NOT EXISTS spend_rule_events (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  spend_rule_id uuid NOT NULL,
+  -- Versioned rule URN, e.g. 'spend_rule:eng-monthly-cap:v3'.
+  rule_urn TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+
+  -- Actor identity as known at evaluation time. user_id is NULL when the
+  -- directory user has not been linked to a Gram user.
+  user_id TEXT,
+  email TEXT NOT NULL,
+  display_name TEXT,
+
+  spend_usd_cents BIGINT NOT NULL,
+  limit_usd_cents BIGINT NOT NULL,
+  window_start timestamptz NOT NULL,
+  window_end timestamptz NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT spend_rule_events_pkey PRIMARY KEY (id),
+  CONSTRAINT spend_rule_events_event_type_check CHECK (event_type IN ('warning', 'breach')),
+  CONSTRAINT spend_rule_events_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT spend_rule_events_organization_id_spend_rule_id_fkey FOREIGN KEY (organization_id, spend_rule_id) REFERENCES spend_rules (organization_id, id) ON DELETE CASCADE
+);
+
+-- spend_rule_id identifies one immutable rule version, so (rule row, actor,
+-- window, type) is the natural idempotency key for evaluator writes.
+CREATE UNIQUE INDEX IF NOT EXISTS spend_rule_events_dedupe_key
+ON spend_rule_events (spend_rule_id, event_type, email, window_start);
+
+-- Backs the events feed: filtered by organization, ordered by id DESC
+-- (UUIDv7, so id order is creation order) with an `id <` cursor.
+CREATE INDEX IF NOT EXISTS spend_rule_events_organization_id_id_idx
+ON spend_rule_events (organization_id, id DESC);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1858,6 +1858,43 @@ type SourceEnvironment struct {
 	UpdatedAt     pgtype.Timestamptz
 }
 
+type SpendRule struct {
+	ID             uuid.UUID
+	OrganizationID string
+	Name           string
+	Slug           string
+	Description    string
+	TargetExpr     string
+	LimitUsdCents  int64
+	RuleExpr       string
+	WindowKind     string
+	WarnAtPct      int32
+	Action         string
+	Enabled        bool
+	Version        int64
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	ArchivedAt     pgtype.Timestamptz
+	Archived       bool
+	SupersededBy   uuid.NullUUID
+}
+
+type SpendRuleEvent struct {
+	ID             uuid.UUID
+	OrganizationID string
+	SpendRuleID    uuid.UUID
+	RuleUrn        string
+	EventType      string
+	UserID         pgtype.Text
+	Email          string
+	DisplayName    pgtype.Text
+	SpendUsdCents  int64
+	LimitUsdCents  int64
+	WindowStart    pgtype.Timestamptz
+	WindowEnd      pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+}
+
 // Durable record of a blocked tool call or prompt. One row per hook-time block decision, carrying the exact reason shown to the agent. Backs the durable /blocks/:id page and its thumbs feedback. The risk_results / risk_policies foreign keys are nullable enrichment links — the page renders from this row alone.
 type ToolCallBlock struct {
 	ID             uuid.UUID

--- a/server/migrations/20260724165656_spend-rules.sql
+++ b/server/migrations/20260724165656_spend-rules.sql
@@ -1,0 +1,55 @@
+-- Create "spend_rules" table
+CREATE TABLE "spend_rules" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "name" text NOT NULL,
+  "slug" text NOT NULL,
+  "description" text NOT NULL DEFAULT '',
+  "target_expr" text NOT NULL,
+  "limit_usd_cents" bigint NOT NULL,
+  "rule_expr" text NOT NULL DEFAULT 'spend_usd >= limit_usd',
+  "window_kind" text NOT NULL,
+  "warn_at_pct" integer NOT NULL DEFAULT 80,
+  "action" text NOT NULL DEFAULT 'flag',
+  "enabled" boolean NOT NULL DEFAULT true,
+  "version" bigint NOT NULL DEFAULT 1,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "archived_at" timestamptz NULL,
+  "archived" boolean NOT NULL GENERATED ALWAYS AS (archived_at IS NOT NULL) STORED,
+  "superseded_by" uuid NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "spend_rules_organization_id_id_key" UNIQUE ("organization_id", "id"),
+  CONSTRAINT "spend_rules_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "spend_rules_organization_id_superseded_by_fkey" FOREIGN KEY ("organization_id", "superseded_by") REFERENCES "spend_rules" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+-- Create index "spend_rules_organization_id_slug_live_key" to table: "spend_rules"
+CREATE UNIQUE INDEX "spend_rules_organization_id_slug_live_key" ON "spend_rules" ("organization_id", "slug") WHERE (archived IS FALSE);
+-- Create index "spend_rules_organization_id_slug_version_key" to table: "spend_rules"
+CREATE UNIQUE INDEX "spend_rules_organization_id_slug_version_key" ON "spend_rules" ("organization_id", "slug", "version");
+-- Create index "spend_rules_superseded_by_idx" to table: "spend_rules"
+CREATE INDEX "spend_rules_superseded_by_idx" ON "spend_rules" ("superseded_by");
+-- Create "spend_rule_events" table
+CREATE TABLE "spend_rule_events" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "spend_rule_id" uuid NOT NULL,
+  "rule_urn" text NOT NULL,
+  "event_type" text NOT NULL,
+  "user_id" text NULL,
+  "email" text NOT NULL,
+  "display_name" text NULL,
+  "spend_usd_cents" bigint NOT NULL,
+  "limit_usd_cents" bigint NOT NULL,
+  "window_start" timestamptz NOT NULL,
+  "window_end" timestamptz NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "spend_rule_events_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "spend_rule_events_organization_id_spend_rule_id_fkey" FOREIGN KEY ("organization_id", "spend_rule_id") REFERENCES "spend_rules" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "spend_rule_events_event_type_check" CHECK (event_type = ANY (ARRAY['warning'::text, 'breach'::text]))
+);
+-- Create index "spend_rule_events_dedupe_key" to table: "spend_rule_events"
+CREATE UNIQUE INDEX "spend_rule_events_dedupe_key" ON "spend_rule_events" ("spend_rule_id", "event_type", "email", "window_start");
+-- Create index "spend_rule_events_organization_id_id_idx" to table: "spend_rule_events"
+CREATE INDEX "spend_rule_events_organization_id_id_idx" ON "spend_rule_events" ("organization_id", "id" DESC);

--- a/server/migrations/20260724173649_directory_users_lower_email_idx.sql
+++ b/server/migrations/20260724173649_directory_users_lower_email_idx.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "directory_users_organization_id_lower_email_idx" to table: "directory_users"
+CREATE INDEX CONCURRENTLY "directory_users_organization_id_lower_email_idx" ON "directory_users" ("organization_id", (lower(email))) WHERE ((deleted IS FALSE) AND (workos_deleted IS FALSE));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:j/Ho3mzo8wgmAu7rq9FO20KFHEOcEXGDUHItJfT4DC4=
+h1:WXzr7q25XvhfRl8rHtx2Un+rSyk7M8ZuM8vlQxxiJzo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -294,3 +294,5 @@ h1:j/Ho3mzo8wgmAu7rq9FO20KFHEOcEXGDUHItJfT4DC4=
 20260722220532_skill-efficacy-reservation-recovery.sql h1:iSc/QDP1ySptfvBBw0GnH7DKOeMx3bCG6YlrmbbzO4o=
 20260723042033_skill-share-links.sql h1:IM3Yk3pO7qHVuxYd6ANArxKcvciakiqJ5NZVwkZSftc=
 20260723190651_chat-analysis-pipeline.sql h1:5ICmWs0+H88nBTjTh5CkgWE2gYcSe1oGbEiakhaToCI=
+20260724165656_spend-rules.sql h1:JolKgUjLUpWw1E4/lG/u8OfG178/wMP2TMPo46HOxdY=
+20260724173649_directory_users_lower_email_idx.sql h1:OphnMDp0OG2qCzr2mVYapCGGExOOfL8/lW3H0NIrjI8=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add PostgreSQL tables and indexes for spend rules, immutable versions, and rule events
- add ClickHouse minute-grained spend usage summaries and materialized view
- regenerate Atlas, golang-migrate, and SQLc schema-model artifacts on top of current `main`

## Testing
- `mise lint:migrations --no-atlas`
- Atlas lint against a clean local PostgreSQL database (266 migrations, 3 checks)
- applied all PostgreSQL migrations to a clean local database and verified all three spend-rule tables
- dry-ran and applied all ClickHouse migrations to a clean local database and verified the summary table and materialized view
- `mise run gen:server && git diff --exit-code`
- `mise lint:server && mise build:server`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03fcac76-8ced-44e3-9dd4-01bbc25f92fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03fcac76-8ced-44e3-9dd4-01bbc25f92fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add org-scoped spend rules in Postgres with append-only, versioned rows, plus a per-minute per-user-per-project cost rollup in ClickHouse for spend control. Money uses integer cents; the MV aligns with the cost dashboard by gating Claude API logs on `gram_urn` and only counting `codex:`/`cursor:` usage rows.

- **New Features**
  - Postgres: `spend_rules` as immutable version snapshots with archiving (`slug` fixed, `version` increments, `superseded_by` links). Table-level `(organization_id, id)` unique key and composite `(organization_id, superseded_by)` FK to pin tenancy. `spend_rule_events` reference the exact rule row, dedupe by `(spend_rule_id, event_type, email, window_start)`, and use `(organization_id, id DESC)` for feed pagination.
  - ClickHouse: `spend_rule_usage_summaries` + MV using `SummingMergeTree` with UTC minute buckets and a 400‑day TTL. Anchors Claude API provenance on `gram_urn` with event guards, sums cost from `cost_usd`/`cost_usd_micros` or `gen_ai.usage.cost`, and excludes Claude Chat and non-agent completions.
  - Index: `directory_users (organization_id, LOWER(email))` partial index for fast, case-insensitive actor resolution during evaluation.

- **Migration**
  - Apply Postgres and ClickHouse migrations; regenerate server DB models (`SpendRule`, `SpendRuleEvent`). Added local `golang_migrate` mirror for ClickHouse.

<sup>Written for commit acef3f75699ee40ef7ac30cc375fb0566350966f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

