### PR TITLE
feat(server): thread the replayed flag onto chat messages and risk results

### DIFF
--- a/.changeset/risk-results-replayed-flag.md
+++ b/.changeset/risk-results-replayed-flag.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Persist the replayed flag on captured chat messages and surface it on risk results: messages redelivered from a device's offline spool after control-plane downtime (X-Gram-Replayed) now carry chat_messages.replayed, and findings produced by scanning them return replayed on the RiskResult type so retroactive findings are distinguishable from live ones.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -52108,6 +52108,9 @@ components:
           type: integer
           description: Policy version when this result was produced.
           format: int64
+        replayed:
+          type: boolean
+          description: True when the scanned message arrived as a replay from a device's offline spool after control-plane downtime — the finding was produced retroactively rather than from live traffic.
         rule_id:
           type: string
           description: The matched rule identifier.
@@ -52138,6 +52141,7 @@ components:
         - chat_message_id
         - source
         - created_at
+        - replayed
     RiskResultRedacted:
       type: object
       properties:

--- a/client/dashboard/src/pages/chatLogs/chatHelpers.test.ts
+++ b/client/dashboard/src/pages/chatLogs/chatHelpers.test.ts
@@ -22,6 +22,7 @@ function result(
     createdAt: new Date("2026-07-06T00:00:00Z"),
     source,
     match,
+    replayed: false,
     ...extra,
   };
 }

--- a/client/dashboard/src/sdk/src/models/components/riskresult.ts
+++ b/client/dashboard/src/sdk/src/models/components/riskresult.ts
@@ -63,6 +63,10 @@ export type RiskResult = {
    */
   policyVersion: number;
   /**
+   * True when the scanned message arrived as a replay from a device's offline spool after control-plane downtime — the finding was produced retroactively rather than from live traffic.
+   */
+  replayed: boolean;
+  /**
    * The matched rule identifier.
    */
   ruleId?: string | undefined;
@@ -108,6 +112,7 @@ export const RiskResult$inboundSchema: z.ZodMiniType<RiskResult, unknown> = z
       match_redacted: z.optional(z.string()),
       policy_id: z.string(),
       policy_version: z.int(),
+      replayed: z.boolean(),
       rule_id: z.optional(z.string()),
       source: z.string(),
       spans: z.optional(z.array(RiskSpan$inboundSchema)),

--- a/server/design/shared/risk.go
+++ b/server/design/shared/risk.go
@@ -256,8 +256,9 @@ var RiskResult = Type("RiskResult", func() {
 	Attribute("created_at", String, "When this result was created.", func() {
 		Format(FormatDateTime)
 	})
+	Attribute("replayed", Boolean, "True when the scanned message arrived as a replay from a device's offline spool after control-plane downtime — the finding was produced retroactively rather than from live traffic.")
 
-	Required("id", "policy_id", "policy_version", "chat_message_id", "source", "created_at")
+	Required("id", "policy_id", "policy_version", "chat_message_id", "source", "created_at", "replayed")
 })
 
 // RiskSpan is one matched span attributed to a finding.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -52476,6 +52476,9 @@ components:
                     type: integer
                     description: Policy version when this result was produced.
                     format: int64
+                replayed:
+                    type: boolean
+                    description: True when the scanned message arrived as a replay from a device's offline spool after control-plane downtime — the finding was produced retroactively rather than from live traffic.
                 rule_id:
                     type: string
                     description: The matched rule identifier.
@@ -52506,6 +52509,7 @@ components:
                 - chat_message_id
                 - source
                 - created_at
+                - replayed
         RiskResultRedacted:
             type: object
             properties:

--- a/server/gen/http/risk/client/encode_decode.go
+++ b/server/gen/http/risk/client/encode_decode.go
@@ -10584,6 +10584,7 @@ func unmarshalRiskResultResponseBodyToTypesRiskResult(v *RiskResultResponseBody)
 		Confidence:    v.Confidence,
 		MatchRedacted: v.MatchRedacted,
 		CreatedAt:     *v.CreatedAt,
+		Replayed:      *v.Replayed,
 	}
 	if v.Tags != nil {
 		res.Tags = make([]string, len(v.Tags))

--- a/server/gen/http/risk/client/types.go
+++ b/server/gen/http/risk/client/types.go
@@ -9409,6 +9409,10 @@ type RiskResultResponseBody struct {
 	MatchRedacted *string `form:"match_redacted,omitempty" json:"match_redacted,omitempty" xml:"match_redacted,omitempty"`
 	// When this result was created.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
+	// True when the scanned message arrived as a replay from a device's offline
+	// spool after control-plane downtime — the finding was produced retroactively
+	// rather than from live traffic.
+	Replayed *bool `form:"replayed,omitempty" json:"replayed,omitempty" xml:"replayed,omitempty"`
 }
 
 // RiskSpanResponseBody is used to define fields on response body types.
@@ -29438,6 +29442,9 @@ func ValidateRiskResultResponseBody(body *RiskResultResponseBody) (err error) {
 	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
+	}
+	if body.Replayed == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("replayed", "body"))
 	}
 	if body.ID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", *body.ID, goa.FormatUUID))

--- a/server/gen/http/risk/server/encode_decode.go
+++ b/server/gen/http/risk/server/encode_decode.go
@@ -10261,6 +10261,7 @@ func marshalTypesRiskResultToRiskResultResponseBody(v *types.RiskResult) *RiskRe
 		Confidence:    v.Confidence,
 		MatchRedacted: v.MatchRedacted,
 		CreatedAt:     v.CreatedAt,
+		Replayed:      v.Replayed,
 	}
 	if v.Tags != nil {
 		res.Tags = make([]string, len(v.Tags))

--- a/server/gen/http/risk/server/types.go
+++ b/server/gen/http/risk/server/types.go
@@ -9397,6 +9397,10 @@ type RiskResultResponseBody struct {
 	MatchRedacted *string `form:"match_redacted,omitempty" json:"match_redacted,omitempty" xml:"match_redacted,omitempty"`
 	// When this result was created.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
+	// True when the scanned message arrived as a replay from a device's offline
+	// spool after control-plane downtime — the finding was produced retroactively
+	// rather than from live traffic.
+	Replayed bool `form:"replayed" json:"replayed" xml:"replayed"`
 }
 
 // RiskSpanResponseBody is used to define fields on response body types.

--- a/server/gen/types/risk_result.go
+++ b/server/gen/types/risk_result.go
@@ -55,4 +55,8 @@ type RiskResult struct {
 	MatchRedacted *string
 	// When this result was created.
 	CreatedAt string
+	// True when the scanned message arrived as a replay from a device's offline
+	// spool after control-plane downtime — the finding was produced retroactively
+	// rather than from live traffic.
+	Replayed bool
 }

--- a/server/internal/assistants/compaction_persist.go
+++ b/server/internal/assistants/compaction_persist.go
@@ -130,6 +130,7 @@ func (s *ServiceCore) RecordCompactedGeneration(ctx context.Context, projectID, 
 		}
 		empty := pgtype.Text{String: "", Valid: false}
 		params = append(params, chatrepo.CreateChatMessageParams{
+			Replayed:         false,
 			ChatID:           threadRow.ChatID,
 			Role:             m.Role,
 			ProjectID:        chatRow.ProjectID,

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -3161,6 +3161,7 @@ func (s *ServiceCore) selfHealCorruptHistory(ctx context.Context, chatID uuid.UU
 	nextGen := currentGen + 1
 	empty := conv.ToPGTextEmpty("")
 	base := chatrepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "user",

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -2033,6 +2033,7 @@ func storeMessages(ctx context.Context, logger *slog.Logger, tx repo.DBTX, asset
 		}
 
 		dbrows[i] = repo.CreateChatMessageParams{
+			Replayed:         false,
 			ChatID:           row.chatID,
 			ProjectID:        row.projectID,
 			Role:             row.role,

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -369,6 +369,7 @@ func buildAssistantRows(
 		content = ""
 	}
 	base := repo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           request.ChatID,
 		Role:             "assistant",
 		ProjectID:        projectID,

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -175,6 +175,7 @@ INSERT INTO chat_messages (
   , source
   , content_hash
   , generation
+  , replayed
 )
 VALUES (
     @chat_id
@@ -200,6 +201,7 @@ VALUES (
   , @source
   , @content_hash
   , @generation
+  , @replayed
 );
 
 -- name: CreateExternalChatMessage :execrows

--- a/server/internal/chat/repo/copyfrom.go
+++ b/server/internal/chat/repo/copyfrom.go
@@ -52,6 +52,7 @@ func (r iteratorForCreateChatMessage) Values() ([]interface{}, error) {
 		r.rows[0].Source,
 		r.rows[0].ContentHash,
 		r.rows[0].Generation,
+		r.rows[0].Replayed,
 	}, nil
 }
 
@@ -60,5 +61,5 @@ func (r iteratorForCreateChatMessage) Err() error {
 }
 
 func (q *Queries) CreateChatMessage(ctx context.Context, arg []CreateChatMessageParams) (int64, error) {
-	return q.db.CopyFrom(ctx, []string{"chat_messages"}, []string{"chat_id", "role", "project_id", "content", "content_raw", "content_asset_url", "storage_error", "model", "message_id", "tool_call_id", "user_id", "external_user_id", "finish_reason", "tool_calls", "prompt_tokens", "completion_tokens", "total_tokens", "origin", "user_agent", "ip_address", "source", "content_hash", "generation"}, &iteratorForCreateChatMessage{rows: arg})
+	return q.db.CopyFrom(ctx, []string{"chat_messages"}, []string{"chat_id", "role", "project_id", "content", "content_raw", "content_asset_url", "storage_error", "model", "message_id", "tool_call_id", "user_id", "external_user_id", "finish_reason", "tool_calls", "prompt_tokens", "completion_tokens", "total_tokens", "origin", "user_agent", "ip_address", "source", "content_hash", "generation", "replayed"}, &iteratorForCreateChatMessage{rows: arg})
 }

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -347,6 +347,7 @@ type CreateChatMessageParams struct {
 	Source           pgtype.Text
 	ContentHash      []byte
 	Generation       int32
+	Replayed         bool
 }
 
 const createChatMessageWithToolCalls = `-- name: CreateChatMessageWithToolCalls :exec

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -525,6 +525,7 @@ func (s *Service) writeCodexToolCallRequestToPG(ctx context.Context, payload *ge
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",
@@ -570,6 +571,7 @@ func (s *Service) writeCodexToolCallResultToPG(ctx context.Context, payload *gen
 	chatID := sessionIDToUUID(metadata.SessionID)
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "tool",
@@ -616,6 +618,7 @@ func (s *Service) writeCodexUserPromptToPG(ctx context.Context, payload *gen.Cod
 	chatID := sessionIDToUUID(metadata.SessionID)
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "user",
@@ -662,6 +665,7 @@ func (s *Service) writeCodexAssistantResponseToPG(ctx context.Context, payload *
 	chatID := sessionIDToUUID(metadata.SessionID)
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -715,6 +715,7 @@ func (s *Service) writeCursorToolCallRequestToPG(ctx context.Context, payload *g
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",
@@ -783,6 +784,7 @@ func (s *Service) writeCursorToolCallResultToPG(ctx context.Context, payload *ge
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "tool",
@@ -830,6 +832,7 @@ func (s *Service) persistCursorAgentResponse(ctx context.Context, payload *gen.C
 	chatID := sessionIDToUUID(*payload.ConversationID)
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",
@@ -893,6 +896,7 @@ func (s *Service) persistCursorUserPrompt(ctx context.Context, payload *gen.Curs
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        parsedProjectID,
 		Role:             "user",

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -797,6 +797,10 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 			Source:           conv.ToPGTextEmpty(strings.TrimSpace(payload.Source.Adapter)),
 			ContentHash:      nil,
 			Generation:       0,
+			// Downtime backlog redelivered from a device's offline spool:
+			// carried onto the row so the offline risk scanner's findings
+			// (and any session view) can distinguish replayed traffic.
+			Replayed: conv.PtrValOr(payload.Replayed, false),
 		}
 	}
 

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -1219,3 +1219,55 @@ func TestTelemetryHookEventName_TranslatesCanonicalVocabulary(t *testing.T) {
 	// provider name must not erase it.
 	require.Equal(t, "skill.activated", telemetryHookEventName(withRaw("claude", "skill.activated", "PostToolUse")))
 }
+
+// TestIngest_ReplayedFlagPersistsOnChatMessage pins the DNO-499 contract: a
+// message redelivered from a device's offline spool (X-Gram-Replayed)
+// persists chat_messages.replayed=true and a live message does not — the bit
+// risk-results reads surface so findings from retroactive scanning stay
+// distinguishable from live ones.
+func TestIngest_ReplayedFlagPersistsOnChatMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := "replayed-flag-" + uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
+
+	replayedPrompt := "replayed prompt from downtime backlog"
+	replayed := true
+	replayedPayload := canonicalIngestPayload("claude", "prompt.submitted", sessionID)
+	replayedPayload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &replayedPrompt},
+	}
+	replayedPayload.Replayed = &replayed
+	res, err := ti.service.Ingest(ctx, replayedPayload)
+	require.NoError(t, err)
+	require.Equal(t, "allow", res.Decision)
+
+	livePrompt := "live prompt after recovery"
+	livePayload := canonicalIngestPayload("claude", "prompt.submitted", sessionID)
+	livePayload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &livePrompt},
+	}
+	res, err = ti.service.Ingest(ctx, livePayload)
+	require.NoError(t, err)
+	require.Equal(t, "allow", res.Decision)
+
+	msgs, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	replayedByContent := make(map[string]bool, len(msgs))
+	for _, m := range msgs {
+		replayedByContent[m.Content] = m.Replayed
+	}
+	require.True(t, replayedByContent[replayedPrompt], "a replayed delivery must persist replayed=true")
+	require.False(t, replayedByContent[livePrompt], "a live delivery must persist replayed=false")
+}

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -332,6 +332,7 @@ func (s *Service) persistConversationEvent(ctx context.Context, payload *gen.Cla
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             role,
@@ -428,6 +429,7 @@ func (s *Service) writeToolCallRequestToPG(ctx context.Context, payload *gen.Cla
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",
@@ -479,6 +481,7 @@ func (s *Service) writeToolCallResultToPG(ctx context.Context, payload *gen.Clau
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		Replayed:         false,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "tool",

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1577,7 +1577,7 @@ func (s *Service) listResultsByChat(ctx context.Context, projectID uuid.UUID, ra
 	var nextCursor *riskResultsCursor
 	for i, row := range rows {
 		cid := row.ChatID.String()
-		results = append(results, foundRowToResult(row.ID, row.RiskPolicyID, row.RiskPolicyVersion, row.BlockID, row.ChatMessageID, &cid, row.ChatTitle, row.ChatUserID, row.Source, row.RuleID, row.Description, row.Match, row.StartPos, row.EndPos, row.Confidence, row.Tags, row.Spans, row.MessageCreatedAt))
+		results = append(results, foundRowToResult(row.ID, row.RiskPolicyID, row.RiskPolicyVersion, row.BlockID, row.ChatMessageID, &cid, row.ChatTitle, row.ChatUserID, row.Source, row.RuleID, row.Description, row.Match, row.StartPos, row.EndPos, row.Confidence, row.Tags, row.Spans, row.MessageCreatedAt, row.Replayed))
 		if i == pageSize {
 			nextCursor = &riskResultsCursor{MessageCreatedAt: row.MessageCreatedAt.Time, ID: row.ID}
 		}
@@ -1609,7 +1609,7 @@ func (s *Service) listResultsByProject(ctx context.Context, projectID uuid.UUID,
 	var nextCursor *riskResultsCursor
 	for i, row := range rows {
 		chatID := row.ChatID.String()
-		results = append(results, foundRowToResult(row.ID, row.RiskPolicyID, row.RiskPolicyVersion, row.BlockID, row.ChatMessageID, &chatID, row.ChatTitle, row.ChatUserID, row.Source, row.RuleID, row.Description, row.Match, row.StartPos, row.EndPos, row.Confidence, row.Tags, row.Spans, row.MessageCreatedAt))
+		results = append(results, foundRowToResult(row.ID, row.RiskPolicyID, row.RiskPolicyVersion, row.BlockID, row.ChatMessageID, &chatID, row.ChatTitle, row.ChatUserID, row.Source, row.RuleID, row.Description, row.Match, row.StartPos, row.EndPos, row.Confidence, row.Tags, row.Spans, row.MessageCreatedAt, row.Replayed))
 		if i == pageSize {
 			nextCursor = &riskResultsCursor{MessageCreatedAt: row.MessageCreatedAt.Time, ID: row.ID}
 		}
@@ -3613,6 +3613,7 @@ func foundRowToResult(
 	source string, ruleID, description, match pgtype.Text,
 	startPos, endPos pgtype.Int4,
 	confidence pgtype.Float8, tags []string, spans []byte, createdAt pgtype.Timestamptz,
+	replayed bool,
 ) *types.RiskResult {
 	return &types.RiskResult{
 		ID:            id.String(),
@@ -3636,6 +3637,7 @@ func foundRowToResult(
 		// for callers ListRiskResults decides shouldn't see raw match/spans.
 		MatchRedacted: nil,
 		CreatedAt:     createdAt.Time.Format(time.RFC3339),
+		Replayed:      replayed,
 	}
 }
 

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -999,14 +999,14 @@ SELECT
     sub.rule_id, sub.description, sub.match, sub.start_pos, sub.end_pos,
     sub.confidence, sub.tags, sub.spans, sub.dead_letter_reason, sub.created_at,
     sub.chat_id, sub.message_created_at, sub.chat_title, sub.chat_user_id,
-    sub.block_id
+    sub.block_id, sub.replayed
 FROM (
   SELECT
       rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id,
       rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found,
       rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos,
       rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.created_at,
-      cm.chat_id, cm.created_at AS message_created_at,
+      cm.chat_id, cm.created_at AS message_created_at, cm.replayed,
       c.title AS chat_title, c.external_user_id AS chat_user_id,
       COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id,
       CASE
@@ -1129,7 +1129,7 @@ ORDER BY cm.created_at DESC, rr.id DESC
 LIMIT @page_limit;
 
 -- name: ListRiskResultsByChatFound :many
-SELECT rr.*, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
+SELECT rr.*, cm.chat_id, cm.created_at AS message_created_at, cm.replayed, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -2339,7 +2339,7 @@ func (q *Queries) ListRiskPolicyEvalReviews(ctx context.Context, arg ListRiskPol
 }
 
 const listRiskResultsByChatFound = `-- name: ListRiskResultsByChatFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, cm.replayed, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -2395,6 +2395,7 @@ type ListRiskResultsByChatFoundRow struct {
 	CreatedAt           pgtype.Timestamptz
 	ChatID              uuid.UUID
 	MessageCreatedAt    pgtype.Timestamptz
+	Replayed            bool
 	ChatTitle           pgtype.Text
 	ChatUserID          pgtype.Text
 	BlockID             uuid.UUID
@@ -2440,6 +2441,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.MessageCreatedAt,
+			&i.Replayed,
 			&i.ChatTitle,
 			&i.ChatUserID,
 			&i.BlockID,
@@ -2582,14 +2584,14 @@ SELECT
     sub.rule_id, sub.description, sub.match, sub.start_pos, sub.end_pos,
     sub.confidence, sub.tags, sub.spans, sub.dead_letter_reason, sub.created_at,
     sub.chat_id, sub.message_created_at, sub.chat_title, sub.chat_user_id,
-    sub.block_id
+    sub.block_id, sub.replayed
 FROM (
   SELECT
       rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id,
       rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found,
       rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos,
       rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.created_at,
-      cm.chat_id, cm.created_at AS message_created_at,
+      cm.chat_id, cm.created_at AS message_created_at, cm.replayed,
       c.title AS chat_title, c.external_user_id AS chat_user_id,
       COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id,
       CASE
@@ -2724,6 +2726,7 @@ type ListRiskResultsByProjectFoundRow struct {
 	ChatTitle         pgtype.Text
 	ChatUserID        pgtype.Text
 	BlockID           uuid.UUID
+	Replayed          bool
 }
 
 // Sort by the underlying chat message's created_at (the event time), NOT
@@ -2796,6 +2799,7 @@ func (q *Queries) ListRiskResultsByProjectFound(ctx context.Context, arg ListRis
 			&i.ChatTitle,
 			&i.ChatUserID,
 			&i.BlockID,
+			&i.Replayed,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Part of [DNO-499](https://linear.app/speakeasy/issue/DNO-499/dcpd-5-observability-for-degraded-mode-flag-fail-open-and-replayed) — the first remaining item from the reconciled scope: findings produced by retroactively scanning replayed downtime backlog must be distinguishable from live findings. Stacked on #4245 (the `chat_messages.replayed` migration), which stacks on #4238 (the `X-Gram-Replayed` ingest decode).

## What

- **Write path:** canonical ingest persists `payload.Replayed` onto the chat row (`baseMsg` → `CreateChatMessageParams.Replayed`; the `:copyfrom` insert gains the column). All other message writers (Elements/Playground live chat) default to `false` via the zero value.
- **Read path:** both risk-findings list queries (`ListRiskResultsByProjectFound`, `ListRiskResultsByChatFound`) select `cm.replayed` through their existing `chat_messages` join, and `RiskResult` gains a required `replayed` field (Goa design + server/http/SDK regen included). **Deliberately no `risk_results` column:** replayed is a property of the *source message*, every findings read already joins `chat_messages`, and denormalizing would mean touching the scanner's `:copyfrom` insert and dead-letter row builders for no current filtering need.
- ClickHouse telemetry rows were already tagged (`gram.hook.replayed`, #4238) — this completes the Postgres/API side so the whole chain (message → finding → API) carries the flag.

## Test plan

- `TestIngest_ReplayedFlagPersistsOnChatMessage` drives the real ingest path against Postgres: a replayed delivery persists `replayed=true`, a live delivery in the same session persists `false` (also proves the migration applies in test infra).
- Full `internal/hooks`, `internal/risk/...`, `internal/chat/...` suites green against local infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads the replay flag from `X-Gram-Replayed` through `chat_messages` and exposes it on `RiskResult` so backlog findings from downtime replays are easy to spot. Supports DNO-499 observability for degraded-mode and replayed sessions.

- **New Features**
  - Ingest persists `payload.Replayed` to `chat_messages.replayed`; all other message writers now explicitly set `Replayed: false` to enforce the default.
  - Risk-result list queries select `cm.replayed`, and `RiskResult` includes a required `replayed` boolean; OpenAPI/Goa and the dashboard SDK updated. No `risk_results` column — read via the existing join.

- **Migration**
  - API change: `RiskResult.replayed` is required. Regenerate clients (dashboard SDK already updated).
  - No DB migration in this PR (relies on the `chat_messages.replayed` migration in the parent stack).

<sup>Written for commit bb5a223c8bd0c039c1fc38ac61c97c8cef194519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

