### PR TITLE
feat(dashboard): template MCP tunnel setup snippets from a config form

### DIFF
--- a/client/dashboard/src/pages/sources/tunneled-mcp/CreateTunneledMcp.tsx
+++ b/client/dashboard/src/pages/sources/tunneled-mcp/CreateTunneledMcp.tsx
@@ -16,7 +16,7 @@ import { useState } from "react";
 import { Navigate } from "react-router";
 import { toast } from "sonner";
 import { useCreateTunneledMcpSource } from "./hooks";
-import { TunneledMcpSetupTabs } from "./TunneledMCPDetails";
+import { TunneledMcpSetupTabs } from "./TunneledMcpSetupTabs";
 
 function validateDisplayName(value: string): string | null {
   if (!value.trim()) return "Display name is required";

--- a/client/dashboard/src/pages/sources/tunneled-mcp/TunneledMCPDetails.tsx
+++ b/client/dashboard/src/pages/sources/tunneled-mcp/TunneledMCPDetails.tsx
@@ -1,4 +1,3 @@
-import { CodeBlock } from "@/components/code";
 import { DetailHero } from "@/components/detail-hero";
 import { MCPServerCard } from "@/components/mcp/MCPServerCard";
 import { Page } from "@/components/page-layout";
@@ -15,7 +14,6 @@ import {
   Tabs,
   TabsContent,
   TabsList,
-  TabsTrigger,
 } from "@/components/ui/tabs";
 import { Type } from "@/components/ui/type";
 import { useTelemetry } from "@/contexts/Telemetry";
@@ -25,7 +23,6 @@ import {
   getTunneledMcpServerArgs,
 } from "@/lib/sources";
 import { TUNNELED_MCP_FEATURE_FLAG } from "@/lib/tunneledMcp";
-import { tunnelGatewayURL } from "@/lib/utils";
 import { useRoutes } from "@/routes";
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { TunneledMcpConnection } from "@gram/client/models/components/tunneledmcpconnection.js";
@@ -61,6 +58,7 @@ import {
   type RotateTunneledMcpServerKeyData,
 } from "./hooks";
 import { RemoveTunneledMcpDialogContent } from "./RemoveTunneledMcpDialog";
+import { TunneledMcpSetupTabs } from "./TunneledMcpSetupTabs";
 
 const VALID_TABS = ["overview", "setup", "mcp-servers", "settings"] as const;
 type TabValue = (typeof VALID_TABS)[number];
@@ -939,268 +937,4 @@ function DangerZoneSection({
       </Dialog>
     </div>
   );
-}
-
-export function TunneledMcpSetupTabs({
-  tunnelKey,
-  keyPrefix,
-  serverName,
-}: {
-  tunnelKey?: string;
-  keyPrefix?: string;
-  serverName?: string;
-}): JSX.Element {
-  const renderedKey = tunnelKey ?? "<YOUR_TUNNEL_KEY>";
-  const slug = slugForSnippet(serverName);
-  const serviceVersion = "2026.06.1";
-  const upstream = "http://localhost:3000/mcp";
-  const clusterUpstream = "http://127.0.0.1:3000/mcp";
-  const dockerUpstream = `http://hello-world-mcp-${slug}:3000/mcp`;
-  const gateway = tunnelGatewayURL();
-  const helloWorldPython = `from mcp.server.fastmcp import FastMCP
-
-mcp = FastMCP(
-    "hello-world",
-    host="0.0.0.0",
-    port=3000,
-    stateless_http=True,
-    json_response=True,
-)
-
-@mcp.tool()
-def hello(name: str = "world") -> str:
-    """Return a friendly greeting."""
-    return f"Hello, {name}!"
-
-@mcp.resource("hello://world")
-def hello_resource() -> str:
-    return "Hello from a tunneled MCP server."
-
-if __name__ == "__main__":
-    mcp.run(transport="streamable-http")`;
-  const kubernetes = `apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: hello-world-mcp
-data:
-  server.py: |
-${indentSnippet(helloWorldPython, 4)}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: gram-tunnel-key
-type: Opaque
-stringData:
-  TUNNEL_KEY: ${yamlQuote(renderedKey)}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: gram-tunnel-${slug}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: gram-tunnel-${slug}
-  template:
-    metadata:
-      labels:
-        app: gram-tunnel-${slug}
-    spec:
-      containers:
-        - name: hello-world-mcp
-          image: python:3.12-slim
-          command: ["/bin/sh", "-lc"]
-          args:
-            - |
-              pip install "mcp[cli]>=1.27,<2" &&
-              python /app/server.py
-          ports:
-            - containerPort: 3000
-          volumeMounts:
-            - name: hello-world-mcp
-              mountPath: /app
-              readOnly: true
-        - name: tunnel-agent
-          image: ghcr.io/speakeasy-api/gram-tunnel-agent:latest
-          env:
-            - name: TUNNEL_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: gram-tunnel-key
-                  key: TUNNEL_KEY
-            - name: TUNNEL_LOCAL_MCP_URL
-              value: ${yamlQuote(clusterUpstream)}
-            - name: TUNNEL_GATEWAY_URL
-              value: ${yamlQuote(gateway)}
-            - name: TUNNEL_SERVICE_VERSION
-              value: ${yamlQuote(serviceVersion)}
-      volumes:
-        - name: hello-world-mcp
-          configMap:
-            name: hello-world-mcp`;
-  const docker = `mkdir -p gram-tunnel-${slug}
-cd gram-tunnel-${slug}
-
-cat > server.py <<'PY'
-${helloWorldPython}
-PY
-
-cat > Dockerfile <<'DOCKERFILE'
-FROM python:3.12-slim
-RUN pip install "mcp[cli]>=1.27,<2"
-WORKDIR /app
-COPY server.py .
-EXPOSE 3000
-CMD ["python", "server.py"]
-DOCKERFILE
-
-docker build -t hello-world-mcp-${slug}:local .
-docker network create gram-tunnel-${slug} >/dev/null 2>&1 || true
-docker rm -f hello-world-mcp-${slug} gram-tunnel-${slug} >/dev/null 2>&1 || true
-trap 'docker rm -f hello-world-mcp-${slug} >/dev/null 2>&1' EXIT
-
-docker run -d --rm --name hello-world-mcp-${slug} \\
-  --network gram-tunnel-${slug} \\
-  hello-world-mcp-${slug}:local
-
-docker run --rm --name gram-tunnel-${slug} \\
-  --network gram-tunnel-${slug} \\
-  -e TUNNEL_KEY=${shellQuote(renderedKey)} \\
-  -e TUNNEL_LOCAL_MCP_URL=${shellQuote(dockerUpstream)} \\
-  -e TUNNEL_GATEWAY_URL=${shellQuote(gateway)} \\
-  -e TUNNEL_SERVICE_VERSION=${shellQuote(serviceVersion)} \\
-  ghcr.io/speakeasy-api/gram-tunnel-agent:latest`;
-  const cli = `TUNNEL_GATEWAY_URL=${shellQuote(gateway)} \\
-TUNNEL_KEY=${shellQuote(renderedKey)} \\
-TUNNEL_LOCAL_MCP_URL=${shellQuote(upstream)} \\
-TUNNEL_SERVICE_VERSION=${shellQuote(serviceVersion)} \\
-gram tunnel run`;
-
-  return (
-    <div className="rounded-lg border p-6">
-      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <Type variant="subheading">Connect your MCP server</Type>
-          <Type muted small className="mt-1">
-            Start a tunnel agent next to the MCP server you already run.
-          </Type>
-        </div>
-        {keyPrefix && (
-          <Badge variant="neutral">
-            <Badge.Text>{keyPrefix}</Badge.Text>
-          </Badge>
-        )}
-      </div>
-
-      <RequiredTunnelConfig
-        serviceVersion={serviceVersion}
-        upstream={upstream}
-      />
-
-      <Tabs defaultValue="kubernetes">
-        <TabsList>
-          <TabsTrigger value="kubernetes">Kubernetes</TabsTrigger>
-          <TabsTrigger value="docker">Docker</TabsTrigger>
-          <TabsTrigger value="cli">CLI</TabsTrigger>
-        </TabsList>
-        <TabsContent value="kubernetes" className="mt-4">
-          <div className="mb-3">
-            <Type variant="subheading">Hello world MCP</Type>
-            <Type muted small className="mt-1">
-              Run a tiny Python MCP server and the tunnel agent in the same pod.
-            </Type>
-          </div>
-          <CodeBlock language="yaml">{kubernetes}</CodeBlock>
-        </TabsContent>
-        <TabsContent value="docker" className="mt-4">
-          <div className="mb-3">
-            <Type variant="subheading">Hello world MCP container</Type>
-            <Type muted small className="mt-1">
-              Build a tiny Python MCP image and run the tunnel agent on the same
-              Docker network.
-            </Type>
-          </div>
-          <CodeBlock language="bash">{docker}</CodeBlock>
-        </TabsContent>
-        <TabsContent value="cli" className="mt-4">
-          <CodeBlock language="bash">{cli}</CodeBlock>
-        </TabsContent>
-      </Tabs>
-    </div>
-  );
-}
-
-function RequiredTunnelConfig({
-  serviceVersion,
-  upstream,
-}: {
-  serviceVersion: string;
-  upstream: string;
-}) {
-  const fields = [
-    {
-      key: "TUNNEL_SERVICE_VERSION",
-      value: serviceVersion,
-      description: "Version of the MCP service behind this tunnel.",
-    },
-    {
-      key: "TUNNEL_LOCAL_MCP_URL",
-      value: upstream,
-      description: "Local Streamable HTTP endpoint the agent proxies to.",
-    },
-  ];
-
-  return (
-    <div className="bg-muted/30 mb-5 rounded-md border p-4">
-      <Type variant="subheading" className="mb-1">
-        Required tunnel config
-      </Type>
-      <Type muted small className="mb-3 max-w-3xl">
-        Each tunnel agent connects with the local Streamable HTTP endpoint and a
-        version string so live connections can be inspected.
-      </Type>
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        {fields.map((field) => (
-          <div key={field.key} className="min-w-0">
-            <Type small mono className="truncate">
-              {field.key}
-            </Type>
-            <Type small className="mt-1 truncate font-medium">
-              {field.value}
-            </Type>
-            <Type muted small className="mt-1">
-              {field.description}
-            </Type>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function slugForSnippet(name: string | undefined): string {
-  const slug = (name ?? "internal-mcp")
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
-  return slug || "internal-mcp";
-}
-
-function yamlQuote(value: string): string {
-  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-}
-
-function indentSnippet(value: string, spaces: number): string {
-  const indent = " ".repeat(spaces);
-  return value
-    .split("\n")
-    .map((line) => (line ? `${indent}${line}` : ""))
-    .join("\n");
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/client/dashboard/src/pages/sources/tunneled-mcp/TunneledMcpSetupTabs.tsx
+++ b/client/dashboard/src/pages/sources/tunneled-mcp/TunneledMcpSetupTabs.tsx
@@ -1,0 +1,222 @@
+import { CodeBlock } from "@/components/code";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Type } from "@/components/ui/type";
+import { tunnelGatewayURL } from "@/lib/utils";
+import { Badge } from "@speakeasy-api/moonshine";
+import { useState } from "react";
+
+const DEFAULT_MCP_URL = "http://localhost:3000/mcp";
+const DEFAULT_SERVICE_VERSION = "1.0.0";
+
+export function TunneledMcpSetupTabs({
+  tunnelKey,
+  keyPrefix,
+  serverName,
+}: {
+  tunnelKey?: string;
+  keyPrefix?: string;
+  serverName?: string;
+}): JSX.Element {
+  const renderedKey = tunnelKey ?? "<YOUR_TUNNEL_KEY>";
+  const slug = slugForSnippet(serverName);
+  const gateway = tunnelGatewayURL();
+
+  const [mcpUrlDraft, setMcpUrlDraft] = useState(DEFAULT_MCP_URL);
+  const [serviceVersionDraft, setServiceVersionDraft] = useState(
+    DEFAULT_SERVICE_VERSION,
+  );
+
+  const mcpUrl = mcpUrlDraft.trim() || "<YOUR_MCP_URL>";
+  const serviceVersion = serviceVersionDraft.trim() || "<YOUR_MCP_VERSION>";
+
+  const kubernetes = `apiVersion: v1
+kind: Secret
+metadata:
+  name: gram-tunnel-key
+type: Opaque
+stringData:
+  TUNNEL_KEY: ${yamlQuote(renderedKey)}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gram-tunnel-${slug}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gram-tunnel-${slug}
+  template:
+    metadata:
+      labels:
+        app: gram-tunnel-${slug}
+    spec:
+      containers:
+        - name: tunnel-agent
+          image: ghcr.io/speakeasy-api/gram-tunnel-agent:latest
+          env:
+            - name: TUNNEL_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: gram-tunnel-key
+                  key: TUNNEL_KEY
+            - name: TUNNEL_LOCAL_MCP_URL
+              value: ${yamlQuote(mcpUrl)}
+            - name: TUNNEL_GATEWAY_URL
+              value: ${yamlQuote(gateway)}
+            - name: TUNNEL_SERVICE_VERSION
+              value: ${yamlQuote(serviceVersion)}`;
+
+  const docker = `docker run --rm --name gram-tunnel-${slug} \\
+  -e TUNNEL_KEY=${shellQuote(renderedKey)} \\
+  -e TUNNEL_LOCAL_MCP_URL=${shellQuote(mcpUrl)} \\
+  -e TUNNEL_GATEWAY_URL=${shellQuote(gateway)} \\
+  -e TUNNEL_SERVICE_VERSION=${shellQuote(serviceVersion)} \\
+  ghcr.io/speakeasy-api/gram-tunnel-agent:latest`;
+
+  const cli = `TUNNEL_GATEWAY_URL=${shellQuote(gateway)} \\
+TUNNEL_KEY=${shellQuote(renderedKey)} \\
+TUNNEL_LOCAL_MCP_URL=${shellQuote(mcpUrl)} \\
+TUNNEL_SERVICE_VERSION=${shellQuote(serviceVersion)} \\
+gram tunnel run`;
+
+  const snippetTabs = [
+    {
+      value: "kubernetes",
+      label: "Kubernetes",
+      language: "yaml",
+      hint: "Deploy the tunnel agent in your cluster. Use your MCP server's in-cluster address, e.g. http://my-mcp.default.svc.cluster.local:3000/mcp.",
+      code: kubernetes,
+    },
+    {
+      value: "docker",
+      label: "Docker",
+      language: "bash",
+      hint: "Run the tunnel agent as a container. If your MCP server runs on the Docker host, use http://host.docker.internal:<port> as the address.",
+      code: docker,
+    },
+    {
+      value: "cli",
+      label: "CLI",
+      language: "bash",
+      hint: "Run the Gram CLI agent on the same host as your MCP server.",
+      code: cli,
+    },
+  ];
+
+  return (
+    <div className="rounded-lg border p-6">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <Type variant="subheading">Connect your MCP server</Type>
+          <Type muted small className="mt-1">
+            Start a tunnel agent next to the MCP server you already run.
+          </Type>
+        </div>
+        {keyPrefix && (
+          <Badge variant="neutral">
+            <Badge.Text>{keyPrefix}</Badge.Text>
+          </Badge>
+        )}
+      </div>
+
+      <div className="bg-muted/30 mb-5 rounded-md border p-4">
+        <Type variant="subheading" className="mb-1">
+          Tunnel config
+        </Type>
+        <Type muted small className="mb-4 max-w-3xl">
+          Describe the MCP server the tunnel agent should proxy to. The values
+          are templated into the setup snippets below.
+        </Type>
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <SnippetField
+            id="tunnel-config-mcp-url"
+            label="MCP server address"
+            description="Internal Streamable HTTP endpoint the agent proxies to."
+            value={mcpUrlDraft}
+            onChange={setMcpUrlDraft}
+            placeholder={DEFAULT_MCP_URL}
+          />
+          <SnippetField
+            id="tunnel-config-service-version"
+            label="Service version"
+            description="Version of the MCP service behind this tunnel."
+            value={serviceVersionDraft}
+            onChange={setServiceVersionDraft}
+            placeholder={DEFAULT_SERVICE_VERSION}
+          />
+        </div>
+      </div>
+
+      <Tabs defaultValue="kubernetes">
+        <TabsList>
+          {snippetTabs.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {snippetTabs.map((tab) => (
+          <TabsContent key={tab.value} value={tab.value} className="mt-4">
+            <Type muted small className="mb-3">
+              {tab.hint}
+            </Type>
+            <CodeBlock language={tab.language}>{tab.code}</CodeBlock>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}
+
+function SnippetField({
+  id,
+  label,
+  description,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <Label htmlFor={id} className="mb-2">
+        {label}
+      </Label>
+      <Input
+        id={id}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+      />
+      <Type muted small className="mt-1">
+        {description}
+      </Type>
+    </div>
+  );
+}
+
+function slugForSnippet(name: string | undefined): string {
+  const slug = (name ?? "internal-mcp")
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  return slug || "internal-mcp";
+}
+
+function yamlQuote(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}


### PR DESCRIPTION
Replace the hard-coded hello-world MCP example in the tunneled MCP setup docs with a form (MCP server address + service version) whose values are templated into the Kubernetes, Docker, and CLI snippets. The snippets now run just the tunnel agent against the user's own MCP server. Extracts TunneledMcpSetupTabs into its own file.

Closes [AIS-318](https://linear.app/speakeasy/issue/AIS-318/chore-add-templating-to-mcp-tunnel-setup-docs)

https://github.com/user-attachments/assets/bcff3484-db0b-42a5-af0b-895574dd1536

---

## Summary by cubic

Adds a config form to the tunneled MCP setup that templates your MCP server address and service version into Kubernetes, Docker, and CLI snippets. Replaces the hello-world example so the snippets run the tunnel agent against your own MCP server, addressing Linear [AIS-318](https://linear.app/speakeasy/issue/AIS-318/chore-add-templating-to-mcp-tunnel-setup-docs).

* **New Features**
  * Form fields for MCP server address and service version with sensible defaults.
  * Live templating into Kubernetes, Docker, and CLI snippets with brief per-tab hints.
  * Supports your tunnel key (or placeholder) and derives a stable slug from `serverName`.
* **Refactors**
  * Extracted `TunneledMcpSetupTabs` to `TunneledMcpSetupTabs.tsx` and updated imports.
  * Removed the hello-world MCP example and related code from `TunneledMCPDetails.tsx`.

Written for commit 6b4d7d07e84707acba0413018c13f708e956dd37. Summary will update on new commits.

[![Review in cubic](https://uploads.linear.app/49865655-68fb-4c55-83c8-f488bdc5a356/b1dce02b-8dc4-434e-b462-53cd0d3cc8cc/baa4c0ba-bc92-49dc-9a10-11ab48abd79f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzQ5ODY1NjU1LTY4ZmItNGM1NS04M2M4LWY0ODhiZGM1YTM1Ni9iMWRjZTAyYi04ZGM0LTQzNGUtYjQ2Mi01M2NkMGQzY2M4Y2MvYmFhNGMwYmEtYmM5Mi00OWRjLTlhMTAtMTFhYjQ4YWJkNzlmIiwiaWF0IjoxNzg0MTU0NTkxLCJleHAiOjE4MTU3MjUxNTF9.umrluV4JlwtBAn0loAwdkppEyQyWjOqE2DrjvuONSiQ)](<https://cubic.dev/pr/speakeasy-api/gram/pull/4252?utm_source=github>)