### PR TITLE
feat: add search filter to shadow mcp inventory view

### DIFF
--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.test.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.test.tsx
@@ -55,6 +55,33 @@ vi.mock("@gram/client/react-query/resolveShadowMCPInventoryRequest.js", () => ({
     mocks.resolveInventoryRequestMutation,
 }));
 
+vi.mock("@/components/page-layout", () => {
+  const Toolbar = Object.assign(
+    ({ children }: { children: ReactNode }) => (
+      <div role="toolbar">{children}</div>
+    ),
+    {
+      Search: ({
+        onChange,
+        placeholder,
+        value,
+      }: {
+        onChange: (value: string) => void;
+        placeholder?: string;
+        value: string;
+      }) => (
+        <input
+          onChange={(event) => onChange(event.currentTarget.value)}
+          placeholder={placeholder}
+          value={value}
+        />
+      ),
+    },
+  );
+
+  return { Page: { Toolbar } };
+});
+
 vi.mock("@speakeasy-api/moonshine", () => ({
   Badge: Object.assign(
     ({ children }: { children: ReactNode }) => <span>{children}</span>,
@@ -204,6 +231,7 @@ vi.mock("@speakeasy-api/moonshine", () => ({
         handleLoadMore,
         hasMore,
         isLoading,
+        noResultsMessage,
         onRowClick,
         rowKey,
       }: {
@@ -215,6 +243,7 @@ vi.mock("@speakeasy-api/moonshine", () => ({
         handleLoadMore?: () => void;
         hasMore?: boolean;
         isLoading?: boolean;
+        noResultsMessage?: ReactNode;
         onRowClick?: (row: ShadowMCPInventoryServer) => void;
         rowKey: (row: ShadowMCPInventoryServer) => string;
       }) => (
@@ -226,6 +255,11 @@ vi.mock("@speakeasy-api/moonshine", () => ({
               ))}
             </tr>
           ))}
+          {data.length === 0 && noResultsMessage ? (
+            <tr>
+              <td colSpan={columns.length}>{noResultsMessage}</td>
+            </tr>
+          ) : null}
           {hasMore && handleLoadMore ? (
             <tr>
               <td colSpan={columns.length}>
@@ -554,6 +588,78 @@ describe("ShadowMCPInventoryTable", () => {
     );
   });
 
+  it("filters loaded inventory rows by name, hostname, and canonical URL", async () => {
+    mockShadowMCPInventory({
+      servers: [
+        inventoryServer({
+          canonicalServerUrl: "https://github.example.com/mcp",
+          serverName: "GitHub MCP",
+        }),
+        inventoryServer({
+          canonicalServerUrl: "https://teams.slack.local/mcp",
+        }),
+        inventoryServer({
+          canonicalServerUrl: "https://gateway.example.dev/linear/mcp",
+          serverName: "Gateway",
+        }),
+      ],
+    });
+
+    renderInventoryTable();
+
+    const search = screen.getByPlaceholderText("Search servers...");
+
+    fireEvent.change(search, { target: { value: "  gItHuB  " } });
+    expect(screen.getByText("GitHub MCP")).toBeTruthy();
+    expect(screen.queryByText("https://teams.slack.local/mcp")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "teams.slack.local" } });
+    expect(screen.getByText("https://teams.slack.local/mcp")).toBeTruthy();
+    expect(screen.queryByText("GitHub MCP")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "/linear/mcp" } });
+    expect(screen.getByText("Gateway")).toBeTruthy();
+    expect(screen.queryByText("https://teams.slack.local/mcp")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "missing" } });
+    expect(screen.getByText("No servers matching “missing”")).toBeTruthy();
+
+    fireEvent.change(search, { target: { value: "" } });
+    expect(screen.getByText("GitHub MCP")).toBeTruthy();
+    expect(screen.getByText("https://teams.slack.local/mcp")).toBeTruthy();
+    expect(screen.getByText("Gateway")).toBeTruthy();
+  });
+
+  it("sorts the filtered inventory rows", () => {
+    mockShadowMCPInventory({
+      servers: [
+        inventoryServer({
+          canonicalServerUrl: "https://zulu.example.com/mcp",
+          serverName: "Zulu Team",
+        }),
+        inventoryServer({
+          canonicalServerUrl: "https://other.example.com/mcp",
+          serverName: "Other",
+        }),
+        inventoryServer({
+          canonicalServerUrl: "https://alpha.example.com/mcp",
+          serverName: "Alpha Team",
+        }),
+      ],
+    });
+
+    renderInventoryTable();
+    fireEvent.change(screen.getByPlaceholderText("Search servers..."), {
+      target: { value: "team" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Server" }));
+
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(within(rows[0]!).getByText("Alpha Team")).toBeTruthy();
+    expect(within(rows[1]!).getByText("Zulu Team")).toBeTruthy();
+    expect(screen.queryByText("Other")).toBeNull();
+  });
+
   it("shows request counts for each Shadow MCP server URL", async () => {
     mockShadowMCPInventory({
       servers: [
@@ -763,6 +869,57 @@ describe("ShadowMCPInventoryTable", () => {
       undefined,
       expect.objectContaining({ enabled: true }),
     );
+  });
+
+  it("applies an active search to newly loaded inventory pages", async () => {
+    const firstPageResponse = {
+      data: {
+        servers: [
+          inventoryServer({
+            canonicalServerUrl: "https://first.example.com/mcp",
+            serverName: "First MCP",
+          }),
+        ],
+        nextCursor: "next-page",
+      },
+      error: null,
+      isFetching: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    const secondPageResponse = {
+      data: {
+        servers: [
+          inventoryServer({
+            canonicalServerUrl: "https://matching.example.com/mcp",
+            serverName: "Matching MCP",
+          }),
+        ],
+        nextCursor: undefined,
+      },
+      error: null,
+      isFetching: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    mocks.useShadowMCPInventory.mockImplementation(
+      (request: { cursor?: string }) =>
+        request.cursor === "next-page" ? secondPageResponse : firstPageResponse,
+    );
+
+    renderInventoryTable();
+    fireEvent.change(screen.getByPlaceholderText("Search servers..."), {
+      target: { value: "matching" },
+    });
+
+    expect(screen.getByText("No servers matching “matching”")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Matching MCP")).toBeTruthy();
+    });
+    expect(screen.queryByText("First MCP")).toBeNull();
+    expect(screen.queryByText("No servers matching “matching”")).toBeNull();
   });
 
   it("keeps loaded inventory rows visible while loading the next page", async () => {

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.tsx
@@ -1,5 +1,6 @@
 import { SkeletonTable } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
+import { Page } from "@/components/page-layout";
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import type { Role } from "@gram/client/models/components/role.js";
 import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
@@ -174,6 +175,7 @@ export function ShadowMCPInventoryTable({
   const upsertPolicyBypass = useUpsertShadowMCPInventoryPolicyBypassMutation();
   const deletePolicyBypass = useDeleteShadowMCPInventoryPolicyBypassMutation();
   const resolveInventoryRequest = useResolveShadowMCPInventoryRequestMutation();
+  const [search, setSearch] = useState("");
   const [sort, setSort] = useState<SortDescriptor | null>({
     id: "lastCalled",
     direction: "desc",
@@ -397,17 +399,34 @@ export function ShadowMCPInventoryTable({
     },
   ];
 
-  const servers =
-    loadedServers.length > 0
-      ? loadedServers
-      : canUseInventoryQueryData
-        ? (inventoryQuery.data?.servers ?? [])
-        : [];
+  const servers = useMemo(() => {
+    if (loadedServers.length > 0) {
+      return loadedServers;
+    }
+
+    return canUseInventoryQueryData ? (inventoryQuery.data?.servers ?? []) : [];
+  }, [canUseInventoryQueryData, inventoryQuery.data?.servers, loadedServers]);
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredServers = useMemo(() => {
+    if (normalizedSearch.length === 0) {
+      return servers;
+    }
+
+    return servers.filter((server) =>
+      [server.serverName, server.urlHost, server.canonicalServerUrl].some(
+        (value) => value?.toLowerCase().includes(normalizedSearch),
+      ),
+    );
+  }, [normalizedSearch, servers]);
   const sortedServers = sortTableData(
-    servers,
+    filteredServers,
     columns,
     sort,
   ) as ShadowMCPInventoryServer[];
+  const noResultsMessage =
+    normalizedSearch.length > 0
+      ? `No servers matching “${search.trim()}”`
+      : undefined;
 
   if (isInitialLoading) {
     return <SkeletonTable />;
@@ -431,7 +450,12 @@ export function ShadowMCPInventoryTable({
   }
 
   return (
-    <div className={cn("min-h-0 shrink overflow-hidden", className)}>
+    <div
+      className={cn(
+        "flex min-h-0 shrink flex-col gap-4 overflow-hidden",
+        className,
+      )}
+    >
       <ShadowMCPInventoryActionSheet
         action={activeAction}
         isSubmitting={isSubmitting}
@@ -446,9 +470,16 @@ export function ShadowMCPInventoryTable({
         roles={roles}
         shadowMCPPolicies={shadowMCPPolicies}
       />
+      <Page.Toolbar className="shrink-0">
+        <Page.Toolbar.Search
+          onChange={setSearch}
+          placeholder="Search servers..."
+          value={search}
+        />
+      </Page.Toolbar>
       <Table
         columns={columns}
-        className="h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-x-auto overflow-y-hidden"
+        className="min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] overflow-x-auto overflow-y-hidden"
       >
         <Table.Header columns={columns} sort={sort} onSortChange={setSort} />
         <Table.Body
@@ -457,6 +488,7 @@ export function ShadowMCPInventoryTable({
           handleLoadMore={loadMoreServers}
           hasMore={Boolean(nextCursor)}
           isLoading={isLoadingMore}
+          noResultsMessage={noResultsMessage}
           onRowClick={onOpenServer}
           rowKey={(row) => row.canonicalServerUrl}
           className="min-h-0 content-start overflow-y-auto"

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyStatus.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyStatus.tsx
@@ -48,15 +48,20 @@ export function ShadowMCPPolicyStatus({
   }
 
   const { label, icon, description } = policyStatusText(policyState);
+
   return (
-    <div className="border-border bg-muted/30 flex items-start gap-2 rounded-md border px-4 py-3">
+    <div className="border-border bg-muted/30 flex max-w-2xs items-start gap-2 rounded-md border px-3 py-2">
       <Icon
-        className="text-muted-foreground mt-1 h-4 w-4 shrink-0"
+        className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0"
         name={icon}
       />
       <div className="min-w-0 flex-1">
-        <Type variant="body">{label}</Type>
-        <Type variant="small">{description}</Type>
+        <Type variant="small" className="font-medium">
+          {label}
+        </Type>
+        <Type muted className="text-xs">
+          {description}
+        </Type>
       </div>
     </div>
   );

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ShadowMCP from "./ShadowMCP";
@@ -42,9 +42,9 @@ vi.mock("@/components/page-layout", () => {
 
     return (
       <section>
-        <div>
+        <div data-testid="section-header">
           {title}
-          {cta}
+          <div data-testid="section-cta">{cta}</div>
         </div>
         {description}
         {body}
@@ -210,9 +210,12 @@ describe("ShadowMCP", () => {
     expect(screen.getByText("Loading table")).toBeTruthy();
     expect(screen.queryByText("No Policy")).toBeNull();
     expect(screen.queryByText(/Shadow MCP inventory for/)).toBeNull();
+    expect(
+      within(screen.getByTestId("section-cta")).queryByText(/./),
+    ).toBeNull();
   });
 
-  it("renders blocking policy status above the inventory table", () => {
+  it("renders blocking policy status in the section header", () => {
     mocks.useRiskListPolicies.mockReturnValue({
       data: {
         policies: [
@@ -226,9 +229,10 @@ describe("ShadowMCP", () => {
 
     render(<ShadowMCP />);
 
-    expect(screen.getByText("Blocking")).toBeTruthy();
+    const sectionCTA = within(screen.getByTestId("section-cta"));
+    expect(sectionCTA.getByText("Blocking")).toBeTruthy();
     expect(
-      screen.getByText(
+      sectionCTA.getByText(
         "Block policy is enabled. Servers without allow rules are not allowed.",
       ),
     ).toBeTruthy();

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
@@ -61,10 +61,14 @@ export default function ShadowMCP(): JSX.Element {
               Manage the Shadow MCP server inventory, allow decisions, and
               requests.
             </Page.Section.Description>
+            {policyDataReady ? (
+              <Page.Section.CTA>
+                <ShadowMCPPolicyStatus policyState={policyState} />
+              </Page.Section.CTA>
+            ) : null}
             <Page.Section.Body>
               {policyDataReady ? (
-                <div className="flex flex-col gap-4 pb-8">
-                  <ShadowMCPPolicyStatus policyState={policyState} />
+                <div className="flex flex-col pb-8">
                   <ShadowMCPInventoryTable
                     members={membersQuery.data?.members ?? []}
                     onOpenServer={(server) =>


### PR DESCRIPTION
## Summary

This change adds a focused search experience to the Shadow MCP inventory while keeping the existing client-side table behavior intact.

- Move the policy icon, label, and explanation into a compact top-right header card so the table controls have a clear row of their own. The card stays hidden until policy data is ready, avoiding a transient ‘No Policy’ state.
- Add the standard search-only Page.Toolbar above populated inventory tables.
- Search only the rows currently loaded into the table, matching server display name, hostname, or canonical URL case-insensitively after trimming the query.
- Apply the existing sort after filtering and preserve manual Load more pagination. Rows fetched later participate in the active search.
- Preserve the existing empty, loading, error, row navigation, and inventory action behavior.

## Snapshot

<img width="2217" height="1275" alt="image" src="https://github.com/user-attachments/assets/6d92fe14-cb77-4a3c-b38a-b91908bd7d6e" />

## Reviewer guide

- ShadowMCP.tsx and ShadowMCPPolicyStatus.tsx: policy status placement and loading behavior.
- ShadowMCPInventoryTable.tsx: local search state, loaded-row filtering, sorting, and pagination behavior.
- Shadow MCP tests: matching, normalization, no-results, clearing, filtered sorting, newly loaded rows, and policy-loading regressions.

## Test plan

- pnpm -F dashboard test (761 tests passed)
- pnpm -F dashboard type-check
- pnpm -F dashboard lint
- git diff --check origin/main...HEAD

Linear: DNO-520