### PR TITLE
chore: add Playwright CLI workflow for agents

### DIFF
--- a/.agents/skills/gram-playwright-cli/SKILL.md
+++ b/.agents/skills/gram-playwright-cli/SKILL.md
@@ -169,7 +169,8 @@ mise run playwright video-chapter "Chapter Title" --description="Details" --dura
 mise run playwright video-stop
 
 # annotate each subsequent action (click, type, ...) with a callout naming the action and highlighting the target
-mise run playwright video-show-actions --duration=600 --position=top-right
+# --cursor accepts pointer (the default) or none
+mise run playwright video-show-actions --duration=600 --position=top-right --cursor=pointer
 mise run playwright video-hide-actions
 
 # launch the dashboard for UI review / design feedback — user annotates the page, you receive the annotated screenshot, snapshot, and notes

--- a/.agents/skills/gram-playwright-cli/SKILL.md
+++ b/.agents/skills/gram-playwright-cli/SKILL.md
@@ -1,0 +1,416 @@
+---
+name: gram-playwright-cli
+description: Use when automating the Gram dashboard in a browser, capturing screenshots, inspecting pages.
+---
+
+# Browser Automation with Playwright CLI in Gram
+
+## Quick start
+
+```bash
+# open new browser
+mise run playwright open
+# navigate to a page
+mise run playwright goto https://playwright.dev
+# interact with the page using refs from the snapshot
+mise run playwright click e15
+mise run playwright type "page.click"
+mise run playwright press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+mise run playwright screenshot
+# close the browser
+mise run playwright close
+```
+
+## Commands
+
+### Core
+
+```bash
+mise run playwright open
+# open and navigate right away
+mise run playwright open https://example.com/
+mise run playwright goto https://playwright.dev
+mise run playwright type "search query"
+mise run playwright click e3
+mise run playwright dblclick e7
+# --submit presses Enter after filling the element
+mise run playwright fill e5 "user@example.com"  --submit
+mise run playwright drag e2 e8
+# drop files or data onto an element (from outside the page)
+mise run playwright drop e4 --path=./image.png
+mise run playwright drop e4 --data="text/plain=hello world"
+mise run playwright hover e4
+mise run playwright select e9 "option-value"
+mise run playwright upload ./document.pdf
+mise run playwright check e12
+mise run playwright uncheck e12
+mise run playwright snapshot
+# search the snapshot for text or a regexp, returns matching nodes with surrounding context
+mise run playwright find "Sign in"
+mise run playwright find --regex "Sign (in|up)"
+# wrap the regexp in slashes to add flags, e.g. /i for case-insensitive
+mise run playwright find --regex "/sign (in|up)/i"
+mise run playwright eval "document.title"
+mise run playwright eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+mise run playwright eval "el => el.id" e5
+mise run playwright eval "el => el.getAttribute('data-testid')" e5
+mise run playwright dialog-accept
+mise run playwright dialog-accept "confirmation text"
+mise run playwright dialog-dismiss
+mise run playwright resize 1920 1080
+mise run playwright close
+```
+
+### Navigation
+
+```bash
+mise run playwright go-back
+mise run playwright go-forward
+mise run playwright reload
+```
+
+### Keyboard
+
+```bash
+mise run playwright press Enter
+mise run playwright press ArrowDown
+mise run playwright keydown Shift
+mise run playwright keyup Shift
+```
+
+### Mouse
+
+```bash
+mise run playwright mousemove 150 300
+mise run playwright mousedown
+mise run playwright mousedown right
+mise run playwright mouseup
+mise run playwright mouseup right
+mise run playwright mousewheel 0 100
+```
+
+### Save as
+
+```bash
+mise run playwright screenshot
+mise run playwright screenshot e5
+mise run playwright screenshot --filename=page.png
+mise run playwright screenshot --hires
+mise run playwright pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+mise run playwright tab-list
+mise run playwright tab-new
+mise run playwright tab-new https://example.com/page
+mise run playwright tab-close
+mise run playwright tab-close 2
+mise run playwright tab-select 0
+```
+
+### Storage
+
+```bash
+mise run playwright state-save
+mise run playwright state-save auth.json
+mise run playwright state-load auth.json
+
+# Cookies
+mise run playwright cookie-list
+mise run playwright cookie-list --domain=example.com
+mise run playwright cookie-get session_id
+mise run playwright cookie-set session_id abc123
+mise run playwright cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+mise run playwright cookie-delete session_id
+mise run playwright cookie-clear
+
+# LocalStorage
+mise run playwright localstorage-list
+mise run playwright localstorage-get theme
+mise run playwright localstorage-set theme dark
+mise run playwright localstorage-delete theme
+mise run playwright localstorage-clear
+
+# SessionStorage
+mise run playwright sessionstorage-list
+mise run playwright sessionstorage-get step
+mise run playwright sessionstorage-set step 3
+mise run playwright sessionstorage-delete step
+mise run playwright sessionstorage-clear
+```
+
+### Network
+
+```bash
+mise run playwright route "**/*.jpg" --status=404
+mise run playwright route "https://api.example.com/**" --body='{"mock": true}'
+mise run playwright route-list
+mise run playwright unroute "**/*.jpg"
+mise run playwright unroute
+```
+
+### DevTools
+
+```bash
+mise run playwright console
+mise run playwright console warning
+mise run playwright requests
+mise run playwright request 5
+mise run playwright run-code "async page => await page.context().grantPermissions(['geolocation'])"
+mise run playwright run-code --filename=script.js
+mise run playwright tracing-start
+mise run playwright tracing-stop
+mise run playwright video-start video.webm
+mise run playwright video-chapter "Chapter Title" --description="Details" --duration=2000
+mise run playwright video-stop
+
+# annotate each subsequent action (click, type, ...) with a callout naming the action and highlighting the target
+mise run playwright video-show-actions --duration=600 --position=top-right
+mise run playwright video-hide-actions
+
+# launch the dashboard for UI review / design feedback — user annotates the page, you receive the annotated screenshot, snapshot, and notes
+mise run playwright show --annotate
+
+# generate a Playwright locator for an element from its ref or selector
+mise run playwright generate-locator e5 --raw
+
+# show a persistent highlight overlay for an element, optionally with a custom style
+mise run playwright highlight e5
+mise run playwright highlight e5 --style="outline: 3px dashed red"
+# hide a single element highlight, or all page highlights when no target is given
+mise run playwright highlight e5 --hide
+mise run playwright highlight --hide
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+mise run playwright --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+mise run playwright --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+mise run playwright --raw snapshot > before.yml
+mise run playwright click e5
+mise run playwright --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(mise run playwright --raw cookie-get session_id)
+mise run playwright --raw localstorage-get theme
+```
+
+For structured output wrapping every reply as JSON, pass --json
+
+```bash
+mise run playwright list --json
+```
+
+## Open parameters
+
+```bash
+# Use specific browser when creating session
+mise run playwright open --browser=chrome
+mise run playwright open --browser=firefox
+mise run playwright open --browser=webkit
+mise run playwright open --browser=msedge
+
+# Emulate a generic mobile device (Pixel 10 for Chromium, iPhone 17 for WebKit).
+# Prefer this when a mobile layout is acceptable: mobile pages are usually
+# lighter, so snapshots are smaller and cheaper.
+mise run playwright open --mobile
+mise run playwright open --device="iPhone 15"
+
+# Use persistent profile (by default profile is in-memory)
+mise run playwright open --persistent
+# Use persistent profile with custom directory
+mise run playwright open --profile=/path/to/profile
+
+# Connect to browser via Playwright Extension
+mise run playwright attach --extension=chrome
+
+# Connect to a running Chrome or Edge by channel name
+mise run playwright attach --cdp=chrome
+mise run playwright attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+mise run playwright attach --cdp=http://localhost:9222
+
+# Start with config file
+mise run playwright open --config=my-config.json
+
+# Close the browser
+mise run playwright close
+# Detach from an attached browser (leaves the external browser running)
+mise run playwright -s=msedge detach
+# Delete user data for the default session
+mise run playwright delete-data
+```
+
+## URLs with `&` on Windows
+
+On Windows, `cmd.exe` and PowerShell treat `&` as a command separator, so URLs with multiple query parameters get truncated before `mise run playwright` runs. Escape `&` with `^&` in `cmd.exe`, or use `--%` in PowerShell:
+
+```batch
+mise run playwright goto "https://example.com/?a=1^&b=2"
+```
+
+```powershell
+mise run playwright --% goto "https://example.com/?a=1&b=2"
+```
+
+## Snapshots
+
+After each command, mise run playwright provides a snapshot of the current browser state.
+
+```bash
+> mise run playwright goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `mise run playwright snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+mise run playwright snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+mise run playwright snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+mise run playwright snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+mise run playwright snapshot --depth=4
+mise run playwright snapshot e34
+
+# include each element's bounding box as [box=x,y,width,height]
+mise run playwright snapshot --boxes
+
+# search a large snapshot instead of capturing it all — returns matching nodes
+# with 3 lines of context around each match (like grep -C)
+mise run playwright find "Add to cart"
+mise run playwright find --regex "\\$[0-9]+\\.[0-9]{2}"
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+mise run playwright snapshot
+
+# interact using a ref
+mise run playwright click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+mise run playwright click "#main > button.submit"
+
+# role locator
+mise run playwright click "getByRole('button', { name: 'Submit' })"
+
+# test id
+mise run playwright click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+mise run playwright -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+mise run playwright -s=mysession open example.com --profile=/path/to/profile
+mise run playwright -s=mysession click e6
+mise run playwright -s=mysession close  # stop a named browser
+mise run playwright -s=mysession delete-data  # delete user data for persistent session
+
+mise run playwright list
+# Close all browsers
+mise run playwright close-all
+# Forcefully kill all browser processes
+mise run playwright kill-all
+```
+
+## Gram repository setup
+
+Run browser automation through `mise run playwright`; the task supplies the repository config and installs Chromium on first use. Use existing `pnpm` package scripts for repository checks. Gram does not install `@playwright/test`, so do not bootstrap a Playwright test suite unless the user explicitly asks.
+
+```bash
+mise run playwright --help
+mise run playwright:install-browser --help
+```
+
+Do not use `npm`, `npx`, or `yarn` in this repository.
+
+## Example: Form submission
+
+```bash
+mise run playwright open https://example.com/form
+mise run playwright snapshot
+
+mise run playwright fill e1 "user@example.com"
+mise run playwright fill e2 "password123"
+mise run playwright click e3
+mise run playwright snapshot
+mise run playwright close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+mise run playwright open https://example.com
+mise run playwright tab-new https://example.com/other
+mise run playwright tab-list
+mise run playwright tab-select 0
+mise run playwright snapshot
+mise run playwright close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+mise run playwright open https://example.com
+mise run playwright click e4
+mise run playwright fill e7 "test"
+mise run playwright console
+mise run playwright requests
+mise run playwright close
+```
+
+```bash
+mise run playwright open https://example.com
+mise run playwright tracing-start
+mise run playwright click e4
+mise run playwright fill e7 "test"
+mise run playwright tracing-stop
+mise run playwright close
+```
+
+## Example: Interactive session
+
+Ask the user for UI review or design feedback. The user draws boxes on the live page and types comments; you receive the annotated screenshot, the snapshot of the marked region, and the user's notes. Use this whenever the user asks for "UI review", "design feedback", or to "ask the user what they think / want / mean":
+
+```bash
+mise run playwright open https://example.com
+mise run playwright show --annotate
+```
+
+## Specific tasks
+
+- **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+- **Running Playwright code** [references/running-code.md](references/running-code.md)
+- **Browser session management** [references/session-management.md](references/session-management.md)
+- **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+- **Tracing** [references/tracing.md](references/tracing.md)
+- **Video recording** [references/video-recording.md](references/video-recording.md)
+- **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/.agents/skills/gram-playwright-cli/references/element-attributes.md
+++ b/.agents/skills/gram-playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+mise run playwright snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+mise run playwright eval "el => el.id" e7
+
+# get all CSS classes
+mise run playwright eval "el => el.className" e7
+
+# get a specific attribute
+mise run playwright eval "el => el.getAttribute('data-testid')" e7
+mise run playwright eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+mise run playwright eval "el => getComputedStyle(el).display" e7
+```

--- a/.agents/skills/gram-playwright-cli/references/request-mocking.md
+++ b/.agents/skills/gram-playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+mise run playwright route "**/*.jpg" --status=404
+
+# Mock with JSON body
+mise run playwright route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+mise run playwright route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+mise run playwright route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+mise run playwright route-list
+
+# Remove a route or all routes
+mise run playwright unroute "**/*.jpg"
+mise run playwright unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+mise run playwright run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+mise run playwright run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+mise run playwright run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+mise run playwright run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.agents/skills/gram-playwright-cli/references/running-code.md
+++ b/.agents/skills/gram-playwright-cli/references/running-code.md
@@ -1,0 +1,240 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+mise run playwright run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+You can also load the function from a file:
+
+```bash
+mise run playwright run-code --filename=./my-script.js
+```
+
+The code must be a single function expression, it is wrapped in `(...)` and evaluated.
+import/export/require syntax is not supported.
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+mise run playwright run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+mise run playwright run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+mise run playwright run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+mise run playwright run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+mise run playwright run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+mise run playwright run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+mise run playwright run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+mise run playwright run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+mise run playwright run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+mise run playwright run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+mise run playwright run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+mise run playwright run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+mise run playwright run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+mise run playwright run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+mise run playwright run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+mise run playwright run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+mise run playwright run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+mise run playwright run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+mise run playwright run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+mise run playwright run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+mise run playwright run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+mise run playwright run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+mise run playwright run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+mise run playwright run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+mise run playwright run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+mise run playwright run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+mise run playwright run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.agents/skills/gram-playwright-cli/references/session-management.md
+++ b/.agents/skills/gram-playwright-cli/references/session-management.md
@@ -1,0 +1,226 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+mise run playwright -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+mise run playwright -s=public open https://example.com
+
+# Commands are isolated by browser session
+mise run playwright -s=auth fill e1 "user@example.com"
+mise run playwright -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+mise run playwright list
+
+# Stop a browser session (close the browser)
+mise run playwright close                # stop the default browser
+mise run playwright -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+mise run playwright close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+mise run playwright kill-all
+
+# Delete browser session user data (profile directory)
+mise run playwright delete-data                # delete default browser data
+mise run playwright -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+mise run playwright open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+mise run playwright -s=site1 open https://site1.com &
+mise run playwright -s=site2 open https://site2.com &
+mise run playwright -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+mise run playwright -s=site1 snapshot
+mise run playwright -s=site2 snapshot
+mise run playwright -s=site3 snapshot
+
+# Cleanup
+mise run playwright close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+mise run playwright -s=variant-a open "https://app.com?variant=a"
+mise run playwright -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+mise run playwright -s=variant-a screenshot
+mise run playwright -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+mise run playwright open https://example.com --persistent
+
+# Use persistent profile with custom directory
+mise run playwright open https://example.com --profile=/path/to/profile
+```
+
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+mise run playwright attach --cdp=chrome
+
+# Attach to Chrome Canary
+mise run playwright attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+mise run playwright attach --cdp=msedge
+
+# Attach to Edge Dev
+mise run playwright attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+When `--session` is not provided, the session is named after the channel (e.g. `--cdp=msedge` creates a session called `msedge`), so parallel attaches to Chrome and Edge don't collide on `default`. Pass `--session=<name>` to override.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+mise run playwright attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+mise run playwright attach --extension
+```
+
+### Detach
+
+Tear down an attached session without affecting the external browser:
+
+```bash
+# Detach the default attached session
+mise run playwright detach
+
+# Detach a specific attached session
+mise run playwright -s=msedge detach
+```
+
+`detach` only works on sessions created via `attach`. For sessions created via `open`, use `close`.
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+mise run playwright open https://example.com
+mise run playwright snapshot
+mise run playwright close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+mise run playwright open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+mise run playwright open https://example.com --browser=firefox
+
+# Open in headed mode
+mise run playwright open https://example.com --headed
+
+# Open with persistent profile
+mise run playwright open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+mise run playwright -s=github-auth open https://github.com
+mise run playwright -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+mise run playwright -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+mise run playwright -s=auth close
+mise run playwright -s=scrape close
+
+# Or stop all at once
+mise run playwright close-all
+
+# If browsers become unresponsive or zombie processes remain
+mise run playwright kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+mise run playwright -s=oldsession delete-data
+```

--- a/.agents/skills/gram-playwright-cli/references/storage-state.md
+++ b/.agents/skills/gram-playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+mise run playwright state-save
+
+# Save to specific filename
+mise run playwright state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+mise run playwright state-load my-auth-state.json
+
+# Reload page to apply cookies
+mise run playwright open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1893456000,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+mise run playwright cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+mise run playwright cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+mise run playwright cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+mise run playwright cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+mise run playwright cookie-set session abc123
+
+# Cookie with options
+mise run playwright cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+mise run playwright cookie-set remember_me token123 --expires=1893456000
+```
+
+### Delete a Cookie
+
+```bash
+mise run playwright cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+mise run playwright cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+mise run playwright run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+mise run playwright localstorage-list
+```
+
+### Get Single Value
+
+```bash
+mise run playwright localstorage-get token
+```
+
+### Set Value
+
+```bash
+mise run playwright localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+mise run playwright localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+mise run playwright localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+mise run playwright localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+mise run playwright run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+mise run playwright sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+mise run playwright sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+mise run playwright sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+mise run playwright sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+mise run playwright sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+mise run playwright run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+mise run playwright run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+mise run playwright open https://app.example.com/login
+mise run playwright snapshot
+mise run playwright fill e1 "user@example.com"
+mise run playwright fill e2 "password123"
+mise run playwright click e3
+
+# Save the authenticated state
+mise run playwright state-save auth.json
+
+# Step 2: Later, restore state and skip login
+mise run playwright state-load auth.json
+mise run playwright open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+mise run playwright open https://example.com
+mise run playwright eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+mise run playwright state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+mise run playwright state-load my-session.json
+mise run playwright open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.agents/skills/gram-playwright-cli/references/tracing.md
+++ b/.agents/skills/gram-playwright-cli/references/tracing.md
@@ -1,0 +1,142 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+mise run playwright tracing-start
+
+# Perform actions
+mise run playwright open https://example.com
+mise run playwright click e1
+mise run playwright fill e2 "test"
+
+# Stop trace recording
+mise run playwright tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category        | Details                                            |
+| --------------- | -------------------------------------------------- |
+| **Actions**     | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM**         | Full DOM snapshot before/after each action         |
+| **Screenshots** | Visual state at each step                          |
+| **Network**     | All requests, responses, headers, bodies, timing   |
+| **Console**     | All console.log, warn, error messages              |
+| **Timing**      | Precise timing for each operation                  |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+mise run playwright tracing-start
+mise run playwright open https://app.example.com
+
+# This click fails - why?
+mise run playwright click e5
+
+mise run playwright tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+mise run playwright tracing-start
+mise run playwright open https://slow-site.com
+mise run playwright tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+mise run playwright tracing-start
+
+mise run playwright open https://app.example.com/checkout
+mise run playwright fill e1 "4111111111111111"
+mise run playwright fill e2 "12/25"
+mise run playwright fill e3 "123"
+mise run playwright click e4
+
+mise run playwright tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature                 | Trace       | Video       | Screenshot       |
+| ----------------------- | ----------- | ----------- | ---------------- |
+| **Format**              | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection**      | Yes         | No          | No               |
+| **Network details**     | Yes         | No          | No               |
+| **Step-by-step replay** | Yes         | Continuous  | Single frame     |
+| **File size**           | Medium      | Large       | Small            |
+| **Best for**            | Debugging   | Demos       | Quick capture    |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+mise run playwright tracing-start
+mise run playwright open https://example.com
+# ... all steps leading to the issue ...
+mise run playwright tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.agents/skills/gram-playwright-cli/references/video-recording.md
+++ b/.agents/skills/gram-playwright-cli/references/video-recording.md
@@ -1,0 +1,157 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+mise run playwright open
+
+# Start recording
+mise run playwright video-start demo.webm
+
+# Add a chapter marker for section transitions
+mise run playwright video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+mise run playwright goto https://example.com
+mise run playwright snapshot
+mise run playwright click e1
+
+# Add another chapter
+mise run playwright video-chapter "Filling Form" --description="Entering test data" --duration=2000
+mise run playwright fill e2 "test input"
+
+# Stop and save
+mise run playwright video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+mise run playwright video-start recordings/login-flow-2024-01-15.webm
+mise run playwright video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows inserting appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1. Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
+2. Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3. Use mise run playwright run-code --filename your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+async (page) => {
+  await page.screencast.start({
+    path: "video.webm",
+    size: { width: 1280, height: 800 },
+  });
+  await page.goto("https://demo.playwright.dev/todomvc");
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter("Adding Todo Items", {
+    description: "We will add several items to the todo list.",
+    duration: 2000,
+  });
+
+  // Perform action
+  await page
+    .getByRole("textbox", { name: "What needs to be done?" })
+    .pressSequentially("Walk the dog", { delay: 60 });
+  await page
+    .getByRole("textbox", { name: "What needs to be done?" })
+    .press("Enter");
+  await page.waitForTimeout(1000);
+
+  // Show next chapter
+  await page.screencast.showChapter("Verifying Results", {
+    description: "Checking the item appeared in the list.",
+    duration: 2000,
+  });
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `);
+
+  // Perform more actions while the annotation is visible
+  await page
+    .getByRole("textbox", { name: "What needs to be done?" })
+    .pressSequentially("Buy groceries", { delay: 60 });
+  await page
+    .getByRole("textbox", { name: "What needs to be done?" })
+    .press("Enter");
+  await page.waitForTimeout(1500);
+
+  // Remove the annotation when done
+  await annotation.dispose();
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText("Walk the dog").boundingBox();
+  await page.screencast.showOverlay(
+    `
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `,
+    { duration: 2000 },
+  );
+
+  await page.screencast.stop();
+};
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method                                                                         | Use Case                                                                       |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })`                             | Custom HTML overlay — use for callouts, labels, highlights                     |
+| `disposable.dispose()`                                                         | Remove a sticky overlay added without duration                                 |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()`            | Temporarily hide/show all overlays                                             |
+
+## Tracing vs Video
+
+| Feature  | Video                | Tracing                                  |
+| -------- | -------------------- | ---------------------------------------- |
+| Output   | WebM file            | Trace file (viewable in Trace Viewer)    |
+| Shows    | Visual recording     | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis                      |
+| Size     | Larger               | Smaller                                  |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.agents/skills/pr-demo-gif/SKILL.md
+++ b/.agents/skills/pr-demo-gif/SKILL.md
@@ -1,149 +1,127 @@
 ---
 name: pr-demo-gif
-description: Use the Playwright MCP browser to capture a demo (screenshots or a GIF recording) of a user-visible frontend change and post it as a PR comment
-metadata:
-  relevant_files:
-    - "client/dashboard/**"
+description: Use when a pull request contains a user-visible Gram dashboard change that reviewers should see as a screenshot or short interaction demo.
 ---
 
 # Demos for frontend PRs
 
-When a PR contains a user-visible frontend change (dropdowns, dialogs, toolbars, filters, any interaction behavior in `client/dashboard`), capture a short demo of the change working and post it as a PR comment — proactively, without being asked. It shows reviewers the behavior instantly in a way a text description of click sequences cannot.
+Capture only the changed dashboard behavior and post it as a PR comment. Use one or two PNGs for a static visual change; use a 10–20 second GIF for an interaction.
 
-Demo **only the changed interaction**. Do not tour the whole page.
-
-Pick the format:
-
-- **Static change** (styling, layout, a new panel or empty state) → one or two screenshots via `browser_take_screenshot`.
-- **Interaction change** (something opens, filters, animates, reorders) → a 10–20 second GIF made from the session video.
+**REQUIRED SUB-SKILL:** Use `gram-playwright-cli` for browser commands.
 
 ## Prerequisites
 
-- Discover the dashboard URL with `mise run zero:summary` — read the address from the **Gram dashboard** row (don't assume a port). The same table shows whether each service is RUNNING; if the dashboard or server is STOPPED, start the stack with `madprocs` first. Dev-idp auto-login is enabled, and the local TLS cert is browser-trusted (mkcert CA in the NSS store, set up by `mise run zero:tls` — rerun that if you see cert errors).
-- Use the **`ecommerce-api`** project for all flows (`default` is empty). Before recording, verify the database is seeded by probing it directly (the connection string is in the **Database** row of `zero:summary`):
+1. Run `mise run zero:summary`. Read the URL from the **Gram dashboard** row; do not assume a port. Start stopped dashboard or server processes with `madprocs`.
+2. Use the `ecommerce-api` project. Verify the seed using the database URL from the **Database** row:
 
-  ```bash
-  psql "<database-url>" -c "SELECT p.slug, om.gram_account_type FROM projects p JOIN organization_metadata om ON om.id = p.organization_id WHERE p.slug = 'ecommerce-api' AND NOT p.deleted;"
-  ```
+   ```bash
+   psql "<database-url>" -c "SELECT p.slug, om.gram_account_type FROM projects p JOIN organization_metadata om ON om.id = p.organization_id WHERE p.slug = 'ecommerce-api' AND NOT p.deleted;"
+   ```
 
-  Expect one row with `gram_account_type = 'enterprise'` (the seed sets that last, so it doubles as a completeness check). No row, or a different account type, means the stack isn't (fully) seeded — run `mise run seed`, then proceed. Paths like `/speakeasy/ecommerce-api/insights` redirect to `/speakeasy/projects/ecommerce-api/insights`.
+   Expect one row with `gram_account_type = 'enterprise'`. Otherwise run `mise run seed` before continuing.
 
-- Drive the browser exclusively through the **Playwright MCP tools**.
-- `ffmpeg` is available at `./tools/ffmpeg` as a managed mise tool. Nothing needs installing.
+3. Invoke Playwright only through `mise run playwright`. The task uses the repo configuration and installs Chromium on demand.
+4. Use `./tools/ffmpeg` for GIF conversion.
 
-## How recording works
+The login flow is credential-less: open the dashboard, click **Login** if redirected, and wait for `/speakeasy`. If the first load is blank after a fresh browser install, navigate to the URL again.
 
-Every Playwright MCP session records video (configured in `.playwright-mcp.config.json` at the repo root). The `.webm` is written to `.playwright-mcp/videos/` when the session ends via `browser_close` — video capture cannot be started or stopped mid-session. That shapes the whole workflow: **rehearse in one session, throw that video away, then do one clean choreographed take in a fresh session.**
+## 1. Rehearse
 
-Login flow (needed at most once — the browser profile persists across sessions, so auth carries over into the clean take): `browser_navigate` to the dashboard URL → redirected to `/login` → click the **Login** button → dev-idp auto-authenticates → lands on `/speakeasy`. If the very first load in a fresh browser profile comes up blank or broken, just navigate again — Chromium's cert verifier can re-initialize mid-flight on first run; subsequent loads are stable.
-
-### 1. Rehearse
-
-Log in, navigate to the feature, and explore with `browser_snapshot` until you know the exact click sequence and the elements involved. Then `browser_close`, and clear out the rehearsal footage so the clean take is unambiguous:
+Use a named session so every command reaches the same browser:
 
 ```bash
-rm -f .playwright-mcp/videos/*.webm
+mise run playwright -s=pr-demo open "<dashboard-url>"
+mise run playwright -s=pr-demo snapshot
 ```
 
-### 2. Clean take
+Navigate to the feature and rehearse the exact interaction using snapshot refs. Keep the browser open. Video recording starts only when requested, so rehearsal does not create footage.
 
-Open a fresh session (already logged in) and:
+Return to the intended starting state before capture. Hide an irrelevant fixed development dock with `eval` only if it obscures the changed behavior; page navigation removes DOM-only adjustments.
 
-1. Navigate directly to the target page. The video records at 1920×1080, matching the default viewport 1:1, so don't `browser_resize` — a mismatched viewport gets letterboxed or scaled in the recording.
-2. Prepare the frame (below).
-3. Drive the interaction at a readable pace — pause with `browser_wait_for` (`time` param) between steps so each state change registers on screen. Keep the whole take ~10–20s.
-4. `browser_close` to flush the video. The lone `.webm` in `.playwright-mcp/videos/` is your take.
+## 2. Capture
 
-If the take goes wrong, just close, delete the videos, and take it again — takes are cheap.
-
-**Preparing the frame** (via `browser_evaluate`):
-
-- **Hide the fixed docks** — the "Ask anything" and "Developer Toolkit" `position:fixed` divs clutter the frame. Find them by `textContent` and set `display: none`.
-- **Inject a fake cursor** — recordings show no pointer, so overlay one:
-
-```js
-() => {
-  const c = document.createElement("div");
-  c.id = "__cursor";
-  Object.assign(c.style, {
-    position: "fixed",
-    left: "0",
-    top: "0",
-    width: "20px",
-    height: "20px",
-    borderRadius: "50%",
-    background: "rgba(255,80,80,.85)",
-    border: "2px solid white",
-    zIndex: "999999",
-    pointerEvents: "none",
-    transition: "transform .45s ease",
-    transform: "translate(-100px,-100px)",
-  });
-  document.body.appendChild(c);
-};
-```
-
-Both of these are DOM state — they vanish on navigation, so re-apply them if the demo crosses a page load (better: choreograph the demo within a single page).
-
-**Before each click**, glide the fake cursor onto the target so the viewer's eye follows the action: call `browser_evaluate` with the target element's ref and
-
-```js
-(el) => {
-  const r = el.getBoundingClientRect();
-  const c = document.getElementById("__cursor");
-  c.style.transform = `translate(${r.x + r.width / 2 - 10}px, ${r.y + r.height / 2 - 10}px)`;
-  c.animate(
-    [
-      { boxShadow: "0 0 0 0 rgba(255,80,80,.6)" },
-      { boxShadow: "0 0 0 14px rgba(255,80,80,0)" },
-    ],
-    { duration: 350, delay: 450 },
-  );
-};
-```
-
-then wait ~0.5s (`browser_wait_for`) for the glide to finish, then `browser_click` the element.
-
-Gotchas:
-
-- **Modal Radix layers set `pointer-events: none` on `<body>`**, so `browser_click` fails its actionability check. Fall back to `browser_run_code_unsafe` with a coordinate click: `const box = await page.locator(...).boundingBox(); await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);`
-- **Targets below the fold**: scroll them into view (`el.scrollIntoView({block: "center"})` via `browser_evaluate`) _before_ moving the cursor or measuring positions.
-- To debug a click that isn't landing, inject document-level capture listeners for `pointerdown/click` that `console.log` the actual target, and read them back with `browser_console_messages` — this reveals e.g. clicks resolving to `<html>` under a modal layer.
-
-### 3. Convert to GIF
-
-Work in the session scratchpad (never the repo tree). Trim the dead setup time at the start (`-ss`) and convert with a two-pass palette:
+Create ignored artifact directories:
 
 ```bash
-./tools/ffmpeg -ss <trim-seconds> -i .playwright-mcp/videos/<file>.webm \
+mkdir -p .playwright-cli/pr-demos /tmp/pr-demo
+```
+
+### Static change
+
+Prepare the exact frame, then capture a viewport or element screenshot:
+
+```bash
+mise run playwright -s=pr-demo screenshot --filename=.playwright-cli/pr-demos/demo.png
+mise run playwright -s=pr-demo screenshot <element-ref> --filename=.playwright-cli/pr-demos/demo-detail.png
+```
+
+Use `--full-page` only when the changed layout cannot fit in the configured 1440×900 viewport.
+
+### Interaction change
+
+Start recording only after the page is ready:
+
+```bash
+mise run playwright -s=pr-demo video-start .playwright-cli/pr-demos/demo.webm --size=1440x900
+mise run playwright -s=pr-demo video-show-actions --duration=700 --position=top-right --cursor=pointer
+```
+
+Perform the rehearsed clicks, fills, and navigation with normal CLI commands. The action overlay supplies the pointer, target highlight, and action label; do not inject a fake cursor. Let each important state remain visible long enough to read. When a longer hold is needed:
+
+```bash
+mise run playwright -s=pr-demo run-code "async page => await page.waitForTimeout(1000)"
+```
+
+For a meaningful transition, optionally add a short chapter card:
+
+```bash
+mise run playwright -s=pr-demo video-chapter "<title>" --description="<what changes>" --duration=1200
+```
+
+Stop recording to flush the WebM, then close the session:
+
+```bash
+mise run playwright -s=pr-demo video-stop
+mise run playwright -s=pr-demo close
+```
+
+If a take goes wrong, stop it, restore the starting state in a new session, and record again. Do not include setup, login, exploration, or unrelated page tours.
+
+## 3. Convert and inspect
+
+Convert interaction footage in the scratchpad with a two-pass palette:
+
+```bash
+./tools/ffmpeg -ss <trim-seconds> -i .playwright-cli/pr-demos/demo.webm \
   -vf "fps=10,scale=1200:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" \
-  demo.gif
+  /tmp/pr-demo/demo.gif
 ```
 
-The 1200px width is a legibility/size compromise for the 1920px-wide recording — UI text shrinks to ~62% in the GIF. If the demo hinges on small text, either bump the scale toward 1440 (bigger GIF) or crop to the relevant region instead of scaling: `crop=w:h:x:y` before the `fps=` filter. Sanity-check the GIF is under ~10 MB so it loads quickly in the PR.
+Inspect the final PNG or GIF before publishing. Confirm it shows the changed behavior, contains no sensitive data, and the GIF is under roughly 10 MB. Increase the scale toward 1440 for small text, or crop to the relevant region before `fps=` instead of shrinking the whole frame.
 
-For the screenshots path there is no conversion — `browser_take_screenshot` writes PNGs into `.playwright-mcp/` directly.
+## 4. Host in a secret gist
 
-### 4. Host in a secret gist
-
-GitHub's PR comment-attachment upload has **no API**, so host the GIF (or PNGs — images render inline from any URL) in a secret gist's git repo:
+GitHub does not expose PR attachment upload through its API. Create a secret gist from a text placeholder, then push the binary through the gist repository:
 
 ```bash
+cd /tmp/pr-demo
 echo "demo" > placeholder.md
-gh gist create placeholder.md --desc "PR demo"     # secret is the default; there is NO --secret flag
-git clone https://gist.github.com/<gist-id>.git gist && cd gist
-cp ../demo.gif .
-git add demo.gif && git commit -m "add demo gif"
-git -c credential.helper='!gh auth git-credential' push   # without this, push hangs on a credential prompt
+gh gist create placeholder.md --desc "PR demo"
+git clone https://gist.github.com/<gist-id>.git gist
+cp demo.gif gist/
+cd gist
+git add demo.gif
+git commit -m "add demo gif"
+git -c credential.helper='!gh auth git-credential' push
 ```
 
-Gotchas:
+For screenshots, copy the PNG from `.playwright-cli/pr-demos/` instead. Secret is the default; `gh gist create` has no `--secret` flag. Never pass a binary directly to `gh gist create`, because it silently fails. The raw URL is:
 
-- `gh gist create` **silently fails on binary files** — always create the gist from a placeholder text file, then push binaries via git.
-- The raw URL format is `https://gist.githubusercontent.com/<user>/<gist-id>/raw/<file>.gif`.
-- The gist raw URL is link-visible (like the PR itself) — fine for normal dashboard demos, but don't record anything sensitive.
+```text
+https://gist.githubusercontent.com/<user>/<gist-id>/raw/<file>
+```
 
-### 5. Post the PR comment
+## 5. Post the PR comment
 
 ```bash
 gh pr comment <pr> --body "$(cat <<'EOF'
@@ -152,11 +130,11 @@ gh pr comment <pr> --body "$(cat <<'EOF'
 ![demo](https://gist.githubusercontent.com/<user>/<gist-id>/raw/demo.gif)
 
 What it shows:
-1. <step>
-2. <step>
+1. <starting state>
+2. <interaction>
 3. <changed behavior>
 EOF
 )"
 ```
 
-Keep the "what it shows" list short and numbered, matching the recorded steps.
+Keep the numbered list short and aligned with the visible steps.

--- a/.agents/skills/pr-demo-gif/SKILL.md
+++ b/.agents/skills/pr-demo-gif/SKILL.md
@@ -51,11 +51,11 @@ mkdir -p .playwright-cli/pr-demos /tmp/pr-demo
 Prepare the exact frame, then capture a viewport or element screenshot:
 
 ```bash
-mise run playwright -s=pr-demo screenshot --filename=.playwright-cli/pr-demos/demo.png
-mise run playwright -s=pr-demo screenshot <element-ref> --filename=.playwright-cli/pr-demos/demo-detail.png
+mise run playwright -s=pr-demo screenshot --hires --filename=.playwright-cli/pr-demos/demo.png
+mise run playwright -s=pr-demo screenshot <element-ref> --hires --filename=.playwright-cli/pr-demos/demo-detail.png
 ```
 
-Use `--full-page` only when the changed layout cannot fit in the configured 1440×900 viewport.
+The shared config keeps the CSS viewport at 1440×900 and uses a 2× device scale factor, so `--hires` produces a crisp 2880×1800 viewport image. Use `--full-page` only when the changed layout cannot fit in the viewport.
 
 ### Interaction change
 

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ __pycache__/
 .uv-cache
 
 .playwright-mcp
+.playwright-cli

--- a/.mise-tasks/playwright/_default
+++ b/.mise-tasks/playwright/_default
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#MISE description="Run Playwright CLI, installing its browser on first use"
+
+set -e
+
+stderr_file="$(mktemp)"
+trap 'rm -f "$stderr_file"' EXIT
+
+if playwright-cli "$@" 2>"$stderr_file"; then
+  cat "$stderr_file" >&2
+  exit 0
+else
+  status=$?
+fi
+
+cat "$stderr_file" >&2
+
+if ! grep -Eq 'is not installed\. Run `playwright-cli install-browser' "$stderr_file"; then
+  exit "$status"
+fi
+
+echo "Installing Playwright browser and system dependencies..." >&2
+playwright-cli install-browser chromium --with-deps
+
+rm -f "$stderr_file"
+trap - EXIT
+exec playwright-cli "$@"

--- a/.mise-tasks/playwright/install-browser.sh
+++ b/.mise-tasks/playwright/install-browser.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+#MISE description="Install the Playwright browser and system dependencies"
+
+set -e
+
+exec playwright-cli install-browser chromium --with-deps "$@"

--- a/.playwright/cli.config.json
+++ b/.playwright/cli.config.json
@@ -1,0 +1,20 @@
+{
+  "browser": {
+    "browserName": "chromium",
+    "launchOptions": {
+      "headless": true
+    },
+    "contextOptions": {
+      "viewport": {
+        "width": 1440,
+        "height": 900
+      },
+      "deviceScaleFactor": 1,
+      "colorScheme": "light",
+      "reducedMotion": "reduce",
+      "locale": "en-US",
+      "timezoneId": "UTC"
+    }
+  },
+  "outputDir": ".playwright-cli"
+}

--- a/.playwright/cli.config.json
+++ b/.playwright/cli.config.json
@@ -9,7 +9,7 @@
         "width": 1440,
         "height": 900
       },
-      "deviceScaleFactor": 1,
+      "deviceScaleFactor": 2,
       "colorScheme": "light",
       "reducedMotion": "reduce",
       "locale": "en-US",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ The main frontend application lives in `client/dashboard/` (not `client/` direct
 
 Use the `gram-playwright-cli` skill and `mise run playwright` for routine dashboard inspection, page interaction, console or network debugging, and screenshots. The mise task uses the repository Playwright config, installs Chromium when missing, and writes ignored artifacts to `.playwright-cli/`.
 
-Use `pr-demo-gif` and its Playwright MCP workflow only when a user-visible change needs a shareable PR screenshot, GIF recording, or PR comment. Do not use `npm`, `npx`, or `yarn` for either workflow.
+Use `pr-demo-gif` when a user-visible change needs a shareable PR screenshot, GIF recording, or PR comment. It builds on the same `mise run playwright` workflow and adds the capture and publishing steps. Do not use `npm`, `npx`, or `yarn` for either workflow.
 
 ### Testing assistants locally
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Activate a skill when your task falls within its scope.
 | `pr`                              | Creating a Pull Request for current changes                                     |
 | `spec`                            | Interviewing user in-depth to produce a detailed spec before building           |
 | `page-toolbar`                    | Dashboard list page search, filters, sort, or view controls                     |
+| `gram-playwright-cli`             | Browser automation, dashboard inspection, screenshots, and page interaction     |
 | `pr-demo-gif`                     | Recording a demo GIF of a user-visible frontend change for a PR comment         |
 
 # Plan Mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,12 @@ The main frontend application lives in `client/dashboard/` (not `client/` direct
 
 </commands>
 
+### Dashboard browser automation
+
+Use the `gram-playwright-cli` skill and `mise run playwright` for routine dashboard inspection, page interaction, console or network debugging, and screenshots. The mise task uses the repository Playwright config, installs Chromium when missing, and writes ignored artifacts to `.playwright-cli/`.
+
+Use `pr-demo-gif` and its Playwright MCP workflow only when a user-visible change needs a shareable PR screenshot, GIF recording, or PR comment. Do not use `npm`, `npx`, or `yarn` for either workflow.
+
 ### Testing assistants locally
 
 `.mcp.json` registers the `assistants-dev` MCP server (`server/cmd/dev-mcp`), which drives the local management API without the dashboard UI. It logs into the local stack on its own (dev-idp auto-approves), so no setup is needed beyond a running dev stack. Use its tools — assistant CRUD, `run_turn` (send a message and wait for the assistant's reply), `load_chat`, and trigger CRUD — to exercise assistant runtime changes end to end. `whoami` lists the available project slugs.

--- a/mise.lock
+++ b/mise.lock
@@ -784,6 +784,10 @@ url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-x64.tar.gz"
 checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111cd56"
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"
 
+[[tools."npm:@playwright/cli"]]
+version = "0.1.17"
+backend = "npm:@playwright/cli"
+
 [[tools.pkl]]
 version = "0.31.1"
 backend = "aqua:apple/pkl"

--- a/mise.toml
+++ b/mise.toml
@@ -32,6 +32,7 @@ pkl = "0.31.1"
 buf = "1.71.0"
 ruff = "0.15.20"
 "github:ast-grep/ast-grep" = "0.44.0"
+"npm:@playwright/cli" = "latest"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.


### PR DESCRIPTION
## Summary

- add `@playwright/cli` as a mise-managed tool with a repo-native `mise run playwright` entrypoint
- install Chromium and its system dependencies only when the CLI reports a missing browser; also provide `mise run playwright:install-browser` for explicit setup
- add deterministic dashboard defaults: headless Chromium, a 1440x900 CSS viewport, light theme, reduced motion, UTC, and 2x device scaling for crisp screenshots
- add Gram-specific agent guidance and migrate `pr-demo-gif` from Playwright MCP to the same CLI workflow

## Why this is useful

Developers and agents now have one discoverable browser workflow for dashboard inspection, interaction, console and network debugging, screenshots, and PR demos. It does not depend on a globally installed browser or ad hoc package-runner commands, and browser artifacts stay in the ignored `.playwright-cli/` directory.

The shared config makes captures reproducible across machines. PR screenshots use `--hires`, producing a 2880x1800 image from the 1440x900 CSS viewport so they remain sharp on high-density displays. Video demos remain 1440x900 and use native action annotations and chapter cards.

## How to use it

```bash
# Open the dashboard and inspect the current page
mise run playwright open https://localhost:5173
mise run playwright snapshot

# Interact using refs returned by the snapshot
mise run playwright click e15
mise run playwright fill e20 "value"

# Capture a Retina-quality screenshot
mise run playwright screenshot --hires --filename=.playwright-cli/dashboard.png

# Inspect browser diagnostics
mise run playwright console
mise run playwright requests

mise run playwright close
```

Chromium installs automatically on the first missing-browser failure. To install it ahead of time:

```bash
mise run playwright:install-browser
```

Agents should use the `gram-playwright-cli` skill for routine browser work and `pr-demo-gif` when a user-visible change needs a shareable screenshot, GIF, or PR comment.

## Reviewer guide

1. `.mise-tasks/playwright/` contains the command wrapper and the Chromium-only installer. The wrapper retries only for the CLI missing-browser error and preserves unrelated failures.
2. `.playwright/cli.config.json` defines the shared browser and capture environment.
3. `.agents/skills/gram-playwright-cli/` documents the supported CLI surface using repo-native commands.
4. `CLAUDE.md` registers the browser workflows, while `pr-demo-gif` now records and captures through the CLI instead of MCP-specific commands.

## Verification

- `pnpm oxfmt --check` across all changed Markdown and JSON files
- `bash -n .mise-tasks/playwright/_default .mise-tasks/playwright/install-browser.sh`
- parsed the Playwright config and both skill frontmatters
- `mise run playwright --version` (`0.1.17`)
- confirmed both mise tasks are discoverable
- confirmed both install paths request Chromium only
- live local-dashboard smoke test: normal screenshot `1440x900`, `--hires` screenshot `2880x1800`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repo-native Playwright workflow via `mise run playwright` for consistent, reproducible browser automation and captures. Migrates PR demo recording to this flow and isolates artifacts in `.playwright-cli/`.

- **New Features**
  - Adds `@playwright/cli` as a mise tool with `mise run playwright` and `mise run playwright:install-browser`; wrapper auto-installs Chromium on first missing-browser error; artifacts go to `.playwright-cli/`.
  - Shared config (`.playwright/cli.config.json`): headless Chromium, 1440x900 viewport, 2x scale, light theme, reduced motion, UTC.
  - New `gram-playwright-cli` skill with docs for interaction, storage, request mocking, tracing, and video (action overlays, chapter cards, and a cursor toggle).
  - `pr-demo-gif` now records and screenshots through the CLI; guidance updated to use action overlays instead of a fake cursor.

- **Migration**
  - Use `mise run playwright` for dashboard inspection, interaction, console/network debugging, screenshots, and demos.
  - If needed, preinstall with `mise run playwright:install-browser`. Do not use `npm`/`npx`/`yarn` for this workflow.

<sup>Written for commit 1dd38e2ef5c468f9a541860d042394d6252491e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

