### PR TITLE
fix: proper chat transcript loading

### DIFF
--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -2,8 +2,10 @@ import { format, formatDistanceToNow } from "date-fns";
 import {
   ArrowLeft,
   ChevronDown,
+  ChevronsDown,
   ChevronUp,
   Info,
+  Loader2,
   Search,
   Sparkles,
   SlidersHorizontal,
@@ -55,6 +57,7 @@ import { personalAccountEmail } from "@/components/observe/account-display-utils
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useIsPlatformAdmin } from "@/contexts/Auth";
+import { useSdkClient } from "@/contexts/Sdk";
 import { handleError, toError } from "@/lib/errors";
 import {
   ExclusionEditor,
@@ -765,6 +768,7 @@ function ChatDetailPanel({
   riskFocus = false,
   dimNonRisk: dimNonRiskProp = false,
 }: ChatDetailPanelProps) {
+  const client = useSdkClient();
   const isPlatformAdmin = useIsPlatformAdmin();
   const { hasScope } = useRBAC();
   const canManageChat = isPlatformAdmin || hasScope("org:admin");
@@ -833,11 +837,11 @@ function ChatDetailPanel({
   const searchTranscript = useWindowedTranscript(chatId, searchActive, {
     query: searchQuery,
   });
-  const active = riskWindowed
-    ? riskTranscript
-    : searchActive
-      ? searchTranscript
-      : transcript;
+  // Risk and search are both server-windowed; only their source differs. The
+  // plain keyset transcript drives loads directly when neither is active.
+  const windowedChoice = riskWindowed ? riskTranscript : searchTranscript;
+  const windowed = riskWindowed || searchActive ? windowedChoice : null;
+  const active = windowed ?? transcript;
   // Prefer the enriched (cost/usage) normal-load chat, but fall back to the
   // active transcript's chat so a windowed view still renders if only that load
   // resolved (otherwise the panel would show "Not found" despite having data).
@@ -948,11 +952,7 @@ function ChatDetailPanel({
   }, [transcriptRows, typeFilter, riskyOnly, riskResultsByMessage]);
   const hasMoreBefore = active.hasMoreBefore;
   const hasMoreAfter = active.hasMoreAfter;
-  const windowGaps = riskWindowed
-    ? riskTranscript.gaps
-    : searchActive
-      ? searchTranscript.gaps
-      : undefined;
+  const windowGaps = windowed?.gaps;
   const displayItems = useMemo(
     () =>
       buildDisplayItems({
@@ -1031,26 +1031,25 @@ function ChatDetailPanel({
   );
 
   const transcriptPagination = useMemo<TranscriptPagination>(() => {
-    // Risk and search are both server-windowed; only their source differs. The
-    // plain keyset transcript drives edge loads directly when neither is active.
-    const windowed = riskWindowed
-      ? riskTranscript
-      : searchActive
-        ? searchTranscript
-        : null;
     return {
       hasMoreBefore,
       hasMoreAfter,
+      // Scrolling near an edge streams single pages; the break buttons load
+      // everything missing in their range in one action.
       onLoadOlder: () =>
         windowed ? windowed.loadBefore() : transcript.fetchOlder(),
       onLoadNewer: () =>
         windowed ? windowed.loadAfter() : transcript.fetchNewer(),
+      onLoadAllOlder: () =>
+        windowed ? windowed.loadAllBefore() : transcript.fetchOlder(),
+      onLoadAllNewer: () =>
+        windowed ? windowed.loadAllAfter() : transcript.loadRest(),
       isFetchingOlder: windowed
         ? windowed.loadingKey === "before"
         : transcript.isFetchingOlder,
       isFetchingNewer: windowed
         ? windowed.loadingKey === "after"
-        : transcript.isFetchingNewer,
+        : transcript.isFetchingNewer || transcript.isLoadingRest,
       onLoadGap: windowed ? windowed.loadGap : undefined,
       isLoadingGap: windowed
         ? (afterSeq: number) => windowed.loadingKey === `gap:${afterSeq}`
@@ -1076,13 +1075,25 @@ function ChatDetailPanel({
     hasMoreAfter,
     riskWindowed,
     searchActive,
-    riskTranscript,
-    searchTranscript,
+    windowed,
     transcript,
     initialScrollIndex,
     scrollNonce,
     activeOccurrence,
   ]);
+
+  // "Load all messages": shown whenever part of the conversation isn't loaded
+  // (a paged-out tail, or un-expanded windowed segments/edges). One click
+  // fetches every missing message.
+  const fullyLoaded =
+    !hasMoreBefore && !hasMoreAfter && (windowGaps?.size ?? 0) === 0;
+  const loadingAllMessages = windowed
+    ? windowed.loadingKey === "all"
+    : transcript.isLoadingRest;
+  const loadAllMessages = useCallback(() => {
+    if (windowed) windowed.loadAll();
+    else transcript.loadRest();
+  }, [windowed, transcript]);
 
   // Personal-account sessions label the user's turns with the account's own
   // email (mirrors the sessions list) instead of the attributed employee's
@@ -1219,10 +1230,12 @@ function ChatDetailPanel({
           )
         }
         onExport={() => {
-          exportTraceDataAsJson({
+          // Fetches the complete transcript server-side — the export must not
+          // depend on which messages the panel happens to have loaded.
+          void exportTraceDataAsJson({
+            client,
             chatId,
             chat,
-            messages: chatMessages,
             telemetryLogLimit: PANEL_TELEMETRY_LOG_LIMIT,
             telemetryLogs: logs,
             riskResults,
@@ -1243,6 +1256,25 @@ function ChatDetailPanel({
           it, so returning lands back at the same scroll position rather than
           re-scrolling to the first finding. */}
       <div className="relative flex flex-1 flex-col overflow-hidden">
+        {!fullyLoaded && (
+          <div className="bg-muted/30 flex items-center justify-center border-b px-4 py-1.5">
+            <button
+              type="button"
+              disabled={loadingAllMessages}
+              onClick={loadAllMessages}
+              className="text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1.5 text-xs font-medium transition-colors disabled:cursor-default"
+            >
+              {loadingAllMessages ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <ChevronsDown className="size-3.5" />
+              )}
+              {loadingAllMessages
+                ? "Loading all messages…"
+                : "Load all messages"}
+            </button>
+          </div>
+        )}
         <CreateExclusionContext.Provider
           value={canManageChat ? openExclusion : null}
         >

--- a/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
@@ -780,10 +780,16 @@ function SegmentDivider({ generation }: { generation: number }) {
 export interface TranscriptPagination {
   hasMoreBefore: boolean;
   hasMoreAfter: boolean;
+  /** Single-page loads driven by scrolling near an edge. */
   onLoadOlder: () => void;
   onLoadNewer: () => void;
   isFetchingOlder: boolean;
   isFetchingNewer: boolean;
+  /** Break-button loads: everything missing in the break's range (all earlier
+   * messages / all remaining messages), not just one page. */
+  onLoadAllOlder: () => void;
+  onLoadAllNewer: () => void;
+  /** Loads the entire un-loaded span after `afterSeq` (windowed views). */
   onLoadGap?: (afterSeq: number) => void;
   isLoadingGap?: (afterSeq: number) => boolean;
   /** Display-item index to bring to the top on first paint, or null to stay at
@@ -811,7 +817,8 @@ export interface TranscriptPagination {
   } | null;
 }
 
-/** Edge "load older/newer" affordance + the risk-gap "load in-between" marker. */
+/** A break in the transcript — messages are missing here. Renders a prominent
+ * button that loads every missing message in the break's range. */
 function LoadDivider({
   icon,
   label,
@@ -826,20 +833,20 @@ function LoadDivider({
   const Glyph =
     icon === "up" ? ChevronUp : icon === "down" ? ChevronDown : Ellipsis;
   return (
-    <div className="flex items-center justify-center gap-2 px-4 py-2">
+    <div className="flex items-center justify-center gap-3 px-4 py-3">
       <div className="bg-border h-px flex-1" />
       <button
         type="button"
         disabled={loading}
         onClick={onClick}
-        className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs transition-colors disabled:opacity-60"
+        className="bg-background text-foreground hover:bg-muted inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium shadow-xs transition-colors disabled:cursor-default disabled:opacity-60"
       >
         {loading ? (
-          <Loader2 className="size-3 animate-spin" />
+          <Loader2 className="size-3.5 animate-spin" />
         ) : (
-          <Glyph className="size-3" />
+          <Glyph className="size-3.5" />
         )}
-        {label}
+        {loading ? "Loading messages…" : label}
       </button>
       <div className="bg-border h-px flex-1" />
     </div>
@@ -931,23 +938,23 @@ function DisplayItemView({
       return item.dir === "older" ? (
         <LoadDivider
           icon="up"
-          label="Load older messages"
+          label="Load earlier messages"
           loading={pagination.isFetchingOlder}
-          onClick={pagination.onLoadOlder}
+          onClick={pagination.onLoadAllOlder}
         />
       ) : (
         <LoadDivider
           icon="down"
-          label="Load newer messages"
+          label="Load remaining messages"
           loading={pagination.isFetchingNewer}
-          onClick={pagination.onLoadNewer}
+          onClick={pagination.onLoadAllNewer}
         />
       );
     case "serverGap":
       return (
         <LoadDivider
           icon="ellipsis"
-          label="Load messages in between"
+          label="Load missing messages"
           loading={pagination.isLoadingGap?.(item.afterSeq) ?? false}
           onClick={() => pagination.onLoadGap?.(item.afterSeq)}
         />

--- a/client/dashboard/src/pages/chatLogs/chatExport.ts
+++ b/client/dashboard/src/pages/chatLogs/chatExport.ts
@@ -1,7 +1,8 @@
 import { toast } from "sonner";
-import type { ChatMessage } from "@gram/client/models/components/chatmessage.js";
+import type { Gram } from "@gram/client";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
 import type { TelemetryLogRecord } from "@gram/client/models/components/telemetrylogrecord.js";
+import { fetchFullTranscript } from "./transcriptFull";
 
 function downloadJsonFile(filename: string, data: unknown) {
   const json = JSON.stringify(data, null, 2);
@@ -24,22 +25,25 @@ function getTraceExportSlug(chat: { id: string; title?: string | null }) {
   return titleSlug || chat.id.slice(0, 8);
 }
 
-export function exportTraceDataAsJson({
+export async function exportTraceDataAsJson({
+  client,
   chatId,
   chat,
-  messages,
   telemetryLogLimit,
   telemetryLogs,
   riskResults,
 }: {
+  client: Gram;
   chatId: string;
   chat: { id: string; title?: string | null };
-  messages: ChatMessage[];
   telemetryLogLimit: number;
   telemetryLogs: TelemetryLogRecord[];
   riskResults: RiskResult[];
-}): void {
+}): Promise<void> {
   try {
+    // The export always carries the complete transcript, fetched here,
+    // regardless of which messages the panel happens to have loaded.
+    const messages = await fetchFullTranscript(client, chatId);
     const exported = {
       schemaVersion: 1,
       exportScope: "chat_detail_panel",

--- a/client/dashboard/src/pages/chatLogs/transcriptFull.ts
+++ b/client/dashboard/src/pages/chatLogs/transcriptFull.ts
@@ -1,0 +1,31 @@
+import type { Gram } from "@gram/client";
+import type { ChatMessage } from "@gram/client/models/components/chatmessage.js";
+
+// The server's max chat.load page (maxLoadChatLimit), so full-range walks
+// complete in as few round trips as possible.
+export const FULL_LOAD_PAGE_SIZE = 200;
+
+/** Every message of the chat's latest generation, walked by seq keyset from
+ * the start until the server reports nothing newer. */
+export async function fetchFullTranscript(
+  client: Gram,
+  chatId: string,
+): Promise<ChatMessage[]> {
+  const messages: ChatMessage[] = [];
+  let page = await client.chat.load({
+    id: chatId,
+    fromStart: true,
+    limit: FULL_LOAD_PAGE_SIZE,
+  });
+  messages.push(...page.messages);
+  while (page.hasMoreAfter && page.messages.length > 0) {
+    const newest = page.messages[page.messages.length - 1]!;
+    page = await client.chat.load({
+      id: chatId,
+      afterSeq: newest.seq,
+      limit: FULL_LOAD_PAGE_SIZE,
+    });
+    messages.push(...page.messages);
+  }
+  return messages;
+}

--- a/client/dashboard/src/pages/chatLogs/useChatTranscript.ts
+++ b/client/dashboard/src/pages/chatLogs/useChatTranscript.ts
@@ -1,12 +1,13 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import type { Chat } from "@gram/client/models/components/chat.js";
 import type { ChatMessage } from "@gram/client/models/components/chatmessage.js";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
 import { useSdkClient } from "@/contexts/Sdk";
+import { FULL_LOAD_PAGE_SIZE } from "./transcriptFull";
 
 // Page size for keyset pagination. Kept under the server's max (200) so the
-// initial paint is cheap on long chats; older pages stream in on scroll.
+// initial paint is cheap on long chats; further pages stream in on scroll.
 export const TRANSCRIPT_PAGE_SIZE = 50;
 
 // Cursor encodes which keyset edge to fetch. "start" requests the oldest page
@@ -34,13 +35,16 @@ export interface ChatTranscript {
   fetchNewer: () => void;
   isFetchingOlder: boolean;
   isFetchingNewer: boolean;
+  /** Load every remaining message below the loaded window (the from-start
+   * transcript's only missing range, so this completes the conversation). */
+  loadRest: () => void;
+  isLoadingRest: boolean;
 }
 
 // useChatTranscript paginates a chat's latest generation by seq keyset. The
-// initial page is the newest slice; scrolling up fetches older pages (mapped to
-// React Query's "previous" direction) and the rare scroll-down tail fetches
-// newer pages ("next"). Pages are stored oldest-first so flattening yields a
-// single ascending transcript.
+// initial page is the start of the thread; scrolling streams further pages in,
+// and loadRest drains every remaining message on demand (the transcript never
+// auto-loads the whole history).
 export function useChatTranscript(
   chatId: string,
   enabled: boolean,
@@ -61,7 +65,12 @@ export function useChatTranscript(
       } = { id: chatId, limit: TRANSCRIPT_PAGE_SIZE };
       if (pageParam.dir === "start") request.fromStart = true;
       if (pageParam.dir === "before") request.beforeSeq = pageParam.seq;
-      if (pageParam.dir === "after") request.afterSeq = pageParam.seq;
+      if (pageParam.dir === "after") {
+        request.afterSeq = pageParam.seq;
+        // Forward pages also serve the load-the-rest drain, so use the server's
+        // max page to finish in as few round trips as possible.
+        request.limit = FULL_LOAD_PAGE_SIZE;
+      }
       return client.chat.load(request);
     },
     // "previous" = older. firstPage is the oldest page currently held.
@@ -86,6 +95,22 @@ export function useChatTranscript(
         (error.statusCode === 404 || error.statusCode === 403)
       ),
   });
+
+  // On-demand drain: while set, keep pulling forward pages until the server
+  // reports nothing newer. Only ever started by loadRest (a user action), so
+  // the transcript stays lazily paginated by default. Errors stop the drain
+  // (the transcript's break divider stays as a manual retry).
+  const [draining, setDraining] = useState(false);
+  useEffect(() => setDraining(false), [chatId]);
+  const { hasNextPage, isFetchingNextPage, isError, fetchNextPage } = query;
+  useEffect(() => {
+    if (!draining) return;
+    if (isError || !hasNextPage) {
+      setDraining(false);
+      return;
+    }
+    if (!isFetchingNextPage) void fetchNextPage();
+  }, [draining, hasNextPage, isFetchingNextPage, isError, fetchNextPage]);
 
   const messages = useMemo(
     () => (query.data?.pages ?? []).flatMap((p) => p.messages),
@@ -124,5 +149,7 @@ export function useChatTranscript(
     },
     isFetchingOlder: query.isFetchingPreviousPage,
     isFetchingNewer: query.isFetchingNextPage,
+    loadRest: () => setDraining(true),
+    isLoadingRest: draining,
   };
 }

--- a/client/dashboard/src/pages/chatLogs/useWindowedTranscript.ts
+++ b/client/dashboard/src/pages/chatLogs/useWindowedTranscript.ts
@@ -6,12 +6,13 @@ import { GramError } from "@gram/client/models/errors/gramerror.js";
 import { useLoadChat } from "@gram/client/react-query/loadChat.js";
 import { useSdkClient } from "@/contexts/Sdk";
 import { TRANSCRIPT_PAGE_SIZE } from "./useChatTranscript";
+import { fetchFullTranscript, FULL_LOAD_PAGE_SIZE } from "./transcriptFull";
 
 // Initial window is generous so most matches + context arrive in one request;
 // gaps between disjoint windows are expanded on demand.
 const WINDOW_INITIAL_LIMIT = 200;
 
-type WindowLoadKey = "before" | "after" | `gap:${number}`;
+type WindowLoadKey = "before" | "after" | "all" | `gap:${number}`;
 
 export interface WindowedTranscript {
   chat: Chat | undefined;
@@ -20,9 +21,15 @@ export interface WindowedTranscript {
   gaps: Set<number>;
   hasMoreBefore: boolean;
   hasMoreAfter: boolean;
+  /** Single-page edge loads, for scroll-driven streaming. */
   loadBefore: () => void;
   loadAfter: () => void;
+  /** Full-range loads: everything above / below the window, the entirety of
+   * one gap, or the chat's whole remaining history. */
+  loadAllBefore: () => void;
+  loadAllAfter: () => void;
   loadGap: (afterSeq: number) => void;
+  loadAll: () => void;
   loadingKey: WindowLoadKey | null;
   isLoading: boolean;
   isError: boolean;
@@ -75,8 +82,9 @@ function buildInitial(chat: Chat, segments: RiskSegment[]): WindowState {
 // disjoint windows. The mode is decided by `request`: `{ riskOnly: true }`
 // windows around risk findings (segments in `risk_segments`), `{ query }`
 // windows around text-search matches (segments in `match_segments`). The
-// incremental expansion is identical for both modes: plain before_seq/after_seq
-// page loads merged into the window.
+// incremental expansion is identical for both modes: scrolling streams
+// single pages at the edges, while the divider buttons load a full range
+// (the whole gap / everything above or below) in one action.
 export function useWindowedTranscript(
   chatId: string,
   enabled: boolean,
@@ -118,7 +126,7 @@ export function useWindowedTranscript(
   // Clear in-flight loading state when the request changes (chat switch or new
   // query). The previous request's in-flight load is guarded out of its own
   // finally (it checks requestKeyRef), so without this reset `loadingKey` could
-  // stay stuck and permanently disable loadBefore/After/Gap.
+  // stay stuck and permanently disable the incremental loads.
   useEffect(() => {
     setLoadingKey(null);
     setLoadError(false);
@@ -135,23 +143,22 @@ export function useWindowedTranscript(
     }
   }, [base.data, riskOnly]);
 
-  // Runs one incremental page load: ignores the result if the active request
-  // changed mid-flight (chat switch or new query), and records failures so they
-  // surface via isError instead of silently no-opping.
+  // Runs one incremental load: `run` fetches (one page or a whole range) and
+  // returns the state update to apply. The result is ignored if the active
+  // request changed mid-flight (chat switch or new query), and failures are
+  // recorded so they surface via isError instead of silently no-opping.
   const runIncrementalLoad = useCallback(
     (
       key: WindowLoadKey,
-      req: { beforeSeq?: number; afterSeq?: number },
-      apply: (prev: WindowState, page: Chat) => WindowState,
+      run: () => Promise<(prev: WindowState) => WindowState>,
     ) => {
       if (loadingKey) return;
       const startKey = requestKeyRef.current;
       setLoadingKey(key);
-      void client.chat
-        .load({ id: chatId, limit: TRANSCRIPT_PAGE_SIZE, ...req })
-        .then((page) => {
+      void run()
+        .then((apply) => {
           if (requestKeyRef.current !== startKey) return; // request changed
-          setState((prev) => (prev ? apply(prev, page) : prev));
+          setState((prev) => (prev ? apply(prev) : prev));
         })
         .catch(() => {
           if (requestKeyRef.current === startKey) setLoadError(true);
@@ -160,58 +167,157 @@ export function useWindowedTranscript(
           if (requestKeyRef.current === startKey) setLoadingKey(null);
         });
     },
-    [client, chatId, loadingKey],
+    [loadingKey],
   );
 
   const loadBefore = useCallback(() => {
     if (!state || !state.hasMoreBefore) return;
     const oldest = state.messages[0];
     if (!oldest) return;
-    runIncrementalLoad("before", { beforeSeq: oldest.seq }, (prev, page) => ({
-      ...prev,
-      messages: mergeSorted(page.messages, prev.messages),
-      hasMoreBefore: page.hasMoreBefore,
-    }));
-  }, [state, runIncrementalLoad]);
+    runIncrementalLoad("before", async () => {
+      const page = await client.chat.load({
+        id: chatId,
+        beforeSeq: oldest.seq,
+        limit: TRANSCRIPT_PAGE_SIZE,
+      });
+      return (prev) => ({
+        ...prev,
+        messages: mergeSorted(page.messages, prev.messages),
+        hasMoreBefore: page.hasMoreBefore,
+      });
+    });
+  }, [state, runIncrementalLoad, client, chatId]);
 
   const loadAfter = useCallback(() => {
     if (!state || !state.hasMoreAfter) return;
     const newest = state.messages[state.messages.length - 1];
     if (!newest) return;
-    runIncrementalLoad("after", { afterSeq: newest.seq }, (prev, page) => ({
-      ...prev,
-      messages: mergeSorted(prev.messages, page.messages),
-      hasMoreAfter: page.hasMoreAfter,
-    }));
-  }, [state, runIncrementalLoad]);
+    runIncrementalLoad("after", async () => {
+      const page = await client.chat.load({
+        id: chatId,
+        afterSeq: newest.seq,
+        limit: TRANSCRIPT_PAGE_SIZE,
+      });
+      return (prev) => ({
+        ...prev,
+        messages: mergeSorted(prev.messages, page.messages),
+        hasMoreAfter: page.hasMoreAfter,
+      });
+    });
+  }, [state, runIncrementalLoad, client, chatId]);
 
+  const loadAllBefore = useCallback(() => {
+    if (!state || !state.hasMoreBefore) return;
+    const oldest = state.messages[0];
+    if (!oldest) return;
+    runIncrementalLoad("before", async () => {
+      const collected: ChatMessage[] = [];
+      let cursor = oldest.seq;
+      let more = true;
+      while (more) {
+        const page = await client.chat.load({
+          id: chatId,
+          beforeSeq: cursor,
+          limit: FULL_LOAD_PAGE_SIZE,
+        });
+        collected.push(...page.messages);
+        // Pages arrive ascending; the first row is the new oldest edge.
+        const pageOldest = page.messages[0];
+        more = page.hasMoreBefore && !!pageOldest && pageOldest.seq !== cursor;
+        cursor = pageOldest?.seq ?? cursor;
+      }
+      return (prev) => ({
+        ...prev,
+        messages: mergeSorted(collected, prev.messages),
+        hasMoreBefore: false,
+      });
+    });
+  }, [state, runIncrementalLoad, client, chatId]);
+
+  const loadAllAfter = useCallback(() => {
+    if (!state || !state.hasMoreAfter) return;
+    const newest = state.messages[state.messages.length - 1];
+    if (!newest) return;
+    runIncrementalLoad("after", async () => {
+      const collected: ChatMessage[] = [];
+      let cursor = newest.seq;
+      let more = true;
+      while (more) {
+        const page = await client.chat.load({
+          id: chatId,
+          afterSeq: cursor,
+          limit: FULL_LOAD_PAGE_SIZE,
+        });
+        collected.push(...page.messages);
+        const pageNewest = page.messages[page.messages.length - 1];
+        more = page.hasMoreAfter && !!pageNewest && pageNewest.seq !== cursor;
+        cursor = pageNewest?.seq ?? cursor;
+      }
+      return (prev) => ({
+        ...prev,
+        messages: mergeSorted(prev.messages, collected),
+        hasMoreAfter: false,
+      });
+    });
+  }, [state, runIncrementalLoad, client, chatId]);
+
+  // Loads the ENTIRE gap after `afterSeq`: pages forward until the walk
+  // reaches the next already-loaded message, so one click closes the break.
   const loadGap = useCallback(
     (afterSeq: number) => {
       if (!state) return;
-      runIncrementalLoad(`gap:${afterSeq}`, { afterSeq }, (prev, page) => {
-        // The message immediately after the gap, by seq (messages stay sorted
-        // ascending via mergeSorted, so find() is enough).
-        const nextSeq = prev.messages.find((m) => m.seq > afterSeq)?.seq;
-        const maxLoaded = page.messages.reduce(
-          (mx, m) => Math.max(mx, m.seq),
-          afterSeq,
-        );
-        const gaps = new Set(prev.gaps);
-        gaps.delete(afterSeq);
-        // Gap stays open (advanced to the new edge) only if the page didn't
-        // reach the next already-loaded message.
-        if (nextSeq !== undefined && maxLoaded < nextSeq) {
-          gaps.add(maxLoaded);
+      // The message immediately after the gap, by seq (messages stay sorted
+      // ascending via mergeSorted, so find() is enough).
+      const nextSeq = state.messages.find((m) => m.seq > afterSeq)?.seq;
+      runIncrementalLoad(`gap:${afterSeq}`, async () => {
+        const collected: ChatMessage[] = [];
+        let cursor = afterSeq;
+        let more = true;
+        while (more) {
+          const page = await client.chat.load({
+            id: chatId,
+            afterSeq: cursor,
+            limit: FULL_LOAD_PAGE_SIZE,
+          });
+          collected.push(...page.messages);
+          const pageNewest = page.messages[page.messages.length - 1];
+          const reachedNext =
+            nextSeq !== undefined && !!pageNewest && pageNewest.seq >= nextSeq;
+          more =
+            !reachedNext &&
+            page.hasMoreAfter &&
+            !!pageNewest &&
+            pageNewest.seq !== cursor;
+          cursor = pageNewest?.seq ?? cursor;
         }
-        return {
-          ...prev,
-          messages: mergeSorted(prev.messages, page.messages),
-          gaps,
+        return (prev) => {
+          const gaps = new Set(prev.gaps);
+          gaps.delete(afterSeq);
+          return {
+            ...prev,
+            messages: mergeSorted(prev.messages, collected),
+            gaps,
+          };
         };
       });
     },
-    [state, runIncrementalLoad],
+    [state, runIncrementalLoad, client, chatId],
   );
+
+  // Loads the chat's complete history in one action: full from-start walk
+  // merged over the window, clearing every gap and both edges.
+  const loadAll = useCallback(() => {
+    if (!state) return;
+    runIncrementalLoad("all", async () => {
+      const all = await fetchFullTranscript(client, chatId);
+      return (prev) => ({
+        messages: mergeSorted(prev.messages, all),
+        gaps: new Set<number>(),
+        hasMoreBefore: false,
+        hasMoreAfter: false,
+      });
+    });
+  }, [state, runIncrementalLoad, client, chatId]);
 
   return {
     chat: base.data,
@@ -223,7 +329,10 @@ export function useWindowedTranscript(
       base.error instanceof GramError && base.error.statusCode === 403,
     loadBefore,
     loadAfter,
+    loadAllBefore,
+    loadAllAfter,
     loadGap,
+    loadAll,
     loadingKey,
     isLoading: base.isLoading,
     isError: base.isError || loadError,

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -2637,8 +2637,12 @@ function SessionTranscript({
       hasMoreAfter: transcript.hasMoreAfter,
       onLoadOlder: transcript.fetchOlder,
       onLoadNewer: transcript.fetchNewer,
+      // The from-start transcript's only missing range is the tail, so the
+      // break button drains the rest of the conversation.
+      onLoadAllOlder: transcript.fetchOlder,
+      onLoadAllNewer: transcript.loadRest,
       isFetchingOlder: transcript.isFetchingOlder,
-      isFetchingNewer: transcript.isFetchingNewer,
+      isFetchingNewer: transcript.isFetchingNewer || transcript.isLoadingRest,
       initialScrollIndex: null,
       scrollToFinding: false,
     }),
@@ -2647,8 +2651,10 @@ function SessionTranscript({
       transcript.hasMoreAfter,
       transcript.fetchOlder,
       transcript.fetchNewer,
+      transcript.loadRest,
       transcript.isFetchingOlder,
       transcript.isFetchingNewer,
+      transcript.isLoadingRest,
     ],
   );
   const rowCtx = useMemo<RowContext>(


### PR DESCRIPTION
Currently, chat transcripts only load some of the messages and it's either finicky or impossible to get it to load the rest. 
- Fixes the chat breakpoints so that clicking them properly loads the missing messages
- The "download chat" button now always downloads the entire transcript

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes partial chat transcript loading so breaks and edges load all missing messages, and the “Download chat” export always includes the full transcript. Adds a one-click “Load all messages” action.

- **Bug Fixes**
  - Break dividers now load the full missing range (entire gap/earlier/remaining messages); scrolling still streams single pages.
  - Risk/search windowed transcripts correctly expand gaps and edges.
  - Export downloads the complete transcript by fetching it server-side, independent of what’s visible.

- **New Features**
  - “Load all messages” button appears when any messages are missing and fetches everything in one click.
  - From-start transcripts can drain the rest of the conversation via `loadRest`; edge buttons use full-range loads.

<sup>Written for commit 3b20b14cc306fc64a8313e3cf777b313e33b510f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

