### PR TITLE
fix: treat anthropic compliance 404 as non-retryable ai usage poll failure

### DIFF
--- a/server/internal/background/activities/poll_ai_data.go
+++ b/server/internal/background/activities/poll_ai_data.go
@@ -98,7 +98,7 @@ func (p *PollAIData) Do(ctx context.Context, configID string) (err error) {
 		}
 
 		attempt := activity.GetInfo(ctx).Attempt
-		nonRetryable := pollAPIKeyRejected(err)
+		nonRetryable := pollRejectedByProvider(err)
 
 		// Temporal records failures, but that's not visible to the user. We
 		// record the failure on the last attempt — or immediately when
@@ -137,8 +137,13 @@ func (p *PollAIData) Do(ctx context.Context, configID string) (err error) {
 		nextCursor, err := p.complianceImporter.SyncAnthropicCompliance(ctx, cfg)
 		if err != nil {
 			var httpErr *anthropicapi.HTTPError
-			if errors.As(err, &httpErr) && (httpErr.StatusCode == 401 || httpErr.StatusCode == 403) {
-				return oops.E(oops.CodeUnauthorized, err, "anthropic compliance rejected the configured api key")
+			if errors.As(err, &httpErr) {
+				switch httpErr.StatusCode {
+				case 401, 403:
+					return oops.E(oops.CodeUnauthorized, err, "anthropic compliance rejected the configured api key")
+				case 404:
+					return oops.E(oops.CodeNotFound, err, "anthropic compliance organization not found or compliance api access not enabled")
+				}
 			}
 			return oops.E(oops.CodeUnexpected, err, "sync anthropic compliance data")
 		}
@@ -153,17 +158,20 @@ func (p *PollAIData) Do(ctx context.Context, configID string) (err error) {
 	return nil
 }
 
-// pollAPIKeyRejected reports whether the poll failed because the provider
-// rejected the configured api key. Those failures are permanent until the
-// user rotates the key, so retrying them is wasted work.
-func pollAPIKeyRejected(err error) bool {
+// pollRejectedByProvider reports whether the poll failed because the provider
+// rejected the request in a way retrying can't fix: a rejected api key
+// (401/403), or — for the anthropic compliance api — a 404, which is how it
+// reports an unknown organization or one without compliance api access. Those
+// failures are permanent until the user fixes the integration configuration,
+// so retrying them is wasted work.
+func pollRejectedByProvider(err error) bool {
 	var cursorErr *cursorapi.HTTPError
 	if errors.As(err, &cursorErr) {
 		return cursorErr.StatusCode == 401
 	}
 	var anthropicErr *anthropicapi.HTTPError
 	if errors.As(err, &anthropicErr) {
-		return anthropicErr.StatusCode == 401 || anthropicErr.StatusCode == 403
+		return anthropicErr.StatusCode == 401 || anthropicErr.StatusCode == 403 || anthropicErr.StatusCode == 404
 	}
 	return false
 }

--- a/server/internal/background/activities/poll_ai_data_test.go
+++ b/server/internal/background/activities/poll_ai_data_test.go
@@ -17,18 +17,20 @@ import (
 	cursorapi "github.com/speakeasy-api/gram/server/internal/thirdparty/cursor"
 )
 
-func TestPollAPIKeyRejectedMatchesProviderAuthFailures(t *testing.T) {
+func TestPollRejectedByProviderMatchesPermanentProviderFailures(t *testing.T) {
 	t.Parallel()
 
-	require.True(t, pollAPIKeyRejected(&cursorapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"}))
-	require.False(t, pollAPIKeyRejected(&cursorapi.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}))
-	require.True(t, pollAPIKeyRejected(&anthropicapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"}))
-	require.True(t, pollAPIKeyRejected(&anthropicapi.HTTPError{StatusCode: 403, Status: "403 Forbidden"}))
-	require.False(t, pollAPIKeyRejected(&anthropicapi.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}))
-	require.False(t, pollAPIKeyRejected(errors.New("network timeout")))
+	require.True(t, pollRejectedByProvider(&cursorapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"}))
+	require.False(t, pollRejectedByProvider(&cursorapi.HTTPError{StatusCode: 404, Status: "404 Not Found"}))
+	require.False(t, pollRejectedByProvider(&cursorapi.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}))
+	require.True(t, pollRejectedByProvider(&anthropicapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"}))
+	require.True(t, pollRejectedByProvider(&anthropicapi.HTTPError{StatusCode: 403, Status: "403 Forbidden"}))
+	require.True(t, pollRejectedByProvider(&anthropicapi.HTTPError{StatusCode: 404, Status: "404 Not Found"}))
+	require.False(t, pollRejectedByProvider(&anthropicapi.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}))
+	require.False(t, pollRejectedByProvider(errors.New("network timeout")))
 }
 
-func TestPollAPIKeyRejectedSeesThroughWrappedSyncErrors(t *testing.T) {
+func TestPollRejectedByProviderSeesThroughWrappedSyncErrors(t *testing.T) {
 	t.Parallel()
 
 	httpErr := &anthropicapi.HTTPError{StatusCode: 401, Status: "401 Unauthorized"}
@@ -51,7 +53,7 @@ func TestPollAPIKeyRejectedSeesThroughWrappedSyncErrors(t *testing.T) {
 	}
 	wrapped := oops.E(oops.CodeUnauthorized, syncErr, "anthropic compliance rejected the configured api key")
 
-	require.True(t, pollAPIKeyRejected(wrapped))
+	require.True(t, pollRejectedByProvider(wrapped))
 }
 
 func TestNewPollFailureErrorCarriesStageAndProgressDetails(t *testing.T) {


### PR DESCRIPTION
## Summary

The Anthropic Compliance API returns **404** on `/v1/compliance/activities` when the configured organization is unknown or doesn't have Compliance API access. That's a misconfiguration only the customer can fix, so retrying is wasted work — but `PollAIData` treated it as a generic retryable failure.

Seen in prod on 2026-07-16: a first-sync `anthropic_compliance` config 404'd deterministically on every attempt, burning all 5 Temporal retries per poll run and keeping the "[Temporal] Activity failure burst" monitor in warning ([monitor 304557077](https://app.datadoghq.com/monitors/304557077)).

## Changes

- `PollAIData.Do`: Anthropic 404s now return `oops.CodeNotFound` with a message pointing at org access ("anthropic compliance organization not found or compliance api access not enabled") instead of the generic unexpected-error path, so the dashboard's `last_poll_error` tells the customer what to actually fix.
- `pollAPIKeyRejected` → `pollRejectedByProvider`: renamed since it now covers more than key rejection; Anthropic 404 added to the non-retryable set alongside 401/403. Cursor 404s deliberately stay retryable — only Anthropic uses 404 to signal "org not found / no access".

## Behavior

- Failure is recorded immediately via `RecordUsagePollFailure` (visible in dashboard, `consecutive_failures` increments) instead of after 5 attempts.
- Watermark and cursor stay frozen, so no backfill window is lost.
- `next_poll_after` still advances — the integration recovers automatically on the normal cadence once the customer enables access.
- Monitor failure delta drops from ~5–6 per 30m to at most 1 per poll run.

## Testing

- `go test -race` on `internal/background/activities` passes.
- `mise lint:server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Anthropic Compliance 404s as non-retryable in the AI usage poll. This fails fast with a clear error and avoids wasting Temporal retries.

- **Bug Fixes**
  - Map Anthropic 404 to a not-found error with guidance (“organization not found or access not enabled”), recorded immediately in the dashboard.
  - Add Anthropic 404 to the non-retryable set alongside 401/403; Cursor 404s remain retryable.
  - Keep watermark/cursor unchanged and advance next poll time so the integration auto-recovers once access is enabled.
  - Reduce monitor noise from multiple retries to a single failure per run.

- **Refactors**
  - Rename helper from pollAPIKeyRejected to pollRejectedByProvider to reflect broader non-retryable cases.

<sup>Written for commit 8eaa419d060f3804d5bebc38ecdcec774eb4e962. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

