### PR TITLE
feat(dashboard): group consecutive tool calls in the chat detail sheet

### DIFF
--- a/client/dashboard/src/elements/index.ts
+++ b/client/dashboard/src/elements/index.ts
@@ -27,11 +27,13 @@ export type { MarkdownProps } from "@/elements/components/Markdown";
 // the dashboard's chat detail panel can reuse the elements tool UI directly.
 export {
   ToolUI,
+  ToolUIGroup,
   ToolUISection,
   SyntaxHighlightedCode,
 } from "@/elements/components/ui/tool-ui";
 export type {
   ToolUIProps,
+  ToolUIGroupProps,
   ToolUISectionProps,
   ToolStatus,
   ContentItem,

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -75,6 +75,7 @@ import {
 import {
   buildDisplayItems,
   buildTranscript,
+  displayItemRows,
   type MessageCategory,
   rowCategory,
   rowHasRiskFlag,
@@ -124,6 +125,9 @@ type ViewMode = "chat" | "tools" | "exclusion";
 interface Occurrence {
   key: string;
   itemIndex: number;
+  /** Row holding the occurrence. A `toolGroup` item covers many rows, so the
+   * item index alone can't say which one to light up. */
+  rowId: string;
   fieldKey: SearchFieldKey;
   indexInField: number;
 }
@@ -969,8 +973,8 @@ function ChatDetailPanel({
   // the top (first message) — even when the session happens to have findings.
   const initialScrollIndex = useMemo(() => {
     if (!dimNonRisk) return null;
-    const idx = displayItems.findIndex(
-      (it) => it.type === "row" && rowIsFlagged(it.row, riskResultsByMessage),
+    const idx = displayItems.findIndex((it) =>
+      displayItemRows(it).some((r) => rowIsFlagged(r, riskResultsByMessage)),
     );
     return idx >= 0 ? idx : null;
   }, [dimNonRisk, displayItems, riskResultsByMessage]);
@@ -984,19 +988,24 @@ function ChatDetailPanel({
     if (!searchActive) return EMPTY_OCCURRENCES;
     const out: Occurrence[] = [];
     displayItems.forEach((it, itemIndex) => {
-      if (it.type !== "row") return;
-      for (const f of rowSearchFields(
-        it.row,
-        searchQuery,
-        riskResultsByMessage,
-      )) {
-        for (let k = 0; k < f.count; k++) {
-          out.push({
-            key: `${it.id}:${f.key}:${k}`,
-            itemIndex,
-            fieldKey: f.key,
-            indexInField: k,
-          });
+      // Walk every row the item renders — a `toolGroup` holds a whole run of
+      // them, and its members stay searchable while collapsed (a match inside
+      // pins the group open).
+      for (const row of displayItemRows(it)) {
+        for (const f of rowSearchFields(
+          row,
+          searchQuery,
+          riskResultsByMessage,
+        )) {
+          for (let k = 0; k < f.count; k++) {
+            out.push({
+              key: `${it.id}:${row.id}:${f.key}:${k}`,
+              itemIndex,
+              rowId: row.id,
+              fieldKey: f.key,
+              indexInField: k,
+            });
+          }
         }
       }
     });
@@ -1065,6 +1074,7 @@ function ChatDetailPanel({
       activeOccurrence: activeOccurrence
         ? {
             itemIndex: activeOccurrence.itemIndex,
+            rowId: activeOccurrence.rowId,
             fieldKey: activeOccurrence.fieldKey,
             indexInField: activeOccurrence.indexInField,
           }

--- a/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
@@ -32,7 +32,12 @@ import {
   DropdownMenuTrigger,
   Icon,
 } from "@speakeasy-api/moonshine";
-import { MessageContent, type SectionMatch, ToolUI } from "@/elements";
+import {
+  MessageContent,
+  type SectionMatch,
+  ToolUI,
+  ToolUIGroup,
+} from "@/elements";
 import type { ClaudeToolUsage } from "@gram/client/models/components/claudetoolusage.js";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
 import {
@@ -653,6 +658,7 @@ function ToolRowView({
   activeNameOccurrence,
   activeArgsOccurrence,
   activeOutputOccurrence,
+  bare = false,
 }: {
   row: ToolRow;
   ctx: ResolvedRowContext;
@@ -665,6 +671,10 @@ function ToolRowView({
   activeArgsOccurrence: number | null;
   /** Active occurrence index within the Output section, or null. */
   activeOutputOccurrence: number | null;
+  /** Render as a flush row inside a ToolUIGroup: the group supplies the card
+   * (border, rounding, inset), so the row drops its own padding and the ToolUI
+   * de-cards itself — mirroring `ToolFallback` in the assistant thread. */
+  bare?: boolean;
 }) {
   const openExclusion = useContext(CreateExclusionContext);
   const name =
@@ -733,7 +743,12 @@ function ToolRowView({
   const decoration = ctx.rowDecoration?.(messageIdsForRow(row)) ?? null;
 
   return (
-    <div className={cn("px-4 py-2.5", dimClass(ctx.dimNonRisk && !flagged))}>
+    <div
+      className={cn(
+        bare ? "flex w-full flex-col" : "px-4 py-2.5",
+        dimClass(ctx.dimNonRisk && !flagged),
+      )}
+    >
       {inputBytes + outputBytes > 0 && (
         <div className="mb-1.5 flex items-center gap-2 pl-1">
           <ToolByteBadge bytes={inputBytes + outputBytes} />
@@ -754,6 +769,7 @@ function ToolRowView({
         resultHighlight={resultHighlight}
         nameQuery={ctx.searchQuery}
         nameActiveOccurrence={activeNameOccurrence}
+        className={bare ? "rounded-none border-0" : undefined}
       />
       <RowDecorationFooter
         decoration={decoration}
@@ -762,6 +778,76 @@ function ToolRowView({
     </div>
   );
 }
+
+function toolRowFlagged(row: ToolRow, ctx: ResolvedRowContext): boolean {
+  const { callResults, resultResults } = toolResults(row, ctx);
+  return (callResults?.length ?? 0) > 0 || (resultResults?.length ?? 0) > 0;
+}
+
+// A run of consecutive tool calls, collapsed by default behind a single summary
+// so a long tool chain doesn't flood the transcript. Presentation is the shared
+// elements `ToolUIGroup` — the same shell the project assistant thread uses via
+// assistant-ui's ToolGroup slot — so both surfaces stay identical. Only the run
+// DETECTION differs: the assistant gets it from assistant-ui, while this
+// virtualized transcript coalesces runs in the model (`coalesceToolGroups`).
+//
+// A finding or the active search match inside the run pins the group open, so
+// neither is ever hidden behind a collapsed summary. ToolUIGroup owns its
+// expanded state internally, so `groupKey` remounts it when that pin toggles;
+// navigating away collapses it back.
+const ToolGroupView = memo(function ToolGroupView({
+  group,
+  ctx,
+  activeRowId,
+  activeField,
+}: {
+  group: Extract<DisplayItem, { type: "toolGroup" }>;
+  ctx: ResolvedRowContext;
+  /** Row inside THIS group holding the active search occurrence, else null
+   * (resolved by the caller so groups without the match skip re-render on nav). */
+  activeRowId: string | null;
+  /** Field + occurrence index within `activeRowId`, or null. */
+  activeField: ActiveField | null;
+}) {
+  const flaggedCount = useMemo(
+    () => group.rows.filter((r) => toolRowFlagged(r, ctx)).length,
+    [group.rows, ctx],
+  );
+  const forceOpen = flaggedCount > 0 || activeRowId != null;
+  const count = group.rows.length;
+  const title =
+    flaggedCount > 0
+      ? `Executed ${count} tools · ${flaggedCount} flagged`
+      : `Executed ${count} tools`;
+
+  return (
+    <div
+      className={cn(
+        "px-4 py-1.5",
+        dimClass(ctx.dimNonRisk && flaggedCount === 0),
+      )}
+    >
+      <ToolUIGroup
+        key={forceOpen ? "pinned-open" : "collapsible"}
+        title={title}
+        defaultExpanded={forceOpen}
+      >
+        <div className="divide-border divide-y">
+          {group.rows.map((r) => (
+            <RowView
+              key={r.id}
+              row={r}
+              ctx={ctx}
+              active={r.id === activeRowId}
+              activeField={r.id === activeRowId ? activeField : null}
+              bare
+            />
+          ))}
+        </div>
+      </ToolUIGroup>
+    </div>
+  );
+});
 
 function SegmentDivider({ generation }: { generation: number }) {
   return (
@@ -812,6 +898,8 @@ export interface TranscriptPagination {
    * else is pale. null when not searching / no matches. */
   activeOccurrence?: {
     itemIndex: number;
+    /** Row within the item holding it — a toolGroup item covers many rows. */
+    rowId: string;
     fieldKey: SearchFieldKey;
     indexInField: number;
   } | null;
@@ -869,6 +957,7 @@ const RowView = memo(function RowView({
   ctx,
   active,
   activeField,
+  bare = false,
 }: {
   row: TranscriptRow;
   ctx: ResolvedRowContext;
@@ -876,6 +965,8 @@ const RowView = memo(function RowView({
   active: boolean;
   /** Which field + occurrence in this row is active, or null when none is. */
   activeField: ActiveField | null;
+  /** Render tool cards without the transcript's row padding (inside a group). */
+  bare?: boolean;
 }) {
   if (row.kind === "message") {
     return (
@@ -902,6 +993,7 @@ const RowView = memo(function RowView({
       activeOutputOccurrence={
         activeField?.key === "output" ? activeField.index : null
       }
+      bare={bare}
     />
   );
 });
@@ -975,6 +1067,23 @@ function DisplayItemView({
           ctx={ctx}
           active={active}
           activeField={activeField}
+        />
+      );
+    }
+    case "toolGroup": {
+      // Resolve the active occurrence only when it lands inside THIS group;
+      // otherwise null, so the memo skips groups that don't hold the match
+      // during nav churn.
+      const occ = pagination.activeOccurrence;
+      const inGroup = occ != null && occ.itemIndex === index;
+      return (
+        <ToolGroupView
+          group={item}
+          ctx={ctx}
+          activeRowId={inGroup ? occ.rowId : null}
+          activeField={
+            inGroup ? { key: occ.fieldKey, index: occ.indexInField } : null
+          }
         />
       );
     }

--- a/client/dashboard/src/pages/chatLogs/transcript.test.ts
+++ b/client/dashboard/src/pages/chatLogs/transcript.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDisplayItems,
+  displayItemRows,
+  type DisplayItem,
+  type ToolRow,
+  type TranscriptRow,
+} from "./transcript";
+
+function toolRow(id: string, seq: number, generation = 1): ToolRow {
+  return {
+    kind: "tool",
+    id,
+    toolCall: { id, type: "function", function: { name: id, arguments: "{}" } },
+    callMessage: { id: `${id}-call`, seq, role: "assistant" } as never,
+    resultMessage: { id: `${id}-result`, seq: seq + 1, role: "tool" } as never,
+    generation,
+  };
+}
+
+function messageRow(id: string, seq: number, generation = 1): TranscriptRow {
+  return {
+    kind: "message",
+    id,
+    entryType: "assistant",
+    message: {
+      id,
+      seq,
+      role: "assistant",
+      content: "hello",
+      createdAt: new Date(0),
+    } as never,
+    generation,
+  };
+}
+
+const types = (items: DisplayItem[]) => items.map((i) => i.type);
+const group = (items: DisplayItem[]) =>
+  items.find((i) => i.type === "toolGroup") as Extract<
+    DisplayItem,
+    { type: "toolGroup" }
+  >;
+
+describe("buildDisplayItems — consecutive tool grouping", () => {
+  it("folds a run of adjacent tool rows into one group", () => {
+    const items = buildDisplayItems({
+      rows: [toolRow("a", 1), toolRow("b", 3), toolRow("c", 5)],
+    });
+    expect(types(items).filter((t) => t === "row")).toHaveLength(0);
+    expect(group(items).rows.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("leaves a lone tool row ungrouped — it is already its own card", () => {
+    const items = buildDisplayItems({ rows: [toolRow("a", 1)] });
+    expect(types(items)).not.toContain("toolGroup");
+    expect(types(items)).toContain("row");
+  });
+
+  it("breaks a run at a non-tool row, so groups never span a turn", () => {
+    const items = buildDisplayItems({
+      rows: [
+        toolRow("a", 1),
+        toolRow("b", 3),
+        messageRow("m", 5),
+        toolRow("c", 7),
+        toolRow("d", 9),
+      ],
+    });
+    const groups = items.filter((i) => i.type === "toolGroup");
+    expect(groups).toHaveLength(2);
+    expect(displayItemRows(groups[0]!).map((r) => r.id)).toEqual(["a", "b"]);
+    expect(displayItemRows(groups[1]!).map((r) => r.id)).toEqual(["c", "d"]);
+  });
+
+  it("never hides a server gap inside a group", () => {
+    // A gap between two tool rows must stay visible as its own affordance
+    // rather than being swallowed into a collapsed run.
+    const items = buildDisplayItems({
+      rows: [toolRow("a", 1), toolRow("b", 3), toolRow("c", 5)],
+      gaps: new Set([3]),
+    });
+    expect(types(items)).toContain("serverGap");
+    const gapIdx = items.findIndex((i) => i.type === "serverGap");
+    const groups = items.filter((i) => i.type === "toolGroup");
+    // The gap splits the run; nothing after it is folded in with what precedes.
+    expect(groups.every((g) => items.indexOf(g) !== gapIdx)).toBe(true);
+    for (const g of groups) {
+      expect(displayItemRows(g).length).toBeGreaterThanOrEqual(2);
+    }
+  });
+});
+
+describe("displayItemRows", () => {
+  it("exposes every row of a group, so a finding inside one is locatable", () => {
+    const items = buildDisplayItems({
+      rows: [toolRow("a", 1), toolRow("b", 3)],
+    });
+    expect(displayItemRows(group(items)).map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("returns nothing for structural items", () => {
+    const items = buildDisplayItems({
+      rows: [messageRow("m", 1)],
+      hasMoreBefore: true,
+    });
+    const loadMore = items.find((i) => i.type === "loadMore")!;
+    expect(displayItemRows(loadMore)).toEqual([]);
+  });
+});

--- a/client/dashboard/src/pages/chatLogs/transcript.ts
+++ b/client/dashboard/src/pages/chatLogs/transcript.ts
@@ -323,10 +323,54 @@ export type DisplayItem =
       createdAt?: Date;
     }
   | { type: "row"; id: string; row: TranscriptRow }
+  /** A run of consecutive tool rows, collapsed into one expandable group so a
+   * long chain of back-to-back tool calls doesn't flood the transcript. */
+  | { type: "toolGroup"; id: string; rows: ToolRow[] }
   /** Keyset-pagination affordance at the top/bottom of the loaded window. */
   | { type: "loadMore"; id: string; dir: "older" | "newer" }
   /** Un-loaded span between two disjoint risk segments (risk-focused view). */
   | { type: "serverGap"; id: string; afterSeq: number };
+
+/** The transcript row(s) a display item carries: the single row for a `row`
+ * item, every member of a `toolGroup`, or none for structural items (headers,
+ * dividers, load/gap markers). Lets callers locate a finding/search match
+ * whether it sits in a standalone row or inside a collapsed tool group. */
+export function displayItemRows(item: DisplayItem): TranscriptRow[] {
+  if (item.type === "row") return [item.row];
+  if (item.type === "toolGroup") return item.rows;
+  return [];
+}
+
+/** Below this, a run of consecutive tool rows stays as individual rows — a lone
+ * tool call is already its own collapsed card, so only coalesce actual runs. */
+const MIN_TOOLS_TO_GROUP = 2;
+
+/** Fold maximal runs of adjacent tool rows into a single `toolGroup` item. Runs
+ * as a post-pass over the built items so anything between two tool rows (a turn
+ * header, a generation divider, a risk gap marker) breaks the run — groups never
+ * span turns or hide a gap affordance. */
+function coalesceToolGroups(items: DisplayItem[]): DisplayItem[] {
+  const out: DisplayItem[] = [];
+  let run: ToolRow[] = [];
+  const flush = () => {
+    if (run.length >= MIN_TOOLS_TO_GROUP) {
+      out.push({ type: "toolGroup", id: `toolgroup-${run[0]!.id}`, rows: run });
+    } else {
+      for (const r of run) out.push({ type: "row", id: r.id, row: r });
+    }
+    run = [];
+  };
+  for (const item of items) {
+    if (item.type === "row" && item.row.kind === "tool") {
+      run.push(item.row);
+    } else {
+      flush();
+      out.push(item);
+    }
+  }
+  flush();
+  return out;
+}
 
 /** The row's display-order anchor seq. Gap anchors are message seqs; for a tool
  * row use the assistant call's seq (its position in the list), not the
@@ -428,5 +472,5 @@ export function buildDisplayItems({
 
   if (hasMoreAfter)
     items.push({ type: "loadMore", id: "load-newer", dir: "newer" });
-  return items;
+  return coalesceToolGroups(items);
 }


### PR DESCRIPTION
Closes [DNO-530](https://linear.app/speakeasy/issue/DNO-530/feat-group-consecutive-tool-calls-in-chat-detail-sheet).

> Note: the issue describes this as affecting project assistant chats. It doesn't — that surface already groups correctly. The affected surface is **agent session transcripts** (the chat detail sheet).

## Problem

An agent session that fires a long run of back-to-back tool calls (often 20+) rendered each call as its own card, putting a huge scroll distance between the messages either side of it.

## What changed

Runs of adjacent tool rows now coalesce into a single expandable group, collapsed by default.

**Detection** (`transcript.ts`) — `coalesceToolGroups` runs as a post-pass over the built display items, so anything between two tool rows (a turn header, a generation divider, a risk gap marker) breaks the run. A group never spans turns or hides a gap affordance. A lone tool call is left alone; it's already its own collapsed card.

**Presentation** (`ChatTranscript.tsx`) — reuses the elements `ToolUIGroup`, the same shell the project assistant thread uses via assistant-ui's `ToolGroup` slot, so both surfaces look identical. Rows render flush with hairline dividers by mirroring `ToolFallback`'s recipe (`rounded-none border-0` on the card, group supplies the inset).

Only the run _detection_ differs between the two surfaces: the assistant gets it from assistant-ui, while this virtualized transcript has no such slot and must coalesce in the model.

## Findings and search are never hidden

Either a finding or the active search match inside a run pins its group open; navigating away collapses it back. Search occurrences now carry the row they belong to — a group is one display item covering many rows, so the item index alone can't say which row to highlight.

## Testing

- New `transcript.test.ts` covers the grouping model: runs fold, lone rows don't, non-tool rows break a run, gaps are never swallowed.
- Full dashboard suite passes (861 tests); type-check clean.
- Verified in the local dashboard against the seeded `Audit auth middleware` session (`mise run seed:chat-detail`), which has a 10-call run: collapsed by default as "Executed 10 tools", expanding to flush rows matching the project assistant.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups consecutive tool calls in the agent session transcript (chat detail sheet) into a single expandable card, collapsed by default, matching the project assistant UI and cutting long scrolls. Implements DNO-530.

- New Features
  - Coalesces adjacent tool rows into `toolGroup` items via `coalesceToolGroups`; groups never span turns or hide server gaps.
  - Renders groups with `ToolUIGroup` for visual parity; tool rows render “bare” for flush dividers.
  - Keeps groups collapsed by default; a finding or active search match inside a group pins it open until you navigate away.
  - Search and pagination now track `rowId` (not just item index); `displayItemRows` exposes rows within an item; initial risk scroll and search use it.
  - Exposes `ToolUIGroup`/`ToolUIGroupProps` from `@/elements`; adds tests in `transcript.test.ts` for grouping and `displayItemRows`.

<sup>Written for commit 29c6cbb3ce267634f6fe713884bb7fcf819f2673. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

