### PR TITLE
feat: unfurl dashboard links shared in Slack

### DIFF
--- a/.changeset/slack-gram-link-unfurls.md
+++ b/.changeset/slack-gram-link-unfurls.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Unfurl Gram dashboard links shared in Slack with the Gram logo and a humanized page title. The generated Slack app manifest now registers the dashboard as an unfurl domain and grants links:write, and the trigger webhook answers link_shared events with chat.unfurl.

--- a/.changeset/slack-gram-link-unfurls.md
+++ b/.changeset/slack-gram-link-unfurls.md
@@ -3,4 +3,4 @@
 "dashboard": patch
 ---
 
-Unfurl Gram dashboard links shared in Slack with the Gram logo and a humanized page title. The generated Slack app manifest now registers the dashboard as an unfurl domain and grants links:write, and the trigger webhook answers link_shared events with chat.unfurl.
+Unfurl Gram dashboard links shared in Slack with the Speakeasy logo (the dashboard favicon) and a humanized page title. The generated Slack app manifest now registers the dashboard as an unfurl domain and grants links:write, and the trigger webhook answers link_shared events with chat.unfurl.

--- a/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
@@ -212,7 +212,12 @@ const SLACK_EVENT_BINDINGS: Record<string, SlackEventBinding> = {
     bot_events: ["group_unarchive"],
     scopes: ["groups:read"],
   },
-  link_shared: { bot_events: ["link_shared"], scopes: ["links:read"] },
+  // links:write lets the trigger webhook answer link_shared with chat.unfurl,
+  // attaching the Gram logo + title to dashboard links shared in Slack.
+  link_shared: {
+    bot_events: ["link_shared"],
+    scopes: ["links:read", "links:write"],
+  },
   member_joined_channel: {
     bot_events: ["member_joined_channel"],
     scopes: ["channels:read", "groups:read"],
@@ -279,6 +284,14 @@ export type SlackManifestInput = {
   webhookUrl?: string | undefined;
   extraScopes?: readonly string[];
   extraBotEvents?: readonly string[];
+  /**
+   * Hostname of the Gram dashboard (e.g. app.getgram.ai). When set alongside
+   * webhookUrl, it is registered as a Slack unfurl domain so link_shared
+   * events fire for dashboard links and the webhook can unfurl them with the
+   * Gram logo. Hostnames without a dot (e.g. localhost) are skipped — Slack
+   * rejects them as unfurl domains.
+   */
+  unfurlDomain?: string | undefined;
 };
 
 export type SlackManifestResult = {
@@ -324,12 +337,20 @@ export function buildSlackManifest(
   const oauthScopes: { bot: string[]; user?: string[] } = { bot: sortedScopes };
   if (sortedUserScopes.length > 0) oauthScopes.user = sortedUserScopes;
 
+  const features: Record<string, unknown> = {
+    bot_user: { display_name: displayName, always_online: true },
+  };
+  // Unfurl domains only make sense when link_shared events can actually be
+  // delivered, which requires the event_subscriptions webhook below.
+  const unfurlDomain = input.unfurlDomain?.trim().toLowerCase();
+  if (input.webhookUrl && unfurlDomain && unfurlDomain.includes(".")) {
+    features.unfurl_domains = [unfurlDomain];
+  }
+
   const manifest: Record<string, unknown> = {
     _metadata: { major_version: 1, minor_version: 1 },
     display_information: { name: displayName },
-    features: {
-      bot_user: { display_name: displayName, always_online: true },
-    },
+    features,
     oauth_config: { scopes: oauthScopes },
   };
   if (input.webhookUrl) {

--- a/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
@@ -213,7 +213,7 @@ const SLACK_EVENT_BINDINGS: Record<string, SlackEventBinding> = {
     scopes: ["groups:read"],
   },
   // links:write lets the trigger webhook answer link_shared with chat.unfurl,
-  // attaching the Gram logo + title to dashboard links shared in Slack.
+  // attaching the Speakeasy logo + title to dashboard links shared in Slack.
   link_shared: {
     bot_events: ["link_shared"],
     scopes: ["links:read", "links:write"],
@@ -288,7 +288,7 @@ export type SlackManifestInput = {
    * Hostname of the Gram dashboard (e.g. app.getgram.ai). When set alongside
    * webhookUrl, it is registered as a Slack unfurl domain so link_shared
    * events fire for dashboard links and the webhook can unfurl them with the
-   * Gram logo. Hostnames without a dot (e.g. localhost) are skipped — Slack
+   * Speakeasy logo. Hostnames without a dot (e.g. localhost) are skipped — Slack
    * rejects them as unfurl domains.
    */
   unfurlDomain?: string | undefined;

--- a/client/dashboard/src/pages/assistants/onboarding/tools/components.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/components.tsx
@@ -323,6 +323,7 @@ export function ShowSlackAppGuideComponent({
         webhookUrl: a.webhook_url,
         extraScopes: a.bot_scopes,
         extraBotEvents: a.bot_events,
+        unfurlDomain: window.location.hostname,
       }),
     [a.app_name, a.webhook_url, a.bot_scopes, a.bot_events, assistantName],
   );

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -797,6 +797,7 @@ func newTriggersApp(
 	telemetryLogger *telemetry.Logger,
 	auditLogger *audit.Logger,
 	serverURL *url.URL,
+	siteURL *url.URL,
 	slackClient *slack_client.SlackClient,
 ) *bgtriggers.App {
 	envEntries := environments.NewEnvironmentEntries(logger, db, enc, nil)
@@ -828,6 +829,7 @@ func newTriggersApp(
 		}),
 		auditLogger,
 		serverURL,
+		siteURL,
 		slackClient,
 		bgtriggers.NewNoopDispatcher(logger),
 	)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -761,7 +761,7 @@ func newStartCommand() *cli.Command {
 			accessStore := accesscontrol.NewRedisStore(cache.NewRedisCacheAdapter(redisClient), accesscontrol.AlphaTTL)
 			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager, identityResolver, guardianPolicy)
 			shadowMCPClient := shadowmcp.NewClient(logger, db, cache.NewRedisCacheAdapter(redisClient), accessStore)
-			triggerApp := newTriggersApp(logger, db, encryptionClient, temporalEnv, telemLogger, auditLogger, serverURL, slackClient)
+			triggerApp := newTriggersApp(logger, db, encryptionClient, temporalEnv, telemLogger, auditLogger, serverURL, siteURL, slackClient)
 
 			platformFeatureChecker := productFeatures.PlatformFeatureCheck
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -642,7 +642,10 @@ func newWorkerCommand() *cli.Command {
 			chatSessionsManager := chatsessions.NewManager(logger, redisClient, c.String(usersessions.JWTSigningKeyFlag))
 
 			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager, identityResolver, guardianPolicy)
-			triggerApp := newTriggersApp(logger, db, encryptionClient, temporalEnv, telemetryLogger, auditLogger, serverURL, slackClient)
+			// The worker never serves webhook ingress (ProcessWebhook lives in
+			// the HTTP server), so the dashboard site URL used for Slack link
+			// unfurls is not needed here.
+			triggerApp := newTriggersApp(logger, db, encryptionClient, temporalEnv, telemetryLogger, auditLogger, serverURL, nil, slackClient)
 
 			assistantTokenManager := assistanttokens.New(c.String(usersessions.JWTSigningKeyFlag), db, authzEngine)
 

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -137,6 +137,7 @@ type App struct {
 	deliveryLogger DeliveryLogger
 	temporalEnv    *tenv.Environment
 	serverURL      *url.URL
+	siteURL        *url.URL
 	dispatchers    map[string]Dispatcher
 	audit          *audit.Logger
 	slackClient    *slackclient.SlackClient
@@ -186,6 +187,7 @@ func NewApp(
 	deliveryLogger DeliveryLogger,
 	auditLogger *audit.Logger,
 	serverURL *url.URL,
+	siteURL *url.URL,
 	slackClient *slackclient.SlackClient,
 	dispatchers ...Dispatcher,
 ) *App {
@@ -204,6 +206,7 @@ func NewApp(
 		deliveryLogger: deliveryLogger,
 		temporalEnv:    temporalEnv,
 		serverURL:      serverURL,
+		siteURL:        siteURL,
 		dispatchers:    dispatcherMap,
 		audit:          auditLogger,
 		slackClient:    slackClient,
@@ -744,6 +747,11 @@ func (a *App) ProcessWebhook(ctx context.Context, instanceID uuid.UUID, body []b
 	if result.Event.CorrelationID == "" {
 		result.Event.CorrelationID = result.Event.EventID
 	}
+
+	// Unfurl before ProcessEvent: link previews should render even when no
+	// assistant subscribes to link_shared (ProcessEvent would filter the event
+	// out and return a nil task).
+	a.unfurlSlackGramLinks(ctx, instance, envMap, body, *result.Event)
 
 	task, err := a.ProcessEvent(ctx, instance, *result.Event)
 	if err != nil {

--- a/server/internal/background/triggers/slack.go
+++ b/server/internal/background/triggers/slack.go
@@ -123,6 +123,26 @@ type slackEventItemBody struct {
 	Ts      string `json:"ts,omitempty"`
 }
 
+// slackLinkSharedEventBody matches link_shared, where the message timestamp
+// is carried in `event.message_ts` (not `event.ts`) alongside the shared
+// links and the unfurl handle used by chat.unfurl.
+// See https://docs.slack.dev/reference/events/link_shared.
+type slackLinkSharedEventBody struct {
+	Type      string                `json:"type"`
+	User      string                `json:"user,omitempty"`
+	Channel   string                `json:"channel,omitempty"`
+	MessageTs string                `json:"message_ts,omitempty"`
+	ThreadTs  string                `json:"thread_ts,omitempty"`
+	Links     []slackSharedLinkBody `json:"links,omitempty"`
+	UnfurlID  string                `json:"unfurl_id,omitempty"`
+	Source    string                `json:"source,omitempty"`
+}
+
+type slackSharedLinkBody struct {
+	Domain string `json:"domain,omitempty"`
+	URL    string `json:"url,omitempty"`
+}
+
 // decodeSlackEvent decodes the inner `event` payload of an event_callback,
 // dispatching by event type because Slack's `event.user` and `event.channel`
 // are sometimes objects (e.g. team_join, channel_rename) and sometimes string
@@ -214,6 +234,26 @@ func decodeSlackEvent(raw json.RawMessage) (slackEventRequestBody, error) {
 			Channel:  ev.NewChannelID,
 			ThreadTs: "",
 			Ts:       "",
+			Reaction: "",
+			ItemUser: "",
+			Item:     nil,
+		}, nil
+	case "link_shared":
+		var ev slackLinkSharedEventBody
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
+		}
+		return slackEventRequestBody{
+			Type:     ev.Type,
+			Subtype:  "",
+			Text:     "",
+			User:     ev.User,
+			Inviter:  "",
+			BotID:    "",
+			AppID:    "",
+			Channel:  ev.Channel,
+			ThreadTs: ev.ThreadTs,
+			Ts:       ev.MessageTs,
 			Reaction: "",
 			ItemUser: "",
 			Item:     nil,

--- a/server/internal/background/triggers/slack_test.go
+++ b/server/internal/background/triggers/slack_test.go
@@ -217,6 +217,19 @@ func TestDecodeSlackEventFileShared(t *testing.T) {
 	require.Equal(t, "C0Z7K8SRH", got.Channel)
 }
 
+func TestDecodeSlackEventLinkShared(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"type":"link_shared","channel":"C024BE91L","is_bot_user_member":true,"user":"U0Z7K8SRH","message_ts":"1593189506.000200","thread_ts":"1593189505.000100","unfurl_id":"C024BE91L.1593189506.000200.9dcb1","source":"conversations_history","links":[{"domain":"app.getgram.ai","url":"https://app.getgram.ai/acme/projects/default/toolsets/my-tools"}]}`)
+	got, err := decodeSlackEvent(raw)
+	require.NoError(t, err)
+	require.Equal(t, "link_shared", got.Type)
+	require.Equal(t, "U0Z7K8SRH", got.User)
+	require.Equal(t, "C024BE91L", got.Channel)
+	require.Equal(t, "1593189506.000200", got.Ts)
+	require.Equal(t, "1593189505.000100", got.ThreadTs)
+}
+
 func TestDecodeSlackEventMemberJoinedChannel(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/triggers/slack_unfurl.go
+++ b/server/internal/background/triggers/slack_unfurl.go
@@ -32,6 +32,11 @@ func (a *App) unfurlSlackGramLinks(ctx context.Context, instance triggerrepo.Tri
 	if a.slackClient == nil || a.siteURL == nil || instance.DefinitionSlug != DefinitionSlugSlack {
 		return
 	}
+	// ProcessEvent runs after this call and only enforces the pause for
+	// dispatch; a paused trigger must not keep producing link previews either.
+	if instance.Status != StatusActive {
+		return
+	}
 	evt, isSlack := event.Event.(slackTriggerEvent)
 	if !isSlack || evt.EventType != "link_shared" {
 		return
@@ -108,21 +113,26 @@ func gramLinkTitle(u *url.URL) string {
 		segments = segments[2:]
 	}
 
-	meaningful := make([]string, 0, len(segments))
+	// Collect humanized labels, dropping opaque ids and separator-only
+	// segments (e.g. "--") whose humanized form is empty.
+	labels := make([]string, 0, len(segments))
 	for _, segment := range segments {
-		if !opaqueSlugPattern.MatchString(segment) {
-			meaningful = append(meaningful, segment)
+		if opaqueSlugPattern.MatchString(segment) {
+			continue
+		}
+		if label := humanizeSlug(segment); label != "" {
+			labels = append(labels, label)
 		}
 	}
-	if len(meaningful) == 0 {
+	if len(labels) == 0 {
 		return "Speakeasy dashboard"
 	}
 
-	section := humanizeSlug(meaningful[0])
-	if len(meaningful) == 1 {
+	section := labels[0]
+	if len(labels) == 1 {
 		return section
 	}
-	return humanizeSlug(meaningful[len(meaningful)-1]) + " · " + section
+	return labels[len(labels)-1] + " · " + section
 }
 
 // humanizeSlug turns a URL slug into title-cased words: "my-cool-toolset" →

--- a/server/internal/background/triggers/slack_unfurl.go
+++ b/server/internal/background/triggers/slack_unfurl.go
@@ -1,0 +1,142 @@
+package triggers
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	slackclient "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
+)
+
+// maxSlackUnfurlLinks caps how many Gram links a single link_shared event can
+// unfurl. Slack itself delivers at most a handful of links per event; the cap
+// bounds the chat.unfurl payload if a message pastes many dashboard URLs.
+const maxSlackUnfurlLinks = 10
+
+// unfurlSlackGramLinks answers a Slack link_shared event with a chat.unfurl
+// call for every shared link that points at the Gram dashboard, attaching the
+// Gram logo and a title derived from the URL path. Best-effort, mirroring
+// ackSlackThreadStatus: a failure here only costs the link preview.
+//
+// Titles are computed purely from the URL (humanized path slugs) — never from
+// database lookups — so an unfurl reveals nothing beyond what the pasted URL
+// already shows to everyone in the channel.
+func (a *App) unfurlSlackGramLinks(ctx context.Context, instance triggerrepo.TriggerInstance, env map[string]string, body []byte, event EventEnvelope) {
+	if a.slackClient == nil || a.siteURL == nil || instance.DefinitionSlug != DefinitionSlugSlack {
+		return
+	}
+	evt, isSlack := event.Event.(slackTriggerEvent)
+	if !isSlack || evt.EventType != "link_shared" {
+		return
+	}
+	token := toolconfig.CIEnvFrom(env).Get("SLACK_BOT_TOKEN")
+	if token == "" {
+		return
+	}
+
+	// slackIngest normalizes away the links array, so recover it from the raw
+	// webhook body rather than widening the CEL-visible event shape.
+	var req slackEventRequest
+	if err := json.Unmarshal(body, &req); err != nil || len(req.Event) == 0 {
+		return
+	}
+	var linkEvent slackLinkSharedEventBody
+	if err := json.Unmarshal(req.Event, &linkEvent); err != nil {
+		return
+	}
+
+	unfurls := make(map[string]any)
+	iconURL := a.siteURL.JoinPath("favicon.png").String()
+	for _, link := range linkEvent.Links {
+		if len(unfurls) >= maxSlackUnfurlLinks {
+			break
+		}
+		parsed, err := url.Parse(link.URL)
+		if err != nil || !strings.EqualFold(parsed.Hostname(), a.siteURL.Hostname()) {
+			continue
+		}
+		unfurls[link.URL] = map[string]any{
+			"blocks": []any{
+				map[string]any{
+					"type": "context",
+					"elements": []any{
+						map[string]any{"type": "image", "image_url": iconURL, "alt_text": "Gram"},
+						map[string]any{"type": "mrkdwn", "text": "<" + link.URL + "|" + escapeSlackText(gramLinkTitle(parsed)) + ">"},
+					},
+				},
+			},
+		}
+	}
+	if len(unfurls) == 0 {
+		return
+	}
+
+	if err := a.slackClient.Unfurl(ctx, token, slackclient.SlackUnfurlInput{
+		ChannelID: linkEvent.Channel,
+		MessageTS: linkEvent.MessageTs,
+		UnfurlID:  linkEvent.UnfurlID,
+		Source:    linkEvent.Source,
+		Unfurls:   unfurls,
+	}); err != nil {
+		a.logger.WarnContext(ctx, "unfurl slack gram links", attr.SlogError(err))
+	}
+}
+
+// opaqueSlugPattern matches path segments that carry no human meaning: UUIDs,
+// long hex identifiers, and purely numeric ids.
+var opaqueSlugPattern = regexp.MustCompile(`^(?i:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{16,}|[0-9]+)$`)
+
+// gramLinkTitle derives a human-readable unfurl title from a dashboard URL
+// path. Dashboard routes look like /{orgSlug}[/projects/{projectSlug}]/...,
+// so the org and project prefix is stripped and the remaining slugs are
+// humanized: /acme/projects/default/toolsets/my-tools → "My Tools · Toolsets".
+// Opaque segments (UUIDs, numeric ids) are skipped so a chat URL falls back
+// to its section name instead of a raw identifier.
+func gramLinkTitle(u *url.URL) string {
+	segments := strings.FieldsFunc(u.Path, func(r rune) bool { return r == '/' })
+	if len(segments) > 0 {
+		segments = segments[1:]
+	}
+	if len(segments) >= 2 && segments[0] == "projects" {
+		segments = segments[2:]
+	}
+
+	meaningful := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		if !opaqueSlugPattern.MatchString(segment) {
+			meaningful = append(meaningful, segment)
+		}
+	}
+	if len(meaningful) == 0 {
+		return "Gram dashboard"
+	}
+
+	section := humanizeSlug(meaningful[0])
+	if len(meaningful) == 1 {
+		return section
+	}
+	return humanizeSlug(meaningful[len(meaningful)-1]) + " · " + section
+}
+
+// humanizeSlug turns a URL slug into title-cased words: "my-cool-toolset" →
+// "My Cool Toolset".
+func humanizeSlug(slug string) string {
+	words := strings.FieldsFunc(slug, func(r rune) bool { return r == '-' || r == '_' })
+	for i, word := range words {
+		runes := []rune(word)
+		words[i] = strings.ToUpper(string(runes[0])) + string(runes[1:])
+	}
+	return strings.Join(words, " ")
+}
+
+// escapeSlackText escapes the three characters Slack's mrkdwn treats as
+// control characters in link labels.
+// See https://docs.slack.dev/messaging/formatting-message-text#escaping.
+func escapeSlackText(s string) string {
+	return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(s)
+}

--- a/server/internal/background/triggers/slack_unfurl.go
+++ b/server/internal/background/triggers/slack_unfurl.go
@@ -20,8 +20,10 @@ const maxSlackUnfurlLinks = 10
 
 // unfurlSlackGramLinks answers a Slack link_shared event with a chat.unfurl
 // call for every shared link that points at the Gram dashboard, attaching the
-// Gram logo and a title derived from the URL path. Best-effort, mirroring
-// ackSlackThreadStatus: a failure here only costs the link preview.
+// Speakeasy logo (the dashboard favicon, so Slack shows the same mark as
+// browser tabs and crawler link previews) and a title derived from the URL
+// path. Best-effort, mirroring ackSlackThreadStatus: a failure here only
+// costs the link preview.
 //
 // Titles are computed purely from the URL (humanized path slugs) — never from
 // database lookups — so an unfurl reveals nothing beyond what the pasted URL
@@ -65,7 +67,7 @@ func (a *App) unfurlSlackGramLinks(ctx context.Context, instance triggerrepo.Tri
 				map[string]any{
 					"type": "context",
 					"elements": []any{
-						map[string]any{"type": "image", "image_url": iconURL, "alt_text": "Gram"},
+						map[string]any{"type": "image", "image_url": iconURL, "alt_text": "Speakeasy"},
 						map[string]any{"type": "mrkdwn", "text": "<" + link.URL + "|" + escapeSlackText(gramLinkTitle(parsed)) + ">"},
 					},
 				},
@@ -113,7 +115,7 @@ func gramLinkTitle(u *url.URL) string {
 		}
 	}
 	if len(meaningful) == 0 {
-		return "Gram dashboard"
+		return "Speakeasy dashboard"
 	}
 
 	section := humanizeSlug(meaningful[0])

--- a/server/internal/background/triggers/slack_unfurl_test.go
+++ b/server/internal/background/triggers/slack_unfurl_test.go
@@ -62,7 +62,7 @@ func TestUnfurlSlackGramLinksCallsChatUnfurl(t *testing.T) {
 		siteURL:     siteURL,
 		slackClient: slackclient.NewSlackClientWithBaseURL(server.URL, server.Client()),
 	}
-	instance := triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack}
+	instance := triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack, Status: StatusActive}
 	env := map[string]string{"SLACK_BOT_TOKEN": "xoxb-test-token"}
 	envelope := EventEnvelope{Event: slackTriggerEvent{EventType: "link_shared"}}
 
@@ -126,13 +126,47 @@ func TestUnfurlSlackGramLinksSkipsForeignLinksOnly(t *testing.T) {
 
 	app.unfurlSlackGramLinks(
 		t.Context(),
-		triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack},
+		triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack, Status: StatusActive},
 		map[string]string{"SLACK_BOT_TOKEN": "xoxb-test-token"},
 		[]byte(body),
 		EventEnvelope{Event: slackTriggerEvent{EventType: "link_shared"}},
 	)
 
 	require.False(t, called, "chat.unfurl must not be called when no dashboard links are shared")
+}
+
+func TestUnfurlSlackGramLinksSkipsPausedTriggers(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	siteURL, err := url.Parse("https://app.getgram.ai")
+	require.NoError(t, err)
+	app := &App{
+		// testenv.NewLogger is unavailable here (import cycle back into this
+		// package); the logger only fires on the warn path anyway.
+		logger:      slog.New(slog.DiscardHandler), //nolint:forbidigo // GG006: testenv imports this package, so testenv.NewLogger(t) cannot be used here
+		siteURL:     siteURL,
+		slackClient: slackclient.NewSlackClientWithBaseURL(server.URL, server.Client()),
+	}
+
+	app.unfurlSlackGramLinks(
+		t.Context(),
+		triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack, Status: StatusPaused},
+		map[string]string{"SLACK_BOT_TOKEN": "xoxb-test-token"},
+		[]byte(linkSharedWebhookBody),
+		EventEnvelope{Event: slackTriggerEvent{EventType: "link_shared"}},
+	)
+
+	require.False(t, called, "chat.unfurl must not be called for a paused trigger")
 }
 
 func TestGramLinkTitleFromDashboardPaths(t *testing.T) {
@@ -150,6 +184,10 @@ func TestGramLinkTitleFromDashboardPaths(t *testing.T) {
 		{"https://app.getgram.ai/acme", "Speakeasy dashboard"},
 		{"https://app.getgram.ai/", "Speakeasy dashboard"},
 		{"https://app.getgram.ai/acme/projects/default/logs/12345", "Logs"},
+		// Separator-only segments humanize to nothing and must not produce
+		// an empty label.
+		{"https://app.getgram.ai/acme/projects/default/--/__", "Speakeasy dashboard"},
+		{"https://app.getgram.ai/acme/projects/default/toolsets/--", "Toolsets"},
 	}
 
 	for _, tc := range cases {

--- a/server/internal/background/triggers/slack_unfurl_test.go
+++ b/server/internal/background/triggers/slack_unfurl_test.go
@@ -1,11 +1,139 @@
 package triggers
 
 import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	slackclient "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
 )
+
+// linkSharedWebhookBody is a Slack event_callback envelope carrying one Gram
+// dashboard link and one foreign link, as delivered to the trigger webhook.
+const linkSharedWebhookBody = `{
+	"type": "event_callback",
+	"team_id": "T024BE7LD",
+	"event_id": "Ev123ABC456",
+	"event": {
+		"type": "link_shared",
+		"channel": "C024BE91L",
+		"user": "U0Z7K8SRH",
+		"message_ts": "1593189506.000200",
+		"unfurl_id": "C024BE91L.1593189506.000200.9dcb1",
+		"source": "conversations_history",
+		"links": [
+			{"domain": "app.getgram.ai", "url": "https://app.getgram.ai/acme/projects/default/toolsets/my-tools"},
+			{"domain": "example.com", "url": "https://example.com/not-ours"}
+		]
+	}
+}`
+
+func TestUnfurlSlackGramLinksCallsChatUnfurl(t *testing.T) {
+	t.Parallel()
+
+	var requestPath, authHeader string
+	var form url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		authHeader = r.Header.Get("Authorization")
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		form = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	siteURL, err := url.Parse("https://app.getgram.ai")
+	require.NoError(t, err)
+	app := &App{
+		// testenv.NewLogger is unavailable here (import cycle back into this
+		// package); the logger only fires on the warn path anyway.
+		logger:      slog.New(slog.DiscardHandler), //nolint:forbidigo // GG006: testenv imports this package, so testenv.NewLogger(t) cannot be used here
+		siteURL:     siteURL,
+		slackClient: slackclient.NewSlackClientWithBaseURL(server.URL, server.Client()),
+	}
+	instance := triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack}
+	env := map[string]string{"SLACK_BOT_TOKEN": "xoxb-test-token"}
+	envelope := EventEnvelope{Event: slackTriggerEvent{EventType: "link_shared"}}
+
+	app.unfurlSlackGramLinks(t.Context(), instance, env, []byte(linkSharedWebhookBody), envelope)
+
+	require.Equal(t, "/chat.unfurl", requestPath)
+	require.Equal(t, "Bearer xoxb-test-token", authHeader)
+	// The unfurl handle addresses the link, so channel/ts stay unset.
+	require.Equal(t, "C024BE91L.1593189506.000200.9dcb1", form.Get("unfurl_id"))
+	require.Equal(t, "conversations_history", form.Get("source"))
+	require.Empty(t, form.Get("channel"))
+
+	var unfurls map[string]struct {
+		Blocks []struct {
+			Type     string `json:"type"`
+			Elements []struct {
+				Type     string `json:"type"`
+				ImageURL string `json:"image_url"`
+				AltText  string `json:"alt_text"`
+				Text     string `json:"text"`
+			} `json:"elements"`
+		} `json:"blocks"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(form.Get("unfurls")), &unfurls))
+
+	// Only the dashboard link is unfurled; the foreign domain is skipped.
+	require.Len(t, unfurls, 1)
+	preview, ok := unfurls["https://app.getgram.ai/acme/projects/default/toolsets/my-tools"]
+	require.True(t, ok)
+	require.Len(t, preview.Blocks, 1)
+	require.Equal(t, "context", preview.Blocks[0].Type)
+	require.Len(t, preview.Blocks[0].Elements, 2)
+	require.Equal(t, "https://app.getgram.ai/favicon.png", preview.Blocks[0].Elements[0].ImageURL)
+	require.Equal(t, "Speakeasy", preview.Blocks[0].Elements[0].AltText)
+	require.Equal(t, "<https://app.getgram.ai/acme/projects/default/toolsets/my-tools|My Tools · Toolsets>", preview.Blocks[0].Elements[1].Text)
+}
+
+func TestUnfurlSlackGramLinksSkipsForeignLinksOnly(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	siteURL, err := url.Parse("https://app.getgram.ai")
+	require.NoError(t, err)
+	app := &App{
+		// testenv.NewLogger is unavailable here (import cycle back into this
+		// package); the logger only fires on the warn path anyway.
+		logger:      slog.New(slog.DiscardHandler), //nolint:forbidigo // GG006: testenv imports this package, so testenv.NewLogger(t) cannot be used here
+		siteURL:     siteURL,
+		slackClient: slackclient.NewSlackClientWithBaseURL(server.URL, server.Client()),
+	}
+	body := `{"type":"event_callback","event":{"type":"link_shared","channel":"C1","message_ts":"1.2","links":[{"domain":"example.com","url":"https://example.com/x"}]}}`
+
+	app.unfurlSlackGramLinks(
+		t.Context(),
+		triggerrepo.TriggerInstance{DefinitionSlug: DefinitionSlugSlack},
+		map[string]string{"SLACK_BOT_TOKEN": "xoxb-test-token"},
+		[]byte(body),
+		EventEnvelope{Event: slackTriggerEvent{EventType: "link_shared"}},
+	)
+
+	require.False(t, called, "chat.unfurl must not be called when no dashboard links are shared")
+}
 
 func TestGramLinkTitleFromDashboardPaths(t *testing.T) {
 	t.Parallel()

--- a/server/internal/background/triggers/slack_unfurl_test.go
+++ b/server/internal/background/triggers/slack_unfurl_test.go
@@ -1,0 +1,46 @@
+package triggers
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGramLinkTitleFromDashboardPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		link  string
+		title string
+	}{
+		{"https://app.getgram.ai/acme/projects/default/toolsets/my-tools", "My Tools · Toolsets"},
+		{"https://app.getgram.ai/acme/projects/default/toolsets", "Toolsets"},
+		{"https://app.getgram.ai/acme/projects/default/chat/6f1e0b6a-9f2c-4d3e-8a5b-0c1d2e3f4a5b", "Chat"},
+		{"https://app.getgram.ai/acme/projects/default/assistants/support_bot/settings", "Settings · Assistants"},
+		{"https://app.getgram.ai/acme/settings", "Settings"},
+		{"https://app.getgram.ai/acme", "Gram dashboard"},
+		{"https://app.getgram.ai/", "Gram dashboard"},
+		{"https://app.getgram.ai/acme/projects/default/logs/12345", "Logs"},
+	}
+
+	for _, tc := range cases {
+		parsed, err := url.Parse(tc.link)
+		require.NoError(t, err)
+		require.Equal(t, tc.title, gramLinkTitle(parsed), "link %s", tc.link)
+	}
+}
+
+func TestHumanizeSlugTitleCasesWords(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "My Cool Toolset", humanizeSlug("my-cool-toolset"))
+	require.Equal(t, "Support Bot", humanizeSlug("support_bot"))
+	require.Equal(t, "Chat", humanizeSlug("chat"))
+}
+
+func TestEscapeSlackTextEscapesControlCharacters(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "A &amp; B &lt;C&gt;", escapeSlackText("A & B <C>"))
+}

--- a/server/internal/background/triggers/slack_unfurl_test.go
+++ b/server/internal/background/triggers/slack_unfurl_test.go
@@ -19,8 +19,8 @@ func TestGramLinkTitleFromDashboardPaths(t *testing.T) {
 		{"https://app.getgram.ai/acme/projects/default/chat/6f1e0b6a-9f2c-4d3e-8a5b-0c1d2e3f4a5b", "Chat"},
 		{"https://app.getgram.ai/acme/projects/default/assistants/support_bot/settings", "Settings · Assistants"},
 		{"https://app.getgram.ai/acme/settings", "Settings"},
-		{"https://app.getgram.ai/acme", "Gram dashboard"},
-		{"https://app.getgram.ai/", "Gram dashboard"},
+		{"https://app.getgram.ai/acme", "Speakeasy dashboard"},
+		{"https://app.getgram.ai/", "Speakeasy dashboard"},
 		{"https://app.getgram.ai/acme/projects/default/logs/12345", "Logs"},
 	}
 

--- a/server/internal/thirdparty/slack/client/client.go
+++ b/server/internal/thirdparty/slack/client/client.go
@@ -19,6 +19,15 @@ func NewSlackClient(guardianPolicy *guardian.Policy) *SlackClient {
 	}
 }
 
+// NewSlackClientWithBaseURL builds a client against a custom Slack API root
+// with a caller-supplied HTTP client. Used by tests to point the client at a
+// fake Slack server.
+func NewSlackClientWithBaseURL(baseURL string, httpClient *guardian.HTTPClient) *SlackClient {
+	return &SlackClient{
+		api: slackapi.NewClient(baseURL, httpClient),
+	}
+}
+
 type SlackSetThreadStatusInput struct {
 	ChannelID       string
 	ThreadTS        string

--- a/server/internal/thirdparty/slack/client/client.go
+++ b/server/internal/thirdparty/slack/client/client.go
@@ -55,3 +55,43 @@ func (s *SlackClient) SetThreadStatus(ctx context.Context, accessToken string, i
 
 	return nil
 }
+
+type SlackUnfurlInput struct {
+	ChannelID string
+	MessageTS string
+	// UnfurlID and Source, when both set, address the link via Slack's unfurl
+	// handle (required for composer-sourced link_shared events) instead of
+	// channel + message ts.
+	UnfurlID string
+	Source   string
+	// Unfurls maps each shared URL to its unfurl payload (e.g. a "blocks"
+	// object), as accepted by chat.unfurl.
+	Unfurls map[string]any
+}
+
+// Unfurl attaches app-provided previews to links in a message via
+// chat.unfurl. Requires a bot token with the links:write scope and only works
+// for domains registered as unfurl domains in the Slack app manifest.
+func (s *SlackClient) Unfurl(ctx context.Context, accessToken string, input SlackUnfurlInput) error {
+	encoded, err := json.Marshal(input.Unfurls)
+	if err != nil {
+		return fmt.Errorf("encode unfurls: %w", err)
+	}
+
+	payload := map[string]any{
+		"unfurls": string(encoded),
+	}
+	if input.UnfurlID != "" && input.Source != "" {
+		payload["unfurl_id"] = input.UnfurlID
+		payload["source"] = input.Source
+	} else {
+		payload["channel"] = input.ChannelID
+		payload["ts"] = input.MessageTS
+	}
+
+	if _, err := s.api.CallWithToken(ctx, "chat.unfurl", payload, accessToken); err != nil {
+		return fmt.Errorf("unfurl slack links: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/triggers/setup_test.go
+++ b/server/internal/triggers/setup_test.go
@@ -111,6 +111,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		auditLogger,
 		serverURL,
 		nil,
+		nil,
 	)
 
 	svc := triggers.NewService(


### PR DESCRIPTION
## Summary

Gram dashboard links pasted in Slack currently render bare — the dashboard is an auth-gated SPA, so Slack's crawler can never show a meaningful icon or title. This PR gives them Linear-style link previews: the Gram logo plus a humanized page title, supplied by the Gram Slack app itself.

**Manifest (dashboard):**
- The generated Slack app manifest registers the dashboard hostname as an `unfurl_domains` entry (gated on a webhook being configured, skipped for dot-less hosts like `localhost`), which is what makes Slack deliver `link_shared` events for our links.
- The `link_shared` event binding now also grants `links:write`, required by `chat.unfurl`.

**Server (trigger webhook):**
- `decodeSlackEvent` gains a `link_shared` branch (`message_ts` → `Ts`, `thread_ts`, channel) so correlation works for these events.
- New `unfurlSlackGramLinks` on the triggers `App`, called at webhook ingress before `ProcessEvent` — link previews render even when no assistant subscribes to `link_shared`. It mirrors the best-effort `ackSlackThreadStatus` pattern: bot token from the trigger environment, failures only cost the preview.
- Titles are derived purely from the URL path (`/acme/projects/default/toolsets/my-tools` → "My Tools · Toolsets"; opaque UUID/numeric segments are skipped). No database lookups, so an unfurl reveals nothing beyond what the pasted URL already shows.
- New `SlackClient.Unfurl` wrapper for `chat.unfurl`, preferring `unfurl_id`+`source` (composer support) over `channel`+`ts`.
- The worker passes a nil site URL — webhook ingress (`ProcessWebhook`) only runs in the HTTP server.

## Notes

- Unfurls only appear in workspaces where a Gram Slack app (created from the updated manifest) is installed — same constraint as Linear. Existing installs need the app manifest updated + reinstalled to pick up `links:write`/`unfurl_domains`.

## Testing

- `mise build:server`, `mise lint:server`, `pnpm -F dashboard lint`, dashboard `tsc -p tsconfig.app.json --noEmit` all pass.
- New unit tests: `link_shared` decode, title derivation, slug humanization, mrkdwn escaping.
- `go test ./internal/background/triggers ./internal/triggers` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VszAzsDK7sBjGW1GeNPNZX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unfurl Gram dashboard links shared in Slack with the Speakeasy logo (dashboard favicon) and a humanized page title. Link previews are sent via `chat.unfurl` at webhook ingress and only when the Slack trigger is active.

- **New Features**
  - Dashboard manifest: add `links:write` and set `unfurl_domains` to the dashboard hostname when a webhook is configured (skips dotless hosts like `localhost`).
  - Trigger webhook: decode `link_shared` and unfurl dashboard links before event processing; runs only for active triggers; titles come from URL paths (drops opaque IDs and separator-only segments); Speakeasy branding with a safe fallback title ("Speakeasy dashboard"); supports both `unfurl_id`/`source` and `channel`/`ts`.
  - Slack client: add `Unfurl` helper and `NewSlackClientWithBaseURL` for end-to-end tests against a fake Slack API; tests cover `chat.unfurl`, composer addressing, and foreign-domain filtering.

- **Migration**
  - Update and reinstall the Slack app from the new manifest to grant `links:write` and register the dashboard host.
  - Ensure `SLACK_BOT_TOKEN` is set for the trigger environment.

<sup>Written for commit 496689377e7fed043a40179ddfb784515b960f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

