### PR TITLE
mig(tunneledmcp): add allow_public consent column

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3413,6 +3413,11 @@ CREATE TABLE IF NOT EXISTS tunneled_mcp_servers (
   key_prefix TEXT NOT NULL CHECK (key_prefix <> ''),
   -- Durable source lifecycle. Live connection state is derived from Redis.
   status TEXT NOT NULL DEFAULT 'created' CHECK (status IN ('created', 'active', 'revoked')),
+  -- Owner consent for serving this source through a public (anonymous) MCP
+  -- endpoint. An mcp_servers row fronting this source may only take
+  -- visibility=public while this is true (double opt-in, enforced in
+  -- application code at create/update validation and at serve time).
+  allow_public boolean NOT NULL DEFAULT false,
   -- Last persisted tunnel agent version reported for this source.
   agent_version TEXT CHECK (agent_version IS NULL OR agent_version <> ''),
   -- Most recent persisted heartbeat time, used when Redis liveness data is absent.
@@ -3446,6 +3451,7 @@ COMMENT ON COLUMN tunneled_mcp_servers.name IS 'User-facing display name for the
 COMMENT ON COLUMN tunneled_mcp_servers.key_hash IS 'Hash of the one-time tunnel key. Used for future tunnel authentication without storing the plaintext key.';
 COMMENT ON COLUMN tunneled_mcp_servers.key_prefix IS 'Non-secret prefix of the tunnel key shown in the UI so users can identify which key/source they are using.';
 COMMENT ON COLUMN tunneled_mcp_servers.status IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
+COMMENT ON COLUMN tunneled_mcp_servers.allow_public IS 'Owner consent for anonymous public MCP serving of this source. Double opt-in with mcp_servers.visibility=public, enforced in application code.';
 COMMENT ON COLUMN tunneled_mcp_servers.agent_version IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
 COMMENT ON COLUMN tunneled_mcp_servers.last_seen_at IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
 COMMENT ON COLUMN tunneled_mcp_servers.created_at IS 'Time when the tunneled MCP source was created.';

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -2066,6 +2066,8 @@ type TunneledMcpServer struct {
 	KeyPrefix string
 	// Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.
 	Status string
+	// Owner consent for anonymous public MCP serving of this source. Double opt-in with mcp_servers.visibility=public, enforced in application code.
+	AllowPublic bool
 	// Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.
 	AgentVersion pgtype.Text
 	// Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.

--- a/server/internal/tunneledmcp/repo/models.go
+++ b/server/internal/tunneledmcp/repo/models.go
@@ -23,6 +23,8 @@ type TunneledMcpServer struct {
 	KeyPrefix string
 	// Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.
 	Status string
+	// Owner consent for anonymous public MCP serving of this source. Double opt-in with mcp_servers.visibility=public, enforced in application code.
+	AllowPublic bool
 	// Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.
 	AgentVersion pgtype.Text
 	// Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.

--- a/server/internal/tunneledmcp/repo/queries.sql.go
+++ b/server/internal/tunneledmcp/repo/queries.sql.go
@@ -31,7 +31,7 @@ func (q *Queries) CountActiveServersByOrganizationID(ctx context.Context, organi
 const createServer = `-- name: CreateServer :one
 INSERT INTO tunneled_mcp_servers (id, project_id, name, key_hash, key_prefix)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, project_id, name, key_hash, key_prefix, status, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateServerParams struct {
@@ -58,6 +58,7 @@ func (q *Queries) CreateServer(ctx context.Context, arg CreateServerParams) (Tun
 		&i.KeyHash,
 		&i.KeyPrefix,
 		&i.Status,
+		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.LastSeenAt,
 		&i.CreatedAt,
@@ -75,7 +76,7 @@ SET
     deleted_at = clock_timestamp(),
     updated_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteServerParams struct {
@@ -93,6 +94,7 @@ func (q *Queries) DeleteServer(ctx context.Context, arg DeleteServerParams) (Tun
 		&i.KeyHash,
 		&i.KeyPrefix,
 		&i.Status,
+		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.LastSeenAt,
 		&i.CreatedAt,
@@ -104,7 +106,7 @@ func (q *Queries) DeleteServer(ctx context.Context, arg DeleteServerParams) (Tun
 }
 
 const getServerByID = `-- name: GetServerByID :one
-SELECT id, project_id, name, key_hash, key_prefix, status, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
 FROM tunneled_mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -124,6 +126,7 @@ func (q *Queries) GetServerByID(ctx context.Context, arg GetServerByIDParams) (T
 		&i.KeyHash,
 		&i.KeyPrefix,
 		&i.Status,
+		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.LastSeenAt,
 		&i.CreatedAt,
@@ -149,7 +152,7 @@ func (q *Queries) GetTunneledMcpServerLimitByOrganizationID(ctx context.Context,
 }
 
 const listServersByProjectID = `-- name: ListServersByProjectID :many
-SELECT id, project_id, name, key_hash, key_prefix, status, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
 FROM tunneled_mcp_servers
 WHERE project_id = $1 AND deleted IS FALSE
 ORDER BY created_at DESC
@@ -171,6 +174,7 @@ func (q *Queries) ListServersByProjectID(ctx context.Context, projectID uuid.UUI
 			&i.KeyHash,
 			&i.KeyPrefix,
 			&i.Status,
+			&i.AllowPublic,
 			&i.AgentVersion,
 			&i.LastSeenAt,
 			&i.CreatedAt,
@@ -210,7 +214,7 @@ SET
     last_seen_at = NULL,
     updated_at = clock_timestamp()
 WHERE id = $3 AND project_id = $4 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type RotateServerKeyParams struct {
@@ -235,6 +239,7 @@ func (q *Queries) RotateServerKey(ctx context.Context, arg RotateServerKeyParams
 		&i.KeyHash,
 		&i.KeyPrefix,
 		&i.Status,
+		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.LastSeenAt,
 		&i.CreatedAt,
@@ -251,7 +256,7 @@ SET
     name = $1,
     updated_at = clock_timestamp()
 WHERE id = $2 AND project_id = $3 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateServerParams struct {
@@ -270,6 +275,7 @@ func (q *Queries) UpdateServer(ctx context.Context, arg UpdateServerParams) (Tun
 		&i.KeyHash,
 		&i.KeyPrefix,
 		&i.Status,
+		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.LastSeenAt,
 		&i.CreatedAt,

--- a/server/migrations/20260727135457_tunneled-mcp-servers-add-allow-public.sql
+++ b/server/migrations/20260727135457_tunneled-mcp-servers-add-allow-public.sql
@@ -1,0 +1,4 @@
+-- Modify "tunneled_mcp_servers" table
+ALTER TABLE "tunneled_mcp_servers" ADD COLUMN "allow_public" boolean NOT NULL DEFAULT false;
+-- Set comment to column: "allow_public" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."allow_public" IS 'Owner consent for anonymous public MCP serving of this source. Double opt-in with mcp_servers.visibility=public, enforced in application code.';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WXzr7q25XvhfRl8rHtx2Un+rSyk7M8ZuM8vlQxxiJzo=
+h1:kK1eCJFUYontBz+DIYvrsqZ7oRuUFi72rZsBI80oZMA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -296,3 +296,4 @@ h1:WXzr7q25XvhfRl8rHtx2Un+rSyk7M8ZuM8vlQxxiJzo=
 20260723190651_chat-analysis-pipeline.sql h1:5ICmWs0+H88nBTjTh5CkgWE2gYcSe1oGbEiakhaToCI=
 20260724165656_spend-rules.sql h1:JolKgUjLUpWw1E4/lG/u8OfG178/wMP2TMPo46HOxdY=
 20260724173649_directory_users_lower_email_idx.sql h1:OphnMDp0OG2qCzr2mVYapCGGExOOfL8/lW3H0NIrjI8=
+20260727135457_tunneled-mcp-servers-add-allow-public.sql h1:yTSYYjmGsEfyHfQxLI5OTodAx8HP5oFFCAc7FsKJpjE=


### PR DESCRIPTION
## What

Adds `tunneled_mcp_servers.allow_public boolean NOT NULL DEFAULT false` — durable owner consent for serving a tunneled MCP source through a public, anonymous MCP endpoint.

Migration-only PR per the repo's PostgreSQL rules (migrations ship alone, no application logic). Additive and backwards-compatible: existing rows default to `false`, and no current code path reads the column yet.

## Why

Part 1 of 2 for public-visibility tunneled MCP servers. The consuming application logic (serve path, validation, dashboard) lands in the stacked follow-up **feat/public-tunnels**, which enforces the double opt-in (this column + `mcp_servers.visibility = public`).

## Test plan

- `mise db:reset && mise db:migrate` applies cleanly.
- Atlas-generated migration + `atlas.sum`; no hand edits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `allow_public` boolean column (NOT NULL, default false) to `tunneled_mcp_servers` to record owner consent for serving a tunneled MCP source via a public, anonymous endpoint. Also updates comments and generated models/queries; backward compatible with no behavior change, and prepares double opt-in with `mcp_servers.visibility = 'public'` (enforced in a follow-up).

<sup>Written for commit 988eb31b0453db4e192507b9f283e5cce6cebc99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

