### PR TITLE
feat: expose mcp clientInfo on tool context in functions

### DIFF
--- a/.changeset/mcp-clientinfo-toolcontext.md
+++ b/.changeset/mcp-clientinfo-toolcontext.md
@@ -1,0 +1,7 @@
+---
+"@gram-ai/functions": minor
+---
+
+feat: expose the calling MCP client's identity to tools via `ctx.clientInfo`
+
+`ToolContext` gains an optional `clientInfo` field (`{ name, version }`) populated when a tool is invoked over MCP — preferring the per-call `_meta["io.modelcontextprotocol/clientInfo"]` hint and falling back to the identity captured during the MCP `initialize` handshake. It is `undefined` for direct invocations and is untrusted, self-reported metadata intended for observability and convenience, never authorization.

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -143,11 +143,9 @@ jobs:
       - name: Checkout base ref
         if: ${{ steps.check.outputs.lint == 'true' }}
         run: git fetch origin "$BASE_REF" && git checkout "$BASE_REF"
-      # Fetch the PR head via the pull ref mirrored into the base repository:
-      # for fork PRs, $HEAD_REF only exists in the fork, not on origin.
       - name: Checkout head ref
         if: ${{ steps.check.outputs.lint == 'true' }}
-        run: git fetch origin "pull/${{ github.event.pull_request.number }}/head" && git checkout FETCH_HEAD
+        run: git fetch origin "$HEAD_REF" && git checkout "$HEAD_REF"
 
       - name: Setup Mise
         if: ${{ steps.check.outputs.lint == 'true' }}

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -143,9 +143,11 @@ jobs:
       - name: Checkout base ref
         if: ${{ steps.check.outputs.lint == 'true' }}
         run: git fetch origin "$BASE_REF" && git checkout "$BASE_REF"
+      # Fetch the PR head via the pull ref mirrored into the base repository:
+      # for fork PRs, $HEAD_REF only exists in the fork, not on origin.
       - name: Checkout head ref
         if: ${{ steps.check.outputs.lint == 'true' }}
-        run: git fetch origin "$HEAD_REF" && git checkout "$HEAD_REF"
+        run: git fetch origin "pull/${{ github.event.pull_request.number }}/head" && git checkout FETCH_HEAD
 
       - name: Setup Mise
         if: ${{ steps.check.outputs.lint == 'true' }}

--- a/ts-framework/functions/src/framework.ts
+++ b/ts-framework/functions/src/framework.ts
@@ -150,6 +150,17 @@ export function assert<V extends { error: string; stack?: never }>(
   }
 }
 
+/**
+ * Identity of the MCP client that initiated a tool call, as reported by the
+ * client during the MCP `initialize` handshake (or forwarded per-call via
+ * `_meta["io.modelcontextprotocol/clientInfo"]`). Present only when the tool is
+ * invoked over MCP; `undefined` for direct (non-MCP) invocations.
+ */
+export interface MCPClientInfo {
+  name: string;
+  version: string;
+}
+
 class ToolContext<Env> {
   /**
    * The parsed environment variables available to the tool.
@@ -160,9 +171,19 @@ class ToolContext<Env> {
    * calls and other async operations to propagate cancellation.
    */
   readonly signal: AbortSignal;
-  constructor(signal: AbortSignal, env: Env) {
+  /**
+   * Identity of the MCP client that initiated the call, when available. This is
+   * populated from the MCP client's `clientInfo` when the tool is invoked over
+   * MCP and is `undefined` otherwise. Tools can use it to adapt behavior for
+   * known clients (e.g. inferring a caller's identity without an explicit
+   * input). Treat it as untrusted, self-reported metadata: use it for
+   * observability and convenience, never for authorization.
+   */
+  readonly clientInfo?: MCPClientInfo;
+  constructor(signal: AbortSignal, env: Env, clientInfo?: MCPClientInfo) {
     this.signal = signal;
     this.env = env;
+    this.clientInfo = clientInfo;
   }
 
   /**
@@ -475,7 +496,7 @@ export class Gram<
       name: TName;
       input: InferInput<TTools[TName]>;
     },
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; clientInfo?: MCPClientInfo },
   ): Promise<InferResult<TTools[TName]>> {
     const tool = this.#tools.get(request.name);
     if (!tool) {
@@ -487,6 +508,7 @@ export class Gram<
     const ctx = new ToolContext(
       options?.signal || new AbortController().signal,
       envSchema.parse(tool.inputEnv ?? process.env),
+      options?.clientInfo,
     );
 
     const schema = zm.object(tool.inputSchema);

--- a/ts-framework/functions/src/mcp.test.ts
+++ b/ts-framework/functions/src/mcp.test.ts
@@ -283,4 +283,64 @@ describe("fromGram", () => {
       expect(JSON.stringify(result.content)).not.toContain("stack");
     });
   });
+
+  describe("clientInfo on ToolContext", () => {
+    // A tool that echoes back whatever `ctx.clientInfo` it was given.
+    const echoClientInfo = new Gram().tool({
+      name: "whoami",
+      description: "Echoes the calling client's info",
+      inputSchema: {},
+      async execute(ctx) {
+        return ctx.json({ clientInfo: ctx.clientInfo ?? null });
+      },
+    });
+
+    function parseClientInfo(result: Awaited<ReturnType<Client["callTool"]>>) {
+      const content = result.content as Array<{ type: string; text: string }>;
+      return JSON.parse(content[0]!.text).clientInfo;
+    }
+
+    test("populates ctx.clientInfo from the initialize handshake", async () => {
+      const client = await setup(echoClientInfo);
+      const result = await client.callTool({ name: "whoami", arguments: {} });
+
+      // setup() connects a Client named "test-client"; that identity is what
+      // the server captures during the MCP initialize handshake.
+      expect(parseClientInfo(result)).toEqual({
+        name: "test-client",
+        version: "0.0.0",
+      });
+    });
+
+    test("prefers per-call _meta clientInfo over the handshake identity", async () => {
+      const client = await setup(echoClientInfo);
+      const result = await client.callTool({
+        name: "whoami",
+        arguments: {},
+        _meta: {
+          "io.modelcontextprotocol/clientInfo": {
+            name: "vega",
+            version: "2.1.0",
+          },
+        },
+      });
+
+      expect(parseClientInfo(result)).toEqual({ name: "vega", version: "2.1.0" });
+    });
+
+    test("ignores a malformed _meta clientInfo and falls back to the handshake", async () => {
+      const client = await setup(echoClientInfo);
+      const result = await client.callTool({
+        name: "whoami",
+        arguments: {},
+        // Missing `name` → not a usable clientInfo; fall back to the handshake.
+        _meta: { "io.modelcontextprotocol/clientInfo": { version: "9.9.9" } },
+      });
+
+      expect(parseClientInfo(result)).toEqual({
+        name: "test-client",
+        version: "0.0.0",
+      });
+    });
+  });
 });

--- a/ts-framework/functions/src/mcp.test.ts
+++ b/ts-framework/functions/src/mcp.test.ts
@@ -325,7 +325,10 @@ describe("fromGram", () => {
         },
       });
 
-      expect(parseClientInfo(result)).toEqual({ name: "vega", version: "2.1.0" });
+      expect(parseClientInfo(result)).toEqual({
+        name: "vega",
+        version: "2.1.0",
+      });
     });
 
     test("ignores a malformed _meta clientInfo and falls back to the handshake", async () => {

--- a/ts-framework/functions/src/mcp.ts
+++ b/ts-framework/functions/src/mcp.ts
@@ -7,6 +7,7 @@ import type {
   ManifestResource,
   ManifestTool,
   ManifestVariables,
+  MCPClientInfo,
 } from "./framework.ts";
 import {
   McpError,
@@ -186,6 +187,26 @@ async function collectResources(
 }
 
 /**
+ * Coerce an untrusted, self-reported client identity into an `MCPClientInfo`.
+ * Accepts the shape used by both the MCP `initialize` handshake and the
+ * `io.modelcontextprotocol/clientInfo` request-`_meta` hint. Returns `undefined`
+ * unless a non-empty `name` string is present; `version` defaults to `""` when
+ * absent so a client that reports only a name is still usable.
+ */
+function normalizeClientInfo(value: unknown): MCPClientInfo | undefined {
+  if (value == null || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const name = record["name"];
+  if (typeof name !== "string" || name === "") {
+    return undefined;
+  }
+  const version = typeof record["version"] === "string" ? record["version"] : "";
+  return { name, version };
+}
+
+/**
  * Creates a low-level MCP server from a Gram instance.
  */
 export function fromGram(
@@ -304,10 +325,21 @@ export function fromGram(
     async (req, extra): Promise<CallToolResult> => {
       const { name, arguments: args } = req.params;
 
+      // Identify the calling MCP client so tools can adapt to known callers via
+      // `ctx.clientInfo`. Prefer the per-call hint carried in request `_meta`
+      // (`io.modelcontextprotocol/clientInfo`); fall back to the identity
+      // captured during the MCP `initialize` handshake. Self-reported metadata:
+      // safe for observability/convenience, never for authorization.
+      const clientInfo =
+        normalizeClientInfo(
+          req.params._meta?.["io.modelcontextprotocol/clientInfo"],
+        ) ?? normalizeClientInfo(server.getClientVersion());
+
       let resp: Response;
       try {
         resp = (await g.handleToolCall({ name, input: args } as any, {
           signal: extra.signal,
+          clientInfo,
         })) as Response;
       } catch (err) {
         // `ctx.fail()` and input validation failures reject with a `Response`

--- a/ts-framework/functions/src/mcp.ts
+++ b/ts-framework/functions/src/mcp.ts
@@ -202,7 +202,8 @@ function normalizeClientInfo(value: unknown): MCPClientInfo | undefined {
   if (typeof name !== "string" || name === "") {
     return undefined;
   }
-  const version = typeof record["version"] === "string" ? record["version"] : "";
+  const version =
+    typeof record["version"] === "string" ? record["version"] : "";
   return { name, version };
 }
 


### PR DESCRIPTION
## Summary

Expose the calling MCP client's identity to Gram tools via `ctx.clientInfo`, so tools can adapt behavior for known clients (e.g. inferring a caller's identity without requiring an explicit input parameter).

Today `fromGram` forwards only the abort signal into `handleToolCall`, and `ToolContext` exposes only `env` + `signal` — a tool has no way to see which MCP client invoked it, even though the server knows (from the `initialize` handshake and per-call `_meta`).

## Changes

- Add `MCPClientInfo` (`{ name, version }`) and an optional `clientInfo` field on `ToolContext`, populated via a new `clientInfo` option on `Gram.handleToolCall`.
- In `fromGram`'s `CallToolRequestSchema` handler, resolve the caller identity per call: prefer the per-call `_meta["io.modelcontextprotocol/clientInfo"]` hint, falling back to the identity captured during the MCP `initialize` handshake (`Server.getClientVersion()`). Malformed values are ignored.
- `clientInfo` is `undefined` for direct (non-MCP) invocations. It is untrusted, self-reported metadata — intended for observability/convenience, never authorization (documented on the field).

## Standards basis

Both identity sources this PR reads are legitimate MCP standards — they just belong to different protocol versions, so reading both bridges the transition:

- **`_meta["io.modelcontextprotocol/clientInfo"]`** is a spec-defined key from the draft "stateless MCP" work ([SEP-2575](https://modelcontextprotocol.io/seps/2575-stateless-mcp)), where the former handshake fields move into per-request `_meta` and `io.modelcontextprotocol/clientInfo` (an `Implementation` = `{ name, version }`) becomes **required on every request** ([spec overview](https://modelcontextprotocol.io/specification/draft/basic), [draft schema.ts](https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.ts)). This is gated on protocol version `2026-07-28` (draft; not yet in effect).
- **`Server.getClientVersion()`** returns the `clientInfo` captured during the `initialize` handshake — the mechanism under the currently-shipped protocol, where `clientInfo` is sent only at initialization.

Reading the `_meta` key first and falling back to the handshake means `ctx.clientInfo` is populated under today's protocol (via the handshake) and continues to work unchanged once clients/servers adopt the stateless per-request model.

One intentional deviation from the draft: SEP-2575 makes `clientInfo` required per request, but `normalizeClientInfo` treats it as optional and defaults a missing `version` to `""`. This is deliberate leniency so legacy/handshake-only clients keep working during the transition — the server falls back rather than hard-rejecting.

## Backwards compatibility

Purely additive: the new constructor param and `handleToolCall` option are optional; existing callers are unaffected.

## Tests

`vitest run` — 50 passing (3 new): handshake population of `ctx.clientInfo`, per-call `_meta` override, and malformed-`_meta` fallback to the handshake identity.

---

Context: we consume this in the LaunchDarkly `gram-functions` tool set to infer a rollout's origin from the calling first-party MCP client. Happy to adjust naming/placement (e.g. the `_meta` key, or preferring handshake over `_meta`) to match your conventions.

via LD Research 🤖