### PR TITLE
mig: translate observability_mode orgs to hooks_fail_open

### DIFF
--- a/.changeset/observability-mode-to-fail-open-mig.md
+++ b/.changeset/observability-mode-to-fail-open-mig.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Data migration translating organizations still on the removed `observability_mode` product feature to `hooks_fail_open` (DNO-497): the new fail-open row preserves the outage tolerance those orgs opted into, and the retired observability_mode rows are soft-deleted.

--- a/server/migrations/20260715174418_observability-mode-to-hooks-fail-open.sql
+++ b/server/migrations/20260715174418_observability-mode-to-hooks-fail-open.sql
@@ -1,0 +1,21 @@
+-- Translate organizations still on the removed observability_mode feature to
+-- the hooks_fail_open feature that supersedes it (DNO-497). Observability
+-- mode was equivalent to fail-open plus not creating blocking policies, so
+-- fail-open preserves the outage tolerance those orgs opted into while any
+-- blocking policies they define now enforce. Runs after the feature's
+-- removal from the API, so no new observability_mode rows can appear.
+INSERT INTO organization_features (organization_id, feature_name)
+SELECT organization_id, 'hooks_fail_open'
+FROM organization_features
+WHERE feature_name = 'observability_mode'
+  AND deleted IS FALSE
+ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE
+DO NOTHING;
+
+-- Retire the observability_mode rows themselves: the feature no longer exists
+-- in the API enum, so a live row would only be dead state.
+UPDATE organization_features
+SET deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE feature_name = 'observability_mode'
+  AND deleted IS FALSE;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:EfzuYvWYdX3DWh69n60tzlesZ+0lk6yP3dFeOPZB7Ok=
+h1:JNgeCZHJHM2tBmvj2FpMBegH7BPHk6/DiQbgYTHVrRo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -265,3 +265,4 @@ h1:EfzuYvWYdX3DWh69n60tzlesZ+0lk6yP3dFeOPZB7Ok=
 20260714022021_mcp-server-tool-metadata.sql h1:1sKmFfyHXtx8MK988nYVkuKhlwoTi7/phABFHhl3WPw=
 20260714202057_chat-messages-listing-probe-indexes.sql h1:raNxlqK5jljXe4Z+JVp5dyx4R/uR9WmziXphoRoTG6w=
 20260715170908_skills-skill-versions.sql h1:Un78+gYfiw76/4vthKJwZdjKyziBLsNkwvk2q4YYD0E=
+20260715174418_observability-mode-to-hooks-fail-open.sql h1:LdG61RUE0xWhm7f/V+KWMdYVPC20yR9U5Q0jY+bj6N8=


### PR DESCRIPTION
Stacked on #4204 (merge that first, then retarget/merge this): once observability mode can no longer be toggled, this data migration translates organizations still carrying an active `observability_mode` row to the `hooks_fail_open` feature that supersedes it, and soft-deletes the retired rows.

Context: [Slack thread](https://speakeasyapi.slack.com/archives/C0ARJG28X29/p1784070299685469) — observability mode was "fail open + don't create any blocking policies", so fail-open preserves the outage tolerance these orgs opted into while their blocking policies (if any) now enforce. As of 2026-07-14 exactly one prod org has observability_mode active (smartnews); in the window between #4204 deploying and this migration running, its already-published plugins keep outage tolerance via the legacy-nonblocking→fail-open compat in the hooks binary.

Verified locally: seeded an `observability_mode` row, ran `mise db:migrate`, confirmed the org ended with an active `hooks_fail_open` row and a soft-deleted `observability_mode` row; re-running is a no-op (partial-unique `ON CONFLICT DO NOTHING`, `deleted IS FALSE` guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates remaining orgs from `observability_mode` to `hooks_fail_open`, then soft-deletes the legacy rows. Preserves fail-open outage tolerance while letting blocking policies enforce (DNO-497).

- **Migration**
  - Backfills `hooks_fail_open` for orgs with active `observability_mode` (`ON CONFLICT DO NOTHING` with `deleted IS FALSE`).
  - Soft-deletes `observability_mode` by setting `deleted_at` and `updated_at`.
  - Runs after the feature’s API removal; idempotent and safe to re-run.

<sup>Written for commit c4852a1042a3846a760f02fec9ccbbee9510f811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

