### PR TITLE
fix: scope UpsertEnvironmentEntry query by project_id

### DIFF
--- a/server/internal/environments/impl.go
+++ b/server/internal/environments/impl.go
@@ -349,6 +349,7 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 
 		if err := entriesRepo.UpdateEnvironmentEntry(ctx, repo.UpsertEnvironmentEntryParams{
 			EnvironmentID: environment.ID,
+			ProjectID:     projectID,
 			Name:          updatedEntry.Name,
 			Value:         value, // This is the actual environment value to update too, do not redact it
 			IsSecret:      isSecret,

--- a/server/internal/environments/queries.sql
+++ b/server/internal/environments/queries.sql
@@ -129,9 +129,6 @@ WHERE ee.environment_id = @source_environment_id::uuid
   AND e.project_id = @project_id::uuid;
 
 -- name: UpsertEnvironmentEntry :one
--- The environment_id is sourced from environments under a project_id check so
--- the upsert is a no-op (returning no rows) when the environment does not
--- belong to the project.
 INSERT INTO environment_entries (environment_id, name, value, is_secret, updated_at)
 SELECT e.id, @name::text, @value::text, @is_secret::boolean, now()
 FROM environments e

--- a/server/internal/environments/queries.sql
+++ b/server/internal/environments/queries.sql
@@ -129,8 +129,13 @@ WHERE ee.environment_id = @source_environment_id::uuid
   AND e.project_id = @project_id::uuid;
 
 -- name: UpsertEnvironmentEntry :one
+-- The environment_id is sourced from environments under a project_id check so
+-- the upsert is a no-op (returning no rows) when the environment does not
+-- belong to the project.
 INSERT INTO environment_entries (environment_id, name, value, is_secret, updated_at)
-VALUES ($1, $2, $3, $4, now())
+SELECT e.id, @name::text, @value::text, @is_secret::boolean, now()
+FROM environments e
+WHERE e.id = @environment_id AND e.project_id = @project_id
 ON CONFLICT (environment_id, name)
 DO UPDATE SET
     value = EXCLUDED.value,

--- a/server/internal/environments/repo/queries.sql.go
+++ b/server/internal/environments/repo/queries.sql.go
@@ -643,7 +643,9 @@ func (q *Queries) UpdateEnvironment(ctx context.Context, arg UpdateEnvironmentPa
 
 const upsertEnvironmentEntry = `-- name: UpsertEnvironmentEntry :one
 INSERT INTO environment_entries (environment_id, name, value, is_secret, updated_at)
-VALUES ($1, $2, $3, $4, now())
+SELECT e.id, $1::text, $2::text, $3::boolean, now()
+FROM environments e
+WHERE e.id = $4 AND e.project_id = $5
 ON CONFLICT (environment_id, name)
 DO UPDATE SET
     value = EXCLUDED.value,
@@ -653,18 +655,23 @@ RETURNING name, value, is_secret, environment_id, created_at, updated_at
 `
 
 type UpsertEnvironmentEntryParams struct {
-	EnvironmentID uuid.UUID
 	Name          string
 	Value         string
 	IsSecret      bool
+	EnvironmentID uuid.UUID
+	ProjectID     uuid.UUID
 }
 
+// The environment_id is sourced from environments under a project_id check so
+// the upsert is a no-op (returning no rows) when the environment does not
+// belong to the project.
 func (q *Queries) UpsertEnvironmentEntry(ctx context.Context, arg UpsertEnvironmentEntryParams) (EnvironmentEntry, error) {
 	row := q.db.QueryRow(ctx, upsertEnvironmentEntry,
-		arg.EnvironmentID,
 		arg.Name,
 		arg.Value,
 		arg.IsSecret,
+		arg.EnvironmentID,
+		arg.ProjectID,
 	)
 	var i EnvironmentEntry
 	err := row.Scan(

--- a/server/internal/environments/repo/queries.sql.go
+++ b/server/internal/environments/repo/queries.sql.go
@@ -662,9 +662,6 @@ type UpsertEnvironmentEntryParams struct {
 	ProjectID     uuid.UUID
 }
 
-// The environment_id is sourced from environments under a project_id check so
-// the upsert is a no-op (returning no rows) when the environment does not
-// belong to the project.
 func (q *Queries) UpsertEnvironmentEntry(ctx context.Context, arg UpsertEnvironmentEntryParams) (EnvironmentEntry, error) {
 	row := q.db.QueryRow(ctx, upsertEnvironmentEntry,
 		arg.Name,

--- a/server/internal/environments/upsertenvironmententry_test.go
+++ b/server/internal/environments/upsertenvironmententry_test.go
@@ -1,0 +1,66 @@
+package environments_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/environments"
+	"github.com/speakeasy-api/gram/server/internal/environments/repo"
+)
+
+func TestUpsertEnvironmentEntry_ScopedByProject(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestEnvironmentService(t)
+
+	env, err := ti.service.CreateEnvironment(ctx, &gen.CreateEnvironmentPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		OrganizationID:   "",
+		Name:             "scoped-env",
+		Description:      nil,
+		Entries: []*gen.EnvironmentEntryInput{
+			{Name: "KEY1", Value: new("value1"), IsSecret: new(false)},
+		},
+	})
+	require.NoError(t, err)
+
+	environmentID, err := uuid.Parse(env.ID)
+	require.NoError(t, err)
+	projectID, err := uuid.Parse(env.ProjectID)
+	require.NoError(t, err)
+
+	queries := repo.New(ti.conn)
+
+	// Upsert scoped to the owning project writes the entry.
+	entry, err := queries.UpsertEnvironmentEntry(ctx, repo.UpsertEnvironmentEntryParams{
+		EnvironmentID: environmentID,
+		ProjectID:     projectID,
+		Name:          "KEY1",
+		Value:         "updated-value",
+		IsSecret:      false,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "updated-value", entry.Value)
+
+	// Upsert scoped to a different project is a no-op returning no rows.
+	_, err = queries.UpsertEnvironmentEntry(ctx, repo.UpsertEnvironmentEntryParams{
+		EnvironmentID: environmentID,
+		ProjectID:     uuid.New(),
+		Name:          "KEY1",
+		Value:         "cross-project-value",
+		IsSecret:      false,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	entries, err := queries.ListEnvironmentEntries(ctx, repo.ListEnvironmentEntriesParams{
+		ProjectID:     projectID,
+		EnvironmentID: environmentID,
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "updated-value", entries[0].Value)
+}

--- a/server/internal/environments/upsertenvironmententry_test.go
+++ b/server/internal/environments/upsertenvironmententry_test.go
@@ -35,7 +35,6 @@ func TestUpsertEnvironmentEntry_ScopedByProject(t *testing.T) {
 
 	queries := repo.New(ti.conn)
 
-	// Upsert scoped to the owning project writes the entry.
 	entry, err := queries.UpsertEnvironmentEntry(ctx, repo.UpsertEnvironmentEntryParams{
 		EnvironmentID: environmentID,
 		ProjectID:     projectID,
@@ -46,7 +45,6 @@ func TestUpsertEnvironmentEntry_ScopedByProject(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "updated-value", entry.Value)
 
-	// Upsert scoped to a different project is a no-op returning no rows.
 	_, err = queries.UpsertEnvironmentEntry(ctx, repo.UpsertEnvironmentEntryParams{
 		EnvironmentID: environmentID,
 		ProjectID:     uuid.New(),


### PR DESCRIPTION
Resolves [AGE-2995](https://linear.app/speakeasy/issue/AGE-2995/scope-upsertenvironmententry-query-by-project-id)

## What changed

- `UpsertEnvironmentEntry` in `server/internal/environments/queries.sql` now sources `environment_id` from a `SELECT` against `environments` with a `project_id` check, matching the neighboring entry queries (`ListEnvironmentEntries`, `CloneEnvironmentEntriesWithValues`, etc.). When the environment does not belong to the project, the upsert is a no-op and returns no rows (`pgx.ErrNoRows` to the caller).
- The only call site (`UpdateEnvironment` in `impl.go`) now passes `ProjectID`.
- Regenerated sqlc code.
- Added a repo-level test asserting the same-project upsert writes and a cross-project upsert returns `ErrNoRows` without writing anything.

## Why

Defense in depth, not a live bug. The upsert previously wrote to `environment_entries` keyed only on `(environment_id, name)` and relied entirely on handler-level validation to prevent cross-project writes. The query itself now rejects them, so a future caller that skips that validation cannot upsert across projects.

Raised by cubic-dev-ai on #4157 and deferred out of that PR because the missing scope predates it.

## Notes for reviewers

- No schema change, no migration. Query and call-site only.
- Behavior change is limited to the unreachable cross-project path: it previously wrote silently, it now errors with no rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped `UpsertEnvironmentEntry` by `project_id` to prevent cross-project writes. Addresses AGE-2995 by making cross-project upserts a no-op that return `pgx.ErrNoRows`.

- **Bug Fixes**
  - Query now selects `environment_id` from `environments` with a `project_id` check; cross-project upserts return no rows.
  - `UpdateEnvironment` passes `ProjectID` to the repo call.
  - Regenerated sqlc code and added a repo test covering same-project write and cross-project no-op.

- **Refactors**
  - Removed redundant comments in query and test files.

<sup>Written for commit cb5b0e49ea55f797e59ad12c481aea7e3be5cc75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

