### PR TITLE
chore(security): rename detector-based policy to built-in detector policy

### DIFF
--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -304,7 +304,7 @@ function PolicyKindChooser(): JSX.Element {
               Choose policy type
             </Heading>
             <Type small muted>
-              Start with a detector-based policy or define criteria in plain
+              Start with a built-in detector policy or define criteria in plain
               language.
             </Type>
           </Stack>
@@ -315,7 +315,7 @@ function PolicyKindChooser(): JSX.Element {
               className="hover:bg-muted/40 rounded-xl border p-5 text-left transition-colors"
             >
               <Shield className="text-muted-foreground mb-3 h-5 w-5" />
-              <Type className="font-medium">Detector-based</Type>
+              <Type className="font-medium">Built-in detector</Type>
               <Type small muted className="mt-1">
                 Scan for secrets, PII, and risky tool calls with built-in and
                 custom detection rules.
@@ -486,7 +486,7 @@ function PolicyHeader({
 }): JSX.Element {
   const KindIcon = kind === "prompt" ? Sparkles : Shield;
   const kindLabel =
-    kind === "prompt" ? "Prompt-based (LLM judge)" : "Detector-based";
+    kind === "prompt" ? "Prompt-based (LLM judge)" : "Built-in detector";
   const placeholder =
     kind === "prompt" ? "Untitled prompt policy" : "Untitled standard policy";
   const isCreate = policy === null;


### PR DESCRIPTION
## Why

The "Detector-based" policy label was ambiguous. Renaming it to "Built-in detector" makes it clearer that these policies are backed by the built-in detection rules.

## What changed

Before/After (user-facing copy in the policy type picker and header):

- "Start with a detector-based policy..." → "Start with a built-in detector policy..."
- "Detector-based" (type card) → "Built-in detector"
- "Detector-based" (policy header kind label) → "Built-in detector"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed "Detector-based" policy to "Built-in detector" in the policy picker, type card, and header. This clarifies that these policies use built-in detection rules.

<sup>Written for commit a460a94d7c3d6ce9854c246667d711422cffac84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

