### PR TITLE
mig(skills): index version history

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -305,6 +305,7 @@ CREATE TABLE IF NOT EXISTS skill_versions (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_skill_id_canonical_sha256_key ON skill_versions (skill_id, canonical_sha256);
+CREATE INDEX IF NOT EXISTS skill_versions_skill_id_created_at_id_idx ON skill_versions (skill_id, created_at DESC, id DESC);
 
 CREATE TABLE IF NOT EXISTS packages (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/migrations/20260715234644_skill_versions_ordering_index.sql
+++ b/server/migrations/20260715234644_skill_versions_ordering_index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "skill_versions_skill_id_created_at_id_idx" to table: "skill_versions"
+CREATE INDEX CONCURRENTLY "skill_versions_skill_id_created_at_id_idx" ON "skill_versions" ("skill_id", "created_at" DESC, "id" DESC);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:QOr9JMx5hzVaNDpO5luCRpsXN9usAobaIIEyjX4eyWU=
+h1:2+E98Kae62hPW7nUsXZkUWG7JUiBC6xKYwOLwDSZTdc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -267,3 +267,4 @@ h1:QOr9JMx5hzVaNDpO5luCRpsXN9usAobaIIEyjX4eyWU=
 20260715170908_skills-skill-versions.sql h1:Un78+gYfiw76/4vthKJwZdjKyziBLsNkwvk2q4YYD0E=
 20260715174418_observability-mode-to-hooks-fail-open.sql h1:LdG61RUE0xWhm7f/V+KWMdYVPC20yR9U5Q0jY+bj6N8=
 20260715203754_chat-messages-add-replayed.sql h1:xieBGqLsKZ4ZST5QAfn/Hq8aSaTCWM4sknr0bmMhHa0=
+20260715234644_skill_versions_ordering_index.sql h1:VrJFF+sNk9bil82fYMMgHmSQKABV3qmvJDcTUFVEw6s=


### PR DESCRIPTION
## Summary

- add a composite index for skill version latest/history ordering
- create the index concurrently to avoid blocking writes
- keep the migration isolated from the DNO-423 application PR

Follow-up for https://github.com/speakeasy-api/gram/pull/4254
Linear: https://linear.app/speakeasy/issue/DNO-423/api-skills-management-service

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a composite index on `skill_versions` to speed up latest-version and version history queries, created concurrently to avoid blocking writes. Supports DNO-423 by indexing the ordering used to derive the latest version `(skill_id, created_at DESC, id DESC)`.

- **Performance**
  - Faster lookups for a skill’s latest version and paginated history.
  - Less sorting/scanning on `skill_versions` due to order-aligned index.

<sup>Written for commit 1f3e1dc409c217f491070ed551a9843f9335ad26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

