### PR TITLE
mig: add skills and skill_versions tables

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -262,6 +262,50 @@ CREATE TABLE IF NOT EXISTS assets (
   CONSTRAINT assets_project_id_sha256_key UNIQUE (project_id, sha256)
 );
 
+CREATE TABLE IF NOT EXISTS skills (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  name TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  summary TEXT,
+  source_kind TEXT NOT NULL DEFAULT 'manual',
+  classification TEXT NOT NULL DEFAULT 'custom',
+
+  archived_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT skills_pkey PRIMARY KEY (id),
+  CONSTRAINT skills_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS skills_project_id_idx ON skills (project_id);
+CREATE UNIQUE INDEX IF NOT EXISTS skills_project_id_name_key ON skills (project_id, name) WHERE archived_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS skill_versions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  skill_id uuid NOT NULL,
+
+  content TEXT NOT NULL,
+  canonical_sha256 TEXT NOT NULL,
+  raw_sha256 TEXT NOT NULL,
+  description TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  spec_valid boolean NOT NULL,
+  validation_errors JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  created_by_user_id TEXT NOT NULL,
+
+  CONSTRAINT skill_versions_pkey PRIMARY KEY (id),
+  CONSTRAINT skill_versions_skill_id_fkey FOREIGN KEY (skill_id) REFERENCES skills (id) ON DELETE CASCADE,
+  CONSTRAINT skill_versions_content_size_check CHECK (octet_length(content) <= 65536)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_skill_id_canonical_sha256_key ON skill_versions (skill_id, canonical_sha256);
+
 CREATE TABLE IF NOT EXISTS packages (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 100),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1628,6 +1628,33 @@ type RiskResult struct {
 	CreatedAt           pgtype.Timestamptz
 }
 
+type Skill struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	Name           string
+	DisplayName    string
+	Summary        pgtype.Text
+	SourceKind     string
+	Classification string
+	ArchivedAt     pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
+type SkillVersion struct {
+	ID               uuid.UUID
+	SkillID          uuid.UUID
+	Content          string
+	CanonicalSha256  string
+	RawSha256        string
+	Description      pgtype.Text
+	Metadata         []byte
+	SpecValid        bool
+	ValidationErrors []byte
+	CreatedAt        pgtype.Timestamptz
+	CreatedByUserID  string
+}
+
 type SlackApp struct {
 	CreatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz

--- a/server/migrations/20260715170908_skills-skill-versions.sql
+++ b/server/migrations/20260715170908_skills-skill-versions.sql
@@ -1,0 +1,38 @@
+-- Create "skills" table
+CREATE TABLE "skills" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "name" text NOT NULL,
+  "display_name" text NOT NULL,
+  "summary" text NULL,
+  "source_kind" text NOT NULL DEFAULT 'manual',
+  "classification" text NOT NULL DEFAULT 'custom',
+  "archived_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skills_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "skills_project_id_idx" to table: "skills"
+CREATE INDEX "skills_project_id_idx" ON "skills" ("project_id");
+-- Create index "skills_project_id_name_key" to table: "skills"
+CREATE UNIQUE INDEX "skills_project_id_name_key" ON "skills" ("project_id", "name") WHERE (archived_at IS NULL);
+-- Create "skill_versions" table
+CREATE TABLE "skill_versions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "skill_id" uuid NOT NULL,
+  "content" text NOT NULL,
+  "canonical_sha256" text NOT NULL,
+  "raw_sha256" text NOT NULL,
+  "description" text NULL,
+  "metadata" jsonb NOT NULL DEFAULT '{}',
+  "spec_valid" boolean NOT NULL,
+  "validation_errors" jsonb NOT NULL DEFAULT '[]',
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "created_by_user_id" text NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skill_versions_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "skill_versions_content_size_check" CHECK (octet_length(content) <= 65536)
+);
+-- Create index "skill_versions_skill_id_canonical_sha256_key" to table: "skill_versions"
+CREATE UNIQUE INDEX "skill_versions_skill_id_canonical_sha256_key" ON "skill_versions" ("skill_id", "canonical_sha256");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zoSbTJvxkqmkEu7W1XZ7OeUQnf2fz6xfDtx7DOC4ok0=
+h1:EfzuYvWYdX3DWh69n60tzlesZ+0lk6yP3dFeOPZB7Ok=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -264,3 +264,4 @@ h1:zoSbTJvxkqmkEu7W1XZ7OeUQnf2fz6xfDtx7DOC4ok0=
 20260713202859_environment-entries-add-is-secret.sql h1:6lQFy0k5gSthCic6INJDuaD/40n4jg54Swrjo9q/38M=
 20260714022021_mcp-server-tool-metadata.sql h1:1sKmFfyHXtx8MK988nYVkuKhlwoTi7/phABFHhl3WPw=
 20260714202057_chat-messages-listing-probe-indexes.sql h1:raNxlqK5jljXe4Z+JVp5dyx4R/uR9WmziXphoRoTG6w=
+20260715170908_skills-skill-versions.sql h1:Un78+gYfiw76/4vthKJwZdjKyziBLsNkwvk2q4YYD0E=


### PR DESCRIPTION
Adds the project-scoped Skills registry schema from DNO-422.

- adds logical `skills` with archive-aware name uniqueness
- adds immutable, content-hashed `skill_versions` with a 64 KiB content cap
- generates the Atlas migration and SQLc database models

Linear: DNO-422

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the project-scoped Skills registry for DNO-422, with new `skills` and `skill_versions` tables plus generated models and an Atlas migration. This enables unique, archivable skill identities and immutable, content-hashed versions.

- **New Features**
  - `skills`: project-scoped; unique `(project_id, name)` when not archived; `display_name`/`summary`; `source_kind`/`classification` as text; FK to projects with `ON DELETE CASCADE`.
  - `skill_versions`: immutable; 64KB `content` cap; unique `(skill_id, canonical_sha256)`; canonical/raw digests; JSONB `metadata` and `validation_errors`; `spec_valid` flag; `created_by_user_id`; FK to skills with `ON DELETE CASCADE`.

<sup>Written for commit 5410f8edbe86138d9871916c9dc2809c81524eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

