### PR TITLE
chore(hooks): send the replay marker via the typed SDK header field

### DIFF
--- a/hooks/relay/client.go
+++ b/hooks/relay/client.go
@@ -78,21 +78,18 @@ type client struct {
 	sdk *sdk.SpeakeasyHooks
 	// budget caps one send end to end; a field so tests can shrink it.
 	budget time.Duration
+	// replayed stamps X-Gram-Replayed on every request via the typed SDK
+	// field, marking a drain redelivery so the server applies the long
+	// idempotency window and tags telemetry. Set by newReplayClient.
+	replayed bool
 }
 
 func newClient(serverURL string) *client {
-	return clientWith(serverURL, &http.Client{Timeout: perAttemptTime})
-}
-
-// clientWith builds the ingest client around a caller-supplied HTTP client,
-// so the drain can layer its replay-marker transport under the same retry
-// posture live sends get.
-func clientWith(serverURL string, hc *http.Client) *client {
 	return &client{
 		budget: sendBudget,
 		sdk: sdk.New(
 			sdk.WithServerURL(strings.TrimRight(serverURL, "/")),
-			sdk.WithClient(hc),
+			sdk.WithClient(&http.Client{Timeout: perAttemptTime}),
 			// Retries cover connection errors and 429/5xx; the SDK rewinds the
 			// request body per attempt, so the Idempotency-Key header minted in
 			// send is reused across redeliveries. The elapsed cap keeps the
@@ -130,7 +127,11 @@ func (cl *client) send(ctx context.Context, c creds, body components.IngestReque
 		GramKey:        new(c.APIKey),
 		GramProject:    nil,
 		IdempotencyKey: new(idemKey),
+		XGramReplayed:  nil,
 		Body:           body,
+	}
+	if cl.replayed {
+		req.XGramReplayed = new(true)
 	}
 	if c.Project != "" {
 		req.GramProject = new(c.Project)

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -382,21 +381,12 @@ func (r *Relay) finishExchange(idemKey string, payload components.IngestRequestB
 }
 
 // newReplayClient is newClient plus the replay marker: every request carries
-// X-Gram-Replayed: 1 so the server can distinguish downtime backlog from
-// live traffic and tag it for observability (DNO-499). The marker rides a
-// transport wrapper because the generated SDK has no per-request header
-// hook.
+// X-Gram-Replayed so the server applies the long idempotency window and can
+// distinguish downtime backlog from live traffic (DNO-499). Uses the SDK's
+// typed header field, regenerated from the same Goa design the server
+// decodes with — the one definition both sides share.
 func newReplayClient(serverURL string) *client {
-	return clientWith(serverURL, &http.Client{
-		Timeout:   perAttemptTime,
-		Transport: replayMarkerTransport{base: http.DefaultTransport},
-	})
-}
-
-type replayMarkerTransport struct{ base http.RoundTripper }
-
-func (t replayMarkerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req = req.Clone(req.Context())
-	req.Header.Set("X-Gram-Replayed", "1")
-	return t.base.RoundTrip(req)
+	cl := newClient(serverURL)
+	cl.replayed = true
+	return cl
 }

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -384,7 +384,10 @@ func (r *Relay) finishExchange(idemKey string, payload components.IngestRequestB
 // X-Gram-Replayed so the server applies the long idempotency window and can
 // distinguish downtime backlog from live traffic (DNO-499). Uses the SDK's
 // typed header field, regenerated from the same Goa design the server
-// decodes with — the one definition both sides share.
+// decodes with — the one definition both sides share. The flag marks only
+// client.send's ingest operation; a future second operation on this client
+// would need its own marker (the deleted transport wrapper stamped every
+// request structurally, this does not).
 func newReplayClient(serverURL string) *client {
 	cl := newClient(serverURL)
 	cl.replayed = true

--- a/hooks/relay/drain_test.go
+++ b/hooks/relay/drain_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -81,7 +82,9 @@ func TestDrainReplaysOldestFirstWithStoredKeys(t *testing.T) {
 	require.Equal(t, keyOld, fs.headers[0].Get("Idempotency-Key"), "replay must reuse the original send's key")
 	require.Equal(t, keyNew, fs.headers[1].Get("Idempotency-Key"))
 	for _, h := range fs.headers {
-		require.Equal(t, "1", h.Get("X-Gram-Replayed"), "replayed traffic must be distinguishable from live traffic")
+		marker, err := strconv.ParseBool(h.Get("X-Gram-Replayed"))
+		require.NoError(t, err)
+		require.True(t, marker, "replayed traffic must be distinguishable from live traffic")
 	}
 }
 

--- a/hooks/relay/spool_test.go
+++ b/hooks/relay/spool_test.go
@@ -303,3 +303,26 @@ func TestTrimSpoolSweepsStaleTmpOrphans(t *testing.T) {
 	_, freshErr := os.Stat(filepath.Join(dir, fresh))
 	require.NoError(t, freshErr, "fresh .tmp files may still belong to a live writer")
 }
+
+// TestLiveSendOmitsReplayMarker pins the other half of the replay contract:
+// the marker rides client state now (not a drain-only transport), so live
+// traffic must provably not carry it — a flipped default would grant every
+// live event the long idempotency window and tag it as downtime backlog,
+// and no other test inspects the header on the live path.
+func TestLiveSendOmitsReplayMarker(t *testing.T) {
+	fs := newFakeServer(t, nil)
+	cl := newClient(fs.URL)
+	cl.send(t.Context(), creds{ServerURL: "", APIKey: "k", Project: "p", Email: "", Org: "", Source: credEnv}, components.IngestRequestBody{
+		SchemaVersion: schemaVersion,
+		Source:        components.HookIngestSource{Adapter: "claude", AdapterVersion: nil, RawEventName: nil, Hostname: nil, UserEmail: nil},
+		Session:       nil,
+		Event:         components.HookIngestEvent{Type: components.TypeSessionUpdated, OccurredAt: nil},
+		Data:          nil,
+		Raw:           nil,
+	}, newIdempotencyToken())
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	require.Len(t, fs.headers, 1)
+	require.Empty(t, fs.headers[0].Values("X-Gram-Replayed"), "live sends must not carry the replay marker")
+}


### PR DESCRIPTION
Follow-up to #4232/#4238 (noted on both): the drain's `X-Gram-Replayed` marker rode a hand-rolled `RoundTripper` because the header predated the SDK regen. Both are on main now, so the drain uses the generated `IngestHookEventRequest.XGramReplayed` field — one definition shared with the server's decoder, no magic string to drift, and the `clientWith` seam folds away. Wire value changes from `"1"` to `"true"`; the server's `strconv.ParseBool` accepts both (test now asserts the parsed semantics rather than the encoding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the drain’s replay marker to the typed SDK field so replayed traffic is marked consistently and the server applies the long idempotency window. This simplifies the client and aligns with DNO-498’s offline replay requirements.

- **Refactors**
  - Use `IngestHookEventRequest.XGramReplayed` to set the `X-Gram-Replayed` header; `newReplayClient` now sets a `replayed` flag used in `send`.
  - Remove the custom `RoundTripper` and `clientWith`; rely on `newClient` with the standard `http.Client` timeout.
  - Change wire value from `"1"` to `"true"`; tests now assert boolean semantics (server accepts both).
  - Add a test to ensure live sends omit the replay marker so only drain replays are tagged.

<sup>Written for commit eeae0f89afd7ca92e2912ffe1c8664fda6dcb04e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

